### PR TITLE
Custom GenBank locus length

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -547,7 +547,9 @@ class GenBankWriter(_InsdcWriter):
             locus = self._get_annotation_str(
                 record, "accession", just_first=True)
         if len(locus) > 16:
-            raise ValueError("Locus identifier %r is too long" % str(locus))
+            #Some user may need a GenBank file with custom Locus length
+            import warnings
+            warnings.warn("Locus identifier %r is too long" % str(locus))
 
         if len(record) > 99999999999:
             #Currently GenBank only officially support up to 350000, but


### PR DESCRIPTION
Instead of an exception, raise a warning, so the file is saved and the user can decide to correct the error.

I don't know if this is a good pratice, but I have some GenBank files provided by the JGI/DOE with locus names longer than 16 chars, so I guess that providing a warning to the user instead of a complete failure could be better.
