### PR TITLE
PDB HETATM waters should be W not H_HOH (using mmCIF parser)

### DIFF
--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -150,7 +150,10 @@ class MMCIFParser(object):
                 raise PDBConstructionException("Invalid or missing occupancy")
             fieldname = fieldname_list[i]
             if fieldname == "HETATM":
-                hetatm_flag = "H"
+                if resname == "HOH" or resname == "WAT":
+                    hetatm_flag = "W"
+                else:
+                    hetatm_flag = "H"
             else:
                 hetatm_flag = " "
 


### PR DESCRIPTION
The mmCIF parser for PDBx files behaves differently to the PDB parser in the treatment of water molecules. In particular, the mmCIF parser labels waters as 'H_HOH', rather than 'W'. The proposed fix borrows from the code in `PDBParser.py`.