### PR TITLE
PDB.parse_pdb_header can parse headers for missing residues

### DIFF
--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -132,13 +132,14 @@ def parse_pdb_header(infile):
     return _parse_pdb_header_list(header)
 
 
-def _parse_remark_465(line, out_dict):
+def _parse_remark_465(line):
     """Parse missing residue remarks.
 
-    Fills two fields in out_dict: has_missing_residues and missing_residues.
-    It specification for REMARK 465 only gives templates, but does not say
-    they have to be followed. So we assume that not all pdb-files with a
-    REMARK 465 can be understood.
+    Returns a dictionary describing the missing residue.
+    The specification for REMARK 465 at
+    http://www.wwpdb.org/documentation/file-format-content/format33/remarks2.html#REMARK%20465
+    only gives templates, but does not say they have to be followed.
+    So we assume that not all pdb-files with a REMARK 465 can be understood.
 
     The dictionary entry "has_missing_residues" will be set to True, if
     at least one REMARK 465 entry with non-empty text exists.
@@ -149,17 +150,19 @@ def _parse_remark_465(line, out_dict):
     empty or incomplete, if the pdb-header is not successfully parsed.
     """
     if line:
-        out_dict["has_missing_residues"] = True
         # Note that line has been stripped.
         assert line[0] != " " and line[-1] not in "\n ", "line has to be stripped"
-    # Optional model number and residue name with 1 (e.g. for RNA) to 3 characters
-    modelnr_and_resname = "(\d+\s[\sA-Z][\sA-Z][A-Z]|[A-Z]?[A-Z]?[A-Z])"
-    chain = "\s([A-Za-z0-9])"
-    # Digit followed by optional insertion code.
-    # Note: Hetero-flags make no sense in contexty with missing residues.
-    ssseq = "\s+(\d+[A-Za-z]?)$"
-    pattern = modelnr_and_resname + chain + ssseq
-    match = re.match(pattern, line)
+    pattern = (r"""
+                (\d+\s[\sA-Z][\sA-Z][A-Z] |   # Either model number + residue name
+                 [A-Z]?[A-Z]?[A-Z])           # Or only residue name with
+                                              # 1 (RNA) to 3 letters
+                \s ([A-Za-z0-9])              # A single character chain
+                \s+(\d+[A-Za-z]?)$            # Residue number: A digit followed
+                                              # by an optional insertion code
+                                              # (Hetero-flags make no sense in
+                                              # context with missing res)
+                """)
+    match = re.match(pattern, line, re.VERBOSE)
     if match is not None:
         residue = {}
         if " " in match.group(1):
@@ -170,12 +173,13 @@ def _parse_remark_465(line, out_dict):
         residue["chain"] = match.group(2)
         try:
             residue["ssseq"] = int(match.group(3))
-        except:
+        except ValueError:
             residue["insertion"] = match.group(3)[-1]
             residue["ssseq"] = int(match.group(3)[:-1])
         else:
             residue["insertion"] = None
-        out_dict["missing_residues"].append(residue)
+        return residue
+    return None
 
 
 def _parse_pdb_header_list(header):
@@ -299,8 +303,11 @@ def _parse_pdb_header_list(header):
                     # print('nonstandard resolution %r' % r)
                     dict['resolution'] = None
             elif hh.startswith("REMARK 465"):
-                # Update the dictionary with content of the remark 465 line (Missing residues)
-                _parse_remark_465(tail, dict)
+                if tail:
+                    dict['has_missing_residues'] = True
+                    missing_res_info = _parse_remark_465(tail)
+                    if missing_res_info:
+                        dict['missing_residues'].append(missing_res_info)
         else:
             # print(key)
             pass

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -192,7 +192,7 @@ def _parse_pdb_header_list(header):
         'author': "",
         'compound': {'1': {'misc': ''}}, 'source': {'1': {'misc': ''}},
         'has_missing_residues': False,
