### PR TITLE
Ignore leading spaces in value

### DIFF
--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -299,7 +299,10 @@ class InsdcScanner(object):
                     # New qualifier
                     i = line.find("=")
                     key = line[1:i]  # does not work if i==-1
-                    value = line[i + 1:].lstrip()  # we ignore 'value' if i==-1
+                    value = line[i + 1:]  # we ignore 'value' if i==-1
+                    if i and value.startswith(' ') and value.lstrip().startswith('"'):
+                        warnings.warn("White space after equals in qualifier", BiopythonParserWarning)
+                        value = value.lstrip()
                     if i == -1:
                         # Qualifier with no key, e.g. /pseudo
                         key = line[1:]

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -299,7 +299,7 @@ class InsdcScanner(object):
                     # New qualifier
                     i = line.find("=")
                     key = line[1:i]  # does not work if i==-1
-                    value = line[i + 1:]  # we ignore 'value' if i==-1
+                    value = line[i + 1:].lstrip()  # we ignore 'value' if i==-1
                     if i == -1:
                         # Qualifier with no key, e.g. /pseudo
                         key = line[1:]


### PR DESCRIPTION
Fixes parsing of quoted, multi-line qualifier values in GenBank feature tables. The following would previously raise `ValueError: Problem with 'CDS' feature:[...]` because the quote in the `/property` qualifier was not properly detected:

```
FH   Key             Location/Qualifiers
FT   CDS             1..756
FT                   /*tag=  a
FT                   /product= "Lactobacillus kefir T76I/V95M/S96L/E145A/F147L
FT                   /V148I/T152A/L153M/Y190G/A202F/M206C/Y249F mutant
FT                   ketoreductase (KRED) protein"
FT                   /partial
FT                   /note= "No stop codon is shown"
```