### PR TITLE
Simplify Bio.PDB.Selection module

### DIFF
--- a/Bio/PDB/Selection.py
+++ b/Bio/PDB/Selection.py
@@ -67,7 +67,8 @@ def unfold_entities(entity_list, target_level):
 
     if level_index > target_index:  # we're going down, e.g. S->A
         for i in range(target_index, level_index):
-            entity_list = itertools.chain.from_iterable(entity_list)
+            #entity_list = itertools.chain.from_iterable(entity_list)  # 2.6+
+            entity_list = itertools.chain(*entity_list)
     else:  # we're going up, e.g. A->S
         for i in range(level_index, target_index):
             # find unique parents


### PR DESCRIPTION
## Summary of changes
- Allow Atoms to be single parameter, as other levels of 'SMCRA' hierarchy can
- Use newer language constructs to de-clutter code, increase speed
- Clean up code to fit PEP 8 guidelines
## Effects, backwards compatibility

The core behavior of Selection is unchanged. The only difference is that a single Atom can now be passed as the `entity_list` instead of converting it to a list first. Accordingly, the code should be backwards-compatible.

Thanks to Peter's comments, I've changed instances of set comprehension (a feature of Python 2.7) to the `set()` constructor instead. I also removed `chain.from_iterable()`, as it was introduced with version 2.6. I left the offending line as a comment, replacing it with the original `chain` constructor in the code.
