### PR TITLE
Fix typo in _foward_recursion method name.

### DIFF
--- a/Bio/HMM/DynamicProgramming.py
+++ b/Bio/HMM/DynamicProgramming.py
@@ -34,7 +34,7 @@ class AbstractDPAlgorithms(object):
         self._mm = markov_model
         self._seq = sequence
 
-    def _foward_recursion(self, cur_state, sequence_pos, forward_vars):
+    def _forward_recursion(self, cur_state, sequence_pos, forward_vars):
         """Calculate the forward recursion value.
         """
         raise NotImplementedError("Subclasses must implement")


### PR DESCRIPTION
This breaks backwards compatibility. However, the function is not implemented
in class AbstractDPAlgorithms and none of the deriving classes in Biopython
implement it either.  Considering this, the impact should be small.

Thanks for the input, @mdehoon !
