### PR TITLE
Additions to the amino acid code display functions in SeqUtils 

### DIFF
--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -252,6 +252,47 @@ def seq3(seq, term_map={'*': 'Ter'}, undef_code='Xaa'):
     return ''.join([threecode.get(aa, undef_code) for aa in seq])
 
 
+def seq1(seq, term_map={'Ter': '*'}, undef_code='X'):
+    """Turns a three-letter code protein sequence into one with single letter codes.
+
+    The single input argument 'seq' should be a protein sequence using three-
+    letter codes, either as a python string or as a Seq or MutableSeq object.
+
+    This function returns the amino acid sequence as a string using the three
+    letter amino acid codes. Output follows the IUPAC standard (including
+    ambiguous characters "Asx" for "B", "Xle" for "J", "Xaa" for "X", "Sel" for
+    "U", and "Pyl" for "O") plus "*" for a terminator given the "Ter" code.
+    Any unknown character (including possible gap characters), is changed into
+    '-'.
+
+    e.g.
+    >>> from Bio.SeqUtils import seq3
+    >>> seq1("MetAlaIleValMetGlyArgTrpLysGlyAlaArgTer")
+    'MAIVMGRWKGAR*'
+
+    You can set a custom translation of the codon termination code using the
+    "term_map" argument, e.g.
+    >>> seq1("MetAlaIleValMetGlyArgTrpLysGlyAlaArg***", term_map={"***": "*"})
+    'MAIVMGRWKGAR*'
+
+    You can also set a custom translation for non-amino acid characters, such
+    as '-', using the "undef_code" argument, e.g.
+    >>> seq1("MetAlaIleValMetGlyArgTrpLysGlyAla------ArgTer", undef_code='?')
+    'MAIVMGRWKGA??R*'
+
+    If not given, "undef_code" defaults to "X", e.g.
+    >>> seq1("MetAlaIleValMetGlyArgTrpLysGlyAla------ArgTer")
+    'MAIVMGRWKGAXXR*'
+
+    """
+    # reverse map of threecode
+    onecode = dict([(x[1], x[0]) for x in _THREECODE.items()])
+    # add the given termination codon code and custom maps
+    onecode.update(term_map)
+    seqlist = [seq[3*i:3*(i+1)] for i in range(len(seq) / 3)]
+    return ''.join([onecode.get(aa, undef_code) for aa in seqlist])
+
+
 # }}}
 
 ######################################


### PR DESCRIPTION
This pull request updates the `SeqUtils.seq3` function and adds a new `SeqUtils.seq1` function.

The updated `SeqUtils.seq3` function now accepts two more extra arguments:
- `term_map`, which is a mapping of custom amino acid termination character (e.g. `{'*': '***'}`)
- `undef_code`, which is a string for undefined characters

I've kept the previously hard coded values as the defaults for these two values, so this shouldn't introduce any bugs.

The new `SeqUtils.seq1` function is basically the reverse of `seq3`; it transforms a string of three-letter amino acid codes into a string containing single codes.

I stumbled on this when I was writing the parser for Exonerate. Exonerate uses three-letter AA codes (which I'm trying to turn into one-letter codes), and I thought it would be more useful if the three-to-one AA transformation code is made available Biopython-wide.

I've also updated the docstrings, and all doctests pass.
