### PR TITLE
Entrez Efetch using int identifier

### DIFF
--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -170,6 +170,9 @@ def efetch(db, **keywords):
         if isinstance(ids, list):
             ids = ",".join(ids)
             variables["id"] = ids
+        elif isinstance(ids, int):
+            variables["id"] = str(ids)
+
         if ids.count(",") >= 200:
             # NCBI prefers an HTTP POST instead of an HTTP GET if there are
             # more than about 200 IDs

--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -171,7 +171,8 @@ def efetch(db, **keywords):
             ids = ",".join(ids)
             variables["id"] = ids
         elif isinstance(ids, int):
-            variables["id"] = str(ids)
+            ids = str(ids)
+            variables["id"] = ids
 
         if ids.count(",") >= 200:
             # NCBI prefers an HTTP POST instead of an HTTP GET if there are

--- a/Tests/test_Entrez_online.py
+++ b/Tests/test_Entrez_online.py
@@ -131,6 +131,15 @@ class EntrezOnlineCase(unittest.TestCase):
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0]['System_sysid']['Sys-id']['Sys-id_bsid'], '1134002')
 
+    def test_efetch_taxonomy_xml(self):
+        """Test Entrez using a integer id - like a taxon id
+        """
+        handle = Entrez.efetch( db="taxonomy", id=3702, retmode="XML")
+        taxon_record = Entrez.read(handle)
+        self.assertTrue(1, len(taxon_record))
+        self.assertTrue('TaxId' in taxon_record[0])
+        self.assertTrue('3702', taxon_record[0]['TaxId'])
+
     def test_elink(self):
         # Commas: Link from protein to gene
         handle = Entrez.elink(db="gene", dbfrom="protein",


### PR DESCRIPTION
Some NCBI identifiers are integers, such as taxonomy ids or GI
numbers. It is natural then that a user may code them as integers
in python. This additional test automatically converts an ID given
to efetch as an integer to a string, which is required by the
entrez API.

As suggested by @peterjc in pull #740 I've moved these changes
into their own PR