### PR TITLE
Handle blank lines in DSSP (closes Redmine 3441)

### DIFF
--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -118,6 +118,8 @@ def make_dssp_dict(filename):
         keys = []
         for l in handle.readlines():
             sl = l.split()
+            if not sl:
+                continue
             if sl[1] == "RESIDUE":
                 # Start parsing from here
                 start = 1


### PR DESCRIPTION
mkdssp 2.1.0 has some output files with blank lines. Check for line existence before indexing.

https://redmine.open-bio.org/issues/3441
