### PR TITLE
Remove unnecessary "global" keyword usage.

### DIFF
--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -748,7 +748,6 @@ class BioSeqDatabase(object):
         db_loader = Loader.DatabaseLoader(self.adaptor, self.dbid,
                                           fetch_NCBI_taxonomy)
         num_records = 0
-        global _POSTGRES_RULES_PRESENT
         for cur_record in record_iterator:
             num_records += 1
             # Hack to work arround BioSQL Bug 2839 - If using PostgreSQL and

--- a/Scripts/xbbtools/nextorf.py
+++ b/Scripts/xbbtools/nextorf.py
@@ -216,7 +216,6 @@ class NextOrf(object):
 
 
 def help():
-    global options
     print('Usage: %s (<options>) <FASTA file>' % sys.argv[0])
     print("")
     print('Options:                                                       default')

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -37,7 +37,6 @@ if __name__ == "__main__":
     raise RuntimeError("Call this via test_BioSQL_*.py not directly")
 
 global DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB, DBSCHEMA, SQL_FILE
-global SYSTEM
 
 SYSTEM = platform.system()
 
@@ -57,8 +56,7 @@ def temp_db_filename():
 
 
 def check_config(dbdriver, dbtype, dbhost, dbuser, dbpasswd, testdb):
-    global DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB, DBSCHEMA
-    global SYSTEM, SQL_FILE
+    global DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB, DBSCHEMA, SQL_FILE
     DBDRIVER = dbdriver
     DBTYPE = dbtype
     DBHOST = dbhost


### PR DESCRIPTION
It's only needed when writing to a global variable.

Identified via landscape.io