### PR TITLE
-w option in RAxML requires absolute path

### DIFF
--- a/Bio/Phylo/Applications/_Raxml.py
+++ b/Bio/Phylo/Applications/_Raxml.py
@@ -326,6 +326,7 @@ class RaxmlCommandline(AbstractCommandline):
                 _Option(['-w', 'working_dir'],
                         "Name of the working directory where RAxML will "
                         "write its output files. Default: current directory.",
+                        filename=True,
                         equate=False,
                         ),
 


### PR DESCRIPTION
-w      FULL (!) path to the directory into which RAxML shall write its output files

```
          DEFAULT: current directory
```
