### PR TITLE
Adding '.count_overlap()' method to Seq.py

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -431,7 +431,7 @@ class Seq(object):
         # If it has one, check the alphabet:
         sub_str = self._get_seq_str_and_check_alphabet(sub)
         return str(self).count(sub_str, start, end)
-    
+
     def count_overlap(self, sub, start=0, end=sys.maxsize):
         """Return an overlapping count.
 
@@ -1467,7 +1467,7 @@ class UnknownSeq(Seq):
         count() method is much for efficient.
         """
         # The implementation is currently identical to that of
-        # Seq.count_overlap() 
+        # Seq.count_overlap()
         sub_str = self._get_seq_str_and_check_alphabet(sub)
         self = str(self)
         overlap_count = 0

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1461,6 +1461,14 @@ class UnknownSeq(Seq):
         3
         >>> UnknownSeq(4, character="N").count_overlap("NNN")
         2
+        >>> UnknownSeq(7, character="N").count_overlap("NN")
+        6
+        >>> UnknownSeq(7, character="N").count_overlap("NNN")
+        5
+        >>> UnknownSeq(7, character="N").count_overlap("NN", 1, 5)
+        3
+        >>> UnknownSeq(7, character="N").count_overlap("NN", -5, -1)
+        3
 
         Where substrings do not overlap, should behave the same as
         the count() method:
@@ -1481,17 +1489,32 @@ class UnknownSeq(Seq):
         HOWEVER, do not use this method for such cases because the
         count() method is much for efficient.
         """
-        # The implementation is currently identical to that of
-        # Seq.count_overlap()
         sub_str = self._get_seq_str_and_check_alphabet(sub)
-        self = str(self)
-        overlap_count = 0
-        while True:
-            start = self.find(sub_str, start, end) + 1
-            if start != 0:
-                overlap_count += 1
+        if len(sub_str) == 1:
+            if str(sub_str) == self._character:
+                if start == 0 and end >= self._length:
+                    return self._length
+                else:
+                    # This could be done more cleverly...
+                    return str(self).count(sub_str, start, end)
             else:
-                return overlap_count
+                return 0
+        else:
+            if set(sub_str) == set(self._character):
+                if start == 0 and end >= self._length:
+                    return self._length - len(sub_str) + 1
+                else:
+                    # This could be done more cleverly...
+                    self = str(self)
+                    overlap_count = 0
+                    while True:
+                        start = self.find(sub_str, start, end) + 1
+                        if start != 0:
+                            overlap_count += 1
+                        else:
+                            return overlap_count
+            else:
+                return 0
 
     def complement(self):
         """Return the complement of an unknown nucleotide equals itself.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -484,10 +484,10 @@ class Seq(object):
         count() method is much for efficient.
         """
         sub_str = self._get_seq_str_and_check_alphabet(sub)
-        self = str(self)
+        self_str = str(self)
         overlap_count = 0
         while True:
-            start = self.find(sub_str, start, end) + 1
+            start = self_str.find(sub_str, start, end) + 1
             if start != 0:
                 overlap_count += 1
             else:
@@ -1485,9 +1485,6 @@ class UnknownSeq(Seq):
         0
         >>> UnknownSeq(4, character="N").count_overlap("AA") == UnknownSeq(4, character="N").count("AA")
         True
-
-        HOWEVER, do not use this method for such cases because the
-        count() method is much for efficient.
         """
         sub_str = self._get_seq_str_and_check_alphabet(sub)
         if len(sub_str) == 1:
@@ -1505,10 +1502,10 @@ class UnknownSeq(Seq):
                     return self._length - len(sub_str) + 1
                 else:
                     # This could be done more cleverly...
-                    self = str(self)
+                    self_str = str(self)
                     overlap_count = 0
                     while True:
-                        start = self.find(sub_str, start, end) + 1
+                        start = self_str.find(sub_str, start, end) + 1
                         if start != 0:
                             overlap_count += 1
                         else:

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1457,7 +1457,7 @@ class UnknownSeq(Seq):
 
         e.g.
 
