### PR TITLE
Patch searchio doc

### DIFF
--- a/Doc/Tutorial.tex
+++ b/Doc/Tutorial.tex
@@ -5580,9 +5580,10 @@ BLAST and BLAT. They are used merely for illustrative purposes, and you should
 be able to adapt the workflow to any other search tools supported by
 \verb|Bio.SearchIO| in a breeze. You're very welcome to follow along with the
 search output files we'll be using. The BLAST output file can be downloaded
-here, and the BLAT output file here. Both output files were generated using
-this sequence:
-%TODO - Add the missing links above.
+\href{http://biopython.org/SRC/Doc/examples/my_blast.xml}{here},
+and the BLAT output file
+\href{http://biopython.org/SRC/Doc/examples/my_blat.psl}{here}.
+Both output files were generated using this sequence:
 
 \begin{verbatim}
 >mystery_seq


### PR DESCRIPTION
Per http://lists.open-bio.org/pipermail/biopython/2013-February/008324.html

I changed some of the SearchIO language style and added actual links to the example files and documentation pages.

Links to the documentation pages are 404 at the moment, as the pages haven't been created (I assume they will be there after 1.61 is released).

Anyway, hope I didn't miss anything :).
