### PR TITLE
Remove 'raise StopIteration' inside _SeqIO_to_alignment_iterator generator function

### DIFF
--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -274,7 +274,6 @@ def _SeqIO_to_alignment_iterator(handle, format, alphabet=None, seq_count=None):
         records = list(SeqIO.parse(handle, format, alphabet))
         if records:
             yield MultipleSeqAlignment(records, alphabet)
-    raise StopIteration
 
 
 def _force_alphabet(alignment_iterator, alphabet):


### PR DESCRIPTION
This PR is to removed the `raise StopIteration` line.  Its placement at the end of the generator loop suggests it is useless.  It is also deprecated inside generator functions (see [PEP 0479](https://www.python.org/dev/peps/pep-0479/)) and currently generates a deprecation warning under python 3.5:

`Bio/AlignIO/__init__.py:374: PendingDeprecationWarning: generator '_SeqIO_to_alignment_iterator' raised StopIteration
`
