### PR TITLE
GenBank: Don't discard 'linear' or 'circular' topology from LOCUS line

### DIFF
--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -1259,8 +1259,6 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                 self.data.annotations['topology'] = 'circular'
             elif 'linear' in self._seq_type.lower():
                 self.data.annotations['topology'] = 'linear'
-            elif 'unspecified' in self._seq_type.lower():
-                self.data.annotations['topology'] = 'unspecified'
 
         if not sequence and self.__expected_size:
             self.data.seq = UnknownSeq(self._expected_size, seq_alphabet)

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -1254,6 +1254,14 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                 raise ValueError("Could not determine alphabet for seq_type %s"
                                  % self._seq_type)
 
+            # Also save the chomosome layout
+            if 'circular' in self._seq_type.lower():
+                self.data.annotations['topology'] = 'circular'
+            elif 'linear' in self._seq_type.lower():
+                self.data.annotations['topology'] = 'linear'
+            elif 'unspecified' in self._seq_type.lower():
+                self.data.annotations['topology'] = 'unspecified'
+
         if not sequence and self.__expected_size:
             self.data.seq = UnknownSeq(self._expected_size, seq_alphabet)
         else:

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -604,6 +604,19 @@ class GenBankWriter(_InsdcWriter):
         assert len(division) == 3
         return division
 
+    def _get_topology(self, record):
+        """Set the topology to 'circular', 'linear' if defined"""
+        max_topology_len = len('circular')
+
+        # return an empty placeholder string if not given
+        if 'topology' not in record.annotations or \
+            record.annotations['topology'] == 'unspecified':
+            return ' ' * max_topology_len
+
+        template = '%%-%ds' % max_topology_len
+
+        return template % record.annotations['topology'][:max_topology_len]
+
     def _write_the_first_line(self, record):
         """Write the LOCUS line."""
 
@@ -647,17 +660,20 @@ class GenBankWriter(_InsdcWriter):
             # just the generic Alphabet (default for fasta files)
             raise ValueError("Need a DNA, RNA or Protein alphabet")
 
+        topology = self._get_topology(record)
+
         division = self._get_data_division(record)
 
         assert len(units) == 2
         assert len(division) == 3
         # TODO - date
         # TODO - mol_type
-        line = "LOCUS       %s %s %s    %s           %s %s\n" \
+        line = "LOCUS       %s %s %s    %s  %s %s %s\n" \
             % (locus.ljust(16),
                str(len(record)).rjust(11),
                units,
                mol_type.ljust(6),
+               topology,
                division,
                self._get_date(record))
         assert len(line) == 79 + 1, repr(line)  # plus one for new line

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -609,8 +609,7 @@ class GenBankWriter(_InsdcWriter):
         max_topology_len = len('circular')
 
         # return an empty placeholder string if not given
-        if 'topology' not in record.annotations or \
-            record.annotations['topology'] == 'unspecified':
+        if 'topology' not in record.annotations:
             return ' ' * max_topology_len
 
         template = '%%-%ds' % max_topology_len

