### PR TITLE
Edited MMCIF2Dict to use either filename or file handler

### DIFF
--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -14,8 +14,14 @@ import shlex
 
 
 class MMCIF2Dict(dict):
+    """Parse a mmCIF file and return a dictionary."""
 
     def __init__(self, filename):
+        """Parse a mmCIF file and return a dictionary.
+
+        Arguments:
+         - file - name of the PDB file OR an open filehandle
+        """
         with as_handle(filename) as handle:
             loop_flag = False
             key = None

--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -7,6 +7,7 @@
 
 from __future__ import print_function
 
+from Bio.File import as_handle
 from Bio._py3k import input as _input
 
 import shlex
@@ -15,7 +16,7 @@ import shlex
 class MMCIF2Dict(dict):
 
     def __init__(self, filename):
-        with open(filename) as handle:
+        with as_handle(filename) as handle:
             loop_flag = False
             key = None
             tokens = self._tokenize(handle)

--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -48,6 +48,12 @@ class MMCIFParser(object):
     # Public methods
 
     def get_structure(self, structure_id, filename):
+        """Return the structure.
+
+        Arguments:
+         - structure_id - string, the id that will be used for the structure
+         - filename - name of the mmCIF file OR an open filehandle
+        """
         with warnings.catch_warnings():
             if self.QUIET:
                 warnings.filterwarnings("ignore", category=PDBConstructionWarning)

--- a/Tests/test_MMCIF.py
+++ b/Tests/test_MMCIF.py
@@ -133,6 +133,14 @@ class ParseReal(unittest.TestCase):
         structure = parser.get_structure("example", "PDB/2OFG.cif")
         self.assertEqual(len(structure), 3)
 
+    def test_filehandle(self):
+        """Test if the parser can handle file handle as well as filename"""
+        parser = MMCIFParser()
+        structure = parser.get_structure("example", "PDB/1A8O.cif")
+        self.assertEqual(len(structure), 1)
+
+        structure = parser.get_structure("example", open("PDB/1A8O.cif"))
+        self.assertEqual(len(structure), 1)
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
MMCIF2Dict is edited to use either filename or file handler, which is consistent behavior of other PDB parsers.