### PR TITLE
Replacing SeqRecord .seq when have .letter_annotation

### DIFF
--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -292,19 +292,28 @@ class SeqRecord(object):
         >>> sub_record.letter_annotations = {}
         >>> sub_record.letter_annotations
         {}
+
+        Note that if replacing the record's sequence with a sequence of a
+        different length you must first clear the letter_annotations dict.
         """)
 
     def _set_seq(self, value):
         # TODO - Add a deprecation warning that the seq should be write only?
         if self._per_letter_annotations:
-            # TODO - Make this a warning? Silently empty the dictionary?
-            raise ValueError("You must empty the letter annotations first!")
-        self._seq = value
-        try:
-            self._per_letter_annotations = _RestrictedDict(length=len(self.seq))
-        except AttributeError:
-            # e.g. seq is None
-            self._per_letter_annotations = _RestrictedDict(length=0)
+            if len(self) != len(value):
+                # TODO - Make this a warning? Silently empty the dictionary?
+                raise ValueError("You must empty the letter annotations first!")
+            else:
+                # Leave the existing per letter annotations unchanged:
+                self._seq = value
+        else:
+            self._seq = value
+            # Reset the (empty) letter annotations dict with new length:
+            try:
+                self._per_letter_annotations = _RestrictedDict(length=len(self.seq))
+            except AttributeError:
+                # e.g. seq is None
+                self._per_letter_annotations = _RestrictedDict(length=0)
 
     seq = property(fget=lambda self: self._seq,
                    fset=_set_seq,

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -1,4 +1,4 @@
-# Copyright 2009 by Peter Cock.  All rights reserved.
+# Copyright 2009-2016 by Peter Cock.  All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
@@ -71,6 +71,23 @@ class SeqRecordCreation(unittest.TestCase):
             self.fail("Wrong length letter_annotations should fail!")
         except (TypeError, ValueError) as e:
             pass
+
+    def test_replacing_seq(self):
+        """Replacing .seq if .letter_annotation present."""
+        rec = SeqRecord(Seq("ACGT", generic_dna),
+                        id="Test", name="Test", description="Test",
+                        letter_annotations={"example": [1, 2, 3, 4]})
+        try:
+            rec.seq = Seq("ACGTACGT", generic_dna)
+            self.fail("Changing .seq length with letter_annotations present should fail!")
+        except ValueError as e:
+            self.assertEqual(str(e), "You must empty the letter annotations first!")
+        # Check we can replace IF the length is the same
+        self.assertEqual(str(rec.seq), "ACGT")
+        self.assertEqual(rec.letter_annotations, {"example": [1, 2, 3, 4]})
+        rec.seq = Seq("NNNN", generic_dna)
+        self.assertEqual(str(rec.seq), "NNNN")
+        self.assertEqual(rec.letter_annotations, {"example": [1, 2, 3, 4]})
 
     def test_valid_id(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
In the special case where the new sequence is the same length, and there was per-letter-annotation, rather than a ``ValueError`` allow the sequence to be replaced and preserve the existing per-letter-annotation.

This should resolve #880 - could you test this @mmokrejs please?