### PR TITLE
Add pseudo count support for information content computation (minor edit)

### DIFF
--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -34,6 +34,7 @@ class SummaryInfo(object):
     results of an alignment. This may either be straight consensus info
     or more complicated things.
     """
+
     def __init__(self, alignment):
         """Initialize with the alignment to calculate information on.
 
@@ -116,7 +117,7 @@ class SummaryInfo(object):
         return Seq(consensus, consensus_alpha)
 
     def gap_consensus(self, threshold=.7, ambiguous="X",
-                       consensus_alpha=None, require_multiple=0):
+                      consensus_alpha=None, require_multiple=0):
         """Same as dumb_consensus(), but allows gap on the output.
 
         Things to do:
@@ -194,7 +195,7 @@ class SummaryInfo(object):
         # Check the ambiguous character we are going to use in the consensus
         # is in the alphabet's list of valid letters (if defined).
         if hasattr(a, "letters") and a.letters is not None \
-        and ambiguous not in a.letters:
+                and ambiguous not in a.letters:
             # We'll need to pick a more generic alphabet...
             if isinstance(a, IUPAC.IUPACUnambiguousDNA):
                 if ambiguous in IUPAC.IUPACUnambiguousDNA().letters:
@@ -303,7 +304,8 @@ class SummaryInfo(object):
                     # modified by the sequence weights
                     start_dict[(residue1, residue2)] += weight1 * weight2
 
-                # if we get a key error, then we've got a problem with alphabets
+                # if we get a key error, then we've got a problem with
+                # alphabets
                 except KeyError:
                     raise ValueError("Residues %s, %s not found in alphabet %s"
                                      % (residue1, residue2,
@@ -353,7 +355,8 @@ class SummaryInfo(object):
         # and drop it out
         if isinstance(self.alignment._alphabet, Alphabet.Gapped):
             skip_items.append(self.alignment._alphabet.gap_char)
-            all_letters = all_letters.replace(self.alignment._alphabet.gap_char, '')
+            all_letters = all_letters.replace(
+                self.alignment._alphabet.gap_char, '')
 
         # now create the dictionary
         for first_letter in all_letters:
@@ -424,8 +427,8 @@ class SummaryInfo(object):
                     # if we get a KeyError then we have an alphabet problem
                     except KeyError:
                         raise ValueError("Residue %s not found in alphabet %s"
-                                     % (this_residue,
-                                        self.alignment._alphabet))
+                                         % (this_residue,
+                                            self.alignment._alphabet))
 
             pssm_info.append((left_seq[residue_num],
                               score_dict))
@@ -450,7 +453,7 @@ class SummaryInfo(object):
             # The alphabet doesn't declare a gap - there could be none
             # in the sequence... or just a vague alphabet.
             gap_char = "-"  # Safe?
-        
+
         return gap_char
 
     def information_content(self, start=0,
@@ -490,7 +493,7 @@ class SummaryInfo(object):
         if start < 0 or end > len(self.alignment[0].seq):
             raise ValueError("Start (%s) and end (%s) are not in the \
                     range %s to %s"
-                    % (start, end, 0, len(self.alignment[0].seq)))
+                             % (start, end, 0, len(self.alignment[0].seq)))
         # determine random expected frequencies, if necessary
         random_expected = None
         if not e_freq_table:
@@ -516,8 +519,8 @@ class SummaryInfo(object):
         info_content = {}
         for residue_num in range(start, end):
             freq_dict = self._get_letter_freqs(residue_num,
-                                               self.alignment, 
-                                               all_letters, 
+                                               self.alignment,
+                                               all_letters,
                                                chars_to_ignore,
                                                pseudo_count,
                                                e_freq_table,
@@ -535,9 +538,8 @@ class SummaryInfo(object):
             self.ic_vector[i] = info_content[i]
         return total_info
 
-
     def _get_letter_freqs(self, residue_num, all_records, letters, to_ignore,
-                                pseudo_count=0, e_freq_table=None, random_expected=None):
+                          pseudo_count=0, e_freq_table=None, random_expected=None):
         """Determine the frequency of specific letters in the alignment.
 
         Arguments:
@@ -553,7 +555,7 @@ class SummaryInfo(object):
               frequencies for each letter. This is a SubsMat.FreqTable instance.
             - random_expected - Optional argument that specify the frequency to use
               when e_freq_table is not defined.
