### PR TITLE
Handle GenBank LOCUS names up to 26 letters if space allows

### DIFF
--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1096,8 +1096,15 @@ class GenBankScanner(InsdcScanner):
             # Should be possible to split them based on position, if
             # a clear definition of the standard exists THAT AGREES with
             # existing files.
-            consumer.locus(name_and_length[0])
-            consumer.size(name_and_length[1])
+            name, length = name_and_length
+            if len(name) > 16:
+                # As long as the sequence is short, can steal its leading spaces
+                # to extend the name over the current 16 character limit.
+                # However, that deserves a warning as it is out of spec.
+                warnings.warn("GenBank LOCUS line identifier over 16 characters",
+                              BiopythonParserWarning)
+            consumer.locus(name)
+            consumer.size(length)
             # consumer.residue_type(line[33:41].strip())
 
             if line[33:51].strip() == "" and line[29:33] == ' aa ':

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -622,6 +622,8 @@ class GenBankWriter(_InsdcWriter):
                 raise ValueError("Locus identifier %r is too long" % locus)
             else:
                 warnings.warn("Stealing space from length field to allow long name in LOCUS line", BiopythonWarning)
+        if len(locus.split()) > 1:
+            raise ValueError("Invalid whitespace in %r for LOCUS line" % locus)
         if len(record) > 99999999999:
             # Currently GenBank only officially support up to 350000, but
             # the length field can take eleven digits
@@ -678,7 +680,7 @@ class GenBankWriter(_InsdcWriter):
         # assert line[28:29] == " "
         # assert line[29:40].lstrip() == str(len(record)), \
         #     'LOCUS line does not contain the length at the expected position:\n' + line
-        assert line[12:40].split() == [locus, str(len(record))]
+        assert line[12:40].split() == [locus, str(len(record))], line
 
         # Tests copied from Bio.GenBank.Scanner
         assert line[40:44] in [' bp ', ' aa '], \

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -487,6 +487,8 @@ class _InsdcWriter(SequentialSequenceWriter):
 
 
 class GenBankWriter(_InsdcWriter):
+    """GenBank writer."""
+
     HEADER_WIDTH = 12
     QUALIFIER_INDENT = 21
 
@@ -895,6 +897,8 @@ class GenBankWriter(_InsdcWriter):
 
 
 class EmblWriter(_InsdcWriter):
+    """EMBL writer."""
+
     HEADER_WIDTH = 5
     QUALIFIER_INDENT = 21
     QUALIFIER_INDENT_STR = "FT" + " " * (QUALIFIER_INDENT - 2)
@@ -1217,6 +1221,8 @@ class EmblWriter(_InsdcWriter):
 
 
 class ImgtWriter(EmblWriter):
+    """IMGT writer (EMBL format variant)."""
+
     HEADER_WIDTH = 5
     QUALIFIER_INDENT = 25  # Not 21 as in EMBL
     QUALIFIER_INDENT_STR = "FT" + " " * (QUALIFIER_INDENT - 2)

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -625,7 +625,12 @@ class GenBankWriter(_InsdcWriter):
             else:
                 warnings.warn("Stealing space from length field to allow long name in LOCUS line", BiopythonWarning)
         if len(locus.split()) > 1:
-            raise ValueError("Invalid whitespace in %r for LOCUS line" % locus)
+            # locus could be unicode, and u'with space' versus 'with space'
+            # causes trouble with doctest or print-and-compare tests, so
+            tmp = repr(locus)
+            if tmp.startswith("u'") and tmp.endswith("'"):
+                tmp = tmp[1:]
+            raise ValueError("Invalid whitespace in %s for LOCUS line" % tmp)
         if len(record) > 99999999999:
             # Currently GenBank only officially support up to 350000, but
             # the length field can take eleven digits

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -805,8 +805,13 @@ class GenBankWriter(_InsdcWriter):
         handle = self.handle
         self._write_the_first_line(record)
 
