### PR TITLE
Use tox under Travis to include pep8, sdist, etc checks

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -1,0 +1,94 @@
+# This is a configuration file for tox, used to test
+# Biopython on various versions of Python etc under
+# the Travis Continous Integration service which is
+# configured in the file .travis.yml
+#
+# By default tox will look for tox.ini, so this file
+# will not conflict with any personal tox setup.
+#
+# You can explicitly use this tox configuration on your
+# own machine (via the -c setting), PROVIDED you have
+# all the relevant versions of Python installed. e.g.
+# specifying a specific target envronment (via -e):
+#
+# $ pip install tox
+# $ tox -c .travis-tox.ini -e py35-nocov
+#
+# Or with test coverage:
+#
+# $ pip install tox coverage
+# $ tox -c .travis-tox.ini -e py35-cover
+#
+# Or to run the pep8 Python coding style checks:
+#
+# $ pip install tox pep8
+# $ tox -c .travis-tox.ini -e pep8
+#
+# See the envlist setting for other valid arguments.
+
+[tox]
+minversion = 2.0
+skipsdist = True
+envlist =
+    pep8
+    sdist
+    {py26,py27,py33,py34,py35,pypy,pypy3}-cover
+    {py26,py27,py33,py34,py35,pypy,pypy3}-nocov
+
+[testenv]
+# TODO: Try tox default sdist based install instead:
+skip_install = True
+sitepackages = True
+whitelist_externals =
+    bash
+    echo
+# Want to avoid overhead of compiling numpy or scipy:
+install_command = pip install --only-binary=numpy,scipy {opts} {packages}
+deps =
+    #Lines startings xxx: are filtered by the environment.
+    #Leaving py34 without any soft dependencies (just numpy)
+    cover: coverage
+    cover: codecov
+    py26: unittest2
+    {py26,py27}: mysql-python
+    {py26,py27,py33,py35}: mmtf-python
+    {py26,py27,py33,py35}: reportlab
+    {py26,py27,py33,py35}: psycopg2
+    {py26,py27,py33,py35,pypy}: mysql-connector-python-rf
+    {py26,py27,py33,py35,pypy}: rdflib
+    {py26,py27,py33,py34,py35}: numpy
+    {py26,py35}: scipy
+    py27: networkx
+    py35: matplotlib
+commands =
+    #The bash call is a work around for the pipe character
+    #The yes is in case we get our prompt about missing NumPy
+    #The /dev/null is to hide the verbose output but leave warnings
+    bash -c \'/usr/bin/yes | python setup.py install > /dev/null\'
+    #The bash call is a work around for the cd command
+    nocov: bash -c \'cd Tests && python run_tests.py --offline\'
+    #See https://codecov.io/ and https://github.com/codecov/example-python
+    cover: bash -c \'cd Tests && coverage run --source=Bio,BioSQL run_tests.py --offline\'
+    cover: codecov
+
+[testenv:pep8]
+# This does not need to install Biopython or any of its dependencies
+skip_install = True
+whitelist_externals =
+    pep8
+deps =
+    pep8
+commands =
+    pep8 --max-line-length 92 BioSQL/
+    pep8 --ignore E402 --max-line-length 90 Scripts/
+    pep8 --max-line-length 90 Doc/examples/
+    pep8 --ignore E122,E123,E126,E127,E128,E129,E501,E731 Bio/
+    pep8 --ignore E122,E123,E126,E127,E128,E241,E402,E501,E731 Tests/
+
+[testenv:sdist]
+# This does not need to install Biopython or any of its dependencies
+skip_install = True
+deps =
+commands =
+    python setup.py sdist --manifest-only
+    python setup.py sdist --formats=gztar,zip

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -32,6 +32,7 @@ skipsdist = True
 envlist =
     pep8
     sdist
+    bdist_wheel
     {py26,py27,py33,py34,py35,pypy,pypy3}-cover
     {py26,py27,py33,py34,py35,pypy,pypy3}-nocov
 
@@ -92,3 +93,11 @@ deps =
 commands =
     python setup.py sdist --manifest-only
     python setup.py sdist --formats=gztar,zip
+
+[testenv:bdist_wheel]
+# This should use NumPy while compiling our C code...
+skip_install = True
+deps =
+    numpy
+commands =
+    python setup.py bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,34 @@
 # Special configuration file to run tests on Travis-CI via GitHub notifications
 # See https://travis-ci.org/biopython/biopython/builds for results
 #
-# The tests are run via the coverage script, and if the tests pass the coverage
-# information is pushed to https://codecov.io/github/biopython/biopython
+# Using TravisCI's configuration alone became too complicated once we wanted
+# to cover more than just running the unit tests on different versions of
+# Python, so this now does all the complicated test configuration via TOX
+# See file .travis-tox.ini
 #
