### PR TITLE
Correct descsription of Patser threshold

### DIFF
--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -1178,9 +1178,9 @@ or a threshold (approximately) satisfying some relation between the false-positi
 >>> print("%5.3f" % threshold)
 6.241
 \end{verbatim}
-or a threshold satisfying (roughly) the equality between the
-false-positive rate and the $-log$ of the information content (as used
-in patser software by Hertz and Stormo):
+or a threshold satisfying (roughly) the equality between the $-log$ of the
+false-positive rate and the information content (as used in patser software by
+Hertz and Stormo):
 %cont-doctest
 \begin{verbatim}
 >>> threshold = distribution.threshold_patser()


### PR DESCRIPTION
The description in documentation and [the docstring](https://github.com/biopython/biopython/blob/fd893554fe343985429da69d5e107d6ee96766be/Bio/motifs/thresholds.py#L106) don't agree. Fixed the description of Patser threshold in documentation.