### PR TITLE
Unittest for Bio.GenBank.read cases

### DIFF
--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -6,16 +6,30 @@
 import unittest
 from os import path
 
+from Bio import GenBank
 from Bio import SeqIO
 
 
 class GenBankTests(unittest.TestCase):
     def test_invalid_product_line_raises_value_error(self):
-        "Test GenBank parsing invalid product line raises ValueError"
+        """Test GenBank parsing invalid product line raises ValueError"""
         def parse_invalid_product_line():
             rec = SeqIO.read(path.join('GenBank', 'invalid_product.gb'),
                              'genbank')
         self.assertRaises(ValueError, parse_invalid_product_line)
+
+    def test_genbank_read(self):
+        with open(path.join("GenBank", "NC_000932.gb")) as handle:
+            record = GenBank.read(handle)
+        self.assertEqual(['NC_000932'], record.accession)
+
+    def test_genbank_read_multirecord(self):
+        with open(path.join("GenBank", "cor6_6.gb")) as handle:
+            self.assertRaises(ValueError, GenBank.read, handle)
+
+    def test_genbank_read_invalid(self):
+        with open(path.join("GenBank", "NC_000932.faa")) as handle:
+            self.assertRaises(ValueError, GenBank.read, handle)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I added additional tests for Bio.GenBank.read() into the
`test_GenBank_unittest.py` file as I couldn't figure out how to implement them
in the old-style test file.
Test coverage for Bio.GenBank went from 78% to 81%.
