### PR TITLE
when parsing paml/codeml config files, split options at first '=' 

### DIFF
--- a/Bio/Phylo/PAML/codeml.py
+++ b/Bio/Phylo/PAML/codeml.py
@@ -108,7 +108,7 @@ class Codeml(Paml):
                         if "=" not in uncommented:
                             raise AttributeError(
                                 "Malformed line in control file:\n%r" % line)
-                        (option, value) = uncommented.split("=")
+                        (option, value) = uncommented.split("=",1)
                         option = option.strip()
                         value = value.strip()
                         if option == "seqfile":


### PR DESCRIPTION
`Bio.Phylo.PAML.codeml.read_ctl_file` cannot parse cofig options that have embeded '='

Parsing a codeml option file like this fails,

    seqfile = /purifying/noindel/pop=1000/sample_aln_fixed.fa

because there are '=' characters in the value.
Fix is to only consider the first '=' as separating name from value.