### PR TITLE
Require numpy and specify this in setup.py

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -70,10 +70,9 @@ deps =
     {py27}: networkx
     {py36}: matplotlib
 commands =
-    #The bash call is a work around for the pipe character
-    #The yes is in case we get our prompt about missing NumPy
+    #The bash call is a work around for special characters
     #The /dev/null is to hide the verbose output but leave warnings
-    bash -c \'/usr/bin/yes | python setup.py install > /dev/null\'
+    bash -c \'python setup.py install > /dev/null\'
     #The bash call is a work around for the cd command
     nocov: bash -c \'cd Tests && python run_tests.py --offline\'
     #See https://codecov.io/ and https://github.com/codecov/example-python

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,7 +18,6 @@ include README
 include DEPRECATED
 
 include MANIFEST.in
-include requirements.txt
 
 recursive-include Scripts *    # Include scripts.
 recursive-include Tests *      # Include regression tests.

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -20,6 +20,10 @@ Biopython now has a new logo, contributed by Patrick Kunzmann. Drawing on our
 original logo and the current Python logo, this shows a yellow and blue snake
 forming a double helix.
 
+For installation Biopython now assumes ``setuptools`` is present, and takes
+advantage of this to declare we require NumPy at install time (except under
+Jython). This should help ensure ``pip install biopython`` works smoothly.
+
 Bio.AlignIO now supports Mauve's eXtended Multi-FastA (XMFA) file format
 under the format name "mauve" (contributed by Eric Rasche).
 

--- a/README.rst
+++ b/README.rst
@@ -101,37 +101,36 @@ Biopython 1.68 was our final release to support Python 2.6.
 Dependencies
 ============
 
-Depending on which parts of Biopython you plan to use, there are a number of
-other optional Python dependencies, which (other than NumPy) can be installed
-after Biopython.
+The following are required at compile time - unless you are using Jython
+(support for which is deprecated) or IronPython (which we do not officially
+support):
 
-- NumPy, see http://www.numpy.org (optional, but strongly recommended)
-  This package is only used in the computationally-oriented modules. It is
-  required for ``Bio.Cluster``, ``Bio.PDB`` and a few other modules.  If you
-  think you might need these modules, then please install NumPy first BEFORE
-  installing Biopython. The older Numeric library is no longer supported in
-  Biopython.
+- NumPy, see http://www.numpy.org
+  This package is used in ``Bio.Cluster``, ``Bio.PDB`` and a few other modules.
+  We use the NumPy C API, which means it must be installed *before* compiling
+  Biopython's C code.
+
+
+Optional Dependencies
+=====================
+
+Depending on which parts of Biopython you plan to use, there are a number of
+other optional Python dependencies, which can be installed later if needed:
 
 - ReportLab, see http://www.reportlab.com/opensource/ (optional)
   This package is only used in ``Bio.Graphics``, so if you do not need this
-  functionality, you will not need to install this package.  You can install
-  it later if needed.
+  functionality, you will not need to install this package.
 
 - matplotlib, see http://matplotlib.org/ (optional)
-  ``Bio.Phylo`` uses this package to plot phylogenetic trees. As with
-  ReportLab, you can install this at any time to enable the plotting
-  functionality.
+  ``Bio.Phylo`` uses this package to plot phylogenetic trees.
 
 - networkx, see http://networkx.lanl.gov/ (optional) and
   pygraphviz or pydot, see http://networkx.lanl.gov/pygraphviz/ and
   http://code.google.com/p/pydot/ (optional)
   These packages are used for certain niche functions in ``Bio.Phylo``.
-  Again, they are only needed to enable these functions and can be installed
-  later if needed.
 
 - rdflib, see https://github.com/RDFLib/rdflib (optional)
-  This package is used in the CDAO parser under ``Bio.Phylo``, and can be
-  installed as needed.
+  This package is used in the CDAO parser under ``Bio.Phylo``.
 
 - psycopg2, see http://initd.org/psycopg/ (optional) or
   PyGreSQL (pgdb), see http://www.pygresql.org/ (optional)
@@ -155,8 +154,9 @@ install such as standalone NCBI BLAST, EMBOSS or ClustalW.
 Installation
 ============
 
-First, **make sure that Python is installed correctly**. Second, we
-recommend you install NumPy (see above). Then install Biopython.
+First, **make sure that Python is installed correctly**. Second (except
+for Jython or IronPython), **make sure NumPy is installed**. Then
+install Biopython.
 
 Windows users should use the appropriate provided installation package
 from our website (each is specific to a different Python version).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-# We want NumPy under CPython or PyPy, but not Jython
-numpy; platform_python_implementation != 'Jython'

--- a/setup.py
+++ b/setup.py
@@ -267,6 +267,18 @@ def is_Numpy_installed():
     return bool(can_import("numpy"))
 
 
