### PR TITLE
Add 'complement' as Seq method, add tests and do PEP8

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2192,7 +2192,8 @@ def reverse_complement(sequence):
     """Returns the reverse complement sequence of a nucleotide string.
 
     If given a string, returns a new string object.
-    Given a Seq or a MutableSeq, returns a new Seq object with the same alphabet.
+    Given a Seq or a MutableSeq, returns a new Seq object with the same
+    alphabet.
 
     Supports unambiguous and ambiguous nucleotide sequences.
 
@@ -2201,17 +2202,36 @@ def reverse_complement(sequence):
     >>> reverse_complement("ACTG-NH")
     'DN-CAGT'
     """
+    return complement(sequence)[::-1]
+
+
+def complement(sequence):
+    """Returns the complement sequence of a nucleotide string.
+
+    If given a string, returns a new string object.
+    Given a Seq or a MutableSeq, returns a new Seq object with the same
+    alphabet.
+
+    Supports unambiguous and ambiguous nucleotide sequences.
+
+    e.g.
+
+    >>> complement("ACTG-NH")
+    'TGAC-ND'
+    """
     if isinstance(sequence, Seq):
         # Return a Seq
-        return sequence.reverse_complement()
+        return sequence.complement()
     elif isinstance(sequence, MutableSeq):
         # Return a Seq
-        # Don't use the MutableSeq reverse_complement method as it is 'in place'.
-        return sequence.toseq().reverse_complement()
+        # Don't use the MutableSeq reverse_complement method as it is
+        # 'in place'.
+        return sequence.toseq().complement()
 
     # Assume its a string.
-    # In order to avoid some code duplication, the old code would turn the string
-    # into a Seq, use the reverse_complement method, and convert back to a string.
+    # In order to avoid some code duplication, the old code would turn the
+    # string into a Seq, use the reverse_complement method, and convert back
+    # to a string.
     # This worked, but is over five times slower on short sequences!
     if ('U' in sequence or 'u' in sequence) \
             and ('T' in sequence or 't' in sequence):
@@ -2220,7 +2240,7 @@ def reverse_complement(sequence):
         ttable = _rna_complement_table
     else:
         ttable = _dna_complement_table
-    return sequence.translate(ttable)[::-1]
+    return sequence.translate(ttable)
 
 
 def _test():

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -28,7 +28,8 @@ from Bio._py3k import basestring
 from Bio import BiopythonWarning
 from Bio import Alphabet
 from Bio.Alphabet import IUPAC
-from Bio.Data.IUPACData import ambiguous_dna_complement, ambiguous_rna_complement
+from Bio.Data.IUPACData import (ambiguous_dna_complement,
+                                ambiguous_rna_complement)
 from Bio.Data import CodonTable
 
 
@@ -84,7 +85,8 @@ class Seq(object):
 
         Arguments:
             - seq - Sequence, required (string)
-            - alphabet - Optional argument, an Alphabet object from Bio.Alphabet
+            - alphabet - Optional argument, an Alphabet object from
+              Bio.Alphabet
 
         You will typically use Bio.SeqIO to read in sequences from files as
         SeqRecord objects, whose sequence will be exposed as a Seq object via
@@ -111,10 +113,10 @@ class Seq(object):
         self.alphabet = alphabet  # Seq API requirement
 
     def __repr__(self):
-        """Returns a (truncated) representation of the sequence for debugging."""
+        """Return (truncated) representation of the sequence for debugging."""
         if len(self) > 60:
-            # Shows the last three letters as it is often useful to see if there
-            # is a stop codon at the end of a sequence.
+            # Shows the last three letters as it is often useful to see if
+            # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
             return "{0}('{1}...{2}', {3!r})".format(self.__class__.__name__,
                                                     str(self)[:54],
@@ -195,7 +197,7 @@ class Seq(object):
 
     def __ne__(self, other):
         """Not equal, see __eq__ documentation."""
-        # Seem to require this method under Python 2 but not needed on Python 3?
+        # Seem to require this method for Python 2 but not needed on Python 3?
         return not (self == other)
 
     def __lt__(self, other):
@@ -220,9 +222,9 @@ class Seq(object):
 
     def __len__(self):
         """Returns the length of the sequence, use len(my_seq)."""
-        return len(self._data)       # Seq API requirement
+        return len(self._data)  # Seq API requirement
 
-    def __getitem__(self, index):                 # Seq API requirement
+    def __getitem__(self, index):  # Seq API requirement
         """Returns a subsequence of single letter, use my_seq[index]."""
         # Note since Python 2.0, __getslice__ is deprecated
         # and __getitem__ is used instead.
@@ -288,8 +290,9 @@ class Seq(object):
             # other should be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet,
                                                     other.alphabet]):
-                raise TypeError("Incompatible alphabets {0!r} and {1!r}".format(
-                                self.alphabet, other.alphabet))
+                raise TypeError(
+                    "Incompatible alphabets {0!r} and {1!r}".format(
+                        self.alphabet, other.alphabet))
             # They should be the same sequence type (or one of them is generic)
             a = Alphabet._consensus_alphabet([self.alphabet, other.alphabet])
             return self.__class__(str(self) + str(other), a)
@@ -319,8 +322,9 @@ class Seq(object):
             # other should be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet,
                                                     other.alphabet]):
-                raise TypeError("Incompatible alphabets {0!r} and {1!r}".format(
-                                self.alphabet, other.alphabet))
+                raise TypeError(
+                    "Incompatible alphabets {0!r} and {1!r}".format(
+                        self.alphabet, other.alphabet))
             # They should be the same sequence type (or one of them is generic)
             a = Alphabet._consensus_alphabet([self.alphabet, other.alphabet])
             return self.__class__(str(other) + str(self), a)
@@ -330,7 +334,7 @@ class Seq(object):
         else:
             raise TypeError
 
-    def tostring(self):                            # Seq API requirement
+    def tostring(self):  # Seq API requirement
         """Returns the full sequence as a python string (DEPRECATED).
 
         You are now encouraged to use str(my_seq) instead of
@@ -341,7 +345,7 @@ class Seq(object):
                       BiopythonDeprecationWarning)
         return str(self)
 
-    def tomutable(self):   # Needed?  Or use a function?
+    def tomutable(self):  # Needed?  Or use a function?
         """Returns the full sequence as a MutableSeq object.
 
         >>> from Bio.Seq import Seq
@@ -588,15 +592,22 @@ class Seq(object):
         >>> my_aa = my_rna.translate()
         >>> my_aa
         Seq('VMAIVMGR*KGAR*L', HasStopCodon(ExtendedIUPACProtein(), '*'))
-        >>> my_aa.split("*")
-        [Seq('VMAIVMGR', HasStopCodon(ExtendedIUPACProtein(), '*')), Seq('KGAR', HasStopCodon(ExtendedIUPACProtein(), '*')), Seq('L', HasStopCodon(ExtendedIUPACProtein(), '*'))]
-        >>> my_aa.split("*", 1)
-        [Seq('VMAIVMGR', HasStopCodon(ExtendedIUPACProtein(), '*')), Seq('KGAR*L', HasStopCodon(ExtendedIUPACProtein(), '*'))]
+        >>> for pep in my_aa.split("*"):
+        ...     pep
+        Seq('VMAIVMGR', HasStopCodon(ExtendedIUPACProtein(), '*'))
+        Seq('KGAR', HasStopCodon(ExtendedIUPACProtein(), '*'))
+        Seq('L', HasStopCodon(ExtendedIUPACProtein(), '*'))
+        >>> for pep in my_aa.split("*", 1):
+        ...     pep
+        Seq('VMAIVMGR', HasStopCodon(ExtendedIUPACProtein(), '*'))
+        Seq('KGAR*L', HasStopCodon(ExtendedIUPACProtein(), '*'))
 
         See also the rsplit method:
 
-        >>> my_aa.rsplit("*", 1)
-        [Seq('VMAIVMGR*KGAR', HasStopCodon(ExtendedIUPACProtein(), '*')), Seq('L', HasStopCodon(ExtendedIUPACProtein(), '*'))]
+        >>> for pep in my_aa.rsplit("*", 1):
+        ...     pep
+        Seq('VMAIVMGR*KGAR', HasStopCodon(ExtendedIUPACProtein(), '*'))
+        Seq('L', HasStopCodon(ExtendedIUPACProtein(), '*'))
         """
         # If it has one, check the alphabet:
         sep_str = self._get_seq_str_and_check_alphabet(sep)
@@ -707,13 +718,15 @@ class Seq(object):
     def lower(self):
         """Returns a lower case copy of the sequence.
 
