### PR TITLE
switch to Unittests for test_seq.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ before_install:
   - "export MSQL=$PG"
   - "if [[ $PY3 == 'yes' ]]; then export MSQL=no; fi"
   - "if [[ $MSQL == 'yes' ]]; then pip install mysql-python; fi"
+#Lib unittest2 is needed for some assertRaises tests under Python 2.6
+  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi"
 
 install:
   - "/usr/bin/yes | python setup.py install"

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -531,8 +531,9 @@ class TestTranscription(unittest.TestCase):
     def test_transcription_dna_into_rna(self):
         for nucleotide_seq in test_seqs:
             if isinstance(nucleotide_seq.alphabet, Alphabet.DNAAlphabet):
+                expected = Seq.transcribe(nucleotide_seq)
                 self.assertEqual(str(nucleotide_seq).replace("t", "u").replace("T", "U"),
-                                 str(Seq.transcribe(nucleotide_seq)))
+                                 str(expected))
 
     def test_seq_object_transcription_method(self):
         for nucleotide_seq in test_seqs:
@@ -542,7 +543,7 @@ class TestTranscription(unittest.TestCase):
                                  repr(nucleotide_seq.transcribe()))
 
     def test_transcription_of_proteins(self):
-        """Transcription shouldn't work on a protein!"""
+        """Test transcription shouldn't work on a protein!"""
         for s in protein_seqs:
             with self.assertRaises(ValueError):
                 Seq.transcribe(s)
@@ -551,39 +552,29 @@ class TestTranscription(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     s.transcribe()
 
-print("")
-print("Back-transcribe RNA into DNA")
-print("============================")
-for nucleotide_seq in test_seqs:
-    try:
-        expected = Seq.back_transcribe(nucleotide_seq)
-        assert str(nucleotide_seq).replace("u", "t").replace("U", "T") == str(expected)
-        print("%s -> %s"
-        % (repr(nucleotide_seq), repr(expected)))
-    except ValueError as e:
-        expected = None
-        print("%s -> %s"
-        % (repr(nucleotide_seq), str(e)))
-    # Now test the Seq object's method
-    if isinstance(nucleotide_seq, Seq.Seq):
-        try:
-            assert repr(expected) == repr(nucleotide_seq.back_transcribe())
-        except ValueError:
-            assert expected is None
+    def test_back_transcribe_rna_into_dna(self):
+        for nucleotide_seq in test_seqs:
+            if isinstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet):
+                expected = Seq.back_transcribe(nucleotide_seq)
+                self.assertEqual(str(nucleotide_seq).replace("u", "t").replace("U", "T"),
+                                 str(expected))
 
-for s in protein_seqs:
-    try:
-        print(Seq.back_transcribe(s))
-        assert False, "Back transcription shouldn't work on a protein!"
-    except ValueError:
-        pass
-    if not isinstance(s, Seq.Seq):
-        continue  # Only Seq has this method
-    try:
-        print(s.back_transcribe())
-        assert False, "Back transcription shouldn't work on a protein!"
-    except ValueError:
-        pass
+    def test_seq_object_back_transcription_method(self):
+        for nucleotide_seq in test_seqs:
+            if isinstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet) and \
+                    isinstance(nucleotide_seq, Seq.Seq):
+                expected = Seq.back_transcribe(nucleotide_seq)
+                self.assertEqual(repr(nucleotide_seq.back_transcribe()), repr(expected))
+
+    def test_back_transcription_of_proteins(self):
+        """Test back-transcription shouldn't work on a protein!"""
+        for s in protein_seqs:
+            with self.assertRaises(ValueError):
+                Seq.back_transcribe(s)
+
+            if isinstance(s, Seq.Seq):
+                with self.assertRaises(ValueError):
+                    s.back_transcribe()
 
 print("")
 print("Reverse Complement")

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -453,6 +453,21 @@ class TestComplement(unittest.TestCase):
                              set(ambiguous_rna_values[ambiguous_rna_complement[ambig_char]]))
 
 
+class TestReverseComplement(unittest.TestCase):
+    def test_reverse_complements(self):
+        """Test double reverse complement preserves the sequence"""
+        for sequence in [Seq.Seq("".join(sorted(ambiguous_rna_values))),
+                         Seq.Seq("".join(sorted(ambiguous_dna_values))),
+                         Seq.Seq("".join(sorted(ambiguous_rna_values)), Alphabet.generic_rna),
+                         Seq.Seq("".join(sorted(ambiguous_dna_values)), Alphabet.generic_dna),
+                         Seq.Seq("".join(sorted(ambiguous_rna_values)).replace("X", ""), IUPAC.IUPACAmbiguousRNA()),
+                         Seq.Seq("".join(sorted(ambiguous_dna_values)).replace("X", ""), IUPAC.IUPACAmbiguousDNA()),
+                         Seq.Seq("AWGAARCKG")]:  # Note no U or T
+            reversed_sequence = sequence.reverse_complement()
+            self.assertEqual(str(sequence),
+                             str(reversed_sequence.reverse_complement()))
+
+
 def complement(sequence):
     return Seq.reverse_complement(sequence)[::-1]
 
@@ -461,25 +476,6 @@ def sorted_dict(d):
     """A sorted repr of a dictionary."""
     return "{%s}" % ", ".join("%s: %s" % (repr(k), repr(v))
                               for k, v in sorted(d.items()))
