### PR TITLE
Added score/keys parsing to EmbossIO

### DIFF
--- a/Bio/AlignIO/EmbossIO.py
+++ b/Bio/AlignIO/EmbossIO.py
@@ -95,6 +95,7 @@ class EmbossIterator(AlignmentIterator):
         number_of_seqs = None
         ids = []
         seqs = []
+        header_dict = {}
 
         while line[0] == "#":
             # Read in the rest of this alignment header,
@@ -116,7 +117,6 @@ class EmbossIterator(AlignmentIterator):
                 length_of_seqs = int(parts[1].strip())
                 
             # Parse the rest of the header
-            header_dict = {}
             if key == 'identity':
                 header_dict['identity'] = int(parts[1].strip().split('/')[0])
             if key == 'similarity':

--- a/Bio/AlignIO/EmbossIO.py
+++ b/Bio/AlignIO/EmbossIO.py
@@ -114,6 +114,17 @@ class EmbossIterator(AlignmentIterator):
                 assert len(ids) == number_of_seqs
             if key == "length":
                 length_of_seqs = int(parts[1].strip())
+                
+            # Parse the rest of the header
+            header_dict = {}
+            if key == 'identity':
+                header_dict['identity'] = int(parts[1].strip().split('/')[0])
+            if key == 'similarity':
+                header_dict['similarity'] = int(parts[1].strip().split('/')[0])
+            if key == 'gaps':
+                header_dict['gaps'] = int(parts[1].strip().split('/')[0])      
+            if key == 'score':
+                header_dict['score'] = float(parts[1].strip())
 
             # And read in another line...
             line = handle.readline()
@@ -223,4 +234,4 @@ class EmbossIterator(AlignmentIterator):
                                  "old version of EMBOSS.")
             records.append(SeqRecord(Seq(seq, self.alphabet),
                                      id=id, description=id))
-        return MultipleSeqAlignment(records, self.alphabet)
+        return MultipleSeqAlignment(records, self.alphabet, annotations=header_dict)


### PR DESCRIPTION
Needed EmbossIO to retain alignment scores from `needle` for a project of mine, was surprised that this wasn't already supported. Found this discussion thread (http://article.gmane.org/gmane.comp.python.bio.general/7979/match=emboss+alignio+score) and figured that this might be a useful addition.

I'm new, so I'm not sure about the grand architecture of this kind of thing. Maybe its proper home is in SearchIO? But it seems like it would be useful in AlignIO as well.

Actual change just reads the values for the tags 'identity', 'similarity', 'gaps', and 'score' into a dictionary, and sets the 'annotations' field of the returned MultipleSeqAlignment object to be that dictionary.
