### PR TITLE
Set taxon left right values

### DIFF
--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -489,6 +489,13 @@ class Adaptor(object):
             sql = sql.replace("%s", "?")
         self.dbutils.execute(self.cursor, sql, args)
 
+    def executemany(self, sql, args):
+        """Just execute an sql command.
+        """
+        if os.name == "java":
+            sql = sql.replace("%s", "?")
+        self.dbutils.executemany(self.cursor, sql, args)
+
     def get_subseq_as_string(self, seqid, start, end):
         length = end - start
         # XXX Check this on MySQL and PostgreSQL. substr should be general,

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -311,12 +311,18 @@ class _CursorWrapper(object):
         self.real_cursor = real_cursor
 
     def execute(self, operation, params=None, multi=False):
+        """Execute a sql statement
+        """
         self.real_cursor.execute(operation, params, multi)
 
     def executemany(self, operation, params):
+        """Execute many sql statements
+        """
         self.real_cursor.executemany(operation, params)
 
     def _convert_tuple(self, tuple_):
+        """Decode any bytestrings present in the row
+        """
         tuple_list = list(tuple_)
         for i, elem in enumerate(tuple_list):
             if type(elem) is bytes:
@@ -493,7 +499,7 @@ class Adaptor(object):
         self.dbutils.execute(self.cursor, sql, args)
 
     def executemany(self, sql, args):
-        """Just execute an sql command.
+        """Execute many sql commands.
         """
         if os.name == "java":
             sql = sql.replace("%s", "?")
@@ -516,10 +522,14 @@ class Adaptor(object):
             (start + 1, length, seqid))[0])
 
     def execute_and_fetch_col0(self, sql, args=None):
+        """Return a list of values from the first column in the row
+        """
         self.execute(sql, args or ())
         return [field[0] for field in self.cursor.fetchall()]
 
     def execute_and_fetchall(self, sql, args=None):
+        """Return a list of tuples of all rows
+        """
         self.execute(sql, args or ())
         return self.cursor.fetchall()
 

--- a/BioSQL/DBUtils.py
+++ b/BioSQL/DBUtils.py
@@ -40,6 +40,11 @@ class Generic_dbutils(object):
         """
         cursor.execute(sql, args or ())
 
+    def executemany(self, cursor, sql, seq):
+        """
+        """
+        cursor.executemany(sql, seq)
+
     def autocommit(self, conn, y=1):
         # Let's hope it was not really needed
         pass
@@ -48,10 +53,19 @@ class Generic_dbutils(object):
 class Sqlite_dbutils(Generic_dbutils):
     """Custom database utilities for SQLite."""
 
+    def _sub_placeholder(self, sql):
+        return sql.replace("%s", "?")
+
     def execute(self, cursor, sql, args=None):
         """Execute SQL command, replacing %s with ? for variable substitution in sqlite3.
         """
-        cursor.execute(sql.replace("%s", "?"), args or ())
+        sql = self._sub_placeholder(sql)
+        cursor.execute(sql, args or ())
+
+    def executemany(self, cursor, sql, seq):
+        sql = self._sub_placeholder(sql)
+        cursor.executemany(sql, seq)
+
 
 _dbutils["sqlite3"] = Sqlite_dbutils
 

--- a/BioSQL/DBUtils.py
+++ b/BioSQL/DBUtils.py
@@ -54,6 +54,8 @@ class Sqlite_dbutils(Generic_dbutils):
     """Custom database utilities for SQLite."""
 
     def _sub_placeholder(self, sql):
+        """Format the argument placeholders for sqlite
+        """
         return sql.replace("%s", "?")
 
     def execute(self, cursor, sql, args=None):

--- a/BioSQL/DBUtils.py
+++ b/BioSQL/DBUtils.py
@@ -41,7 +41,7 @@ class Generic_dbutils(object):
         cursor.execute(sql, args or ())
 
     def executemany(self, cursor, sql, seq):
