### PR TITLE
Some KEGG REST queries now return String not Byte in Python3

### DIFF
--- a/Bio/KEGG/REST.py
+++ b/Bio/KEGG/REST.py
@@ -29,6 +29,8 @@ Nucleic Acids Res. 28, 29-34 (2000).
 
 from Bio._py3k import urlopen as _urlopen
 
+from Bio._py3k import _binary_to_string_handle
+
 __docformat__ = "restructuredtext en"
 
 
@@ -40,7 +42,12 @@ def _q(op, arg1, arg2=None, arg3=None):
         args = "%s/%s/%s" % (op, arg1, arg2)
     else:
         args = "%s/%s" % (op, arg1)
-    return _urlopen(URL % (args))
+    resp = _urlopen(URL % (args))
+
+    if "image" == arg2:
+        return resp
+        
+    return _binary_to_string_handle(resp)
 
 
 # http://www.kegg.jp/kegg/rest/keggapi.html

--- a/Tests/test_KEGG_online.py
+++ b/Tests/test_KEGG_online.py
@@ -15,10 +15,10 @@ import tempfile
 import requires_internet
 requires_internet.check()
 
-from Bio._py3k import _as_string
-
 from Bio.KEGG.KGML import KGML_parser
 from Bio.KEGG.REST import *
+
+from Bio import SeqIO
 
 # TODO - revert to using with statements once we drop
 # Python 2.6 and 2.7, see http://bugs.python.org/issue12487
@@ -120,25 +120,29 @@ class KEGGTests(unittest.TestCase):
     def test_find_compound_C7H10O5_formula(self):
         h = kegg_find("compound", "C7H10O5", "formula")
         h.read()
-        self.assertEqual(h.url, "http://rest.kegg.jp/find/compound/C7H10O5/formula")
+        self.assertEqual(h.url,
+                         "http://rest.kegg.jp/find/compound/C7H10O5/formula")
         h.close()
 
     def test_find_compound_O5C7_formula(self):
         h = kegg_find("compound", "O5C7", "formula")
         h.read()
-        self.assertEqual(h.url, "http://rest.kegg.jp/find/compound/O5C7/formula")
+        self.assertEqual(h.url,
+                         "http://rest.kegg.jp/find/compound/O5C7/formula")
         h.close()
 
     def test_find_compound_exact_mass(self):
         h = kegg_find("compound", "174.05", "exact_mass")
         h.read()
-        self.assertEqual(h.url, "http://rest.kegg.jp/find/compound/174.05/exact_mass")
+        self.assertEqual(h.url,
+                         "http://rest.kegg.jp/find/compound/174.05/exact_mass")
         h.close()
 
     def test_find_compound_weight(self):
         h = kegg_find("compound", "300-310", "mol_weight")
         h.read()
-        self.assertEqual(h.url, "http://rest.kegg.jp/find/compound/300-310/mol_weight")
+        self.assertEqual(h.url,
+                         "http://rest.kegg.jp/find/compound/300-310/mol_weight")
         h.close()
 
     def test_get_cpd_C01290_plus_gl_G00092(self):
@@ -179,15 +183,34 @@ class KEGGTests(unittest.TestCase):
 
     def test_get_hsa_10458_plus_ece_Z5100_as_aaseq(self):
         h = kegg_get("hsa:10458+ece:Z5100", "aaseq")
-        h.read()
-        self.assertEqual(h.url, "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq")
+        self.assertEqual(h.url,
+                         "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq")
+        data = SeqIO.parse(h, 'fasta')
+        self.assertEqual(len(list(data)), 2)
         h.close()
 
     def test_get_hsa_10458_list_ece_Z5100_as_aaseq(self):
         h = kegg_get(["hsa:10458", "ece:Z5100"], "aaseq")
