### PR TITLE
various Nexus parsing fixes

### DIFF
--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -36,7 +36,7 @@ SPECIAL_COMMANDS = ['charstatelabels', 'charlabels', 'taxlabels', 'taxset',
                     'charset', 'charpartition', 'taxpartition', 'matrix',
                     'tree', 'utree', 'translate', 'codonposset', 'title']
 KNOWN_NEXUS_BLOCKS = ['trees', 'data', 'characters', 'taxa', 'sets', 'codons']
-PUNCTUATION = '()[]{}/\,;:=*\'"`+-<>'
+PUNCTUATION = '()[]{}\,;:=*\'"`+-<>'
 MRBAYESSAFE = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_'
 WHITESPACE = ' \t\n'
 # SPECIALCOMMENTS = ['!','&','%','/','\\','@'] # original list of special comments

--- a/Bio/Nexus/Trees.py
+++ b/Bio/Nexus/Trees.py
@@ -100,14 +100,20 @@ class Tree(Nodes.Chain):
             subtrees = []
             plevel = 0
             prev = 1
+            incomment = False
             for p in range(1, closing):
-                if tree[p] == '(':
+                if not incomment and tree[p] == '(':
                     plevel += 1
-                elif tree[p] == ')':
+                elif not incomment and tree[p] == ')':
                     plevel -= 1
-                elif tree[p] == ',' and plevel == 0:
+                elif tree[p:].startswith(NODECOMMENT_START):
+                    incomment = True
+                elif incomment and tree[p] == NODECOMMENT_END:
+                    incomment = False
+                elif not incomment and tree[p] == ',' and plevel == 0:
                     subtrees.append(tree[prev:p])
                     prev = p + 1
+                    
             subtrees.append(tree[prev:closing])
             subclades = [self._parse(subtree) for subtree in subtrees]
             return [subclades, val]
@@ -152,7 +158,6 @@ class Tree(Nodes.Chain):
 
     def _get_values(self, text):
         """Extracts values (support/branchlength) from xx[:yyy], xx."""
-
         if text == '':
             return None
         nodecomment = None

--- a/Tests/test_Nexus.py
+++ b/Tests/test_Nexus.py
@@ -5,6 +5,7 @@
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
+from __future__ import print_function
 
 import os.path
 import unittest
@@ -412,6 +413,33 @@ Root:  16
                     cur_node.get_succ()])
             cur_nodes = new_nodes
         return nodedata
+
+    def test_NexusComments(self):
+        """Test the ability to parse nexus comments at internal and leaf nodes
+        """
+        # A tree with simple comments throughout the tree.
+        ts1b = "((12:0.13,19[&comment1]:0.13)[&comment2]:0.1,(20:0.171,11:0.171):0.13)[&comment3];"
+        tree = Trees.Tree(ts1b)
+        self.assertEqual(self._get_flat_nodes(tree), [(None, 0.0, None, '[&comment3]'),
+                                                      (None, 0.1, None, '[&comment2]'),
+                                                      (None, 0.13, None, None), ('12', 0.13, None, None),
+                                                      ('19', 0.13, None, '[&comment1]'),
+                                                      ('20', 0.171, None, None),
+                                                      ('11', 0.171, None, None)])
+
+        # A tree with more complex comments throughout the tree.
+        # This is typical of the MCC trees produced by `treeannotator` in the beast-mcmc suite of phylogenetic tools
+        # The key difference being tested here is the ability to parse internal node comments that include ','.
+        ts1b = "(((9[&rate_range={1.3E-5,0.10958320752991428},height_95%_HPD={0.309132419999969,0.3091324199999691},length_range={3.513906814545109E-4,0.4381986285528381},height_median=0.309132419999969,length_95%_HPD={0.003011577063374571,0.08041621647998398}]:0.055354097721950546,5[&rate_range={1.3E-5,0.10958320752991428},height_95%_HPD={0.309132419999969,0.3091324199999691},length_range={3.865051168833178E-5,0.4391594442572986},height_median=0.309132419999969,length_95%_HPD={0.003011577063374571,0.08041621647998398}]:0.055354097721950546)[&height_95%_HPD={0.3110921040545068,0.38690865205576275},length_range={0.09675588357303178,0.4332959544380489},length_95%_HPD={0.16680375169879613,0.36500804261814374}]:0.20039426358269385)[&height_95%_HPD={0.5289500597932948,0.6973881165460601},length_range={0.02586430194846201,0.29509451958008265},length_95%_HPD={0.0840287249314221,0.2411078625957056}]:0.23042678598484334)[&height_95%_HPD={0.7527502510685965,0.821862094763501},height_median=0.8014438411766163,height=0.795965080422763,posterior=1.0,height_range={0.49863013698599995,0.821862094763501},length=0.0];"
+        tree = Trees.Tree(ts1b)
+        self.assertEqual(self._get_flat_nodes(tree), [(None, 0.0, None, '[&height_95%_HPD={0.7527502510685965,0.821862094763501},height_median=0.8014438411766163,height=0.795965080422763,posterior=1.0,height_range={0.49863013698599995,0.821862094763501},length=0.0]'),
+                                                      (None, 0.23042678598484334, None, '[&height_95%_HPD={0.5289500597932948,0.6973881165460601},length_range={0.02586430194846201,0.29509451958008265},length_95%_HPD={0.0840287249314221,0.2411078625957056}]'),
+                                                      (None, 0.20039426358269385, None, '[&height_95%_HPD={0.3110921040545068,0.38690865205576275},length_range={0.09675588357303178,0.4332959544380489},length_95%_HPD={0.16680375169879613,0.36500804261814374}]'),
+                                                      ('9', 0.055354097721950546, None, '[&rate_range={1.3E-5,0.10958320752991428},height_95%_HPD={0.309132419999969,0.3091324199999691},length_range={3.513906814545109E-4,0.4381986285528381},height_median=0.309132419999969,length_95%_HPD={0.003011577063374571,0.08041621647998398}]'),
+                                                      ('5', 0.055354097721950546, None, '[&rate_range={1.3E-5,0.10958320752991428},height_95%_HPD={0.309132419999969,0.3091324199999691},length_range={3.865051168833178E-5,0.4391594442572986},height_median=0.309132419999969,length_95%_HPD={0.003011577063374571,0.08041621647998398}]')])
+
+        
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
- remove '/' from the list of prohibited characters in identifiers when reading nexus files.
  I was unable to access the original nexus spec, but this change was made under the robustness
  principle - be liberal in what you accept, conservative in what you produce.
- allow ',' in nexus comments on internal nodes.  Perviously ',' was
  allowed in the comments on the whole tree (most encapsulating node)
  but through a quirk in the parser ',' could not appear in the
  comments of internal nodes.
- add Nexus test cases to check if comment parsing is working as expected.

I ran into problems parsing Nexus format trees produced from sequences whose name contained a date, e.g. 'patient1_1000_116|1M|XXX|XXX|2011/11/10'

Nexus files produced by Beast and treeannotator often have ',' in the comments on each node.  The Nexus parser was not handling that case.   
I added a couple of test cases to demonstrate the enhanced comment parsing.
