### PR TITLE
Return FASTQ and SFF quality scores as an array (RFC, WIP)

### DIFF
--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -118,7 +118,8 @@ EAS54_6_R1_2_1_413_324 CCCTTCTTGTCTTCAGCGTTTCTCC
 EAS54_6_R1_2_1_540_792 TTGGCAGGCCAAGGCCGATGGATCA
 EAS54_6_R1_2_1_443_348 GTTGCTTCTGGCGTGGGTGGGGGGG
 
-The qualities are held as a list of integers in each record's annotation:
+The qualities are held as an array of signed byte integers in each record's
+annotation:
 
 >>> print(record)
 ID: EAS54_6_R1_2_1_443_348
@@ -128,7 +129,7 @@ Number of features: 0
 Per letter annotation for: phred_quality
 Seq('GTTGCTTCTGGCGTGGGTGGGGGGG', SingleLetterAlphabet())
 >>> print(record.letter_annotations["phred_quality"])
-[26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 24, 26, 22, 26, 26, 13, 22, 26, 18, 24, 18, 18, 18, 18]
+array('b', [26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 24, 26, 22, 26, 26, 13, 22, 26, 18, 24, 18, 18, 18, 18])
 
 You can use the SeqRecord format method to show this in the QUAL format:
 
@@ -185,7 +186,7 @@ Number of features: 0
 Per letter annotation for: phred_quality
 Seq('TTCTGGCGTG', SingleLetterAlphabet())
 >>> print(sub_rec.letter_annotations["phred_quality"])
-[26, 26, 26, 26, 26, 26, 24, 26, 22, 26]
+array('b', [26, 26, 26, 26, 26, 26, 24, 26, 22, 26])
 >>> print(sub_rec.format("fastq"))
 @EAS54_6_R1_2_1_443_348
 TTCTGGCGTG
@@ -276,8 +277,9 @@ Traceback (most recent call last):
 ValueError: No suitable quality scores found in letter_annotations of SeqRecord (id=Test).
 
 We created a sample SeqRecord, and can show it in FASTA format - but for QUAL
-or FASTQ format we need to provide some quality scores. These are held as a
-list of integers (one for each base) in the letter_annotations dictionary:
+or FASTQ format we need to provide some quality scores. These can be held as a
+list of integers, or an array of signed byte integers (one for each base) in
+the letter_annotations dictionary:
 
 >>> test.letter_annotations["phred_quality"] = [0, 1, 2, 3, 4, 5, 10, 20, 30, 40]
 >>> print(test.format("qual"))
@@ -363,14 +365,16 @@ are approximately equal.
 """
 from __future__ import print_function
 
+import array
+import warnings
+
+from math import log
+
+from Bio import BiopythonWarning, BiopythonParserWarning
 from Bio.Alphabet import single_letter_alphabet
 from Bio.Seq import Seq, UnknownSeq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqIO.Interfaces import SequentialSequenceWriter
-from math import log
-import warnings
-from Bio import BiopythonWarning, BiopythonParserWarning
-
 
 # define score offsets. See discussion for differences between Sanger and
 # Solexa offsets.
@@ -793,7 +797,6 @@ def _get_solexa_quality_str(record):
                    for qp in qualities)
 
 
-# TODO - Default to nucleotide or even DNA?
 def FastqGeneralIterator(handle):
     """Iterate over Fastq records as string tuples (not as SeqRecord objects).
 
@@ -803,7 +806,7 @@ def FastqGeneralIterator(handle):
 
     Our SeqRecord based FASTQ iterators call this function internally, and then
     turn the strings into a SeqRecord objects, mapping the quality string into
-    a list of numerical scores.  If you want to do a custom quality mapping,
+    an array of numerical scores.  If you want to do a custom quality mapping,
     then you might consider calling this function directly.
 
     For parsing FASTQ files, the title string from the "@" line at the start
