### PR TITLE
Changed codon model

### DIFF
--- a/Bio/Align/Applications/_Prank.py
+++ b/Bio/Align/Applications/_Prank.py
@@ -129,9 +129,8 @@ class PrankCommandline(AbstractCommandline):
                     "Purine/pyrimidine ratio. Default: 1",
                     checker_function=lambda x: isinstance(x, int)),
             # -codon [for DNA: use empirical codon model]
-            # Assuming this is an input file as in -m
-            _Option(["-codon", "codon"],
-                    "Codon model filename. Default: empirical codon model"),
+            _Switch(["-codon", "codon"],
+                    "Codon aware alignment or not"),
             # -termgap [penalise terminal gaps normally]
             _Switch(["-termgap", "termgap"],
                     "Penalise terminal gaps normally"),


### PR DESCRIPTION
It seems that what prank want is whether to conduct a codon aware alignment or not (means when aligning two DNA sequence, whether should prank be aware of the position of codon reading frames). It is not requesting to specify a codon model. Without this change, prank always give an error message like "cannot recognize "**" argument" when I try to do codon alignment.