### PR TITLE
Partially migrated to print-function-like syntax

### DIFF
--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -684,7 +684,7 @@ def print_info_content(summary_info,fout=None,rep_record=0):
                    summary_info.ic_vector[pos]))
 
 if __name__ == "__main__":
-    print "Quick test"
+    print("Quick test")
     from Bio import AlignIO
     from Bio.Align.Generic import Alignment
 
@@ -696,41 +696,41 @@ if __name__ == "__main__":
 
     alignment = AlignIO.read(open(filename), format)
     for record in alignment:
-        print str(record.seq)
-    print "="*alignment.get_alignment_length()
+        print(str(record.seq))
+    print("="*alignment.get_alignment_length())
 
     summary = SummaryInfo(alignment)
     consensus = summary.dumb_consensus(ambiguous="N")
-    print consensus
+    print(consensus)
     consensus = summary.gap_consensus(ambiguous="N")
-    print consensus
+    print(consensus)
     print
-    print summary.pos_specific_score_matrix(chars_to_ignore=['-'],
-                                            axis_seq=consensus)
+    print(summary.pos_specific_score_matrix(chars_to_ignore=['-'],
+                                            axis_seq=consensus))
     print
     #Have a generic alphabet, without a declared gap char, so must tell
     #provide the frequencies and chars to ignore explicitly.
-    print summary.information_content(e_freq_table=expected,
-                                      chars_to_ignore=['-'])
+    print(summary.information_content(e_freq_table=expected,
+                                      chars_to_ignore=['-']))
     print
-    print "Trying a protein sequence with gaps and stops"
+    print("Trying a protein sequence with gaps and stops")
 
     alpha = Alphabet.HasStopCodon(Alphabet.Gapped(Alphabet.generic_protein, "-"), "*")
     a = Alignment(alpha)
     a.add_sequence("ID001", "MHQAIFIYQIGYP*LKSGYIQSIRSPEYDNW-")
     a.add_sequence("ID002", "MH--IFIYQIGYAYLKSGYIQSIRSPEY-NW*")
     a.add_sequence("ID003", "MHQAIFIYQIGYPYLKSGYIQSIRSPEYDNW*")
-    print a
-    print "="*a.get_alignment_length()
+    print(a)
+    print("="*a.get_alignment_length())
 
     s = SummaryInfo(a)
     c = s.dumb_consensus(ambiguous="X")
-    print c
+    print(c)
     c = s.gap_consensus(ambiguous="X")
-    print c
+    print(c)
     print
-    print s.pos_specific_score_matrix(chars_to_ignore=['-', '*'], axis_seq=c)
+    print(s.pos_specific_score_matrix(chars_to_ignore=['-', '*'], axis_seq=c))
 
-    print s.information_content(chars_to_ignore=['-', '*'])
+    print(s.information_content(chars_to_ignore=['-', '*']))
 
-    print "Done"
+    print("Done")

