### PR TITLE
Split biosql tests

### DIFF
--- a/Tests/BioSQL_settings.py
+++ b/Tests/BioSQL_settings.py
@@ -1,0 +1,9 @@
+# Constants for the database driver
+DBHOST = 'localhost'
+DBUSER = 'root'
+DBPASSWD = ''
+TESTDB = 'biosql_test'
+DBDRIVER = ''
+DBTYPE = ''
+SQL_FILE = ''
+DBSCHEMA = ''

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -584,58 +584,6 @@ class LoaderTest(unittest.TestCase):
                                     'M81224.1', 'X55053.1', 'X62281.1'])
 
 
-class TaxonomyTest(unittest.TestCase):
-    """Test proper insertion and retrieval of taxonomy data
-    """
-    def setUp(self):
-        from Bio import Entrez
-        Entrez.email = "biopython-dev@biopython.org"
-        # create TESTDB
-        create_database()
-
-        # load the database
-        db_name = "biosql-test"
-        self.server = BioSeqDatabase.open_database(driver=DBDRIVER,
-                                                   user=DBUSER, passwd=DBPASSWD,
-                                                   host=DBHOST, db=TESTDB)
-
-        # remove the database if it already exists
-        try:
-            self.server[db_name]
-            self.server.remove_database(db_name)
-        except KeyError:
-            pass
-
-        self.db = self.server.new_database(db_name)
-
-        # get the GenBank file we are going to put into it
-        self.iterator = SeqIO.parse("GenBank/cor6_6.gb", "gb")
-
-    def tearDown(self):
-        self.server.close()
-        destroy_database()
-        del self.db
-        del self.server
-
-    def test_taxon_left_right_values(self):
-        self.db.load(self.iterator, True)
-        sql = """SELECT DISTINCT include.ncbi_taxon_id FROM taxon
-                  INNER JOIN taxon AS include ON
-                      (include.left_value BETWEEN taxon.left_value
-                                  AND taxon.right_value)
-                  WHERE taxon.taxon_id IN
-                      (SELECT taxon_id FROM taxon_name
-                                  WHERE name = 'Brassicales')
-                      AND include.right_value - include.left_value = 1"""
-
-        rows = self.db.adaptor.execute_and_fetchall(sql)
-        self.assertEqual(4, len(rows))
-        values = set()
-        for row in rows:
-            values.add(row[0])
-        self.assertEqual(set([3704, 3711, 3708, 3702]), set(values))
-
-
 class DeleteTest(unittest.TestCase):
     """Test proper deletion of entries from a database."""
 

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -89,8 +89,10 @@ def check_config(dbdriver, dbtype, dbhost, dbuser, dbpasswd, testdb):
         if BioSQL_settings.DBDRIVER in ["sqlite3"]:
             server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER, db=BioSQL_settings.TESTDB)
         else:
-            server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER, host=BioSQL_settings.DBHOST,
-                                                  user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", BiopythonWarning)
+                server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER, host=BioSQL_settings.DBHOST,
+                                                      user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD)
         server.close()
         del server
     except Exception as e:
@@ -111,8 +113,10 @@ def _do_db_create():
     Relevant for MySQL and PostgreSQL.
     """
     # first open a connection to create the database
-    server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER, host=BioSQL_settings.DBHOST,
-                                          user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", BiopythonWarning)
+        server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER, host=BioSQL_settings.DBHOST,
+                                              user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD)
 
     if BioSQL_settings.DBDRIVER == "pgdb":
         # The pgdb postgres driver does not support autocommit, so here we
@@ -171,9 +175,11 @@ def create_database():
         _do_db_create()
 
     # now open a connection to load the database
-    server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                          user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD,
-                                          host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", BiopythonWarning)
+        server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                              user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD,
+                                              host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
     try:
         server.load_database_sql(BioSQL_settings.SQL_FILE)
         server.commit()
@@ -200,9 +206,11 @@ def load_database(gb_filename_or_handle):
     create_database()
     # now open a connection to load the database
     db_name = "biosql-test"
-    server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                          user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD,
-                                          host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", BiopythonWarning)
+        server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                              user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD,
+                                              host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
     db = server.new_database(db_name)
 
     # get the GenBank file we are going to put into it
@@ -224,9 +232,11 @@ def load_multi_database(gb_filename_or_handle, gb_filename_or_handle2):
     # now open a connection to load the database
     db_name = "biosql-test"
     db_name2 = "biosql-test2"
-    server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                          user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD,
-                                          host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", BiopythonWarning)
+        server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                              user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD,
+                                              host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
     db = server.new_database(db_name)
 
     # get the GenBank file we are going to put into it
@@ -255,11 +265,11 @@ class MultiReadTest(unittest.TestCase):
         """
         load_multi_database("GenBank/cor6_6.gb", "GenBank/NC_000932.gb")
 
-        self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                                   user=BioSQL_settings.DBUSER,
-                                                   passwd=BioSQL_settings.DBPASSWD,
-                                                   host=BioSQL_settings.DBHOST,
-                                                   db=BioSQL_settings.TESTDB)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonWarning)
+            self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                                       user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD,
+                                                       host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
 
         self.db = self.server["biosql-test"]
         self.db2 = self.server['biosql-test2']
@@ -333,11 +343,13 @@ class ReadTest(unittest.TestCase):
         """
         load_database("GenBank/cor6_6.gb")
 
-        self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                                   user=BioSQL_settings.DBUSER,
-                                                   passwd=BioSQL_settings.DBPASSWD,
-                                                   host=BioSQL_settings.DBHOST,
-                                                   db=BioSQL_settings.TESTDB)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonWarning)
+            self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                                       user=BioSQL_settings.DBUSER,
+                                                       passwd=BioSQL_settings.DBPASSWD,
+                                                       host=BioSQL_settings.DBHOST,
+                                                       db=BioSQL_settings.TESTDB)
 
         self.db = self.server["biosql-test"]
 
@@ -417,9 +429,13 @@ class SeqInterfaceTest(unittest.TestCase):
         """
         load_database("GenBank/cor6_6.gb")
 
-        self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                                   user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD,
-                                                   host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonWarning)
+            self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                                       user=BioSQL_settings.DBUSER,
+                                                       passwd=BioSQL_settings.DBPASSWD,
+                                                       host=BioSQL_settings.DBHOST,
+                                                       db=BioSQL_settings.TESTDB)
         self.db = self.server["biosql-test"]
         self.item = self.db.lookup(accession="X62281")
 
@@ -540,9 +556,13 @@ class LoaderTest(unittest.TestCase):
 
         # load the database
         db_name = "biosql-test"