-        >>> from Bio.Seq import UnknownSeq 
+        >>> from Bio.Seq import UnknownSeq
         >>> UnknownSeq(4, character="N").count_overlap("NN")
         3
         >>> UnknownSeq(4, character="N").count_overlap("NNN")

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -392,6 +392,8 @@ class Seq(object):
         This behaves like the python string method of the same name,
         which does a non-overlapping count!
 
+        For an overlapping search use the newer count_overlap() method.
+
         Returns an integer, the number of occurrences of substring
         argument sub in the (sub)sequence given by [start:end].
         Optional arguments start and end are interpreted as in slice
@@ -429,6 +431,58 @@ class Seq(object):
         # If it has one, check the alphabet:
         sub_str = self._get_seq_str_and_check_alphabet(sub)
         return str(self).count(sub_str, start, end)
+    
+    def count_overlap(self, sub, start=0, end=sys.maxsize):
+        """Return an overlapping count.
+
+        For a non-overlapping search use the count() method.
+
+        Returns an integer, the number of occurrences of substring
+        argument sub in the (sub)sequence given by [start:end].
+        Optional arguments start and end are interpreted as in slice
+        notation.
+
+        Arguments:
+         - sub - a string or another Seq object to look for
+         - start - optional integer, slice start
+         - end - optional integer, slice end
+
+        e.g.
+
+        >>> from Bio.Seq import Seq
+        >>> print(Seq("AAAA").count_overlap("AA"))
+        3
+        >>> print(Seq("ATATATATA").count_overlap("ATA"))
+        4
+        >>> print(Seq("ATATATATA").count_overlap("ATA", 3, -1))
+        1
+
+        Where substrings do not overlap, should behave the same as
+        the count() method:
+
+        >>> from Bio.Seq import Seq
+        >>> my_seq = Seq("AAAATGA")
+        >>> print(my_seq.count_overlap("A"))
+        5
+        >>> print(my_seq.count_overlap("ATG"))
+        1
+        >>> print(my_seq.count_overlap(Seq("AT")))
+        1
+        >>> print(my_seq.count_overlap("AT", 2, -1))
+        1
+
+        HOWEVER, do not use this method for such cases because the
+        count() method is much for efficient.
+        """
+        sub_str = self._get_seq_str_and_check_alphabet(sub)
+        self = str(self)
+        overlap_count = 0
+        while True:
+            start = self.find(sub_str, start, end) + 1
+            if start != 0:
+                overlap_count += 1
+            else:
+                return overlap_count
 
     def __contains__(self, char):
         """Implement the 'in' keyword, like a python string.
@@ -1325,6 +1379,8 @@ class UnknownSeq(Seq):
         This behaves like the python string (and Seq object) method of the
         same name, which does a non-overlapping count!
 
+        For an overlapping search use the newer count_overlap() method.
+
         Returns an integer, the number of occurrences of substring
         argument sub in the (sub)sequence given by [start:end].
         Optional arguments start and end are interpreted as in slice
@@ -1374,6 +1430,53 @@ class UnknownSeq(Seq):
                     return str(self).count(sub_str, start, end)
             else:
                 return 0
+
+    def count_overlap(self, sub, start=0, end=sys.maxsize):
+        """Return an overlapping count.
+
+        For a non-overlapping search use the count() method.
+
+        Returns an integer, the number of occurrences of substring
+        argument sub in the (sub)sequence given by [start:end].
+        Optional arguments start and end are interpreted as in slice
+        notation.
+
+        Arguments:
+         - sub - a string or another Seq object to look for
+         - start - optional integer, slice start
+         - end - optional integer, slice end
+
+        e.g.
+
+        >>> UnknownSeq(4, character="N").count_overlap("NN")
+        3
+        >>> UnknownSeq(4, character="N").count_overlap("NNN")
+        2
+
+        Where substrings do not overlap, should behave the same as
+        the count() method:
+
+        >>> UnknownSeq(4, character="N").count_overlap("N")
+        4
+        >>> UnknownSeq(4, character="N").count_overlap("A")
+        0
+        >>> UnknownSeq(4, character="N").count_overlap("AA")
+        0
+
+        HOWEVER, do not use this method for such cases because the
+        count() method is much for efficient.
+        """
+        # The implementation is currently identical to that of
+        # Seq.count_overlap() 
+        sub_str = self._get_seq_str_and_check_alphabet(sub)
+        self = str(self)
+        overlap_count = 0
+        while True:
+            start = self.find(sub_str, start, end) + 1
+            if start != 0:
+                overlap_count += 1
+            else:
+                return overlap_count
 
     def complement(self):
         """Return the complement of an unknown nucleotide equals itself.
