### PR TITLE
Make a shallow copy of entities in PDBIO.set_structure

### DIFF
--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -123,12 +123,12 @@ class PDBIO(object):
             sb.init_seg(' ')
             # Build parts as necessary
             if pdb_object.level == "M":
-                sb.structure.add(pdb_object)
+                sb.structure.add(pdb_object.copy())
                 self.structure = sb.structure
             else:
                 sb.init_model(0)
                 if pdb_object.level == "C":
-                    sb.structure[0].add(pdb_object)
+                    sb.structure[0].add(pdb_object.copy())
                 else:
                     sb.init_chain('A')
                     if pdb_object.level == "R":
@@ -137,7 +137,7 @@ class PDBIO(object):
                             sb.structure[0]['A'].id = parent_id
                         except Exception:
                             pass
-                        sb.structure[0]['A'].add(pdb_object)
+                        sb.structure[0]['A'].add(pdb_object.copy())
                     else:
                         # Atom
                         sb.init_residue('DUM', ' ', 1, ' ')
@@ -146,7 +146,7 @@ class PDBIO(object):
                             sb.structure[0]['A'].id = parent_id
                         except Exception:
                             pass
-                        sb.structure[0]['A'].child_list[0].add(pdb_object)
+                        sb.structure[0]['A'].child_list[0].add(pdb_object.copy())
 
             # Return structure
             structure = sb.structure

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -874,8 +874,11 @@ class WriteTest(unittest.TestCase):
         """Write a full structure using PDBIO."""
         io = PDBIO()
         struct1 = self.structure
+        # Ensure that set_structure doesn't alter parent
+        parent = struct1.parent
         # Write full model to temp file
         io.set_structure(struct1)
+        self.assertIs(parent, struct1.parent)
         filenumber, filename = tempfile.mkstemp()
         os.close(filenumber)
         try:
@@ -892,8 +895,11 @@ class WriteTest(unittest.TestCase):
         io = PDBIO()
         struct1 = self.structure
         residue1 = list(struct1.get_residues())[0]
+        # Ensure that set_structure doesn't alter parent
+        parent = residue1.parent
         # Write full model to temp file
         io.set_structure(residue1)
+        self.assertIs(parent, residue1.parent)
         filenumber, filename = tempfile.mkstemp()
         os.close(filenumber)
         try:
@@ -912,8 +918,11 @@ class WriteTest(unittest.TestCase):
         atm = Atom.Atom('CA', [0.1, 0.1, 0.1], 1.0, 1.0, ' ', 'CA', 1, 'C')
         res.add(atm)
 
+        # Ensure that set_structure doesn't alter parent
+        parent = res.parent
         # Write full model to temp file
         io.set_structure(res)
+        self.assertIs(parent, res.parent)
         filenumber, filename = tempfile.mkstemp()
         os.close(filenumber)
         try:
@@ -939,8 +948,11 @@ class WriteTest(unittest.TestCase):
 
         io = PDBIO()
         struct1 = self.structure
+        # Ensure that set_structure doesn't alter parent
+        parent = struct1.parent
         # Write to temp file
         io.set_structure(struct1)
+        self.assertIs(parent, struct1.parent)
         filenumber, filename = tempfile.mkstemp()
         os.close(filenumber)
         try:


### PR DESCRIPTION
Fixes #1270 by doing a shallow copy before adding  an entity to a dummy structure for writing. I added a couple of tests to test the parent of each entity isn't affected when calling `set_structure`.