### PR TITLE
Bio.codonalign: replaced "if variable is True" for "if variable"

### DIFF
--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -164,7 +164,7 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char='-', unknown='X',
             pro_nucl_pair.append((pro_rec, nucl_seqs[nucl_id]))
 
     codon_aln = []
-    shift = None
+    shift = False
     for pair in pro_nucl_pair:
         # Beware that the following span corresponds to an ungapped
         # nucleotide sequence.
@@ -184,7 +184,7 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char='-', unknown='X',
             codon_aln.append(codon_rec)
             if corr_span[1] == 2:
                 shift = True
-    if shift is True:
+    if shift:
         return CodonAlignment(_align_shift_recs(codon_aln), alphabet=alphabet)
     else:
         return CodonAlignment(codon_aln, alphabet=alphabet)

--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -299,7 +299,7 @@ def _check_corr(pro, nucl, gap_char='-', codon_table=default_codon_table,
             # pro_re
             if this_anchor_len == anchor_len:
                 for aa in anchor:
-                    if complete_protein is True and i == 0:
+                    if complete_protein and i == 0:
                         qcodon += _codons2re(codon_table.start_codons)
                         fncodon += aa2re['X']
                         continue
@@ -336,7 +336,7 @@ def _check_corr(pro, nucl, gap_char='-', codon_table=default_codon_table,
             first_anchor = True
             shift_id_pos = 0
             # check the first anchor
-            if first_anchor is True and anchor_pos[0][2] != 0:
+            if first_anchor and anchor_pos[0][2] != 0:
                 shift_val_lst = [1, 2, 3 * anchor_len - 2, 3 * anchor_len - 1, 0]
                 sh_anc = anchors[0]
                 for shift_val in shift_val_lst:
@@ -561,7 +561,7 @@ def _get_codon_rec(pro, nucl, span_mode, alphabet, gap_char="-",
         for aa in pro.seq:
             if aa == "-":
                 codon_seq += "---"
-            elif complete_protein is True and aa_num == 0:
+            elif complete_protein and aa_num == 0:
                 this_codon = nucl_seq._data[span[0]:span[0] + 3]
                 if not re.search(_codons2re[codon_table.start_codons],
                                  this_codon.upper()):
@@ -623,7 +623,7 @@ def _get_codon_rec(pro, nucl, span_mode, alphabet, gap_char="-",
         for aa in pro.seq:
             if aa == "-":
                 codon_seq += "---"
-            elif complete_protein is True and aa_num == 0:
+            elif complete_protein and aa_num == 0:
                 this_codon = nucl_seq._data[rf_table[0]:rf_table[0] + 3]
                 if not re.search(_codons2re[codon_table.start_codons],
                                  this_codon.upper()):

--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -40,12 +40,12 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char='-', unknown='X',
     Arguments:
         - pro_align  - a protein MultipleSeqAlignment object
         - nucl_align - an object returned by SeqIO.parse or SeqIO.index
-          or a colloction of SeqRecord.
+          or a collection of SeqRecord.
         - alphabet   - alphabet for the returned codon alignment
         - corr_dict  - a dict that maps protein id to nucleotide id
         - complete_protein - whether the sequence begins with a start
           codon
-        - frameshift - whether to appply frameshift detection
+        - frameshift - whether to apply frameshift detection
 
     Return a CodonAlignment object
 
@@ -98,7 +98,7 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char='-', unknown='X',
                              "({1}) are found!".format(pro_num, nucl_num))
 
         # Determine the protein sequences and nucl sequences
-        # correspondance. If nucl_seqs is a list, tuple or read by
+        # correspondence. If nucl_seqs is a list, tuple or read by
         # SeqIO.parse(), we assume the order of sequences in pro_align
         # and nucl_seqs are the same. If nucl_seqs is a dict or read by
         # SeqIO.index(), we match seqs in pro_align and those in
@@ -109,7 +109,7 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char='-', unknown='X',
             corr_method = 0
         else:
             raise TypeError("Nucl Sequences Error, Unknown type to assign "
-                            "correspondance method")
+                            "correspondence method")
     else:
         if not isinstance(corr_dict, dict):
             raise TypeError("corr_dict should be a dict that corresponds "
@@ -134,7 +134,7 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char='-', unknown='X',
                                "than number of protein records "
                                "({1})".format(len(corr_dict), pro_num))
 
-    # set up pro-nucl correspondance based on corr_method
+    # set up pro-nucl correspondence based on corr_method
     # corr_method = 0, consecutive pairing
     if corr_method == 0:
         pro_nucl_pair = izip(pro_align, nucl_seqs)
@@ -166,7 +166,7 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char='-', unknown='X',
     codon_aln = []
     shift = None
     for pair in pro_nucl_pair:
-        # Beaware that the following span corresponds to an ungapped
+        # Beware that the following span corresponds to an ungapped
         # nucleotide sequence.
         corr_span = _check_corr(pair[0], pair[1], gap_char=gap_char,
                                 codon_table=codon_table,
@@ -204,7 +204,7 @@ def _codons2re(codons):
 
 def _get_aa_regex(codon_table, stop='*', unknown='X'):
     """Set up the regular expression of a given CodonTable for
-    futher use.
+    further use.
 
     >>> from Bio.Data.CodonTable import generic_by_id
     >>> p = generic_by_id[1]

--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -93,7 +93,7 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char='-', unknown='X',
             nucl_seqs = tuple(nucl_seqs)
         nucl_num = len(nucl_seqs)
         if pro_num > nucl_num:
-            raise ValueError("More Number of SeqRecords in Protein Alignment "
+            raise ValueError("Higher Number of SeqRecords in Protein Alignment "
                              "({0}) than the Number of Nucleotide SeqRecords "
                              "({1}) are found!".format(pro_num, nucl_num))
 
@@ -246,7 +246,7 @@ def _check_corr(pro, nucl, gap_char='-', codon_table=default_codon_table,
     from Bio.Alphabet import NucleotideAlphabet
 
     if not all([isinstance(pro, SeqRecord), isinstance(nucl, SeqRecord)]):
-        raise TypeError("_check_corr accept two SeqRecord object. Please "
+        raise TypeError("_check_corr accepts two SeqRecord object. Please "
                         "check your input.")
 
     def get_alpha(alpha):

--- a/Bio/codonalign/chisq.py
+++ b/Bio/codonalign/chisq.py
@@ -4,7 +4,6 @@ Adapted from SciPy: scipy/special/cephes/{chdtr,igam}.
 """
 
 import math
-import sys
 
 __docformat__ = "restructuredtext en"
 

--- a/Bio/codonalign/codonalignment.py
+++ b/Bio/codonalign/codonalignment.py
@@ -43,7 +43,7 @@ class CodonAlignment(MultipleSeqAlignment):
         # check the type of the alignment to be nucleotide
         for rec in self:
             if not isinstance(rec.seq, CodonSeq):
-                raise TypeError("CodonSeq object are expected in each "
+                raise TypeError("CodonSeq objects are expected in each "
                                 "SeqRecord in CodonAlignment")
 
         assert self.get_alignment_length() % 3 == 0, \
@@ -183,7 +183,7 @@ def mktest(codon_alns, codon_table=default_codon_table, alpha=0.05):
     """
     import copy
     if not all([isinstance(i, CodonAlignment) for i in codon_alns]):
-        raise TypeError("mktest accept CodonAlignment list.")
+        raise TypeError("mktest accepts CodonAlignment list.")
     codon_aln_len = [i.get_alignment_length() for i in codon_alns]
     if len(set(codon_aln_len)) != 1:
         raise RuntimeError("CodonAlignment object for mktest should be of"

--- a/Bio/codonalign/codonalignment.py
+++ b/Bio/codonalign/codonalignment.py
@@ -5,7 +5,7 @@
 # as part of this package.
 """Code for dealing with Codon Alignment.
 
-CodonAlignment class is interited from MultipleSeqAlignment class. This is
+CodonAlignment class is inherited from MultipleSeqAlignment class. This is
 the core class to deal with codon alignment in biopython.
 """
 from __future__ import division, print_function
@@ -155,7 +155,7 @@ class CodonAlignment(MultipleSeqAlignment):
             dn_tree = dn_constructor.nj(dn_dm)
             ds_tree = ds_constructor.nj(ds_dm)
         else:
-            raise RuntimeError("Unkown tree method ({0}). Only NJ and UPGMA "
+            raise RuntimeError("Unknown tree method ({0}). Only NJ and UPGMA "
                                "are accepted.".format(tree_method))
         return dn_tree, ds_tree
 
@@ -233,7 +233,7 @@ def mktest(codon_alns, codon_table=default_codon_table, alpha=0.05):
 
 
 def _get_codon2codon_matrix(codon_table=default_codon_table):
-    """Function to get codon codon subsitution matrix. Elements
+    """Function to get codon codon substitution matrix. Elements
     in the matrix are number of synonymous and nonsynonymous
     substitutions required for the substitution (PRIVATE).
     """
@@ -287,7 +287,7 @@ def _dijkstra(graph, start, end):
     Dijkstra's algorithm Python implementation.
     Algorithm adapted from
     http://thomas.pelletier.im/2010/02/dijkstras-algorithm-python-implementation/.
-    However, an abvious bug in::
+    However, an obvious bug in::
 
         if D[child_node] >(<) D[node] + child_value:
 
@@ -296,12 +296,12 @@ def _dijkstra(graph, start, end):
 
     Arguments:
 
-        - graph: Dictionnary of dictionnary (keys are vertices).
+        - graph: Dictionary of dictionary (keys are vertices).
         - start: Start vertex.
         - end: End vertex.
 
     Output:
-        List of vertices from the beggining to the end.
+        List of vertices from the beginning to the end.
     """
     D = {}  # Final distances dict
     P = {}  # Predecessor dict

--- a/Bio/codonalign/codonalphabet.py
+++ b/Bio/codonalign/codonalphabet.py
@@ -17,9 +17,7 @@ try:
 except ImportError:
     izip = zip
 
-from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
-from Bio.Alphabet import IUPAC, Gapped, HasStopCodon, Alphabet, generic_dna
+from Bio.Alphabet import IUPAC, Gapped, HasStopCodon, Alphabet
 from Bio.Data.CodonTable import generic_by_id
 
 default_codon_table = copy.deepcopy(generic_by_id[1])

--- a/Bio/codonalign/codonalphabet.py
+++ b/Bio/codonalign/codonalphabet.py
@@ -5,7 +5,7 @@
 # as part of this package.
 """Code for Codon Alphabet.
 
-CodonAlphabet class is interited from Alphabet class. It is an
+CodonAlphabet class is inherited from Alphabet class. It is an
 alphabet for CodonSeq class.
 """
 __docformat__ = "restructuredtext en"  # Don't just use plain text in epydoc API pages!
@@ -27,8 +27,8 @@ default_codon_table = copy.deepcopy(generic_by_id[1])
 
 def get_codon_alphabet(alphabet, gap="-", stop="*"):
     """Gets alignment alphabet for codon alignment.
-    
-    Only nucleotide alphabet is accepted. Raise an error when the type of 
+
+    Only nucleotide alphabet is accepted. Raise an error when the type of
     alphabet is incompatible.
     """
     from Bio.Alphabet import NucleotideAlphabet

--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -5,7 +5,7 @@
 # as part of this package.
 """Code for dealing with coding sequence.
 
-CodonSeq class is interited from Seq class. This is the core class to
+CodonSeq class is inherited from Seq class. This is the core class to
 deal with sequences in CodonAlignment in biopython.
 
 """
@@ -314,7 +314,7 @@ def cal_dn_ds(codon_seq1, codon_seq2, method="NG86",
     Arguments:
         - codon_seq1 - CodonSeq or or SeqRecord that contains a CodonSeq
         - codon_seq2 - CodonSeq or or SeqRecord that contains a CodonSeq
-        - w  - transition/transvertion ratio
+        - w  - transition/transversion ratio
         - cfreq - Current codon frequency vector can only be specified
           when you are using ML method. Possible ways of
           getting cfreq are: F1x4, F3x4 and F61.
@@ -750,7 +750,7 @@ def _yn00(seq1, seq2, k, codon_table):
                                 codon_table.stop_codons if 'U' not in i]
         Q = _get_Q(pi, kappa, w, codon_lst, codon_table)
         P = expm(Q * t)
-        TV = [0, 0, 0, 0]  # synonymous/nonsynonymous transition/transvertion
+        TV = [0, 0, 0, 0]  # synonymous/nonsynonymous transition/transversion
         sites = [0, 0]
         codon_npath = {}
         for i, j in zip(seq1, seq2):
@@ -896,7 +896,7 @@ def _count_diff_YN00(codon1, codon2, P, codon_lst,
 
     The function will weighted multiple pathways from codon1 to codon2
     according to P matrix of codon substitution. The proportion
-    of transition and transvertion (TV) will also be calculated in
+    of transition and transversion (TV) will also be calculated in
     the function.
     """
     if not all([isinstance(codon1, str), isinstance(codon2, str)]):
@@ -908,7 +908,7 @@ def _count_diff_YN00(codon1, codon2, P, codon_lst,
     if len(codon1) != 3 or len(codon2) != 3:
         raise RuntimeError("codon should be three letter string ({0}, {1} "
                            "detected)".format(len(codon1), len(codon2)))
-    TV = [0, 0, 0, 0]  # transition and transvertion counts (synonymous and nonsynonymous)
+    TV = [0, 0, 0, 0]  # transition and transversion counts (synonymous and nonsynonymous)
     site = 0
     if codon1 == '---' or codon2 == '---':
         return TV

--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -15,9 +15,7 @@ from math import log
 
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.Alphabet import IUPAC, Gapped, HasStopCodon, Alphabet
 from Bio.Alphabet import generic_dna, _ungap
-from Bio.Data.CodonTable import generic_by_id
 
 from Bio.codonalign.codonalphabet import default_codon_alphabet, default_codon_table
 

--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -154,7 +154,7 @@ class CodonSeq(Seq):
         purpose.
         """
         amino_acids = []
-        if ungap_seq is True:
+        if ungap_seq:
             tr_seq = self._data.replace(self.gap_char, "")
         else:
             tr_seq = self._data

--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -1,4 +1,4 @@
-# Copyright 2013 by Zheng Ruan (zruan1991@gmai.com).
+# Copyright 2013 by Zheng Ruan (zruan1991@gmail.com).
 # All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included

--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -114,7 +114,7 @@ class CodonSeq(Seq):
             raise RuntimeError("frameshift detected. "
                                "CodonSeq object is not able to deal "
                                "with codon sequence with frameshift. "
-                               "Plase use normal slice option.")
+                               "Please use normal slice option.")
         if isinstance(index, int):
             if index != -1:
                 return self._data[index * 3:(index + 1) * 3]
@@ -186,8 +186,8 @@ class CodonSeq(Seq):
             try:
                 amino_acids.append(codon_table.forward_table[codon])
             except KeyError:
-                raise RuntimeError("Unknown codon detected ({0}). Do you "
-                                   "forget to speficy ungap_seq "
+                raise RuntimeError("Unknown codon detected ({0}). Did you "
+                                   "forget to specify the ungap_seq "
                                    "argument?".format(codon))
         return "".join(amino_acids)
 
@@ -288,7 +288,7 @@ def _get_codon_list(codonseq):
         elif str(codonseq[int(k):int(k) + 3]) == "---":
             codon_lst.append("---")
         else:
-            # this may be problematic, as normally no codon shoud
+            # this may be problematic, as normally no codon should
             # fall into this condition
             codon_lst.append(codonseq[int(k):int(k) + 3])
     return codon_lst
@@ -458,7 +458,7 @@ def _count_diff_NG86(codon1, codon2, codon_table=default_codon_table):
     into account.
     """
     if not all([isinstance(codon1, str), isinstance(codon2, str)]):
-        raise TypeError("_count_diff_NG86 accept string object to represent "
+        raise TypeError("_count_diff_NG86 accepts string object to represent "
                         "codon ({0}, {1} detected)".format(
                                                         type(codon1),
                                                         type(codon2))
@@ -472,11 +472,11 @@ def _count_diff_NG86(codon1, codon2, codon_table=default_codon_table):
     base_tuple = ('A', 'C', 'G', 'T')
     if not all([i in base_tuple for i in codon1]):
         raise RuntimeError("Unrecognized character detected in codon1 {0} "
-                           "(Codon is consist of "
+                           "(Codons consist of "
                            "A, T, C or G)".format(codon1))
     if not all([i in base_tuple for i in codon2]):
         raise RuntimeError("Unrecognized character detected in codon2 {0} "
-                           "(Codon is consist of "
+                           "(Codons consist of "
                            "A, T, C or G)".format(codon2))
     if codon1 == codon2:
         return SN
@@ -898,7 +898,7 @@ def _count_diff_YN00(codon1, codon2, P, codon_lst,
     the function.
     """
     if not all([isinstance(codon1, str), isinstance(codon2, str)]):
-        raise TypeError("_count_diff_YN00 accept string object to represent "
+        raise TypeError("_count_diff_YN00 accepts string object to represent "
                         "codon ({0}, {1} detected)".format(
                                                         type(codon1),
                                                         type(codon2))
@@ -913,11 +913,11 @@ def _count_diff_YN00(codon1, codon2, P, codon_lst,
     base_tuple = ('A', 'C', 'G', 'T')
     if not all([i in base_tuple for i in codon1]):
         raise RuntimeError("Unrecognized character detected in codon1 {0} "
-                           "(Codon is consist of "
+                           "(Codons consist of "
                            "A, T, C or G)".format(codon1))
     if not all([i in base_tuple for i in codon2]):
         raise RuntimeError("Unrecognized character detected in codon2 {0} "
-                           "(Codon is consist of "
+                           "(Codons consist of "
                            "A, T, C or G)".format(codon2))
     if codon1 == codon2:
         return TV

--- a/Tests/test_codonalign.py
+++ b/Tests/test_codonalign.py
@@ -5,10 +5,8 @@
 
 """Unit tests for the Bio.codonalign modules.
 """
-import sys
 import warnings
 import tempfile
-import platform
 import unittest
 
 from Bio import BiopythonExperimentalWarning


### PR DESCRIPTION
PEP8 recommends against using the following statements:

```python
if variable == True:
```
```python
if variable is True:
```

PEP8 recommends using instead ``if variable:``

In this case, the variable ``shift`` in Bio.codonalign is meant to indicate True
or False. Thus, I replaced the line 167 to ``shift = False`` as None is not quite
the opposite of True.