### PR TITLE
Fix for improper 

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1227,7 +1227,10 @@ class CompoundLocation(object):
     def extract(self, parent_sequence):
         """Extract feature sequence from the supplied parent sequence."""
         # This copes with mixed strand features & all on reverse:
-        parts = [loc.extract(parent_sequence) for loc in self.parts]
+        if self.strand == -1:
+                parts = [loc.extract(parent_sequence) for loc in reversed(self.parts)]
+        else:
+                parts = [loc.extract(parent_sequence) for loc in self.parts]
         # We use addition rather than a join to avoid alphabet issues:
         f_seq = parts[0]
         for part in parts[1:]:


### PR DESCRIPTION
I attempted to file a bug report for this on the redmine tracker, but the tracker appears to be down.

This is a fix for SeqFeature CompoundLocation.extract to properly deal with features on the reverse strand. The old behavior was to revcomp sequences but still join them in the original order, leading to nonsense. Reverse strand sequences are now revcomped *and* reversed in order, so that join yields the correct sequence.

For example,
old behavior: [ATGC][GCAT] -> [GCAT][ATGC]
new behavior: [ATGC][GCAT] -> [ATGC][GCAT]