+        default = record.id
+        if default.count(".") == 1 and default[default.index(".") + 1:].isdigit():
+            # Good, looks like accesion.version and not something
+            # else like identifier.start-end
+            refault = record.id.split(".", 1)[0]
         accession = self._get_annotation_str(record, "accession",
-                                             record.id.split(".", 1)[0],
+                                             default,
                                              just_first=True)
         acc_with_version = accession
         if record.id.startswith(accession + "."):

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -809,7 +809,7 @@ class GenBankWriter(_InsdcWriter):
         if default.count(".") == 1 and default[default.index(".") + 1:].isdigit():
             # Good, looks like accesion.version and not something
             # else like identifier.start-end
-            refault = record.id.split(".", 1)[0]
+            default = record.id.split(".", 1)[0]
         accession = self._get_annotation_str(record, "accession",
                                              default,
                                              just_first=True)

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -659,7 +659,8 @@ class GenBankWriter(_InsdcWriter):
 
         name_length = str(len(record)).rjust(28)
         name_length = locus + name_length[len(locus):]
-        assert len(name_length) == 28 and " " in name_length, name_length
+        assert len(name_length) == 28, name_length
+        assert " " in name_length, name_length
 
         assert len(units) == 2
         assert len(division) == 3

--- a/Tests/output/test_SeqIO
+++ b/Tests/output/test_SeqIO
@@ -486,7 +486,7 @@ Testing reading fasta format file Fasta/loveliesbleeding.pro
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|2781234|pdb|1JLY|B).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|2781234|pdb|1JLY|B' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -582,7 +582,7 @@ Testing reading fasta format file Fasta/f001
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3318709|pdb|1A91|).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|3318709|pdb|1A91|' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -3186,7 +3186,7 @@ Testing reading emboss format file Emboss/needle.txt
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|94970041|receiver).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|94970041|receiver' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -3265,7 +3265,7 @@ Testing reading phd format file Phd/phd1
  Checking can write/read as 'fastq-illumina' format
  Checking can write/read as 'fastq-solexa' format
  Checking can write/read as 'genbank' format
- Failed: Locus identifier '425_7_(71-A03-19).b.ab1' is too long
+ Failed: Locus identifier '425_103_(81-A03-19).g.ab1' is too long
  Checking can write/read as 'imgt' format
  Checking can write/read as 'phd' format
  Checking can write/read as 'qual' format
@@ -3315,7 +3315,6 @@ Testing reading phd format file Phd/phd_solexa
  Checking can write/read as 'fastq-illumina' format
  Checking can write/read as 'fastq-solexa' format
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'HWI-EAS94_4_1_1_602_99' is too long
  Checking can write/read as 'imgt' format
  Checking can write/read as 'phd' format
  Checking can write/read as 'qual' format
@@ -3339,7 +3338,6 @@ Testing reading phd format file Phd/phd_454
  Checking can write/read as 'fastq-illumina' format
  Checking can write/read as 'fastq-solexa' format
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'EBE03TV04IHLTF.77-243' is too long
  Checking can write/read as 'imgt' format
  Checking can write/read as 'phd' format
  Checking can write/read as 'qual' format
@@ -3785,7 +3783,7 @@ Testing reading fasta format file Quality/example.fasta as an alignment
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=EAS54_6_R1_2_1_443_348).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'EAS54_6_R1_2_1_443_348' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -3820,7 +3818,7 @@ Testing reading qual format file Quality/example.qual
  Checking can write/read as 'fastq-illumina' format
  Checking can write/read as 'fastq-solexa' format
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'EAS54_6_R1_2_1_443_348' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -3861,7 +3859,7 @@ Testing reading fastq format file Quality/example.fastq as an alignment
  Checking can write/read as 'fastq-illumina' format
  Checking can write/read as 'fastq-solexa' format
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'EAS54_6_R1_2_1_443_348' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -3902,7 +3900,7 @@ Testing reading fastq format file Quality/example_dos.fastq as an alignment
  Checking can write/read as 'fastq-illumina' format
  Checking can write/read as 'fastq-solexa' format
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'EAS54_6_R1_2_1_443_348' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -4054,7 +4052,7 @@ Testing reading fastq-solexa format file Quality/solexa_faked.fastq
  Checking can write/read as 'fastq-illumina' format
  Checking can write/read as 'fastq-solexa' format
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'slxa_0001_1_0001_01' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -4137,7 +4135,6 @@ Testing reading seqxml format file SeqXML/dna_example.xml
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=minimal).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'ENSMUSG00000076441' is too long
  Checking can write/read as 'imgt' format
  Checking can write/read as 'phd' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=minimal).
