### PR TITLE
fix test_SeqIO_online for GI:16130152

### DIFF
--- a/Tests/test_SeqIO_online.py
+++ b/Tests/test_SeqIO_online.py
@@ -54,6 +54,8 @@ class EntrezTests(unittest.TestCase):
     def simple(self, database, formats, entry, length, checksum):
         for f in formats:
             handle = Entrez.efetch(db=database, id=entry, rettype=f, retmode="text")
+            if f == "gbwithparts":
+                f = "gb"
             record = SeqIO.read(handle, f)
             handle.close()
             self.assertTrue((entry in record.name) or
@@ -69,7 +71,7 @@ for database, formats, entry, length, checksum in [
          "Ktxz0HgMlhQmrKTuZpOxPZJ6zGU"),
         ("nucleotide", ["fasta", "gb"], "6273291", 902,
          "bLhlq4mEFJOoS9PieOx4nhGnjAQ"),
-        ("protein", ["fasta", "gb"], "16130152", 367,
+        ("protein", ["fasta", "gbwithparts"], "16130152", 367,
          "fCjcjMFeGIrilHAn6h+yju267lg"),
         ]:
 


### PR DESCRIPTION
This test fails because GI:16130152 has recently been modified so that the record returned when querying Entrez with rettype="gb" does not contain the protein sequence. This (minimal) patch calls Entrez with rettype="gbwithparts" instead of rettype="gb" so that the returned record includes the protein sequence. 

Since SeqIO does not accept "gbwithparts" as a file format specifier, I added a check to tell SeqIO.read to parse the record as a "gb" file when "gbwithparts" has been specified

biopython-dev thread: http://lists.open-bio.org/pipermail/biopython-dev/2013-May/010608.html
