### PR TITLE
Skip tests for 'bwa aln' when 'aln' is unrecognized

### DIFF
--- a/Tests/test_BWA_tool.py
+++ b/Tests/test_BWA_tool.py
@@ -113,9 +113,6 @@ class BwaTestCase(unittest.TestCase):
                         "Error aligning sequence to reference:\n%s\nStderr:%s"
                         % (cmdline, stderr))
 
-    def skip_aln_tests(self):
-        """Tests using 'aln' should be skipped if aln is unrecognized"""
-
     def create_fasta_index(self):
         """Creates index for fasta file
            BWA requires an indexed fasta for each alignment operation.


### PR DESCRIPTION
As reported on http://lists.open-bio.org/pipermail/biopython-dev/2014-April/011342.html
the tests are now skipped if 'bwa aln' is unrecognized
