### PR TITLE
Adding parameter to return print_that output instead of printing it

### DIFF
--- a/Bio/Restriction/PrintFormat.py
+++ b/Bio/Restriction/PrintFormat.py
@@ -87,8 +87,9 @@ class PrintFormat(object):
 
         return
 
-    def print_that(self, dct, title='', s1=''):
-        """PF.print_that(dct, [title[, s1]]) -> Print dct nicely formatted.
+    def print_that(self, dct, title='', s1='', print_=True):
+        """PF.print_that(dct, [title[, s1[, print_]]]) -> Print dct nicely
+        formatted.
 
         Arguments:
          - dct is a dictionary as returned by a RestrictionBatch.search()
@@ -97,6 +98,8 @@ class PrintFormat(object):
          - s1 is the title separating the list of enzymes that have sites from
            those without sites.
          - s1 must be a formatted string as well.
+         - print_ is a boolean to flag that the method will output to stdout if
+           True. If false, the output will be returned.
 
         The format of print_that is a list."""
         if not dct:
@@ -107,8 +110,10 @@ class PrintFormat(object):
                 ls.append((k, v))
             else:
                 nc.append(k)
-        print(self.make_format(ls, title, nc, s1))
-        return
+        if print_:
+            print(self.make_format(ls, title, nc, s1))
+        else:
+            return self.make_format(ls, title, nc, s1)
 
     def make_format(self, cut=(), title='', nc=(), s1=''):
         """PF.make_format(cut, nc, title, s) -> string

--- a/Bio/Restriction/PrintFormat.py
+++ b/Bio/Restriction/PrintFormat.py
@@ -88,8 +88,7 @@ class PrintFormat(object):
         return
 
     def print_that(self, dct, title='', s1=''):
-        """PF.print_that(dct, [title[, s1[, print_]]]) -> string nicely
-        formatted.
+        """PF.print_that(dct, [title[, s1]]) -> string nicely formatted.
 
         Arguments:
          - dct is a dictionary as returned by a RestrictionBatch.search()

--- a/Bio/Restriction/PrintFormat.py
+++ b/Bio/Restriction/PrintFormat.py
@@ -87,7 +87,7 @@ class PrintFormat(object):
 
         return
 
-    def print_that(self, dct, title='', s1=''):
+    def format_output(self, dct, title='', s1=''):
         """PF.print_that(dct, [title[, s1]]) -> string nicely formatted.
 
         Arguments:
@@ -108,6 +108,22 @@ class PrintFormat(object):
             else:
                 nc.append(k)
         return self.make_format(ls, title, nc, s1)
+
+    def print_that(self, dct, title='', s1=''):
+        """PF.print_that(dct, [title[, s1]]) -> string nicely formatted.
+
+        Arguments:
+         - dct is a dictionary as returned by a RestrictionBatch.search()
+         - title is the title of the map.
+           It must be a formatted string, i.e. you must include the line break.
+         - s1 is the title separating the list of enzymes that have sites from
+           those without sites.
+         - s1 must be a formatted string as well.
+
+        This method prints the output of A.format_output() and it is here
+        for backwards compatibility."""
+        print(format_output(dct, title, s1))
+        return
 
     def make_format(self, cut=(), title='', nc=(), s1=''):
         """PF.make_format(cut, nc, title, s) -> string

--- a/Bio/Restriction/PrintFormat.py
+++ b/Bio/Restriction/PrintFormat.py
@@ -87,8 +87,8 @@ class PrintFormat(object):
 
         return
 
-    def print_that(self, dct, title='', s1='', print_=True):
-        """PF.print_that(dct, [title[, s1[, print_]]]) -> Print dct nicely
+    def print_that(self, dct, title='', s1=''):
+        """PF.print_that(dct, [title[, s1[, print_]]]) -> string nicely
         formatted.
 
         Arguments:
@@ -98,8 +98,6 @@ class PrintFormat(object):
          - s1 is the title separating the list of enzymes that have sites from
            those without sites.
          - s1 must be a formatted string as well.
