### PR TITLE
fix bug in _parse_tag_data

### DIFF
--- a/Bio/SeqIO/AbiIO.py
+++ b/Bio/SeqIO/AbiIO.py
@@ -295,7 +295,7 @@ def _parse_tag_data(elem_code, elem_num, raw_data):
             return bool(data)
         elif elem_code == 18:
             return _bytes_to_string(data[1:])
-        elif self.elem_code == 19:
+        elif elem_code == 19:
             return _bytes_to_string(data[:-1])
         else:
             return data


### PR DESCRIPTION
I tried to migrate the documentaion from epydoc to restructured text, and I saw a code which is obviously a bug in  Bio/SeqIO/AbiIO.py
