### PR TITLE
setup.py now uses setuptools if available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,20 @@ import sys
 import os
 import shutil
 
-from distutils.core import setup
-from distutils.core import Command
-from distutils.command.install import install
-from distutils.command.build_py import build_py
-from distutils.command.build_ext import build_ext
-from distutils.extension import Extension
+try:
+    from setuptools import setup
+    from setuptools import Command
+    from setuptools.command.install import install
+    from setuptools.command.build_py import build_py
+    from setuptools.command.build_ext import build_ext
+    from setuptools import Extension
+except ImportError:
+    from distutils.core import setup
+    from distutils.core import Command
+    from distutils.command.install import install
+    from distutils.command.build_py import build_py
+    from distutils.command.build_ext import build_ext
+    from distutils.extension import Extension
 
 _CHECKED = None
 


### PR DESCRIPTION
I tested my modifications building source, binary egg and wheel distribution files. Local install and develop install work too.

I added this change in order to support creation of binary wheels, especially on Windows. The windows installer is not "virtualenv aware" which restricts its use. 