### PR TITLE
Updated sqlite3 schema to include foreign keys

### DIFF
--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -125,6 +125,11 @@ def open_database(driver="MySQLdb", **kwargs):
             global _POSTGRES_RULES_PRESENT
             _POSTGRES_RULES_PRESENT = True
 
+    elif driver == 'sqlite3':
+        # Tell SQLite that we want to use foreign keys
+        # https://www.sqlite.org/foreignkeys.html#fk_enable
+        server.adaptor.execute('PRAGMA foreign_keys = ON')
+
     return server
 
 

--- a/Tests/BioSQL/biosqldb-sqlite.sql
+++ b/Tests/BioSQL/biosqldb-sqlite.sql
@@ -1,5 +1,5 @@
 --  BioSQL database schema for SQLite.
--- 
+--
 --  This file is part of BioSQL.
 --
 --  BioSQL is free software: you can redistribute it and/or modify it
@@ -19,96 +19,109 @@
 --
 -- See MySQL database schema and BioSQL website for table documentation.
 -- This contains notes specific to SQLite
--- 
+--
 -- A note about Primary Keys in SQLite
 -- SQLite automatically creates a ROWID for each row of a table.
---   Using this ROWID as the primary key is faster than using a 
---   user-defined primary key. By declaring a column as an 
+--   Using this ROWID as the primary key is faster than using a
+--   user-defined primary key. By declaring a column as an
 --   INTEGER PRIMARY KEY, you are actually creating an alias to the
 --   ROWID and get the associated speed benefits.  The ROWID effectively
---   "autoincrements"; however, it can reuse ROWIDs of deleted rows. 
+--   "autoincrements"; however, it can reuse ROWIDs of deleted rows.
 --   To avoid reusing old ROWIDs would require adding the AUTOINCREMENT
 --   keyword, which also reduces the performance.
