### PR TITLE
Use HTTPS to access NCBI Entrez and QBLAST

### DIFF
--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -9,8 +9,7 @@
 """Code to invoke the NCBI BLAST server over the internet.
 
 This module provides code to work with the WWW version of BLAST
-provided by the NCBI.
-http://blast.ncbi.nlm.nih.gov/
+provided by the NCBI. https://blast.ncbi.nlm.nih.gov/
 """
 
 from __future__ import print_function
@@ -22,7 +21,7 @@ from Bio._py3k import urlencode as _urlencode
 from Bio._py3k import Request as _Request
 
 
-NCBI_BLAST_URL = "http://blast.ncbi.nlm.nih.gov/Blast.cgi"
+NCBI_BLAST_URL = "https://blast.ncbi.nlm.nih.gov/Blast.cgi"
 
 
 def qblast(program, database, sequence, url_base=NCBI_BLAST_URL,

--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -123,7 +123,7 @@ def epost(db, **keywds):
 
     Raises an IOError exception if there's a network error.
     """
-    cgi = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/epost.fcgi'
+    cgi = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/epost.fcgi'
     variables = {'db': db}
     variables.update(keywds)
     return _open(cgi, variables, post=True)
@@ -157,7 +157,7 @@ def efetch(db, **keywords):
     **Warning:** The NCBI changed the default retmode in Feb 2012, so many
     databases which previously returned text output now give XML.
     """
-    cgi = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi'
+    cgi = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi'
     variables = {'db': db}
     variables.update(keywords)
     post = False
@@ -209,7 +209,7 @@ def esearch(db, term, **keywds):
     True
 
     """
-    cgi = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi'
+    cgi = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi'
     variables = {'db': db,
                  'term': term}
     variables.update(keywds)
@@ -249,7 +249,7 @@ def elink(**keywds):
 
     This is explained in much more detail in the Biopython Tutorial.
     """
-    cgi = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi'
+    cgi = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi'
     variables = {}
     variables.update(keywds)
     return _open(cgi, variables)
@@ -277,7 +277,7 @@ def einfo(**keywds):
     True
 
     """
-    cgi = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi'
+    cgi = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi'
     variables = {}
     variables.update(keywds)
     return _open(cgi, variables)
@@ -309,7 +309,7 @@ def esummary(**keywds):
     Computational biology and chemistry
 
     """
-    cgi = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi'
+    cgi = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi'
     variables = {}
     variables.update(keywds)
     return _open(cgi, variables)
@@ -343,7 +343,7 @@ def egquery(**keywds):
     True
 
     """
-    cgi = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/egquery.fcgi'
+    cgi = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/egquery.fcgi'
     variables = {}
     variables.update(keywds)
     return _open(cgi, variables)
@@ -372,7 +372,7 @@ def espell(**keywds):
     biopython
 
     """
-    cgi = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/espell.fcgi'
+    cgi = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/espell.fcgi'
     variables = {}
     variables.update(keywds)
     return _open(cgi, variables)
@@ -420,7 +420,7 @@ def ecitmatch(**keywds):
     >>> record = Entrez.ecitmatch(db="pubmed", bdata=[citation_1])
     >>> print(record["Query"])
     """
-    cgi = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/ecitmatch.cgi'
+    cgi = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/ecitmatch.cgi'
     variables = _update_ecitmatch_variables(keywds)
     return _open(cgi, variables, ecitmatch=True)
 

--- a/NEWS
+++ b/NEWS
@@ -32,7 +32,7 @@ added to Bio.Data (and the translation functionality), and table 11 is now
 also available under the alias Archaeal.
 
 In line with NCBI website changes, Biopython now uses HTTPS rather than HTTP
-to connect to the NCBI Entrez API.
+to connect to the NCBI Entrez and QBLAST API.
 
 Additionally, a number of small bugs have been fixed with further additions
 to the test suite, and there has been further work to follow the Python PEP8

--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,9 @@ New NCBI genetic code table 26 (Pachysolen tannophilus Nuclear Code) has been
 added to Bio.Data (and the translation functionality), and table 11 is now
 also available under the alias Archaeal.
 
+In line with NCBI website changes, Biopython now uses HTTPS rather than HTTP
+to connect to the NCBI Entrez API.
+
 Additionally, a number of small bugs have been fixed with further additions
 to the test suite, and there has been further work to follow the Python PEP8
 and best practice standard coding style.

--- a/Tests/test_Entrez_online.py
+++ b/Tests/test_Entrez_online.py
@@ -35,7 +35,7 @@ if os.name == 'java':
 # This lets us set the email address to be sent to NCBI Entrez:
 Entrez.email = "biopython-dev@biopython.org"
 
-URL_HEAD = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
+URL_HEAD = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
 URL_TOOL = "tool=biopython"
 URL_EMAIL = "email=biopython-dev%40biopython.org"
 


### PR DESCRIPTION
See http://www.ncbi.nlm.nih.gov/mailman/pipermail/utilities-announce/2016-June/000104.html

As of 1 September 2016, the NCBI seem to be planning to automatically redirect HTTP connections to HTTPS. From initial testing HTTPS support is already live, so we can make the switch now.