### PR TITLE
We will drop support for Python 2.7 no later than 2020

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -15,6 +15,10 @@ This release of Biopython supports Python 2.7, 3.4, 3.5 and 3.6.
 It has also been tested on PyPy v5.7, PyPy3.5 v5.8 beta, and Jython 2.7
 (although support for Jython is deprecated).
 
+Python 3 is the primary development platform for Biopython. We will drop
+support for Python 2.7 no later than 2020, in line with the end-of-life or
+sunset date for Python 2.7 itself.
+
 Encoding issues have been fixed in several parsers when reading data files
 with non-ASCII characters, like accented letters in people's names. This would
 raise ``UnicodeDecodeError: 'ascii' codec can't decode byte ...`` under some

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,9 @@ implementations:
 
 - Python 2.7, 3.4, 3.5, 3.6 -- see http://www.python.org
 
-  This is the primary development platform for Biopython.
+  Python 3 is the primary development platform for Biopython. We will drop
+  support for Python 2.7 no later than 2020, in line with the end-of-life or
+  sunset date for Python 2.7 itself.
 
 - PyPy v5.7 and also PyPy3.5 v5.8 beta -- see http://www.pypy.org
 


### PR DESCRIPTION
See http://www.python3statement.org/ and https://www.python.org/dev/peps/pep-0373/#update

Proposed on the mailing list, see http://mailman.open-bio.org/pipermail/biopython-dev/2017-June/021794.html