-
-
-print("")
-print("Reverse complements:")
-for sequence in [Seq.Seq("".join(sorted(ambiguous_rna_values))),
-            Seq.Seq("".join(sorted(ambiguous_dna_values))),
-            Seq.Seq("".join(sorted(ambiguous_rna_values)), Alphabet.generic_rna),
-            Seq.Seq("".join(sorted(ambiguous_dna_values)), Alphabet.generic_dna),
-            Seq.Seq("".join(sorted(ambiguous_rna_values)).replace("X", ""), IUPAC.IUPACAmbiguousRNA()),
-            Seq.Seq("".join(sorted(ambiguous_dna_values)).replace("X", ""), IUPAC.IUPACAmbiguousDNA()),
-            Seq.Seq("AWGAARCKG")]:  # Note no U or T
-        print("%s -> %s"
-              % (repr(sequence), repr(Seq.reverse_complement(sequence))))
-        assert str(sequence) \
-           == str(Seq.reverse_complement(Seq.reverse_complement(sequence))), \
-           "Dobule reverse complement didn't preserve the sequence!"
-print("")
-
-###########################################################################
 
 test_seqs = [s, t, u,
              Seq.Seq("ATGAAACTG"),

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -658,54 +658,50 @@ class TestTranslating(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     s.translate()
 
+    def test_translation_of_invalid_codon(self):
+        for codon in ["TA?", "N-N", "AC_", "Ac_"]:
+            with self.assertRaises(TranslationError):
+                Seq.translate(codon)
 
-misc_stops = "TAATAGTGAAGAAGG"
-for nucleotide_seq in [misc_stops, Seq.Seq(misc_stops),
-                       Seq.Seq(misc_stops, Alphabet.generic_nucleotide),
-                       Seq.Seq(misc_stops, Alphabet.DNAAlphabet()),
-                       Seq.Seq(misc_stops, IUPAC.unambiguous_dna)]:
-    assert "***RR" == str(Seq.translate(nucleotide_seq))
-    assert "***RR" == str(Seq.translate(nucleotide_seq, table=1))
-    assert "***RR" == str(Seq.translate(nucleotide_seq, table="SGC0"))
-    assert "**W**" == str(Seq.translate(nucleotide_seq, table=2))
-    assert "**WRR" == str(Seq.translate(nucleotide_seq,
-                                        table='Yeast Mitochondrial'))
-    assert "**WSS" == str(Seq.translate(nucleotide_seq, table=5))
-    assert "**WSS" == str(Seq.translate(nucleotide_seq, table=9))
-    assert "**CRR" == str(Seq.translate(nucleotide_seq,
-                                        table='Euplotid Nuclear'))
-    assert "***RR" == str(Seq.translate(nucleotide_seq, table=11))
-    assert "***RR" == str(Seq.translate(nucleotide_seq, table='Bacterial'))
-del misc_stops
 
-for s in protein_seqs:
-    try:
-        print(Seq.translate(s))
-        assert False, "Shouldn't work on a protein!"
-    except ValueError:
-        pass
+class TestStopCodons(unittest.TestCase):
+    def setUp(self):
+        self.misc_stops = "TAATAGTGAAGAAGG"
 
-assert Seq.translate("TAT") == "Y"
-assert Seq.translate("TAR") == "*"
-assert Seq.translate("TAN") == "X"
-assert Seq.translate("NNN") == "X"
+    def test_stops(self):
+        for nucleotide_seq in [self.misc_stops, Seq.Seq(self.misc_stops),
+                               Seq.Seq(self.misc_stops, Alphabet.generic_nucleotide),
+                               Seq.Seq(self.misc_stops, Alphabet.DNAAlphabet()),
+                               Seq.Seq(self.misc_stops, IUPAC.unambiguous_dna)]:
+            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq)))
+            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table=1)))
+            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table="SGC0")))
+            self.assertEqual("**W**", str(Seq.translate(nucleotide_seq, table=2)))
+            self.assertEqual("**WRR", str(Seq.translate(nucleotide_seq,
+                                              table='Yeast Mitochondrial')))
+            self.assertEqual("**WSS", str(Seq.translate(nucleotide_seq, table=5)))
+            self.assertEqual("**WSS", str(Seq.translate(nucleotide_seq, table=9)))
+            self.assertEqual("**CRR", str(Seq.translate(nucleotide_seq,
+                                              table='Euplotid Nuclear')))
+            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table=11)))
+            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table='Bacterial')))
 
-assert Seq.translate("TAt") == "Y"
-assert Seq.translate("TaR") == "*"
-assert Seq.translate("TaN") == "X"
-assert Seq.translate("nnN") == "X"
+    def test_translation_of_stops(self):
+        self.assertEqual(Seq.translate("TAT"), "Y")
+        self.assertEqual(Seq.translate("TAR"), "*")
+        self.assertEqual(Seq.translate("TAN"), "X")
+        self.assertEqual(Seq.translate("NNN"), "X")
 
-assert Seq.translate("tat") == "Y"
-assert Seq.translate("tar") == "*"
-assert Seq.translate("tan") == "X"
-assert Seq.translate("nnn") == "X"
+        self.assertEqual(Seq.translate("TAt"), "Y")
+        self.assertEqual(Seq.translate("TaR"), "*")
+        self.assertEqual(Seq.translate("TaN"), "X")
+        self.assertEqual(Seq.translate("nnN"), "X")
 
-for codon in ["TA?", "N-N", "AC_", "Ac_"]:
-    try:
-        print(Seq.translate(codon))
-        assert "Translating %s should have failed" % repr(codon)
-    except TranslationError:
-        pass
+        self.assertEqual(Seq.translate("tat"), "Y")
+        self.assertEqual(Seq.translate("tar"), "*")
+        self.assertEqual(Seq.translate("tan"), "X")
+        self.assertEqual(Seq.translate("nnn"), "X")
+
 
 ambig = set(IUPAC.IUPACAmbiguousDNA.letters)
 for c1 in ambig:

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -446,6 +446,12 @@ class TestComplement(unittest.TestCase):
             self.assertEqual(set(compl_values),
                              set(ambiguous_dna_values[ambiguous_dna_complement[ambig_char]]))
 
+    def test_complement_ambiguous_rna_values(self):
+        for ambig_char, values in sorted(ambiguous_rna_values.items()):
+            compl_values = str(Seq.Seq(values, alphabet=IUPAC.ambiguous_rna).complement())
+            self.assertEqual(set(compl_values),
+                             set(ambiguous_rna_values[ambiguous_rna_complement[ambig_char]]))
+
 
 def complement(sequence):
     return Seq.reverse_complement(sequence)[::-1]
@@ -456,14 +462,6 @@ def sorted_dict(d):
     return "{%s}" % ", ".join("%s: %s" % (repr(k), repr(v))
                               for k, v in sorted(d.items()))
 
-print("")
-print("RNA Ambiguity mapping: %s" % sorted_dict(ambiguous_rna_values))
-print("RNA Complement mapping: %s" % sorted_dict(ambiguous_rna_complement))
-for ambig_char, values in sorted(ambiguous_rna_values.items()):
-    compl_values = complement(values).replace("T", "U")  # need to help as no alphabet
-    print("%s={%s} --> {%s}=%s" %
-        (ambig_char, values, compl_values, ambiguous_rna_complement[ambig_char]))
-    assert set(compl_values) == set(ambiguous_rna_values[ambiguous_rna_complement[ambig_char]])
 
 print("")
 print("Reverse complements:")

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -6,8 +6,13 @@ from __future__ import print_function
 import array
 import copy
 import sys
