### PR TITLE
Bio/motifs/matrix.py: require C-accelerated PWM code under CPython

### DIFF
--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -7,6 +7,7 @@ and position-specific scoring matrices.
 """
 
 import math
+import platform
 
 from Bio._py3k import range
 
@@ -313,6 +314,33 @@ class PositionWeightMatrix(GenericPositionMatrix):
 
 class PositionSpecificScoringMatrix(GenericPositionMatrix):
 
+    # Make sure that we use C-accelerated PWM calculations if running under CPython.
+    # Fall back to the slower Python implementation if Jython or IronPython.
+    try:
+        from . import _pwm
+        def _calculate(self, sequence, m, n):
+            logodds = [[self[letter][i] for letter in "ACGT"] for i in range(m)]
+            return self._pwm.calculate(sequence, logodds)
+    except ImportError:
+        if platform.python_implementation() == 'CPython':
+            raise
+        else:
+            def _calculate(self, sequence, m, n):
+                # The C code handles mixed case so Python version must too:
+                sequence = sequence.upper()
+                scores = []
+                for i in range(n - m + 1):
+                    score = 0.0
+                    for position in range(m):
+                        letter = sequence[i + position]
+                        try:
+                            score += self[letter][position]
+                        except KeyError:
+                            score = float("nan")
+                            break
+                    scores.append(score)
+                return scores
+
     def calculate(self, sequence):
         """Returns the PWM score for a given sequence for all positions.
 
@@ -338,29 +366,8 @@ class PositionSpecificScoringMatrix(GenericPositionMatrix):
         m = self.length
         n = len(sequence)
 
-        scores = []
-        # check if the fast C code can be used
-        try:
-            from . import _pwm
-        except ImportError:
-            # use the slower Python code otherwise
-            # The C code handles mixed case so Python version must too:
-            sequence = sequence.upper()
-            for i in range(n - m + 1):
-                score = 0.0
-                for position in range(m):
-                    letter = sequence[i + position]
-                    try:
-                        score += self[letter][position]
-                    except KeyError:
-                        score = float("nan")
-                        break
-                scores.append(score)
-        else:
-            # get the log-odds matrix into a proper shape
-            # (each row contains sorted (ACGT) log-odds values)
-            logodds = [[self[letter][i] for letter in "ACGT"] for i in range(m)]
-            scores = _pwm.calculate(sequence, logodds)
+        scores = self._calculate(sequence, m, n)
+
         if len(scores) == 1:
             return scores[0]
         else:


### PR DESCRIPTION
Instead of attempting to import the `_pwm` module in every call to
`PositionSpecificScoringMatrix.calculate`, import it once at the beginning
of the class body. If the module can't be loaded and the code is running
under CPython, raise an ImportError. Otherwise, conditionally define a
private `_calculate` method, using the `_pwm` module if available and a
Python implementation if not.