### PR TITLE
PDBParser: uppercase element names

### DIFF
--- a/Bio/PDB/PDBParser.py
+++ b/Bio/PDB/PDBParser.py
@@ -201,7 +201,7 @@ class PDBParser(object):
                                                global_line_counter)
                     bfactor = 0.0  # The PDB use a default of zero if the data is missing
                 segid = line[72:76]
-                element = line[76:78].strip()
+                element = line[76:78].strip().upper()
                 if current_segid != segid:
                     current_segid = segid
                     structure_builder.init_seg(current_segid)


### PR DESCRIPTION
Avoid problems with lower/mixed case element names, as discussed on ML:
http://mailman.open-bio.org/pipermail/biopython/2015-May/015619.html

This could be fixed in other ways, or fixed only if `self.PERMISSIVE`.
But if the pdb format definition doesn't say anything about lower/upper case, it shouldn't harm to accept lowercase even in strict mode.