### PR TITLE
increased test coverage for Bio.SeqRecord and other fixes

### DIFF
--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -80,7 +80,7 @@ class _RestrictedDict(dict):
         if not hasattr(value, "__len__") or not hasattr(value, "__getitem__") \
                 or (hasattr(self, "_length") and len(value) != self._length):
             raise TypeError("We only allow python sequences (lists, tuples or "
-                            "strings) of length %i." % self._length)
+                            "strings) of length {0}.".format(self._length))
         dict.__setitem__(self, key, value)
 
     def update(self, new_dict):
@@ -586,20 +586,18 @@ class SeqRecord(object):
         """
         lines = []
         if self.id:
-            lines.append("ID: %s" % self.id)
+            lines.append("ID: {0}".format(self.id))
         if self.name:
-            lines.append("Name: %s" % self.name)
+            lines.append("Name: {0}".format(self.name))
         if self.description:
-            lines.append("Description: %s" % self.description)
+            lines.append("Description: {0}".format(self.description))
         if self.dbxrefs:
-            lines.append("Database cross-references: "
-                         + ", ".join(self.dbxrefs))
-        lines.append("Number of features: %i" % len(self.features))
+            lines.append("Database cross-references: " + ", ".join(self.dbxrefs))
+        lines.append("Number of features: {0}".format(len(self.features)))
         for a in self.annotations:
-            lines.append("/%s=%s" % (a, str(self.annotations[a])))
+            lines.append("/{0}={1}".format(a, str(self.annotations[a])))
         if self.letter_annotations:
-            lines.append("Per letter annotation for: "
-                         + ", ".join(self.letter_annotations))
+            lines.append("Per letter annotation for: " + ", ".join(self.letter_annotations))
         # Don't want to include the entire sequence,
         # and showing the alphabet is useful:
         lines.append(repr(self.seq))
@@ -634,10 +632,10 @@ class SeqRecord(object):
         annotations, letter_annotations and features are not shown (as they
         would lead to a very long string).
         """
-        return self.__class__.__name__ \
-            + "(seq=%s, id=%s, name=%s, description=%s, dbxrefs=%s)" \
-            % tuple(map(repr, (self.seq, self.id, self.name,
-                               self.description, self.dbxrefs)))
+        return "{0}(seq={1!r}, id={2!r}, name={3!r}, description={4!r}, dbxrefs={5!r})".format(
+               self.__class__.__name__,
+               self.seq, self.id, self.name,
+               self.description, self.dbxrefs)
 
     def format(self, format):
         r"""Returns the record as a string in the specified file format.

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -314,7 +314,7 @@ class SeqRecord(object):
         """Returns a sub-sequence or an individual letter.
 
         Slicing, e.g. my_record[5:10], returns a new SeqRecord for
-        that sub-sequence with approriate annotation preserved.  The
+        that sub-sequence with appropriate annotation preserved.  The
         name, id and description are kept.
 
         Any per-letter-annotations are sliced to match the requested
@@ -325,7 +325,7 @@ class SeqRecord(object):
         However, the annotations dictionary and the dbxrefs list are
         not used for the new SeqRecord, as in general they may not
         apply to the subsequence.  If you want to preserve them, you
-        must explictly copy them to the new SeqRecord yourself.
+        must explicitly copy them to the new SeqRecord yourself.
 
         Using an integer index, e.g. my_record[5] is shorthand for
         extracting that letter from the sequence, my_record.seq[5].
@@ -431,7 +431,7 @@ class SeqRecord(object):
                                     id=self.id,
                                     name=self.name,
                                     description=self.description)
-            # TODO - The desription may no longer apply.
+            # TODO - The description may no longer apply.
             # It would be safer to change it to something
             # generic like "edited" or the default value.
 
@@ -1043,7 +1043,7 @@ class SeqRecord(object):
 
         Note that if the SeqFeature annotation includes any strand specific
         information (e.g. base changes for a SNP), this information is not
-        ammended, and would need correction after the reverse complement.
+        amended, and would need correction after the reverse complement.
 
         Note trying to reverse complement a protein SeqRecord raises an
         exception:

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -10,7 +10,7 @@ and confirms they are consistent using our different parsers.
 """
 import unittest
 from Bio import SeqIO
-from Bio.Alphabet import generic_dna, generic_rna, generic_protein
+from Bio.Alphabet import generic_dna, generic_protein
 from Bio.Seq import Seq, MutableSeq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqFeature import SeqFeature, FeatureLocation, ExactPosition

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -8,7 +8,17 @@
 Initially this takes matched tests of GenBank and FASTA files from the NCBI
 and confirms they are consistent using our different parsers.
 """