-        This will adjust the alphabet if required. Note that the IUPAC alphabets
-        are upper case only, and thus a generic alphabet must be substituted.
+        This will adjust the alphabet if required. Note that the IUPAC
+        alphabets are upper case only, and thus a generic alphabet must be
+        substituted.
 
         >>> from Bio.Alphabet import Gapped, generic_dna
         >>> from Bio.Alphabet import IUPAC
         >>> from Bio.Seq import Seq
-        >>> my_seq = Seq("CGGTACGCTTATGTCACGTAG*AAAAAA", Gapped(IUPAC.unambiguous_dna, "*"))
+        >>> my_seq = Seq("CGGTACGCTTATGTCACGTAG*AAAAAA",
+        ...          Gapped(IUPAC.unambiguous_dna, "*"))
         >>> my_seq
         Seq('CGGTACGCTTATGTCACGTAG*AAAAAA', Gapped(IUPACUnambiguousDNA(), '*'))
         >>> my_seq.lower()
@@ -770,8 +783,8 @@ class Seq(object):
             ttable = _rna_complement_table
         else:
             ttable = _dna_complement_table
-        # Much faster on really long sequences than the previous loop based one.
-        # thx to Michael Palmer, University of Waterloo
+        # Much faster on really long sequences than the previous loop based
+        # one. Thanks to Michael Palmer, University of Waterloo.
         return Seq(str(self).translate(ttable), self.alphabet)
 
     def reverse_complement(self):
@@ -891,14 +904,13 @@ class Seq(object):
               (string), an NCBI identifier (integer), or a CodonTable
               object (useful for non-standard genetic codes).  This
               defaults to the "Standard" table.
-            - stop_symbol - Single character string, what to use for terminators.
-              This defaults to the asterisk, "*".
-            - to_stop - Boolean, defaults to False meaning do a full translation
-              continuing on past any stop codons (translated as the
-              specified stop_symbol).  If True, translation is
-              terminated at the first in frame stop codon (and the
-              stop_symbol is not appended to the returned protein
-              sequence).
+            - stop_symbol - Single character string, what to use for
+              terminators.  This defaults to the asterisk, "*".
+            - to_stop - Boolean, defaults to False meaning do a full
+              translation continuing on past any stop codons (translated as the
+              specified stop_symbol).  If True, translation is terminated at
+              the first in frame stop codon (and the stop_symbol is not
+              appended to the returned protein sequence).
             - cds - Boolean, indicates this is a complete CDS.  If True,
               this checks the sequence starts with a valid alternative start
               codon (which will be translated as methionine, M), that the
@@ -932,8 +944,8 @@ class Seq(object):
         >>> coding_dna.translate(table=2, cds=True)
         Seq('MAIVMGRWKGAR', ExtendedIUPACProtein())
 
-        It isn't a valid CDS under NCBI table 1, due to both the start codon and
-        also the in frame stop codons:
+        It isn't a valid CDS under NCBI table 1, due to both the start codon
+        and also the in frame stop codons:
 
         >>> coding_dna.translate(table=1, cds=True)
         Traceback (most recent call last):
@@ -1018,8 +1030,9 @@ class Seq(object):
             if not gap:
                 gap = self.alphabet.gap_char
             elif gap != self.alphabet.gap_char:
-                raise ValueError("Gap {0!r} does not match {1!r} from alphabet".format(
-                    gap, self.alphabet.gap_char))
+                raise ValueError(
+                    "Gap {0!r} does not match {1!r} from alphabet".format(
+                        gap, self.alphabet.gap_char))
 
         protein = _translate_str(str(self), codon_table, stop_symbol, to_stop,
                                  cds, gap=gap)
@@ -1049,8 +1062,9 @@ class Seq(object):
         Seq('ATATGAAATTTGAAAA', DNAAlphabet())
 
         If the gap character is not given as an argument, it will be taken from
-        the sequence's alphabet (if defined). Notice that the returned sequence's
-        alphabet is adjusted since it no longer requires a gapped alphabet:
+        the sequence's alphabet (if defined). Notice that the returned
+        sequence's alphabet is adjusted since it no longer requires a gapped
+        alphabet:
 
         >>> from Bio.Seq import Seq
         >>> from Bio.Alphabet import IUPAC, Gapped, HasStopCodon
@@ -1070,8 +1084,9 @@ class Seq(object):
         >>> my_seq.ungap()
         Seq('CGGGTAGAAAAAA', IUPACUnambiguousDNA())
 
-        As long as it is consistent with the alphabet, although it is redundant,
-        you can still supply the gap character as an argument to this method:
+        As long as it is consistent with the alphabet, although it is
+        redundant, you can still supply the gap character as an argument to
+        this method:
 
         >>> my_seq
         Seq('CGGGTAG=AAAAAA', Gapped(IUPACUnambiguousDNA(), '='))
@@ -1106,11 +1121,13 @@ class Seq(object):
             if not gap:
                 gap = self.alphabet.gap_char
             elif gap != self.alphabet.gap_char:
-                raise ValueError("Gap {0!r} does not match {1!r} from alphabet".format(
-                                 gap, self.alphabet.gap_char))
+                raise ValueError(
+                    "Gap {0!r} does not match {1!r} from alphabet".format(
+                        gap, self.alphabet.gap_char))
             alpha = Alphabet._ungap(self.alphabet)
         elif not gap:
-            raise ValueError("Gap character not given and not defined in alphabet")
+            raise ValueError("Gap character not given and not defined in "
+                             "alphabet")
         else:
             alpha = self.alphabet  # modify!
         if len(gap) != 1 or not isinstance(gap, str):
@@ -1169,7 +1186,8 @@ class UnknownSeq(Seq):
     >>> known_seq + unk_four
     Seq('ACGT????', Alphabet())
     """
-    def __init__(self, length, alphabet=Alphabet.generic_alphabet, character=None):
+    def __init__(self, length, alphabet=Alphabet.generic_alphabet,
+                 character=None):
         """Create a new UnknownSeq object.
 
         If character is omitted, it is determined from the alphabet, "N" for
@@ -1182,7 +1200,8 @@ class UnknownSeq(Seq):
         self.alphabet = alphabet
         if character:
             if len(character) != 1:
-                raise ValueError("character argument should be a single letter string.")
+                raise ValueError("character argument should be a single "
+                                 "letter string.")
             self._character = character
         else:
             base = Alphabet._get_base_alphabet(alphabet)
@@ -1235,7 +1254,8 @@ class UnknownSeq(Seq):
         >>> UnknownSeq(5, generic_protein) + "LV"
         Seq('XXXXXLV', ProteinAlphabet())
         """
-        if isinstance(other, UnknownSeq) and other._character == self._character:
+        if isinstance(other, UnknownSeq) and \
+           other._character == self._character:
             # TODO - Check the alphabets match
             return UnknownSeq(len(self) + len(other),
                               self.alphabet, self._character)
@@ -1437,7 +1457,8 @@ class UnknownSeq(Seq):
 
         This will adjust the alphabet if required. See also the lower method.
         """
-        return UnknownSeq(self._length, self.alphabet._upper(), self._character.upper())
+        return UnknownSeq(self._length, self.alphabet._upper(),
+                          self._character.upper())
 
     def lower(self):
         """Returns a lower case copy of the sequence.
@@ -1458,7 +1479,8 @@ class UnknownSeq(Seq):
 
         See also the upper method.
         """
