### PR TITLE
Update Bio/PDB/DSSP.py

### DIFF
--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -118,7 +118,7 @@ def make_dssp_dict(filename):
         keys = []
         for l in handle.readlines():
             sl = l.split()
-            if sl[1] == "RESIDUE":
+            if len(sl)>1 and sl[1] == "RESIDUE":
                 # Start parsing from here
                 start = 1
                 continue


### PR DESCRIPTION
There is a bug in DSSP module, when some lines whitout text appears in DSSP output (header). I'm solved this problem with a easy modification in line 121:

```
        if len(sl)>1 and sl[1] == "RESIDUE":
```

This len(sl)>1 solves the problem ;)

The next is the output of my dssp (DSSP 2.0.4). The line numper 3 of 5gat-1.dssp_2 has length 1:

['====', 'Secondary', 'Structure', 'Definition', 'by', 'the', 'program', 'DSSP,', 'CMBI', 'version', 'by', 'M.L.', 'Hekkelman/2010-10-21', '====', 'DATE=2012-11-13', '.']
['REFERENCE', 'W.', 'KABSCH', 'AND', 'C.SANDER,', 'BIOPOLYMERS', '22', '(1983)', '2577-2637', '.']
['.']
                                                                                                                               .
A lot of thanks!!! Excuse me for the English

Thanks :)
