### PR TITLE
Patch searchio blast xml encoding

### DIFF
--- a/Bio/File.py
+++ b/Bio/File.py
@@ -23,8 +23,8 @@ use.
 """
 # For with statement in Python 2.5
 from __future__ import with_statement
+import codecs
 import os
-import sys
 import contextlib
 import StringIO
 import itertools
@@ -75,8 +75,7 @@ def as_handle(handleish, mode='r', **kwargs):
     >>> fp.close()
     """
     if isinstance(handleish, basestring):
-        if sys.version_info[0] < 3:
-            import codecs
+        if 'encoding' in kwargs:
             with codecs.open(handleish, mode, **kwargs) as fp:
                 yield fp
         else:

--- a/Bio/SearchIO/__init__.py
+++ b/Bio/SearchIO/__init__.py
@@ -196,6 +196,7 @@ from __future__ import with_statement
 
 __docformat__ = 'epytext en'
 
+import sys
 import warnings
 
 from Bio import BiopythonExperimentalWarning
@@ -299,8 +300,13 @@ def parse(handle, format=None, **kwargs):
     # get the iterator object and do error checking
     iterator = get_processor(format, _ITERATOR_MAP)
 
+    # HACK: force BLAST XML decoding to use utf-8
+    handle_kwargs = {}
+    if format == 'blast-xml' and sys.version_info[0] > 2:
+        handle_kwargs['encoding'] = 'utf-8'
+
     # and start iterating
-    with as_handle(handle, 'rU') as source_file:
+    with as_handle(handle, 'rU', **handle_kwargs) as source_file:
         generator = iterator(source_file, **kwargs)
 
         for qresult in generator:


### PR DESCRIPTION
Re-opening [pull request #99](https://github.com/biopython/biopython/pull/99), this time fixing the regression error on non-Python 3 installations.

For the moment, Travis [seems happy](https://travis-ci.org/bow/biopython/builds/3471856) ~ hopefully the buildbot behaves the same way :).