-        return UnknownSeq(self._length, self.alphabet._lower(), self._character.lower())
+        return UnknownSeq(self._length, self.alphabet._lower(),
+                          self._character.lower())
 
     def translate(self, **kwargs):
         """Translate an unknown nucleotide sequence into an unknown protein.
@@ -1569,10 +1591,10 @@ class MutableSeq(object):
         self.alphabet = alphabet
 
     def __repr__(self):
-        """Returns a (truncated) representation of the sequence for debugging."""
+        """Return (truncated) representation of the sequence for debugging."""
         if len(self) > 60:
-            # Shows the last three letters as it is often useful to see if there
-            # is a stop codon at the end of a sequence.
+            # Shows the last three letters as it is often useful to see if
+            # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
             return "{0}('{1}...{2}', {3!r})".format(self.__class__.__name__,
                                                     str(self[:54]),
@@ -1638,7 +1660,7 @@ class MutableSeq(object):
 
     def __ne__(self, other):
         """Not equal, see __eq__ documentation."""
-        # Seem to require this method under Python 2 but not needed on Python 3?
+        # Seem to require this method for Python 2 but not needed on Python 3?
         return not (self == other)
 
     def __lt__(self, other):
@@ -1712,8 +1734,9 @@ class MutableSeq(object):
             # other should be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet,
                                                     other.alphabet]):
-                raise TypeError("Incompatible alphabets {0!r} and {1!r}".format(
-                                self.alphabet, other.alphabet))
+                raise TypeError(
+                    "Incompatible alphabets {0!r} and {1!r}".format(
+                        self.alphabet, other.alphabet))
             # They should be the same sequence type (or one of them is generic)
             a = Alphabet._consensus_alphabet([self.alphabet, other.alphabet])
             if isinstance(other, MutableSeq):
@@ -1733,8 +1756,9 @@ class MutableSeq(object):
             # other should be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet,
                                                     other.alphabet]):
-                raise TypeError("Incompatible alphabets {0!r} and {1!r}".format(
-                                self.alphabet, other.alphabet))
+                raise TypeError(
+                    "Incompatible alphabets {0!r} and {1!r}".format(
+                        self.alphabet, other.alphabet))
             # They should be the same sequence type (or one of them is generic)
             a = Alphabet._consensus_alphabet([self.alphabet, other.alphabet])
             if isinstance(other, MutableSeq):
@@ -2071,9 +2095,11 @@ def _translate_str(sequence, table, stop_symbol="*", to_stop=False,
                       BiopythonWarning)
     if gap is not None:
         if not isinstance(gap, basestring):
-            raise TypeError("Gap character should be a single character string.")
+            raise TypeError("Gap character should be a single character "
+                            "string.")
         elif len(gap) > 1:
-            raise ValueError("Gap character should be a single character string.")
+            raise ValueError("Gap character should be a single character "
+                             "string.")
 
     for i in range(0, n - n % 3, 3):
         codon = sequence[i:i + 3]
@@ -2107,9 +2133,9 @@ def translate(sequence, table="Standard", stop_symbol="*", to_stop=False,
     MutableSeq, returns a Seq object with a protein alphabet.
 
     Arguments:
-        - table - Which codon table to use?  This can be either a name (string),
-          an NCBI identifier (integer), or a CodonTable object (useful
-          for non-standard genetic codes).  Defaults to the "Standard"
+        - table - Which codon table to use?  This can be either a name
+          (string), an NCBI identifier (integer), or a CodonTable object
+          (useful for non-standard genetic codes).  Defaults to the "Standard"
           table.
         - stop_symbol - Single character string, what to use for any
           terminators, defaults to the asterisk, "*".
@@ -2146,9 +2172,9 @@ def translate(sequence, table="Standard", stop_symbol="*", to_stop=False,
     >>> translate(coding_dna, table=2, to_stop=True)
     'VAIVMGRWKGAR'
 
-    In fact this example uses an alternative start codon valid under NCBI table 2,
-    GTG, which means this example is a complete valid CDS which when translated
-    should really start with methionine (not valine):
+    In fact this example uses an alternative start codon valid under NCBI
+    table 2, GTG, which means this example is a complete valid CDS which
+    when translated should really start with methionine (not valine):
 
     >>> translate(coding_dna, table=2, cds=True)
     'MAIVMGRWKGAR'

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -12,10 +12,10 @@ import warnings
 from Bio import Alphabet
 from Bio import Seq
 from Bio.Alphabet import IUPAC, Gapped
-from Bio.Data.IUPACData import ambiguous_dna_complement, ambiguous_rna_complement
-from Bio.Data.IUPACData import ambiguous_dna_values, ambiguous_rna_values
-from Bio.Data.CodonTable import TranslationError
-from Bio.Data.CodonTable import standard_dna_table
+from Bio.Data.IUPACData import (ambiguous_dna_complement,
+                                ambiguous_rna_complement,
+                                ambiguous_dna_values, ambiguous_rna_values)
+from Bio.Data.CodonTable import TranslationError, standard_dna_table
 from Bio.Seq import MutableSeq
 
 
@@ -55,11 +55,20 @@ protein_seqs = [
     Seq.Seq("ATCGPK", IUPAC.protein),
     Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, ".")),
     Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-")),
-    Seq.Seq("MEDG-KRXR*", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
-    Seq.MutableSeq("ME-K-DRXR*XU", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
-    Seq.Seq("MEDG-KRXR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"), "@")),
-    Seq.Seq("ME-KR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"), "@")),
-    Seq.Seq("MEDG.KRXR@", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "@"), ".")),
+    Seq.Seq("MEDG-KRXR*",
+            Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"),
+                            "-")),
+    Seq.MutableSeq("ME-K-DRXR*XU",
+                   Alphabet.Gapped(Alphabet.HasStopCodon(
+                       IUPAC.extended_protein, "*"), "-")),
+    Seq.Seq("MEDG-KRXR@",
+            Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"),
+                                  "@")),
+    Seq.Seq("ME-KR@",
+            Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"), "@")),
+    Seq.Seq("MEDG.KRXR@",
+            Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "@"),
+                            ".")),
 ]
 
 
@@ -83,7 +92,8 @@ class TestSeq(unittest.TestCase):
 
     def test_truncated_repr(self):
         seq = "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGA"
-        expected = "Seq('TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATG...GGA', IUPACAmbiguousDNA())"
+        expected = "Seq('TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGC" + \
+                   "ATCATG...GGA', IUPACAmbiguousDNA())"
         self.assertEqual(expected, repr(Seq.Seq(seq, IUPAC.ambiguous_dna)))
 
     def test_length(self):
@@ -169,7 +179,8 @@ class TestSeqStringMethods(unittest.TestCase):
             Seq.Seq("AUUUCG", IUPAC.ambiguous_rna),
             Seq.MutableSeq("AUUCG", IUPAC.ambiguous_rna),
             Seq.Seq("uCAg", Alphabet.generic_rna),
-            Seq.MutableSeq("UC-AG", Alphabet.Gapped(Alphabet.generic_rna, "-")),
+            Seq.MutableSeq("UC-AG",
+                           Alphabet.Gapped(Alphabet.generic_rna, "-")),
             Seq.Seq("U.CAG", Alphabet.Gapped(Alphabet.generic_rna, ".")),
         ]
         self.nuc = [Seq.Seq("ATCG", Alphabet.generic_nucleotide)]
@@ -178,11 +189,23 @@ class TestSeqStringMethods(unittest.TestCase):
             Seq.Seq("atcGPK", Alphabet.generic_protein),
             Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, ".")),
             Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-")),
-            Seq.Seq("MEDG-KRXR*", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
-            Seq.MutableSeq("ME-K-DRXR*XU", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
-            Seq.Seq("MEDG-KRXR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"), "@")),
-            Seq.Seq("ME-KR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"), "@")),
-            Seq.Seq("MEDG.KRXR@", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "@"), ".")),
+            Seq.Seq("MEDG-KRXR*",
+                    Alphabet.Gapped(
+                        Alphabet.HasStopCodon(IUPAC.extended_protein, "*"),
+                        "-")),
+            Seq.MutableSeq("ME-K-DRXR*XU",
+                           Alphabet.Gapped(
+                               Alphabet.HasStopCodon(IUPAC.extended_protein,
+                                                     "*"), "-")),
+            Seq.Seq("MEDG-KRXR@",
+                    Alphabet.HasStopCodon(
+                        Alphabet.Gapped(IUPAC.extended_protein, "-"), "@")),
+            Seq.Seq("ME-KR@",
+                    Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"),
+                                          "@")),
+            Seq.Seq("MEDG.KRXR@",
+                    Alphabet.Gapped(Alphabet.HasStopCodon(
+                        IUPAC.extended_protein, "@"), ".")),
         ]
         self.test_chars = ["-", Seq.Seq("-"), Seq.Seq("*"), "-X@"]
 
@@ -202,7 +225,8 @@ class TestSeqStringMethods(unittest.TestCase):
     def test_equal_comparison_of_incompatible_alphabets(self):
         """Test __eq__ comparison method"""
         with warnings.catch_warnings(record=True):
-            Seq.Seq("TCAAAA", IUPAC.ambiguous_dna) == Seq.Seq("TCAAAA", IUPAC.ambiguous_rna)
+            Seq.Seq("TCAAAA", IUPAC.ambiguous_dna) == \
+                              Seq.Seq("TCAAAA", IUPAC.ambiguous_rna)
 
     def test_not_equal_comparsion(self):
         """Test __ne__ comparison method"""
@@ -228,7 +252,8 @@ class TestSeqStringMethods(unittest.TestCase):
             self.s + dict()
 
     def test_radd_method(self):
-        self.assertEqual("TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG", str(self.s.__radd__(self.s)))
+        self.assertEqual("TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG",
+                         str(self.s.__radd__(self.s)))
 
     def test_radd_method_using_incompatible_alphabets(self):
         rna_seq = Seq.Seq("UCAAAA", IUPAC.ambiguous_rna)
@@ -263,8 +288,11 @@ class TestSeqStringMethods(unittest.TestCase):
 
     def test_append_proteins(self):
         self.test_chars.append(Seq.Seq("K", Alphabet.generic_protein))
-        self.test_chars.append(Seq.Seq("K-", Alphabet.Gapped(Alphabet.generic_protein, "-")))
-        self.test_chars.append(Seq.Seq("K@", Alphabet.Gapped(IUPAC.protein, "@")))
+        self.test_chars.append(Seq.Seq("K-",
+                                       Alphabet.Gapped(
+                                           Alphabet.generic_protein, "-")))
+        self.test_chars.append(Seq.Seq("K@",
+                                       Alphabet.Gapped(IUPAC.protein, "@")))
 
         self.assertEqual(7, len(self.test_chars))
 
@@ -281,9 +309,12 @@ class TestSeqStringMethods(unittest.TestCase):
             for char in self.test_chars:
                 str_char = str(char)
                 if isinstance(a, Seq.Seq):
-                    self.assertEqual(str(a.strip(char)), str(a).strip(str_char))
-                    self.assertEqual(str(a.lstrip(char)), str(a).lstrip(str_char))
-                    self.assertEqual(str(a.rstrip(char)), str(a).rstrip(str_char))
+                    self.assertEqual(str(a.strip(char)),
+                                     str(a).strip(str_char))
+                    self.assertEqual(str(a.lstrip(char)),
+                                     str(a).lstrip(str_char))
+                    self.assertEqual(str(a.rstrip(char)),
+                                     str(a).rstrip(str_char))
 
     def test_finding_characters(self):
         for a in self.dna + self.rna + self.nuc + self.protein:
@@ -291,9 +322,11 @@ class TestSeqStringMethods(unittest.TestCase):
                 str_char = str(char)
                 if isinstance(a, Seq.Seq):
                     self.assertEqual(a.find(char), str(a).find(str_char))
-                    self.assertEqual(a.find(char, 2, -2), str(a).find(str_char, 2, -2))
+                    self.assertEqual(a.find(char, 2, -2),
+                                     str(a).find(str_char, 2, -2))
                     self.assertEqual(a.rfind(char), str(a).rfind(str_char))
-                    self.assertEqual(a.rfind(char, 2, -2), str(a).rfind(str_char, 2, -2))
+                    self.assertEqual(a.rfind(char, 2, -2),
+                                     str(a).rfind(str_char, 2, -2))
 
     def test_counting_characters(self):
         for a in self.dna + self.rna + self.nuc + self.protein:
@@ -301,7 +334,8 @@ class TestSeqStringMethods(unittest.TestCase):
                 str_char = str(char)
                 if isinstance(a, Seq.Seq):
                     self.assertEqual(a.count(char), str(a).count(str_char))
-                    self.assertEqual(a.count(char, 2, -2), str(a).count(str_char, 2, -2))
+                    self.assertEqual(a.count(char, 2, -2),
+                                     str(a).count(str_char, 2, -2))
 
     def test_splits(self):
         for a in self.dna + self.rna + self.nuc + self.protein:
@@ -314,8 +348,9 @@ class TestSeqStringMethods(unittest.TestCase):
                                      str(a).rsplit(str_char))
 
                     for max_sep in [0, 1, 2, 999]:
-                        self.assertEqual([str(x) for x in a.split(char, max_sep)],
-                                         str(a).split(str_char, max_sep))
+                        self.assertEqual(
+                            [str(x) for x in a.split(char, max_sep)],
+                            str(a).split(str_char, max_sep))
 
 
 class TestSeqAddition(unittest.TestCase):
@@ -331,8 +366,10 @@ class TestSeqAddition(unittest.TestCase):
             Seq.Seq("AUUUCG", IUPAC.ambiguous_rna),
             Seq.MutableSeq("AUUCG", IUPAC.ambiguous_rna),
             Seq.Seq("uCAg", Alphabet.generic_rna),
-            Seq.MutableSeq("UC-AG", Alphabet.Gapped(Alphabet.generic_rna, "-")),
-            Seq.Seq("U.CAG", Alphabet.Gapped(Alphabet.generic_rna, ".")),
+            Seq.MutableSeq("UC-AG",
+                           Alphabet.Gapped(Alphabet.generic_rna, "-")),
+            Seq.Seq("U.CAG",
+                    Alphabet.Gapped(Alphabet.generic_rna, ".")),
             "UGCAU",
         ]
         self.nuc = [
@@ -344,8 +381,12 @@ class TestSeqAddition(unittest.TestCase):
             Seq.Seq("atcGPK", Alphabet.generic_protein),
             Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, ".")),
             Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-")),
-            Seq.Seq("MEDG-KRXR*", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
-            Seq.MutableSeq("ME-K-DRXR*XU", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-")),
+            Seq.Seq("MEDG-KRXR*",
+                    Alphabet.Gapped(Alphabet.HasStopCodon(
+                        IUPAC.extended_protein, "*"), "-")),
+            Seq.MutableSeq("ME-K-DRXR*XU",
+                           Alphabet.Gapped(Alphabet.HasStopCodon(
+                               IUPAC.extended_protein, "*"), "-")),
             "TEDDF",
         ]
 
@@ -397,14 +438,16 @@ class TestSeqAddition(unittest.TestCase):
         with self.assertRaises(ValueError):
             a + b
 
-    def test_exception_when_added_protein_has_more_than_one_stop_codon_type(self):
+    def test_exception_when_added_protein_has_several_stop_codon_types(self):
         """Test resulting protein has stop codon types '*' and '@'"""
-        a = Seq.Seq("MEDG-KRXR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"), "@"))
-        b = Seq.Seq("MEDG-KRXR*", Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"))
+        a = Seq.Seq("MEDG-KRXR@", Alphabet.HasStopCodon(
+            Alphabet.Gapped(IUPAC.extended_protein, "-"), "@"))
+        b = Seq.Seq("MEDG-KRXR*", Alphabet.Gapped(
+            Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"))
         with self.assertRaises(ValueError):
             a + b
 
-    def test_exception_when_adding_protein_with_nucletides(self):
+    def test_exception_when_adding_protein_with_nucleotides(self):
         for a in self.protein[0:5]:
             for b in self.dna[0:3] + self.rna[0:4]:
                 with self.assertRaises(TypeError):
@@ -428,19 +471,24 @@ class TestMutableSeq(unittest.TestCase):
         self.assertIsInstance(mutable_s, MutableSeq, "Creating MutableSeq")
 
         mutable_s = self.s.tomutable()
-        self.assertIsInstance(mutable_s, MutableSeq, "Converting Seq to mutable")
+        self.assertIsInstance(mutable_s, MutableSeq,
+                              "Converting Seq to mutable")
 
-        array_seq = MutableSeq(array.array(array_indicator, "TCAAAAGGATGCATCATG"),
+        array_seq = MutableSeq(array.array(array_indicator,
+                                           "TCAAAAGGATGCATCATG"),
                                IUPAC.ambiguous_dna)
-        self.assertIsInstance(array_seq, MutableSeq, "Creating MutableSeq using array")
+        self.assertIsInstance(array_seq, MutableSeq,
+                              "Creating MutableSeq using array")
 
     def test_repr(self):
-        self.assertEqual("MutableSeq('TCAAAAGGATGCATCATG', IUPACAmbiguousDNA())",
-                         repr(self.mutable_s))
+        self.assertEqual(
+            "MutableSeq('TCAAAAGGATGCATCATG', IUPACAmbiguousDNA())",
+            repr(self.mutable_s))
 
     def test_truncated_repr(self):
         seq = "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGA"
-        expected = "MutableSeq('TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATG...GGA', IUPACAmbiguousDNA())"
+        expected = "MutableSeq('TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAA" + \
+                   "AGGATGCATCATG...GGA', IUPACAmbiguousDNA())"
         self.assertEqual(expected, repr(MutableSeq(seq, IUPAC.ambiguous_dna)))
 
     def test_equal_comparison(self):
@@ -461,7 +509,8 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_less_than_comparison_of_incompatible_alphabets(self):
         with warnings.catch_warnings(record=True):
-            self.mutable_s[:-1] < MutableSeq("UCAAAAGGAUGCAUCAUG", IUPAC.ambiguous_rna)
+            self.mutable_s[:-1] < MutableSeq("UCAAAAGGAUGCAUCAUG",
+                                             IUPAC.ambiguous_rna)
 
     def test_less_than_comparison_without_alphabet(self):
         self.assertTrue(self.mutable_s[:-1] < "TCAAAAGGATGCATCATG")
@@ -472,7 +521,8 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_less_than_or_equal_comparison_of_incompatible_alphabets(self):
         with warnings.catch_warnings(record=True):
-            self.mutable_s[:-1] <= MutableSeq("UCAAAAGGAUGCAUCAUG", IUPAC.ambiguous_rna)
+            self.mutable_s[:-1] <= MutableSeq("UCAAAAGGAUGCAUCAUG",
+                                              IUPAC.ambiguous_rna)
 
     def test_less_than_or_equal_comparison_without_alphabet(self):
         self.assertTrue(self.mutable_s[:-1] <= "TCAAAAGGATGCATCATG")
@@ -488,7 +538,8 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_radd_method_incompatible_alphabets(self):
         with self.assertRaises(TypeError):
-            self.mutable_s.__radd__(MutableSeq("UCAAAAGGA", IUPAC.ambiguous_rna))
+            self.mutable_s.__radd__(MutableSeq("UCAAAAGGA",
+                                               IUPAC.ambiguous_rna))
 
     def test_radd_method_using_seq_object(self):
         self.assertEqual("TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG",
@@ -515,16 +566,19 @@ class TestMutableSeq(unittest.TestCase):
                          self.mutable_s[1:5], "Slice mutable seq")
 
         self.mutable_s[1:3] = "GAT"
-        self.assertEqual(MutableSeq("TGATAAAGGATGCATCATG", IUPAC.ambiguous_dna),
+        self.assertEqual(MutableSeq("TGATAAAGGATGCATCATG",
+                                    IUPAC.ambiguous_dna),
                          self.mutable_s,
                          "Set slice with string and adding extra nucleotide")
 
         self.mutable_s[1:3] = self.mutable_s[5:7]
-        self.assertEqual(MutableSeq("TAATAAAGGATGCATCATG", IUPAC.ambiguous_dna),
+        self.assertEqual(MutableSeq("TAATAAAGGATGCATCATG",
+                                    IUPAC.ambiguous_dna),
                          self.mutable_s, "Set slice with MutableSeq")
 
         self.mutable_s[1:3] = array.array(array_indicator, "GAT")
-        self.assertEqual(MutableSeq("TGATTAAAGGATGCATCATG", IUPAC.ambiguous_dna),
+        self.assertEqual(MutableSeq("TGATTAAAGGATGCATCATG",
+                                    IUPAC.ambiguous_dna),
                          self.mutable_s, "Set slice with array")
 
     def test_setting_item(self):
@@ -544,12 +598,14 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_appending(self):
         self.mutable_s.append("C")
-        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGC", IUPAC.ambiguous_dna),
+        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGC",
+                                    IUPAC.ambiguous_dna),
                          self.mutable_s)
 
     def test_inserting(self):
         self.mutable_s.insert(4, "G")
-        self.assertEqual(MutableSeq("TCAAGAAGGATGCATCATG", IUPAC.ambiguous_dna),
+        self.assertEqual(MutableSeq("TCAAGAAGGATGCATCATG",
+                                    IUPAC.ambiguous_dna),
                          self.mutable_s)
 
     def test_popping_last_item(self):
@@ -615,18 +671,21 @@ class TestMutableSeq(unittest.TestCase):
             seq.reverse_complement()
 
     def test_to_string_method(self):
-        """This method is currently deprecated, probably will need to remove this test soon"""
+        """This method is currently deprecated, probably will need to remove
+        this test soon"""
         with warnings.catch_warnings(record=True):
             self.mutable_s.tostring()
 
     def test_extend_method(self):
         self.mutable_s.extend("GAT")
-        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGGAT", IUPAC.ambiguous_dna),
+        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGGAT",
+                                    IUPAC.ambiguous_dna),
                          self.mutable_s)
 
     def test_extend_with_mutable_seq(self):
         self.mutable_s.extend(MutableSeq("TTT", IUPAC.ambiguous_dna))
-        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGTTT", IUPAC.ambiguous_dna),
+        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGTTT",
+                                    IUPAC.ambiguous_dna),
                          self.mutable_s)
 
     def test_delete_stride_slice(self):
@@ -636,9 +695,12 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_extract_third_nucleotide(self):
         """Test extracting every third nucleotide (slicing with stride 3)"""
-        self.assertEqual(MutableSeq("TAGTAA", IUPAC.ambiguous_dna), self.mutable_s[0::3])
-        self.assertEqual(MutableSeq("CAGGTT", IUPAC.ambiguous_dna), self.mutable_s[1::3])
-        self.assertEqual(MutableSeq("AAACCG", IUPAC.ambiguous_dna), self.mutable_s[2::3])
+        self.assertEqual(MutableSeq("TAGTAA", IUPAC.ambiguous_dna),
+                         self.mutable_s[0::3])
+        self.assertEqual(MutableSeq("CAGGTT", IUPAC.ambiguous_dna),
+                         self.mutable_s[1::3])
+        self.assertEqual(MutableSeq("AAACCG", IUPAC.ambiguous_dna),
+                         self.mutable_s[2::3])
 
     def test_set_wobble_codon_to_n(self):
         """Test setting wobble codon to N (set slice with stride 3)"""
@@ -653,8 +715,10 @@ class TestUnknownSeq(unittest.TestCase):
 
     def test_construction(self):
         self.assertEqual("??????", str(Seq.UnknownSeq(6)))
-        self.assertEqual("NNNNNN", str(Seq.UnknownSeq(6, Alphabet.generic_dna)))
-        self.assertEqual("XXXXXX", str(Seq.UnknownSeq(6, Alphabet.generic_protein)))
+        self.assertEqual("NNNNNN",
+                         str(Seq.UnknownSeq(6, Alphabet.generic_dna)))
+        self.assertEqual("XXXXXX",
+                         str(Seq.UnknownSeq(6, Alphabet.generic_protein)))
         self.assertEqual("??????", str(Seq.UnknownSeq(6, character="?")))
 
         with self.assertRaises(ValueError):
@@ -667,8 +731,9 @@ class TestUnknownSeq(unittest.TestCase):
         self.assertEqual(6, len(self.s))
 
     def test_repr(self):
-        self.assertEqual("UnknownSeq(6, alphabet = Alphabet(), character = '?')",
-                         repr(self.s))
+        self.assertEqual(
+            "UnknownSeq(6, alphabet = Alphabet(), character = '?')",
+            repr(self.s))
 
     def test_add_method(self):
         seq1 = Seq.UnknownSeq(3, Alphabet.generic_dna)
@@ -693,8 +758,10 @@ class TestUnknownSeq(unittest.TestCase):
         self.assertEqual(3, self.s.count("??"))
         self.assertEqual(0, Seq.UnknownSeq(6, character="N").count("?"))
         self.assertEqual(0, Seq.UnknownSeq(6, character="N").count("??"))
-        self.assertEqual(4, Seq.UnknownSeq(6, character="?").count("?", start=2))
-        self.assertEqual(2, Seq.UnknownSeq(6, character="?").count("??", start=2))
+        self.assertEqual(4,
+                         Seq.UnknownSeq(6, character="?").count("?", start=2))
+        self.assertEqual(2,
+                         Seq.UnknownSeq(6, character="?").count("??", start=2))
 
     def test_complement(self):
         self.s.complement()
@@ -736,10 +803,14 @@ class TestUnknownSeq(unittest.TestCase):
         self.assertRaises(ValueError, seq.translate)
 
     def test_ungap(self):
-        seq = Seq.UnknownSeq(7, alphabet=Alphabet.Gapped(Alphabet.DNAAlphabet(), "-"))
+        seq = Seq.UnknownSeq(7,
+                             alphabet=Alphabet.Gapped(Alphabet.DNAAlphabet(),
+                                                      "-"))
         self.assertEqual("NNNNNNN", str(seq.ungap("-")))
 
-        seq = Seq.UnknownSeq(20, alphabet=Alphabet.Gapped(Alphabet.DNAAlphabet(), "-"), character='-')
+        seq = Seq.UnknownSeq(20,
+                             alphabet=Alphabet.Gapped(Alphabet.DNAAlphabet(),
+                                                      "-"), character='-')
         self.assertEqual("", seq.ungap("-"))
 
 
@@ -753,15 +824,19 @@ class TestAmbiguousComplements(unittest.TestCase):
 class TestComplement(unittest.TestCase):
     def test_complement_ambiguous_dna_values(self):
         for ambig_char, values in sorted(ambiguous_dna_values.items()):
-            compl_values = str(Seq.Seq(values, alphabet=IUPAC.ambiguous_dna).complement())
-            self.assertEqual(set(compl_values),
-                             set(ambiguous_dna_values[ambiguous_dna_complement[ambig_char]]))
+            compl_values = str(
+                Seq.Seq(values, alphabet=IUPAC.ambiguous_dna).complement())
+            ambig_values = (
+                ambiguous_dna_values[ambiguous_dna_complement[ambig_char]])
+            self.assertEqual(set(compl_values), set(ambig_values))
 
     def test_complement_ambiguous_rna_values(self):
         for ambig_char, values in sorted(ambiguous_rna_values.items()):
-            compl_values = str(Seq.Seq(values, alphabet=IUPAC.ambiguous_rna).complement())
-            self.assertEqual(set(compl_values),
-                             set(ambiguous_rna_values[ambiguous_rna_complement[ambig_char]]))
+            compl_values = str(
+                Seq.Seq(values, alphabet=IUPAC.ambiguous_rna).complement())
+            ambig_values = (
+                ambiguous_rna_values[ambiguous_rna_complement[ambig_char]])
+            self.assertEqual(set(compl_values), set(ambig_values))
 
     def test_complement_incompatible_alphabets(self):
         seq = Seq.Seq("CAGGTU")
@@ -796,13 +871,17 @@ class TestReverseComplement(unittest.TestCase):
         test_seqs_copy.pop(21)
 
         for nucleotide_seq in test_seqs_copy:
-            if not isinstance(nucleotide_seq.alphabet, Alphabet.ProteinAlphabet) and \
-                    isinstance(nucleotide_seq, Seq.Seq):
+            if not isinstance(nucleotide_seq.alphabet,
+                              Alphabet.ProteinAlphabet) and \
+                              isinstance(nucleotide_seq, Seq.Seq):
                 expected = Seq.reverse_complement(nucleotide_seq)
-                self.assertEqual(repr(expected), repr(nucleotide_seq.reverse_complement()))
-                self.assertEqual(repr(expected[::-1]), repr(nucleotide_seq.complement()))
-                self.assertEqual(str(nucleotide_seq.complement()),
-                                 str(Seq.reverse_complement(nucleotide_seq))[::-1])
+                self.assertEqual(
+                    repr(expected), repr(nucleotide_seq.reverse_complement()))
+                self.assertEqual(
+                    repr(expected[::-1]), repr(nucleotide_seq.complement()))
+                self.assertEqual(
+                    str(nucleotide_seq.complement()),
+                    str(Seq.reverse_complement(nucleotide_seq))[::-1])
                 self.assertEqual(str(nucleotide_seq.reverse_complement()),
                                  str(Seq.reverse_complement(nucleotide_seq)))
 
@@ -827,22 +906,22 @@ class TestReverseComplement(unittest.TestCase):
             with self.assertRaises(ValueError):
                 s.reverse_complement()
 
-    def test_complement_on_proteins(self):
-        """Test complement shouldn't work on a protein!"""
-        for s in protein_seqs:
-            with self.assertRaises(ValueError):
-                s.complement()
-
 
 class TestDoubleReverseComplement(unittest.TestCase):
     def test_reverse_complements(self):
         """Test double reverse complement preserves the sequence"""
