### PR TITLE
SeqIO: Give better error message on invalid sequence length string

### DIFF
--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -669,7 +669,7 @@ class EmblScanner(InsdcScanner):
 
     def _feed_seq_length(self, consumer, text):
         length_parts = text.split()
-        assert len(length_parts) == 2
+        assert len(length_parts) == 2, "Invalid sequence length string %r" % text
         assert length_parts[1].upper() in ["BP", "BP.", "AA."]
         consumer.size(length_parts[0])
 


### PR DESCRIPTION
Signed-off-by: Kai Blin kai.blin@biotech.uni-tuebingen.de
