### PR TITLE
Write correct fields in PDB TER record

### DIFF
--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -207,7 +207,9 @@ class PDBIO(object):
                             fp.write(s)
                             atom_number = atom_number + 1
                 if chain_residues_written:
-                    fp.write("TER\n")
+                    fp.write("TER   %5i      %3s %c%4i%c                                                      \n"
+                             % (atom_number, resname, chain_id, resseq, icode))
+
             if model_flag and model_residues_written:
                 fp.write("ENDMDL\n")
         if write_end:

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -520,7 +520,7 @@ class ParseTest(unittest.TestCase):
             # Check if there are lines besides 'ATOM', 'TER' and 'END'
             with open(filename, 'rU') as handle:
                 record_set = set(l[0:6] for l in handle)
-            record_set -= set(('ATOM  ', 'HETATM', 'MODEL ', 'ENDMDL', 'TER\n', 'END\n'))
+            record_set -= set(('ATOM  ', 'HETATM', 'MODEL ', 'ENDMDL', 'TER\n',  'TER   ', 'END\n', 'END   '))
             self.assertEqual(record_set, set())
         finally:
             os.remove(filename)


### PR DESCRIPTION
Slight modification of original PDBIO.diff
Closes https://redmine.open-bio.org/issues/2292

> Bio.PDBIO is happy to write TER records as "TER\n", which is inconsistent with PDB format specification.
> 
> The PDB format requires that TER records have some fields similar to ATOM records:
> '''The TER record has the same residue name, chain identifier, sequence number and insertion code as the terminal residue. The serial number of the TER record is one number greater than the serial number of the ATOM/HETATM preceding the TER.'''
> 
> [See http://www.wwpdb.org/documentation/format23/sect9.html#TER]
> 
> It leads to problem with programs that require correct TER records (like multiple structural alignment program MUSTANG), and crash when they are not found.
> 
> PDBIO.diff  - Proposed patch to PDBIO.py (656 Bytes) Michal J., 05/13/2007 05:31 PM