### PR TITLE
added: max_hsps_per_subject option for BLAST+ wrapper

### DIFF
--- a/Bio/Blast/Applications.py
+++ b/Bio/Blast/Applications.py
@@ -563,6 +563,9 @@ class _NcbiblastCommandline(_NcbibaseblastCommandline):
             _Option(["-searchsp", "searchsp"],
                     "Effective length of the search space (integer)",
                     equate=False),
+            _Option(["-max_hsps_per_subject", "max_hsps_per_subject"],
+                    "Override maximum number of HSPs per subject to save for ungapped searches (integer)",
+                    equate=False),
             #Extension options
             _Option(["-xdrop_ungap", "xdrop_ungap"],
                     "X-dropoff value (in bits) for ungapped extensions. Float.",


### PR DESCRIPTION
In BLAST 2.2.26+, there is an extra output option 'max_hsps_per_subject' that controls the number of displayed HSPs per hit. This is available in blastn, blastp, blastx, tblastn, tblastx, rpsblast, and psiblast. I don't know if this option is present in previous versions, but I thought it would be handy to have them available in the wrapper.
