### PR TITLE
Add the new Bio.motifs.jaspar package to the list of packages to install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -314,6 +314,7 @@ PACKAGES = [
     'Bio.Motif.Applications',
     'Bio.motifs',
     'Bio.motifs.applications',
+    'Bio.motifs.jaspar',
     'Bio.NeuralNetwork',
     'Bio.NeuralNetwork.BackPropagation',
     'Bio.NeuralNetwork.Gene',


### PR DESCRIPTION
The new jaspar package wasn't being installed, causing these errors when running 'python setup.py test':
# 

ERROR: test_doctests (test_Tutorial.TutorialTestCase)
## Run tutorial doctests.

Traceback (most recent call last):
  File "test_Tutorial.py", line 152, in test_doctests
ValueError: 1 Tutorial doctests failed: test_from_line_11404
# 

ERROR: test_simple (test_motifs.MotifTestPWM)
## Test if Bio.motifs PWM scoring works.

Traceback (most recent call last):
  File "test_motifs.py", line 1610, in setUp
    self.m = motifs.read(handle, "pfm")
  File "/home/pgarland/Hacking/Source/Biology/biopython/build/lib.linux-x86_64-2.7/Bio/motifs/**init**.py", line 128, in read
    motifs = parse(handle, format)
  File "/home/pgarland/Hacking/Source/Biology/biopython/build/lib.linux-x86_64-2.7/Bio/motifs/**init**.py", line 79, in parse
    from Bio.motifs import jaspar
ImportError: cannot import name jaspar
# 

ERROR: test_pfm_parsing (test_motifs.MotifTestsBasic)
## Test if Bio.motifs can parse JASPAR-style pfm files.

Traceback (most recent call last):
  File "test_motifs.py", line 399, in test_pfm_parsing
    m = motifs.read(self.PFMin, "pfm")
  File "/home/pgarland/Hacking/Source/Biology/biopython/build/lib.linux-x86_64-2.7/Bio/motifs/**init**.py", line 128, in read
    motifs = parse(handle, format)
  File "/home/pgarland/Hacking/Source/Biology/biopython/build/lib.linux-x86_64-2.7/Bio/motifs/**init**.py", line 79, in parse
    from Bio.motifs import jaspar
ImportError: cannot import name jaspar
# 

ERROR: test_sites_parsing (test_motifs.MotifTestsBasic)
## Test if Bio.motifs can parse JASPAR-style sites files.

Traceback (most recent call last):
  File "test_motifs.py", line 405, in test_sites_parsing
    m = motifs.read(self.SITESin,"sites")
  File "/home/pgarland/Hacking/Source/Biology/biopython/build/lib.linux-x86_64-2.7/Bio/motifs/**init**.py", line 128, in read
    motifs = parse(handle, format)
  File "/home/pgarland/Hacking/Source/Biology/biopython/build/lib.linux-x86_64-2.7/Bio/motifs/**init**.py", line 79, in parse
    from Bio.motifs import jaspar
ImportError: cannot import name jaspar
# 

FAIL: read (Bio.motifs)
## Doctest: Bio.motifs.read

Traceback (most recent call last):
  File "/usr/lib/python2.7/doctest.py", line 2201, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for Bio.motifs.read
  File "/home/pgarland/Hacking/Source/Biology/biopython/build/lib.linux-x86_64-2.7/Bio/motifs/**init**.py", line 86, in read

---

File "/home/pgarland/Hacking/Source/Biology/biopython/build/lib.linux-x86_64-2.7/Bio/motifs/**init**.py", line 94, in Bio.motifs.read
Failed example:
    m = motifs.read(open("motifs/SRF.pfm"), "pfm")
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/doctest.py", line 1289, in **run
        compileflags, 1) in test.globs
      File "<doctest Bio.motifs.read[1]>", line 1, in <module>
        m = motifs.read(open("motifs/SRF.pfm"), "pfm")
      File "/home/pgarland/Hacking/Source/Biology/biopython/build/lib.linux-x86_64-2.7/Bio/motifs/__init**.py", line 128, in read
        motifs = parse(handle, format)
      File "/home/pgarland/Hacking/Source/Biology/biopython/build/lib.linux-x86_64-2.7/Bio/motifs/**init**.py", line 79, in parse
        from Bio.motifs import jaspar
##     ImportError: cannot import name jaspar

File "/home/pgarland/Hacking/Source/Biology/biopython/build/lib.linux-x86_64-2.7/Bio/motifs/**init**.py", line 95, in Bio.motifs.read
Failed example:
    m.consensus
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/doctest.py", line 1289, in __run
        compileflags, 1) in test.globs
      File "<doctest Bio.motifs.read[2]>", line 1, in <module>
        m.consensus
    NameError: name 'm' is not defined

~Phillip