-        for sequence in [Seq.Seq("".join(sorted(ambiguous_rna_values))),
-                         Seq.Seq("".join(sorted(ambiguous_dna_values))),
-                         Seq.Seq("".join(sorted(ambiguous_rna_values)), Alphabet.generic_rna),
-                         Seq.Seq("".join(sorted(ambiguous_dna_values)), Alphabet.generic_dna),
-                         Seq.Seq("".join(sorted(ambiguous_rna_values)).replace("X", ""), IUPAC.IUPACAmbiguousRNA()),
-                         Seq.Seq("".join(sorted(ambiguous_dna_values)).replace("X", ""), IUPAC.IUPACAmbiguousDNA()),
+        sorted_amb_rna = sorted(ambiguous_rna_values)
+        sorted_amb_dna = sorted(ambiguous_dna_values)
+        for sequence in [Seq.Seq("".join(sorted_amb_rna)),
+                         Seq.Seq("".join(sorted_amb_dna)),
+                         Seq.Seq("".join(sorted_amb_rna),
+                                 Alphabet.generic_rna),
+                         Seq.Seq("".join(sorted_amb_dna),
+                                 Alphabet.generic_dna),
+                         Seq.Seq("".join(sorted_amb_rna).replace("X", ""),
+                                 IUPAC.IUPACAmbiguousRNA()),
+                         Seq.Seq("".join(sorted_amb_dna).replace("X", ""),
+                                 IUPAC.IUPACAmbiguousDNA()),
                          Seq.Seq("AWGAARCKG")]:  # Note no U or T
             reversed_sequence = sequence.reverse_complement()
             self.assertEqual(str(sequence),
@@ -855,9 +934,11 @@ class TestSequenceAlphabets(unittest.TestCase):
         bug 2597)"""
         for nucleotide_seq in test_seqs:
             if "U" in str(nucleotide_seq).upper():
-                self.assertNotIsInstance(nucleotide_seq.alphabet, Alphabet.DNAAlphabet)
+                self.assertNotIsInstance(nucleotide_seq.alphabet,
+                                         Alphabet.DNAAlphabet)
             if "T" in str(nucleotide_seq).upper():
-                self.assertNotIsInstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet)
+                self.assertNotIsInstance(nucleotide_seq.alphabet,
+                                         Alphabet.RNAAlphabet)
 
 
 class TestTranscription(unittest.TestCase):
@@ -865,8 +946,9 @@ class TestTranscription(unittest.TestCase):
         for nucleotide_seq in test_seqs:
             if isinstance(nucleotide_seq.alphabet, Alphabet.DNAAlphabet):
                 expected = Seq.transcribe(nucleotide_seq)
-                self.assertEqual(str(nucleotide_seq).replace("t", "u").replace("T", "U"),
-                                 str(expected))
+                self.assertEqual(
+                    str(nucleotide_seq).replace("t", "u").replace("T", "U"),
+                    str(expected))
 
     def test_transcription_dna_string_into_rna(self):
         seq = "ATGAAACTG"
@@ -899,8 +981,9 @@ class TestTranscription(unittest.TestCase):
         for nucleotide_seq in test_seqs:
             if isinstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet):
                 expected = Seq.back_transcribe(nucleotide_seq)
-                self.assertEqual(str(nucleotide_seq).replace("u", "t").replace("U", "T"),
-                                 str(expected))
+                self.assertEqual(
+                    str(nucleotide_seq).replace("u", "t").replace("U", "T"),
+                    str(expected))
 
     def test_back_transcribe_rna_string_into_dna(self):
         seq = "AUGAAACUG"
@@ -911,7 +994,8 @@ class TestTranscription(unittest.TestCase):
             if isinstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet) and \
                     isinstance(nucleotide_seq, Seq.Seq):
                 expected = Seq.back_transcribe(nucleotide_seq)
-                self.assertEqual(repr(nucleotide_seq.back_transcribe()), repr(expected))
+                self.assertEqual(repr(nucleotide_seq.back_transcribe()),
+                                 repr(expected))
 
     def test_back_transcription_of_proteins(self):
         """Test back-transcription shouldn't work on a protein!"""
@@ -958,9 +1042,11 @@ class TestTranslating(unittest.TestCase):
     def test_translation(self):
         for nucleotide_seq in self.test_seqs:
             nucleotide_seq = nucleotide_seq[:3 * (len(nucleotide_seq) // 3)]
-            if isinstance(nucleotide_seq, Seq.Seq) and 'X' not in str(nucleotide_seq):
+            if isinstance(nucleotide_seq, Seq.Seq) and \
+               'X' not in str(nucleotide_seq):
                 expected = Seq.translate(nucleotide_seq)
-                self.assertEqual(repr(expected), repr(nucleotide_seq.translate()))
+                self.assertEqual(repr(expected),
+                                 repr(nucleotide_seq.translate()))
 
     def test_alphabets_of_translated_seqs(self):
 
@@ -970,33 +1056,45 @@ class TestTranslating(unittest.TestCase):
                 s += "N"
             return s
 
-        self.assertEqual("IUPACProtein()", repr(self.test_seqs[0].translate().alphabet))
-        self.assertEqual("ExtendedIUPACProtein()", repr(self.test_seqs[1].translate().alphabet))
-        self.assertEqual("ExtendedIUPACProtein()", repr(self.test_seqs[2].translate().alphabet))
-        self.assertEqual("ExtendedIUPACProtein()", repr(self.test_seqs[3].translate().alphabet))
-        self.assertEqual("ExtendedIUPACProtein()", repr(self.test_seqs[10].translate().alphabet))
-        self.assertEqual("ExtendedIUPACProtein()", repr(self.test_seqs[11].translate().alphabet))
-        self.assertEqual("IUPACProtein()", repr(self.test_seqs[12].translate().alphabet))
+        self.assertEqual("IUPACProtein()",
+                         repr(self.test_seqs[0].translate().alphabet))
         self.assertEqual("ExtendedIUPACProtein()",
-                         repr(triple_pad(self.test_seqs[13]).translate().alphabet))
-        self.assertEqual("ExtendedIUPACProtein()", repr(self.test_seqs[14].translate().alphabet))
-        self.assertEqual("IUPACProtein()", repr(self.test_seqs[15].translate().alphabet))
+                         repr(self.test_seqs[1].translate().alphabet))
         self.assertEqual("ExtendedIUPACProtein()",
-                         repr(triple_pad(self.test_seqs[16]).translate().alphabet))
+                         repr(self.test_seqs[2].translate().alphabet))
         self.assertEqual("ExtendedIUPACProtein()",
-                         repr(triple_pad(self.test_seqs[17]).translate().alphabet))
+                         repr(self.test_seqs[3].translate().alphabet))
+        self.assertEqual("ExtendedIUPACProtein()",
+                         repr(self.test_seqs[10].translate().alphabet))
+        self.assertEqual("ExtendedIUPACProtein()",
+                         repr(self.test_seqs[11].translate().alphabet))
+        self.assertEqual("IUPACProtein()",
+                         repr(self.test_seqs[12].translate().alphabet))
+        self.assertEqual(
+            "ExtendedIUPACProtein()",
+            repr(triple_pad(self.test_seqs[13]).translate().alphabet))
+        self.assertEqual("ExtendedIUPACProtein()",
+                         repr(self.test_seqs[14].translate().alphabet))
+        self.assertEqual("IUPACProtein()",
+                         repr(self.test_seqs[15].translate().alphabet))
+        self.assertEqual(
+            "ExtendedIUPACProtein()",
+            repr(triple_pad(self.test_seqs[16]).translate().alphabet))
+        self.assertEqual(
+            "ExtendedIUPACProtein()",
+            repr(triple_pad(self.test_seqs[17]).translate().alphabet))
 
