### PR TITLE
Bug 2947 viterbi

### DIFF
--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -391,7 +391,7 @@ class HiddenMarkovModel:
         # et al, since we are indexing the sequence going from 0 to
         # (Length - 1) not 1 to Length, like in Durbin et al.
         #
-        # v_{0}(0) = 1
+        # v_{0}(0) = 0
         viterbi_probs[(state_letters[0], -1)] = 0
         # v_{k}(0) = 0 for k > 0
         for state_letter in state_letters[1:]:

--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -392,7 +392,7 @@ class HiddenMarkovModel:
         # (Length - 1) not 1 to Length, like in Durbin et al.
         #
         # v_{0}(0) = 1
-        viterbi_probs[(state_letters[0], -1)] = 1
+        viterbi_probs[(state_letters[0], -1)] = 0
         # v_{k}(0) = 0 for k > 0
         for state_letter in state_letters[1:]:
             viterbi_probs[(state_letter, -1)] = 0
@@ -433,11 +433,7 @@ class HiddenMarkovModel:
         all_probs = {}
         for state in state_letters:
             # v_{k}(L)
-            viterbi_part = viterbi_probs[(state, len(sequence) - 1)]
-            # a_{k0}
-            transition_part = log_trans[(state, state_letters[0])]
-
-            all_probs[state] = viterbi_part * transition_part
+            all_probs[state] = viterbi_probs[(state, len(sequence) - 1)]
 
         state_path_prob = max(all_probs.values())
 


### PR DESCRIPTION
Hello,

I think this fixes bug 2947. There were 2 errors in how the state sequence was calcuated. 

The first occurs at the beginning of the sequence.  viterbi_probs[(state_letters[0], -1)] was initialized to 1 and  viterbi_probs[(state_letters[0], -1)]  to 0 for all state letters other than the zeroth. This is how it is described in Biological Sequence Analysis by Durbin, et al, but it doesn't work for the code as written because the code doesn't provide for an particular begin state. By initializing the zeroth state letter to 1, and all the others to 0, you're starting off by assigning a higher probability to a state sequence that begins with the zeroth state letter.

I fixed this error by also setting  viterbi_probs[(state_letters[0], -1)] to 0, so that all possible initial states are equally probable.

There's a second error in the Viterbi termination code. The algorithm described in Durbin et al allows for modeling a particular end state. Since the code as written doesn't provide for specifying an end state, the termination code miscalculates the sequence probability. The pseudocode in Durbin et al confusingly labels the end state as "0", at least in the printing I have, and this seems to have been carried over into the biopython code, where the zeroth state_letter is whichever one is first in the list. The code as written calculated the probability of the discovered state sequence multiplied by the probability of transitioning from the sequence's last element to the zeroth state named in state_letters, when it should just calculate the probability of the discovered state sequence.

I fixed this by deleting the lines that were intended to account for the transition to an end state.

It could be useful to specify particular begin and end states, but I believe this patch should give correct results for all cases that don't need that ability.

~Phillip
