### PR TITLE
Fix for https://redmine.open-bio.org/issues/3353 

### DIFF
--- a/Bio/KEGG/Enzyme/__init__.py
+++ b/Bio/KEGG/Enzyme/__init__.py
@@ -158,7 +158,7 @@ class Record(object):
             s.append(entry[0] + ": " + entry[1] + "  " + entry[2])
         return _write_kegg("DISEASE",
                            [_wrap_kegg(l, wrap_rule = id_wrap(13)) \
-                            for l in s])    
+                            for l in s])
     def _structures(self):
         s = []
         for entry in self.structures:
@@ -175,7 +175,6 @@ class Record(object):
         for entry in self.dblinks:
             s.append(entry[0] + ": " + "  ".join(entry[1]))
         return _write_kegg("DBLINKS", s)
-
 
 
 def parse(handle):
@@ -241,7 +240,7 @@ def parse(handle):
                 row = database, number, name
                 record.disease[-1] = row
         elif keyword=="EFFECTOR    ":
-             record.effector.append(data.strip(";"))
+            record.effector.append(data.strip(";"))
         elif keyword=="GENES       ":
             if data[3:5]==': ':
                 key, values = data.split(":",1)
@@ -257,24 +256,22 @@ def parse(handle):
                 row = key, values
                 record.genes[-1] = row
         elif keyword=="INHIBITOR   ":
-             record.inhibitor.append(data.strip(";"))
+            record.inhibitor.append(data.strip(";"))
         elif keyword=="NAME        ":
-             record.name.append(data.strip(";"))
+            record.name.append(data.strip(";"))
         elif keyword=="PATHWAY     ":
             if data[:5]=='PATH:':
-                path, map, name = data.split(None,2)
-                pathway = (path[:-1], map, name)
+                _, map_num, name = data.split(None,2)
+                pathway = ('PATH', map_num, name)
                 record.pathway.append(pathway)
             else:
-                pathway = record.pathway[-1]
-                path, map, name = pathway
-                name = name + " " + data
-                pathway = path, map, name
-                record.pathway[-1] = pathway
+                ec_num, name = data.split(None,1)
+                pathway = 'PATH', ec_num, name
+                record.pathway.append(pathway)
         elif keyword=="PRODUCT     ":
-             record.product.append(data.strip(";"))
+            record.product.append(data.strip(";"))
         elif keyword=="REACTION    ":
-             record.reaction.append(data.strip(";"))
+            record.reaction.append(data.strip(";"))
         elif keyword=="STRUCTURES  ":
             if data[:4]=='PDB:':
                 database = data[:3]
@@ -288,13 +285,13 @@ def parse(handle):
                 row = (database, accessions)
                 record.structures[-1] = row
         elif keyword=="SUBSTRATE   ":
-             record.substrate.append(data.strip(";"))
+            record.substrate.append(data.strip(";"))
         elif keyword=="SYSNAME     ":
-             record.sysname.append(data.strip(";"))
+            record.sysname.append(data.strip(";"))
 
 def _test():
     """Run the Bio.KEGG.Enzyme module's doctests.
-    
+
     This will try and locate the unit tests directory, and run the doctests
     from there in order that the relative paths used in the examples work.
     """

