### PR TITLE
initialize self.last_occupancy to very small value

### DIFF
--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -311,7 +311,7 @@ class DisorderedAtom(DisorderedEntityWrapper):
         Arguments:
         o id - string, atom name
         """
-        self.last_occupancy=-1
+        self.last_occupancy=-999999
         DisorderedEntityWrapper.__init__(self, id)
 
     # Special methods


### PR DESCRIPTION
self.last_occupancy was initialized as -1 and used later to help decide which disordered atom will be chosen as representative. If the first atom in DisorderedAtom already has -1 occupancy, it will not be chosen as it does not satisfy the comparison. NoneType error will be thrown if, say, get_fullatom() function is invoked. 

Since occupancy value occupies col 55-60 (6 digits). It can never get smaller than -999999 and this issue will never appear again.
