### PR TITLE
Adding some features to the Newick writer

### DIFF
--- a/Bio/Phylo/NewickIO.py
+++ b/Bio/Phylo/NewickIO.py
@@ -251,9 +251,10 @@ class Writer(object):
         def newickize(clade):
             """Convert a node tree to a Newick tree string, recursively."""
             label = clade.name or ''
-            unquoted_label = re.match(token_dict['unquoted node label'], label)
-            if (not unquoted_label) or (unquoted_label.end() < len(label)):
-                label = "'%s'" % label.replace("'", "\\'")
+            if label:
+                unquoted_label = re.match(token_dict['unquoted node label'], label)
+                if (not unquoted_label) or (unquoted_label.end() < len(label)):
+                    label = "'%s'" % label.replace('\\', '\\\\').replace("'", "\\'")
 
             if clade.is_terminal():    # terminal
                 return (label


### PR DESCRIPTION
A smaller one this time:

I tweaked the NewickIO Writer to surround node labels that contain invalid characters (spaces, parentheses, etc.) with quotes and write out node comments in square brackets.
