### PR TITLE
Enforce simple alphabetical sorting of CONTRIB file

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -95,7 +95,7 @@ commands =
     pep8 --ignore E122,E123,E126,E127,E128,E241,E402,E501,E731 Tests/
     # Not exactly PEP8, but an internal style check:
     # (The bash call is a work around for the pipe character)
-    bash -c \'grep -v "^#" CONTRIB | sort -u -c\'
+    bash -c \'grep -v "^#" CONTRIB | LC_ALL=C sort -u -c\'
 
 [testenv:sdist]
 # This does not need to install Biopython or any of its dependencies

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -84,6 +84,7 @@ commands =
 skip_install = True
 whitelist_externals =
     pep8
+    bash
 deps =
     pep8
 commands =
@@ -92,6 +93,9 @@ commands =
     pep8 --max-line-length 90 Doc/examples/
     pep8 --ignore E122,E123,E126,E127,E128,E129,E501,E731 Bio/
     pep8 --ignore E122,E123,E126,E127,E128,E241,E402,E501,E731 Tests/
+    # Not exactly PEP8, but an internal style check:
+    # (The bash call is a work around for the pipe character)
+    bash -c \'grep -v "^#" CONTRIB | sort -u -c\'
 
 [testenv:sdist]
 # This does not need to install Biopython or any of its dependencies

--- a/CONTRIB
+++ b/CONTRIB
@@ -6,7 +6,7 @@
 # (sorry!), please mention it on the development mailing list.
 #
 # People are listed alphabetically, as verfied with tUnix sort:
-# $ grep -v "^#" CONTRIB | sort -u -c
+# $ grep -v "^#" CONTRIB | LC_ALL=C sort -u -c
 #
 Aaron Gallagher <habnabit at gmail>
 Aaron Rosenfeld <https://github.com/arosenfeld>

--- a/CONTRIB
+++ b/CONTRIB
@@ -1,171 +1,172 @@
-CONTRIBUTORS
-============
-
-This is a list of people who have made contributions to Biopython.
-This is certainly not comprehensive, and if you've been overlooked
-(sorry!), please mention it on the development mailing list.
-People are listed alphabetically by surname.
-
-Cecilia Alsmark <Cecilia.Alsmark at domain ebc.uu.se>
-Adrian Altenhoff <https://github.com/alpae>
-Tiago Antao <https://github.com/tiagoantao>
-Wibowo Arindrarto <https://github.com/bow>
-Sebastian Bassi <sbassi at domain asalup.org>
-Bill Barnard <bill at domain barnard-engineering.com>
-Yves Bastide <ybastide at domain irisa.fr>
-Paul T. Bathen
-Yair Benita <Y.Benita at domain pharm.uu.nl>
-Peter Bienstman <Peter.Bienstman at domain rug.ac.be>
-Jose Blanca <https://github.com/JoseBlanca>
-Kai Blin <https://github.com/kblin>
-Steve Bond <https://github.com/biologyguy>
-Bob Bussell <rgb2003 at domain med.cornell.edu>
-Anthony Bradley <https://github.com/abradle>
-John Bradley <https://github.com/johnbradley>
-Diego Brouard <diego at domain conysis.com>
-Christian Brueffer <christian at domain brueffer.de>
-David Cain <gmail, david joseph cain>
-Christiam Camacho <https://github.com/christiam>
-Franco Caramia <https://github.com/fcaramia>
-James Casbon <j.a.casbon at domain qmul.ac.uk>
-Hye-Shik Chang <perky at domain fallin.lv>
-Jeffrey Chang <jchang at domain smi.stanford.edu>
-Brad Chapman <https://github.com/chapmanb>
-Saket Choudhary <https://github.com/saketkc>
-Peter Cock <https://github.com/peterjc>
-Marc Colosimo <mcolosimo at domain mitre.org>
-Andres Colubri <andres dot colubri at gmail dot com>
-Joe Cora <https://github.com/JoeCora>
-Cymon J Cox <cymon at domain duke.edu>
-Gavin E Crooks <gec at domain compbio.berkeley.edu>
-Andrew Dalke <dalke at domain acm.org>
-Kristian Davidsen <https://github.com/krdav>
-Wayne Decatur <https://github.com/fomightez>
-Nigel Delaney <https://github.com/evolvedmicrobe/>
-Michiel de Hoon <mdehoon at domain c2b2.columbia.edu>
-Bart de Koning <bratdaking gmail>
-Sjoerd de Vries <sjoerd at domain nmr.chem.uu.nl>
-Nathan J. Edwards <nje5 at edu domain georgetown>
-Kyle Ellrott <https://github.com/kellrott>
-Gokcen Eraslan <https://github.com/gokceneraslan>
-Tarcisio Fedrizzi <https://github.com/hcraT>
-João D Ferreira <https://github.com/jdferreira>
-Jeffrey Finkelstein <jeffrey.finkelstein at domain gmail.com>
-Konrad Förstner <https://github.com/konrad>
-Iddo Friedberg <idoerg at domain burnham.org>
-Bertrand Frottier <bertrand.frottier at domain free.fr>
-Ben Fulton <https://github.com/benfulton>
-Marco Galardini <https://github.com/mgalardini>
+# CONTRIBUTORS
+# ============
+#
+# This is a list of people who have made contributions to Biopython.
+# This is certainly not comprehensive, and if you've been overlooked
+# (sorry!), please mention it on the development mailing list.
+#
+# People are listed alphabetically, as verfied with tUnix sort:
+# $ grep -v "^#" CONTRIB | sort -u -c
+#
 Aaron Gallagher <habnabit at gmail>
