### PR TITLE
Kalign header fix for Bio/AlignIO

### DIFF
--- a/Bio/AlignIO/ClustalIO.py
+++ b/Bio/AlignIO/ClustalIO.py
@@ -104,7 +104,7 @@ class ClustalIterator(AlignmentIterator):
             raise StopIteration
 
         # Whitelisted headers we know about
-        known_headers = ['CLUSTAL', 'PROBCONS', 'MUSCLE', 'MSAPROBS']
+        known_headers = ['CLUSTAL', 'PROBCONS', 'MUSCLE', 'MSAPROBS','Kalign']
         if line.strip().split()[0] not in known_headers:
             raise ValueError("%s is not a known CLUSTAL header: %s" %
                              (line.strip().split()[0],

--- a/Tests/test_AlignIO_ClustalIO.py
+++ b/Tests/test_AlignIO_ClustalIO.py
@@ -145,6 +145,13 @@ AT3G20900.1-CDS      GCTGGGGATGGAGAGGGAACAGAGTAG
                      *************************  
 """
 
+aln_example4 = \
+"""Kalign (2.0) alignment in ClustalW format
+
+Test1seq             GCTGGGGATGGAGAGGGAACAGAGTT-
+AT3G20900.1-SEQ      GCTGGGGATGGAGAGGGAACAGAGTAG
+
+"""
 
 class TestClustalIO(unittest.TestCase):
 
@@ -213,6 +220,11 @@ class TestClustalIO(unittest.TestCase):
         alignments = list(ClustalIterator(StringIO(aln_example3)))
         self.assertEqual(1, len(alignments))
         self.assertEqual(alignments[0]._version, "2.0.9")
+
+    def test_kalign_header(self):
+        """Make sure we can parse the Kalign header."""
+        alignments = next(ClustalIterator(StringIO(aln_example4)))
+        self.assertEqual(2, len(alignments))
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
I was trying to load a ClustalW alignment file created with Kalign version 2.04 like so

    >>> from Bio import AlignIO
    >>> AlignIO.read('fun.clustalw', 'clustal')
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/home/john/anaconda/lib/python2.7/site-packages/Bio/AlignIO/__init__.py", line 427, in read
        first = next(iterator)
      File "/home/john/anaconda/lib/python2.7/site-packages/Bio/AlignIO/__init__.py", line 374, in parse
        for a in i:
      File "/home/john/anaconda/lib/python2.7/site-packages/Bio/AlignIO/ClustalIO.py", line 107, in     __next__
        ", ".join(known_headers)))
    ValueError: Kalign is not a known CLUSTAL header: CLUSTAL, PROBCONS, MUSCLE, MSAPROBS

The header inside the clustalw file looks like this:
      `Kalign (2.0) alignment in ClustalW format`
I can manually edit it to say "CLUSTAL" and everything works.

The changes of this pull request just add 'Kalign' to known_headers and added a unit test.
Thanks.