### PR TITLE
Optimize starting point selection process of pairwise2

### DIFF
--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -361,13 +361,10 @@ def _align(sequenceA, sequenceB, match_fn, gap_A_fn, gap_B_fn,
     tolerance = 0  # XXX do anything with this?
     # Now find all the positions within some tolerance of the best
     # score.
-    i = 0
-    while i < len(starts):
-        score, pos = starts[i]
-        if rint(abs(score - best_score)) > rint(tolerance):
-            del starts[i]
-        else:
-            i += 1
+    starts = [
+        (score, pos) for score, pos in starts
+        if rint(abs(score - best_score)) <= rint(tolerance)
+    ]
 
     # Recover the alignments and return them.
     x = _recover_alignments(


### PR DESCRIPTION
This commit speeds up the alignment backtrace starting point selection process.
The effect is most noticeable when performing local alignments between long sequences which will have a large number of starting point candidates.

#### Test Performed

Input: a pair of nucleotide sequences with each of its length ~ 4 kbp
Operation: `pairwise2.align.localxs(sequenceA, sequenceB, -0.1, 0)`
Time consumed without optimization: > 1 hr
Time consumed with optimization: ~ 70 sec