### PR TITLE
Avoid blind exceptions and enforce this on TravisCI

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -91,6 +91,7 @@ whitelist_externals =
 deps =
     flake8
     flake8-docstrings
+    flake8-blind-except
     restructuredtext_lint
 commands =
     # These folders each have their own .flake8 file:

--- a/Bio/DocSQL.py
+++ b/Bio/DocSQL.py
@@ -36,7 +36,7 @@ warnings.warn("Bio.DocSQL is now deprecated will be removed in a "
 
 try:
     import MySQLdb
-except:
+except ImportError:
     raise MissingPythonDependencyError("Install MySQLdb if you want to use "
                                        "Bio.DocSQL.")
 

--- a/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
@@ -77,7 +77,7 @@ def page_sizes(size):
              }
     try:
         return sizes[size]
-    except:
+    except KeyError:
         raise ValueError("%s not in list of page sizes" % size)
 
 

--- a/Bio/Graphics/GenomeDiagram/_Colors.py
+++ b/Bio/Graphics/GenomeDiagram/_Colors.py
@@ -148,7 +148,7 @@ class ColorTranslator(object):
                         comment = ""
                     self._colorscheme[label] = (self.int255_color((red, green, blue)),
                                                  comment)
-                except:
+                except ValueError:
                     raise ValueError("Expected INT \t INT \t INT \t INT \t string input")
 
     def get_artemis_colorscheme(self):

--- a/Bio/Graphics/GenomeDiagram/_CrossLink.py
+++ b/Bio/Graphics/GenomeDiagram/_CrossLink.py
@@ -59,7 +59,7 @@ class CrossLink(object):
             track, start, end = self.featureA
             assert track in tracks
             return track
-        except Exception:  # TODO: ValueError?
+        except TypeError:
             for track in tracks:
                 for feature_set in track.get_sets():
                     if hasattr(feature_set, "features"):
@@ -90,7 +90,7 @@ class CrossLink(object):
             track, start, end = self.featureB
             assert track in tracks
             return track
-        except:
+        except TypeError:
             for track in tracks:
                 for feature_set in track.get_sets():
                     if hasattr(feature_set, "features"):

--- a/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
@@ -874,7 +874,7 @@ class LinearDrawer(AbstractDrawer):
             btm += self.fragment_lines[fragment][0]
             ctr += self.fragment_lines[fragment][0]
             top += self.fragment_lines[fragment][0]
-        except:     # Only called if the method screws up big time
+        except Exception:     # Only called if the method screws up big time
             print("We've got a screw-up")
             print("%s %s" % (self.start, self.end))
             print(self.fragment_bases)

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -1274,7 +1274,7 @@ class Nexus(object):
                             plain_list.append(start)
             except NexusError:
                 raise
-            except:
+            except Exception:  # FIXME - this seems unwise
                 return None
         return plain_list
 

--- a/Bio/Nexus/StandardData.py
+++ b/Bio/Nexus/StandardData.py
@@ -88,7 +88,7 @@ class StandardData(object):
     def __next__(self):
         try:
             return_coding = self._data[self._current_pos]
-        except:
+        except IndexError:
             self._current_pos = 0
             raise StopIteration
         else:

--- a/Bio/Nexus/Trees.py
+++ b/Bio/Nexus/Trees.py
@@ -364,7 +364,7 @@ class Tree(Nodes.Chain):
         else:
             try:
                 return frozenset(self.set_subtree(n) for n in self.node(node).succ)
-            except:
+            except Exception:
                 print(node)
                 print(self.node(node).succ)
                 for n in self.node(node).succ:
@@ -763,7 +763,7 @@ class Tree(Nodes.Chain):
                 succnodes = self.node(self.root).succ
                 smallest = min((len(self.get_taxa(n)), n) for n in succnodes)
                 outgroup = self.get_taxa(smallest[1])
-            except:
+            except Exception:
                 raise TreeError("Error determining outgroup.")
         else:  # root with user specified outgroup
             self.root_with_outgroup(outgroup)