-import unittest
 import warnings
+
+# Remove unittest2 import after dropping support for Python2.6
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 from Bio import Alphabet
 from Bio import Seq
@@ -707,8 +712,7 @@ class TestUnknownSeq(unittest.TestCase):
 
     def test_reverse_complement_of_protein(self):
         seq = Seq.UnknownSeq(6, Alphabet.generic_protein)
-        with self.assertRaises(ValueError):
-            seq.reverse_complement()
+        self.assertRaises(ValueError, seq.reverse_complement)
 
     def test_transcribe(self):
         self.assertEqual("??????", self.s.transcribe())
@@ -729,8 +733,7 @@ class TestUnknownSeq(unittest.TestCase):
 
     def test_translation_of_proteins(self):
         seq = Seq.UnknownSeq(6, IUPAC.protein)
-        with self.assertRaises(ValueError):
-            seq.translate()
+        self.assertRaises(ValueError, seq.translate)
 
     def test_ungap(self):
         seq = Seq.UnknownSeq(7, alphabet=Alphabet.Gapped(Alphabet.DNAAlphabet(), "-"))

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -589,6 +589,10 @@ class TestReverseComplement(unittest.TestCase):
                 expected = Seq.reverse_complement(nucleotide_seq)
                 self.assertEqual(repr(expected), repr(nucleotide_seq.reverse_complement()))
                 self.assertEqual(repr(expected[::-1]), repr(nucleotide_seq.complement()))
+                self.assertEqual(str(nucleotide_seq.complement()),
+                                 str(Seq.reverse_complement(nucleotide_seq))[::-1])
+                self.assertEqual(str(nucleotide_seq.reverse_complement()),
+                                 str(Seq.reverse_complement(nucleotide_seq)))
 
     def test_reverse_complement_on_proteins(self):
         """Test reverse complement shouldn't work on a protein!"""
@@ -610,7 +614,6 @@ class TestTranslating(unittest.TestCase):
     def setUp(self):
         self.test_seqs = [
             Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna),
-            Seq.Seq("T", IUPAC.ambiguous_dna),
             Seq.Seq("ATGAAACTG"),
             Seq.Seq("ATGAARCTG"),
             Seq.Seq("AWGAARCKG"),  # Note no U or T