@@ -1012,10 +1015,11 @@ def FastqPhredIterator(handle, alphabet=single_letter_alphabet, title2ids=None):
     EAS54_6_R1_2_1_443_348 GTTGCTTCTGGCGTGGGTGGGGGGG
 
     If you want to look at the qualities, they are record in each record's
-    per-letter-annotation dictionary as a simple list of integers:
+    per-letter-annotation dictionary as a Python array of signed single
+    byte integers:
 
     >>> print(record.letter_annotations["phred_quality"])
-    [26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 24, 26, 22, 26, 26, 13, 22, 26, 18, 24, 18, 18, 18, 18]
+    array('b', [26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 24, 26, 22, 26, 26, 13, 22, 26, 18, 24, 18, 18, 18, 18])
 
     """
     assert SANGER_SCORE_OFFSET == ord("!")
@@ -1036,7 +1040,7 @@ def FastqPhredIterator(handle, alphabet=single_letter_alphabet, title2ids=None):
             name = id
         record = SeqRecord(Seq(seq_string, alphabet),
                            id=id, name=name, description=descr)
-        qualities = [q_mapping[letter] for letter in quality_string]
+        qualities = array.array('b', (q_mapping[letter] for letter in quality_string))
         if qualities and (min(qualities) < 0 or max(qualities) > 93):
             raise ValueError("Invalid character in quality string")
         # For speed, will now use a dirty trick to speed up assigning the
@@ -1110,10 +1114,10 @@ def FastqSolexaIterator(handle, alphabet=single_letter_alphabet, title2ids=None)
     SLXA-B3_649_FC8437_R1_1_1_183_714 GTATTATTTAATGGCATACACTCAA
 
     If you want to look at the qualities, they are recorded in each record's
-    per-letter-annotation dictionary as a simple list of integers:
+    per-letter-annotation dictionary as an array of signed byte integers:
 
     >>> print(record.letter_annotations["solexa_quality"])
-    [25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 23, 25, 25, 25, 25, 23, 25, 23, 23, 21, 23, 23, 23, 17, 17]
+    array('b', [25, 25, 25, 25, 25, 25, 25, 25, 25, 25, 23, 25, 25, 25, 25, 23, 25, 23, 23, 21, 23, 23, 23, 17, 17])
 
     These scores aren't very good, but they are high enough that they map
     almost exactly onto PHRED scores:
@@ -1141,7 +1145,7 @@ def FastqSolexaIterator(handle, alphabet=single_letter_alphabet, title2ids=None)
     >>> print("%s %s" % (record.id, record.seq))
     slxa_0001_1_0001_01 ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTNNNNNN
     >>> print(record.letter_annotations["solexa_quality"])
-    [40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5]
+    array('b', [40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5])
 
     These quality scores are so low that when converted from the Solexa scheme
     into PHRED scores they look quite different:
@@ -1195,7 +1199,7 @@ def FastqSolexaIterator(handle, alphabet=single_letter_alphabet, title2ids=None)
             name = id
         record = SeqRecord(Seq(seq_string, alphabet),
                            id=id, name=name, description=descr)
-        qualities = [q_mapping[letter] for letter in quality_string]
+        qualities = array.array('b', (q_mapping[letter] for letter in quality_string))
         # DO NOT convert these into PHRED qualities automatically!
         if qualities and (min(qualities) < -5 or max(qualities) > 62):
             raise ValueError("Invalid character in quality string")
@@ -1247,7 +1251,7 @@ def FastqIlluminaIterator(handle, alphabet=single_letter_alphabet, title2ids=Non
             name = id
         record = SeqRecord(Seq(seq_string, alphabet),
                            id=id, name=name, description=descr)
-        qualities = [q_mapping[letter] for letter in quality_string]
+        qualities = array.array('b', (q_mapping[letter] for letter in quality_string))
         if qualities and (min(qualities) < 0 or max(qualities) > 62):
             raise ValueError("Invalid character in quality string")
         # Dirty trick to speed up this line:
@@ -1358,6 +1362,10 @@ def QualPhredIterator(handle, alphabet=single_letter_alphabet, title2ids=None):
                            "substituting PHRED zero instead.")
                           % min(qualities), BiopythonParserWarning)
             qualities = [max(0, q) for q in qualities]
+
+        # Provided the max score is not too big, could do this
+        # (although a more efficient implementation would be nice)
+        # qualities = array.array('b', qualities)
 
         # Return the record and then continue...
         record = SeqRecord(UnknownSeq(len(qualities), alphabet),
@@ -1733,8 +1741,8 @@ def PairedFastaQualIterator(fasta_handle, qual_handle, alphabet=single_letter_al
     EAS54_6_R1_2_1_443_348 GTTGCTTCTGGCGTGGGTGGGGGGG
 
     As with the FASTQ or QUAL parsers, if you want to look at the qualities,
-    they are in each record's per-letter-annotation dictionary as a simple
-    list of integers:
+    they are in each record's per-letter-annotation dictionary as an array
+    of signed byte integers:
 
     >>> print(record.letter_annotations["phred_quality"])
     [26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 24, 26, 22, 26, 26, 13, 22, 26, 18, 24, 18, 18, 18, 18]

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -36,8 +36,8 @@ including the PHRED quality scores.
     E3MFGYR02F7Z7G 219
     >>> print("%s..." % record.seq[:10])
     tcagAATCAT...
-    >>> print("%r..." % (record.letter_annotations["phred_quality"][:10]))
-    [22, 21, 23, 28, 26, 15, 12, 21, 28, 21]...
+    >>> print("%r ..." % (record.letter_annotations["phred_quality"][:10]))
+    array('b', [22, 21, 23, 28, 26, 15, 12, 21, 28, 21]) ...
 
 Notice that the sequence is given in mixed case, the central upper case region
 corresponds to the trimmed sequence. This matches the output of the Roche
@@ -118,8 +118,8 @@ example above:
     E3MFGYR02F7Z7G 130
     >>> print("%s..." % record.seq[:10])
     AATCATCCAC...
-    >>> print("%r..." % record.letter_annotations["phred_quality"][:10])
-    [26, 15, 12, 21, 28, 21, 36, 28, 27, 27]...
+    >>> print("%r ..." % record.letter_annotations["phred_quality"][:10])
+    array('b', [26, 15, 12, 21, 28, 21, 36, 28, 27, 27]) ...
     >>> len(record.annotations)
     3
     >>> print(record.annotations["region"])
@@ -235,13 +235,15 @@ http://www.ncbi.nlm.nih.gov/Traces/trace.cgi?cmd=show&f=formats&m=doc&s=formats
 
 from __future__ import print_function
 
+import array
+import re
+import struct
+import sys
+
 from Bio.SeqIO.Interfaces import SequenceWriter
 from Bio import Alphabet
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-import struct
-import sys
-import re
 
 from Bio._py3k import _bytes_to_string, _as_bytes
 
@@ -625,7 +627,7 @@ def _sff_read_seq_record(handle, number_of_flows_per_read, flow_chars,
     temp_fmt = ">%iB" % seq_len  # used for flow index and quals
     flow_index = handle.read(seq_len)  # unpack later if needed
     seq = _bytes_to_string(handle.read(seq_len))  # TODO - Use bytes in Seq?
-    quals = list(struct.unpack(temp_fmt, handle.read(seq_len)))
+    quals = array.array('b', (struct.unpack(temp_fmt, handle.read(seq_len))))
     # now any padding...
     padding = (read_flow_size + seq_len * 3) % 8
     if padding:

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -260,7 +260,7 @@ class SeqRecord(object):
         >>> print(list(record.letter_annotations))
         ['solexa_quality']
         >>> print(record.letter_annotations["solexa_quality"])
-        [40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5]
+        array('b', [40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5])
 
         The letter_annotations get sliced automatically if you slice the
         parent SeqRecord, for example taking the last ten bases:
@@ -269,7 +269,7 @@ class SeqRecord(object):
         >>> print("%s %s" % (sub_record.id, sub_record.seq))
         slxa_0001_1_0001_01 ACGTNNNNNN
         >>> print(sub_record.letter_annotations["solexa_quality"])
-        [4, 3, 2, 1, 0, -1, -2, -3, -4, -5]
+        array('b', [4, 3, 2, 1, 0, -1, -2, -3, -4, -5])
 
         Any python sequence (i.e. list, tuple or string) can be recorded in
         the SeqRecord's letter_annotations dictionary as long as the length
@@ -1014,7 +1014,7 @@ class SeqRecord(object):
         >>> print(list(record.letter_annotations))
         ['solexa_quality']
         >>> print(record.letter_annotations["solexa_quality"])
-        [40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5]
+        array('b', [40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, -1, -2, -3, -4, -5])
 
         Now take the reverse complement, here we explicitly give a new
         identifier (the old identifier with a suffix):
@@ -1027,7 +1027,7 @@ class SeqRecord(object):
         although this may not be appropriate for all cases.
 
         >>> print(rc_record.letter_annotations["solexa_quality"])
-        [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40]
+        array('b', [-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40])
 
         Now for the features, we need a different example. Parsing a GenBank
         file is probably the easiest way to get an nice example with features

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -866,8 +866,8 @@ CCCTTCTTGTCTTCAGCGTTTCTCC
 %TODO - doctest wrapping
 \begin{verbatim}
 >>> print(record.letter_annotations["phred_quality"])
-[26, 26, 18, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 22, 26, 26, 26, 26,
-26, 26, 26, 23, 23]
+array('b', [26, 26, 18, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 22, 26, 26, 26, 26,
+26, 26, 26, 23, 23])
 \end{verbatim}
 
 \noindent Let's suppose this was Roche 454 data, and that from other information
@@ -881,12 +881,12 @@ third \texttt{T}:
 >>> print(left.seq)
 CCCTTCTTGTCTTCAGCGTT
 >>> print(left.letter_annotations["phred_quality"])
-[26, 26, 18, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 22, 26, 26, 26, 26]
+array('b', [26, 26, 18, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 22, 26, 26, 26, 26])
 >>> right = record[21:]
 >>> print(right.seq)
 CTCC
 >>> print(right.letter_annotations["phred_quality"])
-[26, 26, 23, 23]
+array('b', [26, 26, 23, 23])
 \end{verbatim}
 
 \noindent Now add the two parts together:
@@ -901,8 +901,8 @@ CCCTTCTTGTCTTCAGCGTTCTCC
 \end{verbatim}
 \begin{verbatim}
 >>> print(edited.letter_annotations["phred_quality"])
-[26, 26, 18, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 22, 26, 26, 26, 26,
-26, 26, 23, 23]
+array('b', [26, 26, 18, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 22, 26, 26, 26, 26,
+26, 26, 23, 23])
 \end{verbatim}
 
 \noindent Easy and intuitive? We hope so! You can make this shorter with just:

--- a/Tests/test_Emboss.py
+++ b/Tests/test_Emboss.py
@@ -306,11 +306,11 @@ class SeqRetSeqIOTests(unittest.TestCase):
             else:
                 self.assertEqual(old.id, new.id)
             self.assertEqual(str(old.seq), str(new.seq))
-            if emboss_version < (6, 3, 0) and new.letter_annotations["phred_quality"] == [1] * len(old):
+            if emboss_version < (6, 3, 0) and list(new.letter_annotations["phred_quality"]) == [1] * len(old):
                 # Apparent bug in EMBOSS 6.2.0.1 on Windows
                 pass
             else:
-                self.assertEqual(old.letter_annotations, new.letter_annotations)
+                self.assertEqual(list(old.letter_annotations), list(new.letter_annotations))
 
     def test_genbank(self):
         """SeqIO & EMBOSS reading each other's conversions of a GenBank file."""

