### PR TITLE
Added a feature for changing the id of an PDB.Entity's child.

### DIFF
--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -92,45 +92,46 @@ class Entity(object):
     def reset_full_id(self):
         """Reset the full_id.
 
-        Sets the full_id of this entity and 
+        Sets the full_id of this entity and
         recursively of all its children to None.
-        This means that it will be newly generated 
+        This means that it will be newly generated
         at the next call to get_full_id.
         """
         for child in self:
             try:
                 child.reset_full_id()
-            except AttributeError: pass #Atoms do not cache their full ids.
+            except AttributeError: 
+                pass  # Atoms do not cache their full ids.
         self.full_id = None
 
-    def change_child_id(self, old_id, new_id, rename_structure = "_modified"):
+    def change_child_id(self, old_id, new_id, rename_structure="_modified"):
         """Change the id of a child.
 
         @param rename_structure: Append this string to the id
                 of the corresponding (parent) Structure instance.
-                This is to guarantee adherence to point one of 
-                the pdb advisory 
+                This is to guarantee adherence to point one of
+                the pdb advisory
                 (http://www.rcsb.org/pdb/static.do?p=general_information/about_pdb/pdb_advisory.html)
         @type rename_structure: string
         """
         entity = self[old_id]
-        #Pdb does not want people to distribute modified
-        #data under the original id. Changing the id of an
-        #entity can be seen as a modification of the pdb data.
-        #We thus change the id of the Structure object to be on the save side.
+        # Pdb does not want people to distribute modified
+        # data under the original id. Changing the id of an
+        # entity can be seen as a modification of the pdb data.
+        # We thus change the id of the Structure object to be on the save side.
         if rename_structure:
             parent = self
             while parent is not None:
                 if parent.level == "S":
-                    assert parent.get_parent() is None #Structure Entity should not have a parent.
-                    parent.id+=rename_structure
+                    assert parent.get_parent() is None  # Structure Entity should not have a parent.
+                    parent.id += rename_structure
                     break
                 parent = parent.get_parent()
         entity.id = new_id
         self.child_dict[new_id] = entity
         del self.child_dict[old_id]
         entity.reset_full_id()
-            
+     
     def insert(self, pos, entity):
         "Add a child to the Entity at a specified position."
         entity_id = entity.get_id()

--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -51,6 +51,23 @@ class Entity(object):
         for child in self.child_list:
             yield child
 
+    # Private methods
+
+    def _reset_full_id(self):
+        """Reset the full_id.
+
+        Sets the full_id of this entity and
+        recursively of all its children to None.
+        This means that it will be newly generated
+        at the next call to get_full_id.
+        """
+        for child in self:
+            try:
+                child._reset_full_id()
+            except AttributeError:
+                pass  # Atoms do not cache their full ids.
+        self.full_id = None
+
     # Public methods
 
     @property
@@ -77,7 +94,7 @@ class Entity(object):
             self.parent.child_dict[value] = self
 
         self._id = value
