### PR TITLE
motif IC method fixed for non-uniform base distribution

### DIFF
--- a/Bio/Motif/_Motif.py
+++ b/Bio/Motif/_Motif.py
@@ -137,8 +137,14 @@ class Motif(object):
         """
         res=0
         pwm=self.pwm()
+        # compute background entropy for one column
+        bg_entropy=0
+        for a in self.alphabet.letters:
+            if background[a]!=0:
+                bg_entropy-=self.background[a]*math.log(self.background[a],2)
+                
         for i in range(self.length):
-            res+=2
+            res+=bg_entropy
             for a in self.alphabet.letters:
                 if pwm[i][a]!=0:
                     res+=pwm[i][a]*math.log(pwm[i][a],2)


### PR DESCRIPTION
The ic() method in Motif class computes information content as

\sum_b [2 + f(b) * lg(f(b))], where b is base. This formula computes information content for only one position in the motif. The current implementation assumes equal frequency of bases. I modified it to handle nonuniform base frequencies. For each position in the motif, the information content is computed as

\sum_b [-bg(b) * lg(bg(b)) + f(b) * lg(f(b))],

where bg(b) is the background frequency of base b, f(b) is the frequency of base b in that position of the motif.