### PR TITLE
remove assertion comparing Count and IdList

### DIFF
--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -1299,7 +1299,6 @@ additional argument of \verb|usehistory="y"|,
 \begin{verbatim}
 >>> gi_list = search_results["IdList"]
 >>> count = int(search_results["Count"])
->>> assert count == len(gi_list)
 \end{verbatim}
 
 \noindent However, you also get given two additional pieces of information, the {\tt WebEnv} session cookie, and the {\tt QueryKey}:


### PR DESCRIPTION
search_result["IdList"] is constrained by the 'retmax' argument to Entrez.esearch, while search_result["Count"] is the total number of records found. Count can exceed the length of the IdList; this assertion can cause trouble or confusion.