### PR TITLE
Enable NumPy code and most C code under PyPy

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -50,7 +50,8 @@ whitelist_externals =
     bash
     echo
 # Want to avoid overhead of compiling numpy or scipy:
-install_command = pip install --only-binary=numpy,scipy {opts} {packages}
+# (But must compile numpy for PyPy right now)
+install_command = pip install --only-binary=scipy {opts} {packages}
 deps =
     #Lines startings xxx: are filtered by the environment.
     #Leaving py34 without any soft dependencies (just numpy)
@@ -63,7 +64,7 @@ deps =
     {py27,py33,py35}: psycopg2
     {py27,py33,py35,pypy}: mysql-connector-python-rf
     {py27,py33,py35,pypy}: rdflib
-    {py27,py33,py34,py35,py36}: numpy
+    {py27,py33,py34,py35,py36,pypy,pypy3}: numpy
     {py35}: scipy
     py27: networkx
     py35: matplotlib

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -64,7 +64,8 @@ deps =
     {py27,py33,py35}: psycopg2
     {py27,py33,py35,pypy}: mysql-connector-python-rf
     {py27,py33,py35,pypy}: rdflib
-    {py27,py33,py34,py35,py36,pypy,pypy3}: numpy
+    py33: numpy==1.11.3
+    {py27,py34,py35,py36,pypy,pypy3}: numpy
     {py35}: scipy
     py27: networkx
     py35: matplotlib

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -23,6 +23,9 @@ are explicitly available under either license, but most of the code remains
 under the "Biopython License Agreement" only. See the LICENSE file for more
 details.
 
+We now expect and take advantage of NumPy under PyPy, and compile most of the
+Biopython C code modules as well.
+
 Bio.AlignIO now supports the UCSC Multiple Alignment Format (MAF) under the
 format name "maf", using new module Bio.AlignIO.MafIO which also offers
 indexed access to these potentially large files using SQLite3 (contributed by

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ Here you can replace ``python`` with a specific version, e.g. ``python3.5``.
 Python Requirements
 ===================
 
-We currently recommend using Python 3.5 from http://www.python.org
+We currently recommend using Python 3.6 from http://www.python.org
 
 Biopython is currently supported and tested on the following Python
 implementations:
@@ -63,9 +63,9 @@ implementations:
 
 - PyPy v5.7 and also PyPy3.5 v5.7 beta -- see http://www.pypy.org
 
-  Aside from modules with C code or dependent on NumPy, everything should
-  work. PyPy's support of NumPy has improved but we have not reviewed how
-  well that works for Biopython. Older versions of PyPy mostly work too.
+  Aside from ``Bio.trie`` (which does not compile as ``marshal.h`` is
+  currently missing under PyPy), everything should work. Older versions
+  of PyPy mostly work too.
 
 - Jython 2.7 -- see http://www.jython.org
 

--- a/setup.py
+++ b/setup.py
@@ -205,8 +205,6 @@ def check_dependencies():
         return True  # For automated builds go ahead with installed packages
     if os.name == 'java':
         return True  # NumPy is not avaliable for Jython (for now)
-    if is_pypy():
-        return True  # Full NumPy not available for PyPy (for now)
     if is_ironpython():
         return True  # We're ignoring NumPy under IronPython (for now)
 
@@ -316,8 +314,6 @@ def can_import(module_name):
 
 
 def is_Numpy_installed():
-    if is_pypy():
-        return False
     return bool(can_import("numpy"))
 
 # --- set up the packages we are going to install

--- a/setup.py
+++ b/setup.py
@@ -403,9 +403,20 @@ NUMPY_PACKAGES = [
 if os.name == 'java':
     # Jython doesn't support C extensions
     EXTENSIONS = []
-elif is_pypy() or is_ironpython():
+elif is_ironpython():
     # Skip C extensions for now
     EXTENSIONS = []
+elif is_pypy():
+    # Two out of three ain't bad?
+    EXTENSIONS = [
+    Extension('Bio.cpairwise2',
+              ['Bio/cpairwise2module.c'],
+              ),
+    # Bio.trie has a problem under PyPy2 v5.6 and 5.7
+    Extension('Bio.Nexus.cnexus',
+              ['Bio/Nexus/cnexus.c']
+              ),
+    ]
 else:
     EXTENSIONS = [
     Extension('Bio.cpairwise2',

--- a/setup.py
+++ b/setup.py
@@ -142,10 +142,6 @@ if sys.version_info[:2] < (2, 7):
     sys.stderr.write("Biopython requires Python 2.7, or Python 3.3 or later. "
                      "Python %d.%d detected.\n" % sys.version_info[:2])
     sys.exit(1)
-elif is_pypy() and sys.version_info[0] == 3 and sys.version_info[:2] == (3, 2):
-    # PyPy3 2.4.0 is compatibile with Python 3.2.5 plus unicode literals
-    # so ought to work with Biopython
-    pass
 elif sys.version_info[0] == 3 and sys.version_info[:2] < (3, 3):
     sys.stderr.write("Biopython requires Python 3.3 or later (or Python 2.7). "
                      "Python %d.%d detected.\n" % sys.version_info[:2])


### PR DESCRIPTION
This would address #126 (``Bio.PDB`` under PyPy) and #953 (our NumPy code in general under PyPy).

Known issues which I believe are PyPy limitations:

- #1114 ``Bio.trie`` does not compile (and therefore still excluded in ``setup.py``)
- #1112 ``test_NaiveBayes.py`` fails under PyPy3.5 v5.7 beta

I have been testing with both PyPy2 v5.6 and the new release v5.7, plus also PyPy3.5 v5.7 beta.

I would like a second set of eyes on this before merging it, and thoughts on what to do with the Navie Bayes test? The simple answer is mark PyPy3 as an allowed failure under TravisCI...