### PR TITLE
Remove unused imports.

### DIFF
--- a/Bio/Graphics/Distribution.py
+++ b/Bio/Graphics/Distribution.py
@@ -11,7 +11,6 @@ Reportlab is used for producing the graphical output.
 import math
 
 # reportlab
-from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import letter
 from reportlab.lib.units import inch
 from reportlab.lib import colors
@@ -20,7 +19,6 @@ from reportlab.graphics.shapes import Drawing, String
 from reportlab.graphics.charts.barcharts import VerticalBarChart
 from reportlab.graphics.charts.barcharts import BarChartProperties
 from reportlab.graphics.widgetbase import TypedPropertyCollection
-from reportlab.graphics import renderPDF, renderPS
 
 from Bio.Graphics import _write
 

--- a/Bio/Graphics/GenomeDiagram/_Diagram.py
+++ b/Bio/Graphics/GenomeDiagram/_Diagram.py
@@ -29,21 +29,16 @@
 # IMPORTS
 
 # ReportLab
-from reportlab.graphics import renderPS, renderPDF, renderSVG
 try:
     from reportlab.graphics import renderPM
 except ImportError:
     #This is an optional part of ReportLab, so may not be installed.
     renderPM=None
-from reportlab.lib import pagesizes
 
 # GenomeDiagram
 from _LinearDrawer import LinearDrawer
 from _CircularDrawer import CircularDrawer
 from _Track import Track
-
-# Builtins
-import sys
 
 from Bio.Graphics import _write
 

--- a/Bio/Motif/TRANSFAC.py
+++ b/Bio/Motif/TRANSFAC.py
@@ -11,7 +11,6 @@ from Bio import BiopythonExperimentalWarning
 
 warnings.warn("Bio.Motif.TRANSFAC is experimental code. While it is usable, the code is subject to change without warning")
 
-import string
 from Bio.Motif import Motif as BaseMotif
 
 

--- a/Scripts/scop_pdb.py
+++ b/Scripts/scop_pdb.py
@@ -8,7 +8,6 @@
 
 import getopt
 import sys
-import types
 import urllib
 
 from Bio.SCOP import *

--- a/Tests/test_Ace.py
+++ b/Tests/test_Ace.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import unittest
 
 from Bio.Sequencing import Ace

--- a/Tests/test_BioSQL_MySQLdb.py
+++ b/Tests/test_BioSQL_MySQLdb.py
@@ -4,7 +4,6 @@
 # as part of this package.
 
 """Run BioSQL tests using SQLite"""
-import os
 from Bio import MissingExternalDependencyError
 from BioSQL import BioSeqDatabase
 

--- a/Tests/test_BioSQL_psycopg2.py
+++ b/Tests/test_BioSQL_psycopg2.py
@@ -4,7 +4,6 @@
 # as part of this package.
 
 """Run BioSQL tests using SQLite"""
-import os
 from Bio import MissingExternalDependencyError
 from BioSQL import BioSeqDatabase
 

--- a/Tests/test_Chi2.py
+++ b/Tests/test_Chi2.py
@@ -4,9 +4,6 @@
 # as part of this package.
 
 import unittest
-import os
-import os.path
-import sys
 from Bio.Phylo.PAML import chi2
 
 

--- a/Tests/test_CodonTable.py
+++ b/Tests/test_CodonTable.py
@@ -6,7 +6,7 @@
 from Bio.Data import IUPACData
 from Bio.Data.CodonTable import ambiguous_generic_by_id, ambiguous_generic_by_name
 from Bio.Data.CodonTable import ambiguous_rna_by_id, ambiguous_dna_by_id
-from Bio.Data.CodonTable import unambiguous_rna_by_id, unambiguous_dna_by_id
+from Bio.Data.CodonTable import unambiguous_rna_by_id
 from Bio.Data.CodonTable import list_ambiguous_codons, TranslationError
 
 #Check the extension of stop codons to include well defined ambiguous ones

--- a/Tests/test_Crystal.py
+++ b/Tests/test_Crystal.py
@@ -6,7 +6,6 @@
 # python unittest framework
 import unittest
 import copy
-import sys
 
 # modules to be tested
 from Bio.Crystal import Hetero, Chain, Crystal, CrystalError

--- a/Tests/test_Dialign_tool.py
+++ b/Tests/test_Dialign_tool.py
@@ -8,7 +8,6 @@
 import sys
 import os
 import unittest