-        data = _as_string(h.read())
-        self.assertEqual(data.count(">"), 2)
-        self.assertEqual(h.url, "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq")
+        self.assertEqual(h.url,
+                         "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq")
+        data = SeqIO.parse(h, 'fasta')
+        self.assertEqual(len(list(data)), 2)
+        h.close()
+
+    def test_get_hsa_10458_plus_ece_Z5100_as_ntseq(self):
+        h = kegg_get("hsa:10458+ece:Z5100", "ntseq")
+        self.assertEqual(h.url,
+                         "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq")
+        data = SeqIO.parse(h, 'fasta')
+        self.assertEqual(len(list(data)), 2)
+        h.close()
+
+    def test_get_hsa_10458_list_ece_Z5100_as_ntseq(self):
+        h = kegg_get(["hsa:10458", "ece:Z5100"], "ntseq")
+        self.assertEqual(h.url,
+                         "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq")
+        data = SeqIO.parse(h, 'fasta')
+        self.assertEqual(len(list(data)), 2)
         h.close()
 
     def test_get_hsa05130_image(self):
@@ -212,13 +235,15 @@ class KEGGTests(unittest.TestCase):
     def test_conv_ncbi_gi_hsa_10458_plus_ece_Z5100(self):
         h = kegg_conv("ncbi-gi", "hsa:10458+ece:Z5100")
         h.read()
-        self.assertEqual(h.url, "http://rest.kegg.jp/conv/ncbi-gi/hsa:10458+ece:Z5100")
+        self.assertEqual(h.url,
+                         "http://rest.kegg.jp/conv/ncbi-gi/hsa:10458+ece:Z5100")
         h.close()
 
     def test_conv_ncbi_gi_hsa_10458_list_ece_Z5100(self):
         h = kegg_conv("ncbi-gi", ["hsa:10458", "ece:Z5100"])
         h.read()
-        self.assertEqual(h.url, "http://rest.kegg.jp/conv/ncbi-gi/hsa:10458+ece:Z5100")
+        self.assertEqual(h.url,
+                         "http://rest.kegg.jp/conv/ncbi-gi/hsa:10458+ece:Z5100")
         h.close()
 
     def test_link_pathway_hsa(self):
@@ -236,13 +261,15 @@ class KEGGTests(unittest.TestCase):
     def test_pathway_hsa_10458_plus_ece_Z5100(self):
         h = kegg_link("pathway", "hsa:10458+ece:Z5100")
         h.read()
-        self.assertEqual(h.url, "http://rest.kegg.jp/link/pathway/hsa:10458+ece:Z5100")
+        self.assertEqual(h.url,
+                         "http://rest.kegg.jp/link/pathway/hsa:10458+ece:Z5100")
         h.close()
 
     def test_pathway_hsa_10458_list_ece_Z5100(self):
         h = kegg_link("pathway", ["hsa:10458", "ece:Z5100"])
         h.read()
-        self.assertEqual(h.url, "http://rest.kegg.jp/link/pathway/hsa:10458+ece:Z5100")
+        self.assertEqual(h.url,
+                         "http://rest.kegg.jp/link/pathway/hsa:10458+ece:Z5100")
         h.close()
 
 
@@ -250,8 +277,7 @@ class KGMLPathwayTests(unittest.TestCase):
     """Tests with metabolic maps."""
 
     def test_parse_remote_pathway(self):
-        """Download a KEGG pathway from the KEGG server and write KGML."""
-        # Download the KEGG ko03070 pathway as a filehandle
+        """Download a KEGG pathway from the KEGG server and parse KGML."""
         h = kegg_get("ko03070", "kgml")
         pathway = KGML_parser.read(h)
         self.assertEqual(pathway.name, "path:ko03070")


### PR DESCRIPTION
See issue #832.

Python 3 makes a distinction between string types (String and
Byte) that was not made in Python 2. This gave unintuitive results
with print() and SeqIO.read() in Python3. This short fix returns
String rather than Byte handles (as with Bio.Entrez), for all
requests through the KEGG REST API, other than those for image
data, which is still returned as a Byte handle.