### PR TITLE
detele unused get_codon_alphabet method

### DIFF
--- a/Bio/codonalign/codonalphabet.py
+++ b/Bio/codonalign/codonalphabet.py
@@ -20,6 +20,7 @@ from Bio.Data.CodonTable import generic_by_id
 
 default_codon_table = copy.deepcopy(generic_by_id[1])
 
+
 class CodonAlphabet(Alphabet):
     """Generic Codon Alphabet with a size of three"""
     size = 3

--- a/Bio/codonalign/codonalphabet.py
+++ b/Bio/codonalign/codonalphabet.py
@@ -20,28 +20,6 @@ from Bio.Data.CodonTable import generic_by_id
 
 default_codon_table = copy.deepcopy(generic_by_id[1])
 
-
-def get_codon_alphabet(alphabet, gap="-", stop="*"):
-    """Gets alignment alphabet for codon alignment.
-
-    Only nucleotide alphabet is accepted. Raise an error when the type of
-    alphabet is incompatible.
-    """
-    from Bio.Alphabet import NucleotideAlphabet
-    if isinstance(alphabet, NucleotideAlphabet):
-        alpha = alphabet
-        if gap:
-            alpha = Gapped(alpha, gap_char=gap)
-        if stop:
-            alpha = HasStopCodon(alpha, stop_symbol=stop)
-    else:
-        raise TypeError("Only Nuclteotide Alphabet is accepted!")
-    return alpha
-
-
-default_alphabet = get_codon_alphabet(IUPAC.unambiguous_dna)
-
-
 class CodonAlphabet(Alphabet):
     """Generic Codon Alphabet with a size of three"""
     size = 3


### PR DESCRIPTION
get_codon_alphabet is defined twice. Delete the one that is not used in the code.