-        self.reset_full_id()
+        self._reset_full_id()
 
     def get_level(self):
         """Return level in hierarchy.
@@ -114,21 +131,6 @@ class Entity(object):
         entity.set_parent(self)
         self.child_list.append(entity)
         self.child_dict[entity_id] = entity
-
-    def reset_full_id(self):
-        """Reset the full_id.
-
-        Sets the full_id of this entity and
-        recursively of all its children to None.
-        This means that it will be newly generated
-        at the next call to get_full_id.
-        """
-        for child in self:
-            try:
-                child.reset_full_id()
-            except AttributeError:
-                pass  # Atoms do not cache their full ids.
-        self.full_id = None
 
     def insert(self, pos, entity):
         "Add a child to the Entity at a specified position."

--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -89,6 +89,48 @@ class Entity(object):
         self.child_list.append(entity)
         self.child_dict[entity_id] = entity
 
+    def reset_full_id(self):
+        """Reset the full_id.
+
+        Sets the full_id of this entity and 
+        recursively of all its children to None.
+        This means that it will be newly generated 
+        at the next call to get_full_id.
+        """
+        for child in self:
+            try:
+                child.reset_full_id()
+            except AttributeError: pass #Atoms do not cache their full ids.
+        self.full_id = None
+
+    def change_child_id(self, old_id, new_id, rename_structure = "_modified"):
+        """Change the id of a child.
+
+        @param rename_structure: Append this string to the id
+                of the corresponding (parent) Structure instance.
+                This is to guarantee adherence to point one of 
+                the pdb advisory 
+                (http://www.rcsb.org/pdb/static.do?p=general_information/about_pdb/pdb_advisory.html)
+        @type rename_structure: string
+        """
+        entity = self[old_id]
+        #Pdb does not want people to distribute modified
+        #data under the original id. Changing the id of an
+        #entity can be seen as a modification of the pdb data.
+        #We thus change the id of the Structure object to be on the save side.
+        if rename_structure:
+            parent = self
+            while parent is not None:
+                if parent.level == "S":
+                    assert parent.get_parent() is None #Structure Entity should not have a parent.
+                    parent.id+=rename_structure
+                    break
+                parent = parent.get_parent()
+        entity.id = new_id
+        self.child_dict[new_id] = entity
+        del self.child_dict[old_id]
+        entity.reset_full_id()
+            
     def insert(self, pos, entity):
         "Add a child to the Entity at a specified position."
         entity_id = entity.get_id()

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -1014,8 +1014,8 @@ class RenamingElementTests(unittest.TestCase):
     def test_full_id_is_updated(self):
         for atom in self.struc.get_atoms(): break #First atom
         original_id = atom.get_full_id()
-        for chain in self.struc.get_chains(): break #Get first chain
-        chain.change_child_id(('H_PCA', 1, ' '), (' ', 1, ' '))
+        for model in self.struc: break #Get first model
+        model.change_child_id('A', '1_A')
         new_id = atom.get_full_id()
         self.assertNotEqual(original_id, new_id)
     def test_parent_name_is_updated(self):

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -994,7 +994,35 @@ class IterationTests(unittest.TestCase):
         atoms = ["%12s" % str((atom.id, atom.altloc)) for atom in self.struc.get_atoms()]
         self.assertEqual(len(atoms), 756)
 
-
+class RenamingElementTests(unittest.TestCase):
+    def setUp(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PDBConstructionWarning)
+            self.struc = PDBParser(PERMISSIVE=True).get_structure('X', "PDB/a_structure.pdb")
+    def test_rename_chain(self):
+        """Changes the id of a model's child (a chain)"""
+        for model in self.struc: break #Get first model in structure
+        model.change_child_id('A', '1_A')
+        self.assertEqual([chain.id for chain in model.get_chains()] , ["1_A"])
+    def test_rename_residue(self):
+        """Changes the id of a residue"""
+        for chain in self.struc.get_chains(): break #Get first chain
+        chain.change_child_id(('H_PCA', 1, ' '), (' ', 1, ' '))
+        self.assertIn((' ', 1, ' '), chain) #__contains__ uses child_dict
+        for res in chain: break #__iter__ uses child_list
+        self.assertEqual(res.get_id(), (' ', 1, ' ')) 
+    def test_full_id_is_updated(self):
+        for atom in self.struc.get_atoms(): break #First atom
+        original_id = atom.get_full_id()
+        for chain in self.struc.get_chains(): break #Get first chain
+        chain.change_child_id(('H_PCA', 1, ' '), (' ', 1, ' '))
+        new_id = atom.get_full_id()
+        self.assertNotEqual(original_id, new_id)
+    def test_parent_name_is_updated(self):
+        for chain in self.struc.get_chains(): break #Get first chain
+        chain.change_child_id(('H_PCA', 1, ' '), (' ', 1, ' '), "I changed it")
+        self.assertIn("I changed it", self.struc.get_id())
+        
 # class RenumberTests(unittest.TestCase):
 #    """Tests renumbering of structures."""
 #


### PR DESCRIPTION
When changing the id of an `PDB.Entity`, it has to be changed at 2 places:
*) The element's attribute `id`
*) The parent's `child_dict`.
Further more, the `full_id` has to be invalidated recursively for all children.

I do not know biopython well enough to know if there are many usecases for this feature and if there are other pitfalls that I missed, but this is a first reference implementation how changing an entity's id could work.

A probably better implementation would be making `Entity.id` a property with a costum setter method that uses the `.parent` attribute to acces the parent's `child_dict`
If this feature makes sense, I could implement this alternative version.