### PR TITLE
Explicitly record EMBL/GenBank molecule type

### DIFF
--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -659,13 +659,23 @@ class _FeatureConsumer(_BaseGenBankConsumer):
 
         This reflects the fact that the topology (linear/circular) and
         molecule type (e.g. DNA vs RNA) were a single field in early
-        GenBank files. Current GenBank/EMBL files have two fields.
+        files. Current GenBank/EMBL files have two fields.
         """
         self._seq_type = type.strip()
 
     def topology(self, topology):
+        """Record the topology (linear or circular as strings)."""
         if topology:
+            if topology not in ['linear', 'circular']:
+                raise ParserFailureError("Unexpected topology %r should be linear or circular" % topology)
             self.data.annotations['topology'] = topology
+
+    def molecule_type(self, mol_type):
+        """Record the molecule type (for round-trip etc)."""
+        if mol_type:
+            if "circular" in mol_type or 'linear' in mol_type:
+                raise ParserFailureError("Molecule type %r should not include topology" % mol_type)
+            self.data.annotations['molecule_type'] = mol_type
 
     def data_file_division(self, division):
         self.data.annotations['data_file_division'] = division

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -1028,7 +1028,7 @@ Consider this example record:
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.gb", "genbank")
 >>> print("%s %i %i %i %i" % (record.id, len(record), len(record.features), len(record.dbxrefs), len(record.annotations)))
-NC_005816.1 9609 41 1 12
+NC_005816.1 9609 41 1 13
 \end{verbatim}
 
 Here we take the reverse complement and specify a new identifier -- but notice

--- a/Tests/output/test_GenBank
+++ b/Tests/output/test_GenBank
@@ -19,6 +19,8 @@ Key: gi
 Value: 5453633
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: mRNA
 Key: organism
 Value: Homo sapiens
 Key: sequence_version
@@ -73,6 +75,8 @@ Key: gi
 Value: 16229
 Key: keywords
 Value: ['antifreeze protein homology', 'cold-regulated gene', 'cor6.6 gene', 'KIN1 homology']
+Key: molecule_type
+Value: mRNA
 Key: organism
 Value: Arabidopsis thaliana
 References*
@@ -138,6 +142,8 @@ Key: gi
 Value: 16353
 Key: keywords
 Value: ['kin2 gene']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Arabidopsis thaliana
 References*
@@ -262,6 +268,8 @@ Key: gi
 Value: 167145
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: mRNA
 Key: organism
 Value: Brassica napus
 References*
@@ -338,6 +346,8 @@ Key: gi
 Value: 4538892
 Key: keywords
 Value: ['cold shock protein', 'csp14 gene']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Armoracia rusticana
 References*
@@ -426,6 +436,8 @@ Key: gi
 Value: 1209261
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: mRNA
 Key: organism
 Value: Brassica rapa
 References*
@@ -482,6 +494,8 @@ Key: gi
 Value: 10121868
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Brassica napus
 References*
@@ -568,6 +582,8 @@ Key: gi
 Value: 5731880
 Key: keywords
 Value: ['FLI_CDNA']
+Key: molecule_type
+Value: mRNA
 Key: organism
 Value: Homo sapiens
 References*
@@ -644,6 +660,8 @@ Key: gi
 Value: 452475
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Homo sapiens
 References*
@@ -722,6 +740,8 @@ Key: gi
 Value: 6587720
 Key: keywords
 Value: ['HTG']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Arabidopsis thaliana
 References*
@@ -1104,6 +1124,8 @@ Key: gi
 Value: 6946668
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Drosophila melanogaster
 References*
@@ -1333,6 +1355,8 @@ Key: gi
 Value: 885676
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Homo sapiens
 References*
@@ -1432,6 +1456,8 @@ Key: gi
 Value: 16156830
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Homo sapiens
 References*
@@ -1502,6 +1528,8 @@ Key: gi
 Value: 13470324
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Mesorhizobium loti
 References*
@@ -1742,6 +1770,8 @@ Key: gi
 Value: 1769753
 Key: keywords
 Value: ['nonstructural protein 1']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Feline panleukopenia virus
 References*
@@ -1805,6 +1835,8 @@ Key: gi
 Value: 1769755
 Key: keywords
 Value: ['nonstructural protein 1']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Feline panleukopenia virus
 References*
@@ -1868,6 +1900,8 @@ Key: gi
 Value: 1769757
 Key: keywords
 Value: ['capsid protein 2']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Feline panleukopenia virus
 References*
@@ -1935,6 +1969,8 @@ Key: gi
 Value: 45478711
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Yersinia pestis biovar Microtus str. 91001
 References*
@@ -2331,6 +2367,8 @@ Key: gi
 Value: 15823953
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Streptomyces avermitilis
 Key: sequence_version
@@ -2366,6 +2404,8 @@ Key: gi
 Value: 15823953
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Streptomyces avermitilis
 Key: sequence_version
@@ -2436,6 +2476,8 @@ Key: gi
 Value: 15823953
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Streptomyces avermitilis
 Key: sequence_version
@@ -2472,6 +2514,8 @@ Key: gi
 Value: 15823953
 Key: keywords
 Value: ['']
+Key: molecule_type
+Value: DNA
 Key: organism
 Value: Streptomyces avermitilis
 Key: sequence_version

--- a/Tests/test_BioSQL_sqlite3.py
+++ b/Tests/test_BioSQL_sqlite3.py
@@ -63,6 +63,10 @@ class BackwardsCompatibilityTest(unittest.TestCase):
         biosql_records = [db.lookup(name=rec.name)
                           for rec in original_records]
         # And check they agree
+        # Note the old parser used to create BioSQL/cor6_6.db
+        # did not record the molecule_type, so remove it here:
+        for r in original_records:
+            del r.annotations["molecule_type"]
         self.assertTrue(compare_records(original_records, biosql_records))
         server.close()
 

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -230,12 +230,12 @@ class GenBankTests(unittest.TestCase):
             self.assertEqual(seq_len, len(new))
 
 
-class TopologyTests(unittest.TestCase):
-    """Check GenBank/EMBL topology parsing."""
+class LineOneTests(unittest.TestCase):
+    """Check GenBank/EMBL topology / molecule_type parsing."""
 
     def test_topology_genbank(self):
-        """Check GenBank topology parsing."""
-        # This is a bit low level, but can test pasing the ID line only
+        """Check GenBank LOCUS line parsing."""
+        # This is a bit low level, but can test pasing the LOCUS line only
         tests = [
             ("LOCUS       U00096",
              None, None, None),
@@ -256,13 +256,16 @@ class TopologyTests(unittest.TestCase):
             t = consumer.data.annotations.get('topology', None)
             self.assertEqual(t, topo,
                              "Wrong topology %r not %r from %r" % (t, topo, line))
-            # TODO - molecule type - see issue 363 / pull request #1005
+            mt = consumer.data.annotations.get('molecule_type', None)
+            self.assertEqual(mt, mol_type,
+                             "Wrong molecule_type %r not %r from %r" %
+                             (mt, mol_type, line))
             d = consumer.data.annotations.get('data_file_division', None)
             self.assertEqual(d, div,
                              "Wrong division %r not %r from %r" % (d, div, line))
 
     def test_topology_embl(self):
-        """Check EMBL topology parsing."""
+        """Check EMBL ID line parsing."""
         # This is a bit low level, but can test pasing the ID line only
         tests = [
             # Modern examples with sequence version
@@ -296,7 +299,10 @@ class TopologyTests(unittest.TestCase):
             t = consumer.data.annotations.get('topology', None)
             self.assertEqual(t, topo,
                              "Wrong topology %r not %r from %r" % (t, topo, line))
-            # TODO - molecule type - see issue 363 / pull request #1005
+            mt = consumer.data.annotations.get('molecule_type', None)
+            self.assertEqual(mt, mol_type,
+                             "Wrong molecule_type %r not %r from %r" %
+                             (mt, mol_type, line))
             d = consumer.data.annotations.get('data_file_division', None)
             self.assertEqual(d, div,
                              "Wrong division %r not %r from %r" % (d, div, line))
@@ -317,7 +323,10 @@ class TopologyTests(unittest.TestCase):
             t = consumer.data.annotations.get('topology', None)
             self.assertEqual(t, topo,
                              "Wrong topology %r not %r from %r" % (t, topo, line))
-            # TODO - molecule type - see issue 363 / pull request #1005
+            mt = consumer.data.annotations.get('molecule_type', None)
+            self.assertEqual(mt, mol_type,
+                             "Wrong molecule_type %r not %r from %r" %
+                             (mt, mol_type, line))
             d = consumer.data.annotations.get('data_file_division', None)
             self.assertEqual(d, div,
                              "Wrong division %r not %r from %r" % (d, div, line))

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -80,6 +80,13 @@ def compare_record(old, new, expect_minor_diffs=False):
             # have other complications (e.g. different number of accessions
             # allowed in various file formats)
             continue
+        if key == "molecule_type":
+            # EMBL allows e.g. "genomics DNA" where GenBank is limited.
+            common_words = set(old.annotations[key].split()).intersection(new.annotations[key].split())
+            if not common_words:
+                raise ValueError("Annotation mis-match for molecule_type:\n%s\n%s"
+                                % (old.annotations[key], new.annotations[key]))
+            continue
         if key == "comment":
             # Ignore whitespace
             if old.annotations[key].split() != new.annotations[key].split():


### PR DESCRIPTION
This builds on my recent commits to improve the EMBL/GenBank topology parsing (see fd7b17199329d9cda4c0b55a62a93dc25533391d and the subsequent commits which refactored to cover some corner cases, and add more tests), and will really close #363 

Note this means ``record.annotations["topology"]`` and ``record.annotations["molecule_type"]`` together essentially replace the legacy handling of the composite residue type dating from early GenBank/EMBL files where this was one field.