-import subprocess
 from Bio import MissingExternalDependencyError
 from Bio.Align.Applications import DialignCommandline
 

--- a/Tests/test_EmbossPhylipNew.py
+++ b/Tests/test_EmbossPhylipNew.py
@@ -6,7 +6,6 @@
 import os
 import sys
 import unittest
-import subprocess
 
 from Bio import MissingExternalDependencyError
 from Bio import AlignIO

--- a/Tests/test_EmbossPrimer.py
+++ b/Tests/test_EmbossPrimer.py
@@ -2,7 +2,6 @@
 """Tests for Primer-based programs in the Emboss suite.
 """
 # standard library
-import sys
 import os
 import unittest
 

--- a/Tests/test_FSSP.py
+++ b/Tests/test_FSSP.py
@@ -1,9 +1,8 @@
-from Bio import FSSP, Align
+from Bio import FSSP
 from Bio.FSSP import FSSPTools
 import sys
 import os
 import cPickle
-import time
 
 test_file = os.path.join('FSSP', '1cnv.fssp')
 f = sys.stdout

--- a/Tests/test_GAQueens.py
+++ b/Tests/test_GAQueens.py
@@ -18,9 +18,7 @@ When called as part of the Biopython unit test suite, 5 queens are used.
 """
 # standard library
 import sys
-import math
 import random
-import copy
 import time
 import unittest
 

--- a/Tests/test_HotRand.py
+++ b/Tests/test_HotRand.py
@@ -2,7 +2,6 @@
 """Tests HotRand.
 """
 # standard library
-import sys
 import unittest
 
 # local stuff

--- a/Tests/test_LogisticRegression.py
+++ b/Tests/test_LogisticRegression.py
@@ -15,7 +15,6 @@ except ImportError:
         "Install NumPy if you want to use Bio.LogisticRegression.")
 
 import unittest
-import sys
 from Bio import LogisticRegression
 
 

--- a/Tests/test_MMCIF.py
+++ b/Tests/test_MMCIF.py
@@ -9,8 +9,6 @@
 
 """Unit tests for the MMCIF portion of the Bio.PDB module."""
 
-import os
-import tempfile
 import unittest
 import warnings
 

--- a/Tests/test_Medline.py
+++ b/Tests/test_Medline.py
@@ -3,7 +3,6 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
-import sys
 import unittest
 
 from Bio import Medline

--- a/Tests/test_NCBI_qblast.py
+++ b/Tests/test_NCBI_qblast.py
@@ -12,7 +12,6 @@ Goals:
     Make sure that all retrieval is working as expected.
     Make sure we can parse the latest XML format being used by the NCBI.
 """
-import sys
 import requires_internet
 requires_internet.check()
 from Bio import MissingExternalDependencyError

--- a/Tests/test_PAML_baseml.py
+++ b/Tests/test_PAML_baseml.py
@@ -6,7 +6,6 @@
 import unittest
 import os
 import os.path
-import sys
 from Bio.Phylo.PAML import baseml
 from Bio.Phylo.PAML._paml import PamlError
 

--- a/Tests/test_ParserSupport.py
+++ b/Tests/test_ParserSupport.py
@@ -4,7 +4,6 @@
 # as part of this package.
 
 import string
-import sys
 from Bio import File
 from Bio import ParserSupport
 

--- a/Tests/test_Pathway.py
+++ b/Tests/test_Pathway.py
@@ -5,7 +5,6 @@
 
 # python unittest framework
 import unittest
-import sys
 
 # modules to be tested
 from Bio.Pathway import Reaction

--- a/Tests/test_PopGen_DFDist.py
+++ b/Tests/test_PopGen_DFDist.py
@@ -3,7 +3,6 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
-import commands
 import os
 import shutil
 import tempfile

--- a/Tests/test_PopGen_FDist.py
+++ b/Tests/test_PopGen_FDist.py
@@ -3,7 +3,6 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
-import commands
 import os
 import shutil
 import tempfile

--- a/Tests/test_Prank_tool.py
+++ b/Tests/test_Prank_tool.py
@@ -9,7 +9,6 @@ as part of this package.
 import sys
 import os
 import unittest
-import subprocess
 from Bio import AlignIO
 from Bio import SeqIO
 from Bio import MissingExternalDependencyError