-        'missing_residues' : []}
+        'missing_residues': []}
 
     dict['structure_reference'] = _get_references(header)
     dict['journal_reference'] = _get_journal(header)

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -141,13 +141,8 @@ def _parse_remark_465(line):
     only gives templates, but does not say they have to be followed.
     So we assume that not all pdb-files with a REMARK 465 can be understood.
 
-    The dictionary entry "has_missing_residues" will be set to True, if
-    at least one REMARK 465 entry with non-empty text exists.
-
-    The dictionary entry 'missing_residues' will be filled with those
-    missing residues that can be parsed from the PDB header.
-    WARNING: The list out_dict['missing_residues'] will be
-    empty or incomplete, if the pdb-header is not successfully parsed.
+    Returns a dictionary with the following keys:
+    "model", "res_name", "chain", "ssseq", "insertion"
     """
     if line:
         # Note that line has been stripped.

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -166,7 +166,8 @@ def _parse_remark_465(line):
     if match is not None:
         residue = {}
         if " " in match.group(1):
-            residue["model"], residue["res_name"] = match.group(1).split(" ")
+            model, residue["res_name"] = match.group(1).split(" ")
+            residue["model"] = int(model)
         else:
             residue["model"] = None
             residue["res_name"] = match.group(1)

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -131,6 +131,7 @@ def parse_pdb_header(infile):
                 header.append(l)
     return _parse_pdb_header_list(header)
 
+
 def _parse_remark_465(line, out_dict):
     """Parse missing residue remarks.
 