@@ -635,17 +638,15 @@ class TestTranslating(unittest.TestCase):
     def test_translation(self):
         for nucleotide_seq in self.test_seqs:
             nucleotide_seq = nucleotide_seq[:3 * (len(nucleotide_seq) // 3)]
-            expected = Seq.translate(nucleotide_seq)
-
-            if isinstance(nucleotide_seq, Seq.Seq):
+            if isinstance(nucleotide_seq, Seq.Seq) and 'X' not in str(nucleotide_seq):
+                expected = Seq.translate(nucleotide_seq)
                 self.assertEqual(repr(expected), repr(nucleotide_seq.translate()))
 
     def test_translation_to_stop(self):
         for nucleotide_seq in self.test_seqs:
             nucleotide_seq = nucleotide_seq[:3 * (len(nucleotide_seq) // 3)]
-            short = Seq.translate(nucleotide_seq, to_stop=True)
-
-            if isinstance(nucleotide_seq, Seq.Seq):
+            if isinstance(nucleotide_seq, Seq.Seq) and 'X' not in str(nucleotide_seq):
+                short = Seq.translate(nucleotide_seq, to_stop=True)
                 self.assertEqual(str(short), str(Seq.translate(nucleotide_seq).split('*')[0]))
 
     def test_translation_on_proteins(self):
@@ -713,33 +714,3 @@ class TestStopCodons(unittest.TestCase):
         self.assertEqual(Seq.translate("tar"), "*")
         self.assertEqual(Seq.translate("tan"), "X")
         self.assertEqual(Seq.translate("nnn"), "X")
-
-print("")
-print("Seq's .complement() method")
-print("==========================")
-for nucleotide_seq in test_seqs:
-    if isinstance(nucleotide_seq, Seq.Seq):
-        try:
-            print("%s -> %s"
-            % (repr(nucleotide_seq), repr(nucleotide_seq.complement())))
-            assert str(nucleotide_seq.complement()) \
-                == str(Seq.reverse_complement(nucleotide_seq))[::-1], \
-                "Bio.Seq function and method disagree!"
-        except ValueError as e:
-            print("%s -> %s"
-            % (repr(nucleotide_seq), str(e)))
-
-print("")
-print("Seq's .reverse_complement() method")
-print("==================================")
-for nucleotide_seq in test_seqs:
-    if isinstance(nucleotide_seq, Seq.Seq):
-        try:
-            print("%s -> %s"
-            % (repr(nucleotide_seq), repr(nucleotide_seq.reverse_complement())))
-            assert str(nucleotide_seq.reverse_complement()) \
-                == str(Seq.reverse_complement(nucleotide_seq)), \
-                "Bio.Seq function and method disagree!"
-        except ValueError as e:
-            print("%s -> %s"
-            % (repr(nucleotide_seq), str(e)))

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -477,48 +477,56 @@ def sorted_dict(d):
     return "{%s}" % ", ".join("%s: %s" % (repr(k), repr(v))
                               for k, v in sorted(d.items()))
 
-test_seqs = [s, t, u,
-             Seq.Seq("ATGAAACTG"),
-             "ATGAAACtg",
-             # TODO - Fix ambiguous translation
-             # Seq.Seq("ATGAARCTG"),
-             # Seq.Seq("AWGAARCKG"),  # Note no U or T
-             # Seq.Seq("".join(ambiguous_rna_values)),
-             # Seq.Seq("".join(ambiguous_dna_values)),
-             # Seq.Seq("".join(ambiguous_rna_values), Alphabet.generic_rna),
-             # Seq.Seq("".join(ambiguous_dna_values), Alphabet.generic_dna),
-             # Seq.Seq("".join(ambiguous_rna_values), IUPAC.IUPACAmbiguousDNA()),
-             # Seq.Seq("".join(ambiguous_dna_values), IUPAC.IUPACAmbiguousRNA()),
-             # Seq.Seq("AWGAARCKG", Alphabet.generic_dna),
-             Seq.Seq("AUGAAACUG", Alphabet.generic_rna),
-             Seq.Seq("ATGAAACTG", IUPAC.unambiguous_dna),
-             Seq.Seq("ATGAAA-CTG", Alphabet.Gapped(IUPAC.unambiguous_dna)),
-             Seq.Seq("ATGAAACTGWN", IUPAC.ambiguous_dna),
-             Seq.Seq("AUGAAACUG", Alphabet.generic_rna),
-             Seq.Seq("AUGAAA==CUG", Alphabet.Gapped(Alphabet.generic_rna, "=")),
-             Seq.Seq("AUGAAACUG", IUPAC.unambiguous_rna),
-             Seq.Seq("AUGAAACUGWN", IUPAC.ambiguous_rna),
-             Seq.Seq("ATGAAACTG", Alphabet.generic_nucleotide),
-             Seq.Seq("AUGAAACTG", Alphabet.generic_nucleotide),  # U and T
-             Seq.MutableSeq("ATGAAACTG", Alphabet.generic_dna),
-             Seq.MutableSeq("AUGaaaCUG", IUPAC.unambiguous_rna),
-             Seq.Seq("ACTGTCGTCT", Alphabet.generic_protein)]
-protein_seqs = [Seq.Seq("ATCGPK", IUPAC.protein),
-                Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, ".")),
-                Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-")),
-                Seq.Seq("MEDG-KRXR*", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
-                Seq.MutableSeq("ME-K-DRXR*XU", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
-                Seq.Seq("MEDG-KRXR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"), "@")),
-                Seq.Seq("ME-KR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"), "@")),
-                Seq.Seq("MEDG.KRXR@", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "@"), "."))]
+test_seqs = [
+    Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna),
+    Seq.Seq("T", IUPAC.ambiguous_dna),
+    Seq.Seq("ATGAAACTG"),
+    "ATGAAACtg",
+    Seq.Seq("ATGAARCTG"),
+    Seq.Seq("AWGAARCKG"),  # Note no U or T
+    Seq.Seq("".join(ambiguous_rna_values)),
+    Seq.Seq("".join(ambiguous_dna_values)),
+    Seq.Seq("".join(ambiguous_rna_values), Alphabet.generic_rna),
+    Seq.Seq("".join(ambiguous_dna_values), Alphabet.generic_dna),
+    Seq.Seq("".join(ambiguous_rna_values), IUPAC.IUPACAmbiguousRNA()),
+    Seq.Seq("".join(ambiguous_dna_values), IUPAC.IUPACAmbiguousDNA()),
+    Seq.Seq("AWGAARCKG", Alphabet.generic_dna),
+    Seq.Seq("AUGAAACUG", Alphabet.generic_rna),
+    Seq.Seq("ATGAAACTG", IUPAC.unambiguous_dna),
+    Seq.Seq("ATGAAA-CTG", Alphabet.Gapped(IUPAC.unambiguous_dna)),
+    Seq.Seq("ATGAAACTGWN", IUPAC.ambiguous_dna),
+    Seq.Seq("AUGAAACUG", Alphabet.generic_rna),
+    Seq.Seq("AUGAAA==CUG", Alphabet.Gapped(Alphabet.generic_rna, "=")),
+    Seq.Seq("AUGAAACUG", IUPAC.unambiguous_rna),
+    Seq.Seq("AUGAAACUGWN", IUPAC.ambiguous_rna),
+    Seq.Seq("ATGAAACTG", Alphabet.generic_nucleotide),
+    Seq.Seq("AUGAAACTG", Alphabet.generic_nucleotide),  # U and T
+    Seq.MutableSeq("ATGAAACTG", Alphabet.generic_dna),
+    Seq.MutableSeq("AUGaaaCUG", IUPAC.unambiguous_rna),
+    Seq.Seq("ACTGTCGTCT", Alphabet.generic_protein),
+]
+protein_seqs = [
+    Seq.Seq("ATCGPK", IUPAC.protein),
+    Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, ".")),
+    Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-")),
+    Seq.Seq("MEDG-KRXR*", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
+    Seq.MutableSeq("ME-K-DRXR*XU", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
+    Seq.Seq("MEDG-KRXR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"), "@")),
+    Seq.Seq("ME-KR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"), "@")),
+    Seq.Seq("MEDG.KRXR@", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "@"), ".")),
+]
 
-# Sanity test on the test sequence alphabets (see also enhancement bug 2597)
-for nucleotide_seq in test_seqs:
-    if hasattr(nucleotide_seq, "alphabet"):
-        if "U" in str(nucleotide_seq).upper():
-            assert not isinstance(nucleotide_seq.alphabet, Alphabet.DNAAlphabet)
-        if "T" in str(nucleotide_seq).upper():
-            assert not isinstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet)
+
+class TestSequenceAlphabets(unittest.TestCase):
+    def test_sequence_alphabets(self):
+        """Sanity test on the test sequence alphabets (see also enhancement
+        bug 2597)"""
+        for nucleotide_seq in test_seqs:
+            if hasattr(nucleotide_seq, "alphabet"):
+                if "U" in str(nucleotide_seq).upper():
+                    self.assertNotIsInstance(nucleotide_seq.alphabet, Alphabet.DNAAlphabet)
+                if "T" in str(nucleotide_seq).upper():
+                    self.assertNotIsInstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet)
 
 print("")
 print("Transcribe DNA into RNA")

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -431,19 +431,23 @@ class TestSeqStringMethods(unittest.TestCase):
                         self.assertEqual([str(x) for x in a.split(char, max_sep)],
                                          str(a).split(str_char, max_sep))
 
-###########################################################################
-print("")
-print("Checking ambiguous complements")
-print("==============================")
 
