### PR TITLE
Update DSSP tests to check DSSP version before running mmCIF tests

### DIFF
--- a/Tests/test_DSSP_tool.py
+++ b/Tests/test_DSSP_tool.py
@@ -9,6 +9,8 @@
 See also test_PDB.py for dependency free DSSP tests.
 """
 
+from distutils.version import StrictVersion
+import re
 import subprocess
 import unittest
 
@@ -17,18 +19,24 @@ from Bio import MissingExternalDependencyError
 from Bio.PDB import PDBParser, MMCIFParser
 from Bio.PDB import DSSP
 
+# DSSP version, if known, as DSSP <2.2.0 does not support mmcif files
+dssp_version = '0.0.0'
 # Check if DSSP is installed
 quiet_kwargs = dict(stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 try:
     try:
         # Newer versions of DSSP
-        subprocess.check_call(["dssp", "--version"], **quiet_kwargs)
+        version_string = subprocess.check_output(["dssp", "--version"],
+                                                 universal_newlines=True)
+        dssp_version = re.search(r'\s*([\d.]+)', version_string).group(1)
     except subprocess.CalledProcessError:
         # Older versions of DSSP
         subprocess.check_call(["dssp", "-h"], **quiet_kwargs)
 except OSError:
     try:
-        subprocess.check_call(["mkdssp", "--version"], **quiet_kwargs)
+        version_string = subprocess.check_output(["mkdssp", "--version"],
+                                                 universal_newlines=True)
+        dssp_version = re.search(r'\s*([\d.]+)', version_string).group(1)
     except OSError:
         raise MissingExternalDependencyError(
             "Install dssp if you want to use it from Biopython.")
@@ -46,20 +54,23 @@ class DSSP_test(unittest.TestCase):
         self.assertEqual(len(dssp), 130)
 
     def test_dssp_with_mmcif_file(self):
-        """Test DSSP generationg from MMCIF"""
-        p = MMCIFParser()
-        pdbfile = "PDB/2BEG.cif"
-        model = p.get_structure("2BEG", pdbfile)[0]
-        dssp = DSSP(model, pdbfile)
-        self.assertEqual(len(dssp), 130)
+        """Test DSSP generation from MMCIF"""
+        # Only run tests if DSSP version installed supports mmcif
+        if StrictVersion(dssp_version) >= StrictVersion('2.2.0'):
+            p = MMCIFParser()
+            pdbfile = "PDB/2BEG.cif"
+            model = p.get_structure("2BEG", pdbfile)[0]
+            dssp = DSSP(model, pdbfile)
+            self.assertEqual(len(dssp), 130)
 
     def test_dssp_with_mmcif_file_and_nonstandard_residues(self):
-        """Test DSSP generationg from MMCIF"""
-        p = MMCIFParser()
-        pdbfile = "PDB/1AS5.cif"
-        model = p.get_structure("1AS5", pdbfile)[0]
-        dssp = DSSP(model, pdbfile)
-        self.assertEqual(len(dssp), 24)
+        """Test DSSP generation from MMCIF with non-standard residues"""
+        if StrictVersion(dssp_version) >= StrictVersion('2.2.0'):
+            p = MMCIFParser()
+            pdbfile = "PDB/1AS5.cif"
+            model = p.get_structure("1AS5", pdbfile)[0]
+            dssp = DSSP(model, pdbfile)
+            self.assertEqual(len(dssp), 24)
 
 
 if __name__ == '__main__':

--- a/Tests/test_DSSP_tool.py
+++ b/Tests/test_DSSP_tool.py
@@ -53,19 +53,18 @@ class DSSP_test(unittest.TestCase):
         dssp = DSSP(model, pdbfile)
         self.assertEqual(len(dssp), 130)
 
-    def test_dssp_with_mmcif_file(self):
-        """Test DSSP generation from MMCIF"""
-        # Only run tests if DSSP version installed supports mmcif
-        if StrictVersion(dssp_version) >= StrictVersion('2.2.0'):
+    # Only run mmCIF tests if DSSP version installed supports mmcif
+    if StrictVersion(dssp_version) >= StrictVersion('2.2.0'):
+        def test_dssp_with_mmcif_file(self):
+            """Test DSSP generation from MMCIF"""
             p = MMCIFParser()
             pdbfile = "PDB/2BEG.cif"
             model = p.get_structure("2BEG", pdbfile)[0]
             dssp = DSSP(model, pdbfile)
             self.assertEqual(len(dssp), 130)
 
-    def test_dssp_with_mmcif_file_and_nonstandard_residues(self):
-        """Test DSSP generation from MMCIF with non-standard residues"""
-        if StrictVersion(dssp_version) >= StrictVersion('2.2.0'):
+        def test_dssp_with_mmcif_file_and_nonstandard_residues(self):
+            """Test DSSP generation from MMCIF with non-standard residues"""
             p = MMCIFParser()
             pdbfile = "PDB/1AS5.cif"
             model = p.get_structure("1AS5", pdbfile)[0]


### PR DESCRIPTION
Pull request to fix #1200 