@@ -1816,6 +1919,8 @@ class MutableSeq(object):
         This behaves like the python string method of the same name,
         which does a non-overlapping count!
 
+        For an overlapping search use the newer count_overlap() method.
+
         Returns an integer, the number of occurrences of substring
         argument sub in the (sub)sequence given by [start:end].
         Optional arguments start and end are interpreted as in slice
@@ -1869,6 +1974,60 @@ class MutableSeq(object):
         else:
             # TODO - Can we do this more efficiently?
             return str(self).count(search, start, end)
+
+    def count_overlap(self, sub, start=0, end=sys.maxsize):
+        """Return an overlapping count.
+
+        For a non-overlapping search use the count() method.
+
+        Returns an integer, the number of occurrences of substring
+        argument sub in the (sub)sequence given by [start:end].
+        Optional arguments start and end are interpreted as in slice
+        notation.
+
+        Arguments:
+         - sub - a string or another Seq object to look for
+         - start - optional integer, slice start
+         - end - optional integer, slice end
+
+        e.g.
+
+        >>> from Bio.Seq import MutableSeq
+        >>> print(MutableSeq("AAAA").count_overlap("AA"))
+        3
+        >>> print(MutableSeq("ATATATATA").count_overlap("ATA"))
+        4
+        >>> print(MutableSeq("ATATATATA").count_overlap("ATA", 3, -1))
+        1
+
+        Where substrings do not overlap, should behave the same as
+        the count() method:
+
+        >>> from Bio.Seq import MutableSeq
+        >>> my_mseq = MutableSeq("AAAATGA")
+        >>> print(my_mseq.count_overlap("A"))
+        5
+        >>> print(my_mseq.count_overlap("ATG"))
+        1
+        >>> print(my_mseq.count_overlap(Seq("AT")))
+        1
+        >>> print(my_mseq.count_overlap("AT", 2, -1))
+        1
+
+        HOWEVER, do not use this method for such cases because the
+        count() method is much for efficient.
+        """
+        # The implementation is currently identical to that of
+        # Seq.count_overlap() apart from the definition of sub_str
+        sub_str = str(sub)
+        self = str(self)
+        overlap_count = 0
+        while True:
+            start = self.find(sub_str, start, end) + 1
+            if start != 0:
+                overlap_count += 1
+            else:
+                return overlap_count
 
     def index(self, item):
         """Return the position of a subsequence of a single letter."""

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1464,6 +1464,8 @@ class UnknownSeq(Seq):
         2
         >>> UnknownSeq(4, character="N").count_overlap("NNNNN")
         0
+        >>> UnknownSeq(4,character="N").count_overlap('NNN',1,2)
+        0
         >>> UnknownSeq(7, character="N").count_overlap("NN")
         6
         >>> UnknownSeq(7, character="N").count_overlap("NNN")
@@ -1507,8 +1509,8 @@ class UnknownSeq(Seq):
         """
         sub_str = self._get_seq_str_and_check_alphabet(sub)
         len_self, len_sub_str = self._length, len(sub_str)
-        # Handling some pathological edge cases
-        if len_self < len_sub_str or set(sub_str) != set(self._character):
+        # Handling case where substring not in self
+        if set(sub_str) != set(self._character):
             return 0
         # Setting None to the default arguments
         if start is None:
@@ -1520,11 +1522,12 @@ class UnknownSeq(Seq):
         end = max(min(end, len_self), -len_self)
         # Convert start and ends to positive indexes
         if start < 0:
-            start = start + len_self
+            start += len_self
         if end < 0:
-            end = end + len_self
+            end += len_self
         # Handle case where end <= start (no negative step argument here)
-        if end <= start:
+        # and case where len_sub_str is larger than the search space
+        if end <= start or (end - start) < len_sub_str:
             return 0
         # 'Normal' calculation
         return end - start - len_sub_str + 1

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -426,7 +426,8 @@ class Seq(object):
         >>> print(Seq("AAAA").count("AA"))
         2
 
-        An overlapping search would give the answer as three!
+        An overlapping search, as implemented in .count_overlap(),
+        would give the answer as three!
         """
         # If it has one, check the alphabet:
         sub_str = self._get_seq_str_and_check_alphabet(sub)
