### PR TITLE
Small changes to PDB/__init__.py to allow direct import of FastMMCIFParser

### DIFF
--- a/Bio/PDB/__init__.py
+++ b/Bio/PDB/__init__.py
@@ -14,12 +14,8 @@ Author: Thomas Hamelryck.  Additional code by Kristian Rother.
 # Get a Structure object from a PDB file
 from .PDBParser import PDBParser
 
-try:
-    # Get a Structure object from an mmCIF file
-    from .MMCIFParser import MMCIFParser
-except:
-    # Not compiled I guess
-    pass
+from .MMCIFParser import MMCIFParser
+from .MMCIFParser import FastMMCIFParser
 
 # Download from the PDB
 from .PDBList import PDBList


### PR DESCRIPTION
* Removed try/except from old mmCif parser
* Added explicit import of FastMMCIFParser

Only noticed this now. In my previous commit (and tests) there were some leftover files from a previous build that made me think everything was fine, when it was actually quite complicated to import the new parser..