### PR TITLE
Entrez journal examples fixes #735

### DIFF
--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -200,7 +200,6 @@ Note that instead of a species name like \texttt{Cypripedioideae[Orgn]}, you can
 
 As a final example, let's get a list of computational journal titles:
 \begin{verbatim}
-print("{} computational Journals found".format(record["Count"]))
 >>> handle = Entrez.esearch(db="nlmcatalog", term="computational[Journal]", , RetMax='20')
 >>> record = Entrez.read(handle)
 >>> print("{} computational journals found".format(record["Count"]))

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -203,7 +203,7 @@ As a final example, let's get a list of computational journal titles:
 print("{} computational Journals found".format(record["Count"]))
 >>> handle = Entrez.esearch(db="nlmcatalog", term="computational[Journal]", , RetMax='20')
 >>> record = Entrez.read(handle)
->>> print("{} computational Journals found".format(record["Count"]))
+>>> print("{} computational journals found".format(record["Count"]))
 117 computational Journals found
 >>> print("The first 20 are\n{}".format(record['IdList']))
 ['101660833', '101664671', '101661657', '101659814', '101657941',

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -263,7 +263,7 @@ ESummary retrieves document summaries from a list of primary IDs (see the  \href
 \begin{verbatim}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"     # Always tell NCBI who you are
->>> handle = Entrez.esummary(db="journals", id="30367")
+>>> handle = Entrez.esummary(db="nlmcatalog", term="[journal]", id="101660833")
 >>> record = Entrez.read(handle)
 >>> info = record[0]['TitleMainList'][0]
 >>> print("Journal info\nid: {}\nTitle: {}".format(record[0]["Id"], info["Title"]))

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -211,7 +211,7 @@ As a final example, let's get a list of computational journal titles:
 \end{verbatim}
 Again, we could use EFetch to obtain more information for each of these journal IDs.
 
-ESearch has many useful options --- see the \href{http://www.ncbi.nlm.nih.gov/entrez/query/static/esearch\_help.html}{ESearch help page} for more information.
+ESearch has many useful options --- see the \href{https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch}{ESearch help page} for more information.
 
 \section{EPost: Uploading a list of identifiers}
 EPost uploads a list of UIs for use in subsequent search strategies; see the

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -201,7 +201,7 @@ Note that instead of a species name like \texttt{Cypripedioideae[Orgn]}, you can
 As a final example, let's get a list of computational journal titles:
 \begin{verbatim}
 print("{} computational Journals found".format(record["Count"]))
->>> handle = Entrez.esearch(db="nlmcatalog", term="computational[Journal]")
+>>> handle = Entrez.esearch(db="nlmcatalog", term="computational[Journal]", , RetMax='20')
 >>> record = Entrez.read(handle)
 >>> print("{} computational Journals found".format(record["Count"]))
 117 computational Journals found
@@ -265,12 +265,11 @@ ESummary retrieves document summaries from a list of primary IDs (see the  \href
 >>> Entrez.email = "A.N.Other@example.com"     # Always tell NCBI who you are
 >>> handle = Entrez.esummary(db="journals", id="30367")
 >>> record = Entrez.read(handle)
->>> record[0]["Id"]
-'30367'
->>> record[0]["Title"]
-'Computational biology and chemistry'
->>> record[0]["Publisher"]
-'Pergamon,'
+>>> info = record[0]['TitleMainList'][0]
+>>> print("Journal info\nid: {}\nTitle: {}".format(record[0]["Id"], info["Title"]))
+Journal info
+id: 101660833
+Title: IEEE transactions on computational imaging.
 \end{verbatim}
 
 \section{EFetch: Downloading full records from Entrez}

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -200,14 +200,16 @@ Note that instead of a species name like \texttt{Cypripedioideae[Orgn]}, you can
 
 As a final example, let's get a list of computational journal titles:
 \begin{verbatim}
->>> handle = Entrez.esearch(db="journals", term="computational")
+print("{} computational Journals found".format(record["Count"]))
+>>> handle = Entrez.esearch(db="nlmcatalog", term="computational[Journal]")
 >>> record = Entrez.read(handle)
->>> record["Count"]
-'16'
->>> record["IdList"]
-['30367', '33843', '33823', '32989', '33190', '33009', '31986',
- '34502', '8799', '22857', '32675', '20258', '33859', '32534',
- '32357', '32249']
+>>> print("{} computational Journals found".format(record["Count"]))
+117 computational Journals found
+>>> print("The first 20 are\n{}".format(record['IdList']))
+['101660833', '101664671', '101661657', '101659814', '101657941',
+ '101653734', '101669877', '101649614', '101647835', '101639023',
+ '101627224', '101647801', '101589678', '101585369', '101645372',
+ '101586429', '101582229', '101574747', '101564639', '101671907']
 \end{verbatim}
 Again, we could use EFetch to obtain more information for each of these journal IDs.
 

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -200,7 +200,7 @@ Note that instead of a species name like \texttt{Cypripedioideae[Orgn]}, you can
 
 As a final example, let's get a list of computational journal titles:
 \begin{verbatim}
->>> handle = Entrez.esearch(db="nlmcatalog", term="computational[Journal]", , RetMax='20')
+>>> handle = Entrez.esearch(db="nlmcatalog", term="computational[Journal]", retmax='20')
 >>> record = Entrez.read(handle)
 >>> print("{} computational journals found".format(record["Count"]))
 117 computational Journals found
@@ -262,7 +262,7 @@ ESummary retrieves document summaries from a list of primary IDs (see the  \href
 \begin{verbatim}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"     # Always tell NCBI who you are
->>> handle = Entrez.esummary(db="nlmcatalog", term="[journal]", id="101660833")
+>>> handle = Entrez.esummary(db="nlmcatalog", id="101660833")
 >>> record = Entrez.read(handle)
 >>> info = record[0]['TitleMainList'][0]
 >>> print("Journal info\nid: {}\nTitle: {}".format(record[0]["Id"], info["Title"]))


### PR DESCRIPTION
Entrez journal examples fixes #735
Fixed two (all) examples, still searches journals but finds them via the nlmcatalog.