### PR TITLE
Fix docstring in ProteinAnalysis.secondary_structure_fraction

### DIFF
--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -268,7 +268,7 @@ class ProteinAnalysis(object):
         Amino acids in Turn: N, P, G, S.
         Amino acids in sheet: E, M, A, L.
 
-        Returns a tuple of three integers (Helix, Turn, Sheet).
+        Returns a tuple of three floats (Helix, Turn, Sheet).
         """
         aa_percentages = self.get_amino_acids_percent()
 


### PR DESCRIPTION
Fixes the docstring for ProteinAnalysis.secondary_structure_fraction().

The tuple returned contains float values of the fractions of amino acids contributing to each secondary structure (as computed by get_amino_acids_percent()), rather than integers.