### PR TITLE
Expose 'blast_id' for SearchIO's blast-xml and make ID-mangling adjustable.

### DIFF
--- a/Bio/SearchIO/BlastIO/__init__.py
+++ b/Bio/SearchIO/BlastIO/__init__.py
@@ -156,10 +156,18 @@ The blast-xml parser is aware of these modifications and will attempt to extract
 the true sequence IDs out of the descriptions. So when accessing QueryResult or
 Hit objects, you will use the non-BLAST-generated IDs.
 
-Conversely, the blast-xml writer will try to concatenate the true sequence IDs
-with their descriptions and use the BLAST-generated IDs. This enables you to
-write BLAST XML files using SearchIO as if they were written by a real BLAST
-program.
+This behavior on the query IDs can be disabled using the 'use_raw_query_ids'
+parameter while the behavior on the hit IDs can be disabled using the
+'use_raw_hit_ids' parameter. Both are boolean values that can be supplied
+to SearchIO.read or SearchIO.parse, with the default values set to 'False'.
+
+In any case, the raw BLAST IDs can always be accessed using the query or hit
+object's 'blast_id' attribute.
+
+The blast-xml write function also accepts 'use_raw_query_ids' and
+'use_raw_hit_ids' parameters. However, note that the default values for the
+writer are set to 'True'. This is because the writer is meant to mimic native
+BLAST result as much as possible.
 
 
 blast-tab

--- a/Bio/SearchIO/BlastIO/blast_xml.py
+++ b/Bio/SearchIO/BlastIO/blast_xml.py
@@ -329,11 +329,11 @@ class BlastXmlParser(object):
                     if hit:
                         # need to keep track of hit IDs, since there could be duplicates,
                         if hit.id in key_list:
-                            warnings.warn("Adding hit with BLAST-generated ID "
-                                    "%r since hit ID %r is already present "
-                                    "in query %r. Your BLAST database may contain "
+                            warnings.warn("Renaming hit ID %r to a BLAST-generated ID "
+                                    "%r since the ID was already matched "
+                                    "by your query %r. Your BLAST database may contain "
                                     "duplicate entries." %
-                                    (hit.blast_id, hit.id, query_id), BiopythonParserWarning)
+                                    (hit.id, hit.blast_id, query_id), BiopythonParserWarning)
                             # fallback to Blast-generated IDs, if the ID is already present
                             # and restore the desc, too
                             hit.description = '%s %s' % (hit.id, hit.description)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -16,6 +16,12 @@ This release of Biopython supports Python 2.7, 3.3, 3.4, 3.5 and 3.6 (although
 support for Python 3.3 is deprecated). It has also been tested on PyPy v5.7,
 PyPy3.5 v5.7 beta, and Jython 2.7.
 
+Two new arguments for reading and writing blast-xml files have been added
+to the Bio.SearchIO functions (read/parse and write, respectively). They
+are 'use_raw_hit_ids' and 'use_raw_query_ids'. Check out the relevant
+SearchIO.BlastIO documentation for a complete description of what these
+arguments do.
+
 Bio.AlignIO now supports Mauve's eXtended Multi-FastA (XMFA) file format
 under the format name "mauve" (contributed by Eric Rasche).
 

--- a/Tests/test_SearchIO_blast_xml.py
+++ b/Tests/test_SearchIO_blast_xml.py
@@ -3177,8 +3177,31 @@ class BlastXmlSpecialCases(unittest.TestCase):
         # test the Hit IDs only, since this is a special case
         hit1 = qresult[0]
         hit2 = qresult[1]
+        self.assertEqual('gnl|BL_ORD_ID|18', hit1.blast_id)
         self.assertEqual('gi|347972582|ref|XM_309352.4|', hit1.id)
         self.assertEqual('Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds', hit1.description)
+        self.assertEqual('gnl|BL_ORD_ID|17', hit2.blast_id)
+        self.assertEqual('gnl|BL_ORD_ID|17', hit2.id)
+        self.assertEqual('gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds', hit2.description)
+
+    def test_xml_2226_blastn_006_use_raw_hit_ids(self):
+        xml_file = get_file('xml_2226_blastn_006.xml')
+        qresults = parse(xml_file, FMT, use_raw_hit_ids=True)
+
+        exp_warning = 0
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', BiopythonParserWarning)
+            qresult = next(qresults)
+            self.assertEqual(exp_warning, len(w), "Expected {0} warning(s), got"
+                    " {1}".format(exp_warning, len(w)))
+
+        # test the Hit IDs only, since this is a special case
+        hit1 = qresult[0]
+        hit2 = qresult[1]
+        self.assertEqual('gnl|BL_ORD_ID|18', hit1.blast_id)
+        self.assertEqual('gnl|BL_ORD_ID|18', hit1.id)
+        self.assertEqual('gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds', hit1.description)
+        self.assertEqual('gnl|BL_ORD_ID|17', hit2.blast_id)
         self.assertEqual('gnl|BL_ORD_ID|17', hit2.id)
         self.assertEqual('gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds', hit2.description)
 

--- a/Tests/test_SearchIO_blast_xml.py
+++ b/Tests/test_SearchIO_blast_xml.py
@@ -3174,7 +3174,7 @@ class BlastXmlSpecialCases(unittest.TestCase):
             self.assertEqual(exp_warning, len(w), "Expected {0} warning(s), got"
                     " {1}".format(exp_warning, len(w)))
 
-        # test the Hit IDs only, since this is a special case
+        self.assertEqual(qresult.blast_id, 'Query_1')
         hit1 = qresult[0]
         hit2 = qresult[1]
         self.assertEqual('gnl|BL_ORD_ID|18', hit1.blast_id)
@@ -3195,7 +3195,7 @@ class BlastXmlSpecialCases(unittest.TestCase):
             self.assertEqual(exp_warning, len(w), "Expected {0} warning(s), got"
                     " {1}".format(exp_warning, len(w)))
 
-        # test the Hit IDs only, since this is a special case
+        self.assertEqual(qresult.blast_id, 'Query_1')
         hit1 = qresult[0]
         hit2 = qresult[1]
         self.assertEqual('gnl|BL_ORD_ID|18', hit1.blast_id)
@@ -3204,6 +3204,21 @@ class BlastXmlSpecialCases(unittest.TestCase):
         self.assertEqual('gnl|BL_ORD_ID|17', hit2.blast_id)
         self.assertEqual('gnl|BL_ORD_ID|17', hit2.id)
         self.assertEqual('gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds', hit2.description)
+
+    def test_xml_2226_blastn_006_use_raw_query_ids(self):
+        xml_file = get_file('xml_2226_blastn_006.xml')
+        qresults = parse(xml_file, FMT, use_raw_query_ids=True)
+
+        exp_warning = 1
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always', BiopythonParserWarning)
+            qresult = next(qresults)
+            self.assertEqual(exp_warning, len(w), "Expected {0} warning(s), got"
+                    " {1}".format(exp_warning, len(w)))
+
+        self.assertEqual(qresult.id, 'Query_1')
+        self.assertEqual(qresult.description, 'gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds')
+        self.assertEqual(qresult.blast_id, 'Query_1')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Continuing from #795 , this PR does the following things:

* The raw BLAST IDs of the `QueryResult` and `Hit` objects are now public.
* Adds two keyword arguments to the `blast-xml` parser and writer: `use_raw_query_ids` and `use_raw_hit_ids`. They allow users to disable or enable the ID-mangling that SearchIO is doing (this was previously non-configurable). The default values are set so that no backwards-incompatible changes are produced.

The documentation has been updated accordingly as well.

As usual, I will merge this after the tests pass unless there are any objections.