### PR TITLE
KGML_vis.py: Catch argument error for HexColor hasAlpha/alpha

### DIFF
--- a/Bio/Graphics/KGML_vis.py
+++ b/Bio/Graphics/KGML_vis.py
@@ -56,7 +56,10 @@ def color_to_reportlab(color):
         if len(color) == 7:
             return colors.HexColor(color)
         else:
-            return colors.HexColor(color, hasAlpha=True)
+            try:
+                return colors.HexColor(color, hasAlpha=True)
+            except:  # Catch pre-2.7 Reportlab
+                return colors.HexColor(color, alpha=True)
     elif isinstance(color, tuple):  # Tuple implies RGB(alpha) tuple
         return colors.Color(*color)
     return color


### PR DESCRIPTION
Implemented bugfix from #458 suggested by Peter Cock.

Pre-2.7 ReportLab HexColor objects take the argument `alpha`, where 2.7+ ReportLab takes `hasAlpha`. Code should now cope with both.