@@ -4179,7 +4176,7 @@ Testing reading seqxml format file SeqXML/rna_example.xml
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=empty description).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'empty description' is too long
+ Failed: Invalid whitespace in 'empty description' for LOCUS line
  Checking can write/read as 'imgt' format
  Failed: Cannot have spaces in EMBL accession, 'empty description'
  Checking can write/read as 'phd' format
@@ -4221,7 +4218,6 @@ Testing reading seqxml format file SeqXML/protein_example.xml
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=UniprotProtein).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'ENSMUSP00000099904' is too long
  Checking can write/read as 'imgt' format
  Checking can write/read as 'phd' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=UniprotProtein).

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -12,7 +12,9 @@ from Bio import BiopythonParserWarning
 from Bio import BiopythonWarning
 from Bio import GenBank
 from Bio import SeqIO
+from Bio.SeqRecord import SeqRecord
 from Bio.Seq import Seq
+from Bio.Alphabet import generic_dna
 from Bio._py3k import StringIO
 
 
@@ -191,6 +193,24 @@ class GenBankTests(unittest.TestCase):
                 new = SeqIO.read(handle, "gb")
             self.assertEqual(name, new.name)
             self.assertEqual(seq_len, len(new))
+
+
+class OutputTests(unittest.TestCase):
+    def test_mad_dots(self):
+        for identifier in ["example",
+                           "example.1a",
+                           "example.1.2",
+                           "example.1-2",
+                           ]:
+            old = SeqRecord(Seq("ACGT", generic_dna),
+                            id=identifier,
+                            name=identifier,
+                            description="mad dots")
+            new = SeqIO.read(StringIO(old.format("gb")), "gb")
+            self.assertEqual(old.id, new.id)
+            self.assertEqual(old.name, new.name)
+            self.assertEqual(old.description, new.description)
+            self.assertEqual(old.seq, new.seq)
 
 
 if __name__ == "__main__":

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -19,33 +19,40 @@ from Bio._py3k import StringIO
 
 
 class GenBankTests(unittest.TestCase):
+    """GenBank tests."""
+
     def test_invalid_product_line_raises_value_error(self):
-        """Test GenBank parsing invalid product line raises ValueError"""
+        """Parsing invalid product line."""
         def parse_invalid_product_line():
             rec = SeqIO.read(path.join('GenBank', 'invalid_product.gb'),
                              'genbank')
         self.assertRaises(ValueError, parse_invalid_product_line)
 
     def test_genbank_read(self):
+        """GenBank.read(...) simple test."""
         with open(path.join("GenBank", "NC_000932.gb")) as handle:
             record = GenBank.read(handle)
         self.assertEqual(['NC_000932'], record.accession)
 
     def test_genbank_read_multirecord(self):
+        """GenBank.read(...) error on multiple record input."""
         with open(path.join("GenBank", "cor6_6.gb")) as handle:
             self.assertRaises(ValueError, GenBank.read, handle)
 
     def test_genbank_read_invalid(self):
+        """GenBank.read(...) error on invalid file (e.g. FASTA file)."""
         with open(path.join("GenBank", "NC_000932.faa")) as handle:
             self.assertRaises(ValueError, GenBank.read, handle)
 
     def test_genbank_read_no_origin_no_end(self):
+        """GenBank.read(...) error on malformed file."""
         with open(path.join("GenBank", "no_origin_no_end.gb")) as handle:
             self.assertRaises(ValueError, GenBank.read, handle)
 
     # Evil hack with 000 to manipulate sort order to ensure this is tested
     # first (otherwise something silences the warning)
     def test_000_genbank_bad_loc_wrap_warning(self):