-    def test_translation_of_gapped_seq_with_gap_char_given(self):
+    def test_gapped_seq_with_gap_char_given(self):
         seq = Seq.Seq("ATG---AAACTG")
         self.assertEqual("M-KL", seq.translate(gap="-"))
         self.assertRaises(TranslationError, seq.translate, gap="~")
 
-    def test_translation_of_gapped_seq_with_stop_codon_and_gap_char_given(self):
+    def test_gapped_seq_with_stop_codon_and_gap_char_given(self):
         seq = Seq.Seq("GTG---GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG")
         self.assertEqual("V-AIVMGR*KGAR*", seq.translate(gap="-"))
         self.assertRaises(TranslationError, seq.translate)
 
-    def test_translation_of_gapped_seq_with_gap_char_given_and_inferred_from_alphabet(self):
+    def test_gapped_seq_with_gap_char_given_and_inferred_from_alphabet(self):
         seq = Seq.Seq("ATG---AAACTG", Gapped(IUPAC.unambiguous_dna))
         self.assertEqual("M-KL", seq.translate(gap="-"))
         self.assertRaises(ValueError, seq.translate, gap="~")
@@ -1005,7 +1103,7 @@ class TestTranslating(unittest.TestCase):
         self.assertRaises(ValueError, seq.translate, gap="~")
         self.assertRaises(TranslationError, seq.translate, gap="-")
 