+# Using requirements.txt is preferred for an application
+# (and likely will pin specific version numbers), using
+# setup.py's install_requires is preferred for a library
+# (and should try not to be overly narrow with versions).
+REQUIRES = [
+    'numpy',
+]
+
+if is_jython() or is_ironpython():
+    REQUIRES.remove("numpy")
+
+
 # --- set up the packages we are going to install
 # standard biopython packages
 PACKAGES = [
@@ -474,4 +486,5 @@ setup(name='biopython',
       package_data={
           'Bio.Entrez': ['DTDs/*.dtd', 'DTDs/*.ent', 'DTDs/*.mod'],
       },
+      install_requires=REQUIRES,
       )

--- a/setup.py
+++ b/setup.py
@@ -174,23 +174,7 @@ class install_biopython(install):
 
     This will just run the normal install, and then print warning messages
     if packages are missing.
-
     """
-    # Adds support for the single-version-externally-managed flag
-    # which is present in setuptools but not distutils. pip requires it.
-    # In setuptools this forces installation the "old way" which we
-    # only support here, so we just make it a no-op.
-    user_options = install.user_options + [
-        ('single-version-externally-managed', None,
-            "used by system package builders to create 'flat' eggs"),
-    ]
-    boolean_options = install.boolean_options + [
-        'single-version-externally-managed',
-    ]
-
-    def initialize_options(self):
-        install.initialize_options(self)
-        self.single_version_externally_managed = None
 
     def run(self):
         if check_dependencies_once():

--- a/setup.py
+++ b/setup.py
@@ -121,28 +121,6 @@ def is_ironpython():
     # TODO - Use platform as in Pypy test?
 
 
-def get_yes_or_no(question, default):
-    if default:
-        option_str = "(Y/n)"
-        default_str = 'y'
-    else:
-        option_str = "(y/N)"
-        default_str = 'n'
-
-    while True:
-        print("%s %s:" % (question, option_str))
-        if sys.version_info[0] == 3:
-            response = input().lower()
-        else:
-            response = raw_input().lower()
-        if not response:
-            response = default_str
-        if response[0] in ['y', 'n']:
-            break
-        print("Please answer y or n.")
-    return response[0] == 'y'
-
-
 # Make sure we have the right Python version.
 if sys.version_info[:2] < (2, 7):
     sys.stderr.write("Biopython requires Python 2.7, or Python 3.4 or later. "
@@ -166,31 +144,6 @@ def check_dependencies_once():
     return _CHECKED
 
 
-def is_automated():
-    """Check for installation with easy_install or pip.
-    """
-    is_automated = False
-    # easy_install: --dist-dir option passed
-    try:
-        dist_dir_i = sys.argv.index("--dist-dir")
-    except ValueError:
-        dist_dir_i = None
-    if dist_dir_i is not None:
-        dist_dir = sys.argv[dist_dir_i + 1]
-        if "egg-dist-tmp" in dist_dir:
-            is_automated = True
-    # pip -- calls from python directly with "-c"
-    if sys.argv in [["-c", "develop", "--no-deps"],
-                    ["--no-deps", "-c", "develop"],
-                    ["-c", "egg_info"]] \
-                    or "pip-egg-info" in sys.argv \
-                    or sys.argv[:3] == ["-c", "install", "--record"] \
-                    or sys.argv[:4] == ['-c', 'install', '--single-version-externally-managed',
-                                        '--record']:
-        is_automated = True
-    return is_automated
-
-
 def check_dependencies():
     """Return whether the installation should continue."""
     # There should be some way for the user to tell specify not to
@@ -204,29 +157,16 @@ def check_dependencies():
     # We only check for NumPy, as this is a compile time dependency
     if is_Numpy_installed():
         return True
-    if is_automated():
-        return True  # For automated builds go ahead with installed packages
     if is_jython():
         return True  # NumPy is not avaliable for Jython (for now)
     if is_ironpython():
         return True  # We're ignoring NumPy under IronPython (for now)
 
-    print("""
-Numerical Python (NumPy) is not installed.
+    sys.exit("""Missing required dependency NumPy (Numerical Python).
 
-This package is required for many Biopython features.  Please install
-it before you install Biopython. You can install Biopython anyway, but
-anything dependent on NumPy will not work. If you do this, and later
-install NumPy, you should then re-install Biopython.
-
-You can find NumPy at http://www.numpy.org
+Unless running under Jython or IronPython, we require NumPy be installed
+when compiling Biopython. See http://www.numpy.org for details.
 """)
-    # exit automatically if running as part of some script
-    # (e.g. PyPM, ActiveState's Python Package Manager)
-    if not sys.stdout.isatty():
-        sys.exit(-1)
-    # We can ask the user
-    return get_yes_or_no("Do you want to continue this installation?", False)
 
 
 class install_biopython(install):
@@ -269,6 +209,8 @@ class build_py_biopython(build_py):
             self.packages.remove("Bio.Restriction")
         # Add software that requires Numpy to be installed.
         if is_Numpy_installed():
+            # Should be everything (i.e. C Python or PyPy)
+            # except Jython and IronPython
             self.packages.extend(NUMPY_PACKAGES)
         build_py.run(self)
 


### PR DESCRIPTION
This pull request makes NumPy a hard requirement (except on Jython and IronPython). This in itself massively simplifies the ``setup.py`` file - and once we drop Jython (and IronPython) we can go further.

This does mean it is no longer going to be possible to install Biopython on PyPy or C Python without NumPy - currently allowed via a user interaction.

Having made that change, and given we've dropped ``distutils`` in favour of assuming ``setuptools`` will be present, as per https://github.com/pypa/packaging-problems/issues/78 and https://caremad.io/posts/2013/07/setup-vs-requirement/ we should specify our (now strict) dependency on NumPy via ``setup(..., install_requires=...)`` rather than ``requirements.txt`` (see #987).

I believe this means we after this release is on PyPI be able to simply the current README installation instructions from:

```
pip install numpy
pip install biopython
```

to just:

```
pip install biopython
```

This should address #1302 and should more fully resolve #978.