### PR TITLE
Fix "Consider an iterator instead of materializing the list" issue

### DIFF
--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -924,7 +924,7 @@ class ParsimonyScorer(Scorer):
         terms = tree.get_terminals()
         terms.sort(key=lambda term: term.name)
         alignment.sort()
-        if not all([t.name == a.id for t, a in zip(terms, alignment)]):
+        if not all( t.name == a.id for t, a in zip(terms, alignment)):
             raise ValueError(
                 "Taxon names of the input tree should be the same with the alignment.")
         # term_align = dict(zip(terms, alignment))

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -497,7 +497,7 @@ class QueryResult(_BaseSearchObject):
         else:
             hit_key = hit.id
 
-        if hit_key not in self and all([pid not in self for pid in hit.id_all[1:]]):
+        if hit_key not in self and all( pid not in self for pid in hit.id_all[1:]):
             self[hit_key] = hit
         else:
             raise ValueError("The ID or alternative IDs of Hit %r exists in "

--- a/Bio/codonalign/codonalignment.py
+++ b/Bio/codonalign/codonalignment.py
@@ -182,7 +182,7 @@ def mktest(codon_alns, codon_table=default_codon_table, alpha=0.05):
     Return the p-value of test result
     """
     import copy
-    if not all([isinstance(i, CodonAlignment) for i in codon_alns]):
+    if not all( isinstance(i, CodonAlignment) for i in codon_alns):
         raise TypeError("mktest accepts CodonAlignment list.")
     codon_aln_len = [i.get_alignment_length() for i in codon_alns]
     if len(set(codon_aln_len)) != 1:
@@ -212,7 +212,7 @@ def mktest(codon_alns, codon_table=default_codon_table, alpha=0.05):
         all_codon = i[0].union(*i[1:])
         if '-' in all_codon or len(all_codon) == 1:
             continue
-        fix_or_not = all([len(k) == 1 for k in i])
+        fix_or_not = all( len(k) == 1 for k in i)
         if fix_or_not:
             # fixed
             nonsyn_subgraph = _get_subgraph(all_codon, nonsyn_G)

--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -470,11 +470,11 @@ def _count_diff_NG86(codon1, codon2, codon_table=default_codon_table):
     if codon1 == '---' or codon2 == '---':
         return SN
     base_tuple = ('A', 'C', 'G', 'T')
-    if not all([i in base_tuple for i in codon1]):
+    if not all( i in base_tuple for i in codon1):
         raise RuntimeError("Unrecognized character detected in codon1 {0} "
                            "(Codons consist of "
                            "A, T, C or G)".format(codon1))
-    if not all([i in base_tuple for i in codon2]):
+    if not all( i in base_tuple for i in codon2):
         raise RuntimeError("Unrecognized character detected in codon2 {0} "
                            "(Codons consist of "
                            "A, T, C or G)".format(codon2))
@@ -911,11 +911,11 @@ def _count_diff_YN00(codon1, codon2, P, codon_lst,
     if codon1 == '---' or codon2 == '---':
         return TV
     base_tuple = ('A', 'C', 'G', 'T')
-    if not all([i in base_tuple for i in codon1]):
+    if not all( i in base_tuple for i in codon1):
         raise RuntimeError("Unrecognized character detected in codon1 {0} "
                            "(Codons consist of "
                            "A, T, C or G)".format(codon1))
-    if not all([i in base_tuple for i in codon2]):
+    if not all( i in base_tuple for i in codon2):
         raise RuntimeError("Unrecognized character detected in codon2 {0} "
                            "(Codons consist of "
                            "A, T, C or G)".format(codon2))

--- a/Tests/test_SearchIO_model.py
+++ b/Tests/test_SearchIO_model.py
@@ -484,7 +484,7 @@ class QueryResultCases(unittest.TestCase):
         filtered = self.qresult.hit_filter(filter_func)
         self.assertEqual([hit11, hit31], list(filtered.hits))
         # make sure all remaining hits return True for the filter function
-        self.assertTrue(all([filter_func(hit) for hit in filtered]))
+        self.assertTrue(all(filter_func(hit) for hit in filtered))
         self.assertEqual(1102, filtered.seq_len)
         self.assertEqual('refseq_rna', filtered.target)
 
@@ -555,11 +555,11 @@ class QueryResultCases(unittest.TestCase):
         self.assertTrue('hit2' not in filtered)
         self.assertTrue('hit3' in filtered)
         # test hsps in hit11
-        self.assertTrue(all([hsp in filtered['hit1'] for hsp in
-                [hsp111, hsp112, hsp114]]))
+        self.assertTrue(all(hsp in filtered['hit1'] for hsp in
+                [hsp111, hsp112, hsp114]))
         # test hsps in hit31
-        self.assertTrue(all([hsp in filtered['hit3'] for hsp in
-                [hsp311, hsp312]]))
+        self.assertTrue(all(hsp in filtered['hit3'] for hsp in
+                [hsp311, hsp312]))
 
     def test_hsp_filter_no_func(self):
         """Test QueryResult.hsp_filter, no arguments"""
@@ -944,7 +944,7 @@ class HitCases(unittest.TestCase):
         filtered = self.hit.filter(filter_func)
         self.assertEqual([hsp111, hsp113], filtered.hsps)
         # make sure all remaining hits return True for the filter function
-        self.assertTrue(all([filter_func(hit) for hit in filtered]))
+        self.assertTrue(all(filter_func(hit) for hit in filtered))
         self.assertEqual(5e-10, filtered.evalue)
         self.assertEqual('test', filtered.name)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider an iterator instead of materializing the list](https://www.quantifiedcode.com/app/issue_class/53lnAzfW)
Issue details: [https://www.quantifiedcode.com/app/project/gh:biopython:biopython?groups=code_patterns/%3A53lnAzfW](https://www.quantifiedcode.com/app/project/gh:biopython:biopython?groups=code_patterns/%3A53lnAzfW)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)