-    def test_translation_of_gapped_seq_with_gap_char_given_and_inferred_from_alphabet2(self):
+    def test_gapped_seq_with_gap_char_given_and_inferred_from_alphabet2(self):
         """Test using stop codon in sequence"""
         seq = Seq.Seq("ATG---AAACTGTAG", Gapped(IUPAC.unambiguous_dna))
         self.assertEqual("M-KL*", seq.translate(gap="-"))
@@ -1019,11 +1117,11 @@ class TestTranslating(unittest.TestCase):
         self.assertRaises(ValueError, seq.translate, gap="~")
         self.assertRaises(TranslationError, seq.translate, gap="-")
 
-    def test_translation_of_gapped_seq_no_gap_char_given(self):
+    def test_gapped_seq_no_gap_char_given(self):
         seq = Seq.Seq("ATG---AAACTG")
         self.assertRaises(TranslationError, seq.translate)
 
-    def test_translation_of_gapped_seq_no_gap_char_given_and_inferred_from_alphabet(self):
+    def test_gapped_seq_no_gap_char_given_and_inferred_from_alphabet(self):
         seq = Seq.Seq("ATG---AAACTG", Gapped(IUPAC.unambiguous_dna))
         self.assertEqual("M-KL", seq.translate())
 
@@ -1035,31 +1133,39 @@ class TestTranslating(unittest.TestCase):
 
     def test_alphabet_of_translated_gapped_seq(self):
         seq = Seq.Seq("ATG---AAACTG", Gapped(IUPAC.unambiguous_dna))