-        
+
         This will calculate the frequencies of each of the specified letters
         in the alignment at the given frequency, and return this as a
         dictionary where the keys are the letters and the values are the
@@ -564,11 +566,10 @@ class SummaryInfo(object):
         total_count = 0
 
         gap_char = self._get_gap_char()
-        
-        if pseudo_count <0 :
-            raise ValueError("Positive value required for " 
-                             "pseudo_count, %s provided"%(pseudo_count))
 
+        if pseudo_count < 0:
+            raise ValueError("Positive value required for "
+                             "pseudo_count, %s provided" % (pseudo_count))
 
         # collect the count info into the dictionary for all the records
         for record in all_records:
@@ -586,7 +587,7 @@ class SummaryInfo(object):
         if e_freq_table:
             if not isinstance(e_freq_table, FreqTable.FreqTable):
                 raise ValueError("e_freq_table should be a FreqTable object")
-            
+
             # check if all the residus in freq_info are in e_freq_table
             for key in freq_info:
                 if (key != gap_char and key not in e_freq_table):
@@ -604,15 +605,16 @@ class SummaryInfo(object):
             # now convert the counts into frequencies
             for letter in freq_info:
                 if pseudo_count and (random_expected or e_freq_table):
-                    # use either the expected random freq or the 
+                    # use either the expected random freq or the
                     if e_freq_table:
                         ajust_freq = e_freq_table[letter]
                     else:
                         ajust_freq = random_expected
-                    
-                    ajusted_letter_count = freq_info[letter] + ajust_freq * pseudo_count
-                    ajusted_total =  total_count + pseudo_count
-                    freq_info[letter] =  ajusted_letter_count / ajusted_total
+
+                    ajusted_letter_count = freq_info[
+                        letter] + ajust_freq * pseudo_count
+                    ajusted_total = total_count + pseudo_count
+                    freq_info[letter] = ajusted_letter_count / ajusted_total
 
                 else:
                     freq_info[letter] = freq_info[letter] / total_count
@@ -698,6 +700,7 @@ class PSSM(object):
 
     your_pssm[1]['T']
     """
+
     def __init__(self, pssm):
         """Initialize with pssm data to represent.
 
@@ -745,4 +748,4 @@ def print_info_content(summary_info, fout=None, rep_record=0):
     rep_sequence = summary_info.alignment[rep_record].seq
     for pos in sorted(summary_info.ic_vector):
         fout.write("%d %s %.3f\n" % (pos, rep_sequence[pos],
-                   summary_info.ic_vector[pos]))
+                                     summary_info.ic_vector[pos]))

--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -537,7 +537,7 @@ class SummaryInfo(object):
         # reset ic_vector to empty list at each call
         self.ic_vector = []
         for (i, k) in enumerate(info_content):
