### PR TITLE
Raise exceptions for SeqRecord __eq__ and __ne__ methods

### DIFF
--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -712,6 +712,13 @@ class SeqRecord(object):
         """
         return len(self.seq)
 
+    def __eq__(self, other):
+        raise NotImplementedError("SeqRecord equality not implemented because "
+                                  "of object complexity.")
+    def __ne__(self, other):
+        raise NotImplementedError("SeqRecord equality not implemented because "
+                                  "of object complexity.")
+
     # Python 3:
     def __bool__(self):
         """Boolean value of an instance of this class (True).


### PR DESCRIPTION
Fixes #559. 

```
In [1]: from Bio.Seq import Seq

In [2]: from Bio.SeqRecord import SeqRecord

In [3]: SeqRecord(Seq('A')) == SeqRecord(Seq('A'))
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
<ipython-input-3-b7d380bf1975> in <module>()
----> 1 SeqRecord(Seq('A')) == SeqRecord(Seq('A'))

/Users/dkoppstein/src/github.com/dkoppstein/biopython/Bio/SeqRecord.py in __eq__(self, other)
    714
    715     def __eq__(self, other):
--> 716         raise NotImplementedError("SeqRecord equality not implemented because "
    717                                   "of object complexity.")
    718     def __ne__(self, other):

NotImplementedError: SeqRecord equality not implemented because of object complexity.

In [4]: SeqRecord(Seq('A')) != SeqRecord(Seq('A'))
---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
<ipython-input-4-f0580ac61f0c> in <module>()
----> 1 SeqRecord(Seq('A')) != SeqRecord(Seq('A'))

/Users/dkoppstein/src/github.com/dkoppstein/biopython/Bio/SeqRecord.py in __ne__(self, other)
    717                                   "of object complexity.")
    718     def __ne__(self, other):
--> 719         raise NotImplementedError("SeqRecord equality not implemented because "
    720                                   "of object complexity.")
    721

NotImplementedError: SeqRecord equality not implemented because of object complexity.
```
