### PR TITLE
Add CATHDB API support

### DIFF
--- a/Bio/cathdb/__init__.py
+++ b/Bio/cathdb/__init__.py
@@ -1,0 +1,60 @@
+"""Code to access CATHDB API.
+
+See http://www.cathdb.info
+
+
+Functions:
+    - by_funfhmmer : interface to search by sequence
+    - retrieve_results : interface to retrieve results
+    - check_progress : interface to check search task progress
+"""
+
+import json
+# Importing these functions with leading underscore as not intended for reuse
+from Bio._py3k import _as_bytes
+from Bio._py3k import Request as _request
+from Bio._py3k import urlopen as _urlopen
+from Bio._py3k import urlencode as _urlencode
+
+
+def _make_json_request(url, data=None):
+    """Make an application/json accepting request """
+    if data:
+        req = _request(url, _as_bytes(data), {'Accept': 'application/json'})
+    else:
+        req = _request(url, headers = {'Accept': 'application/json'})
+    return req
+
+def search_by_sequence(fasta, url='http://www.cathdb.info/search/by_funfhmmer'):
+    """Search CATH by sequence fasta"""
+    variables = {'fasta': fasta}
+    data = _urlencode(variables)
+    req = _make_json_request(url, data)
+    response = _urlopen(req)
+    try:
+        json_response = json.load(response)#.read())
+    except AttributeError as err:
+        raise ValueError('Error receiving json response from {}. Received response: {}'.format(url, response.read()))
+    return json_response['task_id']
+
+
+def check_progress(task_id, url='http://www.cathdb.info/search/by_funfhmmer/check'):
+    """Check the progress of search job."""
+    url = '{}/{}'.format(url, task_id)
+    response = _urlopen(_make_json_request(url))
+    try:
+        json_response = json.load(response)#.read())
+    except AttributeError as err:
+        raise ValueError('Error receiving json response from {}. Received response: {}'.format(url, response.read()))
+    return json_response
+
+def retrieve_results(task_id, url='http://www.cathdb.info/search/by_funfhmmer/results'):
+    """Retrieve the results of search job."""
+    url = '{}/{}'.format(url, task_id)
+    response = _urlopen(_make_json_request(url))
+    try:
+        json_response = json.load(response)#.read())
+    except AttributeError as err:
+        raise ValueError('Error receiving json response from {}. Received response: {}'.format(url, response.read()))
+    return json_response
+

--- a/Tests/test_cathdb.py
+++ b/Tests/test_cathdb.py
@@ -1,0 +1,46 @@
+"""Testing Bio.cathdb online code."""
+
+import time
+import unittest
+
+import requires_internet
+requires_internet.check()
+
+# We want to test these:
+
+from Bio.cathdb import check_progress
+from Bio.cathdb import retrieve_results
+from Bio.cathdb import search_by_sequence
+
+
+
+# TODO - Use with statement when drop Python 2
+
+class cathdbOnlineTests(unittest.TestCase):
+    """Test cathdb online resources."""
+
+    def setUp(self):
+        self.fasta = '''>tr|G4VGF5|G4VGF5_SCHMA
+        MCSHYAQRNNFSCGGYGFIDFVSEDAANEALQQIKETHPSFTIKFAKENEKDKTNLYVTN'''
+
+    def test_search(self):
+        task_id = search_by_sequence(self.fasta)
+        self.assertTrue(task_id)
+
+    def test_check_progress(self):
+        task_id = search_by_sequence(self.fasta)
+        progress_response = check_progress(task_id)
+        self.assertTrue(progress_response['message'])
+
+    def test_retrieve_results(self):
+        task_id = search_by_sequence(self.fasta)
+        progress_response = check_progress(task_id)
+        while progress_response['success'] != 1:
+            progress_response = check_progress(task_id)
+            time.sleep(2)
+        results = retrieve_results(task_id)
+        self.assertEqual(results['query_fasta'].strip(), self.fasta.strip().replace(' ',''))
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)

--- a/setup.py
+++ b/setup.py
@@ -327,6 +327,7 @@ PACKAGES = [
     'Bio.Alphabet',
     'Bio.Application',
     'Bio.Blast',
+    'Bio.cathdb',
     'Bio.CAPS',
     'Bio.codonalign',
     'Bio.Compass',


### PR DESCRIPTION
CATH database provides information on the evolutionary relationships of
protein domains with a publicly available API. This commit adds support
for accessing this API.