-        self.assertEqual("Gapped(ExtendedIUPACProtein(), '-')", repr(seq.translate().alphabet))
+        self.assertEqual("Gapped(ExtendedIUPACProtein(), '-')",
+                         repr(seq.translate().alphabet))
 
         seq = Seq.Seq("ATG---AAACTG", Gapped(IUPAC.unambiguous_dna, "-"))
-        self.assertEqual("Gapped(ExtendedIUPACProtein(), '-')", repr(seq.translate().alphabet))
+        self.assertEqual("Gapped(ExtendedIUPACProtein(), '-')",
+                         repr(seq.translate().alphabet))
 
         seq = Seq.Seq("ATG~~~AAACTG", Gapped(IUPAC.unambiguous_dna, "~"))
-        self.assertEqual("Gapped(ExtendedIUPACProtein(), '~')", repr(seq.translate().alphabet))
+        self.assertEqual("Gapped(ExtendedIUPACProtein(), '~')",
+                         repr(seq.translate().alphabet))
 
         seq = Seq.Seq("ATG---AAACTG")
-        self.assertEqual("Gapped(ExtendedIUPACProtein(), '-')", repr(seq.translate(gap="-").alphabet))
-
-        seq = Seq.Seq("ATG~~~AAACTG")
-        self.assertEqual("Gapped(ExtendedIUPACProtein(), '~')", repr(seq.translate(gap="~").alphabet))
-
-        seq = Seq.Seq("ATG~~~AAACTGTAG")
-        self.assertEqual("HasStopCodon(Gapped(ExtendedIUPACProtein(), '~'), '*')",
-                         repr(seq.translate(gap="~").alphabet))
-
-        seq = Seq.Seq("ATG---AAACTGTGA")
-        self.assertEqual("HasStopCodon(Gapped(ExtendedIUPACProtein(), '-'), '*')",
+        self.assertEqual("Gapped(ExtendedIUPACProtein(), '-')",
                          repr(seq.translate(gap="-").alphabet))
 
+        seq = Seq.Seq("ATG~~~AAACTG")
+        self.assertEqual("Gapped(ExtendedIUPACProtein(), '~')",
+                         repr(seq.translate(gap="~").alphabet))
+
+        seq = Seq.Seq("ATG~~~AAACTGTAG")
+        self.assertEqual(
+            "HasStopCodon(Gapped(ExtendedIUPACProtein(), '~'), '*')",
+            repr(seq.translate(gap="~").alphabet))
+
         seq = Seq.Seq("ATG---AAACTGTGA")
-        self.assertEqual("HasStopCodon(Gapped(ExtendedIUPACProtein(), '-'), '@')",
-                         repr(seq.translate(gap="-", stop_symbol="@").alphabet))
+        self.assertEqual(
+            "HasStopCodon(Gapped(ExtendedIUPACProtein(), '-'), '*')",
+            repr(seq.translate(gap="-").alphabet))
+
+        seq = Seq.Seq("ATG---AAACTGTGA")
+        self.assertEqual(
+            "HasStopCodon(Gapped(ExtendedIUPACProtein(), '-'), '@')",
+            repr(seq.translate(gap="-", stop_symbol="@").alphabet))
 
     def test_translation_wrong_type(self):
         """Test translation table cannot be CodonTable"""
@@ -1085,12 +1191,16 @@ class TestTranslating(unittest.TestCase):
     def test_translation_to_stop(self):
         for nucleotide_seq in self.test_seqs:
             nucleotide_seq = nucleotide_seq[:3 * (len(nucleotide_seq) // 3)]
-            if isinstance(nucleotide_seq, Seq.Seq) and 'X' not in str(nucleotide_seq):
+            if isinstance(nucleotide_seq, Seq.Seq) and \
+               'X' not in str(nucleotide_seq):
                 short = Seq.translate(nucleotide_seq, to_stop=True)
-                self.assertEqual(str(short), str(Seq.translate(nucleotide_seq).split('*')[0]))
+                self.assertEqual(
+                    str(short),
+                    str(Seq.translate(nucleotide_seq).split('*')[0]))
 
         seq = "GTGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG"
-        self.assertEqual("VAIVMGRWKGAR", Seq.translate(seq, table=2, to_stop=True))
+        self.assertEqual("VAIVMGRWKGAR", Seq.translate(seq, table=2,
+                                                       to_stop=True))
 
     def test_translation_on_proteins(self):
         """Test translation shouldn't work on a protein!"""
@@ -1116,7 +1226,8 @@ class TestTranslating(unittest.TestCase):
             self.assertEqual('B', Seq.translate(codon))
 
     def test_translation_of_leucine(self):
-        for codon in ['WTA', 'MTY', 'MTT', 'MTW', 'MTM', 'MTH', 'MTA', 'MTC', 'HTA']:
+        for codon in ['WTA', 'MTY', 'MTT', 'MTW', 'MTM', 'MTH', 'MTA', 'MTC',
+                      'HTA']:
             self.assertEqual('J', Seq.translate(codon))
 
     def test_translation_with_bad_table_argument(self):
@@ -1126,7 +1237,8 @@ class TestTranslating(unittest.TestCase):
 
     def test_translation_with_codon_table_as_table_argument(self):
         table = standard_dna_table
-        self.assertEqual("VAIVMGR", Seq.translate("GTGGCCATTGTAATGGGCCGC", table=table))
+        self.assertEqual("VAIVMGR", Seq.translate("GTGGCCATTGTAATGGGCCGC",
+                                                  table=table))
 
     def test_translation_incomplete_codon(self):
         with warnings.catch_warnings(record=True):
@@ -1160,21 +1272,31 @@ class TestStopCodons(unittest.TestCase):
 
     def test_stops(self):
         for nucleotide_seq in [self.misc_stops, Seq.Seq(self.misc_stops),
-                               Seq.Seq(self.misc_stops, Alphabet.generic_nucleotide),
-                               Seq.Seq(self.misc_stops, Alphabet.DNAAlphabet()),
-                               Seq.Seq(self.misc_stops, IUPAC.unambiguous_dna)]:
+                               Seq.Seq(self.misc_stops,
+                                       Alphabet.generic_nucleotide),
+                               Seq.Seq(self.misc_stops,
+                                       Alphabet.DNAAlphabet()),
+                               Seq.Seq(self.misc_stops,
+                                       IUPAC.unambiguous_dna)]:
             self.assertEqual("***RR", str(Seq.translate(nucleotide_seq)))
-            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table=1)))
-            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table="SGC0")))
-            self.assertEqual("**W**", str(Seq.translate(nucleotide_seq, table=2)))
+            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq,
+                                                        table=1)))
+            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq,
+                                                        table="SGC0")))
+            self.assertEqual("**W**", str(Seq.translate(nucleotide_seq,
+                                                        table=2)))
             self.assertEqual("**WRR", str(Seq.translate(nucleotide_seq,
                                           table='Yeast Mitochondrial')))