-# See bug 2380, Bio.Nexus was polluting the dictionary.
-assert "-" not in ambiguous_dna_values
-assert "?" not in ambiguous_dna_values
+class TestAmbiguousComplements(unittest.TestCase):
+    def test_ambiguous_values(self):
+        """Test that other tests do not introduce characters to our values"""
+        self.assertFalse("-" in ambiguous_dna_values)
+        self.assertFalse("?" in ambiguous_dna_values)
+
+
+class TestComplement(unittest.TestCase):
+    def test_complement_ambiguous_dna_values(self):
+        for ambig_char, values in sorted(ambiguous_dna_values.items()):
+            compl_values = str(Seq.Seq(values, alphabet=IUPAC.ambiguous_dna).complement())
+            self.assertEqual(set(compl_values),
+                             set(ambiguous_dna_values[ambiguous_dna_complement[ambig_char]]))
 
 
 def complement(sequence):
-    # TODO - Add a complement function to Bio/Seq.py?
-    # There is already a complement method on the Seq and MutableSeq objects.
     return Seq.reverse_complement(sequence)[::-1]
 
 
@@ -451,15 +455,6 @@ def sorted_dict(d):
     """A sorted repr of a dictionary."""
     return "{%s}" % ", ".join("%s: %s" % (repr(k), repr(v))
                               for k, v in sorted(d.items()))
-
-print("")
-print("DNA Ambiguity mapping: %s" % sorted_dict(ambiguous_dna_values))
-print("DNA Complement mapping: %s" % sorted_dict(ambiguous_dna_complement))
-for ambig_char, values in sorted(ambiguous_dna_values.items()):
-    compl_values = complement(values)
-    print("%s={%s} --> {%s}=%s" %
-        (ambig_char, values, compl_values, ambiguous_dna_complement[ambig_char]))
-    assert set(compl_values) == set(ambiguous_dna_values[ambiguous_dna_complement[ambig_char]])
 
 print("")
 print("RNA Ambiguity mapping: %s" % sorted_dict(ambiguous_rna_values))

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -4,14 +4,16 @@
 
 from __future__ import print_function
 import unittest
-
 import sys
+import array
+
+from Bio import Alphabet
 from Bio import Seq
 from Bio.Alphabet import IUPAC
-from Bio import Alphabet
 from Bio.Data.IUPACData import ambiguous_dna_complement, ambiguous_rna_complement
 from Bio.Data.IUPACData import ambiguous_dna_values, ambiguous_rna_values
 from Bio.Data.CodonTable import TranslationError
+from Bio.Seq import MutableSeq
 
 
 if sys.version_info[0] == 3:
@@ -20,7 +22,7 @@ else:
     array_indicator = "c"
 
 
-class SeqTest(unittest.TestCase):
+class TestSeq(unittest.TestCase):
     def setUp(self):
         self.s = Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna)
 
@@ -89,11 +91,7 @@ class SeqTest(unittest.TestCase):
         self.assertEqual("IUPACAmbiguousDNA()", str(u.alphabet))
 
 
-from Bio.Seq import MutableSeq
-import array
-
-
-class MutableSeqTest(unittest.TestCase):
+class TestMutableSeq(unittest.TestCase):
     def setUp(self):
         self.s = Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna)
         self.mutable_s = MutableSeq("TCAAAAGGATGCATCATG", IUPAC.ambiguous_dna)
@@ -233,7 +231,7 @@ array_seq = MutableSeq(array.array(array_indicator, "TCAAAAGGATGCATCATG"),
 converted_seq = s.tomutable()
 
 
-class SeqAdditionTest(unittest.TestCase):
+class TestSeqAddition(unittest.TestCase):
     def setUp(self):
         self.dna = [
             Seq.Seq("ATCG", IUPAC.ambiguous_dna),
@@ -331,86 +329,108 @@ class SeqAdditionTest(unittest.TestCase):
                 c = a + b
                 self.assertEqual(str(c), str(a) + str(b))
 
-dna = [Seq.Seq("ATCG", IUPAC.ambiguous_dna),
-       Seq.Seq("gtca", Alphabet.generic_dna),
-       Seq.MutableSeq("GGTCA", Alphabet.generic_dna),
-       Seq.Seq("CTG-CA", Alphabet.Gapped(IUPAC.unambiguous_dna, "-")),
-       "TGGTCA"]
-rna = [Seq.Seq("AUUUCG", IUPAC.ambiguous_rna),
-       Seq.MutableSeq("AUUCG", IUPAC.ambiguous_rna),
-       Seq.Seq("uCAg", Alphabet.generic_rna),
-       Seq.MutableSeq("UC-AG", Alphabet.Gapped(Alphabet.generic_rna, "-")),
-       Seq.Seq("U.CAG", Alphabet.Gapped(Alphabet.generic_rna, ".")),
-       "UGCAU"]
-nuc = [Seq.Seq("ATCG", Alphabet.generic_nucleotide), "UUUTTTACG"]
-protein = [Seq.Seq("ATCGPK", IUPAC.protein),
-           Seq.Seq("atcGPK", Alphabet.generic_protein),
-           Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, ".")),
-           Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-")),
-           Seq.Seq("MEDG-KRXR*", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
-           Seq.MutableSeq("ME-K-DRXR*XU", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
-           Seq.Seq("MEDG-KRXR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"), "@")),
-           Seq.Seq("ME-KR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"), "@")),
-           Seq.Seq("MEDG.KRXR@", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "@"), ".")),
-           "TEDDF"]
 
