### PR TITLE
Save a PDB file to a string

### DIFF
--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -194,7 +194,7 @@ class PDBIO(object):
             if not preserve_atom_numbering:
                 atom_number = 1
             if model_flag:
-                fp.write("MODEL      %s\n" % model.serial_num)
+                fp.write(u"MODEL      %s\n" % model.serial_num)
             for chain in model.get_list():
                 if not select.accept_chain(chain):
                     continue
@@ -217,17 +217,17 @@ class PDBIO(object):
                                 atom_number = atom.get_serial_number()
                             s = get_atom_line(atom, hetfield, segid, atom_number, resname,
                                               resseq, icode, chain_id)
-                            fp.write(s)
+                            fp.write(unicode(s, "utf-8"))
                             if not preserve_atom_numbering:
                                 atom_number += 1
                 if chain_residues_written:
-                    fp.write("TER   %5i      %3s %c%4i%c                                                      \n"
+                    fp.write(u"TER   %5i      %3s %c%4i%c                                                      \n"
                              % (atom_number, resname, chain_id, resseq, icode))
 
             if model_flag and model_residues_written:
-                fp.write("ENDMDL\n")
+                fp.write(u"ENDMDL\n")
         if write_end:
-            fp.write('END\n')
+            fp.write(u'END\n')
         if close_file:
             fp.close()
 


### PR DESCRIPTION
It would be nice to be able to save a PDB file to a string as well as a file using the same function. This is currently possible on Python 2:

```python
from Bio.PDB import PDBParser, PDBIO
from StringIO import StringIO

parser = PDBParser()
structure = parser.get_structure("1AKE", "1AKE.pdb")

io_pdb = PDBIO()
io_pdb.set_structure(structure)
io_str = StringIO()
io_pdb.save(io_str)

io_str.getvalue()
```

However `StringIO` was updated and in Python3 expects unicode strings, so the above doesn't work. Converting the strings to unicode in `save` as in this PR makes the above work (the import changes to `from io import StringIO`). Let me know if this is the right way to get round the problem.