### PR TITLE
Fix typo in chapter_pdb.tex

### DIFF
--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -57,7 +57,7 @@ object, ie. directly from the PDB file:
 
 \subsection{Reading an mmCIF file}
 
-Similarly to the case the case of PDB files, first create an \texttt{MMCIFParser} object:
+Similarly to the case of PDB files, first create an \texttt{MMCIFParser} object:
 
 \begin{verbatim}
 >>> from Bio.PDB.MMCIFParser import MMCIFParser


### PR DESCRIPTION
The first sentence in subsection "Reading an mmCIF file" has a typo, "the case" is repeated.