### PR TITLE
Deprecate Bio/HotRand.py

### DIFF
--- a/Bio/HotRand.py
+++ b/Bio/HotRand.py
@@ -7,7 +7,9 @@
 """
 
 import urllib
-
+from Bio import BiopythonDeprecationWarning
+import warnings
+warnings.warn("The HotRand module is deprecated and likely to be removed in a future release of Biopython. Please use an alternative RNG.", BiopythonDeprecationWarning)
 
 def byte_concat( text ):
     val = 0

--- a/DEPRECATED
+++ b/DEPRECATED
@@ -12,6 +12,11 @@ Python 2.4
 No longer supported as of Release 1.59, having triggered a warning since
 Release 1.55, with advance notice in the release notes for Release 1.54.
 
+Bio.HotRand
+===========
+Obsolete file Bio/HotRand.py was deprecated in Release 1.61, consider using
+an alternative RNG, or the Python module "randomdotorg".
+
 Bio.Search
 ==========
 Long obsolete file Bio/Search.py was deprecated in Release 1.61.


### PR DESCRIPTION
With improvements in PRNGs & CSPRNGs (e.g. random.SystemRandom, RdRand, etc.),
I doubt this code is very useful anymore.

There are also alternative RANDOM.org modules, e.g.
http://www.random.org/clients/http/archive/
http://pypi.python.org/pypi/randomdotorg/

I can't find /any/ references to this code elsewhere (Google, GitHub), and some
parts seem to be broken (e.g. main's undefined hex_convert() ).

Signed-off-by: Nick Semenkovich <semenko@alum.mit.edu>
