### PR TITLE
BioSeqDatabase __getitem__ bug

### DIFF
--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -629,8 +629,10 @@ class BioSeqDatabase(object):
         return list(self.keys())
 
     def __getitem__(self, key):
-        if key not in self:
-            raise KeyError("Entry %r cannot be found or is invalid" % key)
+        record = BioSeq.DBSeqRecord(self.adaptor, key)
+        if record._biodatabase_id != self.dbid:
+            raise KeyError("Entry %r does exist, but not in current name space" % key)
+        return record
 
         return BioSeq.DBSeqRecord(self.adaptor, key)
 

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -629,6 +629,9 @@ class BioSeqDatabase(object):
         return list(self.keys())
 
     def __getitem__(self, key):
+        if key not in self:
+            raise KeyError(key)
+
         return BioSeq.DBSeqRecord(self.adaptor, key)
 
     def __delitem__(self, key):

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -630,14 +630,14 @@ class BioSeqDatabase(object):
 
     def __getitem__(self, key):
         if key not in self:
-            raise KeyError(key)
+            raise KeyError("Entry %r cannot be found or is invalid" % key)
 
         return BioSeq.DBSeqRecord(self.adaptor, key)
 
     def __delitem__(self, key):
         """Remove an entry and all its annotation."""
         if key not in self:
-            raise KeyError(key)
+            raise KeyError("Entry %r cannot be deleted. It was not found or is invalid" % key)
         # Assuming this will automatically cascade to the other tables...
         sql = "DELETE FROM bioentry " + \
               "WHERE biodatabase_id=%s AND bioentry_id=%s;"

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -634,8 +634,6 @@ class BioSeqDatabase(object):
             raise KeyError("Entry %r does exist, but not in current name space" % key)
         return record
 
-        return BioSeq.DBSeqRecord(self.adaptor, key)
-
     def __delitem__(self, key):
         """Remove an entry and all its annotation."""
         if key not in self:

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -314,8 +314,11 @@ class MultiReadTest(unittest.TestCase):
         db = self.db
         db2 = self.db2
         for db2_id in db2.keys():
-            with self.assertRaises(KeyError):
+            try:
                 rec = db[db2_id]
+                assert False, "Should have raised KeyError"
+            except KeyError:
+                pass
 
 
 class ReadTest(unittest.TestCase):


### PR DESCRIPTION
I discovered that there was no check in the `__getitem__` method of `BioSeqDatabase` to make sure that the identifier was actually part of the current namespace (biodatabase) and thus it was possible to retrieve any sequence that is in the SQL server. This pull request adds this check, raising a KeyError where appropriate, and adds in some new test functionality for databases with multiple namespaces. 