### PR TITLE
Windows does NOT accept colon(:) for file name.

### DIFF
--- a/Doc/Tutorial/chapter_kegg.tex
+++ b/Doc/Tutorial/chapter_kegg.tex
@@ -7,10 +7,11 @@ Please note that the KEGG parser implementation in Biopython is incomplete. Whil
 
 \section{Parsing KEGG records}
 Parsing a KEGG record is as simple as using any other file format parser in Biopython. 
+(Before running the following codes, please open http://rest.kegg.jp/get/ec:5.4.2.2 with your web browser and save it as ec_5.4.2.2.txt.)
 
 \begin{verbatim}
 >>> from Bio.KEGG import Enzyme
->>> records = Enzyme.parse(open("ec:5.4.2.2.txt"))
+>>> records = Enzyme.parse(open("ec_5.4.2.2.txt"))
 >>> record = list(records)[0]
 >>> record.classname
 ['Isomerases;', 'Intramolecular transferases;', 'Phosphotransferases (phosphomutases)']
@@ -30,8 +31,8 @@ First, here is how to extend the above example by downloading the relevant enzym
 >>> from Bio.KEGG import REST
 >>> from Bio.KEGG import Enzyme
 >>> request = REST.kegg_get("ec:5.4.2.2")
->>> open("ec:5.4.2.2.txt", 'w').write(request.read())
->>> records = Enzyme.parse(open("ec:5.4.2.2.txt"))
+>>> open("ec_5.4.2.2.txt", 'w').write(request.read())
+>>> records = Enzyme.parse(open("ec_5.4.2.2.txt"))
 >>> record = list(records)[0]
 >>> record.classname
 ['Isomerases;', 'Intramolecular transferases;', 'Phosphotransferases (phosphomutases)']


### PR DESCRIPTION
I think it would be better to rename the enzyme file (and add how to download the file).