### PR TITLE
Updated FastaWriter's documentation. It was wrong.

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -151,7 +151,6 @@ class FastaWriter(SequentialSequenceWriter):
         Multiple calls to writer.write_record() and/or writer.write_records()
         ...
         writer.write_footer() # does nothing for Fasta files
-        writer.close()
         """
         SequentialSequenceWriter.__init__(self, handle)
         #self.handle = handle


### PR DESCRIPTION
Someone must have edited the code and didn't update the documentation for FastaWriter, because: `AttributeError: 'FastaWriter' object has no attribute 'close'`