+        """Feature line wrapping warning."""
         with warnings.catch_warnings():
             warnings.simplefilter("error", BiopythonParserWarning)
             with open(path.join("GenBank", "bad_loc_wrap.gb")) as handle:
@@ -59,6 +66,7 @@ class GenBankTests(unittest.TestCase):
 
     # Similar hack as we also want to catch that warning here
     def test_001_negative_location_warning(self):
+        """Un-parsable feature location warning."""
         with warnings.catch_warnings():
             warnings.simplefilter("error", BiopythonParserWarning)
             try:
@@ -69,6 +77,7 @@ class GenBankTests(unittest.TestCase):
                 self.assertTrue(False, "Expected specified BiopythonParserWarning here.")
 
     def test_genbank_bad_loc_wrap_parsing(self):
+        """Bad location wrapping."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", BiopythonParserWarning)
             with open(path.join("GenBank", "bad_loc_wrap.gb")) as handle:
@@ -78,12 +87,14 @@ class GenBankTests(unittest.TestCase):
                 self.assertEqual(loc, "join(3462..3615,3698..3978,4077..4307,4408..4797,4876..5028,5141..5332)")
 
     def test_negative_location(self):
+        """Negative feature locations."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", BiopythonParserWarning)
             rec = SeqIO.read(path.join("GenBank", "negative_location.gb"), "genbank")
             self.assertEqual(None, rec.features[-1].location)
 
     def test_dot_lineage(self):
+        """Missing taxonomy lineage."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", BiopythonParserWarning)
             rec = SeqIO.read("GenBank/bad_loc_wrap.gb", "genbank")
@@ -126,6 +137,7 @@ class GenBankTests(unittest.TestCase):
         self.assertTrue("XX\nPR   Project:PRJNA16232;\nXX\n" in embl, embl)
 
     def test_structured_comment_parsing(self):
+        """Structued comment parsing."""
         # GISAID_EpiFlu(TM)Data, HM138502.gbk has both 'comment' and 'structured_comment'
         record = SeqIO.read(path.join('GenBank', 'HM138502.gbk'), 'genbank')
         self.assertEqual(record.annotations['comment'],
@@ -196,7 +208,10 @@ class GenBankTests(unittest.TestCase):
 
 
 class OutputTests(unittest.TestCase):
+    """GenBank output tests."""
+
     def test_mad_dots(self):
+        """Writing and reading back accesssion.version variants."""
         for identifier in ["example",
                            "example.1a",
                            "example.1.2",

--- a/Tests/test_SeqIO_write.py
+++ b/Tests/test_SeqIO_write.py
@@ -50,7 +50,7 @@ test_records = [
                 description="an%sevil\rdescription right\nhere" % os.linesep),
       SeqRecord(Seq("TTTCCTCGGAGGCCAATCTGGATCAAGACCAT", Alphabet.generic_dna), id="Z")],
      "3 DNA seq alignment with CR/LF in name/descr",
-      [(["genbank"], ValueError, r"Locus identifier 'The\nMystery\rSequece:\r\nX' is too long")]),
+      [(["genbank"], ValueError, r"Invalid whitespace in 'The\nMystery\rSequece:\r\nX' for LOCUS line")]),
     ([SeqRecord(Seq("CHSMAIKLSSEHNIPSGIANAL", Alphabet.generic_protein), id="Alpha"),
       SeqRecord(Seq("VHGMAHPLGAFYNTPHGVANAI", Alphabet.generic_protein), id="Beta"),
       SeqRecord(Seq("VHGMAHPLGAFYNTPHGVANAI", Alphabet.generic_protein), id="Beta"),


### PR DESCRIPTION
This pull request implements the relaxation discussed on #747 to better handle the special case where a GenBank LOCUS name is over 16 characters (current official limit) by stealing space from the length field, and thus not disrupting the strict column based layout:

* Add a warning to the parser where currently it silently accepts these longer identifiers;

* Modify the writer to accept long identifiers provided the sequence length is short enough to squeeze in both, but issue a warning in this case.

Includes some testing, although not explicitly verifying when the warnings are triggered.

@kblin could you test this please?