-        """
+        """Execute many sql commands
         """
         cursor.executemany(sql, seq)
 

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -556,8 +556,12 @@ class DatabaseLoader(object):
             # we have reached the top of the lineage but no current taxonomy
             # id has been found
             parent_taxon_id = None
-            right_value = 2
-            left_value = 1
+            left_value = self.adaptor.execute_one(
+                "SELECT MAX(left_value) FROM taxon")[0]
+            if not left_value:
+                left_value = 0
+
+            right_value = left_value + 1
 
         self._update_left_right_taxon_values(left_value)
 

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -329,6 +329,31 @@ class DatabaseLoader(object):
         assert answer == answer.lower()
         return answer
 
+    def _update_left_right_taxon_values(self, left_value):
+        """ update the left and right values in the table
+        """
+        # Due to the UNIQUE constraint on the left and right values in the taxon
+        # table we cannot simply update them through an SQL statement as we risk
+        # colliding values. Instead we must select all of the rows that we want to
+        # update, modify the values in python and then update the rows
+        #self.adaptor.execute("UPDATE taxon SET right_value = right_value + 2 WHERE right_value >= %s", (left_value,))
+        #self.adaptor.execute("UPDATE taxon SET left_value = left_value + 2 WHERE left_value > %s", (left_value,))
+
+        rows = self.adaptor.execute_and_fetchall(
+                "SELECT left_value, right_value, taxon_id FROM taxon WHERE right_value >= %s or left_value > %s",
+                (left_value, left_value))
+
+        for i in range(len(rows)):
+            rows[i] = [rows[i][0] + 2, rows[i][1] + 2, rows[i][2]]
+
+
+        # sort the rows based on the left value from largest to smallest
+        # should ensure no overlaps
+        rows = sorted(rows, key=lambda x: x[0], reverse=True)
+
+        self.adaptor.executemany("UPDATE taxon SET left_value = %s, right_value = %s WHERE taxon_id = %s", rows)
+
+
     def _get_taxon_id_from_ncbi_taxon_id(self, ncbi_taxon_id,
                                          scientific_name=None,
                                          common_name=None):
@@ -372,6 +397,10 @@ class DatabaseLoader(object):
         rank = "species"
         genetic_code = None
         mito_genetic_code = None
+        parent_left_value = None
+        parent_right_value = None
+        left_value = None
+        right_value = None
         species_names = []
         if scientific_name:
             species_names.append(("scientific name", scientific_name))
@@ -387,12 +416,20 @@ class DatabaseLoader(object):
                 assert taxonomic_record[0]["TaxId"] == str(ncbi_taxon_id), \
                     "%s versus %s" % (taxonomic_record[0]["TaxId"],
                                       ncbi_taxon_id)
-                parent_taxon_id = self._get_taxon_id_from_ncbi_lineage(
+
+                parent_taxon_id, parent_left_value, parent_right_value = self._get_taxon_id_from_ncbi_lineage(
                     taxonomic_record[0]["LineageEx"])
+
+                left_value = parent_right_value
+                right_value = parent_right_value + 1
+
                 rank = taxonomic_record[0]["Rank"]
+
                 genetic_code = taxonomic_record[0]["GeneticCode"]["GCId"]
+
                 mito_genetic_code = taxonomic_record[
                     0]["MitoGeneticCode"]["MGCId"]
+
                 species_names = [("scientific name",
                                   taxonomic_record[0]["ScientificName"])]
                 try:
@@ -422,6 +459,10 @@ class DatabaseLoader(object):
             # is in the record annotation as a list of names, as we won't
             # know the NCBI taxon IDs for these parent nodes.
 
+
+
+        self._update_left_right_taxon_values(left_value)
+
         self.adaptor.execute(
             "INSERT INTO taxon(parent_taxon_id, ncbi_taxon_id, node_rank,"
             " genetic_code, mito_genetic_code, left_value, right_value)"
@@ -430,8 +471,9 @@ class DatabaseLoader(object):
                                                      rank,
                                                      genetic_code,
                                                      mito_genetic_code,
-                                                     None,
-                                                     None))
+                                                     left_value,
+                                                     right_value))
+
         taxon_id = self.adaptor.last_id("taxon")
 
         # Record the scientific name, common name, etc
@@ -442,6 +484,7 @@ class DatabaseLoader(object):
                                          name[:255],
                                          name_class))
         return taxon_id
+
 
     def _get_taxon_id_from_ncbi_lineage(self, taxonomic_lineage):
         """This is recursive! (PRIVATE).