---   ( see http://www.sqlite.org/autoinc.html) 
+--   ( see http://www.sqlite.org/autoinc.html)
 
 CREATE TABLE biodatabase (
-  	biodatabase_id 	INTEGER PRIMARY KEY,
-  	name           	VARCHAR(128) NOT NULL,
-	authority	VARCHAR(128),
-	description	TEXT,
-  	UNIQUE (name)
+    biodatabase_id 	INTEGER PRIMARY KEY,
+    name           	VARCHAR(128) NOT NULL,
+    authority	VARCHAR(128),
+    description	TEXT,
+    UNIQUE (name)
 );
 
 CREATE INDEX db_auth on biodatabase(authority);
 
 CREATE TABLE taxon (
-       taxon_id		INTEGER PRIMARY KEY,
-       ncbi_taxon_id 	INT(10),
-       parent_taxon_id	INT(10) ,
-       node_rank	VARCHAR(32),
-       genetic_code	TINYINT ,
-       mito_genetic_code TINYINT ,
-       left_value	INT(10) ,
-       right_value	INT(10) ,
-       UNIQUE (ncbi_taxon_id),
-       UNIQUE (left_value),
-       UNIQUE (right_value)
+    taxon_id		INTEGER PRIMARY KEY,
+    ncbi_taxon_id 	INT(10),
+    parent_taxon_id	INT(10) ,
+    node_rank	VARCHAR(32),
+    genetic_code	TINYINT ,
+    mito_genetic_code TINYINT ,
+    left_value	INT(10) ,
+    right_value	INT(10) ,
+    UNIQUE (ncbi_taxon_id),
+    UNIQUE (left_value),
+    UNIQUE (right_value)
 );
 
 CREATE INDEX taxparent ON taxon(parent_taxon_id);
 
 CREATE TABLE taxon_name (
-       taxon_id		INTEGER,
-       name		VARCHAR(255)  NOT NULL,
-       name_class	VARCHAR(32)  NOT NULL,
-       UNIQUE (taxon_id,name,name_class)
+    taxon_id		INTEGER,
+    name		VARCHAR(255)  NOT NULL,
+    name_class	VARCHAR(32)  NOT NULL,
+    UNIQUE (taxon_id,name,name_class),
+    FOREIGN KEY ( taxon_id ) REFERENCES taxon ( taxon_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX taxnametaxonid ON taxon_name(taxon_id);
 CREATE INDEX taxnamename    ON taxon_name(name);
 
 CREATE TABLE ontology (
-       	ontology_id        INTEGER PRIMARY KEY,
-       	name	   	   VARCHAR(32)  NOT NULL,
-       	definition	   TEXT,
-	UNIQUE (name)
+    ontology_id        INTEGER PRIMARY KEY,
+    name	   	   VARCHAR(32)  NOT NULL,
+    definition	   TEXT,
+    UNIQUE (name)
 );
 
 CREATE TABLE term (
-       	term_id   INTEGER PRIMARY KEY,
-       	name	   	   VARCHAR(255)  NOT NULL,
-       	definition	   TEXT,
-	identifier	   VARCHAR(40) ,
-	is_obsolete	   CHAR(1),
-	ontology_id	   INTEGER,
-	UNIQUE (identifier),
-        UNIQUE (name,ontology_id,is_obsolete)
+    term_id   INTEGER PRIMARY KEY,
+    name	   	   VARCHAR(255)  NOT NULL,
+    definition	   TEXT,
+    identifier	   VARCHAR(40) ,
+    is_obsolete	   CHAR(1),
+    ontology_id	   INTEGER,
+    UNIQUE (identifier),
+    UNIQUE (name,ontology_id,is_obsolete),
+    FOREIGN KEY ( ontology_id ) REFERENCES ontology ( ontology_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX term_ont ON term(ontology_id);
 
 CREATE TABLE term_synonym (
-       synonym		  VARCHAR(255)  NOT NULL,
-       term_id		  INTEGER,
-       PRIMARY KEY (term_id,synonym)
+    synonym		  VARCHAR(255)  NOT NULL,
+    term_id		  INTEGER,
+    PRIMARY KEY (term_id,synonym),
+
+    FOREIGN KEY ( term_id ) REFERENCES term ( term_id ) ON DELETE CASCADE
 );
 
 CREATE TABLE term_dbxref (
-       	term_id	          INTEGER,
-       	dbxref_id         INTEGER,
-	rank		  SMALLINT,
-	PRIMARY KEY (term_id, dbxref_id)
+    term_id	          INTEGER,
+    dbxref_id         INTEGER,
+    rank		  SMALLINT,
+    PRIMARY KEY (term_id, dbxref_id),
+
+    FOREIGN KEY ( dbxref_id ) REFERENCES dbxref ( dbxref_id ) ON DELETE CASCADE,
+    FOREIGN KEY ( term_id ) REFERENCES term ( term_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX trmdbxref_dbxrefid ON term_dbxref(dbxref_id);
 
 CREATE TABLE term_relationship (
-        term_relationship_id INTEGER PRIMARY KEY,
-       	subject_term_id	INTEGER,
-       	predicate_term_id    INTEGER,
-       	object_term_id       INTEGER,
-	ontology_id	INTEGER,
-	UNIQUE (subject_term_id,predicate_term_id,object_term_id,ontology_id)
+    term_relationship_id INTEGER PRIMARY KEY,
+    subject_term_id	INTEGER,
+    predicate_term_id    INTEGER,
+    object_term_id       INTEGER,
+    ontology_id	INTEGER,
+    UNIQUE (subject_term_id,predicate_term_id,object_term_id,ontology_id),
+
+    FOREIGN KEY ( subject_term_id ) REFERENCES term ( term_id ) ON DELETE CASCADE ,
+    FOREIGN KEY ( predicate_term_id ) REFERENCES term ( term_id ) ON DELETE CASCADE ,
+    FOREIGN KEY ( object_term_id ) REFERENCES term ( term_id ) ON DELETE CASCADE ,
+    FOREIGN KEY ( ontology_id ) REFERENCES ontology ( ontology_id ) ON DELETE CASCADE
+
 );
 
 CREATE INDEX trmrel_predicateid ON term_relationship(predicate_term_id);
@@ -116,19 +129,26 @@ CREATE INDEX trmrel_objectid ON term_relationship(object_term_id);
 CREATE INDEX trmrel_ontid ON term_relationship(ontology_id);
 
 CREATE TABLE term_relationship_term (
-        term_relationship_id INTEGER PRIMARY KEY,
-        term_id              INTEGER,
-        UNIQUE ( term_id ) 
+    term_relationship_id INTEGER PRIMARY KEY,
+    term_id              INTEGER,
+    UNIQUE ( term_id ),
+
+    FOREIGN KEY (term_relationship_id) REFERENCES term_relationship(term_relationship_id) ON DELETE CASCADE,
+    FOREIGN KEY (term_id) REFERENCES term(term_id) ON DELETE CASCADE
 );
 
 CREATE TABLE term_path (
-        term_path_id         INTEGER PRIMARY KEY,
-       	subject_term_id	     INTEGER,
-       	predicate_term_id    INTEGER,
-       	object_term_id       INTEGER,
-	ontology_id          INTEGER,
-	distance	     INT(10) ,
-	UNIQUE (subject_term_id,predicate_term_id,object_term_id,ontology_id,distance)
+    term_path_id         INTEGER PRIMARY KEY,
+    subject_term_id	     INTEGER,
+    predicate_term_id    INTEGER,
+    object_term_id       INTEGER,
+    ontology_id          INTEGER,
+    distance	     INT(10) ,
+    UNIQUE (subject_term_id,predicate_term_id,object_term_id,ontology_id,distance),
+    FOREIGN KEY ( subject_term_id ) REFERENCES term ( term_id ) ON DELETE CASCADE ,
+    FOREIGN KEY ( predicate_term_id ) REFERENCES term ( term_id ) ON DELETE CASCADE ,
+    FOREIGN KEY ( object_term_id ) REFERENCES term ( term_id ) ON DELETE CASCADE ,
+    FOREIGN KEY ( ontology_id ) REFERENCES ontology ( ontology_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX trmpath_predicateid ON term_path(predicate_term_id);
@@ -136,17 +156,20 @@ CREATE INDEX trmpath_objectid ON term_path(object_term_id);
 CREATE INDEX trmpath_ontid ON term_path(ontology_id);
 
 CREATE TABLE bioentry (
-	bioentry_id	    INTEGER PRIMARY KEY,
-  	biodatabase_id  INTEGER,
-  	taxon_id     	INT(10) ,
-  	name		VARCHAR(40) NOT NULL,
-  	accession    	VARCHAR(128)  NOT NULL,
-  	identifier   	VARCHAR(40) ,
-	division	VARCHAR(6),
-  	description  	TEXT,
-  	version 	SMALLINT  NOT NULL, 
-  	UNIQUE (accession,biodatabase_id,version),
- 	UNIQUE (identifier, biodatabase_id)
+    bioentry_id	    INTEGER PRIMARY KEY,
+    biodatabase_id  INTEGER,
+    taxon_id     	INT(10) ,
+    name		VARCHAR(40) NOT NULL,
+    accession    	VARCHAR(128)  NOT NULL,
+    identifier   	VARCHAR(40) ,
+    division	VARCHAR(6),
+    description  	TEXT,
+    version 	SMALLINT  NOT NULL,
+    UNIQUE (accession,biodatabase_id,version),
+    UNIQUE (identifier, biodatabase_id),
+
+    FOREIGN KEY ( taxon_id ) REFERENCES taxon ( taxon_id ),
+    FOREIGN KEY ( biodatabase_id ) REFERENCES biodatabase ( biodatabase_id )
 );
 
 CREATE INDEX bioentry_name ON bioentry(name);
@@ -154,171 +177,207 @@ CREATE INDEX bioentry_db   ON bioentry(biodatabase_id);
 CREATE INDEX bioentry_tax  ON bioentry(taxon_id);
 
 CREATE TABLE bioentry_relationship (
-        bioentry_relationship_id INTEGER PRIMARY KEY,
-        object_bioentry_id 	 INTEGER,
-   	subject_bioentry_id 	 INTEGER,
-   	term_id 		 INTEGER,
-   	rank 			 INT(5),
-	UNIQUE (object_bioentry_id,subject_bioentry_id,term_id)
+    bioentry_relationship_id INTEGER PRIMARY KEY,
+    object_bioentry_id 	 INTEGER,
+    subject_bioentry_id 	 INTEGER,
+    term_id 		 INTEGER,
+    rank 			 INT(5),
+    UNIQUE (object_bioentry_id,subject_bioentry_id,term_id),
+    FOREIGN KEY ( term_id ) REFERENCES term ( term_id ),
+    FOREIGN KEY ( object_bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE,
+    FOREIGN KEY ( subject_bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX bioentryrel_trm   ON bioentry_relationship(term_id);
 CREATE INDEX bioentryrel_child ON bioentry_relationship(subject_bioentry_id);
 
 CREATE TABLE bioentry_path (
-   	object_bioentry_id 	INTEGER PRIMARY KEY,
-   	subject_bioentry_id 	INTEGER,
-   	term_id 		INTEGER,
-	distance	     	INT(10) ,
-	UNIQUE (object_bioentry_id,subject_bioentry_id,term_id,distance)
+    object_bioentry_id 	INTEGER PRIMARY KEY,
+    subject_bioentry_id 	INTEGER,
+    term_id 		INTEGER,
+    distance	     	INT(10) ,
+    UNIQUE (object_bioentry_id,subject_bioentry_id,term_id,distance),
+
+    FOREIGN KEY ( term_id ) REFERENCES term ( term_id )
+    FOREIGN KEY ( object_bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE,
+    FOREIGN KEY ( subject_bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX bioentrypath_trm   ON bioentry_path(term_id);
 CREATE INDEX bioentrypath_child ON bioentry_path(subject_bioentry_id);
 
 CREATE TABLE biosequence (
-  	bioentry_id     INTEGER PRIMARY KEY,
-  	version     	SMALLINT, 
-  	length      	INT(10),
-  	alphabet        VARCHAR(10),
-  	seq 		LONGTEXT
+    bioentry_id     INTEGER PRIMARY KEY,
+    version     	SMALLINT,
+    length      	INT(10),
+    alphabet        VARCHAR(10),
+    seq 		LONGTEXT,
+    FOREIGN KEY ( bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE
 );
 
 CREATE TABLE dbxref (
-        dbxref_id	INTEGER PRIMARY KEY,
-        dbname          VARCHAR(40)  NOT NULL,
-        accession       VARCHAR(128)  NOT NULL,
-	version		SMALLINT  NOT NULL,
-        UNIQUE(accession, dbname, version)
+    dbxref_id	INTEGER PRIMARY KEY,
+    dbname          VARCHAR(40)  NOT NULL,
+    accession       VARCHAR(128)  NOT NULL,
+    version		SMALLINT  NOT NULL,
+    UNIQUE(accession, dbname, version)
 );
 
 CREATE INDEX dbxref_db  ON dbxref(dbname);
 
 CREATE TABLE dbxref_qualifier_value (
-       	dbxref_id 		INTEGER,
-       	term_id 		INTEGER,
-  	rank  		   	SMALLINT NOT NULL DEFAULT 0,
-       	value			TEXT,
-	PRIMARY KEY (dbxref_id,term_id,rank)
+    dbxref_id 		INTEGER,
+    term_id 		INTEGER,
+    rank  		   	SMALLINT NOT NULL DEFAULT 0,
+    value			TEXT,
+    PRIMARY KEY (dbxref_id,term_id,rank),
+
+    FOREIGN KEY ( term_id ) REFERENCES term ( term_id ),
+    FOREIGN KEY ( dbxref_id ) REFERENCES dbxref ( dbxref_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX dbxrefqual_dbx ON dbxref_qualifier_value(dbxref_id);
 CREATE INDEX dbxrefqual_trm ON dbxref_qualifier_value(term_id);
 
-CREATE TABLE bioentry_dbxref ( 
-       	bioentry_id        INTEGER,
-       	dbxref_id          INTEGER,
-  	rank  		   SMALLINT,
-	PRIMARY KEY (bioentry_id,dbxref_id)
+CREATE TABLE bioentry_dbxref (
+    bioentry_id        INTEGER,
+    dbxref_id          INTEGER,
+    rank  		   SMALLINT,
+    PRIMARY KEY (bioentry_id,dbxref_id),
+    FOREIGN KEY ( bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE,
+    FOREIGN KEY ( dbxref_id ) REFERENCES dbxref ( dbxref_id ) ON DELETE CASCADE
+
 );
 
 CREATE INDEX dblink_dbx  ON bioentry_dbxref(dbxref_id);
 
 CREATE TABLE reference (
-  	reference_id       INTEGER PRIMARY KEY,
-	dbxref_id	   INT(10) ,
-  	location 	   TEXT NOT NULL,
-  	title    	   TEXT,
-  	authors  	   TEXT,
-  	crc	   	   VARCHAR(32),
-	UNIQUE (dbxref_id),
-	UNIQUE (crc)
+    reference_id       INTEGER PRIMARY KEY,
+    dbxref_id	   INT(10) ,
+    location 	   TEXT NOT NULL,
+    title    	   TEXT,
+    authors  	   TEXT,
+    crc	   	   VARCHAR(32),
+    UNIQUE (dbxref_id),
+    UNIQUE (crc),
+    FOREIGN KEY ( dbxref_id ) REFERENCES dbxref ( dbxref_id )
 );
 
 CREATE TABLE bioentry_reference (
-  	bioentry_id 	INTEGER,
-  	reference_id 	INTEGER,
-  	start_pos	INT(10),
-  	end_pos	  	INT(10),
-  	rank  		SMALLINT NOT NULL DEFAULT 0,
-  	PRIMARY KEY(bioentry_id,reference_id,rank)
+    bioentry_id 	INTEGER,
+    reference_id 	INTEGER,
+    start_pos	INT(10),
+    end_pos	  	INT(10),
+    rank  		SMALLINT NOT NULL DEFAULT 0,
+    PRIMARY KEY(bioentry_id,reference_id,rank),
+    FOREIGN KEY ( bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE
+    FOREIGN KEY ( reference_id ) REFERENCES reference ( reference_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX bioentryref_ref ON bioentry_reference(reference_id);
 
 CREATE TABLE comment (
-  	comment_id  	INTEGER PRIMARY KEY,
-  	bioentry_id    	INTEGER,
-  	comment_text   	TEXT NOT NULL,
-  	rank   		SMALLINT NOT NULL DEFAULT 0,
-  	UNIQUE(bioentry_id, rank)
+    comment_id  	INTEGER PRIMARY KEY,
+    bioentry_id    	INTEGER,
+    comment_text   	TEXT NOT NULL,
+    rank   		SMALLINT NOT NULL DEFAULT 0,
+    UNIQUE(bioentry_id, rank),
+    FOREIGN KEY ( bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE
 );
 
 CREATE TABLE bioentry_qualifier_value (
-	bioentry_id   		INTEGER,
-   	term_id  		INTEGER,
-   	value         		TEXT,
-	rank			INT(5) NOT NULL DEFAULT 0,
-	UNIQUE (bioentry_id,term_id,rank)
+    bioentry_id   		INTEGER,
+    term_id  		INTEGER,
+    value         		TEXT,
+    rank			INT(5) NOT NULL DEFAULT 0,
+    UNIQUE (bioentry_id,term_id,rank),
+    FOREIGN KEY ( bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE,
+    FOREIGN KEY ( term_id ) REFERENCES term ( term_id )
 );
 
 CREATE INDEX bioentryqual_trm ON bioentry_qualifier_value(term_id);
 
 CREATE TABLE seqfeature (
-   	seqfeature_id 		INTEGER PRIMARY KEY,
-   	bioentry_id   		INTEGER,
-   	type_term_id		INTEGER,
-   	source_term_id  	INTEGER,
-	display_name		VARCHAR(64),
-   	rank 			SMALLINT  NOT NULL DEFAULT 0,
-	UNIQUE (bioentry_id,type_term_id,source_term_id,rank)
+    seqfeature_id 		INTEGER PRIMARY KEY,
+    bioentry_id   		INTEGER,
+    type_term_id		INTEGER,
+    source_term_id  	INTEGER,
+    display_name		VARCHAR(64),
+    rank 			SMALLINT  NOT NULL DEFAULT 0,
+    UNIQUE (bioentry_id,type_term_id,source_term_id,rank),
+    FOREIGN KEY ( type_term_id ) REFERENCES term ( term_id ),
+    FOREIGN KEY ( source_term_id ) REFERENCES term ( term_id ),
+    FOREIGN KEY ( bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX seqfeature_trm  ON seqfeature(type_term_id);
 CREATE INDEX seqfeature_fsrc ON seqfeature(source_term_id);
 
 CREATE TABLE seqfeature_relationship (
-        seqfeature_relationship_id INTEGER PRIMARY KEY,
-   	object_seqfeature_id	INTEGER,
-   	subject_seqfeature_id 	INTEGER,
-   	term_id 	        INTEGER,
-   	rank 			INT(5),
-	UNIQUE (object_seqfeature_id,subject_seqfeature_id,term_id)
+    seqfeature_relationship_id INTEGER PRIMARY KEY,
+    object_seqfeature_id	INTEGER,
+    subject_seqfeature_id 	INTEGER,
+    term_id 	        INTEGER,
+    rank 			INT(5),
+    UNIQUE (object_seqfeature_id,subject_seqfeature_id,term_id),
+    FOREIGN KEY ( term_id ) REFERENCES term ( term_id ),
+    FOREIGN KEY ( object_seqfeature_id ) REFERENCES seqfeature ( seqfeature_id ) ON DELETE CASCADE,
+    FOREIGN KEY ( subject_seqfeature_id ) REFERENCES seqfeature ( seqfeature_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX seqfeaturerel_trm   ON seqfeature_relationship(term_id);
 CREATE INDEX seqfeaturerel_child ON seqfeature_relationship(subject_seqfeature_id);
 
 CREATE TABLE seqfeature_path (
-   	object_seqfeature_id	INTEGER,
-   	subject_seqfeature_id 	INTEGER,
-   	term_id 		INTEGER,
-	distance	     	INT(10) ,
-	UNIQUE (object_seqfeature_id,subject_seqfeature_id,term_id,distance)
+    object_seqfeature_id	INTEGER,
+    subject_seqfeature_id 	INTEGER,
+    term_id 		INTEGER,
+    distance	     	INT(10) ,
+    UNIQUE (object_seqfeature_id,subject_seqfeature_id,term_id,distance),
+    FOREIGN KEY ( term_id ) REFERENCES term ( term_id ),
+    FOREIGN KEY ( object_seqfeature_id ) REFERENCES seqfeature ( seqfeature_id ) ON DELETE CASCADE,
+    FOREIGN KEY ( subject_seqfeature_id ) REFERENCES seqfeature ( seqfeature_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX seqfeaturepath_trm   ON seqfeature_path(term_id);
 CREATE INDEX seqfeaturepath_child ON seqfeature_path(subject_seqfeature_id);
 
 CREATE TABLE seqfeature_qualifier_value (
-	seqfeature_id 		INTEGER,
-   	term_id 		INTEGER,
-   	rank 			SMALLINT NOT NULL DEFAULT 0,
-   	value  			TEXT NOT NULL,
-   	PRIMARY KEY (seqfeature_id,term_id,rank)
+    seqfeature_id 		INTEGER,
+    term_id 		INTEGER,
+    rank 			SMALLINT NOT NULL DEFAULT 0,
+    value  			TEXT NOT NULL,
+    PRIMARY KEY (seqfeature_id,term_id,rank),
+    FOREIGN KEY ( term_id ) REFERENCES term ( term_id ),
+    FOREIGN KEY ( seqfeature_id ) REFERENCES seqfeature ( seqfeature_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX seqfeaturequal_trm ON seqfeature_qualifier_value(term_id);
-   
-CREATE TABLE seqfeature_dbxref ( 
-       	seqfeature_id      INTEGER,
-       	dbxref_id          INTEGER,
-  	rank  		   SMALLINT,
-	PRIMARY KEY (seqfeature_id,dbxref_id)
+
+CREATE TABLE seqfeature_dbxref (
+    seqfeature_id      INTEGER,
+    dbxref_id          INTEGER,
+    rank  		   SMALLINT,
+    PRIMARY KEY (seqfeature_id,dbxref_id),
+    FOREIGN KEY ( seqfeature_id ) REFERENCES seqfeature ( seqfeature_id ) ON DELETE CASCADE,
+    FOREIGN KEY ( dbxref_id ) REFERENCES dbxref ( dbxref_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX feadblink_dbx  ON seqfeature_dbxref(dbxref_id);
 
 CREATE TABLE location (
-	location_id		INTEGER PRIMARY KEY,
-   	seqfeature_id		INTEGER,
-	dbxref_id		INT(10),
-	term_id			INT(10),
-   	start_pos              	INT(10),
-   	end_pos                	INT(10),
-   	strand             	TINYINT NOT NULL DEFAULT 0,
-   	rank          		SMALLINT NOT NULL DEFAULT 0,
-   	UNIQUE (seqfeature_id, rank)
+    location_id		INTEGER PRIMARY KEY,
+    seqfeature_id		INTEGER,
+    dbxref_id		INT(10),
+    term_id			INT(10),
+    start_pos              	INT(10),
+    end_pos                	INT(10),
+    strand             	TINYINT NOT NULL DEFAULT 0,
+    rank          		SMALLINT NOT NULL DEFAULT 0,
+    UNIQUE (seqfeature_id, rank),
+    FOREIGN KEY ( seqfeature_id ) REFERENCES seqfeature ( seqfeature_id ) ON DELETE CASCADE,
+    FOREIGN KEY ( dbxref_id ) REFERENCES dbxref ( dbxref_id ),
+    FOREIGN KEY ( term_id ) REFERENCES term ( term_id )
 );
 
 CREATE INDEX seqfeatureloc_start ON location(start_pos, end_pos);
@@ -326,18 +385,13 @@ CREATE INDEX seqfeatureloc_dbx   ON location(dbxref_id);
 CREATE INDEX seqfeatureloc_trm   ON location(term_id);
 
 CREATE TABLE location_qualifier_value (
-	location_id		INTEGER,
-   	term_id 		INTEGER,
-   	value  			VARCHAR(255) NOT NULL,
-   	int_value 		INT(10),
-	PRIMARY KEY (location_id,term_id)
+    location_id		INTEGER,
+    term_id 		INTEGER,
+    value  			VARCHAR(255) NOT NULL,
+    int_value 		INT(10),
+    PRIMARY KEY (location_id,term_id),
+    FOREIGN KEY ( location_id ) REFERENCES location ( location_id ) ON DELETE CASCADE,
+    FOREIGN KEY ( term_id ) REFERENCES term ( term_id )
 );
 
 CREATE INDEX locationqual_trm ON location_qualifier_value(term_id);
-
--- SQLite does not enforce foreign key constraints. There are some trigger
--- based ways to replicate this:
---
--- http://www.sqlite.org/cvstrac/wiki?p=ForeignKeyTriggers
---
--- Currently no foreign key constraints are added.

--- a/Tests/BioSQL/biosqldb-sqlite.sql
+++ b/Tests/BioSQL/biosqldb-sqlite.sql
@@ -1,5 +1,5 @@
 --  BioSQL database schema for SQLite.
---
+-- 
 --  This file is part of BioSQL.
 --
 --  BioSQL is free software: you can redistribute it and/or modify it
@@ -19,48 +19,48 @@
 --
 -- See MySQL database schema and BioSQL website for table documentation.
 -- This contains notes specific to SQLite
---
+-- 
 -- A note about Primary Keys in SQLite
 -- SQLite automatically creates a ROWID for each row of a table.
---   Using this ROWID as the primary key is faster than using a
---   user-defined primary key. By declaring a column as an
+--   Using this ROWID as the primary key is faster than using a 
+--   user-defined primary key. By declaring a column as an 
 --   INTEGER PRIMARY KEY, you are actually creating an alias to the
 --   ROWID and get the associated speed benefits.  The ROWID effectively
---   "autoincrements"; however, it can reuse ROWIDs of deleted rows.
+--   "autoincrements"; however, it can reuse ROWIDs of deleted rows. 
 --   To avoid reusing old ROWIDs would require adding the AUTOINCREMENT
 --   keyword, which also reduces the performance.
---   ( see http://www.sqlite.org/autoinc.html)
+--   ( see http://www.sqlite.org/autoinc.html) 
 
 CREATE TABLE biodatabase (
-    biodatabase_id 	INTEGER PRIMARY KEY,
-    name           	VARCHAR(128) NOT NULL,
-    authority	VARCHAR(128),
-    description	TEXT,
-    UNIQUE (name)
+  	biodatabase_id 	INTEGER PRIMARY KEY,
+  	name           	VARCHAR(128) NOT NULL,
+	authority	VARCHAR(128),
+	description	TEXT,
+  	UNIQUE (name)
 );
 
 CREATE INDEX db_auth on biodatabase(authority);
 
 CREATE TABLE taxon (
-    taxon_id		INTEGER PRIMARY KEY,
-    ncbi_taxon_id 	INT(10),
-    parent_taxon_id	INT(10) ,
-    node_rank	VARCHAR(32),
-    genetic_code	TINYINT ,
-    mito_genetic_code TINYINT ,
-    left_value	INT(10) ,
-    right_value	INT(10) ,
-    UNIQUE (ncbi_taxon_id),
-    UNIQUE (left_value),
-    UNIQUE (right_value)
+       taxon_id		INTEGER PRIMARY KEY,
+       ncbi_taxon_id 	INT(10),
+       parent_taxon_id	INT(10) ,
+       node_rank	VARCHAR(32),
+       genetic_code	TINYINT ,
+       mito_genetic_code TINYINT ,
+       left_value	INT(10) ,
+       right_value	INT(10) ,
+       UNIQUE (ncbi_taxon_id),
+       UNIQUE (left_value),
+       UNIQUE (right_value)
 );
 
 CREATE INDEX taxparent ON taxon(parent_taxon_id);
 
 CREATE TABLE taxon_name (
-    taxon_id		INTEGER,
-    name		VARCHAR(255)  NOT NULL,
-    name_class	VARCHAR(32)  NOT NULL,
+       taxon_id		INTEGER,
+       name		VARCHAR(255)  NOT NULL,
+       name_class	VARCHAR(32)  NOT NULL,
     UNIQUE (taxon_id,name,name_class),
     FOREIGN KEY ( taxon_id ) REFERENCES taxon ( taxon_id ) ON DELETE CASCADE
 );
@@ -69,20 +69,20 @@ CREATE INDEX taxnametaxonid ON taxon_name(taxon_id);
 CREATE INDEX taxnamename    ON taxon_name(name);
 
 CREATE TABLE ontology (
-    ontology_id        INTEGER PRIMARY KEY,
-    name	   	   VARCHAR(32)  NOT NULL,
-    definition	   TEXT,
-    UNIQUE (name)
+       	ontology_id        INTEGER PRIMARY KEY,
+       	name	   	   VARCHAR(32)  NOT NULL,
+       	definition	   TEXT,
+	UNIQUE (name)
 );
 
 CREATE TABLE term (
-    term_id   INTEGER PRIMARY KEY,
-    name	   	   VARCHAR(255)  NOT NULL,
-    definition	   TEXT,
-    identifier	   VARCHAR(40) ,
-    is_obsolete	   CHAR(1),
-    ontology_id	   INTEGER,
-    UNIQUE (identifier),
+       	term_id   INTEGER PRIMARY KEY,
+       	name	   	   VARCHAR(255)  NOT NULL,
+       	definition	   TEXT,
+	identifier	   VARCHAR(40) ,
+	is_obsolete	   CHAR(1),
+	ontology_id	   INTEGER,
+	UNIQUE (identifier),
     UNIQUE (name,ontology_id,is_obsolete),
     FOREIGN KEY ( ontology_id ) REFERENCES ontology ( ontology_id ) ON DELETE CASCADE
 );
@@ -90,17 +90,17 @@ CREATE TABLE term (
 CREATE INDEX term_ont ON term(ontology_id);
 
 CREATE TABLE term_synonym (
-    synonym		  VARCHAR(255)  NOT NULL,
-    term_id		  INTEGER,
+       synonym		  VARCHAR(255)  NOT NULL,
+       term_id		  INTEGER,
     PRIMARY KEY (term_id,synonym),
 
     FOREIGN KEY ( term_id ) REFERENCES term ( term_id ) ON DELETE CASCADE
 );
 
 CREATE TABLE term_dbxref (
-    term_id	          INTEGER,
-    dbxref_id         INTEGER,
-    rank		  SMALLINT,
+       	term_id	          INTEGER,
+       	dbxref_id         INTEGER,
+	rank		  SMALLINT,
     PRIMARY KEY (term_id, dbxref_id),
 
     FOREIGN KEY ( dbxref_id ) REFERENCES dbxref ( dbxref_id ) ON DELETE CASCADE,
@@ -110,11 +110,11 @@ CREATE TABLE term_dbxref (
 CREATE INDEX trmdbxref_dbxrefid ON term_dbxref(dbxref_id);
 
 CREATE TABLE term_relationship (
-    term_relationship_id INTEGER PRIMARY KEY,
-    subject_term_id	INTEGER,
-    predicate_term_id    INTEGER,
-    object_term_id       INTEGER,
-    ontology_id	INTEGER,
+        term_relationship_id INTEGER PRIMARY KEY,
+       	subject_term_id	INTEGER,
+       	predicate_term_id    INTEGER,
+       	object_term_id       INTEGER,
+	ontology_id	INTEGER,
     UNIQUE (subject_term_id,predicate_term_id,object_term_id,ontology_id),
 
     FOREIGN KEY ( subject_term_id ) REFERENCES term ( term_id ) ON DELETE CASCADE ,
@@ -129,8 +129,8 @@ CREATE INDEX trmrel_objectid ON term_relationship(object_term_id);
 CREATE INDEX trmrel_ontid ON term_relationship(ontology_id);
 
 CREATE TABLE term_relationship_term (
-    term_relationship_id INTEGER PRIMARY KEY,
-    term_id              INTEGER,
+        term_relationship_id INTEGER PRIMARY KEY,
+        term_id              INTEGER,
     UNIQUE ( term_id ),
 
     FOREIGN KEY (term_relationship_id) REFERENCES term_relationship(term_relationship_id) ON DELETE CASCADE,
@@ -138,12 +138,12 @@ CREATE TABLE term_relationship_term (
 );
 
 CREATE TABLE term_path (
-    term_path_id         INTEGER PRIMARY KEY,
-    subject_term_id	     INTEGER,
-    predicate_term_id    INTEGER,
-    object_term_id       INTEGER,
-    ontology_id          INTEGER,
-    distance	     INT(10) ,
+        term_path_id         INTEGER PRIMARY KEY,
+       	subject_term_id	     INTEGER,
+       	predicate_term_id    INTEGER,
+       	object_term_id       INTEGER,
+	ontology_id          INTEGER,
+	distance	     INT(10) ,
     UNIQUE (subject_term_id,predicate_term_id,object_term_id,ontology_id,distance),
     FOREIGN KEY ( subject_term_id ) REFERENCES term ( term_id ) ON DELETE CASCADE ,
     FOREIGN KEY ( predicate_term_id ) REFERENCES term ( term_id ) ON DELETE CASCADE ,
@@ -156,16 +156,16 @@ CREATE INDEX trmpath_objectid ON term_path(object_term_id);
 CREATE INDEX trmpath_ontid ON term_path(ontology_id);
 
 CREATE TABLE bioentry (
-    bioentry_id	    INTEGER PRIMARY KEY,
-    biodatabase_id  INTEGER,
-    taxon_id     	INT(10) ,
-    name		VARCHAR(40) NOT NULL,
-    accession    	VARCHAR(128)  NOT NULL,
-    identifier   	VARCHAR(40) ,
-    division	VARCHAR(6),
-    description  	TEXT,
-    version 	SMALLINT  NOT NULL,
-    UNIQUE (accession,biodatabase_id,version),
+	bioentry_id	    INTEGER PRIMARY KEY,
+  	biodatabase_id  INTEGER,
+  	taxon_id     	INT(10) ,
+  	name		VARCHAR(40) NOT NULL,
+  	accession    	VARCHAR(128)  NOT NULL,
+  	identifier   	VARCHAR(40) ,
+	division	VARCHAR(6),
+  	description  	TEXT,
+  	version 	SMALLINT  NOT NULL, 
+  	UNIQUE (accession,biodatabase_id,version),
     UNIQUE (identifier, biodatabase_id),
 
     FOREIGN KEY ( taxon_id ) REFERENCES taxon ( taxon_id ),
@@ -177,11 +177,11 @@ CREATE INDEX bioentry_db   ON bioentry(biodatabase_id);
 CREATE INDEX bioentry_tax  ON bioentry(taxon_id);
 
 CREATE TABLE bioentry_relationship (
-    bioentry_relationship_id INTEGER PRIMARY KEY,
-    object_bioentry_id 	 INTEGER,
-    subject_bioentry_id 	 INTEGER,
-    term_id 		 INTEGER,
-    rank 			 INT(5),
+        bioentry_relationship_id INTEGER PRIMARY KEY,
+        object_bioentry_id 	 INTEGER,
+   	subject_bioentry_id 	 INTEGER,
+   	term_id 		 INTEGER,
+   	rank 			 INT(5),
     UNIQUE (object_bioentry_id,subject_bioentry_id,term_id),
     FOREIGN KEY ( term_id ) REFERENCES term ( term_id ),
     FOREIGN KEY ( object_bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE,
@@ -192,10 +192,10 @@ CREATE INDEX bioentryrel_trm   ON bioentry_relationship(term_id);
 CREATE INDEX bioentryrel_child ON bioentry_relationship(subject_bioentry_id);
 
 CREATE TABLE bioentry_path (
-    object_bioentry_id 	INTEGER PRIMARY KEY,
-    subject_bioentry_id 	INTEGER,
-    term_id 		INTEGER,
-    distance	     	INT(10) ,
+   	object_bioentry_id 	INTEGER PRIMARY KEY,
+   	subject_bioentry_id 	INTEGER,
+   	term_id 		INTEGER,
+	distance	     	INT(10) ,
     UNIQUE (object_bioentry_id,subject_bioentry_id,term_id,distance),
 
     FOREIGN KEY ( term_id ) REFERENCES term ( term_id )
@@ -207,29 +207,29 @@ CREATE INDEX bioentrypath_trm   ON bioentry_path(term_id);
 CREATE INDEX bioentrypath_child ON bioentry_path(subject_bioentry_id);
 
 CREATE TABLE biosequence (
-    bioentry_id     INTEGER PRIMARY KEY,
-    version     	SMALLINT,
-    length      	INT(10),
-    alphabet        VARCHAR(10),
+  	bioentry_id     INTEGER PRIMARY KEY,
+  	version     	SMALLINT, 
+  	length      	INT(10),
+  	alphabet        VARCHAR(10),
     seq 		LONGTEXT,
     FOREIGN KEY ( bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE
 );
 
 CREATE TABLE dbxref (
-    dbxref_id	INTEGER PRIMARY KEY,
-    dbname          VARCHAR(40)  NOT NULL,
-    accession       VARCHAR(128)  NOT NULL,
-    version		SMALLINT  NOT NULL,
-    UNIQUE(accession, dbname, version)
+        dbxref_id	INTEGER PRIMARY KEY,
+        dbname          VARCHAR(40)  NOT NULL,
+        accession       VARCHAR(128)  NOT NULL,
+	version		SMALLINT  NOT NULL,
+        UNIQUE(accession, dbname, version)
 );
 
 CREATE INDEX dbxref_db  ON dbxref(dbname);
 
 CREATE TABLE dbxref_qualifier_value (
-    dbxref_id 		INTEGER,
-    term_id 		INTEGER,
-    rank  		   	SMALLINT NOT NULL DEFAULT 0,
-    value			TEXT,
+       	dbxref_id 		INTEGER,
+       	term_id 		INTEGER,
+  	rank  		   	SMALLINT NOT NULL DEFAULT 0,
+       	value			TEXT,
     PRIMARY KEY (dbxref_id,term_id,rank),
 
     FOREIGN KEY ( term_id ) REFERENCES term ( term_id ),
@@ -239,10 +239,10 @@ CREATE TABLE dbxref_qualifier_value (
 CREATE INDEX dbxrefqual_dbx ON dbxref_qualifier_value(dbxref_id);
 CREATE INDEX dbxrefqual_trm ON dbxref_qualifier_value(term_id);
 
-CREATE TABLE bioentry_dbxref (
-    bioentry_id        INTEGER,
-    dbxref_id          INTEGER,
-    rank  		   SMALLINT,
+CREATE TABLE bioentry_dbxref ( 
+       	bioentry_id        INTEGER,
+       	dbxref_id          INTEGER,
+  	rank  		   SMALLINT,
     PRIMARY KEY (bioentry_id,dbxref_id),
     FOREIGN KEY ( bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE,
     FOREIGN KEY ( dbxref_id ) REFERENCES dbxref ( dbxref_id ) ON DELETE CASCADE
@@ -252,23 +252,23 @@ CREATE TABLE bioentry_dbxref (
 CREATE INDEX dblink_dbx  ON bioentry_dbxref(dbxref_id);
 
 CREATE TABLE reference (
-    reference_id       INTEGER PRIMARY KEY,
-    dbxref_id	   INT(10) ,
-    location 	   TEXT NOT NULL,
-    title    	   TEXT,
-    authors  	   TEXT,
-    crc	   	   VARCHAR(32),
-    UNIQUE (dbxref_id),
+  	reference_id       INTEGER PRIMARY KEY,
+	dbxref_id	   INT(10) ,
+  	location 	   TEXT NOT NULL,
+  	title    	   TEXT,
+  	authors  	   TEXT,
+  	crc	   	   VARCHAR(32),
+	UNIQUE (dbxref_id),
     UNIQUE (crc),
     FOREIGN KEY ( dbxref_id ) REFERENCES dbxref ( dbxref_id )
 );
 
 CREATE TABLE bioentry_reference (
-    bioentry_id 	INTEGER,
-    reference_id 	INTEGER,
-    start_pos	INT(10),
-    end_pos	  	INT(10),
-    rank  		SMALLINT NOT NULL DEFAULT 0,
+  	bioentry_id 	INTEGER,
+  	reference_id 	INTEGER,
+  	start_pos	INT(10),
+  	end_pos	  	INT(10),
+  	rank  		SMALLINT NOT NULL DEFAULT 0,
     PRIMARY KEY(bioentry_id,reference_id,rank),
     FOREIGN KEY ( bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE
     FOREIGN KEY ( reference_id ) REFERENCES reference ( reference_id ) ON DELETE CASCADE
@@ -277,19 +277,19 @@ CREATE TABLE bioentry_reference (
 CREATE INDEX bioentryref_ref ON bioentry_reference(reference_id);
 
 CREATE TABLE comment (
-    comment_id  	INTEGER PRIMARY KEY,
-    bioentry_id    	INTEGER,
-    comment_text   	TEXT NOT NULL,
-    rank   		SMALLINT NOT NULL DEFAULT 0,
+  	comment_id  	INTEGER PRIMARY KEY,
+  	bioentry_id    	INTEGER,
+  	comment_text   	TEXT NOT NULL,
+  	rank   		SMALLINT NOT NULL DEFAULT 0,
     UNIQUE(bioentry_id, rank),
     FOREIGN KEY ( bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE
 );
 
 CREATE TABLE bioentry_qualifier_value (
-    bioentry_id   		INTEGER,
-    term_id  		INTEGER,
-    value         		TEXT,
-    rank			INT(5) NOT NULL DEFAULT 0,
+	bioentry_id   		INTEGER,
+   	term_id  		INTEGER,
+   	value         		TEXT,
+	rank			INT(5) NOT NULL DEFAULT 0,
     UNIQUE (bioentry_id,term_id,rank),
     FOREIGN KEY ( bioentry_id ) REFERENCES bioentry ( bioentry_id ) ON DELETE CASCADE,
     FOREIGN KEY ( term_id ) REFERENCES term ( term_id )
@@ -298,12 +298,12 @@ CREATE TABLE bioentry_qualifier_value (
 CREATE INDEX bioentryqual_trm ON bioentry_qualifier_value(term_id);
 
 CREATE TABLE seqfeature (
-    seqfeature_id 		INTEGER PRIMARY KEY,
-    bioentry_id   		INTEGER,
-    type_term_id		INTEGER,
-    source_term_id  	INTEGER,
-    display_name		VARCHAR(64),
-    rank 			SMALLINT  NOT NULL DEFAULT 0,
+   	seqfeature_id 		INTEGER PRIMARY KEY,
+   	bioentry_id   		INTEGER,
+   	type_term_id		INTEGER,
+   	source_term_id  	INTEGER,
+	display_name		VARCHAR(64),
+   	rank 			SMALLINT  NOT NULL DEFAULT 0,
     UNIQUE (bioentry_id,type_term_id,source_term_id,rank),
     FOREIGN KEY ( type_term_id ) REFERENCES term ( term_id ),
     FOREIGN KEY ( source_term_id ) REFERENCES term ( term_id ),
@@ -314,11 +314,11 @@ CREATE INDEX seqfeature_trm  ON seqfeature(type_term_id);
 CREATE INDEX seqfeature_fsrc ON seqfeature(source_term_id);
 
 CREATE TABLE seqfeature_relationship (
-    seqfeature_relationship_id INTEGER PRIMARY KEY,
-    object_seqfeature_id	INTEGER,
-    subject_seqfeature_id 	INTEGER,
-    term_id 	        INTEGER,
-    rank 			INT(5),
+        seqfeature_relationship_id INTEGER PRIMARY KEY,
+   	object_seqfeature_id	INTEGER,
+   	subject_seqfeature_id 	INTEGER,
+   	term_id 	        INTEGER,
+   	rank 			INT(5),
     UNIQUE (object_seqfeature_id,subject_seqfeature_id,term_id),
     FOREIGN KEY ( term_id ) REFERENCES term ( term_id ),
     FOREIGN KEY ( object_seqfeature_id ) REFERENCES seqfeature ( seqfeature_id ) ON DELETE CASCADE,
@@ -329,10 +329,10 @@ CREATE INDEX seqfeaturerel_trm   ON seqfeature_relationship(term_id);
 CREATE INDEX seqfeaturerel_child ON seqfeature_relationship(subject_seqfeature_id);
 
 CREATE TABLE seqfeature_path (
-    object_seqfeature_id	INTEGER,
-    subject_seqfeature_id 	INTEGER,
-    term_id 		INTEGER,
-    distance	     	INT(10) ,
+   	object_seqfeature_id	INTEGER,
+   	subject_seqfeature_id 	INTEGER,
+   	term_id 		INTEGER,
+	distance	     	INT(10) ,
     UNIQUE (object_seqfeature_id,subject_seqfeature_id,term_id,distance),
     FOREIGN KEY ( term_id ) REFERENCES term ( term_id ),
     FOREIGN KEY ( object_seqfeature_id ) REFERENCES seqfeature ( seqfeature_id ) ON DELETE CASCADE,
@@ -343,21 +343,21 @@ CREATE INDEX seqfeaturepath_trm   ON seqfeature_path(term_id);
 CREATE INDEX seqfeaturepath_child ON seqfeature_path(subject_seqfeature_id);
 
 CREATE TABLE seqfeature_qualifier_value (
-    seqfeature_id 		INTEGER,
-    term_id 		INTEGER,
-    rank 			SMALLINT NOT NULL DEFAULT 0,
-    value  			TEXT NOT NULL,
+	seqfeature_id 		INTEGER,
+   	term_id 		INTEGER,
+   	rank 			SMALLINT NOT NULL DEFAULT 0,
+   	value  			TEXT NOT NULL,
     PRIMARY KEY (seqfeature_id,term_id,rank),
     FOREIGN KEY ( term_id ) REFERENCES term ( term_id ),
     FOREIGN KEY ( seqfeature_id ) REFERENCES seqfeature ( seqfeature_id ) ON DELETE CASCADE
 );
 
 CREATE INDEX seqfeaturequal_trm ON seqfeature_qualifier_value(term_id);
-
-CREATE TABLE seqfeature_dbxref (
-    seqfeature_id      INTEGER,
-    dbxref_id          INTEGER,
-    rank  		   SMALLINT,
+   
+CREATE TABLE seqfeature_dbxref ( 
+       	seqfeature_id      INTEGER,
+       	dbxref_id          INTEGER,
+  	rank  		   SMALLINT,
     PRIMARY KEY (seqfeature_id,dbxref_id),
     FOREIGN KEY ( seqfeature_id ) REFERENCES seqfeature ( seqfeature_id ) ON DELETE CASCADE,
     FOREIGN KEY ( dbxref_id ) REFERENCES dbxref ( dbxref_id ) ON DELETE CASCADE
@@ -366,14 +366,14 @@ CREATE TABLE seqfeature_dbxref (
 CREATE INDEX feadblink_dbx  ON seqfeature_dbxref(dbxref_id);
 
 CREATE TABLE location (
-    location_id		INTEGER PRIMARY KEY,
-    seqfeature_id		INTEGER,
-    dbxref_id		INT(10),
-    term_id			INT(10),
-    start_pos              	INT(10),
-    end_pos                	INT(10),
-    strand             	TINYINT NOT NULL DEFAULT 0,
-    rank          		SMALLINT NOT NULL DEFAULT 0,
+	location_id		INTEGER PRIMARY KEY,
+   	seqfeature_id		INTEGER,
+	dbxref_id		INT(10),
+	term_id			INT(10),
+   	start_pos              	INT(10),
+   	end_pos                	INT(10),
+   	strand             	TINYINT NOT NULL DEFAULT 0,
+   	rank          		SMALLINT NOT NULL DEFAULT 0,
     UNIQUE (seqfeature_id, rank),
     FOREIGN KEY ( seqfeature_id ) REFERENCES seqfeature ( seqfeature_id ) ON DELETE CASCADE,
     FOREIGN KEY ( dbxref_id ) REFERENCES dbxref ( dbxref_id ),
@@ -385,10 +385,10 @@ CREATE INDEX seqfeatureloc_dbx   ON location(dbxref_id);
 CREATE INDEX seqfeatureloc_trm   ON location(term_id);
 
 CREATE TABLE location_qualifier_value (
-    location_id		INTEGER,
-    term_id 		INTEGER,
-    value  			VARCHAR(255) NOT NULL,
-    int_value 		INT(10),
+	location_id		INTEGER,
+   	term_id 		INTEGER,
+   	value  			VARCHAR(255) NOT NULL,
+   	int_value 		INT(10),
     PRIMARY KEY (location_id,term_id),
     FOREIGN KEY ( location_id ) REFERENCES location ( location_id ) ON DELETE CASCADE,
     FOREIGN KEY ( term_id ) REFERENCES term ( term_id )

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -474,6 +474,67 @@ class LoaderTest(unittest.TestCase):
         self.assertEqual(item_ids, ['AF297471.1', 'AJ237582.1', 'L31939.1',
                                     'M81224.1', 'X55053.1', 'X62281.1'])
 
+class DeleteTest(unittest.TestCase):
+    """Test proper deletion of entries from a database."""
+
+    loaded_db = 0
+
+    def setUp(self):
+        """Connect to and load up the database.
+        """
+        load_database("GenBank/cor6_6.gb")
+
+        self.server = BioSeqDatabase.open_database(driver=DBDRIVER,
+                                                   user=DBUSER,
+                                                   passwd=DBPASSWD,
+                                                   host=DBHOST,
+                                                   db=TESTDB)
+
+        self.db = self.server["biosql-test"]
+
+    def tearDown(self):
+        self.server.close()
+        destroy_database()
+        del self.db
+        del self.server
+
+    def test_server(self):
+        """Check BioSeqDatabase methods"""
+        server = self.server
+        self.assertTrue("biosql-test" in server)
+        self.assertEqual(1, len(server))
+        self.assertEqual(["biosql-test"], list(server.keys()))
+        # Check we can delete the namespace...
+        del server["biosql-test"]
+        self.assertEqual(0, len(server))
+        try:
+            del server["non-existant-name"]
+            assert False, "Should have raised KeyError"
+        except KeyError:
+            pass
+
+    def test_del_db_items(self):
+        """Check all associated data is delete from an item"""
+        db = self.db
+        items = list(db.values())
+        keys = list(db)
+        l = len(items)
+
+        for seq_id in self.db.keys():
+            sql = "SELECT seqfeature_id from seqfeature where bioentry_id = '%s'"
+            # get the original number of seqfeatures associated with the bioentry
+            seqfeatures = self.db.adaptor.execute_and_fetchall( sql % (seq_id))
+
+            del db[seq_id]
+            # check to see that the entry in the bioentry table is removed
+            self.assertEqual(seq_id in db, False)
+
+            # no need to check seqfeature presence if it had none to begin with
+            if len(seqfeatures):
+                rows_d = self.db.adaptor.execute_and_fetchall( sql % (seq_id))
+                # check to see that associated data is removed
+                self.assertEqual(len(rows_d), 0)
+
 
 class DupLoadTest(unittest.TestCase):
     """Check a few duplicate conditions fail."""


### PR DESCRIPTION
Fix for biopython/biopython#741 by changing the database schema
for sqlite3 to use foreign keys. A new test has been added in that
explicitly tests to make sure associated data with a bioentry is
removed.

To accommodate the use of foreign keys the connection to an sqlite
database must set the PRAGMA, which is now done automatically when
opening the database.

The sqlite schema for testing has been updated to be identical to
the version in biosql/biosql#3 that is a pull request for the main
biosql repository