### PR TITLE
Solves problems raised in #775

### DIFF
--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -135,7 +135,7 @@ class MMCIFParser(object):
             altloc = alt_list[i]
             if altloc == ".":
                 altloc = " "
-            resseq = seq_id_list[i]
+            int_resseq = int(seq_id_list[i])
             icode = icode_list[i]
             if icode == "?":
                 icode = " "
@@ -154,6 +154,9 @@ class MMCIFParser(object):
                 hetatm_flag = "H"
             else:
                 hetatm_flag = " "
+
+            resseq = (hetatm_flag, int_resseq, icode)
+
             if serial_list is not None:
                 # model column exists; use it
                 serial_id = serial_list[i]
@@ -171,10 +174,10 @@ class MMCIFParser(object):
             if current_chain_id != chainid:
                 current_chain_id = chainid
                 structure_builder.init_chain(current_chain_id)
+                current_residue_id = None
 
             if current_residue_id != resseq:
                 current_residue_id = resseq
-                int_resseq = int(resseq)
                 structure_builder.init_residue(resname, hetatm_flag, int_resseq, icode)
 
             coord = numpy.array((x, y, z), 'f')

--- a/Tests/PDB/4zhl.cif
+++ b/Tests/PDB/4zhl.cif
@@ -1,0 +1,3693 @@
+data_4ZHL
+# 
+_entry.id   4ZHL 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    4.058 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+PDB   4ZHL         
+WWPDB D_1000209290 
+# 
+loop_
+_database_PDB_rev.num 
+_database_PDB_rev.date 
+_database_PDB_rev.date_original 
+_database_PDB_rev.status 
+_database_PDB_rev.replaces 
+_database_PDB_rev.mod_type 
+1 2015-09-16 2015-04-25 ? 4ZHL 0 
+2 2015-10-14 ?          ? 4ZHL 1 
+# 
+_database_PDB_rev_record.rev_num   2 
+_database_PDB_rev_record.type      JRNL 
+_database_PDB_rev_record.details   ? 
+# 
+_pdbx_database_related.db_name        PDB 
+_pdbx_database_related.details        . 
+_pdbx_database_related.db_id          4ZHM 
+_pdbx_database_related.content_type   unspecified 
+# 
+_pdbx_database_status.status_code                      REL 
+_pdbx_database_status.status_code_sf                   REL 
+_pdbx_database_status.status_code_mr                   ? 
+_pdbx_database_status.entry_id                         4ZHL 
+_pdbx_database_status.date_begin_release_preparation   . 
+_pdbx_database_status.SG_entry                         N 
+_pdbx_database_status.deposit_site                     RCSB 
+_pdbx_database_status.process_site                     RCSB 
+_pdbx_database_status.methods_development_category     ? 
+_pdbx_database_status.pdb_format_compatible            Y 
+# 
+loop_
+_audit_author.address 
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+? 'Jiang, L.'       1 
+? 'Andreasen, P.A.' 2 
+? 'Huang, M.'       3 
+# 
+_citation.abstract                  ? 
+_citation.abstract_id_CAS           ? 
+_citation.book_id_ISBN              ? 
+_citation.book_publisher            ? 
+_citation.book_publisher_city       ? 
+_citation.book_title                ? 
+_citation.coordinate_linkage        ? 
+_citation.country                   UK 
+_citation.database_id_Medline       ? 
+_citation.details                   ? 
+_citation.id                        primary 
+_citation.journal_abbrev            J.Mol.Biol. 
+_citation.journal_id_ASTM           JMOBAK 
+_citation.journal_id_CSD            ? 
+_citation.journal_id_ISSN           1089-8638 
+_citation.journal_full              ? 
+_citation.journal_issue             ? 
+_citation.journal_volume            427 
+_citation.language                  ? 
+_citation.page_first                3110 
+_citation.page_last                 3122 
+_citation.title                     
+;Selection of High-Affinity Peptidic Serine Protease Inhibitors with Increased Binding Entropy from a Back-Flip Library of Peptide-Protease Fusions.
+;
+_citation.year                      2015 
+_citation.database_id_CSD           ? 
+_citation.pdbx_database_id_DOI      10.1016/j.jmb.2015.08.005 
+_citation.pdbx_database_id_PubMed   26281711 
+_citation.unpublished_flag          ? 
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+primary 'Srensen, H.P.'      1 
+primary 'Xu, P.'             2 
+primary 'Jiang, L.'          3 
+primary 'Kromann-Hansen, T.' 4 
+primary 'Jensen, K.J.'       5 
+primary 'Huang, M.'          6 
+primary 'Andreasen, P.A.'    7 
+# 
+_cell.entry_id           4ZHL 
+_cell.length_a           122.057 
+_cell.length_b           122.057 
+_cell.length_c           42.555 
+_cell.angle_alpha        90.00 
+_cell.angle_beta         90.00 
+_cell.angle_gamma        120.00 
+_cell.Z_PDB              9 
+_cell.pdbx_unique_axis   ? 
+# 
+_symmetry.entry_id                         4ZHL 
+_symmetry.space_group_name_H-M             'H 3' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                146 
+# 
+loop_
+_entity.id 
+_entity.type 
+_entity.src_method 
+_entity.pdbx_description 
+_entity.formula_weight 
+_entity.pdbx_number_of_molecules 
+_entity.pdbx_ec 
+_entity.pdbx_mutation 
+_entity.pdbx_fragment 
+_entity.details 
+1 polymer man 'Urokinase-type plasminogen activator' 27869.742 1  3.4.21.73 'H99Y, C122A, N145Q' 'UNP RESIDUES 179-425' ? 
+2 polymer syn mupain-1-IG                            1133.322  1  ?         ?                    ?                      ? 
+3 water   nat water                                  18.015    50 ?         ?                    ?                      ? 
+# 
+_entity_name_com.entity_id   1 
+_entity_name_com.name        uPA 
+# 
+loop_
+_entity_poly.entity_id 
+_entity_poly.type 
+_entity_poly.nstd_linkage 
+_entity_poly.nstd_monomer 
+_entity_poly.pdbx_seq_one_letter_code 
+_entity_poly.pdbx_seq_one_letter_code_can 
+_entity_poly.pdbx_strand_id 
+_entity_poly.pdbx_target_identifier 
+1 'polypeptide(L)' no no 
+;IIGGEFTTIENQPWFAAIYRRHRGGSVTYVCGGSLISPCWVISATHCFIDYPKKEDYIVYLGRSRLNSNTQGEMKFEVEN
+LILHKDYSADTLAYHNDIALLKIRSKEGRCAQPSRTIQTIALPSMYNDPQFGTSCEITGFGKEQSTDYLYPEQLKMTVVK
+LISHRECQQPHYYGSEVTTKMLCAADPQWKTDSCQGDSGGPLVCSLQGRMTLTGIVSWGRGCALKDKPGVYTRVSHFLPW
+IRSHTKE
+;
+;IIGGEFTTIENQPWFAAIYRRHRGGSVTYVCGGSLISPCWVISATHCFIDYPKKEDYIVYLGRSRLNSNTQGEMKFEVEN
+LILHKDYSADTLAYHNDIALLKIRSKEGRCAQPSRTIQTIALPSMYNDPQFGTSCEITGFGKEQSTDYLYPEQLKMTVVK
+LISHRECQQPHYYGSEVTTKMLCAADPQWKTDSCQGDSGGPLVCSLQGRMTLTGIVSWGRGCALKDKPGVYTRVSHFLPW
+IRSHTKE
+;
+U ? 
+2 'polypeptide(L)' no no CPAYSRYIGC CPAYSRYIGC P ? 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1   ILE n 
+1 2   ILE n 
+1 3   GLY n 
+1 4   GLY n 
+1 5   GLU n 
+1 6   PHE n 
+1 7   THR n 
+1 8   THR n 
+1 9   ILE n 
+1 10  GLU n 
+1 11  ASN n 
+1 12  GLN n 
+1 13  PRO n 
+1 14  TRP n 
+1 15  PHE n 
+1 16  ALA n 
+1 17  ALA n 
+1 18  ILE n 
+1 19  TYR n 
+1 20  ARG n 
+1 21  ARG n 
+1 22  HIS n 
+1 23  ARG n 
+1 24  GLY n 
+1 25  GLY n 
+1 26  SER n 
+1 27  VAL n 
+1 28  THR n 
+1 29  TYR n 
+1 30  VAL n 
+1 31  CYS n 
+1 32  GLY n 
+1 33  GLY n 
+1 34  SER n 
+1 35  LEU n 
+1 36  ILE n 
+1 37  SER n 
+1 38  PRO n 
+1 39  CYS n 
+1 40  TRP n 
+1 41  VAL n 
+1 42  ILE n 
+1 43  SER n 
+1 44  ALA n 
+1 45  THR n 
+1 46  HIS n 
+1 47  CYS n 
+1 48  PHE n 
+1 49  ILE n 
+1 50  ASP n 
+1 51  TYR n 
+1 52  PRO n 
+1 53  LYS n 
+1 54  LYS n 
+1 55  GLU n 
+1 56  ASP n 
+1 57  TYR n 
+1 58  ILE n 
+1 59  VAL n 
+1 60  TYR n 
+1 61  LEU n 
+1 62  GLY n 
+1 63  ARG n 
+1 64  SER n 
+1 65  ARG n 
+1 66  LEU n 
+1 67  ASN n 
+1 68  SER n 
+1 69  ASN n 
+1 70  THR n 
+1 71  GLN n 
+1 72  GLY n 
+1 73  GLU n 
+1 74  MET n 
+1 75  LYS n 
+1 76  PHE n 
+1 77  GLU n 
+1 78  VAL n 
+1 79  GLU n 
+1 80  ASN n 
+1 81  LEU n 
+1 82  ILE n 
+1 83  LEU n 
+1 84  HIS n 
+1 85  LYS n 
+1 86  ASP n 
+1 87  TYR n 
+1 88  SER n 
+1 89  ALA n 
+1 90  ASP n 
+1 91  THR n 
+1 92  LEU n 
+1 93  ALA n 
+1 94  TYR n 
+1 95  HIS n 
+1 96  ASN n 
+1 97  ASP n 
+1 98  ILE n 
+1 99  ALA n 
+1 100 LEU n 
+1 101 LEU n 
+1 102 LYS n 
+1 103 ILE n 
+1 104 ARG n 
+1 105 SER n 
+1 106 LYS n 
+1 107 GLU n 
+1 108 GLY n 
+1 109 ARG n 
+1 110 CYS n 
+1 111 ALA n 
+1 112 GLN n 
+1 113 PRO n 
+1 114 SER n 
+1 115 ARG n 
+1 116 THR n 
+1 117 ILE n 
+1 118 GLN n 
+1 119 THR n 
+1 120 ILE n 
+1 121 ALA n 
+1 122 LEU n 
+1 123 PRO n 
+1 124 SER n 
+1 125 MET n 
+1 126 TYR n 
+1 127 ASN n 
+1 128 ASP n 
+1 129 PRO n 
+1 130 GLN n 
+1 131 PHE n 
+1 132 GLY n 
+1 133 THR n 
+1 134 SER n 
+1 135 CYS n 
+1 136 GLU n 
+1 137 ILE n 
+1 138 THR n 
+1 139 GLY n 
+1 140 PHE n 
+1 141 GLY n 
+1 142 LYS n 
+1 143 GLU n 
+1 144 GLN n 
+1 145 SER n 
+1 146 THR n 
+1 147 ASP n 
+1 148 TYR n 
+1 149 LEU n 
+1 150 TYR n 
+1 151 PRO n 
+1 152 GLU n 
+1 153 GLN n 
+1 154 LEU n 
+1 155 LYS n 
+1 156 MET n 
+1 157 THR n 
+1 158 VAL n 
+1 159 VAL n 
+1 160 LYS n 
+1 161 LEU n 
+1 162 ILE n 
+1 163 SER n 
+1 164 HIS n 
+1 165 ARG n 
+1 166 GLU n 
+1 167 CYS n 
+1 168 GLN n 
+1 169 GLN n 
+1 170 PRO n 
+1 171 HIS n 
+1 172 TYR n 
+1 173 TYR n 
+1 174 GLY n 
+1 175 SER n 
+1 176 GLU n 
+1 177 VAL n 
+1 178 THR n 
+1 179 THR n 
+1 180 LYS n 
+1 181 MET n 
+1 182 LEU n 
+1 183 CYS n 
+1 184 ALA n 
+1 185 ALA n 
+1 186 ASP n 
+1 187 PRO n 
+1 188 GLN n 
+1 189 TRP n 
+1 190 LYS n 
+1 191 THR n 
+1 192 ASP n 
+1 193 SER n 
+1 194 CYS n 
+1 195 GLN n 
+1 196 GLY n 
+1 197 ASP n 
+1 198 SER n 
+1 199 GLY n 
+1 200 GLY n 
+1 201 PRO n 
+1 202 LEU n 
+1 203 VAL n 
+1 204 CYS n 
+1 205 SER n 
+1 206 LEU n 
+1 207 GLN n 
+1 208 GLY n 
+1 209 ARG n 
+1 210 MET n 
+1 211 THR n 
+1 212 LEU n 
+1 213 THR n 
+1 214 GLY n 
+1 215 ILE n 
+1 216 VAL n 
+1 217 SER n 
+1 218 TRP n 
+1 219 GLY n 
+1 220 ARG n 
+1 221 GLY n 
+1 222 CYS n 
+1 223 ALA n 
+1 224 LEU n 
+1 225 LYS n 
+1 226 ASP n 
+1 227 LYS n 
+1 228 PRO n 
+1 229 GLY n 
+1 230 VAL n 
+1 231 TYR n 
+1 232 THR n 
+1 233 ARG n 
+1 234 VAL n 
+1 235 SER n 
+1 236 HIS n 
+1 237 PHE n 
+1 238 LEU n 
+1 239 PRO n 
+1 240 TRP n 
+1 241 ILE n 
+1 242 ARG n 
+1 243 SER n 
+1 244 HIS n 
+1 245 THR n 
+1 246 LYS n 
+1 247 GLU n 
+2 1   CYS n 
+2 2   PRO n 
+2 3   ALA n 
+2 4   TYR n 
+2 5   SER n 
+2 6   ARG n 
+2 7   TYR n 
+2 8   ILE n 
+2 9   GLY n 
+2 10  CYS n 
+# 
+_entity_src_gen.entity_id                          1 
+_entity_src_gen.pdbx_src_id                        1 
+_entity_src_gen.pdbx_alt_source_flag               sample 
+_entity_src_gen.pdbx_seq_type                      'Biological sequence' 
+_entity_src_gen.pdbx_beg_seq_num                   1 
+_entity_src_gen.pdbx_end_seq_num                   247 
+_entity_src_gen.gene_src_common_name               Human 
+_entity_src_gen.gene_src_genus                     ? 
+_entity_src_gen.pdbx_gene_src_gene                 PLAU 
+_entity_src_gen.gene_src_species                   ? 
+_entity_src_gen.gene_src_strain                    ? 
+_entity_src_gen.gene_src_tissue                    ? 
+_entity_src_gen.gene_src_tissue_fraction           ? 
+_entity_src_gen.gene_src_details                   ? 
+_entity_src_gen.pdbx_gene_src_fragment             ? 
+_entity_src_gen.pdbx_gene_src_scientific_name      'Homo sapiens' 
+_entity_src_gen.pdbx_gene_src_ncbi_taxonomy_id     9606 
+_entity_src_gen.pdbx_gene_src_variant              ? 
+_entity_src_gen.pdbx_gene_src_cell_line            ? 
+_entity_src_gen.pdbx_gene_src_atcc                 ? 
+_entity_src_gen.pdbx_gene_src_organ                ? 
+_entity_src_gen.pdbx_gene_src_organelle            ? 
+_entity_src_gen.pdbx_gene_src_cell                 ? 
+_entity_src_gen.pdbx_gene_src_cellular_location    ? 
+_entity_src_gen.host_org_common_name               ? 
+_entity_src_gen.pdbx_host_org_scientific_name      'Komagataella pastoris' 
+_entity_src_gen.pdbx_host_org_ncbi_taxonomy_id     4922 
+_entity_src_gen.host_org_genus                     ? 
+_entity_src_gen.pdbx_host_org_gene                 ? 
+_entity_src_gen.pdbx_host_org_organ                ? 
+_entity_src_gen.host_org_species                   ? 
+_entity_src_gen.pdbx_host_org_tissue               ? 
+_entity_src_gen.pdbx_host_org_tissue_fraction      ? 
+_entity_src_gen.pdbx_host_org_strain               ? 
+_entity_src_gen.pdbx_host_org_variant              ? 
+_entity_src_gen.pdbx_host_org_cell_line            ? 
+_entity_src_gen.pdbx_host_org_atcc                 ? 
+_entity_src_gen.pdbx_host_org_culture_collection   ? 
+_entity_src_gen.pdbx_host_org_cell                 ? 
+_entity_src_gen.pdbx_host_org_organelle            ? 
+_entity_src_gen.pdbx_host_org_cellular_location    ? 
+_entity_src_gen.pdbx_host_org_vector_type          ? 
+_entity_src_gen.pdbx_host_org_vector               ? 
+_entity_src_gen.host_org_details                   ? 
+_entity_src_gen.expression_system_id               ? 
+_entity_src_gen.plasmid_name                       ? 
+_entity_src_gen.plasmid_details                    ? 
+_entity_src_gen.pdbx_description                   ? 
+# 
+_pdbx_entity_src_syn.entity_id              2 
+_pdbx_entity_src_syn.pdbx_src_id            1 
+_pdbx_entity_src_syn.pdbx_alt_source_flag   sample 
+_pdbx_entity_src_syn.pdbx_beg_seq_num       1 
+_pdbx_entity_src_syn.pdbx_end_seq_num       10 
+_pdbx_entity_src_syn.organism_scientific    'synthetic construct' 
+_pdbx_entity_src_syn.organism_common_name   ? 
+_pdbx_entity_src_syn.ncbi_taxonomy_id       32630 
+_pdbx_entity_src_syn.details                ? 
+# 
+loop_
+_struct_ref.biol_id 
+_struct_ref.db_code 
+_struct_ref.db_name 
+_struct_ref.details 
+_struct_ref.entity_id 
+_struct_ref.id 
+_struct_ref.seq_align 
+_struct_ref.seq_dif 
+_struct_ref.pdbx_db_accession 
+_struct_ref.pdbx_db_isoform 
+_struct_ref.pdbx_seq_one_letter_code 
+_struct_ref.pdbx_align_begin 
+_struct_ref.pdbx_align_end 
+? UROK_HUMAN UNP ? 1 1 ? ? P00749 ? 
+;IIGGEFTTIENQPWFAAIYRRHRGGSVTYVCGGSLISPCWVISATHCFIDYPKKEDYIVYLGRSRLNSNTQGEMKFEVEN
+LILHKDYSADTLAHHNDIALLKIRSKEGRCAQPSRTIQTICLPSMYNDPQFGTSCEITGFGKENSTDYLYPEQLKMTVVK
+LISHRECQQPHYYGSEVTTKMLCAADPQWKTDSCQGDSGGPLVCSLQGRMTLTGIVSWGRGCALKDKPGVYTRVSHFLPW
+IRSHTKE
+;
+179 ? 
+? 4ZHL       PDB ? 2 2 ? ? 4ZHL   ? ? 1   ? 
+# 
+loop_
+_struct_ref_seq.align_id 
+_struct_ref_seq.ref_id 
+_struct_ref_seq.pdbx_PDB_id_code 
+_struct_ref_seq.pdbx_strand_id 
+_struct_ref_seq.seq_align_beg 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code 
+_struct_ref_seq.seq_align_end 
+_struct_ref_seq.pdbx_seq_align_end_ins_code 
+_struct_ref_seq.pdbx_db_accession 
+_struct_ref_seq.db_align_beg 
+_struct_ref_seq.pdbx_db_align_beg_ins_code 
+_struct_ref_seq.db_align_end 
+_struct_ref_seq.pdbx_db_align_end_ins_code 
+_struct_ref_seq.pdbx_auth_seq_align_beg 
+_struct_ref_seq.pdbx_auth_seq_align_end 
+1 1 4ZHL U 1 ? 247 ? P00749 179 ? 425 ? 16 244 
+2 2 4ZHL P 1 ? 10  ? 4ZHL   1   ? 10  ? 1  10  
+# 
+loop_
+_struct_ref_seq_dif.align_id 
+_struct_ref_seq_dif.pdbx_pdb_id_code 
+_struct_ref_seq_dif.mon_id 
+_struct_ref_seq_dif.pdbx_pdb_strand_id 
+_struct_ref_seq_dif.seq_num 
+_struct_ref_seq_dif.pdbx_pdb_ins_code 
+_struct_ref_seq_dif.pdbx_seq_db_name 
+_struct_ref_seq_dif.pdbx_seq_db_accession_code 
+_struct_ref_seq_dif.db_mon_id 
+_struct_ref_seq_dif.pdbx_seq_db_seq_num 
+_struct_ref_seq_dif.details 
+_struct_ref_seq_dif.pdbx_auth_seq_num 
+_struct_ref_seq_dif.pdbx_ordinal 
+1 4ZHL TYR U 94  ? UNP P00749 HIS 272 'engineered mutation' 99  1 
+1 4ZHL ALA U 121 ? UNP P00749 CYS 299 'engineered mutation' 122 2 
+1 4ZHL GLN U 144 ? UNP P00749 ASN 322 'engineered mutation' 145 3 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+ALA 'L-peptide linking' y ALANINE         ? 'C3 H7 N O2'     89.093  
+ARG 'L-peptide linking' y ARGININE        ? 'C6 H15 N4 O2 1' 175.209 
+ASN 'L-peptide linking' y ASPARAGINE      ? 'C4 H8 N2 O3'    132.118 
+ASP 'L-peptide linking' y 'ASPARTIC ACID' ? 'C4 H7 N O4'     133.103 
+CYS 'L-peptide linking' y CYSTEINE        ? 'C3 H7 N O2 S'   121.158 
+GLN 'L-peptide linking' y GLUTAMINE       ? 'C5 H10 N2 O3'   146.144 
+GLU 'L-peptide linking' y 'GLUTAMIC ACID' ? 'C5 H9 N O4'     147.129 
+GLY 'peptide linking'   y GLYCINE         ? 'C2 H5 N O2'     75.067  
+HIS 'L-peptide linking' y HISTIDINE       ? 'C6 H10 N3 O2 1' 156.162 
+HOH non-polymer         . WATER           ? 'H2 O'           18.015  
+ILE 'L-peptide linking' y ISOLEUCINE      ? 'C6 H13 N O2'    131.173 
+LEU 'L-peptide linking' y LEUCINE         ? 'C6 H13 N O2'    131.173 
+LYS 'L-peptide linking' y LYSINE          ? 'C6 H15 N2 O2 1' 147.195 
+MET 'L-peptide linking' y METHIONINE      ? 'C5 H11 N O2 S'  149.211 
+PHE 'L-peptide linking' y PHENYLALANINE   ? 'C9 H11 N O2'    165.189 
+PRO 'L-peptide linking' y PROLINE         ? 'C5 H9 N O2'     115.130 
+SER 'L-peptide linking' y SERINE          ? 'C3 H7 N O3'     105.093 
+THR 'L-peptide linking' y THREONINE       ? 'C4 H9 N O3'     119.119 
+TRP 'L-peptide linking' y TRYPTOPHAN      ? 'C11 H12 N2 O2'  204.225 
+TYR 'L-peptide linking' y TYROSINE        ? 'C9 H11 N O3'    181.189 
+VAL 'L-peptide linking' y VALINE          ? 'C5 H11 N O2'    117.146 
+# 
+_exptl.absorpt_coefficient_mu     ? 
+_exptl.absorpt_correction_T_max   ? 
+_exptl.absorpt_correction_T_min   ? 
+_exptl.absorpt_correction_type    ? 
+_exptl.absorpt_process_details    ? 
+_exptl.entry_id                   4ZHL 
+_exptl.crystals_number            ? 
+_exptl.details                    ? 
+_exptl.method                     'X-RAY DIFFRACTION' 
+_exptl.method_details             ? 
+# 
+_exptl_crystal.colour                      ? 
+_exptl_crystal.density_diffrn              ? 
+_exptl_crystal.density_Matthews            2.10 
+_exptl_crystal.density_method              ? 
+_exptl_crystal.density_percent_sol         41.52 
+_exptl_crystal.description                 ? 
+_exptl_crystal.F_000                       ? 
+_exptl_crystal.id                          1 
+_exptl_crystal.preparation                 ? 
+_exptl_crystal.size_max                    ? 
+_exptl_crystal.size_mid                    ? 
+_exptl_crystal.size_min                    ? 
+_exptl_crystal.size_rad                    ? 
+_exptl_crystal.colour_lustre               ? 
+_exptl_crystal.colour_modifier             ? 
+_exptl_crystal.colour_primary              ? 
+_exptl_crystal.density_meas                ? 
+_exptl_crystal.density_meas_esd            ? 
+_exptl_crystal.density_meas_gt             ? 
+_exptl_crystal.density_meas_lt             ? 
+_exptl_crystal.density_meas_temp           ? 
+_exptl_crystal.density_meas_temp_esd       ? 
+_exptl_crystal.density_meas_temp_gt        ? 
+_exptl_crystal.density_meas_temp_lt        ? 
+_exptl_crystal.pdbx_crystal_image_url      ? 
+_exptl_crystal.pdbx_crystal_image_format   ? 
+_exptl_crystal.pdbx_mosaicity              ? 
+_exptl_crystal.pdbx_mosaicity_esd          ? 
+# 
+_exptl_crystal_grow.apparatus       ? 
+_exptl_crystal_grow.atmosphere      ? 
+_exptl_crystal_grow.crystal_id      1 
+_exptl_crystal_grow.details         ? 
+_exptl_crystal_grow.method          'VAPOR DIFFUSION, SITTING DROP' 
+_exptl_crystal_grow.method_ref      ? 
+_exptl_crystal_grow.pH              4.6 
+_exptl_crystal_grow.pressure        ? 
+_exptl_crystal_grow.pressure_esd    ? 
+_exptl_crystal_grow.seeding         ? 
+_exptl_crystal_grow.seeding_ref     ? 
+_exptl_crystal_grow.temp            298 
+_exptl_crystal_grow.temp_details    ? 
+_exptl_crystal_grow.temp_esd        ? 
+_exptl_crystal_grow.time            ? 
+_exptl_crystal_grow.pdbx_details    '2.0M ammonium sulfate, 50mM sodium citrate, pH 4.6, 5% polyethylene glycol (PEG) 400' 
+_exptl_crystal_grow.pdbx_pH_range   ? 
+# 
+_diffrn.ambient_environment    ? 
+_diffrn.ambient_temp           100 
+_diffrn.ambient_temp_details   ? 
+_diffrn.ambient_temp_esd       ? 
+_diffrn.crystal_id             1 
+_diffrn.crystal_support        ? 
+_diffrn.crystal_treatment      ? 
+_diffrn.details                ? 
+_diffrn.id                     1 
+_diffrn.ambient_pressure       ? 
+_diffrn.ambient_pressure_esd   ? 
+_diffrn.ambient_pressure_gt    ? 
+_diffrn.ambient_pressure_lt    ? 
+_diffrn.ambient_temp_gt        ? 
+_diffrn.ambient_temp_lt        ? 
+# 
+_diffrn_detector.details                      ? 
+_diffrn_detector.detector                     CCD 
+_diffrn_detector.diffrn_id                    1 
+_diffrn_detector.type                         'ADSC QUANTUM 315r' 
+_diffrn_detector.area_resol_mean              ? 
+_diffrn_detector.dtime                        ? 
+_diffrn_detector.pdbx_frames_total            ? 
+_diffrn_detector.pdbx_collection_time_total   ? 
+_diffrn_detector.pdbx_collection_date         2013-07-10 
+# 
+_diffrn_radiation.collimation                      ? 
+_diffrn_radiation.diffrn_id                        1 
+_diffrn_radiation.filter_edge                      ? 
+_diffrn_radiation.inhomogeneity                    ? 
+_diffrn_radiation.monochromator                    ? 
+_diffrn_radiation.polarisn_norm                    ? 
+_diffrn_radiation.polarisn_ratio                   ? 
+_diffrn_radiation.probe                            ? 
+_diffrn_radiation.type                             ? 
+_diffrn_radiation.xray_symbol                      ? 
+_diffrn_radiation.wavelength_id                    1 
+_diffrn_radiation.pdbx_monochromatic_or_laue_m_l   M 
+_diffrn_radiation.pdbx_wavelength_list             ? 
+_diffrn_radiation.pdbx_wavelength                  ? 
+_diffrn_radiation.pdbx_diffrn_protocol             'SINGLE WAVELENGTH' 
+_diffrn_radiation.pdbx_analyzer                    ? 
+_diffrn_radiation.pdbx_scattering_type             x-ray 
+# 
+_diffrn_radiation_wavelength.id           1 
+_diffrn_radiation_wavelength.wavelength   0.979 
+_diffrn_radiation_wavelength.wt           1.0 
+# 
+_diffrn_source.current                     ? 
+_diffrn_source.details                     ? 
+_diffrn_source.diffrn_id                   1 
+_diffrn_source.power                       ? 
+_diffrn_source.size                        ? 
+_diffrn_source.source                      SYNCHROTRON 
+_diffrn_source.target                      ? 
+_diffrn_source.type                        'SSRF BEAMLINE BL17U' 
+_diffrn_source.voltage                     ? 
+_diffrn_source.take-off_angle              ? 
+_diffrn_source.pdbx_wavelength_list        0.979 
+_diffrn_source.pdbx_wavelength             ? 
+_diffrn_source.pdbx_synchrotron_beamline   BL17U 
+_diffrn_source.pdbx_synchrotron_site       SSRF 
+# 
+_reflns.B_iso_Wilson_estimate            ? 
+_reflns.entry_id                         4ZHL 
+_reflns.data_reduction_details           ? 
+_reflns.data_reduction_method            ? 
+_reflns.d_resolution_high                2.05 
+_reflns.d_resolution_low                 50 
+_reflns.details                          ? 
+_reflns.limit_h_max                      ? 
+_reflns.limit_h_min                      ? 
+_reflns.limit_k_max                      ? 
+_reflns.limit_k_min                      ? 
+_reflns.limit_l_max                      ? 
+_reflns.limit_l_min                      ? 
+_reflns.number_all                       ? 
+_reflns.number_obs                       14528 
+_reflns.observed_criterion               ? 
+_reflns.observed_criterion_F_max         ? 
+_reflns.observed_criterion_F_min         ? 
+_reflns.observed_criterion_I_max         ? 
+_reflns.observed_criterion_I_min         ? 
+_reflns.observed_criterion_sigma_F       ? 
+_reflns.observed_criterion_sigma_I       ? 
+_reflns.percent_possible_obs             99.1 
+_reflns.R_free_details                   ? 
+_reflns.Rmerge_F_all                     ? 
+_reflns.Rmerge_F_obs                     ? 
+_reflns.Friedel_coverage                 ? 
+_reflns.number_gt                        ? 
+_reflns.threshold_expression             ? 
+_reflns.pdbx_redundancy                  3.4 
+_reflns.pdbx_Rmerge_I_obs                ? 
+_reflns.pdbx_Rmerge_I_all                ? 
+_reflns.pdbx_Rsym_value                  ? 
+_reflns.pdbx_netI_over_av_sigmaI         ? 
+_reflns.pdbx_netI_over_sigmaI            22.7 
+_reflns.pdbx_res_netI_over_av_sigmaI_2   ? 
+_reflns.pdbx_res_netI_over_sigmaI_2      ? 
+_reflns.pdbx_chi_squared                 ? 
+_reflns.pdbx_scaling_rejects             ? 
+_reflns.pdbx_d_res_high_opt              ? 
+_reflns.pdbx_d_res_low_opt               ? 
+_reflns.pdbx_d_res_opt_method            ? 
+_reflns.phase_calculation_details        ? 
+_reflns.pdbx_Rrim_I_all                  ? 
+_reflns.pdbx_Rpim_I_all                  ? 
+_reflns.pdbx_d_opt                       ? 
+_reflns.pdbx_number_measured_all         ? 
+_reflns.pdbx_diffrn_id                   1 
+_reflns.pdbx_ordinal                     1 
+_reflns.pdbx_CC_half                     ? 
+_reflns.pdbx_R_split                     ? 
+# 
+_computing.entry_id                           4ZHL 
+_computing.cell_refinement                    ? 
+_computing.data_collection                    ? 
+_computing.data_reduction                     ? 
+_computing.molecular_graphics                 ? 
+_computing.publication_material               ? 
+_computing.structure_refinement               'REFMAC 5.7.0029' 
+_computing.structure_solution                 ? 
+_computing.pdbx_structure_refinement_method   ? 
+_computing.pdbx_data_reduction_ii             ? 
+_computing.pdbx_data_reduction_ds             ? 
+# 
+_refine.pdbx_refine_id                           'X-RAY DIFFRACTION' 
+_refine.entry_id                                 4ZHL 
+_refine.pdbx_diffrn_id                           1 
+_refine.pdbx_TLS_residual_ADP_flag               ? 
+_refine.ls_number_reflns_obs                     13804 
+_refine.ls_number_reflns_all                     ? 
+_refine.pdbx_ls_sigma_I                          ? 
+_refine.pdbx_ls_sigma_F                          ? 
+_refine.pdbx_data_cutoff_high_absF               ? 
+_refine.pdbx_data_cutoff_low_absF                ? 
+_refine.pdbx_data_cutoff_high_rms_absF           ? 
+_refine.ls_d_res_low                             30.53 
+_refine.ls_d_res_high                            2.06 
+_refine.ls_percent_reflns_obs                    99.02 
+_refine.ls_R_factor_obs                          0.22184 
+_refine.ls_R_factor_all                          ? 
+_refine.ls_R_factor_R_work                       0.21978 
+_refine.ls_R_factor_R_free                       0.26237 
+_refine.ls_R_factor_R_free_error                 ? 
+_refine.ls_R_factor_R_free_error_details         ? 
+_refine.ls_percent_reflns_R_free                 5.0 
+_refine.ls_number_reflns_R_free                  724 
+_refine.ls_number_parameters                     ? 
+_refine.ls_number_restraints                     ? 
+_refine.occupancy_min                            ? 
+_refine.occupancy_max                            ? 
+_refine.correlation_coeff_Fo_to_Fc               0.950 
+_refine.correlation_coeff_Fo_to_Fc_free          0.932 
+_refine.B_iso_mean                               46.977 
+_refine.aniso_B[1][1]                            -0.52 
+_refine.aniso_B[2][2]                            -0.52 
+_refine.aniso_B[3][3]                            1.69 
+_refine.aniso_B[1][2]                            -0.52 
+_refine.aniso_B[1][3]                            0.00 
+_refine.aniso_B[2][3]                            -0.00 
+_refine.solvent_model_details                    MASK 
+_refine.solvent_model_param_ksol                 ? 
+_refine.solvent_model_param_bsol                 ? 
+_refine.pdbx_solvent_vdw_probe_radii             1.20 
+_refine.pdbx_solvent_ion_probe_radii             0.80 
+_refine.pdbx_solvent_shrinkage_radii             0.80 
+_refine.pdbx_ls_cross_valid_method               THROUGHOUT 
+_refine.details                                  
+;HYDROGENS HAVE BEEN ADDED IN THE RIDING POSITIONS
+ U VALUES
+;
+_refine.pdbx_starting_model                      ? 
+_refine.pdbx_method_to_determine_struct          ? 
+_refine.pdbx_isotropic_thermal_model             ? 
+_refine.pdbx_stereochemistry_target_values       'MAXIMUM LIKELIHOOD' 
+_refine.pdbx_stereochem_target_val_spec_case     ? 
+_refine.pdbx_R_Free_selection_details            RANDOM 
+_refine.pdbx_overall_ESU_R                       0.284 
+_refine.pdbx_overall_ESU_R_Free                  0.214 
+_refine.overall_SU_ML                            0.177 
+_refine.pdbx_overall_phase_error                 ? 
+_refine.overall_SU_B                             6.512 
+_refine.overall_SU_R_Cruickshank_DPI             ? 
+_refine.pdbx_overall_SU_R_free_Cruickshank_DPI   ? 
+_refine.pdbx_overall_SU_R_Blow_DPI               ? 
+_refine.pdbx_overall_SU_R_free_Blow_DPI          ? 
+# 
+_refine_hist.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_hist.cycle_id                         LAST 
+_refine_hist.pdbx_number_atoms_protein        2030 
+_refine_hist.pdbx_number_atoms_nucleic_acid   0 
+_refine_hist.pdbx_number_atoms_ligand         0 
+_refine_hist.number_atoms_solvent             50 
+_refine_hist.number_atoms_total               2080 
+_refine_hist.d_res_high                       2.06 
+_refine_hist.d_res_low                        30.53 
+# 
+loop_
+_refine_ls_restr.type 
+_refine_ls_restr.dev_ideal 
+_refine_ls_restr.dev_ideal_target 
+_refine_ls_restr.weight 
+_refine_ls_restr.number 
+_refine_ls_restr.pdbx_refine_id 
+_refine_ls_restr.pdbx_restraint_function 
+r_bond_refined_d             0.008  0.019  ? 2067 'X-RAY DIFFRACTION' ? 
+r_bond_other_d               0.001  0.020  ? 1943 'X-RAY DIFFRACTION' ? 
+r_angle_refined_deg          1.265  1.946  ? 2767 'X-RAY DIFFRACTION' ? 
+r_angle_other_deg            0.719  3.005  ? 4453 'X-RAY DIFFRACTION' ? 
+r_dihedral_angle_1_deg       6.549  5.000  ? 235  'X-RAY DIFFRACTION' ? 
+r_dihedral_angle_2_deg       33.531 23.077 ? 91   'X-RAY DIFFRACTION' ? 
+r_dihedral_angle_3_deg       16.759 15.000 ? 351  'X-RAY DIFFRACTION' ? 
+r_dihedral_angle_4_deg       18.334 15.000 ? 14   'X-RAY DIFFRACTION' ? 
+r_chiral_restr               0.079  0.200  ? 302  'X-RAY DIFFRACTION' ? 
+r_gen_planes_refined         0.005  0.021  ? 2196 'X-RAY DIFFRACTION' ? 
+r_gen_planes_other           0.001  0.020  ? 474  'X-RAY DIFFRACTION' ? 
+r_nbd_refined                ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_nbd_other                  ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_nbtor_refined              ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_nbtor_other                ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_xyhbond_nbd_refined        ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_xyhbond_nbd_other          ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_metal_ion_refined          ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_metal_ion_other            ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_symmetry_vdw_refined       ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_symmetry_vdw_other         ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_symmetry_hbond_refined     ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_symmetry_hbond_other       ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_symmetry_metal_ion_refined ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_symmetry_metal_ion_other   ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_mcbond_it                  ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_mcbond_other               ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_mcangle_it                 ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_mcangle_other              ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_scbond_it                  ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_scbond_other               ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_scangle_it                 ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_scangle_other              ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_long_range_B_refined       ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_long_range_B_other         ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_rigid_bond_restr           ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_sphericity_free            ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+r_sphericity_bonded          ?      ?      ? ?    'X-RAY DIFFRACTION' ? 
+# 
+_refine_ls_shell.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_ls_shell.pdbx_total_number_of_bins_used   20 
+_refine_ls_shell.d_res_high                       2.057 
+_refine_ls_shell.d_res_low                        2.111 
+_refine_ls_shell.number_reflns_R_work             1025 
+_refine_ls_shell.R_factor_R_work                  0.302 
+_refine_ls_shell.percent_reflns_obs               98.35 
+_refine_ls_shell.R_factor_R_free                  0.307 
+_refine_ls_shell.R_factor_R_free_error            ? 
+_refine_ls_shell.percent_reflns_R_free            ? 
+_refine_ls_shell.number_reflns_R_free             46 
+_refine_ls_shell.number_reflns_all                ? 
+_refine_ls_shell.R_factor_all                     ? 
+# 
+_struct.entry_id                     4ZHL 
+_struct.title                        'The crystal structure of mupain-1-IG in complex with murinised human uPA at pH7.4' 
+_struct.pdbx_descriptor              'Urokinase-type plasminogen activator, mupain-1-IG' 
+_struct.pdbx_model_details           ? 
+_struct.pdbx_formula_weight          ? 
+_struct.pdbx_formula_weight_method   ? 
+_struct.pdbx_model_type_details      ? 
+_struct.pdbx_CASP_flag               ? 
+# 
+_struct_keywords.entry_id        4ZHL 
+_struct_keywords.text            'Peptides inhibitor, uPA, serine protease, HYDROLASE-HYDROLASE INHIBITOR complex' 
+_struct_keywords.pdbx_keywords   'HYDROLASE/HYDROLASE INHIBITOR' 
+# 
+loop_
+_struct_asym.id 
+_struct_asym.pdbx_blank_PDB_chainid_flag 
+_struct_asym.pdbx_modified 
+_struct_asym.entity_id 
+_struct_asym.details 
+A N N 1 ? 
+B N N 2 ? 
+C N N 3 ? 
+D N N 3 ? 
+# 
+loop_
+_struct_conf.conf_type_id 
+_struct_conf.id 
+_struct_conf.pdbx_PDB_helix_id 
+_struct_conf.beg_label_comp_id 
+_struct_conf.beg_label_asym_id 
+_struct_conf.beg_label_seq_id 
+_struct_conf.pdbx_beg_PDB_ins_code 
+_struct_conf.end_label_comp_id 
+_struct_conf.end_label_asym_id 
+_struct_conf.end_label_seq_id 
+_struct_conf.pdbx_end_PDB_ins_code 
+_struct_conf.beg_auth_comp_id 
+_struct_conf.beg_auth_asym_id 
+_struct_conf.beg_auth_seq_id 
+_struct_conf.end_auth_comp_id 
+_struct_conf.end_auth_asym_id 
+_struct_conf.end_auth_seq_id 
+_struct_conf.pdbx_PDB_helix_class 
+_struct_conf.details 
+_struct_conf.pdbx_PDB_helix_length 
+HELX_P HELX_P1 AA1 THR A 8   ? GLN A 12  ? THR U 23  GLN U 27  5 ? 5  
+HELX_P HELX_P2 AA2 ALA A 44  ? PHE A 48  ? ALA U 55  PHE U 59  5 ? 5  
+HELX_P HELX_P3 AA3 LYS A 53  ? GLU A 55  A LYS U 61  GLU U 62  5 ? 3  
+HELX_P HELX_P4 AA4 SER A 163 ? GLN A 168 ? SER U 164 GLN U 169 1 ? 6  
+HELX_P HELX_P5 AA5 TYR A 173 ? VAL A 177 ? TYR U 172 VAL U 176 5 ? 5  
+HELX_P HELX_P6 AA6 PHE A 237 ? LYS A 246 ? PHE U 234 LYS U 243 1 ? 10 
+# 
+_struct_conf_type.id          HELX_P 
+_struct_conf_type.criteria    ? 
+_struct_conf_type.reference   ? 
+# 
+loop_
+_struct_conn.id 
+_struct_conn.conn_type_id 
+_struct_conn.pdbx_leaving_atom_flag 
+_struct_conn.pdbx_PDB_id 
+_struct_conn.ptnr1_label_asym_id 
+_struct_conn.ptnr1_label_comp_id 
+_struct_conn.ptnr1_label_seq_id 
+_struct_conn.ptnr1_label_atom_id 
+_struct_conn.pdbx_ptnr1_label_alt_id 
+_struct_conn.pdbx_ptnr1_PDB_ins_code 
+_struct_conn.pdbx_ptnr1_standard_comp_id 
+_struct_conn.ptnr1_symmetry 
+_struct_conn.ptnr2_label_asym_id 
+_struct_conn.ptnr2_label_comp_id 
+_struct_conn.ptnr2_label_seq_id 
+_struct_conn.ptnr2_label_atom_id 
+_struct_conn.pdbx_ptnr2_label_alt_id 
+_struct_conn.pdbx_ptnr2_PDB_ins_code 
+_struct_conn.ptnr1_auth_asym_id 
+_struct_conn.ptnr1_auth_comp_id 
+_struct_conn.ptnr1_auth_seq_id 
+_struct_conn.ptnr2_auth_asym_id 
+_struct_conn.ptnr2_auth_comp_id 
+_struct_conn.ptnr2_auth_seq_id 
+_struct_conn.ptnr2_symmetry 
+_struct_conn.pdbx_ptnr3_label_atom_id 
+_struct_conn.pdbx_ptnr3_label_seq_id 
+_struct_conn.pdbx_ptnr3_label_comp_id 
+_struct_conn.pdbx_ptnr3_label_asym_id 
+_struct_conn.pdbx_ptnr3_label_alt_id 
+_struct_conn.pdbx_ptnr3_PDB_ins_code 
+_struct_conn.details 
+_struct_conn.pdbx_dist_value 
+_struct_conn.pdbx_value_order 
+disulf1 disulf ? ? A CYS 31  SG ? ? ? 1_555 A CYS 47  SG ? ? U CYS 42  U CYS 58  1_555 ? ? ? ? ? ? ? 2.027 ? 
+disulf2 disulf ? ? A CYS 167 SG ? ? ? 1_555 A CYS 183 SG ? ? U CYS 168 U CYS 182 1_555 ? ? ? ? ? ? ? 1.911 ? 
+disulf3 disulf ? ? A CYS 194 SG ? ? ? 1_555 A CYS 222 SG ? ? U CYS 191 U CYS 220 1_555 ? ? ? ? ? ? ? 1.876 ? 
+disulf4 disulf ? ? B CYS 1   SG ? ? ? 1_555 B CYS 10  SG ? ? P CYS 1   P CYS 10  1_555 ? ? ? ? ? ? ? 2.053 ? 
+# 
+_struct_conn_type.id          disulf 
+_struct_conn_type.criteria    ? 
+_struct_conn_type.reference   ? 
+# 
+loop_
+_struct_sheet.id 
+_struct_sheet.type 
+_struct_sheet.number_strands 
+_struct_sheet.details 
+AA1 ? 8 ? 
+AA2 ? 7 ? 
+AA3 ? 2 ? 
+# 
+loop_
+_struct_sheet_order.sheet_id 
+_struct_sheet_order.range_id_1 
+_struct_sheet_order.range_id_2 
+_struct_sheet_order.offset 
+_struct_sheet_order.sense 
+AA1 1 2 ? anti-parallel 
+AA1 2 3 ? anti-parallel 
+AA1 3 4 ? anti-parallel 
+AA1 4 5 ? anti-parallel 
+AA1 5 6 ? anti-parallel 
+AA1 6 7 ? anti-parallel 
+AA1 7 8 ? anti-parallel 
+AA2 1 2 ? anti-parallel 
+AA2 2 3 ? anti-parallel 
+AA2 3 4 ? anti-parallel 
+AA2 4 5 ? anti-parallel 
+AA2 5 6 ? anti-parallel 
+AA2 6 7 ? anti-parallel 
+AA3 1 2 ? anti-parallel 
+# 
+loop_
+_struct_sheet_range.sheet_id 
+_struct_sheet_range.id 
+_struct_sheet_range.beg_label_comp_id 
+_struct_sheet_range.beg_label_asym_id 
+_struct_sheet_range.beg_label_seq_id 
+_struct_sheet_range.pdbx_beg_PDB_ins_code 
+_struct_sheet_range.end_label_comp_id 
+_struct_sheet_range.end_label_asym_id 
+_struct_sheet_range.end_label_seq_id 
+_struct_sheet_range.pdbx_end_PDB_ins_code 
+_struct_sheet_range.beg_auth_comp_id 
+_struct_sheet_range.beg_auth_asym_id 
+_struct_sheet_range.beg_auth_seq_id 
+_struct_sheet_range.end_auth_comp_id 
+_struct_sheet_range.end_auth_asym_id 
+_struct_sheet_range.end_auth_seq_id 
+AA1 1 GLU A 5   ? PHE A 6   ? GLU U 20  PHE U 21  
+AA1 2 LYS A 155 ? ILE A 162 ? LYS U 156 ILE U 163 
+AA1 3 MET A 181 ? ALA A 185 ? MET U 180 ALA U 184 
+AA1 4 GLY A 229 ? ARG A 233 ? GLY U 226 ARG U 230 
+AA1 5 ARG A 209 ? TRP A 218 ? ARG U 206 TRP U 215 
+AA1 6 PRO A 201 ? LEU A 206 ? PRO U 198 LEU U 203 
+AA1 7 SER A 134 ? GLY A 139 ? SER U 135 GLY U 140 
+AA1 8 LYS A 155 ? ILE A 162 ? LYS U 156 ILE U 163 
+AA2 1 PHE A 15  ? ARG A 21  ? PHE U 30  ARG U 36  
+AA2 2 VAL A 27  ? SER A 37  ? VAL U 38  SER U 48  
+AA2 3 TRP A 40  ? SER A 43  ? TRP U 51  SER U 54  
+AA2 4 ALA A 99  ? ARG A 104 ? ALA U 104 ARG U 109 
+AA2 5 MET A 74  ? LEU A 83  ? MET U 81  LEU U 90  
+AA2 6 TYR A 57  ? LEU A 61  ? TYR U 64  LEU U 68  
+AA2 7 PHE A 15  ? ARG A 21  ? PHE U 30  ARG U 36  
+AA3 1 SER A 88  ? ALA A 89  ? SER U 95  ALA U 96  
+AA3 2 TYR A 94  ? HIS A 95  ? TYR U 99  HIS U 100 
+# 
+loop_
+_pdbx_struct_sheet_hbond.sheet_id 
+_pdbx_struct_sheet_hbond.range_id_1 
+_pdbx_struct_sheet_hbond.range_id_2 
+_pdbx_struct_sheet_hbond.range_1_label_atom_id 
+_pdbx_struct_sheet_hbond.range_1_label_comp_id 
+_pdbx_struct_sheet_hbond.range_1_label_asym_id 
+_pdbx_struct_sheet_hbond.range_1_label_seq_id 
+_pdbx_struct_sheet_hbond.range_1_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_1_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_1_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_1_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_1_auth_seq_id 
+_pdbx_struct_sheet_hbond.range_2_label_atom_id 
+_pdbx_struct_sheet_hbond.range_2_label_comp_id 
+_pdbx_struct_sheet_hbond.range_2_label_asym_id 
+_pdbx_struct_sheet_hbond.range_2_label_seq_id 
+_pdbx_struct_sheet_hbond.range_2_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_2_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_2_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_2_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_2_auth_seq_id 
+AA1 1 2 N GLU A 5   ? N GLU U 20  O MET A 156 ? O MET U 157 
+AA1 2 3 N ILE A 162 ? N ILE U 163 O CYS A 183 ? O CYS U 182 
+AA1 3 4 N LEU A 182 ? N LEU U 181 O TYR A 231 ? O TYR U 228 
+AA1 4 5 O VAL A 230 ? O VAL U 227 N TRP A 218 ? N TRP U 215 
+AA1 5 6 O ARG A 209 ? O ARG U 206 N LEU A 206 ? N LEU U 203 
+AA1 6 7 O VAL A 203 ? O VAL U 200 N GLU A 136 ? N GLU U 137 
+AA1 7 8 N CYS A 135 ? N CYS U 136 O VAL A 159 ? O VAL U 160 
+AA2 1 2 N ILE A 18  ? N ILE U 33  O VAL A 30  ? O VAL U 41  
+AA2 2 3 N SER A 34  ? N SER U 45  O ILE A 42  ? O ILE U 53  
+AA2 3 4 N VAL A 41  ? N VAL U 52  O LEU A 101 ? O LEU U 106 
+AA2 4 5 O LYS A 102 ? O LYS U 107 N GLU A 79  ? N GLU U 86  
+AA2 5 6 O PHE A 76  ? O PHE U 83  N VAL A 59  ? N VAL U 66  
+AA2 6 7 O ILE A 58  ? O ILE U 65  N TYR A 19  ? N TYR U 34  
+AA3 1 2 N SER A 88  ? N SER U 95  O HIS A 95  ? O HIS U 100 
+# 
+_atom_sites.entry_id                    4ZHL 
+_atom_sites.fract_transf_matrix[1][1]   0.008193 
+_atom_sites.fract_transf_matrix[1][2]   0.004730 
+_atom_sites.fract_transf_matrix[1][3]   0.000000 
+_atom_sites.fract_transf_matrix[2][1]   -0.000000 
+_atom_sites.fract_transf_matrix[2][2]   0.009460 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000000 
+_atom_sites.fract_transf_matrix[3][2]   -0.000000 
+_atom_sites.fract_transf_matrix[3][3]   0.023499 
+_atom_sites.fract_transf_vector[1]      0.00000 
+_atom_sites.fract_transf_vector[2]      0.00000 
+_atom_sites.fract_transf_vector[3]      0.00000 
+# 
+loop_
+_atom_type.symbol 
+C 
+N 
+O 
+S 
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.Cartn_x_esd 
+_atom_site.Cartn_y_esd 
+_atom_site.Cartn_z_esd 
+_atom_site.occupancy_esd 
+_atom_site.B_iso_or_equiv_esd 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1    N N   . ILE A 1 1   ? -8.205  -34.800 -23.343 1.00 29.09  ? ? ? ? ? ? 16  ILE U N   1 
+ATOM   2    C CA  . ILE A 1 1   ? -8.506  -36.232 -23.305 1.00 29.78  ? ? ? ? ? ? 16  ILE U CA  1 
+ATOM   3    C C   . ILE A 1 1   ? -9.212  -36.712 -24.582 1.00 34.14  ? ? ? ? ? ? 16  ILE U C   1 
+ATOM   4    O O   . ILE A 1 1   ? -10.327 -36.280 -24.894 1.00 32.31  ? ? ? ? ? ? 16  ILE U O   1 
+ATOM   5    C CB  . ILE A 1 1   ? -9.382  -36.604 -22.100 1.00 30.71  ? ? ? ? ? ? 16  ILE U CB  1 
+ATOM   6    C CG1 . ILE A 1 1   ? -8.712  -36.199 -20.760 1.00 31.15  ? ? ? ? ? ? 16  ILE U CG1 1 
+ATOM   7    C CG2 . ILE A 1 1   ? -9.684  -38.091 -22.115 1.00 31.03  ? ? ? ? ? ? 16  ILE U CG2 1 
+ATOM   8    C CD1 . ILE A 1 1   ? -7.457  -36.945 -20.455 1.00 30.86  ? ? ? ? ? ? 16  ILE U CD1 1 
+ATOM   9    N N   . ILE A 1 2   ? -8.553  -37.638 -25.278 1.00 35.77  ? ? ? ? ? ? 17  ILE U N   1 
+ATOM   10   C CA  . ILE A 1 2   ? -9.098  -38.250 -26.487 1.00 39.69  ? ? ? ? ? ? 17  ILE U CA  1 
+ATOM   11   C C   . ILE A 1 2   ? -9.914  -39.457 -26.064 1.00 37.64  ? ? ? ? ? ? 17  ILE U C   1 
+ATOM   12   O O   . ILE A 1 2   ? -9.431  -40.304 -25.296 1.00 39.78  ? ? ? ? ? ? 17  ILE U O   1 
+ATOM   13   C CB  . ILE A 1 2   ? -7.999  -38.756 -27.451 1.00 40.53  ? ? ? ? ? ? 17  ILE U CB  1 
+ATOM   14   C CG1 . ILE A 1 2   ? -6.902  -37.721 -27.644 1.00 41.63  ? ? ? ? ? ? 17  ILE U CG1 1 
+ATOM   15   C CG2 . ILE A 1 2   ? -8.614  -39.138 -28.799 1.00 43.93  ? ? ? ? ? ? 17  ILE U CG2 1 
+ATOM   16   C CD1 . ILE A 1 2   ? -7.364  -36.417 -28.249 1.00 44.17  ? ? ? ? ? ? 17  ILE U CD1 1 
+ATOM   17   N N   . GLY A 1 3   ? -11.143 -39.537 -26.566 1.00 37.78  ? ? ? ? ? ? 18  GLY U N   1 
+ATOM   18   C CA  . GLY A 1 3   ? -12.083 -40.559 -26.142 1.00 38.70  ? ? ? ? ? ? 18  GLY U CA  1 
+ATOM   19   C C   . GLY A 1 3   ? -12.429 -40.358 -24.674 1.00 39.68  ? ? ? ? ? ? 18  GLY U C   1 
+ATOM   20   O O   . GLY A 1 3   ? -12.441 -39.238 -24.180 1.00 39.31  ? ? ? ? ? ? 18  GLY U O   1 
+ATOM   21   N N   . GLY A 1 4   ? -12.706 -41.445 -23.978 1.00 40.56  ? ? ? ? ? ? 19  GLY U N   1 
+ATOM   22   C CA  . GLY A 1 4   ? -13.076 -41.363 -22.583 1.00 41.99  ? ? ? ? ? ? 19  GLY U CA  1 
+ATOM   23   C C   . GLY A 1 4   ? -14.420 -40.710 -22.374 1.00 40.17  ? ? ? ? ? ? 19  GLY U C   1 
+ATOM   24   O O   . GLY A 1 4   ? -15.261 -40.624 -23.283 1.00 37.05  ? ? ? ? ? ? 19  GLY U O   1 
+ATOM   25   N N   . GLU A 1 5   ? -14.634 -40.246 -21.154 1.00 38.74  ? ? ? ? ? ? 20  GLU U N   1 
+ATOM   26   C CA  . GLU A 1 5   ? -15.945 -39.802 -20.761 1.00 37.20  ? ? ? ? ? ? 20  GLU U CA  1 
+ATOM   27   C C   . GLU A 1 5   ? -15.888 -38.463 -20.059 1.00 33.98  ? ? ? ? ? ? 20  GLU U C   1 
+ATOM   28   O O   . GLU A 1 5   ? -14.894 -38.131 -19.409 1.00 32.19  ? ? ? ? ? ? 20  GLU U O   1 
+ATOM   29   C CB  . GLU A 1 5   ? -16.575 -40.862 -19.873 1.00 43.14  ? ? ? ? ? ? 20  GLU U CB  1 
+ATOM   30   C CG  . GLU A 1 5   ? -16.972 -42.120 -20.634 1.00 52.22  ? ? ? ? ? ? 20  GLU U CG  1 
+ATOM   31   C CD  . GLU A 1 5   ? -17.512 -43.221 -19.733 1.00 59.51  ? ? ? ? ? ? 20  GLU U CD  1 
+ATOM   32   O OE1 . GLU A 1 5   ? -17.296 -44.413 -20.060 1.00 72.63  ? ? ? ? ? ? 20  GLU U OE1 1 
+ATOM   33   O OE2 . GLU A 1 5   ? -18.149 -42.908 -18.697 1.00 63.66  ? ? ? ? ? ? 20  GLU U OE2 1 
+ATOM   34   N N   . PHE A 1 6   ? -16.936 -37.670 -20.233 1.00 30.74  ? ? ? ? ? ? 21  PHE U N   1 
+ATOM   35   C CA  . PHE A 1 6   ? -17.120 -36.491 -19.399 1.00 30.35  ? ? ? ? ? ? 21  PHE U CA  1 
+ATOM   36   C C   . PHE A 1 6   ? -17.371 -36.954 -17.986 1.00 29.47  ? ? ? ? ? ? 21  PHE U C   1 
+ATOM   37   O O   . PHE A 1 6   ? -17.958 -38.015 -17.749 1.00 28.85  ? ? ? ? ? ? 21  PHE U O   1 
+ATOM   38   C CB  . PHE A 1 6   ? -18.254 -35.615 -19.907 1.00 30.52  ? ? ? ? ? ? 21  PHE U CB  1 
+ATOM   39   C CG  . PHE A 1 6   ? -17.897 -34.881 -21.155 1.00 30.79  ? ? ? ? ? ? 21  PHE U CG  1 
+ATOM   40   C CD1 . PHE A 1 6   ? -17.028 -33.808 -21.099 1.00 30.64  ? ? ? ? ? ? 21  PHE U CD1 1 
+ATOM   41   C CD2 . PHE A 1 6   ? -18.367 -35.297 -22.378 1.00 31.85  ? ? ? ? ? ? 21  PHE U CD2 1 
+ATOM   42   C CE1 . PHE A 1 6   ? -16.662 -33.128 -22.230 1.00 30.52  ? ? ? ? ? ? 21  PHE U CE1 1 
+ATOM   43   C CE2 . PHE A 1 6   ? -18.002 -34.627 -23.540 1.00 32.74  ? ? ? ? ? ? 21  PHE U CE2 1 
+ATOM   44   C CZ  . PHE A 1 6   ? -17.150 -33.537 -23.468 1.00 33.01  ? ? ? ? ? ? 21  PHE U CZ  1 
+ATOM   45   N N   . THR A 1 7   ? -16.842 -36.202 -17.040 1.00 33.35  ? ? ? ? ? ? 22  THR U N   1 
+ATOM   46   C CA  . THR A 1 7   ? -16.889 -36.639 -15.650 1.00 31.51  ? ? ? ? ? ? 22  THR U CA  1 
+ATOM   47   C C   . THR A 1 7   ? -17.075 -35.433 -14.775 1.00 32.09  ? ? ? ? ? ? 22  THR U C   1 
+ATOM   48   O O   . THR A 1 7   ? -17.268 -34.331 -15.286 1.00 29.52  ? ? ? ? ? ? 22  THR U O   1 
+ATOM   49   C CB  . THR A 1 7   ? -15.634 -37.460 -15.299 1.00 31.39  ? ? ? ? ? ? 22  THR U CB  1 
+ATOM   50   O OG1 . THR A 1 7   ? -15.792 -38.030 -13.996 1.00 33.51  ? ? ? ? ? ? 22  THR U OG1 1 
+ATOM   51   C CG2 . THR A 1 7   ? -14.332 -36.630 -15.371 1.00 31.85  ? ? ? ? ? ? 22  THR U CG2 1 
+ATOM   52   N N   . THR A 1 8   ? -17.093 -35.634 -13.456 1.00 32.21  ? ? ? ? ? ? 23  THR U N   1 
+ATOM   53   C CA  . THR A 1 8   ? -17.122 -34.517 -12.532 1.00 30.91  ? ? ? ? ? ? 23  THR U CA  1 
+ATOM   54   C C   . THR A 1 8   ? -15.986 -34.686 -11.521 1.00 28.53  ? ? ? ? ? ? 23  THR U C   1 
+ATOM   55   O O   . THR A 1 8   ? -15.423 -35.772 -11.355 1.00 25.30  ? ? ? ? ? ? 23  THR U O   1 
+ATOM   56   C CB  . THR A 1 8   ? -18.484 -34.404 -11.780 1.00 33.82  ? ? ? ? ? ? 23  THR U CB  1 
+ATOM   57   O OG1 . THR A 1 8   ? -18.682 -35.565 -10.979 1.00 32.46  ? ? ? ? ? ? 23  THR U OG1 1 
+ATOM   58   C CG2 . THR A 1 8   ? -19.670 -34.291 -12.760 1.00 35.38  ? ? ? ? ? ? 23  THR U CG2 1 
+ATOM   59   N N   . ILE A 1 9   ? -15.669 -33.598 -10.837 1.00 27.33  ? ? ? ? ? ? 24  ILE U N   1 
+ATOM   60   C CA  . ILE A 1 9   ? -14.538 -33.590 -9.911  1.00 29.72  ? ? ? ? ? ? 24  ILE U CA  1 
+ATOM   61   C C   . ILE A 1 9   ? -14.636 -34.724 -8.867  1.00 28.82  ? ? ? ? ? ? 24  ILE U C   1 
+ATOM   62   O O   . ILE A 1 9   ? -13.606 -35.309 -8.474  1.00 29.97  ? ? ? ? ? ? 24  ILE U O   1 
+ATOM   63   C CB  . ILE A 1 9   ? -14.334 -32.172 -9.302  1.00 27.49  ? ? ? ? ? ? 24  ILE U CB  1 
+ATOM   64   C CG1 . ILE A 1 9   ? -12.905 -31.987 -8.737  1.00 27.89  ? ? ? ? ? ? 24  ILE U CG1 1 
+ATOM   65   C CG2 . ILE A 1 9   ? -15.381 -31.869 -8.247  1.00 30.07  ? ? ? ? ? ? 24  ILE U CG2 1 
+ATOM   66   C CD1 . ILE A 1 9   ? -11.796 -32.250 -9.738  1.00 26.36  ? ? ? ? ? ? 24  ILE U CD1 1 
+ATOM   67   N N   . GLU A 1 10  ? -15.852 -35.120 -8.483  1.00 29.84  ? ? ? ? ? ? 25  GLU U N   1 
+ATOM   68   C CA  . GLU A 1 10  ? -16.001 -36.125 -7.431  1.00 30.45  ? ? ? ? ? ? 25  GLU U CA  1 
+ATOM   69   C C   . GLU A 1 10  ? -15.353 -37.456 -7.782  1.00 33.49  ? ? ? ? ? ? 25  GLU U C   1 
+ATOM   70   O O   . GLU A 1 10  ? -14.967 -38.212 -6.877  1.00 33.52  ? ? ? ? ? ? 25  GLU U O   1 
+ATOM   71   C CB  . GLU A 1 10  ? -17.482 -36.375 -7.070  1.00 33.92  ? ? ? ? ? ? 25  GLU U CB  1 
+ATOM   72   C CG  . GLU A 1 10  ? -18.197 -35.187 -6.460  1.00 34.07  ? ? ? ? ? ? 25  GLU U CG  1 
+ATOM   73   C CD  . GLU A 1 10  ? -18.835 -34.275 -7.494  1.00 33.18  ? ? ? ? ? ? 25  GLU U CD  1 
+ATOM   74   O OE1 . GLU A 1 10  ? -18.400 -34.261 -8.650  1.00 32.10  ? ? ? ? ? ? 25  GLU U OE1 1 
+ATOM   75   O OE2 . GLU A 1 10  ? -19.774 -33.558 -7.147  1.00 34.67  ? ? ? ? ? ? 25  GLU U OE2 1 
+ATOM   76   N N   . ASN A 1 11  ? -15.254 -37.773 -9.075  1.00 30.81  ? ? ? ? ? ? 26  ASN U N   1 
+ATOM   77   C CA  . ASN A 1 11  ? -14.607 -39.006 -9.494  1.00 35.54  ? ? ? ? ? ? 26  ASN U CA  1 
+ATOM   78   C C   . ASN A 1 11  ? -13.101 -38.902 -9.702  1.00 32.17  ? ? ? ? ? ? 26  ASN U C   1 
+ATOM   79   O O   . ASN A 1 11  ? -12.475 -39.875 -10.122 1.00 33.53  ? ? ? ? ? ? 26  ASN U O   1 
+ATOM   80   C CB  . ASN A 1 11  ? -15.269 -39.557 -10.761 1.00 38.17  ? ? ? ? ? ? 26  ASN U CB  1 
+ATOM   81   C CG  . ASN A 1 11  ? -16.610 -40.197 -10.469 1.00 42.29  ? ? ? ? ? ? 26  ASN U CG  1 
+ATOM   82   O OD1 . ASN A 1 11  ? -16.810 -40.772 -9.392  1.00 41.01  ? ? ? ? ? ? 26  ASN U OD1 1 
+ATOM   83   N ND2 . ASN A 1 11  ? -17.550 -40.079 -11.413 1.00 42.92  ? ? ? ? ? ? 26  ASN U ND2 1 
+ATOM   84   N N   . GLN A 1 12  ? -12.548 -37.731 -9.405  1.00 30.68  ? ? ? ? ? ? 27  GLN U N   1 
+ATOM   85   C CA  . GLN A 1 12  ? -11.117 -37.430 -9.514  1.00 32.45  ? ? ? ? ? ? 27  GLN U CA  1 
+ATOM   86   C C   . GLN A 1 12  ? -10.752 -36.236 -8.585  1.00 30.76  ? ? ? ? ? ? 27  GLN U C   1 
+ATOM   87   O O   . GLN A 1 12  ? -10.166 -35.252 -9.034  1.00 28.91  ? ? ? ? ? ? 27  GLN U O   1 
+ATOM   88   C CB  . GLN A 1 12  ? -10.791 -37.049 -10.962 1.00 35.45  ? ? ? ? ? ? 27  GLN U CB  1 
+ATOM   89   C CG  . GLN A 1 12  ? -10.952 -38.156 -11.978 1.00 40.44  ? ? ? ? ? ? 27  GLN U CG  1 
+ATOM   90   C CD  . GLN A 1 12  ? -9.850  -39.198 -11.861 1.00 46.52  ? ? ? ? ? ? 27  GLN U CD  1 
+ATOM   91   O OE1 . GLN A 1 12  ? -8.706  -38.858 -11.556 1.00 51.15  ? ? ? ? ? ? 27  GLN U OE1 1 
+ATOM   92   N NE2 . GLN A 1 12  ? -10.180 -40.464 -12.118 1.00 51.17  ? ? ? ? ? ? 27  GLN U NE2 1 
+ATOM   93   N N   . PRO A 1 13  ? -11.073 -36.341 -7.280  1.00 28.71  ? ? ? ? ? ? 28  PRO U N   1 
+ATOM   94   C CA  . PRO A 1 13  ? -11.068 -35.188 -6.382  1.00 27.48  ? ? ? ? ? ? 28  PRO U CA  1 
+ATOM   95   C C   . PRO A 1 13  ? -9.698  -34.638 -6.001  1.00 27.82  ? ? ? ? ? ? 28  PRO U C   1 
+ATOM   96   O O   . PRO A 1 13  ? -9.619  -33.569 -5.391  1.00 29.23  ? ? ? ? ? ? 28  PRO U O   1 
+ATOM   97   C CB  . PRO A 1 13  ? -11.872 -35.690 -5.169  1.00 28.82  ? ? ? ? ? ? 28  PRO U CB  1 
+ATOM   98   C CG  . PRO A 1 13  ? -11.627 -37.134 -5.141  1.00 27.55  ? ? ? ? ? ? 28  PRO U CG  1 
+ATOM   99   C CD  . PRO A 1 13  ? -11.583 -37.553 -6.604  1.00 28.27  ? ? ? ? ? ? 28  PRO U CD  1 
+ATOM   100  N N   . TRP A 1 14  ? -8.639  -35.332 -6.423  1.00 29.09  ? ? ? ? ? ? 29  TRP U N   1 
+ATOM   101  C CA  . TRP A 1 14  ? -7.261  -34.859 -6.346  1.00 28.48  ? ? ? ? ? ? 29  TRP U CA  1 
+ATOM   102  C C   . TRP A 1 14  ? -6.892  -33.930 -7.504  1.00 29.70  ? ? ? ? ? ? 29  TRP U C   1 
+ATOM   103  O O   . TRP A 1 14  ? -5.856  -33.247 -7.455  1.00 26.67  ? ? ? ? ? ? 29  TRP U O   1 
+ATOM   104  C CB  . TRP A 1 14  ? -6.281  -36.051 -6.370  1.00 30.34  ? ? ? ? ? ? 29  TRP U CB  1 
+ATOM   105  C CG  . TRP A 1 14  ? -6.604  -37.022 -7.437  1.00 30.03  ? ? ? ? ? ? 29  TRP U CG  1 
+ATOM   106  C CD1 . TRP A 1 14  ? -6.248  -36.951 -8.758  1.00 33.16  ? ? ? ? ? ? 29  TRP U CD1 1 
+ATOM   107  C CD2 . TRP A 1 14  ? -7.410  -38.186 -7.305  1.00 33.78  ? ? ? ? ? ? 29  TRP U CD2 1 
+ATOM   108  N NE1 . TRP A 1 14  ? -6.783  -38.004 -9.448  1.00 33.59  ? ? ? ? ? ? 29  TRP U NE1 1 
+ATOM   109  C CE2 . TRP A 1 14  ? -7.498  -38.782 -8.575  1.00 33.24  ? ? ? ? ? ? 29  TRP U CE2 1 
+ATOM   110  C CE3 . TRP A 1 14  ? -8.062  -38.790 -6.229  1.00 35.07  ? ? ? ? ? ? 29  TRP U CE3 1 
+ATOM   111  C CZ2 . TRP A 1 14  ? -8.199  -39.963 -8.792  1.00 35.05  ? ? ? ? ? ? 29  TRP U CZ2 1 
+ATOM   112  C CZ3 . TRP A 1 14  ? -8.769  -39.946 -6.456  1.00 35.80  ? ? ? ? ? ? 29  TRP U CZ3 1 
+ATOM   113  C CH2 . TRP A 1 14  ? -8.827  -40.524 -7.716  1.00 36.29  ? ? ? ? ? ? 29  TRP U CH2 1 
+ATOM   114  N N   . PHE A 1 15  ? -7.712  -33.903 -8.554  1.00 28.80  ? ? ? ? ? ? 30  PHE U N   1 
+ATOM   115  C CA  . PHE A 1 15  ? -7.365  -33.090 -9.703  1.00 24.17  ? ? ? ? ? ? 30  PHE U CA  1 
+ATOM   116  C C   . PHE A 1 15  ? -7.393  -31.581 -9.478  1.00 23.82  ? ? ? ? ? ? 30  PHE U C   1 
+ATOM   117  O O   . PHE A 1 15  ? -8.403  -30.996 -9.088  1.00 25.39  ? ? ? ? ? ? 30  PHE U O   1 
+ATOM   118  C CB  . PHE A 1 15  ? -8.187  -33.484 -10.926 1.00 26.92  ? ? ? ? ? ? 30  PHE U CB  1 
+ATOM   119  C CG  . PHE A 1 15  ? -7.892  -32.625 -12.108 1.00 25.03  ? ? ? ? ? ? 30  PHE U CG  1 
+ATOM   120  C CD1 . PHE A 1 15  ? -6.787  -32.872 -12.879 1.00 27.15  ? ? ? ? ? ? 30  PHE U CD1 1 
+ATOM   121  C CD2 . PHE A 1 15  ? -8.684  -31.518 -12.391 1.00 27.45  ? ? ? ? ? ? 30  PHE U CD2 1 
+ATOM   122  C CE1 . PHE A 1 15  ? -6.491  -32.072 -13.984 1.00 28.31  ? ? ? ? ? ? 30  PHE U CE1 1 
+ATOM   123  C CE2 . PHE A 1 15  ? -8.389  -30.705 -13.477 1.00 27.50  ? ? ? ? ? ? 30  PHE U CE2 1 
+ATOM   124  C CZ  . PHE A 1 15  ? -7.279  -30.986 -14.272 1.00 26.56  ? ? ? ? ? ? 30  PHE U CZ  1 
+ATOM   125  N N   . ALA A 1 16  ? -6.255  -30.939 -9.744  1.00 23.80  ? ? ? ? ? ? 31  ALA U N   1 
+ATOM   126  C CA  . ALA A 1 16  ? -6.089  -29.500 -9.595  1.00 24.25  ? ? ? ? ? ? 31  ALA U CA  1 
+ATOM   127  C C   . ALA A 1 16  ? -6.104  -28.829 -10.965 1.00 25.43  ? ? ? ? ? ? 31  ALA U C   1 
+ATOM   128  O O   . ALA A 1 16  ? -5.471  -29.354 -11.882 1.00 26.91  ? ? ? ? ? ? 31  ALA U O   1 
+ATOM   129  C CB  . ALA A 1 16  ? -4.756  -29.210 -8.945  1.00 24.05  ? ? ? ? ? ? 31  ALA U CB  1 
+ATOM   130  N N   . ALA A 1 17  ? -6.799  -27.685 -11.072 1.00 25.59  ? ? ? ? ? ? 32  ALA U N   1 
+ATOM   131  C CA  . ALA A 1 17  ? -6.861  -26.860 -12.293 1.00 28.20  ? ? ? ? ? ? 32  ALA U CA  1 
+ATOM   132  C C   . ALA A 1 17  ? -5.997  -25.607 -12.139 1.00 28.21  ? ? ? ? ? ? 32  ALA U C   1 
+ATOM   133  O O   . ALA A 1 17  ? -6.269  -24.758 -11.282 1.00 31.80  ? ? ? ? ? ? 32  ALA U O   1 
+ATOM   134  C CB  . ALA A 1 17  ? -8.308  -26.482 -12.604 1.00 26.88  ? ? ? ? ? ? 32  ALA U CB  1 
+ATOM   135  N N   . ILE A 1 18  ? -4.946  -25.492 -12.953 1.00 28.34  ? ? ? ? ? ? 33  ILE U N   1 
+ATOM   136  C CA  . ILE A 1 18  ? -3.972  -24.378 -12.813 1.00 30.06  ? ? ? ? ? ? 33  ILE U CA  1 
+ATOM   137  C C   . ILE A 1 18  ? -4.073  -23.331 -13.928 1.00 28.30  ? ? ? ? ? ? 33  ILE U C   1 
+ATOM   138  O O   . ILE A 1 18  ? -3.978  -23.656 -15.120 1.00 27.59  ? ? ? ? ? ? 33  ILE U O   1 
+ATOM   139  C CB  . ILE A 1 18  ? -2.519  -24.899 -12.750 1.00 30.88  ? ? ? ? ? ? 33  ILE U CB  1 
+ATOM   140  C CG1 . ILE A 1 18  ? -2.428  -26.073 -11.769 1.00 30.29  ? ? ? ? ? ? 33  ILE U CG1 1 
+ATOM   141  C CG2 . ILE A 1 18  ? -1.564  -23.750 -12.394 1.00 31.62  ? ? ? ? ? ? 33  ILE U CG2 1 
+ATOM   142  C CD1 . ILE A 1 18  ? -1.077  -26.746 -11.685 1.00 30.37  ? ? ? ? ? ? 33  ILE U CD1 1 
+ATOM   143  N N   . TYR A 1 19  ? -4.228  -22.096 -13.528 1.00 28.37  ? ? ? ? ? ? 34  TYR U N   1 
+ATOM   144  C CA  . TYR A 1 19  ? -4.441  -20.991 -14.420 1.00 27.98  ? ? ? ? ? ? 34  TYR U CA  1 
+ATOM   145  C C   . TYR A 1 19  ? -3.389  -19.924 -14.199 1.00 32.27  ? ? ? ? ? ? 34  TYR U C   1 
+ATOM   146  O O   . TYR A 1 19  ? -2.775  -19.850 -13.167 1.00 28.65  ? ? ? ? ? ? 34  TYR U O   1 
+ATOM   147  C CB  . TYR A 1 19  ? -5.807  -20.358 -14.201 1.00 27.03  ? ? ? ? ? ? 34  TYR U CB  1 
+ATOM   148  C CG  . TYR A 1 19  ? -7.026  -21.219 -14.421 1.00 26.58  ? ? ? ? ? ? 34  TYR U CG  1 
+ATOM   149  C CD1 . TYR A 1 19  ? -7.385  -22.172 -13.505 1.00 26.20  ? ? ? ? ? ? 34  TYR U CD1 1 
+ATOM   150  C CD2 . TYR A 1 19  ? -7.812  -21.075 -15.539 1.00 26.30  ? ? ? ? ? ? 34  TYR U CD2 1 
+ATOM   151  C CE1 . TYR A 1 19  ? -8.487  -22.955 -13.674 1.00 27.15  ? ? ? ? ? ? 34  TYR U CE1 1 
+ATOM   152  C CE2 . TYR A 1 19  ? -8.921  -21.861 -15.728 1.00 27.93  ? ? ? ? ? ? 34  TYR U CE2 1 
+ATOM   153  C CZ  . TYR A 1 19  ? -9.246  -22.816 -14.781 1.00 28.87  ? ? ? ? ? ? 34  TYR U CZ  1 
+ATOM   154  O OH  . TYR A 1 19  ? -10.334 -23.589 -14.898 1.00 26.72  ? ? ? ? ? ? 34  TYR U OH  1 
+ATOM   155  N N   . ARG A 1 20  ? -3.200  -19.095 -15.207 1.00 35.62  ? ? ? ? ? ? 35  ARG U N   1 
+ATOM   156  C CA  . ARG A 1 20  ? -2.311  -17.943 -15.124 1.00 42.15  ? ? ? ? ? ? 35  ARG U CA  1 
+ATOM   157  C C   . ARG A 1 20  ? -2.981  -16.588 -15.460 1.00 47.22  ? ? ? ? ? ? 35  ARG U C   1 
+ATOM   158  O O   . ARG A 1 20  ? -3.666  -16.473 -16.451 1.00 44.84  ? ? ? ? ? ? 35  ARG U O   1 
+ATOM   159  C CB  . ARG A 1 20  ? -1.090  -18.128 -16.010 1.00 44.92  ? ? ? ? ? ? 35  ARG U CB  1 
+ATOM   160  C CG  . ARG A 1 20  ? -0.140  -16.971 -15.879 1.00 50.76  ? ? ? ? ? ? 35  ARG U CG  1 
+ATOM   161  C CD  . ARG A 1 20  ? 1.079   -17.097 -16.741 1.00 53.58  ? ? ? ? ? ? 35  ARG U CD  1 
+ATOM   162  N NE  . ARG A 1 20  ? 0.744   -16.851 -18.124 1.00 57.38  ? ? ? ? ? ? 35  ARG U NE  1 
+ATOM   163  C CZ  . ARG A 1 20  ? 0.878   -17.761 -19.060 1.00 58.24  ? ? ? ? ? ? 35  ARG U CZ  1 
+ATOM   164  N NH1 . ARG A 1 20  ? 0.532   -17.500 -20.300 1.00 60.63  ? ? ? ? ? ? 35  ARG U NH1 1 
+ATOM   165  N NH2 . ARG A 1 20  ? 1.370   -18.932 -18.740 1.00 58.36  ? ? ? ? ? ? 35  ARG U NH2 1 
+ATOM   166  N N   . ARG A 1 21  ? -2.754  -15.565 -14.651 1.00 48.52  ? ? ? ? ? ? 36  ARG U N   1 
+ATOM   167  C CA  . ARG A 1 21  ? -3.295  -14.247 -14.967 1.00 53.45  ? ? ? ? ? ? 36  ARG U CA  1 
+ATOM   168  C C   . ARG A 1 21  ? -2.285  -13.421 -15.726 1.00 55.80  ? ? ? ? ? ? 36  ARG U C   1 
+ATOM   169  O O   . ARG A 1 21  ? -1.155  -13.317 -15.308 1.00 59.06  ? ? ? ? ? ? 36  ARG U O   1 
+ATOM   170  C CB  . ARG A 1 21  ? -3.775  -13.482 -13.745 1.00 54.23  ? ? ? ? ? ? 36  ARG U CB  1 
+ATOM   171  C CG  . ARG A 1 21  ? -3.452  -14.085 -12.411 1.00 56.79  ? ? ? ? ? ? 36  ARG U CG  1 
+ATOM   172  C CD  . ARG A 1 21  ? -3.833  -13.082 -11.351 1.00 58.90  ? ? ? ? ? ? 36  ARG U CD  1 
+ATOM   173  N NE  . ARG A 1 21  ? -4.120  -13.672 -10.061 1.00 60.54  ? ? ? ? ? ? 36  ARG U NE  1 
+ATOM   174  C CZ  . ARG A 1 21  ? -3.208  -14.189 -9.274  1.00 58.86  ? ? ? ? ? ? 36  ARG U CZ  1 
+ATOM   175  N NH1 . ARG A 1 21  ? -3.550  -14.698 -8.118  1.00 58.53  ? ? ? ? ? ? 36  ARG U NH1 1 
+ATOM   176  N NH2 . ARG A 1 21  ? -1.956  -14.219 -9.667  1.00 60.99  ? ? ? ? ? ? 36  ARG U NH2 1 
+ATOM   177  N N   . HIS A 1 22  ? -2.709  -12.870 -16.852 1.00 56.48  ? ? ? ? ? ? 37  HIS U N   1 
+ATOM   178  C CA  . HIS A 1 22  ? -1.880  -12.046 -17.729 1.00 60.64  ? ? ? ? ? ? 37  HIS U CA  1 
+ATOM   179  C C   . HIS A 1 22  ? -1.860  -10.563 -17.366 1.00 60.91  ? ? ? ? ? ? 37  HIS U C   1 
+ATOM   180  O O   . HIS A 1 22  ? -2.516  -10.135 -16.437 1.00 62.61  ? ? ? ? ? ? 37  HIS U O   1 
+ATOM   181  C CB  . HIS A 1 22  ? -2.272  -12.222 -19.174 1.00 61.91  ? ? ? ? ? ? 37  HIS U CB  1 
+ATOM   182  C CG  . HIS A 1 22  ? -2.435  -13.642 -19.572 1.00 63.77  ? ? ? ? ? ? 37  HIS U CG  1 
+ATOM   183  N ND1 . HIS A 1 22  ? -3.357  -14.467 -18.982 1.00 66.38  ? ? ? ? ? ? 37  HIS U ND1 1 
+ATOM   184  C CD2 . HIS A 1 22  ? -1.782  -14.399 -20.478 1.00 62.68  ? ? ? ? ? ? 37  HIS U CD2 1 
+ATOM   185  C CE1 . HIS A 1 22  ? -3.281  -15.664 -19.518 1.00 64.27  ? ? ? ? ? ? 37  HIS U CE1 1 
+ATOM   186  N NE2 . HIS A 1 22  ? -2.333  -15.651 -20.429 1.00 62.36  ? ? ? ? ? ? 37  HIS U NE2 1 
+ATOM   187  N N   . ARG A 1 23  A -1.085  -9.777  -18.102 1.00 94.28  ? ? ? ? ? ? 37  ARG U N   1 
+ATOM   188  C CA  . ARG A 1 23  A -0.915  -8.380  -17.724 1.00 95.71  ? ? ? ? ? ? 37  ARG U CA  1 
+ATOM   189  C C   . ARG A 1 23  A -2.225  -7.635  -17.710 1.00 91.18  ? ? ? ? ? ? 37  ARG U C   1 
+ATOM   190  O O   . ARG A 1 23  A -2.406  -6.794  -16.868 1.00 85.08  ? ? ? ? ? ? 37  ARG U O   1 
+ATOM   191  C CB  . ARG A 1 23  A 0.087   -7.636  -18.570 1.00 100.69 ? ? ? ? ? ? 37  ARG U CB  1 
+ATOM   192  C CG  . ARG A 1 23  A 0.150   -6.141  -18.231 1.00 103.98 ? ? ? ? ? ? 37  ARG U CG  1 
+ATOM   193  C CD  . ARG A 1 23  A 0.807   -5.878  -16.882 1.00 105.08 ? ? ? ? ? ? 37  ARG U CD  1 
+ATOM   194  N NE  . ARG A 1 23  A 0.535   -4.550  -16.333 1.00 106.39 ? ? ? ? ? ? 37  ARG U NE  1 
+ATOM   195  C CZ  . ARG A 1 23  A 0.470   -3.431  -17.045 1.00 105.57 ? ? ? ? ? ? 37  ARG U CZ  1 
+ATOM   196  N NH1 . ARG A 1 23  A 0.208   -2.279  -16.447 1.00 104.48 ? ? ? ? ? ? 37  ARG U NH1 1 
+ATOM   197  N NH2 . ARG A 1 23  A 0.641   -3.461  -18.356 1.00 105.86 ? ? ? ? ? ? 37  ARG U NH2 1 
+ATOM   198  N N   . GLY A 1 24  B -3.131  -7.922  -18.630 1.00 94.70  ? ? ? ? ? ? 37  GLY U N   1 
+ATOM   199  C CA  . GLY A 1 24  B -4.410  -7.233  -18.626 1.00 93.94  ? ? ? ? ? ? 37  GLY U CA  1 
+ATOM   200  C C   . GLY A 1 24  B -5.286  -7.423  -17.384 1.00 95.41  ? ? ? ? ? ? 37  GLY U C   1 
+ATOM   201  O O   . GLY A 1 24  B -5.869  -6.496  -16.850 1.00 96.75  ? ? ? ? ? ? 37  GLY U O   1 
+ATOM   202  N N   . GLY A 1 25  C -5.339  -8.645  -16.903 1.00 62.34  ? ? ? ? ? ? 37  GLY U N   1 
+ATOM   203  C CA  . GLY A 1 25  C -6.350  -9.082  -15.990 1.00 63.80  ? ? ? ? ? ? 37  GLY U CA  1 
+ATOM   204  C C   . GLY A 1 25  C -6.971  -10.356 -16.530 1.00 68.37  ? ? ? ? ? ? 37  GLY U C   1 
+ATOM   205  O O   . GLY A 1 25  C -7.661  -11.041 -15.790 1.00 69.92  ? ? ? ? ? ? 37  GLY U O   1 
+ATOM   206  N N   . SER A 1 26  D -6.707  -10.692 -17.793 1.00 59.58  ? ? ? ? ? ? 37  SER U N   1 
+ATOM   207  C CA  . SER A 1 26  D -7.216  -11.938 -18.376 1.00 56.06  ? ? ? ? ? ? 37  SER U CA  1 
+ATOM   208  C C   . SER A 1 26  D -6.558  -13.222 -17.834 1.00 54.35  ? ? ? ? ? ? 37  SER U C   1 
+ATOM   209  O O   . SER A 1 26  D -5.372  -13.274 -17.650 1.00 56.12  ? ? ? ? ? ? 37  SER U O   1 
+ATOM   210  C CB  . SER A 1 26  D -7.243  -11.894 -19.912 1.00 56.50  ? ? ? ? ? ? 37  SER U CB  1 
+ATOM   211  O OG  . SER A 1 26  D -5.978  -11.918 -20.510 1.00 57.93  ? ? ? ? ? ? 37  SER U OG  1 
+ATOM   212  N N   . VAL A 1 27  ? -7.359  -14.236 -17.557 1.00 51.14  ? ? ? ? ? ? 38  VAL U N   1 
+ATOM   213  C CA  . VAL A 1 27  ? -6.881  -15.450 -16.912 1.00 47.47  ? ? ? ? ? ? 38  VAL U CA  1 
+ATOM   214  C C   . VAL A 1 27  ? -7.122  -16.633 -17.809 1.00 45.26  ? ? ? ? ? ? 38  VAL U C   1 
+ATOM   215  O O   . VAL A 1 27  ? -8.221  -16.845 -18.227 1.00 42.71  ? ? ? ? ? ? 38  VAL U O   1 
+ATOM   216  C CB  . VAL A 1 27  ? -7.628  -15.708 -15.602 1.00 46.73  ? ? ? ? ? ? 38  VAL U CB  1 
+ATOM   217  C CG1 . VAL A 1 27  ? -7.099  -16.932 -14.894 1.00 45.35  ? ? ? ? ? ? 38  VAL U CG1 1 
+ATOM   218  C CG2 . VAL A 1 27  ? -7.564  -14.506 -14.700 1.00 46.89  ? ? ? ? ? ? 38  VAL U CG2 1 
+ATOM   219  N N   . THR A 1 28  ? -6.090  -17.410 -18.083 1.00 44.54  ? ? ? ? ? ? 39  THR U N   1 
+ATOM   220  C CA  . THR A 1 28  ? -6.239  -18.582 -18.922 1.00 42.57  ? ? ? ? ? ? 39  THR U CA  1 
+ATOM   221  C C   . THR A 1 28  ? -5.630  -19.851 -18.348 1.00 37.32  ? ? ? ? ? ? 39  THR U C   1 
+ATOM   222  O O   . THR A 1 28  ? -4.739  -19.832 -17.570 1.00 37.04  ? ? ? ? ? ? 39  THR U O   1 
+ATOM   223  C CB  . THR A 1 28  ? -5.620  -18.388 -20.284 1.00 41.48  ? ? ? ? ? ? 39  THR U CB  1 
+ATOM   224  O OG1 . THR A 1 28  ? -4.259  -18.104 -20.116 1.00 45.84  ? ? ? ? ? ? 39  THR U OG1 1 
+ATOM   225  C CG2 . THR A 1 28  ? -6.243  -17.294 -21.002 1.00 45.50  ? ? ? ? ? ? 39  THR U CG2 1 
+ATOM   226  N N   . TYR A 1 29  ? -6.152  -20.965 -18.781 1.00 34.13  ? ? ? ? ? ? 40  TYR U N   1 
+ATOM   227  C CA  . TYR A 1 29  ? -5.766  -22.266 -18.247 1.00 33.03  ? ? ? ? ? ? 40  TYR U CA  1 
+ATOM   228  C C   . TYR A 1 29  ? -4.364  -22.631 -18.691 1.00 32.95  ? ? ? ? ? ? 40  TYR U C   1 
+ATOM   229  O O   . TYR A 1 29  ? -3.931  -22.303 -19.797 1.00 36.85  ? ? ? ? ? ? 40  TYR U O   1 
+ATOM   230  C CB  . TYR A 1 29  ? -6.763  -23.320 -18.667 1.00 31.24  ? ? ? ? ? ? 40  TYR U CB  1 
+ATOM   231  C CG  . TYR A 1 29  ? -6.584  -24.677 -18.010 1.00 29.04  ? ? ? ? ? ? 40  TYR U CG  1 
+ATOM   232  C CD1 . TYR A 1 29  ? -6.975  -24.894 -16.698 1.00 26.35  ? ? ? ? ? ? 40  TYR U CD1 1 
+ATOM   233  C CD2 . TYR A 1 29  ? -6.093  -25.749 -18.724 1.00 25.67  ? ? ? ? ? ? 40  TYR U CD2 1 
+ATOM   234  C CE1 . TYR A 1 29  ? -6.862  -26.156 -16.098 1.00 25.41  ? ? ? ? ? ? 40  TYR U CE1 1 
+ATOM   235  C CE2 . TYR A 1 29  ? -5.967  -27.004 -18.155 1.00 24.71  ? ? ? ? ? ? 40  TYR U CE2 1 
+ATOM   236  C CZ  . TYR A 1 29  ? -6.339  -27.208 -16.816 1.00 25.61  ? ? ? ? ? ? 40  TYR U CZ  1 
+ATOM   237  O OH  . TYR A 1 29  ? -6.243  -28.480 -16.250 1.00 21.91  ? ? ? ? ? ? 40  TYR U OH  1 
+ATOM   238  N N   . VAL A 1 30  ? -3.624  -23.251 -17.794 1.00 32.69  ? ? ? ? ? ? 41  VAL U N   1 
+ATOM   239  C CA  . VAL A 1 30  ? -2.239  -23.543 -18.046 1.00 34.50  ? ? ? ? ? ? 41  VAL U CA  1 
+ATOM   240  C C   . VAL A 1 30  ? -2.081  -25.056 -18.149 1.00 34.30  ? ? ? ? ? ? 41  VAL U C   1 
+ATOM   241  O O   . VAL A 1 30  ? -1.752  -25.582 -19.214 1.00 31.21  ? ? ? ? ? ? 41  VAL U O   1 
+ATOM   242  C CB  . VAL A 1 30  ? -1.347  -22.936 -16.946 1.00 34.13  ? ? ? ? ? ? 41  VAL U CB  1 
+ATOM   243  C CG1 . VAL A 1 30  ? 0.096   -23.361 -17.105 1.00 35.74  ? ? ? ? ? ? 41  VAL U CG1 1 
+ATOM   244  C CG2 . VAL A 1 30  ? -1.444  -21.423 -16.983 1.00 36.98  ? ? ? ? ? ? 41  VAL U CG2 1 
+ATOM   245  N N   . CYS A 1 31  ? -2.336  -25.744 -17.041 1.00 31.48  ? ? ? ? ? ? 42  CYS U N   1 
+ATOM   246  C CA  . CYS A 1 31  ? -2.109  -27.178 -16.947 1.00 29.70  ? ? ? ? ? ? 42  CYS U CA  1 
+ATOM   247  C C   . CYS A 1 31  ? -2.929  -27.812 -15.824 1.00 28.02  ? ? ? ? ? ? 42  CYS U C   1 
+ATOM   248  O O   . CYS A 1 31  ? -3.457  -27.136 -14.943 1.00 23.83  ? ? ? ? ? ? 42  CYS U O   1 
+ATOM   249  C CB  . CYS A 1 31  ? -0.657  -27.443 -16.558 1.00 34.09  ? ? ? ? ? ? 42  CYS U CB  1 
+ATOM   250  S SG  . CYS A 1 31  ? 0.612   -27.294 -17.833 1.00 37.77  ? ? ? ? ? ? 42  CYS U SG  1 
+ATOM   251  N N   . GLY A 1 32  ? -2.961  -29.131 -15.844 1.00 26.79  ? ? ? ? ? ? 43  GLY U N   1 
+ATOM   252  C CA  . GLY A 1 32  ? -3.463  -29.891 -14.718 1.00 29.22  ? ? ? ? ? ? 43  GLY U CA  1 
+ATOM   253  C C   . GLY A 1 32  ? -2.403  -30.055 -13.636 1.00 26.88  ? ? ? ? ? ? 43  GLY U C   1 
+ATOM   254  O O   . GLY A 1 32  ? -1.266  -29.597 -13.760 1.00 25.22  ? ? ? ? ? ? 43  GLY U O   1 
+ATOM   255  N N   . GLY A 1 33  ? -2.819  -30.695 -12.552 1.00 27.51  ? ? ? ? ? ? 44  GLY U N   1 
+ATOM   256  C CA  . GLY A 1 33  ? -1.955  -31.049 -11.447 1.00 26.79  ? ? ? ? ? ? 44  GLY U CA  1 
+ATOM   257  C C   . GLY A 1 33  ? -2.722  -31.962 -10.507 1.00 27.66  ? ? ? ? ? ? 44  GLY U C   1 
+ATOM   258  O O   . GLY A 1 33  ? -3.878  -32.316 -10.785 1.00 26.70  ? ? ? ? ? ? 44  GLY U O   1 
+ATOM   259  N N   . SER A 1 34  ? -2.103  -32.306 -9.376  1.00 29.11  ? ? ? ? ? ? 45  SER U N   1 
+ATOM   260  C CA  . SER A 1 34  ? -2.669  -33.257 -8.429  1.00 27.38  ? ? ? ? ? ? 45  SER U CA  1 
+ATOM   261  C C   . SER A 1 34  ? -2.337  -32.889 -6.993  1.00 31.28  ? ? ? ? ? ? 45  SER U C   1 
+ATOM   262  O O   . SER A 1 34  ? -1.183  -32.588 -6.674  1.00 28.94  ? ? ? ? ? ? 45  SER U O   1 
+ATOM   263  C CB  . SER A 1 34  ? -2.097  -34.642 -8.658  1.00 29.15  ? ? ? ? ? ? 45  SER U CB  1 
+ATOM   264  O OG  . SER A 1 34  ? -2.387  -35.131 -9.939  1.00 33.87  ? ? ? ? ? ? 45  SER U OG  1 
+ATOM   265  N N   . LEU A 1 35  ? -3.351  -32.970 -6.139  1.00 30.66  ? ? ? ? ? ? 46  LEU U N   1 
+ATOM   266  C CA  . LEU A 1 35  ? -3.222  -32.684 -4.735  1.00 34.40  ? ? ? ? ? ? 46  LEU U CA  1 
+ATOM   267  C C   . LEU A 1 35  ? -2.629  -33.870 -3.971  1.00 36.06  ? ? ? ? ? ? 46  LEU U C   1 
+ATOM   268  O O   . LEU A 1 35  ? -3.288  -34.878 -3.748  1.00 39.21  ? ? ? ? ? ? 46  LEU U O   1 
+ATOM   269  C CB  . LEU A 1 35  ? -4.599  -32.356 -4.167  1.00 34.51  ? ? ? ? ? ? 46  LEU U CB  1 
+ATOM   270  C CG  . LEU A 1 35  ? -4.581  -31.738 -2.775  1.00 32.68  ? ? ? ? ? ? 46  LEU U CG  1 
+ATOM   271  C CD1 . LEU A 1 35  ? -3.791  -30.435 -2.815  1.00 31.78  ? ? ? ? ? ? 46  LEU U CD1 1 
+ATOM   272  C CD2 . LEU A 1 35  ? -5.998  -31.537 -2.261  1.00 32.49  ? ? ? ? ? ? 46  LEU U CD2 1 
+ATOM   273  N N   . ILE A 1 36  ? -1.385  -33.741 -3.546  1.00 34.37  ? ? ? ? ? ? 47  ILE U N   1 
+ATOM   274  C CA  . ILE A 1 36  ? -0.708  -34.869 -2.914  1.00 35.66  ? ? ? ? ? ? 47  ILE U CA  1 
+ATOM   275  C C   . ILE A 1 36  ? -0.583  -34.726 -1.390  1.00 37.01  ? ? ? ? ? ? 47  ILE U C   1 
+ATOM   276  O O   . ILE A 1 36  ? -0.149  -35.640 -0.709  1.00 38.42  ? ? ? ? ? ? 47  ILE U O   1 
+ATOM   277  C CB  . ILE A 1 36  ? 0.664   -35.102 -3.560  1.00 34.41  ? ? ? ? ? ? 47  ILE U CB  1 
+ATOM   278  C CG1 . ILE A 1 36  ? 1.597   -33.928 -3.289  1.00 34.48  ? ? ? ? ? ? 47  ILE U CG1 1 
+ATOM   279  C CG2 . ILE A 1 36  ? 0.504   -35.294 -5.067  1.00 36.85  ? ? ? ? ? ? 47  ILE U CG2 1 
+ATOM   280  C CD1 . ILE A 1 36  ? 3.050   -34.218 -3.610  1.00 35.77  ? ? ? ? ? ? 47  ILE U CD1 1 
+ATOM   281  N N   . SER A 1 37  ? -0.938  -33.563 -0.876  1.00 39.39  ? ? ? ? ? ? 48  SER U N   1 
+ATOM   282  C CA  . SER A 1 37  ? -1.088  -33.356 0.552   1.00 40.38  ? ? ? ? ? ? 48  SER U CA  1 
+ATOM   283  C C   . SER A 1 37  ? -1.840  -32.048 0.619   1.00 39.36  ? ? ? ? ? ? 48  SER U C   1 
+ATOM   284  O O   . SER A 1 37  ? -1.955  -31.376 -0.409  1.00 37.01  ? ? ? ? ? ? 48  SER U O   1 
+ATOM   285  C CB  . SER A 1 37  ? 0.272   -33.278 1.259   1.00 42.52  ? ? ? ? ? ? 48  SER U CB  1 
+ATOM   286  O OG  . SER A 1 37  ? 0.980   -32.107 0.912   1.00 42.03  ? ? ? ? ? ? 48  SER U OG  1 
+ATOM   287  N N   . PRO A 1 38  ? -2.371  -31.680 1.799   1.00 38.20  ? ? ? ? ? ? 49  PRO U N   1 
+ATOM   288  C CA  . PRO A 1 38  ? -3.238  -30.507 1.843   1.00 37.61  ? ? ? ? ? ? 49  PRO U CA  1 
+ATOM   289  C C   . PRO A 1 38  ? -2.636  -29.221 1.302   1.00 37.67  ? ? ? ? ? ? 49  PRO U C   1 
+ATOM   290  O O   . PRO A 1 38  ? -3.373  -28.420 0.744   1.00 36.64  ? ? ? ? ? ? 49  PRO U O   1 
+ATOM   291  C CB  . PRO A 1 38  ? -3.562  -30.354 3.334   1.00 38.26  ? ? ? ? ? ? 49  PRO U CB  1 
+ATOM   292  C CG  . PRO A 1 38  ? -3.426  -31.721 3.880   1.00 38.94  ? ? ? ? ? ? 49  PRO U CG  1 
+ATOM   293  C CD  . PRO A 1 38  ? -2.288  -32.341 3.117   1.00 41.02  ? ? ? ? ? ? 49  PRO U CD  1 
+ATOM   294  N N   . CYS A 1 39  ? -1.332  -29.007 1.485   1.00 38.12  ? ? ? ? ? ? 50  CYS U N   1 
+ATOM   295  C CA  . CYS A 1 39  ? -0.687  -27.760 1.060   1.00 40.13  ? ? ? ? ? ? 50  CYS U CA  1 
+ATOM   296  C C   . CYS A 1 39  ? 0.029   -27.853 -0.292  1.00 38.70  ? ? ? ? ? ? 50  CYS U C   1 
+ATOM   297  O O   . CYS A 1 39  ? 0.545   -26.838 -0.786  1.00 36.86  ? ? ? ? ? ? 50  CYS U O   1 
+ATOM   298  C CB  . CYS A 1 39  ? 0.328   -27.300 2.109   1.00 43.78  ? ? ? ? ? ? 50  CYS U CB  1 
+ATOM   299  S SG  . CYS A 1 39  ? -0.374  -27.057 3.754   1.00 48.95  ? ? ? ? ? ? 50  CYS U SG  1 
+ATOM   300  N N   . TRP A 1 40  ? 0.047   -29.046 -0.891  1.00 39.41  ? ? ? ? ? ? 51  TRP U N   1 
+ATOM   301  C CA  . TRP A 1 40  ? 0.929   -29.327 -2.028  1.00 40.08  ? ? ? ? ? ? 51  TRP U CA  1 
+ATOM   302  C C   . TRP A 1 40  ? 0.243   -29.937 -3.242  1.00 37.39  ? ? ? ? ? ? 51  TRP U C   1 
+ATOM   303  O O   . TRP A 1 40  ? -0.401  -30.986 -3.152  1.00 31.90  ? ? ? ? ? ? 51  TRP U O   1 
+ATOM   304  C CB  . TRP A 1 40  ? 2.049   -30.268 -1.593  1.00 42.82  ? ? ? ? ? ? 51  TRP U CB  1 
+ATOM   305  C CG  . TRP A 1 40  ? 3.028   -29.617 -0.683  1.00 45.78  ? ? ? ? ? ? 51  TRP U CG  1 
+ATOM   306  C CD1 . TRP A 1 40  ? 3.119   -29.764 0.672   1.00 47.19  ? ? ? ? ? ? 51  TRP U CD1 1 
+ATOM   307  C CD2 . TRP A 1 40  ? 4.057   -28.697 -1.057  1.00 46.26  ? ? ? ? ? ? 51  TRP U CD2 1 
+ATOM   308  N NE1 . TRP A 1 40  ? 4.147   -28.997 1.164   1.00 45.98  ? ? ? ? ? ? 51  TRP U NE1 1 
+ATOM   309  C CE2 . TRP A 1 40  ? 4.740   -28.329 0.129   1.00 46.38  ? ? ? ? ? ? 51  TRP U CE2 1 
+ATOM   310  C CE3 . TRP A 1 40  ? 4.470   -28.149 -2.271  1.00 44.74  ? ? ? ? ? ? 51  TRP U CE3 1 
+ATOM   311  C CZ2 . TRP A 1 40  ? 5.814   -27.437 0.131   1.00 45.63  ? ? ? ? ? ? 51  TRP U CZ2 1 
+ATOM   312  C CZ3 . TRP A 1 40  ? 5.534   -27.266 -2.276  1.00 45.72  ? ? ? ? ? ? 51  TRP U CZ3 1 
+ATOM   313  C CH2 . TRP A 1 40  ? 6.203   -26.919 -1.078  1.00 47.45  ? ? ? ? ? ? 51  TRP U CH2 1 
+ATOM   314  N N   . VAL A 1 41  ? 0.459   -29.300 -4.372  1.00 35.53  ? ? ? ? ? ? 52  VAL U N   1 
+ATOM   315  C CA  . VAL A 1 41  ? -0.013  -29.782 -5.628  1.00 36.42  ? ? ? ? ? ? 52  VAL U CA  1 
+ATOM   316  C C   . VAL A 1 41  ? 1.192   -30.090 -6.464  1.00 34.94  ? ? ? ? ? ? 52  VAL U C   1 
+ATOM   317  O O   . VAL A 1 41  ? 2.089   -29.314 -6.542  1.00 36.38  ? ? ? ? ? ? 52  VAL U O   1 
+ATOM   318  C CB  . VAL A 1 41  ? -0.920  -28.742 -6.314  1.00 36.44  ? ? ? ? ? ? 52  VAL U CB  1 
+ATOM   319  C CG1 . VAL A 1 41  ? -1.040  -28.962 -7.816  1.00 36.92  ? ? ? ? ? ? 52  VAL U CG1 1 
+ATOM   320  C CG2 . VAL A 1 41  ? -2.283  -28.709 -5.669  1.00 36.14  ? ? ? ? ? ? 52  VAL U CG2 1 
+ATOM   321  N N   . ILE A 1 42  ? 1.181   -31.223 -7.111  1.00 33.55  ? ? ? ? ? ? 53  ILE U N   1 
+ATOM   322  C CA  . ILE A 1 42  ? 2.256   -31.591 -7.996  1.00 32.87  ? ? ? ? ? ? 53  ILE U CA  1 
+ATOM   323  C C   . ILE A 1 42  ? 1.852   -31.547 -9.487  1.00 30.74  ? ? ? ? ? ? 53  ILE U C   1 
+ATOM   324  O O   . ILE A 1 42  ? 0.790   -31.921 -9.844  1.00 32.30  ? ? ? ? ? ? 53  ILE U O   1 
+ATOM   325  C CB  . ILE A 1 42  ? 2.812   -32.951 -7.627  1.00 33.61  ? ? ? ? ? ? 53  ILE U CB  1 
+ATOM   326  C CG1 . ILE A 1 42  ? 4.145   -33.162 -8.280  1.00 35.73  ? ? ? ? ? ? 53  ILE U CG1 1 
+ATOM   327  C CG2 . ILE A 1 42  ? 1.883   -34.041 -8.067  1.00 35.20  ? ? ? ? ? ? 53  ILE U CG2 1 
+ATOM   328  C CD1 . ILE A 1 42  ? 4.924   -34.290 -7.689  1.00 36.12  ? ? ? ? ? ? 53  ILE U CD1 1 
+ATOM   329  N N   . SER A 1 43  ? 2.743   -31.056 -10.320 1.00 29.70  ? ? ? ? ? ? 54  SER U N   1 
+ATOM   330  C CA  . SER A 1 43  ? 2.542   -30.862 -11.750 1.00 28.75  ? ? ? ? ? ? 54  SER U CA  1 
+ATOM   331  C C   . SER A 1 43  ? 3.849   -31.035 -12.524 1.00 32.02  ? ? ? ? ? ? 54  SER U C   1 
+ATOM   332  O O   . SER A 1 43  ? 4.732   -31.711 -12.091 1.00 33.14  ? ? ? ? ? ? 54  SER U O   1 
+ATOM   333  C CB  . SER A 1 43  ? 1.960   -29.488 -12.050 1.00 28.79  ? ? ? ? ? ? 54  SER U CB  1 
+ATOM   334  O OG  . SER A 1 43  ? 1.451   -29.379 -13.341 1.00 26.60  ? ? ? ? ? ? 54  SER U OG  1 
+ATOM   335  N N   . ALA A 1 44  ? 3.902   -30.448 -13.710 1.00 31.06  ? ? ? ? ? ? 55  ALA U N   1 
+ATOM   336  C CA  . ALA A 1 44  ? 5.008   -30.548 -14.638 1.00 31.99  ? ? ? ? ? ? 55  ALA U CA  1 
+ATOM   337  C C   . ALA A 1 44  ? 5.739   -29.218 -14.801 1.00 33.55  ? ? ? ? ? ? 55  ALA U C   1 
+ATOM   338  O O   . ALA A 1 44  ? 5.145   -28.191 -14.863 1.00 31.53  ? ? ? ? ? ? 55  ALA U O   1 
+ATOM   339  C CB  . ALA A 1 44  ? 4.511   -31.058 -15.974 1.00 30.04  ? ? ? ? ? ? 55  ALA U CB  1 
+ATOM   340  N N   . THR A 1 45  ? 7.049   -29.256 -14.824 1.00 36.32  ? ? ? ? ? ? 56  THR U N   1 
+ATOM   341  C CA  . THR A 1 45  ? 7.838   -28.027 -14.851 1.00 36.09  ? ? ? ? ? ? 56  THR U CA  1 
+ATOM   342  C C   . THR A 1 45  ? 7.602   -27.194 -16.111 1.00 35.59  ? ? ? ? ? ? 56  THR U C   1 
+ATOM   343  O O   . THR A 1 45  ? 7.688   -25.962 -16.066 1.00 35.76  ? ? ? ? ? ? 56  THR U O   1 
+ATOM   344  C CB  . THR A 1 45  ? 9.352   -28.325 -14.676 1.00 38.16  ? ? ? ? ? ? 56  THR U CB  1 
+ATOM   345  O OG1 . THR A 1 45  ? 9.659   -28.433 -13.281 1.00 38.04  ? ? ? ? ? ? 56  THR U OG1 1 
+ATOM   346  C CG2 . THR A 1 45  ? 10.213  -27.226 -15.247 1.00 40.24  ? ? ? ? ? ? 56  THR U CG2 1 
+ATOM   347  N N   . HIS A 1 46  ? 7.316   -27.851 -17.229 1.00 34.30  ? ? ? ? ? ? 57  HIS U N   1 
+ATOM   348  C CA  . HIS A 1 46  ? 7.181   -27.165 -18.502 1.00 33.05  ? ? ? ? ? ? 57  HIS U CA  1 
+ATOM   349  C C   . HIS A 1 46  ? 5.980   -26.221 -18.485 1.00 36.88  ? ? ? ? ? ? 57  HIS U C   1 
+ATOM   350  O O   . HIS A 1 46  ? 5.918   -25.274 -19.260 1.00 37.70  ? ? ? ? ? ? 57  HIS U O   1 
+ATOM   351  C CB  . HIS A 1 46  ? 7.069   -28.177 -19.651 1.00 33.66  ? ? ? ? ? ? 57  HIS U CB  1 
+ATOM   352  C CG  . HIS A 1 46  ? 5.737   -28.844 -19.746 1.00 35.43  ? ? ? ? ? ? 57  HIS U CG  1 
+ATOM   353  N ND1 . HIS A 1 46  ? 5.516   -30.144 -19.344 1.00 36.94  ? ? ? ? ? ? 57  HIS U ND1 1 
+ATOM   354  C CD2 . HIS A 1 46  ? 4.548   -28.383 -20.195 1.00 38.79  ? ? ? ? ? ? 57  HIS U CD2 1 
+ATOM   355  C CE1 . HIS A 1 46  ? 4.249   -30.457 -19.558 1.00 38.76  ? ? ? ? ? ? 57  HIS U CE1 1 
+ATOM   356  N NE2 . HIS A 1 46  ? 3.642   -29.405 -20.077 1.00 37.64  ? ? ? ? ? ? 57  HIS U NE2 1 
+ATOM   357  N N   . CYS A 1 47  ? 5.012   -26.480 -17.609 1.00 36.96  ? ? ? ? ? ? 58  CYS U N   1 
+ATOM   358  C CA  . CYS A 1 47  ? 3.859   -25.587 -17.464 1.00 35.30  ? ? ? ? ? ? 58  CYS U CA  1 
+ATOM   359  C C   . CYS A 1 47  ? 4.212   -24.175 -17.049 1.00 36.84  ? ? ? ? ? ? 58  CYS U C   1 
+ATOM   360  O O   . CYS A 1 47  ? 3.423   -23.259 -17.238 1.00 35.59  ? ? ? ? ? ? 58  CYS U O   1 
+ATOM   361  C CB  . CYS A 1 47  ? 2.936   -26.131 -16.391 1.00 36.48  ? ? ? ? ? ? 58  CYS U CB  1 
+ATOM   362  S SG  . CYS A 1 47  ? 2.276   -27.753 -16.770 1.00 35.39  ? ? ? ? ? ? 58  CYS U SG  1 
+ATOM   363  N N   . PHE A 1 48  ? 5.343   -24.036 -16.394 1.00 39.75  ? ? ? ? ? ? 59  PHE U N   1 
+ATOM   364  C CA  . PHE A 1 48  ? 5.699   -22.800 -15.746 1.00 38.36  ? ? ? ? ? ? 59  PHE U CA  1 
+ATOM   365  C C   . PHE A 1 48  ? 7.001   -22.172 -16.224 1.00 40.62  ? ? ? ? ? ? 59  PHE U C   1 
+ATOM   366  O O   . PHE A 1 48  ? 7.338   -21.077 -15.869 1.00 39.94  ? ? ? ? ? ? 59  PHE U O   1 
+ATOM   367  C CB  . PHE A 1 48  ? 5.757   -23.008 -14.240 1.00 36.41  ? ? ? ? ? ? 59  PHE U CB  1 
+ATOM   368  C CG  . PHE A 1 48  ? 4.612   -23.789 -13.705 1.00 35.50  ? ? ? ? ? ? 59  PHE U CG  1 
+ATOM   369  C CD1 . PHE A 1 48  ? 3.420   -23.193 -13.444 1.00 33.86  ? ? ? ? ? ? 59  PHE U CD1 1 
+ATOM   370  C CD2 . PHE A 1 48  ? 4.732   -25.129 -13.478 1.00 38.22  ? ? ? ? ? ? 59  PHE U CD2 1 
+ATOM   371  C CE1 . PHE A 1 48  ? 2.361   -23.910 -12.956 1.00 34.90  ? ? ? ? ? ? 59  PHE U CE1 1 
+ATOM   372  C CE2 . PHE A 1 48  ? 3.674   -25.858 -12.980 1.00 37.02  ? ? ? ? ? ? 59  PHE U CE2 1 
+ATOM   373  C CZ  . PHE A 1 48  ? 2.480   -25.244 -12.721 1.00 34.41  ? ? ? ? ? ? 59  PHE U CZ  1 
+ATOM   374  N N   . ILE A 1 49  ? 7.729   -22.899 -17.024 1.00 42.84  ? ? ? ? ? ? 60  ILE U N   1 
+ATOM   375  C CA  . ILE A 1 49  ? 9.076   -22.521 -17.354 1.00 47.48  ? ? ? ? ? ? 60  ILE U CA  1 
+ATOM   376  C C   . ILE A 1 49  ? 9.106   -21.178 -18.096 1.00 48.16  ? ? ? ? ? ? 60  ILE U C   1 
+ATOM   377  O O   . ILE A 1 49  ? 9.938   -20.373 -17.802 1.00 48.43  ? ? ? ? ? ? 60  ILE U O   1 
+ATOM   378  C CB  . ILE A 1 49  ? 9.842   -23.687 -18.024 1.00 47.93  ? ? ? ? ? ? 60  ILE U CB  1 
+ATOM   379  C CG1 . ILE A 1 49  ? 11.336  -23.456 -17.992 1.00 52.13  ? ? ? ? ? ? 60  ILE U CG1 1 
+ATOM   380  C CG2 . ILE A 1 49  ? 9.360   -23.938 -19.428 1.00 48.22  ? ? ? ? ? ? 60  ILE U CG2 1 
+ATOM   381  C CD1 . ILE A 1 49  ? 11.926  -23.294 -16.621 1.00 52.71  ? ? ? ? ? ? 60  ILE U CD1 1 
+ATOM   382  N N   . ASP A 1 50  A 8.163   -20.932 -18.993 1.00 41.35  ? ? ? ? ? ? 60  ASP U N   1 
+ATOM   383  C CA  . ASP A 1 50  A 8.058   -19.640 -19.623 1.00 44.13  ? ? ? ? ? ? 60  ASP U CA  1 
+ATOM   384  C C   . ASP A 1 50  A 7.706   -18.421 -18.760 1.00 44.67  ? ? ? ? ? ? 60  ASP U C   1 
+ATOM   385  O O   . ASP A 1 50  A 8.102   -17.354 -19.101 1.00 42.34  ? ? ? ? ? ? 60  ASP U O   1 
+ATOM   386  C CB  . ASP A 1 50  A 7.194   -19.662 -20.860 1.00 45.99  ? ? ? ? ? ? 60  ASP U CB  1 
+ATOM   387  C CG  . ASP A 1 50  A 7.483   -20.837 -21.731 1.00 49.54  ? ? ? ? ? ? 60  ASP U CG  1 
+ATOM   388  O OD1 . ASP A 1 50  A 8.585   -21.365 -21.626 1.00 56.51  ? ? ? ? ? ? 60  ASP U OD1 1 
+ATOM   389  O OD2 . ASP A 1 50  A 6.622   -21.229 -22.526 1.00 50.70  ? ? ? ? ? ? 60  ASP U OD2 1 
+ATOM   390  N N   . TYR A 1 51  B 6.895   -18.579 -17.749 1.00 52.86  ? ? ? ? ? ? 60  TYR U N   1 
+ATOM   391  C CA  . TYR A 1 51  B 6.498   -17.493 -16.882 1.00 57.14  ? ? ? ? ? ? 60  TYR U CA  1 
+ATOM   392  C C   . TYR A 1 51  B 6.672   -17.915 -15.403 1.00 54.75  ? ? ? ? ? ? 60  TYR U C   1 
+ATOM   393  O O   . TYR A 1 51  B 5.698   -18.216 -14.763 1.00 51.14  ? ? ? ? ? ? 60  TYR U O   1 
+ATOM   394  C CB  . TYR A 1 51  B 5.062   -17.052 -17.183 1.00 61.66  ? ? ? ? ? ? 60  TYR U CB  1 
+ATOM   395  C CG  . TYR A 1 51  B 4.707   -16.650 -18.634 1.00 65.97  ? ? ? ? ? ? 60  TYR U CG  1 
+ATOM   396  C CD1 . TYR A 1 51  B 4.767   -17.543 -19.680 1.00 69.56  ? ? ? ? ? ? 60  TYR U CD1 1 
+ATOM   397  C CD2 . TYR A 1 51  B 4.294   -15.366 -18.935 1.00 70.33  ? ? ? ? ? ? 60  TYR U CD2 1 
+ATOM   398  C CE1 . TYR A 1 51  B 4.468   -17.153 -20.977 1.00 71.17  ? ? ? ? ? ? 60  TYR U CE1 1 
+ATOM   399  C CE2 . TYR A 1 51  B 4.007   -14.973 -20.221 1.00 70.43  ? ? ? ? ? ? 60  TYR U CE2 1 
+ATOM   400  C CZ  . TYR A 1 51  B 4.089   -15.876 -21.227 1.00 72.28  ? ? ? ? ? ? 60  TYR U CZ  1 
+ATOM   401  O OH  . TYR A 1 51  B 3.777   -15.493 -22.492 1.00 73.97  ? ? ? ? ? ? 60  TYR U OH  1 
+ATOM   402  N N   . PRO A 1 52  C 7.979   -17.918 -14.891 1.00 49.51  ? ? ? ? ? ? 60  PRO U N   1 
+ATOM   403  C CA  . PRO A 1 52  C 8.094   -18.564 -13.558 1.00 47.83  ? ? ? ? ? ? 60  PRO U CA  1 
+ATOM   404  C C   . PRO A 1 52  C 7.733   -17.811 -12.282 1.00 46.55  ? ? ? ? ? ? 60  PRO U C   1 
+ATOM   405  O O   . PRO A 1 52  C 8.088   -18.242 -11.214 1.00 47.71  ? ? ? ? ? ? 60  PRO U O   1 
+ATOM   406  C CB  . PRO A 1 52  C 9.548   -19.009 -13.497 1.00 47.73  ? ? ? ? ? ? 60  PRO U CB  1 
+ATOM   407  C CG  . PRO A 1 52  C 10.288  -18.047 -14.304 1.00 49.36  ? ? ? ? ? ? 60  PRO U CG  1 
+ATOM   408  C CD  . PRO A 1 52  C 9.403   -17.636 -15.402 1.00 49.25  ? ? ? ? ? ? 60  PRO U CD  1 
+ATOM   409  N N   . LYS A 1 53  ? 7.098   -16.672 -12.396 1.00 48.29  ? ? ? ? ? ? 61  LYS U N   1 
+ATOM   410  C CA  . LYS A 1 53  ? 6.631   -15.968 -11.223 1.00 49.73  ? ? ? ? ? ? 61  LYS U CA  1 
+ATOM   411  C C   . LYS A 1 53  ? 5.361   -16.583 -10.633 1.00 45.85  ? ? ? ? ? ? 61  LYS U C   1 
+ATOM   412  O O   . LYS A 1 53  ? 4.347   -16.593 -11.253 1.00 44.19  ? ? ? ? ? ? 61  LYS U O   1 
+ATOM   413  C CB  . LYS A 1 53  ? 6.360   -14.515 -11.576 1.00 55.64  ? ? ? ? ? ? 61  LYS U CB  1 
+ATOM   414  C CG  . LYS A 1 53  ? 7.251   -13.948 -12.670 1.00 61.46  ? ? ? ? ? ? 61  LYS U CG  1 
+ATOM   415  C CD  . LYS A 1 53  ? 8.691   -13.950 -12.224 1.00 64.72  ? ? ? ? ? ? 61  LYS U CD  1 
+ATOM   416  C CE  . LYS A 1 53  ? 9.396   -12.700 -12.725 1.00 69.14  ? ? ? ? ? ? 61  LYS U CE  1 
+ATOM   417  N NZ  . LYS A 1 53  ? 10.710  -12.503 -12.074 1.00 71.19  ? ? ? ? ? ? 61  LYS U NZ  1 
+ATOM   418  N N   . LYS A 1 54  ? 5.483   -17.083 -9.418  1.00 44.97  ? ? ? ? ? ? 62  LYS U N   1 
+ATOM   419  C CA  . LYS A 1 54  ? 4.431   -17.730 -8.661  1.00 45.76  ? ? ? ? ? ? 62  LYS U CA  1 
+ATOM   420  C C   . LYS A 1 54  ? 3.191   -16.882 -8.407  1.00 44.59  ? ? ? ? ? ? 62  LYS U C   1 
+ATOM   421  O O   . LYS A 1 54  ? 2.111   -17.384 -8.189  1.00 41.78  ? ? ? ? ? ? 62  LYS U O   1 
+ATOM   422  C CB  . LYS A 1 54  ? 4.992   -18.183 -7.338  1.00 46.22  ? ? ? ? ? ? 62  LYS U CB  1 
+ATOM   423  C CG  . LYS A 1 54  ? 5.476   -17.057 -6.449  1.00 48.63  ? ? ? ? ? ? 62  LYS U CG  1 
+ATOM   424  C CD  . LYS A 1 54  ? 5.835   -17.577 -5.062  1.00 51.35  ? ? ? ? ? ? 62  LYS U CD  1 
+ATOM   425  C CE  . LYS A 1 54  ? 6.801   -16.689 -4.305  1.00 54.94  ? ? ? ? ? ? 62  LYS U CE  1 
+ATOM   426  N NZ  . LYS A 1 54  ? 6.408   -16.489 -2.895  1.00 55.54  ? ? ? ? ? ? 62  LYS U NZ  1 
+ATOM   427  N N   . GLU A 1 55  A 3.389   -15.580 -8.426  1.00 47.73  ? ? ? ? ? ? 62  GLU U N   1 
+ATOM   428  C CA  . GLU A 1 55  A 2.333   -14.602 -8.247  1.00 49.15  ? ? ? ? ? ? 62  GLU U CA  1 
+ATOM   429  C C   . GLU A 1 55  A 1.278   -14.665 -9.343  1.00 44.73  ? ? ? ? ? ? 62  GLU U C   1 
+ATOM   430  O O   . GLU A 1 55  A 0.139   -14.379 -9.109  1.00 43.01  ? ? ? ? ? ? 62  GLU U O   1 
+ATOM   431  C CB  . GLU A 1 55  A 2.917   -13.205 -8.206  1.00 51.22  ? ? ? ? ? ? 62  GLU U CB  1 
+ATOM   432  C CG  . GLU A 1 55  A 3.623   -12.856 -6.938  1.00 53.81  ? ? ? ? ? ? 62  GLU U CG  1 
+ATOM   433  C CD  . GLU A 1 55  A 5.017   -13.383 -6.891  1.00 57.28  ? ? ? ? ? ? 62  GLU U CD  1 
+ATOM   434  O OE1 . GLU A 1 55  A 5.689   -13.491 -7.922  1.00 62.30  ? ? ? ? ? ? 62  GLU U OE1 1 
+ATOM   435  O OE2 . GLU A 1 55  A 5.443   -13.682 -5.792  1.00 64.13  ? ? ? ? ? ? 62  GLU U OE2 1 
+ATOM   436  N N   . ASP A 1 56  ? 1.698   -14.955 -10.551 1.00 43.02  ? ? ? ? ? ? 63  ASP U N   1 
+ATOM   437  C CA  . ASP A 1 56  ? 0.780   -15.023 -11.656 1.00 45.68  ? ? ? ? ? ? 63  ASP U CA  1 
+ATOM   438  C C   . ASP A 1 56  ? -0.146  -16.232 -11.734 1.00 44.27  ? ? ? ? ? ? 63  ASP U C   1 
+ATOM   439  O O   . ASP A 1 56  ? -0.902  -16.337 -12.656 1.00 42.96  ? ? ? ? ? ? 63  ASP U O   1 
+ATOM   440  C CB  . ASP A 1 56  ? 1.544   -14.899 -12.942 1.00 47.77  ? ? ? ? ? ? 63  ASP U CB  1 
+ATOM   441  C CG  . ASP A 1 56  ? 2.149   -13.557 -13.101 1.00 50.56  ? ? ? ? ? ? 63  ASP U CG  1 
+ATOM   442  O OD1 . ASP A 1 56  ? 1.601   -12.585 -12.567 1.00 54.24  ? ? ? ? ? ? 63  ASP U OD1 1 
+ATOM   443  O OD2 . ASP A 1 56  ? 3.168   -13.478 -13.762 1.00 52.86  ? ? ? ? ? ? 63  ASP U OD2 1 
+ATOM   444  N N   . TYR A 1 57  ? -0.080  -17.129 -10.767 1.00 41.55  ? ? ? ? ? ? 64  TYR U N   1 
+ATOM   445  C CA  . TYR A 1 57  ? -0.798  -18.390 -10.855 1.00 40.93  ? ? ? ? ? ? 64  TYR U CA  1 
+ATOM   446  C C   . TYR A 1 57  ? -1.907  -18.527 -9.850  1.00 38.39  ? ? ? ? ? ? 64  TYR U C   1 
+ATOM   447  O O   . TYR A 1 57  ? -1.848  -17.992 -8.733  1.00 34.78  ? ? ? ? ? ? 64  TYR U O   1 
+ATOM   448  C CB  . TYR A 1 57  ? 0.172   -19.553 -10.711 1.00 41.79  ? ? ? ? ? ? 64  TYR U CB  1 
+ATOM   449  C CG  . TYR A 1 57  ? 1.068   -19.633 -11.889 1.00 39.30  ? ? ? ? ? ? 64  TYR U CG  1 
+ATOM   450  C CD1 . TYR A 1 57  ? 0.630   -20.217 -13.072 1.00 39.55  ? ? ? ? ? ? 64  TYR U CD1 1 
+ATOM   451  C CD2 . TYR A 1 57  ? 2.339   -19.064 -11.862 1.00 39.57  ? ? ? ? ? ? 64  TYR U CD2 1 
+ATOM   452  C CE1 . TYR A 1 57  ? 1.444   -20.271 -14.190 1.00 38.25  ? ? ? ? ? ? 64  TYR U CE1 1 
+ATOM   453  C CE2 . TYR A 1 57  ? 3.161   -19.118 -12.975 1.00 39.52  ? ? ? ? ? ? 64  TYR U CE2 1 
+ATOM   454  C CZ  . TYR A 1 57  ? 2.702   -19.719 -14.133 1.00 38.18  ? ? ? ? ? ? 64  TYR U CZ  1 
+ATOM   455  O OH  . TYR A 1 57  ? 3.494   -19.771 -15.230 1.00 40.37  ? ? ? ? ? ? 64  TYR U OH  1 
+ATOM   456  N N   . ILE A 1 58  ? -2.934  -19.248 -10.275 1.00 36.40  ? ? ? ? ? ? 65  ILE U N   1 
+ATOM   457  C CA  . ILE A 1 58  ? -4.035  -19.595 -9.415  1.00 35.67  ? ? ? ? ? ? 65  ILE U CA  1 
+ATOM   458  C C   . ILE A 1 58  ? -4.324  -21.076 -9.576  1.00 35.69  ? ? ? ? ? ? 65  ILE U C   1 
+ATOM   459  O O   . ILE A 1 58  ? -4.316  -21.607 -10.704 1.00 31.59  ? ? ? ? ? ? 65  ILE U O   1 
+ATOM   460  C CB  . ILE A 1 58  ? -5.319  -18.852 -9.791  1.00 39.32  ? ? ? ? ? ? 65  ILE U CB  1 
+ATOM   461  C CG1 . ILE A 1 58  ? -5.113  -17.336 -9.807  1.00 44.29  ? ? ? ? ? ? 65  ILE U CG1 1 
+ATOM   462  C CG2 . ILE A 1 58  ? -6.425  -19.216 -8.818  1.00 40.54  ? ? ? ? ? ? 65  ILE U CG2 1 
+ATOM   463  C CD1 . ILE A 1 58  ? -6.187  -16.613 -10.605 1.00 47.60  ? ? ? ? ? ? 65  ILE U CD1 1 
+ATOM   464  N N   . VAL A 1 59  ? -4.615  -21.728 -8.456  1.00 33.57  ? ? ? ? ? ? 66  VAL U N   1 
+ATOM   465  C CA  . VAL A 1 59  ? -4.941  -23.140 -8.451  1.00 31.83  ? ? ? ? ? ? 66  VAL U CA  1 
+ATOM   466  C C   . VAL A 1 59  ? -6.346  -23.321 -7.923  1.00 33.49  ? ? ? ? ? ? 66  VAL U C   1 
+ATOM   467  O O   . VAL A 1 59  ? -6.674  -22.819 -6.834  1.00 35.13  ? ? ? ? ? ? 66  VAL U O   1 
+ATOM   468  C CB  . VAL A 1 59  ? -3.974  -23.955 -7.593  1.00 31.78  ? ? ? ? ? ? 66  VAL U CB  1 
+ATOM   469  C CG1 . VAL A 1 59  ? -4.437  -25.412 -7.492  1.00 32.70  ? ? ? ? ? ? 66  VAL U CG1 1 
+ATOM   470  C CG2 . VAL A 1 59  ? -2.563  -23.884 -8.157  1.00 34.87  ? ? ? ? ? ? 66  VAL U CG2 1 
+ATOM   471  N N   . TYR A 1 60  ? -7.178  -24.031 -8.691  1.00 31.33  ? ? ? ? ? ? 67  TYR U N   1 
+ATOM   472  C CA  . TYR A 1 60  ? -8.505  -24.426 -8.214  1.00 30.41  ? ? ? ? ? ? 67  TYR U CA  1 
+ATOM   473  C C   . TYR A 1 60  ? -8.530  -25.903 -7.883  1.00 30.74  ? ? ? ? ? ? 67  TYR U C   1 
+ATOM   474  O O   . TYR A 1 60  ? -7.925  -26.733 -8.584  1.00 30.60  ? ? ? ? ? ? 67  TYR U O   1 
+ATOM   475  C CB  . TYR A 1 60  ? -9.597  -24.120 -9.233  1.00 31.58  ? ? ? ? ? ? 67  TYR U CB  1 
+ATOM   476  C CG  . TYR A 1 60  ? -9.948  -22.671 -9.383  1.00 33.34  ? ? ? ? ? ? 67  TYR U CG  1 
+ATOM   477  C CD1 . TYR A 1 60  ? -10.940 -22.077 -8.605  1.00 37.08  ? ? ? ? ? ? 67  TYR U CD1 1 
+ATOM   478  C CD2 . TYR A 1 60  ? -9.303  -21.885 -10.335 1.00 35.11  ? ? ? ? ? ? 67  TYR U CD2 1 
+ATOM   479  C CE1 . TYR A 1 60  ? -11.274 -20.736 -8.777  1.00 36.71  ? ? ? ? ? ? 67  TYR U CE1 1 
+ATOM   480  C CE2 . TYR A 1 60  ? -9.606  -20.555 -10.500 1.00 36.06  ? ? ? ? ? ? 67  TYR U CE2 1 
+ATOM   481  C CZ  . TYR A 1 60  ? -10.599 -19.979 -9.727  1.00 40.30  ? ? ? ? ? ? 67  TYR U CZ  1 
+ATOM   482  O OH  . TYR A 1 60  ? -10.877 -18.643 -9.933  1.00 42.27  ? ? ? ? ? ? 67  TYR U OH  1 
+ATOM   483  N N   . LEU A 1 61  ? -9.242  -26.220 -6.806  1.00 27.82  ? ? ? ? ? ? 68  LEU U N   1 
+ATOM   484  C CA  . LEU A 1 61  ? -9.547  -27.570 -6.441  1.00 27.14  ? ? ? ? ? ? 68  LEU U CA  1 
+ATOM   485  C C   . LEU A 1 61  ? -11.039 -27.656 -6.403  1.00 24.84  ? ? ? ? ? ? 68  LEU U C   1 
+ATOM   486  O O   . LEU A 1 61  ? -11.723 -26.659 -6.229  1.00 27.69  ? ? ? ? ? ? 68  LEU U O   1 
+ATOM   487  C CB  . LEU A 1 61  ? -8.953  -27.915 -5.065  1.00 29.78  ? ? ? ? ? ? 68  LEU U CB  1 
+ATOM   488  C CG  . LEU A 1 61  ? -7.436  -27.780 -4.959  1.00 29.69  ? ? ? ? ? ? 68  LEU U CG  1 
+ATOM   489  C CD1 . LEU A 1 61  ? -7.012  -28.056 -3.516  1.00 32.25  ? ? ? ? ? ? 68  LEU U CD1 1 
+ATOM   490  C CD2 . LEU A 1 61  ? -6.660  -28.690 -5.904  1.00 29.78  ? ? ? ? ? ? 68  LEU U CD2 1 
+ATOM   491  N N   . GLY A 1 62  ? -11.576 -28.832 -6.646  1.00 23.01  ? ? ? ? ? ? 69  GLY U N   1 
+ATOM   492  C CA  . GLY A 1 62  ? -13.028 -28.980 -6.588  1.00 23.48  ? ? ? ? ? ? 69  GLY U CA  1 
+ATOM   493  C C   . GLY A 1 62  ? -13.712 -28.482 -7.864  1.00 23.97  ? ? ? ? ? ? 69  GLY U C   1 
+ATOM   494  O O   . GLY A 1 62  ? -14.902 -28.204 -7.854  1.00 23.73  ? ? ? ? ? ? 69  GLY U O   1 
+ATOM   495  N N   . ARG A 1 63  ? -12.954 -28.342 -8.951  1.00 25.54  ? ? ? ? ? ? 70  ARG U N   1 
+ATOM   496  C CA  . ARG A 1 63  ? -13.453 -27.663 -10.174 1.00 28.15  ? ? ? ? ? ? 70  ARG U CA  1 
+ATOM   497  C C   . ARG A 1 63  ? -13.744 -28.703 -11.266 1.00 29.82  ? ? ? ? ? ? 70  ARG U C   1 
+ATOM   498  O O   . ARG A 1 63  ? -12.839 -29.478 -11.631 1.00 30.54  ? ? ? ? ? ? 70  ARG U O   1 
+ATOM   499  C CB  . ARG A 1 63  ? -12.382 -26.680 -10.633 1.00 31.47  ? ? ? ? ? ? 70  ARG U CB  1 
+ATOM   500  C CG  . ARG A 1 63  ? -12.684 -25.862 -11.866 1.00 33.99  ? ? ? ? ? ? 70  ARG U CG  1 
+ATOM   501  C CD  . ARG A 1 63  ? -12.419 -24.410 -11.566 1.00 36.45  ? ? ? ? ? ? 70  ARG U CD  1 
+ATOM   502  N NE  . ARG A 1 63  ? -12.533 -23.569 -12.730 1.00 39.24  ? ? ? ? ? ? 70  ARG U NE  1 
+ATOM   503  C CZ  . ARG A 1 63  ? -13.021 -22.333 -12.740 1.00 40.19  ? ? ? ? ? ? 70  ARG U CZ  1 
+ATOM   504  N NH1 . ARG A 1 63  ? -13.512 -21.750 -11.642 1.00 40.50  ? ? ? ? ? ? 70  ARG U NH1 1 
+ATOM   505  N NH2 . ARG A 1 63  ? -13.051 -21.684 -13.881 1.00 40.00  ? ? ? ? ? ? 70  ARG U NH2 1 
+ATOM   506  N N   . SER A 1 64  ? -14.984 -28.746 -11.769 1.00 29.34  ? ? ? ? ? ? 71  SER U N   1 
+ATOM   507  C CA  . SER A 1 64  ? -15.365 -29.682 -12.842 1.00 28.23  ? ? ? ? ? ? 71  SER U CA  1 
+ATOM   508  C C   . SER A 1 64  ? -15.496 -28.967 -14.234 1.00 30.84  ? ? ? ? ? ? 71  SER U C   1 
+ATOM   509  O O   . SER A 1 64  ? -15.666 -29.632 -15.263 1.00 29.05  ? ? ? ? ? ? 71  SER U O   1 
+ATOM   510  C CB  . SER A 1 64  ? -16.704 -30.403 -12.559 1.00 29.02  ? ? ? ? ? ? 71  SER U CB  1 
+ATOM   511  O OG  . SER A 1 64  ? -16.767 -31.131 -11.322 1.00 29.80  ? ? ? ? ? ? 71  SER U OG  1 
+ATOM   512  N N   . ARG A 1 65  ? -15.483 -27.641 -14.266 1.00 28.77  ? ? ? ? ? ? 72  ARG U N   1 
+ATOM   513  C CA  . ARG A 1 65  ? -15.612 -26.925 -15.544 1.00 29.41  ? ? ? ? ? ? 72  ARG U CA  1 
+ATOM   514  C C   . ARG A 1 65  ? -14.456 -25.974 -15.752 1.00 29.62  ? ? ? ? ? ? 72  ARG U C   1 
+ATOM   515  O O   . ARG A 1 65  ? -13.892 -25.445 -14.784 1.00 28.27  ? ? ? ? ? ? 72  ARG U O   1 
+ATOM   516  C CB  . ARG A 1 65  ? -16.959 -26.204 -15.620 1.00 31.78  ? ? ? ? ? ? 72  ARG U CB  1 
+ATOM   517  C CG  . ARG A 1 65  ? -18.123 -27.190 -15.498 1.00 35.75  ? ? ? ? ? ? 72  ARG U CG  1 
+ATOM   518  C CD  . ARG A 1 65  ? -19.475 -26.644 -15.947 1.00 40.14  ? ? ? ? ? ? 72  ARG U CD  1 
+ATOM   519  N NE  . ARG A 1 65  ? -19.496 -26.170 -17.345 1.00 44.42  ? ? ? ? ? ? 72  ARG U NE  1 
+ATOM   520  C CZ  . ARG A 1 65  ? -19.708 -26.926 -18.439 1.00 46.48  ? ? ? ? ? ? 72  ARG U CZ  1 
+ATOM   521  N NH1 . ARG A 1 65  ? -19.898 -28.234 -18.373 1.00 45.52  ? ? ? ? ? ? 72  ARG U NH1 1 
+ATOM   522  N NH2 . ARG A 1 65  ? -19.729 -26.355 -19.630 1.00 48.76  ? ? ? ? ? ? 72  ARG U NH2 1 
+ATOM   523  N N   . LEU A 1 66  ? -14.110 -25.761 -17.025 1.00 28.01  ? ? ? ? ? ? 73  LEU U N   1 
+ATOM   524  C CA  . LEU A 1 66  ? -12.915 -25.032 -17.408 1.00 26.47  ? ? ? ? ? ? 73  LEU U CA  1 
+ATOM   525  C C   . LEU A 1 66  ? -13.021 -23.524 -17.204 1.00 30.40  ? ? ? ? ? ? 73  LEU U C   1 
+ATOM   526  O O   . LEU A 1 66  ? -12.101 -22.890 -16.661 1.00 26.60  ? ? ? ? ? ? 73  LEU U O   1 
+ATOM   527  C CB  . LEU A 1 66  ? -12.599 -25.332 -18.897 1.00 28.67  ? ? ? ? ? ? 73  LEU U CB  1 
+ATOM   528  C CG  . LEU A 1 66  ? -11.300 -24.799 -19.493 1.00 29.10  ? ? ? ? ? ? 73  LEU U CG  1 
+ATOM   529  C CD1 . LEU A 1 66  ? -10.127 -25.385 -18.730 1.00 30.80  ? ? ? ? ? ? 73  LEU U CD1 1 
+ATOM   530  C CD2 . LEU A 1 66  ? -11.199 -25.090 -21.002 1.00 29.19  ? ? ? ? ? ? 73  LEU U CD2 1 
+ATOM   531  N N   . ASN A 1 67  ? -14.128 -22.942 -17.667 1.00 32.31  ? ? ? ? ? ? 74  ASN U N   1 
+ATOM   532  C CA  . ASN A 1 67  ? -14.293 -21.502 -17.663 1.00 36.04  ? ? ? ? ? ? 74  ASN U CA  1 
+ATOM   533  C C   . ASN A 1 67  ? -15.437 -21.006 -16.814 1.00 40.05  ? ? ? ? ? ? 74  ASN U C   1 
+ATOM   534  O O   . ASN A 1 67  ? -15.785 -19.828 -16.883 1.00 40.93  ? ? ? ? ? ? 74  ASN U O   1 
+ATOM   535  C CB  . ASN A 1 67  ? -14.527 -21.021 -19.079 1.00 39.03  ? ? ? ? ? ? 74  ASN U CB  1 
+ATOM   536  C CG  . ASN A 1 67  ? -13.363 -21.323 -19.979 1.00 36.50  ? ? ? ? ? ? 74  ASN U CG  1 
+ATOM   537  O OD1 . ASN A 1 67  ? -12.267 -20.846 -19.752 1.00 39.34  ? ? ? ? ? ? 74  ASN U OD1 1 
+ATOM   538  N ND2 . ASN A 1 67  ? -13.597 -22.123 -21.000 1.00 42.48  ? ? ? ? ? ? 74  ASN U ND2 1 
+ATOM   539  N N   . SER A 1 68  ? -16.033 -21.889 -16.026 1.00 40.10  ? ? ? ? ? ? 75  SER U N   1 
+ATOM   540  C CA  . SER A 1 68  ? -17.071 -21.474 -15.081 1.00 44.32  ? ? ? ? ? ? 75  SER U CA  1 
+ATOM   541  C C   . SER A 1 68  ? -16.848 -22.173 -13.746 1.00 42.02  ? ? ? ? ? ? 75  SER U C   1 
+ATOM   542  O O   . SER A 1 68  ? -15.977 -23.035 -13.640 1.00 40.38  ? ? ? ? ? ? 75  SER U O   1 
+ATOM   543  C CB  . SER A 1 68  ? -18.458 -21.770 -15.643 1.00 45.48  ? ? ? ? ? ? 75  SER U CB  1 
+ATOM   544  O OG  . SER A 1 68  ? -18.550 -23.123 -16.023 1.00 54.53  ? ? ? ? ? ? 75  SER U OG  1 
+ATOM   545  N N   . ASN A 1 69  ? -17.639 -21.782 -12.749 1.00 42.37  ? ? ? ? ? ? 76  ASN U N   1 
+ATOM   546  C CA  . ASN A 1 69  ? -17.487 -22.216 -11.364 1.00 42.76  ? ? ? ? ? ? 76  ASN U CA  1 
+ATOM   547  C C   . ASN A 1 69  ? -18.261 -23.506 -11.064 1.00 38.96  ? ? ? ? ? ? 76  ASN U C   1 
+ATOM   548  O O   . ASN A 1 69  ? -19.272 -23.781 -11.679 1.00 38.66  ? ? ? ? ? ? 76  ASN U O   1 
+ATOM   549  C CB  . ASN A 1 69  ? -17.964 -21.105 -10.423 1.00 44.67  ? ? ? ? ? ? 76  ASN U CB  1 
+ATOM   550  C CG  . ASN A 1 69  ? -17.266 -19.775 -10.676 1.00 50.73  ? ? ? ? ? ? 76  ASN U CG  1 
+ATOM   551  O OD1 . ASN A 1 69  ? -17.903 -18.793 -11.070 1.00 50.09  ? ? ? ? ? ? 76  ASN U OD1 1 
+ATOM   552  N ND2 . ASN A 1 69  ? -15.950 -19.736 -10.457 1.00 52.98  ? ? ? ? ? ? 76  ASN U ND2 1 
+ATOM   553  N N   . THR A 1 70  ? -17.748 -24.289 -10.125 1.00 34.70  ? ? ? ? ? ? 77  THR U N   1 
+ATOM   554  C CA  . THR A 1 70  ? -18.346 -25.547 -9.682  1.00 35.39  ? ? ? ? ? ? 77  THR U CA  1 
+ATOM   555  C C   . THR A 1 70  ? -18.674 -25.326 -8.213  1.00 37.56  ? ? ? ? ? ? 77  THR U C   1 
+ATOM   556  O O   . THR A 1 70  ? -17.883 -24.731 -7.497  1.00 35.42  ? ? ? ? ? ? 77  THR U O   1 
+ATOM   557  C CB  . THR A 1 70  ? -17.319 -26.694 -9.769  1.00 35.44  ? ? ? ? ? ? 77  THR U CB  1 
+ATOM   558  O OG1 . THR A 1 70  ? -17.053 -26.998 -11.134 1.00 31.33  ? ? ? ? ? ? 77  THR U OG1 1 
+ATOM   559  C CG2 . THR A 1 70  ? -17.794 -27.976 -9.033  1.00 35.31  ? ? ? ? ? ? 77  THR U CG2 1 
+ATOM   560  N N   . GLN A 1 71  ? -19.826 -25.808 -7.779  1.00 41.15  ? ? ? ? ? ? 78  GLN U N   1 
+ATOM   561  C CA  . GLN A 1 71  ? -20.211 -25.733 -6.378  1.00 47.23  ? ? ? ? ? ? 78  GLN U CA  1 
+ATOM   562  C C   . GLN A 1 71  ? -19.244 -26.576 -5.551  1.00 46.61  ? ? ? ? ? ? 78  GLN U C   1 
+ATOM   563  O O   . GLN A 1 71  ? -19.097 -27.780 -5.780  1.00 46.23  ? ? ? ? ? ? 78  GLN U O   1 
+ATOM   564  C CB  . GLN A 1 71  ? -21.656 -26.213 -6.180  1.00 51.41  ? ? ? ? ? ? 78  GLN U CB  1 
+ATOM   565  C CG  . GLN A 1 71  ? -22.492 -25.267 -5.323  1.00 59.61  ? ? ? ? ? ? 78  GLN U CG  1 
+ATOM   566  C CD  . GLN A 1 71  ? -23.980 -25.284 -5.662  1.00 65.95  ? ? ? ? ? ? 78  GLN U CD  1 
+ATOM   567  O OE1 . GLN A 1 71  ? -24.454 -26.111 -6.458  1.00 68.11  ? ? ? ? ? ? 78  GLN U OE1 1 
+ATOM   568  N NE2 . GLN A 1 71  ? -24.732 -24.371 -5.041  1.00 67.46  ? ? ? ? ? ? 78  GLN U NE2 1 
+ATOM   569  N N   . GLY A 1 72  ? -18.580 -25.927 -4.601  1.00 45.85  ? ? ? ? ? ? 79  GLY U N   1 
+ATOM   570  C CA  . GLY A 1 72  ? -17.627 -26.602 -3.729  1.00 45.06  ? ? ? ? ? ? 79  GLY U CA  1 
+ATOM   571  C C   . GLY A 1 72  ? -16.171 -26.332 -4.057  1.00 44.29  ? ? ? ? ? ? 79  GLY U C   1 
+ATOM   572  O O   . GLY A 1 72  ? -15.280 -26.776 -3.320  1.00 45.23  ? ? ? ? ? ? 79  GLY U O   1 
+ATOM   573  N N   . GLU A 1 73  ? -15.905 -25.607 -5.144  1.00 42.83  ? ? ? ? ? ? 80  GLU U N   1 
+ATOM   574  C CA  . GLU A 1 73  ? -14.520 -25.355 -5.536  1.00 42.05  ? ? ? ? ? ? 80  GLU U CA  1 
+ATOM   575  C C   . GLU A 1 73  ? -13.826 -24.366 -4.596  1.00 39.70  ? ? ? ? ? ? 80  GLU U C   1 
+ATOM   576  O O   . GLU A 1 73  ? -14.473 -23.532 -3.951  1.00 38.30  ? ? ? ? ? ? 80  GLU U O   1 
+ATOM   577  C CB  . GLU A 1 73  ? -14.429 -24.851 -6.972  1.00 42.73  ? ? ? ? ? ? 80  GLU U CB  1 
+ATOM   578  C CG  . GLU A 1 73  ? -14.719 -23.368 -7.130  1.00 44.81  ? ? ? ? ? ? 80  GLU U CG  1 
+ATOM   579  C CD  . GLU A 1 73  ? -14.891 -22.962 -8.579  1.00 45.13  ? ? ? ? ? ? 80  GLU U CD  1 
+ATOM   580  O OE1 . GLU A 1 73  ? -14.881 -23.849 -9.465  1.00 44.54  ? ? ? ? ? ? 80  GLU U OE1 1 
+ATOM   581  O OE2 . GLU A 1 73  ? -15.030 -21.758 -8.827  1.00 46.26  ? ? ? ? ? ? 80  GLU U OE2 1 
+ATOM   582  N N   . MET A 1 74  ? -12.502 -24.460 -4.535  1.00 37.32  ? ? ? ? ? ? 81  MET U N   1 
+ATOM   583  C CA  . MET A 1 74  ? -11.713 -23.562 -3.704  1.00 39.70  ? ? ? ? ? ? 81  MET U CA  1 
+ATOM   584  C C   . MET A 1 74  ? -10.539 -23.034 -4.516  1.00 38.38  ? ? ? ? ? ? 81  MET U C   1 
+ATOM   585  O O   . MET A 1 74  ? -9.808  -23.803 -5.168  1.00 34.71  ? ? ? ? ? ? 81  MET U O   1 
+ATOM   586  C CB  . MET A 1 74  ? -11.218 -24.292 -2.442  1.00 40.37  ? ? ? ? ? ? 81  MET U CB  1 
+ATOM   587  C CG  . MET A 1 74  ? -12.330 -24.942 -1.613  1.00 45.21  ? ? ? ? ? ? 81  MET U CG  1 
+ATOM   588  S SD  . MET A 1 74  ? -13.266 -23.733 -0.647  1.00 56.80  ? ? ? ? ? ? 81  MET U SD  1 
+ATOM   589  C CE  . MET A 1 74  ? -14.974 -24.174 -0.966  1.00 55.38  ? ? ? ? ? ? 81  MET U CE  1 
+ATOM   590  N N   . LYS A 1 75  ? -10.368 -21.722 -4.447  1.00 37.43  ? ? ? ? ? ? 82  LYS U N   1 
+ATOM   591  C CA  . LYS A 1 75  ? -9.313  -20.997 -5.141  1.00 39.98  ? ? ? ? ? ? 82  LYS U CA  1 
+ATOM   592  C C   . LYS A 1 75  ? -8.073  -20.783 -4.245  1.00 38.66  ? ? ? ? ? ? 82  LYS U C   1 
+ATOM   593  O O   . LYS A 1 75  ? -8.209  -20.418 -3.073  1.00 37.54  ? ? ? ? ? ? 82  LYS U O   1 
+ATOM   594  C CB  . LYS A 1 75  ? -9.898  -19.655 -5.582  1.00 40.85  ? ? ? ? ? ? 82  LYS U CB  1 
+ATOM   595  C CG  . LYS A 1 75  ? -8.985  -18.760 -6.407  1.00 45.62  ? ? ? ? ? ? 82  LYS U CG  1 
+ATOM   596  C CD  . LYS A 1 75  ? -9.735  -17.485 -6.766  1.00 48.39  ? ? ? ? ? ? 82  LYS U CD  1 
+ATOM   597  C CE  . LYS A 1 75  ? -8.909  -16.541 -7.614  1.00 53.37  ? ? ? ? ? ? 82  LYS U CE  1 
+ATOM   598  N NZ  . LYS A 1 75  ? -9.736  -15.382 -8.047  1.00 55.13  ? ? ? ? ? ? 82  LYS U NZ  1 
+ATOM   599  N N   . PHE A 1 76  ? -6.875  -20.995 -4.802  1.00 38.87  ? ? ? ? ? ? 83  PHE U N   1 
+ATOM   600  C CA  . PHE A 1 76  ? -5.602  -20.795 -4.080  1.00 37.85  ? ? ? ? ? ? 83  PHE U CA  1 
+ATOM   601  C C   . PHE A 1 76  ? -4.561  -20.000 -4.855  1.00 40.60  ? ? ? ? ? ? 83  PHE U C   1 
+ATOM   602  O O   . PHE A 1 76  ? -4.489  -20.054 -6.095  1.00 38.88  ? ? ? ? ? ? 83  PHE U O   1 
+ATOM   603  C CB  . PHE A 1 76  ? -4.973  -22.129 -3.673  1.00 38.85  ? ? ? ? ? ? 83  PHE U CB  1 
+ATOM   604  C CG  . PHE A 1 76  ? -5.889  -23.012 -2.897  1.00 35.69  ? ? ? ? ? ? 83  PHE U CG  1 
+ATOM   605  C CD1 . PHE A 1 76  ? -6.779  -23.843 -3.551  1.00 34.64  ? ? ? ? ? ? 83  PHE U CD1 1 
+ATOM   606  C CD2 . PHE A 1 76  ? -5.875  -23.001 -1.508  1.00 37.02  ? ? ? ? ? ? 83  PHE U CD2 1 
+ATOM   607  C CE1 . PHE A 1 76  ? -7.641  -24.643 -2.838  1.00 34.68  ? ? ? ? ? ? 83  PHE U CE1 1 
+ATOM   608  C CE2 . PHE A 1 76  ? -6.732  -23.810 -0.786  1.00 34.84  ? ? ? ? ? ? 83  PHE U CE2 1 
+ATOM   609  C CZ  . PHE A 1 76  ? -7.615  -24.629 -1.446  1.00 35.55  ? ? ? ? ? ? 83  PHE U CZ  1 
+ATOM   610  N N   . GLU A 1 77  ? -3.777  -19.237 -4.095  1.00 41.36  ? ? ? ? ? ? 84  GLU U N   1 
+ATOM   611  C CA  . GLU A 1 77  ? -2.550  -18.639 -4.572  1.00 43.68  ? ? ? ? ? ? 84  GLU U CA  1 
+ATOM   612  C C   . GLU A 1 77  ? -1.439  -19.664 -4.450  1.00 40.61  ? ? ? ? ? ? 84  GLU U C   1 
+ATOM   613  O O   . GLU A 1 77  ? -1.586  -20.677 -3.778  1.00 40.90  ? ? ? ? ? ? 84  GLU U O   1 
+ATOM   614  C CB  . GLU A 1 77  ? -2.176  -17.402 -3.739  1.00 49.28  ? ? ? ? ? ? 84  GLU U CB  1 
+ATOM   615  C CG  . GLU A 1 77  ? -3.204  -16.285 -3.744  1.00 54.72  ? ? ? ? ? ? 84  GLU U CG  1 
+ATOM   616  C CD  . GLU A 1 77  ? -3.625  -15.891 -5.142  1.00 58.53  ? ? ? ? ? ? 84  GLU U CD  1 
+ATOM   617  O OE1 . GLU A 1 77  ? -2.749  -15.482 -5.935  1.00 69.44  ? ? ? ? ? ? 84  GLU U OE1 1 
+ATOM   618  O OE2 . GLU A 1 77  ? -4.828  -16.003 -5.459  1.00 65.58  ? ? ? ? ? ? 84  GLU U OE2 1 
+ATOM   619  N N   . VAL A 1 78  ? -0.324  -19.376 -5.100  1.00 42.51  ? ? ? ? ? ? 85  VAL U N   1 
+ATOM   620  C CA  . VAL A 1 78  ? 0.849   -20.224 -5.060  1.00 43.38  ? ? ? ? ? ? 85  VAL U CA  1 
+ATOM   621  C C   . VAL A 1 78  ? 1.891   -19.522 -4.206  1.00 44.18  ? ? ? ? ? ? 85  VAL U C   1 
+ATOM   622  O O   . VAL A 1 78  ? 2.357   -18.455 -4.576  1.00 42.59  ? ? ? ? ? ? 85  VAL U O   1 
+ATOM   623  C CB  . VAL A 1 78  ? 1.428   -20.436 -6.466  1.00 43.37  ? ? ? ? ? ? 85  VAL U CB  1 
+ATOM   624  C CG1 . VAL A 1 78  ? 2.592   -21.426 -6.414  1.00 42.22  ? ? ? ? ? ? 85  VAL U CG1 1 
+ATOM   625  C CG2 . VAL A 1 78  ? 0.332   -20.879 -7.429  1.00 43.12  ? ? ? ? ? ? 85  VAL U CG2 1 
+ATOM   626  N N   . GLU A 1 79  ? 2.233   -20.126 -3.070  1.00 48.61  ? ? ? ? ? ? 86  GLU U N   1 
+ATOM   627  C CA  . GLU A 1 79  ? 3.183   -19.557 -2.109  1.00 51.82  ? ? ? ? ? ? 86  GLU U CA  1 
+ATOM   628  C C   . GLU A 1 79  ? 4.624   -19.956 -2.418  1.00 51.48  ? ? ? ? ? ? 86  GLU U C   1 
+ATOM   629  O O   . GLU A 1 79  ? 5.558   -19.260 -2.025  1.00 52.60  ? ? ? ? ? ? 86  GLU U O   1 
+ATOM   630  C CB  . GLU A 1 79  ? 2.831   -20.032 -0.699  1.00 53.85  ? ? ? ? ? ? 86  GLU U CB  1 
+ATOM   631  C CG  . GLU A 1 79  ? 3.588   -19.326 0.420   1.00 58.64  ? ? ? ? ? ? 86  GLU U CG  1 
+ATOM   632  C CD  . GLU A 1 79  ? 3.504   -20.059 1.744   1.00 58.86  ? ? ? ? ? ? 86  GLU U CD  1 
+ATOM   633  O OE1 . GLU A 1 79  ? 2.562   -20.863 1.921   1.00 57.48  ? ? ? ? ? ? 86  GLU U OE1 1 
+ATOM   634  O OE2 . GLU A 1 79  ? 4.380   -19.824 2.610   1.00 63.66  ? ? ? ? ? ? 86  GLU U OE2 1 
+ATOM   635  N N   . ASN A 1 80  ? 4.800   -21.098 -3.075  1.00 50.59  ? ? ? ? ? ? 87  ASN U N   1 
+ATOM   636  C CA  . ASN A 1 80  ? 6.115   -21.537 -3.553  1.00 50.47  ? ? ? ? ? ? 87  ASN U CA  1 
+ATOM   637  C C   . ASN A 1 80  ? 5.950   -22.295 -4.861  1.00 45.00  ? ? ? ? ? ? 87  ASN U C   1 
+ATOM   638  O O   . ASN A 1 80  ? 5.136   -23.200 -4.947  1.00 46.12  ? ? ? ? ? ? 87  ASN U O   1 
+ATOM   639  C CB  . ASN A 1 80  ? 6.794   -22.470 -2.543  1.00 52.00  ? ? ? ? ? ? 87  ASN U CB  1 
+ATOM   640  C CG  . ASN A 1 80  ? 7.708   -21.755 -1.567  1.00 59.19  ? ? ? ? ? ? 87  ASN U CG  1 
+ATOM   641  O OD1 . ASN A 1 80  ? 8.273   -22.398 -0.682  1.00 65.99  ? ? ? ? ? ? 87  ASN U OD1 1 
+ATOM   642  N ND2 . ASN A 1 80  ? 7.872   -20.442 -1.716  1.00 60.48  ? ? ? ? ? ? 87  ASN U ND2 1 
+ATOM   643  N N   . LEU A 1 81  ? 6.740   -21.935 -5.861  1.00 42.52  ? ? ? ? ? ? 88  LEU U N   1 
+ATOM   644  C CA  . LEU A 1 81  ? 6.693   -22.592 -7.169  1.00 39.98  ? ? ? ? ? ? 88  LEU U CA  1 
+ATOM   645  C C   . LEU A 1 81  ? 8.051   -23.220 -7.415  1.00 38.22  ? ? ? ? ? ? 88  LEU U C   1 
+ATOM   646  O O   . LEU A 1 81  ? 9.015   -22.508 -7.657  1.00 38.94  ? ? ? ? ? ? 88  LEU U O   1 
+ATOM   647  C CB  . LEU A 1 81  ? 6.376   -21.584 -8.263  1.00 36.16  ? ? ? ? ? ? 88  LEU U CB  1 
+ATOM   648  C CG  . LEU A 1 81  ? 6.456   -22.079 -9.716  1.00 35.70  ? ? ? ? ? ? 88  LEU U CG  1 
+ATOM   649  C CD1 . LEU A 1 81  ? 5.442   -23.187 -9.952  1.00 34.55  ? ? ? ? ? ? 88  LEU U CD1 1 
+ATOM   650  C CD2 . LEU A 1 81  ? 6.230   -20.931 -10.685 1.00 34.60  ? ? ? ? ? ? 88  LEU U CD2 1 
+ATOM   651  N N   . ILE A 1 82  ? 8.114   -24.548 -7.330  1.00 36.57  ? ? ? ? ? ? 89  ILE U N   1 
+ATOM   652  C CA  . ILE A 1 82  ? 9.382   -25.277 -7.351  1.00 37.65  ? ? ? ? ? ? 89  ILE U CA  1 
+ATOM   653  C C   . ILE A 1 82  ? 9.522   -26.064 -8.642  1.00 37.70  ? ? ? ? ? ? 89  ILE U C   1 
+ATOM   654  O O   . ILE A 1 82  ? 8.869   -27.080 -8.839  1.00 36.15  ? ? ? ? ? ? 89  ILE U O   1 
+ATOM   655  C CB  . ILE A 1 82  ? 9.505   -26.224 -6.145  1.00 38.48  ? ? ? ? ? ? 89  ILE U CB  1 
+ATOM   656  C CG1 . ILE A 1 82  ? 9.243   -25.459 -4.847  1.00 38.36  ? ? ? ? ? ? 89  ILE U CG1 1 
+ATOM   657  C CG2 . ILE A 1 82  ? 10.892  -26.836 -6.080  1.00 39.35  ? ? ? ? ? ? 89  ILE U CG2 1 
+ATOM   658  C CD1 . ILE A 1 82  ? 9.068   -26.348 -3.633  1.00 38.52  ? ? ? ? ? ? 89  ILE U CD1 1 
+ATOM   659  N N   . LEU A 1 83  ? 10.361  -25.551 -9.530  1.00 38.01  ? ? ? ? ? ? 90  LEU U N   1 
+ATOM   660  C CA  . LEU A 1 83  ? 10.698  -26.233 -10.758 1.00 40.07  ? ? ? ? ? ? 90  LEU U CA  1 
+ATOM   661  C C   . LEU A 1 83  ? 11.911  -27.116 -10.515 1.00 44.64  ? ? ? ? ? ? 90  LEU U C   1 
+ATOM   662  O O   . LEU A 1 83  ? 12.760  -26.820 -9.663  1.00 50.26  ? ? ? ? ? ? 90  LEU U O   1 
+ATOM   663  C CB  . LEU A 1 83  ? 10.981  -25.216 -11.864 1.00 39.28  ? ? ? ? ? ? 90  LEU U CB  1 
+ATOM   664  C CG  . LEU A 1 83  ? 9.855   -24.193 -12.047 1.00 39.59  ? ? ? ? ? ? 90  LEU U CG  1 
+ATOM   665  C CD1 . LEU A 1 83  ? 10.140  -23.246 -13.198 1.00 40.61  ? ? ? ? ? ? 90  LEU U CD1 1 
+ATOM   666  C CD2 . LEU A 1 83  ? 8.518   -24.898 -12.245 1.00 37.47  ? ? ? ? ? ? 90  LEU U CD2 1 
+ATOM   667  N N   . HIS A 1 84  ? 11.983  -28.206 -11.259 1.00 45.47  ? ? ? ? ? ? 91  HIS U N   1 
+ATOM   668  C CA  . HIS A 1 84  ? 13.091  -29.131 -11.130 1.00 49.93  ? ? ? ? ? ? 91  HIS U CA  1 
+ATOM   669  C C   . HIS A 1 84  ? 14.339  -28.563 -11.814 1.00 49.84  ? ? ? ? ? ? 91  HIS U C   1 
+ATOM   670  O O   . HIS A 1 84  ? 14.305  -28.206 -13.000 1.00 47.04  ? ? ? ? ? ? 91  HIS U O   1 
+ATOM   671  C CB  . HIS A 1 84  ? 12.726  -30.492 -11.719 1.00 48.77  ? ? ? ? ? ? 91  HIS U CB  1 
+ATOM   672  C CG  . HIS A 1 84  ? 13.624  -31.591 -11.263 1.00 51.64  ? ? ? ? ? ? 91  HIS U CG  1 
+ATOM   673  N ND1 . HIS A 1 84  ? 14.882  -31.785 -11.789 1.00 52.64  ? ? ? ? ? ? 91  HIS U ND1 1 
+ATOM   674  C CD2 . HIS A 1 84  ? 13.457  -32.546 -10.320 1.00 53.16  ? ? ? ? ? ? 91  HIS U CD2 1 
+ATOM   675  C CE1 . HIS A 1 84  ? 15.451  -32.818 -11.193 1.00 53.82  ? ? ? ? ? ? 91  HIS U CE1 1 
+ATOM   676  N NE2 . HIS A 1 84  ? 14.608  -33.294 -10.294 1.00 55.25  ? ? ? ? ? ? 91  HIS U NE2 1 
+ATOM   677  N N   . LYS A 1 85  ? 15.439  -28.510 -11.064 1.00 53.53  ? ? ? ? ? ? 92  LYS U N   1 
+ATOM   678  C CA  . LYS A 1 85  ? 16.693  -27.916 -11.546 1.00 58.53  ? ? ? ? ? ? 92  LYS U CA  1 
+ATOM   679  C C   . LYS A 1 85  ? 17.238  -28.583 -12.814 1.00 56.64  ? ? ? ? ? ? 92  LYS U C   1 
+ATOM   680  O O   . LYS A 1 85  ? 17.720  -27.908 -13.732 1.00 55.78  ? ? ? ? ? ? 92  LYS U O   1 
+ATOM   681  C CB  . LYS A 1 85  ? 17.747  -27.932 -10.430 1.00 63.87  ? ? ? ? ? ? 92  LYS U CB  1 
+ATOM   682  C CG  . LYS A 1 85  ? 17.404  -27.012 -9.259  1.00 68.59  ? ? ? ? ? ? 92  LYS U CG  1 
+ATOM   683  C CD  . LYS A 1 85  ? 17.457  -25.532 -9.651  1.00 70.32  ? ? ? ? ? ? 92  LYS U CD  1 
+ATOM   684  C CE  . LYS A 1 85  ? 16.200  -24.759 -9.247  1.00 73.74  ? ? ? ? ? ? 92  LYS U CE  1 
+ATOM   685  N NZ  . LYS A 1 85  ? 16.128  -24.441 -7.791  1.00 73.77  ? ? ? ? ? ? 92  LYS U NZ  1 
+ATOM   686  N N   . ASP A 1 86  ? 17.154  -29.904 -12.870 1.00 52.99  ? ? ? ? ? ? 93  ASP U N   1 
+ATOM   687  C CA  . ASP A 1 86  ? 17.554  -30.642 -14.069 1.00 51.95  ? ? ? ? ? ? 93  ASP U CA  1 
+ATOM   688  C C   . ASP A 1 86  ? 16.474  -30.757 -15.142 1.00 48.81  ? ? ? ? ? ? 93  ASP U C   1 
+ATOM   689  O O   . ASP A 1 86  ? 16.613  -31.564 -16.063 1.00 46.91  ? ? ? ? ? ? 93  ASP U O   1 
+ATOM   690  C CB  . ASP A 1 86  ? 18.079  -32.035 -13.681 1.00 54.81  ? ? ? ? ? ? 93  ASP U CB  1 
+ATOM   691  C CG  . ASP A 1 86  ? 19.234  -31.964 -12.699 1.00 54.20  ? ? ? ? ? ? 93  ASP U CG  1 
+ATOM   692  O OD1 . ASP A 1 86  ? 20.106  -31.089 -12.878 1.00 58.10  ? ? ? ? ? ? 93  ASP U OD1 1 
+ATOM   693  O OD2 . ASP A 1 86  ? 19.272  -32.775 -11.753 1.00 57.48  ? ? ? ? ? ? 93  ASP U OD2 1 
+ATOM   694  N N   . TYR A 1 87  ? 15.412  -29.954 -15.064 1.00 47.88  ? ? ? ? ? ? 94  TYR U N   1 
+ATOM   695  C CA  . TYR A 1 87  ? 14.448  -29.910 -16.163 1.00 46.86  ? ? ? ? ? ? 94  TYR U CA  1 
+ATOM   696  C C   . TYR A 1 87  ? 15.151  -29.568 -17.468 1.00 48.08  ? ? ? ? ? ? 94  TYR U C   1 
+ATOM   697  O O   . TYR A 1 87  ? 16.112  -28.796 -17.487 1.00 50.34  ? ? ? ? ? ? 94  TYR U O   1 
+ATOM   698  C CB  . TYR A 1 87  ? 13.316  -28.892 -15.918 1.00 46.92  ? ? ? ? ? ? 94  TYR U CB  1 
+ATOM   699  C CG  . TYR A 1 87  ? 12.475  -28.568 -17.160 1.00 45.16  ? ? ? ? ? ? 94  TYR U CG  1 
+ATOM   700  C CD1 . TYR A 1 87  ? 11.441  -29.412 -17.579 1.00 43.57  ? ? ? ? ? ? 94  TYR U CD1 1 
+ATOM   701  C CD2 . TYR A 1 87  ? 12.706  -27.402 -17.901 1.00 43.89  ? ? ? ? ? ? 94  TYR U CD2 1 
+ATOM   702  C CE1 . TYR A 1 87  ? 10.679  -29.114 -18.700 1.00 41.92  ? ? ? ? ? ? 94  TYR U CE1 1 
+ATOM   703  C CE2 . TYR A 1 87  ? 11.955  -27.101 -19.029 1.00 43.74  ? ? ? ? ? ? 94  TYR U CE2 1 
+ATOM   704  C CZ  . TYR A 1 87  ? 10.940  -27.954 -19.422 1.00 43.80  ? ? ? ? ? ? 94  TYR U CZ  1 
+ATOM   705  O OH  . TYR A 1 87  ? 10.192  -27.640 -20.533 1.00 41.36  ? ? ? ? ? ? 94  TYR U OH  1 
+ATOM   706  N N   . SER A 1 88  ? 14.657  -30.136 -18.558 1.00 45.91  ? ? ? ? ? ? 95  SER U N   1 
+ATOM   707  C CA  . SER A 1 88  ? 15.128  -29.774 -19.868 1.00 49.16  ? ? ? ? ? ? 95  SER U CA  1 
+ATOM   708  C C   . SER A 1 88  ? 14.104  -30.162 -20.929 1.00 49.81  ? ? ? ? ? ? 95  SER U C   1 
+ATOM   709  O O   . SER A 1 88  ? 13.450  -31.203 -20.822 1.00 52.32  ? ? ? ? ? ? 95  SER U O   1 
+ATOM   710  C CB  . SER A 1 88  ? 16.492  -30.431 -20.128 1.00 49.65  ? ? ? ? ? ? 95  SER U CB  1 
+ATOM   711  O OG  . SER A 1 88  ? 16.605  -30.878 -21.476 1.00 49.70  ? ? ? ? ? ? 95  SER U OG  1 
+ATOM   712  N N   . ALA A 1 89  ? 13.977  -29.344 -21.954 1.00 51.29  ? ? ? ? ? ? 96  ALA U N   1 
+ATOM   713  C CA  . ALA A 1 89  ? 13.162  -29.685 -23.092 1.00 53.47  ? ? ? ? ? ? 96  ALA U CA  1 
+ATOM   714  C C   . ALA A 1 89  ? 14.043  -30.041 -24.304 1.00 59.81  ? ? ? ? ? ? 96  ALA U C   1 
+ATOM   715  O O   . ALA A 1 89  ? 14.726  -29.205 -24.849 1.00 63.47  ? ? ? ? ? ? 96  ALA U O   1 
+ATOM   716  C CB  . ALA A 1 89  ? 12.261  -28.521 -23.421 1.00 51.23  ? ? ? ? ? ? 96  ALA U CB  1 
+ATOM   717  N N   . ASP A 1 90  ? 13.967  -31.272 -24.750 1.00 62.35  ? ? ? ? ? ? 97  ASP U N   1 
+ATOM   718  C CA  . ASP A 1 90  ? 14.792  -31.776 -25.816 1.00 64.26  ? ? ? ? ? ? 97  ASP U CA  1 
+ATOM   719  C C   . ASP A 1 90  ? 14.113  -31.368 -27.064 1.00 62.67  ? ? ? ? ? ? 97  ASP U C   1 
+ATOM   720  O O   . ASP A 1 90  ? 13.238  -30.563 -27.031 1.00 63.69  ? ? ? ? ? ? 97  ASP U O   1 
+ATOM   721  C CB  . ASP A 1 90  ? 14.800  -33.280 -25.813 1.00 67.23  ? ? ? ? ? ? 97  ASP U CB  1 
+ATOM   722  C CG  . ASP A 1 90  ? 15.959  -33.857 -25.056 1.00 73.18  ? ? ? ? ? ? 97  ASP U CG  1 
+ATOM   723  O OD1 . ASP A 1 90  ? 16.492  -33.125 -24.206 1.00 75.86  ? ? ? ? ? ? 97  ASP U OD1 1 
+ATOM   724  O OD2 . ASP A 1 90  ? 16.318  -35.047 -25.304 1.00 72.97  ? ? ? ? ? ? 97  ASP U OD2 1 
+ATOM   725  N N   . THR A 1 91  A 14.577  -31.894 -28.181 1.00 65.59  ? ? ? ? ? ? 97  THR U N   1 
+ATOM   726  C CA  . THR A 1 91  A 13.938  -31.721 -29.457 1.00 68.22  ? ? ? ? ? ? 97  THR U CA  1 
+ATOM   727  C C   . THR A 1 91  A 12.538  -32.337 -29.570 1.00 66.38  ? ? ? ? ? ? 97  THR U C   1 
+ATOM   728  O O   . THR A 1 91  A 11.665  -31.741 -30.183 1.00 64.95  ? ? ? ? ? ? 97  THR U O   1 
+ATOM   729  C CB  . THR A 1 91  A 14.855  -32.232 -30.591 1.00 70.20  ? ? ? ? ? ? 97  THR U CB  1 
+ATOM   730  O OG1 . THR A 1 91  A 16.047  -32.792 -30.035 1.00 66.08  ? ? ? ? ? ? 97  THR U OG1 1 
+ATOM   731  C CG2 . THR A 1 91  A 15.238  -31.101 -31.496 1.00 70.18  ? ? ? ? ? ? 97  THR U CG2 1 
+ATOM   732  N N   . LEU A 1 92  B 12.341  -33.541 -29.022 1.00 60.49  ? ? ? ? ? ? 97  LEU U N   1 
+ATOM   733  C CA  . LEU A 1 92  B 11.023  -34.184 -28.990 1.00 59.93  ? ? ? ? ? ? 97  LEU U CA  1 
+ATOM   734  C C   . LEU A 1 92  B 10.319  -34.329 -27.628 1.00 57.24  ? ? ? ? ? ? 97  LEU U C   1 
+ATOM   735  O O   . LEU A 1 92  B 9.122   -34.345 -27.583 1.00 58.01  ? ? ? ? ? ? 97  LEU U O   1 
+ATOM   736  C CB  . LEU A 1 92  B 11.098  -35.577 -29.596 1.00 63.22  ? ? ? ? ? ? 97  LEU U CB  1 
+ATOM   737  C CG  . LEU A 1 92  B 11.110  -35.808 -31.098 1.00 64.15  ? ? ? ? ? ? 97  LEU U CG  1 
+ATOM   738  C CD1 . LEU A 1 92  B 12.069  -34.844 -31.749 1.00 64.12  ? ? ? ? ? ? 97  LEU U CD1 1 
+ATOM   739  C CD2 . LEU A 1 92  B 11.498  -37.230 -31.394 1.00 63.60  ? ? ? ? ? ? 97  LEU U CD2 1 
+ATOM   740  N N   . ALA A 1 93  ? 11.066  -34.430 -26.542 1.00 55.59  ? ? ? ? ? ? 98  ALA U N   1 
+ATOM   741  C CA  . ALA A 1 93  ? 10.526  -34.770 -25.235 1.00 54.33  ? ? ? ? ? ? 98  ALA U CA  1 
+ATOM   742  C C   . ALA A 1 93  ? 11.067  -33.878 -24.135 1.00 51.73  ? ? ? ? ? ? 98  ALA U C   1 
+ATOM   743  O O   . ALA A 1 93  ? 11.925  -33.087 -24.383 1.00 51.68  ? ? ? ? ? ? 98  ALA U O   1 
+ATOM   744  C CB  . ALA A 1 93  ? 10.810  -36.207 -24.908 1.00 54.68  ? ? ? ? ? ? 98  ALA U CB  1 
+ATOM   745  N N   . TYR A 1 94  ? 10.515  -33.989 -22.938 1.00 45.95  ? ? ? ? ? ? 99  TYR U N   1 
+ATOM   746  C CA  . TYR A 1 94  ? 10.949  -33.235 -21.790 1.00 43.29  ? ? ? ? ? ? 99  TYR U CA  1 
+ATOM   747  C C   . TYR A 1 94  ? 11.557  -34.180 -20.793 1.00 43.60  ? ? ? ? ? ? 99  TYR U C   1 
+ATOM   748  O O   . TYR A 1 94  ? 11.166  -35.298 -20.710 1.00 47.06  ? ? ? ? ? ? 99  TYR U O   1 
+ATOM   749  C CB  . TYR A 1 94  ? 9.773   -32.598 -21.077 1.00 42.19  ? ? ? ? ? ? 99  TYR U CB  1 
+ATOM   750  C CG  . TYR A 1 94  ? 8.923   -31.612 -21.801 1.00 39.46  ? ? ? ? ? ? 99  TYR U CG  1 
+ATOM   751  C CD1 . TYR A 1 94  ? 9.287   -30.286 -21.880 1.00 40.17  ? ? ? ? ? ? 99  TYR U CD1 1 
+ATOM   752  C CD2 . TYR A 1 94  ? 7.718   -31.977 -22.329 1.00 37.96  ? ? ? ? ? ? 99  TYR U CD2 1 
+ATOM   753  C CE1 . TYR A 1 94  ? 8.493   -29.374 -22.498 1.00 38.31  ? ? ? ? ? ? 99  TYR U CE1 1 
+ATOM   754  C CE2 . TYR A 1 94  ? 6.924   -31.061 -22.945 1.00 37.18  ? ? ? ? ? ? 99  TYR U CE2 1 
+ATOM   755  C CZ  . TYR A 1 94  ? 7.326   -29.763 -23.029 1.00 35.69  ? ? ? ? ? ? 99  TYR U CZ  1 
+ATOM   756  O OH  . TYR A 1 94  ? 6.547   -28.861 -23.635 1.00 35.58  ? ? ? ? ? ? 99  TYR U OH  1 
+ATOM   757  N N   . HIS A 1 95  ? 12.514  -33.720 -20.026 1.00 42.03  ? ? ? ? ? ? 100 HIS U N   1 
+ATOM   758  C CA  . HIS A 1 95  ? 13.197  -34.522 -19.021 1.00 44.27  ? ? ? ? ? ? 100 HIS U CA  1 
+ATOM   759  C C   . HIS A 1 95  ? 13.026  -33.868 -17.666 1.00 40.35  ? ? ? ? ? ? 100 HIS U C   1 
+ATOM   760  O O   . HIS A 1 95  ? 13.025  -32.641 -17.565 1.00 43.35  ? ? ? ? ? ? 100 HIS U O   1 
+ATOM   761  C CB  . HIS A 1 95  ? 14.690  -34.650 -19.374 1.00 45.01  ? ? ? ? ? ? 100 HIS U CB  1 
+ATOM   762  C CG  . HIS A 1 95  ? 14.941  -35.508 -20.570 1.00 46.12  ? ? ? ? ? ? 100 HIS U CG  1 
+ATOM   763  N ND1 . HIS A 1 95  ? 14.810  -35.042 -21.862 1.00 50.92  ? ? ? ? ? ? 100 HIS U ND1 1 
+ATOM   764  C CD2 . HIS A 1 95  ? 15.270  -36.817 -20.672 1.00 46.22  ? ? ? ? ? ? 100 HIS U CD2 1 
+ATOM   765  C CE1 . HIS A 1 95  ? 15.051  -36.028 -22.709 1.00 49.73  ? ? ? ? ? ? 100 HIS U CE1 1 
+ATOM   766  N NE2 . HIS A 1 95  ? 15.329  -37.116 -22.011 1.00 48.60  ? ? ? ? ? ? 100 HIS U NE2 1 
+ATOM   767  N N   . ASN A 1 96  ? 12.920  -34.690 -16.632 1.00 38.56  ? ? ? ? ? ? 101 ASN U N   1 
+ATOM   768  C CA  . ASN A 1 96  ? 12.687  -34.223 -15.257 1.00 41.04  ? ? ? ? ? ? 101 ASN U CA  1 
+ATOM   769  C C   . ASN A 1 96  ? 11.533  -33.227 -15.208 1.00 38.44  ? ? ? ? ? ? 101 ASN U C   1 
+ATOM   770  O O   . ASN A 1 96  ? 11.626  -32.158 -14.590 1.00 39.59  ? ? ? ? ? ? 101 ASN U O   1 
+ATOM   771  C CB  . ASN A 1 96  ? 13.956  -33.632 -14.653 1.00 42.57  ? ? ? ? ? ? 101 ASN U CB  1 
+ATOM   772  C CG  . ASN A 1 96  ? 15.093  -34.638 -14.616 1.00 46.09  ? ? ? ? ? ? 101 ASN U CG  1 
+ATOM   773  O OD1 . ASN A 1 96  ? 15.080  -35.593 -13.824 1.00 44.95  ? ? ? ? ? ? 101 ASN U OD1 1 
+ATOM   774  N ND2 . ASN A 1 96  ? 16.073  -34.442 -15.487 1.00 43.89  ? ? ? ? ? ? 101 ASN U ND2 1 
+ATOM   775  N N   . ASP A 1 97  ? 10.442  -33.624 -15.859 1.00 36.78  ? ? ? ? ? ? 102 ASP U N   1 
+ATOM   776  C CA  . ASP A 1 97  ? 9.273   -32.777 -16.036 1.00 35.83  ? ? ? ? ? ? 102 ASP U CA  1 
+ATOM   777  C C   . ASP A 1 97  ? 8.369   -32.879 -14.817 1.00 33.87  ? ? ? ? ? ? 102 ASP U C   1 
+ATOM   778  O O   . ASP A 1 97  ? 7.360   -33.588 -14.814 1.00 34.77  ? ? ? ? ? ? 102 ASP U O   1 
+ATOM   779  C CB  . ASP A 1 97  ? 8.551   -33.169 -17.314 1.00 33.31  ? ? ? ? ? ? 102 ASP U CB  1 
+ATOM   780  C CG  . ASP A 1 97  ? 7.626   -32.075 -17.818 1.00 31.82  ? ? ? ? ? ? 102 ASP U CG  1 
+ATOM   781  O OD1 . ASP A 1 97  ? 7.766   -30.907 -17.397 1.00 31.87  ? ? ? ? ? ? 102 ASP U OD1 1 
+ATOM   782  O OD2 . ASP A 1 97  ? 6.754   -32.382 -18.651 1.00 32.25  ? ? ? ? ? ? 102 ASP U OD2 1 
+ATOM   783  N N   . ILE A 1 98  ? 8.774   -32.198 -13.759 1.00 35.25  ? ? ? ? ? ? 103 ILE U N   1 
+ATOM   784  C CA  . ILE A 1 98  ? 8.109   -32.308 -12.468 1.00 35.32  ? ? ? ? ? ? 103 ILE U CA  1 
+ATOM   785  C C   . ILE A 1 98  ? 8.231   -30.995 -11.732 1.00 36.54  ? ? ? ? ? ? 103 ILE U C   1 
+ATOM   786  O O   . ILE A 1 98  ? 9.278   -30.333 -11.793 1.00 37.38  ? ? ? ? ? ? 103 ILE U O   1 
+ATOM   787  C CB  . ILE A 1 98  ? 8.696   -33.460 -11.623 1.00 38.65  ? ? ? ? ? ? 103 ILE U CB  1 
+ATOM   788  C CG1 . ILE A 1 98  ? 7.863   -33.665 -10.355 1.00 39.84  ? ? ? ? ? ? 103 ILE U CG1 1 
+ATOM   789  C CG2 . ILE A 1 98  ? 10.177  -33.221 -11.295 1.00 38.32  ? ? ? ? ? ? 103 ILE U CG2 1 
+ATOM   790  C CD1 . ILE A 1 98  ? 7.957   -35.071 -9.775  1.00 40.87  ? ? ? ? ? ? 103 ILE U CD1 1 
+ATOM   791  N N   . ALA A 1 99  ? 7.151   -30.617 -11.056 1.00 32.80  ? ? ? ? ? ? 104 ALA U N   1 
+ATOM   792  C CA  . ALA A 1 99  ? 7.053   -29.314 -10.418 1.00 34.70  ? ? ? ? ? ? 104 ALA U CA  1 
+ATOM   793  C C   . ALA A 1 99  ? 6.174   -29.404 -9.189  1.00 33.92  ? ? ? ? ? ? 104 ALA U C   1 
+ATOM   794  O O   . ALA A 1 99  ? 5.314   -30.289 -9.084  1.00 34.98  ? ? ? ? ? ? 104 ALA U O   1 
+ATOM   795  C CB  . ALA A 1 99  ? 6.504   -28.279 -11.398 1.00 33.23  ? ? ? ? ? ? 104 ALA U CB  1 
+ATOM   796  N N   . LEU A 1 100 ? 6.403   -28.500 -8.246  1.00 38.17  ? ? ? ? ? ? 105 LEU U N   1 
+ATOM   797  C CA  . LEU A 1 100 ? 5.616   -28.459 -7.025  1.00 37.80  ? ? ? ? ? ? 105 LEU U CA  1 
+ATOM   798  C C   . LEU A 1 100 ? 5.140   -27.052 -6.735  1.00 38.70  ? ? ? ? ? ? 105 LEU U C   1 
+ATOM   799  O O   . LEU A 1 100 ? 5.868   -26.086 -6.935  1.00 40.69  ? ? ? ? ? ? 105 LEU U O   1 
+ATOM   800  C CB  . LEU A 1 100 ? 6.439   -28.988 -5.849  1.00 42.51  ? ? ? ? ? ? 105 LEU U CB  1 
+ATOM   801  C CG  . LEU A 1 100 ? 6.599   -30.504 -5.721  1.00 41.01  ? ? ? ? ? ? 105 LEU U CG  1 
+ATOM   802  C CD1 . LEU A 1 100 ? 7.816   -30.848 -4.856  1.00 43.64  ? ? ? ? ? ? 105 LEU U CD1 1 
+ATOM   803  C CD2 . LEU A 1 100 ? 5.342   -31.102 -5.119  1.00 42.10  ? ? ? ? ? ? 105 LEU U CD2 1 
+ATOM   804  N N   . LEU A 1 101 ? 3.891   -26.954 -6.285  1.00 37.26  ? ? ? ? ? ? 106 LEU U N   1 
+ATOM   805  C CA  . LEU A 1 101 ? 3.260   -25.704 -5.925  1.00 37.27  ? ? ? ? ? ? 106 LEU U CA  1 
+ATOM   806  C C   . LEU A 1 101 ? 2.765   -25.848 -4.500  1.00 37.35  ? ? ? ? ? ? 106 LEU U C   1 
+ATOM   807  O O   . LEU A 1 101 ? 2.016   -26.787 -4.200  1.00 37.50  ? ? ? ? ? ? 106 LEU U O   1 
+ATOM   808  C CB  . LEU A 1 101 ? 2.055   -25.438 -6.825  1.00 39.35  ? ? ? ? ? ? 106 LEU U CB  1 
+ATOM   809  C CG  . LEU A 1 101 ? 2.334   -25.167 -8.303  1.00 40.80  ? ? ? ? ? ? 106 LEU U CG  1 
+ATOM   810  C CD1 . LEU A 1 101 ? 2.681   -26.449 -9.053  1.00 42.83  ? ? ? ? ? ? 106 LEU U CD1 1 
+ATOM   811  C CD2 . LEU A 1 101 ? 1.158   -24.446 -8.956  1.00 40.66  ? ? ? ? ? ? 106 LEU U CD2 1 
+ATOM   812  N N   . LYS A 1 102 ? 3.196   -24.954 -3.615  1.00 39.53  ? ? ? ? ? ? 107 LYS U N   1 
+ATOM   813  C CA  . LYS A 1 102 ? 2.574   -24.858 -2.298  1.00 39.22  ? ? ? ? ? ? 107 LYS U CA  1 
+ATOM   814  C C   . LYS A 1 102 ? 1.446   -23.865 -2.381  1.00 34.16  ? ? ? ? ? ? 107 LYS U C   1 
+ATOM   815  O O   . LYS A 1 102 ? 1.655   -22.710 -2.689  1.00 36.60  ? ? ? ? ? ? 107 LYS U O   1 
+ATOM   816  C CB  . LYS A 1 102 ? 3.547   -24.455 -1.173  1.00 43.78  ? ? ? ? ? ? 107 LYS U CB  1 
+ATOM   817  C CG  . LYS A 1 102 ? 2.807   -24.134 0.133   1.00 49.60  ? ? ? ? ? ? 107 LYS U CG  1 
+ATOM   818  C CD  . LYS A 1 102 ? 3.360   -24.814 1.382   1.00 55.05  ? ? ? ? ? ? 107 LYS U CD  1 
+ATOM   819  C CE  . LYS A 1 102 ? 4.298   -23.917 2.166   1.00 58.30  ? ? ? ? ? ? 107 LYS U CE  1 
+ATOM   820  N NZ  . LYS A 1 102 ? 5.565   -23.677 1.415   1.00 61.03  ? ? ? ? ? ? 107 LYS U NZ  1 
+ATOM   821  N N   . ILE A 1 103 ? 0.257   -24.291 -2.044  1.00 34.15  ? ? ? ? ? ? 108 ILE U N   1 
+ATOM   822  C CA  . ILE A 1 103 ? -0.923  -23.490 -2.220  1.00 33.50  ? ? ? ? ? ? 108 ILE U CA  1 
+ATOM   823  C C   . ILE A 1 103 ? -1.353  -22.832 -0.927  1.00 38.14  ? ? ? ? ? ? 108 ILE U C   1 
+ATOM   824  O O   . ILE A 1 103 ? -1.304  -23.437 0.112   1.00 32.11  ? ? ? ? ? ? 108 ILE U O   1 
+ATOM   825  C CB  . ILE A 1 103 ? -2.077  -24.346 -2.746  1.00 34.30  ? ? ? ? ? ? 108 ILE U CB  1 
+ATOM   826  C CG1 . ILE A 1 103 ? -2.150  -25.657 -1.997  1.00 33.11  ? ? ? ? ? ? 108 ILE U CG1 1 
+ATOM   827  C CG2 . ILE A 1 103 ? -1.862  -24.655 -4.202  1.00 34.18  ? ? ? ? ? ? 108 ILE U CG2 1 
+ATOM   828  C CD1 . ILE A 1 103 ? -3.354  -26.472 -2.330  1.00 32.69  ? ? ? ? ? ? 108 ILE U CD1 1 
+ATOM   829  N N   . ARG A 1 104 ? -1.773  -21.583 -1.028  1.00 39.72  ? ? ? ? ? ? 109 ARG U N   1 
+ATOM   830  C CA  . ARG A 1 104 ? -2.349  -20.873 0.099   1.00 45.65  ? ? ? ? ? ? 109 ARG U CA  1 
+ATOM   831  C C   . ARG A 1 104 ? -3.528  -20.074 -0.321  1.00 44.91  ? ? ? ? ? ? 109 ARG U C   1 
+ATOM   832  O O   . ARG A 1 104 ? -3.409  -19.369 -1.338  1.00 44.66  ? ? ? ? ? ? 109 ARG U O   1 
+ATOM   833  C CB  . ARG A 1 104 ? -1.339  -19.967 0.773   1.00 52.08  ? ? ? ? ? ? 109 ARG U CB  1 
+ATOM   834  C CG  . ARG A 1 104 ? -1.688  -19.628 2.208   1.00 57.31  ? ? ? ? ? ? 109 ARG U CG  1 
+ATOM   835  C CD  . ARG A 1 104 ? -0.587  -18.799 2.848   1.00 63.92  ? ? ? ? ? ? 109 ARG U CD  1 
+ATOM   836  N NE  . ARG A 1 104 ? -0.500  -17.474 2.254   1.00 69.45  ? ? ? ? ? ? 109 ARG U NE  1 
+ATOM   837  C CZ  . ARG A 1 104 ? -0.767  -16.350 2.907   1.00 72.43  ? ? ? ? ? ? 109 ARG U CZ  1 
+ATOM   838  N NH1 . ARG A 1 104 ? -0.671  -15.200 2.289   1.00 73.28  ? ? ? ? ? ? 109 ARG U NH1 1 
+ATOM   839  N NH2 . ARG A 1 104 ? -1.127  -16.376 4.179   1.00 75.36  ? ? ? ? ? ? 109 ARG U NH2 1 
+ATOM   840  N N   . SER A 1 105 ? -4.600  -20.131 0.398   1.00 44.19  ? ? ? ? ? ? 110 SER U N   1 
+ATOM   841  C CA  . SER A 1 105 ? -5.735  -19.279 0.098   1.00 45.45  ? ? ? ? ? ? 110 SER U CA  1 
+ATOM   842  C C   . SER A 1 105 ? -5.322  -17.893 0.624   1.00 46.32  ? ? ? ? ? ? 110 SER U C   1 
+ATOM   843  O O   . SER A 1 105 ? -4.457  -17.654 1.261   1.00 44.74  ? ? ? ? ? ? 110 SER U O   1 
+ATOM   844  C CB  . SER A 1 105 ? -6.987  -19.805 0.685   1.00 46.82  ? ? ? ? ? ? 110 SER U CB  1 
+ATOM   845  O OG  . SER A 1 105 ? -7.254  -19.269 1.959   1.00 54.54  ? ? ? ? ? ? 110 SER U OG  1 
+ATOM   846  N N   . LYS A 1 106 A -6.105  -16.908 0.066   1.00 89.78  ? ? ? ? ? ? 110 LYS U N   1 
+ATOM   847  C CA  . LYS A 1 106 A -5.841  -15.529 0.418   1.00 92.42  ? ? ? ? ? ? 110 LYS U CA  1 
+ATOM   848  C C   . LYS A 1 106 A -6.042  -15.382 1.927   1.00 89.21  ? ? ? ? ? ? 110 LYS U C   1 
+ATOM   849  O O   . LYS A 1 106 A -5.626  -14.419 2.514   1.00 81.99  ? ? ? ? ? ? 110 LYS U O   1 
+ATOM   850  C CB  . LYS A 1 106 A -6.710  -14.578 -0.390  1.00 97.09  ? ? ? ? ? ? 110 LYS U CB  1 
+ATOM   851  C CG  . LYS A 1 106 A -6.506  -13.120 -0.036  1.00 102.34 ? ? ? ? ? ? 110 LYS U CG  1 
+ATOM   852  C CD  . LYS A 1 106 A -7.568  -12.636 0.947   1.00 105.75 ? ? ? ? ? ? 110 LYS U CD  1 
+ATOM   853  C CE  . LYS A 1 106 A -7.026  -11.669 1.992   1.00 107.37 ? ? ? ? ? ? 110 LYS U CE  1 
+ATOM   854  N NZ  . LYS A 1 106 A -8.077  -11.132 2.901   1.00 107.46 ? ? ? ? ? ? 110 LYS U NZ  1 
+ATOM   855  N N   . GLU A 1 107 B -6.722  -16.350 2.525   1.00 76.77  ? ? ? ? ? ? 110 GLU U N   1 
+ATOM   856  C CA  . GLU A 1 107 B -7.006  -16.386 3.948   1.00 75.88  ? ? ? ? ? ? 110 GLU U CA  1 
+ATOM   857  C C   . GLU A 1 107 B -6.050  -17.310 4.703   1.00 71.68  ? ? ? ? ? ? 110 GLU U C   1 
+ATOM   858  O O   . GLU A 1 107 B -6.278  -17.641 5.838   1.00 63.34  ? ? ? ? ? ? 110 GLU U O   1 
+ATOM   859  C CB  . GLU A 1 107 B -8.446  -16.812 4.174   1.00 78.12  ? ? ? ? ? ? 110 GLU U CB  1 
+ATOM   860  C CG  . GLU A 1 107 B -9.484  -15.827 3.669   1.00 82.45  ? ? ? ? ? ? 110 GLU U CG  1 
+ATOM   861  C CD  . GLU A 1 107 B -9.214  -15.301 2.265   1.00 88.20  ? ? ? ? ? ? 110 GLU U CD  1 
+ATOM   862  O OE1 . GLU A 1 107 B -8.621  -16.027 1.447   1.00 92.57  ? ? ? ? ? ? 110 GLU U OE1 1 
+ATOM   863  O OE2 . GLU A 1 107 B -9.558  -14.148 1.973   1.00 89.97  ? ? ? ? ? ? 110 GLU U OE2 1 
+ATOM   864  N N   . GLY A 1 108 C -5.005  -17.756 4.030   1.00 54.37  ? ? ? ? ? ? 110 GLY U N   1 
+ATOM   865  C CA  . GLY A 1 108 C -3.915  -18.483 4.640   1.00 52.53  ? ? ? ? ? ? 110 GLY U CA  1 
+ATOM   866  C C   . GLY A 1 108 C -4.029  -19.969 4.824   1.00 51.96  ? ? ? ? ? ? 110 GLY U C   1 
+ATOM   867  O O   . GLY A 1 108 C -3.116  -20.556 5.349   1.00 58.53  ? ? ? ? ? ? 110 GLY U O   1 
+ATOM   868  N N   . ARG A 1 109 D -5.128  -20.575 4.384   1.00 53.73  ? ? ? ? ? ? 110 ARG U N   1 
+ATOM   869  C CA  . ARG A 1 109 D -5.346  -22.017 4.488   1.00 53.51  ? ? ? ? ? ? 110 ARG U CA  1 
+ATOM   870  C C   . ARG A 1 109 D -4.819  -22.900 3.358   1.00 50.04  ? ? ? ? ? ? 110 ARG U C   1 
+ATOM   871  O O   . ARG A 1 109 D -4.765  -22.484 2.237   1.00 50.74  ? ? ? ? ? ? 110 ARG U O   1 
+ATOM   872  C CB  . ARG A 1 109 D -6.823  -22.302 4.642   1.00 54.66  ? ? ? ? ? ? 110 ARG U CB  1 
+ATOM   873  C CG  . ARG A 1 109 D -7.459  -21.576 5.807   1.00 59.75  ? ? ? ? ? ? 110 ARG U CG  1 
+ATOM   874  C CD  . ARG A 1 109 D -8.787  -22.170 6.189   1.00 61.17  ? ? ? ? ? ? 110 ARG U CD  1 
+ATOM   875  N NE  . ARG A 1 109 D -9.724  -21.103 6.434   1.00 68.01  ? ? ? ? ? ? 110 ARG U NE  1 
+ATOM   876  C CZ  . ARG A 1 109 D -10.771 -21.206 7.226   1.00 74.09  ? ? ? ? ? ? 110 ARG U CZ  1 
+ATOM   877  N NH1 . ARG A 1 109 D -11.018 -22.348 7.852   1.00 73.66  ? ? ? ? ? ? 110 ARG U NH1 1 
+ATOM   878  N NH2 . ARG A 1 109 D -11.571 -20.166 7.393   1.00 75.12  ? ? ? ? ? ? 110 ARG U NH2 1 
+ATOM   879  N N   . CYS A 1 110 ? -4.439  -24.120 3.702   1.00 48.67  ? ? ? ? ? ? 111 CYS U N   1 
+ATOM   880  C CA  . CYS A 1 110 ? -4.184  -25.211 2.778   1.00 49.10  ? ? ? ? ? ? 111 CYS U CA  1 
+ATOM   881  C C   . CYS A 1 110 ? -5.576  -25.824 2.413   1.00 48.69  ? ? ? ? ? ? 111 CYS U C   1 
+ATOM   882  O O   . CYS A 1 110 ? -6.564  -25.384 2.915   1.00 49.90  ? ? ? ? ? ? 111 CYS U O   1 
+ATOM   883  C CB  . CYS A 1 110 ? -3.221  -26.246 3.399   1.00 45.21  ? ? ? ? ? ? 111 CYS U CB  1 
+ATOM   884  S SG  . CYS A 1 110 ? -1.460  -25.845 3.581   1.00 49.12  ? ? ? ? ? ? 111 CYS U SG  1 
+ATOM   885  N N   . ALA A 1 111 ? -5.648  -26.817 1.546   1.00 47.44  ? ? ? ? ? ? 112 ALA U N   1 
+ATOM   886  C CA  . ALA A 1 111 ? -6.923  -27.402 1.122   1.00 46.29  ? ? ? ? ? ? 112 ALA U CA  1 
+ATOM   887  C C   . ALA A 1 111 ? -7.590  -28.190 2.251   1.00 48.29  ? ? ? ? ? ? 112 ALA U C   1 
+ATOM   888  O O   . ALA A 1 111 ? -6.906  -28.792 3.087   1.00 50.61  ? ? ? ? ? ? 112 ALA U O   1 
+ATOM   889  C CB  . ALA A 1 111 ? -6.720  -28.294 -0.087  1.00 43.90  ? ? ? ? ? ? 112 ALA U CB  1 
+ATOM   890  N N   . GLN A 1 112 ? -8.922  -28.186 2.256   1.00 47.86  ? ? ? ? ? ? 113 GLN U N   1 
+ATOM   891  C CA  . GLN A 1 112 ? -9.702  -28.987 3.184   1.00 49.20  ? ? ? ? ? ? 113 GLN U CA  1 
+ATOM   892  C C   . GLN A 1 112 ? -10.562 -30.035 2.470   1.00 46.19  ? ? ? ? ? ? 113 GLN U C   1 
+ATOM   893  O O   . GLN A 1 112 ? -11.475 -29.693 1.721   1.00 47.37  ? ? ? ? ? ? 113 GLN U O   1 
+ATOM   894  C CB  . GLN A 1 112 ? -10.570 -28.076 4.032   1.00 52.82  ? ? ? ? ? ? 113 GLN U CB  1 
+ATOM   895  C CG  . GLN A 1 112 ? -9.764  -27.359 5.105   1.00 55.88  ? ? ? ? ? ? 113 GLN U CG  1 
+ATOM   896  C CD  . GLN A 1 112 ? -10.651 -26.663 6.105   1.00 59.56  ? ? ? ? ? ? 113 GLN U CD  1 
+ATOM   897  O OE1 . GLN A 1 112 ? -10.892 -27.177 7.198   1.00 68.83  ? ? ? ? ? ? 113 GLN U OE1 1 
+ATOM   898  N NE2 . GLN A 1 112 ? -11.164 -25.499 5.728   1.00 61.37  ? ? ? ? ? ? 113 GLN U NE2 1 
+ATOM   899  N N   . PRO A 1 113 ? -10.284 -31.323 2.716   1.00 43.15  ? ? ? ? ? ? 114 PRO U N   1 
+ATOM   900  C CA  . PRO A 1 113 ? -11.062 -32.379 2.080   1.00 42.41  ? ? ? ? ? ? 114 PRO U CA  1 
+ATOM   901  C C   . PRO A 1 113 ? -12.573 -32.171 2.179   1.00 42.46  ? ? ? ? ? ? 114 PRO U C   1 
+ATOM   902  O O   . PRO A 1 113 ? -13.075 -31.708 3.203   1.00 42.37  ? ? ? ? ? ? 114 PRO U O   1 
+ATOM   903  C CB  . PRO A 1 113 ? -10.657 -33.624 2.849   1.00 44.15  ? ? ? ? ? ? 114 PRO U CB  1 
+ATOM   904  C CG  . PRO A 1 113 ? -9.266  -33.333 3.295   1.00 46.46  ? ? ? ? ? ? 114 PRO U CG  1 
+ATOM   905  C CD  . PRO A 1 113 ? -9.217  -31.863 3.571   1.00 44.30  ? ? ? ? ? ? 114 PRO U CD  1 
+ATOM   906  N N   . SER A 1 114 ? -13.267 -32.507 1.100   1.00 37.53  ? ? ? ? ? ? 115 SER U N   1 
+ATOM   907  C CA  . SER A 1 114 ? -14.705 -32.430 1.012   1.00 35.28  ? ? ? ? ? ? 115 SER U CA  1 
+ATOM   908  C C   . SER A 1 114 ? -15.146 -33.489 0.014   1.00 34.98  ? ? ? ? ? ? 115 SER U C   1 
+ATOM   909  O O   . SER A 1 114 ? -14.323 -34.224 -0.533  1.00 37.22  ? ? ? ? ? ? 115 SER U O   1 
+ATOM   910  C CB  . SER A 1 114 ? -15.131 -31.052 0.519   1.00 38.27  ? ? ? ? ? ? 115 SER U CB  1 
+ATOM   911  O OG  . SER A 1 114 ? -14.835 -30.871 -0.876  1.00 36.14  ? ? ? ? ? ? 115 SER U OG  1 
+ATOM   912  N N   . ARG A 1 115 ? -16.443 -33.545 -0.236  1.00 36.90  ? ? ? ? ? ? 116 ARG U N   1 
+ATOM   913  C CA  . ARG A 1 115 ? -17.000 -34.380 -1.282  1.00 37.14  ? ? ? ? ? ? 116 ARG U CA  1 
+ATOM   914  C C   . ARG A 1 115 ? -16.252 -34.194 -2.618  1.00 34.90  ? ? ? ? ? ? 116 ARG U C   1 
+ATOM   915  O O   . ARG A 1 115 ? -16.205 -35.108 -3.429  1.00 36.84  ? ? ? ? ? ? 116 ARG U O   1 
+ATOM   916  C CB  . ARG A 1 115 ? -18.471 -34.046 -1.474  1.00 40.66  ? ? ? ? ? ? 116 ARG U CB  1 
+ATOM   917  C CG  . ARG A 1 115 ? -19.251 -35.089 -2.251  1.00 44.49  ? ? ? ? ? ? 116 ARG U CG  1 
+ATOM   918  C CD  . ARG A 1 115 ? -20.644 -34.609 -2.585  1.00 45.81  ? ? ? ? ? ? 116 ARG U CD  1 
+ATOM   919  N NE  . ARG A 1 115 ? -20.641 -33.617 -3.664  1.00 49.41  ? ? ? ? ? ? 116 ARG U NE  1 
+ATOM   920  C CZ  . ARG A 1 115 ? -20.834 -32.307 -3.505  1.00 52.03  ? ? ? ? ? ? 116 ARG U CZ  1 
+ATOM   921  N NH1 . ARG A 1 115 ? -21.061 -31.773 -2.296  1.00 52.16  ? ? ? ? ? ? 116 ARG U NH1 1 
+ATOM   922  N NH2 . ARG A 1 115 ? -20.805 -31.516 -4.567  1.00 50.43  ? ? ? ? ? ? 116 ARG U NH2 1 
+ATOM   923  N N   . THR A 1 116 ? -15.681 -33.014 -2.842  1.00 32.67  ? ? ? ? ? ? 117 THR U N   1 
+ATOM   924  C CA  . THR A 1 116 ? -15.079 -32.699 -4.145  1.00 33.76  ? ? ? ? ? ? 117 THR U CA  1 
+ATOM   925  C C   . THR A 1 116 ? -13.568 -32.491 -4.093  1.00 33.28  ? ? ? ? ? ? 117 THR U C   1 
+ATOM   926  O O   . THR A 1 116 ? -12.976 -32.239 -5.119  1.00 30.65  ? ? ? ? ? ? 117 THR U O   1 
+ATOM   927  C CB  . THR A 1 116 ? -15.712 -31.449 -4.778  1.00 32.59  ? ? ? ? ? ? 117 THR U CB  1 
+ATOM   928  O OG1 . THR A 1 116 ? -15.670 -30.358 -3.857  1.00 32.18  ? ? ? ? ? ? 117 THR U OG1 1 
+ATOM   929  C CG2 . THR A 1 116 ? -17.100 -31.707 -5.147  1.00 34.11  ? ? ? ? ? ? 117 THR U CG2 1 
+ATOM   930  N N   . ILE A 1 117 ? -12.948 -32.598 -2.908  1.00 34.66  ? ? ? ? ? ? 118 ILE U N   1 
+ATOM   931  C CA  . ILE A 1 117 ? -11.502 -32.387 -2.764  1.00 33.34  ? ? ? ? ? ? 118 ILE U CA  1 
+ATOM   932  C C   . ILE A 1 117 ? -10.874 -33.441 -1.846  1.00 36.94  ? ? ? ? ? ? 118 ILE U C   1 
+ATOM   933  O O   . ILE A 1 117 ? -11.227 -33.553 -0.662  1.00 35.59  ? ? ? ? ? ? 118 ILE U O   1 
+ATOM   934  C CB  . ILE A 1 117 ? -11.206 -30.985 -2.221  1.00 33.91  ? ? ? ? ? ? 118 ILE U CB  1 
+ATOM   935  C CG1 . ILE A 1 117 ? -11.819 -29.898 -3.137  1.00 34.55  ? ? ? ? ? ? 118 ILE U CG1 1 
+ATOM   936  C CG2 . ILE A 1 117 ? -9.707  -30.795 -2.074  1.00 33.91  ? ? ? ? ? ? 118 ILE U CG2 1 
+ATOM   937  C CD1 . ILE A 1 117 ? -11.694 -28.499 -2.577  1.00 35.64  ? ? ? ? ? ? 118 ILE U CD1 1 
+ATOM   938  N N   . GLN A 1 118 ? -9.957  -34.231 -2.393  1.00 36.92  ? ? ? ? ? ? 119 GLN U N   1 
+ATOM   939  C CA  . GLN A 1 118 ? -9.206  -35.220 -1.597  1.00 35.98  ? ? ? ? ? ? 119 GLN U CA  1 
+ATOM   940  C C   . GLN A 1 118 ? -7.772  -35.274 -2.117  1.00 36.81  ? ? ? ? ? ? 119 GLN U C   1 
+ATOM   941  O O   . GLN A 1 118 ? -7.523  -34.927 -3.287  1.00 35.36  ? ? ? ? ? ? 119 GLN U O   1 
+ATOM   942  C CB  . GLN A 1 118 ? -9.823  -36.604 -1.752  1.00 38.21  ? ? ? ? ? ? 119 GLN U CB  1 
+ATOM   943  C CG  . GLN A 1 118 ? -11.275 -36.726 -1.306  1.00 41.27  ? ? ? ? ? ? 119 GLN U CG  1 
+ATOM   944  C CD  . GLN A 1 118 ? -11.405 -36.753 0.209   1.00 43.52  ? ? ? ? ? ? 119 GLN U CD  1 
+ATOM   945  O OE1 . GLN A 1 118 ? -10.549 -37.306 0.890   1.00 47.59  ? ? ? ? ? ? 119 GLN U OE1 1 
+ATOM   946  N NE2 . GLN A 1 118 ? -12.463 -36.147 0.739   1.00 42.20  ? ? ? ? ? ? 119 GLN U NE2 1 
+ATOM   947  N N   . THR A 1 119 ? -6.845  -35.759 -1.286  1.00 32.40  ? ? ? ? ? ? 120 THR U N   1 
+ATOM   948  C CA  . THR A 1 119 ? -5.441  -35.930 -1.689  1.00 31.34  ? ? ? ? ? ? 120 THR U CA  1 
+ATOM   949  C C   . THR A 1 119 ? -5.283  -37.273 -2.365  1.00 31.53  ? ? ? ? ? ? 120 THR U C   1 
+ATOM   950  O O   . THR A 1 119 ? -6.145  -38.111 -2.235  1.00 28.81  ? ? ? ? ? ? 120 THR U O   1 
+ATOM   951  C CB  . THR A 1 119 ? -4.483  -35.857 -0.472  1.00 33.91  ? ? ? ? ? ? 120 THR U CB  1 
+ATOM   952  O OG1 . THR A 1 119 ? -4.841  -36.860 0.491   1.00 32.72  ? ? ? ? ? ? 120 THR U OG1 1 
+ATOM   953  C CG2 . THR A 1 119 ? -4.560  -34.515 0.178   1.00 34.42  ? ? ? ? ? ? 120 THR U CG2 1 
+ATOM   954  N N   . ILE A 1 120 ? -4.210  -37.441 -3.146  1.00 33.28  ? ? ? ? ? ? 121 ILE U N   1 
+ATOM   955  C CA  . ILE A 1 120 ? -3.874  -38.703 -3.793  1.00 34.08  ? ? ? ? ? ? 121 ILE U CA  1 
+ATOM   956  C C   . ILE A 1 120 ? -2.496  -39.127 -3.254  1.00 36.42  ? ? ? ? ? ? 121 ILE U C   1 
+ATOM   957  O O   . ILE A 1 120 ? -1.558  -38.320 -3.208  1.00 33.43  ? ? ? ? ? ? 121 ILE U O   1 
+ATOM   958  C CB  . ILE A 1 120 ? -3.890  -38.594 -5.358  1.00 34.18  ? ? ? ? ? ? 121 ILE U CB  1 
+ATOM   959  C CG1 . ILE A 1 120 ? -3.658  -39.941 -6.037  1.00 36.25  ? ? ? ? ? ? 121 ILE U CG1 1 
+ATOM   960  C CG2 . ILE A 1 120 ? -2.861  -37.605 -5.887  1.00 34.96  ? ? ? ? ? ? 121 ILE U CG2 1 
+ATOM   961  C CD1 . ILE A 1 120 ? -4.834  -40.896 -5.990  1.00 37.76  ? ? ? ? ? ? 121 ILE U CD1 1 
+ATOM   962  N N   . ALA A 1 121 ? -2.391  -40.383 -2.831  1.00 38.89  ? ? ? ? ? ? 122 ALA U N   1 
+ATOM   963  C CA  . ALA A 1 121 ? -1.148  -40.898 -2.272  1.00 38.91  ? ? ? ? ? ? 122 ALA U CA  1 
+ATOM   964  C C   . ALA A 1 121 ? -0.021  -40.991 -3.319  1.00 40.95  ? ? ? ? ? ? 122 ALA U C   1 
+ATOM   965  O O   . ALA A 1 121 ? -0.244  -41.316 -4.492  1.00 34.23  ? ? ? ? ? ? 122 ALA U O   1 
+ATOM   966  C CB  . ALA A 1 121 ? -1.391  -42.262 -1.643  1.00 40.29  ? ? ? ? ? ? 122 ALA U CB  1 
+ATOM   967  N N   . LEU A 1 122 ? 1.195   -40.696 -2.874  1.00 41.47  ? ? ? ? ? ? 123 LEU U N   1 
+ATOM   968  C CA  . LEU A 1 122 ? 2.397   -40.983 -3.656  1.00 42.77  ? ? ? ? ? ? 123 LEU U CA  1 
+ATOM   969  C C   . LEU A 1 122 ? 2.752   -42.453 -3.565  1.00 43.82  ? ? ? ? ? ? 123 LEU U C   1 
+ATOM   970  O O   . LEU A 1 122 ? 2.408   -43.110 -2.574  1.00 41.98  ? ? ? ? ? ? 123 LEU U O   1 
+ATOM   971  C CB  . LEU A 1 122 ? 3.573   -40.161 -3.140  1.00 43.24  ? ? ? ? ? ? 123 LEU U CB  1 
+ATOM   972  C CG  . LEU A 1 122 ? 3.431   -38.657 -3.375  1.00 44.31  ? ? ? ? ? ? 123 LEU U CG  1 
+ATOM   973  C CD1 . LEU A 1 122 ? 4.494   -37.904 -2.586  1.00 42.49  ? ? ? ? ? ? 123 LEU U CD1 1 
+ATOM   974  C CD2 . LEU A 1 122 ? 3.514   -38.368 -4.870  1.00 44.61  ? ? ? ? ? ? 123 LEU U CD2 1 
+ATOM   975  N N   . PRO A 1 123 ? 3.454   -42.983 -4.587  1.00 45.13  ? ? ? ? ? ? 124 PRO U N   1 
+ATOM   976  C CA  . PRO A 1 123 ? 3.901   -44.360 -4.487  1.00 45.17  ? ? ? ? ? ? 124 PRO U CA  1 
+ATOM   977  C C   . PRO A 1 123 ? 5.124   -44.465 -3.589  1.00 45.56  ? ? ? ? ? ? 124 PRO U C   1 
+ATOM   978  O O   . PRO A 1 123 ? 5.662   -43.441 -3.138  1.00 41.08  ? ? ? ? ? ? 124 PRO U O   1 
+ATOM   979  C CB  . PRO A 1 123 ? 4.263   -44.721 -5.933  1.00 46.78  ? ? ? ? ? ? 124 PRO U CB  1 
+ATOM   980  C CG  . PRO A 1 123 ? 4.560   -43.421 -6.609  1.00 46.27  ? ? ? ? ? ? 124 PRO U CG  1 
+ATOM   981  C CD  . PRO A 1 123 ? 4.068   -42.299 -5.739  1.00 45.71  ? ? ? ? ? ? 124 PRO U CD  1 
+ATOM   982  N N   . SER A 1 124 ? 5.528   -45.701 -3.309  1.00 47.71  ? ? ? ? ? ? 125 SER U N   1 
+ATOM   983  C CA  . SER A 1 124 ? 6.776   -45.977 -2.609  1.00 47.99  ? ? ? ? ? ? 125 SER U CA  1 
+ATOM   984  C C   . SER A 1 124 ? 7.873   -45.813 -3.621  1.00 47.23  ? ? ? ? ? ? 125 SER U C   1 
+ATOM   985  O O   . SER A 1 124 ? 7.652   -46.039 -4.823  1.00 46.52  ? ? ? ? ? ? 125 SER U O   1 
+ATOM   986  C CB  . SER A 1 124 ? 6.813   -47.414 -2.084  1.00 51.90  ? ? ? ? ? ? 125 SER U CB  1 
+ATOM   987  O OG  . SER A 1 124 ? 5.652   -47.711 -1.352  1.00 55.23  ? ? ? ? ? ? 125 SER U OG  1 
+ATOM   988  N N   . MET A 1 125 ? 9.062   -45.445 -3.154  1.00 49.17  ? ? ? ? ? ? 126 MET U N   1 
+ATOM   989  C CA  . MET A 1 125 ? 10.140  -45.136 -4.085  1.00 52.50  ? ? ? ? ? ? 126 MET U CA  1 
+ATOM   990  C C   . MET A 1 125 ? 10.486  -46.343 -4.966  1.00 48.07  ? ? ? ? ? ? 126 MET U C   1 
+ATOM   991  O O   . MET A 1 125 ? 10.701  -47.459 -4.485  1.00 46.18  ? ? ? ? ? ? 126 MET U O   1 
+ATOM   992  C CB  . MET A 1 125 ? 11.385  -44.511 -3.405  1.00 59.78  ? ? ? ? ? ? 126 MET U CB  1 
+ATOM   993  C CG  . MET A 1 125 ? 11.881  -45.124 -2.097  1.00 64.92  ? ? ? ? ? ? 126 MET U CG  1 
+ATOM   994  S SD  . MET A 1 125 ? 13.181  -44.078 -1.384  1.00 73.02  ? ? ? ? ? ? 126 MET U SD  1 
+ATOM   995  C CE  . MET A 1 125 ? 13.436  -44.872 0.204   1.00 74.42  ? ? ? ? ? ? 126 MET U CE  1 
+ATOM   996  N N   . TYR A 1 126 ? 10.469  -46.093 -6.271  1.00 48.96  ? ? ? ? ? ? 127 TYR U N   1 
+ATOM   997  C CA  . TYR A 1 126 ? 10.782  -47.078 -7.310  1.00 48.36  ? ? ? ? ? ? 127 TYR U CA  1 
+ATOM   998  C C   . TYR A 1 126 ? 9.753   -48.197 -7.455  1.00 50.29  ? ? ? ? ? ? 127 TYR U C   1 
+ATOM   999  O O   . TYR A 1 126 ? 9.926   -49.091 -8.284  1.00 49.66  ? ? ? ? ? ? 127 TYR U O   1 
+ATOM   1000 C CB  . TYR A 1 126 ? 12.219  -47.584 -7.129  1.00 48.62  ? ? ? ? ? ? 127 TYR U CB  1 
+ATOM   1001 C CG  . TYR A 1 126 ? 13.164  -46.413 -7.226  1.00 48.15  ? ? ? ? ? ? 127 TYR U CG  1 
+ATOM   1002 C CD1 . TYR A 1 126 ? 13.590  -45.952 -8.461  1.00 49.24  ? ? ? ? ? ? 127 TYR U CD1 1 
+ATOM   1003 C CD2 . TYR A 1 126 ? 13.547  -45.702 -6.097  1.00 47.88  ? ? ? ? ? ? 127 TYR U CD2 1 
+ATOM   1004 C CE1 . TYR A 1 126 ? 14.415  -44.849 -8.569  1.00 48.28  ? ? ? ? ? ? 127 TYR U CE1 1 
+ATOM   1005 C CE2 . TYR A 1 126 ? 14.371  -44.593 -6.190  1.00 46.74  ? ? ? ? ? ? 127 TYR U CE2 1 
+ATOM   1006 C CZ  . TYR A 1 126 ? 14.797  -44.169 -7.428  1.00 48.57  ? ? ? ? ? ? 127 TYR U CZ  1 
+ATOM   1007 O OH  . TYR A 1 126 ? 15.614  -43.076 -7.534  1.00 47.59  ? ? ? ? ? ? 127 TYR U OH  1 
+ATOM   1008 N N   . ASN A 1 127 ? 8.663   -48.113 -6.689  1.00 51.91  ? ? ? ? ? ? 128 ASN U N   1 
+ATOM   1009 C CA  . ASN A 1 127 ? 7.573   -49.087 -6.771  1.00 54.32  ? ? ? ? ? ? 128 ASN U CA  1 
+ATOM   1010 C C   . ASN A 1 127 ? 6.525   -48.643 -7.799  1.00 53.23  ? ? ? ? ? ? 128 ASN U C   1 
+ATOM   1011 O O   . ASN A 1 127 ? 5.829   -47.651 -7.582  1.00 51.51  ? ? ? ? ? ? 128 ASN U O   1 
+ATOM   1012 C CB  . ASN A 1 127 ? 6.919   -49.264 -5.392  1.00 54.56  ? ? ? ? ? ? 128 ASN U CB  1 
+ATOM   1013 C CG  . ASN A 1 127 ? 5.952   -50.438 -5.336  1.00 55.60  ? ? ? ? ? ? 128 ASN U CG  1 
+ATOM   1014 O OD1 . ASN A 1 127 ? 5.079   -50.493 -4.464  1.00 56.96  ? ? ? ? ? ? 128 ASN U OD1 1 
+ATOM   1015 N ND2 . ASN A 1 127 ? 6.107   -51.386 -6.254  1.00 54.55  ? ? ? ? ? ? 128 ASN U ND2 1 
+ATOM   1016 N N   . ASP A 1 128 ? 6.452   -49.366 -8.916  1.00 53.13  ? ? ? ? ? ? 129 ASP U N   1 
+ATOM   1017 C CA  . ASP A 1 128 ? 5.469   -49.123 -9.982  1.00 56.26  ? ? ? ? ? ? 129 ASP U CA  1 
+ATOM   1018 C C   . ASP A 1 128 ? 4.711   -50.419 -10.285 1.00 58.41  ? ? ? ? ? ? 129 ASP U C   1 
+ATOM   1019 O O   . ASP A 1 128 ? 5.258   -51.510 -10.107 1.00 58.63  ? ? ? ? ? ? 129 ASP U O   1 
+ATOM   1020 C CB  . ASP A 1 128 ? 6.160   -48.666 -11.266 1.00 57.76  ? ? ? ? ? ? 129 ASP U CB  1 
+ATOM   1021 C CG  . ASP A 1 128 ? 6.842   -47.316 -11.123 1.00 61.96  ? ? ? ? ? ? 129 ASP U CG  1 
+ATOM   1022 O OD1 . ASP A 1 128 ? 7.707   -47.159 -10.233 1.00 63.92  ? ? ? ? ? ? 129 ASP U OD1 1 
+ATOM   1023 O OD2 . ASP A 1 128 ? 6.527   -46.416 -11.926 1.00 59.48  ? ? ? ? ? ? 129 ASP U OD2 1 
+ATOM   1024 N N   . PRO A 1 129 ? 3.469   -50.310 -10.789 1.00 57.92  ? ? ? ? ? ? 130 PRO U N   1 
+ATOM   1025 C CA  . PRO A 1 129 ? 2.702   -51.533 -11.011 1.00 57.29  ? ? ? ? ? ? 130 PRO U CA  1 
+ATOM   1026 C C   . PRO A 1 129 ? 3.104   -52.221 -12.304 1.00 55.31  ? ? ? ? ? ? 130 PRO U C   1 
+ATOM   1027 O O   . PRO A 1 129 ? 3.913   -51.691 -13.064 1.00 50.38  ? ? ? ? ? ? 130 PRO U O   1 
+ATOM   1028 C CB  . PRO A 1 129 ? 1.257   -51.033 -11.082 1.00 58.05  ? ? ? ? ? ? 130 PRO U CB  1 
+ATOM   1029 C CG  . PRO A 1 129 ? 1.364   -49.631 -11.576 1.00 57.70  ? ? ? ? ? ? 130 PRO U CG  1 
+ATOM   1030 C CD  . PRO A 1 129 ? 2.757   -49.118 -11.288 1.00 56.11  ? ? ? ? ? ? 130 PRO U CD  1 
+ATOM   1031 N N   . GLN A 1 130 ? 2.529   -53.393 -12.544 1.00 56.32  ? ? ? ? ? ? 131 GLN U N   1 
+ATOM   1032 C CA  . GLN A 1 130 ? 2.867   -54.194 -13.708 1.00 59.22  ? ? ? ? ? ? 131 GLN U CA  1 
+ATOM   1033 C C   . GLN A 1 130 ? 2.515   -53.464 -14.971 1.00 56.80  ? ? ? ? ? ? 131 GLN U C   1 
+ATOM   1034 O O   . GLN A 1 130 ? 1.588   -52.671 -15.005 1.00 55.40  ? ? ? ? ? ? 131 GLN U O   1 
+ATOM   1035 C CB  . GLN A 1 130 ? 2.107   -55.535 -13.720 1.00 65.76  ? ? ? ? ? ? 131 GLN U CB  1 
+ATOM   1036 C CG  . GLN A 1 130 ? 2.916   -56.744 -13.269 1.00 71.02  ? ? ? ? ? ? 131 GLN U CG  1 
+ATOM   1037 C CD  . GLN A 1 130 ? 3.115   -56.821 -11.765 1.00 73.46  ? ? ? ? ? ? 131 GLN U CD  1 
+ATOM   1038 O OE1 . GLN A 1 130 ? 3.912   -57.627 -11.283 1.00 77.35  ? ? ? ? ? ? 131 GLN U OE1 1 
+ATOM   1039 N NE2 . GLN A 1 130 ? 2.391   -55.996 -11.016 1.00 73.36  ? ? ? ? ? ? 131 GLN U NE2 1 
+ATOM   1040 N N   . PHE A 1 131 ? 3.241   -53.786 -16.027 1.00 60.06  ? ? ? ? ? ? 132 PHE U N   1 
+ATOM   1041 C CA  . PHE A 1 131 ? 2.891   -53.347 -17.356 1.00 60.41  ? ? ? ? ? ? 132 PHE U CA  1 
+ATOM   1042 C C   . PHE A 1 131 ? 1.614   -54.094 -17.746 1.00 58.35  ? ? ? ? ? ? 132 PHE U C   1 
+ATOM   1043 O O   . PHE A 1 131 ? 1.399   -55.228 -17.308 1.00 54.52  ? ? ? ? ? ? 132 PHE U O   1 
+ATOM   1044 C CB  . PHE A 1 131 ? 4.056   -53.621 -18.297 1.00 67.26  ? ? ? ? ? ? 132 PHE U CB  1 
+ATOM   1045 C CG  . PHE A 1 131 ? 5.382   -53.169 -17.738 1.00 73.40  ? ? ? ? ? ? 132 PHE U CG  1 
+ATOM   1046 C CD1 . PHE A 1 131 ? 5.692   -51.811 -17.665 1.00 78.42  ? ? ? ? ? ? 132 PHE U CD1 1 
+ATOM   1047 C CD2 . PHE A 1 131 ? 6.295   -54.089 -17.233 1.00 76.81  ? ? ? ? ? ? 132 PHE U CD2 1 
+ATOM   1048 C CE1 . PHE A 1 131 ? 6.904   -51.385 -17.140 1.00 79.27  ? ? ? ? ? ? 132 PHE U CE1 1 
+ATOM   1049 C CE2 . PHE A 1 131 ? 7.507   -53.669 -16.702 1.00 79.43  ? ? ? ? ? ? 132 PHE U CE2 1 
+ATOM   1050 C CZ  . PHE A 1 131 ? 7.812   -52.316 -16.657 1.00 80.91  ? ? ? ? ? ? 132 PHE U CZ  1 
+ATOM   1051 N N   . GLY A 1 132 ? 0.751   -53.429 -18.516 1.00 53.51  ? ? ? ? ? ? 133 GLY U N   1 
+ATOM   1052 C CA  . GLY A 1 132 ? -0.601  -53.924 -18.792 1.00 51.27  ? ? ? ? ? ? 133 GLY U CA  1 
+ATOM   1053 C C   . GLY A 1 132 ? -1.640  -53.588 -17.718 1.00 48.81  ? ? ? ? ? ? 133 GLY U C   1 
+ATOM   1054 O O   . GLY A 1 132 ? -2.820  -53.910 -17.885 1.00 50.33  ? ? ? ? ? ? 133 GLY U O   1 
+ATOM   1055 N N   . THR A 1 133 ? -1.225  -52.959 -16.616 1.00 44.34  ? ? ? ? ? ? 134 THR U N   1 
+ATOM   1056 C CA  . THR A 1 133 ? -2.180  -52.468 -15.607 1.00 42.75  ? ? ? ? ? ? 134 THR U CA  1 
+ATOM   1057 C C   . THR A 1 133 ? -2.981  -51.274 -16.153 1.00 40.10  ? ? ? ? ? ? 134 THR U C   1 
+ATOM   1058 O O   . THR A 1 133 ? -2.464  -50.463 -16.895 1.00 37.40  ? ? ? ? ? ? 134 THR U O   1 
+ATOM   1059 C CB  . THR A 1 133 ? -1.475  -52.025 -14.320 1.00 41.47  ? ? ? ? ? ? 134 THR U CB  1 
+ATOM   1060 O OG1 . THR A 1 133 ? -0.651  -53.085 -13.832 1.00 41.60  ? ? ? ? ? ? 134 THR U OG1 1 
+ATOM   1061 C CG2 . THR A 1 133 ? -2.488  -51.624 -13.240 1.00 42.05  ? ? ? ? ? ? 134 THR U CG2 1 
+ATOM   1062 N N   . SER A 1 134 ? -4.249  -51.192 -15.777 1.00 41.37  ? ? ? ? ? ? 135 SER U N   1 
+ATOM   1063 C CA  . SER A 1 134 ? -5.136  -50.117 -16.225 1.00 41.39  ? ? ? ? ? ? 135 SER U CA  1 
+ATOM   1064 C C   . SER A 1 134 ? -5.102  -48.944 -15.251 1.00 40.48  ? ? ? ? ? ? 135 SER U C   1 
+ATOM   1065 O O   . SER A 1 134 ? -5.324  -49.124 -14.059 1.00 41.40  ? ? ? ? ? ? 135 SER U O   1 
+ATOM   1066 C CB  . SER A 1 134 ? -6.571  -50.637 -16.347 1.00 40.39  ? ? ? ? ? ? 135 SER U CB  1 
+ATOM   1067 O OG  . SER A 1 134 ? -6.740  -51.324 -17.558 1.00 41.15  ? ? ? ? ? ? 135 SER U OG  1 
+ATOM   1068 N N   . CYS A 1 135 ? -4.846  -47.748 -15.774 1.00 39.96  ? ? ? ? ? ? 136 CYS U N   1 
+ATOM   1069 C CA  . CYS A 1 135 ? -4.759  -46.524 -14.970 1.00 39.34  ? ? ? ? ? ? 136 CYS U CA  1 
+ATOM   1070 C C   . CYS A 1 135 ? -5.729  -45.459 -15.487 1.00 36.62  ? ? ? ? ? ? 136 CYS U C   1 
+ATOM   1071 O O   . CYS A 1 135 ? -6.227  -45.565 -16.606 1.00 35.21  ? ? ? ? ? ? 136 CYS U O   1 
+ATOM   1072 C CB  . CYS A 1 135 ? -3.327  -45.991 -15.025 1.00 43.13  ? ? ? ? ? ? 136 CYS U CB  1 
+ATOM   1073 S SG  . CYS A 1 135 ? -2.110  -47.225 -14.492 1.00 45.64  ? ? ? ? ? ? 136 CYS U SG  1 
+ATOM   1074 N N   . GLU A 1 136 ? -5.978  -44.440 -14.669 1.00 34.81  ? ? ? ? ? ? 137 GLU U N   1 
+ATOM   1075 C CA  . GLU A 1 136 ? -6.893  -43.350 -15.004 1.00 36.61  ? ? ? ? ? ? 137 GLU U CA  1 
+ATOM   1076 C C   . GLU A 1 136 ? -6.136  -42.057 -15.245 1.00 33.80  ? ? ? ? ? ? 137 GLU U C   1 
+ATOM   1077 O O   . GLU A 1 136 ? -5.212  -41.732 -14.500 1.00 33.23  ? ? ? ? ? ? 137 GLU U O   1 
+ATOM   1078 C CB  . GLU A 1 136 ? -7.848  -43.089 -13.839 1.00 43.81  ? ? ? ? ? ? 137 GLU U CB  1 
+ATOM   1079 C CG  . GLU A 1 136 ? -8.914  -44.150 -13.652 1.00 51.99  ? ? ? ? ? ? 137 GLU U CG  1 
+ATOM   1080 C CD  . GLU A 1 136 ? -9.692  -43.966 -12.366 1.00 58.74  ? ? ? ? ? ? 137 GLU U CD  1 
+ATOM   1081 O OE1 . GLU A 1 136 ? -9.218  -43.209 -11.478 1.00 57.19  ? ? ? ? ? ? 137 GLU U OE1 1 
+ATOM   1082 O OE2 . GLU A 1 136 ? -10.785 -44.577 -12.255 1.00 63.33  ? ? ? ? ? ? 137 GLU U OE2 1 
+ATOM   1083 N N   . ILE A 1 137 ? -6.551  -41.319 -16.270 1.00 30.78  ? ? ? ? ? ? 138 ILE U N   1 
+ATOM   1084 C CA  . ILE A 1 137 ? -6.050  -39.956 -16.533 1.00 30.68  ? ? ? ? ? ? 138 ILE U CA  1 
+ATOM   1085 C C   . ILE A 1 137 ? -7.248  -39.028 -16.607 1.00 29.77  ? ? ? ? ? ? 138 ILE U C   1 
+ATOM   1086 O O   . ILE A 1 137 ? -8.356  -39.479 -16.876 1.00 30.43  ? ? ? ? ? ? 138 ILE U O   1 
+ATOM   1087 C CB  . ILE A 1 137 ? -5.240  -39.850 -17.847 1.00 32.00  ? ? ? ? ? ? 138 ILE U CB  1 
+ATOM   1088 C CG1 . ILE A 1 137 ? -5.977  -40.566 -18.988 1.00 33.11  ? ? ? ? ? ? 138 ILE U CG1 1 
+ATOM   1089 C CG2 . ILE A 1 137 ? -3.839  -40.415 -17.634 1.00 33.32  ? ? ? ? ? ? 138 ILE U CG2 1 
+ATOM   1090 C CD1 . ILE A 1 137 ? -5.402  -40.353 -20.382 1.00 34.56  ? ? ? ? ? ? 138 ILE U CD1 1 
+ATOM   1091 N N   . THR A 1 138 ? -7.018  -37.737 -16.371 1.00 29.88  ? ? ? ? ? ? 139 THR U N   1 
+ATOM   1092 C CA  . THR A 1 138 ? -8.084  -36.767 -16.256 1.00 31.21  ? ? ? ? ? ? 139 THR U CA  1 
+ATOM   1093 C C   . THR A 1 138 ? -7.570  -35.452 -16.751 1.00 28.96  ? ? ? ? ? ? 139 THR U C   1 
+ATOM   1094 O O   . THR A 1 138 ? -6.395  -35.145 -16.553 1.00 29.81  ? ? ? ? ? ? 139 THR U O   1 
+ATOM   1095 C CB  . THR A 1 138 ? -8.500  -36.529 -14.780 1.00 36.17  ? ? ? ? ? ? 139 THR U CB  1 
+ATOM   1096 O OG1 . THR A 1 138 ? -8.443  -37.755 -14.048 1.00 44.21  ? ? ? ? ? ? 139 THR U OG1 1 
+ATOM   1097 C CG2 . THR A 1 138 ? -9.907  -35.980 -14.701 1.00 35.56  ? ? ? ? ? ? 139 THR U CG2 1 
+ATOM   1098 N N   . GLY A 1 139 ? -8.446  -34.633 -17.324 1.00 25.83  ? ? ? ? ? ? 140 GLY U N   1 
+ATOM   1099 C CA  . GLY A 1 139 ? -8.043  -33.269 -17.685 1.00 25.07  ? ? ? ? ? ? 140 GLY U CA  1 
+ATOM   1100 C C   . GLY A 1 139 ? -9.023  -32.482 -18.542 1.00 25.81  ? ? ? ? ? ? 140 GLY U C   1 
+ATOM   1101 O O   . GLY A 1 139 ? -10.085 -32.991 -18.916 1.00 26.46  ? ? ? ? ? ? 140 GLY U O   1 
+ATOM   1102 N N   . PHE A 1 140 ? -8.638  -31.232 -18.838 1.00 25.60  ? ? ? ? ? ? 141 PHE U N   1 
+ATOM   1103 C CA  . PHE A 1 140 ? -9.413  -30.307 -19.655 1.00 26.36  ? ? ? ? ? ? 141 PHE U CA  1 
+ATOM   1104 C C   . PHE A 1 140 ? -8.749  -30.174 -21.032 1.00 26.09  ? ? ? ? ? ? 141 PHE U C   1 
+ATOM   1105 O O   . PHE A 1 140 ? -8.950  -29.189 -21.742 1.00 26.20  ? ? ? ? ? ? 141 PHE U O   1 
+ATOM   1106 C CB  . PHE A 1 140 ? -9.504  -28.923 -18.973 1.00 27.59  ? ? ? ? ? ? 141 PHE U CB  1 
+ATOM   1107 C CG  . PHE A 1 140 ? -10.409 -28.865 -17.730 1.00 24.53  ? ? ? ? ? ? 141 PHE U CG  1 
+ATOM   1108 C CD1 . PHE A 1 140 ? -11.780 -29.018 -17.842 1.00 25.90  ? ? ? ? ? ? 141 PHE U CD1 1 
+ATOM   1109 C CD2 . PHE A 1 140 ? -9.891  -28.551 -16.482 1.00 27.11  ? ? ? ? ? ? 141 PHE U CD2 1 
+ATOM   1110 C CE1 . PHE A 1 140 ? -12.613 -28.906 -16.733 1.00 24.91  ? ? ? ? ? ? 141 PHE U CE1 1 
+ATOM   1111 C CE2 . PHE A 1 140 ? -10.717 -28.452 -15.356 1.00 25.48  ? ? ? ? ? ? 141 PHE U CE2 1 
+ATOM   1112 C CZ  . PHE A 1 140 ? -12.078 -28.625 -15.484 1.00 24.44  ? ? ? ? ? ? 141 PHE U CZ  1 
+ATOM   1113 N N   . GLY A 1 141 ? -7.996  -31.195 -21.423 1.00 27.17  ? ? ? ? ? ? 142 GLY U N   1 
+ATOM   1114 C CA  . GLY A 1 141 ? -7.219  -31.141 -22.644 1.00 28.31  ? ? ? ? ? ? 142 GLY U CA  1 
+ATOM   1115 C C   . GLY A 1 141 ? -8.114  -31.366 -23.857 1.00 30.98  ? ? ? ? ? ? 142 GLY U C   1 
+ATOM   1116 O O   . GLY A 1 141 ? -9.283  -31.751 -23.740 1.00 26.18  ? ? ? ? ? ? 142 GLY U O   1 
+ATOM   1117 N N   . LYS A 1 142 ? -7.545  -31.163 -25.038 1.00 33.16  ? ? ? ? ? ? 143 LYS U N   1 
+ATOM   1118 C CA  . LYS A 1 142 ? -8.315  -31.304 -26.269 1.00 32.87  ? ? ? ? ? ? 143 LYS U CA  1 
+ATOM   1119 C C   . LYS A 1 142 ? -8.930  -32.665 -26.414 1.00 29.68  ? ? ? ? ? ? 143 LYS U C   1 
+ATOM   1120 O O   . LYS A 1 142 ? -8.353  -33.660 -26.004 1.00 31.54  ? ? ? ? ? ? 143 LYS U O   1 
+ATOM   1121 C CB  . LYS A 1 142 ? -7.442  -31.000 -27.495 1.00 36.13  ? ? ? ? ? ? 143 LYS U CB  1 
+ATOM   1122 C CG  . LYS A 1 142 ? -6.960  -29.562 -27.538 1.00 38.57  ? ? ? ? ? ? 143 LYS U CG  1 
+ATOM   1123 C CD  . LYS A 1 142 ? -6.288  -29.225 -28.869 1.00 40.16  ? ? ? ? ? ? 143 LYS U CD  1 
+ATOM   1124 C CE  . LYS A 1 142 ? -5.867  -27.765 -28.898 1.00 42.91  ? ? ? ? ? ? 143 LYS U CE  1 
+ATOM   1125 N NZ  . LYS A 1 142 ? -4.817  -27.493 -29.925 1.00 45.54  ? ? ? ? ? ? 143 LYS U NZ  1 
+ATOM   1126 N N   . GLU A 1 143 ? -10.112 -32.711 -27.021 1.00 31.87  ? ? ? ? ? ? 144 GLU U N   1 
+ATOM   1127 C CA  . GLU A 1 143 ? -10.760 -33.980 -27.344 1.00 34.55  ? ? ? ? ? ? 144 GLU U CA  1 
+ATOM   1128 C C   . GLU A 1 143 ? -10.281 -34.575 -28.683 1.00 35.87  ? ? ? ? ? ? 144 GLU U C   1 
+ATOM   1129 O O   . GLU A 1 143 ? -10.622 -35.702 -28.988 1.00 36.47  ? ? ? ? ? ? 144 GLU U O   1 
+ATOM   1130 C CB  . GLU A 1 143 ? -12.277 -33.807 -27.395 1.00 35.10  ? ? ? ? ? ? 144 GLU U CB  1 
+ATOM   1131 C CG  . GLU A 1 143 ? -12.880 -33.408 -26.059 1.00 35.77  ? ? ? ? ? ? 144 GLU U CG  1 
+ATOM   1132 C CD  . GLU A 1 143 ? -14.387 -33.415 -26.105 1.00 35.11  ? ? ? ? ? ? 144 GLU U CD  1 
+ATOM   1133 O OE1 . GLU A 1 143 ? -14.967 -32.328 -26.238 1.00 34.58  ? ? ? ? ? ? 144 GLU U OE1 1 
+ATOM   1134 O OE2 . GLU A 1 143 ? -14.975 -34.510 -26.019 1.00 38.13  ? ? ? ? ? ? 144 GLU U OE2 1 
+ATOM   1135 N N   . GLN A 1 144 ? -9.551  -33.789 -29.472 1.00 39.16  ? ? ? ? ? ? 145 GLN U N   1 
+ATOM   1136 C CA  . GLN A 1 144 ? -8.894  -34.240 -30.711 1.00 38.26  ? ? ? ? ? ? 145 GLN U CA  1 
+ATOM   1137 C C   . GLN A 1 144 ? -7.651  -33.392 -30.947 1.00 35.78  ? ? ? ? ? ? 145 GLN U C   1 
+ATOM   1138 O O   . GLN A 1 144 ? -7.672  -32.161 -30.774 1.00 33.16  ? ? ? ? ? ? 145 GLN U O   1 
+ATOM   1139 C CB  . GLN A 1 144 ? -9.828  -34.084 -31.913 1.00 42.28  ? ? ? ? ? ? 145 GLN U CB  1 
+ATOM   1140 C CG  . GLN A 1 144 ? -11.065 -34.971 -31.872 1.00 45.91  ? ? ? ? ? ? 145 GLN U CG  1 
+ATOM   1141 C CD  . GLN A 1 144 ? -12.206 -34.458 -32.735 1.00 56.27  ? ? ? ? ? ? 145 GLN U CD  1 
+ATOM   1142 O OE1 . GLN A 1 144 ? -12.346 -33.248 -32.962 1.00 62.36  ? ? ? ? ? ? 145 GLN U OE1 1 
+ATOM   1143 N NE2 . GLN A 1 144 ? -13.058 -35.377 -33.189 1.00 59.10  ? ? ? ? ? ? 145 GLN U NE2 1 
+ATOM   1144 N N   . SER A 1 145 ? -6.566  -34.038 -31.359 1.00 38.86  ? ? ? ? ? ? 146 SER U N   1 
+ATOM   1145 C CA  . SER A 1 145 ? -5.338  -33.323 -31.762 1.00 44.56  ? ? ? ? ? ? 146 SER U CA  1 
+ATOM   1146 C C   . SER A 1 145 ? -5.593  -32.069 -32.574 1.00 44.02  ? ? ? ? ? ? 146 SER U C   1 
+ATOM   1147 O O   . SER A 1 145 ? -4.931  -31.046 -32.378 1.00 46.62  ? ? ? ? ? ? 146 SER U O   1 
+ATOM   1148 C CB  . SER A 1 145 ? -4.428  -34.236 -32.594 1.00 45.08  ? ? ? ? ? ? 146 SER U CB  1 
+ATOM   1149 O OG  . SER A 1 145 ? -3.396  -34.742 -31.793 1.00 50.15  ? ? ? ? ? ? 146 SER U OG  1 
+ATOM   1150 N N   . THR A 1 146 ? -6.536  -32.168 -33.505 1.00 43.87  ? ? ? ? ? ? 147 THR U N   1 
+ATOM   1151 C CA  . THR A 1 146 ? -6.772  -31.121 -34.489 1.00 44.09  ? ? ? ? ? ? 147 THR U CA  1 
+ATOM   1152 C C   . THR A 1 146 ? -7.676  -29.990 -34.011 1.00 45.34  ? ? ? ? ? ? 147 THR U C   1 
+ATOM   1153 O O   . THR A 1 146 ? -7.843  -28.993 -34.724 1.00 44.92  ? ? ? ? ? ? 147 THR U O   1 
+ATOM   1154 C CB  . THR A 1 146 ? -7.387  -31.740 -35.758 1.00 45.09  ? ? ? ? ? ? 147 THR U CB  1 
+ATOM   1155 O OG1 . THR A 1 146 ? -8.587  -32.444 -35.420 1.00 41.63  ? ? ? ? ? ? 147 THR U OG1 1 
+ATOM   1156 C CG2 . THR A 1 146 ? -6.400  -32.734 -36.381 1.00 46.78  ? ? ? ? ? ? 147 THR U CG2 1 
+ATOM   1157 N N   . ASP A 1 147 ? -8.264  -30.134 -32.821 1.00 42.74  ? ? ? ? ? ? 148 ASP U N   1 
+ATOM   1158 C CA  . ASP A 1 147 ? -9.169  -29.118 -32.290 1.00 42.79  ? ? ? ? ? ? 148 ASP U CA  1 
+ATOM   1159 C C   . ASP A 1 147 ? -8.409  -27.841 -31.951 1.00 41.48  ? ? ? ? ? ? 148 ASP U C   1 
+ATOM   1160 O O   . ASP A 1 147 ? -7.205  -27.856 -31.708 1.00 38.50  ? ? ? ? ? ? 148 ASP U O   1 
+ATOM   1161 C CB  . ASP A 1 147 ? -9.913  -29.620 -31.026 1.00 44.26  ? ? ? ? ? ? 148 ASP U CB  1 
+ATOM   1162 C CG  . ASP A 1 147 ? -10.984 -30.665 -31.332 1.00 43.73  ? ? ? ? ? ? 148 ASP U CG  1 
+ATOM   1163 O OD1 . ASP A 1 147 ? -11.376 -30.808 -32.504 1.00 39.98  ? ? ? ? ? ? 148 ASP U OD1 1 
+ATOM   1164 O OD2 . ASP A 1 147 ? -11.450 -31.348 -30.390 1.00 41.35  ? ? ? ? ? ? 148 ASP U OD2 1 
+ATOM   1165 N N   . TYR A 1 148 ? -9.145  -26.741 -31.956 1.00 42.35  ? ? ? ? ? ? 149 TYR U N   1 
+ATOM   1166 C CA  . TYR A 1 148 ? -8.658  -25.431 -31.555 1.00 48.15  ? ? ? ? ? ? 149 TYR U CA  1 
+ATOM   1167 C C   . TYR A 1 148 ? -9.212  -25.090 -30.167 1.00 44.82  ? ? ? ? ? ? 149 TYR U C   1 
+ATOM   1168 O O   . TYR A 1 148 ? -8.550  -24.421 -29.381 1.00 45.92  ? ? ? ? ? ? 149 TYR U O   1 
+ATOM   1169 C CB  . TYR A 1 148 ? -9.115  -24.393 -32.581 1.00 53.99  ? ? ? ? ? ? 149 TYR U CB  1 
+ATOM   1170 C CG  . TYR A 1 148 ? -8.594  -22.988 -32.363 1.00 67.30  ? ? ? ? ? ? 149 TYR U CG  1 
+ATOM   1171 C CD1 . TYR A 1 148 ? -7.296  -22.632 -32.743 1.00 72.59  ? ? ? ? ? ? 149 TYR U CD1 1 
+ATOM   1172 C CD2 . TYR A 1 148 ? -9.411  -21.997 -31.805 1.00 75.78  ? ? ? ? ? ? 149 TYR U CD2 1 
+ATOM   1173 C CE1 . TYR A 1 148 ? -6.821  -21.337 -32.553 1.00 78.23  ? ? ? ? ? ? 149 TYR U CE1 1 
+ATOM   1174 C CE2 . TYR A 1 148 ? -8.947  -20.698 -31.614 1.00 78.28  ? ? ? ? ? ? 149 TYR U CE2 1 
+ATOM   1175 C CZ  . TYR A 1 148 ? -7.652  -20.372 -31.987 1.00 78.98  ? ? ? ? ? ? 149 TYR U CZ  1 
+ATOM   1176 O OH  . TYR A 1 148 ? -7.189  -19.088 -31.797 1.00 79.95  ? ? ? ? ? ? 149 TYR U OH  1 
+ATOM   1177 N N   . LEU A 1 149 ? -10.422 -25.560 -29.870 1.00 43.17  ? ? ? ? ? ? 150 LEU U N   1 
+ATOM   1178 C CA  . LEU A 1 149 ? -11.048 -25.318 -28.573 1.00 42.24  ? ? ? ? ? ? 150 LEU U CA  1 
+ATOM   1179 C C   . LEU A 1 149 ? -10.788 -26.442 -27.563 1.00 40.09  ? ? ? ? ? ? 150 LEU U C   1 
+ATOM   1180 O O   . LEU A 1 149 ? -10.355 -27.558 -27.922 1.00 34.76  ? ? ? ? ? ? 150 LEU U O   1 
+ATOM   1181 C CB  . LEU A 1 149 ? -12.546 -25.108 -28.762 1.00 47.45  ? ? ? ? ? ? 150 LEU U CB  1 
+ATOM   1182 C CG  . LEU A 1 149 ? -12.935 -23.958 -29.703 1.00 49.63  ? ? ? ? ? ? 150 LEU U CG  1 
+ATOM   1183 C CD1 . LEU A 1 149 ? -14.432 -23.957 -29.964 1.00 52.12  ? ? ? ? ? ? 150 LEU U CD1 1 
+ATOM   1184 C CD2 . LEU A 1 149 ? -12.495 -22.620 -29.124 1.00 52.03  ? ? ? ? ? ? 150 LEU U CD2 1 
+ATOM   1185 N N   . TYR A 1 150 ? -11.037 -26.130 -26.291 1.00 34.40  ? ? ? ? ? ? 151 TYR U N   1 
+ATOM   1186 C CA  . TYR A 1 150 ? -10.911 -27.100 -25.211 1.00 35.83  ? ? ? ? ? ? 151 TYR U CA  1 
+ATOM   1187 C C   . TYR A 1 150 ? -12.288 -27.368 -24.627 1.00 32.78  ? ? ? ? ? ? 151 TYR U C   1 
+ATOM   1188 O O   . TYR A 1 150 ? -13.167 -26.504 -24.696 1.00 30.24  ? ? ? ? ? ? 151 TYR U O   1 
+ATOM   1189 C CB  . TYR A 1 150 ? -9.958  -26.586 -24.133 1.00 35.82  ? ? ? ? ? ? 151 TYR U CB  1 
+ATOM   1190 C CG  . TYR A 1 150 ? -8.550  -26.444 -24.649 1.00 37.87  ? ? ? ? ? ? 151 TYR U CG  1 
+ATOM   1191 C CD1 . TYR A 1 150 ? -8.174  -25.324 -25.378 1.00 39.44  ? ? ? ? ? ? 151 TYR U CD1 1 
+ATOM   1192 C CD2 . TYR A 1 150 ? -7.592  -27.418 -24.406 1.00 38.18  ? ? ? ? ? ? 151 TYR U CD2 1 
+ATOM   1193 C CE1 . TYR A 1 150 ? -6.882  -25.178 -25.859 1.00 40.53  ? ? ? ? ? ? 151 TYR U CE1 1 
+ATOM   1194 C CE2 . TYR A 1 150 ? -6.299  -27.287 -24.882 1.00 37.97  ? ? ? ? ? ? 151 TYR U CE2 1 
+ATOM   1195 C CZ  . TYR A 1 150 ? -5.949  -26.165 -25.609 1.00 41.92  ? ? ? ? ? ? 151 TYR U CZ  1 
+ATOM   1196 O OH  . TYR A 1 150 ? -4.672  -26.020 -26.095 1.00 40.49  ? ? ? ? ? ? 151 TYR U OH  1 
+ATOM   1197 N N   . PRO A 1 151 ? -12.501 -28.589 -24.105 1.00 30.49  ? ? ? ? ? ? 152 PRO U N   1 
+ATOM   1198 C CA  . PRO A 1 151 ? -13.820 -28.907 -23.600 1.00 31.36  ? ? ? ? ? ? 152 PRO U CA  1 
+ATOM   1199 C C   . PRO A 1 151 ? -14.097 -28.097 -22.340 1.00 30.71  ? ? ? ? ? ? 152 PRO U C   1 
+ATOM   1200 O O   . PRO A 1 151 ? -13.140 -27.703 -21.644 1.00 28.82  ? ? ? ? ? ? 152 PRO U O   1 
+ATOM   1201 C CB  . PRO A 1 151 ? -13.747 -30.410 -23.309 1.00 31.11  ? ? ? ? ? ? 152 PRO U CB  1 
+ATOM   1202 C CG  . PRO A 1 151 ? -12.294 -30.703 -23.147 1.00 32.17  ? ? ? ? ? ? 152 PRO U CG  1 
+ATOM   1203 C CD  . PRO A 1 151 ? -11.618 -29.763 -24.104 1.00 32.55  ? ? ? ? ? ? 152 PRO U CD  1 
+ATOM   1204 N N   . GLU A 1 152 ? -15.372 -27.810 -22.086 1.00 29.22  ? ? ? ? ? ? 153 GLU U N   1 
+ATOM   1205 C CA  . GLU A 1 152 ? -15.755 -27.014 -20.908 1.00 32.47  ? ? ? ? ? ? 153 GLU U CA  1 
+ATOM   1206 C C   . GLU A 1 152 ? -15.900 -27.901 -19.671 1.00 28.25  ? ? ? ? ? ? 153 GLU U C   1 
+ATOM   1207 O O   . GLU A 1 152 ? -15.680 -27.454 -18.553 1.00 31.16  ? ? ? ? ? ? 153 GLU U O   1 
+ATOM   1208 C CB  . GLU A 1 152 ? -17.035 -26.212 -21.172 1.00 35.26  ? ? ? ? ? ? 153 GLU U CB  1 
+ATOM   1209 C CG  . GLU A 1 152 ? -16.861 -24.702 -20.960 1.00 45.25  ? ? ? ? ? ? 153 GLU U CG  1 
+ATOM   1210 C CD  . GLU A 1 152 ? -17.149 -24.235 -19.528 1.00 49.45  ? ? ? ? ? ? 153 GLU U CD  1 
+ATOM   1211 O OE1 . GLU A 1 152 ? -16.209 -23.983 -18.755 1.00 49.01  ? ? ? ? ? ? 153 GLU U OE1 1 
+ATOM   1212 O OE2 . GLU A 1 152 ? -18.337 -24.098 -19.181 1.00 59.35  ? ? ? ? ? ? 153 GLU U OE2 1 
+ATOM   1213 N N   . GLN A 1 153 ? -16.218 -29.165 -19.889 1.00 28.98  ? ? ? ? ? ? 154 GLN U N   1 
+ATOM   1214 C CA  . GLN A 1 153 ? -16.411 -30.134 -18.818 1.00 30.62  ? ? ? ? ? ? 154 GLN U CA  1 
+ATOM   1215 C C   . GLN A 1 153 ? -15.181 -31.040 -18.694 1.00 30.90  ? ? ? ? ? ? 154 GLN U C   1 
+ATOM   1216 O O   . GLN A 1 153 ? -14.579 -31.455 -19.684 1.00 27.99  ? ? ? ? ? ? 154 GLN U O   1 
+ATOM   1217 C CB  . GLN A 1 153 ? -17.671 -30.965 -19.112 1.00 28.97  ? ? ? ? ? ? 154 GLN U CB  1 
+ATOM   1218 C CG  . GLN A 1 153 ? -18.155 -31.875 -17.990 1.00 30.36  ? ? ? ? ? ? 154 GLN U CG  1 
+ATOM   1219 C CD  . GLN A 1 153 ? -18.622 -31.139 -16.751 1.00 30.09  ? ? ? ? ? ? 154 GLN U CD  1 
+ATOM   1220 O OE1 . GLN A 1 153 ? -19.099 -30.004 -16.827 1.00 28.33  ? ? ? ? ? ? 154 GLN U OE1 1 
+ATOM   1221 N NE2 . GLN A 1 153 ? -18.465 -31.781 -15.581 1.00 29.02  ? ? ? ? ? ? 154 GLN U NE2 1 
+ATOM   1222 N N   . LEU A 1 154 ? -14.831 -31.361 -17.460 1.00 29.24  ? ? ? ? ? ? 155 LEU U N   1 
+ATOM   1223 C CA  . LEU A 1 154 ? -13.744 -32.290 -17.198 1.00 27.12  ? ? ? ? ? ? 155 LEU U CA  1 
+ATOM   1224 C C   . LEU A 1 154 ? -13.997 -33.645 -17.822 1.00 26.10  ? ? ? ? ? ? 155 LEU U C   1 
+ATOM   1225 O O   . LEU A 1 154 ? -15.111 -34.165 -17.770 1.00 29.26  ? ? ? ? ? ? 155 LEU U O   1 
+ATOM   1226 C CB  . LEU A 1 154 ? -13.591 -32.455 -15.682 1.00 27.00  ? ? ? ? ? ? 155 LEU U CB  1 
+ATOM   1227 C CG  . LEU A 1 154 ? -12.393 -33.237 -15.159 1.00 25.93  ? ? ? ? ? ? 155 LEU U CG  1 
+ATOM   1228 C CD1 . LEU A 1 154 ? -11.061 -32.552 -15.495 1.00 24.96  ? ? ? ? ? ? 155 LEU U CD1 1 
+ATOM   1229 C CD2 . LEU A 1 154 ? -12.602 -33.370 -13.649 1.00 28.19  ? ? ? ? ? ? 155 LEU U CD2 1 
+ATOM   1230 N N   . LYS A 1 155 ? -12.944 -34.259 -18.339 1.00 25.91  ? ? ? ? ? ? 156 LYS U N   1 
+ATOM   1231 C CA  . LYS A 1 155 ? -13.004 -35.638 -18.793 1.00 25.80  ? ? ? ? ? ? 156 LYS U CA  1 
+ATOM   1232 C C   . LYS A 1 155 ? -11.982 -36.564 -18.131 1.00 24.15  ? ? ? ? ? ? 156 LYS U C   1 
+ATOM   1233 O O   . LYS A 1 155 ? -10.993 -36.117 -17.571 1.00 24.53  ? ? ? ? ? ? 156 LYS U O   1 
+ATOM   1234 C CB  . LYS A 1 155 ? -12.719 -35.686 -20.296 1.00 26.48  ? ? ? ? ? ? 156 LYS U CB  1 
+ATOM   1235 C CG  . LYS A 1 155 ? -13.726 -34.952 -21.174 1.00 28.36  ? ? ? ? ? ? 156 LYS U CG  1 
+ATOM   1236 C CD  . LYS A 1 155 ? -13.372 -35.098 -22.654 1.00 29.65  ? ? ? ? ? ? 156 LYS U CD  1 
+ATOM   1237 C CE  . LYS A 1 155 ? -13.901 -36.391 -23.269 1.00 31.11  ? ? ? ? ? ? 156 LYS U CE  1 
+ATOM   1238 N NZ  . LYS A 1 155 ? -13.273 -36.663 -24.607 1.00 34.73  ? ? ? ? ? ? 156 LYS U NZ  1 
+ATOM   1239 N N   . MET A 1 156 ? -12.216 -37.858 -18.260 1.00 27.40  ? ? ? ? ? ? 157 MET U N   1 
+ATOM   1240 C CA  . MET A 1 156 ? -11.259 -38.894 -17.867 1.00 31.33  ? ? ? ? ? ? 157 MET U CA  1 
+ATOM   1241 C C   . MET A 1 156 ? -11.330 -40.085 -18.813 1.00 31.61  ? ? ? ? ? ? 157 MET U C   1 
+ATOM   1242 O O   . MET A 1 156 ? -12.314 -40.265 -19.532 1.00 32.01  ? ? ? ? ? ? 157 MET U O   1 
+ATOM   1243 C CB  . MET A 1 156 ? -11.523 -39.375 -16.438 1.00 35.87  ? ? ? ? ? ? 157 MET U CB  1 
+ATOM   1244 C CG  . MET A 1 156 ? -12.868 -40.041 -16.216 1.00 44.32  ? ? ? ? ? ? 157 MET U CG  1 
+ATOM   1245 S SD  . MET A 1 156 ? -13.024 -40.704 -14.528 1.00 60.90  ? ? ? ? ? ? 157 MET U SD  1 
+ATOM   1246 C CE  . MET A 1 156 ? -11.749 -41.966 -14.561 1.00 56.17  ? ? ? ? ? ? 157 MET U CE  1 
+ATOM   1247 N N   . THR A 1 157 ? -10.312 -40.930 -18.765 1.00 31.24  ? ? ? ? ? ? 158 THR U N   1 
+ATOM   1248 C CA  . THR A 1 157 ? -10.303 -42.146 -19.561 1.00 33.50  ? ? ? ? ? ? 158 THR U CA  1 
+ATOM   1249 C C   . THR A 1 157 ? -9.359  -43.146 -18.917 1.00 35.48  ? ? ? ? ? ? 158 THR U C   1 
+ATOM   1250 O O   . THR A 1 157 ? -8.731  -42.835 -17.923 1.00 32.95  ? ? ? ? ? ? 158 THR U O   1 
+ATOM   1251 C CB  . THR A 1 157 ? -9.911  -41.861 -21.032 1.00 34.92  ? ? ? ? ? ? 158 THR U CB  1 
+ATOM   1252 O OG1 . THR A 1 157 ? -10.122 -43.034 -21.832 1.00 35.42  ? ? ? ? ? ? 158 THR U OG1 1 
+ATOM   1253 C CG2 . THR A 1 157 ? -8.465  -41.384 -21.143 1.00 35.28  ? ? ? ? ? ? 158 THR U CG2 1 
+ATOM   1254 N N   . VAL A 1 158 ? -9.290  -44.351 -19.477 1.00 36.79  ? ? ? ? ? ? 159 VAL U N   1 
+ATOM   1255 C CA  . VAL A 1 158 ? -8.449  -45.403 -18.942 1.00 38.37  ? ? ? ? ? ? 159 VAL U CA  1 
+ATOM   1256 C C   . VAL A 1 158 ? -7.417  -45.802 -20.002 1.00 39.28  ? ? ? ? ? ? 159 VAL U C   1 
+ATOM   1257 O O   . VAL A 1 158 ? -7.732  -45.920 -21.193 1.00 34.81  ? ? ? ? ? ? 159 VAL U O   1 
+ATOM   1258 C CB  . VAL A 1 158 ? -9.295  -46.618 -18.446 1.00 39.88  ? ? ? ? ? ? 159 VAL U CB  1 
+ATOM   1259 C CG1 . VAL A 1 158 ? -8.405  -47.798 -18.034 1.00 38.15  ? ? ? ? ? ? 159 VAL U CG1 1 
+ATOM   1260 C CG2 . VAL A 1 158 ? -10.162 -46.184 -17.269 1.00 39.06  ? ? ? ? ? ? 159 VAL U CG2 1 
+ATOM   1261 N N   . VAL A 1 159 ? -6.175  -45.953 -19.546 1.00 42.59  ? ? ? ? ? ? 160 VAL U N   1 
+ATOM   1262 C CA  . VAL A 1 159 ? -5.066  -46.410 -20.378 1.00 41.57  ? ? ? ? ? ? 160 VAL U CA  1 
+ATOM   1263 C C   . VAL A 1 159 ? -4.286  -47.465 -19.602 1.00 43.83  ? ? ? ? ? ? 160 VAL U C   1 
+ATOM   1264 O O   . VAL A 1 159 ? -4.388  -47.544 -18.371 1.00 41.98  ? ? ? ? ? ? 160 VAL U O   1 
+ATOM   1265 C CB  . VAL A 1 159 ? -4.122  -45.259 -20.782 1.00 41.45  ? ? ? ? ? ? 160 VAL U CB  1 
+ATOM   1266 C CG1 . VAL A 1 159 ? -4.735  -44.459 -21.924 1.00 39.83  ? ? ? ? ? ? 160 VAL U CG1 1 
+ATOM   1267 C CG2 . VAL A 1 159 ? -3.797  -44.373 -19.586 1.00 41.56  ? ? ? ? ? ? 160 VAL U CG2 1 
+ATOM   1268 N N   . LYS A 1 160 ? -3.519  -48.275 -20.329 1.00 41.48  ? ? ? ? ? ? 161 LYS U N   1 
+ATOM   1269 C CA  . LYS A 1 160 ? -2.715  -49.308 -19.719 1.00 43.76  ? ? ? ? ? ? 161 LYS U CA  1 
+ATOM   1270 C C   . LYS A 1 160 ? -1.236  -48.964 -19.824 1.00 44.55  ? ? ? ? ? ? 161 LYS U C   1 
+ATOM   1271 O O   . LYS A 1 160 ? -0.768  -48.522 -20.881 1.00 44.98  ? ? ? ? ? ? 161 LYS U O   1 
+ATOM   1272 C CB  . LYS A 1 160 ? -2.991  -50.659 -20.382 1.00 48.39  ? ? ? ? ? ? 161 LYS U CB  1 
+ATOM   1273 C CG  . LYS A 1 160 ? -4.424  -51.145 -20.186 1.00 50.56  ? ? ? ? ? ? 161 LYS U CG  1 
+ATOM   1274 C CD  . LYS A 1 160 ? -4.584  -52.622 -20.529 1.00 52.38  ? ? ? ? ? ? 161 LYS U CD  1 
+ATOM   1275 C CE  . LYS A 1 160 ? -5.994  -53.123 -20.235 1.00 52.81  ? ? ? ? ? ? 161 LYS U CE  1 
+ATOM   1276 N NZ  . LYS A 1 160 ? -6.096  -54.614 -20.250 1.00 52.79  ? ? ? ? ? ? 161 LYS U NZ  1 
+ATOM   1277 N N   . LEU A 1 161 ? -0.519  -49.158 -18.719 1.00 40.16  ? ? ? ? ? ? 162 LEU U N   1 
+ATOM   1278 C CA  . LEU A 1 161 ? 0.927   -49.008 -18.685 1.00 45.27  ? ? ? ? ? ? 162 LEU U CA  1 
+ATOM   1279 C C   . LEU A 1 161 ? 1.568   -49.926 -19.704 1.00 47.69  ? ? ? ? ? ? 162 LEU U C   1 
+ATOM   1280 O O   . LEU A 1 161 ? 1.138   -51.077 -19.888 1.00 42.70  ? ? ? ? ? ? 162 LEU U O   1 
+ATOM   1281 C CB  . LEU A 1 161 ? 1.475   -49.340 -17.292 1.00 46.19  ? ? ? ? ? ? 162 LEU U CB  1 
+ATOM   1282 C CG  . LEU A 1 161 ? 1.567   -48.207 -16.258 1.00 48.56  ? ? ? ? ? ? 162 LEU U CG  1 
+ATOM   1283 C CD1 . LEU A 1 161 ? 0.644   -47.030 -16.548 1.00 50.54  ? ? ? ? ? ? 162 LEU U CD1 1 
+ATOM   1284 C CD2 . LEU A 1 161 ? 1.318   -48.749 -14.863 1.00 47.68  ? ? ? ? ? ? 162 LEU U CD2 1 
+ATOM   1285 N N   . ILE A 1 162 ? 2.592   -49.400 -20.367 1.00 50.90  ? ? ? ? ? ? 163 ILE U N   1 
+ATOM   1286 C CA  . ILE A 1 162 ? 3.314   -50.127 -21.401 1.00 53.56  ? ? ? ? ? ? 163 ILE U CA  1 
+ATOM   1287 C C   . ILE A 1 162 ? 4.718   -50.419 -20.880 1.00 53.46  ? ? ? ? ? ? 163 ILE U C   1 
+ATOM   1288 O O   . ILE A 1 162 ? 5.267   -49.659 -20.071 1.00 54.05  ? ? ? ? ? ? 163 ILE U O   1 
+ATOM   1289 C CB  . ILE A 1 162 ? 3.349   -49.324 -22.724 1.00 55.10  ? ? ? ? ? ? 163 ILE U CB  1 
+ATOM   1290 C CG1 . ILE A 1 162 ? 1.933   -49.203 -23.291 1.00 57.74  ? ? ? ? ? ? 163 ILE U CG1 1 
+ATOM   1291 C CG2 . ILE A 1 162 ? 4.247   -50.000 -23.754 1.00 55.65  ? ? ? ? ? ? 163 ILE U CG2 1 
+ATOM   1292 C CD1 . ILE A 1 162 ? 1.751   -48.063 -24.272 1.00 59.80  ? ? ? ? ? ? 163 ILE U CD1 1 
+ATOM   1293 N N   . SER A 1 163 ? 5.283   -51.539 -21.321 1.00 51.93  ? ? ? ? ? ? 164 SER U N   1 
+ATOM   1294 C CA  . SER A 1 163 ? 6.615   -51.939 -20.881 1.00 54.46  ? ? ? ? ? ? 164 SER U CA  1 
+ATOM   1295 C C   . SER A 1 163 ? 7.647   -50.967 -21.428 1.00 52.15  ? ? ? ? ? ? 164 SER U C   1 
+ATOM   1296 O O   . SER A 1 163 ? 7.493   -50.410 -22.518 1.00 54.35  ? ? ? ? ? ? 164 SER U O   1 
+ATOM   1297 C CB  . SER A 1 163 ? 6.940   -53.368 -21.324 1.00 50.19  ? ? ? ? ? ? 164 SER U CB  1 
+ATOM   1298 O OG  . SER A 1 163 ? 7.176   -53.418 -22.724 1.00 49.75  ? ? ? ? ? ? 164 SER U OG  1 
+ATOM   1299 N N   . HIS A 1 164 ? 8.735   -50.793 -20.740 1.00 56.45  ? ? ? ? ? ? 165 HIS U N   1 
+ATOM   1300 C CA  . HIS A 1 164 ? 9.777   -49.985 -21.314 1.00 67.84  ? ? ? ? ? ? 165 HIS U CA  1 
+ATOM   1301 C C   . HIS A 1 164 ? 10.307  -50.540 -22.621 1.00 68.26  ? ? ? ? ? ? 165 HIS U C   1 
+ATOM   1302 O O   . HIS A 1 164 ? 10.509  -49.827 -23.574 1.00 68.60  ? ? ? ? ? ? 165 HIS U O   1 
+ATOM   1303 C CB  . HIS A 1 164 ? 10.908  -49.848 -20.325 1.00 70.86  ? ? ? ? ? ? 165 HIS U CB  1 
+ATOM   1304 C CG  . HIS A 1 164 ? 10.794  -48.616 -19.519 1.00 80.16  ? ? ? ? ? ? 165 HIS U CG  1 
+ATOM   1305 N ND1 . HIS A 1 164 ? 10.983  -47.367 -20.061 1.00 85.61  ? ? ? ? ? ? 165 HIS U ND1 1 
+ATOM   1306 C CD2 . HIS A 1 164 ? 10.415  -48.420 -18.239 1.00 84.15  ? ? ? ? ? ? 165 HIS U CD2 1 
+ATOM   1307 C CE1 . HIS A 1 164 ? 10.752  -46.455 -19.137 1.00 88.15  ? ? ? ? ? ? 165 HIS U CE1 1 
+ATOM   1308 N NE2 . HIS A 1 164 ? 10.415  -47.067 -18.021 1.00 89.48  ? ? ? ? ? ? 165 HIS U NE2 1 
+ATOM   1309 N N   . ARG A 1 165 ? 10.468  -51.837 -22.669 1.00 69.35  ? ? ? ? ? ? 166 ARG U N   1 
+ATOM   1310 C CA  . ARG A 1 165 ? 10.995  -52.476 -23.833 1.00 71.94  ? ? ? ? ? ? 166 ARG U CA  1 
+ATOM   1311 C C   . ARG A 1 165 ? 10.086  -52.206 -24.980 1.00 69.85  ? ? ? ? ? ? 166 ARG U C   1 
+ATOM   1312 O O   . ARG A 1 165 ? 10.549  -51.964 -26.081 1.00 71.36  ? ? ? ? ? ? 166 ARG U O   1 
+ATOM   1313 C CB  . ARG A 1 165 ? 11.059  -53.988 -23.603 1.00 74.16  ? ? ? ? ? ? 166 ARG U CB  1 
+ATOM   1314 C CG  . ARG A 1 165 ? 11.232  -54.808 -24.858 1.00 78.74  ? ? ? ? ? ? 166 ARG U CG  1 
+ATOM   1315 C CD  . ARG A 1 165 ? 10.086  -55.770 -25.053 1.00 81.19  ? ? ? ? ? ? 166 ARG U CD  1 
+ATOM   1316 N NE  . ARG A 1 165 ? 10.458  -57.081 -24.569 1.00 84.43  ? ? ? ? ? ? 166 ARG U NE  1 
+ATOM   1317 C CZ  . ARG A 1 165 ? 10.372  -58.196 -25.278 1.00 89.36  ? ? ? ? ? ? 166 ARG U CZ  1 
+ATOM   1318 N NH1 . ARG A 1 165 ? 9.900   -58.157 -26.513 1.00 91.97  ? ? ? ? ? ? 166 ARG U NH1 1 
+ATOM   1319 N NH2 . ARG A 1 165 ? 10.740  -59.351 -24.742 1.00 89.42  ? ? ? ? ? ? 166 ARG U NH2 1 
+ATOM   1320 N N   . GLU A 1 166 ? 8.801   -52.309 -24.748 1.00 67.25  ? ? ? ? ? ? 167 GLU U N   1 
+ATOM   1321 C CA  . GLU A 1 166 ? 7.935   -52.032 -25.823 1.00 63.86  ? ? ? ? ? ? 167 GLU U CA  1 
+ATOM   1322 C C   . GLU A 1 166 ? 8.146   -50.590 -26.153 1.00 63.77  ? ? ? ? ? ? 167 GLU U C   1 
+ATOM   1323 O O   . GLU A 1 166 ? 8.217   -50.225 -27.292 1.00 64.60  ? ? ? ? ? ? 167 GLU U O   1 
+ATOM   1324 C CB  . GLU A 1 166 ? 6.496   -52.282 -25.463 1.00 65.00  ? ? ? ? ? ? 167 GLU U CB  1 
+ATOM   1325 C CG  . GLU A 1 166 ? 5.627   -52.295 -26.701 1.00 67.37  ? ? ? ? ? ? 167 GLU U CG  1 
+ATOM   1326 C CD  . GLU A 1 166 ? 4.155   -52.382 -26.426 1.00 71.06  ? ? ? ? ? ? 167 GLU U CD  1 
+ATOM   1327 O OE1 . GLU A 1 166 ? 3.774   -52.966 -25.403 1.00 71.41  ? ? ? ? ? ? 167 GLU U OE1 1 
+ATOM   1328 O OE2 . GLU A 1 166 ? 3.377   -51.860 -27.246 1.00 74.75  ? ? ? ? ? ? 167 GLU U OE2 1 
+ATOM   1329 N N   . CYS A 1 167 ? 8.234   -49.759 -25.138 1.00 62.45  ? ? ? ? ? ? 168 CYS U N   1 
+ATOM   1330 C CA  . CYS A 1 167 ? 8.249   -48.335 -25.364 1.00 62.23  ? ? ? ? ? ? 168 CYS U CA  1 
+ATOM   1331 C C   . CYS A 1 167 ? 9.440   -47.851 -26.140 1.00 61.76  ? ? ? ? ? ? 168 CYS U C   1 
+ATOM   1332 O O   . CYS A 1 167 ? 9.331   -46.913 -26.882 1.00 57.53  ? ? ? ? ? ? 168 CYS U O   1 
+ATOM   1333 C CB  . CYS A 1 167 ? 8.050   -47.535 -24.093 1.00 59.94  ? ? ? ? ? ? 168 CYS U CB  1 
+ATOM   1334 S SG  . CYS A 1 167 ? 7.015   -46.133 -24.463 1.00 62.94  ? ? ? ? ? ? 168 CYS U SG  1 
+ATOM   1335 N N   . GLN A 1 168 ? 10.564  -48.512 -25.946 1.00 63.74  ? ? ? ? ? ? 169 GLN U N   1 
+ATOM   1336 C CA  . GLN A 1 168 ? 11.835  -48.156 -26.553 1.00 66.75  ? ? ? ? ? ? 169 GLN U CA  1 
+ATOM   1337 C C   . GLN A 1 168 ? 11.978  -48.704 -27.962 1.00 69.12  ? ? ? ? ? ? 169 GLN U C   1 
+ATOM   1338 O O   . GLN A 1 168 ? 13.020  -48.608 -28.551 1.00 66.73  ? ? ? ? ? ? 169 GLN U O   1 
+ATOM   1339 C CB  . GLN A 1 168 ? 13.000  -48.633 -25.710 1.00 68.82  ? ? ? ? ? ? 169 GLN U CB  1 
+ATOM   1340 C CG  . GLN A 1 168 ? 13.274  -47.776 -24.498 1.00 74.80  ? ? ? ? ? ? 169 GLN U CG  1 
+ATOM   1341 C CD  . GLN A 1 168 ? 13.157  -48.537 -23.185 1.00 79.76  ? ? ? ? ? ? 169 GLN U CD  1 
+ATOM   1342 O OE1 . GLN A 1 168 ? 12.889  -49.736 -23.160 1.00 81.85  ? ? ? ? ? ? 169 GLN U OE1 1 
+ATOM   1343 N NE2 . GLN A 1 168 ? 13.368  -47.835 -22.085 1.00 81.00  ? ? ? ? ? ? 169 GLN U NE2 1 
+ATOM   1344 N N   . GLN A 1 169 ? 10.941  -49.334 -28.468 1.00 72.71  ? ? ? ? ? ? 170 GLN U N   1 
+ATOM   1345 C CA  . GLN A 1 169 ? 10.926  -49.774 -29.839 1.00 72.39  ? ? ? ? ? ? 170 GLN U CA  1 
+ATOM   1346 C C   . GLN A 1 169 ? 10.944  -48.635 -30.826 1.00 72.96  ? ? ? ? ? ? 170 GLN U C   1 
+ATOM   1347 O O   . GLN A 1 169 ? 10.348  -47.605 -30.616 1.00 72.34  ? ? ? ? ? ? 170 GLN U O   1 
+ATOM   1348 C CB  . GLN A 1 169 ? 9.694   -50.586 -30.109 1.00 75.02  ? ? ? ? ? ? 170 GLN U CB  1 
+ATOM   1349 C CG  . GLN A 1 169 ? 9.710   -51.986 -29.560 1.00 76.78  ? ? ? ? ? ? 170 GLN U CG  1 
+ATOM   1350 C CD  . GLN A 1 169 ? 8.570   -52.791 -30.111 1.00 76.82  ? ? ? ? ? ? 170 GLN U CD  1 
+ATOM   1351 O OE1 . GLN A 1 169 ? 7.503   -52.266 -30.384 1.00 79.40  ? ? ? ? ? ? 170 GLN U OE1 1 
+ATOM   1352 N NE2 . GLN A 1 169 ? 8.783   -54.073 -30.258 1.00 76.80  ? ? ? ? ? ? 170 GLN U NE2 1 
+ATOM   1353 N N   . PRO A 1 170 A 11.682  -48.888 -31.988 1.00 93.83  ? ? ? ? ? ? 170 PRO U N   1 
+ATOM   1354 C CA  . PRO A 1 170 A 11.828  -47.726 -32.870 1.00 97.45  ? ? ? ? ? ? 170 PRO U CA  1 
+ATOM   1355 C C   . PRO A 1 170 A 10.541  -47.213 -33.469 1.00 97.89  ? ? ? ? ? ? 170 PRO U C   1 
+ATOM   1356 O O   . PRO A 1 170 A 10.437  -46.039 -33.668 1.00 106.92 ? ? ? ? ? ? 170 PRO U O   1 
+ATOM   1357 C CB  . PRO A 1 170 A 12.800  -48.208 -33.955 1.00 97.74  ? ? ? ? ? ? 170 PRO U CB  1 
+ATOM   1358 C CG  . PRO A 1 170 A 13.569  -49.297 -33.326 1.00 96.65  ? ? ? ? ? ? 170 PRO U CG  1 
+ATOM   1359 C CD  . PRO A 1 170 A 12.466  -50.027 -32.674 1.00 94.64  ? ? ? ? ? ? 170 PRO U CD  1 
+ATOM   1360 N N   . HIS A 1 171 B 9.612   -48.075 -33.809 1.00 55.07  ? ? ? ? ? ? 170 HIS U N   1 
+ATOM   1361 C CA  . HIS A 1 171 B 8.349   -47.606 -34.315 1.00 62.48  ? ? ? ? ? ? 170 HIS U CA  1 
+ATOM   1362 C C   . HIS A 1 171 B 7.492   -46.961 -33.178 1.00 59.71  ? ? ? ? ? ? 170 HIS U C   1 
+ATOM   1363 O O   . HIS A 1 171 B 6.510   -46.296 -33.442 1.00 55.93  ? ? ? ? ? ? 170 HIS U O   1 
+ATOM   1364 C CB  . HIS A 1 171 B 7.664   -48.664 -35.174 1.00 62.91  ? ? ? ? ? ? 170 HIS U CB  1 
+ATOM   1365 C CG  . HIS A 1 171 B 7.301   -49.896 -34.431 1.00 67.40  ? ? ? ? ? ? 170 HIS U CG  1 
+ATOM   1366 N ND1 . HIS A 1 171 B 8.127   -50.461 -33.495 1.00 67.21  ? ? ? ? ? ? 170 HIS U ND1 1 
+ATOM   1367 C CD2 . HIS A 1 171 B 6.193   -50.663 -34.474 1.00 69.20  ? ? ? ? ? ? 170 HIS U CD2 1 
+ATOM   1368 C CE1 . HIS A 1 171 B 7.539   -51.521 -32.983 1.00 69.84  ? ? ? ? ? ? 170 HIS U CE1 1 
+ATOM   1369 N NE2 . HIS A 1 171 B 6.368   -51.669 -33.566 1.00 71.65  ? ? ? ? ? ? 170 HIS U NE2 1 
+ATOM   1370 N N   . TYR A 1 172 ? 7.894   -47.157 -31.928 1.00 57.86  ? ? ? ? ? ? 171 TYR U N   1 
+ATOM   1371 C CA  . TYR A 1 172 ? 7.379   -46.346 -30.833 1.00 57.93  ? ? ? ? ? ? 171 TYR U CA  1 
+ATOM   1372 C C   . TYR A 1 172 ? 8.220   -45.097 -30.624 1.00 57.29  ? ? ? ? ? ? 171 TYR U C   1 
+ATOM   1373 O O   . TYR A 1 172 ? 8.215   -44.222 -31.447 1.00 57.94  ? ? ? ? ? ? 171 TYR U O   1 
+ATOM   1374 C CB  . TYR A 1 172 ? 7.322   -47.114 -29.543 1.00 57.50  ? ? ? ? ? ? 171 TYR U CB  1 
+ATOM   1375 C CG  . TYR A 1 172 ? 6.188   -48.080 -29.478 1.00 57.71  ? ? ? ? ? ? 171 TYR U CG  1 
+ATOM   1376 C CD1 . TYR A 1 172 ? 5.706   -48.674 -30.612 1.00 60.53  ? ? ? ? ? ? 171 TYR U CD1 1 
+ATOM   1377 C CD2 . TYR A 1 172 ? 5.607   -48.400 -28.284 1.00 58.76  ? ? ? ? ? ? 171 TYR U CD2 1 
+ATOM   1378 C CE1 . TYR A 1 172 ? 4.667   -49.566 -30.563 1.00 61.80  ? ? ? ? ? ? 171 TYR U CE1 1 
+ATOM   1379 C CE2 . TYR A 1 172 ? 4.571   -49.292 -28.213 1.00 60.92  ? ? ? ? ? ? 171 TYR U CE2 1 
+ATOM   1380 C CZ  . TYR A 1 172 ? 4.101   -49.876 -29.358 1.00 61.96  ? ? ? ? ? ? 171 TYR U CZ  1 
+ATOM   1381 O OH  . TYR A 1 172 ? 3.068   -50.757 -29.297 1.00 60.68  ? ? ? ? ? ? 171 TYR U OH  1 
+ATOM   1382 N N   . TYR A 1 173 ? 8.940   -45.009 -29.528 1.00 54.61  ? ? ? ? ? ? 172 TYR U N   1 
+ATOM   1383 C CA  . TYR A 1 173 ? 9.700   -43.803 -29.285 1.00 57.83  ? ? ? ? ? ? 172 TYR U CA  1 
+ATOM   1384 C C   . TYR A 1 173 ? 11.201  -43.994 -29.329 1.00 59.42  ? ? ? ? ? ? 172 TYR U C   1 
+ATOM   1385 O O   . TYR A 1 173 ? 11.952  -43.037 -29.301 1.00 57.54  ? ? ? ? ? ? 172 TYR U O   1 
+ATOM   1386 C CB  . TYR A 1 173 ? 9.245   -43.095 -27.996 1.00 56.24  ? ? ? ? ? ? 172 TYR U CB  1 
+ATOM   1387 C CG  . TYR A 1 173 ? 7.881   -42.418 -28.096 1.00 54.14  ? ? ? ? ? ? 172 TYR U CG  1 
+ATOM   1388 C CD1 . TYR A 1 173 ? 7.584   -41.577 -29.132 1.00 49.98  ? ? ? ? ? ? 172 TYR U CD1 1 
+ATOM   1389 C CD2 . TYR A 1 173 ? 6.894   -42.643 -27.145 1.00 52.48  ? ? ? ? ? ? 172 TYR U CD2 1 
+ATOM   1390 C CE1 . TYR A 1 173 ? 6.357   -40.995 -29.241 1.00 49.41  ? ? ? ? ? ? 172 TYR U CE1 1 
+ATOM   1391 C CE2 . TYR A 1 173 ? 5.665   -42.047 -27.248 1.00 49.49  ? ? ? ? ? ? 172 TYR U CE2 1 
+ATOM   1392 C CZ  . TYR A 1 173 ? 5.413   -41.225 -28.298 1.00 48.49  ? ? ? ? ? ? 172 TYR U CZ  1 
+ATOM   1393 O OH  . TYR A 1 173 ? 4.220   -40.631 -28.411 1.00 46.09  ? ? ? ? ? ? 172 TYR U OH  1 
+ATOM   1394 N N   . GLY A 1 174 ? 11.627  -45.236 -29.422 1.00 63.31  ? ? ? ? ? ? 173 GLY U N   1 
+ATOM   1395 C CA  . GLY A 1 174 ? 13.031  -45.563 -29.427 1.00 62.34  ? ? ? ? ? ? 173 GLY U CA  1 
+ATOM   1396 C C   . GLY A 1 174 ? 13.750  -45.093 -28.193 1.00 64.74  ? ? ? ? ? ? 173 GLY U C   1 
+ATOM   1397 O O   . GLY A 1 174 ? 13.325  -45.321 -27.086 1.00 68.20  ? ? ? ? ? ? 173 GLY U O   1 
+ATOM   1398 N N   . SER A 1 175 ? 14.860  -44.419 -28.404 1.00 60.88  ? ? ? ? ? ? 174 SER U N   1 
+ATOM   1399 C CA  . SER A 1 175 ? 15.762  -43.988 -27.354 1.00 65.81  ? ? ? ? ? ? 174 SER U CA  1 
+ATOM   1400 C C   . SER A 1 175 ? 15.238  -42.930 -26.393 1.00 65.08  ? ? ? ? ? ? 174 SER U C   1 
+ATOM   1401 O O   . SER A 1 175 ? 15.772  -42.724 -25.333 1.00 65.60  ? ? ? ? ? ? 174 SER U O   1 
+ATOM   1402 C CB  . SER A 1 175 ? 17.076  -43.498 -27.972 1.00 65.66  ? ? ? ? ? ? 174 SER U CB  1 
+ATOM   1403 O OG  . SER A 1 175 ? 16.872  -42.362 -28.799 1.00 65.97  ? ? ? ? ? ? 174 SER U OG  1 
+ATOM   1404 N N   . GLU A 1 176 ? 14.236  -42.211 -26.836 1.00 69.07  ? ? ? ? ? ? 175 GLU U N   1 
+ATOM   1405 C CA  . GLU A 1 176 ? 13.773  -40.968 -26.228 1.00 70.69  ? ? ? ? ? ? 175 GLU U CA  1 
+ATOM   1406 C C   . GLU A 1 176 ? 12.981  -41.186 -24.937 1.00 70.43  ? ? ? ? ? ? 175 GLU U C   1 
+ATOM   1407 O O   . GLU A 1 176 ? 12.889  -40.274 -24.117 1.00 66.66  ? ? ? ? ? ? 175 GLU U O   1 
+ATOM   1408 C CB  . GLU A 1 176 ? 12.968  -40.145 -27.238 1.00 73.46  ? ? ? ? ? ? 175 GLU U CB  1 
+ATOM   1409 C CG  . GLU A 1 176 ? 12.710  -38.695 -26.833 1.00 78.38  ? ? ? ? ? ? 175 GLU U CG  1 
+ATOM   1410 C CD  . GLU A 1 176 ? 13.970  -37.914 -26.478 1.00 79.70  ? ? ? ? ? ? 175 GLU U CD  1 
+ATOM   1411 O OE1 . GLU A 1 176 ? 14.459  -37.163 -27.349 1.00 81.17  ? ? ? ? ? ? 175 GLU U OE1 1 
+ATOM   1412 O OE2 . GLU A 1 176 ? 14.460  -38.039 -25.330 1.00 76.34  ? ? ? ? ? ? 175 GLU U OE2 1 
+ATOM   1413 N N   . VAL A 1 177 ? 12.419  -42.383 -24.761 1.00 69.71  ? ? ? ? ? ? 176 VAL U N   1 
+ATOM   1414 C CA  . VAL A 1 177 ? 11.818  -42.772 -23.477 1.00 68.88  ? ? ? ? ? ? 176 VAL U CA  1 
+ATOM   1415 C C   . VAL A 1 177 ? 12.883  -43.342 -22.557 1.00 65.06  ? ? ? ? ? ? 176 VAL U C   1 
+ATOM   1416 O O   . VAL A 1 177 ? 13.503  -44.358 -22.866 1.00 66.46  ? ? ? ? ? ? 176 VAL U O   1 
+ATOM   1417 C CB  . VAL A 1 177 ? 10.670  -43.808 -23.607 1.00 73.97  ? ? ? ? ? ? 176 VAL U CB  1 
+ATOM   1418 C CG1 . VAL A 1 177 ? 9.360   -43.111 -23.936 1.00 75.83  ? ? ? ? ? ? 176 VAL U CG1 1 
+ATOM   1419 C CG2 . VAL A 1 177 ? 10.989  -44.892 -24.632 1.00 77.21  ? ? ? ? ? ? 176 VAL U CG2 1 
+ATOM   1420 N N   . THR A 1 178 ? 13.084  -42.682 -21.425 1.00 59.45  ? ? ? ? ? ? 177 THR U N   1 
+ATOM   1421 C CA  . THR A 1 178 ? 14.099  -43.080 -20.458 1.00 56.02  ? ? ? ? ? ? 177 THR U CA  1 
+ATOM   1422 C C   . THR A 1 178 ? 13.421  -43.722 -19.264 1.00 56.63  ? ? ? ? ? ? 177 THR U C   1 
+ATOM   1423 O O   . THR A 1 178 ? 12.185  -43.708 -19.163 1.00 53.04  ? ? ? ? ? ? 177 THR U O   1 
+ATOM   1424 C CB  . THR A 1 178 ? 14.882  -41.857 -19.969 1.00 53.96  ? ? ? ? ? ? 177 THR U CB  1 
+ATOM   1425 O OG1 . THR A 1 178 ? 13.996  -41.001 -19.247 1.00 52.42  ? ? ? ? ? ? 177 THR U OG1 1 
+ATOM   1426 C CG2 . THR A 1 178 ? 15.466  -41.091 -21.149 1.00 51.27  ? ? ? ? ? ? 177 THR U CG2 1 
+ATOM   1427 N N   . THR A 1 179 ? 14.221  -44.267 -18.349 1.00 55.06  ? ? ? ? ? ? 178 THR U N   1 
+ATOM   1428 C CA  . THR A 1 179 ? 13.682  -45.035 -17.223 1.00 55.23  ? ? ? ? ? ? 178 THR U CA  1 
+ATOM   1429 C C   . THR A 1 179 ? 12.968  -44.162 -16.197 1.00 52.69  ? ? ? ? ? ? 178 THR U C   1 
+ATOM   1430 O O   . THR A 1 179 ? 12.304  -44.685 -15.311 1.00 53.39  ? ? ? ? ? ? 178 THR U O   1 
+ATOM   1431 C CB  . THR A 1 179 ? 14.750  -45.883 -16.486 1.00 53.89  ? ? ? ? ? ? 178 THR U CB  1 
+ATOM   1432 O OG1 . THR A 1 179 ? 15.524  -45.050 -15.611 1.00 56.93  ? ? ? ? ? ? 178 THR U OG1 1 
+ATOM   1433 C CG2 . THR A 1 179 ? 15.658  -46.601 -17.464 1.00 52.89  ? ? ? ? ? ? 178 THR U CG2 1 
+ATOM   1434 N N   . LYS A 1 180 ? 13.117  -42.843 -16.305 1.00 54.11  ? ? ? ? ? ? 179 LYS U N   1 
+ATOM   1435 C CA  . LYS A 1 180 ? 12.454  -41.911 -15.389 1.00 53.34  ? ? ? ? ? ? 179 LYS U CA  1 
+ATOM   1436 C C   . LYS A 1 180 ? 11.087  -41.497 -15.932 1.00 49.26  ? ? ? ? ? ? 179 LYS U C   1 
+ATOM   1437 O O   . LYS A 1 180 ? 10.417  -40.661 -15.344 1.00 47.30  ? ? ? ? ? ? 179 LYS U O   1 
+ATOM   1438 C CB  . LYS A 1 180 ? 13.339  -40.689 -15.127 1.00 58.24  ? ? ? ? ? ? 179 LYS U CB  1 
+ATOM   1439 C CG  . LYS A 1 180 ? 14.779  -41.052 -14.775 1.00 61.76  ? ? ? ? ? ? 179 LYS U CG  1 
+ATOM   1440 C CD  . LYS A 1 180 ? 15.522  -39.948 -14.036 1.00 64.91  ? ? ? ? ? ? 179 LYS U CD  1 
+ATOM   1441 C CE  . LYS A 1 180 ? 15.629  -40.242 -12.546 1.00 70.20  ? ? ? ? ? ? 179 LYS U CE  1 
+ATOM   1442 N NZ  . LYS A 1 180 ? 16.137  -39.070 -11.781 1.00 72.99  ? ? ? ? ? ? 179 LYS U NZ  1 
+ATOM   1443 N N   . MET A 1 181 ? 10.691  -42.112 -17.044 1.00 43.39  ? ? ? ? ? ? 180 MET U N   1 
+ATOM   1444 C CA  . MET A 1 181 ? 9.407   -41.898 -17.671 1.00 43.19  ? ? ? ? ? ? 180 MET U CA  1 
+ATOM   1445 C C   . MET A 1 181 ? 8.599   -43.210 -17.691 1.00 42.59  ? ? ? ? ? ? 180 MET U C   1 
+ATOM   1446 O O   . MET A 1 181 ? 9.163   -44.292 -17.613 1.00 40.59  ? ? ? ? ? ? 180 MET U O   1 
+ATOM   1447 C CB  . MET A 1 181 ? 9.631   -41.403 -19.102 1.00 42.10  ? ? ? ? ? ? 180 MET U CB  1 
+ATOM   1448 C CG  . MET A 1 181 ? 10.667  -40.291 -19.238 1.00 41.20  ? ? ? ? ? ? 180 MET U CG  1 
+ATOM   1449 S SD  . MET A 1 181 ? 10.990  -39.856 -20.953 1.00 46.55  ? ? ? ? ? ? 180 MET U SD  1 
+ATOM   1450 C CE  . MET A 1 181 ? 12.109  -38.474 -20.732 1.00 47.02  ? ? ? ? ? ? 180 MET U CE  1 
+ATOM   1451 N N   . LEU A 1 182 ? 7.278   -43.101 -17.793 1.00 43.69  ? ? ? ? ? ? 181 LEU U N   1 
+ATOM   1452 C CA  . LEU A 1 182 ? 6.405   -44.252 -18.082 1.00 43.09  ? ? ? ? ? ? 181 LEU U CA  1 
+ATOM   1453 C C   . LEU A 1 182 ? 5.593   -43.990 -19.331 1.00 39.21  ? ? ? ? ? ? 181 LEU U C   1 
+ATOM   1454 O O   . LEU A 1 182 ? 5.142   -42.865 -19.547 1.00 37.78  ? ? ? ? ? ? 181 LEU U O   1 
+ATOM   1455 C CB  . LEU A 1 182 ? 5.412   -44.494 -16.945 1.00 45.14  ? ? ? ? ? ? 181 LEU U CB  1 
+ATOM   1456 C CG  . LEU A 1 182 ? 5.935   -44.862 -15.559 1.00 49.66  ? ? ? ? ? ? 181 LEU U CG  1 
+ATOM   1457 C CD1 . LEU A 1 182 ? 4.756   -44.904 -14.597 1.00 50.05  ? ? ? ? ? ? 181 LEU U CD1 1 
+ATOM   1458 C CD2 . LEU A 1 182 ? 6.683   -46.191 -15.552 1.00 51.13  ? ? ? ? ? ? 181 LEU U CD2 1 
+ATOM   1459 N N   . CYS A 1 183 ? 5.375   -45.026 -20.134 1.00 37.68  ? ? ? ? ? ? 182 CYS U N   1 
+ATOM   1460 C CA  . CYS A 1 183 ? 4.428   -44.949 -21.237 1.00 39.57  ? ? ? ? ? ? 182 CYS U CA  1 
+ATOM   1461 C C   . CYS A 1 183 ? 3.118   -45.603 -20.834 1.00 38.53  ? ? ? ? ? ? 182 CYS U C   1 
+ATOM   1462 O O   . CYS A 1 183 ? 3.094   -46.527 -20.024 1.00 39.35  ? ? ? ? ? ? 182 CYS U O   1 
+ATOM   1463 C CB  . CYS A 1 183 ? 4.961   -45.629 -22.503 1.00 43.27  ? ? ? ? ? ? 182 CYS U CB  1 
+ATOM   1464 S SG  . CYS A 1 183 ? 6.421   -44.838 -23.190 1.00 51.84  ? ? ? ? ? ? 182 CYS U SG  1 
+ATOM   1465 N N   . ALA A 1 184 ? 2.035   -45.106 -21.414 1.00 37.74  ? ? ? ? ? ? 183 ALA U N   1 
+ATOM   1466 C CA  . ALA A 1 184 ? 0.698   -45.648 -21.189 1.00 38.15  ? ? ? ? ? ? 183 ALA U CA  1 
+ATOM   1467 C C   . ALA A 1 184 ? -0.122  -45.287 -22.415 1.00 38.02  ? ? ? ? ? ? 183 ALA U C   1 
+ATOM   1468 O O   . ALA A 1 184 ? 0.034   -44.202 -22.993 1.00 43.62  ? ? ? ? ? ? 183 ALA U O   1 
+ATOM   1469 C CB  . ALA A 1 184 ? 0.082   -45.080 -19.920 1.00 37.07  ? ? ? ? ? ? 183 ALA U CB  1 
+ATOM   1470 N N   . ALA A 1 185 ? -0.942  -46.210 -22.861 1.00 38.98  ? ? ? ? ? ? 184 ALA U N   1 
+ATOM   1471 C CA  . ALA A 1 185 ? -1.736  -46.005 -24.046 1.00 40.30  ? ? ? ? ? ? 184 ALA U CA  1 
+ATOM   1472 C C   . ALA A 1 185 ? -2.864  -46.960 -24.041 1.00 40.89  ? ? ? ? ? ? 184 ALA U C   1 
+ATOM   1473 O O   . ALA A 1 185 ? -2.907  -47.850 -23.247 1.00 37.18  ? ? ? ? ? ? 184 ALA U O   1 
+ATOM   1474 C CB  . ALA A 1 185 ? -0.929  -46.206 -25.296 1.00 40.64  ? ? ? ? ? ? 184 ALA U CB  1 
+ATOM   1475 N N   . ASP A 1 186 ? -3.782  -46.730 -24.953 1.00 43.12  ? ? ? ? ? ? 185 ASP U N   1 
+ATOM   1476 C CA  . ASP A 1 186 ? -4.851  -47.652 -25.242 1.00 46.58  ? ? ? ? ? ? 185 ASP U CA  1 
+ATOM   1477 C C   . ASP A 1 186 ? -4.410  -48.825 -26.098 1.00 47.01  ? ? ? ? ? ? 185 ASP U C   1 
+ATOM   1478 O O   . ASP A 1 186 ? -3.766  -48.664 -27.111 1.00 48.86  ? ? ? ? ? ? 185 ASP U O   1 
+ATOM   1479 C CB  . ASP A 1 186 ? -5.982  -46.936 -25.930 1.00 48.86  ? ? ? ? ? ? 185 ASP U CB  1 
+ATOM   1480 C CG  . ASP A 1 186 ? -7.122  -47.823 -26.197 1.00 51.39  ? ? ? ? ? ? 185 ASP U CG  1 
+ATOM   1481 O OD1 . ASP A 1 186 ? -7.570  -48.474 -25.281 1.00 50.11  ? ? ? ? ? ? 185 ASP U OD1 1 
+ATOM   1482 O OD2 . ASP A 1 186 ? -7.568  -47.908 -27.325 1.00 56.77  ? ? ? ? ? ? 185 ASP U OD2 1 
+ATOM   1483 N N   . PRO A 1 187 A -4.870  -50.066 -25.641 1.00 64.68  ? ? ? ? ? ? 185 PRO U N   1 
+ATOM   1484 C CA  . PRO A 1 187 A -4.486  -51.188 -26.511 1.00 63.75  ? ? ? ? ? ? 185 PRO U CA  1 
+ATOM   1485 C C   . PRO A 1 187 A -4.944  -51.011 -27.953 1.00 59.62  ? ? ? ? ? ? 185 PRO U C   1 
+ATOM   1486 O O   . PRO A 1 187 A -4.174  -51.325 -28.792 1.00 57.77  ? ? ? ? ? ? 185 PRO U O   1 
+ATOM   1487 C CB  . PRO A 1 187 A -5.187  -52.353 -25.884 1.00 64.93  ? ? ? ? ? ? 185 PRO U CB  1 
+ATOM   1488 C CG  . PRO A 1 187 A -5.052  -52.105 -24.451 1.00 65.30  ? ? ? ? ? ? 185 PRO U CG  1 
+ATOM   1489 C CD  . PRO A 1 187 A -5.498  -50.698 -24.377 1.00 64.44  ? ? ? ? ? ? 185 PRO U CD  1 
+ATOM   1490 N N   . GLN A 1 188 B -6.113  -50.475 -28.245 1.00 63.47  ? ? ? ? ? ? 185 GLN U N   1 
+ATOM   1491 C CA  . GLN A 1 188 B -6.463  -50.169 -29.641 1.00 61.25  ? ? ? ? ? ? 185 GLN U CA  1 
+ATOM   1492 C C   . GLN A 1 188 B -6.157  -48.747 -30.114 1.00 55.76  ? ? ? ? ? ? 185 GLN U C   1 
+ATOM   1493 O O   . GLN A 1 188 B -6.580  -48.346 -31.168 1.00 53.02  ? ? ? ? ? ? 185 GLN U O   1 
+ATOM   1494 C CB  . GLN A 1 188 B -7.904  -50.500 -29.938 1.00 66.74  ? ? ? ? ? ? 185 GLN U CB  1 
+ATOM   1495 C CG  . GLN A 1 188 B -8.110  -51.814 -30.661 1.00 69.79  ? ? ? ? ? ? 185 GLN U CG  1 
+ATOM   1496 C CD  . GLN A 1 188 B -9.568  -52.210 -30.706 1.00 74.72  ? ? ? ? ? ? 185 GLN U CD  1 
+ATOM   1497 O OE1 . GLN A 1 188 B -10.452 -51.360 -30.693 1.00 76.45  ? ? ? ? ? ? 185 GLN U OE1 1 
+ATOM   1498 N NE2 . GLN A 1 188 B -9.823  -53.497 -30.770 1.00 78.62  ? ? ? ? ? ? 185 GLN U NE2 1 
+ATOM   1499 N N   . TRP A 1 189 ? -5.458  -47.980 -29.300 1.00 52.78  ? ? ? ? ? ? 186 TRP U N   1 
+ATOM   1500 C CA  . TRP A 1 189 ? -5.049  -46.633 -29.674 1.00 52.58  ? ? ? ? ? ? 186 TRP U CA  1 
+ATOM   1501 C C   . TRP A 1 189 ? -6.176  -45.625 -29.877 1.00 49.69  ? ? ? ? ? ? 186 TRP U C   1 
+ATOM   1502 O O   . TRP A 1 189 ? -6.065  -44.702 -30.638 1.00 50.81  ? ? ? ? ? ? 186 TRP U O   1 
+ATOM   1503 C CB  . TRP A 1 189 ? -4.196  -46.701 -30.917 1.00 58.56  ? ? ? ? ? ? 186 TRP U CB  1 
+ATOM   1504 C CG  . TRP A 1 189 ? -3.066  -47.578 -30.758 1.00 60.67  ? ? ? ? ? ? 186 TRP U CG  1 
+ATOM   1505 C CD1 . TRP A 1 189 ? -2.968  -48.848 -31.172 1.00 63.63  ? ? ? ? ? ? 186 TRP U CD1 1 
+ATOM   1506 C CD2 . TRP A 1 189 ? -1.854  -47.267 -30.114 1.00 61.62  ? ? ? ? ? ? 186 TRP U CD2 1 
+ATOM   1507 N NE1 . TRP A 1 189 ? -1.764  -49.363 -30.826 1.00 63.38  ? ? ? ? ? ? 186 TRP U NE1 1 
+ATOM   1508 C CE2 . TRP A 1 189 ? -1.058  -48.405 -30.165 1.00 63.67  ? ? ? ? ? ? 186 TRP U CE2 1 
+ATOM   1509 C CE3 . TRP A 1 189 ? -1.370  -46.139 -29.482 1.00 61.67  ? ? ? ? ? ? 186 TRP U CE3 1 
+ATOM   1510 C CZ2 . TRP A 1 189 ? 0.194   -48.450 -29.620 1.00 65.30  ? ? ? ? ? ? 186 TRP U CZ2 1 
+ATOM   1511 C CZ3 . TRP A 1 189 ? -0.144  -46.179 -28.945 1.00 64.20  ? ? ? ? ? ? 186 TRP U CZ3 1 
+ATOM   1512 C CH2 . TRP A 1 189 ? 0.637   -47.323 -29.008 1.00 67.05  ? ? ? ? ? ? 186 TRP U CH2 1 
+ATOM   1513 N N   . LYS A 1 190 ? -7.263  -45.811 -29.172 1.00 47.28  ? ? ? ? ? ? 187 LYS U N   1 
+ATOM   1514 C CA  . LYS A 1 190 ? -8.457  -44.978 -29.327 1.00 50.42  ? ? ? ? ? ? 187 LYS U CA  1 
+ATOM   1515 C C   . LYS A 1 190 ? -8.585  -43.886 -28.255 1.00 47.92  ? ? ? ? ? ? 187 LYS U C   1 
+ATOM   1516 O O   . LYS A 1 190 ? -9.296  -42.905 -28.464 1.00 50.43  ? ? ? ? ? ? 187 LYS U O   1 
+ATOM   1517 C CB  . LYS A 1 190 ? -9.737  -45.839 -29.341 1.00 51.31  ? ? ? ? ? ? 187 LYS U CB  1 
+ATOM   1518 C CG  . LYS A 1 190 ? -9.758  -46.968 -30.366 1.00 55.05  ? ? ? ? ? ? 187 LYS U CG  1 
+ATOM   1519 C CD  . LYS A 1 190 ? -9.491  -46.476 -31.786 1.00 56.67  ? ? ? ? ? ? 187 LYS U CD  1 
+ATOM   1520 C CE  . LYS A 1 190 ? -9.931  -47.501 -32.818 1.00 57.61  ? ? ? ? ? ? 187 LYS U CE  1 
+ATOM   1521 N NZ  . LYS A 1 190 ? -9.640  -47.075 -34.212 1.00 60.50  ? ? ? ? ? ? 187 LYS U NZ  1 
+ATOM   1522 N N   . THR A 1 191 ? -7.916  -44.047 -27.119 1.00 44.56  ? ? ? ? ? ? 188 THR U N   1 
+ATOM   1523 C CA  . THR A 1 191 ? -7.965  -43.026 -26.077 1.00 43.01  ? ? ? ? ? ? 188 THR U CA  1 
+ATOM   1524 C C   . THR A 1 191 ? -6.565  -42.614 -25.597 1.00 41.31  ? ? ? ? ? ? 188 THR U C   1 
+ATOM   1525 O O   . THR A 1 191 ? -5.628  -43.398 -25.674 1.00 41.99  ? ? ? ? ? ? 188 THR U O   1 
+ATOM   1526 C CB  . THR A 1 191 ? -8.870  -43.473 -24.918 1.00 41.89  ? ? ? ? ? ? 188 THR U CB  1 
+ATOM   1527 O OG1 . THR A 1 191 ? -9.215  -42.338 -24.113 1.00 43.76  ? ? ? ? ? ? 188 THR U OG1 1 
+ATOM   1528 C CG2 . THR A 1 191 ? -8.215  -44.588 -24.077 1.00 42.33  ? ? ? ? ? ? 188 THR U CG2 1 
+ATOM   1529 N N   . ASP A 1 192 ? -6.442  -41.367 -25.131 1.00 37.61  ? ? ? ? ? ? 189 ASP U N   1 
+ATOM   1530 C CA  . ASP A 1 192 ? -5.155  -40.773 -24.775 1.00 36.60  ? ? ? ? ? ? 189 ASP U CA  1 
+ATOM   1531 C C   . ASP A 1 192 ? -5.379  -39.453 -24.016 1.00 37.72  ? ? ? ? ? ? 189 ASP U C   1 
+ATOM   1532 O O   . ASP A 1 192 ? -6.487  -38.892 -24.002 1.00 38.44  ? ? ? ? ? ? 189 ASP U O   1 
+ATOM   1533 C CB  . ASP A 1 192 ? -4.331  -40.516 -26.070 1.00 36.16  ? ? ? ? ? ? 189 ASP U CB  1 
+ATOM   1534 C CG  . ASP A 1 192 ? -2.809  -40.513 -25.854 1.00 36.91  ? ? ? ? ? ? 189 ASP U CG  1 
+ATOM   1535 O OD1 . ASP A 1 192 ? -2.322  -40.682 -24.710 1.00 34.76  ? ? ? ? ? ? 189 ASP U OD1 1 
+ATOM   1536 O OD2 . ASP A 1 192 ? -2.071  -40.315 -26.868 1.00 37.12  ? ? ? ? ? ? 189 ASP U OD2 1 
+ATOM   1537 N N   . SER A 1 193 ? -4.317  -38.963 -23.391 1.00 38.86  ? ? ? ? ? ? 190 SER U N   1 
+ATOM   1538 C CA  . SER A 1 193 ? -4.228  -37.544 -23.023 1.00 38.26  ? ? ? ? ? ? 190 SER U CA  1 
+ATOM   1539 C C   . SER A 1 193 ? -3.850  -36.756 -24.277 1.00 39.64  ? ? ? ? ? ? 190 SER U C   1 
+ATOM   1540 O O   . SER A 1 193 ? -3.350  -37.349 -25.236 1.00 40.42  ? ? ? ? ? ? 190 SER U O   1 
+ATOM   1541 C CB  . SER A 1 193 ? -3.187  -37.333 -21.926 1.00 36.73  ? ? ? ? ? ? 190 SER U CB  1 
+ATOM   1542 O OG  . SER A 1 193 ? -1.979  -38.034 -22.198 1.00 33.10  ? ? ? ? ? ? 190 SER U OG  1 
+ATOM   1543 N N   . CYS A 1 194 ? -4.084  -35.442 -24.260 1.00 37.87  ? ? ? ? ? ? 191 CYS U N   1 
+ATOM   1544 C CA  . CYS A 1 194 ? -3.764  -34.571 -25.391 1.00 38.48  ? ? ? ? ? ? 191 CYS U CA  1 
+ATOM   1545 C C   . CYS A 1 194 ? -3.278  -33.199 -24.921 1.00 37.99  ? ? ? ? ? ? 191 CYS U C   1 
+ATOM   1546 O O   . CYS A 1 194 ? -2.972  -33.006 -23.734 1.00 35.65  ? ? ? ? ? ? 191 CYS U O   1 
+ATOM   1547 C CB  . CYS A 1 194 ? -4.980  -34.427 -26.307 1.00 42.36  ? ? ? ? ? ? 191 CYS U CB  1 
+ATOM   1548 S SG  . CYS A 1 194 ? -4.577  -33.967 -28.019 1.00 44.62  ? ? ? ? ? ? 191 CYS U SG  1 
+ATOM   1549 N N   . GLN A 1 195 ? -3.177  -32.249 -25.850 1.00 37.81  ? ? ? ? ? ? 192 GLN U N   1 
+ATOM   1550 C CA  . GLN A 1 195 ? -2.729  -30.904 -25.517 1.00 35.44  ? ? ? ? ? ? 192 GLN U CA  1 
+ATOM   1551 C C   . GLN A 1 195 ? -3.666  -30.313 -24.465 1.00 32.10  ? ? ? ? ? ? 192 GLN U C   1 
+ATOM   1552 O O   . GLN A 1 195 ? -4.870  -30.379 -24.616 1.00 28.26  ? ? ? ? ? ? 192 GLN U O   1 
+ATOM   1553 C CB  . GLN A 1 195 ? -2.682  -29.996 -26.756 1.00 37.78  ? ? ? ? ? ? 192 GLN U CB  1 
+ATOM   1554 C CG  . GLN A 1 195 ? -1.965  -28.664 -26.502 1.00 39.00  ? ? ? ? ? ? 192 GLN U CG  1 
+ATOM   1555 C CD  . GLN A 1 195 ? -1.872  -27.764 -27.732 1.00 40.61  ? ? ? ? ? ? 192 GLN U CD  1 
+ATOM   1556 O OE1 . GLN A 1 195 ? -2.552  -27.981 -28.726 1.00 41.94  ? ? ? ? ? ? 192 GLN U OE1 1 
+ATOM   1557 N NE2 . GLN A 1 195 ? -1.043  -26.739 -27.651 1.00 42.25  ? ? ? ? ? ? 192 GLN U NE2 1 
+ATOM   1558 N N   . GLY A 1 196 ? -3.099  -29.750 -23.401 1.00 32.37  ? ? ? ? ? ? 193 GLY U N   1 
+ATOM   1559 C CA  . GLY A 1 196 ? -3.899  -29.209 -22.309 1.00 31.88  ? ? ? ? ? ? 193 GLY U CA  1 
+ATOM   1560 C C   . GLY A 1 196 ? -4.193  -30.167 -21.156 1.00 30.98  ? ? ? ? ? ? 193 GLY U C   1 
+ATOM   1561 O O   . GLY A 1 196 ? -4.797  -29.765 -20.169 1.00 31.47  ? ? ? ? ? ? 193 GLY U O   1 
+ATOM   1562 N N   . ASP A 1 197 ? -3.783  -31.420 -21.262 1.00 31.38  ? ? ? ? ? ? 194 ASP U N   1 
+ATOM   1563 C CA  . ASP A 1 197 ? -3.872  -32.359 -20.126 1.00 32.73  ? ? ? ? ? ? 194 ASP U CA  1 
+ATOM   1564 C C   . ASP A 1 197 ? -2.562  -32.413 -19.325 1.00 33.97  ? ? ? ? ? ? 194 ASP U C   1 
+ATOM   1565 O O   . ASP A 1 197 ? -2.484  -33.082 -18.263 1.00 31.27  ? ? ? ? ? ? 194 ASP U O   1 
+ATOM   1566 C CB  . ASP A 1 197 ? -4.245  -33.765 -20.623 1.00 30.57  ? ? ? ? ? ? 194 ASP U CB  1 
+ATOM   1567 C CG  . ASP A 1 197 ? -5.683  -33.853 -21.118 1.00 32.29  ? ? ? ? ? ? 194 ASP U CG  1 
+ATOM   1568 O OD1 . ASP A 1 197 ? -6.603  -33.255 -20.486 1.00 30.97  ? ? ? ? ? ? 194 ASP U OD1 1 
+ATOM   1569 O OD2 . ASP A 1 197 ? -5.918  -34.546 -22.139 1.00 31.06  ? ? ? ? ? ? 194 ASP U OD2 1 
+ATOM   1570 N N   . SER A 1 198 ? -1.545  -31.741 -19.878 1.00 33.35  ? ? ? ? ? ? 195 SER U N   1 
+ATOM   1571 C CA  . SER A 1 198 ? -0.218  -31.608 -19.313 1.00 33.59  ? ? ? ? ? ? 195 SER U CA  1 
+ATOM   1572 C C   . SER A 1 198 ? -0.248  -31.274 -17.850 1.00 30.30  ? ? ? ? ? ? 195 SER U C   1 
+ATOM   1573 O O   . SER A 1 198 ? -1.061  -30.464 -17.438 1.00 25.80  ? ? ? ? ? ? 195 SER U O   1 
+ATOM   1574 C CB  . SER A 1 198 ? 0.524   -30.444 -19.988 1.00 35.48  ? ? ? ? ? ? 195 SER U CB  1 
+ATOM   1575 O OG  . SER A 1 198 ? 1.157   -30.886 -21.155 1.00 46.17  ? ? ? ? ? ? 195 SER U OG  1 
+ATOM   1576 N N   . GLY A 1 199 ? 0.699   -31.838 -17.099 1.00 28.28  ? ? ? ? ? ? 196 GLY U N   1 
+ATOM   1577 C CA  . GLY A 1 199 ? 0.749   -31.697 -15.635 1.00 28.43  ? ? ? ? ? ? 196 GLY U CA  1 
+ATOM   1578 C C   . GLY A 1 199 ? -0.239  -32.553 -14.855 1.00 28.94  ? ? ? ? ? ? 196 GLY U C   1 
+ATOM   1579 O O   . GLY A 1 199 ? -0.094  -32.729 -13.634 1.00 26.93  ? ? ? ? ? ? 196 GLY U O   1 
+ATOM   1580 N N   . GLY A 1 200 ? -1.227  -33.116 -15.552 1.00 29.36  ? ? ? ? ? ? 197 GLY U N   1 
+ATOM   1581 C CA  . GLY A 1 200 ? -2.287  -33.906 -14.943 1.00 26.55  ? ? ? ? ? ? 197 GLY U CA  1 
+ATOM   1582 C C   . GLY A 1 200 ? -1.865  -35.279 -14.419 1.00 28.76  ? ? ? ? ? ? 197 GLY U C   1 
+ATOM   1583 O O   . GLY A 1 200 ? -0.766  -35.735 -14.706 1.00 29.09  ? ? ? ? ? ? 197 GLY U O   1 
+ATOM   1584 N N   . PRO A 1 201 ? -2.750  -35.944 -13.629 1.00 26.42  ? ? ? ? ? ? 198 PRO U N   1 
+ATOM   1585 C CA  . PRO A 1 201 ? -2.457  -37.233 -13.024 1.00 27.70  ? ? ? ? ? ? 198 PRO U CA  1 
+ATOM   1586 C C   . PRO A 1 201 ? -2.650  -38.463 -13.905 1.00 29.98  ? ? ? ? ? ? 198 PRO U C   1 
+ATOM   1587 O O   . PRO A 1 201 ? -3.587  -38.549 -14.707 1.00 29.89  ? ? ? ? ? ? 198 PRO U O   1 
+ATOM   1588 C CB  . PRO A 1 201 ? -3.435  -37.310 -11.840 1.00 28.60  ? ? ? ? ? ? 198 PRO U CB  1 
+ATOM   1589 C CG  . PRO A 1 201 ? -4.571  -36.415 -12.201 1.00 27.79  ? ? ? ? ? ? 198 PRO U CG  1 
+ATOM   1590 C CD  . PRO A 1 201 ? -4.031  -35.386 -13.162 1.00 27.37  ? ? ? ? ? ? 198 PRO U CD  1 
+ATOM   1591 N N   . LEU A 1 202 ? -1.745  -39.413 -13.719 1.00 30.93  ? ? ? ? ? ? 199 LEU U N   1 
+ATOM   1592 C CA  . LEU A 1 202 ? -1.978  -40.797 -14.083 1.00 33.41  ? ? ? ? ? ? 199 LEU U CA  1 
+ATOM   1593 C C   . LEU A 1 202 ? -2.093  -41.553 -12.771 1.00 32.35  ? ? ? ? ? ? 199 LEU U C   1 
+ATOM   1594 O O   . LEU A 1 202 ? -1.135  -41.592 -12.004 1.00 31.95  ? ? ? ? ? ? 199 LEU U O   1 
+ATOM   1595 C CB  . LEU A 1 202 ? -0.808  -41.338 -14.884 1.00 34.21  ? ? ? ? ? ? 199 LEU U CB  1 
+ATOM   1596 C CG  . LEU A 1 202 ? -0.803  -42.818 -15.277 1.00 36.81  ? ? ? ? ? ? 199 LEU U CG  1 
+ATOM   1597 C CD1 . LEU A 1 202 ? -1.926  -43.130 -16.246 1.00 35.91  ? ? ? ? ? ? 199 LEU U CD1 1 
+ATOM   1598 C CD2 . LEU A 1 202 ? 0.538   -43.127 -15.924 1.00 38.99  ? ? ? ? ? ? 199 LEU U CD2 1 
+ATOM   1599 N N   . VAL A 1 203 ? -3.246  -42.175 -12.542 1.00 31.59  ? ? ? ? ? ? 200 VAL U N   1 
+ATOM   1600 C CA  . VAL A 1 203 ? -3.545  -42.822 -11.265 1.00 34.91  ? ? ? ? ? ? 200 VAL U CA  1 
+ATOM   1601 C C   . VAL A 1 203 ? -3.796  -44.306 -11.481 1.00 36.76  ? ? ? ? ? ? 200 VAL U C   1 
+ATOM   1602 O O   . VAL A 1 203 ? -4.608  -44.686 -12.317 1.00 34.12  ? ? ? ? ? ? 200 VAL U O   1 
+ATOM   1603 C CB  . VAL A 1 203 ? -4.796  -42.216 -10.606 1.00 36.21  ? ? ? ? ? ? 200 VAL U CB  1 
+ATOM   1604 C CG1 . VAL A 1 203 ? -5.182  -42.999 -9.346  1.00 38.54  ? ? ? ? ? ? 200 VAL U CG1 1 
+ATOM   1605 C CG2 . VAL A 1 203 ? -4.559  -40.756 -10.280 1.00 34.67  ? ? ? ? ? ? 200 VAL U CG2 1 
+ATOM   1606 N N   . CYS A 1 204 ? -3.096  -45.106 -10.718 1.00 41.79  ? ? ? ? ? ? 201 CYS U N   1 
+ATOM   1607 C CA  . CYS A 1 204 ? -3.132  -46.522 -10.871 1.00 44.77  ? ? ? ? ? ? 201 CYS U CA  1 
+ATOM   1608 C C   . CYS A 1 204 ? -3.378  -47.091 -9.499  1.00 44.92  ? ? ? ? ? ? 201 CYS U C   1 
+ATOM   1609 O O   . CYS A 1 204 ? -3.065  -46.475 -8.526  1.00 44.47  ? ? ? ? ? ? 201 CYS U O   1 
+ATOM   1610 C CB  . CYS A 1 204 ? -1.808  -47.000 -11.451 1.00 45.70  ? ? ? ? ? ? 201 CYS U CB  1 
+ATOM   1611 S SG  . CYS A 1 204 ? -1.498  -46.727 -13.199 1.00 49.59  ? ? ? ? ? ? 201 CYS U SG  1 
+ATOM   1612 N N   . SER A 1 205 ? -3.971  -48.264 -9.424  1.00 46.61  ? ? ? ? ? ? 202 SER U N   1 
+ATOM   1613 C CA  . SER A 1 205 ? -4.148  -48.923 -8.152  1.00 50.62  ? ? ? ? ? ? 202 SER U CA  1 
+ATOM   1614 C C   . SER A 1 205 ? -2.915  -49.743 -7.855  1.00 52.40  ? ? ? ? ? ? 202 SER U C   1 
+ATOM   1615 O O   . SER A 1 205 ? -2.580  -50.594 -8.616  1.00 51.03  ? ? ? ? ? ? 202 SER U O   1 
+ATOM   1616 C CB  . SER A 1 205 ? -5.352  -49.835 -8.209  1.00 52.93  ? ? ? ? ? ? 202 SER U CB  1 
+ATOM   1617 O OG  . SER A 1 205 ? -5.326  -50.750 -7.164  1.00 56.77  ? ? ? ? ? ? 202 SER U OG  1 
+ATOM   1618 N N   . LEU A 1 206 ? -2.229  -49.464 -6.762  1.00 54.91  ? ? ? ? ? ? 203 LEU U N   1 
+ATOM   1619 C CA  . LEU A 1 206 ? -0.997  -50.170 -6.468  1.00 61.90  ? ? ? ? ? ? 203 LEU U CA  1 
+ATOM   1620 C C   . LEU A 1 206 ? -1.038  -50.732 -5.077  1.00 66.73  ? ? ? ? ? ? 203 LEU U C   1 
+ATOM   1621 O O   . LEU A 1 206 ? -1.319  -50.011 -4.153  1.00 67.42  ? ? ? ? ? ? 203 LEU U O   1 
+ATOM   1622 C CB  . LEU A 1 206 ? 0.180   -49.229 -6.607  1.00 64.95  ? ? ? ? ? ? 203 LEU U CB  1 
+ATOM   1623 C CG  . LEU A 1 206 ? 1.587   -49.821 -6.532  1.00 66.70  ? ? ? ? ? ? 203 LEU U CG  1 
+ATOM   1624 C CD1 . LEU A 1 206 ? 1.687   -51.081 -7.354  1.00 65.54  ? ? ? ? ? ? 203 LEU U CD1 1 
+ATOM   1625 C CD2 . LEU A 1 206 ? 2.612   -48.795 -6.988  1.00 67.60  ? ? ? ? ? ? 203 LEU U CD2 1 
+ATOM   1626 N N   . GLN A 1 207 ? -0.768  -52.025 -4.906  1.00 71.72  ? ? ? ? ? ? 204 GLN U N   1 
+ATOM   1627 C CA  . GLN A 1 207 ? -1.258  -52.750 -3.738  1.00 73.13  ? ? ? ? ? ? 204 GLN U CA  1 
+ATOM   1628 C C   . GLN A 1 207 ? -2.773  -52.596 -3.814  1.00 71.45  ? ? ? ? ? ? 204 GLN U C   1 
+ATOM   1629 O O   . GLN A 1 207 ? -3.356  -52.876 -4.846  1.00 71.67  ? ? ? ? ? ? 204 GLN U O   1 
+ATOM   1630 C CB  . GLN A 1 207 ? -0.709  -52.229 -2.403  1.00 75.96  ? ? ? ? ? ? 204 GLN U CB  1 
+ATOM   1631 C CG  . GLN A 1 207 ? 0.647   -51.540 -2.430  1.00 77.21  ? ? ? ? ? ? 204 GLN U CG  1 
+ATOM   1632 C CD  . GLN A 1 207 ? 1.819   -52.489 -2.314  1.00 80.39  ? ? ? ? ? ? 204 GLN U CD  1 
+ATOM   1633 O OE1 . GLN A 1 207 ? 2.218   -52.887 -1.204  1.00 78.50  ? ? ? ? ? ? 204 GLN U OE1 1 
+ATOM   1634 N NE2 . GLN A 1 207 ? 2.391   -52.857 -3.462  1.00 78.97  ? ? ? ? ? ? 204 GLN U NE2 1 
+ATOM   1635 N N   . GLY A 1 208 ? -3.406  -52.112 -2.756  1.00 71.52  ? ? ? ? ? ? 205 GLY U N   1 
+ATOM   1636 C CA  . GLY A 1 208 ? -4.802  -51.729 -2.849  1.00 66.27  ? ? ? ? ? ? 205 GLY U CA  1 
+ATOM   1637 C C   . GLY A 1 208 ? -5.060  -50.256 -3.024  1.00 62.24  ? ? ? ? ? ? 205 GLY U C   1 
+ATOM   1638 O O   . GLY A 1 208 ? -6.193  -49.826 -3.065  1.00 64.37  ? ? ? ? ? ? 205 GLY U O   1 
+ATOM   1639 N N   . ARG A 1 209 ? -4.008  -49.469 -3.117  1.00 59.60  ? ? ? ? ? ? 206 ARG U N   1 
+ATOM   1640 C CA  . ARG A 1 209 ? -4.159  -48.044 -3.011  1.00 60.84  ? ? ? ? ? ? 206 ARG U CA  1 
+ATOM   1641 C C   . ARG A 1 209 ? -4.182  -47.400 -4.381  1.00 56.25  ? ? ? ? ? ? 206 ARG U C   1 
+ATOM   1642 O O   . ARG A 1 209 ? -3.475  -47.810 -5.277  1.00 55.48  ? ? ? ? ? ? 206 ARG U O   1 
+ATOM   1643 C CB  . ARG A 1 209 ? -3.082  -47.447 -2.086  1.00 63.47  ? ? ? ? ? ? 206 ARG U CB  1 
+ATOM   1644 C CG  . ARG A 1 209 ? -3.437  -46.111 -1.429  1.00 68.29  ? ? ? ? ? ? 206 ARG U CG  1 
+ATOM   1645 C CD  . ARG A 1 209 ? -4.587  -46.227 -0.425  1.00 73.26  ? ? ? ? ? ? 206 ARG U CD  1 
+ATOM   1646 N NE  . ARG A 1 209 ? -5.446  -45.038 -0.311  1.00 78.15  ? ? ? ? ? ? 206 ARG U NE  1 
+ATOM   1647 C CZ  . ARG A 1 209 ? -6.485  -44.913 0.516   1.00 80.70  ? ? ? ? ? ? 206 ARG U CZ  1 
+ATOM   1648 N NH1 . ARG A 1 209 ? -6.828  -45.882 1.339   1.00 79.08  ? ? ? ? ? ? 206 ARG U NH1 1 
+ATOM   1649 N NH2 . ARG A 1 209 ? -7.181  -43.802 0.532   1.00 80.94  ? ? ? ? ? ? 206 ARG U NH2 1 
+ATOM   1650 N N   . MET A 1 210 ? -5.039  -46.408 -4.519  1.00 52.64  ? ? ? ? ? ? 207 MET U N   1 
+ATOM   1651 C CA  . MET A 1 210 ? -5.034  -45.548 -5.670  1.00 52.89  ? ? ? ? ? ? 207 MET U CA  1 
+ATOM   1652 C C   . MET A 1 210 ? -3.833  -44.680 -5.495  1.00 46.69  ? ? ? ? ? ? 207 MET U C   1 
+ATOM   1653 O O   . MET A 1 210 ? -3.756  -43.968 -4.560  1.00 44.64  ? ? ? ? ? ? 207 MET U O   1 
+ATOM   1654 C CB  . MET A 1 210 ? -6.232  -44.616 -5.623  1.00 55.01  ? ? ? ? ? ? 207 MET U CB  1 
+ATOM   1655 C CG  . MET A 1 210 ? -7.573  -45.250 -5.934  1.00 61.05  ? ? ? ? ? ? 207 MET U CG  1 
+ATOM   1656 S SD  . MET A 1 210 ? -7.664  -45.756 -7.631  1.00 64.56  ? ? ? ? ? ? 207 MET U SD  1 
+ATOM   1657 C CE  . MET A 1 210 ? -9.068  -44.822 -8.174  1.00 65.38  ? ? ? ? ? ? 207 MET U CE  1 
+ATOM   1658 N N   . THR A 1 211 ? -2.933  -44.692 -6.450  1.00 45.14  ? ? ? ? ? ? 208 THR U N   1 
+ATOM   1659 C CA  . THR A 1 211 ? -1.677  -43.984 -6.309  1.00 43.27  ? ? ? ? ? ? 208 THR U CA  1 
+ATOM   1660 C C   . THR A 1 211 ? -1.342  -43.115 -7.526  1.00 38.29  ? ? ? ? ? ? 208 THR U C   1 
+ATOM   1661 O O   . THR A 1 211 ? -1.716  -43.444 -8.607  1.00 36.05  ? ? ? ? ? ? 208 THR U O   1 
+ATOM   1662 C CB  . THR A 1 211 ? -0.553  -44.987 -6.012  1.00 46.68  ? ? ? ? ? ? 208 THR U CB  1 
+ATOM   1663 O OG1 . THR A 1 211 ? -0.787  -45.582 -4.744  1.00 49.73  ? ? ? ? ? ? 208 THR U OG1 1 
+ATOM   1664 C CG2 . THR A 1 211 ? 0.758   -44.327 -5.955  1.00 47.15  ? ? ? ? ? ? 208 THR U CG2 1 
+ATOM   1665 N N   . LEU A 1 212 ? -0.622  -42.018 -7.315  1.00 36.25  ? ? ? ? ? ? 209 LEU U N   1 
+ATOM   1666 C CA  . LEU A 1 212 ? -0.178  -41.144 -8.415  1.00 33.00  ? ? ? ? ? ? 209 LEU U CA  1 
+ATOM   1667 C C   . LEU A 1 212 ? 1.089   -41.709 -9.023  1.00 35.05  ? ? ? ? ? ? 209 LEU U C   1 
+ATOM   1668 O O   . LEU A 1 212 ? 2.193   -41.539 -8.490  1.00 36.32  ? ? ? ? ? ? 209 LEU U O   1 
+ATOM   1669 C CB  . LEU A 1 212 ? 0.089   -39.728 -7.921  1.00 32.58  ? ? ? ? ? ? 209 LEU U CB  1 
+ATOM   1670 C CG  . LEU A 1 212 ? 0.559   -38.756 -9.012  1.00 32.68  ? ? ? ? ? ? 209 LEU U CG  1 
+ATOM   1671 C CD1 . LEU A 1 212 ? -0.548  -38.483 -10.015 1.00 31.98  ? ? ? ? ? ? 209 LEU U CD1 1 
+ATOM   1672 C CD2 . LEU A 1 212 ? 1.053   -37.472 -8.387  1.00 34.41  ? ? ? ? ? ? 209 LEU U CD2 1 
+ATOM   1673 N N   . THR A 1 213 ? 0.920   -42.384 -10.141 1.00 32.61  ? ? ? ? ? ? 210 THR U N   1 
+ATOM   1674 C CA  . THR A 1 213 ? 1.993   -43.107 -10.777 1.00 37.14  ? ? ? ? ? ? 210 THR U CA  1 
+ATOM   1675 C C   . THR A 1 213 ? 2.679   -42.274 -11.871 1.00 37.48  ? ? ? ? ? ? 210 THR U C   1 
+ATOM   1676 O O   . THR A 1 213 ? 3.867   -42.451 -12.136 1.00 41.48  ? ? ? ? ? ? 210 THR U O   1 
+ATOM   1677 C CB  . THR A 1 213 ? 1.434   -44.435 -11.335 1.00 36.82  ? ? ? ? ? ? 210 THR U CB  1 
+ATOM   1678 O OG1 . THR A 1 213 ? 1.043   -45.261 -10.229 1.00 39.44  ? ? ? ? ? ? 210 THR U OG1 1 
+ATOM   1679 C CG2 . THR A 1 213 ? 2.462   -45.170 -12.177 1.00 39.37  ? ? ? ? ? ? 210 THR U CG2 1 
+ATOM   1680 N N   . GLY A 1 214 ? 1.941   -41.362 -12.490 1.00 36.47  ? ? ? ? ? ? 211 GLY U N   1 
+ATOM   1681 C CA  . GLY A 1 214 ? 2.501   -40.503 -13.514 1.00 34.57  ? ? ? ? ? ? 211 GLY U CA  1 
+ATOM   1682 C C   . GLY A 1 214 ? 1.964   -39.087 -13.537 1.00 35.05  ? ? ? ? ? ? 211 GLY U C   1 
+ATOM   1683 O O   . GLY A 1 214 ? 0.944   -38.777 -12.905 1.00 32.72  ? ? ? ? ? ? 211 GLY U O   1 
+ATOM   1684 N N   . ILE A 1 215 ? 2.664   -38.249 -14.307 1.00 33.48  ? ? ? ? ? ? 212 ILE U N   1 
+ATOM   1685 C CA  . ILE A 1 215 ? 2.300   -36.859 -14.562 1.00 31.96  ? ? ? ? ? ? 212 ILE U CA  1 
+ATOM   1686 C C   . ILE A 1 215 ? 2.384   -36.665 -16.067 1.00 34.00  ? ? ? ? ? ? 212 ILE U C   1 
+ATOM   1687 O O   . ILE A 1 215 ? 3.418   -36.949 -16.677 1.00 34.87  ? ? ? ? ? ? 212 ILE U O   1 
+ATOM   1688 C CB  . ILE A 1 215 ? 3.293   -35.887 -13.912 1.00 32.01  ? ? ? ? ? ? 212 ILE U CB  1 
+ATOM   1689 C CG1 . ILE A 1 215 ? 3.278   -36.058 -12.403 1.00 30.50  ? ? ? ? ? ? 212 ILE U CG1 1 
+ATOM   1690 C CG2 . ILE A 1 215 ? 2.998   -34.443 -14.314 1.00 33.11  ? ? ? ? ? ? 212 ILE U CG2 1 
+ATOM   1691 C CD1 . ILE A 1 215 ? 4.270   -35.204 -11.671 1.00 33.53  ? ? ? ? ? ? 212 ILE U CD1 1 
+ATOM   1692 N N   . VAL A 1 216 ? 1.316   -36.171 -16.671 1.00 31.64  ? ? ? ? ? ? 213 VAL U N   1 
+ATOM   1693 C CA  . VAL A 1 216 ? 1.283   -36.094 -18.119 1.00 31.03  ? ? ? ? ? ? 213 VAL U CA  1 
+ATOM   1694 C C   . VAL A 1 216 ? 2.412   -35.199 -18.595 1.00 32.27  ? ? ? ? ? ? 213 VAL U C   1 
+ATOM   1695 O O   . VAL A 1 216 ? 2.483   -34.032 -18.194 1.00 31.82  ? ? ? ? ? ? 213 VAL U O   1 
+ATOM   1696 C CB  . VAL A 1 216 ? -0.041  -35.511 -18.646 1.00 30.18  ? ? ? ? ? ? 213 VAL U CB  1 
+ATOM   1697 C CG1 . VAL A 1 216 ? -0.008  -35.433 -20.161 1.00 29.51  ? ? ? ? ? ? 213 VAL U CG1 1 
+ATOM   1698 C CG2 . VAL A 1 216 ? -1.226  -36.336 -18.191 1.00 29.61  ? ? ? ? ? ? 213 VAL U CG2 1 
+ATOM   1699 N N   . SER A 1 217 ? 3.272   -35.745 -19.464 1.00 33.07  ? ? ? ? ? ? 214 SER U N   1 
+ATOM   1700 C CA  . SER A 1 217 ? 4.489   -35.062 -19.924 1.00 34.62  ? ? ? ? ? ? 214 SER U CA  1 
+ATOM   1701 C C   . SER A 1 217 ? 4.544   -34.792 -21.426 1.00 34.86  ? ? ? ? ? ? 214 SER U C   1 
+ATOM   1702 O O   . SER A 1 217 ? 4.639   -33.639 -21.827 1.00 36.34  ? ? ? ? ? ? 214 SER U O   1 
+ATOM   1703 C CB  . SER A 1 217 ? 5.740   -35.823 -19.496 1.00 35.04  ? ? ? ? ? ? 214 SER U CB  1 
+ATOM   1704 O OG  . SER A 1 217 ? 6.889   -35.004 -19.589 1.00 36.50  ? ? ? ? ? ? 214 SER U OG  1 
+ATOM   1705 N N   . TRP A 1 218 ? 4.497   -35.830 -22.254 1.00 35.10  ? ? ? ? ? ? 215 TRP U N   1 
+ATOM   1706 C CA  . TRP A 1 218 ? 4.537   -35.642 -23.714 1.00 37.36  ? ? ? ? ? ? 215 TRP U CA  1 
+ATOM   1707 C C   . TRP A 1 218 ? 4.014   -36.859 -24.467 1.00 39.07  ? ? ? ? ? ? 215 TRP U C   1 
+ATOM   1708 O O   . TRP A 1 218 ? 3.683   -37.876 -23.876 1.00 43.28  ? ? ? ? ? ? 215 TRP U O   1 
+ATOM   1709 C CB  . TRP A 1 218 ? 5.967   -35.280 -24.190 1.00 36.21  ? ? ? ? ? ? 215 TRP U CB  1 
+ATOM   1710 C CG  . TRP A 1 218 ? 7.010   -36.276 -23.766 1.00 35.22  ? ? ? ? ? ? 215 TRP U CG  1 
+ATOM   1711 C CD1 . TRP A 1 218 ? 7.639   -36.322 -22.568 1.00 36.43  ? ? ? ? ? ? 215 TRP U CD1 1 
+ATOM   1712 C CD2 . TRP A 1 218 ? 7.515   -37.376 -24.526 1.00 34.94  ? ? ? ? ? ? 215 TRP U CD2 1 
+ATOM   1713 N NE1 . TRP A 1 218 ? 8.516   -37.379 -22.527 1.00 37.30  ? ? ? ? ? ? 215 TRP U NE1 1 
+ATOM   1714 C CE2 . TRP A 1 218 ? 8.451   -38.049 -23.715 1.00 37.37  ? ? ? ? ? ? 215 TRP U CE2 1 
+ATOM   1715 C CE3 . TRP A 1 218 ? 7.262   -37.864 -25.810 1.00 36.87  ? ? ? ? ? ? 215 TRP U CE3 1 
+ATOM   1716 C CZ2 . TRP A 1 218 ? 9.150   -39.184 -24.153 1.00 39.28  ? ? ? ? ? ? 215 TRP U CZ2 1 
+ATOM   1717 C CZ3 . TRP A 1 218 ? 7.949   -38.989 -26.244 1.00 39.13  ? ? ? ? ? ? 215 TRP U CZ3 1 
+ATOM   1718 C CH2 . TRP A 1 218 ? 8.885   -39.634 -25.420 1.00 40.07  ? ? ? ? ? ? 215 TRP U CH2 1 
+ATOM   1719 N N   . GLY A 1 219 ? 3.696   -36.679 -25.731 1.00 45.63  ? ? ? ? ? ? 216 GLY U N   1 
+ATOM   1720 C CA  . GLY A 1 219 ? 3.445   -37.747 -26.654 1.00 46.54  ? ? ? ? ? ? 216 GLY U CA  1 
+ATOM   1721 C C   . GLY A 1 219 ? 3.290   -37.148 -28.022 1.00 49.46  ? ? ? ? ? ? 216 GLY U C   1 
+ATOM   1722 O O   . GLY A 1 219 ? 2.894   -36.020 -28.108 1.00 50.30  ? ? ? ? ? ? 216 GLY U O   1 
+ATOM   1723 N N   . ARG A 1 220 ? 3.498   -37.919 -29.077 1.00 51.54  ? ? ? ? ? ? 217 ARG U N   1 
+ATOM   1724 C CA  . ARG A 1 220 ? 3.329   -37.424 -30.431 1.00 54.70  ? ? ? ? ? ? 217 ARG U CA  1 
+ATOM   1725 C C   . ARG A 1 220 ? 1.896   -37.587 -30.821 1.00 53.58  ? ? ? ? ? ? 217 ARG U C   1 
+ATOM   1726 O O   . ARG A 1 220 ? 1.357   -38.661 -30.731 1.00 60.05  ? ? ? ? ? ? 217 ARG U O   1 
+ATOM   1727 C CB  . ARG A 1 220 ? 4.238   -38.193 -31.391 1.00 57.79  ? ? ? ? ? ? 217 ARG U CB  1 
+ATOM   1728 C CG  . ARG A 1 220 ? 4.113   -37.823 -32.849 1.00 62.46  ? ? ? ? ? ? 217 ARG U CG  1 
+ATOM   1729 C CD  . ARG A 1 220 ? 4.793   -38.829 -33.763 1.00 66.41  ? ? ? ? ? ? 217 ARG U CD  1 
+ATOM   1730 N NE  . ARG A 1 220 ? 5.322   -38.196 -34.958 1.00 72.21  ? ? ? ? ? ? 217 ARG U NE  1 
+ATOM   1731 C CZ  . ARG A 1 220 ? 6.238   -38.722 -35.773 1.00 72.39  ? ? ? ? ? ? 217 ARG U CZ  1 
+ATOM   1732 N NH1 . ARG A 1 220 ? 6.649   -38.039 -36.837 1.00 69.34  ? ? ? ? ? ? 217 ARG U NH1 1 
+ATOM   1733 N NH2 . ARG A 1 220 ? 6.749   -39.913 -35.526 1.00 69.94  ? ? ? ? ? ? 217 ARG U NH2 1 
+ATOM   1734 N N   . GLY A 1 221 ? 1.256   -36.499 -31.194 1.00 48.92  ? ? ? ? ? ? 219 GLY U N   1 
+ATOM   1735 C CA  . GLY A 1 221 ? -0.142  -36.526 -31.539 1.00 49.62  ? ? ? ? ? ? 219 GLY U CA  1 
+ATOM   1736 C C   . GLY A 1 221 ? -0.922  -36.891 -30.297 1.00 50.98  ? ? ? ? ? ? 219 GLY U C   1 
+ATOM   1737 O O   . GLY A 1 221 ? -0.387  -36.877 -29.226 1.00 47.58  ? ? ? ? ? ? 219 GLY U O   1 
+ATOM   1738 N N   . CYS A 1 222 ? -2.170  -37.283 -30.463 1.00 48.73  ? ? ? ? ? ? 220 CYS U N   1 
+ATOM   1739 C CA  . CYS A 1 222 ? -2.923  -37.905 -29.401 1.00 47.18  ? ? ? ? ? ? 220 CYS U CA  1 
+ATOM   1740 C C   . CYS A 1 222 ? -3.684  -39.155 -29.906 1.00 44.32  ? ? ? ? ? ? 220 CYS U C   1 
+ATOM   1741 O O   . CYS A 1 222 ? -4.292  -39.111 -30.947 1.00 43.12  ? ? ? ? ? ? 220 CYS U O   1 
+ATOM   1742 C CB  . CYS A 1 222 ? -3.882  -36.885 -28.811 1.00 44.97  ? ? ? ? ? ? 220 CYS U CB  1 
+ATOM   1743 S SG  . CYS A 1 222 ? -3.268  -35.222 -28.499 1.00 49.80  ? ? ? ? ? ? 220 CYS U SG  1 
+ATOM   1744 N N   . ALA A 1 223 ? -3.657  -40.246 -29.159 1.00 44.24  ? ? ? ? ? ? 221 ALA U N   1 
+ATOM   1745 C CA  . ALA A 1 223 ? -4.330  -41.476 -29.565 1.00 45.80  ? ? ? ? ? ? 221 ALA U CA  1 
+ATOM   1746 C C   . ALA A 1 223 ? -3.866  -41.835 -30.984 1.00 50.44  ? ? ? ? ? ? 221 ALA U C   1 
+ATOM   1747 O O   . ALA A 1 223 ? -4.676  -42.175 -31.853 1.00 49.11  ? ? ? ? ? ? 221 ALA U O   1 
+ATOM   1748 C CB  . ALA A 1 223 ? -5.839  -41.299 -29.521 1.00 46.47  ? ? ? ? ? ? 221 ALA U CB  1 
+ATOM   1749 N N   . LEU A 1 224 ? -2.570  -41.765 -31.213 1.00 49.32  ? ? ? ? ? ? 222 LEU U N   1 
+ATOM   1750 C CA  . LEU A 1 224 ? -2.002  -42.001 -32.530 1.00 52.04  ? ? ? ? ? ? 222 LEU U CA  1 
+ATOM   1751 C C   . LEU A 1 224 ? -1.284  -43.303 -32.507 1.00 53.42  ? ? ? ? ? ? 222 LEU U C   1 
+ATOM   1752 O O   . LEU A 1 224 ? -0.503  -43.550 -31.620 1.00 50.49  ? ? ? ? ? ? 222 LEU U O   1 
+ATOM   1753 C CB  . LEU A 1 224 ? -1.033  -40.898 -32.866 1.00 51.24  ? ? ? ? ? ? 222 LEU U CB  1 
+ATOM   1754 C CG  . LEU A 1 224 ? -0.116  -40.939 -34.060 1.00 53.84  ? ? ? ? ? ? 222 LEU U CG  1 
+ATOM   1755 C CD1 . LEU A 1 224 ? -0.901  -40.974 -35.341 1.00 51.26  ? ? ? ? ? ? 222 LEU U CD1 1 
+ATOM   1756 C CD2 . LEU A 1 224 ? 0.716   -39.694 -34.004 1.00 54.48  ? ? ? ? ? ? 222 LEU U CD2 1 
+ATOM   1757 N N   . LYS A 1 225 ? -1.520  -44.140 -33.502 1.00 57.73  ? ? ? ? ? ? 223 LYS U N   1 
+ATOM   1758 C CA  . LYS A 1 225 ? -0.990  -45.489 -33.450 1.00 60.71  ? ? ? ? ? ? 223 LYS U CA  1 
+ATOM   1759 C C   . LYS A 1 225 ? 0.510   -45.464 -33.242 1.00 55.18  ? ? ? ? ? ? 223 LYS U C   1 
+ATOM   1760 O O   . LYS A 1 225 ? 1.217   -44.686 -33.851 1.00 51.83  ? ? ? ? ? ? 223 LYS U O   1 
+ATOM   1761 C CB  . LYS A 1 225 ? -1.328  -46.232 -34.727 1.00 64.23  ? ? ? ? ? ? 223 LYS U CB  1 
+ATOM   1762 C CG  . LYS A 1 225 ? -0.926  -47.685 -34.752 1.00 67.90  ? ? ? ? ? ? 223 LYS U CG  1 
+ATOM   1763 C CD  . LYS A 1 225 ? -1.805  -48.460 -35.721 1.00 69.21  ? ? ? ? ? ? 223 LYS U CD  1 
+ATOM   1764 C CE  . LYS A 1 225 ? -1.316  -49.874 -35.899 1.00 72.31  ? ? ? ? ? ? 223 LYS U CE  1 
+ATOM   1765 N NZ  . LYS A 1 225 ? -2.415  -50.762 -36.351 1.00 77.12  ? ? ? ? ? ? 223 LYS U NZ  1 
+ATOM   1766 N N   . ASP A 1 226 A 0.919   -46.288 -32.285 1.00 56.35  ? ? ? ? ? ? 223 ASP U N   1 
+ATOM   1767 C CA  . ASP A 1 226 A 2.280   -46.618 -31.905 1.00 62.68  ? ? ? ? ? ? 223 ASP U CA  1 
+ATOM   1768 C C   . ASP A 1 226 A 3.054   -45.554 -31.179 1.00 63.30  ? ? ? ? ? ? 223 ASP U C   1 
+ATOM   1769 O O   . ASP A 1 226 A 4.232   -45.717 -30.885 1.00 60.77  ? ? ? ? ? ? 223 ASP U O   1 
+ATOM   1770 C CB  . ASP A 1 226 A 3.078   -47.256 -33.026 1.00 65.15  ? ? ? ? ? ? 223 ASP U CB  1 
+ATOM   1771 C CG  . ASP A 1 226 A 2.598   -48.652 -33.348 1.00 67.13  ? ? ? ? ? ? 223 ASP U CG  1 
+ATOM   1772 O OD1 . ASP A 1 226 A 2.947   -49.597 -32.629 1.00 64.06  ? ? ? ? ? ? 223 ASP U OD1 1 
+ATOM   1773 O OD2 . ASP A 1 226 A 1.855   -48.786 -34.323 1.00 69.76  ? ? ? ? ? ? 223 ASP U OD2 1 
+ATOM   1774 N N   . LYS A 1 227 ? 2.336   -44.510 -30.805 1.00 62.31  ? ? ? ? ? ? 224 LYS U N   1 
+ATOM   1775 C CA  . LYS A 1 227 ? 2.873   -43.401 -30.059 1.00 57.48  ? ? ? ? ? ? 224 LYS U CA  1 
+ATOM   1776 C C   . LYS A 1 227 ? 2.133   -43.180 -28.728 1.00 54.69  ? ? ? ? ? ? 224 LYS U C   1 
+ATOM   1777 O O   . LYS A 1 227 ? 1.234   -42.392 -28.659 1.00 51.72  ? ? ? ? ? ? 224 LYS U O   1 
+ATOM   1778 C CB  . LYS A 1 227 ? 2.772   -42.161 -30.920 1.00 58.65  ? ? ? ? ? ? 224 LYS U CB  1 
+ATOM   1779 C CG  . LYS A 1 227 ? 3.322   -42.339 -32.319 1.00 59.63  ? ? ? ? ? ? 224 LYS U CG  1 
+ATOM   1780 C CD  . LYS A 1 227 ? 4.827   -42.407 -32.260 1.00 61.08  ? ? ? ? ? ? 224 LYS U CD  1 
+ATOM   1781 C CE  . LYS A 1 227 ? 5.471   -42.839 -33.569 1.00 60.77  ? ? ? ? ? ? 224 LYS U CE  1 
+ATOM   1782 N NZ  . LYS A 1 227 ? 6.875   -43.215 -33.286 1.00 62.48  ? ? ? ? ? ? 224 LYS U NZ  1 
+ATOM   1783 N N   . PRO A 1 228 ? 2.540   -43.875 -27.685 1.00 50.53  ? ? ? ? ? ? 225 PRO U N   1 
+ATOM   1784 C CA  . PRO A 1 228 ? 1.904   -43.742 -26.365 1.00 50.03  ? ? ? ? ? ? 225 PRO U CA  1 
+ATOM   1785 C C   . PRO A 1 228 ? 2.020   -42.358 -25.721 1.00 48.14  ? ? ? ? ? ? 225 PRO U C   1 
+ATOM   1786 O O   . PRO A 1 228 ? 2.935   -41.589 -26.022 1.00 46.97  ? ? ? ? ? ? 225 PRO U O   1 
+ATOM   1787 C CB  . PRO A 1 228 ? 2.679   -44.738 -25.489 1.00 49.76  ? ? ? ? ? ? 225 PRO U CB  1 
+ATOM   1788 C CG  . PRO A 1 228 ? 3.371   -45.656 -26.429 1.00 51.71  ? ? ? ? ? ? 225 PRO U CG  1 
+ATOM   1789 C CD  . PRO A 1 228 ? 3.621   -44.877 -27.677 1.00 50.15  ? ? ? ? ? ? 225 PRO U CD  1 
+ATOM   1790 N N   . GLY A 1 229 ? 1.108   -42.054 -24.806 1.00 43.25  ? ? ? ? ? ? 226 GLY U N   1 
+ATOM   1791 C CA  . GLY A 1 229 ? 1.327   -40.940 -23.911 1.00 39.06  ? ? ? ? ? ? 226 GLY U CA  1 
+ATOM   1792 C C   . GLY A 1 229 ? 2.515   -41.255 -23.020 1.00 39.11  ? ? ? ? ? ? 226 GLY U C   1 
+ATOM   1793 O O   . GLY A 1 229 ? 2.734   -42.411 -22.636 1.00 37.46  ? ? ? ? ? ? 226 GLY U O   1 
+ATOM   1794 N N   . VAL A 1 230 ? 3.292   -40.231 -22.690 1.00 37.48  ? ? ? ? ? ? 227 VAL U N   1 
+ATOM   1795 C CA  . VAL A 1 230 ? 4.478   -40.416 -21.862 1.00 36.17  ? ? ? ? ? ? 227 VAL U CA  1 
+ATOM   1796 C C   . VAL A 1 230 ? 4.338   -39.581 -20.617 1.00 35.81  ? ? ? ? ? ? 227 VAL U C   1 
+ATOM   1797 O O   . VAL A 1 230 ? 3.863   -38.432 -20.665 1.00 35.45  ? ? ? ? ? ? 227 VAL U O   1 
+ATOM   1798 C CB  . VAL A 1 230 ? 5.754   -40.005 -22.629 1.00 36.64  ? ? ? ? ? ? 227 VAL U CB  1 
+ATOM   1799 C CG1 . VAL A 1 230 ? 6.998   -40.399 -21.849 1.00 33.70  ? ? ? ? ? ? 227 VAL U CG1 1 
+ATOM   1800 C CG2 . VAL A 1 230 ? 5.726   -40.612 -24.029 1.00 35.76  ? ? ? ? ? ? 227 VAL U CG2 1 
+ATOM   1801 N N   . TYR A 1 231 ? 4.755   -40.158 -19.497 1.00 37.81  ? ? ? ? ? ? 228 TYR U N   1 
+ATOM   1802 C CA  . TYR A 1 231 ? 4.490   -39.580 -18.194 1.00 36.72  ? ? ? ? ? ? 228 TYR U CA  1 
+ATOM   1803 C C   . TYR A 1 231 ? 5.725   -39.596 -17.337 1.00 37.14  ? ? ? ? ? ? 228 TYR U C   1 
+ATOM   1804 O O   . TYR A 1 231 ? 6.563   -40.485 -17.457 1.00 38.67  ? ? ? ? ? ? 228 TYR U O   1 
+ATOM   1805 C CB  . TYR A 1 231 ? 3.393   -40.374 -17.490 1.00 38.41  ? ? ? ? ? ? 228 TYR U CB  1 
+ATOM   1806 C CG  . TYR A 1 231 ? 2.079   -40.394 -18.235 1.00 37.85  ? ? ? ? ? ? 228 TYR U CG  1 
+ATOM   1807 C CD1 . TYR A 1 231 ? 1.918   -41.145 -19.414 1.00 39.30  ? ? ? ? ? ? 228 TYR U CD1 1 
+ATOM   1808 C CD2 . TYR A 1 231 ? 0.987   -39.682 -17.760 1.00 35.57  ? ? ? ? ? ? 228 TYR U CD2 1 
+ATOM   1809 C CE1 . TYR A 1 231 ? 0.711   -41.156 -20.093 1.00 36.43  ? ? ? ? ? ? 228 TYR U CE1 1 
+ATOM   1810 C CE2 . TYR A 1 231 ? -0.214  -39.697 -18.421 1.00 35.14  ? ? ? ? ? ? 228 TYR U CE2 1 
+ATOM   1811 C CZ  . TYR A 1 231 ? -0.353  -40.418 -19.586 1.00 35.67  ? ? ? ? ? ? 228 TYR U CZ  1 
+ATOM   1812 O OH  . TYR A 1 231 ? -1.564  -40.394 -20.221 1.00 35.42  ? ? ? ? ? ? 228 TYR U OH  1 
+ATOM   1813 N N   . THR A 1 232 ? 5.828   -38.609 -16.456 1.00 35.74  ? ? ? ? ? ? 229 THR U N   1 
+ATOM   1814 C CA  . THR A 1 232 ? 6.923   -38.536 -15.524 1.00 35.58  ? ? ? ? ? ? 229 THR U CA  1 
+ATOM   1815 C C   . THR A 1 232 ? 6.692   -39.617 -14.450 1.00 38.63  ? ? ? ? ? ? 229 THR U C   1 
+ATOM   1816 O O   . THR A 1 232 ? 5.630   -39.677 -13.845 1.00 37.06  ? ? ? ? ? ? 229 THR U O   1 
+ATOM   1817 C CB  . THR A 1 232 ? 7.004   -37.139 -14.900 1.00 34.20  ? ? ? ? ? ? 229 THR U CB  1 
+ATOM   1818 O OG1 . THR A 1 232 ? 7.151   -36.150 -15.947 1.00 31.37  ? ? ? ? ? ? 229 THR U OG1 1 
+ATOM   1819 C CG2 . THR A 1 232 ? 8.171   -37.060 -13.904 1.00 33.68  ? ? ? ? ? ? 229 THR U CG2 1 
+ATOM   1820 N N   . ARG A 1 233 ? 7.688   -40.477 -14.252 1.00 40.72  ? ? ? ? ? ? 230 ARG U N   1 
+ATOM   1821 C CA  . ARG A 1 233 ? 7.579   -41.624 -13.357 1.00 42.16  ? ? ? ? ? ? 230 ARG U CA  1 
+ATOM   1822 C C   . ARG A 1 233 ? 7.738   -41.170 -11.918 1.00 44.96  ? ? ? ? ? ? 230 ARG U C   1 
+ATOM   1823 O O   . ARG A 1 233 ? 8.854   -41.074 -11.388 1.00 45.97  ? ? ? ? ? ? 230 ARG U O   1 
+ATOM   1824 C CB  . ARG A 1 233 ? 8.639   -42.663 -13.741 1.00 45.67  ? ? ? ? ? ? 230 ARG U CB  1 
+ATOM   1825 C CG  . ARG A 1 233 ? 8.507   -44.023 -13.091 1.00 47.78  ? ? ? ? ? ? 230 ARG U CG  1 
+ATOM   1826 C CD  . ARG A 1 233 ? 9.439   -45.014 -13.780 1.00 51.35  ? ? ? ? ? ? 230 ARG U CD  1 
+ATOM   1827 N NE  . ARG A 1 233 ? 9.548   -46.265 -13.033 1.00 55.93  ? ? ? ? ? ? 230 ARG U NE  1 
+ATOM   1828 C CZ  . ARG A 1 233 ? 10.170  -47.366 -13.457 1.00 60.26  ? ? ? ? ? ? 230 ARG U CZ  1 
+ATOM   1829 N NH1 . ARG A 1 233 ? 10.766  -47.404 -14.648 1.00 57.22  ? ? ? ? ? ? 230 ARG U NH1 1 
+ATOM   1830 N NH2 . ARG A 1 233 ? 10.198  -48.445 -12.672 1.00 61.39  ? ? ? ? ? ? 230 ARG U NH2 1 
+ATOM   1831 N N   . VAL A 1 234 ? 6.606   -40.899 -11.277 1.00 45.54  ? ? ? ? ? ? 231 VAL U N   1 
+ATOM   1832 C CA  . VAL A 1 234 ? 6.594   -40.278 -9.949  1.00 45.01  ? ? ? ? ? ? 231 VAL U CA  1 
+ATOM   1833 C C   . VAL A 1 234 ? 7.427   -41.016 -8.905  1.00 47.58  ? ? ? ? ? ? 231 VAL U C   1 
+ATOM   1834 O O   . VAL A 1 234 ? 8.110   -40.379 -8.085  1.00 42.07  ? ? ? ? ? ? 231 VAL U O   1 
+ATOM   1835 C CB  . VAL A 1 234 ? 5.144   -40.114 -9.427  1.00 45.33  ? ? ? ? ? ? 231 VAL U CB  1 
+ATOM   1836 C CG1 . VAL A 1 234 ? 5.133   -39.662 -7.976  1.00 45.23  ? ? ? ? ? ? 231 VAL U CG1 1 
+ATOM   1837 C CG2 . VAL A 1 234 ? 4.384   -39.119 -10.304 1.00 44.83  ? ? ? ? ? ? 231 VAL U CG2 1 
+ATOM   1838 N N   . SER A 1 235 ? 7.349   -42.349 -8.922  1.00 48.57  ? ? ? ? ? ? 232 SER U N   1 
+ATOM   1839 C CA  . SER A 1 235 ? 8.043   -43.188 -7.929  1.00 48.44  ? ? ? ? ? ? 232 SER U CA  1 
+ATOM   1840 C C   . SER A 1 235 ? 9.542   -42.916 -7.887  1.00 50.78  ? ? ? ? ? ? 232 SER U C   1 
+ATOM   1841 O O   . SER A 1 235 ? 10.191  -43.190 -6.878  1.00 57.08  ? ? ? ? ? ? 232 SER U O   1 
+ATOM   1842 C CB  . SER A 1 235 ? 7.797   -44.683 -8.208  1.00 46.09  ? ? ? ? ? ? 232 SER U CB  1 
+ATOM   1843 O OG  . SER A 1 235 ? 8.405   -45.089 -9.425  1.00 44.08  ? ? ? ? ? ? 232 SER U OG  1 
+ATOM   1844 N N   . HIS A 1 236 ? 10.089  -42.388 -8.979  1.00 52.99  ? ? ? ? ? ? 233 HIS U N   1 
+ATOM   1845 C CA  . HIS A 1 236 ? 11.504  -42.015 -9.041  1.00 56.17  ? ? ? ? ? ? 233 HIS U CA  1 
+ATOM   1846 C C   . HIS A 1 236 ? 11.853  -40.654 -8.433  1.00 54.08  ? ? ? ? ? ? 233 HIS U C   1 
+ATOM   1847 O O   . HIS A 1 236 ? 13.029  -40.302 -8.392  1.00 53.58  ? ? ? ? ? ? 233 HIS U O   1 
+ATOM   1848 C CB  . HIS A 1 236 ? 12.002  -42.048 -10.493 1.00 57.52  ? ? ? ? ? ? 233 HIS U CB  1 
+ATOM   1849 C CG  . HIS A 1 236 ? 12.248  -43.428 -11.014 1.00 61.06  ? ? ? ? ? ? 233 HIS U CG  1 
+ATOM   1850 N ND1 . HIS A 1 236 ? 11.473  -44.511 -10.655 1.00 63.63  ? ? ? ? ? ? 233 HIS U ND1 1 
+ATOM   1851 C CD2 . HIS A 1 236 ? 13.178  -43.900 -11.879 1.00 61.75  ? ? ? ? ? ? 233 HIS U CD2 1 
+ATOM   1852 C CE1 . HIS A 1 236 ? 11.920  -45.593 -11.270 1.00 64.37  ? ? ? ? ? ? 233 HIS U CE1 1 
+ATOM   1853 N NE2 . HIS A 1 236 ? 12.952  -45.249 -12.020 1.00 64.01  ? ? ? ? ? ? 233 HIS U NE2 1 
+ATOM   1854 N N   . PHE A 1 237 ? 10.867  -39.896 -7.950  1.00 50.30  ? ? ? ? ? ? 234 PHE U N   1 
+ATOM   1855 C CA  . PHE A 1 237 ? 11.132  -38.524 -7.481  1.00 47.22  ? ? ? ? ? ? 234 PHE U CA  1 
+ATOM   1856 C C   . PHE A 1 237 ? 10.774  -38.263 -6.017  1.00 48.08  ? ? ? ? ? ? 234 PHE U C   1 
+ATOM   1857 O O   . PHE A 1 237 ? 10.667  -37.109 -5.588  1.00 46.92  ? ? ? ? ? ? 234 PHE U O   1 
+ATOM   1858 C CB  . PHE A 1 237 ? 10.444  -37.512 -8.398  1.00 45.49  ? ? ? ? ? ? 234 PHE U CB  1 
+ATOM   1859 C CG  . PHE A 1 237 ? 11.076  -37.402 -9.757  1.00 44.01  ? ? ? ? ? ? 234 PHE U CG  1 
+ATOM   1860 C CD1 . PHE A 1 237 ? 10.712  -38.258 -10.770 1.00 41.82  ? ? ? ? ? ? 234 PHE U CD1 1 
+ATOM   1861 C CD2 . PHE A 1 237 ? 12.046  -36.428 -10.022 1.00 44.60  ? ? ? ? ? ? 234 PHE U CD2 1 
+ATOM   1862 C CE1 . PHE A 1 237 ? 11.285  -38.160 -12.029 1.00 41.43  ? ? ? ? ? ? 234 PHE U CE1 1 
+ATOM   1863 C CE2 . PHE A 1 237 ? 12.621  -36.320 -11.278 1.00 42.69  ? ? ? ? ? ? 234 PHE U CE2 1 
+ATOM   1864 C CZ  . PHE A 1 237 ? 12.243  -37.194 -12.282 1.00 42.40  ? ? ? ? ? ? 234 PHE U CZ  1 
+ATOM   1865 N N   . LEU A 1 238 ? 10.639  -39.328 -5.233  1.00 48.13  ? ? ? ? ? ? 235 LEU U N   1 
+ATOM   1866 C CA  . LEU A 1 238 ? 10.296  -39.175 -3.821  1.00 48.67  ? ? ? ? ? ? 235 LEU U CA  1 
+ATOM   1867 C C   . LEU A 1 238 ? 11.294  -38.372 -2.992  1.00 51.19  ? ? ? ? ? ? 235 LEU U C   1 
+ATOM   1868 O O   . LEU A 1 238 ? 10.882  -37.681 -2.050  1.00 52.19  ? ? ? ? ? ? 235 LEU U O   1 
+ATOM   1869 C CB  . LEU A 1 238 ? 10.067  -40.537 -3.166  1.00 51.02  ? ? ? ? ? ? 235 LEU U CB  1 
+ATOM   1870 C CG  . LEU A 1 238 ? 8.768   -41.257 -3.542  1.00 52.30  ? ? ? ? ? ? 235 LEU U CG  1 
+ATOM   1871 C CD1 . LEU A 1 238 ? 8.558   -42.458 -2.634  1.00 54.66  ? ? ? ? ? ? 235 LEU U CD1 1 
+ATOM   1872 C CD2 . LEU A 1 238 ? 7.556   -40.339 -3.453  1.00 52.39  ? ? ? ? ? ? 235 LEU U CD2 1 
+ATOM   1873 N N   . PRO A 1 239 ? 12.603  -38.468 -3.308  1.00 51.45  ? ? ? ? ? ? 236 PRO U N   1 
+ATOM   1874 C CA  . PRO A 1 239 ? 13.566  -37.645 -2.563  1.00 50.77  ? ? ? ? ? ? 236 PRO U CA  1 
+ATOM   1875 C C   . PRO A 1 239 ? 13.427  -36.174 -2.928  1.00 49.84  ? ? ? ? ? ? 236 PRO U C   1 
+ATOM   1876 O O   . PRO A 1 239 ? 13.297  -35.315 -2.035  1.00 48.94  ? ? ? ? ? ? 236 PRO U O   1 
+ATOM   1877 C CB  . PRO A 1 239 ? 14.927  -38.196 -3.008  1.00 49.68  ? ? ? ? ? ? 236 PRO U CB  1 
+ATOM   1878 C CG  . PRO A 1 239 ? 14.634  -39.550 -3.558  1.00 49.22  ? ? ? ? ? ? 236 PRO U CG  1 
+ATOM   1879 C CD  . PRO A 1 239 ? 13.284  -39.447 -4.173  1.00 47.92  ? ? ? ? ? ? 236 PRO U CD  1 
+ATOM   1880 N N   . TRP A 1 240 ? 13.439  -35.896 -4.233  1.00 46.84  ? ? ? ? ? ? 237 TRP U N   1 
+ATOM   1881 C CA  . TRP A 1 240 ? 13.155  -34.555 -4.733  1.00 44.84  ? ? ? ? ? ? 237 TRP U CA  1 
+ATOM   1882 C C   . TRP A 1 240 ? 11.886  -34.033 -4.064  1.00 43.35  ? ? ? ? ? ? 237 TRP U C   1 
+ATOM   1883 O O   . TRP A 1 240 ? 11.890  -32.969 -3.442  1.00 44.13  ? ? ? ? ? ? 237 TRP U O   1 
+ATOM   1884 C CB  . TRP A 1 240 ? 13.038  -34.564 -6.268  1.00 47.28  ? ? ? ? ? ? 237 TRP U CB  1 
+ATOM   1885 C CG  . TRP A 1 240 ? 12.903  -33.186 -6.849  1.00 48.30  ? ? ? ? ? ? 237 TRP U CG  1 
+ATOM   1886 C CD1 . TRP A 1 240 ? 13.913  -32.310 -7.159  1.00 51.54  ? ? ? ? ? ? 237 TRP U CD1 1 
+ATOM   1887 C CD2 . TRP A 1 240 ? 11.681  -32.505 -7.140  1.00 47.99  ? ? ? ? ? ? 237 TRP U CD2 1 
+ATOM   1888 N NE1 . TRP A 1 240 ? 13.387  -31.130 -7.636  1.00 50.76  ? ? ? ? ? ? 237 TRP U NE1 1 
+ATOM   1889 C CE2 . TRP A 1 240 ? 12.019  -31.226 -7.637  1.00 49.18  ? ? ? ? ? ? 237 TRP U CE2 1 
+ATOM   1890 C CE3 . TRP A 1 240 ? 10.330  -32.855 -7.035  1.00 45.30  ? ? ? ? ? ? 237 TRP U CE3 1 
+ATOM   1891 C CZ2 . TRP A 1 240 ? 11.051  -30.303 -8.044  1.00 49.49  ? ? ? ? ? ? 237 TRP U CZ2 1 
+ATOM   1892 C CZ3 . TRP A 1 240 ? 9.372   -31.938 -7.436  1.00 44.24  ? ? ? ? ? ? 237 TRP U CZ3 1 
+ATOM   1893 C CH2 . TRP A 1 240 ? 9.737   -30.680 -7.932  1.00 49.14  ? ? ? ? ? ? 237 TRP U CH2 1 
+ATOM   1894 N N   . ILE A 1 241 ? 10.816  -34.822 -4.107  1.00 46.25  ? ? ? ? ? ? 238 ILE U N   1 
+ATOM   1895 C CA  . ILE A 1 241 ? 9.541   -34.403 -3.505  1.00 45.62  ? ? ? ? ? ? 238 ILE U CA  1 
+ATOM   1896 C C   . ILE A 1 241 ? 9.613   -34.198 -1.988  1.00 49.87  ? ? ? ? ? ? 238 ILE U C   1 
+ATOM   1897 O O   . ILE A 1 241 ? 9.224   -33.138 -1.474  1.00 45.97  ? ? ? ? ? ? 238 ILE U O   1 
+ATOM   1898 C CB  . ILE A 1 241 ? 8.415   -35.414 -3.809  1.00 43.33  ? ? ? ? ? ? 238 ILE U CB  1 
+ATOM   1899 C CG1 . ILE A 1 241 ? 8.057   -35.364 -5.304  1.00 42.43  ? ? ? ? ? ? 238 ILE U CG1 1 
+ATOM   1900 C CG2 . ILE A 1 241 ? 7.190   -35.130 -2.944  1.00 41.30  ? ? ? ? ? ? 238 ILE U CG2 1 
+ATOM   1901 C CD1 . ILE A 1 241 ? 7.360   -36.600 -5.819  1.00 42.78  ? ? ? ? ? ? 238 ILE U CD1 1 
+ATOM   1902 N N   . ARG A 1 242 ? 10.081  -35.213 -1.265  1.00 54.45  ? ? ? ? ? ? 239 ARG U N   1 
+ATOM   1903 C CA  . ARG A 1 242 ? 10.082  -35.132 0.198   1.00 57.40  ? ? ? ? ? ? 239 ARG U CA  1 
+ATOM   1904 C C   . ARG A 1 242 ? 10.957  -33.987 0.705   1.00 55.46  ? ? ? ? ? ? 239 ARG U C   1 
+ATOM   1905 O O   . ARG A 1 242 ? 10.628  -33.378 1.720   1.00 56.87  ? ? ? ? ? ? 239 ARG U O   1 
+ATOM   1906 C CB  . ARG A 1 242 ? 10.462  -36.464 0.854   1.00 60.79  ? ? ? ? ? ? 239 ARG U CB  1 
+ATOM   1907 C CG  . ARG A 1 242 ? 9.311   -37.467 0.920   1.00 65.69  ? ? ? ? ? ? 239 ARG U CG  1 
+ATOM   1908 C CD  . ARG A 1 242 ? 9.643   -38.679 1.783   1.00 70.68  ? ? ? ? ? ? 239 ARG U CD  1 
+ATOM   1909 N NE  . ARG A 1 242 ? 10.797  -39.432 1.268   1.00 78.05  ? ? ? ? ? ? 239 ARG U NE  1 
+ATOM   1910 C CZ  . ARG A 1 242 ? 10.759  -40.653 0.723   1.00 80.90  ? ? ? ? ? ? 239 ARG U CZ  1 
+ATOM   1911 N NH1 . ARG A 1 242 ? 9.615   -41.329 0.607   1.00 82.51  ? ? ? ? ? ? 239 ARG U NH1 1 
+ATOM   1912 N NH2 . ARG A 1 242 ? 11.888  -41.213 0.292   1.00 80.69  ? ? ? ? ? ? 239 ARG U NH2 1 
+ATOM   1913 N N   . SER A 1 243 ? 12.028  -33.657 -0.018  1.00 57.94  ? ? ? ? ? ? 240 SER U N   1 
+ATOM   1914 C CA  . SER A 1 243 ? 12.914  -32.557 0.391   1.00 61.03  ? ? ? ? ? ? 240 SER U CA  1 
+ATOM   1915 C C   . SER A 1 243 ? 12.149  -31.244 0.470   1.00 68.10  ? ? ? ? ? ? 240 SER U C   1 
+ATOM   1916 O O   . SER A 1 243 ? 12.332  -30.462 1.409   1.00 69.05  ? ? ? ? ? ? 240 SER U O   1 
+ATOM   1917 C CB  . SER A 1 243 ? 14.083  -32.381 -0.577  1.00 63.36  ? ? ? ? ? ? 240 SER U CB  1 
+ATOM   1918 O OG  . SER A 1 243 ? 13.763  -31.458 -1.613  1.00 62.27  ? ? ? ? ? ? 240 SER U OG  1 
+ATOM   1919 N N   . HIS A 1 244 ? 11.293  -31.007 -0.523  1.00 68.42  ? ? ? ? ? ? 241 HIS U N   1 
+ATOM   1920 C CA  . HIS A 1 244 ? 10.561  -29.750 -0.617  1.00 68.66  ? ? ? ? ? ? 241 HIS U CA  1 
+ATOM   1921 C C   . HIS A 1 244 ? 9.303   -29.761 0.238   1.00 70.80  ? ? ? ? ? ? 241 HIS U C   1 
+ATOM   1922 O O   . HIS A 1 244 ? 8.932   -28.728 0.794   1.00 69.14  ? ? ? ? ? ? 241 HIS U O   1 
+ATOM   1923 C CB  . HIS A 1 244 ? 10.214  -29.438 -2.071  1.00 68.22  ? ? ? ? ? ? 241 HIS U CB  1 
+ATOM   1924 C CG  . HIS A 1 244 ? 11.414  -29.281 -2.954  1.00 67.18  ? ? ? ? ? ? 241 HIS U CG  1 
+ATOM   1925 N ND1 . HIS A 1 244 ? 11.873  -30.291 -3.770  1.00 68.96  ? ? ? ? ? ? 241 HIS U ND1 1 
+ATOM   1926 C CD2 . HIS A 1 244 ? 12.257  -28.237 -3.137  1.00 68.26  ? ? ? ? ? ? 241 HIS U CD2 1 
+ATOM   1927 C CE1 . HIS A 1 244 ? 12.944  -29.877 -4.422  1.00 68.81  ? ? ? ? ? ? 241 HIS U CE1 1 
+ATOM   1928 N NE2 . HIS A 1 244 ? 13.196  -28.632 -4.059  1.00 67.66  ? ? ? ? ? ? 241 HIS U NE2 1 
+ATOM   1929 N N   . THR A 1 245 ? 8.653   -30.920 0.349   1.00 74.54  ? ? ? ? ? ? 242 THR U N   1 
+ATOM   1930 C CA  . THR A 1 245 ? 7.409   -31.026 1.116   1.00 76.27  ? ? ? ? ? ? 242 THR U CA  1 
+ATOM   1931 C C   . THR A 1 245 ? 7.657   -30.922 2.624   1.00 80.13  ? ? ? ? ? ? 242 THR U C   1 
+ATOM   1932 O O   . THR A 1 245 ? 6.841   -30.341 3.339   1.00 77.76  ? ? ? ? ? ? 242 THR U O   1 
+ATOM   1933 C CB  . THR A 1 245 ? 6.622   -32.311 0.793   1.00 75.34  ? ? ? ? ? ? 242 THR U CB  1 
+ATOM   1934 O OG1 . THR A 1 245 ? 7.438   -33.459 1.042   1.00 76.53  ? ? ? ? ? ? 242 THR U OG1 1 
+ATOM   1935 C CG2 . THR A 1 245 ? 6.172   -32.307 -0.662  1.00 73.83  ? ? ? ? ? ? 242 THR U CG2 1 
+ATOM   1936 N N   . LYS A 1 246 ? 8.768   -31.478 3.107   1.00 86.92  ? ? ? ? ? ? 243 LYS U N   1 
+ATOM   1937 C CA  . LYS A 1 246 ? 9.235   -31.152 4.455   1.00 95.27  ? ? ? ? ? ? 243 LYS U CA  1 
+ATOM   1938 C C   . LYS A 1 246 ? 9.786   -29.722 4.400   1.00 99.56  ? ? ? ? ? ? 243 LYS U C   1 
+ATOM   1939 O O   . LYS A 1 246 ? 10.753  -29.448 3.687   1.00 101.05 ? ? ? ? ? ? 243 LYS U O   1 
+ATOM   1940 C CB  . LYS A 1 246 ? 10.276  -32.164 4.974   1.00 98.66  ? ? ? ? ? ? 243 LYS U CB  1 
+ATOM   1941 C CG  . LYS A 1 246 ? 11.615  -32.201 4.237   1.00 100.95 ? ? ? ? ? ? 243 LYS U CG  1 
+ATOM   1942 C CD  . LYS A 1 246 ? 12.713  -31.416 4.945   1.00 100.55 ? ? ? ? ? ? 243 LYS U CD  1 
+ATOM   1943 C CE  . LYS A 1 246 ? 13.340  -32.222 6.070   1.00 102.22 ? ? ? ? ? ? 243 LYS U CE  1 
+ATOM   1944 N NZ  . LYS A 1 246 ? 14.226  -31.372 6.911   1.00 103.94 ? ? ? ? ? ? 243 LYS U NZ  1 
+ATOM   1945 N N   . GLU A 1 247 ? 9.131   -28.808 5.114   1.00 106.90 ? ? ? ? ? ? 244 GLU U N   1 
+ATOM   1946 C CA  . GLU A 1 247 ? 9.487   -27.380 5.089   1.00 110.20 ? ? ? ? ? ? 244 GLU U CA  1 
+ATOM   1947 C C   . GLU A 1 247 ? 9.927   -26.901 6.471   1.00 111.64 ? ? ? ? ? ? 244 GLU U C   1 
+ATOM   1948 O O   . GLU A 1 247 ? 10.291  -25.738 6.651   1.00 112.43 ? ? ? ? ? ? 244 GLU U O   1 
+ATOM   1949 C CB  . GLU A 1 247 ? 8.299   -26.537 4.604   1.00 108.39 ? ? ? ? ? ? 244 GLU U CB  1 
+ATOM   1950 C CG  . GLU A 1 247 ? 7.955   -26.707 3.131   1.00 104.51 ? ? ? ? ? ? 244 GLU U CG  1 
+ATOM   1951 C CD  . GLU A 1 247 ? 8.855   -25.899 2.210   1.00 101.07 ? ? ? ? ? ? 244 GLU U CD  1 
+ATOM   1952 O OE1 . GLU A 1 247 ? 8.407   -24.836 1.730   1.00 95.77  ? ? ? ? ? ? 244 GLU U OE1 1 
+ATOM   1953 O OE2 . GLU A 1 247 ? 10.008  -26.319 1.965   1.00 97.75  ? ? ? ? ? ? 244 GLU U OE2 1 
+ATOM   1954 N N   . CYS B 2 1   ? 9.932   -25.495 -26.711 1.00 61.14  ? ? ? ? ? ? 1   CYS P N   1 
+ATOM   1955 C CA  . CYS B 2 1   ? 8.757   -26.333 -27.107 1.00 61.95  ? ? ? ? ? ? 1   CYS P CA  1 
+ATOM   1956 C C   . CYS B 2 1   ? 9.165   -27.548 -27.937 1.00 64.13  ? ? ? ? ? ? 1   CYS P C   1 
+ATOM   1957 O O   . CYS B 2 1   ? 9.308   -27.445 -29.164 1.00 66.79  ? ? ? ? ? ? 1   CYS P O   1 
+ATOM   1958 C CB  . CYS B 2 1   ? 7.718   -25.518 -27.887 1.00 61.72  ? ? ? ? ? ? 1   CYS P CB  1 
+ATOM   1959 S SG  . CYS B 2 1   ? 6.591   -24.549 -26.861 1.00 64.20  ? ? ? ? ? ? 1   CYS P SG  1 
+ATOM   1960 N N   . PRO B 2 2   ? 9.343   -28.707 -27.271 1.00 64.07  ? ? ? ? ? ? 2   PRO P N   1 
+ATOM   1961 C CA  . PRO B 2 2   ? 9.575   -29.985 -27.948 1.00 61.08  ? ? ? ? ? ? 2   PRO P CA  1 
+ATOM   1962 C C   . PRO B 2 2   ? 8.482   -30.299 -28.942 1.00 57.86  ? ? ? ? ? ? 2   PRO P C   1 
+ATOM   1963 O O   . PRO B 2 2   ? 7.348   -29.842 -28.777 1.00 58.73  ? ? ? ? ? ? 2   PRO P O   1 
+ATOM   1964 C CB  . PRO B 2 2   ? 9.556   -30.998 -26.801 1.00 58.76  ? ? ? ? ? ? 2   PRO P CB  1 
+ATOM   1965 C CG  . PRO B 2 2   ? 9.989   -30.222 -25.616 1.00 59.79  ? ? ? ? ? ? 2   PRO P CG  1 
+ATOM   1966 C CD  . PRO B 2 2   ? 9.423   -28.847 -25.805 1.00 61.94  ? ? ? ? ? ? 2   PRO P CD  1 
+ATOM   1967 N N   . ALA B 2 3   ? 8.811   -31.082 -29.963 1.00 57.28  ? ? ? ? ? ? 3   ALA P N   1 
+ATOM   1968 C CA  . ALA B 2 3   ? 7.864   -31.357 -31.039 1.00 55.53  ? ? ? ? ? ? 3   ALA P CA  1 
+ATOM   1969 C C   . ALA B 2 3   ? 6.631   -32.123 -30.551 1.00 52.32  ? ? ? ? ? ? 3   ALA P C   1 
+ATOM   1970 O O   . ALA B 2 3   ? 5.561   -32.012 -31.156 1.00 49.22  ? ? ? ? ? ? 3   ALA P O   1 
+ATOM   1971 C CB  . ALA B 2 3   ? 8.543   -32.118 -32.173 1.00 54.04  ? ? ? ? ? ? 3   ALA P CB  1 
+ATOM   1972 N N   . TYR B 2 4   ? 6.793   -32.899 -29.476 1.00 50.93  ? ? ? ? ? ? 4   TYR P N   1 
+ATOM   1973 C CA  . TYR B 2 4   ? 5.711   -33.732 -28.926 1.00 52.40  ? ? ? ? ? ? 4   TYR P CA  1 
+ATOM   1974 C C   . TYR B 2 4   ? 5.147   -33.219 -27.583 1.00 48.85  ? ? ? ? ? ? 4   TYR P C   1 
+ATOM   1975 O O   . TYR B 2 4   ? 4.501   -33.970 -26.851 1.00 47.07  ? ? ? ? ? ? 4   TYR P O   1 
+ATOM   1976 C CB  . TYR B 2 4   ? 6.188   -35.179 -28.742 1.00 55.28  ? ? ? ? ? ? 4   TYR P CB  1 
+ATOM   1977 C CG  . TYR B 2 4   ? 6.721   -35.888 -29.979 1.00 59.55  ? ? ? ? ? ? 4   TYR P CG  1 
+ATOM   1978 C CD1 . TYR B 2 4   ? 6.363   -35.487 -31.271 1.00 60.19  ? ? ? ? ? ? 4   TYR P CD1 1 
+ATOM   1979 C CD2 . TYR B 2 4   ? 7.539   -37.009 -29.846 1.00 63.16  ? ? ? ? ? ? 4   TYR P CD2 1 
+ATOM   1980 C CE1 . TYR B 2 4   ? 6.841   -36.154 -32.387 1.00 63.36  ? ? ? ? ? ? 4   TYR P CE1 1 
+ATOM   1981 C CE2 . TYR B 2 4   ? 8.018   -37.687 -30.959 1.00 67.13  ? ? ? ? ? ? 4   TYR P CE2 1 
+ATOM   1982 C CZ  . TYR B 2 4   ? 7.665   -37.256 -32.228 1.00 66.50  ? ? ? ? ? ? 4   TYR P CZ  1 
+ATOM   1983 O OH  . TYR B 2 4   ? 8.132   -37.931 -33.337 1.00 70.97  ? ? ? ? ? ? 4   TYR P OH  1 
+ATOM   1984 N N   . SER B 2 5   ? 5.378   -31.950 -27.262 1.00 48.66  ? ? ? ? ? ? 5   SER P N   1 
+ATOM   1985 C CA  . SER B 2 5   ? 4.739   -31.325 -26.099 1.00 45.45  ? ? ? ? ? ? 5   SER P CA  1 
+ATOM   1986 C C   . SER B 2 5   ? 3.224   -31.525 -26.132 1.00 45.97  ? ? ? ? ? ? 5   SER P C   1 
+ATOM   1987 O O   . SER B 2 5   ? 2.621   -31.604 -27.206 1.00 45.14  ? ? ? ? ? ? 5   SER P O   1 
+ATOM   1988 C CB  . SER B 2 5   ? 5.039   -29.823 -26.059 1.00 46.03  ? ? ? ? ? ? 5   SER P CB  1 
+ATOM   1989 O OG  . SER B 2 5   ? 4.527   -29.220 -24.880 1.00 43.06  ? ? ? ? ? ? 5   SER P OG  1 
+ATOM   1990 N N   . ARG B 2 6   ? 2.614   -31.621 -24.952 1.00 44.10  ? ? ? ? ? ? 6   ARG P N   1 
+ATOM   1991 C CA  . ARG B 2 6   ? 1.151   -31.611 -24.841 1.00 43.41  ? ? ? ? ? ? 6   ARG P CA  1 
+ATOM   1992 C C   . ARG B 2 6   ? 0.726   -30.410 -23.993 1.00 42.93  ? ? ? ? ? ? 6   ARG P C   1 
+ATOM   1993 O O   . ARG B 2 6   ? -0.314  -30.420 -23.330 1.00 36.73  ? ? ? ? ? ? 6   ARG P O   1 
+ATOM   1994 C CB  . ARG B 2 6   ? 0.657   -32.947 -24.274 1.00 42.63  ? ? ? ? ? ? 6   ARG P CB  1 
+ATOM   1995 C CG  . ARG B 2 6   ? 0.742   -34.062 -25.308 1.00 43.41  ? ? ? ? ? ? 6   ARG P CG  1 
+ATOM   1996 C CD  . ARG B 2 6   ? 0.207   -35.400 -24.813 1.00 43.13  ? ? ? ? ? ? 6   ARG P CD  1 
+ATOM   1997 N NE  . ARG B 2 6   ? 0.206   -36.377 -25.899 1.00 41.21  ? ? ? ? ? ? 6   ARG P NE  1 
+ATOM   1998 C CZ  . ARG B 2 6   ? -0.245  -37.622 -25.809 1.00 43.13  ? ? ? ? ? ? 6   ARG P CZ  1 
+ATOM   1999 N NH1 . ARG B 2 6   ? -0.750  -38.091 -24.669 1.00 41.09  ? ? ? ? ? ? 6   ARG P NH1 1 
+ATOM   2000 N NH2 . ARG B 2 6   ? -0.203  -38.406 -26.879 1.00 41.66  ? ? ? ? ? ? 6   ARG P NH2 1 
+ATOM   2001 N N   . TYR B 2 7   ? 1.559   -29.373 -24.043 1.00 43.50  ? ? ? ? ? ? 7   TYR P N   1 
+ATOM   2002 C CA  . TYR B 2 7   ? 1.356   -28.150 -23.282 1.00 43.68  ? ? ? ? ? ? 7   TYR P CA  1 
+ATOM   2003 C C   . TYR B 2 7   ? 0.548   -27.174 -24.105 1.00 46.17  ? ? ? ? ? ? 7   TYR P C   1 
+ATOM   2004 O O   . TYR B 2 7   ? 0.818   -26.984 -25.307 1.00 38.22  ? ? ? ? ? ? 7   TYR P O   1 
+ATOM   2005 C CB  . TYR B 2 7   ? 2.710   -27.538 -22.937 1.00 45.68  ? ? ? ? ? ? 7   TYR P CB  1 
+ATOM   2006 C CG  . TYR B 2 7   ? 2.675   -26.207 -22.189 1.00 46.46  ? ? ? ? ? ? 7   TYR P CG  1 
+ATOM   2007 C CD1 . TYR B 2 7   ? 1.857   -26.018 -21.078 1.00 45.08  ? ? ? ? ? ? 7   TYR P CD1 1 
+ATOM   2008 C CD2 . TYR B 2 7   ? 3.494   -25.149 -22.588 1.00 46.18  ? ? ? ? ? ? 7   TYR P CD2 1 
+ATOM   2009 C CE1 . TYR B 2 7   ? 1.843   -24.809 -20.402 1.00 44.62  ? ? ? ? ? ? 7   TYR P CE1 1 
+ATOM   2010 C CE2 . TYR B 2 7   ? 3.497   -23.944 -21.911 1.00 45.96  ? ? ? ? ? ? 7   TYR P CE2 1 
+ATOM   2011 C CZ  . TYR B 2 7   ? 2.666   -23.772 -20.824 1.00 45.64  ? ? ? ? ? ? 7   TYR P CZ  1 
+ATOM   2012 O OH  . TYR B 2 7   ? 2.673   -22.560 -20.175 1.00 45.91  ? ? ? ? ? ? 7   TYR P OH  1 
+ATOM   2013 N N   . ILE B 2 8   ? -0.455  -26.572 -23.459 1.00 45.83  ? ? ? ? ? ? 8   ILE P N   1 
+ATOM   2014 C CA  . ILE B 2 8   ? -1.235  -25.479 -24.052 1.00 49.63  ? ? ? ? ? ? 8   ILE P CA  1 
+ATOM   2015 C C   . ILE B 2 8   ? -0.358  -24.407 -24.699 1.00 50.24  ? ? ? ? ? ? 8   ILE P C   1 
+ATOM   2016 O O   . ILE B 2 8   ? -0.668  -23.921 -25.791 1.00 55.47  ? ? ? ? ? ? 8   ILE P O   1 
+ATOM   2017 C CB  . ILE B 2 8   ? -2.126  -24.788 -22.994 1.00 50.22  ? ? ? ? ? ? 8   ILE P CB  1 
+ATOM   2018 C CG1 . ILE B 2 8   ? -3.401  -25.587 -22.810 1.00 51.23  ? ? ? ? ? ? 8   ILE P CG1 1 
+ATOM   2019 C CG2 . ILE B 2 8   ? -2.497  -23.365 -23.414 1.00 50.36  ? ? ? ? ? ? 8   ILE P CG2 1 
+ATOM   2020 C CD1 . ILE B 2 8   ? -4.261  -25.116 -21.663 1.00 53.34  ? ? ? ? ? ? 8   ILE P CD1 1 
+ATOM   2021 N N   . GLY B 2 9   ? 0.720   -24.029 -24.014 1.00 50.02  ? ? ? ? ? ? 9   GLY P N   1 
+ATOM   2022 C CA  . GLY B 2 9   ? 1.612   -22.976 -24.504 1.00 52.80  ? ? ? ? ? ? 9   GLY P CA  1 
+ATOM   2023 C C   . GLY B 2 9   ? 2.339   -23.284 -25.806 1.00 51.95  ? ? ? ? ? ? 9   GLY P C   1 
+ATOM   2024 O O   . GLY B 2 9   ? 2.823   -22.366 -26.468 1.00 54.32  ? ? ? ? ? ? 9   GLY P O   1 
+ATOM   2025 N N   . CYS B 2 10  ? 2.437   -24.565 -26.160 1.00 50.43  ? ? ? ? ? ? 10  CYS P N   1 
+ATOM   2026 C CA  . CYS B 2 10  ? 3.038   -24.985 -27.428 1.00 52.19  ? ? ? ? ? ? 10  CYS P CA  1 
+ATOM   2027 C C   . CYS B 2 10  ? 1.953   -25.392 -28.415 1.00 52.70  ? ? ? ? ? ? 10  CYS P C   1 
+ATOM   2028 O O   . CYS B 2 10  ? 2.051   -25.095 -29.606 1.00 51.82  ? ? ? ? ? ? 10  CYS P O   1 
+ATOM   2029 C CB  . CYS B 2 10  ? 4.008   -26.160 -27.221 1.00 54.24  ? ? ? ? ? ? 10  CYS P CB  1 
+ATOM   2030 S SG  . CYS B 2 10  ? 5.315   -25.901 -25.989 1.00 54.32  ? ? ? ? ? ? 10  CYS P SG  1 
+HETATM 2031 O O   . HOH C 3 .   ? -15.205 -28.509 -1.223  1.00 29.09  ? ? ? ? ? ? 301 HOH U O   1 
+HETATM 2032 O O   . HOH C 3 .   ? -10.582 -31.047 -35.113 1.00 46.52  ? ? ? ? ? ? 302 HOH U O   1 
+HETATM 2033 O O   . HOH C 3 .   ? 7.248   -26.510 -23.512 1.00 44.78  ? ? ? ? ? ? 303 HOH U O   1 
+HETATM 2034 O O   . HOH C 3 .   ? -3.871  -24.043 -27.314 1.00 44.49  ? ? ? ? ? ? 304 HOH U O   1 
+HETATM 2035 O O   . HOH C 3 .   ? -6.024  -30.401 -17.786 1.00 24.98  ? ? ? ? ? ? 305 HOH U O   1 
+HETATM 2036 O O   . HOH C 3 .   ? 3.279   -31.441 -22.381 1.00 38.18  ? ? ? ? ? ? 306 HOH U O   1 
+HETATM 2037 O O   . HOH C 3 .   ? -2.060  -42.028 -22.501 1.00 40.45  ? ? ? ? ? ? 307 HOH U O   1 
+HETATM 2038 O O   . HOH C 3 .   ? -6.449  -39.304 -12.768 1.00 43.65  ? ? ? ? ? ? 308 HOH U O   1 
+HETATM 2039 O O   . HOH C 3 .   ? -11.732 -26.754 -32.343 1.00 47.16  ? ? ? ? ? ? 309 HOH U O   1 
+HETATM 2040 O O   . HOH C 3 .   ? 8.854   -36.746 -19.881 1.00 44.47  ? ? ? ? ? ? 310 HOH U O   1 
+HETATM 2041 O O   . HOH C 3 .   ? -21.614 -29.382 -16.299 1.00 40.58  ? ? ? ? ? ? 311 HOH U O   1 
+HETATM 2042 O O   . HOH C 3 .   ? -13.578 -24.026 -23.861 1.00 39.67  ? ? ? ? ? ? 312 HOH U O   1 
+HETATM 2043 O O   . HOH C 3 .   ? -12.634 -31.149 5.764   1.00 43.05  ? ? ? ? ? ? 313 HOH U O   1 
+HETATM 2044 O O   . HOH C 3 .   ? -4.729  -33.001 -16.829 1.00 27.82  ? ? ? ? ? ? 314 HOH U O   1 
+HETATM 2045 O O   . HOH C 3 .   ? -9.351  -49.347 -35.580 1.00 58.54  ? ? ? ? ? ? 315 HOH U O   1 
+HETATM 2046 O O   . HOH C 3 .   ? -9.715  -31.118 -6.760  1.00 30.03  ? ? ? ? ? ? 316 HOH U O   1 
+HETATM 2047 O O   . HOH C 3 .   ? -10.004 -28.922 -9.641  1.00 27.62  ? ? ? ? ? ? 317 HOH U O   1 
+HETATM 2048 O O   . HOH C 3 .   ? -2.748  -38.564 0.587   1.00 67.64  ? ? ? ? ? ? 318 HOH U O   1 
+HETATM 2049 O O   . HOH C 3 .   ? -1.231  -27.629 -20.903 1.00 30.15  ? ? ? ? ? ? 319 HOH U O   1 
+HETATM 2050 O O   . HOH C 3 .   ? -0.170  -17.083 -6.735  1.00 38.06  ? ? ? ? ? ? 320 HOH U O   1 
+HETATM 2051 O O   . HOH C 3 .   ? -7.957  -36.517 1.153   1.00 39.86  ? ? ? ? ? ? 321 HOH U O   1 
+HETATM 2052 O O   . HOH C 3 .   ? -17.811 -29.994 -2.210  1.00 40.20  ? ? ? ? ? ? 322 HOH U O   1 
+HETATM 2053 O O   . HOH C 3 .   ? 5.563   -42.564 -0.545  1.00 42.63  ? ? ? ? ? ? 323 HOH U O   1 
+HETATM 2054 O O   . HOH C 3 .   ? 0.081   -34.268 -11.373 1.00 25.90  ? ? ? ? ? ? 324 HOH U O   1 
+HETATM 2055 O O   . HOH C 3 .   ? -5.368  -52.995 -14.023 1.00 54.06  ? ? ? ? ? ? 325 HOH U O   1 
+HETATM 2056 O O   . HOH C 3 .   ? -5.478  -54.040 -17.122 1.00 50.78  ? ? ? ? ? ? 326 HOH U O   1 
+HETATM 2057 O O   . HOH C 3 .   ? -10.145 -33.448 -21.719 1.00 22.58  ? ? ? ? ? ? 327 HOH U O   1 
+HETATM 2058 O O   . HOH C 3 .   ? -11.202 -30.221 -27.821 1.00 25.86  ? ? ? ? ? ? 328 HOH U O   1 
+HETATM 2059 O O   . HOH C 3 .   ? -19.287 -38.659 -21.394 1.00 42.56  ? ? ? ? ? ? 329 HOH U O   1 
+HETATM 2060 O O   . HOH C 3 .   ? 6.284   -48.673 1.226   1.00 51.54  ? ? ? ? ? ? 330 HOH U O   1 
+HETATM 2061 O O   . HOH C 3 .   ? 5.772   -43.998 -10.624 1.00 31.93  ? ? ? ? ? ? 331 HOH U O   1 
+HETATM 2062 O O   . HOH C 3 .   ? -13.193 -17.030 -9.501  1.00 49.17  ? ? ? ? ? ? 332 HOH U O   1 
+HETATM 2063 O O   . HOH C 3 .   ? -5.134  -42.308 -2.689  1.00 46.68  ? ? ? ? ? ? 333 HOH U O   1 
+HETATM 2064 O O   . HOH C 3 .   ? -18.403 -32.212 1.364   1.00 48.20  ? ? ? ? ? ? 334 HOH U O   1 
+HETATM 2065 O O   . HOH C 3 .   ? 0.333   -52.903 -21.942 1.00 55.02  ? ? ? ? ? ? 335 HOH U O   1 
+HETATM 2066 O O   . HOH C 3 .   ? 11.524  -22.951 -8.970  1.00 41.19  ? ? ? ? ? ? 336 HOH U O   1 
+HETATM 2067 O O   . HOH C 3 .   ? -15.285 -25.840 -26.512 1.00 41.37  ? ? ? ? ? ? 337 HOH U O   1 
+HETATM 2068 O O   . HOH C 3 .   ? 15.757  -35.672 -9.161  1.00 52.36  ? ? ? ? ? ? 338 HOH U O   1 
+HETATM 2069 O O   . HOH C 3 .   ? -13.785 -29.782 -26.953 1.00 36.62  ? ? ? ? ? ? 339 HOH U O   1 
+HETATM 2070 O O   . HOH C 3 .   ? 17.277  -38.677 -25.037 1.00 61.25  ? ? ? ? ? ? 340 HOH U O   1 
+HETATM 2071 O O   . HOH C 3 .   ? 7.298   -24.742 -21.763 1.00 37.07  ? ? ? ? ? ? 341 HOH U O   1 
+HETATM 2072 O O   . HOH C 3 .   ? 8.838   -20.977 1.814   1.00 53.21  ? ? ? ? ? ? 342 HOH U O   1 
+HETATM 2073 O O   . HOH C 3 .   ? -8.819  -14.105 -10.535 1.00 69.60  ? ? ? ? ? ? 343 HOH U O   1 
+HETATM 2074 O O   . HOH C 3 .   ? -2.071  -20.104 -20.584 1.00 36.73  ? ? ? ? ? ? 344 HOH U O   1 
+HETATM 2075 O O   . HOH C 3 .   ? 8.785   -19.682 -5.908  1.00 43.33  ? ? ? ? ? ? 345 HOH U O   1 
+HETATM 2076 O O   . HOH C 3 .   ? -4.607  -24.422 -29.749 1.00 50.81  ? ? ? ? ? ? 346 HOH U O   1 
+HETATM 2077 O O   . HOH C 3 .   ? 0.634   -19.498 -22.707 1.00 59.12  ? ? ? ? ? ? 347 HOH U O   1 
+HETATM 2078 O O   . HOH C 3 .   ? 14.723  -37.697 -7.396  1.00 54.19  ? ? ? ? ? ? 348 HOH U O   1 
+HETATM 2079 O O   . HOH D 3 .   ? 2.769   -21.902 -31.481 1.00 49.70  ? ? ? ? ? ? 101 HOH P O   1 
+HETATM 2080 O O   . HOH D 3 .   ? 6.454   -23.113 -29.929 1.00 45.25  ? ? ? ? ? ? 102 HOH P O   1 
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1   ILE 1   16  16  ILE ILE U . n 
+A 1 2   ILE 2   17  17  ILE ILE U . n 
+A 1 3   GLY 3   18  18  GLY GLY U . n 
+A 1 4   GLY 4   19  19  GLY GLY U . n 
+A 1 5   GLU 5   20  20  GLU GLU U . n 
+A 1 6   PHE 6   21  21  PHE PHE U . n 
+A 1 7   THR 7   22  22  THR THR U . n 
+A 1 8   THR 8   23  23  THR THR U . n 
+A 1 9   ILE 9   24  24  ILE ILE U . n 
+A 1 10  GLU 10  25  25  GLU GLU U . n 
+A 1 11  ASN 11  26  26  ASN ASN U . n 
+A 1 12  GLN 12  27  27  GLN GLN U . n 
+A 1 13  PRO 13  28  28  PRO PRO U . n 
+A 1 14  TRP 14  29  29  TRP TRP U . n 
+A 1 15  PHE 15  30  30  PHE PHE U . n 
+A 1 16  ALA 16  31  31  ALA ALA U . n 
+A 1 17  ALA 17  32  32  ALA ALA U . n 
+A 1 18  ILE 18  33  33  ILE ILE U . n 
+A 1 19  TYR 19  34  34  TYR TYR U . n 
+A 1 20  ARG 20  35  35  ARG ARG U . n 
+A 1 21  ARG 21  36  36  ARG ARG U . n 
+A 1 22  HIS 22  37  37  HIS HIS U . n 
+A 1 23  ARG 23  37  37  ARG ARG U A n 
+A 1 24  GLY 24  37  37  GLY GLY U B n 
+A 1 25  GLY 25  37  37  GLY GLY U C n 
+A 1 26  SER 26  37  37  SER SER U D n 
+A 1 27  VAL 27  38  38  VAL VAL U . n 
+A 1 28  THR 28  39  39  THR THR U . n 
+A 1 29  TYR 29  40  40  TYR TYR U . n 
+A 1 30  VAL 30  41  41  VAL VAL U . n 
+A 1 31  CYS 31  42  42  CYS CYS U . n 
+A 1 32  GLY 32  43  43  GLY GLY U . n 
+A 1 33  GLY 33  44  44  GLY GLY U . n 
+A 1 34  SER 34  45  45  SER SER U . n 
+A 1 35  LEU 35  46  46  LEU LEU U . n 
+A 1 36  ILE 36  47  47  ILE ILE U . n 
+A 1 37  SER 37  48  48  SER SER U . n 
+A 1 38  PRO 38  49  49  PRO PRO U . n 
+A 1 39  CYS 39  50  50  CYS CYS U . n 
+A 1 40  TRP 40  51  51  TRP TRP U . n 
+A 1 41  VAL 41  52  52  VAL VAL U . n 
+A 1 42  ILE 42  53  53  ILE ILE U . n 
+A 1 43  SER 43  54  54  SER SER U . n 
+A 1 44  ALA 44  55  55  ALA ALA U . n 
+A 1 45  THR 45  56  56  THR THR U . n 
+A 1 46  HIS 46  57  57  HIS HIS U . n 
+A 1 47  CYS 47  58  58  CYS CYS U . n 
+A 1 48  PHE 48  59  59  PHE PHE U . n 
+A 1 49  ILE 49  60  60  ILE ILE U . n 
+A 1 50  ASP 50  60  60  ASP ASP U A n 
+A 1 51  TYR 51  60  60  TYR TYR U B n 
+A 1 52  PRO 52  60  60  PRO PRO U C n 
+A 1 53  LYS 53  61  61  LYS LYS U . n 
+A 1 54  LYS 54  62  62  LYS LYS U . n 
+A 1 55  GLU 55  62  62  GLU GLU U A n 
+A 1 56  ASP 56  63  63  ASP ASP U . n 
+A 1 57  TYR 57  64  64  TYR TYR U . n 
+A 1 58  ILE 58  65  65  ILE ILE U . n 
+A 1 59  VAL 59  66  66  VAL VAL U . n 
+A 1 60  TYR 60  67  67  TYR TYR U . n 
+A 1 61  LEU 61  68  68  LEU LEU U . n 
+A 1 62  GLY 62  69  69  GLY GLY U . n 
+A 1 63  ARG 63  70  70  ARG ARG U . n 
+A 1 64  SER 64  71  71  SER SER U . n 
+A 1 65  ARG 65  72  72  ARG ARG U . n 
+A 1 66  LEU 66  73  73  LEU LEU U . n 
+A 1 67  ASN 67  74  74  ASN ASN U . n 
+A 1 68  SER 68  75  75  SER SER U . n 
+A 1 69  ASN 69  76  76  ASN ASN U . n 
+A 1 70  THR 70  77  77  THR THR U . n 
+A 1 71  GLN 71  78  78  GLN GLN U . n 
+A 1 72  GLY 72  79  79  GLY GLY U . n 
+A 1 73  GLU 73  80  80  GLU GLU U . n 
+A 1 74  MET 74  81  81  MET MET U . n 
+A 1 75  LYS 75  82  82  LYS LYS U . n 
+A 1 76  PHE 76  83  83  PHE PHE U . n 
+A 1 77  GLU 77  84  84  GLU GLU U . n 
+A 1 78  VAL 78  85  85  VAL VAL U . n 
+A 1 79  GLU 79  86  86  GLU GLU U . n 
+A 1 80  ASN 80  87  87  ASN ASN U . n 
+A 1 81  LEU 81  88  88  LEU LEU U . n 
+A 1 82  ILE 82  89  89  ILE ILE U . n 
+A 1 83  LEU 83  90  90  LEU LEU U . n 
+A 1 84  HIS 84  91  91  HIS HIS U . n 
+A 1 85  LYS 85  92  92  LYS LYS U . n 
+A 1 86  ASP 86  93  93  ASP ASP U . n 
+A 1 87  TYR 87  94  94  TYR TYR U . n 
+A 1 88  SER 88  95  95  SER SER U . n 
+A 1 89  ALA 89  96  96  ALA ALA U . n 
+A 1 90  ASP 90  97  97  ASP ASP U . n 
+A 1 91  THR 91  97  97  THR THR U A n 
+A 1 92  LEU 92  97  97  LEU LEU U B n 
+A 1 93  ALA 93  98  98  ALA ALA U . n 
+A 1 94  TYR 94  99  99  TYR TYR U . n 
+A 1 95  HIS 95  100 100 HIS HIS U . n 
+A 1 96  ASN 96  101 101 ASN ASN U . n 
+A 1 97  ASP 97  102 102 ASP ASP U . n 
+A 1 98  ILE 98  103 103 ILE ILE U . n 
+A 1 99  ALA 99  104 104 ALA ALA U . n 
+A 1 100 LEU 100 105 105 LEU LEU U . n 
+A 1 101 LEU 101 106 106 LEU LEU U . n 
+A 1 102 LYS 102 107 107 LYS LYS U . n 
+A 1 103 ILE 103 108 108 ILE ILE U . n 
+A 1 104 ARG 104 109 109 ARG ARG U . n 
+A 1 105 SER 105 110 110 SER SER U . n 
+A 1 106 LYS 106 110 110 LYS LYS U A n 
+A 1 107 GLU 107 110 110 GLU GLU U B n 
+A 1 108 GLY 108 110 110 GLY GLY U C n 
+A 1 109 ARG 109 110 110 ARG ARG U D n 
+A 1 110 CYS 110 111 111 CYS CYS U . n 
+A 1 111 ALA 111 112 112 ALA ALA U . n 
+A 1 112 GLN 112 113 113 GLN GLN U . n 
+A 1 113 PRO 113 114 114 PRO PRO U . n 
+A 1 114 SER 114 115 115 SER SER U . n 
+A 1 115 ARG 115 116 116 ARG ARG U . n 
+A 1 116 THR 116 117 117 THR THR U . n 
+A 1 117 ILE 117 118 118 ILE ILE U . n 
+A 1 118 GLN 118 119 119 GLN GLN U . n 
+A 1 119 THR 119 120 120 THR THR U . n 
+A 1 120 ILE 120 121 121 ILE ILE U . n 
+A 1 121 ALA 121 122 122 ALA ALA U . n 
+A 1 122 LEU 122 123 123 LEU LEU U . n 
+A 1 123 PRO 123 124 124 PRO PRO U . n 
+A 1 124 SER 124 125 125 SER SER U . n 
+A 1 125 MET 125 126 126 MET MET U . n 
+A 1 126 TYR 126 127 127 TYR TYR U . n 
+A 1 127 ASN 127 128 128 ASN ASN U . n 
+A 1 128 ASP 128 129 129 ASP ASP U . n 
+A 1 129 PRO 129 130 130 PRO PRO U . n 
+A 1 130 GLN 130 131 131 GLN GLN U . n 
+A 1 131 PHE 131 132 132 PHE PHE U . n 
+A 1 132 GLY 132 133 133 GLY GLY U . n 
+A 1 133 THR 133 134 134 THR THR U . n 
+A 1 134 SER 134 135 135 SER SER U . n 
+A 1 135 CYS 135 136 136 CYS CYS U . n 
+A 1 136 GLU 136 137 137 GLU GLU U . n 
+A 1 137 ILE 137 138 138 ILE ILE U . n 
+A 1 138 THR 138 139 139 THR THR U . n 
+A 1 139 GLY 139 140 140 GLY GLY U . n 
+A 1 140 PHE 140 141 141 PHE PHE U . n 
+A 1 141 GLY 141 142 142 GLY GLY U . n 
+A 1 142 LYS 142 143 143 LYS LYS U . n 
+A 1 143 GLU 143 144 144 GLU GLU U . n 
+A 1 144 GLN 144 145 145 GLN GLN U . n 
+A 1 145 SER 145 146 146 SER SER U . n 
+A 1 146 THR 146 147 147 THR THR U . n 
+A 1 147 ASP 147 148 148 ASP ASP U . n 
+A 1 148 TYR 148 149 149 TYR TYR U . n 
+A 1 149 LEU 149 150 150 LEU LEU U . n 
+A 1 150 TYR 150 151 151 TYR TYR U . n 
+A 1 151 PRO 151 152 152 PRO PRO U . n 
+A 1 152 GLU 152 153 153 GLU GLU U . n 
+A 1 153 GLN 153 154 154 GLN GLN U . n 
+A 1 154 LEU 154 155 155 LEU LEU U . n 
+A 1 155 LYS 155 156 156 LYS LYS U . n 
+A 1 156 MET 156 157 157 MET MET U . n 
+A 1 157 THR 157 158 158 THR THR U . n 
+A 1 158 VAL 158 159 159 VAL VAL U . n 
+A 1 159 VAL 159 160 160 VAL VAL U . n 
+A 1 160 LYS 160 161 161 LYS LYS U . n 
+A 1 161 LEU 161 162 162 LEU LEU U . n 
+A 1 162 ILE 162 163 163 ILE ILE U . n 
+A 1 163 SER 163 164 164 SER SER U . n 
+A 1 164 HIS 164 165 165 HIS HIS U . n 
+A 1 165 ARG 165 166 166 ARG ARG U . n 
+A 1 166 GLU 166 167 167 GLU GLU U . n 
+A 1 167 CYS 167 168 168 CYS CYS U . n 
+A 1 168 GLN 168 169 169 GLN GLN U . n 
+A 1 169 GLN 169 170 170 GLN GLN U . n 
+A 1 170 PRO 170 170 170 PRO PRO U A n 
+A 1 171 HIS 171 170 170 HIS HIS U B n 
+A 1 172 TYR 172 171 171 TYR TYR U . n 
+A 1 173 TYR 173 172 172 TYR TYR U . n 
+A 1 174 GLY 174 173 173 GLY GLY U . n 
+A 1 175 SER 175 174 174 SER SER U . n 
+A 1 176 GLU 176 175 175 GLU GLU U . n 
+A 1 177 VAL 177 176 176 VAL VAL U . n 
+A 1 178 THR 178 177 177 THR THR U . n 
+A 1 179 THR 179 178 178 THR THR U . n 
+A 1 180 LYS 180 179 179 LYS LYS U . n 
+A 1 181 MET 181 180 180 MET MET U . n 
+A 1 182 LEU 182 181 181 LEU LEU U . n 
+A 1 183 CYS 183 182 182 CYS CYS U . n 
+A 1 184 ALA 184 183 183 ALA ALA U . n 
+A 1 185 ALA 185 184 184 ALA ALA U . n 
+A 1 186 ASP 186 185 185 ASP ASP U . n 
+A 1 187 PRO 187 185 185 PRO PRO U A n 
+A 1 188 GLN 188 185 185 GLN GLN U B n 
+A 1 189 TRP 189 186 186 TRP TRP U . n 
+A 1 190 LYS 190 187 187 LYS LYS U . n 
+A 1 191 THR 191 188 188 THR THR U . n 
+A 1 192 ASP 192 189 189 ASP ASP U . n 
+A 1 193 SER 193 190 190 SER SER U . n 
+A 1 194 CYS 194 191 191 CYS CYS U . n 
+A 1 195 GLN 195 192 192 GLN GLN U . n 
+A 1 196 GLY 196 193 193 GLY GLY U . n 
+A 1 197 ASP 197 194 194 ASP ASP U . n 
+A 1 198 SER 198 195 195 SER SER U . n 
+A 1 199 GLY 199 196 196 GLY GLY U . n 
+A 1 200 GLY 200 197 197 GLY GLY U . n 
+A 1 201 PRO 201 198 198 PRO PRO U . n 
+A 1 202 LEU 202 199 199 LEU LEU U . n 
+A 1 203 VAL 203 200 200 VAL VAL U . n 
+A 1 204 CYS 204 201 201 CYS CYS U . n 
+A 1 205 SER 205 202 202 SER SER U . n 
+A 1 206 LEU 206 203 203 LEU LEU U . n 
+A 1 207 GLN 207 204 204 GLN GLN U . n 
+A 1 208 GLY 208 205 205 GLY GLY U . n 
+A 1 209 ARG 209 206 206 ARG ARG U . n 
+A 1 210 MET 210 207 207 MET MET U . n 
+A 1 211 THR 211 208 208 THR THR U . n 
+A 1 212 LEU 212 209 209 LEU LEU U . n 
+A 1 213 THR 213 210 210 THR THR U . n 
+A 1 214 GLY 214 211 211 GLY GLY U . n 
+A 1 215 ILE 215 212 212 ILE ILE U . n 
+A 1 216 VAL 216 213 213 VAL VAL U . n 
+A 1 217 SER 217 214 214 SER SER U . n 
+A 1 218 TRP 218 215 215 TRP TRP U . n 
+A 1 219 GLY 219 216 216 GLY GLY U . n 
+A 1 220 ARG 220 217 217 ARG ARG U . n 
+A 1 221 GLY 221 219 219 GLY GLY U . n 
+A 1 222 CYS 222 220 220 CYS CYS U . n 
+A 1 223 ALA 223 221 221 ALA ALA U . n 
+A 1 224 LEU 224 222 222 LEU LEU U . n 
+A 1 225 LYS 225 223 223 LYS LYS U . n 
+A 1 226 ASP 226 223 223 ASP ASP U A n 
+A 1 227 LYS 227 224 224 LYS LYS U . n 
+A 1 228 PRO 228 225 225 PRO PRO U . n 
+A 1 229 GLY 229 226 226 GLY GLY U . n 
+A 1 230 VAL 230 227 227 VAL VAL U . n 
+A 1 231 TYR 231 228 228 TYR TYR U . n 
+A 1 232 THR 232 229 229 THR THR U . n 
+A 1 233 ARG 233 230 230 ARG ARG U . n 
+A 1 234 VAL 234 231 231 VAL VAL U . n 
+A 1 235 SER 235 232 232 SER SER U . n 
+A 1 236 HIS 236 233 233 HIS HIS U . n 
+A 1 237 PHE 237 234 234 PHE PHE U . n 
+A 1 238 LEU 238 235 235 LEU LEU U . n 
+A 1 239 PRO 239 236 236 PRO PRO U . n 
+A 1 240 TRP 240 237 237 TRP TRP U . n 
+A 1 241 ILE 241 238 238 ILE ILE U . n 
+A 1 242 ARG 242 239 239 ARG ARG U . n 
+A 1 243 SER 243 240 240 SER SER U . n 
+A 1 244 HIS 244 241 241 HIS HIS U . n 
+A 1 245 THR 245 242 242 THR THR U . n 
+A 1 246 LYS 246 243 243 LYS LYS U . n 
+A 1 247 GLU 247 244 244 GLU GLU U . n 
+B 2 1   CYS 1   1   1   CYS CYS P . n 
+B 2 2   PRO 2   2   2   PRO PRO P . n 
+B 2 3   ALA 3   3   3   ALA ALA P . n 
+B 2 4   TYR 4   4   4   TYR TYR P . n 
+B 2 5   SER 5   5   5   SER SER P . n 
+B 2 6   ARG 6   6   6   ARG ARG P . n 
+B 2 7   TYR 7   7   7   TYR TYR P . n 
+B 2 8   ILE 8   8   8   ILE ILE P . n 
+B 2 9   GLY 9   9   9   GLY GLY P . n 
+B 2 10  CYS 10  10  10  CYS CYS P . n 
+# 
+loop_
+_pdbx_nonpoly_scheme.asym_id 
+_pdbx_nonpoly_scheme.entity_id 
+_pdbx_nonpoly_scheme.mon_id 
+_pdbx_nonpoly_scheme.ndb_seq_num 
+_pdbx_nonpoly_scheme.pdb_seq_num 
+_pdbx_nonpoly_scheme.auth_seq_num 
+_pdbx_nonpoly_scheme.pdb_mon_id 
+_pdbx_nonpoly_scheme.auth_mon_id 
+_pdbx_nonpoly_scheme.pdb_strand_id 
+_pdbx_nonpoly_scheme.pdb_ins_code 
+C 3 HOH 1  301 6  HOH HOH U . 
+C 3 HOH 2  302 19 HOH HOH U . 
+C 3 HOH 3  303 4  HOH HOH U . 
+C 3 HOH 4  304 33 HOH HOH U . 
+C 3 HOH 5  305 9  HOH HOH U . 
+C 3 HOH 6  306 50 HOH HOH U . 
+C 3 HOH 7  307 46 HOH HOH U . 
+C 3 HOH 8  308 35 HOH HOH U . 
+C 3 HOH 9  309 12 HOH HOH U . 
+C 3 HOH 10 310 40 HOH HOH U . 
+C 3 HOH 11 311 44 HOH HOH U . 
+C 3 HOH 12 312 45 HOH HOH U . 
+C 3 HOH 13 313 39 HOH HOH U . 
+C 3 HOH 14 314 5  HOH HOH U . 
+C 3 HOH 15 315 43 HOH HOH U . 
+C 3 HOH 16 316 21 HOH HOH U . 
+C 3 HOH 17 317 7  HOH HOH U . 
+C 3 HOH 18 318 8  HOH HOH U . 
+C 3 HOH 19 319 30 HOH HOH U . 
+C 3 HOH 20 320 1  HOH HOH U . 
+C 3 HOH 21 321 22 HOH HOH U . 
+C 3 HOH 22 322 23 HOH HOH U . 
+C 3 HOH 23 323 17 HOH HOH U . 
+C 3 HOH 24 324 11 HOH HOH U . 
+C 3 HOH 25 325 47 HOH HOH U . 
+C 3 HOH 26 326 31 HOH HOH U . 
+C 3 HOH 27 327 18 HOH HOH U . 
+C 3 HOH 28 328 10 HOH HOH U . 
+C 3 HOH 29 329 34 HOH HOH U . 
+C 3 HOH 30 330 16 HOH HOH U . 
+C 3 HOH 31 331 3  HOH HOH U . 
+C 3 HOH 32 332 41 HOH HOH U . 
+C 3 HOH 33 333 24 HOH HOH U . 
+C 3 HOH 34 334 13 HOH HOH U . 
+C 3 HOH 35 335 36 HOH HOH U . 
+C 3 HOH 36 336 20 HOH HOH U . 
+C 3 HOH 37 337 2  HOH HOH U . 
+C 3 HOH 38 338 25 HOH HOH U . 
+C 3 HOH 39 339 29 HOH HOH U . 
+C 3 HOH 40 340 28 HOH HOH U . 
+C 3 HOH 41 341 42 HOH HOH U . 
+C 3 HOH 42 342 37 HOH HOH U . 
+C 3 HOH 43 343 26 HOH HOH U . 
+C 3 HOH 44 344 14 HOH HOH U . 
+C 3 HOH 45 345 32 HOH HOH U . 
+C 3 HOH 46 346 15 HOH HOH U . 
+C 3 HOH 47 347 38 HOH HOH U . 
+C 3 HOH 48 348 27 HOH HOH U . 
+D 3 HOH 1  101 48 HOH HOH P . 
+D 3 HOH 2  102 49 HOH HOH P . 
+# 
+_pdbx_struct_assembly.id                   1 
+_pdbx_struct_assembly.details              author_and_software_defined_assembly 
+_pdbx_struct_assembly.method_details       PISA 
+_pdbx_struct_assembly.oligomeric_details   dimeric 
+_pdbx_struct_assembly.oligomeric_count     2 
+# 
+_pdbx_struct_assembly_gen.assembly_id       1 
+_pdbx_struct_assembly_gen.oper_expression   1 
+_pdbx_struct_assembly_gen.asym_id_list      A,B,C,D 
+# 
+loop_
+_pdbx_struct_assembly_prop.biol_id 
+_pdbx_struct_assembly_prop.type 
+_pdbx_struct_assembly_prop.value 
+_pdbx_struct_assembly_prop.details 
+1 'ABSA (A^2)' 1460  ? 
+1 MORE         -7    ? 
+1 'SSA (A^2)'  11300 ? 
+# 
+_pdbx_struct_oper_list.id                   1 
+_pdbx_struct_oper_list.type                 'identity operation' 
+_pdbx_struct_oper_list.name                 1_555 
+_pdbx_struct_oper_list.symmetry_operation   ? 
+_pdbx_struct_oper_list.matrix[1][1]         1.0000000000 
+_pdbx_struct_oper_list.matrix[1][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[1][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[1]            0.0000000000 
+_pdbx_struct_oper_list.matrix[2][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[2][2]         1.0000000000 
+_pdbx_struct_oper_list.matrix[2][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[2]            0.0000000000 
+_pdbx_struct_oper_list.matrix[3][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][3]         1.0000000000 
+_pdbx_struct_oper_list.vector[3]            0.0000000000 
+# 
+loop_
+_pdbx_version.entry_id 
+_pdbx_version.revision_date 
+_pdbx_version.major_version 
+_pdbx_version.minor_version 
+_pdbx_version.revision_type 
+_pdbx_version.details 
+4ZHL 2015-09-16 4 0000 'Initial release' 'Initial release' 
+4ZHL 2015-10-14 4 0001 Citation          Citation          
+# 
+loop_
+_software.citation_id 
+_software.classification 
+_software.compiler_name 
+_software.compiler_version 
+_software.contact_author 
+_software.contact_author_email 
+_software.date 
+_software.description 
+_software.dependencies 
+_software.hardware 
+_software.language 
+_software.location 
+_software.mods 
+_software.name 
+_software.os 
+_software.os_version 
+_software.type 
+_software.version 
+_software.pdbx_ordinal 
+? refinement        ? ? ? ? ? ? ? ? ? ? ? REFMAC   ? ? ? 5.7.0029 1 
+? 'model building'  ? ? ? ? ? ? ? ? ? ? ? Coot     ? ? ? .        2 
+? 'data scaling'    ? ? ? ? ? ? ? ? ? ? ? HKL-2000 ? ? ? .        3 
+? 'data processing' ? ? ? ? ? ? ? ? ? ? ? HKL-2000 ? ? ? .        4 
+# 
+loop_
+_pdbx_validate_close_contact.id 
+_pdbx_validate_close_contact.PDB_model_num 
+_pdbx_validate_close_contact.auth_atom_id_1 
+_pdbx_validate_close_contact.auth_asym_id_1 
+_pdbx_validate_close_contact.auth_comp_id_1 
+_pdbx_validate_close_contact.auth_seq_id_1 
+_pdbx_validate_close_contact.PDB_ins_code_1 
+_pdbx_validate_close_contact.label_alt_id_1 
+_pdbx_validate_close_contact.auth_atom_id_2 
+_pdbx_validate_close_contact.auth_asym_id_2 
+_pdbx_validate_close_contact.auth_comp_id_2 
+_pdbx_validate_close_contact.auth_seq_id_2 
+_pdbx_validate_close_contact.PDB_ins_code_2 
+_pdbx_validate_close_contact.label_alt_id_2 
+_pdbx_validate_close_contact.dist 
+1 1 SG  U CYS 136 ? ? SG U CYS 201 ? ? 1.51 
+2 1 SG  U CYS 50  ? ? SG U CYS 111 ? ? 1.64 
+3 1 NH2 U ARG 36  ? ? O  U GLU 62  A ? 2.17 
+# 
+_pdbx_validate_symm_contact.id                1 
+_pdbx_validate_symm_contact.PDB_model_num     1 
+_pdbx_validate_symm_contact.auth_atom_id_1    OD1 
+_pdbx_validate_symm_contact.auth_asym_id_1    U 
+_pdbx_validate_symm_contact.auth_comp_id_1    ASN 
+_pdbx_validate_symm_contact.auth_seq_id_1     76 
+_pdbx_validate_symm_contact.PDB_ins_code_1    ? 
+_pdbx_validate_symm_contact.label_alt_id_1    ? 
+_pdbx_validate_symm_contact.site_symmetry_1   1_555 
+_pdbx_validate_symm_contact.auth_atom_id_2    NH1 
+_pdbx_validate_symm_contact.auth_asym_id_2    U 
+_pdbx_validate_symm_contact.auth_comp_id_2    ARG 
+_pdbx_validate_symm_contact.auth_seq_id_2     206 
+_pdbx_validate_symm_contact.PDB_ins_code_2    ? 
+_pdbx_validate_symm_contact.label_alt_id_2    ? 
+_pdbx_validate_symm_contact.site_symmetry_2   8_444 
+_pdbx_validate_symm_contact.dist              1.87 
+# 
+_pdbx_validate_rmsd_bond.id                        1 
+_pdbx_validate_rmsd_bond.PDB_model_num             1 
+_pdbx_validate_rmsd_bond.auth_atom_id_1            C 
+_pdbx_validate_rmsd_bond.auth_asym_id_1            U 
+_pdbx_validate_rmsd_bond.auth_comp_id_1            SER 
+_pdbx_validate_rmsd_bond.auth_seq_id_1             110 
+_pdbx_validate_rmsd_bond.PDB_ins_code_1            ? 
+_pdbx_validate_rmsd_bond.label_alt_id_1            ? 
+_pdbx_validate_rmsd_bond.auth_atom_id_2            O 
+_pdbx_validate_rmsd_bond.auth_asym_id_2            U 
+_pdbx_validate_rmsd_bond.auth_comp_id_2            SER 
+_pdbx_validate_rmsd_bond.auth_seq_id_2             110 
+_pdbx_validate_rmsd_bond.PDB_ins_code_2            ? 
+_pdbx_validate_rmsd_bond.label_alt_id_2            ? 
+_pdbx_validate_rmsd_bond.bond_value                1.101 
+_pdbx_validate_rmsd_bond.bond_target_value         1.229 
+_pdbx_validate_rmsd_bond.bond_deviation            -0.128 
+_pdbx_validate_rmsd_bond.bond_standard_deviation   0.019 
+_pdbx_validate_rmsd_bond.linker_flag               N 
+# 
+loop_
+_pdbx_validate_torsion.id 
+_pdbx_validate_torsion.PDB_model_num 
+_pdbx_validate_torsion.auth_comp_id 
+_pdbx_validate_torsion.auth_asym_id 
+_pdbx_validate_torsion.auth_seq_id 
+_pdbx_validate_torsion.PDB_ins_code 
+_pdbx_validate_torsion.label_alt_id 
+_pdbx_validate_torsion.phi 
+_pdbx_validate_torsion.psi 
+1 1 GLN U 27  ? ? -157.33 54.96   
+2 1 SER U 54  ? ? -148.41 -157.39 
+3 1 TYR U 171 ? ? -89.01  -111.29 
+4 1 GLN U 204 ? ? 58.66   -126.06 
+# 
+_pdbx_entity_nonpoly.entity_id   3 
+_pdbx_entity_nonpoly.name        water 
+_pdbx_entity_nonpoly.comp_id     HOH 
+# 

--- a/Tests/test_MMCIF.py
+++ b/Tests/test_MMCIF.py
@@ -93,39 +93,39 @@ class ParseReal(unittest.TestCase):
         structure = parser.get_structure("example", "PDB/1LCD.cif")
         self.assertEqual(len(structure), 3)
         for ppbuild in [PPBuilder(), CaPPBuilder()]:
-                # ==========================================================
-                # Check that serial_num (model column) is stored properly
-                self.assertEqual(structure[0].serial_num, 1)
-                self.assertEqual(structure[1].serial_num, 2)
-                self.assertEqual(structure[2].serial_num, 3)
-                # First try allowing non-standard amino acids,
-                polypeptides = ppbuild.build_peptides(structure[0], False)
-                self.assertEqual(len(polypeptides), 1)
-                pp = polypeptides[0]
-                # Check the start and end positions
-                self.assertEqual(pp[0].get_id()[1], 1)
-                self.assertEqual(pp[-1].get_id()[1], 51)
-                # Check the sequence
-                s = pp.get_sequence()
-                self.assertTrue(isinstance(s, Seq))
-                self.assertEqual(s.alphabet, generic_protein)
-                # Here non-standard MSE are shown as M
-                self.assertEqual("MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR",
-                                 str(s))
-                # ==========================================================
-                # Now try strict version with only standard amino acids
-                polypeptides = ppbuild.build_peptides(structure[0], True)
-                self.assertEqual(len(polypeptides), 1)
-                pp = polypeptides[0]
-                # Check the start and end positions
-                self.assertEqual(pp[0].get_id()[1], 1)
-                self.assertEqual(pp[-1].get_id()[1], 51)
-                # Check the sequence
-                s = pp.get_sequence()
-                self.assertTrue(isinstance(s, Seq))
-                self.assertEqual(s.alphabet, generic_protein)
-                self.assertEqual("MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR",
-                                 str(s))
+            # ==========================================================
+            # Check that serial_num (model column) is stored properly
+            self.assertEqual(structure[0].serial_num, 1)
+            self.assertEqual(structure[1].serial_num, 2)
+            self.assertEqual(structure[2].serial_num, 3)
+            # First try allowing non-standard amino acids,
+            polypeptides = ppbuild.build_peptides(structure[0], False)
+            self.assertEqual(len(polypeptides), 1)
+            pp = polypeptides[0]
+            # Check the start and end positions
+            self.assertEqual(pp[0].get_id()[1], 1)
+            self.assertEqual(pp[-1].get_id()[1], 51)
+            # Check the sequence
+            s = pp.get_sequence()
+            self.assertTrue(isinstance(s, Seq))
+            self.assertEqual(s.alphabet, generic_protein)
+            # Here non-standard MSE are shown as M
+            self.assertEqual("MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR",
+                             str(s))
+            # ==========================================================
+            # Now try strict version with only standard amino acids
+            polypeptides = ppbuild.build_peptides(structure[0], True)
+            self.assertEqual(len(polypeptides), 1)
+            pp = polypeptides[0]
+            # Check the start and end positions
+            self.assertEqual(pp[0].get_id()[1], 1)
+            self.assertEqual(pp[-1].get_id()[1], 51)
+            # Check the sequence
+            s = pp.get_sequence()
+            self.assertTrue(isinstance(s, Seq))
+            self.assertEqual(s.alphabet, generic_protein)
+            self.assertEqual("MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR",
+                             str(s))
 
         parser = MMCIFParser()
         # This structure contains several models with multiple lengths.

--- a/Tests/test_MMCIF.py
+++ b/Tests/test_MMCIF.py
@@ -133,6 +133,29 @@ class ParseReal(unittest.TestCase):
         structure = parser.get_structure("example", "PDB/2OFG.cif")
         self.assertEqual(len(structure), 3)
 
+    def testInsertions(self):
+        """Test file with residue insertion codes"""
+        parser = MMCIFParser()
+        structure = parser.get_structure("example", "PDB/4zhl.cif")
+        for ppbuild in [PPBuilder(), CaPPBuilder()]:
+            # First try allowing non-standard amino acids,
+            polypeptides = ppbuild.build_peptides(structure[0], False)
+            self.assertEqual(len(polypeptides), 2)
+            pp = polypeptides[0]
+            # Check the start and end positions (first segment only)
+            self.assertEqual(pp[0].get_id()[1], 16)
+            self.assertEqual(pp[-1].get_id()[1], 244)
+            # Check the sequence
+            refseq = "IIGGEFTTIENQPWFAAIYRRHRGGSVTYVCGGSLISPCWVISATHCFIDYPKKEDYIVYLGR" \
+                     "SRLNSNTQGEMKFEVENLILHKDYSADTLAYHNDIALLKIRSKEGRCAQPSRTIQTIALPSMY" \
+                     "NDPQFGTSCEITGFGKEQSTDYLYPEQLKMTVVKLISHRECQQPHYYGSEVTTKMLCAADPQW" \
+                     "KTDSCQGDSGGPLVCSLQGRMTLTGIVSWGRGCALKDKPGVYTRVSHFLPWIRSHTKE"
+
+            s = pp.get_sequence()
+            self.assertTrue(isinstance(s, Seq))
+            self.assertEqual(s.alphabet, generic_protein)
+            self.assertEqual(refseq, str(s))
+
     def test_filehandle(self):
         """Test if the parser can handle file handle as well as filename"""
         parser = MMCIFParser()


### PR DESCRIPTION
Issue #775 raised two problems with the mmCIF parser:

1. A new Residue was not properly initiated when the first residue of a new chain shared the same number.
2. Insertion codes were not handled altogether.

The changes in the pull request fix both issue and add a test for the second case. Thanks to @ofajardo for raising this issue.