### PR TITLE
Should address the win32 issue in #440. 

### DIFF
--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -269,7 +269,7 @@ def _check_mode(handle):
         raise ValueError("SFF files must NOT be opened in universal new "
                          "lines mode. Binary mode is recommended (although "
                          "on Unix the default mode is also fine).")
-    elif mode and "B" not in mode.upper() \
+    elif mode and not mode == '1' and "B" not in mode.upper() \
             and sys.platform == "win32":
         raise ValueError("SFF files must be opened in binary mode on Windows")
 


### PR DESCRIPTION
I tested with python2.7 & 3 and tests pass with both on Ubuntu
I don't have a windows box to test with, but the test cases now patch sys.path for SffIO module which should do the trick

Addresses #440 
