### PR TITLE
Change Newick tree parsing to handle numeric names

### DIFF
--- a/Bio/Phylo/NewickIO.py
+++ b/Bio/Phylo/NewickIO.py
@@ -217,9 +217,10 @@ class Parser(object):
     def process_clade(self, clade):
         """Final processing of a parsed clade. Removes the node's parent and
         returns it."""
-        if (clade.name and not (self.values_are_confidence or
-                                self.comments_are_confidence)
-            and clade.confidence is None):
+        if ((clade.name) and not
+            (self.values_are_confidence or self.comments_are_confidence) and
+            (clade.confidence is None) and
+            (clade.clades)):
             clade.confidence = _parse_confidence(clade.name)
             if not clade.confidence is None:
                 clade.name = None

--- a/Tests/test_Phylo.py
+++ b/Tests/test_Phylo.py
@@ -114,6 +114,13 @@ class IOTests(unittest.TestCase):
         tree = Phylo.read(mem_file_3, 'newick')
         self.assertEqual(len(tree.get_terminals()), 28)
 
+    def test_int_labels(self):
+        """Read newick formatted tree with numeric labels."""
+        tree = Phylo.read(StringIO('(((0:0.1,1:0.1)0.99:0.1,2:0.1)0.98:0.0);'),
+                          'newick')
+        self.assertEqual(set(leaf.name for leaf in tree.get_terminals()),
+                         set(['0', '1', '2']))
+
 
 class TreeTests(unittest.TestCase):
     """Tests for methods on BaseTree.Tree objects."""


### PR DESCRIPTION
Numeric taxa names in Newick trees are parsed as branch confidence.
For instance a newick file

```
(((0:0.1,1:0.1)0.99:0.1,2:0.1)0.98:0.0);
```

would be parsed as a tree with three, unnamed terminal nodes with confidence values of 0, 1, and 2.

I believe this is a bug, since ~~branches to~~ (edit 9/12) terminal nodes shouldn't have confidence values.
I've edited `Bio/Phylo/NewickIO.py` so that it behaves as I would expect, and written a unit test.
