### PR TITLE
Modified ePrimer3 option -otm to -opttm, to keep up with changes in EMBOSS 6.6.0

### DIFF
--- a/Bio/Emboss/Applications.py
+++ b/Bio/Emboss/Applications.py
@@ -201,12 +201,13 @@ class Primer3Commandline(_EmbossCommandLine):
                    "Nanomolar concentration of annealing oligos in the PCR."),
            _Option(["-maxpolyx", "maxpolyx"],
                    "Maximum allowable mononucleotide repeat length in a primer."),
-           #Primer length:
+            # Primer melting temperature
            _Option(["-otm", "otm"],
                    """Melting temperature for primer oligo (OBSOLETE).
 
                    Option replaced in EMBOSS 6.6.0 by -opttm
                    """),
+           #Primer length:
            _Option(["-productosize", "productosize"],
                    """Optimum size for the PCR product (OBSOLETE).
 


### PR DESCRIPTION
EMBOSS 6.6.0 has changed the old -otm option to -opttm, and this modification to Applications.py keeps up with the change. The -opttm option is the key parameter we want to set when designing primers: the primer oligo melting temperature.
