### PR TITLE
remove importing unittest2 needed for python2.6

### DIFF
--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -8,16 +8,7 @@
 Initially this takes matched tests of GenBank and FASTA files from the NCBI
 and confirms they are consistent using our different parsers.
 """
-import sys
-# Remove unittest2 import after dropping support for Python2.6
-if sys.version_info < (2, 7):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        from Bio import MissingPythonDependencyError
-        raise MissingPythonDependencyError("Under Python 2.6 this test needs the unittest2 library")
-else:
-    import unittest
+import unittest
 
 from Bio import SeqIO
 from Bio.Alphabet import generic_dna, generic_protein

--- a/Tests/test_pairwise2.py
+++ b/Tests/test_pairwise2.py
@@ -3,22 +3,11 @@
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
-
-# Remove unittest2 import after dropping support for Python2.6
-import sys
+import unittest
 
 from Bio import pairwise2
 from Bio.SubsMat.MatrixInfo import blosum62
 
-if sys.version_info < (2, 7):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        from Bio import MissingPythonDependencyError
-        raise MissingPythonDependencyError("Under Python 2.6 this test needs "
-                                           "the unittest2 library")
-else:
-    import unittest
 
 
 class TestPairwiseErrorConditions(unittest.TestCase):

--- a/Tests/test_pairwise2.py
+++ b/Tests/test_pairwise2.py
@@ -9,7 +9,6 @@ from Bio import pairwise2
 from Bio.SubsMat.MatrixInfo import blosum62
 
 
-
 class TestPairwiseErrorConditions(unittest.TestCase):
     """Test several error conditions"""
 

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -6,17 +6,8 @@ from __future__ import print_function
 import array
 import copy
 import sys
+import unittest
 import warnings
-
-# Remove unittest2 import after dropping support for Python2.6
-if sys.version_info < (2, 7):
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        from Bio import MissingPythonDependencyError
-        raise MissingPythonDependencyError("Under Python 2.6 this test needs the unittest2 library")
-else:
-    import unittest
 
 from Bio import Alphabet
 from Bio import Seq


### PR DESCRIPTION
We don't need to import unittest2 (needed for Python2.6) in tests as the new Biopython version will drop support for this version.