--- a/Bio/Align/Applications/_ClustalOmega.py
+++ b/Bio/Align/Applications/_ClustalOmega.py
@@ -199,10 +199,10 @@ class ClustalOmegaCommandline(AbstractCommandline):
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running ClustalOmega doctests..."
+    print("Running ClustalOmega doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/Align/Applications/_Clustalw.py
+++ b/Bio/Align/Applications/_Clustalw.py
@@ -328,10 +328,10 @@ class ClustalwCommandline(AbstractCommandline):
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running ClustalW doctests..."
+    print("Running ClustalW doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/Align/Applications/_Dialign.py
+++ b/Bio/Align/Applications/_Dialign.py
@@ -182,10 +182,10 @@ class DialignCommandline(AbstractCommandline):
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running modules doctests..."
+    print("Running modules doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/Align/Applications/_Muscle.py
+++ b/Bio/Align/Applications/_Muscle.py
@@ -467,10 +467,10 @@ class MuscleCommandline(AbstractCommandline):
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running MUSCLE doctests..."
+    print("Running MUSCLE doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/Align/Applications/_Prank.py
+++ b/Bio/Align/Applications/_Prank.py
@@ -205,10 +205,10 @@ class PrankCommandline(AbstractCommandline):
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running modules doctests..."
+    print("Running modules doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/Align/Applications/_Probcons.py
+++ b/Bio/Align/Applications/_Probcons.py
@@ -111,10 +111,10 @@ class ProbconsCommandline(AbstractCommandline):
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running modules doctests..."
+    print("Running modules doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/Align/Applications/_TCoffee.py
+++ b/Bio/Align/Applications/_TCoffee.py
@@ -102,10 +102,10 @@ class TCoffeeCommandline(AbstractCommandline):
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running modules doctests..."
+    print("Running modules doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/Align/Generic.py
+++ b/Bio/Align/Generic.py
@@ -430,10 +430,10 @@ class Alignment(object):
 
 def _test():
     """Run the Bio.Align.Generic module's doctests."""
-    print "Running doctests..."
+    print("Running doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/AlignIO/ClustalIO.py
+++ b/Bio/AlignIO/ClustalIO.py
@@ -272,7 +272,7 @@ class ClustalIterator(AlignmentIterator):
         return alignment
 
 if __name__ == "__main__":
-    print "Running a quick self-test"
+    print("Running a quick self-test")
 
     #This is a truncated version of the example in Tests/cw02.aln
     #Notice the inclusion of sequence numbers (right hand side)
@@ -371,14 +371,14 @@ HISJ_E_COLI                    LKAKKIDAIMSSLSITEKRQQEIAFTDKLYAADSRLV
           "LKAKKIDAIMSSLSITEKRQQEIAFTDKLYAADSRLV"
 
     for alignment in ClustalIterator(StringIO(aln_example2 + aln_example1)):
-        print "Alignment with %i records of length %i" \
+        print("Alignment with %i records of length %i" \
               % (len(alignment),
-                 alignment.get_alignment_length())
+                 alignment.get_alignment_length()))
 
-    print "Checking empty file..."
+    print("Checking empty file...")
     assert 0 == len(list(ClustalIterator(StringIO(""))))
 
-    print "Checking write/read..."
+    print("Checking write/read...")
     alignments = list(ClustalIterator(StringIO(aln_example1))) \
                + list(ClustalIterator(StringIO(aln_example2)))*2
     handle = StringIO()
@@ -388,7 +388,7 @@ HISJ_E_COLI                    LKAKKIDAIMSSLSITEKRQQEIAFTDKLYAADSRLV
         assert a.get_alignment_length() == alignments[i].get_alignment_length()
     handle.seek(0)
 
-    print "Testing write/read when there is only one sequence..."
+    print("Testing write/read when there is only one sequence...")
     alignment = alignment[0:1]
     handle = StringIO()
     ClustalWriter(handle).write_file([alignment])
@@ -465,4 +465,4 @@ AT3G20900.1-CDS      GCTGGGGATGGAGAGGGAACAGAGTAG
     assert 1 == len(alignments)
     assert alignments[0]._version == "2.0.9"
 
-    print "The End"
+    print("The End")

--- a/Bio/AlignIO/EmbossIO.py
+++ b/Bio/AlignIO/EmbossIO.py
@@ -188,7 +188,7 @@ class EmbossIterator(AlignmentIterator):
                 #Just a spacer?
                 pass
             else:
-                print line
+                print(line)
                 assert False
 
             line = handle.readline()
@@ -221,7 +221,7 @@ class EmbossIterator(AlignmentIterator):
 
 
 if __name__ == "__main__":
-    print "Running a quick self-test"
+    print("Running a quick self-test")
 
     #http://emboss.sourceforge.net/docs/themes/alnformats/align.simple
     simple_example = \
@@ -616,4 +616,4 @@ asis             311 -----------------    311
     assert [r.id for r in alignments[0]] \
            == ["asis", "asis"]
 
-    print "Done"
+    print("Done")

--- a/Bio/AlignIO/FastaIO.py
+++ b/Bio/AlignIO/FastaIO.py
@@ -122,15 +122,15 @@ def FastaM10Iterator(handle, alphabet=single_letter_alphabet):
                 m = _extract_alignment_region(match_seq, match_tags)
             assert len(q) == len(m)
         except AssertionError as err:
-            print "Darn... amino acids vs nucleotide coordinates?"
-            print tool
-            print query_seq
-            print query_tags
+            print("Darn... amino acids vs nucleotide coordinates?")
+            print(tool)
+            print(query_seq)
+            print(query_tags)
             print q, len(q)
-            print match_seq
-            print match_tags
+            print(match_seq)
+            print(match_tags)
             print m, len(m)
-            print handle.name
+            print(handle.name)
             raise err
 
         assert alphabet is not None
@@ -356,7 +356,7 @@ def FastaM10Iterator(handle, alphabet=single_letter_alphabet):
 
 
 if __name__ == "__main__":
-    print "Running a quick self-test"
+    print("Running a quick self-test")
 
     #http://emboss.sourceforge.net/docs/themes/alnformats/align.simple
     simple_example = \
@@ -598,12 +598,12 @@ Function used was FASTA [version 34.26 January 12, 2007]
     assert len(alignments) == 4, len(alignments)
     assert len(alignments[0]) == 2
     for a in alignments:
-        print "Alignment %i sequences of length %i" \
-              % (len(a), a.get_alignment_length())
+        print("Alignment %i sequences of length %i" \
+              % (len(a), a.get_alignment_length()))
         for r in a:
-            print "%s %s %i" % (r.seq, r.id, r.annotations["original_length"])
+            print("%s %s %i" % (r.seq, r.id, r.annotations["original_length"]))
         #print a.annotations
-    print "Done"
+    print("Done")
 
     import os
     path = "../../Tests/Fasta/"
@@ -612,10 +612,10 @@ Function used was FASTA [version 34.26 January 12, 2007]
     for filename in files:
         if os.path.splitext(filename)[-1] == ".m10":
             print
-            print filename
-            print "=" * len(filename)
+            print(filename)
+            print("=" * len(filename))
             for i, a in enumerate(FastaM10Iterator(open(os.path.join(path, filename)))):
-                print "#%i, %s" % (i+1, a)
+                print("#%i, %s" % (i+1, a))
                 for r in a:
                     if "-" in r.seq:
                         assert r.seq.alphabet.gap_char == "-"

--- a/Bio/AlignIO/NexusIO.py
+++ b/Bio/AlignIO/NexusIO.py
@@ -137,9 +137,9 @@ class NexusWriter(AlignmentWriter):
 
 if __name__ == "__main__":
     from StringIO import StringIO
-    print "Quick self test"
+    print("Quick self test")
     print
-    print "Repeated names without a TAXA block"
+    print("Repeated names without a TAXA block")
     handle = StringIO("""#NEXUS
     [TITLE: NoName]
 
@@ -156,13 +156,13 @@ if __name__ == "__main__":
     end; 
     """)
     for a in NexusIterator(handle):
-        print a
+        print(a)
         for r in a:
             print repr(r.seq), r.name, r.id
-    print "Done"
+    print("Done")
 
     print
-    print "Repeated names with a TAXA block"
+    print("Repeated names with a TAXA block")
     handle = StringIO("""#NEXUS
     [TITLE: NoName]
 
@@ -186,21 +186,21 @@ if __name__ == "__main__":
     end; 
     """)
     for a in NexusIterator(handle):
-        print a
+        print(a)
         for r in a:
             print repr(r.seq), r.name, r.id
-    print "Done"
+    print("Done")
     print
-    print "Reading an empty file"
+    print("Reading an empty file")
     assert 0 == len(list(NexusIterator(StringIO())))
-    print "Done"
+    print("Done")
     print
-    print "Writing..."
+    print("Writing...")
 
     handle = StringIO()
     NexusWriter(handle).write_file([a])
     handle.seek(0)
-    print handle.read()
+    print(handle.read())
 
     handle = StringIO()
     try:

--- a/Bio/AlignIO/PhylipIO.py
+++ b/Bio/AlignIO/PhylipIO.py
@@ -439,7 +439,7 @@ class SequentialPhylipIterator(PhylipIterator):
 
 
 if __name__ == "__main__":
-    print "Running short mini-test"
+    print("Running short mini-test")
 
     phylip_text = """     8    286
 V_Harveyi_ --MKNWIKVA VAAIA--LSA A--------- ---------T VQAATEVKVG
@@ -503,7 +503,7 @@ HISJ_E_COL MKKLVLSLSL VLAFSSATAA F--------- ---------- AAIPQNIRIG
     for alignment in PhylipIterator(handle):
         for record in alignment:
             count = count+1
-            print record.id
+            print(record.id)
             #print str(record.seq)
     assert count == 8
 
@@ -600,9 +600,9 @@ Gorilla   AAACCCTTGC CGGTACGCTT AAACCATTGC CGGTACGCTT AA"""
         list5 = list(PhylipIterator(handle))
         assert len(list5) == 1
         assert len(list5[0]) == 5
-        print "That should have failed..."
+        print("That should have failed...")
     except ValueError:
-        print "Evil multiline non-interlaced example failed as expected"
+        print("Evil multiline non-interlaced example failed as expected")
     handle.close()
 
     handle = StringIO(phylip_text5a)
@@ -611,16 +611,16 @@ Gorilla   AAACCCTTGC CGGTACGCTT AAACCATTGC CGGTACGCTT AA"""
     assert len(list5) == 1
     assert len(list4[0]) == 5
 
-    print "Concatenation"
+    print("Concatenation")
     handle = StringIO(phylip_text4 + "\n" + phylip_text4)
     assert len(list(PhylipIterator(handle))) == 2
 
     handle = StringIO(phylip_text3 + "\n" + phylip_text4 + "\n\n\n" + phylip_text)
     assert len(list(PhylipIterator(handle))) == 3
 
-    print "OK"
+    print("OK")
 
-    print "Checking write/read"
+    print("Checking write/read")
     handle = StringIO()
     PhylipWriter(handle).write_file(list5)
     handle.seek(0)
@@ -631,4 +631,4 @@ Gorilla   AAACCCTTGC CGGTACGCTT AAACCATTGC CGGTACGCTT AA"""
         for r1, r2 in zip(a1, a2):
             assert r1.id == r2.id
             assert str(r1.seq) == str(r2.seq)
-    print "Done"
+    print("Done")

--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -70,11 +70,11 @@ class _XMLparser(ContentHandler):
         if hasattr(self, method):
             eval("self.%s()" % method)
             if self._debug > 4:
-                print "NCBIXML: Parsed:  " + method
+                print("NCBIXML: Parsed:  " + method)
         elif self._debug > 3:
             # Doesn't exist (yet) and may want to warn about it
             if method not in self._debug_ignore_list:
-                print "NCBIXML: Ignored: " + method
+                print("NCBIXML: Ignored: " + method)
                 self._debug_ignore_list.append(method)
 
         #We don't care about white space in parent tags like Hsp,
@@ -209,7 +209,7 @@ class BlastParser(_XMLparser):
         self._blast = None
 
         if self._debug:
-            print "NCBIXML: Added Blast record to results"
+            print("NCBIXML: Added Blast record to results")
 
     # Header
     def _end_BlastOutput_program(self):
@@ -695,9 +695,9 @@ if __name__ == '__main__':
     for r in r_list:
         # Small test
         print 'Blast of', r.query
-        print 'Found %s alignments with a total of %s HSPs' % (len(r.alignments),
+        print('Found %s alignments with a total of %s HSPs' % (len(r.alignments),
                   reduce(lambda a,b: a+b,
-                         [len(a.hsps) for a in r.alignments]))
+                         [len(a.hsps) for a in r.alignments])))
 
         for al in r.alignments:
             print al.title[:50], al.length, 'bp', len(al.hsps), 'HSPs'
@@ -707,10 +707,10 @@ if __name__ == '__main__':
         for alignment in r.alignments:
             for hsp in alignment.hsps:
                 if hsp.expect < E_VALUE_THRESH:
-                    print '*****'
+                    print('*****')
                     print 'sequence', alignment.title
                     print 'length', alignment.length
                     print 'e value', hsp.expect
-                    print hsp.query[:75] + '...'
-                    print hsp.match[:75] + '...'
-                    print hsp.sbjct[:75] + '...'
+                    print(hsp.query[:75] + '...')
+                    print(hsp.match[:75] + '...')
+                    print(hsp.sbjct[:75] + '...')

--- a/Bio/Data/CodonTable.py
+++ b/Bio/Data/CodonTable.py
@@ -879,7 +879,7 @@ for n in ambiguous_generic_by_id:
     if "UAA" in unambiguous_rna_by_id[n].stop_codons \
     and "UGA" in unambiguous_rna_by_id[n].stop_codons:
         try:
-            print ambiguous_dna_by_id[n].forward_table["TRA"]
+            print(ambiguous_dna_by_id[n].forward_table["TRA"])
             assert False, "Should be a stop only"
         except KeyError:
             pass

--- a/Bio/DocSQL.py
+++ b/Bio/DocSQL.py
@@ -121,7 +121,7 @@ class Query(object):
 
     def dump(self):
         for item in self:
-            print item
+            print(item)
 
 
 class QueryGeneric(Query):

--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -466,10 +466,10 @@ _open.previous = 0
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running doctests..."
+    print("Running doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/FSSP/__init__.py
+++ b/Bio/FSSP/__init__.py
@@ -266,7 +266,7 @@ def read_fssp(fssp_handle):
             align_dict[key].add_align_list(align_list)
             curline = fssp_handle.readline()
             if not curline:
-                print 'EOFEOFEOF'
+                print('EOFEOFEOF')
                 raise EOFError
     for i in align_dict.itervalues():
         i.pos_align_list2dict()

--- a/Bio/GA/Evolver.py
+++ b/Bio/GA/Evolver.py
@@ -67,7 +67,7 @@ class GenerationEvolver(object):
                 # sort the population so we can look at duplicates
                 self._population.sort()
                 for org in self._population:
-                    print org
+                    print(org)
                 sys.exit()
 
         return self._population

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -78,23 +78,23 @@ class InsdcScanner(object):
                 line = self.handle.readline()
             if not line:
                 if self.debug:
-                    print "End of file"
+                    print("End of file")
                 return None
             if line[:self.HEADER_WIDTH] == self.RECORD_START:
                 if self.debug > 1:
-                    print "Found the start of a record:\n" + line
+                    print("Found the start of a record:\n" + line)
                 break
             line = line.rstrip()
             if line == "//":
                 if self.debug > 1:
-                    print "Skipping // marking end of last record"
+                    print("Skipping // marking end of last record")
             elif line == "":
                 if self.debug > 1:
-                    print "Skipping blank line before record"
+                    print("Skipping blank line before record")
             else:
                 #Ignore any header before the first ID/LOCUS line.
                 if self.debug > 1:
-                        print "Skipping header line before record:\n" + line
+                        print("Skipping header line before record:\n" + line)
         self.line = line
         return line
 
@@ -116,14 +116,14 @@ class InsdcScanner(object):
             line = line.rstrip()
             if line in self.FEATURE_START_MARKERS:
                 if self.debug:
-                    print "Found header table"
+                    print("Found header table")
                 break
             #if line[:self.HEADER_WIDTH]==self.FEATURE_START_MARKER[:self.HEADER_WIDTH]:
             #    if self.debug : print "Found header table (?)"
             #    break
             if line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
                 if self.debug:
-                    print "Found start of sequence"
+                    print("Found start of sequence")
                 break
             if line == "//":
                 raise ValueError("Premature end of sequence data marker '//' found")
@@ -143,7 +143,7 @@ class InsdcScanner(object):
         """
         if self.line.rstrip() not in self.FEATURE_START_MARKERS:
             if self.debug:
-                print "Didn't find any feature table"
+                print("Didn't find any feature table")
             return []
 
         while self.line.rstrip() in self.FEATURE_START_MARKERS:
@@ -156,14 +156,14 @@ class InsdcScanner(object):
                 raise ValueError("Premature end of line during features table")
             if line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
                 if self.debug:
-                    print "Found start of sequence"
+                    print("Found start of sequence")
                 break
             line = line.rstrip()
             if line == "//":
                 raise ValueError("Premature end of features table, marker '//' found")
             if line in self.FEATURE_END_MARKERS:
                 if self.debug:
-                    print "Found end of features"
+                    print("Found end of features")
                 line = self.handle.readline()
                 break
             if line[2:self.FEATURE_QUALIFIER_INDENT].strip() == "":
@@ -291,7 +291,7 @@ class InsdcScanner(object):
                     elif value == '"':
                         #One single quote
                         if self.debug:
-                            print "Single quote %s:%s" % (key, value)
+                            print("Single quote %s:%s" % (key, value))
                         #DO NOT remove the quote...
                         qualifiers.append((key, value))
                     elif value[0] == '"':
@@ -785,7 +785,7 @@ class EmblScanner(InsdcScanner):
                 getattr(consumer, consumer_dict[line_type])(data)
             else:
                 if self.debug:
-                    print "Ignoring EMBL header line:\n%s" % line
+                    print("Ignoring EMBL header line:\n%s" % line)
 
     def _feed_misc_lines(self, consumer, lines):
         #TODO - Should we do something with the information on the SQ line(s)?
@@ -839,7 +839,7 @@ class _ImgtScanner(EmblScanner):
         """
         if self.line.rstrip() not in self.FEATURE_START_MARKERS:
             if self.debug:
-                print "Didn't find any feature table"
+                print("Didn't find any feature table")
             return []
 
         while self.line.rstrip() in self.FEATURE_START_MARKERS:
@@ -854,14 +854,14 @@ class _ImgtScanner(EmblScanner):
                 raise ValueError("Premature end of line during features table")
             if line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
                 if self.debug:
-                    print "Found start of sequence"
+                    print("Found start of sequence")
                 break
             line = line.rstrip()
             if line == "//":
                 raise ValueError("Premature end of features table, marker '//' found")
             if line in self.FEATURE_END_MARKERS:
                 if self.debug:
-                    print "Found end of features"
+                    print("Found end of features")
                 line = self.handle.readline()
                 break
             if line[2:self.FEATURE_QUALIFIER_INDENT].strip() == "":
@@ -1248,14 +1248,14 @@ class GenBankScanner(InsdcScanner):
                         consumer.version(data)
                     else:
                         if self.debug:
-                            print "Version [" + data.split(' GI:')[0] + "], gi [" + data.split(' GI:')[1] + "]"
+                            print("Version [" + data.split(' GI:')[0] + "], gi [" + data.split(' GI:')[1] + "]")
                         consumer.version(data.split(' GI:')[0])
                         consumer.gi(data.split(' GI:')[1])
                     #Read in the next line!
                     line = line_iter.next()
                 elif line_type == 'REFERENCE':
                     if self.debug > 1:
-                        print "Found reference [" + data + "]"
+                        print("Found reference [" + data + "]")
                     #Need to call consumer.reference_num() and consumer.reference_bases()
                     #e.g.
                     # REFERENCE   1  (bases 1 to 86436)
@@ -1275,7 +1275,7 @@ class GenBankScanner(InsdcScanner):
                             #Add this continuation to the data string
                             data += " " + line[GENBANK_INDENT:]
                             if self.debug > 1:
-                                print "Extended reference text [" + data + "]"
+                                print("Extended reference text [" + data + "]")
                         else:
                             #End of the reference, leave this text in the variable "line"
                             break
@@ -1286,11 +1286,11 @@ class GenBankScanner(InsdcScanner):
                         data = data.replace('  ', ' ')
                     if ' ' not in data:
                         if self.debug > 2:
-                            print 'Reference number \"' + data + '\"'
+                            print('Reference number \"' + data + '\"')
                         consumer.reference_num(data)
                     else:
                         if self.debug > 2:
-                            print 'Reference number \"' + data[:data.find(' ')] + '\", \"' + data[data.find(' ') + 1:] + '\"'
+                            print('Reference number \"' + data[:data.find(' ')] + '\", \"' + data[data.find(' ') + 1:] + '\"')
                         consumer.reference_num(data[:data.find(' ')])
                         consumer.reference_bases(data[data.find(' ') + 1:])
                 elif line_type == 'ORGANISM':
@@ -1316,12 +1316,12 @@ class GenBankScanner(InsdcScanner):
                             break
                     consumer.organism(organism_data)
                     if lineage_data.strip() == "" and self.debug > 1:
-                        print "Taxonomy line(s) missing or blank"
+                        print("Taxonomy line(s) missing or blank")
                     consumer.taxonomy(lineage_data.strip())
                     del organism_data, lineage_data
                 elif line_type == 'COMMENT':
                     if self.debug > 1:
-                        print "Found comment"
+                        print("Found comment")
                     #This can be multiline, and should call consumer.comment() once
                     #with a list where each entry is a line.
                     comment_list = []
@@ -1332,7 +1332,7 @@ class GenBankScanner(InsdcScanner):
                             data = line[GENBANK_INDENT:]
                             comment_list.append(data)
                             if self.debug > 2:
-                                print "Comment continuation [" + data + "]"
+                                print("Comment continuation [" + data + "]")
                         else:
                             #End of the comment
                             break
@@ -1352,7 +1352,7 @@ class GenBankScanner(InsdcScanner):
                             break
                 else:
                     if self.debug:
-                        print "Ignoring GenBank header line:\n" % line
+                        print("Ignoring GenBank header line:\n" % line)
                     #Read in next line
                     line = line_iter.next()
         except StopIteration:
@@ -1370,13 +1370,13 @@ class GenBankScanner(InsdcScanner):
                     line = line[10:].strip()
                     if line:
                         if self.debug:
-                            print "base_count = " + line
+                            print("base_count = " + line)
                         consumer.base_count(line)
                 if line.startswith('ORIGIN'):
                     line = line[6:].strip()
                     if line:
                         if self.debug:
-                            print "origin_name = " + line
+                            print("origin_name = " + line)
                         consumer.origin_name(line)
                 if line.startswith('WGS '):
                     line = line[3:].strip()
@@ -1724,58 +1724,58 @@ SQ   Sequence 1859 BP; 609 A; 314 C; 355 G; 581 T; 0 other;
 //
 """
 
-    print "GenBank CDS Iteration"
-    print "====================="
+    print("GenBank CDS Iteration")
+    print("=====================")
 
     g = GenBankScanner()
     for record in g.parse_cds_features(StringIO(gbk_example)):
-        print record
+        print(record)
 
     g = GenBankScanner()
     for record in g.parse_cds_features(StringIO(gbk_example2),
                                        tags2id=('gene', 'locus_tag', 'product')):
-        print record
+        print(record)
 
     g = GenBankScanner()
     for record in g.parse_cds_features(StringIO(gbk_example + "\n" + gbk_example2),
                                        tags2id=('gene', 'locus_tag', 'product')):
-        print record
+        print(record)
 
     print
-    print "GenBank Iteration"
-    print "================="
+    print("GenBank Iteration")
+    print("=================")
     g = GenBankScanner()
     for record in g.parse_records(StringIO(gbk_example), do_features=False):
         print record.id, record.name, record.description
-        print record.seq
+        print(record.seq)
 
     g = GenBankScanner()
     for record in g.parse_records(StringIO(gbk_example), do_features=True):
         print record.id, record.name, record.description
-        print record.seq
+        print(record.seq)
 
     g = GenBankScanner()
     for record in g.parse_records(StringIO(gbk_example2), do_features=False):
         print record.id, record.name, record.description
-        print record.seq
+        print(record.seq)
 
     g = GenBankScanner()
     for record in g.parse_records(StringIO(gbk_example2), do_features=True):
         print record.id, record.name, record.description
-        print record.seq
+        print(record.seq)
 
     print
-    print "EMBL CDS Iteration"
-    print "=================="
+    print("EMBL CDS Iteration")
+    print("==================")
 
     e = EmblScanner()
     for record in e.parse_cds_features(StringIO(embl_example)):
-        print record
+        print(record)
 
     print
-    print "EMBL Iteration"
-    print "=============="
+    print("EMBL Iteration")
+    print("==============")
     e = EmblScanner()
     for record in e.parse_records(StringIO(embl_example), do_features=True):
         print record.id, record.name, record.description
-        print record.seq
+        print(record.seq)

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -1042,8 +1042,8 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                 try:
                     loc = _loc(part, self._expected_size, part_strand)
                 except ValueError as err:
-                    print location_line
-                    print part
+                    print(location_line)
+                    print(part)
                     raise err
                 f = SeqFeature.SeqFeature(location=loc, ref=ref,
                         location_operator=cur_feature.location_operator,
@@ -1513,21 +1513,21 @@ def _test():
     import doctest
     import os
     if os.path.isdir(os.path.join("..","..","Tests")):
-        print "Running doctests..."
+        print("Running doctests...")
         cur_dir = os.path.abspath(os.curdir)
         os.chdir(os.path.join("..","..","Tests"))
         doctest.testmod()
         os.chdir(cur_dir)
         del cur_dir
-        print "Done"
+        print("Done")
     elif os.path.isdir(os.path.join("Tests")):
-        print "Running doctests..."
+        print("Running doctests...")
         cur_dir = os.path.abspath(os.curdir)
         os.chdir(os.path.join("Tests"))
         doctest.testmod()
         os.chdir(cur_dir)
         del cur_dir
-        print "Done"
+        print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/Geo/Record.py
+++ b/Bio/Geo/Record.py
@@ -54,7 +54,7 @@ class Record(object):
                 output = output + '%s: %s\n' % ( key, contents[ :40 ] )
                 output = output + out_block( contents[ 40: ] )
             else:
-                print contents
+                print(contents)
                 output = output + '%s: %s\n' % ( key, val[ :40 ] )
                 output = output + out_block( val[ 40: ] )
         col_keys = self.col_defs.keys()

--- a/Bio/Graphics/GenomeDiagram/_Colors.py
+++ b/Bio/Graphics/GenomeDiagram/_Colors.py
@@ -209,12 +209,12 @@ if __name__ == '__main__':
 
     # Test code
     gdct = ColorTranslator()
-    print gdct.float1_color((0.5, 0.5, 0.5))
-    print gdct.int255_color((1, 75, 240))
-    print gdct.artemis_color(7)
-    print gdct.scheme_color(2)
+    print(gdct.float1_color((0.5, 0.5, 0.5)))
+    print(gdct.int255_color((1, 75, 240)))
+    print(gdct.artemis_color(7))
+    print(gdct.scheme_color(2))
 
-    print gdct.translate((0.5, 0.5, 0.5))
-    print gdct.translate((1, 75, 240))
-    print gdct.translate(7)
-    print gdct.translate(2)
+    print(gdct.translate((0.5, 0.5, 0.5)))
+    print(gdct.translate((1, 75, 240)))
+    print(gdct.translate(7))
+    print(gdct.translate(2))

--- a/Bio/Graphics/GenomeDiagram/_GraphSet.py
+++ b/Bio/Graphics/GenomeDiagram/_GraphSet.py
@@ -235,4 +235,4 @@ if __name__ == '__main__':
     gdgs.add_graph(testdata1, 'TestData 1')
     gdgs.add_graph(testdata2, 'TestData 2')
 
-    print gdgs
+    print(gdgs)

--- a/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
@@ -989,13 +989,13 @@ class LinearDrawer(AbstractDrawer):
             ctr += self.fragment_lines[fragment][0]
             top += self.fragment_lines[fragment][0]
         except:     # Only called if the method screws up big time
-            print "We've got a screw-up"
+            print("We've got a screw-up")
             print self.start, self.end
-            print self.fragment_bases
+            print(self.fragment_bases)
             print x0, x1
             for locstart, locend in feature.locations:
-                print self.canvas_location(locstart)
-                print self.canvas_location(locend)
+                print(self.canvas_location(locstart))
+                print(self.canvas_location(locend))
             print 'FEATURE\n', feature
             1/0
 

--- a/Bio/Graphics/GenomeDiagram/_Track.py
+++ b/Bio/Graphics/GenomeDiagram/_Track.py
@@ -403,9 +403,9 @@ if __name__ == '__main__':
     gdgs.add_graph(graphdata, 'Test Data')
     gdt.add_set(gdgs)
 
-    print gdt.get_ids()
+    print(gdt.get_ids())
     sets = gdt.get_sets()
     for set in sets:
-        print set
+        print(set)
 
-    print gdt.get_element_limits()
+    print(gdt.get_element_limits())

--- a/Bio/HMM/Utilities.py
+++ b/Bio/HMM/Utilities.py
@@ -39,13 +39,13 @@ def pretty_print_prediction(emissions, real_state, predicted_state,
         else:
             extension = len(emissions) - cur_position
 
-        print "%s%s" % (emission_title,
-                        emissions[cur_position:cur_position + seq_length])
-        print "%s%s" % (real_title,
-                        real_state[cur_position:cur_position + seq_length])
-        print "%s%s\n" % (predicted_title,
+        print("%s%s" % (emission_title,
+                        emissions[cur_position:cur_position + seq_length]))
+        print("%s%s" % (real_title,
+                        real_state[cur_position:cur_position + seq_length]))
+        print("%s%s\n" % (predicted_title,
                           predicted_state[cur_position:
-                                          cur_position + seq_length])
+                                          cur_position + seq_length]))
 
         if (len(emissions) < (cur_position + seq_length)):
             break

--- a/Bio/HotRand.py
+++ b/Bio/HotRand.py
@@ -42,7 +42,7 @@ class HotCache(object):
         cache = self.hot_cache
         numbytes = num_digits / 2
         if( len( cache ) % numbytes != 0 ):
-            print 'len_cache is %d' % len( cache )
+            print('len_cache is %d' % len( cache ))
             raise ValueError
         if( cache == '' ):
             self.fill_hot_cache()
@@ -68,7 +68,7 @@ class HotRandom(object):
 if( __name__ == '__main__' ):
     hot_random = HotRandom()
     for j in range( 0, 130 ):
-        print hot_random.hot_rand( 25 )
+        print(hot_random.hot_rand( 25 ))
     nums = [ '0000', 'abcd', '1234', '5555', '4321', 'aaaa', 'ffff' ]
     for num in nums:
-        print hex_convert( num )
+        print(hex_convert( num ))

--- a/Bio/KDTree/KDTree.py
+++ b/Bio/KDTree/KDTree.py
@@ -54,9 +54,9 @@ def _neighbor_test(nr_points, dim, bucket_size, radius):
     else:
         l2 = len(r)
     if l1 == l2:
-        print "Passed."
+        print("Passed.")
     else:
-        print "Not passed: %i != %i." % (l1, l2)
+        print("Not passed: %i != %i." % (l1, l2))
 
 
 def _test(nr_points, dim, bucket_size, radius):
@@ -87,9 +87,9 @@ def _test(nr_points, dim, bucket_size, radius):
         if _dist(p, center) <= radius:
             l2 = l2 + 1
     if l1 == l2:
-        print "Passed."
+        print("Passed.")
     else:
-        print "Not passed: %i != %i." % (l1, l2)
+        print("Not passed: %i != %i." % (l1, l2))
 
 
 class KDTree(object):
@@ -245,7 +245,7 @@ if __name__ == "__main__":
     indices = kdtree.all_get_indices()
     radii = kdtree.all_get_radii()
 
-    print "Found %i point pairs within radius %f." % (len(indices), query_radius)
+    print("Found %i point pairs within radius %f." % (len(indices), query_radius))
 
     # Do 10 individual queries
 
@@ -261,4 +261,4 @@ if __name__ == "__main__":
         radii = kdtree.get_radii()
 
         x, y, z = center
-        print "Found %i points in radius %f around center (%.2f, %.2f, %.2f)." % (len(indices), query_radius, x, y, z)
+        print("Found %i points in radius %f around center (%.2f, %.2f, %.2f)." % (len(indices), query_radius, x, y, z))

--- a/Bio/Motif/Applications/_AlignAce.py
+++ b/Bio/Motif/Applications/_AlignAce.py
@@ -134,10 +134,10 @@ class CompareAceCommandline(AbstractCommandline):
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running AlignAce doctests..."
+    print("Running AlignAce doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 
 if __name__ == "__main__":

--- a/Bio/Motif/Applications/_XXmotif.py
+++ b/Bio/Motif/Applications/_XXmotif.py
@@ -172,10 +172,10 @@ class XXmotifCommandline(AbstractCommandline):
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running XXmotif doctests..."
+    print("Running XXmotif doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 
 if __name__ == "__main__":

--- a/Bio/Motif/__init__.py
+++ b/Bio/Motif/__init__.py
@@ -158,13 +158,13 @@ def _test():
     import doctest
     import os
     if os.path.isdir(os.path.join("..","..","Tests")):
-        print "Runing doctests..."
+        print("Runing doctests...")
         cur_dir = os.path.abspath(os.curdir)
         os.chdir(os.path.join("..","..","Tests"))
         doctest.testmod()
         os.chdir(cur_dir)
         del cur_dir
-        print "Done"
+        print("Done")
 
 if __name__ == "__main__":
     #Run the doctests

--- a/Bio/NeuralNetwork/StopTraining.py
+++ b/Bio/NeuralNetwork/StopTraining.py
@@ -51,20 +51,20 @@ class ValidationIncreaseStop(object):
         """
         if num_iterations % 10 == 0:
             if self.verbose:
-                print "%s; Training Error:%s; Validation Error:%s"\
-                      % (num_iterations, training_error, validation_error)
+                print("%s; Training Error:%s; Validation Error:%s"\
+                      % (num_iterations, training_error, validation_error))
 
         if num_iterations > self.min_iterations:
             if self.last_error is not None:
                 if validation_error > self.last_error:
                     if self.verbose:
-                        print "Validation Error increasing -- Stop"
+                        print("Validation Error increasing -- Stop")
                     return 1
 
         if self.max_iterations is not None:
             if num_iterations > self.max_iterations:
                 if self.verbose:
-                    print "Reached maximum number of iterations -- Stop"
+                    print("Reached maximum number of iterations -- Stop")
                 return 1
 
         self.last_error = validation_error

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -596,7 +596,7 @@ class Nexus(object):
                 file_contents = input
                 self.filename='input_string'
             else:
-                print input.strip()[:50]
+                print(input.strip()[:50])
                 raise NexusError('Unrecognized input: %s ...' % input[:100])
         file_contents=file_contents.strip()
         if file_contents.startswith('#NEXUS'):

--- a/Bio/Nexus/Trees.py
+++ b/Bio/Nexus/Trees.py
@@ -359,11 +359,11 @@ class Tree(Nodes.Chain):
             try:
                 return frozenset([self.set_subtree(n) for n in self.node(node).succ])
             except:
-                print node
-                print self.node(node).succ
+                print(node)
+                print(self.node(node).succ)
                 for n in self.node(node).succ:
                     print n, self.set_subtree(n)
-                print [self.set_subtree(n) for n in self.node(node).succ]
+                print([self.set_subtree(n) for n in self.node(node).succ])
                 raise
 
     def is_identical(self,tree2):
@@ -384,9 +384,9 @@ class Tree(Nodes.Chain):
         missing1=set(tree2.get_taxa())-set(self.get_taxa())
         if strict and (missing1 or missing2):
             if missing1:
-                print 'Taxon/taxa %s is/are missing in tree %s' % (','.join(missing1) , self.name)
+                print('Taxon/taxa %s is/are missing in tree %s' % (','.join(missing1) , self.name))
             if missing2:
-                print 'Taxon/taxa %s is/are missing in tree %s' % (','.join(missing2) , tree2.name)
+                print('Taxon/taxa %s is/are missing in tree %s' % (','.join(missing2) , tree2.name))
             raise TreeError('Can\'t compare trees with different taxon compositions.')
         t1=[(set(self.get_taxa(n)),self.node(n).data.support) for n in self.all_ids() if
             self.node(n).succ and
@@ -552,7 +552,7 @@ class Tree(Nodes.Chain):
                     comment='-'
                 table.append((str(i),tx,str(n.prev),str(n.succ),
                              blength, sum_blength, support, comment))
-        print '\n'.join(['%3s %32s %15s %15s %8s %10s %8s %20s' % l for l in table])
+        print('\n'.join(['%3s %32s %15s %15s %8s %10s %8s %20s' % l for l in table]))
         print '\nRoot: ',self.root
 
     def to_string(self,support_as_branchlengths=False,branchlengths_only=False,plain=True,plain_newick=False,ladderize=None,ignore_comments=True):

--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -326,11 +326,11 @@ if __name__ == "__main__":
     d = DSSP(model, sys.argv[1])
 
     for r in d:
-        print r
+        print(r)
     print "Handled", len(d), "residues"
-    print d.keys()
+    print(d.keys())
     if ('A', 1) in d:
-        print d[('A', 1)]
-        print s[0]['A'][1].xtra
+        print(d[('A', 1)])
+        print(s[0]['A'][1].xtra)
     # Secondary structure
-    print ''.join(d[key][1] for key in d.keys())
+    print(''.join(d[key][1] for key in d.keys()))

--- a/Bio/PDB/FragmentMapper.py
+++ b/Bio/PDB/FragmentMapper.py
@@ -333,6 +333,6 @@ if __name__=="__main__":
 
         print r,
         if r in fm:
-            print fm[r]
+            print(fm[r])
         else:
             print

--- a/Bio/PDB/HSExposure.py
+++ b/Bio/PDB/HSExposure.py
@@ -324,22 +324,22 @@ if __name__=="__main__":
 
     hse=HSExposureCA(model, radius=RADIUS, offset=OFFSET)
     for l in hse:
-        print l
+        print(l)
     print
 
     hse=HSExposureCB(model, radius=RADIUS, offset=OFFSET)
     for l in hse:
-        print l
+        print(l)
     print
 
     hse=ExposureCN(model, radius=RADIUS, offset=OFFSET)
     for l in hse:
-        print l
+        print(l)
     print
 
     for c in model:
         for r in c:
             try:
-                print r.xtra['PCB_CB_ANGLE']
+                print(r.xtra['PCB_CB_ANGLE'])
             except:
                 pass

--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -66,28 +66,28 @@ if __name__=="__main__":
     import sys
 
     if len(sys.argv)!=2:
-        print "Usage: python MMCIF2Dict filename."
+        print("Usage: python MMCIF2Dict filename.")
 
     filename=sys.argv[1]
 
     mmcif_dict = MMCIF2Dict(filename)
 
     entry = ""
-    print "Now type a key ('q' to end, 'k' for a list of all keys):"
+    print("Now type a key ('q' to end, 'k' for a list of all keys):")
     while(entry != "q"):
         entry = raw_input("MMCIF dictionary key ==> ")
         if entry == "q":
             sys.exit()
         if entry == "k":
             for key in mmcif_dict:
-                print key
+                print(key)
             continue
         try:
             value=mmcif_dict[entry]
             if isinstance(value, list):
                 for item in value:
-                    print item
+                    print(item)
             else:
-                print value
+                print(value)
         except KeyError:
-            print "No such key found."
+            print("No such key found.")

--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -165,7 +165,7 @@ if __name__=="__main__":
     import sys
 
     if len(sys.argv) != 2:
-        print "Usage: python MMCIFparser.py filename"
+        print("Usage: python MMCIFparser.py filename")
         raise SystemExit
     filename=sys.argv[1]
 
@@ -174,7 +174,7 @@ if __name__=="__main__":
     structure=p.get_structure("test", filename)
 
     for model in structure.get_list():
-        print model
+        print(model)
         for chain in model.get_list():
-            print chain
-            print "Found %d residues." % len(chain.get_list())
+            print(chain)
+            print("Found %d residues." % len(chain.get_list()))

--- a/Bio/PDB/NACCESS.py
+++ b/Bio/PDB/NACCESS.py
@@ -185,4 +185,4 @@ if __name__=="__main__":
 
     n = NACCESS(model, sys.argv[1])
     for e in n.get_iterator():
-        print e
+        print(e)

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -122,7 +122,7 @@ class PDBList(object):
         PDB entries and some annotation to them.
         Returns a list of PDB codes in the index file.
         """
-        print "retrieving index file. Takes about 5 MB."
+        print("retrieving index file. Takes about 5 MB.")
         url = self.pdb_server + '/pub/pdb/derived_data/index/entries.idx'
         with contextlib.closing(_urlopen(url)) as handle:
             all_entries = [line[:4] for line in handle.readlines()[2:]
@@ -202,11 +202,11 @@ class PDBList(object):
         # Skip download if the file already exists
         if not self.overwrite:
             if os.path.exists(final_file):
-                print "Structure exists: '%s' " % final_file
+                print("Structure exists: '%s' " % final_file)
                 return final_file
 
         # Retrieve the file
-        print "Downloading PDB structure '%s'..." % pdb_code
+        print("Downloading PDB structure '%s'..." % pdb_code)
         urllib.urlretrieve(url, filename)
 
         # Uncompress the archive, delete when done
@@ -235,7 +235,7 @@ class PDBList(object):
             try:
                 self.retrieve_pdb_file(pdb_code)
             except Exception:
-                print 'error %s\n' % pdb_code
+                print('error %s\n' % pdb_code)
                 # you can insert here some more log notes that
                 # something has gone wrong.
 
@@ -256,11 +256,11 @@ class PDBList(object):
                 try:
                     shutil.move(old_file, new_file)
                 except Exception:
-                    print "Could not move %s to obsolete folder" % old_file
+                    print("Could not move %s to obsolete folder" % old_file)
             elif os.path.isfile(new_file):
-                print "Obsolete file %s already moved" % old_file
+                print("Obsolete file %s already moved" % old_file)
             else:
-                print "Obsolete file %s is missing" % old_file
+                print("Obsolete file %s is missing" % old_file)
 
     def download_entire_pdb(self, listfile=None):
         """Retrieve all PDB entries not present in the local PDB copy.
@@ -296,7 +296,7 @@ class PDBList(object):
         """Retrieves a (big) file containing all the sequences of PDB entries
         and writes it to a file.
         """
-        print "Retrieving sequence file (takes about 15 MB)."
+        print("Retrieving sequence file (takes about 15 MB).")
         url = self.pdb_server + '/pub/pdb/derived_data/pdb_seqres.txt'
         urllib.urlretrieve(url, savefile)
 
@@ -321,7 +321,7 @@ if __name__ == '__main__':
        -d   A single directory will be used as <pdb_path>, not a tree.
        -o   Overwrite existing structure files.
     """
-    print doc
+    print(doc)
 
     if len(sys.argv) > 2:
         pdb_path = sys.argv[2]
@@ -341,7 +341,7 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         if sys.argv[1] == 'update':
             # update PDB
-            print "updating local PDB at " + pdb_path
+            print("updating local PDB at " + pdb_path)
             pl.update_pdb()
 
         elif sys.argv[1] == 'all':

--- a/Bio/PDB/PDBParser.py
+++ b/Bio/PDB/PDBParser.py
@@ -305,7 +305,7 @@ if __name__ == "__main__":
             p = c.get_parent()
             assert(p is m)
             for r in c:
-                print r
+                print(r)
                 p = r.get_parent()
                 assert(p is c)
                 for a in r:

--- a/Bio/PDB/Polypeptide.py
+++ b/Bio/PDB/Polypeptide.py
@@ -460,13 +460,13 @@ if __name__=="__main__":
 
     ppb=PPBuilder()
 
-    print "C-N"
+    print("C-N")
     for pp in ppb.build_peptides(s):
-        print pp.get_sequence()
+        print(pp.get_sequence())
     for pp in ppb.build_peptides(s[0]):
-        print pp.get_sequence()
+        print(pp.get_sequence())
     for pp in ppb.build_peptides(s[0]["A"]):
-        print pp.get_sequence()
+        print(pp.get_sequence())
 
     for pp in ppb.build_peptides(s):
         for phi, psi in pp.get_phi_psi_list():
@@ -474,10 +474,10 @@ if __name__=="__main__":
 
     ppb=CaPPBuilder()
 
-    print "CA-CA"
+    print("CA-CA")
     for pp in ppb.build_peptides(s):
-        print pp.get_sequence()
+        print(pp.get_sequence())
     for pp in ppb.build_peptides(s[0]):
-        print pp.get_sequence()
+        print(pp.get_sequence())
     for pp in ppb.build_peptides(s[0]["A"]):
-        print pp.get_sequence()
+        print(pp.get_sequence())

--- a/Bio/PDB/ResidueDepth.py
+++ b/Bio/PDB/ResidueDepth.py
@@ -173,4 +173,4 @@ if __name__=="__main__":
     rd=ResidueDepth(model, sys.argv[1])
 
     for item in rd:
-        print item
+        print(item)

--- a/Bio/PDB/Selection.py
+++ b/Bio/PDB/Selection.py
@@ -79,9 +79,9 @@ def unfold_entities(entity_list, target_level):
 def _test():
     """Run the Bio.PDB.Selection module's doctests (PRIVATE)."""
     import doctest
-    print "Running doctests ..."
+    print("Running doctests ...")
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 
 if __name__ == "__main__":

--- a/Bio/PDB/StructureAlignment.py
+++ b/Bio/PDB/StructureAlignment.py
@@ -103,10 +103,10 @@ if __name__=="__main__":
     from Bio.PDB import PDBParser
 
     if len(sys.argv) != 4:
-        print "Expects three arguments,"
-        print " - FASTA alignment filename (expect two sequences)"
-        print " - PDB file one"
-        print " - PDB file two"
+        print("Expects three arguments,")
+        print(" - FASTA alignment filename (expect two sequences)")
+        print(" - PDB file one")
+        print(" - PDB file two")
         sys.exit()
 
     # The alignment

--- a/Bio/PDB/Superimposer.py
+++ b/Bio/PDB/Superimposer.py
@@ -78,7 +78,7 @@ if __name__=="__main__":
 
     sup.set_atoms(fixed, moving)
 
-    print sup.rotran
-    print sup.rms
+    print(sup.rotran)
+    print(sup.rms)
 
     sup.apply(moving)

--- a/Bio/PDB/Vector.py
+++ b/Bio/PDB/Vector.py
@@ -327,9 +327,9 @@ if __name__=="__main__":
 
     v4.normalize()
 
-    print v4
+    print(v4)
 
-    print calc_angle(v1, v2, v3)
+    print(calc_angle(v1, v2, v3))
     dih=calc_dihedral(v1, v2, v3, v4)
     # Test dihedral sign
     assert(dih>0)
@@ -338,41 +338,41 @@ if __name__=="__main__":
     ref=refmat(v1, v3)
     rot=rotmat(v1, v3)
 
-    print v3
-    print v1.left_multiply(ref)
-    print v1.left_multiply(rot)
-    print v1.right_multiply(numpy.transpose(rot))
+    print(v3)
+    print(v1.left_multiply(ref))
+    print(v1.left_multiply(rot))
+    print(v1.right_multiply(numpy.transpose(rot)))
 
     # -
-    print v1-v2
-    print v1-1
-    print v1+(1,2,3)
+    print(v1-v2)
+    print(v1-1)
+    print(v1+(1,2,3))
     # +
-    print v1+v2
-    print v1+3
-    print v1-(1,2,3)
+    print(v1+v2)
+    print(v1+3)
+    print(v1-(1,2,3))
     # *
-    print v1*v2
+    print(v1*v2)
     # /
-    print v1/2
-    print v1/(1,2,3)
+    print(v1/2)
+    print(v1/(1,2,3))
     # **
-    print v1**v2
-    print v1**2
-    print v1**(1,2,3)
+    print(v1**v2)
+    print(v1**2)
+    print(v1**(1,2,3))
     # norm
-    print v1.norm()
+    print(v1.norm())
     # norm squared
-    print v1.normsq()
+    print(v1.normsq())
     # setitem
     v1[2]=10
-    print v1
+    print(v1)
     # getitem
-    print v1[2]
+    print(v1[2])
 
-    print numpy.array(v1)
+    print(numpy.array(v1))
 
-    print "ROT"
+    print("ROT")
 
     angle=random()*numpy.pi
     axis=Vector(random(3)-random(3))
@@ -382,6 +382,6 @@ if __name__=="__main__":
 
     cangle, caxis=m2rotaxis(m)
 
-    print angle-cangle
-    print axis-caxis
+    print(angle-cangle)
+    print(axis-caxis)
     print

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -266,6 +266,6 @@ if __name__=='__main__':
 
     # print the dictionary
     for k, y in data_dict.iteritems():
-        print "-"*40
-        print k
-        print y
+        print("-"*40)
+        print(k)
+        print(y)

--- a/Bio/Phylo/PAML/_paml.py
+++ b/Bio/Phylo/PAML/_paml.py
@@ -66,7 +66,7 @@ class Paml(object):
     def print_options(self):
         """Print out all of the options and their current settings."""
         for option in self._options.items():
-            print "%s = %s" % (option[0], option[1])
+            print("%s = %s" % (option[0], option[1]))
 
     def set_options(self, **kwargs):
         """Set the value of an option.

--- a/Bio/Phylo/PAML/codeml.py
+++ b/Bio/Phylo/PAML/codeml.py
@@ -152,9 +152,9 @@ class Codeml(Paml):
                 # control file it is specified as a series of numbers
                 # separated by spaces.
                 NSsites = " ".join([str(site) for site in option[1]])
-                print "%s = %s" % (option[0], NSsites)
+                print("%s = %s" % (option[0], NSsites))
             else:
-                print "%s = %s" % (option[0], option[1])
+                print("%s = %s" % (option[0], option[1]))
 
     def _set_rel_paths(self):
         """Convert all file/directory locations to paths relative to the current working directory.

--- a/Bio/Restriction/PrintFormat.py
+++ b/Bio/Restriction/PrintFormat.py
@@ -115,7 +115,7 @@ class PrintFormat(object):
                 ls.append((k,v))
             else:
                 nc.append(k)
-        print self.make_format(ls, title, nc, s1)
+        print(self.make_format(ls, title, nc, s1))
         return
 
     def make_format(self, cut=[], title='', nc=[], s1=''):

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -475,7 +475,7 @@ class AbstractCut(RestrictionType):
         """RE.all_suppliers -> print all the suppliers of R"""
         supply = [x[0] for x in suppliers_dict.itervalues()]
         supply.sort()
-        print ",\n".join(supply)
+        print(",\n".join(supply))
         return
 
     @classmethod
@@ -1779,7 +1779,7 @@ class Commercially_available(AbstractCut):
         supply = suppliers_dict.items()
         for k,v in supply:
             if k in self.suppl:
-                print v[0]+','
+                print(v[0]+',')
         return
 
     @classmethod
@@ -2033,7 +2033,7 @@ class RestrictionBatch(set):
     def show_codes(self):
         """B.show_codes() -> letter codes for the suppliers"""
         supply = [' = '.join(i) for i in self.suppl_codes().iteritems()]
-        print '\n'.join(supply)
+        print('\n'.join(supply))
         return
 
     def search(self, dna, linear=True):

--- a/Bio/Restriction/_Update/RestrictionCompiler.py
+++ b/Bio/Restriction/_Update/RestrictionCompiler.py
@@ -280,12 +280,12 @@ class newenzyme(object):
         cls.charac = (cls.fst5, cls.fst3, cls.scd5, cls.scd3, cls.site)
         if not target[2] and cls.suppl:
             supp = ', '.join([suppliersdict[s][0] for s in cls.suppl])
-            print 'WARNING : It seems that %s is both commercially available\
+            print('WARNING : It seems that %s is both commercially available\
             \n\tand its characteristics are unknown. \
             \n\tThis seems counter-intuitive.\
             \n\tThere is certainly an error either in ranacompiler or\
             \n\tin this REBASE release.\
-            \n\tThe supplier is : %s.' % (name, supp)
+            \n\tThe supplier is : %s.' % (name, supp))
         return
 
 
@@ -458,14 +458,14 @@ class DictionaryBuilder(object):
                 supplier = suppliersdict[letter]
                 suppliersdict[letter][1].append(name)
         if not classdict or not suppliersdict or not typedict:
-            print 'One of the new dictionaries is empty.'
-            print 'Check the integrity of the emboss file before continuing.'
-            print 'Update aborted.'
+            print('One of the new dictionaries is empty.')
+            print('Check the integrity of the emboss file before continuing.')
+            print('Update aborted.')
             sys.exit()
         #
         #   How many enzymes this time?
         #
-        print '\nThe new database contains %i enzymes.\n' % len(classdict)
+        print('\nThe new database contains %i enzymes.\n' % len(classdict))
         #
         #   the dictionaries are done. Build the file
         #
@@ -484,7 +484,7 @@ class DictionaryBuilder(object):
             results.write("    }\n")
             results.write("rest_dict[%s] = _temp()\n" % repr(name))
             results.write("\n")
-        print 'OK.\n'
+        print('OK.\n')
         print 'Writing the dictionary containing the suppliers data.\t\t',
         results.write('suppliers = {}\n')
         for name in sorted(suppliersdict) :
@@ -495,7 +495,7 @@ class DictionaryBuilder(object):
             results.write("    )\n")
             results.write("suppliers[%s] = _temp()\n" % repr(name))
             results.write("\n")
-        print 'OK.\n'
+        print('OK.\n')
         print 'Writing the dictionary containing the Restriction types.\t',
         results.write('typedict = {}\n')
         for name in sorted(typedict) :
@@ -511,7 +511,7 @@ class DictionaryBuilder(object):
         #one the final "del _temp" to clean up the namespace.
         results.write("del _temp\n")
         results.write("\n")
-        print 'OK.\n'
+        print('OK.\n')
         results.close()
         return
 
@@ -521,14 +521,14 @@ class DictionaryBuilder(object):
         Install the newly created dictionary in the site-packages folder.
 
         May need super user privilege on some architectures."""
-        print '\n ' +'*'*78 + ' \n'
-        print '\n\t\tInstalling Restriction_Dictionary.py'
+        print('\n ' +'*'*78 + ' \n')
+        print('\n\t\tInstalling Restriction_Dictionary.py')
         try:
             import Bio.Restriction.Restriction_Dictionary as rd
         except ImportError:
-            print '\
+            print('\
             \n Unable to locate the previous Restriction_Dictionary.py module\
-            \n Aborting installation.'
+            \n Aborting installation.')
             sys.exit()
         #
         #   first save the old file in Updates
@@ -545,24 +545,24 @@ class DictionaryBuilder(object):
         new = os.path.join(update_folder, 'Restriction_Dictionary.py')
         try:
             execfile(new)
-            print '\
-            \n\tThe new file seems ok. Proceeding with the installation.'
+            print('\
+            \n\tThe new file seems ok. Proceeding with the installation.')
         except SyntaxError:
-            print '\
-            \n The new dictionary file is corrupted. Aborting the installation.'
+            print('\
+            \n The new dictionary file is corrupted. Aborting the installation.')
             return
         try:
             shutil.copyfile(new, old)
-            print'\n\t Everything ok. If you need it a version of the old\
+            print('\n\t Everything ok. If you need it a version of the old\
             \n\t dictionary have been saved in the Updates folder under\
-            \n\t the name Restriction_Dictionary.old.'
-            print '\n ' +'*'*78 + ' \n'
+            \n\t the name Restriction_Dictionary.old.')
+            print('\n ' +'*'*78 + ' \n')
         except IOError:
-            print '\n ' +'*'*78 + ' \n'
-            print '\
+            print('\n ' +'*'*78 + ' \n')
+            print('\
             \n\t WARNING : Impossible to install the new dictionary.\
             \n\t Are you sure you have write permission to the folder :\n\
-            \n\t %s ?\n\n' % os.path.split(old)[0]
+            \n\t %s ?\n\n' % os.path.split(old)[0])
             return self.no_install()
         return
 
@@ -570,14 +570,14 @@ class DictionaryBuilder(object):
         """BD.no_install() -> None.
 
         build the new dictionary but do not install the dictionary."""
-        print '\n ' +'*'*78 + '\n'
+        print('\n ' +'*'*78 + '\n')
         #update = config.updatefolder
         try:
             import Bio.Restriction.Restriction_Dictionary as rd
         except ImportError:
-            print '\
+            print('\
             \n Unable to locate the previous Restriction_Dictionary.py module\
-            \n Aborting installation.'
+            \n Aborting installation.')
             sys.exit()
         #
         #   first save the old file in Updates
@@ -587,7 +587,7 @@ class DictionaryBuilder(object):
         update = os.getcwd()
         shutil.copyfile(old, os.path.join(update, 'Restriction_Dictionary.old'))
         places = update, os.path.split(Bio.Restriction.Restriction.__file__)[0]
-        print "\t\tCompilation of the new dictionary : OK.\
+        print("\t\tCompilation of the new dictionary : OK.\
         \n\t\tInstallation : No.\n\
         \n You will find the newly created 'Restriction_Dictionary.py' file\
         \n in the folder : \n\
@@ -596,8 +596,8 @@ class DictionaryBuilder(object):
         \n the other Restriction libraries.\n\
         \n note : \
         \n This folder should be :\n\
-        \n\t%s\n" % places
-        print '\n ' +'*'*78 + '\n'
+        \n\t%s\n" % places)
+        print('\n ' +'*'*78 + '\n')
         return
 
     def lastrebasefile(self):
@@ -624,22 +624,22 @@ class DictionaryBuilder(object):
             #
             #   nothing to be done
             #
-            print '\n Using the files : %s'% ', '.join(emboss_now)
+            print('\n Using the files : %s'% ', '.join(emboss_now))
             return tuple([open(os.path.join(base, n)) for n in emboss_now])
         else:
             #
             #   may be download the files.
             #
-            print '\n The rebase files are more than one month old.\
-            \n Would you like to update them before proceeding?(y/n)'
+            print('\n The rebase files are more than one month old.\
+            \n Would you like to update them before proceeding?(y/n)')
             r = raw_input(' update [n] >>> ')
             if r in ['y', 'yes', 'Y', 'Yes']:
                 updt = RebaseUpdate(self.rebase_pass, self.proxy)
                 updt.openRebase()
                 updt.getfiles()
                 updt.close()
-                print '\n Update complete. Creating the dictionaries.\n'
-                print '\n Using the files : %s'% ', '.join(emboss_now)
+                print('\n Update complete. Creating the dictionaries.\n')
+                print('\n Using the files : %s'% ', '.join(emboss_now))
                 return tuple([open(os.path.join(base, n)) for n in emboss_now])
             else:
                 #
@@ -657,7 +657,7 @@ class DictionaryBuilder(object):
                             pass
                         raise NotFoundError
                     except NotFoundError:
-                        print "\nNo %s file found. Upgrade is impossible.\n"%name
+                        print("\nNo %s file found. Upgrade is impossible.\n"%name)
                         sys.exit()
                     continue
                 pass
@@ -691,7 +691,7 @@ class DictionaryBuilder(object):
                         strmess += '\t%s.\n'%file
                     else:
                         raise ValueError
-                print strmess
+                print(strmess)
                 emboss_e = open(os.path.join(base, 'emboss_e.%s'%number),'r')
                 emboss_r = open(os.path.join(base, 'emboss_r.%s'%number),'r')
                 emboss_s = open(os.path.join(base, 'emboss_s.%s'%number),'r')
@@ -744,10 +744,10 @@ class DictionaryBuilder(object):
             #   Should HaeIV become commercially available or other similar
             #   new enzymes be added, this might be modified.
             #
-            print '\
+            print('\
             \nWARNING : %s cut twice with different overhang length each time.\
             \n\tUnable to deal with this behaviour. \
-            \n\tThis enzyme will not be included in the database. Sorry.' %name
+            \n\tThis enzyme will not be included in the database. Sorry.' %name)
             print '\tChecking :',
             raise OverhangError
         if 0 <= fst5 <= size and 0 <= fst3 <= size:
@@ -956,9 +956,9 @@ class DictionaryBuilder(object):
                 except OverhangError:   # overhang error
                     n = name            # do not include the enzyme
                     if not bl[2]:
-                        print 'Anyway, %s is not commercially available.\n' %n
+                        print('Anyway, %s is not commercially available.\n' %n)
                     else:
-                        print 'Unfortunately, %s is commercially available.\n'%n
+                        print('Unfortunately, %s is commercially available.\n'%n)
 
                     continue
                 #Hyphens can't be used as a Python name, nor as a

--- a/Bio/Restriction/_Update/Update.py
+++ b/Bio/Restriction/_Update/Update.py
@@ -42,7 +42,7 @@ class RebaseUpdate(FancyURLopener):
         return (Rebase_name, Rebase_password)
 
     def openRebase(self, name = ftp_Rebase):
-        print '\n Please wait, trying to connect to Rebase\n'
+        print('\n Please wait, trying to connect to Rebase\n')
         try:
             self.open(name)
         except:
@@ -86,30 +86,30 @@ class RebaseUpdate(FancyURLopener):
 class FtpNameError(ValueError):
 
     def __init__(self, which_server):
-        print " In order to connect to %s ftp server, you must provide a name.\
-        \n Please edit Bio.Restriction.RanaConfig\n" % which_server
+        print(" In order to connect to %s ftp server, you must provide a name.\
+        \n Please edit Bio.Restriction.RanaConfig\n" % which_server)
         sys.exit()
 
 
 class FtpPasswordError(ValueError):
 
     def __init__(self, which_server):
-        print "\n\
+        print("\n\
         \n In order to connect to %s ftp server, you must provide a password.\
         \n Use the --e-mail switch to enter your e-mail address.\
-        \n\n" % which_server
+        \n\n" % which_server)
         sys.exit()
 
 
 class ConnectionError(IOError):
 
     def __init__(self, which_server):
-        print '\
+        print('\
         \n Unable to connect to the %s ftp server, make sure your computer\
         \n is connected to the internet and that you have correctly configured\
         \n the ftp proxy.\
         \n Use the --proxy switch to enter the address of your proxy\
-        \n' % which_server
+        \n' % which_server)
         sys.exit()
 
 

--- a/Bio/SCOP/__init__.py
+++ b/Bio/SCOP/__init__.py
@@ -235,7 +235,7 @@ class Scop(object):
                 records = Hie.parse(hie_handle)
                 for record in records:
                     if record.sunid not in sunidDict:
-                        print record.sunid
+                        print(record.sunid)
 
                     n = sunidDict[record.sunid]
 

--- a/Bio/SVDSuperimposer/SVDSuperimposer.py
+++ b/Bio/SVDSuperimposer/SVDSuperimposer.py
@@ -154,8 +154,8 @@ if __name__ == "__main__":
     # same thing
     y_on_x2 = sup.get_transformed()
 
-    print y_on_x1
+    print(y_on_x1)
     print
-    print y_on_x2
+    print(y_on_x2)
     print
-    print "%.2f" % rms
+    print("%.2f" % rms)

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2117,13 +2117,13 @@ def reverse_complement(sequence):
 def _test():
     """Run the Bio.Seq module's doctests (PRIVATE)."""
     if sys.version_info[0:2] == (3, 1):
-        print "Not running Bio.Seq doctest on Python 3.1"
-        print "See http://bugs.python.org/issue7490"
+        print("Not running Bio.Seq doctest on Python 3.1")
+        print("See http://bugs.python.org/issue7490")
     else:
-        print "Running doctests..."
+        print("Running doctests...")
         import doctest
         doctest.testmod(optionflags=doctest.IGNORE_EXCEPTION_DETAIL)
-        print "Done"
+        print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -198,7 +198,7 @@ class FastaWriter(SequentialSequenceWriter):
             self.handle.write(data + "\n")
 
 if __name__ == "__main__":
-    print "Running quick self test"
+    print("Running quick self test")
 
     import os
     from Bio.Alphabet import generic_protein, generic_nucleotide
@@ -217,31 +217,31 @@ if __name__ == "__main__":
     def print_record(record):
         #See also bug 2057
         #http://bugzilla.open-bio.org/show_bug.cgi?id=2057
-        print "ID:" + record.id
-        print "Name:" + record.name
-        print "Descr:" + record.description
-        print record.seq
+        print("ID:" + record.id)
+        print("Name:" + record.name)
+        print("Descr:" + record.description)
+        print(record.seq)
         for feature in record.annotations:
-            print '/%s=%s' % (feature, record.annotations[feature])
+            print('/%s=%s' % (feature, record.annotations[feature]))
         if record.dbxrefs:
-            print "Database cross references:"
+            print("Database cross references:")
             for x in record.dbxrefs:
-                print " - %s" % x
+                print(" - %s" % x)
 
     if os.path.isfile(fna_filename):
-        print "--------"
-        print "FastaIterator (single sequence)"
+        print("--------")
+        print("FastaIterator (single sequence)")
         iterator = FastaIterator(open(fna_filename, "r"), alphabet=generic_nucleotide, title2ids=genbank_name_function)
         count = 0
         for record in iterator:
             count += 1
             print_record(record)
         assert count == 1
-        print str(record.__class__)
+        print(str(record.__class__))
 
     if os.path.isfile(faa_filename):
-        print "--------"
-        print "FastaIterator (multiple sequences)"
+        print("--------")
+        print("FastaIterator (multiple sequences)")
         iterator = FastaIterator(open(faa_filename, "r"), alphabet=generic_protein, title2ids=genbank_name_function)
         count = 0
         for record in iterator:
@@ -249,11 +249,11 @@ if __name__ == "__main__":
             print_record(record)
             break
         assert count > 0
-        print str(record.__class__)
+        print(str(record.__class__))
 
     from cStringIO import StringIO
-    print "--------"
-    print "FastaIterator (empty input file)"
+    print("--------")
+    print("FastaIterator (empty input file)")
     #Just to make sure no errors happen
     iterator = FastaIterator(StringIO(""))
     count = 0
@@ -261,4 +261,4 @@ if __name__ == "__main__":
         count += 1
     assert count == 0
 
-    print "Done"
+    print("Done")

--- a/Bio/SeqIO/IgIO.py
+++ b/Bio/SeqIO/IgIO.py
@@ -83,7 +83,7 @@ def IgIterator(handle, alphabet=single_letter_alphabet):
     assert not line
 
 if __name__ == "__main__":
-    print "Running quick self test"
+    print("Running quick self test")
 
     import os
     path = "../../Tests/IntelliGenetics/"
@@ -91,12 +91,12 @@ if __name__ == "__main__":
         for filename in os.listdir(path):
             if os.path.splitext(filename)[-1] == ".txt":
                 print
-                print filename
-                print "-" * len(filename)
+                print(filename)
+                print("-" * len(filename))
                 handle = open(os.path.join(path, filename))
                 for record in IgIterator(handle):
                     print record.id, len(record)
                 handle.close()
-        print "Done"
+        print("Done")
     else:
-        print "Could not find input files"
+        print("Could not find input files")

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -1114,7 +1114,7 @@ class ImgtWriter(EmblWriter):
     FEATURE_HEADER = "FH   Key                 Location/Qualifiers\n"
 
 if __name__ == "__main__":
-    print "Quick self test"
+    print("Quick self test")
     import os
     from StringIO import StringIO
 
@@ -1212,7 +1212,7 @@ if __name__ == "__main__":
         try:
             EmblWriter(handle).write_file(records)
         except ValueError as err:
-            print err
+            print(err)
             return
         handle.seek(0)
 
@@ -1222,7 +1222,7 @@ if __name__ == "__main__":
     for filename in os.listdir("../../Tests/GenBank"):
         if not filename.endswith(".gbk") and not filename.endswith(".gb"):
             continue
-        print filename
+        print(filename)
 
         handle = open("../../Tests/GenBank/%s" % filename)
         records = list(GenBankIterator(handle))
@@ -1234,7 +1234,7 @@ if __name__ == "__main__":
     for filename in os.listdir("../../Tests/EMBL"):
         if not filename.endswith(".embl"):
             continue
-        print filename
+        print(filename)
 
         handle = open("../../Tests/EMBL/%s" % filename)
         records = list(EmblIterator(handle))
@@ -1247,7 +1247,7 @@ if __name__ == "__main__":
     for filename in os.listdir("../../Tests/SwissProt"):
         if not filename.startswith("sp"):
             continue
-        print filename
+        print(filename)
 
         handle = open("../../Tests/SwissProt/%s" % filename)
         records = list(SeqIO.parse(handle, "swiss"))

--- a/Bio/SeqIO/PirIO.py
+++ b/Bio/SeqIO/PirIO.py
@@ -167,15 +167,15 @@ def PirIterator(handle):
     assert False, "Should not reach this line"
 
 if __name__ == "__main__":
-    print "Running quick self test"
+    print("Running quick self test")
 
     import os
 
     for name in ["clustalw", "DMA_nuc", "DMB_prot", "B_nuc", "Cw_prot"]:
-        print name
+        print(name)
         filename = "../../Tests/NBRF/%s.pir" % name
         if not os.path.isfile(filename):
-            print "Missing %s" % filename
+            print("Missing %s" % filename)
             continue
 
         records = list(PirIterator(open(filename)))
@@ -185,4 +185,4 @@ if __name__ == "__main__":
             parts = record.description.split()
             if "bases," in parts:
                 assert len(record) == int(parts[parts.index("bases,") - 1])
-        print "Could read %s (%i records)" % (name, count)
+        print("Could read %s (%i records)" % (name, count))

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -400,7 +400,7 @@ class SeqXmlWriter(SequentialSequenceWriter):
                     self.xml_generator.endElement("property")
 
 if __name__ == "__main__":
-    print "Running quick self test"
+    print("Running quick self test")
 
     from Bio import SeqIO
     import sys

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -1180,7 +1180,7 @@ class SffWriter(SequenceWriter):
 
 
 if __name__ == "__main__":
-    print "Running quick self test"
+    print("Running quick self test")
     filename = "../../Tests/Roche/E3MFGYR02_random_10_reads.sff"
     metadata = ReadRocheXmlManifest(open(filename, "rb"))
     index1 = sorted(_sff_read_roche_index(open(filename, "rb")))
@@ -1247,7 +1247,7 @@ if __name__ == "__main__":
 
     sff_trim = list(SffIterator(open(filename, "rb"), trim=True))
 
-    print ReadRocheXmlManifest(open(filename, "rb"))
+    print(ReadRocheXmlManifest(open(filename, "rb")))
 
     from Bio import SeqIO
     filename = "../../Tests/Roche/E3MFGYR02_random_10_reads_no_trim.fasta"
@@ -1263,7 +1263,7 @@ if __name__ == "__main__":
     for s, sT, f, q, fT, qT in zip(sff, sff_trim, fasta_no_trim,
                                    qual_no_trim, fasta_trim, qual_trim):
         #print
-        print s.id
+        print(s.id)
         #print s.seq
         #print s.letter_annotations["phred_quality"]
 
@@ -1277,12 +1277,12 @@ if __name__ == "__main__":
         assert sT.letter_annotations[
             "phred_quality"] == qT.letter_annotations["phred_quality"]
 
-    print "Writing with a list of SeqRecords..."
+    print("Writing with a list of SeqRecords...")
     handle = StringIO()
     w = SffWriter(handle, xml=metadata)
     w.write_file(sff)  # list
     data = handle.getvalue()
-    print "And again with an iterator..."
+    print("And again with an iterator...")
     handle = StringIO()
     w = SffWriter(handle, xml=metadata)
     w.write_file(iter(sff))
@@ -1295,15 +1295,15 @@ if __name__ == "__main__":
     del data
     handle.close()
 
-    print "-" * 50
+    print("-" * 50)
     filename = "../../Tests/Roche/greek.sff"
     for record in SffIterator(open(filename, "rb")):
-        print record.id
+        print(record.id)
     index1 = sorted(_sff_read_roche_index(open(filename, "rb")))
     index2 = sorted(_sff_do_slow_index(open(filename, "rb")))
     assert index1 == index2
     try:
-        print ReadRocheXmlManifest(open(filename, "rb"))
+        print(ReadRocheXmlManifest(open(filename, "rb")))
         assert False, "Should fail!"
     except ValueError:
         pass
@@ -1313,11 +1313,11 @@ if __name__ == "__main__":
         pass
     try:
         for record in SffIterator(handle):
-            print record.id
+            print(record.id)
         assert False, "Should have failed"
     except ValueError as err:
-        print "Checking what happens on re-reading a handle:"
-        print err
+        print("Checking what happens on re-reading a handle:")
+        print(err)
 
     """
     #Ugly code to make test files...
@@ -1433,4 +1433,4 @@ if __name__ == "__main__":
         open("../../Tests/Roche/E3MFGYR02_alt_index_at_end.sff", "rb")))
     """
 
-    print "Done"
+    print("Done")

--- a/Bio/SeqIO/SwissIO.py
+++ b/Bio/SeqIO/SwissIO.py
@@ -142,23 +142,23 @@ def SwissIterator(handle):
         yield record
 
 if __name__ == "__main__":
-    print "Quick self test..."
+    print("Quick self test...")
 
     example_filename = "../../Tests/SwissProt/sp008"
 
     import os
     if not os.path.isfile(example_filename):
-        print "Missing test file %s" % example_filename
+        print("Missing test file %s" % example_filename)
     else:
         #Try parsing it!
         handle = open(example_filename)
         records = SwissIterator(handle)
         for record in records:
-            print record.name
-            print record.id
-            print record.annotations['keywords']
-            print repr(record.annotations['organism'])
-            print str(record.seq)[:20] + "..."
+            print(record.name)
+            print(record.id)
+            print(record.annotations['keywords'])
+            print(repr(record.annotations['organism']))
+            print(str(record.seq)[:20] + "...")
             for f in record.features:
-                print f
+                print(f)
         handle.close()

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -93,7 +93,7 @@ class TabWriter(SequentialSequenceWriter):
 
 
 if __name__ == "__main__":
-    print "Running quick self test"
+    print("Running quick self test")
     from StringIO import StringIO
 
     #This example has a trailing blank line which should be ignored
@@ -109,4 +109,4 @@ if __name__ == "__main__":
         #Good!
         pass
 
-    print "Done"
+    print("Done")

--- a/Bio/SeqUtils/CheckSum.py
+++ b/Bio/SeqUtils/CheckSum.py
@@ -115,7 +115,7 @@ def seguid(seq):
 
 
 if __name__ == "__main__":
-    print "Quick self test"
+    print("Quick self test")
 
     str_light_chain_one = "QSALTQPASVSGSPGQSITISCTGTSSDVGSYNLVSWYQQHPGK" \
                     + "APKLMIYEGSKRPSGVSNRFSGSKSGNTASLTISGLQAEDEADY" \
@@ -131,4 +131,4 @@ if __name__ == "__main__":
     assert 'BpBeDdcNUYNsdk46JoJdw7Pd3BI' == seguid(str_light_chain_one)
     assert 'X5XEaayob1nZLOc7eVT9qyczarY' == seguid(str_light_chain_two)
 
-    print "Done"
+    print("Done")

--- a/Bio/SeqUtils/CodonUsage.py
+++ b/Bio/SeqUtils/CodonUsage.py
@@ -152,4 +152,4 @@ class CodonAdaptationIndex(object):
     def print_index(self):
         """Prints out the index used."""
         for i in sorted(self.index):
-            print "%s\t%.3f" % (i, self.index[i])
+            print("%s\t%.3f" % (i, self.index[i]))

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -178,9 +178,9 @@ def Tm_staluc(s, dnac=50, saltc=50, rna=0):
 def _test():
     """Run the module's doctests (PRIVATE)."""
     import doctest
-    print "Running doctests..."
+    print("Running doctests...")
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -434,21 +434,21 @@ def _test():
     import os
     import doctest
     if os.path.isdir(os.path.join("..", "Tests")):
-        print "Running doctests..."
+        print("Running doctests...")
         cur_dir = os.path.abspath(os.curdir)
         os.chdir(os.path.join("..", "Tests"))
         doctest.testmod()
         os.chdir(cur_dir)
         del cur_dir
-        print "Done"
+        print("Done")
     elif os.path.isdir(os.path.join("Tests")):
-        print "Running doctests..."
+        print("Running doctests...")
         cur_dir = os.path.abspath(os.curdir)
         os.chdir(os.path.join("Tests"))
         doctest.testmod()
         os.chdir(cur_dir)
         del cur_dir
-        print "Done"
+        print("Done")
 
 
 if __name__ == "__main__":

--- a/Bio/Sequencing/Applications/_Novoalign.py
+++ b/Bio/Sequencing/Applications/_Novoalign.py
@@ -176,10 +176,10 @@ class NovoalignCommandline(AbstractCommandline):
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running Novoalign doctests..."
+    print("Running Novoalign doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/Sequencing/Applications/_bwa.py
+++ b/Bio/Sequencing/Applications/_bwa.py
@@ -372,10 +372,10 @@ class BwaBwaswCommandline(AbstractCommandline):
 
 def _test():
         """Run the module's doctests (PRIVATE)."""
-        print "Running modules doctests..."
+        print("Running modules doctests...")
         import doctest
         doctest.testmod()
-        print "Done"
+        print("Done")
 
 
 if __name__ == "__main__":

--- a/Bio/Statistics/lowess.py
+++ b/Bio/Statistics/lowess.py
@@ -95,10 +95,10 @@ def lowess(x, y, f=2. / 3., iter=3):
 
 def _test():
     """Run the Bio.Statistics.lowess module's doctests."""
-    print "Running doctests..."
+    print("Running doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Bio/SwissProt/KeyWList.py
+++ b/Bio/SwissProt/KeyWList.py
@@ -75,7 +75,7 @@ def parse(handle):
             elif key in ("DE", "SY", "GO", "HI", "WW"):
                 record[key].append(value)
             else:
-                print "Ignoring: %s" % line.strip()
+                print("Ignoring: %s" % line.strip())
     # Read the footer and throw it away
     for line in handle:
         pass

--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -543,22 +543,22 @@ def _read_ft(record, line):
 
 
 if __name__ == "__main__":
-    print "Quick self test..."
+    print("Quick self test...")
 
     example_filename = "../../Tests/SwissProt/sp008"
 
     import os
     if not os.path.isfile(example_filename):
-        print "Missing test file %s" % example_filename
+        print("Missing test file %s" % example_filename)
     else:
         #Try parsing it!
 
         handle = open(example_filename)
         records = parse(handle)
         for record in records:
-            print record.entry_name
-            print ",".join(record.accessions)
-            print record.keywords
-            print repr(record.organism)
-            print record.sequence[:20] + "..."
+            print(record.entry_name)
+            print(",".join(record.accessions))
+            print(record.keywords)
+            print(repr(record.organism))
+            print(record.sequence[:20] + "...")
         handle.close()

--- a/Bio/UniGene/UniGene.py
+++ b/Bio/UniGene/UniGene.py
@@ -192,20 +192,20 @@ class UniGeneParser( sgmllib.SGMLParser ):
             indent = indent + '    '
         if isinstance(item, str):
             if( item != '' ):
-                print '%s%s' % ( indent, item )
+                print('%s%s' % ( indent, item ))
         elif isinstance(item, list):
             for subitem in item:
                 self.print_item( subitem, level + 1 )
         elif( isinstance( item, UserDict.UserDict ) ):
             for subitem in item:
-                print '%skey is %s' % ( indent, subitem )
+                print('%skey is %s' % ( indent, subitem ))
                 self.print_item( item[ subitem ], level + 1 )
         else:
-            print item
+            print(item)
 
     def print_tags( self ):
         for key in self.queue:
-            print 'key %s' % key
+            print('key %s' % key)
             self.print_item( self.queue[ key ] )
 
 

--- a/Bio/Wise/__init__.py
+++ b/Bio/Wise/__init__.py
@@ -74,12 +74,12 @@ def align(cmdline, pair, kbyte=None, force_type=None, dry_run=False, quiet=False
     input_files = tempfile.NamedTemporaryFile(mode="w"), tempfile.NamedTemporaryFile(mode="w")
 
     if dry_run:
-        print _build_align_cmdline(cmdline,
+        print(_build_align_cmdline(cmdline,
                                    pair,
                                    output_file.name,
                                    kbyte,
                                    force_type,
-                                   quiet)
+                                   quiet))
         return
 
     for filename, input_file in zip(pair, input_files):

--- a/Bio/Wise/dnal.py
+++ b/Bio/Wise/dnal.py
@@ -124,11 +124,11 @@ def align(pair, match=_SCORE_MATCH, mismatch=_SCORE_MISMATCH, gap=_SCORE_GAP_STA
 def main():
     import sys
     stats = align(sys.argv[1:3])
-    print "\n".join(["%s: %s" % (attr, getattr(stats, attr))
+    print("\n".join(["%s: %s" % (attr, getattr(stats, attr))
                      for attr in
-                     ("matches", "mismatches", "gaps", "extensions")])
-    print "identity_fraction: %s" % stats.identity_fraction()
-    print "coords: %s" % stats.coords
+                     ("matches", "mismatches", "gaps", "extensions")]))
+    print("identity_fraction: %s" % stats.identity_fraction())
+    print("coords: %s" % stats.coords)
 
 
 def _test(*args, **keywds):

--- a/Bio/Wise/psw.py
+++ b/Bio/Wise/psw.py
@@ -137,7 +137,7 @@ def align(pair,
 
 
 def main():
-    print align(sys.argv[1:3])
+    print(align(sys.argv[1:3]))
 
 
 def _test(*args, **keywds):

--- a/Bio/_utils.py
+++ b/Bio/_utils.py
@@ -109,14 +109,14 @@ def run_doctest(target_dir=None, *args, **kwargs):
 
     cur_dir = os.path.abspath(os.curdir)
 
-    print "Runing doctests..."
+    print("Runing doctests...")
     try:
         os.chdir(find_test_dir(target_dir))
         doctest.testmod(*args, **kwargs)
     finally:
         # and revert back to initial directory
         os.chdir(cur_dir)
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     run_doctest()

--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -787,19 +787,19 @@ class BgzfWriter(object):
 if __name__ == "__main__":
     import sys
     if len(sys.argv) > 1:
-        print "Call this with no arguments and pipe uncompressed data in on stdin"
-        print "and it will produce BGZF compressed data on stdout. e.g."
+        print("Call this with no arguments and pipe uncompressed data in on stdin")
+        print("and it will produce BGZF compressed data on stdout. e.g.")
         print
-        print "./bgzf.py < example.fastq > example.fastq.bgz"
+        print("./bgzf.py < example.fastq > example.fastq.bgz")
         print
-        print "The extension convention of *.bgz is to distinugish these from *.gz"
-        print "used for standard gzipped files without the block structure of BGZF."
-        print "You can use the standard gunzip command to decompress BGZF files,"
-        print "if it complains about the extension try something like this:"
+        print("The extension convention of *.bgz is to distinugish these from *.gz")
+        print("used for standard gzipped files without the block structure of BGZF.")
+        print("You can use the standard gunzip command to decompress BGZF files,")
+        print("if it complains about the extension try something like this:")
         print
-        print "cat example.fastq.bgz | gunzip > example.fastq"
+        print("cat example.fastq.bgz | gunzip > example.fastq")
         print
-        print "See also the tool bgzip that comes with samtools"
+        print("See also the tool bgzip that comes with samtools")
         sys.exit(0)
 
     sys.stderr.write("Producing BGZF output from stdin...\n")

--- a/Bio/motifs/applications/_alignace.py
+++ b/Bio/motifs/applications/_alignace.py
@@ -134,10 +134,10 @@ class CompareAceCommandline(AbstractCommandline):
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running alignace doctests..."
+    print("Running alignace doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 
 if __name__ == "__main__":

--- a/Bio/motifs/applications/_xxmotif.py
+++ b/Bio/motifs/applications/_xxmotif.py
@@ -172,10 +172,10 @@ class XXmotifCommandline(AbstractCommandline):
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running XXmotif doctests..."
+    print("Running XXmotif doctests...")
     import doctest
     doctest.testmod()
-    print "Done"
+    print("Done")
 
 
 if __name__ == "__main__":

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -855,8 +855,8 @@ def print_matrix(matrix):
     ndigits = map(max, matrixT)
     for i in range(len(matrix)):
         #Using string formatting trick to add leading spaces,
-        print " ".join("%*s " % (ndigits[j], matrix[i][j])
-                       for j in range(len(matrix[i])))
+        print(" ".join("%*s " % (ndigits[j], matrix[i][j])
+                       for j in range(len(matrix[i]))))
 
 
 def format_alignment(align1, align2, score, begin, end):
@@ -883,10 +883,10 @@ except ImportError:
 
 def _test():
     """Run the module's doctests (PRIVATE)."""
-    print "Running doctests..."
+    print("Running doctests...")
     import doctest
     doctest.testmod(optionflags=doctest.IGNORE_EXCEPTION_DETAIL)
-    print "Done"
+    print("Done")
 
 if __name__ == "__main__":
     _test()

--- a/Doc/examples/ACT_example.py
+++ b/Doc/examples/ACT_example.py
@@ -22,7 +22,7 @@ file_a_vs_b = "af063097_v_b132222.crunch"
 
 for f in [file_a, file_b, file_a_vs_b]:
     if not os.path.isfile(os.path.join(input_folder, f)):
-        print "Missing input file %s.fna" % f
+        print("Missing input file %s.fna" % f)
         sys.exit(1)
 
 #Only doing a_vs_b here, could also have b_vs_c and c_vs_d etc
@@ -46,7 +46,7 @@ for f, format in genomes:
                                      greytrack=True, greytrack_labels=0)
     feature_sets[f] = tracks[f].new_set()
 
-print "Drawing matches..."
+print("Drawing matches...")
 for i, crunch_file in enumerate(comparisons):
     q = genomes[i+1][0]  # query file
     s = genomes[i][0]  # subject file
@@ -96,7 +96,7 @@ for i, crunch_file in enumerate(comparisons):
         #Note ACT puts long hits at the back, and colours by hit score
     handle.close()
 
-print "Drawing CDS features..."
+print("Drawing CDS features...")
 for f, format in genomes:
     record = records[f]
     feature_set = feature_sets[f]

--- a/Doc/examples/clustal_run.py
+++ b/Doc/examples/clustal_run.py
@@ -28,7 +28,7 @@ assert return_code == 0, "Calling ClustalW failed"
 alignment = AlignIO.read("test.aln", "clustal",
                          alphabet=Gapped(IUPAC.unambiguous_dna))
 
-print alignment
+print(alignment)
 
 print 'first description:', alignment[0].description
 print 'first sequence:', alignment[0].seq
@@ -36,7 +36,7 @@ print 'first sequence:', alignment[0].seq
 # get the length of the alignment
 print 'length', alignment.get_alignment_length()
 
-print alignment
+print(alignment)
 
 # print out interesting information about the alignment
 summary_align = AlignInfo.SummaryInfo(alignment)
@@ -47,7 +47,7 @@ print 'consensus', consensus
 my_pssm = summary_align.pos_specific_score_matrix(consensus,
                                                   chars_to_ignore=['N'])
 
-print my_pssm
+print(my_pssm)
 
 expect_freq = {
     'A': .3,

--- a/Doc/examples/fasta_iterator.py
+++ b/Doc/examples/fasta_iterator.py
@@ -18,7 +18,7 @@ def extract_organisms(file_to_parse, format):
     return all_species
 
 if __name__ == "__main__":
-    print "Using Bio.SeqIO on a FASTA file"
+    print("Using Bio.SeqIO on a FASTA file")
     all_species = extract_organisms("ls_orchid.fasta", "fasta")
     print "number of species:", len(all_species)
     print 'species names:', all_species
@@ -55,7 +55,7 @@ def extract_organisms(file_to_parse):
     return all_species
 
 if __name__ == "__main__":
-    print "Using Bio.Fasta"
+    print("Using Bio.Fasta")
     all_species = extract_organisms("ls_orchid.fasta")
     print "number of species:", len(all_species)
     print 'species names:', all_species

--- a/Doc/examples/getgene.py
+++ b/Doc/examples/getgene.py
@@ -261,8 +261,8 @@ class DB_Index:
 
 def help(exit=0):
     name = os.path.basename(sys.argv[0])
-    print 'Usage: %s <db> <gene ID>' % name
-    print '  or   %s --index <db.dat>' % name
+    print('Usage: %s <db> <gene ID>' % name)
+    print('  or   %s --index <db.dat>' % name)
     if exit:
         sys.exit(0)
 
@@ -303,4 +303,4 @@ if __name__ == '__main__':
     db_index.Open(dbfile)
     for id in ids:
         #print db_index.Get(id)
-        print func(id)
+        print(func(id))

--- a/Doc/examples/local_blast.py
+++ b/Doc/examples/local_blast.py
@@ -16,7 +16,7 @@ my_blast_file = os.path.join(os.getcwd(), 'at-est', 'test_blast',
                              'sorghum_est-test.fasta')
 my_blast_exe = os.path.join(os.getcwd(), 'blast', 'blastall')
 
-print 'Running blastall...'
+print('Running blastall...')
 blast_out, error_info = NCBIStandalone.blastall(my_blast_exe, 'blastn',
                                                 my_blast_db, my_blast_file)
 
@@ -35,7 +35,7 @@ while 1:
     for alignment in b_record.alignments:
         for hsp in alignment.hsps:
             if hsp.expect < E_VALUE_THRESH:
-                print '****Alignment****'
+                print('****Alignment****')
                 print 'sequence:', alignment.title
                 print 'length:', alignment.length
                 print 'e value:', hsp.expect
@@ -45,6 +45,6 @@ while 1:
                 else:
                     dots = ''
 
-                print hsp.query[0:75] + dots
-                print hsp.match[0:75] + dots
-                print hsp.sbjct[0:75] + dots
+                print(hsp.query[0:75] + dots)
+                print(hsp.match[0:75] + dots)
+                print(hsp.sbjct[0:75] + dots)

--- a/Doc/examples/make_subsmat.py
+++ b/Doc/examples/make_subsmat.py
@@ -22,7 +22,7 @@ replace_info = summary_align.replacement_dictionary(["G", "A", "V", "L", "I",
 
 my_arm = SubsMat.SeqMat(replace_info)
 
-print replace_info
+print(replace_info)
 
 my_lom = SubsMat.make_log_odds_matrix(my_arm)
 

--- a/Doc/examples/www_blast.py
+++ b/Doc/examples/www_blast.py
@@ -17,7 +17,7 @@ f_iterator = Fasta.Iterator(file_for_blast)
 
 f_record = f_iterator.next()
 
-print 'Doing the BLAST and retrieving the results...'
+print('Doing the BLAST and retrieving the results...')
 result_handle = NCBIWWW.qblast('blastn', 'nr', f_record)
 
 # save the results for later, in case we want to look at it
@@ -26,7 +26,7 @@ blast_results = result_handle.read()
 save_file.write(blast_results)
 save_file.close()
 
-print 'Parsing the results and extracting info...'
+print('Parsing the results and extracting info...')
 b_parser = NCBIWWW.BlastParser()
 
 # option 1 -- parse the string directly
@@ -42,10 +42,10 @@ E_VALUE_THRESH = 0.1
 for alignment in b_record.alignments:
     for hsp in alignment.hsps:
         if hsp.expect < E_VALUE_THRESH:
-            print '****Alignment****'
+            print('****Alignment****')
             print 'sequence:', alignment.title
             print 'length:', alignment.length
             print 'e value:', hsp.expect
-            print hsp.query[0:75] + '...'
-            print hsp.match[0:75] + '...'
-            print hsp.sbjct[0:75] + '...'
+            print(hsp.query[0:75] + '...')
+            print(hsp.match[0:75] + '...')
+            print(hsp.sbjct[0:75] + '...')

--- a/Scripts/GenBank/check_output.py
+++ b/Scripts/GenBank/check_output.py
@@ -50,7 +50,7 @@ def do_comparison(good_record, test_record):
 def write_format(file):
     record_parser = GenBank.RecordParser(debug_level=2)
 
-    print "Testing GenBank writing for %s..." % os.path.basename(file)
+    print("Testing GenBank writing for %s..." % os.path.basename(file))
     # be able to handle gzipped files
     if '.gz' in file:
         cur_handle = gzip.open(file, "r")
@@ -75,15 +75,15 @@ def write_format(file):
         try:
             do_comparison(compare_record, output_record)
         except AssertionError as msg:
-            print "\tTesting for %s" % cur_record.version
-            print msg
+            print("\tTesting for %s" % cur_record.version)
+            print(msg)
 
     cur_handle.close()
     compare_handle.close()
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print __doc__
+        print(__doc__)
         sys.exit()
 
     write_format(sys.argv[1])

--- a/Scripts/GenBank/check_output_simple.py
+++ b/Scripts/GenBank/check_output_simple.py
@@ -16,7 +16,7 @@ import sys
 from Bio import GenBank
 
 if len(sys.argv) != 2:
-    print "Usage ./check_output.py <GenBank file to parse>"
+    print("Usage ./check_output.py <GenBank file to parse>")
     sys.exit()
 
 parser = GenBank.FeatureParser(debug_level=2)
@@ -31,22 +31,22 @@ while 1:
     if not(cur_record):
         break
 
-    print "***Record"
+    print("***Record")
     print "Seq:", cur_record.seq
     print "Id:", cur_record.id
     print "Name:", cur_record.name
     print "Description", cur_record.description
-    print "Annotations****"
+    print("Annotations****")
     for annotation_key in cur_record.annotations.keys():
         if annotation_key != 'references':
-            print "Key: %s" % annotation_key
-            print "Value: %s" % cur_record.annotations[annotation_key]
+            print("Key: %s" % annotation_key)
+            print("Value: %s" % cur_record.annotations[annotation_key])
         else:
-            print "References*"
+            print("References*")
             for reference in cur_record.annotations[annotation_key]:
-                print str(reference)
-    print "Feaures"
+                print(str(reference))
+    print("Feaures")
     for feature in cur_record.features:
-        print feature
+        print(feature)
 
 handle.close()

--- a/Scripts/GenBank/find_parser_problems.py
+++ b/Scripts/GenBank/find_parser_problems.py
@@ -16,7 +16,7 @@ from Bio import GenBank
 verbose = 0
 
 if len(sys.argv) != 2:
-    print "Usage ./find_parser_problems <GenBank file to parse>"
+    print("Usage ./find_parser_problems <GenBank file to parse>")
     sys.exit()
 
 feature_parser = GenBank.FeatureParser(debug_level=0)
@@ -42,14 +42,14 @@ while 1:
     print "Successfully parsed record", cur_record.id
 
     if verbose:
-        print "***Record"
+        print("***Record")
         print "Seq:", cur_record.seq
         print "Id:", cur_record.id
         print "Name:", cur_record.name
         print "Description", cur_record.description
         print "Annotations", cur_record.annotations
-        print "Feaures"
+        print("Feaures")
         for feature in cur_record.features:
-            print feature
+            print(feature)
 
 handle.close()

--- a/Scripts/PDB/generate_three_to_one_dict.py
+++ b/Scripts/PDB/generate_three_to_one_dict.py
@@ -26,7 +26,7 @@ cifname = os.extsep.join(gzname.split(os.extsep)[:-1])
 url_handle = urllib.urlopen(url)
 
 with open(gzname, 'wb') as gzh:
-    print "Downloading file... (approx. 29 MB)"
+    print("Downloading file... (approx. 29 MB)")
     while True:
         data = url_handle.read(1024)
         if len(data) == 0:

--- a/Scripts/Performance/biosql_performance_load.py
+++ b/Scripts/Performance/biosql_performance_load.py
@@ -27,6 +27,6 @@ start_time = time.time()
 num_records = db.load(iterator)
 end_time = time.time()
 elapsed_time = end_time - start_time
-print "Loading"
-print "\tDid %s records in %s seconds for\n\t%f records per second" % \
-      (num_records, elapsed_time, float(num_records) / float(elapsed_time))
+print("Loading")
+print("\tDid %s records in %s seconds for\n\t%f records per second" % \
+      (num_records, elapsed_time, float(num_records) / float(elapsed_time)))

--- a/Scripts/Performance/biosql_performance_read.py
+++ b/Scripts/Performance/biosql_performance_read.py
@@ -20,9 +20,9 @@ for junk_id, record in all_records:
 end_time = time.time()
 num_records = len(all_records)
 elapsed_time = end_time - start_time
-print "Fasta"
-print "\tDid %s records in %s seconds for\n\t%f records per second" % \
-      (num_records, elapsed_time, float(num_records) / float(elapsed_time))
+print("Fasta")
+print("\tDid %s records in %s seconds for\n\t%f records per second" % \
+      (num_records, elapsed_time, float(num_records) / float(elapsed_time)))
 
 # -- do the "EMBL" timing part
 start_time = time.time()
@@ -40,6 +40,6 @@ for junk_id, record in all_records:
 end_time = time.time()
 num_records = len(all_records)
 elapsed_time = end_time - start_time
-print "EMBL"
-print "\tDid %s records in %s seconds for\n\t%f records per second" % \
-      (num_records, elapsed_time, float(num_records) / float(elapsed_time))
+print("EMBL")
+print("\tDid %s records in %s seconds for\n\t%f records per second" % \
+      (num_records, elapsed_time, float(num_records) / float(elapsed_time)))

--- a/Scripts/SeqGui/SeqGui.py
+++ b/Scripts/SeqGui/SeqGui.py
@@ -144,12 +144,12 @@ class SeqPanel(wx.Panel):
     def OnApply(self, event):
         codon_table_lb = self.parent.params_panel.codon_table_lb
         selection = codon_table_lb.GetStringSelection()
-        print selection
+        print(selection)
         codon_table = selection[:]
         transform_lb = self.parent.params_panel.transform_lb
         selection = transform_lb.GetStringSelection()
         transform = selection[:]
-        print transform
+        print(transform)
         if(transform == 'Translate'):
             self.translate(codon_table)
         elif(transform == 'Transcribe'):
@@ -163,20 +163,20 @@ class SeqPanel(wx.Panel):
 
     def translate(self, codon_table):
         seq = "".join(self.src_text.GetValue().split())  # remove whitespace
-        print seq
+        print(seq)
         self.dest_text.Clear()
         self.dest_text.SetValue(translate(seq, table=codon_table,
                                           to_stop=True))
 
     def transcribe(self):
         seq = "".join(self.src_text.GetValue().split())  # remove whitespace
-        print seq
+        print(seq)
         self.dest_text.Clear()
         self.dest_text.SetValue(transcribe(seq))
 
     def back_transcribe(self):
         seq = "".join(self.src_text.GetValue().split())  # remove whitespace
-        print seq
+        print(seq)
         self.dest_text.Clear()
         self.dest_text.SetValue(back_transcribe(seq))
 

--- a/Scripts/debug/debug_blast_parser.py
+++ b/Scripts/debug/debug_blast_parser.py
@@ -75,19 +75,19 @@ def choose_parser(outfile):
 def test_blast_output(outfile):
     # Try to auto-detect the format
     if 1:
-        print "No parser specified.  I'll try to choose one for you based"
-        print "on the format of the output file."
+        print("No parser specified.  I'll try to choose one for you based")
+        print("on the format of the output file.")
         print
 
         parser_class = choose_parser(outfile)
-        print "It looks like you have given output that should be parsed"
-        print "with %s.%s.  If I'm wrong, you can select the correct parser" %\
-              (parser_class.__module__, parser_class.__name__)
-        print "on the command line of this script (NOT IMPLEMENTED YET)."
+        print("It looks like you have given output that should be parsed")
+        print("with %s.%s.  If I'm wrong, you can select the correct parser" %\
+              (parser_class.__module__, parser_class.__name__))
+        print("on the command line of this script (NOT IMPLEMENTED YET).")
     else:
         raise NotImplementedError
         parser_class = NCBIWWW.BlastParser
-        print "Using %s to parse the file." % parser_class.__name__
+        print("Using %s to parse the file." % parser_class.__name__)
     print
 
     scanner_class = parser_class()._scanner.__class__
@@ -95,7 +95,7 @@ def test_blast_output(outfile):
 
     #parser_class()._scanner.feed(
     #    open(outfile), ParserSupport.TaggingConsumer())
-    print "I'm going to run the data through the parser to see what happens..."
+    print("I'm going to run the data through the parser to see what happens...")
     parser = parser_class()
     try:
         rec = parser.parse_file(outfile)
@@ -103,19 +103,19 @@ def test_blast_output(outfile):
         raise
     except Exception as x:
         exception_info = str(x)
-        print "Dang, the parsing failed."
+        print("Dang, the parsing failed.")
     else:
-        print "Parsing succeeded, no problems detected."
-        print "However, you should check to make sure the following scanner"
-        print "trace looks reasonable."
+        print("Parsing succeeded, no problems detected.")
+        print("However, you should check to make sure the following scanner")
+        print("trace looks reasonable.")
         print
         parser_class()._scanner.feed(
             open(outfile), ParserSupport.TaggingConsumer())
         return 0
     print
 
-    print "Alright.  Let me try and figure out where in the parser the"
-    print "problem occurred..."
+    print("Alright.  Let me try and figure out where in the parser the")
+    print("problem occurred...")
     etype, value, tb = sys.exc_info()
     ftb = traceback.extract_tb(tb)
     ftb.reverse()
@@ -128,21 +128,21 @@ def test_blast_output(outfile):
             class_found = scanner_class
             break
     if class_found is None:
-        print "Sorry, I could not pinpoint the error to the parser."
-        print "There's nothing more I can tell you."
-        print "Here's the traceback:"
+        print("Sorry, I could not pinpoint the error to the parser.")
+        print("There's nothing more I can tell you.")
+        print("Here's the traceback:")
         traceback.print_exception(etype, value, tb)
         return 1
     else:
-        print "I found the problem in %s.%s.%s, line %d:" % \
+        print("I found the problem in %s.%s.%s, line %d:" % \
               (class_found.__module__, class_found.__name__,
-               err_function, err_line)
-        print "    %s" % err_text
-        print "This output caused an %s to be raised with the" % etype
-        print "information %r." % exception_info
+               err_function, err_line))
+        print("    %s" % err_text)
+        print("This output caused an %s to be raised with the" % etype)
+        print("information %r." % exception_info)
     print
 
-    print "Let me find the line in the file that triggers the problem..."
+    print("Let me find the line in the file that triggers the problem...")
     parser = parser_class()
     scanner, consumer = parser._scanner, parser._consumer
     consumer = DebuggingConsumer(consumer)
@@ -151,9 +151,9 @@ def test_blast_output(outfile):
     except etype as x:
         pass
     else:
-        print "Odd, the exception disappeared!  What happened?"
+        print("Odd, the exception disappeared!  What happened?")
         return 3
-    print "It's caused by line %d:" % consumer.linenum
+    print("It's caused by line %d:" % consumer.linenum)
     lines = open(outfile).readlines()
     start, end = consumer.linenum - CONTEXT, consumer.linenum + CONTEXT + 1
     if start < 0:
@@ -170,47 +170,47 @@ def test_blast_output(outfile):
 
         s = "%s%*d %s" % (prefix, ndigits, linenum, line)
         s = s[:80]
-        print s
+        print(s)
     print
 
     if class_found == scanner_class:
-        print "Problems in %s are most likely caused by changed formats." % \
-              class_found.__name__
-        print "You can start to fix this by going to line %d in module %s." % \
-              (err_line, class_found.__module__)
-        print "Perhaps the scanner needs to be made more lenient by accepting"
-        print "the changed format?"
+        print("Problems in %s are most likely caused by changed formats." % \
+              class_found.__name__)
+        print("You can start to fix this by going to line %d in module %s." % \
+              (err_line, class_found.__module__))
+        print("Perhaps the scanner needs to be made more lenient by accepting")
+        print("the changed format?")
         print
 
         if VERBOSITY <= 0:
-            print "For more help, you can run this script in verbose mode"
-            print "to see detailed information about how the scanner"
-            print "identifies each line."
+            print("For more help, you can run this script in verbose mode")
+            print("to see detailed information about how the scanner")
+            print("identifies each line.")
         else:
-            print "OK, let's see what the scanner's doing!"
+            print("OK, let's see what the scanner's doing!")
             print
-            print "*" * 20 + " BEGIN SCANNER TRACE " + "*" * 20
+            print("*" * 20 + " BEGIN SCANNER TRACE " + "*" * 20)
             try:
                 parser_class()._scanner.feed(
                     open(outfile), ParserSupport.TaggingConsumer())
             except etype as x:
                 pass
-            print "*" * 20 + " END SCANNER TRACE " + "*" * 20
+            print("*" * 20 + " END SCANNER TRACE " + "*" * 20)
         print
 
     elif class_found == consumer_class:
-        print "Problems in %s can be caused by two things:" % \
-              class_found.__name__
-        print "    - The format of the line parsed by '%s' changed." % \
-              err_function
-        print "    - The scanner misidentified the line."
-        print "Check to make sure '%s' should parse the line:" % \
-              err_function
+        print("Problems in %s can be caused by two things:" % \
+              class_found.__name__)
+        print("    - The format of the line parsed by '%s' changed." % \
+              err_function)
+        print("    - The scanner misidentified the line.")
+        print("Check to make sure '%s' should parse the line:" % \
+              err_function)
         s = "    %s" % chomp(lines[consumer.linenum])
         s = s[:80]
-        print s
-        print "If so, debug %s.%s.  Otherwise, debug %s." % \
-              (class_found.__name__, err_function, scanner_class.__name__)
+        print(s)
+        print("If so, debug %s.%s.  Otherwise, debug %s." % \
+              (class_found.__name__, err_function, scanner_class.__name__))
 
 
 VERBOSITY = 0
@@ -231,7 +231,7 @@ if __name__ == '__main__':
     PROTEIN = NUCLEOTIDE = OUTPUT = None
     for opt, arg in optlist:
         if opt == '-h':
-            print USAGE
+            print(USAGE)
             sys.exit(0)
         elif opt == '-p':
             PROTEIN = 1

--- a/Scripts/query_pubmed.py
+++ b/Scripts/query_pubmed.py
@@ -12,7 +12,7 @@ from Bio import Entrez
 
 
 def print_usage():
-    print """query_pubmed.py [-h] [-c] [-d delay] query
+    print("""query_pubmed.py [-h] [-c] [-d delay] query
 
 This script sends a query to PubMed (via the NCBI Entrez webservice*)
 and prints the MEDLINE formatted results to the screen.
@@ -22,13 +22,13 @@ Arguments:
     -c           Count the hits, and don't print them out.
 
 * http://www.ncbi.nlm.nih.gov/Entrez/
-"""
+""")
 
 if __name__ == '__main__':
     try:
         optlist, args = getopt.getopt(sys.argv[1:], "hcd:")
     except getopt.error as x:
-        print x
+        print(x)
         sys.exit(0)
     if len(args) != 1:     # If they gave extraneous arguments,
         print_usage()      # print the instructions and quit.
@@ -48,7 +48,7 @@ if __name__ == '__main__':
         print_usage()
         sys.exit(0)
 
-    print "Doing a PubMed search for %s..." % repr(query)
+    print("Doing a PubMed search for %s..." % repr(query))
 
     if count_only:
         handle = Entrez.esearch(db="pubmed", term=query)
@@ -57,7 +57,7 @@ if __name__ == '__main__':
     search_results = Entrez.read(handle)
     ids = search_results["IdList"]
     count = len(ids)
-    print "Found %d citations" % count
+    print("Found %d citations" % count)
 
     if count_only:
         sys.exit(0)

--- a/Scripts/scop_pdb.py
+++ b/Scripts/scop_pdb.py
@@ -14,8 +14,7 @@ from Bio.SCOP import *
 
 
 def usage():
-    print \
-"""Extract a SCOP domain's ATOM and HETATOM records from the relevant PDB file.
+    print("""Extract a SCOP domain's ATOM and HETATOM records from the relevant PDB file.
 
 For example:
   scop_pdb.py astral-rapid-access-1.55.raf dir.cla.scop.txt_1.55 d3hbib_
@@ -53,7 +52,7 @@ Usage: scop_pdb [-h] [-i file] [-o file] [-p pdb_url_prefix]
               See [http://scop.berkeley.edu/parse/index.html]
 
   sid      -- A SCOP domain identifier. e.g. d3hbib_
-"""
+""")
 
 default_pdb_url = "http://www.rcsb.org/pdb/cgi/export.cgi/somefile.pdb?" \
                       "format=PDB&pdbId=%s&compression=None"

--- a/Scripts/xbbtools/nextorf.py
+++ b/Scripts/xbbtools/nextorf.py
@@ -207,35 +207,35 @@ class NextOrf:
 
             if out == 'aa':
                 orf = subs.translate(table=self.genetic_code)
-                print self.ToFasta(head, orf.data)
+                print(self.ToFasta(head, orf.data))
             elif out == 'nt':
-                print self.ToFasta(head, subs.data)
+                print(self.ToFasta(head, subs.data))
             elif out == 'pos':
-                print head
+                print(head)
 
 
 def help():
     global options
     print 'Usage:', sys.argv[0], '(<options>) <FASTA file>'
 
-    print 'Options:                                                       default'
-    print '--start       Start position in sequence                             0'
-    print '--stop        Stop position in sequence            (end of seqence)'
-    print '--minlength   Minimum length of orf in bp                          100'
-    print '--maxlength   Maximum length of orf in bp, default           100000000'
-    print '--strand      Strand to analyse [both, plus, minus]               both'
-    print '--frame       Frame to analyse [1 2 3]                             all'
-    print '--noframe     Ignore start codons [0 1]                              0'
-    print '--output      Output to generate [aa nt pos]                        aa'
-    print '--gc          Creates GC statistics of ORF [0 1]                     0'
-    print '--table       Genetic code to use (see below)                        1'
+    print('Options:                                                       default')
+    print('--start       Start position in sequence                             0')
+    print('--stop        Stop position in sequence            (end of seqence)')
+    print('--minlength   Minimum length of orf in bp                          100')
+    print('--maxlength   Maximum length of orf in bp, default           100000000')
+    print('--strand      Strand to analyse [both, plus, minus]               both')
+    print('--frame       Frame to analyse [1 2 3]                             all')
+    print('--noframe     Ignore start codons [0 1]                              0')
+    print('--output      Output to generate [aa nt pos]                        aa')
+    print('--gc          Creates GC statistics of ORF [0 1]                     0')
+    print('--table       Genetic code to use (see below)                        1')
 
 #    for a,b in options.items(): print '\t', a,b
 #    print ''
-    print "\nNCBI's Codon Tables:"
+    print("\nNCBI's Codon Tables:")
     for key, table in CodonTable.ambiguous_dna_by_id.items():
         print '\t', key, table._codon_table.names[0]
-    print '\ne.g.\n./nextorf.py --minlength 5 --strand plus --output nt --gc 1 testjan.fas'
+    print('\ne.g.\n./nextorf.py --minlength 5 --strand plus --output nt --gc 1 testjan.fas')
     sys.exit(0)
 
 

--- a/Scripts/xbbtools/xbb_blast.py
+++ b/Scripts/xbbtools/xbb_blast.py
@@ -109,7 +109,7 @@ class BlastIt:
 
         self.Update()
 
-        print self.command
+        print(self.command)
         self.pipe = posix.popen(self.command)
         while 1:
             try:

--- a/Scripts/xbbtools/xbb_blastbg.py
+++ b/Scripts/xbbtools/xbb_blastbg.py
@@ -73,8 +73,8 @@ class BlastWorker(threading.Thread):
         self.queue = queue
         threading.Thread.__init__(self)
         self.finished = 0
-        print dir(queue)
-        print queue.queue
+        print(dir(queue))
+        print(queue.queue)
 
     def shutdown(self):
         # GRRRR How do I explicitely kill a thread ???????

--- a/Scripts/xbbtools/xbb_translations.py
+++ b/Scripts/xbbtools/xbb_translations.py
@@ -117,8 +117,8 @@ if __name__ == '__main__':
 #         print test.frame1(s[i:])
     #print s
     #print test.complement(s)
-    print '============================================================'
-    print test.gcframe(s)
+    print('============================================================')
+    print(test.gcframe(s))
 
 #     for i in Translate.unambiguous_dna_by_id.keys():
 #         print Translate.unambiguous_dna_by_id[i].table.names[0]

--- a/Scripts/xbbtools/xbb_widget.py
+++ b/Scripts/xbbtools/xbb_widget.py
@@ -378,7 +378,7 @@ class xbb_widget:
         if not seq:
             return
         aa_seq = self.translator.frame(seq, frame, self.current_codon_table_id)
-        print '>%s<' % aa_seq
+        print('>%s<' % aa_seq)
         aa_seq = re.sub('(.{50})', '\\1\n', str(aa_seq))
         np = NotePad()
         tid = np.text_id()

--- a/Tests/PAML/gen_results.py
+++ b/Tests/PAML/gen_results.py
@@ -29,7 +29,7 @@ def codeml(vers=None, verbose=False):
             ("SE", "alignment.phylip", "species.tree")]
 
     for test in tests:
-        print test[0]
+        print(test[0])
         cml = codeml.Codeml()
         cml.working_dir = "temp"
         ctl_file = os.path.join("Control_files",
@@ -41,7 +41,7 @@ def codeml(vers=None, verbose=False):
         cml.alignment = alignment
         cml.tree = tree
         for version in versions:
-            print "\t{0}".format(version.replace('_', '.'))
+            print("\t{0}".format(version.replace('_', '.')))
             if test[0] in ["ngene2_mgene02", "ngene2_mgene34"] and \
                version == "4_6":
                 cml.tree = ".".join([cml.tree, "4.6"])
@@ -62,16 +62,16 @@ def baseml(vers=None, verbose=False):
     alignment = os.path.join("Alignments", "alignment.phylip")
     tree = os.path.join("Trees", "species.tree")
     for test in tests:
-        print test[0]
+        print(test[0])
         bml = baseml.Baseml()
         for version in versions:
-            print "\t{0}".format(version.replace('_', '.'))
+            print("\t{0}".format(version.replace('_', '.')))
             if test[1] is not None:
                 for n in test[1]:
                     if (version in ["4_3", "4_4", "4_4c", "4_5"] and
                             test[0] == "nparK" and n in [3, 4]):
                         continue
-                    print "\t\tn = {0}".format(n)
+                    print("\t\tn = {0}".format(n))
                     ctl_file = os.path.join("Control_files", "baseml",
                         "{0}{1}.ctl".format(test[0], n))
                     bml.read_ctl_file(ctl_file)
@@ -107,10 +107,10 @@ def yn00(vers=None, verbose=False):
     tests = ["yn00"]
     alignment = os.path.join("Alignments", "alignment.phylip")
     for test in tests:
-        print test[0]
+        print(test[0])
         yn = yn00.Yn00()
         for version in versions:
-            print "\t{0}".format(version.replace('_', '.'))
+            print("\t{0}".format(version.replace('_', '.')))
             ctl_file = os.path.join("Control_files", "yn00",
                 "{0}.ctl".format(test))
             yn.read_ctl_file(ctl_file)
@@ -150,18 +150,18 @@ if __name__ == "__main__":
             verbose = True
         elif arg in programs:
             if prog is not None:
-                print "Only one program at a time, please."
+                print("Only one program at a time, please.")
                 print_usage()
             prog = arg
         elif arg.replace(".", "_") in VERSIONS:
             if vers is not None:
-                print "Only one version at a time, sorry."
+                print("Only one version at a time, sorry.")
             vers = arg.replace(".", "_")
         else:
-            print "Unrecognized argument"
+            print("Unrecognized argument")
             print_usage()
     if prog is None:
-        print "No program specified"
+        print("No program specified")
         print_usage()
     if prog == "codeml":
         codeml(vers, verbose)

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -207,8 +207,8 @@ def main(argv):
         opts, args = getopt.getopt(argv, 'gv', ["generate", "verbose",
             "doctest", "help", "offline"])
     except getopt.error as msg:
-        print msg
-        print __doc__
+        print(msg)
+        print(__doc__)
         return 2
 
     verbosity = VERBOSITY
@@ -216,22 +216,22 @@ def main(argv):
     # deal with the options
     for o, a in opts:
         if o == "--help":
-            print __doc__
+            print(__doc__)
             return 0
         if o == "--offline":
-            print "Skipping any tests requiring internet access"
+            print("Skipping any tests requiring internet access")
             #This is a bit of a hack...
             import requires_internet
             requires_internet.check.available = False
             #The check() function should now report internet not available
         if o == "-g" or o == "--generate":
             if len(args) > 1:
-                print "Only one argument (the test name) needed for generate"
-                print __doc__
+                print("Only one argument (the test name) needed for generate")
+                print(__doc__)
                 return 2
             elif len(args) == 0:
-                print "No test name specified to generate output for."
-                print __doc__
+                print("No test name specified to generate output for.")
+                print(__doc__)
                 return 2
             # strip off .py if it was included
             if args[0][-3:] == ".py":

--- a/Tests/search_tests_common.py
+++ b/Tests/search_tests_common.py
@@ -36,7 +36,7 @@ class CheckRaw(unittest.TestCase):
 
         if os.path.isfile(filename + ".bgz"):
             #Do the tests again with the BGZF compressed file
-            print "[BONUS %s.bgz]" % filename
+            print("[BONUS %s.bgz]" % filename)
             self.check_raw(filename + ".bgz", id, raw, **kwargs)
 
 
@@ -88,7 +88,7 @@ class CheckIndex(unittest.TestCase):
 
         if os.path.isfile(filename + ".bgz"):
             #Do the tests again with the BGZF compressed file
-            print "[BONUS %s.bgz]" % filename
+            print("[BONUS %s.bgz]" % filename)
             self.check_index(filename + ".bgz", format, **kwargs)
 
 def _num_difference(obj_a, obj_b):

--- a/Tests/test_AlignIO.py
+++ b/Tests/test_AlignIO.py
@@ -112,7 +112,7 @@ def check_simple_write_read(alignments, indent=" "):
         and format not in test_write_read_alignment_formats:
             continue
 
-        print indent+"Checking can write/read as '%s' format" % format
+        print(indent+"Checking can write/read as '%s' format" % format)
 
         #Going to write to a handle...
         handle = StringIO()
@@ -123,7 +123,7 @@ def check_simple_write_read(alignments, indent=" "):
         except ValueError as e:
             #This is often expected to happen, for example when we try and
             #write sequences of different lengths to an alignment file.
-            print indent+"Failed: %s" % str(e)
+            print(indent+"Failed: %s" % str(e))
             #Carry on to the next format:
             continue
 
@@ -249,8 +249,8 @@ del list_of_records, t_format
 
 #Main tests...
 for (t_format, t_per, t_count, t_filename) in test_files:
-    print "Testing reading %s format file %s with %i alignments" \
-          % (t_format, t_filename, t_count)
+    print("Testing reading %s format file %s with %i alignments" \
+          % (t_format, t_filename, t_count))
     assert os.path.isfile(t_filename), t_filename
 
     #Try as an iterator using handle
@@ -321,13 +321,13 @@ for (t_format, t_per, t_count, t_filename) in test_files:
     #Print the alignment
     for i,alignment in enumerate(alignments):
         if i < 3 or i+1 == t_count:
-            print " Alignment %i, with %i sequences of length %i" \
+            print(" Alignment %i, with %i sequences of length %i" \
                   % (i,
                      len(alignment),
-                     alignment.get_alignment_length())
-            print alignment_summary(alignment)
+                     alignment.get_alignment_length()))
+            print(alignment_summary(alignment))
         elif i==3:
-            print " ..."
+            print(" ...")
 
     #Check AlignInfo.SummaryInfo likes the alignment
     summary = AlignInfo.SummaryInfo(alignment)
@@ -359,4 +359,4 @@ for (t_format, t_per, t_count, t_filename) in test_files:
     alignments.reverse()
     check_simple_write_read(alignments)
 
-print "Finished tested reading files"
+print("Finished tested reading files")

--- a/Tests/test_AlignIO_FastaIO.py
+++ b/Tests/test_AlignIO_FastaIO.py
@@ -33,8 +33,8 @@ test_files = [
 for (t_format, t_per, t_count, t_filename) in test_files:
     assert t_format == "fasta-m10" and t_per == 2
 
-    print "Testing reading %s format file %s with %i alignments" \
-          % (t_format, t_filename, t_count)
+    print("Testing reading %s format file %s with %i alignments" \
+          % (t_format, t_filename, t_count))
     assert os.path.isfile(t_filename), t_filename
 
     #Try as an iterator using handle
@@ -48,24 +48,24 @@ for (t_format, t_per, t_count, t_filename) in test_files:
 
     #Print the alignment
     for i,alignment in enumerate(alignments):
-        print "="*78
-        print "Alignment %i, with %i sequences of length %i" \
+        print("="*78)
+        print("Alignment %i, with %i sequences of length %i" \
               % (i,
                  len(alignment),
-                 alignment.get_alignment_length())
+                 alignment.get_alignment_length()))
         for k in sorted(alignment._annotations):
-            print " - %s: %r" % (k, alignment._annotations[k])
+            print(" - %s: %r" % (k, alignment._annotations[k]))
         assert alignment[0].name == "query"
         assert alignment[1].name == "match"
         #Show each sequence row horizontally
         for record in alignment:
-            print "-"*78
-            print record.id
-            print record.description
-            print repr(record.seq)
+            print("-"*78)
+            print(record.id)
+            print(record.description)
+            print(repr(record.seq))
             assert not record.features
             assert not record.letter_annotations
             for k in sorted(record.annotations):
-                print " - %s: %r" % (k, record.annotations[k])
-    print "="*78
-print "Finished tested reading files"
+                print(" - %s: %r" % (k, record.annotations[k]))
+    print("="*78)
+print("Finished tested reading files")

--- a/Tests/test_Clustalw_tool.py
+++ b/Tests/test_Clustalw_tool.py
@@ -297,7 +297,7 @@ class ClustalWTestVersionTwoSpecific(ClustalWTestCase):
             self.standard_test_procedure(cline)
             self.assertTrue(os.path.isfile(statistics_file))
         else:
-            print "Skipping ClustalW2 specific test."
+            print("Skipping ClustalW2 specific test.")
 
 
 if __name__ == "__main__":

--- a/Tests/test_CodonTable.py
+++ b/Tests/test_CodonTable.py
@@ -49,17 +49,17 @@ for n in ambiguous_generic_by_id.keys():
     if "UAA" in unambiguous_rna_by_id[n].stop_codons \
     and "UGA" in unambiguous_rna_by_id[n].stop_codons:
         try:
-            print ambiguous_dna_by_id[n].forward_table["TRA"]
+            print(ambiguous_dna_by_id[n].forward_table["TRA"])
             assert False, "Should be a stop only"
         except KeyError:
             pass
         try:
-            print ambiguous_rna_by_id[n].forward_table["URA"]
+            print(ambiguous_rna_by_id[n].forward_table["URA"])
             assert False, "Should be a stop only"
         except KeyError:
             pass
         try:
-            print ambiguous_generic_by_id[n].forward_table["URA"]
+            print(ambiguous_generic_by_id[n].forward_table["URA"])
             assert False, "Should be a stop only"
         except KeyError:
             pass
@@ -72,22 +72,22 @@ for n in ambiguous_generic_by_id.keys():
     and "UAA" in unambiguous_rna_by_id[n].stop_codons \
     and "UGA" in unambiguous_rna_by_id[n].stop_codons:
         try:
-            print ambiguous_dna_by_id[n].forward_table["TAR"]
+            print(ambiguous_dna_by_id[n].forward_table["TAR"])
             assert False, "Should be a stop only"
         except KeyError:
             pass
         try:
-            print ambiguous_rna_by_id[n].forward_table["UAR"]
+            print(ambiguous_rna_by_id[n].forward_table["UAR"])
             assert False, "Should be a stop only"
         except KeyError:
             pass
         try:
-            print ambiguous_generic_by_id[n].forward_table["UAR"]
+            print(ambiguous_generic_by_id[n].forward_table["UAR"])
             assert False, "Should be a stop only"
         except KeyError:
             pass
         try:
-            print ambiguous_generic_by_id[n].forward_table["URR"]
+            print(ambiguous_generic_by_id[n].forward_table["URR"])
             assert False, "Should be a stop OR an amino"
         except TranslationError:
             pass
@@ -125,4 +125,4 @@ assert ambiguous_generic_by_id[1].stop_codons == ambiguous_generic_by_name["Stan
 assert ambiguous_generic_by_id[4].stop_codons == ambiguous_generic_by_name["SGC3"].stop_codons
 assert ambiguous_generic_by_id[15].stop_codons == ambiguous_generic_by_name['Blepharisma Macronuclear'].stop_codons
 
-print "Done"
+print("Done")

--- a/Tests/test_CodonUsage.py
+++ b/Tests/test_CodonUsage.py
@@ -10,14 +10,14 @@ if os.path.exists("./CodonUsage/HighlyExpressedGenes.txt"):
 elif os.path.exists("./Tests/CodonUsage/HighlyExpressedGenes.txt"):
     X.generate_index("./Tests/CodonUsage/HighlyExpressedGenes.txt")
 else:
-    print "Cannot find the file HighlyExpressedGene.txt\nMake sure you run the tests from within the Tests folder"
+    print("Cannot find the file HighlyExpressedGene.txt\nMake sure you run the tests from within the Tests folder")
     sys.exit()
 # alternatively you could use any predefined dictionary like this:
 # from CaiIndices import SharpIndex # you can save your dictionary in this file.
 # X.SetCaiIndex(SharpIndex)
 
-print "The current index used:"
+print("The current index used:")
 X.print_index()
 
-print "-" * 60
-print "codon adaptation index for test gene: %.2f" % X.cai_for_gene("ATGAAACGCATTAGCACCACCATTACCACCACCATCACCATTACCACAGGTAACGGTGCGGGCTGA")
+print("-" * 60)
+print("codon adaptation index for test gene: %.2f" % X.cai_for_gene("ATGAAACGCATTAGCACCACCATTACCACCACCATCACCATTACCACAGGTAACGGTGCGGGCTGA"))

--- a/Tests/test_DocSQL.py
+++ b/Tests/test_DocSQL.py
@@ -4,7 +4,7 @@
 
 import Bio.DocSQL
 
-print "Skipping Bio.DocSQL doctests."
+print("Skipping Bio.DocSQL doctests.")
 #print "Running Bio.DocSQL doctests..."
 #Bio.DocSQL._test()
 #print "Bio.DocSQL doctests complete."

--- a/Tests/test_Fasttree_tool.py
+++ b/Tests/test_Fasttree_tool.py
@@ -62,10 +62,10 @@ if not fasttree_exe:
 
 #################################################################
 
-print "Checking error conditions"
-print "========================="
+print("Checking error conditions")
+print("=========================")
 
-print "Empty file"
+print("Empty file")
 input_file = "does_not_exist.fasta"
 assert not os.path.isfile(input_file)
 cline = FastTreeCommandline(fasttree_exe, input=input_file)
@@ -73,7 +73,7 @@ try:
     stdout, stderr = cline()
     assert False, "Should have failed, returned:\n%s\n%s" % (stdout, stderr)
 except ApplicationError as err:
-    print "Failed (good)"
+    print("Failed (good)")
     #Python 2.3 on Windows gave (0, 'Error')
     #Python 2.5 on Windows gives [Errno 0] Error
     assert "Cannot open sequence file" in str(err) or \
@@ -81,7 +81,7 @@ except ApplicationError as err:
            "non-zero exit status" in str(err), str(err)
 
 print
-print "Single sequence"
+print("Single sequence")
 input_file = "Fasta/f001"
 assert os.path.isfile(input_file)
 assert len(list(SeqIO.parse(input_file,"fasta")))==1
@@ -89,15 +89,15 @@ cline = FastTreeCommandline(fasttree_exe, input=input_file)
 try:
     stdout, stderr = cline()
     if "Unique: 1/1" in stderr:
-        print "Failed (good)"
+        print("Failed (good)")
     else:
         assert False, "Should have failed, returned:\n%s\n%s" % (stdout, stderr)
 except ApplicationError as err:
-    print "Failed (good)"
+    print("Failed (good)")
     #assert str(err) == "No records found in handle", str(err)
 
 print
-print "Invalid sequence"
+print("Invalid sequence")
 input_file = "Medline/pubmed_result1.txt"
 assert os.path.isfile(input_file)
 cline = FastTreeCommandline(fasttree_exe, input=input_file)
@@ -105,7 +105,7 @@ try:
     stdout, stderr = cline()
     assert False, "Should have failed, returned:\n%s\n%s" % (stdout, stderr)
 except ApplicationError as err:
-    print "Failed (good)"
+    print("Failed (good)")
     #Ideally we'd catch the return code and raise the specific
     #error for "invalid format", rather than just notice there
     #is not output file.
@@ -119,8 +119,8 @@ except ApplicationError as err:
 
 #################################################################
 print
-print "Checking normal situations"
-print "=========================="
+print("Checking normal situations")
+print("==========================")
 
 #Create a temp fasta file with a space in the name
 temp_filename_with_spaces = "Clustalw/temp horses.fasta"
@@ -131,8 +131,8 @@ handle.close()
 for input_file in ["Quality/example.fasta", "Clustalw/temp horses.fasta"]:
     input_records = SeqIO.to_dict(SeqIO.parse(input_file,"fasta"))
     print
-    print "Calling fasttree on %s (with %i records)" \
-          % (repr(input_file), len(input_records))
+    print("Calling fasttree on %s (with %i records)" \
+          % (repr(input_file), len(input_records)))
 
     #Any filesnames with spaces should get escaped with quotes automatically.
     #Using keyword arguments here.
@@ -143,7 +143,7 @@ for input_file in ["Quality/example.fasta", "Clustalw/temp horses.fasta"]:
     assert err.strip().startswith("FastTree")
 
     print
-    print "Checking generation of tree terminals"
+    print("Checking generation of tree terminals")
     tree = Phylo.read(StringIO(out), 'newick')
 
     def lookup_by_names(tree):
@@ -158,10 +158,10 @@ for input_file in ["Quality/example.fasta", "Clustalw/temp horses.fasta"]:
     names = lookup_by_names(tree)
 
     assert len(names) > 0.0
-    print "Success"
+    print("Success")
 
     print
-    print "Checking distances between tree terminals"
+    print("Checking distances between tree terminals")
     def terminal_neighbor_dists(self):
         """Return a list of distances between adjacent terminals."""
         def generate_pairs(self):
@@ -174,7 +174,7 @@ for input_file in ["Quality/example.fasta", "Clustalw/temp horses.fasta"]:
     for dist in terminal_neighbor_dists(tree):
         assert dist > 0.0
 
-    print "Success"
+    print("Success")
 
 print
-print "Done"
+print("Done")

--- a/Tests/test_File.py
+++ b/Tests/test_File.py
@@ -22,33 +22,33 @@ file"""
 
 h = File.UndoHandle(StringIO(data))
 
-print h.readline()   # 'This'
-print h.peekline()   # 'is'
-print h.readline()   # 'is'
+print(h.readline())   # 'This'
+print(h.peekline())   # 'is'
+print(h.readline())   # 'is'
 h.saveline("saved")
-print h.peekline()   # 'saved'
+print(h.peekline())   # 'saved'
 h.saveline("another")
-print h.readline()   # 'another'
-print h.readline()   # 'saved'
+print(h.readline())   # 'another'
+print(h.readline())   # 'saved'
 
 # Test readlines after saveline
 h.saveline("saved again")
 lines = h.readlines()
-print repr(lines[0])   # 'saved again'
-print repr(lines[1])   # 'a multi-line'
-print repr(lines[2])   # 'file'
+print(repr(lines[0]))   # 'saved again'
+print(repr(lines[1]))   # 'a multi-line'
+print(repr(lines[2]))   # 'file'
 
 # should be empty now
-print repr(h.readline())       # ''
+print(repr(h.readline()))       # ''
 
 h.saveline("save after empty")
-print h.readline()             # 'save after empty'
-print repr(h.readline())       # ''
+print(h.readline())             # 'save after empty'
+print(repr(h.readline()))       # ''
 
 # test read method
 h = File.UndoHandle(StringIO("some text"))
 h.saveline("more text")
-print h.read()                 # 'more textsome text'
+print(h.read())                 # 'more textsome text'
 
 
 class AsHandleTestCase(unittest.TestCase):

--- a/Tests/test_GAQueens.py
+++ b/Tests/test_GAQueens.py
@@ -38,16 +38,16 @@ VERBOSE = 0
 
 def main(num_queens):
 
-    print "Calculating for %s queens..." % num_queens
+    print("Calculating for %s queens..." % num_queens)
 
     num_orgs = 1000
-    print "Generating an initial population of %s organisms..." % num_orgs
+    print("Generating an initial population of %s organisms..." % num_orgs)
     queen_alphabet = QueensAlphabet(num_queens)
 
     start_population = Organism.random_population(queen_alphabet, num_queens,
                                                   num_orgs, queens_fitness)
 
-    print "Evolving the population and searching for a solution..."
+    print("Evolving the population and searching for a solution...")
 
     mutator = QueensMutation(mutation_rate = 0.05)
     crossover = QueensCrossover(queens_fitness, crossover_prob = .2,
@@ -68,7 +68,7 @@ def main(num_queens):
                 unique_solutions.append(org)
 
     if VERBOSE:
-        print "Search started at %s and ended at %s" % (start_time, end_time)
+        print("Search started at %s and ended at %s" % (start_time, end_time))
         for orgm in unique_solutions:
             print "We did it!", org
             display_board(org.genome)
@@ -80,7 +80,7 @@ def display_board(genome):
     Inspired by the display function in the queens.py solution to the N-queens
     problem in the Python demo scripts.
     """
-    print '+-' + '--'*len(genome) + '+'
+    print('+-' + '--'*len(genome) + '+')
 
     for row in range(len(genome)):
         print '|',
@@ -89,9 +89,9 @@ def display_board(genome):
                 print 'Q',
             else:
                 print '.',
-        print '|'
+        print('|')
 
-    print '+-' + '--'*len(genome) + '+'
+    print('+-' + '--'*len(genome) + '+')
 
 
 def queens_solved(organisms):
@@ -402,10 +402,10 @@ if __name__ == "__main__":
         num_queens = int(sys.argv[1])
         main(num_queens)
     else:
-        print "Usage:"
-        print "python test_GAQueens.py <Number of Queens to place>\n"
-        print "where <Number of Queens to place> is an optional parameter"
-        print "specifying how many queens you want to try to calculate"
-        print "this for. The default number of queens to place is 5."
-        print "Range 1 to 9 is supported."
+        print("Usage:")
+        print("python test_GAQueens.py <Number of Queens to place>\n")
+        print("where <Number of Queens to place> is an optional parameter")
+        print("specifying how many queens you want to try to calculate")
+        print("this for. The default number of queens to place is 5.")
+        print("Range 1 to 9 is supported.")
         sys.exit(1)

--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -53,11 +53,11 @@ feature_parser = GenBank.FeatureParser(debug_level = 0)
 record_parser = GenBank.RecordParser(debug_level = 0)
 
 all_parsers = [feature_parser, record_parser]
-print "Testing parsers..."
+print("Testing parsers...")
 for parser in all_parsers:
     for filename in files_to_parse:
         if not os.path.isfile(filename):
-            print "Missing test input file: %s" % filename
+            print("Missing test input file: %s" % filename)
             continue
 
         handle = open(filename, 'r')
@@ -70,27 +70,27 @@ for parser in all_parsers:
                 break
 
             if isinstance(parser, GenBank.FeatureParser):
-                print "***Record from %s with the FeatureParser" \
-                      % filename.split(os.path.sep)[-1]
+                print("***Record from %s with the FeatureParser" \
+                      % filename.split(os.path.sep)[-1])
                 print "Seq:", repr(cur_record.seq)
                 print "Id:", cur_record.id
                 print "Name:", cur_record.name
                 print "Description", cur_record.description
-                print "Annotations***"
+                print("Annotations***")
                 ann_keys = cur_record.annotations.keys()
                 ann_keys.sort()
                 for ann_key in ann_keys:
                     if ann_key != 'references':
-                        print "Key: %s" % ann_key
-                        print "Value: %s" % \
-                              cur_record.annotations[ann_key]
+                        print("Key: %s" % ann_key)
+                        print("Value: %s" % \
+                              cur_record.annotations[ann_key])
                     else:
-                        print "References*"
+                        print("References*")
                         for reference in cur_record.annotations[ann_key]:
-                            print str(reference)
-                print "Feaures"
+                            print(str(reference))
+                print("Feaures")
                 for feature in cur_record.features:
-                    print feature
+                    print(feature)
                     if isinstance(_get_base_alphabet(cur_record.seq.alphabet),
                                   ProteinAlphabet):
                         assert feature.strand is None
@@ -99,9 +99,9 @@ for parser in all_parsers:
                         assert feature.strand is not None
                 print "DB cross refs", cur_record.dbxrefs
             elif isinstance(parser, GenBank.RecordParser):
-                print "***Record from %s with the RecordParser" \
-                      % filename.split(os.path.sep)[-1]
-                print "sequence length: %i" % len(cur_record.sequence)
+                print("***Record from %s with the RecordParser" \
+                      % filename.split(os.path.sep)[-1])
+                print("sequence length: %i" % len(cur_record.sequence))
                 print "locus:", cur_record.locus
                 print "definition:", cur_record.definition
                 print "accession:", cur_record.accession
@@ -122,7 +122,7 @@ for parser in all_parsers:
 #...
 
 # test writing GenBank format
-print "Testing writing GenBank format..."
+print("Testing writing GenBank format...")
 
 
 def do_comparison(good_record, test_record):
@@ -155,7 +155,7 @@ def t_write_format():
     record_parser = GenBank.RecordParser(debug_level = 0)
 
     for file in write_format_files:
-        print "Testing GenBank writing for %s..." % os.path.basename(file)
+        print("Testing GenBank writing for %s..." % os.path.basename(file))
         cur_handle = open(os.path.join("GenBank", file), "r")
         compare_handle = open(os.path.join("GenBank", file), "r")
 
@@ -169,7 +169,7 @@ def t_write_format():
             if cur_record is None or compare_record is None:
                 break
 
-            print "\tTesting for %s" % cur_record.version
+            print("\tTesting for %s" % cur_record.version)
 
             output_record = str(cur_record) + "\n"
             do_comparison(compare_record, output_record)
@@ -200,7 +200,7 @@ def t_cleaning_features():
 
     handle.close()
 
-print "Testing feature cleaning..."
+print("Testing feature cleaning...")
 t_cleaning_features()
 
 
@@ -233,7 +233,7 @@ def t_ensembl_locus():
     assert c.data.name == "HG506_HG1000_1_PATCH", c.data.name
     assert c._expected_size == 1219964, c._expected_size
 
-    print "Done"
+    print("Done")
 
-print "Testing EnsEMBL LOCUS lines..."
+print("Testing EnsEMBL LOCUS lines...")
 t_ensembl_locus()

--- a/Tests/test_GraphicsChromosome.py
+++ b/Tests/test_GraphicsChromosome.py
@@ -283,11 +283,11 @@ class OrganismSubAnnotationsTest(unittest.TestCase):
                 record = SeqIO.read(filename, "gb")
                 assert length == len(record)
                 features = [f for f in record.features if f.type=="tRNA"]
-                print name
+                print(name)
                 #Strip of the first three chars, AT# where # is the chr
-                print [(int(f.location.start), int(f.location.end),
+                print([(int(f.location.start), int(f.location.end),
                         f.strand, f.qualifiers['locus_tag'][0][3:])
-                       for f in features]
+                       for f in features])
                 #Output was copy and pasted to the script, see above.
                 #Continue test using SeqFeature objects!
                 #To test colours from the qualifiers,

--- a/Tests/test_HMMCasino.py
+++ b/Tests/test_HMMCasino.py
@@ -168,15 +168,15 @@ def stop_training(log_likelihood_change, num_iterations):
         return 0
 
 # -- Standard Training with known states
-print "Training with the Standard Trainer..."
+print("Training with the Standard Trainer...")
 known_training_seq = Trainer.TrainingSequence(rolls, states)
 
 trainer = Trainer.KnownStateTrainer(standard_mm)
 trained_mm = trainer.train([known_training_seq])
 
 if VERBOSE:
-    print trained_mm.transition_prob
-    print trained_mm.emission_prob
+    print(trained_mm.transition_prob)
+    print(trained_mm.emission_prob)
 
 test_rolls, test_states = generate_rolls(300)
 
@@ -186,15 +186,15 @@ if VERBOSE:
     Utilities.pretty_print_prediction(test_rolls, test_states, predicted_states)
 
 # -- Baum-Welch training without known state sequences
-print "Training with Baum-Welch..."
+print("Training with Baum-Welch...")
 training_seq = Trainer.TrainingSequence(rolls, Seq("", DiceTypeAlphabet()))
 
 trainer = Trainer.BaumWelchTrainer(baum_welch_mm)
 trained_mm = trainer.train([training_seq], stop_training)
 
 if VERBOSE:
-    print trained_mm.transition_prob
-    print trained_mm.emission_prob
+    print(trained_mm.transition_prob)
+    print(trained_mm.emission_prob)
 
 test_rolls, test_states = generate_rolls(300)
 

--- a/Tests/test_HotRand.py
+++ b/Tests/test_HotRand.py
@@ -20,10 +20,10 @@ from Bio.HotRand import HotRandom
 def are_items_in_range( a, high, low ):
     for j in range( 0, len( a ) ):
         if( a[ j ] > high ):
-            print 'a[ %d ] is %d' % ( j , a[ j ] )
+            print('a[ %d ] is %d' % ( j , a[ j ] ))
             return 0
         if( a[ j ] < low ):
-            print 'a[ %d ] is %d' % ( j , a[ j ] )
+            print('a[ %d ] is %d' % ( j , a[ j ] ))
             return 0
     return 1
 

--- a/Tests/test_KEGG.py
+++ b/Tests/test_KEGG.py
@@ -17,11 +17,11 @@ def t_KEGG_Enzyme(testfiles):
     """Tests Bio.KEGG.Enzyme functionality."""
     for file in testfiles:
         fh = open(os.path.join("KEGG", file))
-        print "Testing Bio.KEGG.Enzyme on " + file + "\n\n"
+        print("Testing Bio.KEGG.Enzyme on " + file + "\n\n")
         records = Enzyme.parse(fh)
         for record in records:
-            print record
-        print "\n"
+            print(record)
+        print("\n")
         fh.close()
 
 
@@ -29,11 +29,11 @@ def t_KEGG_Compound(testfiles):
     """Tests Bio.KEGG.Compound functionality."""
     for file in testfiles:
         fh = open(os.path.join("KEGG", file))
-        print "Testing Bio.KEGG.Compound on " + file + "\n\n"
+        print("Testing Bio.KEGG.Compound on " + file + "\n\n")
         records = Compound.parse(fh)
         for record in records:
-            print record
-        print "\n"
+            print(record)
+        print("\n")
         fh.close()
 
 
@@ -41,7 +41,7 @@ def t_KEGG_Map(testfiles):
     """Tests Bio.KEGG.Map functionality."""
     for file in testfiles:
         fh = open(os.path.join("KEGG", file))
-        print "Testing Bio.KEGG.Map on " + file + "\n\n"
+        print("Testing Bio.KEGG.Map on " + file + "\n\n")
         reactions = Map.parse(fh)
         system = System()
         for reaction in reactions:
@@ -56,7 +56,7 @@ def t_KEGG_Map(testfiles):
         #  solution below proves resilient
         rxs.sort(key=lambda x:str(x))
         for x in rxs:
-            print str(x)
+            print(str(x))
         fh.close()
 
 

--- a/Tests/test_Location.py
+++ b/Tests/test_Location.py
@@ -7,7 +7,7 @@ are working properly.
 from Bio import SeqFeature
 
 # --- test fuzzy representations
-print "Testing fuzzy representations..."
+print("Testing fuzzy representations...")
 
 # check the positions alone
 exact_pos = SeqFeature.ExactPosition(5)
@@ -18,9 +18,9 @@ before_pos = SeqFeature.BeforePosition(15)
 after_pos = SeqFeature.AfterPosition(40)
 
 print "Exact:", exact_pos
-print "Within (as start, %i): %s" % (int(within_pos_s), within_pos_s)
-print "Within (as end, %i): %s" % (int(within_pos_e), within_pos_e)
-print "Between (as end, %i): %s" % (int(between_pos_e), between_pos_e)
+print("Within (as start, %i): %s" % (int(within_pos_s), within_pos_s))
+print("Within (as end, %i): %s" % (int(within_pos_e), within_pos_e))
+print("Between (as end, %i): %s" % (int(between_pos_e), between_pos_e))
 print "Before:", before_pos
 print "After:", after_pos
 
@@ -35,7 +35,7 @@ for location in [location1, location2, location3]:
     print "   End  :", location.end
 
 # --- test non-fuzzy represenations
-print "Testing non-fuzzy representations..."
+print("Testing non-fuzzy representations...")
 for location in [location1, location2, location3]:
     print "Location:", location
     print "  Non-Fuzzy Start:", location.nofuzzy_start

--- a/Tests/test_NCBI_qblast.py
+++ b/Tests/test_NCBI_qblast.py
@@ -53,9 +53,9 @@ ACATTAGTATCATATGGCTATTTGCTCAATTGCAGATTTCTTTCTTTTGTGAATG""",
      0.0000001, None, ["21554275","18409071","296087288"]),
 ]
 
-print "Checking Bio.Blast.NCBIWWW.qblast() with various queries"
+print("Checking Bio.Blast.NCBIWWW.qblast() with various queries")
 for program,database,query,e_value,entrez_filter,expected_hits in tests:
-    print "qblast('%s', '%s', %s, ...)" % (program, database, repr(query))
+    print("qblast('%s', '%s', %s, ...)" % (program, database, repr(query)))
     try:
         if program=="blastn":
             #Check the megablast parameter is accepted
@@ -103,9 +103,9 @@ for program,database,query,e_value,entrez_filter,expected_hits in tests:
                     found_result = True
                     break
         if len(expected_hits)==1:
-            print "Update this test to have some redundancy..."
+            print("Update this test to have some redundancy...")
             for alignment in record.alignments:
-                print alignment.hit_id
+                print(alignment.hit_id)
         assert found_result, "Missing all of %s in alignments" \
                % ", ".join(expected_hits)
 
@@ -123,4 +123,4 @@ for program,database,query,e_value,entrez_filter,expected_hits in tests:
                     break
         assert found_result, "Missing all of %s in descriptions" % expected_hit
 
-print "Done"
+print("Done")

--- a/Tests/test_NNExclusiveOr.py
+++ b/Tests/test_NNExclusiveOr.py
@@ -17,7 +17,7 @@ def main():
     Since we have so few examples, we use all of them for training,
     validation and testing.
     """
-    print "Setting up training examples..."
+    print("Setting up training examples...")
     # set up the training examples
     examples = []
     examples.append(TrainingExample([0, 0], [0]))
@@ -32,19 +32,19 @@ def main():
 
     network = BasicNetwork(input, hidden, output)
 
-    print "Training the network..."
+    print("Training the network...")
     # train it
     learning_rate = .5
     momentum = .1
     network.train(examples, examples, stopping_criteria, learning_rate,
                   momentum)
 
-    print "Predicting..."
+    print("Predicting...")
     # try predicting
     for example in examples:
         prediction = network.predict(example.inputs)
         if VERBOSE:
-            print "%s;%s=> %s" % (example.inputs, example.outputs, prediction)
+            print("%s;%s=> %s" % (example.inputs, example.outputs, prediction))
 
 
 def stopping_criteria(num_iterations, validation_error, training_error):

--- a/Tests/test_NNGene.py
+++ b/Tests/test_NNGene.py
@@ -524,9 +524,9 @@ class SchemaFactoryTest(unittest.TestCase):
 
         schema_bank = self.factory.from_motifs(motif_bank, .5, 2)
         if VERBOSE:
-            print "\nSchemas:"
+            print("\nSchemas:")
             for schema in schema_bank.get_all():
-                print "%s: %s" % (schema, schema_bank.count(schema))
+                print("%s: %s" % (schema, schema_bank.count(schema)))
 
     def test_hard_from_motifs(self):
         """Generating schema from a real life set of motifs.
@@ -534,9 +534,9 @@ class SchemaFactoryTest(unittest.TestCase):
         schema_bank = self._load_schema_repository()
 
         if VERBOSE:
-            print "\nSchemas:"
+            print("\nSchemas:")
             for schema in schema_bank.get_top(5):
-                print "%s: %s" % (schema, schema_bank.count(schema))
+                print("%s: %s" % (schema, schema_bank.count(schema)))
 
     def _load_schema_repository(self):
         """Helper function to load a schema repository from a file.

--- a/Tests/test_ParserSupport.py
+++ b/Tests/test_ParserSupport.py
@@ -18,12 +18,12 @@ def pb(b):
 
 ### TaggingConsumer
 
-print "Running tests on TaggingConsumer"
+print("Running tests on TaggingConsumer")
 
 
 class TestHandle:
     def write(self, s):
-        print s
+        print(s)
 
 h = TestHandle()
 tc = ParserSupport.TaggingConsumer(handle=h, colwidth=5)
@@ -34,27 +34,27 @@ tc.end_section()    # '***** end_section\n'
 
 ### is_blank_line
 
-print "Running tests on is_blank_line"
+print("Running tests on is_blank_line")
 
 is_blank_line = lambda *args, **keywds: \
                 pb(ParserSupport.is_blank_line(*args, **keywds))
 
-print is_blank_line('\n')                              # 1
-print is_blank_line('\r\n')                            # 1
-print is_blank_line('\r')                              # 1
-print is_blank_line('')                                # 1
-print is_blank_line('', allow_spaces=1)                # 1
-print is_blank_line('', allow_spaces=0)                # 1
-print is_blank_line(string.whitespace, allow_spaces=1) # 1
-print is_blank_line('hello')                           # 0
-print is_blank_line('hello', allow_spaces=1)           # 0
-print is_blank_line('hello', allow_spaces=0)           # 0
-print is_blank_line(string.whitespace, allow_spaces=0) # 0
+print(is_blank_line('\n'))                              # 1
+print(is_blank_line('\r\n'))                            # 1
+print(is_blank_line('\r'))                              # 1
+print(is_blank_line(''))                                # 1
+print(is_blank_line('', allow_spaces=1))                # 1
+print(is_blank_line('', allow_spaces=0))                # 1
+print(is_blank_line(string.whitespace, allow_spaces=1)) # 1
+print(is_blank_line('hello'))                           # 0
+print(is_blank_line('hello', allow_spaces=1))           # 0
+print(is_blank_line('hello', allow_spaces=0))           # 0
+print(is_blank_line(string.whitespace, allow_spaces=0)) # 0
 
 
 ### safe_readline
 
-print "Running tests on safe_readline"
+print("Running tests on safe_readline")
 
 data = """This
 file"""
@@ -62,19 +62,19 @@ file"""
 h = File.UndoHandle(StringIO(data))
 
 safe_readline = ParserSupport.safe_readline
-print safe_readline(h)    # "This"
-print safe_readline(h)    # "file"
+print(safe_readline(h))    # "This"
+print(safe_readline(h))    # "file"
 try:
     safe_readline(h)
 except ValueError:
-    print "correctly failed"
+    print("correctly failed")
 else:
-    print "ERROR, should have failed"
+    print("ERROR, should have failed")
 
 
 ### safe_peekline
 
-print "Running tests on safe_peekline"
+print("Running tests on safe_peekline")
 safe_peekline = ParserSupport.safe_peekline
 
 data = """This
@@ -82,23 +82,23 @@ file"""
 
 h = File.UndoHandle(StringIO(data))
 
-print safe_peekline(h) # "This"
+print(safe_peekline(h)) # "This"
 h.readline()
-print safe_peekline(h) # "file"
+print(safe_peekline(h)) # "file"
 h.readline()
 try:
     safe_peekline(h)
 except ValueError:
-    print "correctly failed"
+    print("correctly failed")
 else:
-    print "ERROR, should have failed"
+    print("ERROR, should have failed")
 h.saveline('hello')
-print safe_peekline(h) # 'hello'
+print(safe_peekline(h)) # 'hello'
 
 
 ### read_and_call
 
-print "Running tests on read_and_call"
+print("Running tests on read_and_call")
 
 data = """>gi|132871|sp|P19947|RL30_BACSU 50S RIBOSOMAL PROTEIN L30 (BL27)
 MAKLEITLKRSVIGRPEDQRVTVRTLGLKKTNQTVVHEDNAAIRGMINKVSHLVSVKEQ
@@ -120,7 +120,7 @@ def m(line):
     lines.append(line)
 
 rac(h, m)
-print lines[-1][:10]   # '>gi|132871'
+print(lines[-1][:10])   # '>gi|132871'
 rac(h, m, start='MAKLE', end='KEQ', contains='SVIG')
 rac(h, m, blank=0)
 
@@ -128,42 +128,42 @@ rac(h, m, blank=0)
 try:
     rac(h, m, blank=1)
 except ValueError:
-    print "correctly failed"
+    print("correctly failed")
 else:
-    print "ERROR, should have failed"
+    print("ERROR, should have failed")
 
 try:
     rac(h, m, start='foobar')
 except ValueError:
-    print "correctly failed"
+    print("correctly failed")
 else:
-    print "ERROR, should have failed"
+    print("ERROR, should have failed")
 
 try:
     rac(h, m, end='foobar')
 except ValueError:
-    print "correctly failed"
+    print("correctly failed")
 else:
-    print "ERROR, should have failed"
+    print("ERROR, should have failed")
 
 try:
     rac(h, m, contains='foobar')
 except ValueError:
-    print "correctly failed"
+    print("correctly failed")
 else:
-    print "ERROR, should have failed"
+    print("ERROR, should have failed")
 
 try:
     rac(h, m, blank=0)
 except ValueError:
-    print "correctly failed"
+    print("correctly failed")
 else:
-    print "ERROR, should have failed"
+    print("ERROR, should have failed")
 
 
 ### attempt_read_and_call
 
-print "Running tests on attempt_read_and_call"
+print("Running tests on attempt_read_and_call")
 
 data = """>gi|132871|sp|P19947|RL30_BACSU 50S RIBOSOMAL PROTEIN L30 (BL27)
 MAKLEITLKRSVIGRPEDQRVTVRTLGLKKTNQTVVHEDNAAIRGMINKVSHLVSVKEQ
@@ -182,7 +182,7 @@ lines = []
 def m(line):
     lines.append(line)
 
-print arac(h, m, contains="RIBOSOMAL PROTEIN")   # 1
-print arac(h, m, start="foobar")                 # 0
-print arac(h, m, blank=1)                        # 0
-print arac(h, m, end="LVSVKEQ")                  # 1
+print(arac(h, m, contains="RIBOSOMAL PROTEIN"))   # 1
+print(arac(h, m, start="foobar"))                 # 0
+print(arac(h, m, blank=1))                        # 0
+print(arac(h, m, end="LVSVKEQ"))                  # 1

--- a/Tests/test_PopGen_DFDist.py
+++ b/Tests/test_PopGen_DFDist.py
@@ -119,6 +119,6 @@ class AppTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print "Running fdist tests, which might take some time, please wait"
+    print("Running fdist tests, which might take some time, please wait")
     runner = unittest.TextTestRunner(verbosity = 2)
     unittest.main(testRunner=runner)

--- a/Tests/test_PopGen_FDist.py
+++ b/Tests/test_PopGen_FDist.py
@@ -113,6 +113,6 @@ class AppTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    print "Running fdist tests, which might take some time, please wait"
+    print("Running fdist tests, which might take some time, please wait")
     runner = unittest.TextTestRunner(verbosity = 2)
     unittest.main(testRunner=runner)

--- a/Tests/test_SCOP_Scop.py
+++ b/Tests/test_SCOP_Scop.py
@@ -24,8 +24,8 @@ class ScopTests(unittest.TestCase):
         """
         fields1 = cla_line_1.rstrip().split('\t')
         fields2 = cla_line_2.rstrip().split('\t')
-        print fields1
-        print fields2
+        print(fields1)
+        print(fields2)
         # compare the first five fields in a Cla line, which should be exactly
         # the same
         if fields1[:5] != fields2[:5]:

--- a/Tests/test_SVDSuperimposer.py
+++ b/Tests/test_SVDSuperimposer.py
@@ -71,8 +71,8 @@ def simple_matrix_print(matrix):
     + "]"
 
 # output results
-print simple_matrix_print(y_on_x1)
+print(simple_matrix_print(y_on_x1))
 print
-print simple_matrix_print(y_on_x2)
+print(simple_matrix_print(y_on_x2))
 print
-print "%.2f" % rms
+print("%.2f" % rms)

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -320,7 +320,7 @@ def check_simple_write_read(records, indent=" "):
             #Skipping for speed.  Some of the unknown sequences are
             #rather long, and it seems a bit pointless to record them.
             continue
-        print indent+"Checking can write/read as '%s' format" % format
+        print(indent+"Checking can write/read as '%s' format" % format)
 
         #Going to write to a handle...
         if format in SeqIO._BinaryFormats:
@@ -344,9 +344,9 @@ def check_simple_write_read(records, indent=" "):
                 #>>> len(None)
                 #...
                 #TypeError: object of type 'NoneType' has no len()
-                print "Failed: Probably len() of None"
+                print("Failed: Probably len() of None")
             else:
-                print indent+"Failed: %s" % str(e)
+                print(indent+"Failed: %s" % str(e))
             if records[0].seq.alphabet.letters is not None:
                 assert format != t_format, \
                        "Should be able to re-write in the original format!"
@@ -433,7 +433,7 @@ for (t_format, t_alignment, t_filename, t_count) in test_files:
     else:
         mode = "r"
 
-    print "Testing reading %s format file %s" % (t_format, t_filename)
+    print("Testing reading %s format file %s" % (t_format, t_filename))
     assert os.path.isfile(t_filename), t_filename
 
     #Try as an iterator using handle
@@ -534,12 +534,12 @@ for (t_format, t_alignment, t_filename, t_count) in test_files:
         assert compare_record(record, records5[i])
 
         if i < 3:
-            print record_summary(record)
+            print(record_summary(record))
     # Only printed the only first three records: 0,1,2
     if t_count > 4:
-        print " ..."
+        print(" ...")
     if t_count > 3:
-        print record_summary(records[-1])
+        print(record_summary(records[-1]))
 
     # Check Bio.SeqIO.read(...)
     if t_count == 1:
@@ -599,7 +599,7 @@ for (t_format, t_alignment, t_filename, t_count) in test_files:
         #These should all fail...
         h = open(t_filename,mode)
         try:
-            print SeqIO.parse(h,t_format,given_alpha).next()
+            print(SeqIO.parse(h,t_format,given_alpha).next())
             h.close()
             assert False, "Forcing wrong alphabet, %s, should fail (%s)" \
                    % (repr(given_alpha), t_filename)
@@ -610,8 +610,8 @@ for (t_format, t_alignment, t_filename, t_count) in test_files:
     del good, bad, given_alpha, base_alpha
 
     if t_alignment:
-        print "Testing reading %s format file %s as an alignment" \
-              % (t_format, t_filename)
+        print("Testing reading %s format file %s as an alignment" \
+              % (t_format, t_filename))
 
         alignment = MultipleSeqAlignment(SeqIO.parse(
                     handle=t_filename, format=t_format))
@@ -625,7 +625,7 @@ for (t_format, t_alignment, t_filename, t_count) in test_files:
             assert compare_record(records[i], alignment[i])
             assert len(records[i].seq) == alignment_len
 
-        print alignment_summary(alignment)
+        print(alignment_summary(alignment))
 
     #Some alignment file formats have magic characters which mean
     #use the letter in this position in the first sequence.
@@ -634,4 +634,4 @@ for (t_format, t_alignment, t_filename, t_count) in test_files:
     records.reverse()
     check_simple_write_read(records)
 
-print "Finished tested reading files"
+print("Finished tested reading files")

--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -103,9 +103,9 @@ def compare_record(old, new, truncate=None):
             converted = [min(q,truncate) for q in converted]
         if converted != new.letter_annotations["solexa_quality"]:
             print
-            print old.letter_annotations["phred_quality"]
-            print converted
-            print new.letter_annotations["solexa_quality"]
+            print(old.letter_annotations["phred_quality"])
+            print(converted)
+            print(new.letter_annotations["solexa_quality"])
             raise ValueError("Mismatch in phred_quality vs solexa_quality")
     if "solexa_quality" in old.letter_annotations \
     and "phred_quality" in new.letter_annotations:
@@ -116,9 +116,9 @@ def compare_record(old, new, truncate=None):
         if truncate:
             converted = [min(q,truncate) for q in converted]
         if converted != new.letter_annotations["phred_quality"]:
-            print old.letter_annotations["solexa_quality"]
-            print converted
-            print new.letter_annotations["phred_quality"]
+            print(old.letter_annotations["solexa_quality"])
+            print(converted)
+            print(new.letter_annotations["phred_quality"])
             raise ValueError("Mismatch in solexa_quality vs phred_quality")
     return True
 

--- a/Tests/test_SeqIO_convert.py
+++ b/Tests/test_SeqIO_convert.py
@@ -131,9 +131,9 @@ def compare_record(old, new, truncate=None):
             converted = [min(q,truncate) for q in converted]
         if converted != new.letter_annotations["solexa_quality"]:
             print
-            print old.letter_annotations["phred_quality"]
-            print converted
-            print new.letter_annotations["solexa_quality"]
+            print(old.letter_annotations["phred_quality"])
+            print(converted)
+            print(new.letter_annotations["solexa_quality"])
             raise ValueError("Mismatch in phred_quality vs solexa_quality")
     if "solexa_quality" in old.letter_annotations \
     and "phred_quality" in new.letter_annotations:
@@ -144,9 +144,9 @@ def compare_record(old, new, truncate=None):
         if truncate:
             converted = [min(q,truncate) for q in converted]
         if converted != new.letter_annotations["phred_quality"]:
-            print old.letter_annotations["solexa_quality"]
-            print converted
-            print new.letter_annotations["phred_quality"]
+            print(old.letter_annotations["solexa_quality"])
+            print(converted)
+            print(new.letter_annotations["phred_quality"])
             raise ValueError("Mismatch in solexa_quality vs phred_quality")
     return True
 

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -1021,9 +1021,9 @@ class NC_000932(unittest.TestCase):
             try:
                 pro = nuc.translate(table=self.table, cds=True)
             except TranslationError as e:
-                print e
+                print(e)
                 print r.id, nuc, self.table
-                print f
+                print(f)
                 raise
             if pro[-1] == "*":
                 self.assertEqual(str(pro)[:-1], str(r.seq))

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -301,7 +301,7 @@ class StringMethodTests(unittest.TestCase):
                     for step in range(-3,4):
                         if step == 0:
                             try:
-                                print example1[i:j:step]
+                                print(example1[i:j:step])
                                 self._assert(False)  # Should fail!
                             except ValueError:
                                 pass
@@ -449,7 +449,7 @@ class StringMethodTests(unittest.TestCase):
                     raise e
                 #This is based on the limited example not having stop codons:
                 if tran.alphabet not in [extended_protein, protein, generic_protein]:
-                    print tran.alphabet
+                    print(tran.alphabet)
                     self.assertTrue(False)
                 #TODO - check the actual translation, and all the optional args
 
@@ -503,7 +503,7 @@ class StringMethodTests(unittest.TestCase):
                         Seq(codon, generic_dna),
                         Seq(codon, unambiguous_dna)]:
                 try :
-                    print nuc.translate()
+                    print(nuc.translate())
                     self.assertTrue(False, "Transating %s should fail" % codon)
                 except TranslationError :
                     pass

--- a/Tests/test_TogoWS.py
+++ b/Tests/test_TogoWS.py
@@ -463,7 +463,7 @@ class TogoSearch(unittest.TestCase):
             raise ValueError("Only %i matches, expected at least %i"
                              % (search_count, len(expected_matches)))
         if search_count > 5000 and not limit:
-            print "%i results, skipping" % search_count
+            print("%i results, skipping" % search_count)
             return
         if limit:
             count = min(search_count, limit)

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -33,7 +33,7 @@ def _extract(handle):
         line = handle.readline()
         if not line:
             if lines:
-                print "".join(lines[:30])
+                print("".join(lines[:30]))
                 raise ValueError("Didn't find end of test starting: %r", lines[0])
             else:
                 raise ValueError("Didn't find end of test!")
@@ -159,13 +159,13 @@ class TutorialTestCase(unittest.TestCase):
 #This is to run the doctests if the script is called directly:
 if __name__ == "__main__":
     if missing_deps:
-        print "Skipping tests needing the following:"
+        print("Skipping tests needing the following:")
         for dep in sorted(missing_deps):
-            print " - %s" % dep
-    print "Running Tutorial doctests..."
+            print(" - %s" % dep)
+    print("Running Tutorial doctests...")
     import doctest
     tests = doctest.testmod()
     if tests[0]:
         #Note on Python 2.5+ can use tests.failed rather than tests[0]
         raise RuntimeError("%i/%i tests failed" % tests)
-    print "Tests done"
+    print("Tests done")

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -55,7 +55,7 @@ assert alignment[::-1][2].id == "mixed"
 del alignment
 del letters
 
-print "testing reading and writing clustal format..."
+print("testing reading and writing clustal format...")
 test_dir = os.path.join(os.getcwd(), 'Clustalw')
 test_names = ['opuntia.aln', 'cw02.aln']
 
@@ -68,49 +68,49 @@ for test_file in test_files:
     alignment = AlignIO.read(test_file, "clustal")
 
     # print the alignment back out
-    print alignment.format("clustal")
+    print(alignment.format("clustal"))
 
 alignment = AlignIO.read(os.path.join(test_dir, test_names[0]), "clustal",
                          alphabet = Alphabet.Gapped(IUPAC.unambiguous_dna))
 
 # test the base alignment stuff
-print 'all_seqs...'
+print('all_seqs...')
 for seq_record in alignment:
     print 'description:', seq_record.description
     print 'seq:', repr(seq_record.seq)
 print 'length:', alignment.get_alignment_length()
 
-print 'Calculating summary information...'
+print('Calculating summary information...')
 align_info = AlignInfo.SummaryInfo(alignment)
 consensus = align_info.dumb_consensus()
 assert isinstance(consensus, Seq)
 print 'consensus:', repr(consensus)
 
 
-print 'Replacement dictionary'
+print('Replacement dictionary')
 ks = align_info.replacement_dictionary(['N']).keys()
 ks.sort()
 for key in ks:
-    print "%s : %s" % (key, align_info.replacement_dictionary(['N'])[key])
+    print("%s : %s" % (key, align_info.replacement_dictionary(['N'])[key]))
 
-print 'position specific score matrix.'
-print 'with a supplied consensus sequence...'
-print align_info.pos_specific_score_matrix(consensus, ['N'])
+print('position specific score matrix.')
+print('with a supplied consensus sequence...')
+print(align_info.pos_specific_score_matrix(consensus, ['N']))
 
-print 'defaulting to a consensus sequence...'
-print align_info.pos_specific_score_matrix(chars_to_ignore = ['N'])
+print('defaulting to a consensus sequence...')
+print(align_info.pos_specific_score_matrix(chars_to_ignore = ['N']))
 
-print 'with a selected sequence...'
+print('with a selected sequence...')
 second_seq = alignment[1].seq
-print align_info.pos_specific_score_matrix(second_seq, ['N'])
+print(align_info.pos_specific_score_matrix(second_seq, ['N']))
 
-print 'information content'
-print 'part of alignment: %0.2f' \
-      % align_info.information_content(5, 50, chars_to_ignore = ['N'])
-print 'entire alignment: %0.2f' \
-      % align_info.information_content(chars_to_ignore = ['N'])
+print('information content')
+print('part of alignment: %0.2f' \
+      % align_info.information_content(5, 50, chars_to_ignore = ['N']))
+print('entire alignment: %0.2f' \
+      % align_info.information_content(chars_to_ignore = ['N']))
 
-print 'relative information content'
+print('relative information content')
 e_freq = {'G' : 0.25,
           'C' : 0.25,
           'A' : 0.25,
@@ -119,17 +119,17 @@ e_freq = {'G' : 0.25,
 e_freq_table = FreqTable.FreqTable(e_freq, FreqTable.FREQ,
                                    IUPAC.unambiguous_dna)
 
-print 'relative information: %0.2f' \
+print('relative information: %0.2f' \
       % align_info.information_content(e_freq_table = e_freq_table,
-                                       chars_to_ignore = ['N'])
+                                       chars_to_ignore = ['N']))
 
 print 'Column 1:', align_info.get_column(1)
-print 'IC for column 1: %0.2f' % align_info.ic_vector[1]
+print('IC for column 1: %0.2f' % align_info.ic_vector[1])
 print 'Column 7:', align_info.get_column(7)
-print 'IC for column 7: %0.2f' % align_info.ic_vector[7]
-print 'test print_info_content'
+print('IC for column 7: %0.2f' % align_info.ic_vector[7])
+print('test print_info_content')
 AlignInfo.print_info_content(align_info)
-print "testing reading and writing fasta format..."
+print("testing reading and writing fasta format...")
 
 to_parse = os.path.join(os.curdir, 'Quality', 'example.fasta')
 
@@ -137,7 +137,7 @@ alignment = AlignIO.read(to_parse, "fasta",
                          alphabet = Alphabet.Gapped(IUPAC.ambiguous_dna))
 
 # test the base alignment stuff
-print 'all_seqs...'
+print('all_seqs...')
 for seq_record in alignment:
     print 'description:', seq_record.description
     print 'seq:', repr(seq_record.seq)
@@ -148,19 +148,19 @@ consensus = align_info.dumb_consensus(ambiguous="N", threshold=0.6)
 assert isinstance(consensus, Seq)
 print 'consensus:', repr(consensus)
 
-print alignment
+print(alignment)
 
 
-print "Test format conversion..."
+print("Test format conversion...")
 
 # parse the alignment file and get an aligment object
 alignment = AlignIO.read(os.path.join(os.curdir, 'Clustalw', 'opuntia.aln'),
                          'clustal')
 
-print "As FASTA:"
-print alignment.format("fasta")
-print "As Clustal:"
-print alignment.format("clustal")
+print("As FASTA:")
+print(alignment.format("fasta"))
+print("As Clustal:")
+print(alignment.format("clustal"))
 
 """
 # test to find a position in an original sequence given a

--- a/Tests/test_geo.py
+++ b/Tests/test_geo.py
@@ -24,9 +24,9 @@ for file in testfiles:
         fh = open(os.path.join("Geo", file), encoding="latin")
     else:
         fh = open(os.path.join("Geo", file))
-    print "Testing Bio.Geo on " + file + "\n\n"
+    print("Testing Bio.Geo on " + file + "\n\n")
     records = Bio.Geo.parse(fh)
     for record in records:
-        print record
-    print "\n"
+        print(record)
+    print("\n")
     fh.close()

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -17,65 +17,65 @@ else:
     array_indicator = "c"
 
 print
-print "Testing Seq"
-print "==========="
+print("Testing Seq")
+print("===========")
 
 s = Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna)
 
-print str(s)
-print len(s)
-print s[0]
-print s[-1]
-print str(s[3:5])
+print(str(s))
+print(len(s))
+print(s[0])
+print(s[-1])
+print(str(s[3:5]))
 
 print "Reverse using -1 stride:", repr(s[::-1])
 
-print "Extract every third nucleotide (slicing with stride 3):"
-print repr(s[0::3])
-print repr(s[1::3])
-print repr(s[2::3])
+print("Extract every third nucleotide (slicing with stride 3):")
+print(repr(s[0::3]))
+print(repr(s[1::3]))
+print(repr(s[2::3]))
 
-print s.alphabet.letters
+print(s.alphabet.letters)
 
 t = Seq.Seq("T", IUPAC.unambiguous_dna)
 u = s + t
-print str(u.alphabet)
-print len(u)
+print(str(u.alphabet))
+print(len(u))
 assert str(s) + "T" == str(u)
 
 t = Seq.Seq("T", IUPAC.protein)
 try:
     u = s + t
 except TypeError:
-    print "expected error, and got it"
+    print("expected error, and got it")
 else:
-    print "huh?  ERROR"
+    print("huh?  ERROR")
 
 t = Seq.Seq("T", IUPAC.ambiguous_dna)
 u = s + t
-print str(u.alphabet)
+print(str(u.alphabet))
 
 from Bio.Seq import MutableSeq
 import array
 
 print
-print "Testing MutableSeq"
-print "=================="
+print("Testing MutableSeq")
+print("==================")
 
-print "Testing creating MutableSeqs in multiple ways"
+print("Testing creating MutableSeqs in multiple ways")
 string_seq = MutableSeq("TCAAAAGGATGCATCATG", IUPAC.ambiguous_dna)
 array_seq = MutableSeq(array.array(array_indicator, "TCAAAAGGATGCATCATG"),
                        IUPAC.ambiguous_dna)
 converted_seq = s.tomutable()
 
 for test_seq in [string_seq]:
-    print repr(test_seq)
-    print str(test_seq)
-    print len(test_seq)
-    print repr(test_seq.toseq())
+    print(repr(test_seq))
+    print(str(test_seq))
+    print(len(test_seq))
+    print(repr(test_seq.toseq()))
 
-    print test_seq[0]
-    print repr(test_seq[1:5])
+    print(test_seq[0])
+    print(repr(test_seq[1:5]))
 
     test_seq[1:3] = "GAT"
     print "Set slice with string:", repr(test_seq)
@@ -106,7 +106,7 @@ for test_seq in [string_seq]:
         test_seq.remove("Z")
         raise AssertionError("Did not get expected value error.")
     except ValueError:
-        print "Expected value error and got it"
+        print("Expected value error and got it")
 
     print "A count:", test_seq.count("A")
     print "A index:", test_seq.index("A")
@@ -123,19 +123,19 @@ for test_seq in [string_seq]:
     del test_seq[4:6:-1]
     print "Delete stride slice:", repr(test_seq)
 
-    print "Extract every third nucleotide (slicing with stride 3):"
-    print repr(test_seq[0::3])
-    print repr(test_seq[1::3])
-    print repr(test_seq[2::3])
+    print("Extract every third nucleotide (slicing with stride 3):")
+    print(repr(test_seq[0::3]))
+    print(repr(test_seq[1::3]))
+    print(repr(test_seq[2::3]))
 
-    print "Setting wobble codon to N (set slice with stride 3):"
+    print("Setting wobble codon to N (set slice with stride 3):")
     test_seq[2::3] = "N" * len(test_seq[2::3])
-    print repr(test_seq)
+    print(repr(test_seq))
 
 ###########################################################################
 print
-print "Testing Seq addition"
-print "===================="
+print("Testing Seq addition")
+print("====================")
 dna = [Seq.Seq("ATCG", IUPAC.ambiguous_dna),
        Seq.Seq("gtca", Alphabet.generic_dna),
        Seq.MutableSeq("GGTCA", Alphabet.generic_dna),
@@ -168,14 +168,14 @@ for a in rna:
             c=a+b
             assert str(c) == str(a) + str(b)
         except ValueError as e:
-            print "%s + %s\n-> %s" % (repr(a.alphabet), repr(b.alphabet), str(e))
+            print("%s + %s\n-> %s" % (repr(a.alphabet), repr(b.alphabet), str(e)))
 for a in dna:
     for b in dna:
         try:
             c=a+b
             assert str(c) == str(a) + str(b)
         except ValueError as e:
-            print "%s + %s\n-> %s" % (repr(a.alphabet), repr(b.alphabet), str(e))
+            print("%s + %s\n-> %s" % (repr(a.alphabet), repr(b.alphabet), str(e)))
     for b in rna:
         try:
             c=a+b
@@ -195,7 +195,7 @@ for a in protein:
             c=a+b
             assert str(c) == str(a) + str(b)
         except ValueError as e:
-            print "%s + %s\n-> %s" % (repr(a.alphabet), repr(b.alphabet), str(e))
+            print("%s + %s\n-> %s" % (repr(a.alphabet), repr(b.alphabet), str(e)))
     for b in nuc+dna+rna:
         try:
             c=a+b
@@ -218,8 +218,8 @@ for a in dna+rna+nuc:
 
 ###########################################################################
 print
-print "Testing Seq string methods"
-print "=========================="
+print("Testing Seq string methods")
+print("==========================")
 for a in dna + rna + nuc + protein:
     if not isinstance(a, Seq.Seq):
         continue
@@ -245,7 +245,7 @@ for a in dna + rna + nuc + protein:
     else:
         b = Seq.Seq("-", Alphabet.generic_protein)
     try:
-        print str(a.strip(b))
+        print(str(a.strip(b)))
         assert False, "Alphabet should have clashed!"
     except TypeError:
         pass  # Good!
@@ -275,8 +275,8 @@ del a, alpha, chars, str_chars, test_chars
 del dna, rna, nuc, protein
 ###########################################################################
 print
-print "Checking ambiguous complements"
-print "=============================="
+print("Checking ambiguous complements")
+print("==============================")
 
 #See bug 2380, Bio.Nexus was polluting the dictionary.
 assert "-" not in ambiguous_dna_values
@@ -299,8 +299,8 @@ print "DNA Ambiguity mapping:", sorted_dict(ambiguous_dna_values)
 print "DNA Complement mapping:", sorted_dict(ambiguous_dna_complement)
 for ambig_char, values in sorted(ambiguous_dna_values.iteritems()):
     compl_values = complement(values)
-    print "%s={%s} --> {%s}=%s" % \
-        (ambig_char, values, compl_values, ambiguous_dna_complement[ambig_char])
+    print("%s={%s} --> {%s}=%s" % \
+        (ambig_char, values, compl_values, ambiguous_dna_complement[ambig_char]))
     assert set(compl_values) == set(ambiguous_dna_values[ambiguous_dna_complement[ambig_char]])
 
 print
@@ -308,12 +308,12 @@ print "RNA Ambiguity mapping:", sorted_dict(ambiguous_rna_values)
 print "RNA Complement mapping:", sorted_dict(ambiguous_rna_complement)
 for ambig_char, values in sorted(ambiguous_rna_values.iteritems()):
     compl_values = complement(values).replace("T","U")  # need to help as no alphabet
-    print "%s={%s} --> {%s}=%s" % \
-        (ambig_char, values, compl_values, ambiguous_rna_complement[ambig_char])
+    print("%s={%s} --> {%s}=%s" % \
+        (ambig_char, values, compl_values, ambiguous_rna_complement[ambig_char]))
     assert set(compl_values) == set(ambiguous_rna_values[ambiguous_rna_complement[ambig_char]])
 
 print
-print "Reverse complements:"
+print("Reverse complements:")
 for sequence in [Seq.Seq("".join(sorted(ambiguous_rna_values))),
             Seq.Seq("".join(sorted(ambiguous_dna_values))),
             Seq.Seq("".join(sorted(ambiguous_rna_values)), Alphabet.generic_rna),
@@ -321,8 +321,8 @@ for sequence in [Seq.Seq("".join(sorted(ambiguous_rna_values))),
             Seq.Seq("".join(sorted(ambiguous_rna_values)).replace("X",""), IUPAC.IUPACAmbiguousRNA()),
             Seq.Seq("".join(sorted(ambiguous_dna_values)).replace("X",""), IUPAC.IUPACAmbiguousDNA()),
             Seq.Seq("AWGAARCKG")]:  # Note no U or T
-        print "%s -> %s" \
-              % (repr(sequence), repr(Seq.reverse_complement(sequence)))
+        print("%s -> %s" \
+              % (repr(sequence), repr(Seq.reverse_complement(sequence))))
         assert str(sequence) \
            == str(Seq.reverse_complement(Seq.reverse_complement(sequence))), \
            "Dobule reverse complement didn't preserve the sequence!"
@@ -374,18 +374,18 @@ for nucleotide_seq in test_seqs:
             assert not isinstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet)
 
 print
-print "Transcribe DNA into RNA"
-print "======================="
+print("Transcribe DNA into RNA")
+print("=======================")
 for nucleotide_seq in test_seqs:
     try:
         expected = Seq.transcribe(nucleotide_seq)
         assert str(nucleotide_seq).replace("t","u").replace("T","U") == str(expected)
-        print "%s -> %s" \
-        % (repr(nucleotide_seq) , repr(expected))
+        print("%s -> %s" \
+        % (repr(nucleotide_seq) , repr(expected)))
     except ValueError as e:
         expected = None
-        print "%s -> %s" \
-        % (repr(nucleotide_seq) , str(e))
+        print("%s -> %s" \
+        % (repr(nucleotide_seq) , str(e)))
     #Now test the Seq object's method
     if isinstance(nucleotide_seq, Seq.Seq):
         try:
@@ -395,31 +395,31 @@ for nucleotide_seq in test_seqs:
 
 for s in protein_seqs:
     try:
-        print Seq.transcribe(s)
+        print(Seq.transcribe(s))
         assert False, "Transcription shouldn't work on a protein!"
     except ValueError:
         pass
     if not isinstance(s, Seq.Seq):
         continue  # Only Seq has this method
     try:
-        print s.transcribe()
+        print(s.transcribe())
         assert False, "Transcription shouldn't work on a protein!"
     except ValueError:
         pass
 
 print
-print "Back-transcribe RNA into DNA"
-print "============================"
+print("Back-transcribe RNA into DNA")
+print("============================")
 for nucleotide_seq in test_seqs:
     try:
         expected = Seq.back_transcribe(nucleotide_seq)
         assert str(nucleotide_seq).replace("u","t").replace("U","T") == str(expected)
-        print "%s -> %s" \
-        % (repr(nucleotide_seq) , repr(expected))
+        print("%s -> %s" \
+        % (repr(nucleotide_seq) , repr(expected)))
     except ValueError as e:
         expected = None
-        print "%s -> %s" \
-        % (repr(nucleotide_seq) , str(e))
+        print("%s -> %s" \
+        % (repr(nucleotide_seq) , str(e)))
     #Now test the Seq object's method
     if isinstance(nucleotide_seq, Seq.Seq):
         try:
@@ -429,30 +429,30 @@ for nucleotide_seq in test_seqs:
 
 for s in protein_seqs:
     try:
-        print Seq.back_transcribe(s)
+        print(Seq.back_transcribe(s))
         assert False, "Back transcription shouldn't work on a protein!"
     except ValueError:
         pass
     if not isinstance(s, Seq.Seq):
         continue  # Only Seq has this method
     try:
-        print s.back_transcribe()
+        print(s.back_transcribe())
         assert False, "Back transcription shouldn't work on a protein!"
     except ValueError:
         pass
 
 print
-print "Reverse Complement"
-print "=================="
+print("Reverse Complement")
+print("==================")
 for nucleotide_seq in test_seqs:
     try:
         expected = Seq.reverse_complement(nucleotide_seq)
-        print "%s\n-> %s" \
-        % (repr(nucleotide_seq) , repr(expected))
+        print("%s\n-> %s" \
+        % (repr(nucleotide_seq) , repr(expected)))
     except ValueError as e:
         expected = None
-        print "%s\n-> %s" \
-        % (repr(nucleotide_seq) , str(e))
+        print("%s\n-> %s" \
+        % (repr(nucleotide_seq) , str(e)))
     #Now test the Seq object's method
     #(The MutualSeq object acts in place)
     if isinstance(nucleotide_seq, Seq.Seq):
@@ -464,34 +464,34 @@ for nucleotide_seq in test_seqs:
 
 for s in protein_seqs:
     try:
-        print Seq.reverse_complement(s)
+        print(Seq.reverse_complement(s))
         assert False, "Reverse complement shouldn't work on a protein!"
     except ValueError:
         pass
     #Note that these methods are "in place" for the MutableSeq:
     try:
-        print s.complement()
+        print(s.complement())
         assert False, "Complement shouldn't work on a protein!"
     except ValueError:
         pass
     try:
-        print s.reverse_complement()
+        print(s.reverse_complement())
         assert False, "Reverse complement shouldn't work on a protein!"
     except ValueError:
         pass
 
 print
-print "Translating"
-print "==========="
+print("Translating")
+print("===========")
 for nucleotide_seq in test_seqs:
     #Truncate to a whole number of codons to avoid translation warning
     nucleotide_seq = nucleotide_seq[:3 * (len(nucleotide_seq) // 3)]
     try:
         expected = Seq.translate(nucleotide_seq)
-        print "%s\n-> %s" % (repr(nucleotide_seq), repr(expected))
+        print("%s\n-> %s" % (repr(nucleotide_seq), repr(expected)))
     except (ValueError, TranslationError) as e:
         expected = None
-        print "%s\n-> %s" % (repr(nucleotide_seq), str(e))
+        print("%s\n-> %s" % (repr(nucleotide_seq), str(e)))
     #Now test the Seq object's method
     if isinstance(nucleotide_seq, Seq.Seq):
         try:
@@ -514,14 +514,14 @@ for nucleotide_seq in test_seqs:
 
 for s in protein_seqs:
     try:
-        print Seq.translate(s)
+        print(Seq.translate(s))
         assert False, "Translation shouldn't work on a protein!"
     except ValueError:
         pass
     if not isinstance(s, Seq.Seq):
         continue  # Only Seq has this method
     try:
-        print s.translate()
+        print(s.translate())
         assert False, "Translation shouldn't work on a protein!"
     except ValueError:
         pass
@@ -548,7 +548,7 @@ del misc_stops
 
 for s in protein_seqs:
     try:
-        print Seq.translate(s)
+        print(Seq.translate(s))
         assert False, "Shouldn't work on a protein!"
     except ValueError:
         pass
@@ -570,7 +570,7 @@ assert Seq.translate("nnn")=="X"
 
 for codon in ["TA?", "N-N", "AC_", "Ac_"]:
     try:
-        print Seq.translate(codon)
+        print(Seq.translate(codon))
         assert "Translating %s should have failed" % repr(codon)
     except TranslationError:
         pass
@@ -603,31 +603,31 @@ for c1 in ambig:
 del t,c1,c2,c3,ambig
 
 print
-print "Seq's .complement() method"
-print "=========================="
+print("Seq's .complement() method")
+print("==========================")
 for nucleotide_seq in test_seqs:
     if isinstance(nucleotide_seq, Seq.Seq):
         try:
-            print "%s -> %s" \
-            % (repr(nucleotide_seq) , repr(nucleotide_seq.complement()))
+            print("%s -> %s" \
+            % (repr(nucleotide_seq) , repr(nucleotide_seq.complement())))
             assert str(nucleotide_seq.complement()) \
                 == str(Seq.reverse_complement(nucleotide_seq))[::-1], \
                 "Bio.Seq function and method disagree!"
         except ValueError as e:
-            print "%s -> %s" \
-            % (repr(nucleotide_seq) , str(e))
+            print("%s -> %s" \
+            % (repr(nucleotide_seq) , str(e)))
 
 print
-print "Seq's .reverse_complement() method"
-print "=================================="
+print("Seq's .reverse_complement() method")
+print("==================================")
 for nucleotide_seq in test_seqs:
     if isinstance(nucleotide_seq, Seq.Seq):
         try:
-            print "%s -> %s" \
-            % (repr(nucleotide_seq) , repr(nucleotide_seq.reverse_complement()))
+            print("%s -> %s" \
+            % (repr(nucleotide_seq) , repr(nucleotide_seq.reverse_complement())))
             assert str(nucleotide_seq.reverse_complement()) \
                 == str(Seq.reverse_complement(nucleotide_seq)), \
                 "Bio.Seq function and method disagree!"
         except ValueError as e:
-            print "%s -> %s" \
-            % (repr(nucleotide_seq) , str(e))
+            print("%s -> %s" \
+            % (repr(nucleotide_seq) , str(e)))

--- a/Tests/test_translate.py
+++ b/Tests/test_translate.py
@@ -68,23 +68,23 @@ print len(protein), "ungapped residues translated"
 
 gapped_protein = dna.translate()
 assert isinstance(gapped_protein.alphabet, Alphabet.HasStopCodon)
-print str(protein)
+print(str(protein))
 
 print len(gapped_protein), "residues translated, including gaps"
-print str(gapped_protein)
+print(str(gapped_protein))
 
 # This has "AGG" as a stop codon
 p2 = dna.translate(table=2, to_stop=True)
 print len(p2), "SGC1 has a stop codon"
-print str(p2)
+print(str(p2))
 p2 = dna.translate(table=2)
 print "Actually, there are", p2.count("*"), "stops."
-print str(p2)
+print(str(p2))
 
 # Make sure I can change the stop character
 p2 = dna.translate(table=2, stop_symbol="+")
 print "Yep,", p2.count("+"), "stops."
-print str(p2)
+print(str(p2))
 
 
 # Some of the same things, with RNA
@@ -95,23 +95,23 @@ print "RNA translation ...",
 protein_from_rna = rna.translate(to_stop=True)
 assert protein.alphabet is protein_from_rna.alphabet
 assert str(protein) == str(protein_from_rna)
-print "works."
+print("works.")
 
 print "RNA translation to stop ...",
 gapped_protein_from_rna = rna.translate()
 assert len(gapped_protein) == len(gapped_protein_from_rna)
 assert str(gapped_protein) == str(gapped_protein_from_rna)
-print "works."
+print("works.")
 
 # some tests for "by name"
 # How about some forward ambiguity?
-print "Forward ambiguous"
+print("Forward ambiguous")
 s = "RATGATTARAATYTA"
 #     B  D  *  N  L
 dna = Seq.Seq(s, IUPAC.ambiguous_dna)
 protein = dna.translate('Vertebrate Mitochondrial')
-print str(protein)
+print(str(protein))
 stop_protein = dna.translate('SGC1', to_stop=True)
-print str(stop_protein)
+print(str(stop_protein))
 
 # XXX (Backwards with ambiguity code is unfinished!)


### PR DESCRIPTION
  For now we only handle the 'print' statement with a single argument,
  i. e.:

```
  print ... -> print(...)
```

  Migration was performed using a 2to3 fixer class:

```
  from lib2to3 import fixer_base, patcomp
  from lib2to3.fixer_util import Name, Call

  parend_expr = patcomp.compile_pattern(
      """atom< '(' [atom|term|testlist_gexp|STRING|NAME] ')' >""")

  class FixSinglePrint(fixer_base.BaseFix):
      PATTERN = "print_stmt"
      BM_compatible = True

      def transform(self, node, results):
          assert results
          assert node.children[0] == Name(u"print")
          args = node.children[1:]
          if len(args) != 1 or parend_expr.match(args[0]):
              # We only fix 'print' statements which have _exactly_ one
              # non-parenthesized argument.
              return

          l_args = [arg.clone() for arg in args]
          l_args[0].prefix = u""
          n_stmt = Call(Name(u"print"), l_args)
          n_stmt.prefix = node.prefix
          return n_stmt
```
