### PR TITLE
Fix bug with Bio.PDB DSSP variable names

### DIFF
--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -351,7 +351,7 @@ class DSSP(AbstractResiduePropertyMap):
             # calling 'dssp' will not work in some operating systems
             # (Debian distribution of DSSP includes a symlink for 'dssp' argument)
             try:
-                dssp_dict, dssp_keys = dssp_dict_from_pdb_file(pdb_file, dssp)
+                dssp_dict, dssp_keys = dssp_dict_from_pdb_file(in_file, dssp)
             except FileNotFoundError:
                 if dssp == 'dssp':
                     dssp = 'mkdssp'
@@ -359,7 +359,7 @@ class DSSP(AbstractResiduePropertyMap):
                     dssp = 'dssp'
                 else:
                     raise
-            dssp_dict, dssp_keys = dssp_dict_from_pdb_file(pdb_file, dssp)
+            dssp_dict, dssp_keys = dssp_dict_from_pdb_file(in_file, dssp)
         # If the input file is a DSSP file just parse it directly:
         elif file_type == 'DSSP':
             dssp_dict, dssp_keys = make_dssp_dict(in_file)


### PR DESCRIPTION
Just a quick fix for a variable name bug that must have got missed with one of the recent commits. Just noticed that the `test_DSSP_tool` test didn't pass when I ran tests for the latest master version. The variable `pdb_file` has been changed to `in_file` at some point, but not updated everywhere.