### PR TITLE
Python 3: Cope with StringIO in Entrez parser

### DIFF
--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -35,6 +35,7 @@ written solution, since the number of DTDs is rather large and their
 contents may change over time. About half the code in this parser deals
 wih parsing the DTD, and the other half with the XML itself.
 """
+import sys
 import re
 import os
 import warnings
@@ -213,6 +214,14 @@ class DataHandler(object):
             # Should avoid a possible Segmentation Fault, see:
             # http://bugs.python.org/issue4877
             raise IOError("Can't parse a closed handle")
+        if sys.version_info[0] >= 3:
+            # Another nasty hack to cope with a unicode StringIO handle
+            # since the Entrez XML parser expects binary data (bytes)
+            from io import StringIO
+            if isinstance(handle, StringIO):
+                from io import BytesIO
+                from Bio._py3k import _as_bytes
+                handle = BytesIO(_as_bytes(handle.read()))
         try:
             self.parser.ParseFile(handle)
         except expat.ExpatError as e:

--- a/Tests/test_Entrez.py
+++ b/Tests/test_Entrez.py
@@ -9,7 +9,6 @@
 import unittest
 import sys
 import os
-import platform
 if os.name == 'java':
     try:
         from xml.parsers.expat import XML_PARAM_ENTITY_PARSING_ALWAYS
@@ -59,14 +58,8 @@ class GeneralTests(unittest.TestCase):
         with open("Entrez/einfo1.xml", "rt") as in_handle:
             data = in_handle.read()
         handle = StringIO(data)
-        if sys.version_info[0] < 3 or platform.python_implementation() == 'PyPy':
-            # Python 2 didn't care
-            # PyPy3 doesn't seem to care either
-            record = Entrez.read(handle)
-            self.assertTrue("DbList" in record)
-        else:
-            # TODO - Could we handle this as another special case?
-            self.assertRaises(TypeError, Entrez.read, handle)
+        record = Entrez.read(handle)
+        self.assertTrue("DbList" in record)
         handle.close()
 
 


### PR DESCRIPTION
What do you think about this @mdehoon to address the issue reported on #788.

Long term I'd like to get rid of these text/binary unicode/bytes handles workarounds, which would require the underlying parser to cope with text mode (or both text and binary).