### PR TITLE
Update QualityIO.py

### DIFF
--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -952,7 +952,6 @@ def FastqGeneralIterator(handle):
 
         # Return the record and then continue...
         yield (title_line, seq_string, quality_string)
-    raise StopIteration
 
 
 def FastqPhredIterator(handle, alphabet=single_letter_alphabet, title2ids=None):


### PR DESCRIPTION
This PR is to remove the  `raise StopIteration` at the end of the generator loop.  Its use is deprecated inside generator functions (see PEP 0479) and currently generates a deprecation warning under python 3.5:

`Bio/SeqIO/QualityIO.py:1031: PendingDeprecationWarning: generator 'FastqGeneralIterator' raised StopIteration`

Quoting from [PEP0479](https://www.python.org/dev/peps/pep-0479/):  "If `raise StopIteration` occurs directly in a generator, simply replace it with return."