-###########################################################################
-print("")
-print("Testing Seq string methods")
-print("==========================")
-for a in dna + rna + nuc + protein:
-    if not isinstance(a, Seq.Seq):
-        continue
-    assert str(a.strip()) == str(a).strip()
-    assert str(a.lstrip()) == str(a).lstrip()
-    assert str(a.rstrip()) == str(a).rstrip()
-    assert str(a.lower()) == str(a).lower()
-    assert str(a.upper()) == str(a).upper()
-    test_chars = ["-", Seq.Seq("-"), Seq.Seq("*"), "-X@"]
-    alpha = Alphabet._get_base_alphabet(a.alphabet)
-    if isinstance(alpha, Alphabet.DNAAlphabet):
-        test_chars.append(Seq.Seq("A", IUPAC.ambiguous_dna))
-    if isinstance(alpha, Alphabet.RNAAlphabet):
-        test_chars.append(Seq.Seq("A", IUPAC.ambiguous_rna))
-    if isinstance(alpha, Alphabet.NucleotideAlphabet):
-        test_chars.append(Seq.Seq("A", Alphabet.generic_nucleotide))
-    if isinstance(alpha, Alphabet.ProteinAlphabet):
-        test_chars.append(Seq.Seq("K", Alphabet.generic_protein))
-        test_chars.append(Seq.Seq("K-", Alphabet.Gapped(Alphabet.generic_protein, "-")))
-        test_chars.append(Seq.Seq("K@", Alphabet.Gapped(IUPAC.protein, "@")))
-        # Setup a clashing alphabet sequence
+class TestSeqStringMethods(unittest.TestCase):
+    def setUp(self):
+        self.dna = [
+            Seq.Seq("ATCG", IUPAC.ambiguous_dna),
+            Seq.Seq("gtca", Alphabet.generic_dna),
+            Seq.MutableSeq("GGTCA", Alphabet.generic_dna),
+            Seq.Seq("CTG-CA", Alphabet.Gapped(IUPAC.unambiguous_dna, "-")),
+        ]
+        self.rna = [
+            Seq.Seq("AUUUCG", IUPAC.ambiguous_rna),
+            Seq.MutableSeq("AUUCG", IUPAC.ambiguous_rna),
+            Seq.Seq("uCAg", Alphabet.generic_rna),
+            Seq.MutableSeq("UC-AG", Alphabet.Gapped(Alphabet.generic_rna, "-")),
+            Seq.Seq("U.CAG", Alphabet.Gapped(Alphabet.generic_rna, ".")),
+        ]
+        self.nuc = [Seq.Seq("ATCG", Alphabet.generic_nucleotide)]
+        self.protein = [
+            Seq.Seq("ATCGPK", IUPAC.protein),
+            Seq.Seq("atcGPK", Alphabet.generic_protein),
+            Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, ".")),
+            Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-")),
+            Seq.Seq("MEDG-KRXR*", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
+            Seq.MutableSeq("ME-K-DRXR*XU", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
+            Seq.Seq("MEDG-KRXR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"), "@")),
+            Seq.Seq("ME-KR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"), "@")),
+            Seq.Seq("MEDG.KRXR@", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "@"), ".")),
+        ]
+        self.test_chars = ["-", Seq.Seq("-"), Seq.Seq("*"), "-X@"]
+
+    def test_string_methods(self):
+        for a in self.dna + self.rna + self.nuc + self.protein:
+            if isinstance(a, Seq.Seq):
+                self.assertEqual(str(a.strip()), str(a).strip())
+                self.assertEqual(str(a.lstrip()), str(a).lstrip())
+                self.assertEqual(str(a.rstrip()), str(a).rstrip())
+                self.assertEqual(str(a.lower()), str(a).lower())
+                self.assertEqual(str(a.upper()), str(a).upper())
+
+    def test_append_nucleotides(self):
+        self.test_chars.append(Seq.Seq("A", IUPAC.ambiguous_dna))
+        self.test_chars.append(Seq.Seq("A", IUPAC.ambiguous_rna))
+        self.test_chars.append(Seq.Seq("A", Alphabet.generic_nucleotide))
+
+        self.assertEqual(7, len(self.test_chars))
+
+    def test_append_proteins(self):
+        self.test_chars.append(Seq.Seq("K", Alphabet.generic_protein))
+        self.test_chars.append(Seq.Seq("K-", Alphabet.Gapped(Alphabet.generic_protein, "-")))
+        self.test_chars.append(Seq.Seq("K@", Alphabet.Gapped(IUPAC.protein, "@")))
+
+        self.assertEqual(7, len(self.test_chars))
+
+    def test_exception_when_clashing_alphabets(self):
+        """Test by setting up clashing alphabet sequences"""
         b = Seq.Seq("-", Alphabet.generic_nucleotide)
-    else:
-        b = Seq.Seq("-", Alphabet.generic_protein)
-    try:
-        print(str(a.strip(b)))
-        assert False, "Alphabet should have clashed!"
-    except TypeError:
-        pass  # Good!
+        self.assertRaises(TypeError, self.protein[0].strip, b)
 
-    for chars in test_chars:
-        str_chars = str(chars)
-        assert str(a.strip(chars)) == str(a).strip(str_chars)
-        assert str(a.lstrip(chars)) == str(a).lstrip(str_chars)
-        assert str(a.rstrip(chars)) == str(a).rstrip(str_chars)
-        assert a.find(chars) == str(a).find(str_chars)
-        assert a.find(chars, 2, -2) == str(a).find(str_chars, 2, -2)
-        assert a.rfind(chars) == str(a).rfind(str_chars)
-        assert a.rfind(chars, 2, -2) == str(a).rfind(str_chars, 2, -2)
-        assert a.count(chars) == str(a).count(str_chars)
-        assert a.count(chars, 2, -2) == str(a).count(str_chars, 2, -2)
-        # Now check splits
-        assert [str(x) for x in a.split(chars)] \
-               == str(a).split(str(chars))
-        assert [str(x) for x in a.rsplit(chars)] \
-               == str(a).rsplit(str(chars))
-        for max_sep in [0, 1, 2, 999]:
-            assert [str(x) for x in a.split(chars, max_sep)] \
-                   == str(a).split(str(chars), max_sep)
-            assert [str(x) for x in a.rsplit(chars, max_sep)] \
-                   == str(a).rsplit(str(chars), max_sep)
-del a, alpha, chars, str_chars, test_chars
-del dna, rna, nuc, protein
+        b = Seq.Seq("-", Alphabet.generic_protein)
+        self.assertRaises(TypeError, self.dna[0].strip, b)
+
+    def test_stripping_characters(self):
+        for a in self.dna + self.rna + self.nuc + self.protein:
+            for char in self.test_chars:
+                str_char = str(char)
+                if isinstance(a, Seq.Seq):
+                    self.assertEqual(str(a.strip(char)), str(a).strip(str_char))
+                    self.assertEqual(str(a.lstrip(char)), str(a).lstrip(str_char))
+                    self.assertEqual(str(a.rstrip(char)), str(a).rstrip(str_char))
+
+    def test_finding_characters(self):
+        for a in self.dna + self.rna + self.nuc + self.protein:
+            for char in self.test_chars:
+                str_char = str(char)
+                if isinstance(a, Seq.Seq):
+                    self.assertEqual(a.find(char), str(a).find(str_char))
+                    self.assertEqual(a.find(char, 2, -2), str(a).find(str_char, 2, -2))
+                    self.assertEqual(a.rfind(char), str(a).rfind(str_char))
+                    self.assertEqual(a.rfind(char, 2, -2), str(a).rfind(str_char, 2, -2))
+
+    def test_counting_characters(self):
+        for a in self.dna + self.rna + self.nuc + self.protein:
+            for char in self.test_chars:
+                str_char = str(char)
+                if isinstance(a, Seq.Seq):
+                    self.assertEqual(a.count(char), str(a).count(str_char))
+                    self.assertEqual(a.count(char, 2, -2), str(a).count(str_char, 2, -2))
+
+    def test_splits(self):
+        for a in self.dna + self.rna + self.nuc + self.protein:
+            for char in self.test_chars:
+                str_char = str(char)
+                if isinstance(a, Seq.Seq):
+                    self.assertEqual([str(x) for x in a.split(char)],
+                                     str(a).split(str_char))
+                    self.assertEqual([str(x) for x in a.rsplit(char)],
+                                     str(a).rsplit(str_char))
+
+                    for max_sep in [0, 1, 2, 999]:
+                        self.assertEqual([str(x) for x in a.split(char, max_sep)],
+                                         str(a).split(str_char, max_sep))
+
 ###########################################################################
 print("")
 print("Checking ambiguous complements")

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -3,6 +3,7 @@
 # as part of this package.
 
 from __future__ import print_function
