### PR TITLE
Use the same code path for SeqUtils.molecular_weigth and ProtParam.molecular weight

### DIFF
--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -26,6 +26,7 @@ from . import IsoelectricPoint  # Local
 from Bio.Seq import Seq
 from Bio.Alphabet import IUPAC
 from Bio.Data import IUPACData
+from Bio.SeqUtils import molecular_weight
 
 
 class ProteinAnalysis(object):
@@ -96,24 +97,7 @@ class ProteinAnalysis(object):
 
     def molecular_weight(self):
         """Calculate MW from Protein sequence"""
-        # make local dictionary for speed
-        if self.monoisotopic:
-            water = 18.01
-            iupac_weights = IUPACData.monoisotopic_protein_weights
-        else:
-            iupac_weights = IUPACData.protein_weights
-            water = 18.02
-
-        aa_weights = {}
-        for i in iupac_weights:
-            # remove a molecule of water from the amino acid weight
-            aa_weights[i] = iupac_weights[i] - water
-
-        total_weight = water  # add just one water molecule for the whole sequence
-        for aa in self.sequence:
-            total_weight += aa_weights[aa]
-
-        return total_weight
+        return molecular_weight(self.sequence, monoisotopic=self.monoisotopic)
 
     def aromaticity(self):
         """Calculate the aromaticity according to Lobry, 1994.

--- a/Tests/test_ProtParam.py
+++ b/Tests/test_ProtParam.py
@@ -7,7 +7,10 @@
 # as part of this package.
 
 import unittest
+from Bio.Seq import Seq
+from Bio.Alphabet import IUPAC
 from Bio.SeqUtils import ProtParam, ProtParamData
+from Bio.SeqUtils import molecular_weight
 
 
 class ProtParamTest(unittest.TestCase):
@@ -31,13 +34,27 @@ class ProtParamTest(unittest.TestCase):
     def test_get_molecular_weight(self):
         "Test calculating protein molecular weight"
         self.assertAlmostEqual(round(self.analysis.molecular_weight(), 2),
-                               17102.45)
+                               17103.16)
 
     def test_get_monoisotopic_molecular_weight(self):
         "Test calculating the monoisotopic molecular weight"
         self.analysis = ProtParam.ProteinAnalysis(self.seq_text, monoisotopic=True)
         self.assertAlmostEqual(round(self.analysis.molecular_weight(), 2),
-                               17092.70)
+                               17092.61)
+
+    def test_get_molecular_weight_identical(self):
+        "Test calculating the protein molecular weight agrees with calculation from Bio.SeqUtils"
+        mw_1 = self.analysis.molecular_weight()
+        mw_2 = molecular_weight(Seq(self.seq_text, IUPAC.protein))
+        self.assertAlmostEqual(mw_1, mw_2)
+
+    def test_get_monoisotopic_molecular_weight_identical(self):
+        "Test calculating the protein molecular weight agrees with calculation from Bio.SeqUtils"
+        self.analysis = ProtParam.ProteinAnalysis(self.seq_text, monoisotopic=True)
+        mw_1 = self.analysis.molecular_weight()
+        mw_2 = molecular_weight(Seq(self.seq_text, IUPAC.protein), monoisotopic=True)
+        self.assertAlmostEqual(mw_1, mw_2)
+
 
     def test_aromaticity(self):
         "Test calculating protein aromaticity"


### PR DESCRIPTION
Previously depending on which of these you used, you could get different molecular weights.

Signed-off-by: Kai Blin kai@samba.org
