### PR TITLE
Per column annotation for AlignIO Stockholm format etc

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -802,8 +802,13 @@ class MultipleSeqAlignment(object):
             return self._records[index]
         elif isinstance(index, slice):
             # e.g. sub_align = align[i:j:k]
-            # TODO - Should this drop the annotations and column_annotations?
-            return MultipleSeqAlignment(self._records[index], self._alphabet)
+            new = MultipleSeqAlignment(self._records[index], self._alphabet)
+            if self.column_annotations and len(new) == len(self):
+                # All rows kept (although could have been reversed)
+                # Perserve the column annotations too,
+                for k, v in self.column_annotations.items():
+                    new.column_annotations[k] = v
+            return new
         elif len(index) != 2:
             raise TypeError("Invalid index type.")
 
@@ -817,9 +822,14 @@ class MultipleSeqAlignment(object):
             return "".join(rec[col_index] for rec in self._records[row_index])
         else:
             # e.g. sub_align = align[1:4, 5:7], gives another alignment
-            # TODO - If all the rows are kept, want to slice column_annotations
-            return MultipleSeqAlignment((rec[col_index] for rec in self._records[row_index]),
-                                        self._alphabet)
+            new = MultipleSeqAlignment((rec[col_index] for rec in self._records[row_index]),
+                                       self._alphabet)
+            if self.column_annotations and len(new) == len(self):
+                # All rows kept (although could have been reversed)
+                # Perserve the column annotations too,
+                for k, v in self.column_annotations.items():
+                    new.column_annotations[k] = v[col_index]
+            return new
 
     def sort(self, key=None, reverse=False):
         """Sort the rows (SeqRecord objects) of the alignment in place.

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -209,8 +209,21 @@ class MultipleSeqAlignment(object):
             self._per_col_annotations = None
             if value:
                 raise ValueError("Can't set per-column-annotations without an alignment")
+
+    def _get_per_column_annotations(self):
+        if self._per_col_annotations is None:
+            # This happens if empty at initialisation
+            if len(self):
+                # Use the standard method to get the length
+                expected_length = self.get_alignment_length()
+            else:
+                # Should this raise an exception? Compare SeqRecord behaviour...
+                expected_length = 0
+            self._per_col_annotations = _RestrictedDict(length=expected_length)
+        return self._per_col_annotations
+
     column_annotations = property(
-        fget=lambda self: self._per_col_annotations,
+        fget=_get_per_column_annotations,
         fset=_set_per_column_annotations,
         doc="""Dictionary of per-letter-annotation for the sequence.""")
 

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -12,7 +12,7 @@ class, used in the Bio.AlignIO module.
 from __future__ import print_function
 
 from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
+from Bio.SeqRecord import SeqRecord, _RestrictedDict
 from Bio import Alphabet
 
 
@@ -103,7 +103,7 @@ class MultipleSeqAlignment(object):
     """
 
     def __init__(self, records, alphabet=None,
-                 annotations=None):
+                 annotations=None, column_annotations=None):
         """Initialize a new MultipleSeqAlignment object.
 
         Arguments:
@@ -115,6 +115,10 @@ class MultipleSeqAlignment(object):
                       record alphabets.  If omitted, a consensus alphabet is
                       used.
          - annotations - Information about the whole alignment (dictionary).
+         - column_annotations - Per column annotation (restricted dictionary).
+                      This holds Python sequences (lists, strings, tuples)
+                      whose length matches the number of columns. A typical
+                      use would be a secondary structure consensus string.
 
         You would normally load a MSA from a file using Bio.AlignIO, but you
         can do this from a list of SeqRecord objects too:
@@ -126,7 +130,9 @@ class MultipleSeqAlignment(object):
         >>> a = SeqRecord(Seq("AAAACGT", generic_dna), id="Alpha")
         >>> b = SeqRecord(Seq("AAA-CGT", generic_dna), id="Beta")
         >>> c = SeqRecord(Seq("AAAAGGT", generic_dna), id="Gamma")
-        >>> align = MultipleSeqAlignment([a, b, c], annotations={"tool": "demo"})
+        >>> align = MultipleSeqAlignment([a, b, c],
+        ...                              annotations={"tool": "demo"},
+        ...                              column_annotations={"stats": "CCCXCCC"})
         >>> print(align)
         DNAAlphabet() alignment with 3 rows and 7 columns
         AAAACGT Alpha
@@ -134,6 +140,8 @@ class MultipleSeqAlignment(object):
         AAAAGGT Gamma
         >>> align.annotations
         {'tool': 'demo'}
+        >>> align.column_annotations
+        {'stats': 'CCCXCCC'}
 
         NOTE - The older Bio.Align.Generic.Alignment class only accepted a
         single argument, an alphabet.  This is still supported via a backwards
@@ -179,6 +187,32 @@ class MultipleSeqAlignment(object):
         elif not isinstance(annotations, dict):
             raise TypeError("annotations argument should be a dict")
         self.annotations = annotations
+
+        # Annotations about each colum of the alignment
+        if column_annotations is None:
+            column_annotations = {}
+        # Handle this via the property set function which will validate it
+        self.column_annotations = column_annotations
+
+    def _set_per_column_annotations(self, value):
+        if not isinstance(value, dict):
+            raise TypeError("The per-column-annotations should be a "
+                            "(restricted) dictionary.")
+        # Turn this into a restricted-dictionary (and check the entries)
+        if len(self):
+            # Use the standard method to get the length
+            expected_length = self.get_alignment_length()
+            self._per_col_annotations = _RestrictedDict(length=expected_length)
+            self._per_col_annotations.update(value)
+        else:
+            # Bit of a problem case... number of columns is undefined
+            self._per_col_annotations = None
+            if value:
+                raise ValueError("Can't set per-column-annotations without an alignment")
+    column_annotations = property(
+        fget=lambda self: self._per_col_annotations,
+        fset=_set_per_column_annotations,
+        doc="""Dictionary of per-letter-annotation for the sequence.""")
 
     def _str_line(self, record, length=50):
         """Return a truncated string representation of a SeqRecord (PRIVATE).