--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -79,7 +79,7 @@ def compare_record(old, new, truncate=None):
             raise ValueError("'%s...' vs '%s...'" % (old.seq[:100], new.seq[:100]))
     if "phred_quality" in old.letter_annotations \
     and "phred_quality" in new.letter_annotations \
-    and old.letter_annotations["phred_quality"] != new.letter_annotations["phred_quality"]:
+    and list(old.letter_annotations["phred_quality"]) != list(new.letter_annotations["phred_quality"]):
         if truncate and [min(q, truncate) for q in old.letter_annotations["phred_quality"]] == \
                         [min(q, truncate) for q in new.letter_annotations["phred_quality"]]:
             pass
@@ -87,7 +87,7 @@ def compare_record(old, new, truncate=None):
             raise ValueError("Mismatch in phred_quality")
     if "solexa_quality" in old.letter_annotations \
     and "solexa_quality" in new.letter_annotations \
-    and old.letter_annotations["solexa_quality"] != new.letter_annotations["solexa_quality"]:
+    and list(old.letter_annotations["solexa_quality"]) != list(new.letter_annotations["solexa_quality"]):
         if truncate and [min(q, truncate) for q in old.letter_annotations["solexa_quality"]] == \
                         [min(q, truncate) for q in new.letter_annotations["solexa_quality"]]:
             pass