-         - print_ is a boolean to flag that the method will output to stdout if
-           True. If false, the output will be returned.
 
         The format of print_that is a list."""
         if not dct:
@@ -110,10 +108,7 @@ class PrintFormat(object):
                 ls.append((k, v))
             else:
                 nc.append(k)
-        if print_:
-            print(self.make_format(ls, title, nc, s1))
-        else:
-            return self.make_format(ls, title, nc, s1)
+        return self.make_format(ls, title, nc, s1)
 
     def make_format(self, cut=(), title='', nc=(), s1=''):
         """PF.make_format(cut, nc, title, s) -> string

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -2255,8 +2255,9 @@ class Analysis(RestrictionBatch, PrintFormat):
         """
         return start <= site <= len(self.sequence) or 1 <= site < end
 
-    def format(self, dct=None, title='', s1=''):
-        """A.format([dct[, title[, s1]]]) -> print the results from dct.
+    def format_output(self, dct=None, title='', s1=''):
+        """A.format_output([dct[, title[, s1]]]) -> print the results from
+        dct.
 
         If dct is not given the full dictionary is used.
         """
@@ -2269,10 +2270,10 @@ class Analysis(RestrictionBatch, PrintFormat):
         from dct.
 
         If dct is not given the full dictionary is used.
-        This method prints the output of A.format() and it is here for
-        backwards compatibility.
+        This method prints the output of A.format_output() and it is here
+        for backwards compatibility.
         """
-        print(self.format(dct, title, s1))
+        print(self.format_output(dct, title, s1))
 
     def change(self, **what):
         """A.change(**attribute_name) -> Change attribute of Analysis.

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -2255,16 +2255,24 @@ class Analysis(RestrictionBatch, PrintFormat):
         """
         return start <= site <= len(self.sequence) or 1 <= site < end
 
-    def print_that(self, dct=None, title='', s1='', print_=True):
-        """A.print_that([dct[, title[, s1[,print_]]]]) -> print the results
-        from dct.
+    def format(self, dct=None, title='', s1=''):
+        """A.format([dct[, title[, s1]]]) -> print the results from dct.
 
         If dct is not given the full dictionary is used.
         """
         if not dct:
             dct = self.mapping
-        print("")
-        return PrintFormat.print_that(self, dct, title, s1, print_)
+        return PrintFormat.print_that(self, dct, title, s1)
+
+    def print_that(self, dct=None, title='', s1=''):
+        """A.print_that([dct[, title[, s1[,print_]]]]) -> print the results
+        from dct.
+
+        If dct is not given the full dictionary is used.
+        This method prints the output of A.format() and it is here for
+        backwards compatibility.
+        """
+        print(self.format(dct, title, s1))
 
     def change(self, **what):
         """A.change(**attribute_name) -> Change attribute of Analysis.

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -2255,15 +2255,16 @@ class Analysis(RestrictionBatch, PrintFormat):
         """
         return start <= site <= len(self.sequence) or 1 <= site < end
 
-    def print_that(self, dct=None, title='', s1=''):
-        """A.print_that([dct[, title[, s1]]]) -> print the results from dct.
+    def print_that(self, dct=None, title='', s1='', print_=True):
+        """A.print_that([dct[, title[, s1[,print_]]]]) -> print the results
+        from dct.
 
         If dct is not given the full dictionary is used.
         """
         if not dct:
             dct = self.mapping
         print("")
-        return PrintFormat.print_that(self, dct, title, s1)
+        return PrintFormat.print_that(self, dct, title, s1, print_)
 
     def change(self, **what):
         """A.change(**attribute_name) -> Change attribute of Analysis.

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -2256,14 +2256,13 @@ class Analysis(RestrictionBatch, PrintFormat):
         return start <= site <= len(self.sequence) or 1 <= site < end
 
     def format_output(self, dct=None, title='', s1=''):
-        """A.format_output([dct[, title[, s1]]]) -> print the results from
-        dct.
+        """A.format_output([dct[, title[, s1]]]) -> dct.
 
         If dct is not given the full dictionary is used.
         """
         if not dct:
             dct = self.mapping
-        return PrintFormat.print_that(self, dct, title, s1)
+        return PrintFormat.format_output(self, dct, title, s1)
 
     def print_that(self, dct=None, title='', s1=''):
         """A.print_that([dct[, title[, s1[,print_]]]]) -> print the results


### PR DESCRIPTION
This change allows to return the output of print_that instead of sending to stdout. This is usefull when you need this output for a template system.