### PR TITLE
New restriction analysis library, v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ MANIFEST
 #Ignore potential directory created during install:
 biopython.egg-info
  
+#Files are downloaded on install, should not be included
+Bio/Restriction2/emboss_*.txt
+
 #The graphics unit tests produce output files for human inspection
 #(at the time of writing, only PDF and PNG files are created)
 Tests/Graphics/*.pdf

--- a/Bio/Restriction2/Restriction.py
+++ b/Bio/Restriction2/Restriction.py
@@ -1,0 +1,246 @@
+# Copyright 2013 Antony Lee
+# All rights reserved.
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+"""Restriction enzyme and sequence objects, and analysis utilities.
+"""
+
+from __future__ import division, print_function
+
+from collections import namedtuple
+import re
+
+from . import RestrictionDB
+
+
+_codes = {"A": "A", "C": "C", "G": "G", "T": "T",
+          "R": "GA", "Y": "TC", "K": "GT", "M": "AC", "S": "GC", "W": "AT",
+          "B": "GTC", "D": "GAT", "H": "ACT", "V": "GCA", "N": "ACGT"}
+
+
+_complement = {"A": "T", "C": "G", "G": "C", "T": "A",
+               "R": "Y", "Y": "R", "M": "K", "K": "M", "S": "S", "W": "W",
+               "B": "D", "D": "B", "H": "V", "V": "H", "N": "N"}
+
+
+class Seq(str):
+    """A DNA sequence object, including linear/circular information.
+    """
+
+    def __new__(cls, s, circular=False):
+        self = super(Seq, cls).__new__(Seq, s)
+        self.circular = circular
+        return self
+
+    @property
+    def reverse_complement(self):
+        return Seq("".join(_complement[base] for base in reversed(self)),
+                   self.circular)
+
+
+class Restriction(namedtuple("Restriction",
+                             ("name", "site", "cuts", "methylation", "suppliers"))):
+    """Type of all enzymes.
+
+    The following attributes are defined:
+        - name: enzyme name
+        - site: recongnized site
+        - cuts: list of (5', 3') cutting sites
+        - methylation: list of methylation site and type pairs
+        - suppliers: string of REBASE codes
+
+    The following class attributes are defined:
+        - all: all defined enzymes
+        - commercial: all commercially available enzymes
+
+    Enzymes with unknown cutting sites are ignored.
+    """
+
+    all = {}
+    commercial = {}
+
+    @classmethod
+    def load_all(cls):
+        """Populate cls.all and cls.commercial from the database.
+        """
+        patterns = RestrictionDB.patterns()
+        information = RestrictionDB.information()
+        for name, pattern in patterns.items():
+            if not pattern.cuts:
+                continue # ignore enzymes with unknown cutting site
+            if len(pattern.cuts) == 2:
+                (c1, c2), (c3, c4) = pattern.cuts
+                if c2 - c1 != c4 - c3:
+                    continue # ignore HaeIV (EMBOSS v301)
+            info = information[name]
+            cls.all[name] = cls(name, pattern.site, pattern.cuts,
+                                info.methylation, info.suppliers)
+            if info.suppliers:
+                cls.commercial[name] = cls.all[name]
+
+    def __len__(self):
+        """Return the length of the recognition site.
+        """
+        return len(self.site)
+
+    def isoschizomer(self, other):
+        """Return whether two enzymes have the same site.
+        """
+        return isinstance(other, Restriction) and self.site == other.site
+
+    def neoschizomer(self, other):
+        """Return whether two enzymes have the same site but cut differently.
+        """
+        return self.isoschizomer(other) and self.cuts != other.cuts
+
+    def isoschizomers(self, batch=None):
+        """Lists the isoschizomers of an enzyme from a batch, or all enzymes.
+        """
+        if batch is None:
+            batch = self.all
+        return sorted(x for x in batch if x.isoschizomer(self) and x != self)
+
+    def neoschizomers(self, batch=None):
+        """Lists the neoschizomers of an enzyme from a batch, or all enzymes.
+        """
+        if batch is None:
+            batch = self.all
+        return sorted(x for x in batch if x.neoschizomer(self))
+
+    def __str__(self):
+        """Return the enzyme name followed by its pattern.
+        """
+        cuts_pos, cuts_neg = zip(*self.cuts)
+        markers = sorted([(cut, "^") for cut in cuts_pos] +
+                         [(cut, "_") for cut in cuts_neg])
+        offset5 = max(-markers[0][0], 0)
+        offset3 = max(markers[-1][0] - len(self.site), 0)
+        site = "N" * offset5 + self.site + "N" * offset3
+        str = ""
+        previdx = 0
+        for idx, char in markers:
+            idx += offset5
+            str += site[previdx:idx] + char
+            previdx = idx
+        str += site[previdx:]
+        return self.name + ":" + str
+
+    @property
+    def overhang(self):
+        """Return an overhang type and sequence pair.
+
+        The overhang type is one of 5, 3 or None and the overhang sequence is
+        given on the + strand, 5'-to-3'.
+        """
+        str_self = str(self)
+        cut_pos = str_self.find("^")
+        cut_neg = str_self.find("_")
+        if cut_neg == cut_pos + 1:
+            return None, ""
+        if cut_pos > cut_neg:
+            return 3, str_self[cut_neg+1:cut_pos]
+        else:
+            return 5, str_self[cut_pos+1:cut_neg]
+
+    def always_compatible(self, other):
+        """Test whether the product of two digests are always compatible.
+        """
+        type1, ov1 = self.overhang
+        type2, ov2 = other.overhang
+        return (type1 == type2 and ov1 == ov2 and
+                "N" not in ov1 and "N" not in ov2)
+
+    def perhaps_compatible(self, other):
+        """Test whether the product of two digests may be compatible.
+        """
+        type1, ov1 = self.overhang
+        type2, ov2 = other.overhang
+        return (type1 == type2 and len(ov1) == len(ov2) and
+                all(set(_codes[b1]).intersection(_codes[b2])
+                    for b1, b2 in zip(ov1, ov2)))
+
+    @property
+    def frequency(self):
+        """Return the inverse of the frequency of a site.
+        """
+        f = 1
+        for b in self.site:
+            f *= 4 / len(_codes[b])
+        return f
+
+    def search(self, seq):
+        """List in order the indices after which an enzyme cuts on a + strand.
+        """
+        if seq.circular:
+            seq += seq[:len(self.site) - 1]
+        regexp_pos = "".join("[" + _codes[b] + "]" for b in self.site)
+        regexp_neg = "".join("[" + _codes[b] + "]"
+                             for b in Seq(self.site).reverse_complement)
+        matches = [match.start() + cut_pos
+                   for match in re.finditer(regexp_pos, seq)
+                   for cut_pos, cut_neg in self.cuts]
+        if regexp_pos != regexp_neg:
+            matches += [match.start() + len(self.site) - cut_neg
+                        for match in re.finditer(regexp_neg, seq)
+                        for cut_pos, cut_neg in self.cuts]
+        return sorted(matches)
+
+    def catalyze(self, seq):
+        """List the + strands obtained by a digest.
+        """
+        fragments = []
+        previdx = 0
+        for idx in self.search(seq):
+            fragments.append(seq[previdx:idx])
+            previdx = idx
+        fragments.append(seq[previdx:])
+        if seq.circular:
+            fragments[0] = fragments[-1] + fragments[0]
+            fragments.pop()
+        return fragments
+
+
+Restriction.load_all()
+
+
+def analyze(seq, enzymes=Restriction.all.values()):
+    """Maps enzymes (by default, all) to the points they cut in a sequence.
+    """
+    return {enzyme.name: enzyme.search(seq) for enzyme in enzymes}
+
+
+def pretty_str(seq, analysis):
+    """Creates a prettified string of a restriction analysis.
+    """
+    width = 80
+    start = 0
+    pretty = ""
+    while seq:
+        stop = start + width
+        cps = {cp: [name for name, cps in analysis.items() if cp in cps]
+               for cp in {cp for cps in analysis.values() for cp in cps
+                          if start <= cp < stop}}
+        ss = [[" "] * width]
+        markers = [set()]
+        for cp in sorted(cps):
+            for name in cps[cp]:
+                for s, marker in zip(ss, markers):
+                    if all(c == " " for c in s[cp:cp+len(name)]):
+                        s[cp:cp+len(name)] = name
+                        marker.add(cp)
+                        break
+                else:
+                    ss.append([" "] * len(seq))
+                    ss[-1][cp:cp+len(name)] = name
+                    markers.append({cp})
+        ss.insert(0, [" "] * len(seq))
+        for i, s in enumerate(ss):
+            for j, c in enumerate(s):
+                if c == " " and any(j in marker for marker in markers[i:]):
+                    s[j] = u"\u258f"
+        pretty += ("\n".join("".join(s) for s in reversed(ss)) + "\n"
+                   + seq + "\n" + Seq(seq).reverse_complement[::-1] + "\n")
+        start = stop
+        seq = seq[width:]
+    return pretty

--- a/Bio/Restriction2/RestrictionDB.py
+++ b/Bio/Restriction2/RestrictionDB.py
@@ -1,0 +1,120 @@
+# Copyright 2013 Antony Lee
+# All rights reserved.
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+"""Utilities for downloading and parsing REBASE data files in EMBOSS format.
+
+Importing this module will have the side-effect of trying to fetch the REBASE
+data files if they are not present!
+"""
+
+from collections import namedtuple
+import os
+import urllib2
+
+
+_dir = os.path.dirname(__file__)
+
+
+def suppliers():
+    """Return a dict of supplier keys to supplier names.
+    """
+    with open(os.path.join(_dir, "emboss_s.txt")) as f:
+        return dict(line.strip().split(None, 1)
+                    for line in f if not line.startswith("#"))
+
+
+def patterns():
+    """Return a dict of enzyme names to enzyme patterns.
+    """
+    Pattern = namedtuple("Pattern", ("name", "site", "cuts"))
+    def to_restriction(name, site, length, ncuts, blunt, c1, c2, c3, c4):
+        c1, c2, c3, c4 = map(int, (c1, c2, c3, c4))
+        if ncuts == "0":
+            cuts = []
+        elif ncuts == "2":
+            cuts = [(c1, c2)]
+        elif ncuts == "4":
+            cuts = [(c1, c2), (c3, c4)]
+        return name, Pattern(name, site.upper(), cuts)
+    with open(os.path.join(_dir, "emboss_e.txt")) as f:
+        return dict(to_restriction(*line.strip().split())
+                    for line in f if not line.startswith("#"))
+
+
+def information():
+    """Return a dict of enzyme names to enzyme informations.
+    """
+    Information = namedtuple(
+        "Information",
+        ("name", "organism", "isoschizomers", "methylation", "source",
+         "suppliers", "references"))
+    informations = {}
+    with open(os.path.join(_dir, "emboss_r.txt")) as f:
+        for enz in "".join(line for line in f
+                           if not line.startswith("#")).split("//\n")[:-1]:
+            (name, organism, isoschizomers, _methylation, source, suppliers,
+             nref, references) = enz.split("\n", 7)
+            references = references.splitlines()
+            methylation = []
+            if _methylation:
+                for spec in _methylation.split(","):
+                    base = spec[:spec.index("(")]
+                    base = None if base == "?" else int(base)
+                    type = int(spec[-2])
+                    methylation.append((base, type))
+            informations[name] = Information(
+                name, organism, isoschizomers, methylation, source, suppliers,
+                references)
+    return informations
+
+
+def update_db():
+    """Download the EMBOSS files from the NEB server and check their validity.
+    """
+    for fname in ["emboss_e.txt", "emboss_r.txt", "emboss_s.txt"]:
+        file = urllib2.urlopen("ftp://ftp.neb.com/pub/rebase/" + fname)
+        with open(os.path.join(_dir, fname), "w") as out:
+            out.write(file.read())
+        file.close()
+    e_names = []
+    r_names = []
+    with open(os.path.join(_dir, "emboss_e.txt")) as f:
+        for line in f:
+            if line.startswith("#"):
+                continue
+            name, site, length, ncuts, blunt, c1, c2, c3, c4 = line.strip().split()
+            e_names.append(name)
+            assert len(site) == int(length)
+            c1, c2, c3, c4 = map(int, (c1, c2, c3, c4))
+            if ncuts == "0":
+                assert c1 == c2 == c3 == c4 == 0
+            elif ncuts == "2":
+                assert c3 == c4 == 0
+            elif ncuts == "4":
+                pass
+            else:
+                raise AssertionError
+            if blunt == "1":
+                assert ncuts == "2" and c1 == c2
+    with open(os.path.join(_dir, "emboss_r.txt")) as f:
+        for enz in "".join(line for line in f
+                           if not line.startswith("#")).split("//\n")[:-1]:
+            (name, organism, isoschizomers, methylation, source, suppliers,
+             nref, references) = enz.split("\n", 7)
+            r_names.append(name)
+            references = references.splitlines()
+            assert len(references) == int(nref)
+    assert sorted(e_names) == sorted(r_names)
+
+
+def ensure_db():
+    """Download the missing EMBOSS files, if needed.
+    """
+    required = ["emboss_{}.txt".format(c) for c in "ers"]
+    if any(fname not in os.listdir(_dir) for fname in required):
+        update_db()
+
+
+ensure_db()

--- a/Bio/Restriction2/__init__.py
+++ b/Bio/Restriction2/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2013 Antony Lee
+# Inspired from Fredecic Sohm's Bio.Restriction.
+# All rights reserved.
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+"""Restriction analysis library.
+"""


### PR DESCRIPTION
This supersedes #148.  I created a new branch so that the emboss db doesn't appear in the history (and also to restart from the current master).  Now, importing the library will have the side-effect of dowloading the db.  Note, though, that setup.py may need to be modified so that the db is present before biopython is written to a directory owned by root (probably just an import is enough, but untested).
I also got rid of the custom Seq class, now I just rely on the standard Seq and pass circular as a kwarg.
Finally, I removed the patch for the old restriction library as it doesn't seem to apply cleanly and I have little interest in figuring out why -- but you can still get it from #148 and give it a try.