@@ -149,15 +150,14 @@ def _parse_remark_465(line, out_dict):
     """
     if line:
         out_dict["has_missing_residues"] = True
-
-    # Note that line has been stripped.
-    assert  not line or (line[0]!=" " and line[-1] not in "\n "), "line has to be stripped"
-    #Optional model number and residue name with 1 (e.g. for RNA) to 3 characters
+        # Note that line has been stripped.
+        assert line[0] != " " and line[-1] not in "\n ", "line has to be stripped"
+    # Optional model number and residue name with 1 (e.g. for RNA) to 3 characters
     modelnr_and_resname = "(\d+\s[\sA-Z][\sA-Z][A-Z]|[A-Z]?[A-Z]?[A-Z])"
-    chain="\s([A-Za-z0-9])"
-    #Digit followed by optional insertion code.
-    #Note: Hetero-flags make no sense in contexty with missing residues.
-    ssseq="\s+(\d+[A-Za-z]?)$"
+    chain = "\s([A-Za-z0-9])"
+    # Digit followed by optional insertion code.
+    # Note: Hetero-flags make no sense in contexty with missing residues.
+    ssseq = "\s+(\d+[A-Za-z]?)$"
     pattern = modelnr_and_resname + chain + ssseq
     match = re.match(pattern, line)
     if match is not None:
@@ -192,8 +192,7 @@ def _parse_pdb_header_list(header):
         'author': "",
         'compound': {'1': {'misc': ''}}, 'source': {'1': {'misc': ''}},
         'has_missing_residues': False,
-        'missing_residues' : []
-        }
+        'missing_residues' : []}
 
     dict['structure_reference'] = _get_references(header)
     dict['journal_reference'] = _get_journal(header)
@@ -300,7 +299,7 @@ def _parse_pdb_header_list(header):
                     # print('nonstandard resolution %r' % r)
                     dict['resolution'] = None
             elif hh.startswith("REMARK 465"):
-                #Update the dictionary with content of the remark 465 line (Missing residues)
+                # Update the dictionary with content of the remark 465 line (Missing residues)
                 _parse_remark_465(tail, dict)
         else:
             # print(key)

--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -44,7 +44,20 @@ Example:
 >>> resolution = structure.header["resolution"]
 >>> keywords = structure.header["keywords"]
 \end{verbatim}
-The available keys are \verb+name+, \verb+head+, \verb+deposition_date+, \verb+release_date+, \verb+structure_method+, \verb+resolution+, \verb+structure_reference+ (which maps to a list of references), \verb+journal_reference+, \verb+author+, and \verb+compound+ (which maps to a dictionary with various information about the crystallized compound).
+The available keys are \verb+name+, \verb+head+, \verb+deposition_date+, 
+\verb+release_date+, \verb+structure_method+, \verb+resolution+, 
+\verb+structure_reference+ (which maps to a list of references), 
+\verb+journal_reference+, \verb+author+, \verb+compound+ (which maps to a dictionary with various information about the crystallized compound),
+\verb+has_missing_residues+, and \verb+missing_residues+.
+
+\verb+has_missing_residues+ maps to a bool that is True if at least
+one non-empty \verb+REMARK 465+ header line was found. In this case
+you should assume that the molecule used in the experiment has some 
+residues for which no ATOM coordinates could be determined. 
+\verb+missing_residues+ maps to a list of dictionaries with information
+about the missing residues. \emph{The list of missing residues will be
+empty or incomplete if the PDB header does not follow the template from
+the PDB specification.}
 
 The dictionary can also be created without creating a \texttt{Structure}
 object, ie. directly from the PDB file:

--- a/Tests/test_PDB_parse_pdb_header.py
+++ b/Tests/test_PDB_parse_pdb_header.py
@@ -22,6 +22,7 @@ from Bio.PDB.parse_pdb_header import parse_pdb_header, _parse_remark_465
 
 class ParseReal(unittest.TestCase):
     """Testing with real PDB file(s)."""
+
     def test_parse_pdb_with_remark_465(self):
         """Tests that parse_pdb_header now can identify some REMARK 465 entries."""
         header = parse_pdb_header("PDB/2XHE.pdb")
@@ -35,16 +36,17 @@ class ParseReal(unittest.TestCase):
 
     def test_parse_remark_465(self):
         """A UNIT-test for the private function _parse_remark_465."""
-        out_d = {"has_missing_residues": False, "missing_residues": []}
-        _parse_remark_465("", out_d)
-        self.assertFalse(out_d["has_missing_residues"])
-        _parse_remark_465("GLU B   276", out_d)
-        self.assertTrue(out_d["has_missing_residues"])
-        self.assertEqual(len(out_d["missing_residues"]), 1)
-        out_d = {"has_missing_residues": False, "missing_residues": []}
-        _parse_remark_465("SOME OTHER TEXT THAT CAN'T BE PARSED WITH NUMBERS 1234", out_d)
-        self.assertTrue(out_d["has_missing_residues"])
-        self.assertEqual(out_d["missing_residues"], [])
+        info = _parse_remark_465("GLU B   276")
+        self.assertEqual(info, {"model": None, "res_name": "GLU",
+                                "chain": "B", "ssseq": 276, "insertion": None})
+
+        info = _parse_remark_465("2 GLU B   276B")
+        self.assertEqual(info, {"model": 2, "res_name": "GLU",
+                                "chain": "B", "ssseq": 276, "insertion": "B"})
+
+        info = _parse_remark_465("A 2    11")
+        self.assertEqual(info, {"model": None, "res_name": "A",
+                                "chain": "2", "ssseq": 11, "insertion": None})
 
 
 if __name__ == '__main__':

--- a/Tests/test_PDB_parse_pdb_header.py
+++ b/Tests/test_PDB_parse_pdb_header.py
@@ -1,0 +1,50 @@
+"""Unit tests for PARTS of the parse_pdb_header module of Bio.PDB"""
+
+import unittest
+import warnings
+
+try:
+    import numpy
+    from numpy import dot  # Missing on old PyPy's micronumpy
+    del dot
+    from numpy.linalg import svd, det  # Missing in PyPy 2.0 numpypy
+except ImportError:
+    from Bio import MissingPythonDependencyError
+    raise MissingPythonDependencyError(
+        "Install NumPy if you want to use Bio.PDB.")
+
+
+from Bio.PDB.parse_pdb_header import parse_pdb_header, _parse_remark_465
+
+
+class ParseReal(unittest.TestCase):
+    """Testing with real PDB file(s)."""
+    def test_parse_pdb_with_remark_465(self):
+        """
+        Tests that parse_pdb_header now can identify some REMARK 465 entries.
+        """
+        header = parse_pdb_header("PDB/2XHE.pdb")
+        self.assertTrue(header["has_missing_residues"])
+        self.assertEqual(len(header["missing_residues"]), 142)
+        self.assertIn( {"model":None, "res_name":"GLN", "chain":"B", "ssseq":267, "insertion":None}  , header["missing_residues"])
+        header = parse_pdb_header("PDB/1A8O.pdb")
+        self.assertFalse(header["has_missing_residues"])
+        self.assertEqual(header["missing_residues"], [])
+    def test_parse_remark_465(self):
+        "A UNIT-test for the private function _parse_remark_465"
+        out_d = {"has_missing_residues": False, "missing_residues": []}
+        _parse_remark_465("", out_d)
+        self.assertFalse(out_d["has_missing_residues"])
+        _parse_remark_465("GLU B   276", out_d)
+        self.assertTrue(out_d["has_missing_residues"])
+        self.assertEqual(len(out_d["missing_residues"]), 1)
+        out_d = {"has_missing_residues": False, "missing_residues": []}
+        _parse_remark_465("SOME OTHER TEXT THAT CAN'T BE PARSED WITH NUMBERS 1234", out_d)
+        self.assertTrue(out_d["has_missing_residues"])
+        self.assertEqual(out_d["missing_residues"], [])
+
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)

--- a/Tests/test_PDB_parse_pdb_header.py
+++ b/Tests/test_PDB_parse_pdb_header.py
@@ -1,18 +1,21 @@
+# Copyright 2017 by Bernhard Thiel.  All rights reserved.
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
+
 """Unit tests for PARTS of the parse_pdb_header module of Bio.PDB"""
+
 
 import unittest
 import warnings
 
 try:
     import numpy
-    from numpy import dot  # Missing on old PyPy's micronumpy
-    del dot
-    from numpy.linalg import svd, det  # Missing in PyPy 2.0 numpypy
 except ImportError:
     from Bio import MissingPythonDependencyError
     raise MissingPythonDependencyError(
         "Install NumPy if you want to use Bio.PDB.")
-
 
 from Bio.PDB.parse_pdb_header import parse_pdb_header, _parse_remark_465
 
@@ -20,18 +23,18 @@ from Bio.PDB.parse_pdb_header import parse_pdb_header, _parse_remark_465
 class ParseReal(unittest.TestCase):
     """Testing with real PDB file(s)."""
     def test_parse_pdb_with_remark_465(self):
-        """
-        Tests that parse_pdb_header now can identify some REMARK 465 entries.
-        """
+        """Tests that parse_pdb_header now can identify some REMARK 465 entries."""
         header = parse_pdb_header("PDB/2XHE.pdb")
         self.assertTrue(header["has_missing_residues"])
         self.assertEqual(len(header["missing_residues"]), 142)
-        self.assertIn( {"model":None, "res_name":"GLN", "chain":"B", "ssseq":267, "insertion":None}  , header["missing_residues"])
+        self.assertIn({"model": None, "res_name": "GLN", "chain": "B", "ssseq": 267, "insertion": None},
+                      header["missing_residues"])
         header = parse_pdb_header("PDB/1A8O.pdb")
         self.assertFalse(header["has_missing_residues"])
         self.assertEqual(header["missing_residues"], [])
+
     def test_parse_remark_465(self):
-        "A UNIT-test for the private function _parse_remark_465"
+        """A UNIT-test for the private function _parse_remark_465."""
         out_d = {"has_missing_residues": False, "missing_residues": []}
         _parse_remark_465("", out_d)
         self.assertFalse(out_d["has_missing_residues"])
@@ -42,7 +45,6 @@ class ParseReal(unittest.TestCase):
         _parse_remark_465("SOME OTHER TEXT THAT CAN'T BE PARSED WITH NUMBERS 1234", out_d)
         self.assertTrue(out_d["has_missing_residues"])
         self.assertEqual(out_d["missing_residues"], [])
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It can now parse certain REMARK 465 headers.

It can certainly detect the presence of this remark and
can parse the content of this remark, if it follows the
template in the pdb-specification.