### PR TITLE
Add STANDARD datatype support to Nexus parser

### DIFF
--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -1,5 +1,5 @@
 # Copyright 2005-2008 by Frank Kauff & Cymon J. Cox. All rights reserved.
-#                2014 by Joe Cora (standard data)
+#           2014-2015 by Joe Cora (standard data)
 # This code is part of the Biopython distribution and governed by its
 # license. Please see the LICENSE file that should have been included
 # as part of this package.

--- a/Bio/Nexus/StandardData.py
+++ b/Bio/Nexus/StandardData.py
@@ -1,0 +1,113 @@
+# Copyright 2014 Joe Cora.
+# All rights reserved.
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+"""Provides objects to represent NEXUS standard data type matrix coding
+"""
+from __future__ import print_function
+
+class NexusError(Exception):
+    pass
+
+class StandardData(object):
+    """Create a StandardData iterable object.
+        Each coding specifies t [type] => (std [standard], multi [multistate] or uncer [uncertain]) and d [data]
+    """
+    def __init__(self, data):
+        self._data = []
+        self._current_pos = 0
+        
+        # Enforce string data requirement
+        if not isinstance(data, basestring):
+            raise NexusError('The coding data given to a StandardData object should be a string')
+        
+        # Transfer each coding to a position within a sequence
+        multi_coding = False
+        uncertain_coding = False
+        coding_list = {'t':'std', 'd':[]}
+        
+        for pos, coding in enumerate(data):
+            # Check if in a multiple coded or uncertain character
+            if multi_coding:
+                # End multicoding if close parenthesis
+                if coding == ')':
+                    multi_coding = False
+                else:
+                    # Add current coding to list and advance to next coding
+                    coding_list['d'].append(coding)
+                    
+                    continue
+            elif uncertain_coding:
+                # End multicoding if close parenthesis
+                if coding == '}':
+                    uncertain_coding = False
+                else:
+                    # Add current coding to list and advance to next coding
+                    coding_list['d'].append(coding)
+                    
+                    continue
+            else:
+                # Check if a multiple coded or uncertain character is starting
+                if coding == '(':
+                    multi_coding = True
+                    coding_list['t'] = 'multi'
+                    
+                    continue
+                elif coding == '{':
+                    uncertain_coding = True
+                    coding_list['t'] = 'uncer'
+                    
+                    continue
+                elif coding in [')', '}']:
+                    raise NexusError('Improper character "' + coding + '" at position ' + pos + ' of a coding sequence.')
+                else:
+                    coding_list['d'].append(coding)
+            
+            # Add character coding to data
+            self._data.append(coding_list.copy())
+            
+            coding_list = {'t':'std', 'd':[]}
+    
+    def __len__(self):
+        """Returns the length of the coding, use len(my_coding).
+        """
+        return len(self._data)
+    
+    def __getitem__(self, arg):
+        return self._data[arg]
+    
+    def __iter__(self):
+        return self
+    
+    def next(self):
+        try:
+            return_coding = self._data[self._current_pos]
+        except:
+            self._current_pos = 0
+            
+            raise StopIteration
+        else:
+            self._current_pos += 1
+            
+            return return_coding
+    
+    def raw(self):
+        """Returns the full coding as a python list
+        """
+        return self._data
+
+    def __str__(self):
+        """Returns the full coding as a python string, use str(my_coding).
+        """
+        str_return = ''
+        
+        for coding in self._data:
+            if coding['t'] == 'multi':
+                str_return += '(' + ''.join(coding['d']) + ')'
+            elif coding['t'] == 'uncer':
+                str_return += '{' + ''.join(coding['d']) + '}'
+            else:
+                str_return += coding['d'][0]
+        
+        return str_return