-Oscar G. Garcia <https://github.com/oscarmaestre>
-Phillip Garland <pgarland at gmail>
-Walter Gillett <https://github.com/wgillett>
-Chaitanya Gupta <https://github.com/iCHAIT>
-Melissa Gymrek <https://github.com/mgymrek>
-Frederik Gwinner
-Jason A. Hackney <jhackney at domain stanford.edu>
-Thomas Hamelryck <thamelry at domain binf.ku.dk>
-Kian Ho <https://github.com/kianho>
-Michael Hoffman <hoffman+biopython at domain ebi.ac.uk>
-Thomas Holder <https://github.com/speleo3>
-Yu Huang <krocea at domain yahoo.com.cn>
-Gert Hulselmans <https://github.com/ghuls>
-Jeff Hussmann <first dot last at gmail dot com>
-Kevin Jacobs <jacobs at bioinformed dot com>
-Diana Jaunzeikare
-Sunhwan Jo <https://github.com/sunhwan>
-Terry Jones <https://github.com/terrycojones>
-Joanna & Dominik Kasprzak
-Frank Kauff <fkauff at domain duke.edu>
-Siong Kong
-David Koppstein <https://github.com/dkoppstein>
-Andreas Kuntzagk <andreas.kuntzagk at domain mdc-berlin.de>
-Adam Kurkiewicz <adam@kurkiewicz.pl>
-Michal Kurowski <michal at domain genesilico.pl>
-Gleb Kuznetsov <https://github.com/glebkuznetsov>
-Uri Laserson <https://github.com/laserson>
-Chris Lasher <chris.lasher at gmail.com>
-Sergei Lebedev <https://github.com/superbobry>
-Antony Lee <https://github.com/anntzer>
-Gaetan Lehman <gaetan.lehmann at domain jouy.inra.fr>
-Kuan-Yi Li <https://github.com/kuanyili>
-Edward Liaw <https://github.com/edliaw>
-Katharine Lindner <katel at domain worldpath.net>
-Bryan Lunt <https://github.com/bryan-lunt>
-Milind Luthra <https://github.com/milindl>
-Fábio Madeira<https://github.com/biomadeira>
-Steve Marshall <https://github.com/hungryhoser>
-Erick Matsen <surname at fhcrc dot org>
-Connor McCoy <cmccoy at the dot org domain fhcrc>
-Alan Medlar <https://github.com/ajm>
-Stefans Mezulis <https://github.com/StefansM/>
-Tarjei Mikkelsen <tarjei at domain genome.wi.mit.edu>
-Chris Mitchell <https://github.com/chrismit>
-Olivier Morelle <https://github.com/Oli4>
-Ben Morris <https://github.com/bendmorris>
-Nader Morshed <https://github.com/naderm>
-Barbara Mühlemann <https://github.com/bamueh>
-Richard Neher <https://github.com/rneher>
-Bertrand Néron <https://github.com/bneron>
-David Nicholson <https://github.com/danich1>
-Kozo Nishida <https://github.com/kozo2>
-Emmanuel Noutahi <https://github.com/maclandrol>
-Konstantin Okonechnikov <k.okonechnikov at domain gmail.com>
-Cheng Soon Ong <chengsoon.ong at tuebingen.mpg.de>
-Brian Osborne <https://github.com/bosborne>
-Anne Pajon <ap one two at sanger ac uk>
-Alessio Papini <first dot last at unifi dot it>
-Claude Paroz <claude at two (as digit) xlibre dot net>
-Carlos Pena <https://github.com/carlosp420>
-Lenna Peterson <ark first-name at gmail dot com>
-Andrea Pierleoni <andrea at the Italian domain biocomp dot unibo>
-Markus Piotrowski <https://github.com/MarkusPiotrowski>
-Anders Pitman <https://github.com/anderspitman>
-Mike Poidinger <Michael.Poidinger at domain eBioinformatics.com>
-Leighton Pritchard <lpritc at domain scri.sari.ac.uk>
-Leszek Pryszcz <https://github.com/lpryszcz>
-Eric Rasche <https://github.com/erasche>
-Carlos Ríos <https://github.com/Crosvera>
-Andrea Rizzi <https://github.com/andrrizzi>
-Joao Rodrigues <anaryin at the domain gmail dot com>
 Aaron Rosenfeld <https://github.com/arosenfeld>
