### PR TITLE
KGML_vis.py: Fixed typo for BytesIO

### DIFF
--- a/Bio/Graphics/KGML_vis.py
+++ b/Bio/Graphics/KGML_vis.py
@@ -45,7 +45,7 @@ def get_temp_imagefilename(url):
     and return the filename.
     """
     img = _urlopen(url).read()
-    im = Image.open(BtyesIO(img))
+    im = Image.open(BytesIO(img))
     # im.transpose(Image.FLIP_TOP_BOTTOM)
     f = tempfile.NamedTemporaryFile(delete=False, suffix='.png')
     fname = f.name


### PR DESCRIPTION
There's a typo in the KGML_vis module that slipped through the tests. It prevents automatic import of KEGG images when instantiating a KGMLCanvas from a Pathway object.
