### PR TITLE
Fix set random probabilities

### DIFF
--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -257,12 +257,19 @@ class MarkovModelBuilder(object):
         return self.transition_prob
 
     def set_random_emission_probabilities(self):
-        """Set all emission probabilities to a randomly generated distribution.
-        Returns the dictionary containing the emission probabilities.
+        """Set all allowed emission probabilities to a randomly generated
+        distribution.  Returns the dictionary containing the emission
+        probabilities.
         """
-        for state in self._state_alphabet.letters:
-            freqs = _gen_random_array(len(self._emission_alphabet.letters))
-            for symbol in self._emission_alphabet.letters:
+
+        if not self.emission_prob:
+            raise Exception("No emissions have been allowed yet. " +
+                            "Allow some or all emissions.")
+
+        emissions = _calculate_emissions(self.emission_prob)
+        for state in emissions.iterkeys():
+            freqs = _gen_random_array(len(emissions[state]))
+            for symbol in emissions[state]:
                 self.emission_prob[(state, symbol)] = freqs.pop()
 
         return self.emission_prob


### PR DESCRIPTION
This fixes the MarkovModelBuilder.set_random_probabilities method to set meaningful probabilities for initial states, transitions, and emissions, and adds methods set_random_initial_probabilities, set_random_transition_probabilities, and set_random_emission_probabilities so users can randomize initial state probabilities, state transition probabilities,and emission probabilities separately.

Right now, set_random_probabilities assigns a random number to each of the initial states, permitted transitions, and permitted emissions, without ensuring that the individual probabilities within each category sum to 1. This patch changes the method, so:

1) the initial probabilities for each state sum to 1 
2) For each allow source state, the probabilities of transitioning to each allowed successor state sum to 1 
3) For each state, the probabilities of emitting each allowed symbol from that state sum to 1.

This passes the existing tests on python 2.5.5, 2.6.6, and 2.7.1 on Debian GNU/Linux.

~Phillip