@@ -464,12 +465,20 @@ class Seq(object):
         >>> my_seq = Seq("AAAATGA")
         >>> print(my_seq.count_overlap("A"))
         5
+        >>> my_seq.count_overlap("A") == my_seq.count("A")
+        True
         >>> print(my_seq.count_overlap("ATG"))
         1
+        >>> my_seq.count_overlap("ATG") == my_seq.count("ATG")
+        True
         >>> print(my_seq.count_overlap(Seq("AT")))
         1
+        >>> my_seq.count_overlap(Seq("AT")) == my_seq.count(Seq("AT"))
+        True
         >>> print(my_seq.count_overlap("AT", 2, -1))
         1
+        >>> my_seq.count_overlap("AT", 2, -1) == my_seq.count("AT", 2, -1)
+        True
 
         HOWEVER, do not use this method for such cases because the
         count() method is much for efficient.
@@ -1458,10 +1467,16 @@ class UnknownSeq(Seq):
 
         >>> UnknownSeq(4, character="N").count_overlap("N")
         4
+        >>> UnknownSeq(4, character="N").count_overlap("N") == UnknownSeq(4, character="N").count("N")
+        True
         >>> UnknownSeq(4, character="N").count_overlap("A")
         0
+        >>> UnknownSeq(4, character="N").count_overlap("A") == UnknownSeq(4, character="N").count("A")
+        True
         >>> UnknownSeq(4, character="N").count_overlap("AA")
         0
+        >>> UnknownSeq(4, character="N").count_overlap("AA") == UnknownSeq(4, character="N").count("AA")
+        True
 
         HOWEVER, do not use this method for such cases because the
         count() method is much for efficient.
@@ -2007,12 +2022,20 @@ class MutableSeq(object):
         >>> my_mseq = MutableSeq("AAAATGA")
         >>> print(my_mseq.count_overlap("A"))
         5
+        >>> my_mseq.count_overlap("A") == my_mseq.count("A")
+        True
         >>> print(my_mseq.count_overlap("ATG"))
         1
+        >>> my_mseq.count_overlap("ATG") == my_mseq.count("ATG")
+        True
         >>> print(my_mseq.count_overlap(Seq("AT")))
         1
+        >>> my_mseq.count_overlap(Seq("AT")) == my_mseq.count(Seq("AT"))
+        True
         >>> print(my_mseq.count_overlap("AT", 2, -1))
         1
+        >>> my_mseq.count_overlap("AT", 2, -1) == my_mseq.count("AT", 2, -1)
+        True
 
         HOWEVER, do not use this method for such cases because the
         count() method is much for efficient.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1462,34 +1462,6 @@ class UnknownSeq(Seq):
         3
         >>> UnknownSeq(4, character="N").count_overlap("NNN")
         2