--- a/Tests/Nexus/vSysLab_Ganaspidium_multistate.nex
+++ b/Tests/Nexus/vSysLab_Ganaspidium_multistate.nex
@@ -1,0 +1,48 @@
+#NEXUS
+
+BEGIN TAXA;
+	DIMENSIONS NTAX=6;
+	TAXLABELS
+		'Ganaspidium didionae'
+		'Ganaspidium eldiablo'
+		'Ganaspidium flemingi'
+		'Ganaspidium kolmaci'
+		'Ganaspidium konzaense'
+		'Ganaspidium pusillae'
+	;
+END;
+
+BEGIN CHARACTERS;
+	DIMENSIONS NCHAR=14;
+	FORMAT DATATYPE=STANDARD MISSING=? GAP=-
+		SYMBOLS="012345"
+	;
+	CHARSET 'Head' = 1 2 3 4;
+	CHARSET 'Mesosoma' = 5 6 7 8 9 10 11 12;
+	CHARSET 'Forewing' = 13;
+	CHARSET 'Metasoma' = 14;
+	CHARSTATELABELS
+		1 'Malar sulcus'/'simple' 'compound',
+		2 'Malar space'/'smooth' 'partially striate, striations extending 1/2 to 2/3 distance from ventral margin of malar space to base of compound eye' 'completely striate from ventral margin of malar space to base of compound eye' 'partially striate, striations extending to 1/4 distance from ventral margin of malar space to base of compound eye',
+		3 'Malar protuberance'/'smooth, elongate, extending beyond length of ventral margin of malar space' 'striate, elongate, extending beyond length of ventral margin of malar space' 'smooth, short, not extending beyond length of ventral margin of malar space' 'striate, short, not extending beyond length of ventral margin of malar space',
+		4 'Clypeal protuberance'/'elongate, overhanging anterior margin of clypeus' 'short, not overhanging anterior margin of clypeus',
+		5 'Tubercles of scutellar plate'/'present, extremely reduced, hardly distinguishable' 'present, distinct, small, length of tuber less than 1/2 width of tubercle base' 'present, distinct, large, length of tubercle equal to or greater than width of tubercle base' 'absent',
+		6 'Dorsal surface of scutellar plate'/'flat, smooth, setal bearing pits present surrounding midpit' 'flat, horizontally striate, setal bearing pits present surrounding midpit' 'gently convex, smooth, setal bearing pits surrounding midpit' 'concave, smooth, setal bearing pits surrounding midpit' 'concave around midpit, two setal bearing pits at base of each tubercle' 'concave, radially striate, setal bearing pits surrounding midpit',
+		7 'Carina along posterior margin of scutellum'/'absent' 'present, delicate, defining transition from dorsal surface of scutellum from posterior surface' 'present, distinctly cleft, defining transition from dorsal surface of scutellum from posterior surface',
+		8 'Dorsal surface of scutellum'/'entirely smooth' 'smooth except for faint wrinkles along posterior carina' 'smooth anteriorly, reticular/strigate posteriorly' 'smooth anteriorly, longitudinally striate posteriorly' 'entirely rugulose/wrinkled' 'smooth anteriorly, gently striate posteriorly',
+		9 'Midpit of scutellar plate'/'in center of plate; plate large, obscuring dorsal surface of scutellum when viewed dorsally' 'in center of plate; plate small, revealing dorsal surface of scutellum when viewed dorsally' 'in posterior half of plate; plate small, revealing dorsal surface of scutellum when viewed dorsally',
+		10 'Mesopopleura setal patch'/'present' 'absent',
+		11 'Mesopleuron'/'entirely smooth' 'smooth anteriorly, striate along the postero-dorsal margin' 'distinctly striate along the anterior, posterior margins; often entire sclerite striate' 'striate within confines of mesopleural triangle, remainder of sclerite smooth',
+		12 'Lateral aspect of pronotum'/'covered in long, thin, white setae' 'anteriorly with some short setae, remainder glabrous',
+		13 'Marginal cell of forewing'/'as deep as long' 'distinctly deeper than long',
+		14 'Size of metasoma (in lateral view)'/'sub-equal in size to mesosoma' 'distinctly larger than mesosoma (longer and deeper)'
+	;
+	MATRIX
+		'Ganaspidium didionae' 1100242421(01)110
+		'Ganaspidium eldiablo' 10000405210110
+		'Ganaspidium flemingi' 10(02)(01)1411210110
+		'Ganaspidium kolmaci' 010000(01)221(01)100
+		'Ganaspidium konzaense' 12002424212100
+		'Ganaspidium pusillae' 01(02)(01)141221(01)110
+	;
+END;

