### PR TITLE
add back off delay to qblast

### DIFF
--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -145,8 +145,8 @@ def qblast(program, database, sequence,
     query = [x for x in parameters if x[1] is not None]
     message = _as_bytes(_urlencode(query))
 
-    # Poll NCBI until the results are ready.  Use a 3 second wait
-    delay = 3.0
+    # Poll NCBI until the results are ready.  Use a backoff delay from 2 - 120 second wait
+    delay = 2.0
     previous = time.time()
     while True:
         current = time.time()
@@ -156,6 +156,10 @@ def qblast(program, database, sequence,
             previous = current + wait
         else:
             previous = current
+        if delay + .5*delay <= 120:
+            delay += .5*delay
+        else:
+            delay = 120
 
         request = _Request("http://blast.ncbi.nlm.nih.gov/Blast.cgi",
                            message,


### PR DESCRIPTION
This pull request is in reference to http://permalink.gmane.org/gmane.comp.python.bio.general/7522 
"query upper limit for NCBIWWW.qblast?"

Previous delay was a constant 3 sec. Now the delay starts at 2sec and increases as follows: delay += .5*delay to a max of 120sec.
The approx. delay and total time is as follows;
(delay, total)(2, 2)
(delay, total)(3, 5)
(delay, total)(4, 9)
(delay, total)(6, 16)
(delay, total)(10, 26)
(delay, total)(15, 41)
(delay, total)(22, 64)
(delay, total)(34, 98)
(delay, total)(51, 149)
(delay, total)(76, 226)
(delay, total)(115, 341)
(delay, total)(120, 461)
