### PR TITLE
Fix for ScanProsite.read, works with Python 2 and 3

### DIFF
--- a/Bio/ExPASy/ScanProsite.py
+++ b/Bio/ExPASy/ScanProsite.py
@@ -71,7 +71,7 @@ class Parser(ExpatParser):
         # The error message is (hopefully) contained in the data that was just
         # fed to the parser.
         if self.firsttime:
-            if data[:5]!="<?xml":
+            if data[:5].decode('utf-8') != "<?xml":
                 raise ValueError(data)
         self.firsttime = False
         return ExpatParser.feed(self, data, isFinal)


### PR DESCRIPTION
ScanProsite.read fails on Python 3, this fix is backwards compatible
with Python 2.
# 

Which operating system and hardware (32 bit or 64 bit) you are using:
Linux 3.9.4-1-ARCH #1 SMP PREEMPT Sat May 25 16:14:55 CEST 2013 x86_64 GNU/Linux

Python version:
Python 3.3.2 / Python 2.7.5

Biopython version
1.61

Traceback that occurs (the full error message):
    Traceback (most recent call last):
      File "prst.py", line 14, in <module>
        result = ScanProsite.read(handle)
      File "/usr/lib/python3.3/site-packages/Bio/ExPASy/ScanProsite.py", line 54, in read
        saxparser.parse(handle)
      File "/usr/lib/python3.3/xml/sax/expatreader.py", line 107, in parse
        xmlreader.IncrementalParser.parse(self, source)
      File "/usr/lib/python3.3/xml/sax/xmlreader.py", line 123, in parse
        self.feed(buffer)
      File "/usr/lib/python3.3/site-packages/Bio/ExPASy/ScanProsite.py", line 75, in feed
        raise ValueError(data)
    ValueError: b'<?xml version="1.0" encoding="UTF-8"?>\n<matchset xmlns="urn:expasy:scanprosite" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:expasy:scanprosite http://expasy.org/tools/scanprosite/scanprosite.xsd" n_match="3" n_seq="1">\n  <match>\n    <sequence_ac>USERSEQ1</sequence_ac> <start>428</start> <stop>436</stop> <signature_ac>PS00197</signature_ac> <level_tag>(-1)</level_tag>\n  </match>\n  <match>\n    <sequence_ac>USERSEQ1</sequence_ac> <start>452</start> <stop>463</stop> <signature_ac>PS00022</signature_ac> <level_tag>(-1)</level_tag>\n  </match>\n  <match>\n    <sequence_ac>USERSEQ1</sequence_ac> <start>463</start> <stop>471</stop> <signature_ac>PS00197</signature_ac> <level_tag>(-1)</level_tag>\n  </match>\n\n</matchset>\n'

Example code that breaks:
https://github.com/luizirber/rosalind/blob/master/prst.py

A data file that causes the problem:
The sample dataset from http://rosalind.info/problems/prst/ can be used, but any valid search with ScanProsite will trigger the error.
