### PR TITLE
DSSP: Fix ValueError: too many values to unpack in __main__

### DIFF
--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -336,4 +336,4 @@ if __name__ == "__main__":
         print(d[('A', 1)])
         print(s[0]['A'][1].xtra)
     # Secondary structure
-    print(''.join(d[key][1] for key in d))
+    print(''.join(item[1] for item in d))


### PR DESCRIPTION
Commit 3e287df caused a minor issue since `__iter__` and `keys` methods of DSSP class return different tuples. DSSP objects cannot be indexed by tuples returned by `__iter__`. 

Either `[d[x][1] for x in d.keys()]` or `[x[1] for x in d]` must be used to get the secondary structure.
