### PR TITLE
Fix broken downloading of large PDB structures

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -213,8 +213,9 @@ class PDBList(object):
         urllib.urlretrieve(url, filename)
 
         # Uncompress the archive, delete when done
-        with gzip.open(filename, 'rb') as gz, open(final_file, 'wb') as out:
-            out.writelines(gz)
+        with gzip.open(filename, 'rb') as gz:
+            with open(final_file, 'wb') as out:
+                out.writelines(gz)
         os.remove(filename)
 
         return final_file


### PR DESCRIPTION
## Summary of changes
- Fix failure to download large PDB files
- Use `with` statements for safer file I/O
- Remove obsolete parameters
- PEP 8 changes, update documentation
### Failure to download large PDB files

(See: [Redmine bug #3403](https://redmine.open-bio.org/issues/3403))

The current `PDBList` module will often fail to download large PDB files.

```
>>> from Bio.PDB import PDBList
>>> pdbl = PDBList()
>>> pdbl.retrieve_pdb_file("1hgg")
...
IOError: CRC check failed 0x21d7a5f7 != 0x4b5eabb6L
>>>
```

The source of this problem is that the entire gzipped file must be read
into memory before it's written to disk locally.

Instead of this memory-intensive approach, I changed the downloading to
use `urllib.urlretrieve`, which is more readable and far more efficient.
### Obsolete parameters

The long-obsolete parameters to `retrieve_pdb_file(()` have been
removed. Formerly, the function allowed the user to specify compression
and/or a system utility to perform decompression. But all archives are
now gzipped, and `PDBList` uses Python's `gzip` module to decompress
archives. These parameters have been obsolete for over a year (they were
marked deprecated with commit 7ebf6e9ecb).
