### PR TITLE
Deprecate Bio.PDB.Dice

### DIFF
--- a/Bio/PDB/Dice.py
+++ b/Bio/PDB/Dice.py
@@ -8,6 +8,10 @@ import warnings
 
 from Bio.PDB.PDBIO import PDBIO
 from Bio import BiopythonWarning
+from Bio import BiopythonDeprecationWarning
+
+warnings.warn("Bio.PDB.Dice is now deprecated will be removed in a "
+              "future release of Biopython.", BiopythonDeprecationWarning)
 
 _hydrogen = re.compile("[123 ]*H.*")
 

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -36,7 +36,7 @@ at installation time.
 Bio.PDB.Dice
 ============
 This was deprecated in Biopython 1.70, it was likely intended as an example
-script using PDBIO for select parts of a PDB file.
+script using PDBIO for selecting parts of a PDB file.
 
 Bio.DocSQL
 ==========

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -33,6 +33,11 @@ Python 3.3
 Still suported but deprecated as of Release 1.67, triggering a warning
 at installation time.
 
+Bio.PDB.Dice
+============
+This was deprecated in Biopython 1.70, it was likely intended as an example
+script using PDBIO for select parts of a PDB file.
+
 Bio.DocSQL
 ==========
 This was deprecated in Biopython 1.69.


### PR DESCRIPTION
As discussed on #820, ``Bio.PDB.Dice``was likely intended as an example script using ``PDBIO`` rather than as part of the ``Bio.PDB`` public API.

See mailing list thread:

http://mailman.open-bio.org/pipermail/biopython/2017-April/016132.html
http://mailman.open-bio.org/pipermail/biopython-dev/2017-April/021687.html