-            self.ic_vector.append(info_content[i])
+            self.ic_vector.append(info_content[i+start])
         return total_info
 
     def _get_letter_freqs(self, residue_num, all_records, letters, to_ignore,

--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -549,7 +549,7 @@ class SummaryInfo(object):
             - letters - The letters we are interested in getting the frequency
               for.
             - to_ignore - Letters we are specifically supposed to ignore.
-            - pseudo_count - Optional argument specifying the Pseudo count (k) 
+            - pseudo_count - Optional argument specifying the Pseudo count (k)
               to add in order to prevent a frequency of 0 for a letter.
             - e_freq_table - An optional argument specifying the expected
               frequencies for each letter. This is a SubsMat.FreqTable instance.

--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -536,7 +536,7 @@ class SummaryInfo(object):
         # fill in the ic_vector member: holds IC for each column
         # reset ic_vector to empty list at each call
         self.ic_vector = []
-        for (i,k) in enumerate(info_content):
+        for (i, k) in enumerate(info_content):
             self.ic_vector.append(info_content[i])
         return total_info
 

--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -537,7 +537,7 @@ class SummaryInfo(object):
         # reset ic_vector to empty list at each call
         self.ic_vector = []
         for (i, k) in enumerate(info_content):
-            self.ic_vector.append(info_content[i+start])
+            self.ic_vector.append(info_content[i + start])
         return total_info
 
     def _get_letter_freqs(self, residue_num, all_records, letters, to_ignore,

--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -565,6 +565,10 @@ class SummaryInfo(object):
 
         gap_char = self._get_gap_char()
         
+        if pseudo_count <0 :
+            raise ValueError("Positive value required for " 
+                             "pseudo_count, %s provided"%(pseudo_count))
+
 
         # collect the count info into the dictionary for all the records
         for record in all_records:

--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -38,10 +38,10 @@ class SummaryInfo(object):
     def __init__(self, alignment):
         """Initialize with the alignment to calculate information on.
 
-        ic_vector attribute. A dictionary. Keys: column numbers. Values:
+        ic_vector attribute. A list of ic content for each column number.
         """
         self.alignment = alignment
-        self.ic_vector = {}
+        self.ic_vector = []
 
     def dumb_consensus(self, threshold=.7, ambiguous="X",
                        consensus_alpha=None, require_multiple=0):
@@ -534,8 +534,10 @@ class SummaryInfo(object):
         # sum up the score
         total_info = sum(info_content.values())
         # fill in the ic_vector member: holds IC for each column
-        for i in info_content:
-            self.ic_vector[i] = info_content[i]
+        # reset ic_vector to empty list at each call
+        self.ic_vector = []
+        for (i,k) in enumerate(info_content):
+            self.ic_vector.append(info_content[i])
         return total_info
 
     def _get_letter_freqs(self, residue_num, all_records, letters, to_ignore,
@@ -746,6 +748,5 @@ def print_info_content(summary_info, fout=None, rep_record=0):
     if not summary_info.ic_vector:
         summary_info.information_content()
     rep_sequence = summary_info.alignment[rep_record].seq
-    for pos in sorted(summary_info.ic_vector):
-        fout.write("%d %s %.3f\n" % (pos, rep_sequence[pos],
-                                     summary_info.ic_vector[pos]))
+    for pos, ic in enumerate(summary_info.ic_vector):
+        fout.write("%d %s %.3f\n" % (pos, rep_sequence[pos], ic))

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1478,6 +1478,27 @@ info_content = summary_align.information_content(5, 30, log_base = 10,
                                                  chars_to_ignore = ['N'])
 \end{verbatim}
 
+By default nucleotide or amino acid residues with a frequency of 0 in a column are not take into account when the relative information column for that column is computed. If this is not the desired result, you can use \verb|pseudo_count| instead.
+
+\begin{verbatim}
+info_content = summary_align.information_content(5, 30,
+                                                 chars_to_ignore = ['N'],
+                                                 pseudo_count = 1)
+\end{verbatim}
+
+In this case, the observed frequency $P_{ij}$ of a particular letter $i$ in the $j$-th column is computed as follow :
+
+\begin{displaymath}
+P_{ij} = \frac{P_{ij} + k\times Q_{i}}{N + k}
+\end{displaymath}
+
+\noindent where:
+
+\begin{itemize}
+  \item $k$ -- the pseudo count you pass as argument.
+  \item $Q_{i}$ --  The expected frequency of the letter $i$ as described above.
+\end{itemize}
+
 Well, now you are ready to calculate information content. If you want to try applying this to some real life problems, it would probably be best to dig into the literature on information content to get an idea of how it is used. Hopefully your digging won't reveal any mistakes made in coding this function!
 
 \section{Substitution Matrices}

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1489,12 +1489,13 @@ info_content = summary_align.information_content(5, 30,
 In this case, the observed frequency $P_{ij}$ of a particular letter $i$ in the $j$-th column is computed as follow :
 
 \begin{displaymath}
-P_{ij} = \frac{P_{ij} + k\times Q_{i}}{N + k}
+P_{ij} = \frac{n_{ij} + k\times Q_{i}}{N_{j} + k}
 \end{displaymath}
 
 \noindent where:
 
 \begin{itemize}
+  \item $k$ -- the pseudo count you pass as argument.
   \item $k$ -- the pseudo count you pass as argument.
   \item $Q_{i}$ --  The expected frequency of the letter $i$ as described above.
 \end{itemize}

--- a/Tests/test_AlignInfo.py
+++ b/Tests/test_AlignInfo.py
@@ -23,7 +23,7 @@ class AlignInfoTests(unittest.TestCase):
 
     def assertAlmostEqualList(self, list1, list2, **kwargs):
         self.assertEqual(len(list1), len(list2))
-        for i in xrange(len(list1)):
+        for i in range(len(list1)):
             self.assertAlmostEqual(list1[i], list2[i], **kwargs)
 
     def test_nucleotides(self):
@@ -139,7 +139,7 @@ X  0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
         ic = summary.information_content(e_freq_table=expected,
                                          log_base=math.exp(1),
                                          pseudo_count=1)
-        ic_vector = summary.ic_vector.values()
+        ic_vector = list(summary.ic_vector.values())
         self.assertAlmostEqualList(ic_vector, [0.110, 0.090, 0.360, 1.290, 0.800, \
                                         1.290, 1.290, 0.80, 0.610, 0.390, 0.470, 0.040], places=2)
         self.assertAlmostEqual(ic, 7.546, places=3)

--- a/Tests/test_AlignInfo.py
+++ b/Tests/test_AlignInfo.py
@@ -121,7 +121,7 @@ X  0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
 
 
     def test_pseudo_count(self):
-        # use example from http://homepages.ulb.ac.be/~dgonze/TEACHING/info_content.pdf
+        # use example from http://biologie.univ-mrs.fr/upload/p202/01.4.PSSM_theory.pdf
         alpha = unambiguous_dna
         dna_align = MultipleSeqAlignment([
                 SeqRecord(Seq("AACCACGTTTAA", alpha), id="ID001"),

--- a/Tests/test_AlignInfo.py
+++ b/Tests/test_AlignInfo.py
@@ -139,9 +139,7 @@ X  0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
         ic = summary.information_content(e_freq_table=expected,
                                          log_base=math.exp(1),
                                          pseudo_count=1)
-        print(ic)
         ic_vector = summary.ic_vector.values()
-        print(ic_vector)
         self.assertAlmostEqualList(ic_vector, [0.110, 0.090, 0.360, 1.290, 0.800, \
                                         1.290, 1.290, 0.80, 0.610, 0.390, 0.470, 0.040], places=2)
         self.assertAlmostEqual(ic, 7.546, places=3)

--- a/Tests/test_AlignInfo.py
+++ b/Tests/test_AlignInfo.py
@@ -23,8 +23,8 @@ class AlignInfoTests(unittest.TestCase):
 
     def assertAlmostEqualList(self, list1, list2, **kwargs):
         self.assertEqual(len(list1), len(list2))
-        for i in range(len(list1)):
-            self.assertAlmostEqual(list1[i], list2[i], **kwargs)
+        for (v1, v2) in zip(list1, list2):
+            self.assertAlmostEqual(v1, v2, **kwargs)
 
     def test_nucleotides(self):
         filename = "GFF/multi.fna"
@@ -67,9 +67,9 @@ N  0.0 2.0 1.0 0.0
     def test_proteins(self):
         alpha = HasStopCodon(Gapped(generic_protein, "-"), "*")
         a = MultipleSeqAlignment([
-                SeqRecord(Seq("MHQAIFIYQIGYP*LKSGYIQSIRSPEYDNW-", alpha), id="ID001"),
-                SeqRecord(Seq("MH--IFIYQIGYAYLKSGYIQSIRSPEY-NW*", alpha), id="ID002"),
-                SeqRecord(Seq("MHQAIFIYQIGYPYLKSGYIQSIRSPEYDNW*", alpha), id="ID003")])
+            SeqRecord(Seq("MHQAIFIYQIGYP*LKSGYIQSIRSPEYDNW-", alpha), id="ID001"),
+            SeqRecord(Seq("MH--IFIYQIGYAYLKSGYIQSIRSPEY-NW*", alpha), id="ID002"),
+            SeqRecord(Seq("MHQAIFIYQIGYPYLKSGYIQSIRSPEYDNW*", alpha), id="ID003")])
         self.assertEqual(32, a.get_alignment_length())
 
         s = SummaryInfo(a)
@@ -119,29 +119,30 @@ X  0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
         ic = s.information_content(chars_to_ignore=['-', '*'])
         self.assertAlmostEqual(ic, 133.061475107, places=6)
 
-
     def test_pseudo_count(self):
-        # use example from http://biologie.univ-mrs.fr/upload/p202/01.4.PSSM_theory.pdf
+        # use example from
+        # http://biologie.univ-mrs.fr/upload/p202/01.4.PSSM_theory.pdf
         alpha = unambiguous_dna
         dna_align = MultipleSeqAlignment([
-                SeqRecord(Seq("AACCACGTTTAA", alpha), id="ID001"),
-                SeqRecord(Seq("CACCACGTGGGT", alpha), id="ID002"),
-                SeqRecord(Seq("CACCACGTTCGC", alpha), id="ID003"),
-                SeqRecord(Seq("GCGCACGTGGGG", alpha), id="ID004"),
-                SeqRecord(Seq("TCGCACGTTGTG", alpha), id="ID005"),
-                SeqRecord(Seq("TGGCACGTGTTT", alpha), id="ID006"),
-                SeqRecord(Seq("TGACACGTGGGA", alpha), id="ID007"),
-                SeqRecord(Seq("TTACACGTGCGC", alpha), id="ID008")])
+            SeqRecord(Seq("AACCACGTTTAA", alpha), id="ID001"),
+            SeqRecord(Seq("CACCACGTGGGT", alpha), id="ID002"),
+            SeqRecord(Seq("CACCACGTTCGC", alpha), id="ID003"),
+            SeqRecord(Seq("GCGCACGTGGGG", alpha), id="ID004"),
+            SeqRecord(Seq("TCGCACGTTGTG", alpha), id="ID005"),
+            SeqRecord(Seq("TGGCACGTGTTT", alpha), id="ID006"),
+            SeqRecord(Seq("TGACACGTGGGA", alpha), id="ID007"),
+            SeqRecord(Seq("TTACACGTGCGC", alpha), id="ID008")])
 
         summary = SummaryInfo(dna_align)
         expected = FreqTable({"A": 0.325, "G": 0.175, "T": 0.325, "C": 0.175},
-                                                        FREQ, unambiguous_dna)
+                             FREQ, unambiguous_dna)
         ic = summary.information_content(e_freq_table=expected,
                                          log_base=math.exp(1),
                                          pseudo_count=1)
-        ic_vector = list(summary.ic_vector.values())
-        self.assertAlmostEqualList(ic_vector, [0.110, 0.090, 0.360, 1.290, 0.800, \
-                                        1.290, 1.290, 0.80, 0.610, 0.390, 0.470, 0.040], places=2)
+        ic_vector = [summary.ic_vector[i]
+                     for (i, k) in enumerate(summary.ic_vector)]
+        self.assertAlmostEqualList(ic_vector, [0.110, 0.090, 0.360, 1.290, 0.800,
+                                               1.290, 1.290, 0.80, 0.610, 0.390, 0.470, 0.040], places=2)
         self.assertAlmostEqual(ic, 7.546, places=3)
 
 

--- a/Tests/test_AlignInfo.py
+++ b/Tests/test_AlignInfo.py
@@ -139,9 +139,7 @@ X  0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
         ic = summary.information_content(e_freq_table=expected,
                                          log_base=math.exp(1),
                                          pseudo_count=1)
-        ic_vector = [summary.ic_vector[i]
-                     for (i, k) in enumerate(summary.ic_vector)]
-        self.assertAlmostEqualList(ic_vector, [0.110, 0.090, 0.360, 1.290, 0.800,
+        self.assertAlmostEqualList(summary.ic_vector, [0.110, 0.090, 0.360, 1.290, 0.800,
                                                1.290, 1.290, 0.80, 0.610, 0.390, 0.470, 0.040], places=2)
         self.assertAlmostEqual(ic, 7.546, places=3)
 


### PR DESCRIPTION
Current implementation ignore missing residues when the information content of each column of the alignment is computed. Sometimes, the desired action is the use of pseudo count instead. Here I added an optional argument (`pseudo_count`) with default value 0. When `pseudo_count` is specified (>0), the information content is computed using pseudo count, otherwise, the default behaviour is conserved.

With pseudo counts, the frequency of a letter `i` in column  `j` become :

![image](https://cloud.githubusercontent.com/assets/5290110/18798534/f286b814-81a0-11e6-9422-cc378bb0ddcc.png)  

 instead of 

  ![image](https://cloud.githubusercontent.com/assets/5290110/18798558/1016b0fa-81a1-11e6-9626-431e3c83f96a.png)


With Qi being the expected frequency (prior) for letter `i`  (either from `e_freq_table`  or `random_expected`)