-Thomas Rosleff Soerensen <rosleff at domain mpiz-koeln.mpg.de>
-Matt Ruffalo <https://github.com/mruffalo>
-Thomas Schmitt <Thomas dot Schmitt at Swedish domain sbc.su>
-Uwe Schmitt <https://github.com/uweschmitt>
-Wolfgang Schueler <wolfgang at domain proceryon.at>
-Anuj Sharma <https://github.com/xulesc>
-Matt Shirley <https://github.com/mdshw5>
-Thomas Sicheritz-Ponten <thomas at domain cbs.dtu.dk>
-Seth Sims <seth.sims at gmail>
-Lucas Sinclair <https://github.com/xapple>
-Sourav Singh <https://github.com/souravsingh>
-Connor T. Skennerton <https://github.com/ctSkennerton>
-Peter Slickers <piet at domain clondiag.com>
-Kamil Slowikowski <k no dot slowikowski at gmail dot com>
-Jacek Śmietański <https://github.com/dadoskawina>
-Frederic Sohm <fsms at domain users.sourceforge.net>
-Owen Solberg <https://github.com/odoublewen>
-Matteo Sticco <https://github.com/sticken88/>
-Nate Sutton <https://github.com/nmsutton>
-Anuj Sharma <https://github.com/xulesc>
-Eric Talevich <https://github.com/etal>
+Adam Kurkiewicz <adam@kurkiewicz.pl>
+Adrian Altenhoff <https://github.com/alpae>
+Alan Medlar <https://github.com/ajm>
+Alessio Papini <first dot last at unifi dot it>
 Allis Tauri <https://github.com/allista>
-Bartosz Telenczuk <bartosz.telenczuk at domain gmail.com>
-Bernhard Thiel <https://github.com/Bernhard10>
-Bogdan T. <bogdan at pearlgen dot com>
-Tyghe Vallard <https://github.com/necrolyte2>
-Johann Visagie <wjv at domain cityip.co.za>
-Dan Vogel <dmv at domain andrew.cmu.edu>
-Chris Warth <https://github.com/cswarth>
-David Weisman <david.weisman at domain acm.org>
+Anders Pitman <https://github.com/anderspitman>
+Andrea Pierleoni <andrea at the Italian domain biocomp dot unibo>
+Andrea Rizzi <https://github.com/andrrizzi>
+Andreas Kuntzagk <andreas.kuntzagk at domain mdc-berlin.de>
+Andres Colubri <andres dot colubri at gmail dot com>
+Andrew Dalke <dalke at domain acm.org>
+Anne Pajon <ap one two at sanger ac uk>
+Anthony Bradley <https://github.com/abradle>
+Antony Lee <https://github.com/anntzer>
+Anuj Sharma <https://github.com/xulesc>
+Barbara Mühlemann <https://github.com/bamueh>
+Bart de Koning <bratdaking gmail>
 Bartek Wilczynski <bartek at domain rezolwenta.eu.org>
-David Winter <david dot winter at gmail dot com>
+Bartosz Telenczuk <bartosz.telenczuk at domain gmail.com>
+Ben Fulton <https://github.com/benfulton>
+Ben Morris <https://github.com/bendmorris>
 Ben Woodcroft <https://github.com/wwood>
