### PR TITLE
bug fix to handle NoneType when writing to newick with branch_length_only=True

### DIFF
--- a/Bio/Phylo/NewickIO.py
+++ b/Bio/Phylo/NewickIO.py
@@ -319,7 +319,7 @@ class Writer(object):
         elif branch_length_only:
             # write only branchlengths, ignore support
             def make_info_string(clade, terminal=False):
-                return (':' + format_branch_length % clade.branch_length) + _get_comment(clade)
+                return (':' + format_branch_length % (clade.branch_length or 0.0)) + _get_comment(clade)
 
         else:
             # write support and branchlengths (e.g. .con tree of mrbayes)

--- a/Tests/test_Phylo.py
+++ b/Tests/test_Phylo.py
@@ -143,6 +143,19 @@ class IOTests(unittest.TestCase):
         os.remove(tmp_filename)
         self.assertEqual(13, count)
 
+    def test_convert_phyloxml_to_newick_branch_length_only(self):
+        """Write phyloxml with bootstrap values to newick format using branch_length_only=True"""
+        trees = Phylo.parse(EX_APAF, "phyloxml")
+        tmp_filename = tempfile.mktemp()
+
+        try :
+            Phylo.write(trees, tmp_filename, "newick", branch_length_only=True)
+            os.remove(tmp_filename)
+            self.assertTrue(True)
+
+        except TypeError:
+            self.assertTrue(False)
+
     def test_int_labels(self):
         """Read newick formatted tree with numeric labels."""
         tree = Phylo.read(StringIO('(((0:0.1,1:0.1)0.99:0.1,2:0.1)0.98:0.0);'),

--- a/Tests/test_Phylo.py
+++ b/Tests/test_Phylo.py
@@ -151,10 +151,9 @@ class IOTests(unittest.TestCase):
         try :
             Phylo.write(trees, tmp_filename, "newick", branch_length_only=True)
             os.remove(tmp_filename)
-            self.assertTrue(True)
 
         except TypeError:
-            self.assertTrue(False)
+            self.fail()
 
     def test_int_labels(self):
         """Read newick formatted tree with numeric labels."""


### PR DESCRIPTION
Writing a newick file with branch_length_only=True can crash with a NoneType exception (I have noticed this when using trees read from PhyloXML files).

The problem is probably with the PhyloXML reader, but as other options (e.g. when writing with support and branch lengths) have the same "or 0.0" to guard against this, maybe this is by design.
