### PR TITLE
Partial codons for SearchIO when parsing Exonerate

### DIFF
--- a/Bio/SearchIO/ExonerateIO/_base.py
+++ b/Bio/SearchIO/ExonerateIO/_base.py
@@ -59,8 +59,24 @@ def _make_triplets(seq, phase=0):
 
 
 def _get_fragments_coord(frags):
-    """Given a list of three-letter amino acid fragments, return each
-    fragment's letter position in the full, flattened sequence."""
+    """Returns the letter coordinate of the given list of fragments.
+
+    This function takes a list of three-letter amino acid sequences and
+    returns a list of coordinates for each fragment had all the input
+    sequences been flattened.
+
+    This is an internal private function and is meant for parsing Exonerate's
+    three-letter amino acid output.
+
+    >>> from Bio.SearchIO.ExonerateIO._base import _get_fragments_coord
+    >>> _get_fragments_coord(['Thr', 'Ser', 'Ala'])
+    [0, 3, 6]
+    >>> _get_fragments_coord(['Thr', 'SerAlaPro', 'GlyLeu'])
+    [0, 3, 12, ]
+    >>> _get_fragments_coord(['Thr', 'SerAlaPro', 'GlyLeu', 'Cys'])
+    [0, 3, 12, 18]
+
+    """
     if not frags:
         return []
     # first fragment always starts from position 0

--- a/Bio/SearchIO/ExonerateIO/_base.py
+++ b/Bio/SearchIO/ExonerateIO/_base.py
@@ -30,9 +30,25 @@ def _set_frame(frag):
 
 
 def _make_triplets(seq, phase=0):
-    """Given a sequence of three-letter amino acid codes and its phase,
-    return the letters discarded to reach the first full triplet, the
-    triplets, and the remaining non-triplets."""
+    """Selects a valid amino acid sequence given a 3-letter code input.
+
+    This function takes a single three-letter amino acid sequence and the phase
+    of the sequence to return the longest intact amino acid sequence possible.
+    Parts of the input sequence before and after the selected sequence are also
+    returned.
+
+    This is an internal private function and is meant for parsing Exonerate's
+    three-letter amino acid output.
+
+    >>> from Bio.SearchIO.ExonerateIO._base import _make_triplets
+    >>> _make_triplets('GlyThrSerAlaPro')
+    ('', ['Gly', 'Thr', 'Ser', 'Ala', 'Pro'], '')
+    >>> _make_triplets('yThSerAla', phase=1)
+    ('y', ['Thr', 'Ser', 'Ala'], '')
+    >>> _make_triplets('yThSerAlaPr', phase=1)
+    ('y', ['Thr', 'Ser', 'Ala'], 'Pr')
+
+    """
     pre = seq[:phase]
     np_seq = seq[phase:]
     non_triplets = len(np_seq) % 3

--- a/Bio/SearchIO/ExonerateIO/_base.py
+++ b/Bio/SearchIO/ExonerateIO/_base.py
@@ -86,8 +86,24 @@ def _get_fragments_coord(frags):
 
 
 def _get_fragments_phase(frags):
-    """Given a list of three-letter amino acid fragments, return their
-    phase."""
+    """Returns the phases of the given list of 3-letter amino acid fragments.
+
+    This is an internal private function and is meant for parsing Exonerate's
+    three-letter amino acid output.
+
+    >>> from Bio.SearchIO.ExonerateIO._base import _get_fragments_phase
+    >>> _get_fragments_phase(['Thr', 'Ser', 'Ala'])
+    [0, 0, 0]
+    >>> _get_fragments_phase(['ThrSe', 'rAla'])
+    [0, 1]
+    >>> _get_fragments_phase(['ThrSe', 'rAlaLeu', 'ProCys'])
+    [0, 1, 0]
+    >>> _get_fragments_phase(['ThrSe', 'rAlaLeuP', 'roCys'])
+    [0, 1, 2]
+    >>> _get_fragments_phase(['ThrSe', 'rAlaLeuPr', 'oCys'])
+    [0, 1, 1]
+
+    """
     return [(3 - (x % 3)) % 3 for x in _get_fragments_coord(frags)]
 
 

