### PR TITLE
Not all calls to `.keys()` should be deleted.

### DIFF
--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -996,7 +996,7 @@ class Nexus(object):
         the name CodonPositions and the partitions N,1,2,3
         """
 
-        prev_partitions=self.charpartitions
+        prev_partitions=self.charpartitions.keys()
         self._charpartition(options)
         # mcclade calls it CodonPositions, but you never know...
         codonname=[n for n in self.charpartitions if n not in prev_partitions]


### PR DESCRIPTION
Commit bdf94b3b70 deleted a lot of calls to `.keys()`. Some of those calls should not be deleted. I spotted one of them.

Removing the call to `keys()` on line 999 caused `prev_partitions` to be a shallow copy of `self.charpartitions` instead of a previous copy of the keys. In the next line, `self.charpartitions` is modified and therefore so is `prev_partitions`. So, the requirement in the list comprehension `n not in prev_partitions` is impossible to meet and the `NexusError` will always be raised. I encountered the raised error when trying to read a nexus file.
