### PR TITLE
Add template tox.ini file to documentation (based on suggestion by @msabramo

### DIFF
--- a/Doc/Tutorial.tex
+++ b/Doc/Tutorial.tex
@@ -17162,6 +17162,36 @@ the test are failing. For example,
 python test_Cluster.py
 \end{verbatim}
 
+\subsection{Running the tests using Tox}
+
+Like most Python projects, you can also use
+\href{http://tox.readthedocs.org/en/latest/}{Tox} to run the tests on multiple
+Python versions, provided they are already installed in your system.
+
+We do not provide the configuration \texttt{tox.ini} file in our code base because
+of difficulties pinning down user-specific settings (e.g. executable names of the
+Python versions). You may also only be interested in testing Biopython only against
+a subset of the Python versions that we support.
+
+If you are interested in using Tox, you may start with the example \texttt{tox.ini}
+shown below:
+
+\begin{verbatim}
+[tox]
+envlist = py26, py27, pypy, py33, py34, jython
+
+[testenv]
+changedir = Tests
+commands = {envpython} run_tests.py --offline
+deps =
+    numpy
+\end{verbatim}
+
+Using the template above, executing \texttt{tox} will test your Biopython code against
+Python2.6, Python2.7, PyPy, Python3.3, Python3.4, and Jython. It assumes that those
+Pythons' executables are named accordingly: python2.6 for Python2.6, and so on.
+
+
 \section{Writing tests}
 
 Let's say you want to write some tests for a module called \verb|Biospam|.


### PR DESCRIPTION
This puts the `tox.ini` file in #50, with slight modifications, into the Documentation instead of the codebase.
