### PR TITLE
SeqIO write refactor to speed up common usage

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -217,10 +217,14 @@ def FastaTwoLineIterator(handle, alphabet=single_letter_alphabet):
 
 
 class FastaWriter(SequentialSequenceWriter):
-    """Class to write Fasta format files."""
+    """Class to write Fasta format files (OBSOLETE).
+
+    Please use the ``as_fasta`` function instead, or the top level
+    ``Bio.SeqIO.write()`` function instead using ``format="fasta"``.
+    """
 
     def __init__(self, handle, wrap=60, record2title=None):
-        """Create a Fasta writer.
+        """Create a Fasta writer (OBSOLETE).
 
         Arguments:
          - handle - Handle to an output file, e.g. as returned
@@ -298,7 +302,7 @@ class FastaWriter(SequentialSequenceWriter):
 
 
 class FastaTwoLineWriter(FastaWriter):
-    """Class to write 2-line per record Fasta format files.
+    """Class to write 2-line per record Fasta format files (OBSOLETE).
 
     This means we write the sequence information  without line
     wrapping, and will always write a blank line for an empty
@@ -306,7 +310,7 @@ class FastaTwoLineWriter(FastaWriter):
     """
 
     def __init__(self, handle, record2title=None):
-        """Create a Fasta writer.
+        """Create a 2-line per record Fasta writer (OBSOLETE).
 
         Arguments:
          - handle - Handle to an output file, e.g. as returned

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -1,4 +1,4 @@
-# Copyright 2006-2015 by Peter Cock.  All rights reserved.
+# Copyright 2006-2017 by Peter Cock.  All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
@@ -18,6 +18,7 @@ from Bio.Alphabet import single_letter_alphabet
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqIO.Interfaces import SequentialSequenceWriter
+from Bio.SeqIO.Interfaces import _clean, _get_seq_string
 
 
 def SimpleFastaParser(handle):
@@ -337,6 +338,59 @@ class FastaTwoLineWriter(FastaWriter):
         """
         super(FastaTwoLineWriter, self).__init__(handle, wrap=None,
                                                  record2title=record2title)
+
+
+def as_fasta(record):
+    """Turn a SeqRecord into a FASTA formated string.
+
+    This is used internally by the SeqRecord's .format("fasta")
+    method and by the SeqIO.write(..., ..., "fasta") function.
+    """
+    id = _clean(record.id)
+    description = _clean(record.description)
+    if description and description.split(None, 1)[0] == id:
+        # The description includes the id at the start
+        title = description
+    elif description:
+        title = "%s %s" % (id, description)
+    else:
+        title = id
+    assert "\n" not in title
+    assert "\r" not in title
+    lines = [">%s\n" % title]
+
+    data = _get_seq_string(record)  # Catches sequence being None
+    assert "\n" not in data
+    assert "\r" not in data
+    for i in range(0, len(data), 60):
+        lines.append(data[i:i + 60] + "\n")
+
+    return "".join(lines)
+
+
+def as_fasta_2line(record):
+    """Turn a SeqRecord into a two-line FASTA formated string.
+
+    This is used internally by the SeqRecord's .format("fasta-2line")
+    method and by the SeqIO.write(..., ..., "fasta-2line") function.
+    """
+    id = _clean(record.id)
+    description = _clean(record.description)
+    if description and description.split(None, 1)[0] == id:
+        # The description includes the id at the start
+        title = description
+    elif description:
+        title = "%s %s" % (id, description)
+    else:
+        title = id
+    assert "\n" not in title
+    assert "\r" not in title
+
+    data = _get_seq_string(record)  # Catches sequence being None
+    assert "\n" not in data
+    assert "\r" not in data
+
+    return ">%s\n%s\n" % (title, data)
 
 
 if __name__ == "__main__":

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -74,6 +74,26 @@ class SequenceIterator(object):
         return iter(self.__next__, None)
 
 
