### PR TITLE
Change FeatureLocation str to math notation.

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -586,7 +586,7 @@ class FeatureLocation(object):
         (zero based counting) which GenBank would call 123..150 (one based
         counting).
         """
-        answer = "[%s:%s]" % (self._start, self._end)
+        answer = "[%s,%s)" % (self._start, self._end)
         if self.ref and self.ref_db:
             answer = "%s:%s%s" % (self.ref_db, self.ref, answer)
         elif self.ref:


### PR DESCRIPTION
I propose that, given the tangled mess of gene sequence numbering, it would be more clear for the string representation of FeatureLocation to use mathematical notation. 

1-based, fully closed, a la GenBank: 123..150, very confusing for programmers.
FeatureLocation currently represents this as [122:150], zero-based, right-open, just like a Python list.
This patch would change the string representation to [122,150).

This would be useful to emphasize to an end user that these coordinates are right-open.

The question is, would this cosmetic alteration break anything?
