### PR TITLE
'dumb_consensus' conservation fix at AlignInfo.py

### DIFF
--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -84,13 +84,14 @@ class SummaryInfo(object):
                 # make sure we haven't run past the end of any sequences
                 # if they are of different lengths
                 if n < len(record.seq):
+                    # Count atoms here or a position with 1 residue and 99 gaps
+                    # will be treated as 100% conserved instead of 1%
+                    num_atoms += 1
                     if record.seq[n] != '-' and record.seq[n] != '.':
                         if record.seq[n] not in atom_dict:
                             atom_dict[record.seq[n]] = 1
                         else:
                             atom_dict[record.seq[n]] += 1
-
-                        num_atoms = num_atoms + 1
 
             max_atoms = []
             max_size = 0
@@ -142,12 +143,11 @@ class SummaryInfo(object):
                 # make sure we haven't run past the end of any sequences
                 # if they are of different lengths
                 if n < len(record.seq):
+                    num_atoms += 1
                     if record.seq[n] not in atom_dict:
                         atom_dict[record.seq[n]] = 1
                     else:
                         atom_dict[record.seq[n]] += 1
-
-                    num_atoms += 1
 
             max_atoms = []
             max_size = 0


### PR DESCRIPTION
Hello,
Currently, 'dumb_consensus' counts atoms just after skipping gaps, so if there are 100 sequences in an alignment, and in a given position there is an insertion in only one sequence (meaning 1 residue and 99 gaps), the position will be treated as 100% conserved instead of just 1%, and will pass any threshold. Since I'm looking for strings with different degrees of conservation, this is creating strings with some residues that are not as conserved as expected.

To fix it I moved the atom counting just after the length check, before the gap skipping, and did the same for 'gap_consensus' for consistency. Hope you can merge it.

Best regards,