+# Function variant of the SequenceWriter method.
+def _get_seq_string(record):
+    """Use this to catch errors like the sequence being None."""
+    if not isinstance(record, SeqRecord):
+        raise TypeError("Expected a SeqRecord object")
+    if record.seq is None:
+        raise TypeError("SeqRecord (id=%s) has None for its sequence."
+                        % record.id)
+    elif not isinstance(record.seq, (Seq, MutableSeq)):
+        raise TypeError("SeqRecord (id=%s) has an invalid sequence."
+                        % record.id)
+    return str(record.seq)
+
+
+# Function variant of the SequenceWriter method.
+def _clean(text):
+    """Use this to avoid getting newlines in the output."""
+    return text.replace("\n", " ").replace("\r", " ").replace("  ", " ")
+
+
 class SequenceWriter(object):
     """Base class for building SeqRecord writers.
 

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -1,4 +1,4 @@
-# Copyright 2009-2015 by Peter Cock.  All rights reserved.
+# Copyright 2009-2017 by Peter Cock.  All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
@@ -367,6 +367,8 @@ from Bio.Alphabet import single_letter_alphabet
 from Bio.Seq import Seq, UnknownSeq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqIO.Interfaces import SequentialSequenceWriter
+from Bio.SeqIO.Interfaces import _clean, _get_seq_string
+
 from math import log
 import warnings
 from Bio import BiopythonWarning, BiopythonParserWarning
@@ -1448,6 +1450,29 @@ class FastqPhredWriter(SequentialSequenceWriter):
         self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str))
 
 
+def as_fastq(record):
+    """Turn a SeqRecord into a Sanger FASTQ formated string.
+
+    This is used internally by the SeqRecord's .format("fastq")
+    method and by the SeqIO.write(..., ..., "fastq") function,
+    and under the format alias "fastq-sanger" as well.
+    """
+    seq_str = _get_seq_string(record)
+    qualities_str = _get_sanger_quality_str(record)
+    if len(qualities_str) != len(seq_str):
+        raise ValueError("Record %s has sequence length %i but %i quality scores"
+                         % (record.id, len(seq_str), len(qualities_str)))
+    id = _clean(record.id)
+    description = _clean(record.description)
+    if description and description.split(None, 1)[0] == id:
+        title = description
+    elif description:
+        title = "%s %s" % (id, description)
+    else:
+        title = id
+    return "@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str)
+
+
 class QualPhredWriter(SequentialSequenceWriter):
     """Class to write QUAL format files (using PHRED quality scores).
 
@@ -1559,6 +1584,43 @@ class QualPhredWriter(SequentialSequenceWriter):
             handle.write(data + "\n")
 
 
+def as_qual(record):
+    """Turn a SeqRecord into a QUAL formated string.
+
+    This is used internally by the SeqRecord's .format("qual")
+    method and by the SeqIO.write(..., ..., "qual") function.
+    """
+    id = _clean(record.id)
+    description = _clean(record.description)
+    if description and description.split(None, 1)[0] == id:
+        title = description
+    elif description:
+        title = "%s %s" % (id, description)
+    else:
+        title = id
+    lines = [">%s\n" % title]
+
+    qualities = _get_phred_quality(record)
+    try:
+        # This rounds to the nearest integer.
+        # TODO - can we record a float in a qual file?
+        qualities_strs = [("%i" % round(q, 0)) for q in qualities]
+    except TypeError as e:
+        if None in qualities:
+            raise TypeError("A quality value of None was found")
+        else:
+            raise e
+
+    # Safe wrapping
+    while qualities_strs:
+        line = qualities_strs.pop(0)
+        while qualities_strs \
+                and len(line) + 1 + len(qualities_strs[0]) < 60:
+            line += " " + qualities_strs.pop(0)
+        lines.append(line + "\n")
+    return "".join(lines)
+
+
 class FastqSolexaWriter(SequentialSequenceWriter):
     r"""Write old style Solexa/Illumina FASTQ format files (with Solexa qualities).
 
@@ -1638,6 +1700,29 @@ class FastqSolexaWriter(SequentialSequenceWriter):
         self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str))
 
 
+def as_fastq_solexa(record):
+    """Turn a SeqRecord into a Solexa FASTQ formated string.
+
+    This is used internally by the SeqRecord's .format("fastq-solexa")
+    method and by the SeqIO.write(..., ..., "fastq-solexa") function.
+    """
+    seq_str = _get_seq_string(record)
+    qualities_str = _get_solexa_quality_str(record)
+    if len(qualities_str) != len(seq_str):
+        raise ValueError("Record %s has sequence length %i but %i quality scores"
+                         % (record.id, len(seq_str), len(qualities_str)))
+    id = _clean(record.id)
+    description = _clean(record.description)
+    if description and description.split(None, 1)[0] == id:
+        # The description includes the id at the start
+        title = description
+    elif description:
+        title = "%s %s" % (id, description)
+    else:
+        title = id
+    return "@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str)
+
+
 class FastqIlluminaWriter(SequentialSequenceWriter):
     r"""Write Illumina 1.3+ FASTQ format files (with PHRED quality scores).
 