--- a/Bio/PDB/HSExposure.py
+++ b/Bio/PDB/HSExposure.py
@@ -117,7 +117,7 @@ class _AbstractHSExposure(AbstractPropertyMap):
             n_v = residue["N"].get_vector()
             c_v = residue["C"].get_vector()
             ca_v = residue["CA"].get_vector()
-        except:
+        except Exception:
             return None
         # center at origin
         n_v = n_v - ca_v
@@ -171,7 +171,7 @@ class HSExposureCA(_AbstractHSExposure):
             ca1 = r1['CA'].get_vector()
             ca2 = r2['CA'].get_vector()
             ca3 = r3['CA'].get_vector()
-        except:
+        except Exception:
             return None
         # center
         d1 = ca2 - ca1

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -244,7 +244,7 @@ def _parse_pdb_header_list(header):
                 r = re.sub("\s+ANGSTROM.*", "", r)
                 try:
                     dict['resolution'] = float(r)
-                except:
+                except ValueError:
                     # print('nonstandard resolution %r' % r)
                     dict['resolution'] = None
         else:

--- a/Bio/Phylo/CDAOIO.py
+++ b/Bio/Phylo/CDAOIO.py
@@ -21,13 +21,15 @@ them to a file.
 
 from Bio._py3k import StringIO
 
+from Bio import MissingPythonDependencyError
+
 from Bio.Phylo import CDAO
 from ._cdao_owl import cdao_elements, cdao_namespaces, resolve_uri
 import os
 
 
 class CDAOError(Exception):
-    """Exception raised when CDAO object construction cannot continue."""
+    """Exception raised when CDAO object construction cannot continue (DEPRECATED)."""
 
     pass
 
@@ -36,10 +38,11 @@ try:
     import rdflib
     rdfver = rdflib.__version__
     if rdfver[0] in ["1", "2"] or (rdfver in ["3.0.0", "3.1.0", "3.2.0"]):
