### PR TITLE
Issue 797

### DIFF
--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -429,10 +429,17 @@ class SeqRecord(object):
             if self.seq is None:
                 raise ValueError("If the sequence is None, we cannot slice it.")
             parent_length = len(self)
-            answer = self.__class__(self.seq[index],
-                                    id=self.id,
-                                    name=self.name,
-                                    description=self.description)
+            from BioSQL.BioSeq import DBSeqRecord
+            if isinstance(self, DBSeqRecord):
+                answer = SeqRecord(self.seq[index],
+                                        id=self.id,
+                                        name=self.name,
+                                        description=self.description)
+            else:
+                answer = self.__class__(self.seq[index],
+                                        id=self.id,
+                                        name=self.name,
+                                        description=self.description)
             # TODO - The description may no longer apply.
             # It would be safer to change it to something
             # generic like "edited" or the default value.

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -502,6 +502,14 @@ class SeqInterfaceTest(unittest.TestCase):
         self.assertEqual(str(test_seq[-10:][5:]), "TTATA")
         self.assertEqual(str(test_seq[-10:][5:]), "TTATA")
 
+    def test_record_slicing(self):
+        """Check that slices of DBSeqRecord are retrieved properly.
+        """
+        new_rec = self.item[400:]
+        self.assertTrue(isinstance(new_rec, SeqRecord))
+        self.assertEqual(len(new_rec), 480)
+        self.assertEqual(len(new_rec.features), 5)
+
     def test_seq_features(self):
         """Check SeqFeatures of a sequence.
         """


### PR DESCRIPTION
Same changes as #801 minus the change in doctest that I couldn't figure out how to fix

Implements a solution to #797 by checking for `DBSeqRecord` and explicitly returning `SeqRecord`