@@ -1693,6 +1778,28 @@ class FastqIlluminaWriter(SequentialSequenceWriter):
             title = id
 
         self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str))
+
+
+def as_fastq_illumina(record):
+    """Turn a SeqRecord into an Illumina FASTQ formated string.
+
+    This is used internally by the SeqRecord's .format("fastq-illumina")
+    method and by the SeqIO.write(..., ..., "fastq-illumina") function.
+    """
+    seq_str = _get_seq_string(record)
+    qualities_str = _get_illumina_quality_str(record)
+    if len(qualities_str) != len(seq_str):
+        raise ValueError("Record %s has sequence length %i but %i quality scores"
+                         % (record.id, len(seq_str), len(qualities_str)))
+    id = _clean(record.id)
+    description = _clean(record.description)
+    if description and description.split(None, 1)[0] == id:
+        title = description
+    elif description:
+        title = "%s %s" % (id, description)
+    else:
+        title = id
+    return "@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str)
 
 
 def PairedFastaQualIterator(fasta_handle, qual_handle, alphabet=single_letter_alphabet, title2ids=None):

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -1375,13 +1375,14 @@ def QualPhredIterator(handle, alphabet=single_letter_alphabet, title2ids=None):
 
 
 class FastqPhredWriter(SequentialSequenceWriter):
-    """Class to write standard FASTQ format files (using PHRED quality scores).
+    """Class to write standard FASTQ format files (using PHRED quality scores) (OBSOLETE).
 
     Although you can use this class directly, you are strongly encouraged
-    to use the Bio.SeqIO.write() function instead via the format name "fastq"
-    or the alias "fastq-sanger".  For example, this code reads in a standard
-    Sanger style FASTQ file (using PHRED scores) and re-saves it as another
-    Sanger style FASTQ file:
+    to use the ``as_fastq`` function, or top level ``Bio.SeqIO.write()``
+    function instead via the format name "fastq" or the alias "fastq-sanger".
+
+    For example, this code reads in a standard Sanger style FASTQ file
+    (using PHRED scores) and re-saves it as another Sanger style FASTQ file:
 
     >>> from Bio import SeqIO
     >>> record_iterator = SeqIO.parse("Quality/example.fastq", "fastq")
@@ -1474,11 +1475,14 @@ def as_fastq(record):
 
 
 class QualPhredWriter(SequentialSequenceWriter):
-    """Class to write QUAL format files (using PHRED quality scores).
+    """Class to write QUAL format files (using PHRED quality scores) (OBSOLETE).
 
     Although you can use this class directly, you are strongly encouraged
-    to use the Bio.SeqIO.write() function instead.  For example, this code
-    reads in a FASTQ file and saves the quality scores into a QUAL file:
+    to use the ``as_qual`` function, or top level ``Bio.SeqIO.write()``
+    function instead.
+
+    For example, this code reads in a FASTQ file and saves the quality scores
+    into a QUAL file:
 
     >>> from Bio import SeqIO
     >>> record_iterator = SeqIO.parse("Quality/example.fastq", "fastq")
@@ -1622,7 +1626,7 @@ def as_qual(record):
 
 
 class FastqSolexaWriter(SequentialSequenceWriter):
