### PR TITLE
fixed taxon label export in NexusIO.py.

### DIFF
--- a/Bio/Phylo/NexusIO.py
+++ b/Bio/Phylo/NexusIO.py
@@ -67,7 +67,7 @@ def write(obj, handle, **kwargs):
                    for idx, nwk in enumerate(
         writer.to_strings(plain=False, plain_newick=True,
                           **kwargs))]
-    tax_labels = [str(x) for x in chain(*(t.get_terminals() for t in trees))]
+    tax_labels = [str(x.name) for x in chain(*(t.get_terminals() for t in trees))]
     text = NEX_TEMPLATE % {
         'count': len(tax_labels),
         'labels': ' '.join(tax_labels),


### PR DESCRIPTION
 Avoid truncation by `Phylo.BaseTree.Clade.__str__` by exporting `str(node.name)` instead of `str(node)`