### PR TITLE
MOTIF: added a ignoreCase option to motifs.instances.search

### DIFF
--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -203,15 +203,17 @@ class Instances(list):
         """
         a generator function, returning found positions of motif instances in a given sequence
         """
+        seq_str = str(sequence)
+        if case_sensitive is False:
+            seq_str = seq_str.lower()
         for pos in range(0, len(sequence) - self.length + 1):
             for instance in self:
                 instance_str = str(instance)
-                seq_str = str(sequence[pos:pos + self.length])
+                current_seq = seq_str[pos:pos + self.length]
                 if case_sensitive is False:
                     instance_str = instance_str.lower()
-                    seq_str = seq_str.lower()
 
-                if instance_str == seq_str:
+                if instance_str == current_seq:
                     yield (pos, instance)
                     break  # no other instance will fit (we don't want to return multiple hits)
 

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -199,7 +199,7 @@ class Instances(list):
                 counts[letter][position] += 1
         return counts
 
-    def search(self, sequence, case_sensitive=True, minratio=1):
+    def search(self, sequence, case_sensitive=True):
         """
         A generator function, returning found positions of 
         motif instances in a given sequence.
@@ -233,21 +233,13 @@ class Instances(list):
         a sequence.
         """
 
-        seq_str = str(sequence)
+        sequence = str(sequence)
         if case_sensitive is False:
-            seq_str = seq_str.lower()
+            sequence = sequence.lower()
 
-        for pos in range(0, len(seq_str) - self.length + 1):
-            current_seq = str(seq_str[pos:pos + self.length])
-
+        for pos in range(0, len(sequence) - self.length + 1):
             for instance in self:
-                instance_str = str(instance)
-                if case_sensitive is False:
-                    instance_str = instance_str.lower()
-
-                totmatches = sum(c1==c2 for c1,c2 in zip(current_seq,instance_str))
-                ratio = 1. * totmatches / len(current_seq)
-                if ratio >= minratio:
+                if str(instance) == str(sequence[pos:pos + self.length]):
                     yield (pos, instance)
                     break  # no other instance will fit (we don't want to return multiple hits)
 

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -215,12 +215,12 @@ class Instances(list):
         A search with default options will give a match for each instance:
         >>> matches = mymot.instances.search(Seq('gggggACTggggaTTggggact'))
         >>> print(list(matches))
-        [(5, Seq('ACT', Alphabet())), (12, Seq('aTT', Alphabet()))]
+        [(5, Seq('ACT', Alphabet())), (12, Seq('ATT', Alphabet()))]
 
         Use the case_sensitive option to ignore the case of both sequences:
         >>> print(list(mymot.instances.search(Seq('gggggAcTggggaTtt'), 
         ... case_sensitive=False)))
