### PR TITLE
GenBank.Scanner: Raise ValueErrors instead of AssertionErrors when parsi...

### DIFF
--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -457,9 +457,12 @@ class InsdcScanner(object):
             record = self.parse(handle, do_features)
             if record is None:
                 break
-            assert record.id is not None
-            assert record.name != "<unknown name>"
-            assert record.description != "<unknown description>"
+            if record.id is None:
+                raise ValueError("Failed to parse the record's ID. Invalid ID line?")
+            if record.name == "<unknown name>":
+                raise ValueError("Failed to parse the record's name. Invalid ID line?")
+            if record.description == "<unknown description>":
+                raise ValueError("Failed to parse the record's description")
             yield record
 
     def parse_cds_features(self, handle,


### PR DESCRIPTION
...ng fails

Other parts of the parser code all raise ValueError()s when they
encounter unexpected input, just the checks for record.id, record.name
and record.description raise AssertionErrors. Fix this and provide more
meaningful error messages.

For record.name, this code path can be triggered by a GenBank file with
the locus line of "LOCUS        \n".

Signed-off-by: Kai Blin kai.blin@biotech.uni-tuebingen.de
