### PR TITLE
Add check in FastqRandomAccess iterator for zero length sequences

### DIFF
--- a/Bio/SeqIO/_index.py
+++ b/Bio/SeqIO/_index.py
@@ -554,6 +554,8 @@ class FastqRandomAccess(SeqFileRandomAccess):
                 seq_len += len(line.strip())
             if not line:
                 raise ValueError("Premature end of file in seq section")
+            elif seq_len == 0:
+                raise ValueError("Zero-length sequence found in file")
             #assert line[0]=="+"
             #Find the qual line(s)
             qual_len = 0


### PR DESCRIPTION
If the FastqRandomAccess iterator encounters a zero-length sequence in a fastq file, it skips over it (since seq_len == 0 and then qual_len immediately is equal to seq_len) and when parsing next starts at the blank line instead of starting at the next record, causing an IndexError on line 545.

This change checks for zero length sequences and aborts with a ValueError if one is found.
