### PR TITLE
use a single RNG rather than a new one for each use.

### DIFF
--- a/Bio/GA/Mutation/Simple.py
+++ b/Bio/GA/Mutation/Simple.py
@@ -26,12 +26,17 @@ class SinglePositionMutation(object):
         genome.
         """
         self._mutation_rate = mutation_rate
+        # Originally there was an RNG for each case. Python 3.6 was
+        # released with a bug under Windows where all RNGs created
+        # within a 15ms window have the same initial seed.
+        # To reduce possible correlations, re-use a single RNG.
+        rng = random.Random()
         # a random number generator to test if we have a mutation
-        self._mutation_rand = random.Random()
+        self._mutation_rand = rng
         # a random number generator to switch to a new alphabet letter
-        self._switch_rand = random.Random()
+        self._switch_rand = rng
         # a random number generator to find the mutation position
-        self._pos_rand = random.Random()
+        self._pos_rand = rng
 
     def mutate(self, organism):
         """Mutate the organisms genome.


### PR DESCRIPTION
Random is random, but there's a bug under Python 3.6 for Windows where multiple RNGs created in a short window (about 15ms) all have the same initial seed, and hence be correlated. While it's not likely to be a serious problem, there's no need to have multiple RNGs in the first place. Instead, simply share the same generator for all three tasks.

See issue #1044 for more details.