### PR TITLE
Use container-based testing in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 #
 #Note when testing Python 3, the 'python' command will invoke Python 3
 #and similarly for PyPy too.
-
+sudo: false
 language: python
 python:
   - "2.6"


### PR DESCRIPTION
The new testing infrastructure in Travis-CI is container-based, faster and
probably better.

It has to be activated by using: ``sudo: false``

See [more info](http://docs.travis-ci.com/user/workers/container-based-infrastructure/).