### PR TITLE
Fix Biopython installation with pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,20 @@ elif sys.version_info[0] == 3:
         if not os.path.isdir("build"):
             os.mkdir("build")
         do2to3.main(".", python3_source)
+    # Ugly hack to make pip work with Python 3, from 2to3 numpy setup:
+    # https://github.com/numpy/numpy/blob/bb726ca19f434f5055c0efceefe48d89469fcbbe/setup.py#L172
+    # Explanation: pip messes with __file__ which interacts badly with the
+    # change in directory due to the 2to3 conversion. Therefore we restore
+    # __file__ to what it would have been otherwise.
+    local_path = os.path.dirname(os.path.abspath(sys.argv[0]))
+    global __file__
+    __file__ = os.path.join(os.curdir, os.path.basename(__file__))
+    if '--egg-base' in sys.argv:
+        # Change pip-egg-info entry to absolute path, so pip can find it
+        # after changing directory.
+        idx = sys.argv.index('--egg-base')
+        if sys.argv[idx + 1] == 'pip-egg-info':
+            sys.argv[idx + 1] = os.path.join(local_path, 'pip-egg-info')
 
 # use setuptools, falling back on core modules if not found
 try:


### PR DESCRIPTION
Hi all;
This is yet another take on making Biopython install nicely with pip in virtual environments. This avoids adding numpy as an explicit dependency and instead uses it if present or skips it if not.

The problem with the previous install_requires approach is that pip doesn't build and install all requirements before setting up Biopython, so Biopython will fail with a numpy missing error. Additionally, our old approach drags in numpy so creates a heavyweight dependency for isolated environments.

The new approach requires users to explicitly install numpy if needed but doesn't penalize them if it's not present.

I submitted as a pull request for documentation and feedback from anyone. If y'all agree, merge away. Thanks,
Brad
