### PR TITLE
Improving UnknownSeq.count() when it is used with variable start and end args

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1421,24 +1421,29 @@ class UnknownSeq(Seq):
         1
         """
         sub_str = self._get_seq_str_and_check_alphabet(sub)
-        if len(sub_str) == 1:
-            if str(sub_str) == self._character:
-                if start == 0 and end >= self._length:
-                    return self._length
-                else:
-                    # This could be done more cleverly...
-                    return str(self).count(sub_str, start, end)
-            else:
-                return 0
-        else:
-            if set(sub_str) == set(self._character):
-                if start == 0 and end >= self._length:
-                    return self._length // len(sub_str)
-                else:
-                    # This could be done more cleverly...
-                    return str(self).count(sub_str, start, end)
-            else:
-                return 0
+        len_self, len_sub_str = self._length, len(sub_str)
+        # Handling case where substring not in self
+        if set(sub_str) != set(self._character):
+            return 0
+        # Setting None to the default arguments
+        if start is None:
+            start = 0
+        if end is None:
+            end = sys.maxsize
+        # Truncating start and end to max of self._length and min of -self._length
+        start = max(min(start, len_self), -len_self)
+        end = max(min(end, len_self), -len_self)
+        # Convert start and ends to positive indexes
+        if start < 0:
+            start += len_self
+        if end < 0:
+            end += len_self
+        # Handle case where end <= start (no negative step argument here)
+        # and case where len_sub_str is larger than the search space
+        if end <= start or (end - start) < len_sub_str:
+            return 0
+        # 'Normal' calculation
+        return (end - start) // len_sub_str
 
     def count_overlap(self, sub, start=0, end=sys.maxsize):
         """Return an overlapping count.

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -97,7 +97,7 @@ class StringMethodTests(unittest.TestCase):
     for seq in _examples[:]:
         if isinstance(seq, Seq):
             _examples.append(seq.tomutable())
-    _start_end_values = [0, 1, 2, 1000, -1, -2, -999]
+    _start_end_values = [0, 1, 2, 1000, -1, -2, -999, None]
 
     def _test_method(self, method_name, pre_comp_function=None,
                      start_end=False):
@@ -490,7 +490,7 @@ class StringMethodTests(unittest.TestCase):
         for example1 in self._examples:
             str1 = str(example1)
             for i in self._start_end_values:
-                if abs(i) < len(example1):
+                if i is not None and abs(i) < len(example1):
                     self.assertEqual(str(example1[i]), str1[i])
                 self.assertEqual(str(example1[:i]), str1[:i])
                 self.assertEqual(str(example1[i:]), str1[i:])


### PR DESCRIPTION
In pull request #1301 it was mentioned that `UnknownSeq.count()` could be improved, because when variable start and/or end argument are used, the current implementation converts the entire sequence to a string. This will have a substantial memory burden for long sequences. The comments in the current code also hint at this: `# This could be done more cleverly...` (for example [here](https://github.com/chris-rands/biopython/blob/master/Bio/Seq.py#L1429)).

Since Peter and I implemented `UnknownSeq.count_overlap()` in [97709cc](https://github.com/biopython/biopython/commit/97709cc7a4b8591e794b442796d41e4f7b855a0f), I knew a similar approach should work for `UnknownSeq.count()` and this is what is implemented here.

The new implementation passes the original doctests and the tests in `Tests/test_Seq_objs.py`; no further tests have been added. Someone should carefully check the logic and ensure that I haven't done anything stupid.

Note, I haven't done any formal benchmarks of speed or memory usage of the old vs. suggested new implementations, I don't know if this is necessary or indeed handled by Biopython's own tests.

Please advise how to proceed, thank you!