### PR TITLE
Fix for Bug 3439

### DIFF
--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -489,10 +489,6 @@ def _read_cc(record, line):
 
 
 def _read_dr(record, value):
-    # Remove the comments at the end of the line
-    i = value.find(' [')
-    if i >= 0:
-        value = value[:i]
     cols = value.rstrip(".").split('; ')
     record.cross_references.append(tuple(cols))
 


### PR DESCRIPTION
Fix for https://redmine.open-bio.org/issues/3439

Reading the relevant section of the SwissProt spec (http://web.expasy.org/docs/userman.html#DR_line), DR lines in SwissProt records don't have comments  so it should be safe to delete the code for splicing out comments from DR lines. 

This patch doesn't cause any new unit test failures for me on Python 2.7.5 on Debian GNU/Linux.

~Phillip
