### PR TITLE
Use setuptools in place of distutils

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -116,7 +116,6 @@ commands =
 skip_install = True
 deps =
 commands =
-    python setup.py sdist --manifest-only
     python setup.py sdist --formats=gztar,zip
 
 [testenv:bdist_wheel]

--- a/setup.py
+++ b/setup.py
@@ -499,6 +499,28 @@ setup_args = {
     "description": 'Freely available tools for computational molecular biology.',
     "long_description": readme_rst,
     "download_url": 'http://biopython.org/DIST/',
+    "classifiers": [
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'License :: Freely Distributable',
+        # Technically the "Biopython License Agreement" is not OSI approved,
+        # but is almost https://opensource.org/licenses/HPND so might put:
+        # 'License :: OSI Approved',
+        # To resolve this we are moving to dual-licensing with 3-clause BSD:
+        # 'License :: OSI Approved :: BSD License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Scientific/Engineering :: Bio-Informatics',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+    ],
     "cmdclass": {
         "install": install_biopython,
         "build_py": build_py_biopython,

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,21 @@
-"""Distutils based setup script for Biopython.
+"""setuptools based setup script for Biopython.
 
-This uses Distutils (http://python.org/sigs/distutils-sig/) the standard
-python mechanism for installing packages. For the easiest installation
-just type the command:
+This uses setuptools which is now the standard python mechanism for
+installing packages. If you have downloaded and uncompressed the
+Biopython source code, or fetched it from git, for the simplest
+installation just type the command::
 
-python setup.py install
+    python setup.py install
+
+However, you would normally install the latest Biopython release from
+the PyPI archive with::
+
+    pip install biopython
 
 For more in-depth instructions, see the installation section of the
 Biopython manual, linked to from:
 
 http://biopython.org/wiki/Documentation
-
-Or for more details about the options available from distutils, look at
-the 'Installing Python Modules' distutils documentation, available from:
-
-http://python.org/sigs/distutils-sig/doc/
 
 Or, if all else fails, feel free to write to the sign up to the Biopython
 mailing list and ask for help.  See:
@@ -27,28 +28,21 @@ import sys
 import os
 import shutil
 
-if "bdist_wheel" in sys.argv:
-    try:
-        import setuptools
-        import wheel
-    except ImportError:
-        sys.exit("We need both setuptools AND wheel packages installed for bdist_wheel to work")
-    # Import specific bits of setuptools ...
+try:
     from setuptools import setup
     from setuptools import Command
     from setuptools.command.install import install
     from setuptools.command.build_py import build_py
     from setuptools.command.build_ext import build_ext
     from setuptools import Extension
-else:
-    # Except for wheels, stick with standard library's distutils
-    from distutils.core import setup
-    from distutils.core import Command
-    from distutils.command.install import install
-    from distutils.command.build_py import build_py
-    from distutils.command.build_ext import build_ext
-    from distutils.extension import Extension
+except ImportError:
+    sys.exit("We need the Python library setuptools to be installed. Try runnning: python -m ensurepip")
 
+if "bdist_wheel" in sys.argv:
+    try:
+        import wheel
+    except ImportError:
+        sys.exit("We need both setuptools AND wheel packages installed for bdist_wheel to work. Try running: pip install wheel")
 
 _CHECKED = None
 


### PR DESCRIPTION
This would close #1183.

It does add classifiers to ``setup.py``, but otherwise does not attempt to make any changes to the installation process. I am deliberately being cautious here for Biopython 1.70, and if that throws up no issues we can move forward with further modernisations to the ``setup.py`` file.