--- a/Tests/test_Probcons_tool.py
+++ b/Tests/test_Probcons_tool.py
@@ -7,7 +7,6 @@
 import sys
 import os
 import unittest
-import subprocess
 from cStringIO import StringIO
 from Bio import AlignIO, SeqIO, MissingExternalDependencyError
 from Bio.Align.Applications import ProbconsCommandline

--- a/Tests/test_SearchIO_blast_tab.py
+++ b/Tests/test_SearchIO_blast_tab.py
@@ -11,7 +11,7 @@ from __future__ import with_statement
 import os
 import unittest
 
-from Bio.SearchIO import parse, read
+from Bio.SearchIO import parse
 
 # test case files are in the Blast directory
 TEST_DIR = 'Blast'

--- a/Tests/test_SearchIO_blast_xml.py
+++ b/Tests/test_SearchIO_blast_xml.py
@@ -9,7 +9,7 @@
 import os
 import unittest
 
-from Bio.SearchIO import parse, read
+from Bio.SearchIO import parse
 
 # test case files are in the Blast directory
 TEST_DIR = 'Blast'

--- a/Tests/test_SearchIO_hmmer3_domtab.py
+++ b/Tests/test_SearchIO_hmmer3_domtab.py
@@ -9,7 +9,7 @@
 import os
 import unittest
 
-from Bio.SearchIO import parse, read
+from Bio.SearchIO import parse
 
 # test case files are in the Blast directory
 TEST_DIR = 'Hmmer'

--- a/Tests/test_SearchIO_hmmer3_tab.py
+++ b/Tests/test_SearchIO_hmmer3_tab.py
@@ -9,7 +9,7 @@
 import os
 import unittest
 
-from Bio.SearchIO import parse, read
+from Bio.SearchIO import parse
 
 # test case files are in the Blast directory
 TEST_DIR = 'Hmmer'

--- a/Tests/test_SearchIO_hmmer3_text.py
+++ b/Tests/test_SearchIO_hmmer3_text.py
@@ -9,7 +9,7 @@
 import os
 import unittest
 
-from Bio.SearchIO import parse, read
+from Bio.SearchIO import parse
 
 # test case files are in the Blast directory
 TEST_DIR = 'Hmmer'

--- a/Tests/test_SeqIO_AbiIO.py
+++ b/Tests/test_SeqIO_AbiIO.py
@@ -8,9 +8,7 @@ import unittest
 from os.path import join, basename
 
 from Bio import SeqIO
-from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
-from Bio._py3k import _bytes_to_string, _as_bytes
+from Bio._py3k import _as_bytes
 
 test_data = {
 'data_empty': {

--- a/Tests/test_SeqIO_convert.py
+++ b/Tests/test_SeqIO_convert.py
@@ -4,7 +4,6 @@
 # as part of this package.
 
 """Unit tests for Bio.SeqIO.convert(...) function."""
-import os
 import unittest
 import warnings
 from Bio.Seq import UnknownSeq

--- a/Tests/test_TCoffee_tool.py
+++ b/Tests/test_TCoffee_tool.py
@@ -7,8 +7,6 @@
 import sys
 import os
 import unittest
-import subprocess
-from cStringIO import StringIO
 from Bio import AlignIO, SeqIO, MissingExternalDependencyError
 from Bio.Align.Applications import TCoffeeCommandline
 

--- a/Tests/test_TogoWS.py
+++ b/Tests/test_TogoWS.py
@@ -5,9 +5,7 @@
 
 """Testing Bio.TogoWS online code.
 """
-import sys
 import unittest
-import urllib
 from StringIO import StringIO
 
 import requires_internet

--- a/Tests/test_Uniprot.py
+++ b/Tests/test_Uniprot.py
@@ -2,7 +2,6 @@
 """Test for the Uniprot parser on Uniprot XML files.
 """
 import os
-import copy
 import unittest
 
 from Bio import SeqIO

--- a/Tests/test_XXmotif_tool.py
+++ b/Tests/test_XXmotif_tool.py
@@ -10,7 +10,6 @@ import shutil
 import sys
 import unittest
 from Bio import MissingExternalDependencyError
-from Bio import Motif
 from Bio import SeqIO
 from Bio.Application import ApplicationError
 from Bio.Motif.Applications import XXmotifCommandline


### PR DESCRIPTION
Imports in tests that hint at untested functionality were left in place.
