### PR TITLE
TravisCI: Use flake8-rst-docstrings plugin

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -91,6 +91,7 @@ deps =
     flake8
     flake8-docstrings
     flake8-blind-except
+    flake8-rst-docstrings
     restructuredtext_lint
 commands =
     # These folders each have their own .flake8 file:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,7 +45,7 @@ checks, so if you are making a contribution it is best to check this locally.
 We use the tool ``flake8`` for code style checks, together with various
 plugins which can be installed as follows::
 
-    $ pip install flake8 flake8-docstrings flake8-blind-except
+    $ pip install flake8 flake8-docstrings flake8-blind-except flake8-rst-docstrings
 
 You can then run ``flake8`` directly as follows:
 


### PR DESCRIPTION
This will put our docstrings though docutils to check they are valid as reStructuredText (RST), using my flake8 plugin:

* https://pypi.python.org/pypi/flake8-rst-docstrings
* https://github.com/peterjc/flake8-rst-docstrings

Note just because a docstring passes this validation does not mean it will render as expected.

Cross reference #1221 