### PR TITLE
Bio.PDB.PDBList update

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -30,7 +30,6 @@
 # Any maintainer of the Biopython code may change this notice
 # when appropriate.
 
-
 """ Access the PDB over the internet (e.g. to download structures). """
 
 from __future__ import print_function
@@ -42,6 +41,7 @@ import shutil
 import re
 
 # Importing these functions with leading underscore as not intended for reuse
+from Bio._py3k import _as_string
 from Bio._py3k import urlopen as _urlopen
 from Bio._py3k import urlretrieve as _urlretrieve
 from Bio._py3k import urlcleanup as _urlcleanup
@@ -110,7 +110,7 @@ class PDBList(object):
             for line in handle:
                 pdb = line.strip()
                 assert len(pdb) == 4
-                answer.append(pdb.decode())
+                answer.append(_as_string(pdb))
         return answer
 
     def get_recent_changes(self):
@@ -143,7 +143,7 @@ class PDBList(object):
         url = self.pdb_server + '/pub/pdb/derived_data/index/entries.idx'
         print("Retrieving index file. Takes about 27 MB.")
         with contextlib.closing(_urlopen(url)) as handle:
-            all_entries = [line[:4] for line in handle.readlines()[2:]
+            all_entries = [_as_string(line[:4]) for line in handle.readlines()[2:]
                            if len(line) > 4]
         return all_entries
 
@@ -180,7 +180,7 @@ class PDBList(object):
                     continue
                 pdb = line.split()[2]
                 assert len(pdb) == 4
-                obsolete.append(pdb)
+                obsolete.append(_as_string(pdb))
         return obsolete
 
     def retrieve_pdb_file(self, pdb_code, obsolete=False, pdir=None, file_format='mmCif', overwrite=False):

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -459,15 +459,15 @@ if __name__ == '__main__':
         if sys.argv[1] == 'update':
             # update PDB
             print("updating local PDB at " + pdb_path)
-            pl.update_pdb()
+            pl.update_pdb(file_format=file_format)
 
         elif sys.argv[1] == 'all':
             # get the entire PDB
-            pl.download_entire_pdb()
+            pl.download_entire_pdb(file_format=file_format)
 
         elif sys.argv[1] == 'obsol':
             # get all obsolete entries
-            pl.download_obsolete_entries(pdb_path)
+            pl.download_obsolete_entries(pdb_path, file_format=file_format)
 
         elif len(sys.argv[1]) == 4 and sys.argv[1][0].isdigit():
             # get single PDB entry

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -230,7 +230,6 @@ class PDBList(object):
         @return: filename
         @rtype: string
         """
-
         file_format = self._print_default_format_warning(file_format)  # Deprecation warning
 
         # Get the compressed PDB structure

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -23,8 +23,11 @@
 #   homepage : http://jaceksmietanski.net
 #   email    : jacek.smietanski@ii.uj.edu.pl
 #
-# This code is released under the conditions of the Biopython license.
-# It may be distributed freely with respect to the original author.
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
+# It may be distributed freely with respect to the original authors.
 # Any maintainer of the Biopython code may change this notice
 # when appropriate.
 
@@ -180,7 +183,7 @@ class PDBList(object):
                 obsolete.append(pdb)
         return obsolete
 
-    def retrieve_pdb_file(self, pdb_code, file_format='mmCif', overwrite=False, obsolete=False, pdir=None):
+    def retrieve_pdb_file(self, pdb_code, obsolete=False, pdir=None, file_format='mmCif', overwrite=False):
         """ Retrieves a PDB structure file from the PDB server and
         stores it in a local file tree.
 
@@ -282,7 +285,7 @@ class PDBList(object):
 
         for pdb_code in new + modified:
             try:
-                self.retrieve_pdb_file(pdb_code, file_format)
+                self.retrieve_pdb_file(pdb_code, file_format=file_format)
             except Exception:
                 print('error %s\n' % pdb_code)
                 # you can insert here some more log notes that
@@ -343,7 +346,7 @@ class PDBList(object):
         @rtype: string
         """
         for pdb_code in pdb_codes:
-            self.retrieve_pdb_file(pdb_code, file_format, overwrite, obsolete, pdir)
+            self.retrieve_pdb_file(pdb_code, obsolete=obsolete, pdir=pdir, file_format=file_format, overwrite=overwrite)
 
     def download_entire_pdb(self, file_format='mmCif', listfile=None):
         """Retrieve all PDB entries not present in the local PDB copy.
@@ -353,7 +356,7 @@ class PDBList(object):
         """
         entries = self.get_all_entries()
         for pdb_code in entries:
-            self.retrieve_pdb_file(pdb_code, file_format)
+            self.retrieve_pdb_file(pdb_code, file_format=file_format)
         # Write the list
         if listfile:
             with open(listfile, 'w') as outfile:
@@ -368,7 +371,7 @@ class PDBList(object):
         """
         entries = self.get_all_obsolete()
         for pdb_code in entries:
-            self.retrieve_pdb_file(pdb_code, file_format, obsolete=True)
+            self.retrieve_pdb_file(pdb_code, obsolete=True, file_format=file_format)
 
         # Write the list
         if listfile:
@@ -451,10 +454,10 @@ if __name__ == '__main__':
 
         elif len(sys.argv[1]) == 4 and sys.argv[1][0].isdigit():
             # get single PDB entry
-            pl.retrieve_pdb_file(sys.argv[1], file_format=file_format, overwrite=overwrite, pdir=pdb_path)
+            pl.retrieve_pdb_file(sys.argv[1], pdir=pdb_path, file_format=file_format, overwrite=overwrite)
 
         elif sys.argv[1][0] == '(':
             # get a set of PDB entries
             pdb_ids = re.findall(sys.argv[1], "[0-9A-Za-z]{4}")
             for pdb_id in pdb_ids:
-                pl.retrieve_pdb_file(pdb_id, file_format=file_format, overwrite=overwrite, pdir=pdb_path)
+                pl.retrieve_pdb_file(pdb_id, pdir=pdb_path, file_format=file_format, overwrite=overwrite)

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -44,6 +44,7 @@ import re
 # Importing these functions with leading underscore as not intended for reuse
 from Bio._py3k import urlopen as _urlopen
 from Bio._py3k import urlretrieve as _urlretrieve
+from Bio._py3k import urlcleanup as _urlcleanup
 
 
 class PDBList(object):
@@ -262,6 +263,7 @@ class PDBList(object):
         # Retrieve the file
         print("Downloading PDB structure '%s'..." % pdb_code)
         try:
+            _urlcleanup()
             _urlretrieve(url, filename)
         except IOError:
             print("Desired structure doesn't exists")

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -23,8 +23,7 @@
 #   homepage : http://jaceksmietanski.net
 #   email    : jacek.smietanski@ii.uj.edu.pl
 #
-# This file is part of the Biopython distribution and governed by your
-# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# This code is released under the conditions of the Biopython license.
 # Please see the LICENSE file that should have been included as part of this
 # package.
 # It may be distributed freely with respect to the original authors.
@@ -190,6 +189,8 @@ class PDBList(object):
         The PDB structure's file name is returned as a single string.
         If obsolete ``==`` True, the file will be saved in a special file tree.
 
+        NOTE. The default download format has changed from PDB to PDBx/mmCif
+
         @param pdb_code: 4-symbols structure Id from PDB (e.g. 3J92).
         @type pdb_code: string
 
@@ -314,7 +315,7 @@ class PDBList(object):
             else:
                 print("Obsolete file %s is missing" % old_file)
 
-    def download_pdb_files(self, pdb_codes, file_format='mmCif', overwrite=False, obsolete=False, pdir=None):
+    def download_pdb_files(self, pdb_codes, obsolete=False, pdir=None, file_format='mmCif', overwrite=False):
         """ Retrieves a set of PDB structure files from the PDB server and stores them in a local file tree.
 
         The PDB structure's file name is returned as a single string.
@@ -348,11 +349,19 @@ class PDBList(object):
         for pdb_code in pdb_codes:
             self.retrieve_pdb_file(pdb_code, obsolete=obsolete, pdir=pdir, file_format=file_format, overwrite=overwrite)
 
-    def download_entire_pdb(self, file_format='mmCif', listfile=None):
+    def download_entire_pdb(self, listfile=None, file_format='mmCif'):
         """Retrieve all PDB entries not present in the local PDB copy.
 
-        Writes a list file containing all PDB codes (optional, if listfile is
-        given).
+        @param listfile: filename to which all PDB codes will be written (optional)
+
+        @param file_format: file format. Available options:
+            "mmCif" (default, PDBx/mmCif file),
+            "pdb" (format PDB),
+            "xml" (PMDML/XML format),
+            "mmtf" (highly compressed),
+            "bundle" (PDB formatted archive for large structure}
+
+        NOTE. The default download format has changed from PDB to PDBx/mmCif
         """
         entries = self.get_all_entries()
         for pdb_code in entries:
@@ -362,12 +371,18 @@ class PDBList(object):
             with open(listfile, 'w') as outfile:
                 outfile.writelines((x + '\n' for x in entries))
 
-    def download_obsolete_entries(self, file_format='mmCif', listfile=None):
+    def download_obsolete_entries(self, listfile=None, file_format='mmCif'):
         """Retrieve all obsolete PDB entries not present in the local obsolete
         PDB copy.
 
-        Writes a list file containing all PDB codes (optional, if listfile is
-        given).
+        @param listfile: filename to which all PDB codes will be written (optional)
+
+        @param file_format: file format. Available options:
+            "mmCif" (default, PDBx/mmCif file),
+            "pdb" (format PDB),
+            "xml" (PMDML/XML format),
+
+        NOTE. The default download format has changed from PDB to PDBx/mmCif
         """
         entries = self.get_all_obsolete()
         for pdb_code in entries:

--- a/Bio/_py3k/__init__.py
+++ b/Bio/_py3k/__init__.py
@@ -162,7 +162,7 @@ if sys.version_info[0] >= 3:
     from io import StringIO
 
     # On Python 3 urllib, urllib2, and urlparse were merged:
-    from urllib.request import urlopen, Request, urlretrieve, urlparse
+    from urllib.request import urlopen, Request, urlretrieve, urlparse, urlcleanup
     from urllib.parse import urlencode, quote
     from urllib.error import HTTPError
 
@@ -219,7 +219,7 @@ else:
 
     # Under urllib.request on Python 3:
     from urllib2 import urlopen, Request
-    from urllib import urlretrieve
+    from urllib import urlretrieve, urlcleanup
     from urlparse import urlparse
 
     # Under urllib.parse on Python 3:

--- a/Tests/test_NCBI_qblast.py
+++ b/Tests/test_NCBI_qblast.py
@@ -43,9 +43,10 @@ print("Checking Bio.Blast.NCBIWWW.qblast() with various queries")
 class TestQblast(unittest.TestCase):
 
     def test_blastp_nr_actin(self):
-        # Simple protein blast filtered for rat only, using protein GI:160837788
+        # Simple protein blast filtered for rat only, using protein
+        # GI:160837788 aka NP_075631.2
         # the actin related protein 2/3 complex, subunit 1B [Mus musculus]
-        self.run_qblast("blastp", "nr", "160837788", 0.001,
+        self.run_qblast("blastp", "nr", "NP_075631.2", 0.001,
                         "rat [ORGN]", ['9506405', '13592137', '37589612', '149064087', '56912225'])
 
     def test_pcr_primers(self):

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -28,7 +28,7 @@ class TestPBDListGetList(unittest.TestCase):
         """
         Tests the Bio.PDB.PDBList.get_recent_changes method.
         """
-        pdblist = PDBList()
+        pdblist = PDBList(obsolete_pdb="unimpotrant")  # obsolete_pdb declared to prevent from creating the "obsolete" directory
         url = pdblist.pdb_server + '/pub/pdb/data/status/latest/added.pdb'
         entries = pdblist.get_status_list(url)
         self.assertIsNotNone(entries)
@@ -37,7 +37,7 @@ class TestPBDListGetList(unittest.TestCase):
         """
         Tests the Bio.PDB.PDBList.get_all_entries method.
         """
-        pdblist = PDBList()
+        pdblist = PDBList(obsolete_pdb="unimpotrant")  # obsolete_pdb declared to prevent from creating the "obsolete" directory
         entries = pdblist.get_all_entries()
         # As number of entries constantly grow, test checks if a certain number was exceeded
         self.assertTrue(len(entries) > 100000)
@@ -46,7 +46,7 @@ class TestPBDListGetList(unittest.TestCase):
         """
         Tests the Bio.PDB.PDBList.get_all_obsolete method.
         """
-        pdblist = PDBList()
+        pdblist = PDBList(obsolete_pdb="unimpotrant")  # obsolete_pdb declared to prevent from creating the "obsolete" directory
         entries = pdblist.get_all_obsolete()
         # As number of obsolete entries constantly grow, test checks if a certain number was exceeded
         self.assertTrue(len(entries) > 3000)
@@ -125,9 +125,21 @@ class TestPDBListGetStructure(unittest.TestCase):
             self.assertTrue(os.path.isfile(path))
             os.remove(path)
 
+    def test_retrieve_pdb_file_obsolete_xml(self):
+        """
+        Tests retrieving the obsolete molecule in mmcif format
+        """
+        structure = "347d"
+        with self.make_temp_directory(os.getcwd()) as tmp:
+            pdblist = PDBList(pdb=tmp, obsolete_pdb=os.path.join(tmp, "obsolete"))
+            path = os.path.join(tmp, "obsolete", structure[1:3], "%s.xml" % structure)
+            pdblist.retrieve_pdb_file(structure, obsolete=True, file_format="xml")
+            self.assertTrue(os.path.isfile(path))
+            os.remove(path)
+
     def test_retrieve_pdb_file_xml(self):
         """
-        Tests retrieving the molecule in xml format
+        Tests retrieving the (non obsolete) molecule in xml format
         """
         structure = "127d"
         with self.make_temp_directory(os.getcwd()) as tmp:

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -20,42 +20,32 @@ from Bio.PDB.PDBList import PDBList
 
 
 class TestPBDListGetList(unittest.TestCase):
-    """
-    Test methods responsible for getting lists of entries.
-    """
+    """Test methods responsible for getting lists of entries."""
 
     def test_get_recent_changes(self):
-        """
-        Tests the Bio.PDB.PDBList.get_recent_changes method.
-        """
-        pdblist = PDBList(obsolete_pdb="unimpotrant")  # obsolete_pdb declared to prevent from creating the "obsolete" directory
+        """Tests the Bio.PDB.PDBList.get_recent_changes method."""
+        pdblist = PDBList(obsolete_pdb="unimportant")  # obsolete_pdb declared to prevent from creating the "obsolete" directory
         url = pdblist.pdb_server + '/pub/pdb/data/status/latest/added.pdb'
         entries = pdblist.get_status_list(url)
         self.assertIsNotNone(entries)
 
     def test_get_all_entries(self):
-        """
-        Tests the Bio.PDB.PDBList.get_all_entries method.
-        """
-        pdblist = PDBList(obsolete_pdb="unimpotrant")  # obsolete_pdb declared to prevent from creating the "obsolete" directory
+        """Tests the Bio.PDB.PDBList.get_all_entries method."""
+        pdblist = PDBList(obsolete_pdb="unimportant")  # obsolete_pdb declared to prevent from creating the "obsolete" directory
         entries = pdblist.get_all_entries()
         # As number of entries constantly grow, test checks if a certain number was exceeded
         self.assertTrue(len(entries) > 100000)
 
     def test_get_all_obsolete(self):
-        """
-        Tests the Bio.PDB.PDBList.get_all_obsolete method.
-        """
-        pdblist = PDBList(obsolete_pdb="unimpotrant")  # obsolete_pdb declared to prevent from creating the "obsolete" directory
+        """Tests the Bio.PDB.PDBList.get_all_obsolete method."""
+        pdblist = PDBList(obsolete_pdb="unimportant")  # obsolete_pdb declared to prevent from creating the "obsolete" directory
         entries = pdblist.get_all_obsolete()
         # As number of obsolete entries constantly grow, test checks if a certain number was exceeded
         self.assertTrue(len(entries) > 3000)
 
 
 class TestPDBListGetStructure(unittest.TestCase):
-    """
-    Test methods responsible for getting structures.
-    """
+    """Test methods responsible for getting structures."""
 
     @contextlib.contextmanager
     def make_temp_directory(self, dir):
@@ -65,98 +55,50 @@ class TestPDBListGetStructure(unittest.TestCase):
         finally:
             shutil.rmtree(temp_dir)
 
-    def test_retrieve_pdb_file_small_pdb(self):
-        """
-        Tests retrieving the small molecule in pdb format
-        """
-        structure = "127d"
+    def check(self, structure, filename, file_format, obsolete=False):
         with self.make_temp_directory(os.getcwd()) as tmp:
             pdblist = PDBList(pdb=tmp, obsolete_pdb=os.path.join(tmp, "obsolete"))
-            path = os.path.join(tmp, structure[1:3], "pdb%s.ent" % structure)
-            pdblist.retrieve_pdb_file(structure, file_format="pdb")
+            path = os.path.join(tmp, filename)
+            pdblist.retrieve_pdb_file(structure, obsolete=obsolete, file_format=file_format)
             self.assertTrue(os.path.isfile(path))
             os.remove(path)
+
+    def test_retrieve_pdb_file_small_pdb(self):
+        """Tests retrieving the small molecule in pdb format."""
+        structure = "127d"
+        self.check(structure, os.path.join(structure[1:3], "pdb%s.ent" % structure), "pdb")
 
     def test_retrieve_pdb_file_large_pdb(self):
-        """
-        Tests retrieving the bundle for large molecule in pdb-like format
-        """
+        """Tests retrieving the bundle for large molecule in pdb-like format."""
         structure = "3k1q"
-        with self.make_temp_directory(os.getcwd()) as tmp:
-            pdblist = PDBList(pdb=tmp, obsolete_pdb=os.path.join(tmp, "obsolete"))
-            path = os.path.join(tmp, structure[1:3], "%s-pdb-bundle.tar" % structure)
-            pdblist.retrieve_pdb_file(structure, file_format="bundle")
-            self.assertTrue(os.path.isfile(path))
-            os.remove(path)
+        self.check(structure, os.path.join(structure[1:3], "%s-pdb-bundle.tar" % structure), "bundle")
 
     def test_retrieve_pdb_file_obsolete_pdb(self):
-        """
-        Tests retrieving the obsolete molecule in pdb format
-        """
+        """Tests retrieving the obsolete molecule in pdb format"""
         structure = "347d"
-        with self.make_temp_directory(os.getcwd()) as tmp:
-            pdblist = PDBList(pdb=tmp, obsolete_pdb=os.path.join(tmp, "obsolete"))
-            path = os.path.join(tmp, "obsolete", structure[1:3], "pdb%s.ent" % structure)
-            pdblist.retrieve_pdb_file(structure, obsolete=True, file_format="pdb")
-            self.assertTrue(os.path.isfile(path))
-            os.remove(path)
+        self.check(structure, os.path.join("obsolete", structure[1:3], "pdb%s.ent" % structure), "pdb", obsolete=True)
 
     def test_retrieve_pdb_file_obsolete_mmcif(self):
-        """
-        Tests retrieving the obsolete molecule in mmcif format
-        """
+        """Tests retrieving the obsolete molecule in mmcif format."""
         structure = "347d"
-        with self.make_temp_directory(os.getcwd()) as tmp:
-            pdblist = PDBList(pdb=tmp, obsolete_pdb=os.path.join(tmp, "obsolete"))
-            path = os.path.join(tmp, "obsolete", structure[1:3], "%s.cif" % structure)
-            pdblist.retrieve_pdb_file(structure, obsolete=True, file_format="mmCif")
-            self.assertTrue(os.path.isfile(path))
-            os.remove(path)
+        self.check(structure, os.path.join("obsolete", structure[1:3], "%s.cif" % structure), "mmCif", obsolete=True)
 
     def test_retrieve_pdb_file_mmcif(self):
-        """
-        Tests retrieving the (non-obsolete) molecule in mmcif format
-        """
+        """Tests retrieving the (non-obsolete) molecule in mmcif format."""
         structure = "127d"
-        with self.make_temp_directory(os.getcwd()) as tmp:
-            pdblist = PDBList(pdb=tmp, obsolete_pdb=os.path.join(tmp, "obsolete"))
-            path = os.path.join(tmp, structure[1:3], "%s.cif" % structure)
-            pdblist.retrieve_pdb_file(structure, file_format="mmCif")
-            self.assertTrue(os.path.isfile(path))
-            os.remove(path)
+        self.check(structure, os.path.join(structure[1:3], "%s.cif" % structure), "mmCif")
 
     def test_retrieve_pdb_file_obsolete_xml(self):
-        """
-        Tests retrieving the obsolete molecule in mmcif format
-        """
+        """Tests retrieving the obsolete molecule in mmcif format."""
         structure = "347d"
-        with self.make_temp_directory(os.getcwd()) as tmp:
-            pdblist = PDBList(pdb=tmp, obsolete_pdb=os.path.join(tmp, "obsolete"))
-            path = os.path.join(tmp, "obsolete", structure[1:3], "%s.xml" % structure)
-            pdblist.retrieve_pdb_file(structure, obsolete=True, file_format="xml")
-            self.assertTrue(os.path.isfile(path))
-            os.remove(path)
+        self.check(structure, os.path.join("obsolete", structure[1:3], "%s.xml" % structure), "xml", obsolete=True)
 
     def test_retrieve_pdb_file_xml(self):
-        """
-        Tests retrieving the (non obsolete) molecule in xml format
-        """
+        """Tests retrieving the (non obsolete) molecule in xml format."""
         structure = "127d"
-        with self.make_temp_directory(os.getcwd()) as tmp:
-            pdblist = PDBList(pdb=tmp, obsolete_pdb=os.path.join(tmp, "obsolete"))
-            path = os.path.join(tmp, structure[1:3], "%s.xml" % structure)
-            pdblist.retrieve_pdb_file(structure, file_format="xml")
-            self.assertTrue(os.path.isfile(path))
-            os.remove(path)
+        self.check(structure, os.path.join(structure[1:3], "%s.xml" % structure), "xml")
 
     def test_retrieve_pdb_file_mmtf(self):
-        """
-        Tests retrieving the molecule in mmtf format
-        """
+        """Tests retrieving the molecule in mmtf format."""
         structure = "127d"
-        with self.make_temp_directory(os.getcwd()) as tmp:
-            pdblist = PDBList(pdb=tmp, obsolete_pdb=os.path.join(tmp, "obsolete"))
-            path = os.path.join(tmp, structure[1:3], "%s.mmtf" % structure)
-            pdblist.retrieve_pdb_file(structure, file_format="mmtf")
-            self.assertTrue(os.path.isfile(path))
-            os.remove(path)
+        self.check(structure, os.path.join(structure[1:3], "%s.mmtf" % structure), "mmtf")

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -48,8 +48,8 @@ class TestPDBListGetStructure(unittest.TestCase):
     """Test methods responsible for getting structures."""
 
     @contextlib.contextmanager
-    def make_temp_directory(self, dir):
-        temp_dir = tempfile.mkdtemp(dir=dir)
+    def make_temp_directory(self, directory):
+        temp_dir = tempfile.mkdtemp(directory=directory)
         try:
             yield temp_dir
         finally:

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -55,11 +55,13 @@ class TestPDBListGetStructure(unittest.TestCase):
         finally:
             shutil.rmtree(temp_dir)
 
-    def check(self, structure, filename, file_format, obsolete=False):
+    def check(self, structure, filename, file_format, obsolete=False, pdir=None):
         with self.make_temp_directory(os.getcwd()) as tmp:
             pdblist = PDBList(pdb=tmp, obsolete_pdb=os.path.join(tmp, "obsolete"))
             path = os.path.join(tmp, filename)
-            pdblist.retrieve_pdb_file(structure, obsolete=obsolete, file_format=file_format)
+            if pdir:
+                pdir = os.path.join(tmp, pdir)
+            pdblist.retrieve_pdb_file(structure, obsolete=obsolete, pdir=pdir, file_format=file_format)
             self.assertTrue(os.path.isfile(path))
             os.remove(path)
 
@@ -102,3 +104,9 @@ class TestPDBListGetStructure(unittest.TestCase):
         """Tests retrieving the molecule in mmtf format."""
         structure = "127d"
         self.check(structure, os.path.join(structure[1:3], "%s.mmtf" % structure), "mmtf")
+
+    def test_double_retrieve(self):
+        """Tests retrieving the same file to different directories."""
+        structure = "127d"
+        self.check(structure, os.path.join("a", "%s.cif" % structure), "mmCif", pdir="a")
+        self.check(structure, os.path.join("b", "%s.cif" % structure), "mmCif", pdir="b")


### PR DESCRIPTION
Changes to module:
1. Possibility to download structures in PDBx/mmCif, PDB, PDBML/XML and
mmtf formats (both from function and command line)
2. Possibility to download large structures in PDB-like formatted bundles
3. New function: download specified set of structures
4. Code is now python 3.x compatible
5. Unit tests added
6. Some minor updates

Note. The default download format changed from (deprecated) PDB to
(recommended by RCSB) PDBx/mmCIf.
