### PR TITLE
pairwise2: Allow insertion after deletion and performance improvements

### DIFF
--- a/Bio/cpairwise2module.c
+++ b/Bio/cpairwise2module.c
@@ -1,8 +1,8 @@
-/* Copyright 2002 by Jeffrey Chang.  
+/* Copyright 2002 by Jeffrey Chang.
  * Copyright 2016 by Markus Piotrowski.
  * All rights reserved.
  * This code is part of the Biopython distribution and governed by its
- * license.  Please see the LICENSE file that should have been included
+ * license. Please see the LICENSE file that should have been included
  * as part of this package.
  *
  * cpairwise2module.c
@@ -33,11 +33,11 @@ static double calc_affine_penalty(int length, double open, double extend,
 }
 
 static double _get_match_score(PyObject *py_sequenceA, PyObject *py_sequenceB,
-                        PyObject *py_match_fn, int i, int j,
-                        char *sequenceA, char *sequenceB,
-                        int use_sequence_cstring,
-                        double match, double mismatch,
-                        int use_match_mismatch_scores)
+                               PyObject *py_match_fn, int i, int j,
+                               char *sequenceA, char *sequenceB,
+                               int use_sequence_cstring,
+                               double match, double mismatch,
+                               int use_match_mismatch_scores)
 {
     PyObject *py_A=NULL, *py_B=NULL;
     PyObject *py_arglist=NULL, *py_result=NULL;
@@ -58,6 +58,7 @@ static double _get_match_score(PyObject *py_sequenceA, PyObject *py_sequenceB,
     if(!(py_result = PyEval_CallObject(py_match_fn, py_arglist)))
         goto _get_match_score_cleanup;
     score = PyFloat_AsDouble(py_result);
+
  _get_match_score_cleanup:
     if(py_A) {
         Py_DECREF(py_A);
@@ -75,7 +76,8 @@ static double _get_match_score(PyObject *py_sequenceA, PyObject *py_sequenceB,
 }
 
 #if PY_MAJOR_VERSION >= 3
-static PyObject* _create_bytes_object(PyObject* o) {
+static PyObject* _create_bytes_object(PyObject* o)
+{
     PyObject* b;
     if (PyBytes_Check(o)) {
         return o;
@@ -93,15 +95,15 @@ static PyObject* _create_bytes_object(PyObject* o) {
 #endif
 
 /* This function is a more-or-less straightforward port of the
- * equivalent function in pairwise2.  Please see there for algorithm
+ * equivalent function in pairwise2. Please see there for algorithm
  * documentation.
  */
