### PR TITLE
Bio.SeqIO._index: removed duplicated key in dictionary

### DIFF
--- a/Bio/SeqIO/_index.py
+++ b/Bio/SeqIO/_index.py
@@ -176,7 +176,6 @@ class SequentialSeqFileRandomAccess(SeqFileRandomAccess):
                   "phd": "BEGIN_SEQUENCE",
                   "pir": ">..;",
                   "qual": ">",
-                  "qual": ">",
                   "swiss": "ID ",
                   "uniprot-xml": "<entry ",
                   }[format]


### PR DESCRIPTION
Bug identified by QuantifiedCode: <https://www.quantifiedcode.com/app/project/554b34dfff644b75b9f647aeab1d6461>