-        [(5, Seq('ACT', Alphabet())), (12, Seq('aTT', Alphabet()))]
+        [(5, Seq('ACT', Alphabet())), (12, Seq('ATT', Alphabet()))]
 
 
         See also pairwise2.align.globalxx for aligning each instance to 

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -201,10 +201,11 @@ class Instances(list):
 
     def search(self, sequence, case_sensitive=True, minratio=1):
         """
-        a generator function, returning found positions of motif instances in a given sequence
+        A generator function, returning found positions of 
+        motif instances in a given sequence.
 
-            - case_sensitive: ignore case of both motif instance and sequence
-            - minratio: minimum ratio of sequence match to consider (from 0 to 1)
+            - case_sensitive: ignore case of instances and sequence
+            - minratio: minimum ratio of sequence match (from 0 to 1)
 
         >>> from Bio import motifs
         >>> from Bio.Seq import Seq
@@ -212,21 +213,24 @@ class Instances(list):
         Let's create a motif with two instances:
         >>> mymot = motifs.create([Seq('ACT'), Seq('ATT')])
         
-        A search with the default options will give a match for each instance:
+        A search with default options will give a match for each instance:
         >>> matches = mymot.instances.search(Seq('gggggACTggggATTggggact'))
         >>> print(list(matches))
         [(5, Seq('ACT', Alphabet())), (12, Seq('ATT', Alphabet()))]
 
         Use the case_sensitive option to ignore the case of both sequences:
-        >>> print(list(mymot.instances.search(Seq('gggggACTggggATTggggact'), case_sensitive=False)))
-        [(5, Seq('ACT', Alphabet())), (12, Seq('ATT', Alphabet())), (19, Seq('ACT', Alphabet()))]
+        >>> print(list(mymot.instances.search(Seq('ggggAcTggggaTtt'), 
+        ... case_sensitive=False)))
+        [(5, Seq('ACT', Alphabet())), (12, Seq('ATT', Alphabet()))]
 
         Use minratio to get imperfect matches:
-        >>> print(list(mymot.instances.search(Seq('gggggACTggggATTggggact'), minratio=0.3)))
-        [(5, Seq('ACT', Alphabet())), (6, Seq('ATT', Alphabet())), (11, Seq('ACT', Alphabet())), (12, Seq('ACT', Alphabet())), (13, Seq('ATT', Alphabet()))]
+        >>> print(list(mymot.instances.search(Seq('gggggACTgggg'), 
+        ... minratio=0.3)))
+        [(5, Seq('ACT', Alphabet())), (6, Seq('ATT', Alphabet()))]
 
 
-        See also pairwise2.align.globalxx for aligning each instance to a sequence.
+        See also pairwise2.align.globalxx for aligning each instance to 
+        a sequence.
         """
 
         seq_str = str(sequence)

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -213,12 +213,12 @@ class Instances(list):
         >>> mymot = motifs.create([Seq('ACT'), Seq('ATT')])
         
         A search with default options will give a match for each instance:
-        >>> matches = mymot.instances.search(Seq('gggggACTggggaTTggggact'))
+        >>> matches = mymot.instances.search(Seq('gggggACTggggATTggggact'))
         >>> print(list(matches))
         [(5, Seq('ACT', Alphabet())), (12, Seq('ATT', Alphabet()))]
 
         Use the case_sensitive option to ignore the case of both sequences:
