### PR TITLE
Move self-test from Bio\PDB\PDBParser.py

### DIFF
--- a/Bio/PDB/PDBParser.py
+++ b/Bio/PDB/PDBParser.py
@@ -288,28 +288,3 @@ class PDBParser(object):
         else:
             # exceptions are fatal - raise again with new message (including line nr)
             raise PDBConstructionException(message)
-
-
-if __name__ == "__main__":
-
-    import sys
-
-    p = PDBParser(PERMISSIVE=True)
-
-    filename = sys.argv[1]
-    s = p.get_structure("scr", filename)
-
-    for m in s:
-        p = m.get_parent()
-        assert(p is s)
-        for c in m:
-            p = c.get_parent()
-            assert(p is m)
-            for r in c:
-                print(r)
-                p = r.get_parent()
-                assert(p is c)
-                for a in r:
-                    p = a.get_parent()
-                    if p is not r:
-                        print("%s %s" % (p, r))

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -1256,6 +1256,28 @@ class TransformTests(unittest.TestCase):
                         "Want %r and %r to be almost equal" % (axis.get_array(), caxis.get_array()))
 
 
+class PDBParserTests(unittest.TestCase):
+    """Test PDBParser module."""
+
+    def test_PDBParser(self):
+        """Walk down the structure hierarchy and test parser reliability."""
+        p = PDBParser(PERMISSIVE=True)
+        filename = "PDB/1A8O.pdb"
+        s = p.get_structure("scr", filename)
+        for m in s:
+            p = m.get_parent()
+            self.assertEqual(s, p)
+            for c in m:
+                p = c.get_parent()
+                self.assertEqual(m, p)
+                for r in c:
+                    p = r.get_parent()
+                    self.assertEqual(c, p)
+                    for a in r:
+                        p = a.get_parent()
+                        self.assertEqual(r.get_resname(), p.get_resname())
+
+
 class CopyTests(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
As mentioned in issue #820 , I've moved the self test from `Bio\PDB\PDBParser.py` to `Tests\test_PDB.py`.