### PR TITLE
Fix recursion error when performing deepcopy on PDB structures.

### DIFF
--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -246,6 +246,9 @@ class DisorderedEntityWrapper(object):
 
     def __getattr__(self, method):
         """Forward the method call to the selected child."""
+        if method == '__setstate__':
+            # Avoid issues with recursion when attempting deepcopy
+            raise AttributeError
         if not hasattr(self, 'selected_child'):
             # Avoid problems with pickling
             # Unpickling goes into infinite loop!

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -12,6 +12,7 @@
 """Unit tests for the Bio.PDB module."""
 from __future__ import print_function
 
+from copy import deepcopy
 import os
 import sys
 import tempfile
@@ -525,6 +526,11 @@ class ParseTest(unittest.TestCase):
         finally:
             os.remove(filename)
 
+    def test_deepcopy_of_structure_with_disorder(self):
+        """Test deepcopy of a structure with disordered atoms.
+        Shouldn't cause recursion.
+        """
+        _ = deepcopy(self.structure)
 
 class ParseReal(unittest.TestCase):
     """Testing with real PDB files."""

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -532,6 +532,7 @@ class ParseTest(unittest.TestCase):
         """
         _ = deepcopy(self.structure)
 
+
 class ParseReal(unittest.TestCase):
     """Testing with real PDB files."""
 

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -528,7 +528,7 @@ class ParseTest(unittest.TestCase):
 
     def test_deepcopy_of_structure_with_disorder(self):
         """Test deepcopy of a structure with disordered atoms.
-        
+
         Shouldn't cause recursion.
         """
         _ = deepcopy(self.structure)

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -528,6 +528,7 @@ class ParseTest(unittest.TestCase):
 
     def test_deepcopy_of_structure_with_disorder(self):
         """Test deepcopy of a structure with disordered atoms.
+        
         Shouldn't cause recursion.
         """
         _ = deepcopy(self.structure)


### PR DESCRIPTION
Trying to perform a `deepcopy` of a PDB structure with disordered atoms causes recursion errors in Python  3+. See issue #787 

This proposed fix raises an AttributeError when `__getattr__('__setstate__')` is called on a disordered entity to stop `copy.deepcopy` recursing.