### PR TITLE
GenBank: Avoid infinite loop while parsing

### DIFF
--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -201,7 +201,7 @@ class InsdcScanner(object):
                     feature_lines = [line[self.FEATURE_QUALIFIER_INDENT:]]
                 line = self.handle.readline()
                 while line[:self.FEATURE_QUALIFIER_INDENT] == self.FEATURE_QUALIFIER_SPACER \
-                        or line.rstrip() == "":  # cope with blank lines in the midst of a feature
+                        or (line != '' and line.rstrip() == ""):  # cope with blank lines in the midst of a feature
                     # Use strip to remove any harmless trailing white space AND and leading
                     # white space (e.g. out of spec files with too much indentation)
                     feature_lines.append(line[self.FEATURE_QUALIFIER_INDENT:].strip())

--- a/Tests/GenBank/no_origin_no_end.gb
+++ b/Tests/GenBank/no_origin_no_end.gb
@@ -1,0 +1,14 @@
+LOCUS       AB070938                6497 bp    DNA     linear   BCT 11-OCT-2001
+DEFINITION  Streptomyces avermitilis melanin biosynthetic gene cluster.
+ACCESSION   AB070938
+VERSION     AB070938.1  GI:15823953
+KEYWORDS    .
+SOURCE      Streptomyces avermitilis
+  ORGANISM  Streptomyces avermitilis
+            Bacteria; Actinobacteria; Actinobacteridae; Actinomycetales;
+            Streptomycineae; Streptomycetaceae; Streptomyces.
+FEATURES             Location/Qualifiers
+     source          1..6497
+                     /organism="Streptomyces avermitilis"
+                     /mol_type="genomic DNA"
+                     /db_xref="taxon:33903"

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -31,6 +31,10 @@ class GenBankTests(unittest.TestCase):
         with open(path.join("GenBank", "NC_000932.faa")) as handle:
             self.assertRaises(ValueError, GenBank.read, handle)
 
+    def test_genbank_read_no_origin_no_end(self):
+        with open(path.join("GenBank", "no_origin_no_end.gb")) as handle:
+            self.assertRaises(ValueError, GenBank.read, handle)
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
While parsing input files that for some reason end while in the Features
table, the GenBank code designed to skip empty lines triggered an
infinite loop.

This patch fixes the infinite loop by breaking out of the "consume empty
lines" loop when readline() returns '' (readline()'s way of
saying "end of file") while still supporting the original "consume empty
lines" use case where readline() will return '\n'.

Please note that the provided test case causes the unpatched code to get
stuck in an infinite loop without the provided patch.
This fixes issue #510.

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>