### PR TITLE
Moved self-test from Bio/PDB/parse_pdb_header.py

### DIFF
--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -65,7 +65,7 @@ def _get_references(inl):
 
 # bring dates to format: 1909-01-08
 def _format_date(pdb_date):
-    """Converts dates from DD-Mon-YY to YYYY-MM-DD format."""
+    """Convert dates from DD-Mon-YY to YYYY-MM-DD format."""
     date = ""
     year = int(pdb_date[7:])
     if year < 50:
@@ -93,7 +93,7 @@ def _chop_end_misc(line):
 
 
 def _nice_case(line):
-    """Makes A Lowercase String With Capitals."""
+    """Make A Lowercase String With Capitals."""
     l = line.lower()
     s = ""
     i = 0
@@ -112,7 +112,7 @@ def _nice_case(line):
 
 
 def parse_pdb_header(infile):
-    """Returns the header lines of a pdb file as a dictionary.
+    """Return the header lines of a pdb file as a dictionary.
 
     Dictionary keys are: head, deposition_date, release_date, structure_method,
     resolution, structure_reference, journal_reference, author and
@@ -254,18 +254,3 @@ def _parse_pdb_header_list(header):
         if dict['resolution'] > 0.0:
             dict['structure_method'] = 'x-ray diffraction'
     return dict
-
-
-if __name__ == '__main__':
-    # Reads a PDB file passed as argument, parses its header, extracts
-    # some data and returns it as a dictionary.
-    import sys
-    filename = sys.argv[1]
-    with open(filename, 'r') as handle:
-        data_dict = parse_pdb_header(handle)
-
-    # print the dictionary
-    for k, y in data_dict.items():
-        print("-" * 40)
-        print(k)
-        print(y)


### PR DESCRIPTION
As mentioned in issue #820 , I removed the self test in `Bio/PDB/parse_pdb_header.py`.

The testing is already present in `Tests/test_PDB.py` at line 123.