-        >>> print(list(mymot.instances.search(Seq('gggggAcTggggaTtt'), 
+        >>> print(list(mymot.instances.search(Seq('gggggAcTggggATtt'), 
         ... case_sensitive=False)))
         [(5, Seq('ACT', Alphabet())), (12, Seq('ATT', Alphabet()))]
 
@@ -229,7 +229,7 @@ class Instances(list):
 
         sequence = str(sequence)
         if case_sensitive is False:
-            sequence = sequence.lower()
+            sequence = sequence.upper()
 
         for pos in range(0, len(sequence) - self.length + 1):
             for instance in self:

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -210,22 +210,17 @@ class Instances(list):
         >>> from Bio.Seq import Seq
 
         Let's create a motif with two instances:
-        >>> mymot = motifs.create([Seq('ACT'), Seq('ATT')])
+        >>> mymot = motifs.create([Seq('ACT'), Seq('aTT')])
         
         A search with default options will give a match for each instance:
-        >>> matches = mymot.instances.search(Seq('gggggACTggggATTggggact'))
+        >>> matches = mymot.instances.search(Seq('gggggACTggggaTTggggact'))
         >>> print(list(matches))
-        [(5, Seq('ACT', Alphabet())), (12, Seq('ATT', Alphabet()))]
+        [(5, Seq('ACT', Alphabet())), (12, Seq('aTT', Alphabet()))]
 
         Use the case_sensitive option to ignore the case of both sequences:
         >>> print(list(mymot.instances.search(Seq('gggggAcTggggaTtt'), 
         ... case_sensitive=False)))
-        [(5, Seq('ACT', Alphabet())), (12, Seq('ATT', Alphabet()))]
-
-        Use minratio to get imperfect matches:
-        >>> print(list(mymot.instances.search(Seq('gggggACTgggg'), 
-        ... minratio=0.3)))
-        [(5, Seq('ACT', Alphabet())), (6, Seq('ATT', Alphabet()))]
+        [(5, Seq('ACT', Alphabet())), (12, Seq('aTT', Alphabet()))]
 
 
         See also pairwise2.align.globalxx for aligning each instance to 
@@ -238,6 +233,9 @@ class Instances(list):
 
         for pos in range(0, len(sequence) - self.length + 1):
             for instance in self:
+                instance_str = str(instance)
+                if case_sensitive is False:
+                    instance_str = str(instance).lower()
                 if str(instance) == str(sequence[pos:pos + self.length]):
                     yield (pos, instance)
                     break  # no other instance will fit (we don't want to return multiple hits)

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -206,6 +206,26 @@ class Instances(list):
             - case_sensitive: ignore case of both motif instance and sequence
             - minratio: minimum ratio of sequence match to consider (from 0 to 1)
 
+        >>> from Bio import motifs
+        >>> from Bio.Seq import Seq
+
+        Let's create a motif with two instances:
+        >>> mymot = motifs.create([Seq('ACT'), Seq('ATT')])
+        
+        A search with the default options will give a match for each instance:
+        >>> matches = mymot.instances.search(Seq('gggggACTggggATTggggact'))
+        >>> print(list(matches))
+        [(5, Seq('ACT', Alphabet())), (12, Seq('ATT', Alphabet()))]
+
+        Use the case_sensitive option to ignore the case of both sequences:
+        >>> print(list(mymot.instances.search(Seq('gggggACTggggATTggggact'), case_sensitive=False)))
+        [(5, Seq('ACT', Alphabet())), (12, Seq('ATT', Alphabet())), (19, Seq('ACT', Alphabet()))]
+
+        Use minratio to get imperfect matches:
+        >>> print(list(mymot.instances.search(Seq('gggggACTggggATTggggact'), minratio=0.3)))
+        [(5, Seq('ACT', Alphabet())), (6, Seq('ATT', Alphabet())), (11, Seq('ACT', Alphabet())), (12, Seq('ACT', Alphabet())), (13, Seq('ATT', Alphabet()))]
+
+
         See also pairwise2.align.globalxx for aligning each instance to a sequence.
         """
 

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -18,7 +18,6 @@ from __future__ import print_function
 from Bio._py3k import range
 
 import math
-import difflib
 
 __docformat__ = "restructuredtext en"
 
@@ -206,8 +205,9 @@ class Instances(list):
 
             - case_sensitive: ignore case of both motif instance and sequence
             - minratio: minimum ratio of sequence match to consider (from 0 to 1)
+
+        See also pairwise2.align.globalxx for aligning each instance to a sequence.
         """
-        sm = difflib.SequenceMatcher(None)
 
         seq_str = str(sequence)
         if case_sensitive is False:
@@ -215,15 +215,15 @@ class Instances(list):
 
         for pos in range(0, len(seq_str) - self.length + 1):
             current_seq = str(seq_str[pos:pos + self.length])
-            sm.set_seq2(current_seq)  # better to set seq2 before seq1
 
             for instance in self:
                 instance_str = str(instance)
                 if case_sensitive is False:
                     instance_str = instance_str.lower()
-                sm.set_seq1(instance_str)
 
-                if sm.ratio() >= minratio:
+                totmatches = sum(c1==c2 for c1,c2 in zip(current_seq,instance_str))
+                ratio = 1. * totmatches / len(current_seq)
+                if ratio >= minratio:
                     yield (pos, instance)
                     break  # no other instance will fit (we don't want to return multiple hits)
 

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -200,20 +200,14 @@ class Instances(list):
                 counts[letter][position] += 1
         return counts
 
-    def search(self, sequence, case_sensitive=True, minratio=1, junk=None):
+    def search(self, sequence, case_sensitive=True, minratio=1):
         """
         a generator function, returning found positions of motif instances in a given sequence
 
             - case_sensitive: ignore case of both motif instance and sequence
             - minratio: minimum ratio of sequence match to consider (from 0 to 1)
-            - junk: list of character to be ignored (e.g. 'Nn'.split())
         """
-        def isjunk(x):
-            if junk is None:
-                return None
-            else:
-                return x in junk
-        sm = difflib.SequenceMatcher(isjunk)
+        sm = difflib.SequenceMatcher(None)
 
         seq_str = str(sequence)
         if case_sensitive is False:
@@ -221,7 +215,7 @@ class Instances(list):
 
         for pos in range(0, len(seq_str) - self.length + 1):
             current_seq = str(seq_str[pos:pos + self.length])
-            sm.set_seq2(current_seq)
+            sm.set_seq2(current_seq)  # better to set seq2 before seq1
 
             for instance in self:
                 instance_str = str(instance)

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -199,17 +199,17 @@ class Instances(list):
                 counts[letter][position] += 1
         return counts
 
-    def search(self, sequence, ignoreCase=False):
+    def search(self, sequence, case_sensitive=True):
         """
         a generator function, returning found positions of motif instances in a given sequence
         """
         for pos in range(0, len(sequence) - self.length + 1):
             for instance in self:
-                instance_str    = str(instance)
-                seq_str         = str(sequence[pos:pos + self.length])
-                if ignoreCase is True:
+                instance_str = str(instance)
+                seq_str = str(sequence[pos:pos + self.length])
+                if case_sensitive is False:
                     instance_str = instance_str.lower()
-                    seq_str      = seq_str.lower()
+                    seq_str = seq_str.lower()
 
                 if instance_str == seq_str:
                     yield (pos, instance)

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -219,7 +219,7 @@ class Instances(list):
         [(5, Seq('ACT', Alphabet())), (12, Seq('ATT', Alphabet()))]
 
         Use the case_sensitive option to ignore the case of both sequences:
-        >>> print(list(mymot.instances.search(Seq('ggggAcTggggaTtt'), 
+        >>> print(list(mymot.instances.search(Seq('gggggAcTggggaTtt'), 
         ... case_sensitive=False)))
         [(5, Seq('ACT', Alphabet())), (12, Seq('ATT', Alphabet()))]
 

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -199,13 +199,19 @@ class Instances(list):
                 counts[letter][position] += 1
         return counts
 
-    def search(self, sequence):
+    def search(self, sequence, ignoreCase=False):
         """
         a generator function, returning found positions of motif instances in a given sequence
         """
         for pos in range(0, len(sequence) - self.length + 1):
             for instance in self:
-                if str(instance) == str(sequence[pos:pos + self.length]):
+                instance_str    = str(instance)
+                seq_str         = str(sequence[pos:pos + self.length])
+                if ignoreCase is True:
+                    instance_str = instance_str.lower()
+                    seq_str      = seq_str.lower()
+
+                if instance_str == seq_str:
                     yield (pos, instance)
                     break  # no other instance will fit (we don't want to return multiple hits)
 

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -210,7 +210,7 @@ class Instances(list):
         >>> from Bio.Seq import Seq
 
         Let's create a motif with two instances:
-        >>> mymot = motifs.create([Seq('ACT'), Seq('aTT')])
+        >>> mymot = motifs.create([Seq('ACT'), Seq('ATT')])
         
         A search with default options will give a match for each instance:
         >>> matches = mymot.instances.search(Seq('gggggACTggggaTTggggact'))
@@ -233,9 +233,6 @@ class Instances(list):
 
         for pos in range(0, len(sequence) - self.length + 1):
             for instance in self:
-                instance_str = str(instance)
-                if case_sensitive is False:
-                    instance_str = str(instance).lower()
                 if str(instance) == str(sequence[pos:pos + self.length]):
                     yield (pos, instance)
                     break  # no other instance will fit (we don't want to return multiple hits)

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -205,7 +205,6 @@ class Instances(list):
         motif instances in a given sequence.
 
             - case_sensitive: ignore case of instances and sequence
-            - minratio: minimum ratio of sequence match (from 0 to 1)
 
         >>> from Bio import motifs
         >>> from Bio.Seq import Seq

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -429,9 +429,9 @@ class TestMotifSearch(unittest.TestCase):
         result_sensitive = self.m.instances.search(myseq, case_sensitive=True)
         result_insensitive = self.m.instances.search(myseq, case_sensitive=False)
 
-        self.assertEqual(1, len(result_sensitive))
-        self.assertEqual(1, len(result_default))
-        self.assertEqual(2, len(result_insensitive))
+        self.assertEqual(1, len(list(result_default)))
+        self.assertEqual(1, len(list(result_sensitive)))
+        self.assertEqual(2, len(list(result_insensitive)))
 
 
 class TestMEME(unittest.TestCase):

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -414,6 +414,26 @@ class MotifTestsBasic(unittest.TestCase):
         output_handle.close()
 
 
+class TestMotifSearch(unittest.TestCase):
+    def setUp(self):
+        instance = Seq("CTG")
+        instances = [instance]
+        self.m = motifs.create(instances)
+
+    def test_instance_search_mixed_case(self):
+        """Test the case_sensitive option in motifs.instances.search."""
+        myseq = Seq('AAAACTGAAActg')  
+
+        # we expect two matches with case insensitive, and one with case sensitive
+        result_default = self.m.instances.search(myseq)
+        result_sensitive = self.m.instances.search(myseq, case_sensitive=True)
+        result_insensitive = self.m.instances.search(myseq, case_sensitive=False)
+
+        self.assertEqual(1, len(result_sensitive))
+        self.assertEqual(1, len(result_default))
+        self.assertEqual(2, len(result_insensitive))
+
+
 class TestMEME(unittest.TestCase):
 
     def test_meme_parser_1(self):

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -434,6 +434,35 @@ class TestMotifSearch(unittest.TestCase):
         self.assertEqual(2, len(list(result_insensitive)))
 
 
+    def test_minratio_cutoff(self):
+        """Test the minratio option in motifs.instances.search."""
+        myseq = Seq('aaaCTGaaaCGGaaaCtG')  
+
+        # we expect two matches with case insensitive, and one with case sensitive,
+        # plus one additional match with minratio 0.5 and case insensitive
+        result_default = self.m.instances.search(myseq)
+        result_sensitive = self.m.instances.search(myseq, case_sensitive=True)
+
+        result_insensitive = self.m.instances.search(myseq, case_sensitive=False)
+        
+        result_minratio05_sensitive = self.m.instances.search(myseq, case_sensitive=True, minratio=0.5)
+        result_minratio05_insensitive = self.m.instances.search(myseq, case_sensitive=False, minratio=0.5)
+
+        result_minratio0 = self.m.instances.search(myseq, minratio=0)
+        result_minratio04_insensitive = self.m.instances.search(myseq, minratio=0.4)
+
+        self.assertEqual(1, len(list(result_default)))
+        self.assertEqual(1, len(list(result_sensitive)))
+
+        self.assertEqual(2, len(list(result_insensitive)))
+
+        self.assertEqual(2, len(list(result_minratio05_sensitive)))
+        self.assertEqual(3, len(list(result_minratio05_insensitive)))
+
+        self.assertEqual(16, len(list(result_minratio0)))
+        self.assertEqual(7, len(list(result_minratio04_insensitive)))
+
+
 class TestMEME(unittest.TestCase):
 
     def test_meme_parser_1(self):

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -434,36 +434,6 @@ class TestMotifSearch(unittest.TestCase):
         self.assertEqual(2, len(list(result_insensitive)))
 
 
-    def test_minratio_cutoff(self):
-        """Test the minratio option in motifs.instances.search."""
-        myseq = Seq('aaaCTGaaaCGGaaaCtGaaaCgg')  
-
-        # we expect two matches with case insensitive, and one with case sensitive,
-        # plus two additional match with minratio 0.5 and case insensitive
-        result_default = self.m.instances.search(myseq)
-        result_sensitive = self.m.instances.search(myseq, case_sensitive=True)
-        result_insensitive = self.m.instances.search(myseq, case_sensitive=False)
-        
-        # minratio = 0.7 means two out of three bases matching
-        result_minratio06_sensitive = self.m.instances.search(myseq, case_sensitive=True, minratio=0.6)
-        result_minratio06_insensitive = self.m.instances.search(myseq, case_sensitive=False, minratio=0.6)
-
-        # matching any base
-        result_minratio0 = self.m.instances.search(myseq, minratio=0)
-        # matching one base
-        result_minratio03_insensitive = self.m.instances.search(myseq, minratio=0.3)
-
-        self.assertEqual(1, len(list(result_default)))
-        self.assertEqual(1, len(list(result_sensitive)))
-        self.assertEqual(2, len(list(result_insensitive)))
-
-        self.assertEqual(3, len(list(result_minratio06_sensitive)))
-        self.assertEqual(4, len(list(result_minratio06_insensitive)))
-
-        self.assertEqual(22, len(list(result_minratio0)))
-        self.assertEqual(5, len(list(result_minratio03_insensitive)))
-
-
 class TestMEME(unittest.TestCase):
 
     def test_meme_parser_1(self):

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -436,32 +436,32 @@ class TestMotifSearch(unittest.TestCase):
 
     def test_minratio_cutoff(self):
         """Test the minratio option in motifs.instances.search."""
-        myseq = Seq('aaaCTGaaaCGGaaaCtG')  
+        myseq = Seq('aaaCTGaaaCGGaaaCtGaaaCgg')  
 
         # we expect two matches with case insensitive, and one with case sensitive,
-        # plus one additional match with minratio 0.5 and case insensitive
+        # plus two additional match with minratio 0.5 and case insensitive
         result_default = self.m.instances.search(myseq)
         result_sensitive = self.m.instances.search(myseq, case_sensitive=True)
-
         result_insensitive = self.m.instances.search(myseq, case_sensitive=False)
         
         # minratio = 0.7 means two out of three bases matching
-        result_minratio07_sensitive = self.m.instances.search(myseq, case_sensitive=True, minratio=0.7)
-        result_minratio07_insensitive = self.m.instances.search(myseq, case_sensitive=False, minratio=0.7)
+        result_minratio06_sensitive = self.m.instances.search(myseq, case_sensitive=True, minratio=0.6)
+        result_minratio06_insensitive = self.m.instances.search(myseq, case_sensitive=False, minratio=0.6)
 
+        # matching any base
         result_minratio0 = self.m.instances.search(myseq, minratio=0)
-        result_minratio04_insensitive = self.m.instances.search(myseq, minratio=0.4)
+        # matching one base
+        result_minratio03_insensitive = self.m.instances.search(myseq, minratio=0.3)
 
         self.assertEqual(1, len(list(result_default)))
         self.assertEqual(1, len(list(result_sensitive)))
-
         self.assertEqual(2, len(list(result_insensitive)))
 
-        self.assertEqual(1, len(list(result_minratio07_sensitive)))
-        self.assertEqual(3, len(list(result_minratio07_insensitive)))
+        self.assertEqual(3, len(list(result_minratio06_sensitive)))
+        self.assertEqual(4, len(list(result_minratio06_insensitive)))
 
-        self.assertEqual(16, len(list(result_minratio0)))
-        self.assertEqual(7, len(list(result_minratio04_insensitive)))
+        self.assertEqual(22, len(list(result_minratio0)))
+        self.assertEqual(5, len(list(result_minratio03_insensitive)))
 
 
 class TestMEME(unittest.TestCase):

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -445,8 +445,9 @@ class TestMotifSearch(unittest.TestCase):
 
         result_insensitive = self.m.instances.search(myseq, case_sensitive=False)
         
-        result_minratio05_sensitive = self.m.instances.search(myseq, case_sensitive=True, minratio=0.5)
-        result_minratio05_insensitive = self.m.instances.search(myseq, case_sensitive=False, minratio=0.5)
+        # minratio = 0.7 means two out of three bases matching
+        result_minratio07_sensitive = self.m.instances.search(myseq, case_sensitive=True, minratio=0.7)
+        result_minratio07_insensitive = self.m.instances.search(myseq, case_sensitive=False, minratio=0.7)
 
         result_minratio0 = self.m.instances.search(myseq, minratio=0)
         result_minratio04_insensitive = self.m.instances.search(myseq, minratio=0.4)
@@ -456,8 +457,8 @@ class TestMotifSearch(unittest.TestCase):
 
         self.assertEqual(2, len(list(result_insensitive)))
 
-        self.assertEqual(2, len(list(result_minratio05_sensitive)))
-        self.assertEqual(3, len(list(result_minratio05_insensitive)))
+        self.assertEqual(1, len(list(result_minratio07_sensitive)))
+        self.assertEqual(3, len(list(result_minratio07_insensitive)))
 
         self.assertEqual(16, len(list(result_minratio0)))
         self.assertEqual(7, len(list(result_minratio04_insensitive)))


### PR DESCRIPTION
This commit adds an ignoreCase option to motifs.instances.search, allowing to search a motif in a sequence ignoring the case of the sequence.

Would it make sense to use re.findall instead of a loop for this function?

Would it be useful to have a fuzzy_search function in motif, to search for motif instances, while accepting a given number of mismatches?

Should I add also some unit or doc test for this function?

Thanks
Gio
