### PR TITLE
Cope with trailing comma in GenBank locations

### DIFF
--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -1023,6 +1023,13 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                                                               strand)
             return
 
+        if ",)" in location_line:
+            import warnings
+            from Bio import BiopythonParserWarning
+            warnings.warn("Dropping trailing comma in malformed feature location",
+                          BiopythonParserWarning)
+            location_line = location_line.replace(",)", ")")
+
         if _solo_bond.search(location_line):
             # e.g. bond(196)
             # e.g. join(bond(284),bond(305),bond(309),bond(305))

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -1052,6 +1052,14 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                 locs.append(SeqFeature.FeatureLocation(int(s) - 1,
                                                        int(e),
                                                        strand))
+            if len(locs) < 2:
+                # The CompoundLocation will raise a ValueError here!
+                import warnings
+                from Bio import BiopythonParserWarning
+                warnings.warn("Should have at least 2 parts for compound location",
+                              BiopythonParserWarning)
+                cur_feature.location = None
+                return
             if strand == -1:
                 cur_feature.location = SeqFeature.CompoundLocation(locs[::-1],
                                                                    operator=location_line[:i])


### PR DESCRIPTION
This would solve #937 (*edit*, fixed) where a GenBank file on the NCBI FTP site contains malformed location strings with trailing commas, e.g. ``order(1071..1076,1188..1193,1371..1376,1380..1385,)``

The first commit removes the trailing comma and then parses the location.

The second commit gives an explicit warning for single-part compound locations like ``order(20991..20999,)`` (and location set to ``None``), rather than the current behaviour of an exception.

I believe all of these problematic locations are due to an error in how this GenBank record was created, and the trailing comma hints at a missing location part.

Test case:

```
$ wget ftp://ftp.ncbi.nih.gov/refseq/release/plastid/plastid.1.genomic.gbff.gz
$ tar -zxvf plastid.1.genomic.gbff.gz
```

If you want to pull out the problem record as a single file:

``` python
from Bio import SeqIO
d = SeqIO.index('plastid.1.genomic.gbff', 'gb')
with open("NC_024258.gbk", "w") as h:
    h.write(d.get_raw("NC_024258.1"))
```

Parsing the problem record with the current code:

```
$ python -c "from Bio import SeqIO; print(SeqIO.read('NC_024258.gbk', 'gb'))"
print(d['NC_024258.1'])"
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(1071..1076,1188..1193,1371..1376,1380..1385,)'
  % (location_line)))
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(618..626,858..866,870..878,882..887,918..923,927..932,1005..1010,1017..1022,1026..1034,1095..1100,1122..1127,1188..1202,1359..1364,)'
  % (location_line)))
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(1161..1166,1338..1343,1350..1355,1362..1367,)'
  % (location_line)))
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(837..842,849..854,1038..1043,1344..1349,)'
  % (location_line)))
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(474..479,1155..1160,1167..1172,1182..1187,1284..1289,)'
  % (location_line)))
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(480..485,)'
  % (location_line)))
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(684..692,723..728,834..839,)'
  % (location_line)))
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(540..557,)'
  % (location_line)))
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(462..470,480..485,)'
  % (location_line)))
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(537..545,549..557,)'
  % (location_line)))
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(762..767,1248..1256,1263..1268,)'
  % (location_line)))
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(11221..11226,11500..11505,11755..11763,)'
  % (location_line)))
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(20757..20762,20820..20831,20835..20840,20844..20858,20883..20894,20934..20939,20979..20984,21144..21149,21156..21167,21192..21200,21213..21236,21279..21284,21531..21536,22809..22817,23046..23051,)'
  % (location_line)))
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1123: BiopythonParserWarning: Couldn't parse feature location: 'order(20991..20999,)'
  % (location_line)))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Python/2.7/site-packages/Bio/SeqIO/__init__.py", line 597, in parse
    for r in i:
  File "/Library/Python/2.7/site-packages/Bio/GenBank/Scanner.py", line 478, in parse_records
    record = self.parse(handle, do_features)
  File "/Library/Python/2.7/site-packages/Bio/GenBank/Scanner.py", line 462, in parse
    if self.feed(handle, consumer, do_features):
  File "/Library/Python/2.7/site-packages/Bio/GenBank/Scanner.py", line 434, in feed
    self._feed_feature_table(consumer, self.parse_features(skip=False))
  File "/Library/Python/2.7/site-packages/Bio/GenBank/Scanner.py", line 383, in _feed_feature_table
    consumer.location(location_string)
  File "/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py", line 1050, in location
    operator=location_line[:i])
  File "/Library/Python/2.7/site-packages/Bio/SeqFeature.py", line 1051, in __init__
    "CompoundLocation should have at least 2 parts, not %r" % parts)
ValueError: CompoundLocation should have at least 2 parts, not [FeatureLocation(ExactPosition(34504), ExactPosition(34510), strand=1)]
```

With the proposed fix:

```
$ python -c "from Bio import SeqIO; print(SeqIO.read('NC_024258.gbk', 'gb'))"
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1030: BiopythonParserWarning: Dropping trailing comma in malformed feature location
  BiopythonParserWarning)
/Library/Python/2.7/site-packages/Bio/GenBank/__init__.py:1060: BiopythonParserWarning: Should have at least 2 parts for compound location
  BiopythonParserWarning)
ID: NC_024258.1
Name: NC_024258
Description: Fragaria iinumae voucher fc199s5 plastid, complete genome
Database cross-references: BioProject:PRJNA252471
Number of features: 839
/comment=PROVISIONAL REFSEQ: This record has not yet been subject to final
NCBI review. The reference sequence is identical to KC507759.
COMPLETENESS: full length.
/sequence_version=1
/source=plastid Fragaria iinumae
/taxonomy=['Eukaryota', 'Viridiplantae', 'Streptophyta', 'Embryophyta', 'Tracheophyta', 'Spermatophyta', 'Magnoliophyta', 'eudicotyledons', 'Gunneridae', 'Pentapetalae', 'rosids', 'fabids', 'Rosales', 'Rosaceae', 'Rosoideae', 'Potentilleae', 'Fragariinae', 'Fragaria']
/structured_comment=defaultdict(<type 'dict'>, {'Assembly-Data': {'Assembly Method': 'Alignreads v. 2.2', 'Sequencing Technology': 'Illumina', 'Coverage': '50-100x'}})
/keywords=['RefSeq']
/references=[Reference(title='Discovery of a cryptic cytoplasmic male sterility locus in Fragaria: Implications for the evolution of plant sexual system diversity', ...), Reference(title='Direct Submission', ...), Reference(title='Direct Submission', ...)]
/accessions=['NC_024258']
/data_file_division=PLN
/date=02-JUL-2014
/organism=Fragaria iinumae
/gi=657171703
/topology=circular
Seq('GAATTTGTTTCTTCGTCTTAAAAAAAAATATTAGGGCGAACGACGGGAATTGAA...ATG', IUPACAmbiguousDNA())
```