### PR TITLE
Ability to specify codon table for dn_ds matrix calculation and test for get_dn_ds_matrix

### DIFF
--- a/Bio/codonalign/codonalignment.py
+++ b/Bio/codonalign/codonalignment.py
@@ -111,7 +111,7 @@ class CodonAlignment(MultipleSeqAlignment):
 
     def get_dn_ds_matrix(self, method="NG86", codon_table=default_codon_table):
         """Available methods include NG86, LWL85, YN00 and ML.
-        
+
         Argument:
             - method       - Available methods include NG86, LWL85, YN00 and ML.
             - codon_table  - Codon table to use for forward translation.

--- a/Bio/codonalign/codonalignment.py
+++ b/Bio/codonalign/codonalignment.py
@@ -109,8 +109,13 @@ class CodonAlignment(MultipleSeqAlignment):
                 rec in self._records]
         return MultipleSeqAlignment(alignments)
 
-    def get_dn_ds_matrix(self, method="NG86"):
-        """Available methods include NG86, LWL85, YN00 and ML."""
+    def get_dn_ds_matrix(self, method="NG86", codon_table=default_codon_table):
+        """Available methods include NG86, LWL85, YN00 and ML.
+        
+        Argument:
+            - method       - Available methods include NG86, LWL85, YN00 and ML.
+            - codon_table  - Codon table to use for forward translation.
+        """
         from Bio.Phylo.TreeConstruction import _DistanceMatrix as DM
         names = [i.id for i in self._records]
         size = len(self._records)
@@ -122,7 +127,7 @@ class CodonAlignment(MultipleSeqAlignment):
             for j in range(i + 1):
                 if i != j:
                     dn, ds = cal_dn_ds(self._records[i], self._records[j],
-                                       method=method)
+                                       method=method, codon_table=codon_table)
                     dn_matrix[i].append(dn)
                     ds_matrix[i].append(ds)
                 else:
@@ -132,7 +137,7 @@ class CodonAlignment(MultipleSeqAlignment):
         ds_dm = DM(names, matrix=ds_matrix)
         return dn_dm, ds_dm
 
-    def get_dn_ds_tree(self, dn_ds_method="NG86", tree_method="UPGMA"):
+    def get_dn_ds_tree(self, dn_ds_method="NG86", tree_method="UPGMA", codon_table=default_codon_table):
         """Method for constructing dn tree and ds tree.
 
         Argument:
@@ -141,7 +146,7 @@ class CodonAlignment(MultipleSeqAlignment):
             - tree_method  - Available methods include UPGMA and NJ.
         """
         from Bio.Phylo.TreeConstruction import DistanceTreeConstructor
-        dn_dm, ds_dm = self.get_dn_ds_matrix(method=dn_ds_method)
+        dn_dm, ds_dm = self.get_dn_ds_matrix(method=dn_ds_method, codon_table=codon_table)
         dn_constructor = DistanceTreeConstructor()
         ds_constructor = DistanceTreeConstructor()
         if tree_method == "UPGMA":

--- a/Tests/test_codonalign.py
+++ b/Tests/test_codonalign.py
@@ -200,6 +200,36 @@ class Test_dn_ds(unittest.TestCase):
             # TODO - Show a warning?
             pass
 
+    def test_dn_ds_matrix(self):
+        # NG86 method with default codon table
+        dn_correct = [0, 0.02090783050583131, 0, 0.6115239249238438, 0.6102203266798018, 0, 0.6140350835631757, 0.6040168621204747, 0.041180350405913294, 0, 0.6141532531400524, 0.6018263135601294, 0.06701051445629494, 0.061470360954086874, 0, 0.6187088340904762, 0.6068687248870475, 0.07386903034833081, 0.07357890927918581, 0.05179847072570129, 0]
+        ds_correct = [0, 0.01783718763890243, 0, 2.9382055377913687, 3.0375115405379267, 0, 2.008913071877126, 2.0182088023715616, 0.5638033197005285, 0, 2.771425931736778, 2.7353083173058295, 0.6374483799734671, 0.723542095485497, 0, -1, -1, 0.953865978141643, 1.182154857347706, 0.843182957978177, 0]
+        dn, ds = self.aln.get_dn_ds_matrix()
+        dn_list = []
+        for i in dn.matrix:
+            dn_list.extend(i)
+        for dn_cal, dn_corr in zip(dn_list, dn_correct):
+            self.assertAlmostEqual(round(dn_cal, 4), round(dn_corr, 4), places=4)
+        ds_list = []
+        for i in ds.matrix:
+            ds_list.extend(i)
+        for ds_cal, ds_corr in zip(ds_list, ds_correct):
+            self.assertAlmostEqual(round(ds_cal, 4), round(ds_corr, 4), places=4)
+        # YN00 method with user specified codon table
+        dn_correct = [0, 0.019701773284646867, 0, 0.6109649819852769, 0.6099903856901369, 0, 0.6114499930666559, 0.6028068208599121, 0.045158286242251426, 0, 0.6151835071687592, 0.6053227393422296, 0.07034397741651377, 0.06956967795096626, 0, 0.6103850655769698, 0.5988716898831496, 0.07905930042150053, 0.08203052937107111, 0.05659346894088538, 0]
+        ds_correct = [0, 0.01881718550096053, 0, 1.814457265482046, 1.8417575124882066, 0, 1.5627041719628896, 1.563930819079887, 0.4748890153032888, 0, 1.6754828466084355, 1.6531212012501901, 0.5130923627791538, 0.5599667707191436, 0, 2.0796114236540943, 2.1452591651827304, 0.7243066372971764, 0.8536617406770075, 0.6509203399899367, 0]
+        dn, ds = self.aln.get_dn_ds_matrix(method="LWL85", codon_table=CodonTable.unambiguous_dna_by_id[3])
+        dn_list = []
+        for i in dn.matrix:
+            dn_list.extend(i)
+        for dn_cal, dn_corr in zip(dn_list, dn_correct):
+            self.assertAlmostEqual(round(dn_cal, 4), round(dn_corr, 4), places=4)
+        ds_list = []
+        for i in ds.matrix:
+            ds_list.extend(i)
+        for ds_cal, ds_corr in zip(ds_list, ds_correct):
+            self.assertAlmostEqual(round(ds_cal, 4), round(ds_corr, 4), places=4)
+
 
 from run_tests import is_numpy
 try:


### PR DESCRIPTION
New pull request to allow user specified codon_table for the get_dn_ds_matrix method and associated test. The pull request is based on discussion at #765 and #1148.