### PR TITLE
Bio.Phylo._utils: usage of "if variable" and "if not variable"

### DIFF
--- a/Bio/Phylo/_utils.py
+++ b/Bio/Phylo/_utils.py
@@ -419,14 +419,14 @@ def draw(tree, label_func=str, do_show=True, show_confidence=True,
         Graphical formatting of the lines representing clades in the plot can be
         customized by altering this function.
         """
-        if (use_linecollection is False and orientation == 'horizontal'):
+        if not use_linecollection and orientation == 'horizontal':
             axes.hlines(y_here, x_start, x_here, color=color, lw=lw)
-        elif (use_linecollection is True and orientation == 'horizontal'):
+        elif use_linecollection and orientation == 'horizontal':
             horizontal_linecollections.append(mpcollections.LineCollection(
                 [[(x_start, y_here), (x_here, y_here)]], color=color, lw=lw),)
-        elif (use_linecollection is False and orientation == 'vertical'):
+        elif not use_linecollection and orientation == 'vertical':
             axes.vlines(x_here, y_bot, y_top, color=color)
-        elif (use_linecollection is True and orientation == 'vertical'):
+        elif use_linecollection and orientation == 'vertical':
             vertical_linecollections.append(mpcollections.LineCollection(
                 [[(x_here, y_bot), (x_here, y_top)]], color=color, lw=lw),)
 


### PR DESCRIPTION
PEP8 recommends against using the following statements:
```python
if variable == True:

if variable is True:
```

PEP8 recommends using instead ``if variable`` and ``if not variable`` when testing
for boolean values in variables.
Also removed redundant parentheses.

I guess this PR needs approval from @etal 