### PR TITLE
Added support for deuterium as an element.

### DIFF
--- a/Bio/Data/IUPACData.py
+++ b/Bio/Data/IUPACData.py
@@ -297,6 +297,7 @@ extended_protein_weight_ranges, avg_extended_protein_weights = \
 # Taken from http://www.chem.qmul.ac.uk/iupac/AtWt/ & PyMol
 atom_weights = {
     'H': 1.00794,
+    'D': 2.01410,
     'He': 4.002602,
     'Li': 6.941,
     'Be': 9.012182,

--- a/CONTRIB
+++ b/CONTRIB
@@ -85,6 +85,7 @@ Hongbo Zhu <https://github.com/hongbo-zhu-cn>
 Hye-Shik Chang <perky at domain fallin.lv>
 Iddo Friedberg <idoerg at domain burnham.org>
 Jacek Śmietański <https://github.com/dadoskawina>
+Jack Twilley <https://github.com/mathuin>
 James Casbon <j.a.casbon at domain qmul.ac.uk>
 Jason A. Hackney <jhackney at domain stanford.edu>
 Jeff Hussmann <first dot last at gmail dot com>

--- a/NEWS
+++ b/NEWS
@@ -64,6 +64,7 @@ Carlos Pena
 Carlos Ríos
 Chris Warth
 Emmanuel Noutahi
+Jack Twilley (first contribution)
 Lenna Peterson
 Markus Piotrowski
 Michiel de Hoon

--- a/Tests/PDB/a_structure.pdb
+++ b/Tests/PDB/a_structure.pdb
@@ -10,7 +10,7 @@ HETATM    1  N   PCA A   1       0.525   2.690  13.317  1.00 20.26      A
 HETATM    2  CA  PCA A   1      -0.993   2.924  13.160  1.00 21.23      A
 HETATM    3  CB  PCA A   1      -1.783   1.879  14.043  1.00 24.73           C
 HETATM    4  CG  PCA A   1      -0.609   1.208  14.621  1.00 22.31           C
-HETATM    5  CD  PCA A   1       0.869   1.560  14.229  1.00 23.27           C
+HETATM    5  DA  PCA A   1       0.869   1.560  14.229  1.00 23.27           D
 HETATM    6  OE  PCA A   1       2.053   1.323  14.293  1.00 26.24           O
 HETATM    7  C   PCA A   1      -1.375   4.270  13.719  1.00 19.21           C
 HETATM    8  O   PCA A   1      -0.389   5.021  14.230  1.00 18.05           O

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -425,9 +425,9 @@ class ParseTest(unittest.TestCase):
         self.assertEqual(len(chain), 1)
         self.assertEqual(" ".join(residue.resname for residue in chain), "PCA")
         self.assertEqual(" ".join(atom.name for atom in chain.get_atoms()),
-                         "N CA CB CG CD OE C O CA  ")
+                         "N CA CB CG DA OE C O CA  ")
         self.assertEqual(" ".join(atom.element for atom in chain.get_atoms()),
-                         "N C C C C O C O CA")
+                         "N C C C D O C O CA")
         # Second model
         model = structure[1]
         self.assertEqual(model.id, 1)
@@ -935,6 +935,7 @@ class Atom_Element(unittest.TestCase):
         self.assertEqual('N', atoms[0].element)  # N
         self.assertEqual('C', atoms[1].element)  # Alpha Carbon
         self.assertEqual('CA', atoms[8].element)  # Calcium
+        self.assertEqual('D', atoms[4].element)  # Deuterium
 
     def test_ions(self):
         """Element for magnesium is assigned correctly."""


### PR DESCRIPTION
For some proteins in the PDB, it is important for researchers to
distinguish between hydrogen isotopes.  Those researchers will often
populate the element field with 'D' for deuterium.  This usage is
in accordance with IUPAC provisional recommendation IR-3.3.2, but
there is no reference to deuterium in the atom_weights table in the
IUPACData.py file so these values are not recognized.

The value used for the atomic weight of deuterium was taken from
http://www.ciaaw.org/hydrogen.htm.

For the purposes of testing this change, one of the HETATM lines in the
a_structure.pdb file was modified to reference a deuterium atom instead
of the carbon atom it originally represented.  This required minor
changes to the ParseTest class.  A specific test for this change was
added to the Atom_Element class.