### PR TITLE
Py3.3 test errors

### DIFF
--- a/Tests/test_PAML_baseml.py
+++ b/Tests/test_PAML_baseml.py
@@ -44,12 +44,12 @@ class ModTest(unittest.TestCase):
         self.bml = baseml.Baseml()
         
     def testAlignmentFileIsValid(self):
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             baseml.Baseml, alignment = list())
         self.bml.alignment = list()
         self.bml.tree = self.tree_file
         self.bml.out_file = self.out_file
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.bml.run)
         
     def testAlignmentExists(self):
@@ -62,12 +62,12 @@ class ModTest(unittest.TestCase):
             self.bml.run)
     
     def testTreeFileValid(self):
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             baseml.Baseml, tree = list())
         self.bml.alignment = self.align_file
         self.bml.tree = list()
         self.bml.out_file = self.out_file
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.bml.run)
         
     def testTreeExists(self):
@@ -84,14 +84,14 @@ class ModTest(unittest.TestCase):
         self.bml.alignment = self.align_file
         self.bml.out_file = self.out_file
         self.bml.working_dir = list()
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.bml.run)
     
     def testOutputFileValid(self):
         self.bml.tree = self.tree_file
         self.bml.alignment = self.align_file
         self.bml.out_file = list()
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, ValueError, OSError),
             self.bml.run)
     
     def testOptionExists(self):
@@ -129,7 +129,7 @@ class ModTest(unittest.TestCase):
         self.bml.alignment = self.align_file
         self.bml.tree = self.tree_file
         self.bml.out_file = self.out_file
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.bml.run, ctl_file = list())
         
     def testCtlFileExistsOnRun(self):
@@ -140,7 +140,7 @@ class ModTest(unittest.TestCase):
             self.bml.run, ctl_file = "nonexistent")
             
     def testCtlFileValidOnRead(self):
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.bml.read_ctl_file, list())
         self.assertRaises((AttributeError, KeyError), 
             self.bml.read_ctl_file, self.bad_ctl_file1)
@@ -183,7 +183,7 @@ class ModTest(unittest.TestCase):
             self.bml.read_ctl_file, ctl_file = "nonexistent")
         
     def testResultsValid(self):
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             baseml.read, list())
     
     def testResultsExist(self):

--- a/Tests/test_PAML_codeml.py
+++ b/Tests/test_PAML_codeml.py
@@ -54,12 +54,12 @@ class ModTest(unittest.TestCase):
         self.cml = codeml.Codeml()
         
     def testAlignmentFileIsValid(self):
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             codeml.Codeml, alignment = list())
         self.cml.alignment = list()
         self.cml.tree = self.tree_file
         self.cml.out_file = self.out_file
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.cml.run)
         
     def testAlignmentExists(self):
@@ -71,12 +71,12 @@ class ModTest(unittest.TestCase):
         self.assertRaises(IOError, self.cml.run)
     
     def testTreeFileValid(self):
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             codeml.Codeml, tree = list())
         self.cml.alignment = self.align_file
         self.cml.tree = list()
         self.cml.out_file = self.out_file
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.cml.run)
         
     def testTreeExists(self):
@@ -92,14 +92,14 @@ class ModTest(unittest.TestCase):
         self.cml.alignment = self.align_file
         self.cml.out_file = self.out_file
         self.cml.working_dir = list()
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.cml.run)
     
     def testOutputFileValid(self):
         self.cml.tree = self.tree_file
         self.cml.alignment = self.align_file
         self.cml.out_file = list()
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, ValueError, OSError),
             self.cml.run)
     
     def testOptionExists(self):
@@ -137,7 +137,7 @@ class ModTest(unittest.TestCase):
         self.cml.alignment = self.align_file
         self.cml.tree = self.tree_file
         self.cml.out_file = self.out_file
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.cml.run, ctl_file = list())
         
     def testCtlFileExistsOnRun(self):
@@ -148,7 +148,7 @@ class ModTest(unittest.TestCase):
             self.cml.run, ctl_file = "nonexistent")
             
     def testCtlFileValidOnRead(self):
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.cml.read_ctl_file, list())
         self.assertRaises((AttributeError, KeyError), 
             self.cml.read_ctl_file, self.bad_ctl_file1)
@@ -197,7 +197,7 @@ class ModTest(unittest.TestCase):
             self.cml.read_ctl_file, ctl_file = "nonexistent")
         
     def testResultsValid(self):
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             codeml.read, list())
     
     def testResultsExist(self):

--- a/Tests/test_PAML_yn00.py
+++ b/Tests/test_PAML_yn00.py
@@ -41,11 +41,11 @@ class ModTest(unittest.TestCase):
         self.yn00 = yn00.Yn00()
         
     def testAlignmentFileIsValid(self):
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             yn00.Yn00, alignment = list())
         self.yn00.alignment = list()
         self.yn00.out_file = self.out_file
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.yn00.run)
         
     def testAlignmentExists(self):
@@ -59,13 +59,13 @@ class ModTest(unittest.TestCase):
         self.yn00.alignment = self.align_file
         self.yn00.out_file = self.out_file
         self.yn00.working_dir = list()
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.yn00.run)
     
     def testOutputFileValid(self):
         self.yn00.alignment = self.align_file
         self.yn00.out_file = list()
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, ValueError, OSError),
             self.yn00.run)
     
     def testOptionExists(self):
@@ -93,7 +93,7 @@ class ModTest(unittest.TestCase):
     def testCtlFileValidOnRun(self):
         self.yn00.alignment = self.align_file
         self.yn00.out_file = self.out_file
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.yn00.run, ctl_file = list())
         
     def testCtlFileExistsOnRun(self):
@@ -103,7 +103,7 @@ class ModTest(unittest.TestCase):
             self.yn00.run, ctl_file = "nonexistent")
             
     def testCtlFileValidOnRead(self):
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             self.yn00.read_ctl_file, list())
         self.assertRaises((AttributeError, KeyError), 
             self.yn00.read_ctl_file, self.bad_ctl_file1)
@@ -122,7 +122,7 @@ class ModTest(unittest.TestCase):
             self.yn00.read_ctl_file, ctl_file = "nonexistent")
         
     def testResultsValid(self):
-        self.assertRaises((AttributeError, Exception),
+        self.assertRaises((AttributeError, TypeError, OSError),
             yn00.read, list())
     
     def testResultsExist(self):


### PR DESCRIPTION
The problem seems to have stemmed from this:
http://docs.python.org/dev/whatsnew/3.3.html#pep-3151

FYI the problems were twofold. First of all, I was testing that arguments expected to be filenames were actually strings by checking that a TypeError was raised from os.path.exists(). Apparently now in Py3.3, os.path.exists(1) returns True rather than raises an exception. Makes...uh...sense....I guess. 

Second, when I changed to passing list() instead of an int as a bogus value, I found that Py3.3 now throws OSErrors insteald of TypeErrors. So, I added OSError to the appropriate assertRaises tuples. 

The tests now pass for me with 2.7.3, 3.2.3 and 3.3.0. 
