### PR TITLE
Use flake8-docstrings to run pydocstyle via flake8

### DIFF
--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,6 +1,0 @@
-[pydocstyle]
-# pydocstyle v2.0.0 default is ignore=D101,D2
-# where D2 mean D200, D201, etc.
-# We ignore D412 as it seems to block valid RST bullet point
-# lists of arguments or attributes
-ignore = D100,D101,D102,D103,D104,D105,D200,D203,D204,D205,D207,D208,D210,D212,D213,D214,D301,D302,D400,D401,D402,D403,D406,D407,D412

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -86,20 +86,19 @@ commands =
 skip_install = True
 whitelist_externals =
     flake8
-    pydocstyle
     rst-lint
     bash
 deps =
     flake8
-    pydocstyle
+    flake8-docstrings
     restructuredtext_lint
 commands =
+    # These folders each have their own .flake8 file:
     flake8 BioSQL/
     flake8 Scripts/
     flake8 Doc/examples/
     flake8 Bio/
     flake8 Tests/
-    pydocstyle Bio/ BioSQL/ Tests/ Scripts/ Doc/
     # Now do various checks on our RST files:
     # Calling via bash to get it to expand the wildcard for us
     bash -c \'rst-lint --level warning *.rst\'

--- a/Bio/.flake8
+++ b/Bio/.flake8
@@ -7,7 +7,7 @@ ignore =
     # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
     E122,E123,E126,E127,E128,E501,E731,F401,F812,F841,
     # =====================================
-    # pydocstyle: D### - Missing Docstrings
+    # pydocstyle: D1## - Missing Docstrings
     # =====================================
     # D100	Missing docstring in public module
     # D101	Missing docstring in public class
@@ -18,7 +18,7 @@ ignore =
     # TODO: Fix some of these?
     D100,D101,D102,D103,D104,D105,
     # ====================================
-    # pydocstyle: D### - Whitespace Issues
+    # pydocstyle: D2## - Whitespace Issues
     # ====================================
     # D200	One-line docstring should fit on one line with quotes
     # D202	No blank lines allowed after function docstring
@@ -28,13 +28,10 @@ ignore =
     # D207	Docstring is under-indented
     # D208	Docstring is over-indented
     # D210	No whitespaces allowed surrounding docstring text
-    # D412	No blank lines allowed between a section header and its content
     # TODO: Fix these:
     D200,D202,D204,D205,D207,D208,D210,
     # We ignore	D203 deliberately in favour of passing D211,
     D203,
-    # We ignore D412 deliberately:
-    D412,
     # ================================
     # pydocstyle: D3## - Quotes Issues
     # ================================
@@ -42,29 +39,20 @@ ignore =
     # D301	Use r""" if any backslashes in a docstring
     # TODO: Fix this?:
     D301,
-    # ====================================
-    # pydocstyle: Docstring Content Issues
-    # ====================================
+    # ===========================================
+    # pydocstyle: D4## - Docstring Content Issues
+    # ===========================================
     # D400	First line should end with a period
     # D401	First line should be in imperative mood
-    # D401	First line should be in imperative mood; try rephrasing
-    # D402	First line should not be the function’s “signature”
+    # D402	First line should not be the function’s "signature"
     # D403	First word of the first line should be properly capitalized
-    # D404	First word of the docstring should not be This
-    # D405	Section name should be properly capitalized
-    # D406	Section name should end with a newline
-    # D407	Missing dashed underline after section
-    # D408	Section underline should be in the line following the section’s name
-    # D409	Section underline should match the length of its name
-    # D410	Missing blank line after section
-    # D411	Missing blank line before section
     # D412	No blank lines allowed between a section header and its content
-    # D413	Missing blank line after last section
-    # D414	Section has no content
     D400,D401,D402,D403,
-    # =========================================
-    # flake8-commas (in case installed locally)
-    # =========================================
+    # We ignore D412 deliberately:
+    D412,
+    # ================================================
+    # flake8-commas: C#### (in case installed locally)
+    # ================================================
     # C812	missing trailing comma
     # C815	missing trailing comma in Python 3.5+
     C812,C815

--- a/Bio/.flake8
+++ b/Bio/.flake8
@@ -1,5 +1,67 @@
 [flake8]
-# pycodestyle v2.3.1 default ignore is E121,E123,E126,E226,E24,E704,W503
-# flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
-# where ignoring E24 means all E240, E241, etc
-ignore = E122,E123,E126,E127,E128,E501,E731,F401,F812,F841
+ignore =
+    # =======================
+    # flake: E###, F###, W###
+    # =======================
+    # pycodestyle v2.3.1 default ignore is E121,E123,E126,E226,E24,E704,W503
+    # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
+    E122,E123,E126,E127,E128,E501,E731,F401,F812,F841,
+    # =====================================
+    # pydocstyle: D### - Missing Docstrings
+    # =====================================
+    # D100	Missing docstring in public module
+    # D101	Missing docstring in public class
+    # D102	Missing docstring in public method
+    # D103	Missing docstring in public function
+    # D104	Missing docstring in public package
+    # D105	Missing docstring in magic method
+    # TODO: Fix some of these?
+    D100,D101,D102,D103,D104,D105,
+    # ====================================
+    # pydocstyle: D### - Whitespace Issues
+    # ====================================
+    # D200	One-line docstring should fit on one line with quotes
+    # D202	No blank lines allowed after function docstring
+    # D204	1 blank line required after class docstring
+    # D205	1 blank line required between summary line and description
+    # D207	Docstring is under-indented
+    # D208	Docstring is over-indented
+    # D210	No whitespaces allowed surrounding docstring text
+    # D412	No blank lines allowed between a section header and its content
+    # TODO: Fix these:
+    D200,D202,D204,D205,D207,D208,D210,
+    # We ignore D412 deliberately:
+    D412,
+    # ================================
+    # pydocstyle: D3## - Quotes Issues
+    # ================================
+    # D300	Use """triple double quotes"""
+    # D301	Use r""" if any backslashes in a docstring
+    # TODO: Fix this?:
+    D301,
+    # ====================================
+    # pydocstyle: Docstring Content Issues
+    # ====================================
+    # D400	First line should end with a period
+    # D401	First line should be in imperative mood
+    # D401	First line should be in imperative mood; try rephrasing
+    # D402	First line should not be the function’s “signature”
+    # D403	First word of the first line should be properly capitalized
+    # D404	First word of the docstring should not be This
+    # D405	Section name should be properly capitalized
+    # D406	Section name should end with a newline
+    # D407	Missing dashed underline after section
+    # D408	Section underline should be in the line following the section’s name
+    # D409	Section underline should match the length of its name
+    # D410	Missing blank line after section
+    # D411	Missing blank line before section
+    # D412	No blank lines allowed between a section header and its content
+    # D413	Missing blank line after last section
+    # D414	Section has no content
+    D400,D401,D402,D403,
+    # =========================================
+    # flake8-commas (in case installed locally)
+    # =========================================
+    # C812	missing trailing comma
+    # C815	missing trailing comma in Python 3.5+
+    C812,C815

--- a/Bio/.flake8
+++ b/Bio/.flake8
@@ -22,6 +22,7 @@ ignore =
     # ====================================
     # D200	One-line docstring should fit on one line with quotes
     # D202	No blank lines allowed after function docstring
+    # D203	1 blank line required before class docstring
     # D204	1 blank line required after class docstring
     # D205	1 blank line required between summary line and description
     # D207	Docstring is under-indented
@@ -30,6 +31,8 @@ ignore =
     # D412	No blank lines allowed between a section header and its content
     # TODO: Fix these:
     D200,D202,D204,D205,D207,D208,D210,
+    # We ignore	D203 deliberately in favour of passing D211,
+    D203,
     # We ignore D412 deliberately:
     D412,
     # ================================

--- a/Bio/Align/Applications/_ClustalOmega.py
+++ b/Bio/Align/Applications/_ClustalOmega.py
@@ -17,7 +17,7 @@ from Bio.Application import _Option, _Switch, AbstractCommandline
 
 
 class ClustalOmegaCommandline(AbstractCommandline):
-    """Command line wrapper for clustal omega
+    u"""Command line wrapper for clustal omega.
 
     http://www.clustal.org/omega
 

--- a/Bio/motifs/applications/_xxmotif.py
+++ b/Bio/motifs/applications/_xxmotif.py
@@ -13,7 +13,7 @@ from Bio.Application import AbstractCommandline, _Option, _Switch, _Argument
 
 
 class XXmotifCommandline(AbstractCommandline):
-    """Command line wrapper for XXmotif.
+    u"""Command line wrapper for XXmotif.
 
     http://xxmotif.genzentrum.lmu.de/
 

--- a/BioSQL/.flake8
+++ b/BioSQL/.flake8
@@ -1,2 +1,13 @@
 [flake8]
 max-line-length = 92
+ignore =
+    # =====================================
+    # pydocstyle: D### - Missing Docstrings
+    # =====================================
+    # D100	Missing docstring in public module
+    # D101	Missing docstring in public class
+    # D102	Missing docstring in public method
+    # D103	Missing docstring in public function
+    # D104	Missing docstring in public package
+    # D105	Missing docstring in magic method
+    D101,D102,D103,D105

--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -103,7 +103,7 @@ class DBSeq(Seq):
             return Seq(full[::index.step], self.alphabet)
 
     def tostring(self):
-        """Returns the full sequence as a python string (DEPRECATED).
+        """Return the full sequence as a python string (DEPRECATED).
 
         You are now encouraged to use str(my_seq) instead of
         my_seq.tostring().
@@ -117,7 +117,7 @@ class DBSeq(Seq):
                                                  self.start + self._length)
 
     def __str__(self):
-        """Returns the full sequence as a python string."""
+        """Return the full sequence as a python string."""
         return self.adaptor.get_subseq_as_string(self.primary_id,
                                                  self.start,
                                                  self.start + self._length)
@@ -125,7 +125,7 @@ class DBSeq(Seq):
     data = property(tostring, doc="Sequence as string (DEPRECATED)")
 
     def toseq(self):
