### PR TITLE
Only use EvilHandleHack on Python 3.3

### DIFF
--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -207,6 +207,8 @@ class DataHandler(object):
         # expects binary data
         if handle.__class__.__name__ == 'EvilHandleHack':
             handle = handle._handle
+        if handle.__class__.__name__ == 'TextIOWrapper':
+            handle = handle.buffer
         if hasattr(handle, "closed") and handle.closed:
             # Should avoid a possible Segmentation Fault, see:
             # http://bugs.python.org/issue4877

--- a/Bio/_py3k/__init__.py
+++ b/Bio/_py3k/__init__.py
@@ -89,59 +89,64 @@ if sys.version_info[0] >= 3:
 
     import io
 
-    def _binary_to_string_handle(handle):
-        """Treat a binary (bytes) handle like a text (unicode) handle."""
-        # TODO, once drop all of Python 3.0 - 3.3, replace this with just:
-        #
-        # return io.TextIOWrapper(io.BufferedReader(handle))
-        #
-        # See also http://bugs.python.org/issue5628
-        # and http://bugs.python.org/issue13541
-        # and http://bugs.python.org/issue13464 which should be fixed in Python 3.3
-        #
-        # However, still have problems under Python 3.3.0, e.g.
-        #
-        # $ python3.3 test_SeqIO_online.py
-        # test_nuccore_X52960 (__main__.EntrezTests)
-        # Bio.Entrez.efetch('nuccore', id='X52960', ...) ... ERROR
-        # test_nucleotide_6273291 (__main__.EntrezTests)
-        # Bio.Entrez.efetch('nucleotide', id='6273291', ...) ... ERROR
-        # test_protein_16130152 (__main__.EntrezTests)
-        # Bio.Entrez.efetch('protein', id='16130152', ...) ... ERROR
-        # test_get_sprot_raw (__main__.ExPASyTests)
-        # Bio.ExPASy.get_sprot_raw("O23729") ... ok
-        # ..
-        # ValueError: I/O operation on closed file.
-        #
-        class EvilHandleHack(object):
-            def __init__(self, handle):
-                self._handle = handle
-                try:
-                    # If wrapping an online handle, this this is nice to have:
-                    self.url = handle.url
-                except AttributeError:
-                    pass
+    if sys.version_info[:2] <= (3, 3):
+        def _binary_to_string_handle(handle):
+            """Treat a binary (bytes) handle like a text (unicode) handle."""
+            # TODO, once drop all of Python 3.0 - 3.3, remove this!
+            #
+            # See also http://bugs.python.org/issue5628
+            # and http://bugs.python.org/issue13541
+            # and http://bugs.python.org/issue13464 which should be fixed in Python 3.3
+            #
+            # However, still have problems under Python 3.3.0, e.g.
+            #
+            # $ python3.3 test_SeqIO_online.py
+            # test_nuccore_X52960 (__main__.EntrezTests)
+            # Bio.Entrez.efetch('nuccore', id='X52960', ...) ... ERROR
+            # test_nucleotide_6273291 (__main__.EntrezTests)
+            # Bio.Entrez.efetch('nucleotide', id='6273291', ...) ... ERROR
+            # test_protein_16130152 (__main__.EntrezTests)
+            # Bio.Entrez.efetch('protein', id='16130152', ...) ... ERROR
+            # test_get_sprot_raw (__main__.ExPASyTests)
+            # Bio.ExPASy.get_sprot_raw("O23729") ... ok
+            # ..
+            # ValueError: I/O operation on closed file.
+            #
+            class EvilHandleHack(object):
+                """Biopython internal class to work around bugs in early versions of Python 3."""
+                def __init__(self, handle):
+                    self._handle = handle
+                    try:
+                        # If wrapping an online handle, this this is nice to have:
+                        self.url = handle.url
+                    except AttributeError:
+                        pass
 
-            def read(self, length=None):
-                return _as_string(self._handle.read(length))
+                def read(self, length=None):
+                    return _as_string(self._handle.read(length))
 
-            def readline(self):
-                return _as_string(self._handle.readline())
+                def readline(self):
+                    return _as_string(self._handle.readline())
 
-            def __iter__(self):
-                for line in self._handle:
-                    yield _as_string(line)
+                def __iter__(self):
+                    for line in self._handle:
+                        yield _as_string(line)
 
-            def close(self):
-                return self._handle.close()
+                def close(self):
+                    return self._handle.close()
 
-            def seek(self, pos):
-                return self._handle.seek(pos)
+                def seek(self, pos):
+                    return self._handle.seek(pos)
 
-            def tell(self):
-                return self._handle.tell()
+                def tell(self):
+                    return self._handle.tell()
 
-        return EvilHandleHack(handle)
+            return EvilHandleHack(handle)
+    else:
+        # Python 3.4 onwards, the standard library wrappers should work:
+        def _binary_to_string_handle(handle):
+            """Treat a binary (bytes) handle like a text (unicode) handle."""
+            return io.TextIOWrapper(io.BufferedReader(handle))
 
     # This is to avoid the deprecation warning from open(filename, "rU")
     _universal_read_mode = "r"  # text mode does universal new lines

--- a/Bio/_py3k/__init__.py
+++ b/Bio/_py3k/__init__.py
@@ -146,7 +146,13 @@ if sys.version_info[0] >= 3:
         # Python 3.4 onwards, the standard library wrappers should work:
         def _binary_to_string_handle(handle):
             """Treat a binary (bytes) handle like a text (unicode) handle."""
-            return io.TextIOWrapper(io.BufferedReader(handle))
+            wrapped = io.TextIOWrapper(io.BufferedReader(handle))
+            try:
+                # If wrapping an online handle, this this is nice to have:
+                wrapped.url = handle.url
+            except AttributeError:
+                pass
+            return wrapped
 
     # This is to avoid the deprecation warning from open(filename, "rU")
     _universal_read_mode = "r"  # text mode does universal new lines


### PR DESCRIPTION
As discussed on #721, we should phase out the ``EvilHandleHack`` which was created to work around bugs in the Python 3.0 to 3.3 ``io.TextIOWrapper`` class. We still currently support Python 3.3, which means it is the only version of Python where we need this hack.

I've been primarily using ``test_Entrez_online.py`` for this - note the TravisCI tests are run with ``--offline`` so will not cover these changes.