-        raise CDAOError(
+        raise MissingPythonDependencyError(
             'Support for CDAO tree format requires RDFlib v3.2.1 or later.')
 except ImportError:
-    raise CDAOError('Support for CDAO tree format requires RDFlib.')
+    raise MissingPythonDependencyError(
+        'Support for CDAO tree format requires RDFlib.')
 
 RDF_NAMESPACES = {
     'owl': 'http://www.w3.org/2002/07/owl#',

--- a/Bio/Phylo/PAML/_parse_yn00.py
+++ b/Bio/Phylo/PAML/_parse_yn00.py
@@ -133,7 +133,7 @@ def parse_others(lines, results, sequences):
                     value = stat_pair.split('=')[1].strip()
                     try:
                         stats[stat] = float(value)
-                    except:
+                    except ValueError:
                         stats[stat] = None
                 if "LWL85:" in line:
                     results[seq_name1][seq_name2]["LWL85"] = stats

--- a/Bio/Phylo/PAML/baseml.py
+++ b/Bio/Phylo/PAML/baseml.py
@@ -128,12 +128,12 @@ class Baseml(Paml):
                             if "." in value or "e-" in value:
                                 try:
                                     converted_value = float(value)
-                                except:
+                                except ValueError:
                                     converted_value = value
                             else:
                                 try:
                                     converted_value = int(value)
-                                except:
+                                except ValueError:
                                     converted_value = value
                             temp_options[option] = converted_value
         for option in self._options:

--- a/Bio/Phylo/PAML/codeml.py
+++ b/Bio/Phylo/PAML/codeml.py
@@ -120,7 +120,7 @@ class Codeml(Paml):
                             for n in range(len(site_classes)):
                                 try:
                                     site_classes[n] = int(site_classes[n])
-                                except:
+                                except ValueError:
                                     raise TypeError(
                                         "Invalid site class: %s" % site_classes[n])
                             temp_options["NSsites"] = site_classes
@@ -130,12 +130,12 @@ class Codeml(Paml):
                             if "." in value:
                                 try:
                                     converted_value = float(value)
-                                except:
+                                except ValueError:
                                     converted_value = value
                             else:
                                 try:
                                     converted_value = int(value)
-                                except:
+                                except ValueError:
                                     converted_value = value
                             temp_options[option] = converted_value
         for option in self._options:

--- a/Bio/Phylo/PAML/yn00.py
+++ b/Bio/Phylo/PAML/yn00.py
@@ -80,12 +80,12 @@ class Yn00(Paml):
                             if "." in value or "e-" in value:
                                 try:
                                     converted_value = float(value)
-                                except:
+                                except ValueError:
                                     converted_value = value
                             else:
                                 try:
                                     converted_value = int(value)
-                                except:
+                                except ValueError:
                                     converted_value = value
                             temp_options[option] = converted_value
         for option in self._options:

--- a/Bio/Phylo/PhyloXMLIO.py
+++ b/Bio/Phylo/PhyloXMLIO.py
@@ -145,7 +145,7 @@ def _split_namespace(tag):
     """Split a tag into namespace and local tag strings."""
     try:
         return tag[1:].split('}', 1)
-    except:
+    except ValueError:
         return ('', tag)
 
 

--- a/Bio/Phylo/_io.py
+++ b/Bio/Phylo/_io.py
@@ -29,7 +29,7 @@ supported_formats = {
 try:
     from Bio.Phylo import CDAOIO
     supported_formats['cdao'] = CDAOIO
-except:
+except ImportError:
     pass
 
 

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -74,7 +74,7 @@ def TabIterator(handle, alphabet=single_letter_alphabet):
     for line in handle:
         try:
             title, seq = line.split("\t")  # will fail if more than one tab!
-        except:
+        except ValueError:
             if line.strip() == "":
                 # It's a blank line, ignore it
                 continue

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -218,7 +218,7 @@ class SeqRecord(object):
                 try:
                     self._per_letter_annotations = \
                         _RestrictedDict(length=len(seq))
-                except:
+                except TypeError:
                     raise TypeError("seq argument should be a Seq object or similar")
         else:
             # This will be handled via the property set function, which will

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -445,8 +445,6 @@ def molecular_weight(seq, seq_type=None, double_stranded=False, circular=False,
     except KeyError as e:
         raise ValueError('%s is not a valid unambiguous letter for %s'
                          % (e, seq_type))
-    except:
-        raise
 
     if seq_type in ('DNA', 'RNA') and double_stranded:
         seq = str(Seq(seq).complement())

--- a/Bio/TogoWS/__init__.py
+++ b/Bio/TogoWS/__init__.py
@@ -265,11 +265,11 @@ def search(db, query, offset=None, limit=None, format=None):
     if offset is not None and limit is not None:
         try:
             offset = int(offset)
-        except:
+        except ValueError:
             raise ValueError("Offset should be an integer (at least one), not %r" % offset)
         try:
             limit = int(limit)
-        except:
+        except ValueError:
             raise ValueError("Limit should be an integer (at least one), not %r" % limit)
         if offset <= 0:
             raise ValueError("Offset should be at least one, not %i" % offset)

--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -1050,7 +1050,7 @@ def _ml(seq1, seq2, cmethod, codon_table):
                     else:
                         # nonsynonymous count
                         Nd += pi[c1] * Q[i, j]
-                except:
+                except KeyError:
                     # This is probably due to stop codons
                     pass
     Sd *= t
@@ -1073,7 +1073,7 @@ def _ml(seq1, seq2, cmethod, codon_table):
                     else:
                         # nonsynonymous count
                         rhoN += pi[c1] * Q[i, j]
-                except:
+                except KeyError:
                     # This is probably due to stop codons
                     pass
     rhoS *= 3

--- a/Bio/motifs/jaspar/db.py
+++ b/Bio/motifs/jaspar/db.py
@@ -69,7 +69,7 @@ from Bio import MissingPythonDependencyError
 
 try:
     import MySQLdb as mdb
-except:
+except ImportError:
     raise MissingPythonDependencyError("Install MySQLdb if you want to use "
                                        "Bio.motifs.jaspar.db")
 

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -1065,7 +1065,7 @@ class DatabaseLoader(object):
                 dbxref_data = value.replace(' ', '').replace('\n', '').split(':')
                 db = dbxref_data[0]
                 accessions = dbxref_data[1:]
-            except:
+            except Exception:
                 raise ValueError("Parsing of db_xref failed: '%s'" % value)
             # Loop over all the grabbed accessions, and attempt to fill the
             # table
@@ -1146,7 +1146,7 @@ class DatabaseLoader(object):
                 db, accession = value.split(':', 1)
                 db = db.strip()
                 accession = accession.strip()
-            except:
+            except Exception:
                 raise ValueError(
                     "Parsing of dbxrefs list failed: '%s'" % value)
             # Get the dbxref_id value for the dbxref data

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -33,6 +33,11 @@ Python 3.3
 Still suported but deprecated as of Release 1.67, triggering a warning
 at installation time.
 
+Bio.Phylo.CDAOIO.CDAOError
+==========================
+This exception was deprecated as of Release 1.70, and is no longer used
+within Biopython.
+
 Bio.PDB.Dice
 ============
 This was deprecated in Biopython 1.70, it was likely intended as an example

--- a/Doc/examples/getgene.py
+++ b/Doc/examples/getgene.py
@@ -77,7 +77,7 @@ class DB_Index(object):
                         db[id] = value
                         db[acc] = value
                         id, acc, start, stop = None, None, None, None
-                    except:
+                    except Exception:
                         print("AARRGGGG %d %d %s %s" %
                               (start, stop, type(start), type(stop)))
                         print("%s %s" % (id, acc))
@@ -98,7 +98,7 @@ class DB_Index(object):
     def Get(self, id):
         try:
             values = self.db[id]
-        except:
+        except Exception:
             return None
         start, stop = [int(x) for x in values.split()]
         self.fid.seek(start)
@@ -306,7 +306,7 @@ if __name__ == '__main__':
         try:
             db = sys.argv[1]
             ids = sys.argv[2:]
-        except:
+        except Exception:
             usage(exit=1)
 
     dbfile = os.path.join(pyphy_home, db + '.indexed')

--- a/Scripts/Restriction/rebase_update.py
+++ b/Scripts/Restriction/rebase_update.py
@@ -52,7 +52,7 @@ class RebaseUpdate(FancyURLopener):
         print('\n Please wait, trying to connect to Rebase\n')
         try:
             self.open(name)
-        except:
+        except Exception:
             raise ConnectionError('Rebase')
         return
 

--- a/Scripts/xbbtools/nextorf.py
+++ b/Scripts/xbbtools/nextorf.py
@@ -119,7 +119,7 @@ class NextOrf(object):
             try:
                 n = d['G'][i] + d['C'][i] + d['T'][i] + d['A'][i]
                 gc[i] = (d['G'][i] + d['C'][i]) * 100.0 / n
-            except:
+            except KeyError:
                 gc[i] = 0
 
             gcall = gcall + d['G'][i] + d['C'][i]

--- a/Scripts/xbbtools/xbb_blastbg.py
+++ b/Scripts/xbbtools/xbb_blastbg.py
@@ -97,7 +97,7 @@ class BlastDisplayer(object):
                 txt = fid.read()
                 self.tid.insert('end', txt)
                 self.tid.update()
-            except:
+            except Exception:
                 # text widget is detroyed, we assume the search
                 # has been cancelled
                 pass

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -182,7 +182,7 @@ def create_database():
         if os.path.exists(TESTDB):
             try:
                 os.remove(TESTDB)
-            except:
+            except Exception:
                 time.sleep(1)
                 try:
                     os.remove(TESTDB)
@@ -205,7 +205,7 @@ def create_database():
         server.load_database_sql(SQL_FILE)
         server.commit()
         server.close()
-    except:
+    except Exception:
         # Failed, but must close the handle...
         server.close()
         raise

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -501,7 +501,7 @@ class TestRunner(unittest.TextTestRunner):
             # Want to allow this, and abort the test
             # (see below for special case)
             raise err
-        except:
+        except:  # noqa: B901
             # This happens in Jython with java.lang.ClassFormatError:
             # Invalid method Code length ...
             sys.stderr.write("ERROR\n")

--- a/Tests/test_GraphicsBitmaps.py
+++ b/Tests/test_GraphicsBitmaps.py
@@ -23,14 +23,14 @@ try:
     # Skip the test if reportlab is not installed
     import reportlab as r
     del r
-except:
+except Exception:
     raise MissingPythonDependencyError(
         "Install ReportLab if you want to use Bio.Graphics.")
 try:
     # Skip the test if reportlab is not installed
     from reportlab.graphics import renderPM
     del renderPM
-except:
+except Exception:
     raise MissingPythonDependencyError(
         "Install ReportLab's renderPM module if you want to create "
         "bitmaps with Bio.Graphics.")
@@ -42,7 +42,7 @@ try:
     except ImportError:
         import Image as i
     del i
-except:
+except Exception:
     raise MissingPythonDependencyError(
         "Install Pillow or its predecessor PIL (Python Imaging Library) "
         "if you want to create bitmaps with Bio.Graphics.")

--- a/Tests/test_GraphicsChromosome.py
+++ b/Tests/test_GraphicsChromosome.py
@@ -26,7 +26,7 @@ from Bio import MissingPythonDependencyError
 try:
     # reportlab
     from reportlab.lib import colors
-except:
+except ImportError:
     raise MissingPythonDependencyError(
         "Install reportlab if you want to use Bio.Graphics.")
 

--- a/Tests/test_GraphicsDistribution.py
+++ b/Tests/test_GraphicsDistribution.py
@@ -18,7 +18,7 @@ from Bio import MissingExternalDependencyError
 try:
     import reportlab as r
     del r
-except:
+except ImportError:
     raise MissingExternalDependencyError(
         "Install reportlab if you want to use Bio.Graphics.")
 

--- a/Tests/test_GraphicsGeneral.py
+++ b/Tests/test_GraphicsGeneral.py
@@ -27,7 +27,7 @@ try:
     # Skip the test if reportlab is not installed
     import reportlab as r
     del r
-except:
+except ImportError:
     raise MissingExternalDependencyError(
         "Install reportlab if you want to use Bio.Graphics.")
 

--- a/Tests/test_NNGene.py
+++ b/Tests/test_NNGene.py
@@ -102,7 +102,7 @@ class PatternIOTest(unittest.TestCase):
             raise AssertionError("Did not report error on bad alphabet.")
         except ValueError:
             pass  # expected behavior
-        except:
+        except Exception:
             raise AssertionError("Got unexpected error while reading.")
         input_handle.close()
 

--- a/Tests/test_Phylo_CDAO.py
+++ b/Tests/test_Phylo_CDAO.py
@@ -16,7 +16,7 @@ import Bio.Phylo as bp
 from Bio.Phylo import CDAO
 try:
     from Bio.Phylo import CDAOIO
-except:
+except ImportError:
     raise MissingExternalDependencyError('Install RDFlib if you want to use the CDAO tree format.')
 
 # Example CDAO files


### PR DESCRIPTION
This pull request 'fixes' a lot of exception handling accross the code base, and expands our TravisCI style checks to include the ``flake8-blind-except`` add-on for ``flake8`` which adds a new error code:

```
B901 blind except: statement
```

https://github.com/elijahandrews/flake8-blind-except

In general I have defaulted to ``except Exception:`` which is still quite generic, but in places I have used ``except ImportError:``, ``except ValueError:`` or ``except KeyError`` where this looked appropriate.

Because it touches lots of files, I'd like extra eyes on this.

CC @lennax (thanks for flagging this on https://github.com/biopython/biopython/pull/1237#discussion_r117775370 during a pull request review)