+import unittest
 
 import sys
 from Bio import Seq
@@ -18,51 +19,89 @@ if sys.version_info[0] == 3:
 else:
     array_indicator = "c"
 
-print("")
-print("Testing Seq")
-print("===========")
 
-s = Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna)
+class SeqTest(unittest.TestCase):
+    def setUp(self):
+        self.s = Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna)
 
-print(str(s))
-print(len(s))
-print(s[0])
-print(s[-1])
-print(str(s[3:5]))
+    def test_as_string(self):
+        """Test converting Seq to string"""
+        self.assertEqual("TCAAAAGGATGCATCATG", str(self.s))
 
-print("Reverse using -1 stride: %r" % s[::-1])
+    def test_length(self):
+        """Test len method on Seq object"""
+        self.assertEqual(18, len(self.s))
 
-print("Extract every third nucleotide (slicing with stride 3):")
-print(repr(s[0::3]))
-print(repr(s[1::3]))
-print(repr(s[2::3]))
+    def test_first_nucleotide(self):
+        """Test getting first nucleotide of Seq"""
+        self.assertEqual("T", self.s[0])
 
-print(s.alphabet.letters)
+    def test_last_nucleotide(self):
+        """Test getting last nucleotide of Seq"""
+        self.assertEqual("G", self.s[-1])
 
-t = Seq.Seq("T", IUPAC.unambiguous_dna)
-u = s + t
-print(str(u.alphabet))
-print(len(u))
-assert str(s) + "T" == str(u)
+    def test_slicing(self):
+        """Test slicing of Seq"""
+        self.assertEqual("AA", str(self.s[3:5]))
 
-t = Seq.Seq("T", IUPAC.protein)
-try:
-    u = s + t
-except TypeError:
-    print("expected error, and got it")
-else:
-    print("huh?  ERROR")
+    def test_reverse(self):
+        """Test reverse using -1 stride"""
+        self.assertEqual("GTACTACGTAGGAAAACT", self.s[::-1])
 
-t = Seq.Seq("T", IUPAC.ambiguous_dna)
-u = s + t
-print(str(u.alphabet))
+    def test_extract_third_nucleotide(self):
+        """Test extracting every third nucleotide (slicing with stride 3)"""
+        self.assertEqual("TAGTAA", str(self.s[0::3]))
+        self.assertEqual("CAGGTT", str(self.s[1::3]))
+        self.assertEqual("AAACCG", str(self.s[2::3]))
+
+    def test_alphabet_letters(self):
+        """Test nucleotides in DNA Seq"""
+        self.assertEqual("GATC", self.s.alphabet.letters)
+
+    def test_alphabet(self):
+        """Test alphabet of derived Seq object"""
+        t = Seq.Seq("T", IUPAC.unambiguous_dna)
+        u = self.s + t
+        self.assertEqual("IUPACUnambiguousDNA()", str(u.alphabet))
+
+    def test_length_concatenated_unambiguous_seq(self):
+        """Test length of concatenated Seq object with unambiguous DNA"""
+        t = Seq.Seq("T", IUPAC.unambiguous_dna)
+        u = self.s + t
+        self.assertEqual(19, len(u))
+
+    def test_concatenation_of_seq(self):
+        t = Seq.Seq("T", IUPAC.unambiguous_dna)
+        u = self.s + t
+        self.assertEqual(str(self.s) + "T", str(u))
+
+    def test_concatenation_error(self):
+        """Test DNA Seq objects cannot be concatenated with Protein Seq
+        objects"""
+        with self.assertRaises(TypeError):
+            self.s + Seq.Seq("T", IUPAC.protein)
+
+    def test_concatenation_of_ambiguous_and_unambiguous_dna(self):
+        """Test concatenated Seq object with ambiguous and unambiguous DNA
+        returns ambiguous Seq"""
+        t = Seq.Seq("T", IUPAC.ambiguous_dna)
+        u = self.s + t
+        self.assertEqual("IUPACAmbiguousDNA()", str(u.alphabet))
+
 
 from Bio.Seq import MutableSeq
 import array
 
-print("")
-print("Testing MutableSeq")
-print("==================")
+
+class MutableSeqTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+
+s = Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna)
+t = Seq.Seq("T", IUPAC.ambiguous_dna)
+u = s + t
+
 
 print("Testing creating MutableSeqs in multiple ways")
 string_seq = MutableSeq("TCAAAAGGATGCATCATG", IUPAC.ambiguous_dna)

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -24,15 +24,6 @@ if sys.version_info[0] == 3:
 else:
     array_indicator = "c"
 
-###########################################################################
-s = Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna)
-t = Seq.Seq("T", IUPAC.ambiguous_dna)
-u = s + t
-string_seq = MutableSeq("TCAAAAGGATGCATCATG", IUPAC.ambiguous_dna)
-array_seq = MutableSeq(array.array(array_indicator, "TCAAAAGGATGCATCATG"),
-                       IUPAC.ambiguous_dna)
-converted_seq = s.tomutable()
-
 test_seqs = [
     Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna),
     Seq.Seq("T", IUPAC.ambiguous_dna),
