### PR TITLE
Feature location equality

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1198,6 +1198,24 @@ class CompoundLocation(object):
             for pos in loc:
                 yield pos
 
+    def __eq__(self, other):
+        """Check if all parts of CompoundLocation are equal to all parts of other CompoundLocation"""
+        if not isinstance(other, CompoundLocation):
+            return False
+        if not len(self.parts) == len(other.parts):
+            return False
+        if not self.operator == other.operator:
+            return False
+        identical = True
+        for i, self_part in enumerate(self.parts):
+            other_part = other.parts[i]
+            identical = identical and self_part == other_part
+        return identical
+
+    def __ne__(self, other):
+        """Needed for py2, not needed for py3"""
+        return not (self == other)
+
     def _shift(self, offset):
         """Return a copy of the CompoundLocation shifted by an offset (PRIVATE)."""
         return CompoundLocation([loc._shift(offset) for loc in self.parts],

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -851,6 +851,16 @@ class FeatureLocation(object):
             for i in range(self._start, self._end):
                 yield i
 
+    def __eq__(self, other):
+        """Check if start, end and strand of this location are the same as in the other location"""
+        if not isinstance(other, FeatureLocation):
+            return False
+        return self._start == other.start and self._end == other.end and self._strand == other.strand
+
+    def __ne__(self, other):
+        """Needed for py2, not needed for py3"""
+        return not (self == other)
+
     def _shift(self, offset):
         """Return a copy of the FeatureLocation shifted by an offset (PRIVATE)."""
         # TODO - What if offset is a fuzzy position?

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -852,13 +852,18 @@ class FeatureLocation(object):
                 yield i
 
     def __eq__(self, other):
-        """Check if start, end and strand of this location are the same as in the other location"""
+        """Implement equality by comparing all the location attributes."""
         if not isinstance(other, FeatureLocation):
             return False
-        return self._start == other.start and self._end == other.end and self._strand == other.strand
+        return self._start == other.start and \
+            self._end == other.end and \
+            self._strand == other.strand and \
+            self.ref == other.ref and \
+            self.ref_db == other.ref_db
 
     def __ne__(self, other):
-        """Needed for py2, not needed for py3"""
+        """Implement the not-equal operand."""
+        # This is needed for py2, but not for py3.
         return not (self == other)
 
     def _shift(self, offset):
@@ -1199,21 +1204,21 @@ class CompoundLocation(object):
                 yield pos
 
     def __eq__(self, other):
-        """Check if all parts of CompoundLocation are equal to all parts of other CompoundLocation"""
+        """Check if all parts of CompoundLocation are equal to all parts of other CompoundLocation."""
         if not isinstance(other, CompoundLocation):
             return False
-        if not len(self.parts) == len(other.parts):
+        if len(self.parts) != len(other.parts):
             return False
-        if not self.operator == other.operator:
+        if self.operator != other.operator:
             return False
         identical = True
-        for i, self_part in enumerate(self.parts):
-            other_part = other.parts[i]
+        for self_part, other_part in zip(self.parts, other.parts):
             identical = identical and self_part == other_part
         return identical
 
     def __ne__(self, other):
-        """Needed for py2, not needed for py3"""
+        """Implement the not-equal operand."""
+        # This is needed for py2, but not for py3.
         return not (self == other)
 
     def _shift(self, offset):

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -864,7 +864,7 @@ class FeatureLocation(object):
     def __ne__(self, other):
         """Implement the not-equal operand."""
         # This is needed for py2, but not for py3.
-        return not (self == other)
+        return not self == other
 
     def _shift(self, offset):
         """Return a copy of the FeatureLocation shifted by an offset (PRIVATE)."""
@@ -1213,13 +1213,14 @@ class CompoundLocation(object):
             return False
         identical = True
         for self_part, other_part in zip(self.parts, other.parts):
-            identical = identical and self_part == other_part
+            if self_part != other_part:
+                return False
         return identical
 
     def __ne__(self, other):
         """Implement the not-equal operand."""
         # This is needed for py2, but not for py3.
-        return not (self == other)
+        return not self == other
 
     def _shift(self, offset):
         """Return a copy of the CompoundLocation shifted by an offset (PRIVATE)."""

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -8,7 +8,7 @@
 import unittest
 from os import path
 from Bio import SeqIO
-from Bio.SeqFeature import FeatureLocation, AfterPosition, BeforePosition
+from Bio.SeqFeature import FeatureLocation, AfterPosition, BeforePosition, CompoundLocation
 
 
 class TestReference(unittest.TestCase):
@@ -62,4 +62,37 @@ class TestFeatureLocation(unittest.TestCase):
 
         loc1 = FeatureLocation(23, 42, 1)
         loc2 = (23, 42, 1)
+        self.assertNotEqual(loc1, loc2)
+
+
+class TestCompoundLocation(unittest.TestCase):
+    """Tests for the SeqFeature.CompoundLocation class"""
+
+    def test_eq_identical(self):
+        """Test two identical locations are equal"""
+        loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
+        loc2 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
+        self.assertEqual(loc1, loc2)
+
+        loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
+        loc2 = CompoundLocation([FeatureLocation(12, 17, 1), FeatureLocation(23, 42, 1)])
+        self.assertEqual(loc1, loc2)
+
+    def test_eq_not_identical(self):
+        """Test two different locations are not equal"""
+
+        loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
+        loc2 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1) + FeatureLocation(50, 60, 1)
+        self.assertNotEqual(loc1, loc2)
+
+        loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
+        loc2 = FeatureLocation(12, 17, -1) + FeatureLocation(23, 42, -1)
+        self.assertNotEqual(loc1, loc2)
+
+        loc1 = CompoundLocation([FeatureLocation(12, 17, 1), FeatureLocation(23, 42, 1)])
+        loc2 = CompoundLocation([FeatureLocation(12, 17, 1), FeatureLocation(23, 42, 1)], 'order')
+        self.assertNotEqual(loc1, loc2)
+
+        loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
+        loc2 = 5
         self.assertNotEqual(loc1, loc2)

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -46,6 +46,10 @@ class TestFeatureLocation(unittest.TestCase):
         loc2 = FeatureLocation(23, 42, 1)
         self.assertEqual(loc1, loc2)
 