-            self.assertEqual("**WSS", str(Seq.translate(nucleotide_seq, table=5)))
-            self.assertEqual("**WSS", str(Seq.translate(nucleotide_seq, table=9)))
+            self.assertEqual("**WSS", str(Seq.translate(nucleotide_seq,
+                                                        table=5)))
+            self.assertEqual("**WSS", str(Seq.translate(nucleotide_seq,
+                                                        table=9)))
             self.assertEqual("**CRR", str(Seq.translate(nucleotide_seq,
                                           table='Euplotid Nuclear')))
-            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table=11)))
-            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table='Bacterial')))
+            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq,
+                                                        table=11)))
+            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq,
+                                                        table='Bacterial')))
 
     def test_translation_of_stops(self):
         self.assertEqual(Seq.translate("TAT"), "Y")

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -768,6 +768,27 @@ class TestComplement(unittest.TestCase):
         with self.assertRaises(ValueError):
             seq.complement()
 
+    def test_complement_of_mixed_dna_rna(self):
+        seq = "AUGAAACTG"  # U and T
+        self.assertRaises(ValueError, Seq.complement, seq)
+
+    def test_complement_of_rna(self):
+        seq = "AUGAAACUG"
+        self.assertEqual("UACUUUGAC", Seq.complement(seq))
+
+    def test_complement_of_dna(self):
+        seq = "ATGAAACTG"
+        self.assertEqual("TACTTTGAC", Seq.complement(seq))
+
+    def test_complement_on_proteins(self):
+        """Test complement shouldn't work on a protein!"""
+        for s in protein_seqs:
+            with self.assertRaises(ValueError):
+                Seq.complement(s)
+
+            with self.assertRaises(ValueError):
+                s.complement()
+
 
 class TestReverseComplement(unittest.TestCase):
     def test_reverse_complement(self):


### PR DESCRIPTION
 * The `Seq` __module__ has methods `transcribe(dna)`, `back_transcribe(rna)`, `translate(seq, ...)` and  `reverse_complement(seq)`, but misses `complement(seq)`. This is sometimes confusing since this method   is available under the `Seq` __class__. E.g. `Seq.reverse_complement(seq)` and `seq.reverse_complement()` are both working, but `Seq.complement(seq)` fails.

 * Added tests to `tests_seq.py` to include `Seq.complement(seq)`
 * PEP8 revision for `Seq.py` and `test_seq.py` (actually much more work than the other two tasks)