### PR TITLE
motifs/matrix.py: fix import of C-accelerated PWM code in Python 3

### DIFF
--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -364,7 +364,7 @@ class PositionSpecificScoringMatrix(GenericPositionMatrix):
         scores = []
         # check if the fast C code can be used
         try:
-            import _pwm
+            from . import _pwm
         except ImportError:
             # use the slower Python code otherwise
             # The C code handles mixed case so Python version must too:


### PR DESCRIPTION
While running many PWM searches, I found that my Python processes had no open
handles to _pwm.cpython-35m-x86_64-linux-gnu.so, making me suspect that the
fallback Python implementation was being used instead of the C-accelerated
version. I verified this with a `print` call inside the `except ImportError`
block (much easier than using a debugger on cluster compute nodes).

Change the absolute _pwm import to the relative `from . import _pwm`.