+        loc1 = FeatureLocation(23, 42, 1, 'foo', 'bar')
+        loc2 = FeatureLocation(23, 42, 1, 'foo', 'bar')
+        self.assertEqual(loc1, loc2)
+
     def test_eq_not_identical(self):
         """Test two different locations are not equal"""
         loc1 = FeatureLocation(22, 42, 1)
@@ -62,6 +66,14 @@ class TestFeatureLocation(unittest.TestCase):
 
         loc1 = FeatureLocation(23, 42, 1)
         loc2 = (23, 42, 1)
+        self.assertNotEqual(loc1, loc2)
+
+        loc1 = FeatureLocation(23, 42, 1, 'foo')
+        loc2 = FeatureLocation(23, 42, 1, 'bar')
+        self.assertNotEqual(loc1, loc2)
+
+        loc1 = FeatureLocation(23, 42, 1, 'foo', 'bar')
+        loc2 = FeatureLocation(23, 42, 1, 'foo', 'baz')
         self.assertNotEqual(loc1, loc2)
 
 

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -1,4 +1,4 @@
-# Copyright 2015 by Kai Blin.  All rights reserved.
+# Copyright 2015-2017 by Kai Blin.  All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
@@ -8,6 +8,7 @@
 import unittest
 from os import path
 from Bio import SeqIO
+from Bio.SeqFeature import FeatureLocation, AfterPosition, BeforePosition
 
 
 class TestReference(unittest.TestCase):
@@ -26,3 +27,39 @@ class TestReference(unittest.TestCase):
         self.assertNotEqual(rec1.annotations['references'][0], rec2.annotations['references'][1])
         self.assertEqual(rec1.annotations['references'][1], rec1.annotations['references'][1])
         self.assertEqual(rec1.annotations['references'][1], rec2.annotations['references'][1])
+
+
+class TestFeatureLocation(unittest.TestCase):
+    """Tests for the SeqFeature.FeatureLocation class"""
+
+    def test_eq_identical(self):
+        """Test two identical locations are equal"""
+        loc1 = FeatureLocation(23, 42, 1)
+        loc2 = FeatureLocation(23, 42, 1)
+        self.assertEqual(loc1, loc2)
+
+        loc1 = FeatureLocation(23, 42, -1)
+        loc2 = FeatureLocation(23, 42, -1)
+        self.assertEqual(loc1, loc2)
+
+        loc1 = FeatureLocation(BeforePosition(23), AfterPosition(42), 1)
+        loc2 = FeatureLocation(23, 42, 1)
+        self.assertEqual(loc1, loc2)
+
+    def test_eq_not_identical(self):
+        """Test two different locations are not equal"""
+        loc1 = FeatureLocation(22, 42, 1)
+        loc2 = FeatureLocation(23, 42, 1)
+        self.assertNotEqual(loc1, loc2)
+
+        loc1 = FeatureLocation(23, 42, 1)
+        loc2 = FeatureLocation(23, 43, 1)
+        self.assertNotEqual(loc1, loc2)
+
+        loc1 = FeatureLocation(23, 42, 1)
+        loc2 = FeatureLocation(23, 42, -1)
+        self.assertNotEqual(loc1, loc2)
+
+        loc1 = FeatureLocation(23, 42, 1)
+        loc2 = (23, 42, 1)
+        self.assertNotEqual(loc1, loc2)


### PR DESCRIPTION
As discussed with @peterjc on Twitter, it would be nice to have a strict* equality check for `FeatureLocation` and `CompoundLocation` objects. This allows to directly compare locations using `==` and `!=` instead of having to go via `list(loc_a) == list(loc_b)` or similar.


* This is strict in as much as a `BeforePosition(x)` or `AfterPosition(x)` is assumed to be equal to an `ExactPosition(x)`, but this matches our other non-string conversions of fuzzy features. This can lead to a situation where `loc_a == loc_b` is `True` but `str(loc_a) == str(loc_b)` is `False`. It does match the behaviour for comparisons via a `list` conversion, though.