--- a/Tests/KEGG/enzyme.new
+++ b/Tests/KEGG/enzyme.new
@@ -1,0 +1,105 @@
+ENTRY       EC 6.2.1.25                 Enzyme
+NAME        benzoate---CoA ligase;
+            benzoate---coenzyme A ligase;
+            benzoyl-coenzyme A synthetase;
+            benzoyl CoA synthetase (AMP forming)
+CLASS       Ligases;
+            Forming carbon-sulfur bonds;
+            Acid-thiol ligases
+SYSNAME     benzoate:CoA ligase (AMP-forming)
+REACTION    ATP + benzoate + CoA = AMP + diphosphate + benzoyl-CoA [RN:R01422]
+ALL_REAC    R01422
+SUBSTRATE   ATP [CPD:C00002];
+            benzoate [CPD:C00180];
+            CoA [CPD:C00010]
+PRODUCT     AMP [CPD:C00020];
+            diphosphate [CPD:C00013];
+            benzoyl-CoA [CPD:C00512]
+COMMENT     Also acts on 2-, 3- and 4-fluorobenzoate, but only very slowly on the corresponding chlorobenzoates.
+REFERENCE   1
+  AUTHORS   Hutber, G.N. and Ribbons, D.W.
+  TITLE     Involvement of coenzyme-A esters in the metabolism of benzoate and cyclohexanecarboxylate by Rhodopseudomonas palustris.
+  JOURNAL   J. Gen. Microbiol. 129 (1983) 2413-2420.
+REFERENCE   2  [PMID:2857161]
+  AUTHORS   Schennen U, Braun K, Knackmuss HJ.
+  TITLE     Anaerobic degradation of 2-fluorobenzoate by benzoate-degrading, denitrifying bacteria.
+  JOURNAL   J. Bacteriol. 161 (1985) 321-5.
+  ORGANISM  Pseudomonas sp.
+PATHWAY     ec00362  Benzoate degradation
+            ec00627  Aminobenzoate degradation
+            ec01100  Metabolic pathways
+            ec01120  Microbial metabolism in diverse environments
+ORTHOLOGY   K04105  4-hydroxybenzoate-CoA ligase
+            K04110  benzoate-CoA ligase
+GENES       REU: Reut_A1327
+            REH: H16_A1412(h16_A1412) H16_B1918
+            RME: Rmet_1224(bzdA)
+            CTI: RALTA_A1325 RALTA_B1617
+            CNC: CNE_1c14400(bclA) CNE_2c18780(boxD)
+            BXE: Bxe_A1419 Bxe_C0896
+            BPH: Bphy_1543
+            BPY: Bphyt_2700
+            BGL: bglu_2g11460
+            BUG: BC1001_2395
+            BGE: BC1002_1980
+            BGF: BC1003_1063
+            BRH: RBRH_00494
+            BPT: Bpet3574
+            AXY: AXYL_05035
+            AKA: TKWG_07570
+            RFR: Rfer_0216
+            POL: Bpro_1624 Bpro_2983
+            PNA: Pnap_2948
+            VEI: Veis_0730
+            DAC: Daci_0076
+            DEL: DelCs14_0077
+            VAP: Vapar_0089
+            VPE: Varpa_0102
+            CTT: CtCNB1_0097
+            RTA: Rta_22340
+            LCH: Lcho_3655
+            EBA: ebA2757(bclA) ebA5301(bclA)
+            AZO: azo3052(bzdA)
+            TMZ: Tmz1t_3136
+            GME: Gmet_2143
+            GLO: Glov_2397
+            GEO: Geob_0200
+            GEM: GM21_2825
+            DMA: DMR_19390
+            DAS: Daes_3238
+            DPR: Despr_3172
+            DTI: Desti_5323
+            BJA: blr1077
+            BRA: BRADO6791
+            BBT: BBta_0747 BBta_6637(badA)
+            RPA: RPA0661(badA) RPA0669(hbaA)
+            RPB: RPB_4656
+            RPC: RPC_1016 RPC_1025
+            RPD: RPD_1526 RPD_1534
+            RPE: RPE_0592 RPE_0604
+            RPT: Rpal_0728 Rpal_0736
+            RPX: Rpdx1_4117 Rpdx1_4125
+            RVA: Rvan_0044
+            SIL: SPO3697(badA-1)
+            JAN: Jann_0669
+            SWI: Swit_0829
+            RPM: RSPPHO_01133
+            MAG: amb2869
+            GYC: GYMC61_2828
+            GYA: GYMC52_1957
+            GCT: GC56T3_1519
+            SCB: SCAB_8391
+            SCT: SCAT_5491
+            SCY: SCATT_54890
+            BSD: BLASA_2555(badA)
+            AMD: AMED_8609(badA)
+            AMN: RAM_35745 RAM_44185
+            AMM: AMES_6861(badA) AMES_8478(badA)
+            PDX: Psed_1491
+DBLINKS     ExplorEnz - The Enzyme Database: 6.2.1.25
+            IUBMB Enzyme Nomenclature: 6.2.1.25
+            ExPASy - ENZYME nomenclature database: 6.2.1.25
+            UM-BBD (Biocatalysis/Biodegradation Database): 6.2.1.25
+            BRENDA, the Enzyme Database: 6.2.1.25
+            CAS: 95329-17-2
+///

--- a/Tests/output/test_KEGG
+++ b/Tests/output/test_KEGG
@@ -410,6 +410,105 @@ DBLINKS     IUBMB Enzyme Nomenclature: 3.4.21.50
 ///
 
 
