### PR TITLE
Proposed fix Issue #892

### DIFF
--- a/Bio/triemodule.c
+++ b/Bio/triemodule.c
@@ -691,6 +691,12 @@ _read_from_handle(void *wasread, const int length, void *handle)
     }
 
     py_retval = PyObject_CallMethod(py_handle, "read", "i", length);
+    if (!py_retval)
+    {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to read from file. "
+                "Verify that you did not open a binary file('rb') in text mode('r') or vice versa.");
+        goto error;
+    }
 #ifdef IS_PY3K
     if(!PyBytes_Check(py_retval)) {
 #else

--- a/Bio/triemodule.c
+++ b/Bio/triemodule.c
@@ -694,7 +694,7 @@ _read_from_handle(void *wasread, const int length, void *handle)
     if (!py_retval)
     {
         PyErr_SetString(PyExc_RuntimeError, "Failed to read from file. "
-                "Verify that you did not open a binary file('rb') in text mode('r') or vice versa.");
+                "Verify that you did not open a binary file ('rb') in text mode ('r') or vice versa.");
         goto error;
     }
 #ifdef IS_PY3K

--- a/Tests/test_trie.py
+++ b/Tests/test_trie.py
@@ -37,7 +37,7 @@ class TestTrie(unittest.TestCase):
         self.assertEqual(len(trieobj), 5)
         trieobj["blah"] = "snew"
         self.assertEqual(trieobj["blah"], "snew")
-
+object
     def test_prefix(self):
         trieobj = trie.trie()
         trieobj["hello"] = 5
@@ -128,6 +128,36 @@ class TestTrie(unittest.TestCase):
                          set(trieobj.with_prefix("A")))
         self.assertEqual(set(['ANA', 'ANANA']),
                          set(trieobj.with_prefix("AN")))
+
+
+    def test_large_save_load(self):
+        """
+        Generate random key/val pairs in three length categories,
+        100 in each category. Insert them into a trie and into a reference dict.
+        Write the trie to a temp file and read it back, verify that trie entries match
+        the reference dict.
+        """
+        import random
+        import tempfile
+        from string import ascii_lowercase
+        trieobj = trie.trie()
+        self.assertEqual(trieobj.get("foobar"), None)
+        for max_str_len in [100, 1000, 10000]:
+            cmp_dict = {}
+            for i in range(1000):
+                key = ''.join([random.choice(ascii_lowercase) for _ in range(max_str_len)])
+                val = ''.join([random.choice(ascii_lowercase) for _ in range(max_str_len)])
+                trieobj[key] = val
+                cmp_dict[key] = val
+            for key in cmp_dict:
+                self.assertEqual(trieobj[key], cmp_dict[key])
+
+        with tempfile.TemporaryFile(mode='w+b') as f:
+            trie.save(f, trieobj)
+            f.seek(0)
+            trieobj = trie.load(f)
+        for key in cmp_dict:
+            self.assertEqual(trieobj[key], cmp_dict[key])
 
 
 class TestTrieFind(unittest.TestCase):

--- a/Tests/test_trie.py
+++ b/Tests/test_trie.py
@@ -129,7 +129,6 @@ class TestTrie(unittest.TestCase):
         self.assertEqual(set(['ANA', 'ANANA']),
                          set(trieobj.with_prefix("AN")))
 
-
     def test_large_save_load(self):
         """
         Generate random key/val pairs in three length categories,
@@ -140,6 +139,7 @@ class TestTrie(unittest.TestCase):
         import random
         import tempfile
         from string import ascii_lowercase
+        cmp_dict = {}
         trieobj = trie.trie()
         self.assertEqual(trieobj.get("foobar"), None)
         for max_str_len in [100, 1000, 10000]:

--- a/Tests/test_trie.py
+++ b/Tests/test_trie.py
@@ -37,7 +37,7 @@ class TestTrie(unittest.TestCase):
         self.assertEqual(len(trieobj), 5)
         trieobj["blah"] = "snew"
         self.assertEqual(trieobj["blah"], "snew")
-object
+
     def test_prefix(self):
         trieobj = trie.trie()
         trieobj["hello"] = 5

--- a/Tests/test_trie.py
+++ b/Tests/test_trie.py
@@ -130,9 +130,9 @@ class TestTrie(unittest.TestCase):
                          set(trieobj.with_prefix("AN")))
 
     def test_large_save_load(self):
-        """
-        Generate random key/val pairs in three length categories,
-        100 in each category. Insert them into a trie and into a reference dict.
+        """ Generate random key/val pairs in three length categories.
+
+        100 items in each category. Insert them into a trie and into a reference dict.
         Write the trie to a temp file and read it back, verify that trie entries match
         the reference dict.
         """


### PR DESCRIPTION
Problem due to PyObject_CallMethod(py_handle, "read", "i", length) at line number 693 returning null when a file with key lengths over 125 chars was opened in 'r' mode instead of 'rb' mode. This did not happen with shorter key lengths. 

[Peter: Edited to avoid hash+number which GitHub treats as a link to an issue or pull request]