-import unittest
+import sys
+# Remove unittest2 import after dropping support for Python2.6
+if sys.version_info < (2, 7):
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        from Bio import MissingPythonDependencyError
+        raise MissingPythonDependencyError("Under Python 2.6 this test needs the unittest2 library")
+else:
+    import unittest
+
 from Bio import SeqIO
 from Bio.Alphabet import generic_dna, generic_protein
 from Bio.Seq import Seq, MutableSeq
@@ -19,6 +29,7 @@ from Bio.SeqFeature import WithinPosition, BeforePosition, AfterPosition, OneOfP
 
 class SeqRecordCreation(unittest.TestCase):
     """Test basic creation of SeqRecords."""
+
     def test_annotations(self):
         """Pass in annotations to SeqRecords"""
         rec = SeqRecord(Seq("ACGT", generic_dna),
@@ -288,9 +299,11 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX', ProteinAlphabet())"""
         s = SeqRecord(Seq("ACTG"), id="TestID", name="TestName",
                       description="TestDescription", dbxrefs=["TestDbxrefs"],
                       features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
-                      annotations={'organism': 'bombyx'}, letter_annotations={'test': 'abcd'})
+                      annotations={'organism': 'bombyx'},
+                      letter_annotations={'test': 'abcd'})
         rc = s.reverse_complement(id=True, name=True, description=True,
-                                  dbxrefs=True, features=True, annotations=True, letter_annotations=True)
+                                  dbxrefs=True, features=True, annotations=True,
+                                  letter_annotations=True)
 
         self.assertEqual("CAGT", str(rc.seq))
         self.assertEqual("TestID", rc.id)
@@ -324,6 +337,7 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX', ProteinAlphabet())"""
     def test_reverse_complement_mutable_seq(self):
         s = SeqRecord(MutableSeq("ACTG"))
         self.assertEqual("CAGT", str(s.reverse_complement().seq))
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -11,7 +11,7 @@ and confirms they are consistent using our different parsers.
 import unittest
 from Bio import SeqIO
 from Bio.Alphabet import generic_dna, generic_rna, generic_protein
-from Bio.Seq import Seq
+from Bio.Seq import Seq, MutableSeq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqFeature import SeqFeature, FeatureLocation, ExactPosition
 from Bio.SeqFeature import WithinPosition, BeforePosition, AfterPosition, OneOfPosition
@@ -61,6 +61,30 @@ class SeqRecordCreation(unittest.TestCase):
         except (TypeError, ValueError) as e:
             pass
 
+    def test_valid_id(self):
+        with self.assertRaises(TypeError):
+            SeqRecord(Seq("ACGT", generic_dna), id=dict())
+
+    def test_valid_name(self):
+        with self.assertRaises(TypeError):
+            SeqRecord(Seq("ACGT", generic_dna), name=dict())
+
+    def test_valid_description(self):
+        with self.assertRaises(TypeError):
+            SeqRecord(Seq("ACGT", generic_dna), description=dict())
+
+    def test_valid_dbxrefs(self):
+        with self.assertRaises(TypeError):
+            SeqRecord(Seq("ACGT", generic_dna), dbxrefs=dict())
+
+    def test_valid_annotations(self):
+        with self.assertRaises(TypeError):
+            SeqRecord(Seq("ACGT", generic_dna), annotations=list())
+
+    def test_valid_features(self):
+        with self.assertRaises(TypeError):
+            SeqRecord(Seq("ACGT", generic_dna), features=dict())
+
 
 class SeqRecordMethods(unittest.TestCase):
     """Test SeqRecord methods."""
@@ -78,7 +102,48 @@ class SeqRecordMethods(unittest.TestCase):
                                 letter_annotations={"fake": "X" * 26},
                                 features=[f0, f1, f2, f3])
 
