### PR TITLE
Fixed Bio.motifs.motif.weblogo() for protein sequences

### DIFF
--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -440,6 +440,16 @@ class Motif(object):
 
         """
         from Bio._py3k import urlopen, urlencode, Request
+        from Bio import Alphabet
+
+        if isinstance(self.alphabet, Alphabet.ProteinAlphabet):
+            alpha = "alphabet_protein"
+        elif isinstance(self.alphabet, Alphabet.RNAAlphabet):
+            alpha = "alphabet_rna"
+        elif isinstance(self.alphabet, Alphabet.DNAAlphabet):
+            alpha = "alphabet_dna"
+        else:
+            alpha = "auto"
 
         frequencies = self.format('transfac')
         url = 'http://weblogo.threeplusone.com/create.cgi'
@@ -447,7 +457,7 @@ class Motif(object):
                   'format': format.lower(),
                   'stack_width': 'medium',
                   'stack_per_line': '40',
-                  'alphabet': 'alphabet_dna',
+                  'alphabet': alpha,
                   'ignore_lower_case': True,
                   'unit_name': "bits",
                   'first_index': '1',

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -201,7 +201,7 @@ class GenericPositionMatrix(dict):
                 key = "".join(sorted(nucleotides[:3]))
             else:
                 key = "ACGT"
-            nucleotide = degenerate_nucleotide[key]
+            nucleotide = degenerate_nucleotide.get(key, key)
             sequence += nucleotide
         return Seq(sequence, alphabet=IUPAC.ambiguous_dna)
 

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -13,6 +13,7 @@ from Bio._py3k import range
 
 from Bio.Seq import Seq
 from Bio.Alphabet import IUPAC
+from Bio import Alphabet
 
 __docformat__ = "restructuredtext en"
 
@@ -203,7 +204,15 @@ class GenericPositionMatrix(dict):
                 key = "ACGT"
             nucleotide = degenerate_nucleotide.get(key, key)
             sequence += nucleotide
-        return Seq(sequence, alphabet=IUPAC.ambiguous_dna)
+        if isinstance(self.alphabet, Alphabet.DNAAlphabet):
+            alpha = IUPAC.ambiguous_dna
+        elif isinstance(self.alphabet, Alphabet.RNAAlphabet):
+            alpha = IUPAC.amiguous_rna
+        elif isinstance(self.alphabet, Alphabet.ProteinAlphabet):
+            alpha = IUPAC.protein
+        else:
+            raise Exception("Unknown alphabet")
+        return Seq(sequence, alphabet=alpha)
 
     @property
     def gc_content(self):

--- a/Bio/motifs/transfac.py
+++ b/Bio/motifs/transfac.py
@@ -189,7 +189,6 @@ XX
 
                     lines.append(line)
                     for i in range(length):
-                    for i in range(length):
                         line = " ".join(
                             ["%02.d"] +
                             ["%6.20g" for l in motif.alphabet.letters]) + \

--- a/Bio/motifs/transfac.py
+++ b/Bio/motifs/transfac.py
@@ -184,18 +184,19 @@ XX
                     length = motif.length
                     if length == 0:
                         continue
-                    sequence = motif.degenerate_consensus
-                    line = "      ".join(["P0"] + list(motif.alphabet.letters))
+                        sequence = motif.degenerate_consensus
+                    letters = sorted(motif.alphabet.letters)
+                    line = "      ".join(["P0"] + letters)
 
                     lines.append(line)
                     for i in range(length):
                         line = " ".join(
                             ["%02.d"] +
-                            ["%6.20g" for l in motif.alphabet.letters]) + \
+                            ["%6.20g" for l in letters]) + \
                             "      %s"
                         line = line % tuple(
                             [i + 1] +
-                            [motif.counts[l][i] for l in motif.alphabet.letters] +
+                            [motif.counts[l][i] for l in letters] +
                             [sequence[i]]
                         )
                         lines.append(line)

--- a/Bio/motifs/transfac.py
+++ b/Bio/motifs/transfac.py
@@ -184,7 +184,7 @@ XX
                     length = motif.length
                     if length == 0:
                         continue
-                        sequence = motif.degenerate_consensus
+                    sequence = motif.degenerate_consensus
                     letters = sorted(motif.alphabet.letters)
                     line = "      ".join(["P0"] + letters)
 

--- a/Bio/motifs/transfac.py
+++ b/Bio/motifs/transfac.py
@@ -185,17 +185,20 @@ XX
                     if length == 0:
                         continue
                     sequence = motif.degenerate_consensus
-                    line = "P0      A      C      G      T"
+                    line = "      ".join(["P0"] + list(motif.alphabet.letters))
+
                     lines.append(line)
                     for i in range(length):
-                        line = "%02.d %6.20g %6.20g %6.20g %6.20g      %s" % (
-                                             i + 1,
-                                             motif.counts['A'][i],
-                                             motif.counts['C'][i],
-                                             motif.counts['G'][i],
-                                             motif.counts['T'][i],
-                                             sequence[i],
-                                            )
+                    for i in range(length):
+                        line = " ".join(
+                            ["%02.d"] +
+                            ["%6.20g" for l in motif.alphabet.letters]) + \
+                            "      %s"
+                        line = line % tuple(
+                            [i + 1] +
+                            [motif.counts[l][i] for l in motif.alphabet.letters] +
+                            [sequence[i]]
+                        )
                         lines.append(line)
                     blank = True
                 else:

--- a/Tests/test_motifs_online.py
+++ b/Tests/test_motifs_online.py
@@ -20,6 +20,9 @@ from Bio.Seq import Seq
 
 
 class TestDNAMotifWeblogo(unittest.TestCase):
+    """
+    Tests Bio.motifs online code with DNA sequences.
+    """
     def setUp(self):
         self.m = motifs.create(
             [
@@ -30,10 +33,16 @@ class TestDNAMotifWeblogo(unittest.TestCase):
         )
 
     def test_weblogo(self):
+        """
+        Test Bio.Motif.weblogo with a DNA sequence.
+        """
         self.m.weblogo(os.devnull)
 
 
 class TestRNAMotifWeblogo(unittest.TestCase):
+    """
+    Tests Bio.motifs online code with RNA sequences.
+    """
     def setUp(self):
         self.m = motifs.create(
             [
@@ -44,10 +53,16 @@ class TestRNAMotifWeblogo(unittest.TestCase):
         )
 
     def test_weblogo(self):
+        """
+        Test Bio.Motif.weblogo with an RNA sequence.
+        """
         self.m.weblogo(os.devnull)
 
 
 class TestProteinMotifWeblogo(unittest.TestCase):
+    """
+    Tests Bio.motifs online code with protein sequences.
+    """
     def setUp(self):
         self.m = motifs.create(
             [
@@ -58,6 +73,9 @@ class TestProteinMotifWeblogo(unittest.TestCase):
         )
 
     def test_weblogo(self):
+        """
+        Test Bio.Motif.weblogo with a protein sequence.
+        """
         self.m.weblogo(os.devnull)
 
 

--- a/Tests/test_motifs_online.py
+++ b/Tests/test_motifs_online.py
@@ -13,16 +13,49 @@ requires_internet.check()
 
 # We want to test these:
 from Bio import motifs
+from Bio.Alphabet import IUPAC
 
 # In order to check any sequences returned
 from Bio.Seq import Seq
 
 
-class TestMotifWeblogo(unittest.TestCase):
+class TestDNAMotifWeblogo(unittest.TestCase):
     def setUp(self):
-        self.m = motifs.create([
-            Seq("TACAA"), Seq("TACGC"), Seq("TACAC"), Seq("TACCC"),
-            Seq("AACCC"), Seq("AATGC"), Seq("AATGC")])
+        self.m = motifs.create(
+            [
+                Seq("TACAA"), Seq("TACGC"), Seq("TACAC"), Seq("TACCC"),
+                Seq("AACCC"), Seq("AATGC"), Seq("AATGC")
+            ],
+            alphabet=IUPAC.extended_dna,
+        )
+
+    def test_weblogo(self):
+        self.m.weblogo(os.devnull)
+
+
+class TestRNAMotifWeblogo(unittest.TestCase):
+    def setUp(self):
+        self.m = motifs.create(
+            [
+                Seq("UACAA"), Seq("UACGC"), Seq("UACAC"), Seq("UACCC"),
+                Seq("AACCC"), Seq("AAUGC"), Seq("AAUGC")
+            ],
+            alphabet=IUPAC.unambiguous_rna,
+        )
+
+    def test_weblogo(self):
+        self.m.weblogo(os.devnull)
+
+
+class TestProteinMotifWeblogo(unittest.TestCase):
+    def setUp(self):
+        self.m = motifs.create(
+            [
+                Seq("ACDEG"), Seq("AYCRN"), Seq("HYLID"), Seq("AYHEL"),
+                Seq("ACDEH"), Seq("AYYRN"), Seq("HYIID")
+            ],
+            alphabet=IUPAC.extended_protein,
+        )
 
     def test_weblogo(self):
         self.m.weblogo(os.devnull)


### PR DESCRIPTION
I fixed all the exceptions that were raised when calling `weblogo()` on a motif made up of protein sequences. I also changed the frequencies table that is sent to the server as well as the "alphabet" in order to ensure that letters other than A and C were considered!

I had one uncertainty in my changes however: It seems that `Bio.motifs.matrix.GenericPositionMatrix` has a function called `degenerate_consensus()` that was written with only DNA in mind. I was able to fix an exception that occurred in this function, however the change does not incorporate any new functionality for handling degenerate protein sequences.