### PR TITLE
AlignIO: improve StockholmIO performance by eliminating array search

### DIFF
--- a/Bio/AlignIO/StockholmIO.py
+++ b/Bio/AlignIO/StockholmIO.py
@@ -136,7 +136,7 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Align import MultipleSeqAlignment
 from .Interfaces import AlignmentIterator, SequentialAlignmentWriter
-
+from collections import OrderedDict
 
 class StockholmWriter(SequentialAlignmentWriter):
     """Stockholm/PFAM alignment writer."""
@@ -337,7 +337,7 @@ class StockholmIterator(AlignmentIterator):
         # if present it agrees with our parsing.
 
         seqs = {}
-        ids = []
+        ids = OrderedDict() # Really only need an OrderedSet, but python lacks this
         gs = {}
         gr = {}
         gf = {}
@@ -368,7 +368,7 @@ class StockholmIterator(AlignmentIterator):
                                       + "and sequence:\n" + line)
                 id, seq = parts
                 if id not in ids:
-                    ids.append(id)
+                    ids[id] = True
                 seqs.setdefault(id, '')
                 seqs[id] += seq.replace(".", "-")
             elif len(line) >= 5:
@@ -419,7 +419,7 @@ class StockholmIterator(AlignmentIterator):
         # assert len(gs)   <= len(ids)
         # assert len(gr)   <= len(ids)
 
-        self.ids = ids
+        self.ids = ids.keys()
         self.sequences = seqs
         self.seq_annotation = gs
         self.seq_col_annotation = gr
@@ -433,7 +433,7 @@ class StockholmIterator(AlignmentIterator):
 
             alignment_length = len(list(seqs.values())[0])
             records = []  # Alignment obj will put them all in a list anyway
-            for id in ids:
+            for id in ids.keys():
                 seq = seqs[id]
                 if alignment_length != len(seq):
                     raise ValueError("Sequences have different lengths, or repeated identifier")

--- a/Bio/AlignIO/StockholmIO.py
+++ b/Bio/AlignIO/StockholmIO.py
@@ -3,6 +3,8 @@
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
+
+# Ben Woodcroft added modifications to improve read performance
 """Bio.AlignIO support for "stockholm" format (used in the PFAM database).
 
 You are expected to use this module via the Bio.AlignIO functions (or the
@@ -136,7 +138,7 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Align import MultipleSeqAlignment
 from .Interfaces import AlignmentIterator, SequentialAlignmentWriter
-from collections import OrderedDict
+from Bio._py3k import OrderedDict
 
 class StockholmWriter(SequentialAlignmentWriter):
     """Stockholm/PFAM alignment writer."""
@@ -433,7 +435,7 @@ class StockholmIterator(AlignmentIterator):
 
             alignment_length = len(list(seqs.values())[0])
             records = []  # Alignment obj will put them all in a list anyway
-            for id in ids.keys():
+            for id in ids:
                 seq = seqs[id]
                 if alignment_length != len(seq):
                     raise ValueError("Sequences have different lengths, or repeated identifier")


### PR DESCRIPTION
Hi,

I noticed that reading stockholm format files becomes quite slow when there are large numbers of sequences involved. The slowness gets worse quickly, super-linearly, so cutting it down to something more manageable,

before
```
$ time hmmalign DNGNGWU00016_mingle_output_good_seqs.hmm <(head -n50000 a.fa) | seqmagick convert --input-format stockholm - out2.fa 

real	0m9.803s
user	0m9.972s
sys	0m0.140s
```
after (output was the same)
```
$ time hmmalign DNGNGWU00016_mingle_output_good_seqs.hmm <(head -n50000 a.fa) | seqmagick convert --input-format stockholm - out2.fa 

real	0m2.423s
user	0m2.504s
sys	0m0.132s
```
The specific issue was a repeated search of the `ids` array, so I replaced this with a hash. Only really want an OrderedSet not an OrderedDict, but figured OrderedDict does the job and all the mess incurred is contained the `__next__` function.

Thanks
ben