### PR TITLE
Use getattr instead of eval in NCBIXML

### DIFF
--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -61,7 +61,7 @@ class _XMLparser(ContentHandler):
         # Note could use try / except AttributeError
         # BUT I found often triggered by nested errors...
         if hasattr(self, method):
-            eval("self.%s()" % method)
+            getattr(self, method)()
             if self._debug > 4:
                 print("NCBIXML: Parsed:  " + method)
         elif self._debug > 3:
@@ -96,7 +96,7 @@ class _XMLparser(ContentHandler):
         # Note could use try / except AttributeError
         # BUT I found often triggered by nested errors...
         if hasattr(self, method):
-            eval("self.%s()" % method)
+            getattr(self, method)()
             if self._debug > 2:
                 print("NCBIXML: Parsed:  %s %s" % (method, self._value))
         elif self._debug > 1:


### PR DESCRIPTION
I've been using BioPython with pypy a little. Yesterday I upgraded to pypy 5.0.0 and was surprised to see a piece of BioPython-using code parsing BLAST XML run much slower. I made a small test case and posted it to the pypy project: https://bitbucket.org/pypy/pypy/issues/2261/pypy-500-very-slow-when-using-biopython (that ticket includes some very rough timing numbers).

The pypy folks quickly found a use of `eval` in BioPython that causes the XML parsing to run so slowly. This pull request just implements the simple fix suggested by them.

I don't understand the comment:

```
        # Note could use try / except AttributeError
        # BUT I found often triggered by nested errors...
```

that appears in `NCBIXML.py` just before these two changes. I have a feeling the comment could be deleted. I don't see how `try/except` could be used here. Given that the attribute is in a variable name and so `hasattr` needs to be used (unless the comment writer meant they could wrap an `eval` in a `try/except`). But there's no need for that.  So if people agree with this change and with that thinking, I'll also delete the two comments.

Note that there are some other uses of `eval` in BioPython and, if I understand correctly, they too will make pypy much slower. IMO, having BioPython run very quickly under pypy is a major advantage to its users, not just to me :-)