### PR TITLE
Remove closure as default argument in QueryResult.__init__

### DIFF
--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -184,8 +184,7 @@ class QueryResult(_BaseSearchObject):
     # from this one
     _NON_STICKY_ATTRS = ('_items', '__alt_hit_ids', )
 
-    def __init__(self, hits=(), id=None,
-            hit_key_function=lambda hit: hit.id):
+    def __init__(self, hits=(), id=None, hit_key_function=None):
         """Initializes a QueryResult object.
 
         :param id: query sequence ID
@@ -198,7 +197,7 @@ class QueryResult(_BaseSearchObject):
         """
         # default values
         self._id = id
-        self._hit_key_function = hit_key_function
+        self._hit_key_function = hit_key_function or QueryResult._hit_key_func
         self._items = OrderedDict()
         self._description = None
         self.__alt_hit_ids = {}
@@ -761,6 +760,11 @@ class QueryResult(_BaseSearchObject):
             obj = self.__class__(sorted_hits, self.id, self._hit_key_function)
             self._transfer_attrs(obj)
             return obj
+
+    # Default function for hit_key_function argument in QueryResult.__init__
+    @staticmethod
+    def _hit_key_func(hit):
+        return hit.id
 
 
 # if not used as a module, run the doctest


### PR DESCRIPTION
Continuing from the #1241 , this PR adds a fix so that QueryResult can be pickled.

Things to still consider:
* Should we add pickle (de)serialization tests as well?
* Is making the default argument the class's staticmethod a good idea?