@@ -481,6 +515,9 @@ class MultipleSeqAlignment(object):
                 return
             expected_length = len(rec)
             self._append(rec, expected_length)
+            # Can now setup the per-column-annotations as well, set to None
+            # while missing the length:
+            self.column_annotations = {}
             # Now continue to the rest of the records as usual
 
         for rec in records:
@@ -573,9 +610,11 @@ class MultipleSeqAlignment(object):
         >>> b2 = SeqRecord(Seq("GT", generic_dna), id="Beta")
         >>> c2 = SeqRecord(Seq("GT", generic_dna), id="Gamma")
         >>> left = MultipleSeqAlignment([a1, b1, c1],
-        ...                             annotations={"tool": "demo", "name": "start"})
+        ...                             annotations={"tool": "demo", "name": "start"},
+        ...                             column_annotations={"stats": "CCCXC"})
         >>> right = MultipleSeqAlignment([a2, b2, c2],
-        ...                             annotations={"tool": "demo", "name": "end"})
+        ...                             annotations={"tool": "demo", "name": "end"},
+        ...                             column_annotations={"stats": "CC"})
 
         Now, let's look at these two alignments:
 
@@ -621,6 +660,11 @@ class MultipleSeqAlignment(object):
         >>> combined.annotations
         {'tool': 'demo'}
 
+        Similarly any common per-column-annotations are combined:
+
+        >>> combined.column_annotations
+        {'stats': 'CCCXCCC'}
+
         """
         if not isinstance(other, MultipleSeqAlignment):
             raise NotImplementedError
@@ -634,7 +678,11 @@ class MultipleSeqAlignment(object):
         for k, v in self.annotations.items():
             if k in other.annotations and other.annotations[k] == v:
                 annotations[k] = v
-        return MultipleSeqAlignment(merged, alpha, annotations)
+        column_annotations = dict()
+        for k, v in self.column_annotations.items():
+            if k in other.column_annotations:
+                column_annotations[k] = v + other.column_annotations[k]
+        return MultipleSeqAlignment(merged, alpha, annotations, column_annotations)
 
     def __getitem__(self, index):
         """Access part of the alignment.
@@ -754,6 +802,7 @@ class MultipleSeqAlignment(object):
             return self._records[index]
         elif isinstance(index, slice):
             # e.g. sub_align = align[i:j:k]
+            # TODO - Should this drop the annotations and column_annotations?
             return MultipleSeqAlignment(self._records[index], self._alphabet)
         elif len(index) != 2:
             raise TypeError("Invalid index type.")
@@ -768,6 +817,7 @@ class MultipleSeqAlignment(object):
             return "".join(rec[col_index] for rec in self._records[row_index])
         else:
             # e.g. sub_align = align[1:4, 5:7], gives another alignment
+            # TODO - If all the rows are kept, want to slice column_annotations
             return MultipleSeqAlignment((rec[col_index] for rec in self._records[row_index]),
                                         self._alphabet)
 

