### PR TITLE
SeqFeature.Reference: Implement __eq__

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -545,6 +545,16 @@ class Reference(object):
         return "%s(title=%s, ...)" % (self.__class__.__name__,
                                       repr(self.title))
 
+    def __eq__(self, other):
+        """Check if two Reference objects should be considered equal"""
+        return self.authors == other.authors and \
+            self.consrtm == other.consrtm and \
+            self.title == other.title and \
+            self.journal == other.journal and \
+            self.medline_id == other.medline_id and \
+            self.pubmed_id == other.pubmed_id and \
+            self.comment == other.comment
+
 
 # --- Handling feature locations
 

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -546,7 +546,11 @@ class Reference(object):
                                       repr(self.title))
 
     def __eq__(self, other):
-        """Check if two Reference objects should be considered equal"""
+        """Check if two Reference objects should be considered equal
+
+        Note that the location is not compared, as __eq__ for the
+        FeatureLocation class is not defined.
+        """
         return self.authors == other.authors and \
             self.consrtm == other.consrtm and \
             self.title == other.title and \

--- a/Tests/test_Reference.py
+++ b/Tests/test_Reference.py
@@ -1,0 +1,27 @@
+# Copyright 2015 by Kai Blin.  All rights reserved.
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+
+"""Tests for Reference objects from Bio.SeqFeature.
+"""
+import unittest
+from os import path
+from Bio import SeqIO
+from Bio.SeqFeature import Reference
+
+class TestReference(unittest.TestCase):
+
+    def test_eq_identical(self):
+        """Test two identical references eq() to True"""
+        testfile = path.join('GenBank', 'origin_line.gb')
+        rec1 = SeqIO.read(testfile, 'genbank')
+        rec2 = SeqIO.read(testfile, 'genbank')
+
+        self.assertEqual(rec1.annotations['references'][0], rec1.annotations['references'][0])
+        cmp1, cmp2 = rec1.annotations['references'][0], rec2.annotations['references'][0]
+        self.assertEqual(cmp1, cmp2, "%s vs %s" % (cmp1, cmp2))
+        self.assertNotEqual(rec1.annotations['references'][0], rec1.annotations['references'][1])
+        self.assertNotEqual(rec1.annotations['references'][0], rec2.annotations['references'][1])
+        self.assertEqual(rec1.annotations['references'][1], rec1.annotations['references'][1])
+        self.assertEqual(rec1.annotations['references'][1], rec2.annotations['references'][1])

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -21,7 +21,7 @@ class TestReference(unittest.TestCase):
 
         self.assertEqual(rec1.annotations['references'][0], rec1.annotations['references'][0])
         cmp1, cmp2 = rec1.annotations['references'][0], rec2.annotations['references'][0]
-        self.assertEqual(cmp1, cmp2, "{} vs {}".format(cmp1, cmp2))
+        self.assertEqual(cmp1, cmp2)
         self.assertNotEqual(rec1.annotations['references'][0], rec1.annotations['references'][1])
         self.assertNotEqual(rec1.annotations['references'][0], rec2.annotations['references'][1])
         self.assertEqual(rec1.annotations['references'][1], rec1.annotations['references'][1])

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -3,7 +3,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
-"""Tests for Reference objects from Bio.SeqFeature.
+"""Tests Bio.SeqFeature.
 """
 import unittest
 from os import path
@@ -11,6 +11,7 @@ from Bio import SeqIO
 from Bio.SeqFeature import Reference
 
 class TestReference(unittest.TestCase):
+    """Tests for the SeqFeature.Reference class"""
 
     def test_eq_identical(self):
         """Test two identical references eq() to True"""

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -8,7 +8,7 @@
 import unittest
 from os import path
 from Bio import SeqIO
-from Bio.SeqFeature import Reference
+
 
 class TestReference(unittest.TestCase):
     """Tests for the SeqFeature.Reference class"""
@@ -21,7 +21,7 @@ class TestReference(unittest.TestCase):
 
         self.assertEqual(rec1.annotations['references'][0], rec1.annotations['references'][0])
         cmp1, cmp2 = rec1.annotations['references'][0], rec2.annotations['references'][0]
-        self.assertEqual(cmp1, cmp2, "%s vs %s" % (cmp1, cmp2))
+        self.assertEqual(cmp1, cmp2, "{} vs {}".format(cmp1, cmp2))
         self.assertNotEqual(rec1.annotations['references'][0], rec1.annotations['references'][1])
         self.assertNotEqual(rec1.annotations['references'][0], rec2.annotations['references'][1])
         self.assertEqual(rec1.annotations['references'][1], rec1.annotations['references'][1])


### PR DESCRIPTION
Allow two reference objects to be checked for equality. This should fix issue #600.
Note that this currently does not check for location identity, as FeatureLocations
also don't implement __eq__ at the moment.

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>