### PR TITLE
Also clean aux files created in Doc/Tutorial

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -33,6 +33,7 @@ clean: clean-subdirs
 	rm -f biopdb_faq.aux
 	rm -f biopdb_faq.log
 	rm -f biopdb_faq.out
+	rm -f Tutorial/*.aux
 
 distclean-subdirs: $(subdirs)
 	( for f in $^ ; do $(MAKE) distclean -C $$f ; done )


### PR DESCRIPTION
The include instructions in Doc/tutorial.tex each spawn a corresponding aux file.

Just something I noticed for repeated builds of the Debian package.

Cheers,

Steffen