### PR TITLE
README: drop 2.6 from list of supported Python versions

### DIFF
--- a/README
+++ b/README
@@ -57,7 +57,7 @@ We currently recommend using Python 3.5 from http://www.python.org
 Biopython is currently supported and tested on the following Python
 implementations:
 
-- Python 2.6, 2.7, 3.3, 3.4, 3.5 -- see http://www.python.org
+- Python 2.7, 3.3, 3.4, 3.5 -- see http://www.python.org
 
   This is the primary development platform for Biopython.
 


### PR DESCRIPTION
As stated in the News, the next version of Biopython 1.69 will not support
Python 2.6.

This version has also been removed from the Travis configuration file.
So maybe is good to remove it from the README as well.