### PR TITLE
Small fix to gc skew

### DIFF
--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -103,7 +103,10 @@ def GC_skew(seq, window=100):
         s = seq[i: i + window]
         g = s.count('G') + s.count('g')
         c = s.count('C') + s.count('c')
-        skew = (g - c) / float(g + c)
+        if g == c:
+            skew = 0
+        else:
+            skew = (g - c) / float(g + c)
         values.append(skew)
     return values
 

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -94,7 +94,9 @@ def GC_skew(seq, window=100):
 
     Returns a list of ratios (floats), controlled by the length of the sequence
     and the size of the window.
-
+    
+    If the number of G and C is equal, returns 0. Fixes the issue when the window is devoid of G/Cs.
+    
     Does NOT look at any ambiguous nucleotides.
     """
     # 8/19/03: Iddo: added lowercase

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -94,9 +94,9 @@ def GC_skew(seq, window=100):
 
     Returns a list of ratios (floats), controlled by the length of the sequence
     and the size of the window.
-    
+
     If the numbers of G and C are equal, returns 0. Fixes the issue when the window is devoid of G/Cs.
-    
+
     Does NOT look at any ambiguous nucleotides.
     """
     # 8/19/03: Iddo: added lowercase

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -95,7 +95,7 @@ def GC_skew(seq, window=100):
     Returns a list of ratios (floats), controlled by the length of the sequence
     and the size of the window.
 
-    If the numbers of G and C are equal, returns 0. Fixes the issue when the window is devoid of G/Cs.
+    Returns 0 for windows without any G/C by handling zero division errors.
 
     Does NOT look at any ambiguous nucleotides.
     """

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -95,7 +95,7 @@ def GC_skew(seq, window=100):
     Returns a list of ratios (floats), controlled by the length of the sequence
     and the size of the window.
     
-    If the number of G and C is equal, returns 0. Fixes the issue when the window is devoid of G/Cs.
+    If the numbers of G and C are equal, returns 0. Fixes the issue when the window is devoid of G/Cs.
     
     Does NOT look at any ambiguous nucleotides.
     """

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -105,10 +105,10 @@ def GC_skew(seq, window=100):
         s = seq[i: i + window]
         g = s.count('G') + s.count('g')
         c = s.count('C') + s.count('c')
-        if g == c:
-            skew = 0
-        else:
+        try:
             skew = (g - c) / float(g + c)
+        except ZeroDivisionError:
+            skew = 0.0
         values.append(skew)
     return values
 

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -140,6 +140,10 @@ class SeqUtilsTests(unittest.TestCase):
         seq = "ACGGGCTACCGTATAGGCAAGAGATGATGCCC"
         self.assertEqual(GC(seq), 56.25)
 
+    def test_GC_skew(self):
+        seq = "A"*50
+        self.assertEqual(GC_skew(seq)[0], 0)
+
     def test_seq1_seq3(self):
         s3 = "MetAlaTyrtrpcysthrLYSLEUILEGlYPrOGlNaSnaLapRoTyRLySSeRHisTrpLysThr"
         s1 = "MAYWCTKLIGPQNAPYKSHWKT"

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -10,7 +10,7 @@ from Bio import SeqIO
 from Bio.Alphabet import single_letter_alphabet
 from Bio.Seq import Seq, MutableSeq
 from Bio.SeqRecord import SeqRecord
-from Bio.SeqUtils import GC, seq1, seq3
+from Bio.SeqUtils import GC, seq1, seq3, GC_skew
 from Bio.SeqUtils.lcc import lcc_simp, lcc_mult
 from Bio.SeqUtils.CheckSum import crc32, crc64, gcg, seguid
 from Bio.SeqUtils.CodonUsage import CodonAdaptationIndex
@@ -141,7 +141,7 @@ class SeqUtilsTests(unittest.TestCase):
         self.assertEqual(GC(seq), 56.25)
 
     def test_GC_skew(self):
-        seq = "A"*50
+        seq = "A" * 50
         self.assertEqual(GC_skew(seq)[0], 0)
 
     def test_seq1_seq3(self):


### PR DESCRIPTION
In reference to issue #1107 I have add a check whether G and C are in same quantity and return 0 if so. And a unittest on a window with no G or C. 