-Chunlei Wu <https://github.com/newgene/>
-Kevin Wu <https://github.com/kevinwuhoo>
-Yanbo Ye <https://github.com/lijax>
-Hongbo Zhu <https://github.com/hongbo-zhu-cn>
+Bernhard Thiel <https://github.com/Bernhard10>
+Bertrand Frottier <bertrand.frottier at domain free.fr>
+Bertrand Néron <https://github.com/bneron>
+Bill Barnard <bill at domain barnard-engineering.com>
+Bob Bussell <rgb2003 at domain med.cornell.edu>
+Bogdan T. <bogdan at pearlgen dot com>
+Brad Chapman <https://github.com/chapmanb>
+Brian Osborne <https://github.com/bosborne>
+Bryan Lunt <https://github.com/bryan-lunt>
+Carlos Pena <https://github.com/carlosp420>
+Carlos Ríos <https://github.com/Crosvera>
+Cecilia Alsmark <Cecilia.Alsmark at domain ebc.uu.se>
+Chaitanya Gupta <https://github.com/iCHAIT>
+Cheng Soon Ong <chengsoon.ong at tuebingen.mpg.de>
+Chris Lasher <chris.lasher at gmail.com>
+Chris Mitchell <https://github.com/chrismit>
+Chris Warth <https://github.com/cswarth>
+Christiam Camacho <https://github.com/christiam>
+Christian Brueffer <christian at domain brueffer.de>
 Christian Zmasek <https://github.com/cmzmasek>
-Xiaoyu Zhuo <https://github.com/xzhuo>
+Chunlei Wu <https://github.com/newgene/>
+Claude Paroz <claude at two (as digit) xlibre dot net>
+Connor McCoy <cmccoy at the dot org domain fhcrc>
+Connor T. Skennerton <https://github.com/ctSkennerton>
+Cymon J Cox <cymon at domain duke.edu>
+Dan Vogel <dmv at domain andrew.cmu.edu>
+David Cain <gmail, david joseph cain>
+David Koppstein <https://github.com/dkoppstein>
+David Nicholson <https://github.com/danich1>
+David Weisman <david.weisman at domain acm.org>
+David Winter <david dot winter at gmail dot com>
+Diana Jaunzeikare
+Diego Brouard <diego at domain conysis.com>
+Edward Liaw <https://github.com/edliaw>
+Emmanuel Noutahi <https://github.com/maclandrol>
+Eric Rasche <https://github.com/erasche>
+Eric Talevich <https://github.com/etal>
+Erick Matsen <surname at fhcrc dot org>
+Fábio Madeira<https://github.com/biomadeira>
+Franco Caramia <https://github.com/fcaramia>
+Frank Kauff <fkauff at domain duke.edu>
+Frederic Sohm <fsms at domain users.sourceforge.net>
+Frederik Gwinner
+Gaetan Lehman <gaetan.lehmann at domain jouy.inra.fr>
+Gavin E Crooks <gec at domain compbio.berkeley.edu>
+Gert Hulselmans <https://github.com/ghuls>
+Gleb Kuznetsov <https://github.com/glebkuznetsov>
+Gokcen Eraslan <https://github.com/gokceneraslan>
 Harry Zuzan <iliketobicycle at domain yahoo.ca>