@@ -459,35 +502,44 @@ class DatabaseLoader(object):
         (database key, not NCBI taxon id) of the final entry (the species).
         """
         ncbi_taxon_id = taxonomic_lineage[-1]["TaxId"]
-
+        left_value = None
+        right_value = None
+        parent_left_value = None
+        parent_right_value = None
         # Is this in the database already?  Check the taxon table...
-        taxon_id = self.adaptor.execute_and_fetch_col0(
-            "SELECT taxon_id FROM taxon"
+        rows = self.adaptor.execute_and_fetchall(
+            "SELECT taxon_id, left_value, right_value FROM taxon"
             " WHERE ncbi_taxon_id=%s" % ncbi_taxon_id)
-        if taxon_id:
+        if rows:
             # we could verify that the Scientific Name etc in the database
             # is the same and update it or print a warning if not...
-            if isinstance(taxon_id, list):
-                assert len(taxon_id) == 1
-                return taxon_id[0]
-            else:
-                return taxon_id
+            assert len(rows) == 1
+            return rows[0]
 
         # We have to record this.
         if len(taxonomic_lineage) > 1:
             # Use recursion to find out the taxon id (database key) of the
             # parent.
-            parent_taxon_id = self._get_taxon_id_from_ncbi_lineage(
+            parent_taxon_id, parent_left_value, parent_right_value = self._get_taxon_id_from_ncbi_lineage(
                 taxonomic_lineage[:-1])
+            left_value = parent_right_value
+            right_value = parent_right_value + 1
             assert _is_int_or_long(parent_taxon_id), repr(parent_taxon_id)
         else:
+            # we have reached the top of the lineage but no current taxonomy
+            # id has been found
             parent_taxon_id = None
+            right_value = 2
+            left_value = 1
+
+        self._update_left_right_taxon_values(left_value)
 
         # INSERT new taxon
         rank = taxonomic_lineage[-1].get("Rank")
         self.adaptor.execute(
-            "INSERT INTO taxon(ncbi_taxon_id, parent_taxon_id, node_rank)"
-            " VALUES (%s, %s, %s)", (ncbi_taxon_id, parent_taxon_id, rank))
+            "INSERT INTO taxon(ncbi_taxon_id, parent_taxon_id, node_rank, left_value, right_value)"
+            " VALUES (%s, %s, %s, %s, %s)", (ncbi_taxon_id, parent_taxon_id, rank, left_value, right_value))
+
         taxon_id = self.adaptor.last_id("taxon")
         assert isinstance(taxon_id, (int, long)), repr(taxon_id)
         # ... and its name in taxon_name
@@ -497,7 +549,7 @@ class DatabaseLoader(object):
                 "INSERT INTO taxon_name(taxon_id, name, name_class)"
                 " VALUES (%s, %s, 'scientific name')", (taxon_id,
                                                         scientific_name[:255]))
-        return taxon_id
+        return taxon_id, left_value, right_value
 
     def _load_bioentry_table(self, record):
         """Fill the bioentry table with sequence information (PRIVATE).

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -349,16 +349,16 @@ class DatabaseLoader(object):
 
         right_rows = []
         left_rows = []
-        for i in range(len(rows)):
-            new_right = rows[i][1]
-            new_left = rows[i][0]
+        for row in rows:
+            new_right = row[1]
+            new_left = row[0]
             if new_right >= left_value:
                 new_right += 2
 
             if new_left > left_value:
                 new_left += 2
-            right_rows.append((new_right, rows[i][2]))
-            left_rows.append((new_left, rows[i][2]))
+            right_rows.append((new_right, row[2]))
+            left_rows.append((new_left, row[2]))
 
 
         # sort the rows based on the value from largest to smallest

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -330,7 +330,7 @@ class DatabaseLoader(object):
         return answer
 
     def _update_left_right_taxon_values(self, left_value):