-        >>> UnknownSeq(4, character="N").count_overlap("NNNNN")
-        0
-        >>> UnknownSeq(4,character="N").count_overlap('NNN',1,2)
-        0
-        >>> UnknownSeq(7, character="N").count_overlap("NN")
-        6
-        >>> UnknownSeq(7, character="N").count_overlap("NNN")
-        5
-        >>> UnknownSeq(7, character="N").count_overlap("NN", 1, 5)
-        3
-        >>> UnknownSeq(7, character="N").count_overlap("NN", -5, -1)
-        3
-        >>> UnknownSeq(7, character="N").count_overlap("NN", 8, 2)
-        0
-        >>> UnknownSeq(7, character="N").count_overlap("N", 2, 8)
-        5
-        >>> UnknownSeq(7, character="N").count_overlap("N", 8, 2)
-        0
-        >>> UnknownSeq(7, character="N").count_overlap("N", -2, -8)
-        0
-        >>> UnknownSeq(7, character="N").count_overlap("N", -8, -2)
-        5
-        >>> UnknownSeq(7, character="N").count_overlap("N", 4, -1)
-        2
-        >>> UnknownSeq(7, character="N").count_overlap("N", -1, 4)
-        0
-        >>> UnknownSeq(7, character="N").count_overlap("N", 100, 105)
-        0
 
         Where substrings do not overlap, should behave the same as
         the count() method:

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -59,6 +59,7 @@ please open an issue on GitHub or mention it on the development mailing list.
 - Cheng Soon Ong <chengsoon.ong at tuebingen.mpg.de>
 - Chris Lasher <chris.lasher at gmail.com>
 - Chris Mitchell <https://github.com/chrismit>
+- Chris Rands <https://github.com/chris-rands>
 - Chris Warth <https://github.com/cswarth>
 - Christiam Camacho <https://github.com/christiam>
 - Christian Brueffer <christian at domain brueffer.de>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -46,6 +46,7 @@ possible, especially the following contributors:
 - Andrew Guy
 - Ariel Aptekmann (first contribution)
 - Bertrand Caron (first contribution)
+- Chris Rands
 - Connor T. Skennerton
 - Eric Rasche
 - Francesco Gastaldello

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -181,6 +181,88 @@ class StringMethodTests(unittest.TestCase):
         """Check matches the python string count method."""
         self._test_method("count", start_end=True)
 
+    def test_str_count_overlap_GG(self):
+        """Check our count_overlap method using GG."""
+
+        # Testing with self._examples
+        expected = [3, 3, 3, 3, 1, 1, 1, 1, 0, 0, 0, 0,  # Seq() Tests
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  # UnknownSeq() Tests
+        expected *= 2  # MutableSeq() Tests
+
+        assert len(self._examples) == len(expected)
+
+        for seq, exp in zip(self._examples, expected):
+            # Using search term GG as a string
+            self.assertEqual(seq.count_overlap("GG"), exp)
+            # Using search term GG as a Seq with generic alphabet
+            self.assertEqual(seq.count_overlap(Seq("GG")), exp)
+
+        # Testing Seq() and MutableSeq() with variable start and end arguments
+        start_end_exp = [(1, 7, 3),
+                         (3, None, 3),
+                         (3, 6, 2),
+                         (4, 6, 1),
+                         (4, -1, 2),
+                         (-5, None, 2)]
+
+        testing_seq = "ACGAAAACG"
+
+        for start, end, exp in start_end_exp:
+            self.assertEqual(Seq(testing_seq).count_overlap("AA", start, end), exp)
+            self.assertEqual(MutableSeq(testing_seq).count_overlap("AA", start, end), exp)
+
+        # Testing UnknownSeq() with variable start and end arguments
+        alphabet_char_start_end_exp = [(generic_rna, "N", 1, 7, 0),
+                                       (generic_dna, "N", 1, 7, 0),
+                                       (generic_rna, "N", -4, None, 0),
+                                       (generic_dna, "N", -4, None, 0),
+                                       (generic_protein, "X", 1, 7, 0)]
+
+        for alpha, char, start, end, exp in alphabet_char_start_end_exp:
+            self.assertEqual(UnknownSeq(12, alpha, char).count_overlap("AA", start, end), exp)
+        self.assertEqual(UnknownSeq(12, character="X").count_overlap("AA", 1, 7), 0)
+
+    def test_str_count_overlap_NN(self):
+        """Check our count_overlap method using NN."""
+
+        # Testing with self._examples
+        expected = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  # Seq() Tests
+                    0, 0, 0, 0, 0, 11, 11, 11, 0, 0, 0]  # UnknownSeq() Tests
+        expected *= 2  # MutableSeq() Tests
+
+        assert len(self._examples) == len(expected)
+
+        for seq, exp in zip(self._examples, expected):
+            # Using search term NN as a string
+            self.assertEqual(seq.count_overlap("NN"), exp)
+            # Using search term GG as a Seq with generic alphabet
+            self.assertEqual(seq.count_overlap(Seq("NN")), exp)
+
+        # Testing Seq() and MutableSeq() with variable start and end arguments
+        start_end_exp = [(1, 7, 0),
+                         (3, None, 0),
+                         (3, 6, 0),
+                         (4, 6, 0),
+                         (4, -1, 0),
+                         (-5, None, 0)]
+
+        testing_seq = "ACGAAAACG"
+
+        for start, end, exp in start_end_exp:
+            self.assertEqual(Seq(testing_seq).count_overlap("NN", start, end), exp)
+            self.assertEqual(MutableSeq(testing_seq).count_overlap("NN", start, end), exp)
+
+        # Testing UnknownSeq() with variable start and end arguments
+        alphabet_char_start_end_exp = [(generic_rna, "N", 1, 7, 5),
+                                       (generic_dna, "N", 1, 7, 5),
+                                       (generic_rna, "N", -4, None, 3),
+                                       (generic_dna, "N", -4, None, 3),
+                                       (generic_protein, "X", 1, 7, 0)]
+
+        for alpha, char, start, end, exp in alphabet_char_start_end_exp:
+            self.assertEqual(UnknownSeq(12, alpha, char).count_overlap("NN", start, end), exp)
+        self.assertEqual(UnknownSeq(12, character="X").count_overlap("NN", 1, 7), 0)
+
     def test_str_find(self):
         """Check matches the python string find method."""
         self._test_method("find", start_end=True)

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -194,10 +194,10 @@ class StringMethodTests(unittest.TestCase):
         for seq, exp in zip(self._examples, expected):
             # Using search term GG as a string
             self.assertEqual(seq.count_overlap("GG"), exp)
