### PR TITLE
[IMP] Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+NumPy
+ReportLab
+matplotlib
+networkx
+pygraphviz
+rdflib
+psycopg2
+MySQLdb


### PR DESCRIPTION
No we can install all requirements by typing
```
pip install -r requirements.txt
```