### PR TITLE
Parse XML files in bytes mode to avoid encoding error

### DIFF
--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -579,9 +579,17 @@ def parse(handle, debug=0):
     BLOCK = 1024
     MARGIN = 10  # must be at least length of newline + XML start
     XML_START = "<?xml"
+    NEW_LINE = "\n"
+    NULL = ""
 
-    text = handle.read(BLOCK)
     pending = ""
+    text = handle.read(BLOCK)
+    if isinstance(text, bytes):
+        # Not a text handle, raw bytes mode
+        XML_START = b"<?xml"
+        NEW_LINE = b"\n"
+        NULL = b""
+        pending = b""
 
     if not text:
         # NO DATA FOUND!
@@ -590,9 +598,9 @@ def parse(handle, debug=0):
     while text:
         # We are now starting a new XML file
         if not text.startswith(XML_START):
-            raise ValueError("Your XML file did not start with %s... "
-                             "but instead %s"
-                             % (XML_START, repr(text[:20])))
+            raise ValueError("Your XML file did not start with %b... "
+                             "but instead %b"
+                             % (XML_START, text[:20]))
 
         expat_parser = expat.ParserCreate()
         blast_parser = BlastParser(debug)
@@ -611,14 +619,14 @@ def parse(handle, debug=0):
             text, pending = pending + handle.read(BLOCK), ""
             if not text:
                 # End of the file!
-                expat_parser.Parse("", True)  # End of XML record
+                expat_parser.Parse(NULL, True)  # End of XML record
                 break
 
             # Now read a little bit more so we can check for the
             # start of another XML file...
             pending = handle.read(MARGIN)
 
-            if ("\n" + XML_START) not in (text + pending):
+            if (NEW_LINE + XML_START) not in (text + pending):
                 # Good - still dealing with the same XML file
                 expat_parser.Parse(text, False)
                 while blast_parser._records:
@@ -628,7 +636,7 @@ def parse(handle, debug=0):
                 # one XML file for each query!
 
                 # Finish the old file:
-                text, pending = (text + pending).split("\n" + XML_START, 1)
+                text, pending = (text + pending).split(NEW_LINE + XML_START, 1)
                 pending = XML_START + pending
 
                 expat_parser.Parse(text, True)  # End of XML record
@@ -637,7 +645,7 @@ def parse(handle, debug=0):
 
                 # Now we are going to re-loop, reset the
                 # parsers and start reading the next XML file
-                text, pending = pending, ""
+                text, pending = pending, NULL
                 break
 
         # this was added because it seems that the Jython expat parser
@@ -648,10 +656,10 @@ def parse(handle, debug=0):
         # At this point we have finished the first XML record.
         # If the file is from an old version of blast, it may
         # contain more XML records (check if text=="").
-        assert pending == ""
-        assert len(blast_parser._records) == 0
+        assert not pending, pending
+        assert len(blast_parser._records) == 0, len(blast_parser._records)
 
     # We should have finished the file!
-    assert text == ""
-    assert pending == ""
-    assert len(blast_parser._records) == 0
+    assert not text, text
+    assert not pending, pending
+    assert len(blast_parser._records) == 0, len(blast_parser._records)

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -442,7 +442,7 @@ _FormatToWriter = {"fasta": FastaIO.FastaWriter,
                    "seqxml": SeqXmlIO.SeqXmlWriter,
                    }
 
-_BinaryFormats = ["sff", "sff-trim", "abi", "abi-trim"]
+_BinaryFormats = ["sff", "sff-trim", "abi", "abi-trim", "seqxml"]
 
 
 def write(sequences, handle, format):

--- a/Tests/test_NCBIXML.py
+++ b/Tests/test_NCBIXML.py
@@ -17,7 +17,7 @@ class TestNCBIXML(unittest.TestCase):
 
         filename = 'xml_2212L_blastp_001.xml'
         datafile = os.path.join("Blast", filename)
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         records = NCBIXML.parse(handle)
         record = next(records)
 
@@ -1393,7 +1393,7 @@ class TestNCBIXML(unittest.TestCase):
         self.assertRaises(StopIteration, next, records)
         handle.close()
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         record = NCBIXML.read(handle)
         handle.close()
 
@@ -1402,7 +1402,7 @@ class TestNCBIXML(unittest.TestCase):
 
         filename = 'xml_2212L_blastn_001.xml'
         datafile = os.path.join("Blast", filename)
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         records = NCBIXML.parse(handle)
         record = next(records)
         alignments = record.alignments
