### PR TITLE
Added ability to change the seqfeature source

### DIFF
--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -751,12 +751,26 @@ class DatabaseLoader:
     def _load_seqfeature(self, feature, feature_rank, bioentry_id):
         """Load a biopython SeqFeature into the database (PRIVATE).
         """
-        seqfeature_id = self._load_seqfeature_basic(feature.type, feature_rank,
-                                                    bioentry_id)
+        # records loaded from a gff file using BCBio.GFF will contain the value
+        # of the 2nd column of the gff as a feature qualifier. The BioSQL wiki
+        # suggests that the source should not go in with the other feature 
+        # mappings but instead be put in the term table
+        # (http://www.biosql.org/wiki/Annotation_Mapping)
+        try:
+            source = feature.qualifiers['source']
+            if isinstance(source, list):
+                source = source[0]
+            seqfeature_id = self._load_seqfeature_basic(feature.type, feature_rank,
+                                                bioentry_id, source=source)
+            del feature.qualifiers['source']
+        except KeyError:
+            seqfeature_id = self._load_seqfeature_basic(feature.type, feature_rank,
+                                                bioentry_id)
+
         self._load_seqfeature_locations(feature, seqfeature_id)
         self._load_seqfeature_qualifiers(feature.qualifiers, seqfeature_id)
 
-    def _load_seqfeature_basic(self, feature_type, feature_rank, bioentry_id):
+    def _load_seqfeature_basic(self, feature_type, feature_rank, bioentry_id, source='EMBL/GenBank/SwissProt'):
         """Load the first tables of a seqfeature and returns the id (PRIVATE).
 
         This loads the "key" of the seqfeature (ie. CDS, gene) and
@@ -765,10 +779,8 @@ class DatabaseLoader:
         ontology_id = self._get_ontology_id('SeqFeature Keys')
         seqfeature_key_id = self._get_term_id(feature_type,
                                               ontology_id=ontology_id)
-        # XXX source is always EMBL/GenBank/SwissProt here; it should depend on
-        # the record (how?)
         source_cat_id = self._get_ontology_id('SeqFeature Sources')
-        source_term_id = self._get_term_id('EMBL/GenBank/SwissProt',
+        source_term_id = self._get_term_id(source,
                                       ontology_id=source_cat_id)
 
         sql = r"INSERT INTO seqfeature (bioentry_id, type_term_id, " \

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -762,7 +762,6 @@ class DatabaseLoader:
                 source = source[0]
             seqfeature_id = self._load_seqfeature_basic(feature.type, feature_rank,
                                                 bioentry_id, source=source)
-            del feature.qualifiers['source']
         except KeyError:
             seqfeature_id = self._load_seqfeature_basic(feature.type, feature_rank,
                                                 bioentry_id)


### PR DESCRIPTION
Added a new kwarg to BioSQL.Loader._load_seqfeature_basic that
allows the source to be changed dynamically based on the value
of the source qualifier found in the annotations of the SeqRecord

Background:
GFF files set aside column 2 for the source of the feature that
is set to the value of the program/algorithm that generated that
feature. Parsing a gff file using BCBio.GFF returns a SeqRecord
object that contains the source as a qualifier key-value pair.
Normally these key-value pairs are loaded into the
seqfeature_qualifier_value table, but the BioSQL wiki suggests that the
source should instead go into the term table.

The current code in biopython sets the value of source for a
seqfeature to be the same value regardless of whether the SeqRecord
object contains the source qualifier. This change adds in code that
will search for a source qualifier in the SeqRecord, set the value to
the source of the seqfeature and remove the key from the SeqRecord
qualifiers dict so that it is not mistakenly added to the
seqfeature_qualifier_value table