-            self.assertEqual(seq.count_overlap("G"*5), 0)
+            self.assertEqual(seq.count_overlap("G" * 5), 0)
             # Using search term GG as a Seq with generic alphabet
             self.assertEqual(seq.count_overlap(Seq("GG")), exp)
-            self.assertEqual(seq.count_overlap(Seq("G"*5)), 0)
+            self.assertEqual(seq.count_overlap(Seq("G" * 5)), 0)
 
     def test_count_overlap_start_end_GG(self):
         """Check our count_overlap method using GG with variable ends and starts."""
@@ -275,10 +275,10 @@ class StringMethodTests(unittest.TestCase):
         for seq, exp in zip(self._examples, expected):
             # Using search term NN as a string
             self.assertEqual(seq.count_overlap("NN"), exp)
-            self.assertEqual(seq.count_overlap("N"*13), 0)
+            self.assertEqual(seq.count_overlap("N" * 13), 0)
             # Using search term NN as a Seq with generic alphabet
             self.assertEqual(seq.count_overlap(Seq("NN")), exp)
-            self.assertEqual(seq.count_overlap(Seq("N"*13)), 0)
+            self.assertEqual(seq.count_overlap(Seq("N" * 13)), 0)
 
     def test_count_overlap_start_end_NN(self):
         """Check our count_overlap method using NN with variable ends and starts."""

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -194,22 +194,42 @@ class StringMethodTests(unittest.TestCase):
         for seq, exp in zip(self._examples, expected):
             # Using search term GG as a string
             self.assertEqual(seq.count_overlap("GG"), exp)
+            self.assertEqual(seq.count_overlap("G"*5), 0)
             # Using search term GG as a Seq with generic alphabet
             self.assertEqual(seq.count_overlap(Seq("GG")), exp)
+            self.assertEqual(seq.count_overlap(Seq("G"*5)), 0)
 