-        """Returns the full sequence as a Seq object."""
+        """Return the full sequence as a Seq object."""
         # Note - the method name copies that of the MutableSeq object
         return Seq(str(self), self.alphabet)
 

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -552,7 +552,7 @@ class MysqlConnectorAdaptor(Adaptor):
 _interface_specific_adaptors = {
     # If SQL interfaces require a specific adaptor, use this to map the adaptor
     "mysql.connector": MysqlConnectorAdaptor
-    }
+}
 
 _allowed_lookups = {
     # Lookup name / function name to get id, function to list all ids

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -29,7 +29,7 @@ _POSTGRES_RULES_PRESENT = False  # Hack for BioSQL Bug 2839
 
 
 def open_database(driver="MySQLdb", **kwargs):
-    """Main interface for loading a existing BioSQL-style database.
+    """Load an existing BioSQL-style database.
 
     This function is the easiest way to retrieve a connection to a
     database, doing something like:
@@ -38,6 +38,7 @@ def open_database(driver="MySQLdb", **kwargs):
         >>> server = BioSeqDatabase.open_database(user="root", db="minidb")
 
     Arguments:
+
      - driver - The name of the database driver to use for connecting. The
        driver should implement the python DB API. By default, the MySQLdb
        driver is used.
@@ -45,6 +46,7 @@ def open_database(driver="MySQLdb", **kwargs):
      - password, passwd - the password to connect with
      - host - the hostname of the database
      - database or db - the name of the database
+
     """
     if driver == "psycopg":
         raise ValueError("Using BioSQL with psycopg (version one) is no "
@@ -161,7 +163,7 @@ class DBServer(object):
         return BioSeqDatabase(self.adaptor, name)
 
     def __len__(self):
-        """Number of namespaces (sub-databases) in this database."""
+        """Return number of namespaces (sub-databases) in this database."""
         sql = "SELECT COUNT(name) FROM biodatabase;"
         return int(self.adaptor.execute_and_fetch_col0(sql)[0])
 
@@ -229,13 +231,14 @@ class DBServer(object):
     def remove_database(self, db_name):
         """Remove a namespace and all its entries (OBSOLETE).
 
-        Try to remove all references to items in a database.
+        Try to remove all references to items in a database:
 
-        server.remove_database(name)
+        >>> server.remove_database(name)
 
         In keeping with the dictionary interface, you can now do this:
 
-        del server[name]
+        >>> del server[name]
+
         """
         import warnings
         warnings.warn("This method is deprecated.  In keeping with the "
@@ -291,11 +294,11 @@ class DBServer(object):
                              (self.module_name))
 
     def commit(self):
-        """Commits the current transaction to the database."""
+        """Commit the current transaction to the database."""
         return self.adaptor.commit()
 
     def rollback(self):
-        """Rolls backs the current transaction."""
+        """Roll-back the current transaction."""
         return self.adaptor.rollback()
 
     def close(self):
@@ -342,7 +345,7 @@ class _CursorWrapper(object):
 
 
 class Adaptor(object):
-    """High level wrapper for a database connection and cursor
+    """High level wrapper for a database connection and cursor.
 
     Most database calls in BioSQL are done indirectly though this adaptor
     class. This provides helper methods for fetching data and executing
@@ -365,11 +368,11 @@ class Adaptor(object):
         return self.dbutils.autocommit(self.conn, y)
 
     def commit(self):
-        """Commits the current transaction."""
+        """Commit the current transaction."""
         return self.conn.commit()
 
     def rollback(self):
-        """Rolls backs the current transaction."""
+        """Roll-back the current transaction."""
         return self.conn.rollback()
 
     def close(self):
@@ -481,7 +484,7 @@ class Adaptor(object):
         return self.execute_and_fetch_col0(sql, args)
 
     def execute_one(self, sql, args=None):
-        """Execute sql that returns 1 record, and return the record"""
+        """Execute sql that returns 1 record, and return the record."""
         self.execute(sql, args or ())
         rv = self.cursor.fetchall()
         assert len(rv) == 1, "Expected 1 response, got %d" % len(rv)
@@ -527,7 +530,7 @@ class Adaptor(object):
 
 
 class MysqlConnectorAdaptor(Adaptor):
-    """A BioSQL Adaptor class with fixes for the MySQL interface
+    """A BioSQL Adaptor class with fixes for the MySQL interface.
 
     BioSQL was failing due to returns of bytearray objects from
     the mysql-connector-python database connector. This adaptor
@@ -536,6 +539,7 @@ class MysqlConnectorAdaptor(Adaptor):
     response to backwards incompatible changes added to
     mysql-connector-python in release 2.0.0 of the package.
     """
+
     def execute_one(self, sql, args=None):
         out = super(MysqlConnectorAdaptor, self).execute_one(sql, args)
         return tuple(bytearray_to_str(v) for v in out)
@@ -551,7 +555,7 @@ class MysqlConnectorAdaptor(Adaptor):
 
 _interface_specific_adaptors = {
     # If SQL interfaces require a specific adaptor, use this to map the adaptor
-    "mysql.connector": MysqlConnectorAdaptor
+    "mysql.connector": MysqlConnectorAdaptor,
 }
 
 _allowed_lookups = {
@@ -581,7 +585,7 @@ class BioSeqDatabase(object):
         return "BioSeqDatabase(%r, %r)" % (self.adaptor, self.name)
 
     def get_Seq_by_id(self, name):
-        """Gets a DBSeqRecord object by its name.
+        """Get a DBSeqRecord object by its name.
 
         Example: seq_rec = db.get_Seq_by_id('ROA1_HUMAN')
 
@@ -592,7 +596,7 @@ class BioSeqDatabase(object):
         return BioSeq.DBSeqRecord(self.adaptor, seqid)
 
     def get_Seq_by_acc(self, name):
-        """Gets a DBSeqRecord object by accession number.
+        """Get a DBSeqRecord object by accession number.
 
         Example: seq_rec = db.get_Seq_by_acc('X77802')
 
@@ -603,7 +607,7 @@ class BioSeqDatabase(object):
         return BioSeq.DBSeqRecord(self.adaptor, seqid)
 
     def get_Seq_by_ver(self, name):
-        """Gets a DBSeqRecord object by version number.
+        """Get a DBSeqRecord object by version number.
 
         Example: seq_rec = db.get_Seq_by_ver('X77802.1')
 
@@ -614,7 +618,7 @@ class BioSeqDatabase(object):
         return BioSeq.DBSeqRecord(self.adaptor, seqid)
 
     def get_Seqs_by_acc(self, name):
-        """Gets a list of DBSeqRecord objects by accession number.
+        """Get a list of DBSeqRecord objects by accession number.
 
         Example: seq_recs = db.get_Seq_by_acc('X77802')
 
@@ -657,7 +661,7 @@ class BioSeqDatabase(object):
         self.adaptor.execute(sql, (self.dbid, key))
 
     def __len__(self):
-        """Number of records in this namespace (sub database)."""
+        """Return number of records in this namespace (sub database)."""
         sql = "SELECT COUNT(bioentry_id) FROM bioentry " + \
               "WHERE biodatabase_id=%s;"
         return int(self.adaptor.execute_and_fetch_col0(sql, (self.dbid, ))[0])

--- a/BioSQL/DBUtils.py
+++ b/BioSQL/DBUtils.py
@@ -8,6 +8,8 @@
 #
 # Note that BioSQL (including the database schema and scripts) is
 # available and licensed separately.  Please consult www.biosql.org
+"""Helper code for Biopython's BioSQL code (for internal use)."""
+
 import os
 
 

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -74,7 +74,7 @@ class DatabaseLoader(object):
             self._load_seqfeature(seq_feature, seq_feature_num, bioentry_id)
 
     def _get_ontology_id(self, name, definition=None):
-        """Returns the identifier for the named ontology (PRIVATE).
+        """Return identifier for the named ontology (PRIVATE).
 
         This looks through the onotology table for a the given entry name.
         If it is not found, a row is added for this ontology (using the
@@ -138,7 +138,9 @@ class DatabaseLoader(object):
     def _get_taxon_id(self, record):
         """Get the taxon id for this record (PRIVATE).
 
-        record - a SeqRecord object
+        Arguments:
+
+        - record - a SeqRecord object
 
         This searches the taxon/taxon_name tables using the
         NCBI taxon ID, scientific name and common name to find
@@ -307,10 +309,12 @@ class DatabaseLoader(object):
         We need to make this conversion to match the taxon_name.name_class
         values used by the BioSQL load_ncbi_taxonomy.pl script.
 
-        e.g.
-        "ScientificName" -> "scientific name",
-        "EquivalentName" -> "equivalent name",
-        "Synonym" -> "synonym",
+        e.g.::
+
+            "ScientificName" -> "scientific name",
+            "EquivalentName" -> "equivalent name",
+            "Synonym" -> "synonym",
+
         """
         # Add any special cases here:
         #
@@ -322,7 +326,7 @@ class DatabaseLoader(object):
 
         # Try automatically by adding spaces before each capital
         def add_space(letter):
-            """Adds a space before a capital letter."""
+            """Add a space before a capital letter."""
             if letter.isupper():
                 return " " + letter.lower()
             else:
@@ -377,9 +381,11 @@ class DatabaseLoader(object):
                                          common_name=None):
         """Get the taxon id for record from NCBI taxon ID (PRIVATE).
 
-        ncbi_taxon_id - string containing an NCBI taxon id
-        scientific_name - string, used if a stub entry is recorded
-        common_name - string, used if a stub entry is recorded
+        Arguments:
+
+        - ncbi_taxon_id - string containing an NCBI taxon id
+        - scientific_name - string, used if a stub entry is recorded
+        - common_name - string, used if a stub entry is recorded
 
         This searches the taxon table using ONLY the NCBI taxon ID
         to find the matching taxon table entry's ID (database key).
@@ -504,13 +510,17 @@ class DatabaseLoader(object):
     def _get_taxon_id_from_ncbi_lineage(self, taxonomic_lineage):
         """Recursive method to get taxon ID from NCBI lineage (PRIVATE).
 
-        taxonomic_lineage - list of taxonomy dictionaries from Bio.Entrez
+        Arguments:
+
+        - taxonomic_lineage - list of taxonomy dictionaries from Bio.Entrez
 
         First dictionary in list is the taxonomy root, highest would be
         the species. Each dictionary includes:
+
         - TaxID (string, NCBI taxon id)
         - Rank (string, e.g. "species", "genus", ..., "phylum", ...)
         - ScientificName (string)
+
         (and that is all at the time of writing)
 
         This method will record all the lineage given, returning the taxon id
@@ -574,7 +584,10 @@ class DatabaseLoader(object):
     def _load_bioentry_table(self, record):
         """Fill the bioentry table with sequence information (PRIVATE).
 
-        record - SeqRecord object to add to the database.
+        Arguments:
+
+        - record - SeqRecord object to add to the database.
+
         """
         # get the pertinent info and insert it
 
@@ -666,8 +679,11 @@ class DatabaseLoader(object):
     def _load_biosequence(self, record, bioentry_id):
         """Record SeqRecord's sequence and alphabet in DB (PRIVATE).
 
-        record - a SeqRecord object with a seq property
-        bioentry_id - corresponding database identifier
+        Arguments:
+
+        - record - a SeqRecord object with a seq property
+        - bioentry_id - corresponding database identifier
+
         """
         if record.seq is None:
             # The biosequence table entry is optional, so if we haven't
@@ -725,8 +741,11 @@ class DatabaseLoader(object):
         table, except for special cases like the reference, comment and
         taxonomy which are handled with their own tables.
 
-        record - a SeqRecord object with an annotations dictionary
-        bioentry_id - corresponding database identifier
+        Arguments:
+
+        - record - a SeqRecord object with an annotations dictionary
+        - bioentry_id - corresponding database identifier
+
         """
         mono_sql = "INSERT INTO bioentry_qualifier_value" \
                    "(bioentry_id, term_id, value)" \
@@ -763,8 +782,11 @@ class DatabaseLoader(object):
     def _load_reference(self, reference, rank, bioentry_id):
         """Record SeqRecord's annotated references in the database (PRIVATE).
 
-        record - a SeqRecord object with annotated references
-        bioentry_id - corresponding database identifier
+        Arguments:
+
+        - record - a SeqRecord object with annotated references
+        - bioentry_id - corresponding database identifier
+
         """
         refs = None
         if reference.medline_id:
@@ -978,8 +1000,10 @@ class DatabaseLoader(object):
     def _load_seqfeature_qualifiers(self, qualifiers, seqfeature_id):
         """Insert feature's (key, value) pair qualifiers (PRIVATE).
 
-        Qualifiers should be a dictionary of the form:
+        Qualifiers should be a dictionary of the form::
+
             {key : [value1, value2]}
+
         """
         tag_ontology_id = self._get_ontology_id('Annotation Tags')
         for qualifier_key in qualifiers:
@@ -1016,18 +1040,19 @@ class DatabaseLoader(object):
     def _load_seqfeature_dbxref(self, dbxrefs, seqfeature_id):
         """Add SeqFeature's DB cross-references to the database (PRIVATE).
 
-            o dbxrefs           List, dbxref data from the source file in the
-                                format <database>:<accession>
+        Arguments:
 
-            o seqfeature_id     Int, the identifier for the seqfeature in the
-                                seqfeature table
+        - dbxrefs - List, dbxref data from the source file in the
+          format <database>:<accession>
+        - seqfeature_id - Int, the identifier for the seqfeature in the
+          seqfeature table
 
-            Insert dbxref qualifier data for a seqfeature into the
-            seqfeature_dbxref and, if required, dbxref tables.
-            The dbxref_id qualifier/value sets go into the dbxref table
-            as dbname, accession, version tuples, with dbxref.dbxref_id
-            being automatically assigned, and into the seqfeature_dbxref
-            table as seqfeature_id, dbxref_id, and rank tuples
+        Insert dbxref qualifier data for a seqfeature into the
+        seqfeature_dbxref and, if required, dbxref tables.
+        The dbxref_id qualifier/value sets go into the dbxref table
+        as dbname, accession, version tuples, with dbxref.dbxref_id
+        being automatically assigned, and into the seqfeature_dbxref
+        table as seqfeature_id, dbxref_id, and rank tuples.
         """
         # NOTE - In older versions of Biopython, we would map the GenBank
         # db_xref "name", for example "GI" to "GeneIndex", and give a warning
@@ -1051,16 +1076,17 @@ class DatabaseLoader(object):
                 self._get_seqfeature_dbxref(seqfeature_id, dbxref_id, rank + 1)
 
     def _get_dbxref_id(self, db, accession):
-        """ _get_dbxref_id(self, db, accession) -> Int
+        """Get DB cross-reference for accession.
 
-            o db          String, the name of the external database containing
-                          the accession number
+        Arguments:
 
-            o accession   String, the accession of the dbxref data
+        - db - String, the name of the external database containing
+        the accession number
+        - accession - String, the accession of the dbxref data
 
-            Finds and returns the dbxref_id for the passed data.  The method
-            attempts to find an existing record first, and inserts the data
-            if there is no record.
+        Finds and returns the dbxref_id for the passed data.  The method
+        attempts to find an existing record first, and inserts the data
+        if there is no record.
         """
         # Check for an existing record
         sql = r'SELECT dbxref_id FROM dbxref WHERE dbname = %s ' \
@@ -1073,10 +1099,11 @@ class DatabaseLoader(object):
         return self._add_dbxref(db, accession, 0)
 
     def _get_seqfeature_dbxref(self, seqfeature_id, dbxref_id, rank):
-        """ Check for a pre-existing seqfeature_dbxref entry with the passed
-            seqfeature_id and dbxref_id.  If one does not exist, insert new
-            data
+        """Get DB cross-reference, creating it if needed (PRIVATE).
 
+        Check for a pre-existing seqfeature_dbxref entry with the passed
+        seqfeature_id and dbxref_id.  If one does not exist, insert new
+        data.
         """
         # Check for an existing record
         sql = r"SELECT seqfeature_id, dbxref_id FROM seqfeature_dbxref " \
@@ -1090,8 +1117,10 @@ class DatabaseLoader(object):
         return self._add_seqfeature_dbxref(seqfeature_id, dbxref_id, rank)
 
     def _add_seqfeature_dbxref(self, seqfeature_id, dbxref_id, rank):
-        """ Insert a seqfeature_dbxref row and return the seqfeature_id and
-            dbxref_id
+        """Add DB cross-reference (PRIVATE).
+
+        Insert a seqfeature_dbxref row and return the seqfeature_id and
+        dbxref_id
         """
         sql = r'INSERT INTO seqfeature_dbxref ' \
               '(seqfeature_id, dbxref_id, rank) VALUES' \

--- a/BioSQL/__init__.py
+++ b/BioSQL/__init__.py
@@ -6,9 +6,11 @@
 #
 # Note that BioSQL (including the database schema and scripts) is
 # available and licensed separately.  Please consult www.biosql.org
-"""Code for storing and retrieving biological sequences from a BioSQL
-relational database.  See:
+"""Storing and retrieve biological sequences in a BioSQL relational database.
 
-http://biopython.org/wiki/BioSQL
-http://www.biosql.org/
+See:
+
+- http://biopython.org/wiki/BioSQL
+- http://www.biosql.org/
+
 """

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -79,9 +79,10 @@ be run, and their results reported on the pull request.
 
 We use TravisCI to run most of the Biopython tests (although currently only
 under Linux, and not with all the optional dependencies included), plus also
-check Python coding style using the ``flake8`` and ``pydocstyle`` tools, and
-reStructuredText using ``rst-lint``. These checks must pass before your pull
-request will be merged. https://travis-ci.org/biopython/biopython
+check Python coding style using the ``flake8`` tool with the ``pydocstyle``
+pluging (``flake8-docstrings``), and reStructuredText using ``rst-lint``.
+These checks must pass before your pull request will be merged.
+https://travis-ci.org/biopython/biopython
 
 Some of the TravisCI runs collect test coverage information via CodeCov:
 https://codecov.io/github/biopython/biopython/

--- a/Doc/examples/.flake8
+++ b/Doc/examples/.flake8
@@ -1,2 +1,13 @@
 [flake8]
 max-line-length = 90
+ignore =
+    # =======================
+    # flake: E###, F###, W###
+    # =======================
+    # pycodestyle v2.3.1 default ignore is E121,E123,E126,E226,E24,E704,W503
+    # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
+    E122,E123,E126,E127,E128,E501,E731,F401,F812,F841,
+    # =====================================
+    # pydocstyle: D### - Missing Docstrings
+    # =====================================
+    D100,D101,D102,D103

--- a/Doc/examples/Proux_et_al_2002_Figure_6.py
+++ b/Doc/examples/Proux_et_al_2002_Figure_6.py
@@ -3,7 +3,7 @@
 # as part of this package.
 #
 
-"""GenomeDiagram script to mimic Proux et al 2002 Figure 6
+"""GenomeDiagram script to mimic Proux et al 2002 Figure 6.
 
 You can use the Entrez module to download the 3 required GenBank files
 

--- a/Doc/examples/clustal_run.py
+++ b/Doc/examples/clustal_run.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""clustal_run.py
+"""Run clustalw and parse the output.
 
 Example code to show how to create a clustalw command line, run clustalw
 and parse the results into an object that can be dealt with easily.

--- a/Scripts/.flake8
+++ b/Scripts/.flake8
@@ -1,2 +1,26 @@
 [flake8]
 max-line-length = 90
+ignore =
+    # =======================
+    # flake: E###, F###, W###
+    # =======================
+    # pycodestyle v2.3.1 default ignore is E121,E123,E126,E226,E24,E704,W503
+    # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
+    # E122,E123,E126,E127,E128,E241,E402,E501,E731,F401,F405,F821,F841,
+    # =====================================
+    # pydocstyle: D### - Missing Docstrings
+    # =====================================
+    # D100	Missing docstring in public module
+    # D101	Missing docstring in public class
+    # D102	Missing docstring in public method
+    # D103	Missing docstring in public function
+    # D104	Missing docstring in public package
+    # D105	Missing docstring in magic method
+    # TODO: Fix some of these?
+    D100,D101,D102,D103,D105,
+    # ====================================
+    # pydocstyle: D### - Whitespace Issues
+    # ====================================
+    # D412	No blank lines allowed between a section header and its content
+    # We ignore D412 deliberately:
+    D412

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -104,7 +104,7 @@ def regex(site):
 
 
 def is_palindrom(sequence):
-    """Is the sequence (Seq objecT) as a palindrom."""
+    """Check whether the sequence is a palindrome or not."""
     return str(sequence) == str(sequence.reverse_complement())
 
 

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -104,6 +104,19 @@ def regex(site):
 
 
 def is_palindrom(sequence):
+    """Check whether the sequence is a palindrome or not (DEPRECATED).
+
+    Deprecated alias for is_palindrome (with e at end).
+    """
+    import warnings
+    from Bio import BiopythonDeprecationWarning
+    warnings.warn("is_palindrom is deprecated, please use "
+                  "is_palindrome instead.",
+                  BiopythonDeprecationWarning)
+    return is_palindrome(sequence)
+
+
+def is_palindrome(sequence):
     """Check whether the sequence is a palindrome or not."""
     return str(sequence) == str(sequence.reverse_complement())
 

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -78,15 +78,17 @@ typedict = {}
 
 class OverhangError(ValueError):
     """Exception for dealing with overhang."""
+
     pass
 
 
 def regex(site):
-    """regex(site) -> string.
+    """Construct a regular expression (string) from a DNA sequence.
 
-    Construct a regular expression from a DNA sequence.
-    i.e.:
+    i.e.::
+
         site = 'ABCGN'   -> 'A[CGT]CG.'
+
     """
     reg_ex = str(site)
     for base in reg_ex:
@@ -102,20 +104,12 @@ def regex(site):
 
 
 def is_palindrom(sequence):
-    """is_palindrom(sequence) -> bool.
-
-    True is the sequence is a palindrom.
-    sequence is a Seq object.
-    """
+    """Is the sequence (Seq objecT) as a palindrom."""
     return str(sequence) == str(sequence.reverse_complement())
 
 
 def LocalTime():
-    """LocalTime() -> string.
-
-    LocalTime calculate the extension for emboss file for the current year and
-    month.
-    """
+    """Extension for emboss file for the current year and month."""
     t = time.gmtime()
     year = str(t.tm_year)[-1]
     month = str(t.tm_mon)
@@ -126,6 +120,7 @@ def LocalTime():
 
 class newenzyme(object):
     """construct the attributes of the enzyme corresponding to 'name'."""
+
     def __init__(cls, name):
         cls.opt_temp = 37
         cls.inact_temp = 65
@@ -269,18 +264,14 @@ class newenzyme(object):
 
 
 class TypeCompiler(object):
-    """Build the different types possible for Restriction Enzymes"""
+    """Build the different types possible for Restriction Enzymes."""
 
     def __init__(self):
         """TypeCompiler() -> new TypeCompiler instance."""
         pass
 
     def buildtype(self):
-        """TC.buildtype() -> generator.
-
-        build the new types that will be needed for constructing the
-        restriction enzymes.
-        """
+        """Build new types that will be needed for constructing the enzymes."""
         baT = (AbstractCut, RestrictionType)
         cuT = (NoCut, OneCut, TwoCuts)
         meT = (Meth_Dep, Meth_Undep)
@@ -366,11 +357,7 @@ class DictionaryBuilder(object):
         self.proxy = ftp_proxy or config.ftp_proxy
 
     def build_dict(self):
-        """DB.build_dict() -> None.
-
-        Construct the dictionary and build the files containing the new
-        dictionaries.
-        """
+        """Construct dictionary and build files containing new dictionaries."""
         #
         #   first parse the emboss files.
         #
@@ -504,9 +491,7 @@ class DictionaryBuilder(object):
         return
 
     def install_dict(self):
-        """DB.install_dict() -> None.
-
-        Install the newly created dictionary in the site-packages folder.
+        """Install the newly created dictionary in the site-packages folder.
 
         May need super user privilege on some architectures.
         """
@@ -556,10 +541,7 @@ class DictionaryBuilder(object):
         return
 
     def no_install(self):
-        """BD.no_install() -> None.
-
-        build the new dictionary but do not install the dictionary.
-        """
+        """Build the new dictionary but do not install the dictionary."""
         print('\n ' + '*' * 78 + '\n')
         # update = config.updatefolder
         try:
@@ -592,10 +574,7 @@ class DictionaryBuilder(object):
         return
 
     def lastrebasefile(self):
-        """BD.lastrebasefile() -> None.
-
-        Check the emboss files are up to date and download them if not.
-        """
+        """Check the emboss files are up to date and download them if not."""
         embossnames = ('emboss_e', 'emboss_r', 'emboss_s')
         #
         #   first check if we have the last update:

--- a/Scripts/Restriction/rebase_update.py
+++ b/Scripts/Restriction/rebase_update.py
@@ -8,8 +8,9 @@
 # as part of this package.
 #
 
-"""Update the Rebase emboss files used by Restriction to build the
-Restriction_Dictionary.py module.
+"""Update the Rebase emboss files.
+
+These are used by Restriction to build the Restriction_Dictionary.py module.
 """
 
 from __future__ import print_function

--- a/Scripts/xbbtools/xbb_blast.py
+++ b/Scripts/xbbtools/xbb_blast.py
@@ -174,7 +174,7 @@ class BlastIt(object):
             self.ok.config(state='disabled')
 
     def _Run(self):
-        """Setup options for Blast commandline (PRIVATE)."""
+        """Initialise options for Blast commandline (PRIVATE)."""
         command_options = self.option.get()
         options = ''
         if len(command_options.strip()):

--- a/Scripts/xbbtools/xbb_translations.py
+++ b/Scripts/xbbtools/xbb_translations.py
@@ -85,7 +85,7 @@ class xbb_translations(object):
         return res
 
     def gc(self, seq):
-        """Returns a float between 0 and 100."""
+        """Return a float between 0 and 100."""
         return GC(seq)
 
     def gcframe(self, seq, translation_table=1, direction='both'):

--- a/Tests/.flake8
+++ b/Tests/.flake8
@@ -7,7 +7,7 @@ ignore =
     # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
     E122,E123,E126,E127,E128,E241,E402,E501,E731,F401,F405,F821,F841,
     # =====================================
-    # pydocstyle: D### - Missing Docstrings
+    # pydocstyle: D1## - Missing Docstrings
     # =====================================
     # D100	Missing docstring in public module
     # D101	Missing docstring in public class
@@ -18,45 +18,33 @@ ignore =
     # TODO: Fix some of these?
     D100,D101,D102,D103,D105,
     # ====================================
-    # pydocstyle: D### - Whitespace Issues
+    # pydocstyle: D2## - Whitespace Issues
     # ====================================
     # D200	One-line docstring should fit on one line with quotes
     # D202	No blank lines allowed after function docstring
     # D203	1 blank line required before class docstring
     # D204	1 blank line required after class docstring
-    # D412	No blank lines allowed between a section header and its content
     # TODO: Fix these:
     D200,D202,D204,
     # We ignore D203 deliberately in favour of passing D211,
     D203,
-    # We ignore D412 deliberately:
-    D412,
     # ================================
     # pydocstyle: D3## - Quotes Issues
     # ================================
     # D300  Use """triple double quotes"""
     # TODO: Fix this:
     D300,
-    # ====================================
-    # pydocstyle: Docstring Content Issues
-    # ====================================
-    # D400  First line should end with a period
-    # D401  First line should be in imperative mood
-    # D401  First line should be in imperative mood; try rephrasing
-    # D402  First line should not be the function’s “signature”
-    # D403  First word of the first line should be properly capitalized
-    # D404  First word of the docstring should not be This
-    # D405  Section name should be properly capitalized
-    # D406  Section name should end with a newline
-    # D407  Missing dashed underline after section
-    # D408  Section underline should be in the line following the section’s name
-    # D409  Section underline should match the length of its name
-    # D410  Missing blank line after section
-    # D411  Missing blank line before section
-    # D412  No blank lines allowed between a section header and its content
-    # D413  Missing blank line after last section
-    # D414  Section has no content
+    # ===========================================
+    # pydocstyle: D4## - Docstring Content Issues
+    # ===========================================
+    # D400	First line should end with a period
+    # D401	First line should be in imperative mood
+    # D402	First line should not be the function’s "signature"
+    # D403	First word of the first line should be properly capitalized
+    # D412	No blank lines allowed between a section header and its content
     D400,D401,D403,
+    # We ignore D412 deliberately:
+    D412,
     # =========================================
     # flake8-commas (in case installed locally)
     # =========================================

--- a/Tests/.flake8
+++ b/Tests/.flake8
@@ -22,10 +22,13 @@ ignore =
     # ====================================
     # D200	One-line docstring should fit on one line with quotes
     # D202	No blank lines allowed after function docstring
+    # D203	1 blank line required before class docstring
     # D204	1 blank line required after class docstring
     # D412	No blank lines allowed between a section header and its content
     # TODO: Fix these:
     D200,D202,D204,
+    # We ignore D203 deliberately in favour of passing D211,
+    D203,
     # We ignore D412 deliberately:
     D412,
     # ================================

--- a/Tests/.flake8
+++ b/Tests/.flake8
@@ -1,5 +1,61 @@
 [flake8]
-# pycodestyle v2.3.1 default ignore is E121,E123,E126,E226,E24,E704,W503
-# flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
-# where ignoring E24 means all E240, E241, etc
-ignore = E122,E123,E126,E127,E128,E241,E402,E501,E731,F401,F405,F821,F841
+ignore =
+    # =======================
+    # flake: E###, F###, W###
+    # =======================
+    # pycodestyle v2.3.1 default ignore is E121,E123,E126,E226,E24,E704,W503
+    # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
+    E122,E123,E126,E127,E128,E241,E402,E501,E731,F401,F405,F821,F841,
+    # =====================================
+    # pydocstyle: D### - Missing Docstrings
+    # =====================================
+    # D100	Missing docstring in public module
+    # D101	Missing docstring in public class
+    # D102	Missing docstring in public method
+    # D103	Missing docstring in public function
+    # D104	Missing docstring in public package
+    # D105	Missing docstring in magic method
+    # TODO: Fix some of these?
+    D100,D101,D102,D103,D105,
+    # ====================================
+    # pydocstyle: D### - Whitespace Issues
+    # ====================================
+    # D200	One-line docstring should fit on one line with quotes
+    # D202	No blank lines allowed after function docstring
+    # D204	1 blank line required after class docstring
+    # D412	No blank lines allowed between a section header and its content
+    # TODO: Fix these:
+    D200,D202,D204,
+    # We ignore D412 deliberately:
+    D412,
+    # ================================
+    # pydocstyle: D3## - Quotes Issues
+    # ================================
+    # D300  Use """triple double quotes"""
+    # TODO: Fix this:
+    D300,
+    # ====================================
+    # pydocstyle: Docstring Content Issues
+    # ====================================
+    # D400  First line should end with a period
+    # D401  First line should be in imperative mood
+    # D401  First line should be in imperative mood; try rephrasing
+    # D402  First line should not be the function’s “signature”
+    # D403  First word of the first line should be properly capitalized
+    # D404  First word of the docstring should not be This
+    # D405  Section name should be properly capitalized
+    # D406  Section name should end with a newline
+    # D407  Missing dashed underline after section
+    # D408  Section underline should be in the line following the section’s name
+    # D409  Section underline should match the length of its name
+    # D410  Missing blank line after section
+    # D411  Missing blank line before section
+    # D412  No blank lines allowed between a section header and its content
+    # D413  Missing blank line after last section
+    # D414  Section has no content
+    D400,D401,D403,
+    # =========================================
+    # flake8-commas (in case installed locally)
+    # =========================================
+    # C812	missing trailing comma
+    C812

--- a/Tests/test_AlignIO.py
+++ b/Tests/test_AlignIO.py
@@ -210,10 +210,7 @@ def simple_alignment_comparison(alignments, alignments2, format):
 
 # Check Phylip files reject duplicate identifiers.
 def check_phylip_reject_duplicate():
-    """
-    Ensure that attempting to write sequences with duplicate IDs after
-    truncation fails for Phylip format.
-    """
+    """Writing post-truncation duplicated IDs should fail for PHYLIP."""
     handle = StringIO()
     sequences = [SeqRecord(Seq('AAAA'), id='longsequencename1'),
                  SeqRecord(Seq('AAAA'), id='longsequencename2'),

--- a/Tests/test_BWA_tool.py
+++ b/Tests/test_BWA_tool.py
@@ -128,7 +128,7 @@ class BwaTestCase(unittest.TestCase):
     if not skip_aln_tests:
 
         def test_samse(self):
-            """Test for single end sequencing """
+            """Test for single end sequencing."""
             self.create_fasta_index()
             self.do_aln(self.infile1, self.saifile1)
             cmdline = BwaSamseCommandline(bwa_exe)
@@ -144,7 +144,7 @@ class BwaTestCase(unittest.TestCase):
                             % (cmdline, headline))
 
         def test_sampe(self):
-            """Test for generating samfile by paired end sequencing"""
+            """Test for generating samfile by paired end sequencing."""
             self.create_fasta_index()
 
             # Generate sai files from paired end data

--- a/Tests/test_ColorSpiral.py
+++ b/Tests/test_ColorSpiral.py
@@ -4,8 +4,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
-""" Tests for general functionality of the ColorSpiral utility
-"""
+"""Tests for general functionality of the ColorSpiral utility."""
 
 # Builtins
 import colorsys

--- a/Tests/test_Emboss.py
+++ b/Tests/test_Emboss.py
@@ -893,7 +893,8 @@ class TranslationTests(unittest.TestCase):
     def check(self, sequence):
         """Compare our translation to EMBOSS's using all tables.
 
-        Takes a Seq object (and a filename containing it)."""
+        Takes a Seq object (and a filename containing it).
+        """
         translation = emboss_translate(sequence)
         self.assertTrue(check_translation(sequence, translation))
 

--- a/Tests/test_EmbossPrimer.py
+++ b/Tests/test_EmbossPrimer.py
@@ -67,8 +67,7 @@ class Primer3ParseTest(unittest.TestCase):
         self.assertEqual(primer_info.primers[4].reverse_gc, 40.91)
 
     def test_in_depth_single_parse(self):
-        """Make sure we get info right from a single primer find.
-        """
+        """Make sure we get info right from a single primer find."""
         file = self.test_files[1]
         h = open(file, "r")
         primer_info = Primer3.read(h)
@@ -85,7 +84,7 @@ class Primer3ParseTest(unittest.TestCase):
         self.assertEqual(primer_info.primers[3].forward_start, 253)
 
     def test_internal_oligo_single_parse(self):
-        ''' Make sure we can parse an internal oligo file correctly '''
+        """Make sure we can parse an internal oligo file correctly."""
         # these files are generated when designing hybridization probes.
         file = self.test_files[4]
         h = open(file, "r")
@@ -103,7 +102,7 @@ class Primer3ParseTest(unittest.TestCase):
         self.assertEqual(primer_info.primers[4].internal_gc, 35.00)
 
     def test_mutli_record_fwd(self):
-        """Test parsing multiple primer sets (NirK forward)"""
+        """Test parsing multiple primer sets (NirK forward)."""
         h = open(os.path.join("Emboss", "NirK.primer3"))
         targets = list(Primer3.parse(h))
         h.close()

--- a/Tests/test_GAQueens.py
+++ b/Tests/test_GAQueens.py
@@ -116,7 +116,7 @@ def queens_fitness(genome):
 
     Arguments:
 
-    o genome -- A MutableSeq object specifying an organism genome.
+    - genome - A MutableSeq object specifying an organism genome.
 
     The number returned is the number of unattacked queens on the board.
     """
@@ -151,8 +151,7 @@ def queens_fitness(genome):
 
 class QueensAlphabet(Alphabet.Alphabet):
     def __init__(self, num_queens):
-        """Initialize with the number of queens we are calculating for.
-        """
+        """Initialize with the number of queens we are calculating for."""
         # set up the letters for the alphabet
         assert 0 < num_queens <= 9
         self.letters = "".join(str(i) for i in range(num_queens))
@@ -176,7 +175,8 @@ class QueensRepair(object):
 
         Arguments:
 
-        o repair_prob -- The probability that we'll repair a genome.
+        - repair_prob -- The probability that we'll repair a genome.
+
         By default, we always repair.
         """
         self._repair_prob = repair_prob
@@ -213,8 +213,9 @@ class QueensRepair(object):
 
         Arguments:
 
-        o organism -- The Organism object we are going to perform the
-        repair on.
+        - organism -- The Organism object we are going to perform the
+          repair on.
+
         """
         # check if we should repair or not
         repair_chance = random.random()
@@ -256,22 +257,19 @@ class QueensCrossover(object):
 
         Arguments:
 
-        o fitness_func -- A function that can calculate the fitness of
-        a genome.
-
-        o crossover_prob -- The probability of having a crossover
-        between two passed in organisms.
-
-        o max_crossover_size -- The maximum crossover size of the 'best' region
-        to search for.
+        - fitness_func -- A function that can calculate the fitness of
+          a genome.
+        - crossover_prob -- The probability of having a crossover
+          between two passed in organisms.
+        - max_crossover_size -- The maximum crossover size of the 'best' region
+          to search for.
         """
         self._crossover_prob = crossover_prob
         self._fitness_calc = fitness_func
         self._max_crossover_size = max_crossover_size
 
     def do_crossover(self, org_1, org_2):
-        """Perform a crossover between two organisms.
-        """
+        """Perform a crossover between two organisms."""
         new_org_1 = org_1.copy()
         new_org_2 = org_2.copy()
 
@@ -297,18 +295,19 @@ class QueensCrossover(object):
 
         Arguments:
 
-        o genome -- A MutableSeq object specifying the genome of an organism
-
-        o make_best_larger -- A flag to determine whether the best region
-        we should search for should be the larger region of the split
-        caused by crossover or the smaller region. This makes it easy
-        to split two genomes, recombine them, and get a solution that
-        makes sense.
+        - genome - A MutableSeq object specifying the genome of an organism
+        - make_best_larger - A flag to determine whether the best region
+          we should search for should be the larger region of the split
+          caused by crossover or the smaller region. This makes it easy
+          to split two genomes, recombine them, and get a solution that
+          makes sense.
 
         Returns:
-        o Two MutableSeq objects. They are both half of the size of the passed
-        genome. The first is the highest fitness region of the genome and the
-        second is the rest of the genome.
+
+        - Two MutableSeq objects. They are both half of the size of the passed
+          genome. The first is the highest fitness region of the genome and the
+          second is the rest of the genome.
+
         """
         first_region = max(len(genome) / 2, self._max_crossover_size)
         second_region = len(genome) - first_region
@@ -353,14 +352,14 @@ class QueensMutation(object):
 
         Arguments:
 
-        o mutation_rate -- The change of a mutation happening at any
-        position in the genome.
+        - mutation_rate - The change of a mutation happening at any
+          position in the genome.
+
         """
         self._mutation_rate = mutation_rate
 
     def mutate(self, organism):
-        """Mutate the genome trying to put in 'helpful' mutations.
-        """
+        """Mutate the genome trying to put in 'helpful' mutations."""
         new_org = organism.copy()
         gene_choices = list(new_org.genome.alphabet.letters)
 
@@ -394,7 +393,7 @@ num_queens = 5
 # Class defined for use via run_tests.py
 class QueensTest(unittest.TestCase):
     def test_queens(self):
-        """Place five queens with a GA"""
+        """Place five queens with a GA."""
         main(num_queens)
 
 

--- a/Tests/test_GenomeDiagram.py
+++ b/Tests/test_GenomeDiagram.py
@@ -64,18 +64,20 @@ def fill_and_border(base_color, alpha=0.5):
 
 
 def apply_to_window(sequence, window_size, function, step=None):
-    """Returns a list of (position, value) tuples for fragments of the passed
+    """Apply function to windows of the given sequence.
+
+    Returns a list of (position, value) tuples for fragments of the passed
     sequence of length window_size (stepped by step), calculated by the passed
     function.  Returned positions are the midpoint of each window.
 
     Arguments:
-        - sequence      - Bio.Seq.Seq object.
-        - window_size   - an integer describing the length of sequence to consider.
-        - step          - an integer describing the step to take between windows
-          (default = window_size//2).
 
-        - function      - Method or function that accepts a Bio.Seq.Seq object
-          as its sole argument and returns a single value.
+    - sequence - Bio.Seq.Seq object.
+    - window_size - an integer describing the length of sequence to consider.
+    - step - an integer describing the step to take between windows
+      (default = window_size//2).
+    - function - Method or function that accepts a Bio.Seq.Seq object
+      as its sole argument and returns a single value.
 
     apply_to_window(sequence, window_size, function) -> [(int, float),(int, float),...]
     """
@@ -348,7 +350,8 @@ class LabelTest(unittest.TestCase):
 class SigilsTest(unittest.TestCase):
     """Check the different feature sigils.
 
-    These figures are intended to be used in the Tutorial..."""
+    These figures are intended to be used in the Tutorial...
+    """
     def setUp(self):
         self.gdd = Diagram('Test Diagram', circular=False,
                            y=0.01, yt=0.01, yb=0.01,

--- a/Tests/test_HMMCasino.py
+++ b/Tests/test_HMMCasino.py
@@ -88,9 +88,9 @@ def generate_rolls(num_rolls):
 
     Returns:
 
-    o The generate roll sequence
+    - The generate roll sequence
+    - The state sequence that generated the roll.
 
-    o The state sequence that generated the roll.
     """
     # start off in the fair state
     cur_state = 'F'

--- a/Tests/test_HMMGeneral.py
+++ b/Tests/test_HMMGeneral.py
@@ -301,10 +301,7 @@ class HiddenMarkovModelTest(unittest.TestCase):
         test_assertion("log probability", round(prob, 11), round(max_prob, 11))
 
     def test_non_ergodic(self):
-        """Test a non-ergodic model (meaning that some transitions are not
-        allowed).
-        """
-
+        """Non-ergodic model (meaning that some transitions are not allowed)."""
         # make state '1' the initial state
         prob_1_initial = 1.0
         self.mm_builder.set_initial_probabilities(

--- a/Tests/test_KGML_nographics.py
+++ b/Tests/test_KGML_nographics.py
@@ -5,8 +5,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
-""" Tests for general functionality of the KGML parser and pathway model
-"""
+"""Tests for general functionality of the KGML parser and pathway model."""
 
 # Builtins
 from __future__ import with_statement
@@ -19,8 +18,7 @@ from Bio.KEGG.KGML.KGML_parser import read
 
 
 class PathwayData(object):
-    """ Convenience structure for testing pathway data
-    """
+    """Convenience structure for testing pathway data."""
     def __init__(self, infilename, outfilename, element_counts,
                  pathway_image, show_pathway_image=False):
         self.infilename = infilename
@@ -31,9 +29,12 @@ class PathwayData(object):
 
 
 class KGMLPathwayTest(unittest.TestCase):
-    """ Import the ko01100 metabolic map from a local .xml KGML file, and from
-        the KEGG site, and write valid KGML output for each
+    """KGML checks using ko01100 metabolic map.
+
+    Import the ko01100 metabolic map from a local .xml KGML file, and from
+    the KEGG site, and write valid KGML output for each
     """
+
     def setUp(self):
         # Does our output director exist?  If not, create it
         if not os.path.isdir('KEGG'):
@@ -75,8 +76,9 @@ class KGMLPathwayTest(unittest.TestCase):
                 os.remove(p.outfilename)
 
     def test_read_and_write_KGML_files(self):
-        """ Read KGML from, and write KGML to, local files.
-            Check we read/write the correct number of elements.
+        """Read KGML from, and write KGML to, local files.
+
+        Check we read/write the correct number of elements.
         """
         for p in self.data:
             # Test opening file

--- a/Tests/test_MafIO_index.py
+++ b/Tests/test_MafIO_index.py
@@ -382,12 +382,12 @@ if sqlite3:
             self.assertEqual(str(result[0].seq), "N" * 1000)
 
         def test_correct_retrieval_1(self):
-            """
+            """Correct retrievel of Cnksr3 in mouse.
+
             This is the real thing. We're pulling the spliced alignment of
             an actual gene (Cnksr3) in mouse. It should perfectly match the
             spliced transcript pulled independently from UCSC.
             """
-
             result = self.idx.get_spliced((3134303, 3185733, 3192055, 3193589,
                                            3203538, 3206102, 3208126, 3211424,
                                            3211872, 3217393, 3219697, 3220356,

--- a/Tests/test_MafIO_index.py
+++ b/Tests/test_MafIO_index.py
@@ -382,7 +382,7 @@ if sqlite3:
             self.assertEqual(str(result[0].seq), "N" * 1000)
 
         def test_correct_retrieval_1(self):
-            """Correct retrievel of Cnksr3 in mouse.
+            """Correct retrieval of Cnksr3 in mouse.
 
             This is the real thing. We're pulling the spliced alignment of
             an actual gene (Cnksr3) in mouse. It should perfectly match the

--- a/Tests/test_Mafft_tool.py
+++ b/Tests/test_Mafft_tool.py
@@ -76,9 +76,7 @@ class MafftApplication(unittest.TestCase):
             os.remove("Fasta/f002.tree")
 
     def test_Mafft_simple(self):
-        """Simple round-trip through app with infile.
-        Result passed to stdout.
-        """
+        """Simple round-trip through app with infile, result passed to stdout."""
         # Use a keyword argument at init,
         cmdline = MafftCommandline(mafft_exe, input=self.infile1)
         self.assertEqual(str(eval(repr(cmdline))), str(cmdline))
@@ -91,9 +89,7 @@ class MafftApplication(unittest.TestCase):
         self.assertNotIn("$#=0", stderrdata)
 
     def test_Mafft_with_options(self):
-        """Simple round-trip through app with infile and options.
-        Result passed to stdout.
-        """
+        """Simple round-trip through app with infile and options, result passed to stdout."""
         cmdline = MafftCommandline(mafft_exe)
         cmdline.set_parameter("input", self.infile1)
         cmdline.set_parameter("maxiterate", 100)
@@ -104,7 +100,7 @@ class MafftApplication(unittest.TestCase):
         self.assertNotIn("$#=0", stderrdata)
 
     def test_Mafft_with_Clustalw_output(self):
-        """Simple round-trip through app with clustal output"""
+        """Simple round-trip through app with clustal output."""
         cmdline = MafftCommandline(mafft_exe)
         # Use some properties:
         cmdline.input = self.infile1
@@ -118,7 +114,7 @@ class MafftApplication(unittest.TestCase):
 
     if version_major >= 7:
         def test_Mafft_with_PHYLIP_output(self):
-            """Simple round-trip through app with PHYLIP output"""
+            """Simple round-trip through app with PHYLIP output."""
             cmdline = MafftCommandline(mafft_exe, input=self.infile1,
                                        phylipout=True)
             self.assertEqual(str(eval(repr(cmdline))), str(cmdline))
@@ -134,7 +130,7 @@ class MafftApplication(unittest.TestCase):
             self.assertNotIn("$#=0", stderrdata)
 
         def test_Mafft_with_PHYLIP_namelength(self):
-            """Check PHYLIP with --namelength"""
+            """Check PHYLIP with --namelength."""
             cmdline = MafftCommandline(mafft_exe, input=self.infile1,
                                        phylipout=True, namelength=50)
             self.assertEqual(str(eval(repr(cmdline))), str(cmdline))

--- a/Tests/test_PAML_codeml.py
+++ b/Tests/test_PAML_codeml.py
@@ -545,8 +545,10 @@ class ModTest(unittest.TestCase):
             self.assertEqual(len(distances), 2, version_msg)
 
     def testTreeParseVersatility(self):
-        """Test finding trees in the results, in response to bug #453, where
-        trees like (A, (B, C)); weren't being caught"""
+        """Test finding trees in the results.
+
+        In response to bug #453, where trees like (A, (B, C)); weren't being caught.
+        """
         res_file = os.path.join(self.results_dir, "codeml",
                                 "tree_regexp_versatility.out")
         results = codeml.read(res_file)

--- a/Tests/test_PAML_tools.py
+++ b/Tests/test_PAML_tools.py
@@ -73,9 +73,7 @@ class CodemlTest(Common):
         self.cml = codeml.Codeml()
 
     def testCodemlBinary(self):
-        """Test that the codeml binary runs and generates correct output
-        and is the correct version.
-        """
+        """codeml runs, generates correct output, and is the correct version."""
         ctl_file = os.path.join("PAML", "Control_files", "codeml", "codeml.ctl")
         self.cml.read_ctl_file(ctl_file)
         self.cml.alignment = os.path.join("PAML", "Alignments", "alignment.phylip")
@@ -96,9 +94,7 @@ class BasemlTest(Common):
         self.bml = baseml.Baseml()
 
     def testBasemlBinary(self):
-        """Test that the baseml binary runs and generates correct output
-        and is the correct version.
-        """
+        """baseml runs, generates correct output, and is the correct version."""
         ctl_file = os.path.join("PAML", "Control_files", "baseml", "baseml.ctl")
         self.bml.read_ctl_file(ctl_file)
         self.bml.alignment = os.path.join("PAML", "Alignments", "alignment.phylip")
@@ -118,7 +114,8 @@ class Yn00Test(Common):
         self.yn = yn00.Yn00()
 
     def testYn00Binary(self):
-        """Test that the yn00 binary runs and generates correct output.
+        """yn00 binary runs and generates correct output.
+
         yn00 output does not specify the version number.
         """
         ctl_file = os.path.join("PAML", "Control_files", "yn00", "yn00.ctl")

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -53,6 +53,7 @@ class A_ExceptionTest(unittest.TestCase):
     These tests must be executed because of the way Python's warnings module
     works -- a warning is only logged the first time it is encountered.
     """
+
     def test_1_warnings(self):
         """Check warnings: Parse a flawed PDB file in permissive mode."""
         with warnings.catch_warnings(record=True) as w:
@@ -530,10 +531,11 @@ class ParseTest(unittest.TestCase):
             os.remove(filename)
 
     def test_deepcopy_of_structure_with_disorder(self):
-            """Test deepcopy of a structure with disordered atoms.
-            Shouldn't cause recursion.
-            """
-            _ = deepcopy(self.structure)
+        """Test deepcopy of a structure with disordered atoms.
+
+        Shouldn't cause recursion.
+        """
+        _ = deepcopy(self.structure)
 
 
 class ParseReal(unittest.TestCase):
@@ -939,7 +941,7 @@ class Atom_Element(unittest.TestCase):
         self.residue = structure[0]['A'][('H_PCA', 1, ' ')]
 
     def test_AtomElement(self):
-        """ Atom Element """
+        """Atom Element."""
         atoms = self.residue.child_list
         self.assertEqual('N', atoms[0].element)  # N
         self.assertEqual('C', atoms[1].element)  # Alpha Carbon
@@ -1125,10 +1127,7 @@ class TransformTests(unittest.TestCase):
         self.a = self.r.get_list()[0]
 
     def get_total_pos(self, o):
-        """
-        Returns the sum of the positions of atoms in an entity along
-        with the number of atoms.
-        """
+        """Sum of positions of atoms in an entity along with the number of atoms."""
         if hasattr(o, "get_coord"):
             return o.get_coord(), 1
         total_pos = numpy.array((0.0, 0.0, 0.0))
@@ -1140,9 +1139,7 @@ class TransformTests(unittest.TestCase):
         return total_pos, total_count
 
     def get_pos(self, o):
-        """
-        Returns the average atom position in an entity.
-        """
+        """Average atom position in an entity."""
         pos, count = self.get_total_pos(o)
         return 1.0 * pos / count
 
@@ -1455,9 +1452,10 @@ def eprint(*args, **kwargs):
 
 
 def will_it_float(s):
-    """ Helper function that converts the input into a float if it is a number.
+    """Helper function that converts the input into a float if it is a number.
 
-    If the input is a string, the output does not change."""
+    If the input is a string, the output does not change.
+    """
     try:
         return float(s)
     except ValueError:
@@ -1469,13 +1467,14 @@ class DsspTests(unittest.TestCase):
 
     See also test_DSSP_tool.py for run time testing with the tool.
     """
+
     def test_DSSP_file(self):
-        """Test parsing of pregenerated DSSP"""
+        """Test parsing of pregenerated DSSP."""
         dssp, keys = make_dssp_dict("PDB/2BEG.dssp")
         self.assertEqual(len(dssp), 130)
 
     def test_DSSP_noheader_file(self):
-        """Test parsing of pregenerated DSSP missing header information"""
+        """Test parsing of pregenerated DSSP missing header information."""
         # New DSSP prints a line containing only whitespace and "."
         dssp, keys = make_dssp_dict("PDB/2BEG_noheader.dssp")
         self.assertEqual(len(dssp), 130)
@@ -1501,7 +1500,7 @@ class DsspTests(unittest.TestCase):
         self.assertEqual((dssp_indices & hb_indices), hb_indices)
 
     def test_DSSP_in_model_obj(self):
-        """ Test that all the elements are added correctly to the xtra attribute of the input model object."""
+        """All elements correctly added to xtra attribute of input model object."""
         p = PDBParser()
         s = p.get_structure("example", "PDB/2BEG.pdb")
         m = s[0]

--- a/Tests/test_Phylo.py
+++ b/Tests/test_Phylo.py
@@ -181,6 +181,7 @@ class IOTests(unittest.TestCase):
 
 class TreeTests(unittest.TestCase):
     """Tests for methods on BaseTree.Tree objects."""
+
     def test_randomized(self):
         """Tree.randomized: generate a new randomized tree."""
         for N in (2, 5, 20):
@@ -260,6 +261,7 @@ class TreeTests(unittest.TestCase):
 
 class MixinTests(unittest.TestCase):
     """Tests for TreeMixin methods."""
+
     def setUp(self):
         self.phylogenies = list(Phylo.parse(EX_PHYLO, 'phyloxml'))
 

--- a/Tests/test_Phylo_matplotlib.py
+++ b/Tests/test_Phylo_matplotlib.py
@@ -52,8 +52,11 @@ class UtilTests(unittest.TestCase):
         Phylo.draw(apaf, do_show=False, branch_labels=lambda c: c.branch_length)
 
     def test_draw_with_label_colors_dict(self):
-        """Run the tree layout algorithm with a label_colors argument passed in
-        as a dictionary. Don't display tree."""
+        """Layout tree with label colors as dict.
+
+        Run the tree layout algorithm with a label_colors argument passed in
+        as a dictionary. Don't display tree.
+        """
         pyplot.ioff()   # Turn off interactive display
         dollo = Phylo.read(EX_DOLLO, 'phyloxml')
         apaf = Phylo.read(EX_APAF, 'phyloxml')
@@ -69,8 +72,11 @@ class UtilTests(unittest.TestCase):
         Phylo.draw(apaf, label_colors=label_colors_apaf, do_show=False)
 
     def test_draw_with_label_colors_callable(self):
-        """Run the tree layout algorithm with a label_colors argument passed in
-        as a callable. Don't display tree."""
+        """Layout tree with label colors as callable.
+
+        Run the tree layout algorithm with a label_colors argument passed in
+        as a callable. Don't display tree.
+        """
         pyplot.ioff()   # Turn off interactive display
         dollo = Phylo.read(EX_DOLLO, 'phyloxml')
         apaf = Phylo.read(EX_APAF, 'phyloxml')

--- a/Tests/test_PopGen_DFDist.py
+++ b/Tests/test_PopGen_DFDist.py
@@ -56,8 +56,8 @@ if not is_pypy() and sys.version_info[0] == 3 and sys.version_info < (3, 2, 4):
 
 
 class AppTest(unittest.TestCase):
-    """Tests the Dfdist suite of applications.
-    """
+    """Tests the Dfdist suite of applications."""
+
     def _copyfile(self, inname, outname):
         shutil.copyfile(
             'PopGen' + os.sep + inname,
@@ -80,8 +80,7 @@ class AppTest(unittest.TestCase):
             os.rmdir(self.dirname)
 
     def test_ddatacal(self):
-        """Test Ddatacal execution.
-        """
+        """Test Ddatacal execution."""
         fst, samp_size, loci, pops, F, obs = \
             self.ctrl.run_datacal(data_dir=self.dirname, version=2)
         self.assertTrue(fst - 0.23 < 0.02)
@@ -92,8 +91,7 @@ class AppTest(unittest.TestCase):
         self.assertEqual(obs, 300)
 
     def test_dfdist(self):
-        """Test Dfdist execution.
-        """
+        """Test Dfdist execution."""
         # The number of simulations in real life should be at least 10000,
         # see the fdist2 documentation.
         fst = self.ctrl.run_fdist(npops=15, nsamples=10, fst=0.1,
@@ -104,7 +102,8 @@ class AppTest(unittest.TestCase):
 
     def atest_dfdist_force_fst(self):
         """Test dfdist execution approximating Fst.
-           THIS IS TOO SLOW
+
+        THIS IS TOO SLOW
         """
         # The number of simulations in real life should be at least 10000,
         # see the fdist2 documentation.
@@ -116,14 +115,12 @@ class AppTest(unittest.TestCase):
                         "Stochastic result, expected %f close to 0.09" % fst)
 
     def test_cplot2(self):
-        """Test cplot2 execution.
-        """
+        """Test cplot2 execution."""
         cpl_interval = self.ctrl.run_cplot(data_dir=self.dirname, version=2)
         self.assertEqual(len(cpl_interval), 300)
 
     def test_pv2(self):
-        """Test pv2 execution.
-        """
+        """Test pv2 execution."""
         pv_data = self.ctrl.run_pv(data_dir=self.dirname, version=2)
         self.assertEqual(len(pv_data), 300)
 

--- a/Tests/test_PopGen_FastSimCoal.py
+++ b/Tests/test_PopGen_FastSimCoal.py
@@ -34,8 +34,8 @@ if not found:
 
 
 class AppTest(unittest.TestCase):
-    """Tests fastsimcoal execution via biopython.
-    """
+    """Tests fastsimcoal execution via biopython."""
+
     def setUp(self):
         self.tidy()
 
@@ -50,8 +50,7 @@ class AppTest(unittest.TestCase):
         shutil.rmtree(os.path.join('PopGen', 'simple'))
 
     def test_fastsimcoal(self):
-        """Test fastsimcoal execution.
-        """
+        """Test fastsimcoal execution."""
         ctrl = FastSimCoalController(fastsimcoal_dir=fastsimcoal_dir)
         ctrl.run_fastsimcoal('simple.par', 50, par_dir='PopGen')
         assert os.path.isdir(os.path.join('PopGen', 'simple')), \

--- a/Tests/test_Prank_tool.py
+++ b/Tests/test_Prank_tool.py
@@ -55,7 +55,8 @@ class PrankApplication(unittest.TestCase):
         self.infile1 = "Fasta/fa01"
 
     def tearDown(self):
-        """
+        """Remove generated files.
+
         output.1.dnd  output.1.fas  output.1.xml  output.2.dnd  output.2.fas  output.2.xml
         """
         if os.path.isfile("output.1.dnd"):
@@ -77,6 +78,7 @@ class PrankApplication(unittest.TestCase):
 
     def test_Prank_simple(self):
         """Simple round-trip through app with infile.
+
         output.?.??? files written to cwd - no way to redirect
         """
         cmdline = PrankCommandline(prank_exe)
@@ -89,7 +91,8 @@ class PrankApplication(unittest.TestCase):
         self.assertIn("Total time", output)
 
     def test_Prank_simple_with_NEXUS_output(self):
-        """Simple round-trip through app with infile, output in NEXUS
+        """Simple round-trip through app with infile, output in NEXUS.
+
         output.?.??? files written to cwd - no way to redirect
         """
         records = list(SeqIO.parse(self.infile1, "fasta"))

--- a/Tests/test_SearchIO_blast_xml_index.py
+++ b/Tests/test_SearchIO_blast_xml_index.py
@@ -11,7 +11,6 @@ from search_tests_common import CheckRaw, CheckIndex
 
 
 class BlastXmlRawCases(CheckRaw):
-
     """Check BLAST XML get_raw method."""
 
     fmt = 'blast-xml'

--- a/Tests/test_SeqIO_FastaIO.py
+++ b/Tests/test_SeqIO_FastaIO.py
@@ -70,6 +70,7 @@ def read_title_and_seq(filename):
 
 class TitleFunctions(unittest.TestCase):
     """Cunning unit test where methods are added at run time."""
+
     def simple_check(self, filename, alphabet):
         """Basic test for parsing single record FASTA files."""
         title, seq = read_title_and_seq(filename)  # crude parser

--- a/Tests/test_SeqIO_PdbIO.py
+++ b/Tests/test_SeqIO_PdbIO.py
@@ -102,7 +102,6 @@ class TestPdbAtom(unittest.TestCase):
 
     def test_atom_noheader(self):
         """Parse a PDB with no HEADER line."""
-
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', PDBConstructionWarning)
             warnings.simplefilter('ignore', UserWarning)

--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -135,6 +135,7 @@ def compare_records(old_list, new_list, truncate_qual=None):
 
 class TestFastqErrors(unittest.TestCase):
     """Test reject invalid FASTQ files."""
+
     def check_fails(self, filename, good_count, formats=None, raw=True):
         if not formats:
             formats = ["fastq-sanger", "fastq-solexa", "fastq-illumina"]
@@ -276,6 +277,7 @@ class TestReferenceSffConversions(unittest.TestCase):
 
 class TestReferenceFastqConversions(unittest.TestCase):
     """Tests where we have reference output."""
+
     def simple_check(self, base_name, in_variant):
         for out_variant in ["sanger", "solexa", "illumina"]:
             in_filename = "Quality/%s_original_%s.fastq" \
@@ -325,6 +327,7 @@ for base_name, variant in tests:
 
 class TestQual(unittest.TestCase):
     """Tests with QUAL files."""
+
     def test_paired(self):
         """Check FASTQ parsing matches FASTA+QUAL parsing"""
         with open("Quality/example.fasta") as f:
@@ -398,6 +401,7 @@ BB!!!<!!21!=9,!'!!!>!)>9!!))!5!.!!).!=+9!+!!!%!!('
 
 class TestReadWrite(unittest.TestCase):
     """Test can read and write back files."""
+
     def test_fastq_2000(self):
         """Read and write back simple example with upper case 2000bp read"""
         data = "@%s\n%s\n+\n%s\n" \
@@ -455,6 +459,7 @@ class TestReadWrite(unittest.TestCase):
 
 class TestWriteRead(unittest.TestCase):
     """Test can write and read back files."""
+
     def test_generated(self):
         """Write and read back odd SeqRecord objects"""
         record1 = SeqRecord(Seq("ACGT" * 500, generic_dna), id="Test", description="Long " * 500,
@@ -609,6 +614,8 @@ class TestWriteRead(unittest.TestCase):
 
 
 class MappingTests(unittest.TestCase):
+    """Quality mapping tests."""
+
     def test_solexa_quality_from_phred(self):
         """Mapping check for function solexa_quality_from_phred"""
         self.assertEqual(-5, round(QualityIO.solexa_quality_from_phred(0)))
@@ -721,6 +728,7 @@ class MappingTests(unittest.TestCase):
 
 class TestSFF(unittest.TestCase):
     """Test SFF specific details."""
+
     def test_overlapping_clip(self):
         with open("Roche/greek.sff", "rb") as handle:
             record = next(SeqIO.parse(handle, "sff"))

--- a/Tests/test_SeqIO_convert.py
+++ b/Tests/test_SeqIO_convert.py
@@ -161,6 +161,7 @@ def compare_records(old_list, new_list, truncate_qual=None):
 
 class ConvertTests(unittest.TestCase):
     """Cunning unit test where methods are added at run time."""
+
     def simple_check(self, filename, in_format, out_format, alphabet):
         check_convert(filename, in_format, out_format, alphabet)
 

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -502,8 +502,7 @@ class SeqFeatureCreation(unittest.TestCase):
     """Test basic creation of SeqFeatures."""
 
     def test_qualifiers(self):
-        """Pass in qualifiers to SeqFeatures.
-        """
+        """Pass in qualifiers to SeqFeatures."""
         f = SeqFeature(FeatureLocation(10, 20), strand=+1, type="CDS")
         self.assertEqual(f.qualifiers, {})
         f = SeqFeature(FeatureLocation(10, 20), strand=+1, type="CDS",
@@ -1168,6 +1167,7 @@ class NC_005816(NC_000932):
 
 class TestWriteRead(unittest.TestCase):
     """Test can write and read back files."""
+
     def test_NC_000932(self):
         """Write and read back NC_000932.gb"""
         write_read(os.path.join("GenBank", "NC_000932.gb"), "gb")

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -98,6 +98,7 @@ if sqlite3:
         >>> len(d)
         54
         """
+
         def setUp(self):
             os.chdir(CUR_DIR)
 
@@ -178,6 +179,7 @@ if sqlite3:
 
     class NewIndexTest(unittest.TestCase):
         """Check paths etc in newly built index."""
+
         def setUp(self):
             os.chdir(CUR_DIR)
 
@@ -295,6 +297,7 @@ if sqlite3:
 
 class IndexDictTests(unittest.TestCase):
     """Cunning unit test where methods are added at run time."""
+
     def setUp(self):
         os.chdir(CUR_DIR)
         h, self.index_tmp = tempfile.mkstemp("_idx.tmp")

--- a/Tests/test_SeqIO_online.py
+++ b/Tests/test_SeqIO_online.py
@@ -36,6 +36,7 @@ Entrez.email = "biopython-dev@biopython.org"
 
 class ExPASyTests(unittest.TestCase):
     """Tests for Bio.ExPASy module."""
+
     def test_get_sprot_raw(self):
         """Bio.ExPASy.get_sprot_raw("O23729")"""
         identifier = "O23729"

--- a/Tests/test_SeqIO_write.py
+++ b/Tests/test_SeqIO_write.py
@@ -75,6 +75,7 @@ test_records[4][0][2].annotations["weight"] = 2.5
 
 class WriterTests(unittest.TestCase):
     """Cunning unit test where methods are added at run time."""
+
     def check(self, records, format):
         """General test function with with a little format specific information.
 

--- a/Tests/test_SffIO.py
+++ b/Tests/test_SffIO.py
@@ -368,7 +368,7 @@ class TestConcatenated(unittest.TestCase):
 
 
 class TestSelf(unittest.TestCase):
-    """ These tests were originally self-tests run in SffIO.py """
+    """These tests were originally defined in SffIO.py as self-tests."""
 
     def test_read(self):
         filename = "Roche/E3MFGYR02_random_10_reads.sff"

--- a/Tests/test_SwissProt.py
+++ b/Tests/test_SwissProt.py
@@ -4,8 +4,7 @@
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
-"""Test for the SwissProt parser on SwissProt files.
-"""
+"""Test for the SwissProt parser on SwissProt files."""
 import os
 import unittest
 
@@ -17,7 +16,7 @@ from Bio.SeqRecord import SeqRecord
 class TestSwissProt(unittest.TestCase):
 
     def test_sp001(self):
-        "Parsing SwissProt file sp001"
+        """Parsing SwissProt file sp001."""
         filename = 'sp001'
         # test the record parser
 
@@ -92,8 +91,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp002(self):
-        "Parsing SwissProt file sp002"
-
+        """Parsing SwissProt file sp002."""
         filename = 'sp002'
         # test the record parser
 
@@ -171,8 +169,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp003(self):
-        "Parsing SwissProt file sp003"
-
+        """Parsing SwissProt file sp003."""
         filename = 'sp003'
         # test the record parser
 
@@ -290,8 +287,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp004(self):
-        "Parsing SwissProt file sp004"
-
+        """Parsing SwissProt file sp004."""
         filename = 'sp004'
         # test the record parser
 
@@ -383,8 +379,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp005(self):
-        "Parsing SwissProt file sp005"
-
+        """Parsing SwissProt file sp005."""
         filename = 'sp005'
         # test the record parser
 
@@ -457,8 +452,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp006(self):
-        "Parsing SwissProt file sp006"
-
+        """Parsing SwissProt file sp006."""
         filename = 'sp006'
         # test the record parser
 
@@ -527,8 +521,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp007(self):
-        "Parsing SwissProt file sp007"
-
+        """Parsing SwissProt file sp007."""
         filename = 'sp007'
         # test the record parser
 
@@ -606,8 +599,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp008(self):
-        "Parsing SwissProt file sp008"
-
+        """Parsing SwissProt file sp008."""
         filename = 'sp008'
         # test the record parser
 
@@ -848,8 +840,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp009(self):
-        "Parsing SwissProt file sp009"
-
+        """Parsing SwissProt file sp009."""
         filename = 'sp009'
         # test the record parser
 
@@ -918,8 +909,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp010(self):
-        "Parsing SwissProt file sp010"
-
+        """Parsing SwissProt file sp010."""
         filename = 'sp010'
         # test the record parser
 
@@ -1029,8 +1019,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp011(self):
-        "Parsing SwissProt file sp011"
-
+        """Parsing SwissProt file sp011."""
         filename = 'sp011'
         # test the record parser
 
@@ -1184,8 +1173,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp012(self):
-        "Parsing SwissProt file sp012"
-
+        """Parsing SwissProt file sp012."""
         filename = 'sp012'
         # test the record parser
 
@@ -1253,8 +1241,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp013(self):
-        "Parsing SwissProt file sp013"
-
+        """Parsing SwissProt file sp013."""
         filename = 'sp013'
         # test the record parser
 
@@ -1322,8 +1309,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp014(self):
-        "Parsing SwissProt file sp014"
-
+        """Parsing SwissProt file sp014."""
         filename = 'sp014'
         # test the record parser
 
@@ -1482,8 +1468,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(records[0].accessions, record.accessions)
 
     def test_sp015(self):
-        "Parsing SwissProt file sp015"
-
+        """Parsing SwissProt file sp015."""
         filename = 'sp015'
         # test the record parser
 

--- a/Tests/test_TCoffee_tool.py
+++ b/Tests/test_TCoffee_tool.py
@@ -49,8 +49,7 @@ class TCoffeeApplication(unittest.TestCase):
             os.remove(self.outfile4)
 
     def test_TCoffee_1(self):
-        """Round-trip through app and read clustal alignment from file
-        """
+        """Round-trip through app and read clustal alignment from file."""
         cmdline = TCoffeeCommandline(t_coffee_exe, infile=self.infile1)
         self.assertEqual(str(cmdline), t_coffee_exe + " -infile Fasta/fa01")
         stdout, stderr = cmdline()
@@ -63,8 +62,7 @@ class TCoffeeApplication(unittest.TestCase):
             self.assertEqual(str(new.seq).replace("-", ""), str(old.seq).replace("-", ""))
 
     def test_TCoffee_2(self):
-        """Round-trip through app and read pir alignment from file
-        """
+        """Round-trip through app and read pir alignment from file."""
         cmdline = TCoffeeCommandline(t_coffee_exe, quiet=True)
         cmdline.infile = self.infile1
         cmdline.outfile = self.outfile3
@@ -82,8 +80,7 @@ class TCoffeeApplication(unittest.TestCase):
             self.assertEqual(str(new.seq).replace("-", ""), str(old.seq).replace("-", ""))
 
     def test_TCoffee_3(self):
-        """Round-trip through app and read clustalw alignment from file
-        """
+        """Round-trip through app and read clustalw alignment from file."""
         cmdline = TCoffeeCommandline(t_coffee_exe, gapopen=-2)
         cmdline.infile = self.infile1
         cmdline.outfile = self.outfile4

--- a/Tests/test_TogoWS.py
+++ b/Tests/test_TogoWS.py
@@ -3,8 +3,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
-"""Testing Bio.TogoWS online code.
-"""
+"""Testing Bio.TogoWS online code."""
 
 from __future__ import print_function
 

--- a/Tests/test_TreeConstruction.py
+++ b/Tests/test_TreeConstruction.py
@@ -29,6 +29,7 @@ temp_dir = tempfile.mkdtemp()
 
 class DistanceMatrixTest(unittest.TestCase):
     """Test for _DistanceMatrix construction and manipulation"""
+
     def setUp(self):
         self.names = ['Alpha', 'Beta', 'Gamma', 'Delta']
         self.matrix = [[0], [1, 0], [2, 3, 0], [4, 5, 6, 0]]
@@ -145,6 +146,7 @@ class DistanceCalculatorTest(unittest.TestCase):
 
 class DistanceTreeConstructorTest(unittest.TestCase):
     """Test DistanceTreeConstructor"""
+
     def setUp(self):
         self.aln = AlignIO.read('TreeConstruction/msa.phy', 'phylip')
         calculator = DistanceCalculator('blosum62')

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -113,7 +113,7 @@ def _extract(handle):
 
 
 def extract_doctests(latex_filename):
-    """Scans LaTeX file and pulls out marked doctests as strings.
+    """Scan LaTeX file and pull out marked doctests as strings.
 
     This is a generator, yielding one tuple per doctest.
     """
@@ -159,6 +159,7 @@ def extract_doctests(latex_filename):
 
 class TutorialDocTestHolder(object):
     """Python doctests extracted from the Biopython Tutorial."""
+
     pass
 
 
@@ -210,6 +211,7 @@ for latex in files:
 # This is a TestCase class so it is found by run_tests.py
 class TutorialTestCase(unittest.TestCase):
     """Python doctests extracted from the Biopython Tutorial."""
+
     # Single method to be invoked by run_tests.py
     def test_doctests(self):
         """Run tutorial doctests."""

--- a/Tests/test_Uniprot.py
+++ b/Tests/test_Uniprot.py
@@ -4,8 +4,7 @@
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
-"""Test for the Uniprot parser on Uniprot XML files.
-"""
+"""Test for the Uniprot parser on Uniprot XML files."""
 import os
 import unittest
 

--- a/Tests/test_XXmotif_tool.py
+++ b/Tests/test_XXmotif_tool.py
@@ -48,7 +48,7 @@ class XXmotifTestCase(unittest.TestCase):
             shutil.rmtree(self.out_dir)
 
     def standard_test_procedure(self, cline):
-        """Standard testing procedure used by all tests."""
+        """Standard test procedure used by all tests."""
         output, error = cline()
 
         self.assertTrue(os.path.isdir(self.out_dir))
@@ -63,7 +63,8 @@ class XXmotifTestCase(unittest.TestCase):
         # MEME parser does not like what XXmotif produces yet.
 
     def copy_and_mark_for_cleanup(self, path):
-        """
+        """Copy file to working directory and marks it for removal.
+
         XXmotif currently only handles a canonical filename as input, no paths.
         This method copies the specified file in the specified path to the
         current working directory and marks it for removal.
@@ -76,7 +77,7 @@ class XXmotifTestCase(unittest.TestCase):
         return filename
 
     def add_file_to_clean(self, filename):
-        """Adds a file for deferred removal by the tearDown routine."""
+        """Add a file for deferred removal by the tearDown routine."""
         self.files_to_clean.add(filename)
 
 

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -5,14 +5,15 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
-"""test_align.py
-
-A script to test alignment stuff.
+"""Test alignment stuff.
 
 Right now we've got tests for:
-o Reading and Writing clustal format
-o Reading and Writing fasta format
-o Converting between formats"""
+
+- Reading and Writing clustal format
+- Reading and Writing fasta format
+- Converting between formats
+
+"""
 
 # standard library
 from __future__ import print_function

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -154,14 +154,13 @@ class TestSeq(unittest.TestCase):
         self.assertEqual(str(self.s) + "T", str(u))
 
     def test_concatenation_error(self):
-        """Test DNA Seq objects cannot be concatenated with Protein Seq
-        objects"""
+        """DNA Seq objects cannot be concatenated with Protein Seq objects."""
+
         with self.assertRaises(TypeError):
             self.s + Seq.Seq("T", IUPAC.protein)
 
     def test_concatenation_of_ambiguous_and_unambiguous_dna(self):
-        """Test concatenated Seq object with ambiguous and unambiguous DNA
-        returns ambiguous Seq"""
+        """Concatenate Seq object with ambiguous and unambiguous DNA returns ambiguous Seq."""
         t = Seq.Seq("T", IUPAC.ambiguous_dna)
         u = self.s + t
         self.assertEqual("IUPACAmbiguousDNA()", str(u.alphabet))
@@ -681,8 +680,6 @@ class TestMutableSeq(unittest.TestCase):
             seq.reverse_complement()
 
     def test_to_string_method(self):
-        """This method is currently deprecated, probably will need to remove
-        this test soon"""
         with self.assertWarns(BiopythonWarning):
             self.mutable_s.tostring()
 
@@ -940,8 +937,10 @@ class TestDoubleReverseComplement(unittest.TestCase):
 
 class TestSequenceAlphabets(unittest.TestCase):
     def test_sequence_alphabets(self):
-        """Sanity test on the test sequence alphabets (see also enhancement
-        bug 2597)"""
+        """Sanity test on the test sequence alphabets.
+
+        See also enhancement bug 2597.
+        """
         for nucleotide_seq in test_seqs:
             if "U" in str(nucleotide_seq).upper():
                 self.assertNotIsInstance(nucleotide_seq.alphabet,


### PR DESCRIPTION
This would close #1199

It replaces the central ``.pydocstyle`` configuration file for ``pydocstyle`` with top-level folder specific ``.flake8`` entries used with ``flake8-docstrings`` via ``flake8`` instead.

Our long term goal should be to unify on a single base-level ``.flake8`` file for the entire project, but right now this setup allows e.g. ``BioSQL/`` and ``Scripts/`` to be more strictly checked until ``Bio/`` and ``Tests/`` catch up.