### PR TITLE
Bug in - print_that() as map in Restriction #605

### DIFF
--- a/Bio/Restriction/PrintFormat.py
+++ b/Bio/Restriction/PrintFormat.py
@@ -317,14 +317,14 @@ class PrintFormat(object):
         for x in range(60, length, 60):
             counter = x - 60
             l = []
+            cutloc[counter] = l
+            remaining = []
             for key in mapping:
                 if key <= x:
                     l.append(key)
                 else:
-                    cutloc[counter] = l
-                    mapping = mapping[mapping.index(key):]
-                    break
-            cutloc[x] = l
+                    remaining.append(key)
+            mapping = remaining 
         cutloc[x] = mapping
         sequence = str(self.sequence)
         revsequence = str(self.sequence.complement())

--- a/Tests/test_Restriction.py
+++ b/Tests/test_Restriction.py
@@ -74,6 +74,114 @@ class EnzymeComparison(unittest.TestCase):
         self.assertFalse(Acc65I % KpnI)
 
 
+class RestrictionBatchPrintTest(unittest.TestCase):
+    """Tests Restriction.Analysis printing functionality.
+    """
+    def createAnalysis(self, seq_str, batch_ary):
+        """Restriction.Analysis creation helper method."""
+        rb = Restriction.RestrictionBatch(batch_ary)
+        seq = Seq(seq_str)
+        return Restriction.Analysis(rb, seq)
+
+    def assertAnalysisFormat(self, analysis, expected):
+        """Asserts that the Restriction.Analysis make_format(print_that) matches some string."""
+        dct = analysis.mapping
+        ls, nc = [], []
+        for k, v in dct.items():
+            if v:
+                ls.append((k, v))
+            else:
+                nc.append(k)
+        result = analysis.make_format(ls, '', [], '')
+        self.assertEqual(result.replace(' ',''), expected.replace(' ',''))
+
+    def test_make_format_map1(self):
+        """Make sure print_as('map'); print_that() does not error on wrap round with no markers.
+        """
+        analysis = self.createAnalysis(
+                'CCAGTCTATAATTCG' +
+                Restriction.BamHI.site +
+                'GCGGCATCATACTCGAATATCGCGTGATGATACGTAGTAATTACGCATG',
+                ["BamHI"])
+        analysis.print_as('map')
+        expected = [
+            "                17 BamHI",
+            "                |                                           ",
+            "CCAGTCTATAATTCGGGATCCGCGGCATCATACTCGAATATCGCGTGATGATACGTAGTA",
+            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
+            "GGTCAGATATTAAGCCCTAGGCGCCGTAGTATGAGCTTATAGCGCACTACTATGCATCAT",
+            "1                                                         60",
+            "",
+            "ATTACGCATG",
+            "||||||||||",
+            "TAATGCGTAC",
+            "61                          70",
+            "", ""]
+        self.assertAnalysisFormat(analysis, '\n'.join(expected))
+
+    def test_make_format_map2(self):
+        """Make sure print_as('map'); print_that() does not error on wrap round with marker.
+        """
+        analysis = self.createAnalysis(
+                'CCAGTCTATAATTCG' + 
+                Restriction.BamHI.site +
+                'GCGGCATCATACTCGA' + 
+                Restriction.BamHI.site + 
+                'ATATCGCGTGATGATA' +
+                Restriction.NdeI.site +
+                'CGTAGTAATTACGCATG',
+                ["NdeI","EcoRI","BamHI","BsmBI"])
+        analysis.print_as('map')
+        expected = [
+            "                17 BamHI",
+            "                |                                           ",
+            "                |                     39 BamHI",
+            "                |                     |                     ",
+            "CCAGTCTATAATTCGGGATCCGCGGCATCATACTCGAGGATCCATATCGCGTGATGATAC",
+            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
+            "GGTCAGATATTAAGCCCTAGGCGCCGTAGTATGAGCTCCTAGGTATAGCGCACTACTATG",
+            "1                                                         60",
+            "",
+            " 62 NdeI",
+            " |                                                          ",
+            "ATATGCGTAGTAATTACGCATG",
+            "||||||||||||||||||||||",
+            "TATACGCATCATTAATGCGTAC",
+            "61                          82",
+            "", ""]
+        self.assertAnalysisFormat(analysis, '\n'.join(expected))
+
+    def test_make_format_map3(self):
+        """Make sure print_as('map'); print_that() does not error on wrap round with marker restricted.
+        """
+        analysis = self.createAnalysis(
+                'CCAGTCTATAATTCG' +
+                Restriction.BamHI.site +
+                'GCGGCATCATACTCGA' +
+                Restriction.BamHI.site +
+                'ATATCGCGTGATGATA' +
+                Restriction.EcoRV.site +
+                'CGTAGTAATTACGCATG',
+                ["NdeI","EcoRI","BamHI","BsmBI"])
+        analysis.print_as('map')
+        expected = [
+            "                17 BamHI",
+            "                |                                           ",
+            "                |                     39 BamHI",
+            "                |                     |                     ",
+            "CCAGTCTATAATTCGGGATCCGCGGCATCATACTCGAGGATCCATATCGCGTGATGATAG",
+            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
+            "GGTCAGATATTAAGCCCTAGGCGCCGTAGTATGAGCTCCTAGGTATAGCGCACTACTATC",
+            "1                                                         60",
+            "",
+            "ATATCCGTAGTAATTACGCATG",
+            "||||||||||||||||||||||",
+            "TATAGGCATCATTAATGCGTAC",
+            "61                          82",
+            "", ""]
+        self.assertAnalysisFormat(analysis, '\n'.join(expected))
+
+
 class RestrictionBatches(unittest.TestCase):
     """Tests for dealing with batches of restriction enzymes.
     """


### PR DESCRIPTION
I made a small change to fix print_as('map')/print_that() from issue 605.
The root cause was an assumption that there would be markers on every row of annotated seq output.
I created three rather large unit tests.
Simplified example of original bug:

    from Bio import Restriction
    from Bio.Seq import Seq

    rb = Restriction.RestrictionBatch(["NdeI","EcoRI","BamHI","BsmBI"])
    my_seq = Seq('CCAGTCTATAATTCG' +     Restriction.BamHI.site+'GCGGCATCATACTCGAATATCGCGTGATGATACGTAGTAATTACGCATG')
    Analong = Restriction.Analysis(rb, my_seq)
    Analong.print_as('map')
    Analong.print_that()
 
Thanks