+    def test_count_overlap_start_end_GG(self):
+        """Check our count_overlap method using GG with variable ends and starts."""
         # Testing Seq() and MutableSeq() with variable start and end arguments
         start_end_exp = [(1, 7, 3),
                          (3, None, 3),
                          (3, 6, 2),
                          (4, 6, 1),
                          (4, -1, 2),
-                         (-5, None, 2)]
+                         (-5, None, 2),
+                         (-5, 7, 2),
+                         (7, -5, 0),
+                         (-100, None, 3),
+                         (None, 100, 3),
+                         (-100, 1000, 3)]
 
-        testing_seq = "ACGAAAACG"
+        testing_seq = "GTAGGGGAG"
 
         for start, end, exp in start_end_exp:
-            self.assertEqual(Seq(testing_seq).count_overlap("AA", start, end), exp)
-            self.assertEqual(MutableSeq(testing_seq).count_overlap("AA", start, end), exp)
+            self.assertEqual(Seq(testing_seq).count_overlap("GG", start, end), exp)
+            self.assertEqual(MutableSeq(testing_seq).count_overlap("GG", start, end), exp)
+
+        # Testing Seq() and MutableSeq() with a more heterogenous sequenece
+        self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("GG"), 5)
+        self.assertEqual(MutableSeq("GGGTGGTAGGG").count_overlap("GG"), 5)
+        self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("GG", 2, 8), 1)
+        self.assertEqual(MutableSeq("GGGTGGTAGGG").count_overlap("GG", 2, 8), 1)
+        self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("GG", -11, 6), 3)
+        self.assertEqual(MutableSeq("GGGTGGTAGGG").count_overlap("GG", -11, 6), 3)
+        self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("GG", 7, 2), 0)
+        self.assertEqual(MutableSeq("GGGTGGTAGGG").count_overlap("GG", 7, 2), 0)
+        self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("GG", -2, -10), 0)
 
         # Testing UnknownSeq() with variable start and end arguments
         alphabet_char_start_end_exp = [(generic_rna, "N", 1, 7, 0),
@@ -219,8 +239,28 @@ class StringMethodTests(unittest.TestCase):
                                        (generic_protein, "X", 1, 7, 0)]
 
         for alpha, char, start, end, exp in alphabet_char_start_end_exp:
-            self.assertEqual(UnknownSeq(12, alpha, char).count_overlap("AA", start, end), exp)
-        self.assertEqual(UnknownSeq(12, character="X").count_overlap("AA", 1, 7), 0)
+            self.assertEqual(UnknownSeq(12, alpha, char).count_overlap("GG", start, end), exp)
+        self.assertEqual(UnknownSeq(12, character="X").count_overlap("GG", 1, 7), 0)
+
+        # Testing UnknownSeq() with some more cases including unusual edge cases
+        substr_start_end_exp = [("G", 100, 105, 0),
+                                ("G", -1, 4, 0),
+                                ("G", 4, -1, 0),
+                                ("G", -8, -2, 0),
+                                ("G", -2, -8, 0),
+                                ("G", 8, 2, 0),
+                                ("G", 2, 8, 0),
+                                ("GG", 8, 2, 0),
+                                ("GG", 2, 8, 0),
+                                ("GG", -5, -1, 0),
+                                ("GG", 1, 5, 0),
+                                ("GGG", None, None, 0),
+                                ("GGGGGGGGG", None, None, 0),
+                                ("GGG", 1, 2, 0)]
+
+        for substr, start, end, exp in substr_start_end_exp:
+            self.assertEqual(UnknownSeq(7, character="N").count_overlap(substr, start, end), exp)
+        self.assertEqual(UnknownSeq(7, character="N").count_overlap("GG", 1), 0)
 
     def test_str_count_overlap_NN(self):
         """Check our count_overlap method using NN."""
@@ -235,22 +275,42 @@ class StringMethodTests(unittest.TestCase):
         for seq, exp in zip(self._examples, expected):
             # Using search term NN as a string
             self.assertEqual(seq.count_overlap("NN"), exp)
-            # Using search term GG as a Seq with generic alphabet
+            self.assertEqual(seq.count_overlap("N"*13), 0)
+            # Using search term NN as a Seq with generic alphabet
             self.assertEqual(seq.count_overlap(Seq("NN")), exp)
+            self.assertEqual(seq.count_overlap(Seq("N"*13)), 0)
 
