### PR TITLE
new options use_sw_tback and comp_based_stats options

### DIFF
--- a/Bio/Blast/Applications.py
+++ b/Bio/Blast/Applications.py
@@ -1030,9 +1030,25 @@ class NcbirpstblastnCommandline(_NcbiblastCommandline):
                     Format: "yes", "window locut hicut", or "no" to disable.
                     Default is "12 2.2 2.5""",
                     equate=False),
+            # General search options:
+            _Option(["-comp_based_stats", "comp_based_stats"],
+                    """Use composition-based statistics.
+
+                    D or d: default (equivalent to 0 )
+                    0 or F or f: Simplified Composition-based statistics as in
+                                 Bioinformatics 15:1000-1011, 1999
+                    1 or T or t: Composition-based statistics as in NAR 29:2994-3005, 2001
+
+                    Default = `0'
+                    """,
+                    checker_function=lambda value: value in "Dd0Ff1Tt",
+                    equate=False),
             # Extension options:
             _Switch(["-ungapped", "ungapped"],
                     "Perform ungapped alignment only?"),
+            # Miscellaneous options:
+            _Switch(["-use_sw_tback", "use_sw_tback"],
+                    "Compute locally optimal Smith-Waterman alignments?"),
         ]
         _NcbiblastCommandline.__init__(self, cmd, **kwargs)
 

--- a/Tests/test_NCBI_BLAST_tools.py
+++ b/Tests/test_NCBI_BLAST_tools.py
@@ -253,19 +253,19 @@ class CheckCompleteArgList(unittest.TestCase):
         if exe_name in ["blastx", "tblastn"]:
             # Removed in BLAST 2.2.27+ so will look like extra arg on new BLAST
             extra = extra.difference(["-frame_shift_penalty"])
-        if exe_name == "rpsblast":
-            # New in BLAST 2.2.28+ so will look like extra args on old BLAST:
-            extra = extra.difference(["-comp_based_stats", "-use_sw_tback"])
         if exe_name in ["blastn", "blastp", "blastx", "tblastn", "tblastx",
                         "psiblast", "rpstblastn", "rpsblast"]:
             # New in BLAST 2.2.29+ so will look like extra args on old BLAST:
             extra = extra.difference(["-max_hsps", "-sum_statistics"])
         if exe_name in ["rpstblastn", "rpsblast"]:
             # Removed in BLAST 2.2.29+ so will look like extra args on new BLAST
-            extra = extra.difference(["-gilist", "-negative_gilist"])
+            extra = extra.difference(["-gilist", "-negative_gilist" ])
             # Removed in BLAST 2.2.30 so will look like extra args on new BLAST
             # Apparently -word_size should never have been added to these tools.
             extra = extra.difference(["-word_size"])
+            # New in BLAST 2.2.28+ (for rpsblast) and BLAST 2.6+ (for rpstblastn)
+            # so will look like extra args on old BLAST:
+            extra = extra.difference(["-comp_based_stats", "-use_sw_tback"])
         if exe_name == "deltablast":
             # New in BLAST+ 2.2.29 so will look like extra args on BLAST+ 2.2.28
             extra = extra.difference(["-entrez_query", "-max_hsps", "-sum_statistics"])

--- a/Tests/test_NCBI_BLAST_tools.py
+++ b/Tests/test_NCBI_BLAST_tools.py
@@ -259,7 +259,7 @@ class CheckCompleteArgList(unittest.TestCase):
             extra = extra.difference(["-max_hsps", "-sum_statistics"])
         if exe_name in ["rpstblastn", "rpsblast"]:
             # Removed in BLAST 2.2.29+ so will look like extra args on new BLAST
-            extra = extra.difference(["-gilist", "-negative_gilist" ])
+            extra = extra.difference(["-gilist", "-negative_gilist"])
             # Removed in BLAST 2.2.30 so will look like extra args on new BLAST
             # Apparently -word_size should never have been added to these tools.
             extra = extra.difference(["-word_size"])


### PR DESCRIPTION
As of blast 2.6, use_sw_tback and comp_based_stats options are available for rpstblastn (They are already available for various other versions).