### PR TITLE
fix seq. phylip writer

### DIFF
--- a/Bio/AlignIO/PhylipIO.py
+++ b/Bio/AlignIO/PhylipIO.py
@@ -356,7 +356,7 @@ class SequentialPhylipWriter(SequentialAlignmentWriter):
             handle.write(name[:id_width].ljust(id_width))
             # Write the entire sequence to one line (see sequential format
             # notes in the SequentialPhylipIterator docstring
-            handle.write(sequence)
+            handle.write(" %s" % sequence)
             handle.write("\n")
 
 


### PR DESCRIPTION
When writing a sequential phylip alignment in which the sequence IDs are the maximum allowed length (10 chars), there was no space between the ID and the sequence. This patch fixes that.