-        """ update the left and right values in the table
+        """update the left and right values in the table
         """
         if not left_value:
             return

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -366,20 +366,8 @@ class DatabaseLoader(object):
         right_rows = sorted(right_rows, key=lambda x: x[0], reverse=True)
         left_rows = sorted(left_rows, key=lambda x: x[0], reverse=True)
 
-        try:
-            self.adaptor.executemany("UPDATE taxon SET left_value = %s WHERE taxon_id = %s", left_rows)
-            self.adaptor.executemany("UPDATE taxon SET right_value = %s WHERE taxon_id = %s", right_rows)
-        except:
-            #print(orig_rows)
-            #print(rows2)
-            #print(rows)
-
-            #for r in self.adaptor.execute_and_fetchall("select * from taxon"):
-            #    print(r)
-
-            raise
-
-
+        self.adaptor.executemany("UPDATE taxon SET left_value = %s WHERE taxon_id = %s", left_rows)
+        self.adaptor.executemany("UPDATE taxon SET right_value = %s WHERE taxon_id = %s", right_rows)
 
     def _get_taxon_id_from_ncbi_taxon_id(self, ncbi_taxon_id,
                                          scientific_name=None,

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -567,8 +567,8 @@ class TaxonomyTest(unittest.TestCase):
                                   AND taxon.right_value)
                   WHERE taxon.taxon_id IN
                       (SELECT taxon_id FROM taxon_name
-                                  WHERE name LIKE '%Brassicales%')
-                      AND include.right_value - include.left_value == 1"""
+                                  WHERE name = 'Brassicales')
+                      AND include.right_value - include.left_value = 1"""
 
         rows = self.db.adaptor.execute_and_fetch_col0(sql)
         self.assertEqual(4, len(rows))

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -529,6 +529,8 @@ class SeqInterfaceTest(unittest.TestCase):
         self.assertTrue("SWISS-PROT:P31169" in multi_ann)
 
 class TaxonomyTest(unittest.TestCase):
+    """Test proper insertion and retrieval of taxonomy data
+    """
     def setUp(self):
         from Bio import Entrez
         Entrez.email = "biopython-dev@biopython.org"

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -528,10 +528,7 @@ class SeqInterfaceTest(unittest.TestCase):
         self.assertTrue("GI:16354" in multi_ann)
         self.assertTrue("SWISS-PROT:P31169" in multi_ann)
 
-
-class LoaderTest(unittest.TestCase):
-    """Load a database from a GenBank file."""
-
+class TaxonomyTest(unittest.TestCase):
     def setUp(self):
         # create TESTDB
         create_database()
@@ -560,27 +557,20 @@ class LoaderTest(unittest.TestCase):
         del self.db
         del self.server
 
-    def test_load_database(self):
-        """Load SeqRecord objects into a BioSQL database.
-        """
-        self.db.load(self.iterator)
+    def test_taxon_left_right_values(self):
+        self.db.load(self.iterator, True)
+        sql = """SELECT DISTINCT include.ncbi_taxon_id FROM taxon
+                  INNER JOIN taxon AS include ON
+                      (include.left_value BETWEEN taxon.left_value
+                                  AND taxon.right_value)
+                  WHERE taxon.taxon_id IN
+                      (SELECT taxon_id FROM taxon_name
+                                  WHERE name LIKE '%Brassicales%')
+                      AND include.right_value - include.left_value == 1"""
 
-        # do some simple tests to make sure we actually loaded the right
-        # thing. More advanced tests in a different module.
-        items = list(self.db.values())
-        self.assertEqual(len(items), 6)
-        self.assertEqual(len(self.db), 6)
-        item_names = []
-        item_ids = []
-        for item in items:
-            item_names.append(item.name)
-            item_ids.append(item.id)
-        item_names.sort()
-        item_ids.sort()
-        self.assertEqual(item_names, ['AF297471', 'ARU237582', 'ATCOR66M',
-                                      'ATKIN2', 'BNAKINI', 'BRRBIF72'])
-        self.assertEqual(item_ids, ['AF297471.1', 'AJ237582.1', 'L31939.1',
-                                    'M81224.1', 'X55053.1', 'X62281.1'])
+        rows = self.db.adaptor.execute_and_fetch_col0(sql)
+        self.assertEqual(4, len(rows))
+        self.assertEqual(set([3704, 3711, 3708, 3702]), set(rows))
 
 
 class DeleteTest(unittest.TestCase):
@@ -643,6 +633,60 @@ class DeleteTest(unittest.TestCase):
                 rows_d = self.db.adaptor.execute_and_fetchall(sql % (seq_id))
                 # check to see that associated data is removed
                 self.assertEqual(len(rows_d), 0)
+
+
+class LoaderTest(unittest.TestCase):
+    """Load a database from a GenBank file."""
+
+    def setUp(self):
+        # create TESTDB
+        create_database()
+
+        # load the database
+        db_name = "biosql-test"
+        self.server = BioSeqDatabase.open_database(driver=DBDRIVER,
+                                                   user=DBUSER, passwd=DBPASSWD,
+                                                   host=DBHOST, db=TESTDB)
+
+        # remove the database if it already exists
+        try:
+            self.server[db_name]
+            self.server.remove_database(db_name)
+        except KeyError:
+            pass
+
+        self.db = self.server.new_database(db_name)
+
+        # get the GenBank file we are going to put into it
+        self.iterator = SeqIO.parse("GenBank/cor6_6.gb", "gb")
+
+    def tearDown(self):
+        self.server.close()
+        destroy_database()
+        del self.db
+        del self.server
+
+    def test_load_database(self):
+        """Load SeqRecord objects into a BioSQL database.
+        """
+        self.db.load(self.iterator)
+
+        # do some simple tests to make sure we actually loaded the right
+        # thing. More advanced tests in a different module.
+        items = list(self.db.values())
+        self.assertEqual(len(items), 6)
+        self.assertEqual(len(self.db), 6)
+        item_names = []
+        item_ids = []
+        for item in items:
+            item_names.append(item.name)
+            item_ids.append(item.id)
+        item_names.sort()
+        item_ids.sort()
+        self.assertEqual(item_names, ['AF297471', 'ARU237582', 'ATCOR66M',
+                                      'ATKIN2', 'BNAKINI', 'BRRBIF72'])
+        self.assertEqual(item_ids, ['AF297471.1', 'AJ237582.1', 'L31939.1',
+                                    'M81224.1', 'X55053.1', 'X62281.1'])
 
 
 class DupLoadTest(unittest.TestCase):

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -530,6 +530,8 @@ class SeqInterfaceTest(unittest.TestCase):
 
 class TaxonomyTest(unittest.TestCase):
     def setUp(self):
+        from Bio import Entrez
+        Entrez.email = "biopython-dev@biopython.org"
         # create TESTDB
         create_database()
 

--- a/Tests/test_BioSQL_psycopg2.py
+++ b/Tests/test_BioSQL_psycopg2.py
@@ -15,7 +15,7 @@ from common_BioSQL import *
 
 # Constants for the database driver
 DBHOST = 'localhost'
-DBUSER = 'root'
+DBUSER = 'postgres'
 DBPASSWD = ''
 TESTDB = 'biosql_test'
 

--- a/Tests/test_BioSQL_psycopg2.py
+++ b/Tests/test_BioSQL_psycopg2.py
@@ -15,8 +15,8 @@ from common_BioSQL import *
 
 # Constants for the database driver
 DBHOST = 'localhost'
-DBUSER = 'cts'
-DBPASSWD = 'OCean1.pgs'
+DBUSER = 'root'
+DBPASSWD = ''
 TESTDB = 'biosql_test'
 
 ################################


### PR DESCRIPTION
This pull request adds the ability to set/update the left and right values of the taxonomy table when a new taxonomy is added in. This is useful when the database has not been created using the `load_ncbi_taxonomy.pl` script or when a new species (or other taxon) is added into a database with an outdated copy of the NCBI taxonomy loaded into it. As a side effect to this I also added in an `executemany` method to the database adaptor as it makes the code for updating the left and right values much easier. I think that executemany is required in the python DBI 2.0 spec so there shouldn't be a problem with the underlying DBI adaptors not implementing it.