@@ -89,7 +80,6 @@ class TestSeq(unittest.TestCase):
         seq = "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGA"
         expected = "Seq('TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATG...GGA', IUPACAmbiguousDNA())"
         self.assertEqual(expected, repr(Seq.Seq(seq, IUPAC.ambiguous_dna)))
-
 
     def test_length(self):
         """Test len method on Seq object"""
@@ -230,7 +220,7 @@ class TestSeqStringMethods(unittest.TestCase):
 
     def test_add_method_using_wrong_object(self):
         with self.assertRaises(TypeError):
-            c = self.s + dict()
+            self.s + dict()
 
     def test_radd_method(self):
         self.assertEqual("TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG", str(self.s.__radd__(self.s)))
@@ -370,7 +360,7 @@ class TestSeqAddition(unittest.TestCase):
     def test_exception_when_added_rna_has_more_than_one_gap_type(self):
         """Test resulting sequence has gap types '-' and '.'"""
         with self.assertRaises(ValueError):
-            c = self.rna[3] + self.rna[4]
+            self.rna[3] + self.rna[4]
 
     def test_addition_dna_with_dna(self):
         for a in self.dna:
@@ -384,9 +374,9 @@ class TestSeqAddition(unittest.TestCase):
         for a in self.dna:
             for b in self.rna:
                 with self.assertRaises(TypeError):
-                    c = a + b
+                    a + b
                 with self.assertRaises(TypeError):
-                    c = b + a
+                    b + a
 
     def test_addition_proteins(self):
         self.protein.pop(2)
@@ -400,20 +390,20 @@ class TestSeqAddition(unittest.TestCase):
         a = Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, "."))
         b = Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-"))
         with self.assertRaises(ValueError):
-            c = a + b
+            a + b
 
     def test_exception_when_added_protein_has_more_than_one_stop_codon_type(self):
         """Test resulting protein has stop codon types '*' and '@'"""
         a = Seq.Seq("MEDG-KRXR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"), "@"))
         b = Seq.Seq("MEDG-KRXR*", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"))
         with self.assertRaises(ValueError):
-            c = a + b
+            a + b
 
     def test_exception_when_adding_protein_with_nucletides(self):
         for a in self.protein[0:5]:
             for b in self.dna[0:3] + self.rna[0:4]:
                 with self.assertRaises(TypeError):
-                    c = a + b
+                    a + b
 
     def test_adding_generic_nucleotide_with_other_nucleotides(self):
         for a in self.nuc:
@@ -485,7 +475,7 @@ class TestMutableSeq(unittest.TestCase):
     def test_add_method(self):
         """Test adding wrong type to MutableSeq"""
         with self.assertRaises(TypeError):
-            c = self.mutable_s + 1234
+            self.mutable_s + 1234
 
     def test_radd_method(self):
         self.assertEqual("TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG",
@@ -501,7 +491,7 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_radd_method_wrong_type(self):
         with self.assertRaises(TypeError):
-            c = self.mutable_s.__radd__(1234)
+            self.mutable_s.__radd__(1234)
 
     def test_as_string(self):
         self.assertEqual("TCAAAAGGATGCATCATG", str(self.mutable_s))
@@ -691,7 +681,7 @@ class TestUnknownSeq(unittest.TestCase):
         self.assertEqual("???", self.s[1:6:2])
         self.assertEqual("????", self.s[1:-1])
         with self.assertRaises(ValueError):
-            c = self.s[1:6:0]
+            self.s[1:6:0]
 
     def test_count(self):
         self.assertEqual(6, self.s.count("?"))
@@ -740,7 +730,7 @@ class TestUnknownSeq(unittest.TestCase):
     def test_translation_of_proteins(self):
         seq = Seq.UnknownSeq(6, IUPAC.protein)
         with self.assertRaises(ValueError):
-            c = seq.translate()
+            seq.translate()
 
     def test_ungap(self):
         seq = Seq.UnknownSeq(7, alphabet=Alphabet.Gapped(Alphabet.DNAAlphabet(), "-"))
@@ -820,7 +810,6 @@ class TestReverseComplement(unittest.TestCase):
                 s.complement()
 
 
-
 class TestDoubleReverseComplement(unittest.TestCase):
     def test_reverse_complements(self):
         """Test double reverse complement preserves the sequence"""
@@ -834,7 +823,6 @@ class TestDoubleReverseComplement(unittest.TestCase):
             reversed_sequence = sequence.reverse_complement()
             self.assertEqual(str(sequence),
                              str(reversed_sequence.reverse_complement()))
-
 
 
 class TestSequenceAlphabets(unittest.TestCase):
@@ -1046,11 +1034,11 @@ class TestStopCodons(unittest.TestCase):
             self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table="SGC0")))
             self.assertEqual("**W**", str(Seq.translate(nucleotide_seq, table=2)))
             self.assertEqual("**WRR", str(Seq.translate(nucleotide_seq,
-                                              table='Yeast Mitochondrial')))
+                                          table='Yeast Mitochondrial')))
             self.assertEqual("**WSS", str(Seq.translate(nucleotide_seq, table=5)))
             self.assertEqual("**WSS", str(Seq.translate(nucleotide_seq, table=9)))
             self.assertEqual("**CRR", str(Seq.translate(nucleotide_seq,
-                                              table='Euplotid Nuclear')))
+                                          table='Euplotid Nuclear')))
             self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table=11)))
             self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table='Bacterial')))
 


### PR DESCRIPTION
I [read that contributions for the test suite](http://mailman.open-bio.org/pipermail/biopython-dev/2015-October/021064.html) are needed.

In this patch, I replaced the tests in ``Test/test_seq.py`` for unittests. I also noticed that the test coverage for the module Bio.Seq was at 61%. So I added tests to get higher coverage, currently 96%.

Some of the test cases for exceptions in the code required using assert statements like this:

```python
with self.assertRaises(ValueError):
   do_something_to_trigger_exception
```

Those cases were failing in Python2.6 due to its old unittest library. That's why I am importing the library ``unittest2`` and installing it in ``.travis.yml``. The usage of ``unittest2`` can be removed after Biopython drops support for Python 2.6.

Sorry for the long patch.