### PR TITLE
TravisCI: Build LaTeX documentation (Tutorial etc)

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -78,12 +78,12 @@ deps =
 commands =
     #The bash call is a work around for special characters
     #The /dev/null is to hide the verbose output but leave warnings
-    bash -c \'python setup.py install > /dev/null\'
+    bash -c 'python setup.py install > /dev/null'
     #The bash call is a work around for the cd command
-    nocov: bash -c \'cd Tests && python run_tests.py --offline\'
+    nocov: bash -c 'cd Tests && python run_tests.py --offline'
     #See https://codecov.io/ and https://github.com/codecov/example-python
-    cover: bash -c \'rm -rf Tests/coverage.xml\'
-    cover: bash -c \'cd Tests && coverage run run_tests.py --offline && coverage xml\'
+    cover: bash -c 'rm -rf Tests/coverage.xml'
+    cover: bash -c 'cd Tests && coverage run run_tests.py --offline && coverage xml'
     cover: codecov --file Tests/coverage.xml -X pycov -X gcov
 
 [testenv:style]
@@ -117,11 +117,11 @@ commands =
     flake8
     # Now do various checks on our RST files:
     # Calling via bash to get it to expand the wildcard for us
-    bash -c \'rst-lint --level warning *.rst\'
+    bash -c 'rst-lint --level warning *.rst'
     # Check sort order (bash call work around for pipe character)
-    bash -c \'grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f\'
+    bash -c 'grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f'
     # Check copyright date
-    bash -c \'grep "1999-`date +'%Y'`" LICENSE.rst\'
+    bash -c 'grep "1999-`date +'%Y'`" LICENSE.rst'
     # Would like to tell doc8 to just check *.rst but does *.txt too:
     bash -c "doc8 --ignore-path 'Doc/examples/ec_*.txt' *.rst Doc/"
     # Check no __docformat__ lines
@@ -165,6 +165,6 @@ deps =
     pygments
     sphinx_rtd_theme
 commands =
-    bash -c \'python setup.py install > /dev/null\'
-    bash -c \'mkdir -p Doc/api/_templates Doc/api/_static Doc/api/_build\'
+    bash -c 'python setup.py install > /dev/null'
+    bash -c 'mkdir -p Doc/api/_templates Doc/api/_static Doc/api/_build'
     make -C Doc/api/ html

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,21 @@ matrix:
         apt:
           packages:
       before_install: echo "Going to run basic checks"
+    - stage: basics
+      env: TOXENV=docs
+      addons:
+        apt:
+          packages:
+          - texlive
+          - texlive-latex-extra
+          - hevea
+      before_install:
+      - echo "Going to build the LaTeX documentation"
+      install:
+      - echo "Installed pdflatex and hevea via apt-get"
+      script:
+      - cd Doc
+      - make
     - stage: test
       python: 3.7
       env: TOXENV=api

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@
 # - basics - quick things like style and packaging
 # - test - the actual functional tests which are slow
 
-dist: xenial
+dist: bionic
 services:
   - mysql
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,13 +52,13 @@ matrix:
           packages:
           - texlive
           - texlive-latex-extra
-          - hevea
+          #- hevea
       before_install:
       - echo "Going to build the LaTeX documentation"
       install:
-      - echo "Installed pdflatex and hevea via apt-get"
+      - echo "Installed pdflatex via apt-get"
       script:
-      - make -C Doc/
+      - make -C Doc/ Tutorial.pdf
     - stage: test
       python: 3.7
       env: TOXENV=api

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,7 @@ matrix:
       install:
       - echo "Installed pdflatex and hevea via apt-get"
       script:
-      - cd Doc
-      - make
+      - make -C Doc/
     - stage: test
       python: 3.7
       env: TOXENV=api


### PR DESCRIPTION
Rather than using Tox, this just uses the TravisCI config.

Build times seem quicker than our style checks, so having this as another basic check in the first stage seems best (rather than as part of the main test stage).

This doesn't (yet) do anything with the compiled PDF and HTML files, but ensures we don't have any undetected LaTeX syntax errors lurking until next time someone tries to build things (e.g. the next release).