-    r"""Write old style Solexa/Illumina FASTQ format files (with Solexa qualities).
+    r"""Write old style Solexa/Illumina FASTQ format files (with Solexa qualities) (OBSOLETE).
 
     This outputs FASTQ files like those from the early Solexa/Illumina
     pipeline, using Solexa scores and an ASCII offset of 64. These are
@@ -1634,8 +1638,9 @@ class FastqSolexaWriter(SequentialSequenceWriter):
     of quality scores are present, an exception is raised.
 
     Although you can use this class directly, you are strongly encouraged
-    to use the Bio.SeqIO.write() function instead.  For example, this code
-    reads in a FASTQ file and re-saves it as another FASTQ file:
+    to use the ``as_fastq_solexa`` function, or top-level ``Bio.SeqIO.write()``
+    function instead.  For example, this code reads in a FASTQ file and re-saves
+    it as another FASTQ file:
 
     >>> from Bio import SeqIO
     >>> record_iterator = SeqIO.parse("Quality/solexa_example.fastq", "fastq-solexa")
@@ -1724,7 +1729,7 @@ def as_fastq_solexa(record):
 
 
 class FastqIlluminaWriter(SequentialSequenceWriter):
-    r"""Write Illumina 1.3+ FASTQ format files (with PHRED quality scores).
+    r"""Write Illumina 1.3+ FASTQ format files (with PHRED quality scores) (OBSOLETE).
 
     This outputs FASTQ files like those from the Solexa/Illumina 1.3+ pipeline,
     using PHRED scores and an ASCII offset of 64. Note these files are NOT
@@ -1732,9 +1737,9 @@ class FastqIlluminaWriter(SequentialSequenceWriter):
     ASCII offset of 32.
 
     Although you can use this class directly, you are strongly encouraged to
-    use the Bio.SeqIO.write() function with format name "fastq-illumina"
-    instead. This code is also called if you use the .format("fastq-illumina")
-    method of a SeqRecord. For example,
+    use the ``as_fastq_illumina`` or top-level ``Bio.SeqIO.write()`` function
+    with format name "fastq-illumina" instead. This code is also called if you
+    use the .format("fastq-illumina") method of a SeqRecord. For example,
 
     >>> from Bio import SeqIO
     >>> record = SeqIO.read("Quality/sanger_faked.fastq", "fastq-sanger")

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -1,4 +1,4 @@
-# Copyright 2008-2015 by Peter Cock.  All rights reserved.
+# Copyright 2008-2017 by Peter Cock.  All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
@@ -37,6 +37,7 @@ from Bio.Alphabet import single_letter_alphabet
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqIO.Interfaces import SequentialSequenceWriter
+from Bio.SeqIO.Interfaces import _clean, _get_seq_string
 
 
 def TabIterator(handle, alphabet=single_letter_alphabet):
@@ -111,6 +112,18 @@ class TabWriter(SequentialSequenceWriter):
         assert "\n" not in seq
         assert "\r" not in seq
         self.handle.write("%s\t%s\n" % (title, seq))
+
+
+def as_tab(record):
+    title = _clean(record.id)
+    seq = _get_seq_string(record)  # Catches sequence being None
+    assert "\t" not in title
+    assert "\n" not in title
+    assert "\r" not in title
+    assert "\t" not in seq
+    assert "\n" not in seq
+    assert "\r" not in seq
+    return "%s\t%s\n" % (title, seq)
 
 
 if __name__ == "__main__":

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -90,11 +90,14 @@ def TabIterator(handle, alphabet=single_letter_alphabet):
 
 
 class TabWriter(SequentialSequenceWriter):
-    """Class to write simple tab separated format files.
+    """Class to write simple tab separated format files (OBSOLETE).
 
     Each line consists of "id(tab)sequence" only.
 
     Any description, name or other annotation is not recorded.