-# Note when testing Python 3, the 'python' command will invoke Python 3
-# and similarly for PyPy too.
-
-# Environment variables setup via the matrix
-# - DEP = list of python packages to install via default pip install
-# - COV = yes/no; should tests be run with coverage metric collection
-# - OPT = options to run_tests.py such as --offline
+# Environment variables setup here:
+# - TOXENV = environment used in Tox (conventionally uses py35 etc)
 #
-# Note we're explicitly allowing the online test targets to fail without
-# considering the whole test run to be a failure.
 
 language: python
 matrix:
   include:
-    - python: "2.6"
-      env: DEP="mmtf-python rdflib reportlab psycopg2 mysql-python mysql-connector-python-rf unittest2 scipy" COV="yes" OPT="--offline"
-    - python: "2.7"
-      env: DEP="mmtf-python rdflib reportlab psycopg2 mysql-python mysql-connector-python-rf networkx" COV="yes" OPT="--offline"
-    - python: "3.3"
-      env: DEP="mmtf-python psycopg2 mysql-connector-python-rf" COV="yes" OPT=""
-    - python: "3.4"
-      env: DEP="" COV="yes" OPT="--offline"
-    - python: "3.5"
-      env: DEP="mmtf-python rdflib reportlab psycopg2 mysql-connector-python-rf scipy matplotlib" COV="yes" OPT="--offline"
-    - python: "pypy"
-      env: DEP="rdflib mysql-connector-python-rf" COV="yes" OPT="--offline"
-    - python: "pypy3"
-      env: COV="no" OPT="--offline"
-  allow_failures:
-    - python: "3.3"
+    - env: TOXENV=pep8
+    - env: TOXENV=sdist
+    - python: 2.6
+      env: TOXENV=py26-cover
+    - python: 2.7
+      env: TOXENV=py27-cover
+    - python: 3.3
+      env: TOXENV=py33-cover
+    - python: 3.4
+      env: TOXENV=py34-cover
+    - python: 3.5
+      env: TOXENV=py35-cover
+    - python: pypy
+      env: TOXENV=pypy-cover
+    - python: pypy3
+      env: TOXENV=pypy3-nocov
 
 sudo: false
 addons:
@@ -49,30 +44,14 @@ addons:
     - samtools
     - wise
 
-before_install:
-  - "pip install --upgrade pip setuptools"
-  - "pip install --only-binary=numpy,scipy $DEP"
-  - "if [[ $COV == 'yes' ]]; then pip install coverage; fi"
-
-
 install:
-#The yes is in case we get our prompt about missing NumPy
-  - "/usr/bin/yes | python setup.py install"
-
-before_script:
-  - cd Tests
-  - cp biosql.ini.sample biosql.ini
+  - "cp Tests/biosql.ini.sample Tests/biosql.ini"
+  - "pip install --upgrade pip setuptools"
+  - "pip install tox"
+  - "tox -c .travis-tox.ini -e $TOXENV --notest"
 
 script:
-#Using just coverage should match up to the current Python version:
-  - "if [[ $COV == 'yes' ]]; then coverage run --source=Bio,BioSQL run_tests.py $OPT; fi"
-  - "if [[ $COV != 'yes' ]]; then python run_tests.py $OPT; fi"
+  - "tox -c .travis-tox.ini -e $TOXENV"
 
-after_success:
-#See https://codecov.io/ and https://github.com/codecov/example-python
-  - "if [[ $COV == 'yes' ]]; then pip install codecov; fi"
-  - "if [[ $COV == 'yes' ]]; then codecov; fi"
-
-#The email defaults are too talkative
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
   include:
     - env: TOXENV=pep8
     - env: TOXENV=sdist
+    - env: TOXENV=bdist_wheel
     - python: 2.6
       env: TOXENV=py26-cover
     - python: 2.7

--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -285,7 +285,7 @@ class DSSP(AbstractResiduePropertyMap):
         """
 
         self.residue_max_acc = residue_max_acc[acc_array]
-        
+
         # create DSSP dictionary
         dssp_dict, dssp_keys = dssp_dict_from_pdb_file(pdb_file, dssp)
         dssp_map = {}


### PR DESCRIPTION
This would close #840 by including a pep8 target on TravisCI (the exact options to the pep8 tool and those for the git pre-commit hook on #493 can be refined).

It also adds TravisCI targets to check ``python setup.py sdist --manifest-only`` and ``python setup.py sdist --formats=gztar,zip`` works (as used in our build process) which is how I came to commit d90f53b8ab91fcaf71679898f86bb649b969bd59 which was a regression from getting ``python setup.py bdist_wheel`` to run (which would also now be tested on TravisCI).

The new build targets (``pep8``, ``sdist``, and ``bdist_wheel``) are all quite quick (1.5 mins, 1 min, 1 min) and so do not unduly add to the TravisCI load compared to our main test suite.

Note I am deliberately avoiding using ``tox.ini`` in order to allow this to co-exist with any user's own Tox configuration on their own machine (see #50). We could explicitly add that to the ``.gitignore`` file?

CC @cbrueffer @tiagoantao @msabramo @bow 