-static PyObject *cpairwise2__make_score_matrix_fast(
-    PyObject *self, PyObject *args)
+static PyObject *cpairwise2__make_score_matrix_fast(PyObject *self,
+                                                    PyObject *args)
 {
     int i;
     int row, col;
-	PyObject *py_sequenceA, *py_sequenceB, *py_match_fn;
+    PyObject *py_sequenceA, *py_sequenceB, *py_match_fn;
 #if PY_MAJOR_VERSION >= 3
     PyObject *py_bytesA, *py_bytesB;
 #endif
@@ -114,17 +116,17 @@ static PyObject *cpairwise2__make_score_matrix_fast(
     PyObject *py_match=NULL, *py_mismatch=NULL;
     double first_A_gap, first_B_gap;
     double match, mismatch;
-	double score;
+    double score;
     int use_match_mismatch_scores;
     int lenA, lenB;
     double *score_matrix = NULL;
-	unsigned char *trace_matrix = NULL;
+    unsigned char *trace_matrix = NULL;
     PyObject *py_score_matrix=NULL, *py_trace_matrix=NULL;
 
     double *col_cache_score = NULL;
     PyObject *py_retval = NULL;
-	
-	if(!PyArg_ParseTuple(args, "OOOddddi(ii)ii", &py_sequenceA, &py_sequenceB,
+
+    if(!PyArg_ParseTuple(args, "OOOddddi(ii)ii", &py_sequenceA, &py_sequenceB,
                          &py_match_fn, &open_A, &extend_A, &open_B, &extend_B,
                          &penalize_extend_when_opening,
                          &penalize_end_gaps_A, &penalize_end_gaps_B,
@@ -136,7 +138,7 @@ static PyObject *cpairwise2__make_score_matrix_fast(
         return NULL;
     }
 
-    /* Optimize for the common case.  Check to see if py_sequenceA and
+    /* Optimize for the common case. Check to see if py_sequenceA and
        py_sequenceB are strings.  If they are, use the c string
        representation. */
 #if PY_MAJOR_VERSION < 3
@@ -165,10 +167,10 @@ static PyObject *cpairwise2__make_score_matrix_fast(
         PyErr_SetString(PyExc_TypeError, "py_match_fn must be callable.");
         return NULL;
     }
-    /* Optimize for the common case.  Check to see if py_match_fn is
-       an identity_match.  If so, pull out the match and mismatch
+    /* Optimize for the common case. Check to see if py_match_fn is
+       an identity_match. If so, pull out the match and mismatch
        member variables and calculate the scores myself. */
-	match = mismatch = 0;
+    match = mismatch = 0;
     use_match_mismatch_scores = 0;
     if(!(py_match = PyObject_GetAttrString(py_match_fn, "match")))
         goto cleanup_after_py_match_fn;
@@ -181,7 +183,8 @@ static PyObject *cpairwise2__make_score_matrix_fast(
     if(mismatch==-1.0 && PyErr_Occurred())
         goto cleanup_after_py_match_fn;
     use_match_mismatch_scores = 1;
-cleanup_after_py_match_fn:
+
+ cleanup_after_py_match_fn:
     if(PyErr_Occurred())
         PyErr_Clear();
     if(py_match) {
@@ -190,8 +193,8 @@ cleanup_after_py_match_fn:
     if(py_mismatch) {
         Py_DECREF(py_mismatch);
     }
-	/* Cache some commonly used gap penalties */
-	first_A_gap = calc_affine_penalty(1, open_A, extend_A,
+    /* Cache some commonly used gap penalties */
+    first_A_gap = calc_affine_penalty(1, open_A, extend_A,
                                       penalize_extend_when_opening);
     first_B_gap = calc_affine_penalty(1, open_B, extend_B,
                                       penalize_extend_when_opening);
@@ -200,65 +203,65 @@ cleanup_after_py_match_fn:
     lenA = PySequence_Length(py_sequenceA);
     lenB = PySequence_Length(py_sequenceB);
     score_matrix = malloc((lenA+1)*(lenB+1)*sizeof(*score_matrix));
-	if(!score_matrix) {
+    if(!score_matrix) {
         PyErr_SetString(PyExc_MemoryError, "Out of memory");
         goto _cleanup_make_score_matrix_fast;
     }
-	for(i=0; i<(lenB+1); i++)
+    for(i=0; i<(lenB+1); i++)
         score_matrix[i] = 0;
-	for(i=0; i<(lenA+1)*(lenB+1); i += (lenB+1))
-		score_matrix[i] = 0;
-	/* If we only want the score, we don't need the trace matrix. */
-	if (!score_only){
-		trace_matrix = malloc((lenA+1)*(lenB+1)*sizeof(*trace_matrix));
-		if(!trace_matrix) {
-			PyErr_SetString(PyExc_MemoryError, "Out of memory");
-			goto _cleanup_make_score_matrix_fast;
-		}
-		for(i=0; i<(lenB+1); i++)
-			trace_matrix[i] = 0;
-		for(i=0; i<(lenA+1)*(lenB+1); i += (lenB+1))
-			trace_matrix[i] = 0; 
-		}
-	else
-		trace_matrix = malloc(1);
-    
-	/* Initialize the first row and col of the score matrix. */
-	for(i=0; i<=lenA; i++) {
-		if(penalize_end_gaps_B)
+    for(i=0; i<(lenA+1)*(lenB+1); i += (lenB+1))
+        score_matrix[i] = 0;
+    /* If we only want the score, we don't need the trace matrix. */
+    if (!score_only){
+        trace_matrix = malloc((lenA+1)*(lenB+1)*sizeof(*trace_matrix));
+        if(!trace_matrix) {
+            PyErr_SetString(PyExc_MemoryError, "Out of memory");
+            goto _cleanup_make_score_matrix_fast;
+        }
+        for(i=0; i<(lenB+1); i++)
+            trace_matrix[i] = 0;
+        for(i=0; i<(lenA+1)*(lenB+1); i += (lenB+1))
+            trace_matrix[i] = 0;
+        }
+    else
+        trace_matrix = malloc(1);
+
+    /* Initialize the first row and col of the score matrix. */
+    for(i=0; i<=lenA; i++) {
+        if(penalize_end_gaps_B)
             score = calc_affine_penalty(i, open_B, extend_B,
                                         penalize_extend_when_opening);
-		else
-			score = 0;
+        else
+            score = 0;
         score_matrix[i*(lenB+1)] = score;
     }
-	for(i=0; i<=lenB; i++) {
+    for(i=0; i<=lenB; i++) {
         if(penalize_end_gaps_A)
             score = calc_affine_penalty(i, open_A, extend_A,
                                         penalize_extend_when_opening);
-		else
-			score = 0;
+        else
+            score = 0;
         score_matrix[i] = score;
     }
 
-	/* Now initialize the col cache. */
+    /* Now initialize the col cache. */
     col_cache_score = malloc((lenB+1)*sizeof(*col_cache_score));
     memset((void *)col_cache_score, 0, (lenB+1)*sizeof(*col_cache_score));
     for(i=0; i<=lenB; i++) {
         col_cache_score[i] = calc_affine_penalty(i, (2*open_B), extend_B,
-							 penalize_extend_when_opening);
+                             penalize_extend_when_opening);
     }
 
     /* Fill in the score matrix. The row cache is calculated on the fly.*/
-	for(row=1; row<=lenA; row++) {
-		double row_cache_score = calc_affine_penalty(row, (2*open_A), extend_A,
-							     penalize_extend_when_opening);
+    for(row=1; row<=lenA; row++) {
+        double row_cache_score = calc_affine_penalty(row, (2*open_A), extend_A,
+                                 penalize_extend_when_opening);
         for(col=1; col<=lenB; col++) {
-			double match_score, nogap_score;
-			double row_open, row_extend, col_open, col_extend, best_score;
+            double match_score, nogap_score;
+            double row_open, row_extend, col_open, col_extend, best_score;
             int best_score_rint, row_score_rint, col_score_rint;
-			unsigned char row_trace_score, col_trace_score, trace_score;
-                                    
+            unsigned char row_trace_score, col_trace_score, trace_score;
+
             /* Calculate the best score. */
             match_score = _get_match_score(py_sequenceA, py_sequenceB,
                                            py_match_fn, row-1, col-1,
@@ -266,129 +269,131 @@ cleanup_after_py_match_fn:
                                            use_sequence_cstring,
                                            match, mismatch,
                                            use_match_mismatch_scores);
-			if(match_score==-1.0 && PyErr_Occurred())
+            if(match_score==-1.0 && PyErr_Occurred())
                 goto _cleanup_make_score_matrix_fast;
             nogap_score = score_matrix[(row-1)*(lenB+1)+col-1] + match_score;
-			
-			if (!penalize_end_gaps_A && row==lenA) {
-				row_open = score_matrix[(row)*(lenB+1)+col-1];
-				row_extend = row_cache_score;
-			}
-			else {
-				row_open = score_matrix[(row)*(lenB+1)+col-1] + first_A_gap;
-				row_extend = row_cache_score + extend_A;
-			}
-			row_cache_score = (row_open > row_extend) ? row_open : row_extend;
-			
-			if (!penalize_end_gaps_B && col==lenB){
-				col_open = score_matrix[(row-1)*(lenB+1)+col];
-				col_extend = col_cache_score[col];
-			}
-			else {
-				col_open = score_matrix[(row-1)*(lenB+1)+col] + first_B_gap;
-				col_extend = col_cache_score[col] + extend_B;
-			}
-			col_cache_score[col] = (col_open > col_extend) ? col_open : col_extend;
-			
-			best_score = (row_cache_score > col_cache_score[col]) ? row_cache_score : col_cache_score[col];
-			if(nogap_score > best_score)
+
+            if (!penalize_end_gaps_A && row==lenA) {
+                row_open = score_matrix[(row)*(lenB+1)+col-1];
+                row_extend = row_cache_score;
+            }
+            else {
+                row_open = score_matrix[(row)*(lenB+1)+col-1] + first_A_gap;
+                row_extend = row_cache_score + extend_A;
+            }
+            row_cache_score = (row_open > row_extend) ? row_open : row_extend;
+
+            if (!penalize_end_gaps_B && col==lenB){
+                col_open = score_matrix[(row-1)*(lenB+1)+col];
+                col_extend = col_cache_score[col];
+            }
+            else {
+                col_open = score_matrix[(row-1)*(lenB+1)+col] + first_B_gap;
+                col_extend = col_cache_score[col] + extend_B;
+            }
+            col_cache_score[col] = (col_open > col_extend) ? col_open : col_extend;
+
+            best_score = (row_cache_score > col_cache_score[col]) ? row_cache_score : col_cache_score[col];
+            if(nogap_score > best_score)
                 best_score = nogap_score;
-				
-			if(!align_globally && best_score < 0)
+
+            if(!align_globally && best_score < 0)
                 score_matrix[row*(lenB+1)+col] = 0;
-			else
-				score_matrix[row*(lenB+1)+col] = best_score;
-				
-			if (!score_only) {
-				row_score_rint = rint(row_cache_score);
-				col_score_rint = rint(col_cache_score[col]);
-				row_trace_score = 0;
-				col_trace_score = 0;
-				if (rint(row_open) == row_score_rint)
-					row_trace_score = row_trace_score|1;
-				if (rint(row_extend) == row_score_rint)
-					row_trace_score = row_trace_score|8;
-				if (rint(col_open) == col_score_rint)
-					col_trace_score = col_trace_score|4;
-				if (rint(col_extend) == col_score_rint)
-					col_trace_score = col_trace_score|16;
-					
-				trace_score = 0;
-				best_score_rint = rint(best_score);
-				if (rint(nogap_score) == best_score_rint)
-					trace_score = trace_score|2;
-				if (row_score_rint == best_score_rint)
-					trace_score += row_trace_score;
-				if (col_score_rint == best_score_rint)
-					trace_score += col_trace_score;
-				trace_matrix[row*(lenB+1)+col] = trace_score;
-			}
-		}
+            else
+                score_matrix[row*(lenB+1)+col] = best_score;
+
+            if (!score_only) {
+                row_score_rint = rint(row_cache_score);
+                col_score_rint = rint(col_cache_score[col]);
+                row_trace_score = 0;
+                col_trace_score = 0;
+                if (rint(row_open) == row_score_rint)
+                    row_trace_score = row_trace_score|1;
+                if (rint(row_extend) == row_score_rint)
+                    row_trace_score = row_trace_score|8;
+                if (rint(col_open) == col_score_rint)
+                    col_trace_score = col_trace_score|4;
+                if (rint(col_extend) == col_score_rint)
+                    col_trace_score = col_trace_score|16;
+
+                trace_score = 0;
+                best_score_rint = rint(best_score);
+                if (rint(nogap_score) == best_score_rint)
+                    trace_score = trace_score|2;
+                if (row_score_rint == best_score_rint)
+                    trace_score += row_trace_score;
+                if (col_score_rint == best_score_rint)
+                    trace_score += col_trace_score;
+                trace_matrix[row*(lenB+1)+col] = trace_score;
+            }
+        }
     }
-	
+
     /* Save the score and traceback matrices into real python objects. */
     if(!(py_score_matrix = PyList_New(lenA+1)))
         goto _cleanup_make_score_matrix_fast;
-	if(!score_only){
-		if(!(py_trace_matrix = PyList_New(lenA+1)))
-			goto _cleanup_make_score_matrix_fast;
-	}
-	else
-		py_trace_matrix = PyList_New(1);
-	
-	for(row=0; row<=lenA; row++) {
-		PyObject *py_score_row, *py_trace_row;
-		if(!(py_score_row = PyList_New(lenB+1)))
+    if(!score_only){
+        if(!(py_trace_matrix = PyList_New(lenA+1)))
+            goto _cleanup_make_score_matrix_fast;
+    }
+    else
+        py_trace_matrix = PyList_New(1);
+
+    for(row=0; row<=lenA; row++) {
+        PyObject *py_score_row, *py_trace_row;
+        if(!(py_score_row = PyList_New(lenB+1)))
             goto _cleanup_make_score_matrix_fast;
         PyList_SET_ITEM(py_score_matrix, row, py_score_row);
-		if(!score_only){
-			if(!(py_trace_row = PyList_New(lenB+1)))
-				goto _cleanup_make_score_matrix_fast;
-			PyList_SET_ITEM(py_trace_matrix, row, py_trace_row);
-		}
-		
-		for(col=0; col<=lenB; col++) {
-            PyObject *py_score, *py_trace; 
+        if(!score_only){
+            if(!(py_trace_row = PyList_New(lenB+1)))
+                goto _cleanup_make_score_matrix_fast;
+            PyList_SET_ITEM(py_trace_matrix, row, py_trace_row);
+        }
+
+        for(col=0; col<=lenB; col++) {
+            PyObject *py_score, *py_trace;
             int offset = row*(lenB+1) + col;
-			
-			/* Set py_score_matrix[row][col] to the score. */
+
+            /* Set py_score_matrix[row][col] to the score. */
             if(!(py_score = PyFloat_FromDouble(score_matrix[offset])))
                 goto _cleanup_make_score_matrix_fast;
             PyList_SET_ITEM(py_score_row, col, py_score);
-			
+
             if(score_only)
                 continue;
             /* Set py_trace_matrix[row][col] to a list of indexes.  On
                the edges of the matrix (row or column is 0), the
                matrix should be [None]. */
             if(!row || !col) {
-				if(!(py_trace = Py_BuildValue("B", 1)))
-					goto _cleanup_make_score_matrix_fast;
-				Py_INCREF(Py_None);
+                if(!(py_trace = Py_BuildValue("B", 1)))
+                    goto _cleanup_make_score_matrix_fast;
+                Py_INCREF(Py_None);
                 PyList_SET_ITEM(py_trace_row, col, Py_None);
             }
             else {
-				if(!(py_trace = Py_BuildValue("B", trace_matrix[offset])))
-					goto _cleanup_make_score_matrix_fast;
-				PyList_SET_ITEM(py_trace_row, col, py_trace);
-				
+                if(!(py_trace = Py_BuildValue("B", trace_matrix[offset])))
+                    goto _cleanup_make_score_matrix_fast;
+                PyList_SET_ITEM(py_trace_row, col, py_trace);
+
             }
-		}
+        }
     }
-	py_retval = Py_BuildValue("(OO)", py_score_matrix, py_trace_matrix);
-	
+    py_retval = Py_BuildValue("(OO)", py_score_matrix, py_trace_matrix);
+
  _cleanup_make_score_matrix_fast:
     if(score_matrix)
         free(score_matrix);
     if(trace_matrix)
         free(trace_matrix);
-	if(col_cache_score)
+    if(col_cache_score)
         free(col_cache_score);
-	if(py_score_matrix)
+    if(py_score_matrix){
         Py_DECREF(py_score_matrix);
-    if(py_trace_matrix)
+    }
+    if(py_trace_matrix){
         Py_DECREF(py_trace_matrix);
-	
+    }
+
 #if PY_MAJOR_VERSION >= 3
     if (py_bytesA != NULL && py_bytesA != py_sequenceA) Py_DECREF(py_bytesA);
     if (py_bytesB != NULL && py_bytesB != py_sequenceB) Py_DECREF(py_bytesB);
@@ -397,8 +402,8 @@ cleanup_after_py_match_fn:
     return py_retval;
 }
 
-static PyObject *cpairwise2_rint(
-    PyObject *self, PyObject *args, PyObject *keywds)
+static PyObject *cpairwise2_rint(PyObject *self, PyObject *args,
+                                 PyObject *keywds)
 {
     double x;
     int precision = _PRECISION;


### PR DESCRIPTION
Updated <code>pairwise2</code> module:

1. Allow insertion after deletion (and vice versa). An alignment of this type:
      ```

A-
-B
```
is now possible (depending on the gap open penalties), like in EMBOSS' needle. This change was inspired by this [pre-print paper](http://biorxiv.org/content/early/2015/11/12/031500) and this [list](http://www.exelixis-lab.org/web/software/alignment/).

2. Improvements in speed and maximum sequence length for both the pure Python implementation and the C module. (#297, #603, #631). Sequences may be at least 3 times longer before raising a  memory error (on 32 bit Python, which has a maximum memory of 2 GByte), and speed can be up to 10 times faster (see table below).

3. Solved problems with wrong local alignments  (#766, #279).

4. Raise warning, when not using the C module ( #657).

Comparison of old and new <code>pairwise2</code> on 32 bit Python 2.7.11 (with 2 GByte memory limit), Win7 64 bit, Intel Core i5, 2.8 Ghz

 ```
#bad case
length_of_sequence = ...
seq1 = ''.join(['A',]+['I' for x in range(length_of_sequence)])
seq2 = ''.join(['V',]+['I' for x in range(length_of_sequence)])
aln = pairwise2.align.globalxx(seq1, seq2)

 #"real" conditions
seq1 = '...'[:length_of_sequence]  # Just two normal DNA sequences, e.g. human
seq2 = '...'[:length_of_sequence]  # and green monkey dystrophin mRNA (>13 kBp)
aln = pairwise2.align.globalms(seq1, seq2, 5, -4, -10, -1)
 ```

|               | old pairwise2|   --           | new pairwise2|   --     
|---------------|--------------|----------------|--------------|--------
|               | with C module|without C module| with C module| without C module|
|bad case:      |              |                |
|max. length    | ~445         | ~1,050         |   ~7,450     | ~10,200
|time (max len) | 9 sec        | 110 sec        |10 sec        | 730 sec
|time (445 chars)| 9 sec       | 6 sec          | 0.05 sec     | 1.3 sec
|score_only:    |          |||
|max. length    | ~710         | ~1,050         | ~8,430       | ~11,400
|time (max len) | 1.5 sec      | 110 sec        | 6 sec        | 300 sec
|real conditions:||||
|max. length    | ~1,900       | ~3,625         |   ~7,450     | ~10,000
|time (max len) | 10 sec       | 140 sec        | 12 sec       | 690 sec
|time (1900 chars)| 10 sec     | 35 sec         | 1 sec        | 25 sec
|score_only:    |          |||
|max. length    | ~3,230       | ~3,625         | ~ 8,420      | ~11,250
|time (max len) |  4 sec       |  140 sec       | 6 sec        | 300 sec
