### PR TITLE
Blast-XML unicode writer fix

### DIFF
--- a/Bio/SearchIO/BlastIO/blast_xml.py
+++ b/Bio/SearchIO/BlastIO/blast_xml.py
@@ -609,7 +609,7 @@ class _BlastXmlGenerator(XMLGenerator):
 
     def startDocument(self):
         """Starts the XML document."""
-        self.write('<?xml version="1.0"?>\n'
+        self.write(u'<?xml version="1.0"?>\n'
                 '<!DOCTYPE BlastOutput PUBLIC "-//NCBI//NCBI BlastOutput/EN" '
                 '"http://www.ncbi.nlm.nih.gov/dtd/NCBI_BlastOutput.dtd">\n')
 
@@ -628,7 +628,7 @@ class _BlastXmlGenerator(XMLGenerator):
     def endElement(self, name):
         """Ends and XML element of the given name."""
         XMLGenerator.endElement(self, name)
-        self.write('\n')
+        self.write(u'\n')
 
     def startParent(self, name, attrs={}):
         """Starts an XML element which has children.
@@ -640,7 +640,7 @@ class _BlastXmlGenerator(XMLGenerator):
         """
         self.startElement(name, attrs, children=True)
         self._level += self._increment
-        self.write('\n')
+        self.write(u'\n')
         # append the element name, so we can end it later
         self._parent_stack.append(name)
 
@@ -670,9 +670,8 @@ class _BlastXmlGenerator(XMLGenerator):
         self.endElement(name)
 
     def characters(self, content):
-        # apply sax's filter first, then ours
-        content = escape(content)
-        for a, b in (('"', '&quot;'), ("'", '&apos;')):
+        content = escape(unicode(content))
+        for a, b in ((u'"', u'&quot;'), (u"'", u'&apos;')):
             content = content.replace(a, b)
         self.write(content)
 


### PR DESCRIPTION
See the initial report [here](http://lists.open-bio.org/pipermail/biopython-dev/2013-April/010503.html).

This is the fix to address the unicode writing bug. Travis doesn't have Python2.7.4 up and running yet (and its Py3.x tests unfortunately stalled, last time I checked). I resorted to testing this patch locally (under 2.7.4 and 3.3.1) and the write tests all pass.
