### PR TITLE
skip test for QCPSuperimposer if the C module is not compiled

### DIFF
--- a/Tests/test_QCPSuperimposer.py
+++ b/Tests/test_QCPSuperimposer.py
@@ -12,7 +12,13 @@ except ImportError:
     raise MissingPythonDependencyError(
         "Install NumPy if you want to use Bio.QCPSuperimposer.")
 
-from Bio.PDB.QCPSuperimposer import QCPSuperimposer
+try:
+    from Bio.PDB.QCPSuperimposer import QCPSuperimposer
+except ImportError:
+    from Bio import MissingExternalDependencyError
+    raise MissingExternalDependencyError(
+        "C module in Bio.QCPSuperimposer not compiled")
+
 
 # start with two coordinate sets (Nx3 arrays - Float0)
 


### PR DESCRIPTION
The QCPSuperimposer test fails with an `ImportError` if the C module is not compiled
```
$ python3 run_tests.py test_QCPSuperimposer
Python version: 3.5.2 (default, Nov 17 2016, 17:05:23) 
[GCC 5.4.0 20160609]
Operating system: posix linux
test_QCPSuperimposer ... loading tests failed:
Failed to import test module: test_QCPSuperimposer
Traceback (most recent call last):
  File "/usr/lib/python3.5/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/jeroen/OpenSource/biopython/Tests/test_QCPSuperimposer.py", line 15, in <module>
    from Bio.PDB.QCPSuperimposer import QCPSuperimposer
  File "/home/jeroen/OpenSource/biopython/Bio/PDB/QCPSuperimposer/__init__.py", line 15, in <module>
    from .qcprotmodule import FastCalcRMSDAndRotation
ImportError: No module named 'Bio.PDB.QCPSuperimposer.qcprotmodule'

----------------------------------------------------------------------
Ran 1 test in 0.059 seconds

FAILED (failures = 1)
```

This patch adds an `MissingExternalDependencyError` so that the test is skipped if the C module is not compiled.