--- a/Tests/Nexus/vSysLab_Heptascelio_no-states_10+chars.nex
+++ b/Tests/Nexus/vSysLab_Heptascelio_no-states_10+chars.nex
@@ -1,0 +1,105 @@
+#NEXUS
+
+BEGIN TAXA;
+	DIMENSIONS NTAX=19;
+	TAXLABELS
+		'Heptascelio albipes'
+		'Heptascelio anthonyi'
+		'Heptascelio aquilinus'
+		'Heptascelio bivius'
+		'Heptascelio castor'
+		'Heptascelio dayi'
+		'Heptascelio dispar'
+		'Heptascelio hamatus'
+		'Heptascelio lateralis'
+		'Heptascelio noyesi'
+		'Heptascelio orarius'
+		'Heptascelio paralugens'
+		'Heptascelio strigatus'
+		'Heptascelio teres'
+		'Heptascelio watshami'
+		'Heptascelio lugens'
+		'Heptascelio sicarius'
+		'Heptascelio striatosternus'
+		'A'
+	;
+END;
+
+BEGIN CHARACTERS;
+	DIMENSIONS NCHAR=43;
+	FORMAT DATATYPE=STANDARD MISSING=? GAP=-
+		SYMBOLS="0123456789A"
+	;
+	CHARSET 'Head' = 1 2 3 4 5 6 7 8 9 10;
+	CHARSET 'Antenna' = 11 12;
+	CHARSET 'Mesosoma' = 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31;
+	CHARSET 'Legs' = 32 33;
+	CHARSET 'Wings' = 34 35 36;
+	CHARSET 'Metasoma' = 37 38 39 40 41 42 43;
+	CHARSTATELABELS
+		1 'body color of female'/'entirely dark, dark brown to black' 'bicolored: head and mesosoma dark brown, metasoma yellow',
+		2 'body color of male'/'entirely black' 'entirely dark brown' 'head and metasoma black, mesosoma reddish brown' 'head and mesosoma black, metasoma dark brown',
+		3 'sculpture of occiput and posterior vertex'/'areolate-rugose' 'with strong transverse rugae' 'coarsely punctate' 'irregularly rugulose' 'areolate rugose, with distinct transverse tendency' 'with strong arched rugae',
+		4 'sculpture of frons below ocellus in female'/'transversely striate' 'areolate rugose' 'coarsely punctate' 'dorsoventrally striate',
+		5 'shape of dorsal margin of frontal scrobe'/'evenly arcuate, weakly produced' 'distinctly incised medially, strongly produced anteriorly' 'ecarinate, rounded onto dorsal portion of frons',
+		6 'sculpture of frontal depression in female'/'transversely striate ventrally, with smooth field dorsomedially' 'entirely smooth' 'with short transverse striae on sides, medially entirely smooth' 'irregularly areolate ventrally, smooth dorsally and medially' 'coarsely punctate ventrally and laterally, otherwise smooth' 'transversely rugose throughout' 'diagonally striate laterally, smooth medially' 'coarsely punctate' 'punctate, with broad smooth spaces between punctures',
+		7 'sculpture of gena'/'with irregular dorsoventral rugae' 'with irregular, nearly longitudinal rugulae' 'coarsely punctate' 'areolate rugose, with distinct dorsoventral tendency',
+		8 'setation of gena'/'with short, uniform setae, with few short bristles interspersed' 'with numerous strong, erect, dark bristles amid shorter setation' 'with short, uniform setae, without bristles',
+		9 'shape of mandibles'/'normal length, crossed transversely below head when closed, tips overlapping' 'elongate, extending ventrally below head, tips meeting apically',
+		10 'sculpture of male mesoscutellum'/'coarsely reticulate' 'coarsely reticulate, with distinct longitudinal elements' 'areolate rugose' 'coarsely longitudinally areolate rugose' 'longitudinally strigose',
+		11 'color of female antenna'/'A1-A2 pale brown, A3-A6 brown, A7-A12 dark brown' 'A1 brown, A2-A5 light brown, A6-A12 dark brown' 'dark brown to black throughout' 'dark brown to black throughout, extremities of A1, A2 lighter in color' 'brown to dark brown throughout' 'A1 brownish yellow, A2-A5 yellow, A6-A12 dark brown to black' 'A1 dark brown, A2-A5 off-white, A6-A12 dark brown to black' 'A1 dark brown, A2-A4 brownish yellow, A5-A12 dark brown to black' 'A1 brown, A2-A5 yellow, A6-A12 generally brown to dark brown, A12 lighter' 'A1 brown, A2-A5 yellow, A6-A12 dark brown',
+		12 'color of male antenna'/'light brown throughout' 'brown to dark brown throughout' 'brown' 'A1-A5 brown, A6-A12 pale brown',
+		13 'sculpture of dorsal pronotum'/'longitudinally aciculate, with smooth interspaces' 'areolate rugose' 'coarsely reticulate' 'coarsely punctate' 'areolate rugose, with distinct longitudinal tendency' 'longitudinally strigose',
+		14 'notaulus',
+		15 'sculpture of mesoscutum in female'/'coarsely areolate-rugose' 'finely longitudinally aciculate with smooth interspaces' 'coarsely longitudinally strigose with smooth interspaces' 'longitudinally strigose, with strong transverse sculpture in interspaces' 'sparsely punctate, with broad smooth areas between punctures' 'longitudinally strigose with fine sculpture in interspaces' 'sparsely punctate, with broad smooth areas between punctures, with weak indications of longitudinal rugulae' 'midlobe coarsely punctate, lateral lobes with punctures sparser, separated by smooth areas',
+		16 'sculpture of mesoscutum in male'/'with dense umbilicate punctures' 'finely longitudinally aciculate' 'coarsely areolate rugose' 'sparsely punctate, largely smooth' 'longitudinally strigose, with strong transverse sculpture in interspaces' 'sparsely punctate, with broad smooth areas between punctures, with weak indications of longitudinal rugulae' 'coarsely areolate rugose with distinct longitudinal tendency' 'coarsely longitudinally areolate rugose',
+		17 'parapsidal line'/'present, clearly impressed' 'absent' 'present, evanescent',
+		18 'mesoscutellum shape'/'distinctly narrowed apically, with median longitudinal depression' 'broad, weakly convex, apex broadly rounded' 'nearly parallel-sided, apex weakly excavate, with weak median longitudinal impression' 'semicircular, posteriorly distinctly sloping ventrad, without distinct median longitudinal furrow' 'roughly trapezoidal, sides weakly converging apically, apex excavate, with distinct median longitudinal furrow' 'roughly semicircular, with distinct median longitudinal impression in apical half' 'roughly trapezoidal, sides converging apically, apex weakly excavate, without distinct median longitudinal impression',
+		19 'sculpture of female mesoscutellum'/'coarsely reticulate, with distinct longitudinal elements' 'areolate rugose' 'longitudinally strigate' 'coarsely punctate',
+		20 'mesoscutellar points of female'/'absent, scutellum with rounded lobes laterally' 'broad, short, acute' 'narrow, elongate, acute' 'forming short, acute teeth' 'forming short, sharp angles, not protruding' 'flattened, broadly rounded apically' 'moderately elongate, narrow, acute, curving medially',
+		21 'mesoscutellar points of male'/'apex of scutellum transverse, posterolateral corners very weakly produced' 'apex of scutellum rounded, points entirely absent' 'narrow, short, acute' 'flattened, broadly rounded apically' 'broad, short, acute',
+		22 'posterior surface of propodeum'/'with distinct straight longitudinal paramedian keel arising from apex of inner propodeal projection' 'with medial area covered by elongate areolae, bounded laterally by irregular carinae' 'with central row of quadrate areolae above large smooth central area, bounded laterally by carinae' 'irregularly areolate, without distinct paramedian keel' 'with medial area with elongate areolae, bounded laterally by distinct paramedial carinae' 'with sinuous paramedian keel arising from apex of inner propodeal projection' 'longitudinally carinate, without distinct paramedian keel' 'longitudinally carinate with well-developed transverse striae, without distinct paramedian keel',
+		23 'length of outer propodeal projection in female'/'extending beyond apex of T1' 'extending at most to midlength of T1' 'rather short, extending at most to midlength of T1, distinctly longer than inner propodeal projection' 'moderately elongate, not reaching midpoint of length of T1, subequal in length to inner propodeal projection' 'elongate, extending near or beyond apex of T1, distinctly longer than inner propodeal projection' 'moderately elongate, extending to midpoint of length of T1, distinctly longer than inner propodeal projection' 'rather short, extending at most to midlength of T1, slightly longer than inner propodeal projection',
+		24 'sculpture of propodeum between inner and outer propodeal projections'/'areolate rugose' 'coarsely punctate' 'largely smooth, with variably developed diagonal carinae' 'longitudinally carinate with punctures in interspaces' 'areolate rugose, with distinct longitudinal tendency',
+		25 'netrion shape'/'moderately wide, parallel-sided in ventral half, open' 'strongly narrowed, nearly linear, foveae on surface nearly as high as wide' 'narrow, gradually widened ventrally, foveae on surface distinctly wider than high' 'moderately wide, nearly parallel-sided, with two columns of large punctures' 'moderately wide, nearly parallel-sided, weakly widened ventrally, with single column of large foveae' 'moderately wide, weakly fusiform, with column of elongate foveae' 'moderately wide, weakly fusiform, anterior margin foveate',
+		26 'netrion setation'/'glabrous' 'densely setose',
+		27 'sculpture of lateral pronotum posterior to epomial carina'/'smooth' 'coarsely sculptured' 'with large smooth field dorsally, elsewhere finely rugulose' 'with smooth field dorsally, elsewhere areolate rugose' 'with small smooth field near posterior margin, elsewhere finely rugulose' 'coarsely punctate' 'coarsely rugulose throughout' 'coarsely foveolate immediately behind epomial carina, elsewhere sparsely punctate',
+		28 'setation of posterior half of lateral pronotum'/'largely glabrous, setae limited to small patch near spiracle' 'with numerous scattered setae, densest near spiracle',
+		29 'sculpture of mesopleural scrobe'/'smooth' 'coarsely areolate to rugose' 'finely microreticulate to smooth' 'coarsely punctate' 'with narrow smooth field medially, elsewhere diagonally striate' 'smooth medially, elsewhere rugose',
+		30 'sculpture of lower mesepisternum'/'smooth' 'rugulose to punctate' 'finely microreticulate, nearly smooth, sparsely punctate' 'with distinctly separated, coarse punctures' 'largely smooth, with 2-3 longitudinal lines of punctures',
+		31 'sculpture of metapleuron'/'areolate rugose' 'irregularly longitudinally rugose, with smooth field medially' 'largely smooth' 'areolate rugose above, with smooth or finely sculptured field ventrally' 'coarsely punctate' 'with smooth field in posteroventral quadrant, elsewhere areolate rugose' 'coarsely areolate to rugose throughout' 'with smooth field medially, elsewhere coarsely punctate',
+		32 'color of legs'/'coxae and femora dark brown, tibiae and tarsi yellow' 'coxae dark brown, femora largely brown, legs otherwise brownish yellow' 'tarsi light brown, otherwise brown to dark brown throughout' 'coxae dark brown to black, legs otherwise brown to dark brown' 'coxae, femora dark brown, tarsi brown, tibiae pale, contrasting with femora and tibiae' 'coxae and femora dark brown, otherwise brown' 'coxae dark brown, otherwise yellowish brown throughout' 'coxae dark brown to black, femora dark brown, legs otherwise very pale brown, nearly white' 'coxae and femora brown, elsewhere light brown' 'coxae, femora, tibiae dark brown, otherwise brown' 'entirely yellow',
+		33 'long dark bristles on legs'/'present on all femora, tibiae' 'absent' 'present on hind femur only',
+		34 'color of wing membrane'/'generally hyaline throughout' 'with faint brown infuscation throughout, with strong dark streak below submarginal vein' 'hyaline basally, infuscate in apical two-thirds, streak below submarginal vein weak' 'with weak general brown infuscation, longitudinal dark streak below submarginal vein moderately developed' 'with weak general brown infuscation, longitudinal streak below submarginal vein weak' 'moderately infuscate throughout, streak below submarginal vein darkly pigmented' 'infuscate in apical two thirds, streak below submarginal vein strongly pigmented',
+		35 'fore wing venation'/'well-developed, with R, r-rs clearly visible' 'reduced to basal stub of R, with pale pseudostigma in wing disk',
+		36 'submarginal vein bristles'/'with 1-2 dark bristles near base of fore wing' 'with dark bristles extending length of submarginal vein' 'with dark bristles in basal half of submarginal vein' 'absent',
+		37 'T1 depression'/'glabrous or sparsely setose' 'moderately to densely setose',
+		38 'sublateral lamella on T1'/'distinctly raised more or less perpendicular to T1' 'indicated as low carina' 'absent',
+		39 'sculpture of T2-T4'/'longitudinally striate, with fine cross striae, punctures, smooth or finely punctulate transverse band apically' 'longitudinally striate with cross striae laterally, sculpture effaced medially',
+		40 'setation of laterotergites'/'glabrous' 'setose' 'very sparsely setose',
+		41 'sculpture of S2, S3 of female'/'strongly longitudinally rugose' 'nearly smooth, with scattered small punctures' 'irregularly longitudinally rugulose, apex of S3 nearly smooth' 'longitudinally rugulose laterally, nearly smooth medially, with scattered small punctures',
+		42 'sculpture of S2, S3 of male'/'longitudinal rugulae largely effaced, strongest laterally, otherwise smooth with scattered setigerous punctures' 'strongly longitudinally rugose' 'nearly smooth, with scattered setigerous punctures',
+		43 'distribution of felt fields'/'present on S2-S3' 'present on S3-S4' 'present on S3 only'
+	;
+	MATRIX
+		'Heptascelio albipes' 001(01)0(06)0004(46)15?5413224(04)4(23)(12)030(45)1(16)(47)1101010(12)320
+		'Heptascelio anthonyi' 0?1103000?1?1?3?1012?02010310111120101020?0
+		'Heptascelio aquilinus' ?130161110?12??301??11?020402202001001002?2
+		'Heptascelio bivius' 0?2221200?4?3?7?1134?23051713049130310013?0
+		'Heptascelio castor' 0321053002324?341213203241610151130110010?0
+		'Heptascelio dayi' 0?2224220?2?3?4?1234?33131510343110210010?0
+		'Heptascelio dispar' 1113100101000?111?0500201020213000100200121
+		'Heptascelio hamatus' 0(03)010(0137)0002311?02141(13)(24)33(01)41(56)1(01)1(03)(26)(12)30110010(01)0
+		'Heptascelio lateralis' 0?0102300?5?4?0?1510?(15)5040312101120102013?0
+		'Heptascelio noyesi' 0(03)(05)3010002225?26060320441000002115010111120
+		'Heptascelio orarius' 0201010002431?0?163333404000002803010111?20
+		'Heptascelio paralugens' 0022282002224?43121113516151036614011001310
+		'Heptascelio strigatus' 0011000003725?2(27)132230402021116916010202120
+		'Heptascelio teres' 0?4301000?8?3?4?0630?6645000002A150201010?0
+		'Heptascelio watshami' 0001000002901?32161330401020016922010101020
+		'Heptascelio lugens' 0022043002315?6502162350(05)1(16)1013114011001010
+		'Heptascelio sicarius' 0?2301220?9?3?4?2230?7403030047A160101022?0
+		'Heptascelio striatosternus' 0041000102434?34141330312121017503011001000
+		'A' ???????????????????????????????????????????
+	;
+END;

