### PR TITLE
Write feature qualifiers alphabetically by key.

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -346,7 +346,8 @@ class _InsdcWriter(SequentialSequenceWriter):
                + self._wrap_location(location) + "\n"
         self.handle.write(line)
         # Now the qualifiers...
-        for key, values in feature.qualifiers.items():
+        for key in sorted(feature.qualifiers.keys()):
+            values = feature.qualifiers[key]
             if isinstance(values, list) or isinstance(values, tuple):
                 for value in values:
                     self._write_feature_qualifier(key, value)


### PR DESCRIPTION
The motivation for this change is that if you are iterating on versions of, say, a Genbank, then it's helpful for the feature qualifiers to be written in a deterministic order so you can more easily track changes.