-        self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                                   user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD,
-                                                   host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonWarning)
+            self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                                       user=BioSQL_settings.DBUSER,
+                                                       passwd=BioSQL_settings.DBPASSWD,
+                                                       host=BioSQL_settings.DBHOST,
+                                                       db=BioSQL_settings.TESTDB)
 
         # remove the database if it already exists
         try:
@@ -595,11 +615,13 @@ class DeleteTest(unittest.TestCase):
         """
         load_database("GenBank/cor6_6.gb")
 
-        self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                                   user=BioSQL_settings.DBUSER,
-                                                   passwd=BioSQL_settings.DBPASSWD,
-                                                   host=BioSQL_settings.DBHOST,
-                                                   db=BioSQL_settings.TESTDB)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonWarning)
+            self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                                  user=BioSQL_settings.DBUSER,
+                                                  passwd=BioSQL_settings.DBPASSWD,
+                                                  host=BioSQL_settings.DBHOST,
+                                                  db=BioSQL_settings.TESTDB)
 
         self.db = self.server["biosql-test"]
 
@@ -654,9 +676,13 @@ class DupLoadTest(unittest.TestCase):
         # drop any old database and create a new one:
         create_database()
         # connect to new database:
-        self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                                   user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD,
-                                                   host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonWarning)
+            self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                                  user=BioSQL_settings.DBUSER,
+                                                  passwd=BioSQL_settings.DBPASSWD,
+                                                  host=BioSQL_settings.DBHOST,
+                                                  db=BioSQL_settings.TESTDB)
         # Create new namespace within new empty database:
         self.db = self.server.new_database("biosql-test")
 
@@ -758,9 +784,13 @@ class ClosedLoopTest(unittest.TestCase):
     def loop(self, filename, format):
         original_records = list(SeqIO.parse(filename, format))
         # now open a connection to load the database
-        server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                              user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD,
-                                              host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonWarning)
+            server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                                  user=BioSQL_settings.DBUSER,
+                                                  passwd=BioSQL_settings.DBPASSWD,
+                                                  host=BioSQL_settings.DBHOST,
+                                                  db=BioSQL_settings.TESTDB)
         db_name = "test_loop_%s" % filename  # new namespace!
         db = server.new_database(db_name)
         count = db.load(original_records)
@@ -834,9 +864,13 @@ class TransferTest(unittest.TestCase):
     def trans(self, filename, format):
         original_records = list(SeqIO.parse(filename, format))
         # now open a connection to load the database
-        server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                              user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD,
-                                              host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonWarning)
+            server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                                  user=BioSQL_settings.DBUSER,
+                                                  passwd=BioSQL_settings.DBPASSWD,
+                                                  host=BioSQL_settings.DBHOST,
+                                                  db=BioSQL_settings.TESTDB)
         db_name = "test_trans1_%s" % filename  # new namespace!
         db = server.new_database(db_name)
         count = db.load(original_records)
@@ -871,9 +905,13 @@ class InDepthLoadTest(unittest.TestCase):
         gb_file = os.path.join(os.getcwd(), "GenBank", "cor6_6.gb")
         load_database(gb_file)
 
-        self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                                   user=BioSQL_settings.DBUSER, passwd=BioSQL_settings.DBPASSWD,
-                                                   host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonWarning)
+            self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                                  user=BioSQL_settings.DBUSER,
+                                                  passwd=BioSQL_settings.DBPASSWD,
+                                                  host=BioSQL_settings.DBHOST,
+                                                  db=BioSQL_settings.TESTDB)
         self.db = self.server["biosql-test"]
 
     def tearDown(self):
@@ -996,14 +1034,16 @@ class AutoSeqIOTests(unittest.TestCase):
     def setUp(self):
         """Connect to the database."""
         db_name = "biosql-test-seqio"
-        server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                              user=BioSQL_settings.DBUSER,
-                                              passwd=BioSQL_settings.DBPASSWD,
-                                              host=BioSQL_settings.DBHOST, db=BioSQL_settings.TESTDB)
-        self.server = server
-        if db_name not in server:
-            self.db = server.new_database(db_name)
-            server.commit()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonWarning)
+            self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                                  user=BioSQL_settings.DBUSER,
+                                                  passwd=BioSQL_settings.DBPASSWD,
+                                                  host=BioSQL_settings.DBHOST,
+                                                  db=BioSQL_settings.TESTDB)
+        if db_name not in self.server:
+            self.db = self.server.new_database(db_name)
+            self.server.commit()
         self.db = self.server[db_name]
 
     def tearDown(self):

--- a/Tests/common_BioSQL_online.py
+++ b/Tests/common_BioSQL_online.py
@@ -58,11 +58,13 @@ class TaxonomyTest(unittest.TestCase):
 
         # load the database
         db_name = "biosql-test"
-        self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
-                                                   user=BioSQL_settings.DBUSER,
-                                                   passwd=BioSQL_settings.DBPASSWD,
-                                                   host=BioSQL_settings.DBHOST,
-                                                   db=BioSQL_settings.TESTDB)
+        with warning.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonWarning)
+            self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                                       user=BioSQL_settings.DBUSER,
+                                                       passwd=BioSQL_settings.DBPASSWD,
+                                                       host=BioSQL_settings.DBHOST,
+                                                       db=BioSQL_settings.TESTDB)
 
         # remove the database if it already exists
         try:

--- a/Tests/common_BioSQL_online.py
+++ b/Tests/common_BioSQL_online.py
@@ -32,188 +32,20 @@ from BioSQL import BioSeqDatabase
 from BioSQL import BioSeq
 from Bio import Entrez
 
+from common_BioSQL import create_database, destroy_database
+import BioSQL_settings
+
 from seq_tests_common import compare_record, compare_records
 
 import requires_internet
 
 if __name__ == "__main__":
-    raise RuntimeError("Call this via test_BioSQL_*.py not directly")
+    raise RuntimeError("Call this via test_BioSQL_*online.py not directly")
 
 # Exporting these to the test_BioSQL_XXX.py files which import this file:
 # DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB, DBSCHEMA, SQL_FILE, SYSTEM
 
 SYSTEM = platform.system()
-
-
-def temp_db_filename():
-    # In memory SQLite does not work with current test structure since the tests
-    # expect databases to be retained between individual tests.
-    # TESTDB = ':memory:'
-    # Instead, we use (if we can) /dev/shm
-    try:
-        h, test_db_fname = tempfile.mkstemp("_BioSQL.db", dir='/dev/shm')
-    except OSError:
-        # We can't use /dev/shm
-        h, test_db_fname = tempfile.mkstemp("_BioSQL.db")
-    os.close(h)
-    return test_db_fname
-
-
-def check_config(dbdriver, dbtype, dbhost, dbuser, dbpasswd, testdb):
-    global DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB, DBSCHEMA
-    global SYSTEM, SQL_FILE
-    DBDRIVER = dbdriver
-    DBTYPE = dbtype
-    DBHOST = dbhost
-    DBUSER = dbuser
-    DBPASSWD = dbpasswd
-    TESTDB = testdb
-
-    # Check the database driver is installed:
-    if SYSTEM == "Java":
-        try:
-            if DBDRIVER in ["MySQLdb"]:
-                import com.mysql.jdbc.Driver
-            elif DBDRIVER in ["psycopg2"]:
-                import org.postgresql.Driver
-        except ImportError:
-            message = "Install the JDBC driver for %s to use BioSQL " % DBTYPE
-            raise MissingExternalDependencyError(message)
-    else:
-        try:
-            __import__(DBDRIVER)
-        except ImportError:
-            message = "Install %s if you want to use %s with BioSQL " % (DBDRIVER, DBTYPE)
-            raise MissingExternalDependencyError(message)
-
-    try:
-        if DBDRIVER in ["sqlite3"]:
-            server = BioSeqDatabase.open_database(driver=DBDRIVER, db=TESTDB)
-        else:
-            server = BioSeqDatabase.open_database(driver=DBDRIVER, host=DBHOST,
-                                                  user=DBUSER, passwd=DBPASSWD)
-        server.close()
-        del server
-    except Exception as e:
-        message = "Connection failed, check settings if you plan to use BioSQL: %s" % e
-        raise MissingExternalDependencyError(message)
-
-    DBSCHEMA = "biosqldb-" + DBTYPE + ".sql"
-    SQL_FILE = os.path.join(os.getcwd(), "BioSQL", DBSCHEMA)
-
-    if not os.path.isfile(SQL_FILE):
-        message = "Missing SQL schema file: %s" % SQL_FILE
-        raise MissingExternalDependencyError(message)
-
-
-def _do_db_create():
-    """Do the actual work of database creation.
-
-    Relevant for MySQL and PostgreSQL.
-    """
-    # first open a connection to create the database
-    server = BioSeqDatabase.open_database(driver=DBDRIVER, host=DBHOST,
-                                          user=DBUSER, passwd=DBPASSWD)
-
-    if DBDRIVER == "pgdb":
-        # The pgdb postgres driver does not support autocommit, so here we
-        # commit the current transaction so that 'drop database' query will
-        # be outside a transaction block
-        server.adaptor.cursor.execute("COMMIT")
-    else:
-        # Auto-commit: postgresql cannot drop database in a transaction
-        try:
-            server.adaptor.autocommit()
-        except AttributeError:
-            pass
-
-    # drop anything in the database
-    try:
-        # with Postgres, can get errors about database still being used and
-        # not able to be dropped. Wait briefly to be sure previous tests are
-        # done with it.
-        time.sleep(1)
-        sql = r"DROP DATABASE " + TESTDB
-        server.adaptor.cursor.execute(sql, ())
-    except (server.module.OperationalError,
-            server.module.Error,
-            server.module.DatabaseError) as e:  # the database doesn't exist
-        pass
-    except (server.module.IntegrityError,
-            server.module.ProgrammingError) as e:  # ditto--perhaps
-        if str(e).find('database "%s" does not exist' % TESTDB) == -1:
-            server.close()
-            raise
-    # create a new database
-    sql = r"CREATE DATABASE " + TESTDB
-    server.adaptor.execute(sql, ())
-    server.close()
-
-
-def create_database():
-    """Delete any existing BioSQL test database, then (re)create an empty BioSQL database."""
-    if DBDRIVER in ["sqlite3"]:
-        global TESTDB
-        if os.path.exists(TESTDB):
-            try:
-                os.remove(TESTDB)
-            except:
-                time.sleep(1)
-                try:
-                    os.remove(TESTDB)
-                except Exception:
-                    # Seen this with PyPy 2.1 (and older) on Windows -
-                    # which suggests an open handle still exists?
-                    print("Could not remove %r" % TESTDB)
-                    pass
-        # Now pick a new filename - just in case there is a stale handle
-        # (which might be happening under Windows...)
-        TESTDB = temp_db_filename()
-    else:
-        _do_db_create()
-
-    # now open a connection to load the database
-    server = BioSeqDatabase.open_database(driver=DBDRIVER,
-                                          user=DBUSER, passwd=DBPASSWD,
-                                          host=DBHOST, db=TESTDB)
-    try:
-        server.load_database_sql(SQL_FILE)
-        server.commit()
-        server.close()
-    except:
-        # Failed, but must close the handle...
-        server.close()
-        raise
-
-
-def destroy_database():
-    """Delete any temporary BioSQL sqlite3 database files."""
-    if DBDRIVER in ["sqlite3"]:
-        if os.path.exists(TESTDB):
-            os.remove(TESTDB)
-
-
-def load_database(gb_filename_or_handle):
-    """Load a GenBank file into a new BioSQL database.
-
-    This is useful for running tests against a newly created database.
-    """
-
-    create_database()
-    # now open a connection to load the database
-    db_name = "biosql-test"
-    server = BioSeqDatabase.open_database(driver=DBDRIVER,
-                                          user=DBUSER, passwd=DBPASSWD,
-                                          host=DBHOST, db=TESTDB)
-    db = server.new_database(db_name)
-
-    # get the GenBank file we are going to put into it
-    iterator = SeqIO.parse(gb_filename_or_handle, "gb")
-    # finally put it in the database
-    count = db.load(iterator)
-    server.commit()
-    server.close()
-    return count
 
 
 class TaxonomyTest(unittest.TestCase):
@@ -226,9 +58,11 @@ class TaxonomyTest(unittest.TestCase):
 
         # load the database
         db_name = "biosql-test"
-        self.server = BioSeqDatabase.open_database(driver=DBDRIVER,
-                                                   user=DBUSER, passwd=DBPASSWD,
-                                                   host=DBHOST, db=TESTDB)
+        self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
+                                                   user=BioSQL_settings.DBUSER,
+                                                   passwd=BioSQL_settings.DBPASSWD,
+                                                   host=BioSQL_settings.DBHOST,
+                                                   db=BioSQL_settings.TESTDB)
 
         # remove the database if it already exists
         try:

--- a/Tests/common_BioSQL_online.py
+++ b/Tests/common_BioSQL_online.py
@@ -1,0 +1,269 @@
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+"""Tests for dealing with storage of biopython objects in a relational db.
+"""
+from __future__ import print_function
+
+import os
+import platform
+import unittest
+import tempfile
+import time
+
+from Bio._py3k import StringIO
+from Bio._py3k import zip
+from Bio._py3k import basestring
+
+# Hide annoying warnings from things like bonds in GenBank features,
+# or PostgreSQL schema rules. TODO - test these warnings are raised!
+import warnings
+from Bio import BiopythonWarning
+
+# local stuff
+from Bio import MissingExternalDependencyError
+from Bio.Seq import Seq, MutableSeq
+from Bio.SeqFeature import SeqFeature
+from Bio import Alphabet
+from Bio import SeqIO
+from Bio.SeqRecord import SeqRecord
+
+from BioSQL import BioSeqDatabase
+from BioSQL import BioSeq
+from Bio import Entrez
+
+from seq_tests_common import compare_record, compare_records
+
+import requires_internet
+
+if __name__ == "__main__":
+    raise RuntimeError("Call this via test_BioSQL_*.py not directly")
+
+# Exporting these to the test_BioSQL_XXX.py files which import this file:
+# DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB, DBSCHEMA, SQL_FILE, SYSTEM
+
+SYSTEM = platform.system()
+
+
+def temp_db_filename():
+    # In memory SQLite does not work with current test structure since the tests
+    # expect databases to be retained between individual tests.
+    # TESTDB = ':memory:'
+    # Instead, we use (if we can) /dev/shm
+    try:
+        h, test_db_fname = tempfile.mkstemp("_BioSQL.db", dir='/dev/shm')
+    except OSError:
+        # We can't use /dev/shm
+        h, test_db_fname = tempfile.mkstemp("_BioSQL.db")
+    os.close(h)
+    return test_db_fname
+
+
+def check_config(dbdriver, dbtype, dbhost, dbuser, dbpasswd, testdb):
+    global DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB, DBSCHEMA
+    global SYSTEM, SQL_FILE
+    DBDRIVER = dbdriver
+    DBTYPE = dbtype
+    DBHOST = dbhost
+    DBUSER = dbuser
+    DBPASSWD = dbpasswd
+    TESTDB = testdb
+
+    # Check the database driver is installed:
+    if SYSTEM == "Java":
+        try:
+            if DBDRIVER in ["MySQLdb"]:
+                import com.mysql.jdbc.Driver
+            elif DBDRIVER in ["psycopg2"]:
+                import org.postgresql.Driver
+        except ImportError:
+            message = "Install the JDBC driver for %s to use BioSQL " % DBTYPE
+            raise MissingExternalDependencyError(message)
+    else:
+        try:
+            __import__(DBDRIVER)
+        except ImportError:
+            message = "Install %s if you want to use %s with BioSQL " % (DBDRIVER, DBTYPE)
+            raise MissingExternalDependencyError(message)
+
+    try:
+        if DBDRIVER in ["sqlite3"]:
+            server = BioSeqDatabase.open_database(driver=DBDRIVER, db=TESTDB)
+        else:
+            server = BioSeqDatabase.open_database(driver=DBDRIVER, host=DBHOST,
+                                                  user=DBUSER, passwd=DBPASSWD)
+        server.close()
+        del server
+    except Exception as e:
+        message = "Connection failed, check settings if you plan to use BioSQL: %s" % e
+        raise MissingExternalDependencyError(message)
+
+    DBSCHEMA = "biosqldb-" + DBTYPE + ".sql"
+    SQL_FILE = os.path.join(os.getcwd(), "BioSQL", DBSCHEMA)
+
+    if not os.path.isfile(SQL_FILE):
+        message = "Missing SQL schema file: %s" % SQL_FILE
+        raise MissingExternalDependencyError(message)
+
+
+def _do_db_create():
+    """Do the actual work of database creation.
+
+    Relevant for MySQL and PostgreSQL.
+    """
+    # first open a connection to create the database
+    server = BioSeqDatabase.open_database(driver=DBDRIVER, host=DBHOST,
+                                          user=DBUSER, passwd=DBPASSWD)
+
+    if DBDRIVER == "pgdb":
+        # The pgdb postgres driver does not support autocommit, so here we
+        # commit the current transaction so that 'drop database' query will
+        # be outside a transaction block
+        server.adaptor.cursor.execute("COMMIT")
+    else:
+        # Auto-commit: postgresql cannot drop database in a transaction
+        try:
+            server.adaptor.autocommit()
+        except AttributeError:
+            pass
+
+    # drop anything in the database
+    try:
+        # with Postgres, can get errors about database still being used and
+        # not able to be dropped. Wait briefly to be sure previous tests are
+        # done with it.
+        time.sleep(1)
+        sql = r"DROP DATABASE " + TESTDB
+        server.adaptor.cursor.execute(sql, ())
+    except (server.module.OperationalError,
+            server.module.Error,
+            server.module.DatabaseError) as e:  # the database doesn't exist
+        pass
+    except (server.module.IntegrityError,
+            server.module.ProgrammingError) as e:  # ditto--perhaps
+        if str(e).find('database "%s" does not exist' % TESTDB) == -1:
+            server.close()
+            raise
+    # create a new database
+    sql = r"CREATE DATABASE " + TESTDB
+    server.adaptor.execute(sql, ())
+    server.close()
+
+
+def create_database():
+    """Delete any existing BioSQL test database, then (re)create an empty BioSQL database."""
+    if DBDRIVER in ["sqlite3"]:
+        global TESTDB
+        if os.path.exists(TESTDB):
+            try:
+                os.remove(TESTDB)
+            except:
+                time.sleep(1)
+                try:
+                    os.remove(TESTDB)
+                except Exception:
+                    # Seen this with PyPy 2.1 (and older) on Windows -
+                    # which suggests an open handle still exists?
+                    print("Could not remove %r" % TESTDB)
+                    pass
+        # Now pick a new filename - just in case there is a stale handle
+        # (which might be happening under Windows...)
+        TESTDB = temp_db_filename()
+    else:
+        _do_db_create()
+
+    # now open a connection to load the database
+    server = BioSeqDatabase.open_database(driver=DBDRIVER,
+                                          user=DBUSER, passwd=DBPASSWD,
+                                          host=DBHOST, db=TESTDB)
+    try:
+        server.load_database_sql(SQL_FILE)
+        server.commit()
+        server.close()
+    except:
+        # Failed, but must close the handle...
+        server.close()
+        raise
+
+
+def destroy_database():
+    """Delete any temporary BioSQL sqlite3 database files."""
+    if DBDRIVER in ["sqlite3"]:
+        if os.path.exists(TESTDB):
+            os.remove(TESTDB)
+
+
+def load_database(gb_filename_or_handle):
+    """Load a GenBank file into a new BioSQL database.
+
+    This is useful for running tests against a newly created database.
+    """
+
+    create_database()
+    # now open a connection to load the database
+    db_name = "biosql-test"
+    server = BioSeqDatabase.open_database(driver=DBDRIVER,
+                                          user=DBUSER, passwd=DBPASSWD,
+                                          host=DBHOST, db=TESTDB)
+    db = server.new_database(db_name)
+
+    # get the GenBank file we are going to put into it
+    iterator = SeqIO.parse(gb_filename_or_handle, "gb")
+    # finally put it in the database
+    count = db.load(iterator)
+    server.commit()
+    server.close()
+    return count
+
+
+class TaxonomyTest(unittest.TestCase):
+    """Test proper insertion and retrieval of taxonomy data
+    """
+    def setUp(self):
+        Entrez.email = "biopython-dev@biopython.org"
+        # create TESTDB
+        create_database()
+
+        # load the database
+        db_name = "biosql-test"
+        self.server = BioSeqDatabase.open_database(driver=DBDRIVER,
+                                                   user=DBUSER, passwd=DBPASSWD,
+                                                   host=DBHOST, db=TESTDB)
+
+        # remove the database if it already exists
+        try:
+            self.server[db_name]
+            self.server.remove_database(db_name)
+        except KeyError:
+            pass
+
+        self.db = self.server.new_database(db_name)
+
+        # get the GenBank file we are going to put into it
+        self.iterator = SeqIO.parse("GenBank/cor6_6.gb", "gb")
+
+    def tearDown(self):
+        self.server.close()
+        destroy_database()
+        del self.db
+        del self.server
+
+    def test_taxon_left_right_values(self):
+        self.db.load(self.iterator, True)
+        sql = """SELECT DISTINCT include.ncbi_taxon_id FROM taxon
+                  INNER JOIN taxon AS include ON
+                      (include.left_value BETWEEN taxon.left_value
+                                  AND taxon.right_value)
+                  WHERE taxon.taxon_id IN
+                      (SELECT taxon_id FROM taxon_name
+                                  WHERE name = 'Brassicales')
+                      AND include.right_value - include.left_value = 1"""
+
+        rows = self.db.adaptor.execute_and_fetchall(sql)
+        self.assertEqual(4, len(rows))
+        values = set()
+        for row in rows:
+            values.add(row[0])
+        self.assertEqual(set([3704, 3711, 3708, 3702]), set(values))
+
+

--- a/Tests/common_BioSQL_online.py
+++ b/Tests/common_BioSQL_online.py
@@ -58,7 +58,7 @@ class TaxonomyTest(unittest.TestCase):
 
         # load the database
         db_name = "biosql-test"
-        with warning.catch_warnings():
+        with warnings.catch_warnings():
             warnings.simplefilter("ignore", BiopythonWarning)
             self.server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
                                                        user=BioSQL_settings.DBUSER,

--- a/Tests/test_BioSQL_MySQLdb.py
+++ b/Tests/test_BioSQL_MySQLdb.py
@@ -8,26 +8,31 @@ from Bio import MissingExternalDependencyError
 from BioSQL import BioSeqDatabase
 
 from common_BioSQL import *
-
+import BioSQL_settings
 ##################################
 # Start of user-editable section #
 ##################################
 
 # Constants for the database driver
-DBHOST = 'localhost'
-DBUSER = 'root'
-DBPASSWD = ''
-TESTDB = 'biosql_test'
+BioSQL_settings.DBHOST = 'localhost'
+BioSQL_settings.DBUSER = 'root'
+BioSQL_settings.DBPASSWD = ''
+BioSQL_settings.TESTDB = 'biosql_test'
 
 ################################
 # End of user-editable section #
 ################################
 
-DBDRIVER = 'MySQLdb'
-DBTYPE = 'mysql'
+BioSQL_settings.DBDRIVER = 'MySQLdb'
+BioSQL_settings.DBTYPE = 'mysql'
 
 # This will abort if driver not installed etc:
-check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)
+check_config(BioSQL_settings.DBDRIVER,
+             BioSQL_settings.DBTYPE,
+             BioSQL_settings.DBHOST,
+             BioSQL_settings.DBUSER,
+             BioSQL_settings.DBPASSWD,
+             BioSQL_settings.TESTDB)
 
 # Some of the unit tests don't create their own database,
 # so just in case there is no database already:

--- a/Tests/test_BioSQL_MySQLdb_online.py
+++ b/Tests/test_BioSQL_MySQLdb_online.py
@@ -8,26 +8,32 @@ from Bio import MissingExternalDependencyError
 from BioSQL import BioSeqDatabase
 
 from common_BioSQL_online import *
+import BioSQL_settings
 
 ##################################
 # Start of user-editable section #
 ##################################
 
 # Constants for the database driver
-DBHOST = 'localhost'
-DBUSER = 'root'
-DBPASSWD = ''
-TESTDB = 'biosql_test'
+BioSQL_settings.DBHOST = 'localhost'
+BioSQL_settings.DBUSER = 'root'
+BioSQL_settings.DBPASSWD = ''
+BioSQL_settings.TESTDB = 'biosql_test'
 
 ################################
 # End of user-editable section #
 ################################
 
-DBDRIVER = 'MySQLdb'
-DBTYPE = 'mysql'
+BioSQL_settings.DBDRIVER = 'MySQLdb'
+BioSQL_settings.DBTYPE = 'mysql'
 
 # This will abort if driver not installed etc:
-check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)
+check_config(BioSQL_settings.DBDRIVER,
+             BioSQL_settings.DBTYPE,
+             BioSQL_settings.DBHOST,
+             BioSQL_settings.DBUSER,
+             BioSQL_settings.DBPASSWD,
+             BioSQL_settings.TESTDB)
 
 # Some of the unit tests don't create their own database,
 # so just in case there is no database already:

--- a/Tests/test_BioSQL_MySQLdb_online.py
+++ b/Tests/test_BioSQL_MySQLdb_online.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+
+"""Run BioSQL tests using SQLite"""
+from Bio import MissingExternalDependencyError
+from BioSQL import BioSeqDatabase
+
+from common_BioSQL_online import *
+
+##################################
+# Start of user-editable section #
+##################################
+
+# Constants for the database driver
+DBHOST = 'localhost'
+DBUSER = 'root'
+DBPASSWD = ''
+TESTDB = 'biosql_test'
+
+################################
+# End of user-editable section #
+################################
+
+DBDRIVER = 'MySQLdb'
+DBTYPE = 'mysql'
+
+# This will abort if driver not installed etc:
+check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)
+
+# Some of the unit tests don't create their own database,
+# so just in case there is no database already:
+create_database()
+
+if __name__ == "__main__":
+    # Run the test cases
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)

--- a/Tests/test_BioSQL_MySQLdb_online.py
+++ b/Tests/test_BioSQL_MySQLdb_online.py
@@ -8,6 +8,7 @@ from Bio import MissingExternalDependencyError
 from BioSQL import BioSeqDatabase
 
 from common_BioSQL_online import *
+from common_BioSQL import check_config, create_database
 import BioSQL_settings
 
 ##################################

--- a/Tests/test_BioSQL_mysql_connector.py
+++ b/Tests/test_BioSQL_mysql_connector.py
@@ -8,26 +8,32 @@ from Bio import MissingExternalDependencyError
 from BioSQL import BioSeqDatabase
 
 from common_BioSQL import *
+import BioSQL_settings
 
 ##################################
 # Start of user-editable section #
 ##################################
 
 # Constants for the database driver
-DBHOST = 'localhost'
-DBUSER = 'root'
-DBPASSWD = ''
-TESTDB = 'biosql_test'
+BioSQL_settings.DBHOST = 'localhost'
+BioSQL_settings.DBUSER = 'root'
+BioSQL_settings.DBPASSWD = ''
+BioSQL_settings.TESTDB = 'biosql_test'
 
 ################################
 # End of user-editable section #
 ################################
 
-DBDRIVER = 'mysql.connector'
-DBTYPE = 'mysql'
+BioSQL_settings.DBDRIVER = 'mysql.connector'
+BioSQL_settings.DBTYPE = 'mysql'
 
 # This will abort if driver not installed etc:
-check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)
+check_config(BioSQL_settings.DBDRIVER,
+             BioSQL_settings.DBTYPE,
+             BioSQL_settings.DBHOST,
+             BioSQL_settings.DBUSER,
+             BioSQL_settings.DBPASSWD,
+             BioSQL_settings.TESTDB)
 
 # Some of the unit tests don't create their own database,
 # so just in case there is no database already:

--- a/Tests/test_BioSQL_mysql_connector_online.py
+++ b/Tests/test_BioSQL_mysql_connector_online.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+
+"""Run BioSQL tests using SQLite"""
+from Bio import MissingExternalDependencyError
+from BioSQL import BioSeqDatabase
+
+from common_BioSQL_online import *
+
+##################################
+# Start of user-editable section #
+##################################
+
+# Constants for the database driver
+DBHOST = 'localhost'
+DBUSER = 'root'
+DBPASSWD = ''
+TESTDB = 'biosql_test'
+
+################################
+# End of user-editable section #
+################################
+
+DBDRIVER = 'mysql.connector'
+DBTYPE = 'mysql'
+
+# This will abort if driver not installed etc:
+check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)
+
+# Some of the unit tests don't create their own database,
+# so just in case there is no database already:
+create_database()
+
+if __name__ == "__main__":
+    # Run the test cases
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)

--- a/Tests/test_BioSQL_mysql_connector_online.py
+++ b/Tests/test_BioSQL_mysql_connector_online.py
@@ -8,6 +8,7 @@ from Bio import MissingExternalDependencyError
 from BioSQL import BioSeqDatabase
 
 from common_BioSQL_online import *
+from common_BioSQL import check_config, create_database
 import BioSQL_settings
 
 ##################################

--- a/Tests/test_BioSQL_mysql_connector_online.py
+++ b/Tests/test_BioSQL_mysql_connector_online.py
@@ -8,26 +8,32 @@ from Bio import MissingExternalDependencyError
 from BioSQL import BioSeqDatabase
 
 from common_BioSQL_online import *
+import BioSQL_settings
 
 ##################################
 # Start of user-editable section #
 ##################################
 
 # Constants for the database driver
-DBHOST = 'localhost'
-DBUSER = 'root'
-DBPASSWD = ''
-TESTDB = 'biosql_test'
+BioSQL_settings.DBHOST = 'localhost'
+BioSQL_settings.DBUSER = 'root'
+BioSQL_settings.DBPASSWD = ''
+BioSQL_settings.TESTDB = 'biosql_test'
 
 ################################
 # End of user-editable section #
 ################################
 
-DBDRIVER = 'mysql.connector'
-DBTYPE = 'mysql'
+BioSQL_settings.DBDRIVER = 'mysql.connector'
+BioSQL_settings.DBTYPE = 'mysql'
 
 # This will abort if driver not installed etc:
-check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)
+check_config(BioSQL_settings.DBDRIVER,
+             BioSQL_settings.DBTYPE,
+             BioSQL_settings.DBHOST,
+             BioSQL_settings.DBUSER,
+             BioSQL_settings.DBPASSWD,
+             BioSQL_settings.TESTDB)
 
 # Some of the unit tests don't create their own database,
 # so just in case there is no database already:

--- a/Tests/test_BioSQL_psycopg2.py
+++ b/Tests/test_BioSQL_psycopg2.py
@@ -8,26 +8,32 @@ from Bio import MissingExternalDependencyError
 from BioSQL import BioSeqDatabase
 
 from common_BioSQL import *
+import BioSQL_settings
 
 ##################################
 # Start of user-editable section #
 ##################################
 
 # Constants for the database driver
-DBHOST = 'localhost'
-DBUSER = 'postgres'
-DBPASSWD = ''
-TESTDB = 'biosql_test'
+BioSQL_settings.DBHOST = 'localhost'
+BioSQL_settings.DBUSER = 'postgres'
+BioSQL_settings.DBPASSWD = ''
+BioSQL_settings.TESTDB = 'biosql_test'
 
 ################################
 # End of user-editable section #
 ################################
 
-DBDRIVER = 'psycopg2'
-DBTYPE = 'pg'
+BioSQL_settings.DBDRIVER = 'psycopg2'
+BioSQL_settings.DBTYPE = 'pg'
 
 # This will abort if driver not installed etc:
-check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)
+check_config(BioSQL_settings.DBDRIVER,
+             BioSQL_settings.DBTYPE,
+             BioSQL_settings.DBHOST,
+             BioSQL_settings.DBUSER,
+             BioSQL_settings.DBPASSWD,
+             BioSQL_settings.TESTDB)
 
 # Some of the unit tests don't create their own database,
 # so just in case there is no database already:

--- a/Tests/test_BioSQL_psycopg2_online.py
+++ b/Tests/test_BioSQL_psycopg2_online.py
@@ -8,16 +8,17 @@ from Bio import MissingExternalDependencyError
 from BioSQL import BioSeqDatabase
 
 from common_BioSQL_online import *
+import BioSQL_settings
 
 ##################################
 # Start of user-editable section #
 ##################################
 
 # Constants for the database driver
-DBHOST = 'localhost'
-DBUSER = 'postgres'
-DBPASSWD = ''
-TESTDB = 'biosql_test'
+BioSQL_settings.DBHOST = 'localhost'
+BioSQL_settings.DBUSER = 'postgres'
+BioSQL_settings.DBPASSWD = ''
+BioSQL_settings.TESTDB = 'biosql_test'
 
 ################################
 # End of user-editable section #
@@ -27,7 +28,12 @@ DBDRIVER = 'psycopg2'
 DBTYPE = 'pg'
 
 # This will abort if driver not installed etc:
-check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)
+check_config(BioSQL_settings.DBDRIVER,
+             BioSQL_settings.DBTYPE,
+             BioSQL_settings.DBHOST,
+             BioSQL_settings.DBUSER,
+             BioSQL_settings.DBPASSWD,
+             BioSQL_settings.TESTDB)
 
 # Some of the unit tests don't create their own database,
 # so just in case there is no database already:

--- a/Tests/test_BioSQL_psycopg2_online.py
+++ b/Tests/test_BioSQL_psycopg2_online.py
@@ -8,6 +8,7 @@ from Bio import MissingExternalDependencyError
 from BioSQL import BioSeqDatabase
 
 from common_BioSQL_online import *
+from common_BioSQL import check_config, create_database
 import BioSQL_settings
 
 ##################################
@@ -24,8 +25,8 @@ BioSQL_settings.TESTDB = 'biosql_test'
 # End of user-editable section #
 ################################
 
-DBDRIVER = 'psycopg2'
-DBTYPE = 'pg'
+BioSQL_settings.DBDRIVER = 'psycopg2'
+BioSQL_settings.DBTYPE = 'pg'
 
 # This will abort if driver not installed etc:
 check_config(BioSQL_settings.DBDRIVER,

--- a/Tests/test_BioSQL_psycopg2_online.py
+++ b/Tests/test_BioSQL_psycopg2_online.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+
+"""Run BioSQL tests using PostgreSQL"""
+from Bio import MissingExternalDependencyError
+from BioSQL import BioSeqDatabase
+
+from common_BioSQL_online import *
+
+##################################
+# Start of user-editable section #
+##################################
+
+# Constants for the database driver
+DBHOST = 'localhost'
+DBUSER = 'postgres'
+DBPASSWD = ''
+TESTDB = 'biosql_test'
+
+################################
+# End of user-editable section #
+################################
+
+DBDRIVER = 'psycopg2'
+DBTYPE = 'pg'
+
+# This will abort if driver not installed etc:
+check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)
+
+# Some of the unit tests don't create their own database,
+# so just in case there is no database already:
+create_database()
+
+if __name__ == "__main__":
+    # Run the test cases
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)

--- a/Tests/test_BioSQL_sqlite3.py
+++ b/Tests/test_BioSQL_sqlite3.py
@@ -11,20 +11,26 @@ from Bio import SeqIO
 from BioSQL import BioSeqDatabase
 
 from common_BioSQL import *
+import BioSQL_settings
 
 # Constants for the database driver
-DBHOST = 'localhost'
-DBUSER = 'root'
-DBPASSWD = ''
+BioSQL_settings.DBHOST = 'localhost'
+BioSQL_settings.DBUSER = 'root'
+BioSQL_settings.DBPASSWD = ''
 
-DBDRIVER = 'sqlite3'
-DBTYPE = 'sqlite'
+BioSQL_settings.DBDRIVER = 'sqlite3'
+BioSQL_settings.DBTYPE = 'sqlite'
 
-TESTDB = temp_db_filename()
+BioSQL_settings.TESTDB = temp_db_filename()
 
 
 # This will abort if driver not installed etc:
-check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)
+check_config(BioSQL_settings.DBDRIVER,
+             BioSQL_settings.DBTYPE,
+             BioSQL_settings.DBHOST,
+             BioSQL_settings.DBUSER,
+             BioSQL_settings.DBPASSWD,
+             BioSQL_settings.TESTDB)
 
 # Some of the unit tests don't create their own database,
 # so just in case there is no database already:
@@ -37,12 +43,12 @@ if False:
     # catch any regressions in how we map GenBank entries to
     # the database.
     assert not os.path.isfile("BioSQL/cor6_6.db")
-    server = BioSeqDatabase.open_database(driver=DBDRIVER,
+    server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
                                           db="BioSQL/cor6_6.db")
-    DBSCHEMA = "biosqldb-" + DBTYPE + ".sql"
-    SQL_FILE = os.path.join(os.getcwd(), "BioSQL", DBSCHEMA)
-    assert os.path.isfile(SQL_FILE), SQL_FILE
-    server.load_database_sql(SQL_FILE)
+    BioSQL_settings.DBSCHEMA = "biosqldb-" + BioSQL_settings.DBTYPE + ".sql"
+    BioSQL_settings.SQL_FILE = os.path.join(os.getcwd(), "BioSQL", BioSQL_settings.DBSCHEMA)
+    assert os.path.isfile(BioSQL_settings.SQL_FILE), BioSQL_settings.SQL_FILE
+    server.load_database_sql(BioSQL_settings.SQL_FILE)
     server.commit()
     db = server.new_database("OLD")
     count = db.load(SeqIO.parse("GenBank/cor6_6.gb", "gb"))
@@ -57,7 +63,7 @@ class BackwardsCompatibilityTest(unittest.TestCase):
         """Check can re-use an old BioSQL SQLite3 database."""
         original_records = list(SeqIO.parse("GenBank/cor6_6.gb", "gb"))
         # now open a connection to load the database
-        server = BioSeqDatabase.open_database(driver=DBDRIVER,
+        server = BioSeqDatabase.open_database(driver=BioSQL_settings.DBDRIVER,
                                               db="BioSQL/cor6_6.db")
         db = server["OLD"]
         self.assertEqual(len(db), len(original_records))

--- a/Tests/test_BioSQL_sqlite3_online.py
+++ b/Tests/test_BioSQL_sqlite3_online.py
@@ -12,7 +12,7 @@ from BioSQL import BioSeqDatabase
 
 from common_BioSQL_online import *
 import BioSQL_settings
-from common_BioSQL import temp_db_filename, check_config, create_database
+from common_BioSQL import check_config, create_database
 
 # Constants for the database driver
 BioSQL_settings.DBHOST = 'localhost'

--- a/Tests/test_BioSQL_sqlite3_online.py
+++ b/Tests/test_BioSQL_sqlite3_online.py
@@ -11,61 +11,29 @@ from Bio import SeqIO
 from BioSQL import BioSeqDatabase
 
 from common_BioSQL_online import *
+import BioSQL_settings
+from common_BioSQL import temp_db_filename, check_config, create_database
 
 # Constants for the database driver
-DBHOST = 'localhost'
-DBUSER = 'root'
-DBPASSWD = ''
+BioSQL_settings.DBHOST = 'localhost'
+BioSQL_settings.DBUSER = 'root'
+BioSQL_settings.DBPASSWD = ''
 
-DBDRIVER = 'sqlite3'
-DBTYPE = 'sqlite'
+BioSQL_settings.DBDRIVER = 'sqlite3'
+BioSQL_settings.DBTYPE = 'sqlite'
 
-TESTDB = temp_db_filename()
+
+
+BioSQL_settings.TESTDB = temp_db_filename()
 
 
 # This will abort if driver not installed etc:
-check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)
+check_config(BioSQL_settings.DBDRIVER, BioSQL_settings.DBTYPE, BioSQL_settings.DBHOST, BioSQL_settings.DBUSER, BioSQL_settings.DBPASSWD, BioSQL_settings.TESTDB)
 
 # Some of the unit tests don't create their own database,
 # so just in case there is no database already:
+
 create_database()
-
-
-if False:
-    # This is how I generated test file Tests/BioSQL/cor6_6.db
-    # which is test cross-checked with the latest bindings to
-    # catch any regressions in how we map GenBank entries to
-    # the database.
-    assert not os.path.isfile("BioSQL/cor6_6.db")
-    server = BioSeqDatabase.open_database(driver=DBDRIVER,
-                                          db="BioSQL/cor6_6.db")
-    DBSCHEMA = "biosqldb-" + DBTYPE + ".sql"
-    SQL_FILE = os.path.join(os.getcwd(), "BioSQL", DBSCHEMA)
-    assert os.path.isfile(SQL_FILE), SQL_FILE
-    server.load_database_sql(SQL_FILE)
-    server.commit()
-    db = server.new_database("OLD")
-    count = db.load(SeqIO.parse("GenBank/cor6_6.gb", "gb"))
-    assert count == 6
-    server.commit()
-    assert len(db) == 6
-    server.close()
-
-
-class BackwardsCompatibilityTest(unittest.TestCase):
-    def test_backwards_compatibility(self):
-        """Check can re-use an old BioSQL SQLite3 database."""
-        original_records = list(SeqIO.parse("GenBank/cor6_6.gb", "gb"))
-        # now open a connection to load the database
-        server = BioSeqDatabase.open_database(driver=DBDRIVER,
-                                              db="BioSQL/cor6_6.db")
-        db = server["OLD"]
-        self.assertEqual(len(db), len(original_records))
-        # Now read them back...
-        biosql_records = [db.lookup(name=rec.name)
-                          for rec in original_records]
-        # And check they agree
-        self.assertTrue(compare_records(original_records, biosql_records))
 
 if __name__ == "__main__":
     # Run the test cases

--- a/Tests/test_BioSQL_sqlite3_online.py
+++ b/Tests/test_BioSQL_sqlite3_online.py
@@ -12,7 +12,7 @@ from BioSQL import BioSeqDatabase
 
 from common_BioSQL_online import *
 import BioSQL_settings
-from common_BioSQL import check_config, create_database
+from common_BioSQL import temp_db_filename, check_config, create_database
 
 # Constants for the database driver
 BioSQL_settings.DBHOST = 'localhost'

--- a/Tests/test_BioSQL_sqlite3_online.py
+++ b/Tests/test_BioSQL_sqlite3_online.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+
+"""Run BioSQL tests using SQLite"""
+import os
+
+from Bio import MissingExternalDependencyError
+from Bio import SeqIO
+from BioSQL import BioSeqDatabase
+
+from common_BioSQL_online import *
+
+# Constants for the database driver
+DBHOST = 'localhost'
+DBUSER = 'root'
+DBPASSWD = ''
+
+DBDRIVER = 'sqlite3'
+DBTYPE = 'sqlite'
+
+TESTDB = temp_db_filename()
+
+
+# This will abort if driver not installed etc:
+check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)
+
+# Some of the unit tests don't create their own database,
+# so just in case there is no database already:
+create_database()
+
+
+if False:
+    # This is how I generated test file Tests/BioSQL/cor6_6.db
+    # which is test cross-checked with the latest bindings to
+    # catch any regressions in how we map GenBank entries to
+    # the database.
+    assert not os.path.isfile("BioSQL/cor6_6.db")
+    server = BioSeqDatabase.open_database(driver=DBDRIVER,
+                                          db="BioSQL/cor6_6.db")
+    DBSCHEMA = "biosqldb-" + DBTYPE + ".sql"
+    SQL_FILE = os.path.join(os.getcwd(), "BioSQL", DBSCHEMA)
+    assert os.path.isfile(SQL_FILE), SQL_FILE
+    server.load_database_sql(SQL_FILE)
+    server.commit()
+    db = server.new_database("OLD")
+    count = db.load(SeqIO.parse("GenBank/cor6_6.gb", "gb"))
+    assert count == 6
+    server.commit()
+    assert len(db) == 6
+    server.close()
+
+
+class BackwardsCompatibilityTest(unittest.TestCase):
+    def test_backwards_compatibility(self):
+        """Check can re-use an old BioSQL SQLite3 database."""
+        original_records = list(SeqIO.parse("GenBank/cor6_6.gb", "gb"))
+        # now open a connection to load the database
+        server = BioSeqDatabase.open_database(driver=DBDRIVER,
+                                              db="BioSQL/cor6_6.db")
+        db = server["OLD"]
+        self.assertEqual(len(db), len(original_records))
+        # Now read them back...
+        biosql_records = [db.lookup(name=rec.name)
+                          for rec in original_records]
+        # And check they agree
+        self.assertTrue(compare_records(original_records, biosql_records))
+
+if __name__ == "__main__":
+    # Run the test cases
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)


### PR DESCRIPTION
As discussed in #819, I've split out the `TaxonomyTest` class which requires the internet into a separate file.