### PR TITLE
changed a few assertTrue(False) -> fail()

### DIFF
--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -41,7 +41,7 @@ class SeqRecordCreation(unittest.TestCase):
         # Now try modifying it to a bad value...
         try:
             rec.letter_annotations["bad"] = "abc"
-            self.assertTrue(False, "Adding a bad letter_annotation should fail!")
+            self.fail("Adding a bad letter_annotation should fail!")
         except (TypeError, ValueError) as e:
             pass
         # Now try setting it afterwards to a bad value...
@@ -49,7 +49,7 @@ class SeqRecordCreation(unittest.TestCase):
                         id="Test", name="Test", description="Test")
         try:
             rec.letter_annotations = {"test": [1, 2, 3]}
-            self.assertTrue(False, "Changing to bad letter_annotations should fail!")
+            self.fail("Changing to bad letter_annotations should fail!")
         except (TypeError, ValueError) as e:
             pass
         # Now try setting it at creation time to a bad value...
@@ -57,7 +57,7 @@ class SeqRecordCreation(unittest.TestCase):
             rec = SeqRecord(Seq("ACGT", generic_dna),
                             id="Test", name="Test", description="Test",
                             letter_annotations={"test": [1, 2, 3]})
-            self.assertTrue(False, "Wrong length letter_annotations should fail!")
+            self.fail("Wrong length letter_annotations should fail!")
         except (TypeError, ValueError) as e:
             pass
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -479,7 +479,7 @@ class StringMethodTests(unittest.TestCase):
                 # This is based on the limited example not having stop codons:
                 if tran.alphabet not in [extended_protein, protein, generic_protein]:
                     print(tran.alphabet)
-                    self.assertTrue(False)
+                    self.fail()
                 # TODO - check the actual translation, and all the optional args
 
     def test_the_translation_of_stops(self):
@@ -533,7 +533,7 @@ class StringMethodTests(unittest.TestCase):
                         Seq(codon, unambiguous_dna)]:
                 try:
                     print(nuc.translate())
-                    self.assertTrue(False, "Transating %s should fail" % codon)
+                    self.fail("Transating %s should fail" % codon)
                 except TranslationError:
                     pass
 

--- a/Tests/test_Wise.py
+++ b/Tests/test_Wise.py
@@ -55,7 +55,7 @@ class TestWise(unittest.TestCase):
             pass
         else:
             # Bad!
-            self.assertTrue(False, line)
+            self.fail(line)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In a previous pull request @peterjc suggested that assertTrue(False) should all be replaced with fail() as it is more explicit.