### PR TITLE
Do not append additional periods to GenBank DEFINITION field

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -834,7 +834,7 @@ class GenBankWriter(_InsdcWriter):
         # see ftp://ftp.ncbi.nih.gov/genbank/gbrel.txt [3.4.5]
         # and discussion https://github.com/biopython/biopython/pull/616
         # So let's add a period
-        descr += '.' if descr[-1] != "." else ""
+        descr += '.' if descr and descr[-1] != "." else ""
         self._write_multi_line("DEFINITION", descr)
 
         self._write_single_line("ACCESSION", accession)

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -834,7 +834,7 @@ class GenBankWriter(_InsdcWriter):
         # see ftp://ftp.ncbi.nih.gov/genbank/gbrel.txt [3.4.5]
         # and discussion https://github.com/biopython/biopython/pull/616
         # So let's add a period
-        descr += '.'
+        descr += '.' if descr[-1] != "." else ""
         self._write_multi_line("DEFINITION", descr)
 
         self._write_single_line("ACCESSION", accession)


### PR DESCRIPTION
Currently, if converting from FASTA format where a period already exists
 in the def line, an additional period is appended.