-    def test_slice_variantes(self):
+    def test_iter(self):
+        for amino in self.record:
+            self.assertEqual("A", amino)
+            break
+
+    def test_contains(self):
+        self.assertTrue(Seq("ABC", generic_protein) in self.record)
+
+    def test_str(self):
+        expected = """
+ID: TestID
+Name: TestName
+Description: TestDescr
+Database cross-references: TestXRef
+Number of features: 4
+/k=v
+Per letter annotation for: fake
+Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX', ProteinAlphabet())"""
+        self.assertEqual(expected.lstrip(), str(self.record))
+
+    def test_repr(self):
+        expected = "SeqRecord(seq=Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX', ProteinAlphabet()), " \
+                   "id='TestID', name='TestName', description='TestDescr', dbxrefs=['TestXRef'])"
+        self.assertEqual(expected, repr(self.record))
+
+    def test_format(self):
+        expected = ">TestID TestDescr\nABCDEFGHIJKLMNOPQRSTUVWZYX\n"
+        self.assertEqual(expected, self.record.format('fasta'))
+
+    def test_upper(self):
+        self.assertEqual("ABCDEFGHIJKLMNOPQRSTUVWZYX", str(self.record.lower().upper().seq))
+
+    def test_lower(self):
+        self.assertEqual("abcdefghijklmnopqrstuvwzyx", str(self.record.lower().seq))
+
+    def test_slicing(self):
+        self.assertEqual("B", self.record[1])
+        self.assertEqual("BC", self.record[1:3].seq)
+        with self.assertRaises(ValueError):
+            c = self.record['a'].seq
+
+    def test_slice_variants(self):
         """Simple slices using different start/end values"""
         for start in list(range(-30, 30)) + [None]:
             for end in list(range(-30, 30)) + [None]:
@@ -218,6 +283,47 @@ class SeqRecordMethods(unittest.TestCase):
             self.assertEqual(rec.annotations, {})  # May change this...
             self.assertEqual(rec.letter_annotations, {"fake": "X" * 26})
             self.assertTrue(len(rec.features) <= len(self.record.features))
+
+    def test_reverse_complement_seq(self):
+        s = SeqRecord(Seq("ACTG"), id="TestID", name="TestName",
+                      description="TestDescription", dbxrefs=["TestDbxrefs"],
+                      features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
+                      annotations={'organism': 'bombyx'}, letter_annotations={'test': 'abcd'})
+        rc = s.reverse_complement(id=True, name=True, description=True,
+                                  dbxrefs=True, features=True, annotations=True, letter_annotations=True)
+
+        self.assertEqual("CAGT", str(rc.seq))
+        self.assertEqual("TestID", rc.id)
+        self.assertEqual("TestID", s.reverse_complement(id="TestID").id)
+
+        self.assertEqual("TestName", rc.name)
+        self.assertEqual("TestName", s.reverse_complement(name="TestName").name)
+
+        self.assertEqual("TestDescription", rc.description)
+        self.assertEqual("TestDescription",
+                         s.reverse_complement(description="TestDescription").description)
+
+        self.assertEqual(["TestDbxrefs"], rc.dbxrefs)
+        self.assertEqual(["TestDbxrefs"],
+                         s.reverse_complement(dbxrefs=["TestDbxrefs"]).dbxrefs)
+
+        self.assertEqual("[SeqFeature(FeatureLocation(ExactPosition(1), ExactPosition(4)), type='Site')]",
+                         repr(rc.features))
+        rc2 = s.reverse_complement(features=[SeqFeature(FeatureLocation(1, 4), type="Site")])
+        self.assertEqual("[SeqFeature(FeatureLocation(ExactPosition(1), ExactPosition(4)), type='Site')]",
+                         repr(rc2.features))
+
+        self.assertEqual({'organism': 'bombyx'}, rc.annotations)
+        self.assertEqual({'organism': 'bombyx'},
+                         s.reverse_complement(annotations={'organism': 'bombyx'}).annotations)
+
+        self.assertEqual({'test': 'dcba'}, rc.letter_annotations)
+        self.assertEqual({'test': 'abcd'},
+                         s.reverse_complement(letter_annotations={'test': 'abcd'}).letter_annotations)
+
+    def test_reverse_complement_mutable_seq(self):
+        s = SeqRecord(MutableSeq("ACTG"))
+        self.assertEqual("CAGT", str(s.reverse_complement().seq))
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
such as typos and usage of ``format`` method with the ``!r`` conversion in ``Bio.SeqRecord``.
Coverage increased from 54% to 90%.