### PR TITLE
Record missing data in Bio.Phylo.PAML.codeml

### DIFF
--- a/Bio/Phylo/PAML/_parse_codeml.py
+++ b/Bio/Phylo/PAML/_parse_codeml.py
@@ -412,7 +412,9 @@ def parse_pairwise(lines, results):
     #
     # t= 0.0126  S=    81.4  N=   140.6  dN/dS= 0.0010  dN= 0.0000  dS= 0.0115
     pair_re = re.compile("\d+ \((.+)\) ... \d+ \((.+)\)")
-    pairwise, seq1, seq2 = collections.defaultdict(dict), None, None
+    pairwise = collections.defaultdict(dict)
+    seq1 = None
+    seq2 = None
     for line in lines:
         # Find all floating point numbers in this line
         line_floats_res = line_floats_re.findall(line)

--- a/Bio/Phylo/PAML/_parse_codeml.py
+++ b/Bio/Phylo/PAML/_parse_codeml.py
@@ -5,8 +5,6 @@
 
 import re
 
-import collections
-
 line_floats_re = re.compile("-*\d+\.\d+")
 
 try:
@@ -412,7 +410,7 @@ def parse_pairwise(lines, results):
     #
     # t= 0.0126  S=    81.4  N=   140.6  dN/dS= 0.0010  dN= 0.0000  dS= 0.0115
     pair_re = re.compile("\d+ \((.+)\) ... \d+ \((.+)\)")
-    pairwise = collections.defaultdict(dict)
+    pairwise = {}
     seq1 = None
     seq2 = None
     for line in lines:
@@ -423,6 +421,10 @@ def parse_pairwise(lines, results):
         if pair_res:
             seq1 = pair_res.group(1)
             seq2 = pair_res.group(2)
+            if seq1 not in pairwise:
+                pairwise[seq1] = {}
+            if seq2 not in pairwise:
+                pairwise[seq2] = {}
         if len(line_floats) == 1 and seq1 is not None and seq2 is not None:
             pairwise[seq1][seq2] = {"lnL": line_floats[0]}
             pairwise[seq2][seq1] = pairwise[seq1][seq2]

--- a/Tests/test_PAML_codeml.py
+++ b/Tests/test_PAML_codeml.py
@@ -481,8 +481,11 @@ class ModTest(unittest.TestCase):
                         % version.replace('_', '.')
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
-            for seq2 in results['pairwise'].values():
-                for data in seq2.values():
+            for seq in results["pairwise"]:
+                seq_vals = results["pairwise"][seq]
+                self.assertTrue(len(seq_vals) > 0,
+                                "no parsed parameters for '%s'" % seq)
+                for data in seq_vals.values():
                     for param in ("t", "S", "N", "omega", "dN", "dS", "lnL"):
                         self.assertTrue(param in data, version_msg +
                                         ": '%s' not in parsed parameters" % param)

--- a/Tests/test_PAML_codeml.py
+++ b/Tests/test_PAML_codeml.py
@@ -6,7 +6,6 @@
 import unittest
 import os
 import os.path
-import numbers
 from Bio.Phylo.PAML import codeml
 from Bio.Phylo.PAML._paml import PamlError
 
@@ -487,7 +486,7 @@ class ModTest(unittest.TestCase):
                     for param in ("t", "S", "N", "omega", "dN", "dS", "lnL"):
                         self.assertTrue(param in data, version_msg +
                                         ": '%s' not in parsed parameters" % param)
-                        self.assertTrue(isinstance(data[param], numbers.Number))
+                        self.assertTrue(isinstance(data[param], float))
                         if param != "lnL":
                             self.assertTrue(data[param] >= 0)
 


### PR DESCRIPTION
The long existing issue #483 was also a problem in one of my analysis. I've added a fix and a unittest. The codeml parser parses now all site parameters of a pairwise codeml analysis.