### PR TITLE
GenBank: Improve error message from EMBL parser

### DIFF
--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -595,7 +595,7 @@ class EmblScanner(InsdcScanner):
             self.line = self.line.rstrip()
 
         assert self.line[:self.HEADER_WIDTH] == " " * self.HEADER_WIDTH \
-            or self.line.strip() == '//', repr(self.line)
+            or self.line.strip() == '//', "Unexpected content after SQ or CO line: %r" % self.line
 
         seq_lines = []
         line = self.line

--- a/Tests/EMBL/xx_after_co.embl
+++ b/Tests/EMBL/xx_after_co.embl
@@ -1,0 +1,16 @@
+ID   Tester  Unannotated; unspecified; UNC; 120 BP.
+XX
+AC   Test;
+XX
+CO   This will break
+XX
+FH   Key             Location/Qualifiers
+FH
+FT   CDS             1..110
+FT                   /protein_id="Test"
+FT                   /db_xref="PEDANT:PE04150000123"
+XX
+SQ   Sequence 120 BP;
+     CGACTTTCCA CTGCCCTCTA CGCCCGCGCA ATGGGTCGTA CGCGGTTGTG GTTGGTATAG        60
+     CTGGTTAGGG TTTTTCGAGA GCTTTCGATT GGTGGTTGTT TTGGGCGTTT TGCCTACGTT       120
+//

--- a/Tests/test_EMBL_unittest.py
+++ b/Tests/test_EMBL_unittest.py
@@ -1,0 +1,31 @@
+# Copyright 2015 by Kai Blin.
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+
+import unittest
+import warnings
+from os import path
+
+from Bio import SeqIO
+
+
+class EMBLTests(unittest.TestCase):
+    def test_embl_content_after_co(self):
+        """Test an AssertionError is thrown by content after a CO line"""
+        def parse_content_after_co():
+            rec = SeqIO.read(path.join('EMBL', 'xx_after_co.embl'), 'embl')
+
+        self.assertRaises(AssertionError, parse_content_after_co)
+
+        try:
+            parse_content_after_co()
+        except AssertionError as e:
+            self.assertEqual(str(e), "Unexpected content after SQ or CO line: 'XX'")
+        else:
+            self.assertTrue(False, "Error message without explanation raised by content after CO line")
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)


### PR DESCRIPTION
When there is content in an EMBL file after SQ or CO lines that is not // or whitespace, the
parser throws an AssertionError. Unfortunately, the error message is less than helpful.
Improve the error message.

This fixes issue #431

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>