### PR TITLE
Python 3 compatible sorting of atoms in PDB Residues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,14 @@ cache: pip
 matrix:
   include:
     - stage: basics
+      python: 2.7
+      env: TOXENV=style
+      addons:
+        apt:
+          packages:
+      before_install: echo "Going to run basic checks"
+    - stage: basics
+      python: 3.6
       env: TOXENV=style
       addons:
         apt:

--- a/Bio/PDB/Chain.py
+++ b/Bio/PDB/Chain.py
@@ -13,30 +13,6 @@ class Chain(Entity):
         self.level = "C"
         Entity.__init__(self, id)
 
-    # Private methods
-
-    def _sort(self, r1, r2):
-        """Sort function for residues in a chain (PRIVATE).
-
-        Residues are first sorted according to their hetatm records.
-        Protein and nucleic acid residues first, hetatm residues next,
-        and waters last. Within each group, the residues are sorted according
-        to their resseq's (sequence identifiers). Finally, residues with the
-        same resseq's are sorted according to icode.
-
-        Arguments:
-
-        - r1, r2 - Residue objects
-
-        """
-        hetflag1, resseq1, icode1 = r1.id
-        hetflag2, resseq2, icode2 = r2.id
-        if hetflag1 != hetflag2:
-            return cmp(hetflag1[0], hetflag2[0])
-        elif resseq1 != resseq2:
-            return cmp(resseq1, resseq2)
-        return cmp(icode1, icode2)
-
     def _translate_id(self, id):
         """Translate sequence identifer to tuple form (PRIVATE).
 
@@ -55,8 +31,6 @@ class Chain(Entity):
         if isinstance(id, int):
             id = (' ', id, ' ')
         return id
-
-    # Special methods
 
     def __getitem__(self, id):
         """Return the residue with given id.

--- a/Bio/PDB/Model.py
+++ b/Bio/PDB/Model.py
@@ -31,34 +31,8 @@ class Model(Entity):
 
         Entity.__init__(self, id)
 
-    # Private methods
-
-    def _sort(self, c1, c2):
-        """Sort the Chains instances in the Model instance.
-
-        Chain instances are sorted alphabetically according to
-        their chain id. Blank chains come last, as they often consist
-        of waters.
-
-        Arguments:
-         - c1, c2 - Chain objects
-
-        """
-        id1 = c1.get_id()
-        id2 = c2.get_id()
-        # make sure blank chains come last (often waters)
-        if id1 == " " and not id2 == " ":
-            return 1
-        elif id2 == " " and not id1 == " ":
-            return -1
-        return cmp(id1, id2)
-
-    # Special methods
-
     def __repr__(self):
         return "<Model id=%s>" % self.get_id()
-
-    # Public
 
     def get_chains(self):
         for c in self:

--- a/Bio/PDB/Residue.py
+++ b/Bio/PDB/Residue.py
@@ -29,47 +29,11 @@ class Residue(Entity):
         self.segid = segid
         Entity.__init__(self, id)
 
-    # Special methods
-
     def __repr__(self):
         resname = self.get_resname()
         hetflag, resseq, icode = self.get_id()
         full_id = (resname, hetflag, resseq, icode)
         return "<Residue %s het=%s resseq=%s icode=%s>" % full_id
-
-    # Private methods
-
-    def _sort(self, a1, a2):
-        """Sort the Atom objects.
-
-        Atoms are sorted alphabetically according to their name,
-        but N, CA, C, O always come first.
-
-        Arguments:
-         - a1, a2 - Atom objects
-
-        """
-        name1 = a1.get_name()
-        name2 = a2.get_name()
-        if name1 == name2:
-            return cmp(a1.get_altloc(), a2.get_altloc())
-        if name1 in _atom_name_dict:
-            index1 = _atom_name_dict[name1]
-        else:
-            index1 = None
-        if name2 in _atom_name_dict:
-            index2 = _atom_name_dict[name2]
-        else:
-            index2 = None
-        if index1 and index2:
-            return cmp(index1, index2)
-        if index1:
-            return -1
-        if index2:
-            return 1
-        return cmp(name1, name2)
-
-    # Public methods
 
     def add(self, atom):
         """Add an Atom object.

--- a/Bio/PDB/Residue.py
+++ b/Bio/PDB/Residue.py
@@ -84,7 +84,25 @@ class Residue(Entity):
         Entity.add(self, atom)
 
     def sort(self):
-        self.child_list.sort(self._sort)
+        """Sort child atoms.
+
+        Atoms N, CA, C, O always come first, thereafter alphabetically
+        by name, with any alternative location specifier for disordered
+        atoms (altloc) as a tie-breaker.
+        """
+        # Defining sort key function within the sort method's scope:
+        def sort_index(atom):
+            """Build tuple of (int, name, alt-loc) for sorting.
+
+            The first integer is 0, 1, 2, 3, 4 for atoms N, CA, C, O, other.
+            """
+            try:
+                i = ["N", "CA", "C", "O"].index(atom.name)
+            except ValueError:
+                i = 4
+            return (i, atom.name, atom.altloc)
+
+        self.child_list.sort(key=sort_index)
 
     def flag_disordered(self):
         """Set the disordered flag."""

--- a/Bio/PDB/Structure.py
+++ b/Bio/PDB/Structure.py
@@ -15,27 +15,8 @@ class Structure(Entity):
         self.level = "S"
         Entity.__init__(self, id)
 
-    # Special methods
-
     def __repr__(self):
         return "<Structure id=%s>" % self.get_id()
-
-    # Private methods
-
-    def _sort(self, m1, m2):
-        """Sort models.
-
-        This sorting function sorts the Model instances in the Structure instance.
-        The sorting is done based on the model id, which is a simple int that
-        reflects the order of the models in the PDB file.
-
-        Arguments:
-         - m1, m2 - Model instances
-
-        """
-        return cmp(m1.get_id(), m2.get_id())
-
-    # Public
 
     def get_models(self):
         for m in self:


### PR DESCRIPTION
This should close #1189, Bio.PDB sorting not tested and Python 2 only.

Note this removes the (apparently unused) private ``._sort()`` methods of all the objects, and updates the only public ``.sort()`` method which is on the ``Residue`` object - for which I have added a test.

We could define (Python 3 compatible) public ``.sort()`` methods for the ``Chain``, ``Model`` and ``Structure`` based on the existing Python 2 only private sort methods - but are they useful?