### PR TITLE
Change Enzyme __str__ to use new-lines not spaces.

### DIFF
--- a/Bio/ExPASy/Enzyme.py
+++ b/Bio/ExPASy/Enzyme.py
@@ -92,15 +92,15 @@ class Record(dict):
             return "%s ( )" % (self.__class__.__name__)
 
     def __str__(self):
-        output = "ID: " + self["ID"]
-        output += " DE: " + self["DE"]
-        output += " AN: " + repr(self["AN"])
-        output += " CA: '" + self["CA"] + "'"
-        output += " CF: " + self["CF"]
-        output += " CC: " + repr(self["CC"])
-        output += " PR: " + repr(self["PR"])
-        output += " DR: %d Records" % len(self["DR"])
-        return output
+        output = ["ID: " + self["ID"],
+                  "DE: " + self["DE"],
+                  "AN: " + repr(self["AN"]),
+                  "CA: '" + self["CA"] + "'",
+                  "CF: " + self["CF"],
+                  "CC: " + repr(self["CC"]),
+                  "PR: " + repr(self["PR"]),
+                  "DR: %d Records" % len(self["DR"])]
+        return "\n".join(output)
 
 # Everything below is private
 

--- a/Tests/test_Enzyme.py
+++ b/Tests/test_Enzyme.py
@@ -77,7 +77,7 @@ class TestEnzyme(unittest.TestCase):
         self.assertEqual(record["CC"], ["Also acts on L-leucine."])
         self.assertEqual(len(record["DR"]), 0)
         self.assertTrue(str(record).startswith("ID: 4.1.1.14\nDE: Valine decarboxylase.\n"),
-                        "Did not expect:\n%s" %record)
+                        "Did not expect:\n%s" % record)
 
     def test_lactate(self):
         """Parsing ENZYME record for lactate racemase (5.1.2.1)"""
@@ -94,7 +94,7 @@ class TestEnzyme(unittest.TestCase):
         self.assertEqual(record["CA"], "(S)-lactate = (R)-lactate.")
         self.assertEqual(len(record["DR"]), 0)
         self.assertTrue(str(record).startswith("ID: 5.1.2.1\nDE: Lactate racemase.\n"),
-                        "Did not expect:\n%s" %record)
+                        "Did not expect:\n%s" % record)
 
 
 if __name__ == "__main__":

--- a/Tests/test_Enzyme.py
+++ b/Tests/test_Enzyme.py
@@ -39,6 +39,8 @@ class TestEnzyme(unittest.TestCase):
         self.assertEqual(record["DR"][8], ["P49923", "LIPL_PIG"])
         self.assertEqual(record["DR"][9], ["Q06000", "LIPL_RAT"])
         self.assertEqual(record["DR"][10], ["Q29524", "LIPL_SHEEP"])
+        self.assertTrue(str(record).startswith("ID: 3.1.1.34\nDE: Lipoprotein lipase.\n"),
+                        "Did not expect:\n%s" % record)
 
     def test_proline(self):
         """Parsing ENZYME record for proline racemase (5.1.1.4)"""
@@ -59,6 +61,8 @@ class TestEnzyme(unittest.TestCase):
         self.assertEqual(record["DR"][6], ["Q9CXA2", "PRCM_MOUSE"])
         self.assertEqual(record["DR"][7], ["Q5RC28", "PRCM_PONAB"])
         self.assertEqual(record["DR"][8], ["Q66II5", "PRCM_XENTR"])
+        self.assertTrue(str(record).startswith("ID: 5.1.1.4\nDE: Proline racemase.\n"),
+                        "Did not expect:\n%s" % record)
 
     def test_valine(self):
         """Parsing ENZYME record for valine decarboxylase (4.1.1.14)"""
@@ -72,6 +76,8 @@ class TestEnzyme(unittest.TestCase):
         self.assertEqual(record["CF"], "Pyridoxal 5'-phosphate.")
         self.assertEqual(record["CC"], ["Also acts on L-leucine."])
         self.assertEqual(len(record["DR"]), 0)
+        self.assertTrue(str(record).startswith("ID: 4.1.1.14\nDE: Valine decarboxylase.\n"),
+                        "Did not expect:\n%s" %record)
 
     def test_lactate(self):
         """Parsing ENZYME record for lactate racemase (5.1.2.1)"""
@@ -87,6 +93,8 @@ class TestEnzyme(unittest.TestCase):
         self.assertEqual(record["AN"][2], "Lacticoracemase.")
         self.assertEqual(record["CA"], "(S)-lactate = (R)-lactate.")
         self.assertEqual(len(record["DR"]), 0)
+        self.assertTrue(str(record).startswith("ID: 5.1.2.1\nDE: Lactate racemase.\n"),
+                        "Did not expect:\n%s" %record)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
By using new-lines, the string output closely resembles the raw file format.

Includes test for the modified __str__ method.

(I spotted this will looking at gaps in our test coverage)