+Testing Bio.KEGG.Enzyme on enzyme.new
+
+
+ENTRY       EC 6.2.1.25
+NAME        benzoate---CoA ligase
+            benzoate---coenzyme A ligase
+            benzoyl-coenzyme A synthetase
+            benzoyl CoA synthetase (AMP forming)
+CLASS       Ligases;
+            Forming carbon-sulfur bonds;
+            Acid-thiol ligases
+SYSNAME     benzoate:CoA ligase (AMP-forming)
+REACTION    ATP + benzoate + CoA = AMP + diphosphate + benzoyl-CoA [RN:R01422]
+SUBSTRATE   ATP [CPD:C00002]
+            benzoate [CPD:C00180]
+            CoA [CPD:C00010]
+PRODUCT     AMP [CPD:C00020]
+            diphosphate [CPD:C00013]
+            benzoyl-CoA [CPD:C00512]
+COMMENT     Also acts on 2-, 3- and 4-fluorobenzoate, but only very slowly on
+            the corresponding chlorobenzoates.
+PATHWAY     PATH: ec00362  Benzoate degradation
+            PATH: ec00627  Aminobenzoate degradation
+            PATH: ec01100  Metabolic pathways
+            PATH: ec01120  Microbial metabolism in diverse environments
+GENES       REU: Reut_A1327
+            REH: H16_A1412 H16_B1918
+            RME: Rmet_1224
+            CTI: RALTA_A1325 RALTA_B1617
+            CNC: CNE_1c14400 CNE_2c18780
+            BXE: Bxe_A1419 Bxe_C0896
+            BPH: Bphy_1543
+            BPY: Bphyt_2700
+            BGL: bglu_2g11460
+            BUG: BC1001_2395
+            BGE: BC1002_1980
+            BGF: BC1003_1063
+            BRH: RBRH_00494
+            BPT: Bpet3574
+            AXY: AXYL_05035
+            AKA: TKWG_07570
+            RFR: Rfer_0216
+            POL: Bpro_1624 Bpro_2983
+            PNA: Pnap_2948
+            VEI: Veis_0730
+            DAC: Daci_0076
+            DEL: DelCs14_0077
+            VAP: Vapar_0089
+            VPE: Varpa_0102
+            CTT: CtCNB1_0097
+            RTA: Rta_22340
+            LCH: Lcho_3655
+            EBA: ebA2757 ebA5301
+            AZO: azo3052
+            TMZ: Tmz1t_3136
+            GME: Gmet_2143
+            GLO: Glov_2397
+            GEO: Geob_0200
+            GEM: GM21_2825
+            DMA: DMR_19390
+            DAS: Daes_3238
+            DPR: Despr_3172
+            DTI: Desti_5323
+            BJA: blr1077
+            BRA: BRADO6791
+            BBT: BBta_0747 BBta_6637
+            RPA: RPA0661 RPA0669
+            RPB: RPB_4656
+            RPC: RPC_1016 RPC_1025
+            RPD: RPD_1526 RPD_1534
+            RPE: RPE_0592 RPE_0604
+            RPT: Rpal_0728 Rpal_0736
+            RPX: Rpdx1_4117 Rpdx1_4125
+            RVA: Rvan_0044
+            SIL: SPO3697
+            JAN: Jann_0669
+            SWI: Swit_0829
+            RPM: RSPPHO_01133
+            MAG: amb2869
+            GYC: GYMC61_2828
+            GYA: GYMC52_1957
+            GCT: GC56T3_1519
+            SCB: SCAB_8391
+            SCT: SCAT_5491
+            SCY: SCATT_54890
+            BSD: BLASA_2555
+            AMD: AMED_8609
+            AMN: RAM_35745 RAM_44185
+            AMM: AMES_6861 AMES_8478
+            PDX: Psed_1491
+DBLINKS     ExplorEnz - The Enzyme Database: 6.2.1.25
+            IUBMB Enzyme Nomenclature: 6.2.1.25
+            ExPASy - ENZYME nomenclature database: 6.2.1.25
+            UM-BBD (Biocatalysis/Biodegradation Database): 6.2.1.25
+            BRENDA, the Enzyme Database: 6.2.1.25
+            CAS: 95329-17-2
+///
+
+
 Testing Bio.KEGG.Compound on compound.sample
 
 

--- a/Tests/test_KEGG.py
+++ b/Tests/test_KEGG.py
@@ -8,8 +8,8 @@ from Bio.KEGG import Compound
 from Bio.KEGG import Map
 from Bio.Pathway import System
 
-test_KEGG_Enzyme_files   = ["enzyme.sample", "enzyme.irregular"]
-test_KEGG_Compound_files = ["compound.sample", "compound.irregular"] 
+test_KEGG_Enzyme_files   = ["enzyme.sample", "enzyme.irregular", "enzyme.new"]
+test_KEGG_Compound_files = ["compound.sample", "compound.irregular"]
 test_KEGG_Map_files      = ["map00950.rea"]
 
 def t_KEGG_Enzyme(testfiles):
@@ -60,5 +60,3 @@ def t_KEGG_Map(testfiles):
 t_KEGG_Enzyme(test_KEGG_Enzyme_files)
 t_KEGG_Compound(test_KEGG_Compound_files)
 t_KEGG_Map(test_KEGG_Map_files)
-
-


### PR DESCRIPTION
The layout changed from:
    "PATHWAY PATH: MAP00130 Ubiquinone biosynthesis"
to:
    "PATHWAY ec00030 Pentose phosphate pathway"

Both versions are supported.

The test file was generated like this:
http://rest.kegg.jp/get/ec:6.2.1.25
