### PR TITLE
Show failing sequence ID in PhylipWriter

### DIFF
--- a/Bio/AlignIO/PhylipIO.py
+++ b/Bio/AlignIO/PhylipIO.py
@@ -40,7 +40,7 @@ class PhylipWriter(SequentialAlignmentWriter):
         http://evolution.genetics.washington.edu/phylip/doc/sequence.html
         http://evolution.genetics.washington.edu/phylip/doc/main.html#inputfiles
         """
-        truncate=10
+        truncate = 10
         handle = self.handle        
         
         if len(alignment)==0:
@@ -52,9 +52,13 @@ class PhylipWriter(SequentialAlignmentWriter):
         if length_of_seqs <= 0:
             raise ValueError("Non-empty sequences are required")
         
-        if len(alignment) > len(set([r.id[:truncate] for r in alignment])):
-            raise ValueError("Repeated identifier, possibly due to truncation")
-
+        # Check for repeated identifiers
+        ids = set()
+        for trunc_id in (r.id[:truncate] for r in alignment):
+            if trunc_id in ids:
+                raise ValueError(("Repeated identifier '%s', possibly due to "
+                                  "truncation" % trunc_id))
+            ids.add(trunc_id)
 
         # From experimentation, the use of tabs is not understood by the
         # EMBOSS suite.  The nature of the expected white space is not

--- a/Tests/output/test_AlignIO
+++ b/Tests/output/test_AlignIO
@@ -50,7 +50,7 @@ Testing reading clustal format file Clustalw/odd_consensus.aln with 1 alignments
  Checking can write/read as 'nexus' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phylip' format
- Failed: Repeated identifier, possibly due to truncation
+ Failed: Repeated identifier 'AT3G20900.', possibly due to truncation
  Checking can write/read as 'stockholm' format
  Checking can write/read as 'fasta' format
  Checking can write/read as 'tab' format
@@ -67,7 +67,7 @@ Testing reading clustal format file Clustalw/protein.aln with 1 alignments
  Checking can write/read as 'nexus' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phylip' format
- Failed: Repeated identifier, possibly due to truncation
+ Failed: Repeated identifier 'gi|1377497', possibly due to truncation
  Checking can write/read as 'stockholm' format
  Checking can write/read as 'fasta' format
  Checking can write/read as 'tab' format
@@ -84,7 +84,7 @@ Testing reading clustal format file Clustalw/promals3d.aln with 1 alignments
  Checking can write/read as 'nexus' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phylip' format
- Failed: Repeated identifier, possibly due to truncation
+ Failed: Repeated identifier 'gi_1393639', possibly due to truncation
  Checking can write/read as 'stockholm' format
  Checking can write/read as 'fasta' format
  Checking can write/read as 'tab' format
@@ -289,7 +289,7 @@ Testing reading emboss format file Emboss/needle_asis.txt with 1 alignments
  Checking can write/read as 'nexus' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phylip' format
- Failed: Repeated identifier, possibly due to truncation
+ Failed: Repeated identifier 'asis', possibly due to truncation
  Checking can write/read as 'stockholm' format
  Failed: Duplicate record identifier: asis
  Checking can write/read as 'fasta' format
@@ -313,7 +313,7 @@ Testing reading emboss format file Emboss/water2.txt with 1 alignments
  Checking can write/read as 'nexus' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phylip' format
- Failed: Repeated identifier, possibly due to truncation
+ Failed: Repeated identifier 'asis', possibly due to truncation
  Checking can write/read as 'stockholm' format
  Failed: Duplicate record identifier: asis
  Checking can write/read as 'fasta' format
@@ -416,7 +416,7 @@ Testing reading fasta-m10 format file Fasta/output004.m10 with 1 alignments
  Checking can write/read as 'nexus' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phylip' format
- Failed: Repeated identifier, possibly due to truncation
+ Failed: Repeated identifier 'ref|NC_002', possibly due to truncation
  Checking can write/read as 'stockholm' format
  Checking can write/read as 'fasta' format
  Checking can write/read as 'tab' format

--- a/Tests/test_AlignIO.py
+++ b/Tests/test_AlignIO.py
@@ -8,7 +8,9 @@ from StringIO import StringIO
 from Bio import SeqIO
 from Bio import AlignIO
 from Bio.Align.Generic import Alignment
-from Bio.Align import AlignInfo
+from Bio.Align import AlignInfo, MultipleSeqAlignment
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
 
 test_write_read_alignment_formats = sorted(AlignIO._FormatToWriter)
 test_write_read_align_with_seq_count = test_write_read_alignment_formats \
@@ -22,7 +24,7 @@ test_write_read_align_with_seq_count = test_write_read_alignment_formats \
 #
 # Most of the input files are also used by test_SeqIO.py,
 # and by other additional tests as noted below.
-test_files = [ \
+test_files = [
 #Following examples are also used in test_Clustalw.py
     ("clustal", 2, 1, 'Clustalw/cw02.aln'),
     ("clustal", 7, 1, 'Clustalw/opuntia.aln'),
@@ -185,6 +187,28 @@ def simple_alignment_comparison(alignments, alignments2, format):
                 assert r1.id == r2.id, \
                        "'%s' vs '%s'" % (r1.id, r2.id)
     return True
+
+#Check Phylip files reject duplicate identifiers.
+def check_phylip_reject_duplicate():
+    """
+    Ensure that attempting to write sequences with duplicate IDs after
+    truncation fails for Phylip format.
+    """
+    handle = StringIO()
+    sequences = [SeqRecord(Seq('AAAA'), id='longsequencename1'),
+                 SeqRecord(Seq('AAAA'), id='longsequencename2'),
+                 SeqRecord(Seq('AAAA'), id='other_sequence'),]
+    alignment = MultipleSeqAlignment(sequences)
+    try:
+        # This should raise a ValueError
+        AlignIO.write(alignment, handle, 'phylip')
+        assert False, "Duplicate IDs after truncation are not allowed."
+    except ValueError, e:
+        # Expected - check the error
+        assert e.message.startswith("Repeated identifier 'longsequen'")
+
+check_phylip_reject_duplicate()
+
 
 #Check parsers can cope with an empty file
 for t_format in AlignIO._FormatToIterator:


### PR DESCRIPTION
- ValueError raised on duplicate sequence ID in PhylipWriter now identifies the (possibly truncated) problematic sequence ID
- Added a simple test - not quite sure how to integrate with BioPython test suite - let me know if that should be changed.
