### PR TITLE
SeqIO: Better cope with wrong LOCUS line spacing in GenBank

### DIFF
--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1141,6 +1141,20 @@ class GenBankScanner(InsdcScanner):
                 #We should be able to continue parsing... we need real world testcases!
                 warnings.warn("Minimal LOCUS line found - is this "
                               "correct?\n:%r" % line, BiopythonParserWarning)
+        elif len(line.split()) == 8 and line.split()[3] in ("aa", "bp") and \
+             line.split()[5] in ('linear', 'circular'):
+            # Cope with invalidly spaced GenBank LOCUS lines like
+            #LOCUS       AB070938          6497 bp    DNA     linear   BCT 11-OCT-2001
+            splitline = line.split()
+            consumer.locus(splitline[1])
+            consumer.size(splitline[2])
+            consumer.residue_type(splitline[4])
+            consumer.data_file_division(splitline[6])
+            consumer.date(splitline[7])
+            warnings.warn("Attempting to parse malformed locus line:\n%r\n"
+                          "found locus %r size %r residue_type %r\n"
+                          "Some field may be wrong." % (line, splitline[1],
+                          splitline[2], splitline[4]), BiopythonParserWarning)
         elif len(line.split()) == 7 and line.split()[3] in ["aa", "bp"]:
             #Cope with EnsEMBL genbank files which use space separation rather
             #than the expected column based layout. e.g.

--- a/Tests/output/test_GenBank
+++ b/Tests/output/test_GenBank
@@ -3367,13 +3367,17 @@ qualifiers:
 
 DB cross refs []
 ***Record from invalid_locus_line_spacing.gb with the FeatureParser
-Seq: Seq('CTAGCAGCCCGCATCGCCCTCGACGTTGGCGATCATCGTGCGCAGCACCTTGAG...TGA', Alphabet())
+Seq: Seq('CTAGCAGCCCGCATCGCCCTCGACGTTGGCGATCATCGTGCGCAGCACCTTGAG...TGA', IUPACAmbiguousDNA())
 Id: AB070938.1
 Name: AB070938
 Description Streptomyces avermitilis melanin biosynthetic gene cluster.
 Annotations***
 Key: accessions
 Value: ['AB070938']
+Key: data_file_division
+Value: BCT
+Key: date
+Value: 11-OCT-2001
 Key: gi
 Value: 15823953
 Key: keywords


### PR DESCRIPTION
Rebased on complementary patches from @peterjc
Includes the warning requested in https://github.com/biopython/biopython/pull/187#issuecomment-19538248

Supersedes the old pull request 187.

Signed-off-by: Kai Blin kai.blin@biotech.uni-tuebingen.de
