### PR TITLE
Fix PDBIO blank occupancy handling

### DIFF
--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -8,7 +8,7 @@
 from Bio.PDB.StructureBuilder import StructureBuilder # To allow saving of chains, residues, etc..
 from Bio.Data.IUPACData import atom_weights # Allowed Elements
 
-_ATOM_FORMAT_STRING="%s%5i %-4s%c%3s %c%4i%c   %8.3f%8.3f%8.3f%6.2f%6.2f      %4s%2s%2s\n"
+_ATOM_FORMAT_STRING="%s%5i %-4s%c%3s %c%4i%c   %8.3f%8.3f%8.3f%s%6.2f      %4s%2s%2s\n"
 
 
 class Select(object):
@@ -85,8 +85,21 @@ class PDBIO(object):
         x, y, z=atom.get_coord()
         bfactor=atom.get_bfactor()
         occupancy=atom.get_occupancy()
+        try:
+            occupancy_str = "%6.2f" % occupancy
+        except TypeError:
+            if occupancy is None:
+                occupancy_str = " " * 6
+                import warnings
+                from Bio import BiopythonWarning
+                warnings.warn("Missing occupancy in atom %s written as blank" %
+                              repr(atom.get_full_id()), BiopythonWarning)
+            else:
+                raise TypeError("Invalid occupancy %r in atom %r"
+                                % (occupancy, atom.get_full_id()))
+            pass
         args=(record_type, atom_number, name, altloc, resname, chain_id,
-            resseq, icode, x, y, z, occupancy, bfactor, segid,
+            resseq, icode, x, y, z, occupancy_str, bfactor, segid,
             element, charge)
         return _ATOM_FORMAT_STRING % args
 

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -783,6 +783,27 @@ class WriteTest(unittest.TestCase):
         finally:
             os.remove(filename)
 
+    def test_pdbio_missing_occupancy(self):
+        """Write PDB file with missing occupancy"""
+
+        from Bio import BiopythonWarning
+        warnings.simplefilter('ignore', BiopythonWarning)
+
+        io = PDBIO()
+        structure = self.parser.get_structure("test", "PDB/occupancy.pdb")
+        io.set_structure(structure)
+        filenumber, filename = tempfile.mkstemp()
+        os.close(filenumber)
+        try:
+            io.save(filename)
+            struct2 = self.parser.get_structure("test", filename)
+            atoms = struct2[0]['A'][(' ', 152, ' ')]
+            self.assertEqual(atoms['N'].get_occupancy(), None)
+        finally:
+            os.remove(filename)
+            warnings.filters.pop()
+
+
 class Exposure(unittest.TestCase):
     "Testing Bio.PDB.HSExposure."
     def setUp(self):


### PR DESCRIPTION
Cribbed @peterjc's suggested fix (with a few minor tweaks to warning strings): http://lists.open-bio.org/pipermail/biopython-dev/2013-August/010831.html

The atom.get_full_id() does look a bit heavy but it's technically all needed for unambiguous atom identification.

Added a brief unit test to check that writing 1. doesn't throw an error 2. round-trips to `None`.