+    def test_count_overlap_start_end_NN(self):
+        """Check our count_overlap method using NN with variable ends and starts."""
         # Testing Seq() and MutableSeq() with variable start and end arguments
         start_end_exp = [(1, 7, 0),
                          (3, None, 0),
                          (3, 6, 0),
                          (4, 6, 0),
                          (4, -1, 0),
-                         (-5, None, 0)]
+                         (-5, None, 0),
+                         (-5, 7, 0),
+                         (7, -5, 0),
+                         (-100, None, 0),
+                         (None, 100, 0),
+                         (-100, 1000, 0)]
 
-        testing_seq = "ACGAAAACG"
+        testing_seq = "GTAGGGGAG"
 
         for start, end, exp in start_end_exp:
             self.assertEqual(Seq(testing_seq).count_overlap("NN", start, end), exp)
             self.assertEqual(MutableSeq(testing_seq).count_overlap("NN", start, end), exp)
+
+        # Testing Seq() and MutableSeq() with a more heterogenous sequenece
+        self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("NN"), 0)
+        self.assertEqual(MutableSeq("GGGTGGTAGGG").count_overlap("NN"), 0)
+        self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("NN", 2, 8), 0)
+        self.assertEqual(MutableSeq("GGGTGGTAGGG").count_overlap("NN", 2, 8), 0)
+        self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("NN", -11, 6), 0)
+        self.assertEqual(MutableSeq("GGGTGGTAGGG").count_overlap("NN", -11, 6), 0)
+        self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("NN", 7, 2), 0)
+        self.assertEqual(MutableSeq("GGGTGGTAGGG").count_overlap("NN", 7, 2), 0)
+        self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("NN", -10, -2), 0)
 
         # Testing UnknownSeq() with variable start and end arguments
         alphabet_char_start_end_exp = [(generic_rna, "N", 1, 7, 5),
@@ -262,6 +322,26 @@ class StringMethodTests(unittest.TestCase):
         for alpha, char, start, end, exp in alphabet_char_start_end_exp:
             self.assertEqual(UnknownSeq(12, alpha, char).count_overlap("NN", start, end), exp)
         self.assertEqual(UnknownSeq(12, character="X").count_overlap("NN", 1, 7), 0)
+
+        # Testing UnknownSeq() with some more cases including unusual edge cases
+        substr_start_end_exp = [("N", 100, 105, 0),
+                                ("N", -1, 4, 0),
+                                ("N", 4, -1, 2),
+                                ("N", -8, -2, 5),
+                                ("N", -2, -8, 0),
+                                ("N", 8, 2, 0),
+                                ("N", 2, 8, 5),
+                                ("NN", 8, 2, 0),
+                                ("NN", 2, 8, 4),
+                                ("NN", -5, -1, 3),
+                                ("NN", 1, 5, 3),
+                                ("NNN", None, None, 5),
+                                ("NNNNNNNNN", None, None, 0),
+                                ("NNN", 1, 2, 0)]
+
+        for substr, start, end, exp in substr_start_end_exp:
+            self.assertEqual(UnknownSeq(7, character="N").count_overlap(substr, start, end), exp)
+        self.assertEqual(UnknownSeq(7, character="N").count_overlap("NN", 1), 5)
 
     def test_str_find(self):
         """Check matches the python string find method."""


### PR DESCRIPTION
Following [issue 1294](https://github.com/biopython/biopython/issues/1294), I have added a `.count_overlap()` method to the `Seq`, `UnknownSeq` and `MutableSeq` classes in `Bio/Seq.py`. I have also added a line in each `.count()` method docstring referring to the new method.

Unresolved issues:
- The implementations for the 3 classes are basically the same and all rely on conversion of `self` to strings so that `str.find()` can be used. There might be better implementations for the `UnknownSeq` and `MutableSeq` classes. 
- Doctests have been added but no other tests yet. In the Issue, it was suggested that tests should be added to `Tests/test_Seq_objs.py` but I was not clear how best to implement this. 

I would appreciate feedback, suggestions and any contributions, thank you!