--- a/Tests/Nexus/vSysLab_Oreiscelio_discrete+continuous.nex
+++ b/Tests/Nexus/vSysLab_Oreiscelio_discrete+continuous.nex
@@ -1,0 +1,162 @@
+#NEXUS
+
+BEGIN TAXA;
+	DIMENSIONS NTAX=19;
+	TAXLABELS
+		'Oreiscelio zulu'
+		'Oreiscelio aequalis'
+		'Oreiscelio alluaudi'
+		'Oreiscelio badius'
+		'Oreiscelio coracinus'
+		'Oreiscelio cultrarius'
+		'Oreiscelio gryphus'
+		'Oreiscelio iommii'
+		'Oreiscelio magnipennis'
+		'Oreiscelio majikununuensis'
+		'Oreiscelio megadontus'
+		'Oreiscelio naevus'
+		'Oreiscelio paradoxus'
+		'Oreiscelio rostratus'
+		'Oreiscelio rugosus'
+		'Oreiscelio scapularis'
+		'Oreiscelio sechellensis'
+		'Oreiscelio turneri'
+		'Oreiscelio zuzkae'
+	;
+END;
+
+BEGIN CHARACTERS;
+	DIMENSIONS NCHAR=68;
+	FORMAT DATATYPE=STANDARD MISSING=? GAP=-
+		SYMBOLS="0123456789"
+	;
+	CHARSET 'General' = 1;
+	CHARSET 'Antenna' = 2 3 4;
+	CHARSET 'Head' = 5 6 7 8 9 10 11 12 13 14 15 16 17 18;
+	CHARSET 'Legs' = 19;
+	CHARSET 'Mesosoma' = 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42;
+	CHARSET 'Metasoma' = 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68;
+	CHARSTATELABELS
+		1 'body color'/'dark brown to black' 'black' 'head and mesosoma black; metasoma dark brown to black' 'metasoma often lighter than head and mesosoma',
+		2 'color of antennae in female'/'dark brown to black throughout' 'A1-A6 yellow; A7-A12 dark brown to black' 'A1-A6 pale brown; A7-A12 dark brown' 'pale brown throughout' 'A1, A3-A6 dark brown; A2 yellow; A7-A12 black' 'A1 black, A2-A6 pale brown, A7-A12 black' 'A1 dark brown, A2-A6 yellow, A7-A12 dark brown' 'A1-A6 brown; A7-A12 dark brown to black' 'A1 brown, A2-A6 yellow, A7-A12 brown' 'A1 brown, A2 pale brown, A3-A12 brown',
+		3 'color of antennae in male'/'A1-A2 brown; A3-A12 variably becoming yellow apically, antennomeres often yellow ventrally' 'A1 brown; A2-A12 yellow' 'brown' 'A1-A2 brown; A3-A12 yellow',
+		4 'seta on pedicel of antenna in female'/'present, reaching past apex of A3' 'present, not reaching apex of A3' 'present, reaching to apex of A3',
+		5 'color of setae on the head'/'white' 'brown' 'yellow',
+		6 'sculpture of dorsal frons between frontal carina and median ocellus'/'coarsely foveate' 'areolate' 'areolate, effaced medially' 'foveate with contiguous cells' 'transversely rugose',
+		7 'preocellar pit in females'/'absent' 'indicated by a small round depression' 'present as a distinct pit',
+		8 'transverse rugae at vertex'/'absent' 'present',
+		9 'sculpture of posterior vertex'/'areolate' 'coarsely foveate' 'transversely strigose',
+		10 'sculpture of occipital rim'/'areolate' 'coarsely foveate, cells often contiguous.',
+		11 'interantennal process'/'extended dorsally into medial flange, flange reaching from near apex of interantennal process to frons' 'diverging into two carinae that extend laterally along surface of frons' 'simple' 'with semiparallel carinae dorsally that do not extend laterally onto frons',
+		12 'number of anteriorly projecting setae on anteclypeus'/'6' '8',
+		13 'color of mandibles in male'/'yellow throughout, teeth brown' 'basal half black; apical half pale brown' 'black throughout' 'black throughout with brown teeth' 'basal half black, apical half brown' 'basal half black, apical half brown, teeth dark brown to black',
+		14 'color of mandibles in female'/'brown throughout with teeth black' 'basal half black; apical half dark brown' 'yellow throughout with teeth brown' 'dark brown throughout' 'black throughout' 'basal half black; apical half pale brown' 'brown throughout' 'basal half black; apical half yellow' 'pale brown with teeth dark brown',
+		15 'mandibular teeth in female'/'dorsal tooth larger' 'teeth of equal size' 'ventral tooth larger, but less than 2x as long as dorsal tooth' 'ventral tooth at least twice as long and wide at base than dorsal tooth',
+		16 'sculpture of ventral gena anterior to genal carina'/'row of areolae' 'row of shallow areolae with reduced ridges between cells' 'row of contiguous punctures' 'row of well separated punctures' 'dorsoventrally rugose',
+		17 'sculpture of ventral gena posterior to genal carina'/'areolate' 'smooth' 'mostly smooth, with sparse large punctures' 'mostly smooth, with sparse small punctures' 'coarsely and irregularly punctate' 'irregularly rugose',
+		18 'shape of anteclypeus'/'striplike, straight to slightly convex' 'concave medially, with points laterally',
+		19 'color of legs'/'entirely yellow' 'dark brown, tarsi and distal portion of tibiae light brown' 'coxae brown, legs otherwise yellow' 'coxae dark brown, femora light brown, tibiae and tarsi yellow' 'brown, tarsi and distal portion of tibiae yellow' 'brown, distal portion of tibiae and tarsomeres 1-4 yellow, apical tarsomere brown' 'coxae and femora dark brown, trochanters, tibia and tarsi yellowish-brown' 'coxae black; femora brown; trochanters, tibia and tarsomeres 1-4 yellowish-brown; apical tarsomere brown',
+		20 'sculpture of dorsal pronotum'/'areolate' 'areolate with expanded ridges' 'shallowly areolate',
+		21 'color of setae on the dorsal mesosoma'/'white' 'brown' 'yellow',
+		22 'sculpture of medial mesoscutum'/'coarsely foveate' 'areolate' 'areolate, with pronounced longitudinal ridges' 'shallowly areolate, becoming smooth posteriorly' 'longitudinally strigose throughout' 'partially to mostly effaced',
+		23 'sculpture of lateral mesoscutum'/'same as medial mesoscutum with a subtle confusion of sculptural elements' 'smooth throughout' 'with an elevated patch of smoother sculpture, bounded by mesoscutal humeral sulcus laterally, extending to scuto-scutellar sulcus posteriorly' 'with small patch of smoother sculpture, formed by fusion of sculptural ridges, smooth patch not extending to scuto-scutellar sulcus' 'areolate',
+		24 'notaulus in female'/'present' 'absent',
+		25 'parapsidal line'/'delimited' 'indistinguishable',
+		26 'sculpture of scutellum'/'coarsely foveate' 'areolate',
+		27 'median furrow on scutellum'/'absent' 'present as a weak indentation' 'present as a distinct furrow reaching from posterior to anterior margin',
+		28 'posterior margin of scutellum'/'emarginate' 'deeply notched' 'convex',
+		29 'outer projection of the propodeum'/'present as distinct corner or posteriorly projecting spine' 'rounded',
+		30 'posterior margin of propodeal shelf between inner and outer propodeal projections in female'/'nearly straight, perpendicular to lateral margin of propodeal shelf' 'concave' 'nearly straight, strongly oblique',
+		31 'posterior margin of propodeal shelf between inner and outer propodeal projections in male'/'nearly straight' 'concave',
+		32 'sculpture of ventral pronotum'/'foveate reticulate, becoming smooth at anterolateral corner' 'obliterated' 'mostly smooth with longitudinal rugulae ventrally' 'mostly smooth with small foveolae around antespiracular patch',
+		33 'anterior pronotal pit'/'absent' 'small' 'large',
+		34 'pronotal cervical sulcus'/'poorly defined' 'well defined by contiguous punctures',
+		35 'mesepimeral sulcus'/'indicated by dorsoventral line of foveae' 'crenulate' 'indicated by a row of faint and shallow depressions',
+		36 'sculpture of femoral depression in female'/'smooth throughout' 'transversely striate throughout' 'anterior half smooth, posterior half finely foveate' 'finely foveate throughout' 'anterior half smooth, posterior half longitudinally striate',
+		37 'sculpture of femoral depression in male'/'smooth throughout' 'smooth medially, bounded by small foveae' 'finely foveate throughout' 'with weak transverse striae throughout' 'anterior half smooth, posterior half finely foveate' 'anterior half smooth, posterior half longitudinally striate',
+		38 'mesopleural carina'/'indicated by one or two rows of punctures' 'present as one or two carinae' 'absent' 'weakly defined by fine ridges',
+		39 'sculpture of ventral mesepisternum'/'smooth' 'foveate' 'with smooth area surrounded by small foveae' 'irregularly areolate',
+		40 'pilosity of metapleural triangle in female'/'present as many short fine white setae' 'glabrous or with at most 3 small setae',
+		41 'pilosity of metapleural triangle in male'/'absent' 'present as many short fine white setae' 'sparsely setose',
+		42 'sculpture of ventral area of metapleuron'/'smooth' 'foveate reticulate' 'foveate reticulate, with slightly appressed ridges',
+		43 'submarginal ridge on T1'/'percurrent, well-defined' 'indicated by an irregular ridge' 'absent' 'partially fused with marginal carina',
+		44 'sublateral carina on T2'/'percurrent' 'absent' 'present in anterior half',
+		45 'sculpture of T2-T3'/'reticulate rugose' 'longitudinally striate' 'longitudinally strigose with rugose interstices' 'weakly rugulose',
+		46 'sculpture of T4'/'reticulate with finely rugulose interstices' 'longitudinally strigose' 'weakly rugulose' 'longitudinally striate' 'reticulate rugose',
+		47 'sculpure of T5'/'longitudinally strigose' 'weakly rugulose' 'reticulate rugose',
+		48 'shape of subapical T6 in female in dorsal view'/'semicircular, width along anterior margin twice the length.' 'short, width along anterior margin at least three times the length' 'trapezoidal, basal width twice the apical width',
+		49 'apex of T7 in male'/'slightly convex' 'bispinose' 'straight to slightly concave, with small points laterally',
+		50 'longitudinal medial keel on S1'/'absent' 'present',
+		51 'sculpture of medial S2 in female'/'punctate reticulate' 'reticulate rugose' 'foveolate' 'punctate',
+		52 'sculpture of medial S3 in female'/'longitudinally strigose' 'foveate' 'effaced to smooth',
+		53 'sculpture of medial S4 in female'/'longitudinally strigose' 'effaced to smooth',
+		54 'sculpture of medial S5 in female'/'reticulate rugose' 'longitudinally strigose' 'effaced to smooth',
+		55 'sculpture of lateral S3 in female'/'reticulate rugose' 'foveolate' 'longitudinally strigose' 'smooth' 'punctate crenulate' 'rugulose',
+		56 'sculpture of lateral S4 in female'/'reticulate rugose' 'longitudinally strigose' 'foveolate' 'smooth' 'rugulose' 'punctate crenulate',
+		57 'sculpture of lateral S5 in female'/'reticulate rugose' 'foveate' 'longitudinally strigose' 'punctate crenulate',
+		58 'sculpture of marginal depression of S2 in female'/'mostly smooth, with scattered punctures or shallow rugulae' 'rugulose' 'finely punctate throughout' 'smooth',
+		59 'sculpture of marginal depression of S3 in female'/'mostly smooth, with scattered punctures or shallow rugulae' 'smooth' 'finely punctate throughout' 'rugulose',
+		60 'sculpture of marginal depression of S4 in female'/'mostly smooth with scattered punctures or shallow rugulae' 'finely punctate throughout' 'rugulose',
+		61 'sculpture of marginal depression of S5 in female'/'rugulose' 'mostly smooth with scattered punctures' 'finely punctate throughout',
+		62 'apical spine on S6 in female'/'not extending beyond apex of T6 and not visible in dorsal view' 'extending beyond apex of T6 and visible in dorsal view',
+		63 'sculpture of medial S2 in male'/'punctate reticulate' 'longitudinally strigose' 'foveolate' 'punctate' 'reticulate rugose',
+		64 'sculpture of medial S3 in male'/'smooth' 'foveate' 'longitudinally reticulate' 'weakly longitudinally strigose',
+		65 'sculpture of lateral S3 in male'/'smooth' 'reticulate rugose' 'longitudinally strigose' 'foveolate' 'rugulose',
+		66 'sculpture of lateral S4 in male'/'smooth' 'rugulose' 'longitudinally strigose' 'foveolate' 'reticulate rugose',
+		67 'sculpture of medial S5 in male'/'smooth' 'foveate' 'longitudinally strigose',
+		68 'sculpture of lateral S5 in male'/'foveolate' 'longitudinally strigose' 'smooth' 'reticulate rugose' 'rugulose'
+	;
+	MATRIX
+		'Oreiscelio zulu' 1000010100003511(05)06001(04)111110110111(13)312022200421100(12)114531320(01)031221
+		'Oreiscelio aequalis' 25?021210010?12000402101011001?021(01)(13)?110?1002102?0021245310011??????
+		'Oreiscelio alluaudi' 1(17)1020(12)11020020(02)(24)0012020010(02)01102102(23)01102210421010212121(02)(02)200003300
+		'Oreiscelio badius' (03)3000(12)(01)1002012(12)(04)(02)0(45)00(12)0111(01)(02)010(02)(01)(01)(01)4(03)(13)2010(12)10101201212(02)(01)013201002101
+		'Oreiscelio coracinus' 0000(012)1(012)10010(23)(145)(12)0(04)0(15)0(012)(12)01(01)1(01)00110(12)1(01)(0123)(023)1(12)01(012)0(01)0(14)01100(012)11(015)(01)(02)(012)(02)(02)01(02)1(034)(013)(01)(013)
+		'Oreiscelio cultrarius' 2(01)?000(12)11030?(23)(12)140(23)0010101(01)001?0210(03)?(13)10?20(12)0101?00212(14)(15)(02)00(02)(01)1??????
+		'Oreiscelio gryphus' 10?011210010?1(12)04010110111(01)001?01103?130?1010101?002120001(03)201??????
+		'Oreiscelio iommii' 10?021110000?11130122311010101?10020?200?0023211?0021134222201??????
+		'Oreiscelio magnipennis' 16?011(12)11010?61200701(12)01011001?01111?110?2022101?002120(01)(02)13201??????
+		'Oreiscelio majikununuensis' 04?22(01)000021?031(04)160210101(01)000?0(12)002?0(13)0?0000401?00(12)121(02)0(03)0201??????
+		'Oreiscelio megadontus' 11?020211021?23130202231010001?01100?020?0300101?0021012031201??????
+		'Oreiscelio naevus' 10000(01)01(01)02002(012)04030012(01)01(01)(02)011(02)110(03)(34)10010210(04)21003212(01)(02)(01)(12)(23)(12)(02)0003(134)(01)(03)
+		'Oreiscelio paradoxus' 10?101211010?5(12)150(14)00(12)01010212?0100(013)?3(02)0?1000101?00(02)(01)(12)4120(01)001??????
+		'Oreiscelio rostratus' 1(01)002(01)01(01)000020(23)(24)00(01)20200002011321000021(01)(02)201121010212(01)2(01)(13)(13)200(04)(02)(13)(34)0(03)
+		'Oreiscelio rugosus' 20202(14)(12)1(02)0201(1567)1110502(1245)(013)1(01)1(01)(02)011(012)(01)(01)(01)4(35)(13)201(02)(0123)(12)0(14)0100221(12)(03)(03)0(13)(13)20100(04)1(02)(14)
+		'Oreiscelio scapularis' 11002(03)011120020(23)(24)001202000020110210010210020130000?(02)(01)(12)21231(02)001(03)22(02)1
+		'Oreiscelio sechellensis' 12312011102046112020213101(12)1011001004(01)201(12)010(14)(02)120321233(03)302(01)0300002
+		'Oreiscelio turneri' (03)(05689)(02)221(01)100105(168)3(12)(04)0402(12)0111(01)00110(01)0(01)(012)(0234)1(12)01(012)(012)(12)0(14)(02)11(01)1212(45)(145)011001(02)(01)(23)(123)(01)(0134)
+		'Oreiscelio zuzkae' 11?101(012)10020?221(45)020(02)100012101?021(01)(123)?1(12)0?(012)(01)2(02)(13)01?01(12)11(01)(02)(02)(01)00(01)0??????
+	;
+END;
+
+BEGIN CHARACTERS;
+	DIMENSIONS NCHAR=2;
+	FORMAT DATATYPE=CONTINUOUS MISSING=?
+		ITEMS=(MIN MAX MEDIAN AVERAGE VARIANCE SAMPLESIZE)
+	;
+	CHARSTATELABELS
+		1 'body length of female'
+		2 'body length of male'
+	;
+	MATRIX
+		'Oreiscelio zulu' (2.40 2.50 ? 2.45 0.0025 3)?
+		'Oreiscelio aequalis' (3.30 3.30 ? 3.30 ? 1)?
+		'Oreiscelio alluaudi' (3.20 3.80 ? 3.50 ? 10)(3.01 3.01 ? 3.01 ? 1)
+		'Oreiscelio badius' (2.20 2.40 ? 2.30 0.0036 20)(2.10 2.10 ? 2.10 ? 1)
+		'Oreiscelio coracinus' (2.30 3.10 ? 2.60 0.0400 20)(2.30 2.90 ? 2.70 0.0400 20)
+		'Oreiscelio cultrarius' (3.00 3.20 ? 3.10 0.0025 5)?
+		'Oreiscelio gryphus' (2.90 3.30 2.90 3.00 0.0289 5)?
+		'Oreiscelio iommii' (2.42 2.42 2.42 2.42 ? 1)?
+		'Oreiscelio magnipennis' (3.10 3.20 ? 3.20 0.0100 2)?
+		'Oreiscelio majikununuensis' ??
+		'Oreiscelio megadontus' (4.10 4.10 4.10 4.10 ? 4.1)?
+		'Oreiscelio naevus' (2.20 3.00 ? 2.70 0.0900 20)(2.20 3.00 ? 2.70 0.0900 20)
+		'Oreiscelio paradoxus' (3.00 3.00 3.00 3.00 0.0000 2)?
+		'Oreiscelio rostratus' (3.30 3.70 ? 3.50 0.0100 20)(3.40 3.90 ? 3.60 0.0400 5)
+		'Oreiscelio rugosus' (2.10 2.70 ? 2.40 0.0100 20)(2.30 2.50 ? 2.50 ? 4)
+		'Oreiscelio scapularis' (3.10 4.10 ? 3.70 0.0400 15)(3.60 3.80 ? 3.70 0.0100 6)
+		'Oreiscelio sechellensis' (3.10 3.40 ? 3.20 0.0081 9)(? ? ? 3.00 ? 1)
+		'Oreiscelio turneri' (2.30 2.90 ? 2.60 0.0400 20)(2.20 2.70 ? 2.40 0.0100 20)
+		'Oreiscelio zuzkae' (3.30 3.90 ? 3.70 0.0225 14)?
+	;
+END;


### PR DESCRIPTION
The Nexus parser within BioPython did not support the STANDARD datatype for the Nexus file format, which holds discrete character information. These changes add support for discrete (STANDARD) character data to the parser but not CONTINUOUS data. A test suite was also included within the Nexus.py file to check for proper parsing of supported Nexus blocks within included test files. A handful of minor cosmetic changes were also made.