@@ -101,7 +101,7 @@ def compare_record(old, new, truncate=None):
                      for q in old.letter_annotations["phred_quality"]]
         if truncate:
             converted = [min(q, truncate) for q in converted]
-        if converted != new.letter_annotations["solexa_quality"]:
+        if converted != list(new.letter_annotations["solexa_quality"]):
             print("")
             print(old.letter_annotations["phred_quality"])
             print(converted)
@@ -115,7 +115,7 @@ def compare_record(old, new, truncate=None):
                      for q in old.letter_annotations["solexa_quality"]]
         if truncate:
             converted = [min(q, truncate) for q in converted]
-        if converted != new.letter_annotations["phred_quality"]:
+        if converted != list(new.letter_annotations["phred_quality"]):
             print(old.letter_annotations["solexa_quality"])
             print(converted)
             print(new.letter_annotations["phred_quality"])
@@ -662,7 +662,7 @@ class MappingTests(unittest.TestCase):
         out_handle.seek(0)
         record = SeqIO.read(out_handle, "fastq-solexa")
         self.assertEqual(str(record.seq), seq)
-        self.assertEqual(record.letter_annotations["solexa_quality"],
+        self.assertEqual(list(record.letter_annotations["solexa_quality"]),
                          expected_sol)
 
     def test_solexa_to_sanger(self):
@@ -681,7 +681,7 @@ class MappingTests(unittest.TestCase):
         out_handle.seek(0)
         record = SeqIO.read(out_handle, "fastq-sanger")
         self.assertEqual(str(record.seq), seq)
-        self.assertEqual(record.letter_annotations["phred_quality"],
+        self.assertEqual(list(record.letter_annotations["phred_quality"]),
                          expected_phred)
 
     def test_sanger_to_illumina(self):
@@ -699,7 +699,7 @@ class MappingTests(unittest.TestCase):
         out_handle.seek(0)
         record = SeqIO.read(out_handle, "fastq-illumina")
         self.assertEqual(str(record.seq), seq)
-        self.assertEqual(record.letter_annotations["phred_quality"],
+        self.assertEqual(list(record.letter_annotations["phred_quality"]),
                          expected_phred)
 
     def test_illumina_to_sanger(self):
@@ -714,7 +714,7 @@ class MappingTests(unittest.TestCase):
         out_handle.seek(0)
         record = SeqIO.read(out_handle, "fastq-sanger")
         self.assertEqual(str(record.seq), seq)
-        self.assertEqual(record.letter_annotations["phred_quality"],
+        self.assertEqual(list(record.letter_annotations["phred_quality"]),
                          expected_phred)
 
 

--- a/Tests/test_SeqIO_convert.py
+++ b/Tests/test_SeqIO_convert.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 
 import unittest
 import warnings
+
 from Bio import BiopythonWarning
 from Bio.Seq import UnknownSeq
 from Bio import SeqIO
@@ -105,7 +106,7 @@ def compare_record(old, new, truncate=None):
             raise ValueError("'%s...' vs '%s...'" % (old.seq[:100], new.seq[:100]))
     if "phred_quality" in old.letter_annotations \
     and "phred_quality" in new.letter_annotations \
-    and old.letter_annotations["phred_quality"] != new.letter_annotations["phred_quality"]:
+    and list(old.letter_annotations["phred_quality"]) != list(new.letter_annotations["phred_quality"]):
         if truncate and [min(q, truncate) for q in old.letter_annotations["phred_quality"]] == \
                         [min(q, truncate) for q in new.letter_annotations["phred_quality"]]:
             pass
@@ -113,7 +114,7 @@ def compare_record(old, new, truncate=None):
             raise ValueError("Mismatch in phred_quality")
     if "solexa_quality" in old.letter_annotations \
     and "solexa_quality" in new.letter_annotations \
-    and old.letter_annotations["solexa_quality"] != new.letter_annotations["solexa_quality"]:
+    and list(old.letter_annotations["solexa_quality"]) != list(new.letter_annotations["solexa_quality"]):
         if truncate and [min(q, truncate) for q in old.letter_annotations["solexa_quality"]] == \
                         [min(q, truncate) for q in new.letter_annotations["solexa_quality"]]:
             pass
@@ -127,7 +128,7 @@ def compare_record(old, new, truncate=None):
                      for q in old.letter_annotations["phred_quality"]]
         if truncate:
             converted = [min(q, truncate) for q in converted]
-        if converted != new.letter_annotations["solexa_quality"]:
+        if converted != list(new.letter_annotations["solexa_quality"]):
             print("")
             print(old.letter_annotations["phred_quality"])
             print(converted)
@@ -141,7 +142,7 @@ def compare_record(old, new, truncate=None):
                      for q in old.letter_annotations["solexa_quality"]]
         if truncate:
             converted = [min(q, truncate) for q in converted]
-        if converted != new.letter_annotations["phred_quality"]:
+        if converted != list(new.letter_annotations["phred_quality"]):
             print(old.letter_annotations["solexa_quality"])
             print(converted)
             print(new.letter_annotations["phred_quality"])

--- a/Tests/test_SffIO.py
+++ b/Tests/test_SffIO.py
@@ -390,10 +390,12 @@ class TestSelf(unittest.TestCase):
         for s, sT, f, q, fT, qT in zip(sff, sff_trim, fasta_no_trim, qual_no_trim, fasta_trim, qual_trim):
             self.assertEqual(len({s.id, f.id, q.id}), 1)  # All values are the same
             self.assertEqual(str(s.seq), str(f.seq))
-            self.assertEqual(s.letter_annotations["phred_quality"], q.letter_annotations["phred_quality"])
+            self.assertEqual(list(s.letter_annotations["phred_quality"]),
+                             list(q.letter_annotations["phred_quality"]))
             self.assertEqual(len({s.id, sT.id, fT.id, qT.id}), 1)  # All values are the same
             self.assertEqual(str(sT.seq), str(fT.seq))
-            self.assertEqual(sT.letter_annotations["phred_quality"], qT.letter_annotations["phred_quality"])
+            self.assertEqual(list(sT.letter_annotations["phred_quality"]),
+                             list(qT.letter_annotations["phred_quality"]))
 
     def test_write(self):
         filename = "Roche/E3MFGYR02_random_10_reads.sff"


### PR DESCRIPTION
**Request for comment, work in progress**

Previously the FASTQ and SFF parsers returned a list of integers, here we return a unsigned byte integer array instead.

Note could do this on ABI and QUAL parser too, although the later has a test case which causes an overflow.

This change in itself is a proof of principle, and to allow checking of side effects. Step two would be to use this for speeding up the parser...