### PR TITLE
BioSQL test configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ Tests/Graphics/*.eps
 Tests/Graphics/*.svg
 Tests/Graphics/*.png
 
+#Ignore the local BioSQL test settings:
+Tests/biosql.ini
+
 #TODO - The unit tests shouldn't leave temp files after running:
 Tests/BioSQL/temp_sqlite.db
 Tests/BioSQL/temp_sqlite.db-journal

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ install:
 
 before_script:
   - cd Tests
+  - cp biosql.ini.sample biosql.ini
 
 script:
 #Using just coverage should match up to the current Python version:

--- a/Tests/biosql.ini.sample
+++ b/Tests/biosql.ini.sample
@@ -1,0 +1,28 @@
+# We provide biosql.ini.sample as an example
+# (preconfigured to work on the virtual machines
+# used for automated TravisCI testing)
+#
+# Please copy this to biosql.ini and edit it
+# match your local system if you want to run
+# the Biopython BioSQL tests locally yourself.
+
+[mysql]
+# Covers DBDRIVER="MySQLdb" and "mysql.connector" etc
+dbhost=localhost
+dbuser=root
+dbpasswd=
+testdb=biosql_test
+
+[pg]
+# Covers DBDRIVER="psycopg2" etc
+dbhost=localhost
+dbuser=postgres
+dbpasswd=
+testdb=biosql_test
+
+[sqlite]
+# Covers DBDRIVER="sqlite3" where these are essentially dummy values
+dbhost=localhost
+dbuser=root
+dbpasswd=
+testdb=

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -47,6 +47,7 @@ SYSTEM = platform.system()
 
 
 def load_biosql_ini(DBTYPE):
+    """Load the database settings from INI file."""
     if not os.path.isfile("biosql.ini"):
         raise MissingExternalDependencyError("BioSQL test configuration"
                                              " file biosql.ini missing"
@@ -62,6 +63,7 @@ def load_biosql_ini(DBTYPE):
 
 
 def temp_db_filename():
+    """Generate a temporary filename for SQLite database."""
     # In memory SQLite does not work with current test structure since the tests
     # expect databases to be retained between individual tests.
     # TESTDB = ':memory:'
@@ -76,6 +78,7 @@ def temp_db_filename():
 
 
 def check_config(dbdriver, dbtype, dbhost, dbuser, dbpasswd, testdb):
+    """Verify the database settings work for connecting."""
     global DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB, DBSCHEMA
     global SYSTEM, SQL_FILE
     DBDRIVER = dbdriver
@@ -167,7 +170,7 @@ def _do_db_create():
 
 
 def create_database():
-    """Delete any existing BioSQL test database, then (re)create an empty BioSQL database."""
+    """Delete any existing BioSQL test DB, then (re)create an empty BioSQL DB."""
     if DBDRIVER in ["sqlite3"]:
         global TESTDB
         if os.path.exists(TESTDB):

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -10,6 +10,7 @@ import platform
 import unittest
 import tempfile
 import time
+import configparser
 
 from Bio._py3k import StringIO
 from Bio._py3k import zip
@@ -40,6 +41,21 @@ if __name__ == "__main__":
 # DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB, DBSCHEMA, SQL_FILE, SYSTEM
 
 SYSTEM = platform.system()
+
+
+def load_biosql_ini(DBTYPE):
+    if not os.path.isfile("biosql.ini"):
+        raise MissingExternalDependencyError("BioSQL test configuration"
+                                             " file biosql.ini missing"
+                                             " (see biosql.ini.sample)")
+
+    config = configparser.ConfigParser()
+    config.read("biosql.ini")
+    DBHOST = config[DBTYPE]["dbhost"]
+    DBUSER = config[DBTYPE]["dbuser"]
+    DBPASSWD = config[DBTYPE]["dbpasswd"]
+    TESTDB = config[DBTYPE]["testdb"]
+    return DBHOST, DBUSER, DBPASSWD, TESTDB
 
 
 def temp_db_filename():

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -10,7 +10,10 @@ import platform
 import unittest
 import tempfile
 import time
-import configparser
+try:
+    import configparser  # Python 3
+except ImportError:
+    import ConfigParser as configparser  # Python 2
 
 from Bio._py3k import StringIO
 from Bio._py3k import zip
@@ -51,10 +54,10 @@ def load_biosql_ini(DBTYPE):
 
     config = configparser.ConfigParser()
     config.read("biosql.ini")
-    DBHOST = config[DBTYPE]["dbhost"]
-    DBUSER = config[DBTYPE]["dbuser"]
-    DBPASSWD = config[DBTYPE]["dbpasswd"]
-    TESTDB = config[DBTYPE]["testdb"]
+    DBHOST = config.get(DBTYPE, "dbhost")
+    DBUSER = config.get(DBTYPE, "dbuser")
+    DBPASSWD = config.get(DBTYPE, "dbpasswd")
+    TESTDB = config.get(DBTYPE, "testdb")
     return DBHOST, DBUSER, DBPASSWD, TESTDB
 
 

--- a/Tests/test_BioSQL_MySQLdb.py
+++ b/Tests/test_BioSQL_MySQLdb.py
@@ -9,22 +9,10 @@ from BioSQL import BioSeqDatabase
 
 from common_BioSQL import *
 
-##################################
-# Start of user-editable section #
-##################################
-
-# Constants for the database driver
-DBHOST = 'localhost'
-DBUSER = 'root'
-DBPASSWD = ''
-TESTDB = 'biosql_test'
-
-################################
-# End of user-editable section #
-################################
-
 DBDRIVER = 'MySQLdb'
 DBTYPE = 'mysql'
+
+DBHOST, DBUSER, DBPASSWD, TESTDB = load_biosql_ini(DBTYPE)
 
 # This will abort if driver not installed etc:
 check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)

--- a/Tests/test_BioSQL_mysql_connector.py
+++ b/Tests/test_BioSQL_mysql_connector.py
@@ -9,22 +9,10 @@ from BioSQL import BioSeqDatabase
 
 from common_BioSQL import *
 
-##################################
-# Start of user-editable section #
-##################################
-
-# Constants for the database driver
-DBHOST = 'localhost'
-DBUSER = 'root'
-DBPASSWD = ''
-TESTDB = 'biosql_test'
-
-################################
-# End of user-editable section #
-################################
-
 DBDRIVER = 'mysql.connector'
 DBTYPE = 'mysql'
+
+DBHOST, DBUSER, DBPASSWD, TESTDB = load_biosql_ini(DBTYPE)
 
 # This will abort if driver not installed etc:
 check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)

--- a/Tests/test_BioSQL_psycopg2.py
+++ b/Tests/test_BioSQL_psycopg2.py
@@ -9,22 +9,9 @@ from BioSQL import BioSeqDatabase
 
 from common_BioSQL import *
 
-##################################
-# Start of user-editable section #
-##################################
-
-# Constants for the database driver
-DBHOST = 'localhost'
-DBUSER = 'postgres'
-DBPASSWD = ''
-TESTDB = 'biosql_test'
-
-################################
-# End of user-editable section #
-################################
-
 DBDRIVER = 'psycopg2'
 DBTYPE = 'pg'
+DBHOST, DBUSER, DBPASSWD, TESTDB = load_biosql_ini(DBTYPE)
 
 # This will abort if driver not installed etc:
 check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)

--- a/Tests/test_BioSQL_sqlite3.py
+++ b/Tests/test_BioSQL_sqlite3.py
@@ -13,15 +13,11 @@ from BioSQL import BioSeqDatabase
 from common_BioSQL import *
 
 # Constants for the database driver
-DBHOST = 'localhost'
-DBUSER = 'root'
-DBPASSWD = ''
-
 DBDRIVER = 'sqlite3'
 DBTYPE = 'sqlite'
 
+DBHOST, DBUSER, DBPASSWD, TESTDB = load_biosql_ini(DBTYPE)
 TESTDB = temp_db_filename()
-
 
 # This will abort if driver not installed etc:
 check_config(DBDRIVER, DBTYPE, DBHOST, DBUSER, DBPASSWD, TESTDB)


### PR DESCRIPTION
This moves the BioSQL database settings used in the test suite into a new INI file, currently kept in ``test_BioSQL_*.py`` files themselves - which has a number of drawbacks (see e.g. refactoring in #823).

Under each buildslave for buildbot we can manually add a locally appropriate ``Tests/biosql.ini`` file (which is NOT under git version control).

Under TravisCI we setup suitable values for all the BioSQL tests to pass (via ``Tests/biosql.ini.sample`` which is under git version control).

@tiagoantao and @ctSkennerton could you look over this please?