+Hongbo Zhu <https://github.com/hongbo-zhu-cn>
+Hye-Shik Chang <perky at domain fallin.lv>
+Iddo Friedberg <idoerg at domain burnham.org>
+Jacek Śmietański <https://github.com/dadoskawina>
+James Casbon <j.a.casbon at domain qmul.ac.uk>
+Jason A. Hackney <jhackney at domain stanford.edu>
+Jeff Hussmann <first dot last at gmail dot com>
+Jeffrey Chang <jchang at domain smi.stanford.edu>
+Jeffrey Finkelstein <jeffrey.finkelstein at domain gmail.com>
+Joanna & Dominik Kasprzak
+Joao Rodrigues <anaryin at the domain gmail dot com>
+Joe Cora <https://github.com/JoeCora>
+Johann Visagie <wjv at domain cityip.co.za>
+John Bradley <https://github.com/johnbradley>
+Jose Blanca <https://github.com/JoseBlanca>
+João D Ferreira <https://github.com/jdferreira>
+Kai Blin <https://github.com/kblin>
+Kamil Slowikowski <k no dot slowikowski at gmail dot com>
+Katharine Lindner <katel at domain worldpath.net>
+Kevin Jacobs <jacobs at bioinformed dot com>
+Kevin Wu <https://github.com/kevinwuhoo>
+Kian Ho <https://github.com/kianho>
+Konrad Förstner <https://github.com/konrad>
+Konstantin Okonechnikov <k.okonechnikov at domain gmail.com>
+Kozo Nishida <https://github.com/kozo2>
+Kristian Davidsen <https://github.com/krdav>
+Kuan-Yi Li <https://github.com/kuanyili>
+Kyle Ellrott <https://github.com/kellrott>
+Leighton Pritchard <lpritc at domain scri.sari.ac.uk>
+Lenna Peterson <ark first-name at gmail dot com>
+Leszek Pryszcz <https://github.com/lpryszcz>
+Lucas Sinclair <https://github.com/xapple>
+Marc Colosimo <mcolosimo at domain mitre.org>
+Marco Galardini <https://github.com/mgalardini>
+Markus Piotrowski <https://github.com/MarkusPiotrowski>
+Matt Ruffalo <https://github.com/mruffalo>
+Matt Shirley <https://github.com/mdshw5>
+Matteo Sticco <https://github.com/sticken88/>
+Melissa Gymrek <https://github.com/mgymrek>
+Michael Hoffman <hoffman+biopython at domain ebi.ac.uk>
+Michal Kurowski <michal at domain genesilico.pl>
+Michiel de Hoon <mdehoon at domain c2b2.columbia.edu>
+Mike Poidinger <Michael.Poidinger at domain eBioinformatics.com>
+Milind Luthra <https://github.com/milindl>
+Nader Morshed <https://github.com/naderm>
+Nate Sutton <https://github.com/nmsutton>
+Nathan J. Edwards <nje5 at edu domain georgetown>
+Nigel Delaney <https://github.com/evolvedmicrobe/>
+Olivier Morelle <https://github.com/Oli4>
+Oscar G. Garcia <https://github.com/oscarmaestre>
+Owen Solberg <https://github.com/odoublewen>
+Paul T. Bathen
+Peter Bienstman <Peter.Bienstman at domain rug.ac.be>
+Peter Cock <https://github.com/peterjc>
+Peter Slickers <piet at domain clondiag.com>
+Phillip Garland <pgarland at gmail>
+Richard Neher <https://github.com/rneher>
+Saket Choudhary <https://github.com/saketkc>
+Sebastian Bassi <sbassi at domain asalup.org>
+Sergei Lebedev <https://github.com/superbobry>
+Seth Sims <seth.sims at gmail>
+Siong Kong
+Sjoerd de Vries <sjoerd at domain nmr.chem.uu.nl>
+Sourav Singh <https://github.com/souravsingh>
+Stefans Mezulis <https://github.com/StefansM/>
+Steve Bond <https://github.com/biologyguy>
+Steve Marshall <https://github.com/hungryhoser>
+Sunhwan Jo <https://github.com/sunhwan>
+Tarcisio Fedrizzi <https://github.com/hcraT>
+Tarjei Mikkelsen <tarjei at domain genome.wi.mit.edu>
+Terry Jones <https://github.com/terrycojones>
+Thomas Hamelryck <thamelry at domain binf.ku.dk>
+Thomas Holder <https://github.com/speleo3>
+Thomas Rosleff Soerensen <rosleff at domain mpiz-koeln.mpg.de>
+Thomas Schmitt <Thomas dot Schmitt at Swedish domain sbc.su>
+Thomas Sicheritz-Ponten <thomas at domain cbs.dtu.dk>
+Tiago Antao <https://github.com/tiagoantao>
+Tyghe Vallard <https://github.com/necrolyte2>
+Uri Laserson <https://github.com/laserson>
+Uwe Schmitt <https://github.com/uweschmitt>
+Walter Gillett <https://github.com/wgillett>
+Wayne Decatur <https://github.com/fomightez>
+Wibowo Arindrarto <https://github.com/bow>
+Wolfgang Schueler <wolfgang at domain proceryon.at>
+Xiaoyu Zhuo <https://github.com/xzhuo>
+Yair Benita <Y.Benita at domain pharm.uu.nl>
+Yanbo Ye <https://github.com/lijax>
+Yu Huang <krocea at domain yahoo.com.cn>
+Yves Bastide <ybastide at domain irisa.fr>


### PR DESCRIPTION
We already sort names in the ``NEWS`` file alphabetically by first name, while the ``CONTRIB`` file was traditionally done by surname. This was inconsistent, and also is harder to get right.

This change sorts the ``CONTRIB`` file using Unix sort, which means by first name, and enforces this via the TravisCI Tox setup.

Ideally it would be added to any official git pre-commit hook as well, see #493 