### PR TITLE
Removed (first) section on Substitution Matrices because example given used deprecated module

### DIFF
--- a/Doc/Tutorial.tex
+++ b/Doc/Tutorial.tex
@@ -13760,7 +13760,7 @@ The \verb|summary_align| object is very useful, and will do the following neat t
   \item Calculate a quick consensus sequence -- see section~\ref{sec:consensus}
   \item Get a position specific score matrix for the alignment -- see section~\ref{sec:pssm}
   \item Calculate the information content for the alignment -- see section~\ref{sec:getting_info_content}
-  \item Generate information on substitutions in the alignment -- section~\ref{sec:sub_matrix} details using this to generate a substitution matrix.
+  \item Generate information on substitutions in the alignment
 \end{enumerate}
 
 \subsection{Calculating a quick consensus sequence}
@@ -13941,124 +13941,6 @@ info_content = summary_align.information_content(5, 30, log_base = 10,
 \end{verbatim}
 
 Well, now you are ready to calculate information content. If you want to try applying this to some real life problems, it would probably be best to dig into the literature on information content to get an idea of how it is used. Hopefully your digging won't reveal any mistakes made in coding this function!
-
-\section{Substitution Matrices}
-\label{sec:sub_matrix}
-
-Substitution matrices are an extremely important part of everyday bioinformatics work. They provide the scoring terms for classifying how likely two different residues are to substitute for each other. This is essential in doing sequence comparisons. The book ``Biological Sequence Analysis'' by Durbin et al. provides a really nice introduction to Substitution Matrices and their uses. Some famous substitution matrices are the PAM and BLOSUM series of matrices.
-
-Biopython provides a ton of common substitution matrices, and also provides functionality for creating your own substitution matrices.
-
-\subsection{Using common substitution matrices}
-
-\subsection{Creating your own substitution matrix from an alignment}
-\label{sec:subs_mat_ex}
-
-A very cool thing that you can do easily with the substitution matrix
-classes is to create your own substitution matrix from an
-alignment. In practice, this is normally done with protein
-alignments. In this example, we'll first get a Biopython alignment
-object and then get a summary object to calculate info about the
-alignment. The file containing \href{examples/protein.aln}{protein.aln}
-(also available online
-\href{http://biopython.org/DIST/docs/tutorial/examples/protein.aln}{here})
-contains the Clustalw alignment output.
-
-\begin{verbatim}
-from Bio import Clustalw
-from Bio.Alphabet import IUPAC
-from Bio.Align import AlignInfo
-
-# get an alignment object from a Clustalw alignment output
-c_align = Clustalw.parse_file("protein.aln", IUPAC.protein)
-summary_align = AlignInfo.SummaryInfo(c_align)
-\end{verbatim}
-
-Sections~\ref{sec:align_clustal} and~\ref{sec:summary_info} contain
-more information on doing this.
-
-Now that we've got our \verb|summary_align| object, we want to use it
-to find out the number of times different residues substitute for each
-other. To make the example more readable, we'll focus on only amino
-acids with polar charged side chains. Luckily, this can be done easily
-when generating a replacement dictionary, by passing in all of the
-characters that should be ignored. Thus we'll create a dictionary of
-replacements for only charged polar amino acids using:
-
-\begin{verbatim}
-replace_info = summary_align.replacement_dictionary(["G", "A", "V", "L", "I",
-                                                     "M", "P", "F", "W", "S",
-                                                     "T", "N", "Q", "Y", "C"])
-\end{verbatim}
-
-This information about amino acid replacements is represented as a
-python dictionary which will look something like:
-
-\begin{verbatim}
-{('R', 'R'): 2079.0, ('R', 'H'): 17.0, ('R', 'K'): 103.0, ('R', 'E'): 2.0,
-('R', 'D'): 2.0, ('H', 'R'): 0, ('D', 'H'): 15.0, ('K', 'K'): 3218.0,
-('K', 'H'): 24.0, ('H', 'K'): 8.0, ('E', 'H'): 15.0, ('H', 'H'): 1235.0,
-('H', 'E'): 18.0, ('H', 'D'): 0, ('K', 'D'): 0, ('K', 'E'): 9.0,
-('D', 'R'): 48.0, ('E', 'R'): 2.0, ('D', 'K'): 1.0, ('E', 'K'): 45.0,
-('K', 'R'): 130.0, ('E', 'D'): 241.0, ('E', 'E'): 3305.0,
-('D', 'E'): 270.0, ('D', 'D'): 2360.0}
-\end{verbatim}
-
-This information gives us our accepted number of replacements, or how
-often we expect different things to substitute for each other. It
-turns out, amazingly enough, that this is all of the information we
-need to go ahead and create a substitution matrix. First, we use the
-replacement dictionary information to create an Accepted Replacement
-Matrix (ARM):
-
-\begin{verbatim}
-from Bio import SubsMat
-my_arm = SubsMat.SeqMat(replace_info)
-\end{verbatim}
-
-With this accepted replacement matrix, we can go right ahead and
-create our log odds matrix (i.~e.~a standard type Substitution Matrix):
-
-\begin{verbatim}
-my_lom = SubsMat.make_log_odds_matrix(my_arm)
-\end{verbatim}
-
-The log odds matrix you create is customizable with the following
-optional arguments:
-
-\begin{itemize}
-  \item \verb|exp_freq_table| -- You can pass a table of expected
-  frequencies for each alphabet. If supplied, this will be used
-  instead of the passed accepted replacement matrix when calculate
-  expected replacments.
-
-  \item \verb|logbase| - The base of the logarithm taken to create the
-  log odd matrix. Defaults to base 10.
-
-  \item \verb|factor| - The factor to multiply each matrix entry
-  by. This defaults to 10, which normally makes the matrix numbers
-  easy to work with.
-
-  \item \verb|round_digit| - The digit to round to in the matrix. This
-  defaults to 0 (i.~e.~no digits).
-
-\end{itemize}
-
-Once you've got your log odds matrix, you can display it prettily
-using the function \verb|print_mat|. Doing this on our created matrix
-gives:
-
-\begin{verbatim}
->>> my_lom.print_mat()
-D   6
-E  -5   5
-H -15 -13  10
-K -31 -15 -13   6
-R -13 -25 -14  -7   7
-   D   E   H   K   R
-\end{verbatim}
-
-Very nice. Now we've got our very own substitution matrix to play with!
 
 \section{BioSQL -- storing sequences in a relational database}
 \label{sec:BioSQL}
@@ -14554,6 +14436,10 @@ produces SwissProt format specific record objects, which get converted
 into \verb|SeqRecord| objects.
 
 \section{Substitution Matrices}
+
+Substitution matrices are an extremely important part of everyday bioinformatics work. They provide the scoring terms for classifying how likely two different residues are to substitute for each other. This is essential in doing sequence comparisons. The book ``Biological Sequence Analysis'' by Durbin et al. provides a really nice introduction to Substitution Matrices and their uses. Some famous substitution matrices are the PAM and BLOSUM series of matrices.
+
+Biopython provides a ton of common substitution matrices, and also provides functionality for creating your own substitution matrices.
 
 \subsection{SubsMat}
 


### PR DESCRIPTION
The change is for the bug found here: https://redmine.open-bio.org/issues/3340. There are two sections on substitution matrices. The first was removed because it used the deprecated module Bio.Clustalw. The introduction to substitution matrices in the first substitution matrices section was moved to the second.
