### PR TITLE
Fixed a bug that prevented reading DSSP 2.0.4 files (and maybe others.)

### DIFF
--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -133,7 +133,7 @@ def _make_dssp_dict(handle):
         sl = l.split()
         if len(sl) < 2:
             continue
-        if sl[1] == "RESIDUE":
+        if len(sl) >= 2 and sl[1] == "RESIDUE":
             # Start parsing from here
             start = 1
             continue


### PR DESCRIPTION
Code would crash at around this line in a DSSP output file:

  #  RESIDUE AA STRUCTURE BP1 BP2  ACC     N-H-->O    O-->H-N    N-H-->O    O-->H-N    TCO  KAPPA ALPHA  PHI   PSI    X-CA   Y-CA   Z-CA 

Which is where it's supposed to begin parsing. I added a small short-circuit conditional to prevent that.
Other bugs may linger.
