### PR TITLE
Close #206: greytrack_font_rotation is linear only

### DIFF
--- a/Bio/Graphics/GenomeDiagram/_Track.py
+++ b/Bio/Graphics/GenomeDiagram/_Track.py
@@ -90,7 +90,7 @@ class Track(object):
                                 labels on the grey track
 
         o greytrack_font_rotation   Int describing the angle through which to
-                                    rotate the grey track labels
+                                    rotate the grey track labels (Linear only)
 
         o greytrack_font_color     colors.Color describing the color to draw
                                     the grey track labels
@@ -168,7 +168,7 @@ class Track(object):
                                     labels on the grey track
 
             o greytrack_font_rotation   Int describing the angle through which to
-                                        rotate the grey track labels
+                                        rotate the grey track labels (Linear only)
 
             o greytrack_font_color     colors.Color describing the color to draw
                                        the grey track labels (overridden by


### PR DESCRIPTION
See Issue #206

I confirmed that greytrack_font_rotation is only used by the Linear diagram and added comments to that effect in the code. 

However, I don't see the source for the old documentation [1] offhand, so that is not specific.

1: http://biopython.org/DIST/docs/GenomeDiagram/userguide.pdf

P.S. At an @openhatch event! (task 71)
