### PR TITLE
Fix codon alignment using a codon_table

### DIFF
--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -179,6 +179,7 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char='-', unknown='X',
             codon_rec = _get_codon_rec(pair[0], pair[1], corr_span,
                                        alphabet=alphabet,
                                        complete_protein=False,
+                                       codon_table=codon_table,
                                        max_score=max_score)
             codon_aln.append(codon_rec)
             if corr_span[1] == 2:

--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -580,7 +580,7 @@ def _get_codon_rec(pro, nucl, span_mode, alphabet, gap_char="-",
             else:
                 this_codon = nucl_seq._data[(span[0] + 3 * aa_num):
                                             (span[0] + 3 * (aa_num + 1))]
-                if not str(Seq(this_codon.upper()).translate()) == aa:
+                if not str(Seq(this_codon.upper()).translate(table=codon_table)) == aa:
                     max_score -= 1
                     warnings.warn("%s(%s %d) does not correspond to %s(%s)"
                                   % (pro.id, aa, aa_num, nucl.id, this_codon))
@@ -653,7 +653,7 @@ def _get_codon_rec(pro, nucl, span_mode, alphabet, gap_char="-",
                     start = rf_table[aa_num]
                     end = start + 3
                     this_codon = nucl_seq._data[start:end]
-                    if not str(Seq(this_codon.upper()).translate()) == aa:
+                    if not str(Seq(this_codon.upper()).translate(codon_table)) == aa:
                         max_score -= 1
                         warnings.warn("Codon of {0}({1} {2}) does not "
                                       "correspond to {3}({4})".format(

--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -653,7 +653,7 @@ def _get_codon_rec(pro, nucl, span_mode, alphabet, gap_char="-",
                     start = rf_table[aa_num]
                     end = start + 3
                     this_codon = nucl_seq._data[start:end]
-                    if not str(Seq(this_codon.upper()).translate(codon_table)) == aa:
+                    if not str(Seq(this_codon.upper()).translate(table=codon_table)) == aa:
                         max_score -= 1
                         warnings.warn("Codon of {0}({1} {2}) does not "
                                       "correspond to {3}({4})".format(

--- a/Tests/test_codonalign.py
+++ b/Tests/test_codonalign.py
@@ -18,6 +18,7 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Alphabet import IUPAC
 from Bio.Align import MultipleSeqAlignment
+from Bio.Data import CodonTable
 
 with warnings.catch_warnings():
     warnings.simplefilter('ignore', BiopythonExperimentalWarning)
@@ -137,9 +138,23 @@ class Test_build(unittest.TestCase):
         self.aln2 = aln2
         self.seqlist2 = [seq3, seq4, seq5]
 
+        # Test set 3
+        # use Yeast mitochondrial codon table
+        seq6 = SeqRecord(Seq('ATGGCAAGGGACCACCCAGTTGGGCACTGATATGATCGGGTGTATTTGCAGAGTAGTAACCTTTCTTTTCTCAAGACCATCCAG', alphabet=IUPAC.IUPACUnambiguousDNA()), id='pro6')
+        seq7 = SeqRecord(Seq('ATGGCAAGGCACCATCCAGTTGAGCACTGATATGATCGGGTGTATTTGCAGAGTAGTAACGTGTCTCTGCTCAAGACCATCCAG', alphabet=IUPAC.IUPACUnambiguousDNA()), id='pro7')
+        seq8 = SeqRecord(Seq('ATGGCAGGGGACCACCCAGTTGGGCACTGATATGATCGTGTGTATCTGCAGAGTAGTAACCACTCTTTTCTCATGACCATCCAG', alphabet=IUPAC.IUPACUnambiguousDNA()), id='pro8')
+        pro6 = SeqRecord(Seq('MARDHPVGHWYDRVYLQSSNTSFTKTIQ', alphabet=IUPAC.protein), id='pro6')
+        pro7 = SeqRecord(Seq('MARHHPVEHWYDRVYLQSSNVSTTKTIQ', alphabet=IUPAC.protein), id='pro7')
+        pro8 = SeqRecord(Seq('MAGDHPVGHWYDRVYTQSSNHSFTMTIQ', alphabet=IUPAC.protein), id='pro8')
+        aln3 = MultipleSeqAlignment([pro6, pro7, pro8])
+        self.aln3 = aln3
+        self.seqlist3 = [seq6, seq7, seq8]
+        self.codontable3 = CodonTable.unambiguous_dna_by_id[3]
+
     def test_build(self):
         codon_aln1 = codonalign.build(self.aln1, self.seqlist1)
         codon_aln2 = codonalign.build(self.aln2, self.seqlist2)
+        codon_aln3 = codonalign.build(self.aln3, self.seqlist3, codon_table=self.codontable3)
 
 
 class Test_dn_ds(unittest.TestCase):


### PR DESCRIPTION
The user codon_table  is not used when performing codon alignment based on a protein multialignment and nucleotides sequence. I was trying to make a codon alignment using mitochondrial proteins and I got an error resulting of TGA being considered as a stop codon instead of Tryptophan, although the genetic code was provided. 