+
+    This class is now obsolete. Please use the function ``as_tab`` instead,
+    or the top level ``Bio.SeqIO.write()`` function with ``format="tab"``.
     """
 
     def write_record(self, record):
@@ -102,16 +105,7 @@ class TabWriter(SequentialSequenceWriter):
         assert self._header_written
         assert not self._footer_written
         self._record_written = True
-
-        title = self.clean(record.id)
-        seq = self._get_seq_string(record)  # Catches sequence being None
-        assert "\t" not in title
-        assert "\n" not in title
-        assert "\r" not in title
-        assert "\t" not in seq
-        assert "\n" not in seq
-        assert "\r" not in seq
-        self.handle.write("%s\t%s\n" % (title, seq))
+        self.handle.write(as_tab(record))
 
 
 def as_tab(record):

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -430,6 +430,19 @@ _FormatToIterator = {"fasta": FastaIO.FastaIterator,
                      "abi-trim": AbiIO._AbiTrimIterator,
                      }
 
+_FormatToString = {
+    "fasta": FastaIO.as_fasta,
+    "fasta-2line": FastaIO.as_fasta_2line,
+    "tab": TabIO.as_tab,
+    "fastq": QualityIO.as_fastq,
+    "fastq-sanger": QualityIO.as_fastq,
+    "fastq-solexa": QualityIO.as_fastq_solexa,
+    "fastq-illumina": QualityIO.as_fastq_illumina,
+    "qual": QualityIO.as_qual,
+}
+
+# This could exclude file formats covered by _FormatToString?
+# Right now used in the unit tests as proxy for all supported outputs...
 _FormatToWriter = {"fasta": FastaIO.FastaWriter,
                    "fasta-2line": FastaIO.FastaTwoLineWriter,
                    "gb": InsdcIO.GenBankWriter,
@@ -491,8 +504,14 @@ def write(sequences, handle, format):
         mode = 'w'
 
     with as_handle(handle, mode) as fp:
-        # Map the file format to a writer class
-        if format in _FormatToWriter:
+        # Map the file format to a writer function/class
+        if format in _FormatToString:
+            format_function = _FormatToString[format]
+            count = 0
+            for record in sequences:
+                fp.write(format_function(record))
+                count += 1
+        elif format in _FormatToWriter:
             writer_class = _FormatToWriter[format]
             count = writer_class(fp).write_file(sequences)
         elif format in AlignIO._FormatToWriter:

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -708,6 +708,12 @@ class SeqRecord(object):
             # Follow python convention and default to using __str__
             return str(self)
         from Bio import SeqIO
+
+        # Easy case, can call string-building function directly
+        if format_spec in SeqIO._FormatToString:
+            return SeqIO._FormatToString[format_spec](self)
+
+        # Harder case, make a temp handle instead
         if format_spec in SeqIO._BinaryFormats:
             # Return bytes on Python 3
             from io import BytesIO

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -11,7 +11,8 @@ The latest news is at the top of this file.
 (In progress, not yet released) Biopython 1.71
 ==============================================
 
-Nothing note worthy as yet.
+Internal changes to Bio.SeqIO have sped up the SeqRecord .format method and
+SeqIO.write (especially when used in a for loop).
 
 
 3 April 2018: Biopython 1.71
@@ -121,7 +122,6 @@ possible, especially the following contributors:
 - Yasar L. Ahmed (first contribution)
 - Zachary Sailer (first contribution)
 - Zaid Ur-Rehman (first contribution)
-
 
 
 10 July 2017: Biopython 1.70


### PR DESCRIPTION
When I wrote ``Bio.SeqIO.write(...)``, I was expecting people to make a single call to the function to write an entire file. However, for most formats you can make multiple calls to the write function (using the same open handle), and this seems to be easier for beginners to do. The downside is there is a lot of writer-object creation overhead here.

The same applies to the ``SeqRecord`` object's ``.format(...)`` method - behind the scenes it makes a ``StringIO`` handle and calls ``SeqIO.write(...)`` on it - making it slower than it need be.

This branch refactors the code behind the sequence writers to special case those 'sequential' files where there is no header/footer and all we need is a low-level function to map a ``SeqRecord`` into a single string.

Benchmarks to follow...