### PR TITLE
Fixed newick format writer: node labels should not be separated by colon.

### DIFF
--- a/Bio/Phylo/NewickIO.py
+++ b/Bio/Phylo/NewickIO.py
@@ -333,7 +333,7 @@ class Writer(object):
                     return (':' + format_branch_length
                             ) % (clade.branch_length or 0.0) + _get_comment(clade)
                 else:
-                    return (':' + format_confidence + ':' + format_branch_length
+                    return (format_confidence + ':' + format_branch_length
                             ) % (clade.confidence, clade.branch_length or 0.0) + _get_comment(clade)
 
         return make_info_string


### PR DESCRIPTION
As per @peterjc [request](https://github.com/biopython/biopython/pull/722#issuecomment-299436002), opening another PR for newick fix.

**Additional info:** 
In newick, confidence is stored as a label of an internal node.
But:

> For example, interior nodes can have names in that standard. These names follow the right parenthesis for that interior node, as in this example:
> (B:6.0,(A:5.0,C:3.0,E:4.0)Ancestor1:5.0,D:11.0);

[from here](http://evolution.genetics.washington.edu/phylip/newicktree.html)

So no need for a colon before a label or a confidence value.