### PR TITLE
Add name length option for MAFFT

### DIFF
--- a/Bio/Align/Applications/_Mafft.py
+++ b/Bio/Align/Applications/_Mafft.py
@@ -286,6 +286,15 @@ class MafftCommandline(AbstractCommandline):
             _Switch(["--fmodel", "fmodel"],
                     "Incorporate the AA/nuc composition information into "
                     "the scoring matrix (True) or not (False, default)"),
+            #Name length n in a CLUSTAL format output can be controlled by --
+            #clustalout --namelength n.
+            #Support for titles of >10 characters in the phylip format (--
+            #phylipout --namelength n).  n = 10 by default.
+            _Option(["--namelength", "namelength"],
+                    "Name length n in a CLUSTAL format output can be controlled "
+                    "by --clustalout --namelength n.",
+                    checker_function=lambda x: isinstance(x, int),
+                    equate=False),
             #**** Output ****
             #Output format: clustal format. Default: off (fasta format)
             _Switch(["--clustalout", "clustalout"],


### PR DESCRIPTION
About this option: http://mafft.cbrc.jp/alignment/software/changelog.html
The '--namelength' option is required for our case.