--- a/Bio/SearchIO/ExonerateIO/_base.py
+++ b/Bio/SearchIO/ExonerateIO/_base.py
@@ -6,6 +6,7 @@
 """Bio.SearchIO abstract base parser for Exonerate standard output format."""
 
 import re
+from functools import reduce
 
 from Bio.SearchIO._index import SearchIndexer
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
@@ -28,40 +29,80 @@ def _set_frame(frag):
     frag.query_frame = (frag.query_start % 3 + 1) * frag.query_strand
 
 
-def _make_triplets(seq):
-    """Splits a string into a list containing triplets of the original
-    string."""
-    return [seq[3 * i:3 * (i + 1)] for i in range(len(seq) // 3)]
+def _make_triplets(seq, phase=0):
+    """Given a sequence of three-letter amino acid codes and its phase,
+    return the letters discarded to reach the first full triplet, the
+    triplets, and the remaining non-triplets."""
+    pre = seq[:phase]
+    np_seq = seq[phase:]
+    non_triplets = len(np_seq) % 3
+    post = "" if not non_triplets else np_seq[-1 * non_triplets:]
+    intacts = [np_seq[3 * i:3 * (i + 1)]
+               for i in range(len(np_seq) // 3)]
+    return pre, intacts, post
+
+
+def _get_fragments_coord(frags):
+    """Given a list of three-letter amino acid fragments, return each
+    fragment's letter position in the full, flattened sequence."""
+    if not frags:
+        return []
+    # first fragment always starts from position 0
+    init = [0]
+    return reduce(lambda acc, frag: acc + [acc[-1] + len(frag)],
+                  frags[:-1], init)
+
+
+def _get_fragments_phase(frags):
+    """Given a list of three-letter amino acid fragments, return their
+    phase."""
+    return [(3 - (x % 3)) % 3 for x in _get_fragments_coord(frags)]
 
 
 def _adjust_aa_seq(fraglist):
     """Transforms three-letter amino acid codes into one-letters in the
     given HSPFragments."""
+    custom_map = {'***': '*', '<->': '-'}
     hsp_hstart = fraglist[0].hit_start
     hsp_qstart = fraglist[0].query_start
-    for frag in fraglist:
+    frag_phases = _get_fragments_phase(fraglist)
+    for frag, phase in zip(fraglist, frag_phases):
         assert frag.query_strand == 0 or frag.hit_strand == 0
-        # fragment should have a length that is a multiple of 3
-        assert len(frag) % 3 == 0
         # hit step may be -1 as we're aligning to DNA
         hstep = 1 if frag.hit_strand >= 0 else -1
+
+        # set fragment phase
+        frag.phase = phase
+
+        # fragment should have a length that is a multiple of 3
+        # assert len(frag) % 3 == 0
+        qseq = str(frag.query.seq)
+        q_triplets_pre, q_triplets, q_triplets_post = \
+            _make_triplets(qseq, phase)
+
+        hseq = str(frag.hit.seq)
+        h_triplets_pre, h_triplets, h_triplets_post = \
+            _make_triplets(hseq, phase)
+
         # get one letter codes
         # and replace gap codon markers and termination characters
-        custom_map = {'***': '*', '<->': '-'}
-
-        hseq1 = seq1(str(frag.hit.seq), custom_map=custom_map)
-        hstart = hsp_hstart
+        hseq1_pre = "X" if h_triplets_pre else ""
+        hseq1_post = "X" if h_triplets_post else ""
+        hseq1 = seq1("".join(h_triplets), custom_map=custom_map)
+        hstart = hsp_hstart + (len(hseq1_pre) * hstep)
         hend = hstart + len(hseq1.replace('-', '')) * hstep
 
-        qseq1 = seq1(str(frag.query.seq), custom_map=custom_map)
-        qstart = hsp_qstart
+        qseq1_pre = "X" if q_triplets_pre else ""
+        qseq1_post = "X" if q_triplets_post else ""
+        qseq1 = seq1("".join(q_triplets), custom_map=custom_map)
+        qstart = hsp_qstart + len(qseq1_pre)
         qend = qstart + len(qseq1.replace('-', ''))
 
         # replace the old frag sequences with the new ones
         frag.hit = None
         frag.query = None
-        frag.hit = hseq1
-        frag.query = qseq1
+        frag.hit = hseq1_pre + hseq1 + hseq1_post
+        frag.query = qseq1_pre + qseq1 + qseq1_post
 
         # set coordinates for the protein sequence
         if frag.query_strand == 0:
@@ -72,7 +113,9 @@ def _adjust_aa_seq(fraglist):
         # update alignment annotation
         # by turning them into list of triplets
         for annot, annotseq in frag.aln_annotation.items():
-            frag.aln_annotation[annot] = _make_triplets(annotseq)
+            pre, intact, post = _make_triplets(annotseq, phase)
+            frag.aln_annotation[annot] = \
+                list(filter(None, [pre])) + intact + list(filter(None, [post]))
 
         # update values for next iteration
         hsp_hstart, hsp_qstart = hend, qend

--- a/Tests/test_SearchIO_exonerate.py
+++ b/Tests/test_SearchIO_exonerate.py
@@ -1424,6 +1424,77 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual('RKVGRPGRKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKS', str(hsp[0].query.seq)[-40:])
         self.assertEqual('RKVGRPGRKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKS', str(hsp[0].hit.seq)[-40:])
 
+    def test_exn_22_m_protein2genome(self):
+        """Test parsing exonerate output (exn_22_m_protein2genome.exn)"""
+
+        exn_file = get_file('exn_22_m_protein2genome.exn')
+        qresult = read(exn_file, self.fmt)
+
+        # check common attributes
+        for hit in qresult:
+            self.assertEqual(qresult.id, hit.query_id)
+            for hsp in hit:
+                self.assertEqual(hit.id, hsp.hit_id)
+                self.assertEqual(qresult.id, hsp.query_id)
+
+        self.assertEqual('sp|P24813|YAP2_YEAST', qresult.id)
+        self.assertEqual('AP-1-like transcription activator YAP2 OS=Saccharomyces cerevisiae (strain ATCC 204508 / S288c) GN=CAD1 PE=1 SV=2', qresult.description)
+        self.assertEqual('exonerate', qresult.program)
+        self.assertEqual('protein2genome:local', qresult.model)
+        self.assertEqual(3, len(qresult))
+        # first hit
+        hit = qresult[0]
+        self.assertEqual('gi|330443520|ref|NC_001136.10|', hit.id)
+        self.assertEqual('Saccharomyces cerevisiae S288c chromosome IV, complete sequence', hit.description)
+        self.assertEqual(1, len(hit))
+        # first hit, first hsp
+        hsp = qresult[0][0]
+        self.assertEqual(2105, hsp.score)
+        self.assertEqual(0, hsp.query_strand)
+        self.assertEqual(-1, hsp.hit_strand)
+        self.assertEqual(0, hsp.query_start)
+        self.assertEqual(1318048, hsp.hit_start)
+        self.assertEqual(409, hsp.query_end)
+        self.assertEqual(1319275, hsp.hit_end)
+        self.assertEqual('MGNILRKGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKR', str(hsp[0].query.seq)[:40])
+        self.assertEqual('MGNILRKGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKR', str(hsp[0].hit.seq)[:40])
+        self.assertEqual('SSLDIDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL', str(hsp[0].query.seq)[-40:])
+        self.assertEqual('SSLDIDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL', str(hsp[0].hit.seq)[-40:])
+
+        # last hit
+        hit = qresult[-1]
+        self.assertEqual('gi|330443590|ref|NC_001140.6|', hit.id)
+        self.assertEqual('Saccharomyces cerevisiae S288c chromosome VIII, complete sequence', hit.description)
+        self.assertEqual(1, len(hit))
+        # last hit, first hsp
+        hsp = qresult[-1][0]
+        self.assertEqual(122, hsp.score)
+        self.assertEqual([0, 0], hsp.query_strand_all)
+        self.assertEqual([-1, -1], hsp.hit_strand_all)
+        self.assertEqual('RKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKSLQERX', str(hsp[0].query.seq))
+        self.assertEqual('NENVPDDSKAKKKAQNRAAQKAFRERKEARMKELQDKX', str(hsp[0].hit.seq))
+        self.assertEqual('!.!', hsp.aln_annotation_all[0]['similarity'][0])
+        self.assertEqual(':!', hsp.aln_annotation_all[0]['similarity'][-1])
+        self.assertEqual('AAT', hsp.aln_annotation_all[0]['hit_annotation'][0])
+        self.assertEqual('TT', hsp.aln_annotation_all[0]['hit_annotation'][-1])
+        self.assertEqual('XELLEQKDAQNKTTTDFLLCSLKSLLSEITKYRAKNSDDERILAFLDDLQE', str(hsp[-1].query.seq))
+        self.assertEqual('XNKILNRDPQFMSNSSFHQCVSLDSINTIEKDEEKNSDDDAGLQAATDARE', str(hsp[-1].hit.seq))
+        self.assertEqual('!', hsp.aln_annotation_all[-1]['similarity'][0])
+        self.assertEqual('|||', hsp.aln_annotation_all[-1]['similarity'][-1])
+        self.assertEqual('A', hsp.aln_annotation_all[-1]['hit_annotation'][0])
+        self.assertEqual('GAA', hsp.aln_annotation_all[-1]['hit_annotation'][-1])
+
+        self.assertEqual([(37, 74), (75, 125)], hsp.query_range_all)
+        self.assertEqual([(84533, 84646), (68450, 68601)], hsp.hit_range_all)
+        self.assertEqual([(74, 75)], hsp.query_inter_ranges)
+        self.assertEqual([(68601, 84533)], hsp.hit_inter_ranges)
+        self.assertEqual([0, 0], hsp.query_frame_all)
+        self.assertEqual([-3, -3], hsp.hit_frame_all)
+        self.assertEqual(2, len(hsp.query_all))
+        self.assertEqual(2, len(hsp.hit_all))
+        self.assertEqual(2, len(hsp.aln_annotation_all))
+
+
     def test_exn_22_q_none(self):
         """Test parsing exonerate output (exn_22_q_none.exn)"""
         exn_file = get_file('exn_22_q_none.exn')

--- a/Tests/test_SearchIO_exonerate.py
+++ b/Tests/test_SearchIO_exonerate.py
@@ -1494,7 +1494,6 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(2, len(hsp.hit_all))
         self.assertEqual(2, len(hsp.aln_annotation_all))
 
-
     def test_exn_22_q_none(self):
         """Test parsing exonerate output (exn_22_q_none.exn)"""
         exn_file = get_file('exn_22_q_none.exn')


### PR DESCRIPTION
This was reported first in #367 some time ago by @pschwede. Based on the discussion and a suggestion by @zbwrnz, this pull request was made. It treats the partial codons (on each of the HSP fragment) as the amino acid `X`. The actual codon sequence that is split is still kept in the fragment's `.aln_annotation_all` attribute. Additionally, there is now also a `phase` attribute for HSP fragments where this adjustment is made.

I did not add any new exonerate outputs since this was a known issue when the Exonerate parser was written (which i realized as I wrote the pull request). So there was already an unused test case in our test suite (the `exn_22_m_protein2genome.exn` file) where we observe Exonerate splitting a codon. This file was never actually tested, but now that we can handle such scenarios, I also added some tests based on that file.
