### PR TITLE
Change instances of string.find() to use the "in" operator instead

### DIFF
--- a/Bio/AlignIO/StockholmIO.py
+++ b/Bio/AlignIO/StockholmIO.py
@@ -456,7 +456,7 @@ class StockholmIterator(AlignmentIterator):
 
     def _identifier_split(self, identifier):
         """Returns (name,start,end) string tuple from an identier."""
-        if identifier.find("/")!=-1:
+        if '/' in identifier:
             name, start_end = identifier.rsplit("/",1)
             if start_end.count("-")==1:
                 try:

--- a/Bio/Blast/NCBIStandalone.py
+++ b/Bio/Blast/NCBIStandalone.py
@@ -255,7 +255,7 @@ class _Scanner(object):
             if (not line.startswith('Searching') and
                 not line.startswith('Results from round') and
                 re.search(r"Score +E", line) is None and
-                line.find('No hits found') == -1):
+                'No hits found' not in line):
                 break
             self._scan_descriptions(uhandle, consumer)
             self._scan_alignments(uhandle, consumer)
@@ -304,7 +304,7 @@ class _Scanner(object):
         # Check for these error lines and ignore them for now.  Let
         # the BlastErrorParser deal with them.
         line = uhandle.peekline()
-        if line.find("ERROR:") != -1 or line.startswith("done"):
+        if "ERROR:" in line or line.startswith("done"):
             read_and_call_while(uhandle, consumer.noevent, contains="ERROR:")
             read_and_call(uhandle, consumer.noevent, start="done")
 
@@ -610,7 +610,7 @@ class _Scanner(object):
 
             line = safe_readline(uhandle)
             uhandle.saveline(line)
-            if line.find('Lambda') != -1:
+            if 'Lambda' in line:
                 break
 
         read_and_call(uhandle, consumer.noevent, start='Lambda')
@@ -1160,14 +1160,14 @@ class _HSPConsumer(object):
         self._hsp.identities = _safe_int(x), _safe_int(y)
         self._hsp.align_length = _safe_int(y)
 
-        if line.find('Positives') != -1:
+        if 'Positives' in line:
             x, y = _re_search(
                 r"Positives = (\d+)\/(\d+)", line,
                 "I could not find the positives in line\n%s" % line)
             self._hsp.positives = _safe_int(x), _safe_int(y)
             assert self._hsp.align_length == _safe_int(y)
 
-        if line.find('Gaps') != -1:
+        if 'Gaps' in line:
             x, y = _re_search(
                 r"Gaps = (\d+)\/(\d+)", line,
                 "I could not find the gaps in line\n%s" % line)
@@ -1184,7 +1184,7 @@ class _HSPConsumer(object):
         # Frame can be in formats:
         # Frame = +1
         # Frame = +2 / +2
-        if line.find('/') != -1:
+        if '/' in line:
             self._hsp.frame = _re_search(
                 r"Frame\s?=\s?([-+][123])\s?/\s?([-+][123])", line,
                 "I could not find the frame in line\n%s" % line)
@@ -1315,7 +1315,7 @@ class _ParametersConsumer(object):
         self._params.gap_penalties = map(_safe_float, x)
 
     def num_hits(self, line):
-        if line.find('1st pass') != -1:
+        if '1st pass' in line:
             x, = _get_cols(line, (-4,), ncols=11, expected={2:"Hits"})
             self._params.num_hits = _safe_int(x)
         else:
@@ -1323,7 +1323,7 @@ class _ParametersConsumer(object):
             self._params.num_hits = _safe_int(x)
 
     def num_sequences(self, line):
-        if line.find('1st pass') != -1:
+        if '1st pass' in line:
             x, = _get_cols(line, (-4,), ncols=9, expected={2:"Sequences:"})
             self._params.num_sequences = _safe_int(x)
         else:
@@ -1331,7 +1331,7 @@ class _ParametersConsumer(object):
             self._params.num_sequences = _safe_int(x)
 
     def num_extends(self, line):