@@ -1422,7 +1422,7 @@ class TestNCBIXML(unittest.TestCase):
         self.assertRaises(StopIteration, next, records)
         handle.close()
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         record = NCBIXML.read(handle)
         handle.close()
 
@@ -1432,7 +1432,7 @@ class TestNCBIXML(unittest.TestCase):
         filename = 'xml_2212L_blastx_001.xml'
         datafile = os.path.join("Blast", filename)
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         records = NCBIXML.parse(handle)
         record = next(records)
         alignments = record.alignments
@@ -1442,7 +1442,7 @@ class TestNCBIXML(unittest.TestCase):
         self.assertRaises(StopIteration, next, records)
         handle.close()
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         record = NCBIXML.read(handle)
         handle.close()
 
@@ -1452,7 +1452,7 @@ class TestNCBIXML(unittest.TestCase):
         filename = 'xml_2212L_tblastn_001.xml'
         datafile = os.path.join("Blast", filename)
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         records = NCBIXML.parse(handle)
         record = next(records)
         alignments = record.alignments
@@ -1462,7 +1462,7 @@ class TestNCBIXML(unittest.TestCase):
         self.assertRaises(StopIteration, next, records)
         handle.close()
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         record = NCBIXML.read(handle)
         handle.close()
 
@@ -1472,7 +1472,7 @@ class TestNCBIXML(unittest.TestCase):
         filename = 'xml_2212L_tblastx_001.xml'
         datafile = os.path.join("Blast", filename)
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         records = NCBIXML.parse(handle)
         record = next(records)
         alignments = record.alignments
@@ -1482,7 +1482,7 @@ class TestNCBIXML(unittest.TestCase):
         self.assertRaises(StopIteration, next, records)
         handle.close()
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         record = NCBIXML.read(handle)
         handle.close()
 
@@ -1493,7 +1493,7 @@ class TestNCBIXML(unittest.TestCase):
         filename = 'xml_2218_blastp_001.xml'
         datafile = os.path.join("Blast", filename)
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         records = NCBIXML.parse(handle)
 
         record = next(records)
@@ -1549,7 +1549,7 @@ class TestNCBIXML(unittest.TestCase):
         self.assertRaises(StopIteration, next, records)
         handle.close()
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         record = NCBIXML.read(handle)
         handle.close()
 
@@ -1558,7 +1558,7 @@ class TestNCBIXML(unittest.TestCase):
 
         filename = 'xml_2218_blastp_002.xml'
         datafile = os.path.join("Blast", filename)
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         records = NCBIXML.parse(handle)
         record = next(records)
         self.assertEqual(record.query_id, "gi|585505|sp|Q08386|MOPB_RHOCA")
@@ -1576,7 +1576,7 @@ class TestNCBIXML(unittest.TestCase):
         filename = 'xml_2218L_blastp_001.xml'
         datafile = os.path.join("Blast", filename)
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         records = NCBIXML.parse(handle)
         record = next(records)
         self.assertEqual(record.query_id, "lcl|1_0")
@@ -1585,7 +1585,7 @@ class TestNCBIXML(unittest.TestCase):
         self.assertRaises(StopIteration, next, records)
         handle.close()
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         record = NCBIXML.read(handle)
         handle.close()
 
@@ -1596,7 +1596,7 @@ class TestNCBIXML(unittest.TestCase):
         filename = 'xml_2222_blastx_001.xml'
         datafile = os.path.join("Blast", filename)
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         records = NCBIXML.parse(handle)
 
         record = next(records)
@@ -1720,7 +1720,7 @@ class TestNCBIXML(unittest.TestCase):
         filename = 'xml_2222_blastp_001.xml'
         datafile = os.path.join("Blast", filename)
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         records = NCBIXML.parse(handle)
 
         record = next(records)
@@ -1763,7 +1763,7 @@ class TestNCBIXML(unittest.TestCase):
         filename = 'xml_2218L_rpsblast_001.xml'
         datafile = os.path.join("Blast", filename)
 
-        handle = open(datafile)
+        handle = open(datafile, "rb")
         records = NCBIXML.parse(handle)
 
         record = next(records)


### PR DESCRIPTION
This would resolve #855 and #1319 

A similar approach might work for #1320 and #1321 

For testing you need to (temporarily) change the locale settings, e.g. with ``LANG=C``, see detailed notes on #855.