### PR TITLE
parse PE line, debug sequence version and propagate to record, add te…

### DIFF
--- a/Bio/SeqIO/SwissIO.py
+++ b/Bio/SeqIO/SwissIO.py
@@ -102,13 +102,18 @@ def SwissIterator(handle):
                 record.dbxrefs.append(dbxref)
         annotations = record.annotations
         annotations['accessions'] = swiss_record.accessions
+        if swiss_record.protein_existence:
+            annotations['protein_existence'] = swiss_record.protein_existence
         if swiss_record.created:
             annotations['date'] = swiss_record.created[0]
+            annotations['sequence_version'] = swiss_record.created[1]
         if swiss_record.sequence_update:
             annotations[
                 'date_last_sequence_update'] = swiss_record.sequence_update[0]
+            annotations['sequence_version'] = swiss_record.sequence_update[1]
         if swiss_record.annotation_update:
             annotations['date_last_annotation_update'] = swiss_record.annotation_update[0]
+            annotations['entry_version'] = swiss_record.annotation_update[1]
         if swiss_record.gene_name:
             annotations['gene_name'] = swiss_record.gene_name
         annotations['organism'] = swiss_record.organism.rstrip(".")

--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -537,9 +537,11 @@ def _read_dr(record, value):
     cols = value.rstrip(".").split('; ')
     record.cross_references.append(tuple(cols))
 
+
 def _read_pe(record, value):
     pe = value.split(":")
     record.protein_existence = int(pe[0])
+
 
 def _read_kw(record, value):
     # Old style - semi-colon separated, multi-line. e.g. Q13639.txt

--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -58,6 +58,7 @@ class Record(object):
         - features          List of tuples (key name, from, to, description).
           from and to can be either integers for the residue
           numbers, '<', '>', or '?'
+        - protein_existence Numerical value describing the evidence for the existence of the protein.
 
         - seqinfo           tuple of (length, molecular weight, CRC32 value)
         - sequence          The sequence.
@@ -106,6 +107,7 @@ class Record(object):
         self.cross_references = []
         self.keywords = []
         self.features = []
+        self.protein_existence = ''
 
         self.seqinfo = None
         self.sequence = ''
@@ -244,8 +246,7 @@ def _read(handle):
         elif key == 'DR':
             _read_dr(record, value)
         elif key == 'PE':
-            # TODO - Record this information?
-            pass
+            _read_pe(record, value)
         elif key == 'KW':
             _read_kw(record, value)
         elif key == 'FT':
@@ -382,7 +383,10 @@ def _read_dt(record, line):
         # Get the version number if there is one.
         # For the three DT lines above: 0, 3, 14
         try:
-            version = int(cols[-1])
+            version = 0
+            for s in cols[-1].split('.'):
+                if s.isdigit():
+                        version = int(s)
         except ValueError:
             version = 0
         date = cols[0].rstrip(",")
@@ -533,6 +537,9 @@ def _read_dr(record, value):
     cols = value.rstrip(".").split('; ')
     record.cross_references.append(tuple(cols))
 
+def _read_pe(record, value):
+    pe = value.split(":")
+    record.protein_existence = int(pe[0])
 
 def _read_kw(record, value):
     # Old style - semi-colon separated, multi-line. e.g. Q13639.txt

--- a/Tests/test_Uniprot.py
+++ b/Tests/test_Uniprot.py
@@ -246,6 +246,44 @@ class TestUniprot(unittest.TestCase):
                 ['LD(50) is 50 ug/kg in mouse by intracerebroventricular '
                 'injection and 600 ng/g in Blatella germanica.'])
 
+    def test_sp016(self):
+        "Parsing SwissProt file sp016"
+        filename = 'sp016'
+        # test the record parser
+
+        datafile = os.path.join('SwissProt', filename)
+
+        test_handle = open(datafile)
+        seq_record = SeqIO.read(test_handle, "swiss")
+        test_handle.close()
+
+        self.assertTrue(isinstance(seq_record, SeqRecord))
+
+        # test ProteinExistence (the numerical value describing the evidence for the existence of the protein)
+        self.assertEqual(seq_record.annotations['protein_existence'], 1)
+        # test Sequence version
+        self.assertEqual(seq_record.annotations['sequence_version'], 1)
+        # test Entry version
+        self.assertEqual(seq_record.annotations['entry_version'], 93)
+
+    def test_sp002(self):
+        "Parsing SwissProt file sp002"
+        filename = 'sp002'
+        # test the record parser
+
+        datafile = os.path.join('SwissProt', filename)
+
+        test_handle = open(datafile)
+        seq_record = SeqIO.read(test_handle, "swiss")
+        test_handle.close()
+
+        self.assertTrue(isinstance(seq_record, SeqRecord))
+
+        # test Sequence version
+        self.assertEqual(seq_record.annotations['sequence_version'], 34)
+        # test Entry version
+        self.assertEqual(seq_record.annotations['entry_version'], 36)
+
     def compare_txt_xml(self, old, new):
         self.assertEqual(old.id, new.id)
         self.assertEqual(old.name, new.name)


### PR DESCRIPTION
In order to get an Uniprot fasta header (http://www.uniprot.org/help/fasta-headers), you need to retrieve Protein Existence value and sequence version as well.

The PE tag was not yet parsed.
The value of version seemed to be broken (always retrieved as 0).

Using the patch, you will be able to create PE and SV tags

Tests have been updated according to these changes