--- a/Tests/GenBank/melanin.gbk
+++ b/Tests/GenBank/melanin.gbk
@@ -1,0 +1,229 @@
+LOCUS       AB070938                6497 bp    DNA     linear   BCT 11-OCT-2001
+DEFINITION  Streptomyces avermitilis melanin biosynthetic gene cluster.
+ACCESSION   AB070938
+VERSION     AB070938.1  GI:15823953
+KEYWORDS    .
+SOURCE      Streptomyces avermitilis
+  ORGANISM  Streptomyces avermitilis
+            Bacteria; Actinobacteria; Streptomycetales; Streptomycetaceae;
+            Streptomyces.
+REFERENCE   1
+  AUTHORS   Omura,S., Ikeda,H., Ishikawa,J., Hanamoto,A., Takahashi,C.,
+            Shinose,M., Takahashi,Y., Horikawa,H., Nakazawa,H., Osonoe,T.,
+            Kikuchi,H., Shiba,T., Sakaki,Y. and Hattori,M.
+  TITLE     Genome sequence of an industrial microorganism Streptomyces
+            avermitilis: deducing the ability of producing secondary
+            metabolites
+  JOURNAL   Proc. Natl. Acad. Sci. U.S.A. 98 (21), 12215-12220 (2001)
+   PUBMED   11572948
+REFERENCE   2  (bases 1 to 6497)
+  AUTHORS   Ikeda,H.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (01-SEP-2001) Haruo Ikeda, Kitasato University, Dept. of
+            Microbial Chemistry, School of Pharmaceutical Sciences; 5-9-1
+            Shirokane, Minato-ku, Tokyo 108-8641, Japan
+            (E-mail:ikeda@mc.pharm.kitasato-u.ac.jp, Tel:+81-3-5791-6242,
+            Fax:+81-3-3444-6197)
+FEATURES             Location/Qualifiers
+     source          1..6497
+                     /organism="Streptomyces avermitilis"
+                     /mol_type="genomic DNA"
+                     /db_xref="taxon:33903"
+     CDS             complement(1..492)
+                     /codon_start=1
+                     /transl_table=11
+                     /product="hypothetical protein"
+                     /protein_id="BAB69173.1"
+                     /db_xref="GI:15823954"
+                     /translation="MKPLTGSTTDQAPADPAATDDVLATQPIGYWSGLAHTAVTRQLR
+                     DAMARIDVTQPQYWVLNRVHGGPAAPGREEVVTQLTPLADGPHEIARVVDQLLHRGWL
+                     RIDAGQRLRLTDTGEAARKRLRELVTELRAVVHEGISDEEYVTALKVLRTMIANVEGD
+                     AGC"
+     CDS             701..1411
+                     /codon_start=1
+                     /transl_table=11
+                     /product="ribonuclease H"
+                     /protein_id="BAB69174.1"
+                     /db_xref="GI:15823955"
+                     /translation="MIGGMSERVVAACDGASKGNPGPAGWAWVVADGEETPTRWAAGA
+                     LGTATNNVAELTALERLLSAMDPDVPLEIRMDSQYAMKAVTTWLPGWKRKGWKTAAGK
+                     PVANQELVARIDELLDGRSVEFRYVPAHQVDGDRLNDFADRAASQAAIVQEPAGSEYG
+                     SPEPPKSPDTVAAGSAGRGAPAKKRASARTAKTSTRTIKAKFPGRCVCGRPYAAGEPI
+                     AKNAQGWGHPECRTADDV"
+     gene            complement(1553..2377)
+                     /gene="melC2"
+     CDS             complement(1553..2377)
+                     /gene="melC2"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="tyrosinase"
+                     /protein_id="BAB69175.1"
+                     /db_xref="GI:15823956"
+                     /translation="MTVRKNQATLTADEKRRFVDALVALKRSGRYDEFVTTHNAFIMG
+                     DTDSGERTGHRSPSFLPWHRRFLIEFEQALQAVDPSVALPYWDWSTDRTARASLWAPD
+                     FLGGSGRSLDGRVMDGPFAASTGNWPVNVRVDSRTYLRRTLGGGGRELPTRAEVDSVL
+                     AMSTYDMAPWNSASDGFRNHLEGWRGVNLHNRVHVWVGGQMATGVSPNDPVFWLHHAY
+                     IDRLWAQWQSRHPGSGYVPTGGTPNVVDLNETMKPWNDVRPADLLDHTAHYTFDTV"
+     gene            complement(2413..2769)
+                     /gene="melC1"
+     CDS             complement(2413..2769)
+                     /gene="melC1"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="tyrosinase co-factor protein"
+                     /protein_id="BAB69176.1"
+                     /db_xref="GI:15823957"
+                     /translation="MPELTRRHALGAAAALAAVAGTQALAAPSASAAGHHGGPQPFDE
+                     VYQGRRIEGRATGGGHHHGSGYGVFIDGMELHVMQNVDGSWISVVSHYDPVATPRAAA
+                     RAAVVELQGAPLVPFN"
+     CDS             complement(3051..3518)
+                     /codon_start=1
+                     /transl_table=11
+                     /product="hypothetical protein"
+                     /protein_id="BAB69177.1"
+                     /db_xref="GI:15823958"
+                     /translation="MTHPPAGPVLAALVSRATGGRYWRLDRPGAGLDAEAMHIPPGAA
+                     AEPPGDRSRDVLVIALDGGGRLRTPGGWLELAPPAAVWLPPAAGYRLHAGEAGLHCVT
+                     VRPRRPAAPPALPTTGATGEPACLLHQVCAECGRMATESDARYCNRCGNPLER"
+     CDS             3672..4877
+                     /codon_start=1
+                     /transl_table=11
+                     /product="putative hydroxylase"
+                     /protein_id="BAB69178.1"
+                     /db_xref="GI:15823959"
+                     /translation="MKIACVGGGPASLYFSILMKRQDPSHDITVHERNPAGSTYGWGV
+                     TYWSGLLDKLRGSDPESALAVSENSVRWSDGVAHVRNRTTVHHGDEGFGIGRRRFLDV
+                     LADRARSLGVRIEYEHEIGADDPLPEADLVVAGDGVNSVLRGRYADHFGSETVLGRNR
+                     YIWLGTTKVFDSFTFAFVESEHGWIWCYGYGFSDGHSTCVIECSPETWTGLGLDRASE
+                     ADGLALLEKLFADVLDGHELIGRAQSDGAAQWLNFRTLTNRTWHRDNLVLIGDAAHTT
+                     HYSIGAGTTLALEDAIALAEALSAHRDLPGALAAYERERKSALLHIQSAARLSAQWYE
+                     NLPRYIRLPPPQMFALLGQRHSPLLPYVPPQLYYRIDRAAGQLEALRRLKRWLGPRLA
+                     RTVQARTGR"
+     CDS             4941..6497
+                     /codon_start=1
+                     /transl_table=11
+                     /product="membrane transport protein"
+                     /protein_id="BAB69179.1"
+                     /db_xref="GI:15823960"
+                     /translation="MNSYSPPFFTSAAAPGVTMVPISTPSDRSATPDGPAGRPGVRDR
+                     LTVPVLAFGGILMAVMQTVVVPLLPDLPRLTGASAGAVSWMVTATLLSGAVLTPVLGR
+                     AGDMYGKRRVLLAALALMTLGSLLCAVTSDIRVLIAARALQGAAAAVVPLSISILRDE
+                     LPPERTGSAVALMSSTVGIGAALGLPIAAMIVQYADWHVMFWATTGLGAGGLALAWWA
+                     VRESPVRQPGRFDTLGALGLAAGLVCLLLGVSQGGQWGWTSPRIVGLLVACVLVLTLW
+                     WFQQWRAPRPLVDLKLASRPRVALPHVAALLTGFAFYGNSLVTAQLVQAPKATGYGLG
+                     LSIVQTGLCLLPGGVIMLLFSPVSARISAARGPRVTLALGAAVIAVGYAVRIADSRDL
+                     WMIIVGATVIAVGTTLAYSALPTLILRAVPAGQTASANGVNVLMRTIGQAVCSAAVAA
+                     VLVHHTSLVGGAPVPTLHGYLLAFAMAGTVAVMACAAALVIPGDPDSHGTRRARGRTR
+                     PSHDEALEGA"
+ORIGIN      
+        1 ctagcagccc gcatcgccct cgacgttggc gatcatcgtg cgcagcacct tgagcgcggt
+       61 cacgtactcc tcgtcgctga tgccctcgtg gaccaccgcg cgcagctcgg tcaccagctc
+      121 acgcagccgc ttcctggcag cctccccggt gtcggtgaga cgcaggcgct gtccggcgtc
+      181 gatccgaagc cagccccggt gaagcagctg gtcgacgacc cgcgcgatct cgtgcggccc
+      241 gtccgcgagg ggcgtcagct gggtgaccac ctcctcccgg cccggcgccg cgggcccgcc
+      301 gtgcacgcgg ttgagcaccc agtactgcgg ctgtgtgacg tcgatcctgg ccatggcgtc
+      361 ccgcagctgc cgggtgaccg ccgtgtgggc cagaccgctc cagtagccga tgggctgggt
+      421 ggccaacacg tcgtcggtgg cggccggatc ggccggtgcc tggtcggtgg tgctgccggt
+      481 caacggtttc atgatcgtga cgctaggtcc ccgtagcgtg cgtgaacacc gtcgaaccag
+      541 gcaaggtctg gccgaaacct ccgcccctcc aggtggacca ccccgtgcgg cgcgaccttc
+      601 gtccacgtcc cgacgcacgg tgatcgtgct gggggccagc ccctcctgga gggcgtcggc
+      661 ggcgtcggac ccgggcccgg agcgcccggc ggagcgtggc atgatcgggg gcatgtctga
+      721 acgtgtggtg gccgcctgtg acggggcgtc gaagggaaac cccggaccgg ccggatgggc
+      781 ctgggtcgtc gccgacggcg aggagacccc gacccgctgg gcggccgggg cgctcggcac
+      841 ggccacgaac aacgtggccg aactcaccgc gctggagcgc ttgttgagcg cgatggatcc
+      901 ggacgtcccg ctggagatcc ggatggactc ccagtacgcg atgaaggccg tcacgacctg
+      961 gctgcccggc tggaagcgca agggctggaa gacggccgcg gggaagccgg tcgccaacca
+     1021 ggaactggtc gcccgcatcg acgaactgct cgacggacgc tccgtcgagt tccgttacgt
+     1081 ccccgcgcac caggtcgacg gcgaccggct caacgacttc gccgaccgtg ccgccagcca
+     1141 ggcggcgatc gtccaggaac cggcgggcag cgagtacggc tccccggagc cgccgaagtc
+     1201 gcccgacacc gtcgcggccg gctccgcggg tcgcggcgct cccgccaaga agcgtgcctc
+     1261 cgcgcgcacc gccaagacga gcacgcgcac gatcaaggcg aagttccccg gccgctgtgt
+     1321 ctgcggccgc ccctacgcgg cgggcgagcc catcgccaag aacgcgcagg gctggggcca
+     1381 cccggagtgc cgtaccgccg acgacgtcta ggacctcccc ggcggagcat gcccaaggac
+     1441 gcgggggctg acaggccgtg cggcttttcc cgcccgcctg atccgccggc cctggatcac
+     1501 gaccccggcg gcctcccacg agtggccgcc gggacctcga gcgcctcggc cgtcagacgg
+     1561 tgtcgaacgt gtagtgcgcg gtgtggtcca gcaggtccgc ggggcgtacg tcgttccacg
+     1621 gcttcatggt ctcgttcagg tcgacgacgt tcggcgtgcc gcccgtcggc acataaccgg
+     1681 agcccgggtg gcggctctgc cactgggccc agagcctgtc gatgtaggcg tggtggagcc
+     1741 agaagaccgg gtcgttgggg gagaccccgg tggccatctg gccgccgacc cagacgtgga
+     1801 cgcggttgtg caggttcaca ccgcgccagc cctcgagatg gttgcggaac ccgtccgacg
+     1861 cgctgttcca cggggccatg tcgtacgtgg acatcgcgag cacggagtcg acctccgccc
+     1921 gggtcggcag ctcgcgcccg ccgccgccga gcgtgcgccg cagatacgta cggctgtcga
+     1981 cccgcacgtt gaccggccag ttgccggtgg acgccgcgaa cggcccgtcc atcacccggc
+     2041 cgtccaggct gcgtccgctg ccgccgagga agtcgggcgc ccacagggag gcacgcgccg
+     2101 tgcggtcggt gctccagtcc cagtacggca gcgcgaccga cgggtcgacc gcctggagcg
+     2161 cctgctcgaa ctcgatcaaa aatctgcggt gccagggcag gaaggaaggc gaacgatggc
+     2221 ccgtgcgttc gccgctgtcg gtgtcgccca tgatgaaggc gttgtgggtc gtgacgaact
+     2281 cgtcgtagcg gccactgcgc ttgagcgcca cgagcgcgtc gacgaagcgc cgcttctcgt
+     2341 cggccgtcag ggtcgcctgg ttcttgcgta cggtcatgtg cgggtgactc cagaactcta
+     2401 cgtgcgggac ggtcagttga aggggacgag cggcgcgccc tgaagctcca cgaccgcggc
+     2461 gcgggcggcg gcgcgcgggg tggccacggg gtcgtagtgg ctgacgacgc tgatccagct
+     2521 gccgtcgacg ttctgcatca cgtgcagttc catcccgtcg atgaacacgc cgtacccgga
+     2581 gccgtggtga tgaccgcccc cggtcgcgcg gccctctatt cggcgcccct gatagacctc
+     2641 gtcgaacggc tggggacccc cgtggtgccc ggccgcggac gcggacggag cggcaagggc
+     2701 ctgagtgccg gccacggccg ccagggcggc ggcggccccg agggcatgac ggcgggtgag
+     2761 ttcgggcatg cgaagtcctt ctgagtcgag gtgtgttgac gactcggcat gcctatccgc
+     2821 ccggtcggga gccggagaaa tcgacgaaaa ccggttggct acgatccgga caattaccta
+     2881 catgtcatac aggattgaac gaagatgatc ttgccgcccc gggtggccca cccggcggcg
+     2941 gagggggaag ttccaccccg gatcggcgcc atcgcggtga tcttttgccg tcgatgcggg
+     3001 gcgagtggtg cggctcacgt gcgcagactg gcgcgaactg gcgcctgccc tcaccgctcc
+     3061 agggggttcc cgcagcgatt gcagtagcgg gcgtcgctct ccgtggccat acgtccgcac
+     3121 tcggcgcaga cctggtgcag caggcatgcg ggctctccgg tcgcccccgt cgtcggcagg
+     3181 gccgggggag cggccggacg gcgcgggcgt acggtcacgc agtgcagccc cgcctccccc
+     3241 gcgtgcagcc ggtatccagc ggcggggggc agccacacgg cggccggggg tgccaactcc
+     3301 agccatccgc ccggtgtccg gagccggccg cccccgtcga gggcgatcac gaggacgtcc
+     3361 cgcgagcggt caccgggcgg ctcggccgcc gcacccggcg ggatgtgcat cgcctcggcg
+     3421 tcgagaccgg cgcccggccg gtccagtcgc cagtagcggc ccccggtcgc ccgggagacg
+     3481 agtgcggcca ggaccgggcc ggcgggcgga tgcgtcacag gggctcctgt cgtctgcggc
+     3541 gggacgggcc gcgatcgtac gaccgccccc gcccgccgcg cggcggaaga ggccgggacg
+     3601 gtcggtctgc acgatggcgc tgctaccctt cgtggtcaat tgaccgcttt gcgtaacata
+     3661 ggggagtgcg cgtgaagatc gcgtgcgtcg gcggcggacc cgcaagcctg tacttctcga
+     3721 tcctgatgaa gcgccaggac ccgtcccacg acatcaccgt ccacgagcgg aaccccgccg
+     3781 gatcgaccta cggctggggc gtgacctact ggagcggcct gctcgacaaa ctccgcggga
+     3841 gtgaccccga gtcggcgctc gccgtcagcg agaactccgt ccgctggagc gacggagtcg
+     3901 cccacgtccg gaaccgcacc acggtccacc acggcgacga gggcttcggc atcggccgcc
+     3961 gcagattcct cgacgtactg gccgaccggg cccggtccct gggcgtccgc atcgagtacg
+     4021 agcatgagat cggcgccgac gacccactgc ccgaggccga tctggtcgtc gccggcgacg
+     4081 gggtcaacag cgtgctgcgc ggccgctacg ccgaccactt cggcagcgag accgtgctcg
+     4141 gccgcaaccg ctacatctgg ctcggcacca ccaaggtctt cgactcgttc accttcgcct
+     4201 ttgtggagag cgaacacggc tggatctggt gctacggcta tggattcagc gacggccaca
+     4261 gcacctgcgt catcgagtgc tccccggaaa cctggaccgg gctcggcctc gaccgggcca
+     4321 gcgaggccga cggtctcgcc ctgctggaga agctcttcgc cgacgtcctc gacgggcacg
+     4381 agctgatcgg ccgggcgcag agcgacggtg ccgcccagtg gctgaacttc cgcaccctca
+     4441 ccaaccgcac ctggcatcgc gacaacctcg tcctgatcgg cgacgccgcc cacaccaccc
+     4501 actactccat cggcgcgggc accaccctcg ccctggagga cgccatcgcc ctcgccgaag
+     4561 ccctgagcgc gcaccgcgac ctgccgggcg cgctcgccgc ctacgagcgg gaacgcaagt
+     4621 ccgcgctcct gcacatccag agcgcggccc ggctcagcgc ccagtggtac gagaacctcc
+     4681 cgcgctacat ccgccttccg cccccgcaga tgttcgccct gctcggccag cgccattccc
+     4741 cgctgctgcc gtacgtgcct ccgcagctct actaccggat cgaccgggcg gccggacaac
+     4801 tggaggcgct gcgcaggctc aagcgctggc tggggccgcg actggcgcgt accgtccagg
+     4861 cgcgcacggg ccggtaggcc ggccgccggc ggccgcgtcc gacggagaat tctgggtgaa
+     4921 tgaccattca cccggctaag gtgaattcct attcacctcc cttcttcacg tcggctgccg
+     4981 cccctggagt gaccatggtc ccgatatcca ccccgtccga ccggtccgcg acccccgacg
+     5041 gaccggccgg acggccgggt gtccgcgacc ggctgacggt ccccgtcctg gcgttcggcg
+     5101 gaatcctcat ggccgtcatg cagacggtcg tggtgccgct gctgcccgac ctgccgcgcc
+     5161 tgaccggcgc ttccgcgggc gccgtctcct ggatggtcac cgccaccctg ctctccggcg
+     5221 cggtgctgac cccggtgctc ggccgggccg gcgacatgta cggcaagcgg cgggttctgc
+     5281 tcgccgccct cgcgctgatg accctgggct cgctgctgtg cgccgtcacc tccgacatcc
+     5341 gcgtgctcat cgccgcgcgg gccctccagg gcgcggcggc cgccgtcgta ccgctgtcga
+     5401 tcagcatcct gcgcgacgaa ctcccgcccg agcgcacggg ttccgcggtg gccctgatga
+     5461 gttccaccgt gggcatcggc gccgcgctcg gtctgccgat cgccgcgatg atcgtgcagt
+     5521 acgccgactg gcacgtcatg ttctgggcga ccaccgggct cggcgccggc ggactggcac
+     5581 tggcgtggtg ggcggtgcgc gagtcgcccg tccggcagcc gggccgcttc gacacgctgg
+     5641 gtgcgctggg gctggccgcg ggcctggtct gcctgctcct cggtgtgtcg cagggcgggc
+     5701 agtggggctg gaccagtccg cggatcgtcg gcctgctcgt ggcctgcgta ctcgtactga
+     5761 cgctgtggtg gttccagcag tggcgggccc cgcggcccct ggtggacctg aagctggcct
+     5821 cccgcccccg ggtcgccctg ccgcacgtgg ccgcgctgct gaccggattc gccttctacg
+     5881 gcaactcgct ggtcacggcg cagctggtgc aggcgcccaa ggccaccggc tacggactcg
+     5941 ggctgtccat cgtgcagacc ggtctgtgcc tgctgcccgg cggcgtcatc atgctgctgt
+     6001 tctcgccggt ctcggcgcgc atctcggccg cccgcggccc gcgcgtgacg ctggcactcg
+     6061 gggccgcggt catcgccgtc ggctacgccg tgcgcatcgc ggacagccgc gacctgtgga
+     6121 tgatcatcgt gggcgccacg gtcatcgcgg tcggcacgac cctcgcctac tcggccctgc
+     6181 ccaccctgat cctgcgtgcc gtgcccgccg gacagaccgc ctccgccaac ggcgtcaacg
+     6241 tcctgatgcg caccatcggc caagccgtgt gcagcgcggc ggtcgccgcc gtcctggtcc
+     6301 accacaccag cctggtggga ggcgccccgg tacccaccct gcacggctat ctgctggcgt
+     6361 tcgcgatggc gggtacggtc gcagtgatgg cctgcgccgc cgccctcgtc atccccgggg
+     6421 accccgactc ccacggcacg cgacgggccc gcggccgtac ccggccgtcc cacgacgagg
+     6481 cgctggaagg agcatga
+//
+

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -143,6 +143,19 @@ class GenBankTests(unittest.TestCase):
                          'reference sequence was derived from AP000423.\n'
                          'COMPLETENESS: full length.')
 
+    def test_locus_line_topogoly(self):
+        """Test if chromosome topology is conserved"""
+        record = SeqIO.read(path.join('GenBank', 'melanin.gbk'), 'genbank')
+        self.assertEqual(record.annotations['topology'], 'linear')
+        from StringIO import StringIO
+        out_handle = StringIO()
+        SeqIO.write([record], out_handle, 'genbank')
+        first_line = out_handle.getvalue().split('\n')[0]
+        self.assertIn('linear', first_line)
+        with open(path.join('GenBank', 'melanin.gbk'), 'r') as fh:
+            orig_first_line = fh.readline().strip()
+        self.assertEqual(first_line, orig_first_line)
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
Just ran into issue #363 myself, so here's a fix.