### PR TITLE
Preserve PDB atom numbering (redmine 3291)

### DIFF
--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -140,7 +140,7 @@ class PDBIO(object):
             structure = sb.structure
         self.structure = structure
 
-    def save(self, file, select=Select(), write_end=True):
+    def save(self, file, select=Select(), write_end=True, preserve_atom_numbering=False):
         """
         @param file: output file
         @type file: string or filehandle
@@ -181,7 +181,8 @@ class PDBIO(object):
             # do not write ENDMDL if no residues were written
             # for this model
             model_residues_written = 0
-            atom_number = 1
+            if not preserve_atom_numbering:
+                atom_number = 1
             if model_flag:
                 fp.write("MODEL      %s\n" % model.serial_num)
             for chain in model.get_list():
@@ -202,10 +203,13 @@ class PDBIO(object):
                         if select.accept_atom(atom):
                             chain_residues_written = 1
                             model_residues_written = 1
+                            if preserve_atom_numbering:
+                                atom_number = atom.get_serial_number()
                             s = get_atom_line(atom, hetfield, segid, atom_number, resname,
                                 resseq, icode, chain_id)
                             fp.write(s)
-                            atom_number = atom_number + 1
+                            if not preserve_atom_numbering:
+                                atom_number = atom_number + 1
                 if chain_residues_written:
                     fp.write("TER\n")
             if model_flag and model_residues_written:


### PR DESCRIPTION
https://redmine.open-bio.org/issues/3291
I manually applied the patch and changed the parameter name to `preserve_atom_numbering`

@crosvera wrote:

> As we know, Bio.PDB.PDBIO.save() renumbers the atom serial number starting with 1 in the first atom (per model), but sometimes people needs conserve the original serial number. A request of this can be found in 
> http://lists.open-bio.org/pipermail/biopython/2009-May/005163.html
> 
> I made a little patch, where I add a new parameter in Bio.PDB.PDBIO.save(), `conserve_atoms_number`, with default value conserve_atoms_number=False for backward compatibility.