### PR TITLE
BioSQL ncbi taxonomy fetch bug

### DIFF
--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -464,11 +464,8 @@ def _retrieve_taxon(adaptor, primary_id, taxon_id):
             # load_ncbi_taxonomy.pl this is how top parent nodes are stored.
             # Personally, I would have used a NULL parent_taxon_id here.
             break
-        if rank != "no rank":
-            # For consistency with older versions of Biopython, we are only
-            # interested in taxonomy entries with a stated rank.
-            # Add this to the start of the lineage list.
-            taxonomy.insert(0, name)
+
+        taxonomy.insert(0, name)
         taxon_id = parent_taxon_id
 
     if taxonomy:

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -620,16 +620,27 @@ class LoaderTest(unittest.TestCase):
     def test_load_database_with_tax_lookup(self):
         """Load SeqRecord objects and fetch the taxonomy information from NCBI.
         """
-
-        from Bio import Entrez
-        Entrez.email = "biopython-dev@biopython.org"
-
-        handle = Entrez.efetch(db="taxonomy", id=3702, retmode="XML")
-
-        taxon_record = Entrez.read(handle)
-        entrez_tax = []
-        for t in taxon_record[0]['LineageEx']:
-            entrez_tax.append(t['ScientificName'])
+        tax = ['cellular organisms',
+               'Eukaryota',
+               'Viridiplantae',
+               'Streptophyta',
+               'Streptophytina',
+               'Embryophyta',
+               'Tracheophyta',
+               'Euphyllophyta',
+               'Spermatophyta',
+               'Magnoliophyta',
+               'Mesangiospermae',
+               'eudicotyledons',
+               'Gunneridae',
+               'Pentapetalae',
+               'rosids',
+               'malvids',
+               'Brassicales',
+               'Brassicaceae',
+               'Camelineae',
+               'Arabidopsis',
+               'Arabidopsis thaliana']
 
         self.db.load(self.iterator, True)
 
@@ -645,8 +656,7 @@ class LoaderTest(unittest.TestCase):
         self.assertEqual(test_record.annotations['ncbi_taxid'], 3702)
         # make sure that the taxonomic lineage is the same as reported
         # using the Entrez module
-        self.assertEqual(test_record.annotations['taxonomy'],
-                entrez_tax)
+        self.assertEqual(test_record.annotations['taxonomy'], tax)
 
 
 class DeleteTest(unittest.TestCase):

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -617,46 +617,6 @@ class LoaderTest(unittest.TestCase):
         self.assertEqual(item_ids, ['AF297471.1', 'AJ237582.1', 'L31939.1',
                                     'M81224.1', 'X55053.1', 'X62281.1'])
 
-    def test_load_database_with_tax_lookup(self):
-        """Load SeqRecord objects and fetch the taxonomy information from NCBI.
-        """
-        tax = ['cellular organisms',
-               'Eukaryota',
-               'Viridiplantae',
-               'Streptophyta',
-               'Streptophytina',
-               'Embryophyta',
-               'Tracheophyta',
-               'Euphyllophyta',
-               'Spermatophyta',
-               'Magnoliophyta',
-               'Mesangiospermae',
-               'eudicotyledons',
-               'Gunneridae',
-               'Pentapetalae',
-               'rosids',
-               'malvids',
-               'Brassicales',
-               'Brassicaceae',
-               'Camelineae',
-               'Arabidopsis',
-               'Arabidopsis thaliana']
-
-        self.db.load(self.iterator, True)
-
-        # do some simple tests to make sure we actually loaded the right
-        # thing. More advanced tests in a different module.
-        items = list(self.db.values())
-        self.assertEqual(len(items), 6)
-        self.assertEqual(len(self.db), 6)
-
-        test_record = self.db.lookup(accession="X55053")
-
-        # make sure that the ncbi taxonomy id is corrent
-        self.assertEqual(test_record.annotations['ncbi_taxid'], 3702)
-        # make sure that the taxonomic lineage is the same as reported
-        # using the Entrez module
-        self.assertEqual(test_record.annotations['taxonomy'], tax)
 
 
 class DeleteTest(unittest.TestCase):

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -624,7 +624,7 @@ class LoaderTest(unittest.TestCase):
         from Bio import Entrez
         Entrez.email = "biopython-dev@biopython.org"
 
-        handle = Entrez.efetch( db="taxonomy", id=3702, retmode="XML")
+        handle = Entrez.efetch(db="taxonomy", id=3702, retmode="XML")
 
         taxon_record = Entrez.read(handle)
         entrez_tax = []
@@ -639,7 +639,6 @@ class LoaderTest(unittest.TestCase):
         self.assertEqual(len(items), 6)
         self.assertEqual(len(self.db), 6)
 
-
         test_record = self.db.lookup(accession="X55053")
 
         # make sure that the ncbi taxonomy id is corrent
@@ -648,7 +647,6 @@ class LoaderTest(unittest.TestCase):
         # using the Entrez module
         self.assertEqual(test_record.annotations['taxonomy'],
                 entrez_tax)
-
 
 
 class DeleteTest(unittest.TestCase):

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -618,7 +618,6 @@ class LoaderTest(unittest.TestCase):
                                     'M81224.1', 'X55053.1', 'X62281.1'])
 
 
-
 class DeleteTest(unittest.TestCase):
     """Test proper deletion of entries from a database."""
 

--- a/Tests/common_BioSQL_online.py
+++ b/Tests/common_BioSQL_online.py
@@ -109,3 +109,30 @@ class TaxonomyTest(unittest.TestCase):
         for row in rows:
             values.add(row[0])
         self.assertEqual(set([3704, 3711, 3708, 3702]), set(values))
+
+    def test_load_database_with_tax_lookup(self):
+        """Load SeqRecord objects and fetch the taxonomy information from NCBI.
+        """
+        handle = Entrez.efetch(db="taxonomy", id=3702, retmode="XML")
+
+        taxon_record = Entrez.read(handle)
+        entrez_tax = []
+
+        for t in taxon_record[0]['LineageEx']:
+            entrez_tax.append(t['ScientificName'])
+        entrez_tax.append(taxon_record[0]['ScientificName'])
+        self.db.load(self.iterator, True)
+
+        # do some simple tests to make sure we actually loaded the right
+        # thing. More advanced tests in a different module.
+        items = list(self.db.values())
+        self.assertEqual(len(items), 6)
+        self.assertEqual(len(self.db), 6)
+
+        test_record = self.db.lookup(accession="X55053")
+
+        # make sure that the ncbi taxonomy id is corrent
+        self.assertEqual(test_record.annotations['ncbi_taxid'], 3702)
+        # make sure that the taxonomic lineage is the same as reported
+        # using the Entrez module
+        self.assertEqual(test_record.annotations['taxonomy'], entrez_tax)


### PR DESCRIPTION
I've encountered two bugs when trying to populate the taxonomy information from NCBI when loading a record into a BioSQL database. The first was that the `DatabaseLoader` class (sometimes) automatically converts an NCBI taxonomy ID into an integer, however `Entrez.efetch` expects this value as a string (or a list of strings). I've modified  `Entrez.efetch` such that it automatically converts integers into strings to solve this. The second bug was in the `DBSeq` class removes any taxonomic name that has a rank of 'no rank'. This can change the returned taxonomy of the sequence significantly and is incorrect with what is reported at NCBI. It is further confusing as the taxonomic names are stored correctly in the database but are filtered out after their retrieval.

I've written in a new test to `common_BioSQL.py` to check that the taxonomy info returned from the database is the same as obtained by using the `Entrez` module 