-        if line.find('1st pass') != -1:
+        if '1st pass' in line:
             x, = _get_cols(line, (-4,), ncols=9, expected={2:"extensions:"})
             self._params.num_extends = _safe_int(x)
         else:
@@ -1339,7 +1339,7 @@ class _ParametersConsumer(object):
             self._params.num_extends = _safe_int(x)
 
     def num_good_extends(self, line):
-        if line.find('1st pass') != -1:
+        if '1st pass' in line:
             x, = _get_cols(line, (-4,), ncols=10, expected={3:"extensions:"})
             self._params.num_good_extends = _safe_int(x)
         else:
@@ -2119,7 +2119,7 @@ class _BlastErrorConsumer(_BlastConsumer):
     def __init__(self):
         _BlastConsumer.__init__(self)
     def noevent(self, line):
-        if line.find("Query must be at least wordsize") != -1:
+        if 'Query must be at least wordsize' in line:
             raise ShortQueryBlastError("Query must be at least wordsize")
         # Now pass the line back up to the superclass.
         method = getattr(_BlastConsumer, 'noevent',

--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -167,7 +167,7 @@ def qblast(program, database, sequence,
         if results=="\n\n":
             continue
         # XML results don't have the Status tag when finished
-        if results.find("Status=") < 0:
+        if "Status=" not in results:
             break
         i = results.index("Status=")
         j = results.index("\n", i)

--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -647,7 +647,7 @@ def parse(handle, debug=0):
             #start of another XML file...
             pending = handle.read(MARGIN)
 
-            if (text+pending).find("\n" + XML_START) == -1:
+            if ("\n" + XML_START) not in (text + pending):
                 # Good - still dealing with the same XML file
                 expat_parser.Parse(text, False)        
                 while blast_parser._records:

--- a/Bio/Blast/ParseBlastTable.py
+++ b/Bio/Blast/ParseBlastTable.py
@@ -44,7 +44,7 @@ class BlastTableReader(object):
       self.handle = handle
       inline = self.handle.readline()
       # zip forward to start of record
-      while inline and inline.find('BLASTP') == -1:
+      while inline and 'BLASTP' not in inline:
          inline = self.handle.readline()
       self._lookahead = inline
       self._n = 0
@@ -75,7 +75,7 @@ class BlastTableReader(object):
       self.table_record.add_entry(current_entry)
    def _consume_header(self, inline):
       for keyword in reader_keywords:
-         if inline.find(keyword) > -1:
+         if keyword in inline:
             in_header = self._Parse('_parse_%s' % reader_keywords[keyword],inline)
             break
       return in_header

--- a/Bio/GenBank/Record.py
+++ b/Bio/GenBank/Record.py
@@ -233,17 +233,17 @@ class Record(object):
         output += "%-9s" % self.locus
         output += " " # 22 space
         output += "%7s" % self.size
-        if self.residue_type.find("PROTEIN") >= 0:
+        if "PROTEIN" in self.residue_type:
             output += " aa"
         else:
             output += " bp "
 
         # treat circular types differently, since they'll have long residue
         # types
-        if self.residue_type.find("circular") >= 0:
+        if "circular" in self.residue_type:
              output += "%17s" % self.residue_type
         # second case: ss-DNA types of records
-        elif self.residue_type.find("-") >= 0:
+        elif "-" in self.residue_type:
             output += "%7s" % self.residue_type
             output += " " * 10 # spaces for circular
         else:
@@ -635,7 +635,7 @@ class Feature(object):
             space_wrap = 1
             for no_space_key in \
                 Bio.GenBank._BaseGenBankConsumer.remove_space_keys:
-                if qualifier.key.find(no_space_key) >= 0:
+                if no_space_key in qualifier.key:
                     space_wrap = 0
             
             output += _wrapped_genbank(qualifier.key + qualifier.value,

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -918,9 +918,9 @@ class GenBankScanner(InsdcScanner):
                 continue
             if line=='//':
                 break
-            if line.find('CONTIG')==0:
+            if line.startswith('CONTIG'):
                 break
-            if len(line) > 9 and  line[9:10]!=' ':
+            if len(line) > 9 and line[9:10]!=' ':
                 raise ValueError("Sequence line mal-formed, '%s'" % line)
             seq_lines.append(line[10:]) #remove spaces later
             line = self.handle.readline()
@@ -986,7 +986,7 @@ class GenBankScanner(InsdcScanner):
                        'LOCUS line does not contain - at position 69 in date:\n' + line
 
             name_and_length_str = line[GENBANK_INDENT:29]
-            while name_and_length_str.find('  ')!=-1:
+            while '  ' in name_and_length_str:
                 name_and_length_str = name_and_length_str.replace('  ',' ')
             name_and_length = name_and_length_str.split(' ')
             assert len(name_and_length)<=2, \
@@ -1039,8 +1039,8 @@ class GenBankScanner(InsdcScanner):
             assert line[44:47] in ['   ', 'ss-', 'ds-', 'ms-'], \
                    'LOCUS line does not have valid strand type (Single stranded, ...):\n' + line
             assert line[47:54].strip() == "" \
-            or line[47:54].strip().find('DNA') != -1 \
-            or line[47:54].strip().find('RNA') != -1, \
+            or 'DNA' in line[47:54].strip() \
+            or 'RNA' in line[47:54].strip(), \
                    'LOCUS line does not contain valid sequence type (DNA, RNA, ...):\n' + line
             assert line[54:55] == ' ', \
                    'LOCUS line does not contain space at position 55:\n' + line
@@ -1057,7 +1057,7 @@ class GenBankScanner(InsdcScanner):
                        'LOCUS line does not contain - at position 75 in date:\n' + line
 
             name_and_length_str = line[GENBANK_INDENT:40]
-            while name_and_length_str.find('  ')!=-1:
+            while '  ' in name_and_length_str:
                 name_and_length_str = name_and_length_str.replace('  ',' ')
             name_and_length = name_and_length_str.split(' ')
             assert len(name_and_length)<=2, \
@@ -1181,9 +1181,9 @@ class GenBankScanner(InsdcScanner):
                     #Need to call consumer.version(), and maybe also consumer.gi() as well.
                     #e.g.
                     # VERSION     AC007323.5  GI:6587720
-                    while data.find('  ')!=-1:
+                    while '  ' in data:
                         data = data.replace('  ',' ')
-                    if data.find(' GI:')==-1:
+                    if ' GI:' not in data:
                         consumer.version(data)
                     else:
                         if self.debug : print "Version [" + data.split(' GI:')[0] + "], gi [" + data.split(' GI:')[1] + "]"
@@ -1218,9 +1218,9 @@ class GenBankScanner(InsdcScanner):
 
                     #We now have all the reference line(s) stored in a string, data,
                     #which we pass to the consumer
-                    while data.find('  ')!=-1:
+                    while '  ' in data:
                         data = data.replace('  ',' ')
-                    if data.find(' ')==-1:
+                    if ' ' not in data:
                         if self.debug >2 : print 'Reference number \"' + data + '\"'
                         consumer.reference_num(data)
                     else:
@@ -1298,23 +1298,23 @@ class GenBankScanner(InsdcScanner):
         line_iter = iter(lines)
         try:
             for line in line_iter:
-                if line.find('BASE COUNT')==0:
+                if line.startswith('BASE COUNT'):
                     line = line[10:].strip()
                     if line:
                         if self.debug : print "base_count = " + line
                         consumer.base_count(line)
-                if line.find("ORIGIN")==0:
+                if line.startswith('ORIGIN'):
                     line = line[6:].strip()
                     if line:
                         if self.debug : print "origin_name = " + line
                         consumer.origin_name(line)
-                if line.find("WGS ")==0 :                        
+                if line.startswith('WGS '):
                     line = line[3:].strip()
                     consumer.wgs(line)
-                if line.find("WGS_SCAFLD")==0 :                        
+                if line.startswith('WGS_SCAFLD'):
                     line = line[10:].strip()
                     consumer.add_wgs_scafld(line)
-                if line.find("CONTIG")==0:
+                if line.startswith('CONTIG'):
                     line = line[6:].strip()
                     contig_location = line
                     while True:

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -813,14 +813,12 @@ class _FeatureConsumer(_BaseGenBankConsumer):
 
         all_locations = []
         # parse if we've got 'bases' and 'to'
-        if ref_base_info.find('bases') != -1 and \
-            ref_base_info.find('to') != -1:
+        if 'bases' in ref_base_info and 'to' in ref_base_info:
             # get rid of the beginning 'bases'
             ref_base_info = ref_base_info[5:]
             locations = self._split_reference_locations(ref_base_info)
             all_locations.extend(locations)
-        elif (ref_base_info.find("residues") >= 0 and
-              ref_base_info.find("to") >= 0):
+        elif 'residues' in ref_base_info and 'to' in ref_base_info:
             residues_start = ref_base_info.find("residues")
             # get only the information after "residues"
             ref_base_info = ref_base_info[(residues_start + len("residues ")):]
@@ -944,7 +942,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         # the number 266 and have the information in a more reasonable
         # place. So we'll just grab out the number and feed this to the
         # parser. We shouldn't really be losing any info this way.
-        if location_line.find('replace') != -1:
+        if 'replace' in location_line:
             comma_pos = location_line.find(',')
             location_line = location_line[8:comma_pos]
         
@@ -955,8 +953,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
             assert location_line.endswith(")")
             location_line = location_line[11:-1]
             strand = -1
-        elif self._seq_type.find("DNA") >= 0 \
-        or self._seq_type.find("RNA") >= 0:
+        elif 'DNA' in self._seq_type or 'RNA' in self._seq_type:
             #Nucleotide
             strand = 1
         else:
@@ -1162,18 +1159,17 @@ class _FeatureConsumer(_BaseGenBankConsumer):
 
         if self._seq_type:
             # mRNA is really also DNA, since it is actually cDNA
-            if self._seq_type.find('DNA') != -1 or \
-               self._seq_type.find('mRNA') != -1:
+            if 'DNA' in self._seq_type or 'mRNA' in self._seq_type:
                 seq_alphabet = IUPAC.ambiguous_dna
             # are there ever really RNA sequences in GenBank?
-            elif self._seq_type.find('RNA') != -1:
+            elif 'RNA' in self._seq_type:
                 #Even for data which was from RNA, the sequence string
                 #is usually given as DNA (T not U).  Bug 2408
                 if "T" in sequence and "U" not in sequence:
                     seq_alphabet = IUPAC.ambiguous_dna
                 else:
                     seq_alphabet = IUPAC.ambiguous_rna
-            elif self._seq_type.upper().find('PROTEIN') != -1:
+            elif 'PROTEIN' in self._seq_type.upper():
                 seq_alphabet = IUPAC.protein  # or extended protein?
             # work around ugly GenBank records which have circular or
             # linear but no indication of sequence type
@@ -1374,7 +1370,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
         import Record
         for content in content_list:
             # the record parser keeps the /s -- add them if we don't have 'em
-            if content.find("/") != 0:
+            if not content.startswith("/"):
                 content = "/%s" % content
             # add on a qualifier if we've got one
             if self._cur_qualifier is not None:
@@ -1385,13 +1381,13 @@ class _RecordConsumer(_BaseGenBankConsumer):
 
     def feature_qualifier_description(self, content):
         # if we have info then the qualifier key should have a ='s
-        if self._cur_qualifier.key.find("=") == -1:
+        if '=' not in self._cur_qualifier.key:
             self._cur_qualifier.key = "%s=" % self._cur_qualifier.key
         cur_content = self._remove_newlines(content)
         # remove all spaces from the value if it is a type where spaces
         # are not important
         for remove_space_key in self.__class__.remove_space_keys:
-            if self._cur_qualifier.key.find(remove_space_key) >= 0:
+            if remove_space_key in self._cur_qualifier.key:
                 cur_content = self._remove_spaces(cur_content)
         self._cur_qualifier.value = self._normalize_spaces(cur_content)
 

--- a/Bio/NeuralNetwork/Gene/Pattern.py
+++ b/Bio/NeuralNetwork/Gene/Pattern.py
@@ -84,7 +84,7 @@ class PatternIO(object):
 
             cur_pattern = cur_line.rstrip()
             # split up signatures
-            if cur_pattern.find(self.separator) >= 0:
+            if self.separator in cur_pattern:
                 cur_pattern = tuple(cur_pattern.split(self.separator))
 
             if self._alphabet is not None:

--- a/Bio/ParserSupport.py
+++ b/Bio/ParserSupport.py
@@ -379,7 +379,7 @@ def _fails_conditions(line, start=None, end=None, contains=None, blank=None,
         if line.rstrip()[-len(end):] != end:
             return "Line does not end with '%s':\n%s" % (end, line)
     if contains is not None:
-        if line.find(contains) == -1:
+        if contains not in line:
             return "Line does not contain '%s':\n%s" % (contains, line)
     if blank is not None:
         if blank:

--- a/Bio/PopGen/GenePop/Controller.py
+++ b/Bio/PopGen/GenePop/Controller.py
@@ -38,10 +38,10 @@ def _gp_int(tok):
     
 def _read_allele_freq_table(f):
     l = f.readline()
-    while l.find(" --")==-1:
+    while ' --' not in l:
         if l == "":
             raise StopIteration
-        if l.find("No data")>-1:
+        if 'No data' in l:
             return None, None
         l = f.readline()
     alleles = filter(lambda x: x != '', f.readline().rstrip().split(" "))
@@ -66,10 +66,10 @@ def _read_allele_freq_table(f):
 def _read_table(f, funs):
     table = []
     l = f.readline().rstrip()
-    while l.find("---")==-1:
+    while '---' not in l:
         l = f.readline().rstrip()
     l = f.readline().rstrip()
-    while l.find("===")==-1 and l.find("---")==-1 and l != "":
+    while '===' not in l and '---' not in l and l != "":
         toks = filter(lambda x: x != "", l.split(" ")) 
         line = []
         for i in range(len(toks)):
@@ -94,7 +94,7 @@ def _read_triangle_matrix(f):
 def _read_headed_triangle_matrix(f):
     matrix = {}
     header = f.readline().rstrip()
-    if header.find("---")>-1 or header.find("===")>-1:
+    if '---' in header or '===' in header:
         header = f.readline().rstrip()
     nlines = len(filter(lambda x:x != '', header.split(' '))) - 1
     for line_pop in range(nlines):
@@ -301,17 +301,17 @@ class GenePopController(object):
             return _read_table(self.stream, [str, _gp_float, _gp_float, _gp_float])
         f1 = open(fname + ext)
         l = f1.readline()
-        while l.find("by population") == -1:
+        while "by population" not in l:
             l = f1.readline()
         pop_p = _read_table(f1, [str, _gp_float, _gp_float, _gp_float])
         f2 = open(fname + ext)
         l = f2.readline()
-        while l.find("by locus") == -1:
+        while "by locus" not in l:
             l = f2.readline()
         loc_p = _read_table(f2, [str, _gp_float, _gp_float, _gp_float])
         f = open(fname + ext)
         l = f.readline()
-        while l.find("all locus") == -1:
+        while "all locus" not in l:
             l = f.readline()
         f.readline()
         f.readline()
@@ -454,14 +454,14 @@ class GenePopController(object):
             return (locus1, locus2), (chi2, df, p)
         f1 = open(fname + ".DIS")
         l = f1.readline()
-        while l.find("----")==-1:
+        while "----" not in l:
             l = f1.readline()
         shutil.copyfile(fname + ".DIS", fname + ".DI2")
         f2 = open(fname + ".DI2")
         l = f2.readline()
-        while l.find("Locus pair")==-1:
+        while "Locus pair" not in l:
             l = f2.readline()
-        while l.find("----")==-1:
+        while "----" not in l:
             l = f2.readline()
         return _FileIterator(ld_pop_func, f1, fname+".DIS"), _FileIterator(ld_func, f2, fname + ".DI2")
 
@@ -573,7 +573,7 @@ class GenePopController(object):
             loci_content = {}
             while l != '':
                 l = l.rstrip()
-                if l.find("Tables of allelic frequencies for each locus")>-1:
+                if "Tables of allelic frequencies for each locus" in l:
                     return self.curr_pop, loci_content
                 match = re.match(".*Pop: (.+) Locus: (.+)", l)
                 if match != None:
@@ -595,9 +595,9 @@ class GenePopController(object):
                     continue
                 geno_list = []
                 l = self.stream.readline()
-                if l.find("No data")>-1: continue
+                if "No data" in l: continue
 
-                while l.find("Genotypes  Obs.")==-1:
+                while "Genotypes  Obs." not in l:
                     l = self.stream.readline()
 
                 while l != "\n":
@@ -610,7 +610,7 @@ class GenePopController(object):
                         continue
                     l = self.stream.readline()
 
-                while l.find("Expected number of ho")==-1:
+                while "Expected number of ho" not in l:
                     l = self.stream.readline()
                 expHo =  _gp_float(l[38:])
                 l = self.stream.readline()
@@ -621,12 +621,12 @@ class GenePopController(object):
                 obsHe =  _gp_int(l[38:])
                 l = self.stream.readline()
 
-                while l.find("Sample count")==-1:
+                while "Sample count" not in l:
                     l = self.stream.readline()
                 l = self.stream.readline()
                 freq_fis={}
                 overall_fis = None
-                while l.find("----")==-1:
+                while "----" not in l:
                     vals = filter(lambda x: x!='',
                             l.rstrip().split(' '))
                     if vals[0]=="Tot":
@@ -680,7 +680,7 @@ class GenePopController(object):
                 if m != None:
                     locus = m.group(1)
                     self.stream.readline()
-                    if self.stream.readline().find("No complete")>-1: return locus, None
+                    if "No complete" in self.stream.readline(): return locus, None
                     self.stream.readline()
                     fis_table = _read_table(self.stream, [str, _gp_float, _gp_float, _gp_float])
                     self.stream.readline()

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -564,8 +564,8 @@ class GenBankWriter(_InsdcWriter):
         assert line[44:47] in ['   ', 'ss-', 'ds-', 'ms-'], \
                'LOCUS line does not have valid strand type (Single stranded, ...):\n' + line
         assert line[47:54].strip() == "" \
-        or line[47:54].strip().find('DNA') != -1 \
-        or line[47:54].strip().find('RNA') != -1, \
+        or 'DNA' in line[47:54].strip() \
+        or 'RNA' in line[47:54].strip(), \
                'LOCUS line does not contain valid sequence type (DNA, RNA, ...):\n' + line
         assert line[54:55] == ' ', \
                'LOCUS line does not contain space at position 55:\n' + line

--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -305,7 +305,7 @@ def _read_dt(record, line):
         uprcols = uprline.split()
         rel_index = -1
         for index in range(len(uprcols)):
-            if uprcols[index].find("REL.") >= 0:
+            if 'REL.' in uprcols[index]:
                 rel_index = index
         assert rel_index >= 0, \
                 "Could not find Rel. in DT line: %s" % line
@@ -316,7 +316,7 @@ def _read_dt(record, line):
         if str_version == '':
             version = 0
         # dot versioned
-        elif str_version.find(".") >= 0:
+        elif '.' in str_version:
             version = str_version
         # integer versioned
         else:

--- a/Bio/UniGene/UniGene.py
+++ b/Bio/UniGene/UniGene.py
@@ -129,7 +129,7 @@ class UniGeneParser( sgmllib.SGMLParser ):
                     self.master_key = key
         elif( self.context == 'general_info' ):
             self.master_key = key
-            if( string.find( key, 'SEQUENCE' ) != -1 ):
+            if 'SEQUENCE' in key:
                 self.context = 'seq_info'
             self.queue[ key ] = UserDict.UserDict()
         elif( self.context == 'seq_info' ):

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -227,9 +227,9 @@ class DBServer:
         sql_handle = open(sql_file, "rU")
         sql = r""
         for line in sql_handle:
-            if line.find("--") == 0: # don't include comment lines
+            if line.startswith("--"): # don't include comment lines
                 pass
-            elif line.find("#") == 0: # ditto for MySQL comments
+            elif line.startswith("#"): # ditto for MySQL comments
                 pass
             elif line.strip(): # only include non-blank lines
                 sql += line.strip()

--- a/Scripts/GenBank/check_output.py
+++ b/Scripts/GenBank/check_output.py
@@ -50,7 +50,7 @@ def write_format(file):
 
     print "Testing GenBank writing for %s..." % os.path.basename(file)
     # be able to handle gzipped files
-    if file.find(".gz") >= 0:
+    if '.gz' in file:
         cur_handle = gzip.open(file, "r")
         compare_handle = gzip.open(file, "r")
     else:

--- a/Scripts/debug/debug_blast_parser.py
+++ b/Scripts/debug/debug_blast_parser.py
@@ -58,9 +58,9 @@ def chomp(line):
 def choose_parser(outfile):
     data = open(outfile).read()
     ldata = data.lower()
-    if ldata.find("<html>") >= 0 or ldata.find("<pre>") >= 0:
+    if "<html>" in ldata or "<pre>" in ldata:
         return NCBIWWW.BlastParser
-    if ldata.find("results from round") >= 0 or ldata.find("converged!") >= 0:
+    if "results from round") in ldata or "converged!" in ldata:
         return NCBIStandalone.PSIBlastParser
     return NCBIStandalone.BlastParser
 

--- a/Tests/requires_wise.py
+++ b/Tests/requires_wise.py
@@ -18,7 +18,7 @@ not_found_types = ["command not found", "dnal: not found", "not recognized"]
 dnal_output = commands.getoutput("dnal")
 
 for not_found in not_found_types:
-    if dnal_output.find(not_found) != -1:
+    if not_found in dnal_output:
         #raise MissingExternalDependencyError(dnal_output)
         raise MissingExternalDependencyError(\
             "Install Wise2 (dnal) if you want to use Bio.Wise.")

--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -173,9 +173,9 @@ def t_cleaning_features():
     # test for cleaning of translation
     translation_feature = first_record.features[1]
     test_trans = translation_feature.qualifiers["translation"][0]
-    assert test_trans.find(" ") == -1, \
+    assert ' ' not in test_trans, \
       "Did not clean spaces out of the translation"
-    assert test_trans.find("\012") == -1, \
+    assert '\012' not in test_trans, \
       "Did not clean newlines out of the translation"
 
     handle.close()

--- a/Tests/test_GraphicsChromosome.py
+++ b/Tests/test_GraphicsChromosome.py
@@ -240,7 +240,7 @@ class OrganismGraphicTest(unittest.TestCase):
         properties = new_stdout.getvalue()
         sys.stdout = save_stdout
 
-        self.assertTrue(properties.find(expected_string) >= 0,
+        self.assertTrue(expected_string in properties,
                "Unexpected results from dumpProperties: \n %s" % properties)
 
         properties = test_widget.getProperties()


### PR DESCRIPTION
I got a bit confused debugging recently, where code used a mixture of `.find()` with
different comparisons (== -1, <0, >-1, >0, == 0, etc.) to check for substrings.

This changes simple substring testing to be more Pythonic and readable, e.g.:
-  `haystack.find(needle) >= -1`   -->   `needle in haystack`
-  `haystack.find(needle) == -1`   -->   `needle not in haystack`
-  `haystack.find(needle) == 0`    -->   `haystack.startswith(needle)`

[As a bonus, this makes things ever-so-slightly faster: http://goo.gl/vgtCa ]

Signed-off-by: Nick Semenkovich <semenko@alum.mit.edu>