--- a/Bio/AlignIO/StockholmIO.py
+++ b/Bio/AlignIO/StockholmIO.py
@@ -141,6 +141,32 @@ secondary structure string here, are also sliced:
     >>> print(sub_record.letter_annotations['secondary_structure'])
     -------<<<
 
+Likewise with the alignment object, as long as you are not dropping any rows,
+slicing specific columns of an alignment will slice any per-column-annotations:
+
+    >>> align.column_annotations["secondary_structure"]
+    '.................<<<<<<<<...<<<<<<<........>>>>>>>........<<<<<<<.......>>>>>>>..>>>>>>>>...............'
+    >>> part_align = align[:,10:20]
+    >>> part_align.column_annotations["secondary_structure"]
+    '.......<<<'
+
+You can also see this in the Stockholm output of this partial-alignment:
+
+    >>> print(part_align.format("stockholm"))
+    # STOCKHOLM 1.0
+    #=GF SQ 2
+    AP001509.1 UCAACACUCU
+    #=GS AP001509.1 AC AP001509.1
+    #=GS AP001509.1 DE AP001509.1
+    #=GR AP001509.1 SS -------<<<
+    AE007476.1 AUCGUUUUAC
+    #=GS AE007476.1 AC AE007476.1
+    #=GS AE007476.1 DE AE007476.1
+    #=GR AE007476.1 SS -------<<<
+    #=GC SS_cons .......<<<
+    //
+    <BLANKLINE>
+
 """
 from __future__ import print_function
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -26,6 +26,10 @@ system locale settings.
 
 Bio.KEGG can now parse Gene files.
 
+The multiple-sequence-alignment object used by Bio.AlignIO etc now supports
+a per-column annotation dictionary, useful for richly annotated alignments
+in the Stockholm/PFAM format.
+
 The SeqRecord object now has a translate method, following the approach used
 for its existing reverse_complement method etc.
 

--- a/Tests/output/test_AlignIO
+++ b/Tests/output/test_AlignIO
@@ -3,6 +3,7 @@ Testing reading clustal format file Clustalw/cw02.aln with 1 alignments
  Alignment 0, with 2 sequences of length 601
   MENSDSNDKGSDQSAAQRRSQMDRLDREEAFYQFVN...SVV gi|4959044|gb|AAD34209.1|AF069
   ---------MSPQTETKASVGFKAGVKEYKLTYYTP...--- gi|671626|emb|CAA85685.1|
+            * *: ::    :.   :*  :  :. ...    clustal_consensus
  Checking can write/read as 'clustal' format
  Checking can write/read as 'maf' format
  Checking can write/read as 'mauve' format
@@ -58,6 +59,7 @@ Testing reading clustal format file Clustalw/odd_consensus.aln with 1 alignments
  Alignment 0, with 2 sequences of length 687
   ------------------------------------...TAG AT3G20900.1-CDS
   ATGAACAAAGTAGCGAGGAAGAACAAAACATCAGGT...TAG AT3G20900.1-SEQ
+                                      ...*** clustal_consensus
  Checking can write/read as 'clustal' format
  Checking can write/read as 'maf' format
  Checking can write/read as 'mauve' format
@@ -169,6 +171,7 @@ Testing reading stockholm format file Stockholm/simple.sth with 1 alignments
  Alignment 0, with 2 sequences of length 104
   UUAAUCGAGCUCAACACUCUUCGUAUAUCCUC-UCA...UGU AP001509.1
   AAAAUUGAAUAUCGUUUUACUUGUUUAU-GUCGUGA...GAU AE007476.1
+  .................<<<<<<<<...<<<<<<<....... secondary_structure
  Checking can write/read as 'clustal' format
  Checking can write/read as 'maf' format
  Checking can write/read as 'mauve' format

--- a/Tests/test_AlignIO.py
+++ b/Tests/test_AlignIO.py
@@ -93,6 +93,10 @@ def alignment_summary(alignment, index="  ", vertical_threshold=5):
         for record in alignment:
             answer.append("%s%s %s" % (
                 index, str_summary(str(record.seq)), record.id))
+        for key, value in alignment.column_annotations.items():
+            if isinstance(value, str):
+                answer.append("%s%s %s" %
+                              (index, str_summary(str(value)), key))
     else:
         # Show each sequence row vertically
         for i in range(min(5, alignment_len)):


### PR DESCRIPTION
This ought to resolve #516 (per-column annotation) and #357 (Stockholm parser currently ignores per-column annotation).

Requesting comments please, in particular on the slicing logic (should it preserve per-column annotation even when dropping rows) and naming of Stockholm annotation keys (e.g. should it keep the `_cons` suffix?)
