### PR TITLE
Use LOCUS as fallback when indexing GenBank

### DIFF
--- a/Bio/SeqIO/_index.py
+++ b/Bio/SeqIO/_index.py
@@ -252,15 +252,20 @@ class GenBankRandomAccess(SequentialSeqFileRandomAccess):
         while marker_re.match(line):
             # We cannot assume the record.id is the first word after LOCUS,
             # normally the first entry on the VERSION or ACCESSION line is used.
-            key = None
+            # However if both missing, GenBank parser falls back on LOCUS entry.
+            try:
+                key = line[5:].split(None, 1)[0]
+            except ValueError:
+                # Warning?
+                # No content in LOCUS line
+                key = None
             length = len(line)
             while True:
                 end_offset = handle.tell()
                 line = handle.readline()
                 if marker_re.match(line) or not line:
                     if not key:
-                        raise ValueError(
-                            "Did not find usable ACCESSION/VERSION lines")
+                        raise ValueError("Did not find usable ACCESSION/VERSION/LOCUS lines")
                     yield _bytes_to_string(key), start_offset, length
                     start_offset = end_offset
                     break

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -295,33 +295,6 @@ if sqlite3:
                        expt_sff_files)
 
 
-class Problems(unittest.TestCase):
-    """Corner cases where we expect indexing to fail.
-
-    Goal of these tests is to make sure they fail the right way.
-    """
-
-    def setUp(self):
-        os.chdir(CUR_DIR)
-        h, self.index_tmp = tempfile.mkstemp("_idx.tmp")
-        os.close(h)
-
-    def tearDown(self):
-        os.chdir(CUR_DIR)
-        if os.path.isfile(self.index_tmp):
-            os.remove(self.index_tmp)
-
-    def test_genbank_empty_accession(self):
-        """Test an empty ACCESSION line causes a ValueError."""
-        filename = "GenBank/empty_accession.gbk"
-        self.assertRaises(ValueError, SeqIO.index, filename, 'genbank')
-
-    def test_genbank_empty_version(self):
-        """Test an empty VERSION line causes a ValueError."""
-        filename = "GenBank/empty_version.gbk"
-        self.assertRaises(ValueError, SeqIO.index, filename, 'genbank')
-
-
 class IndexDictTests(unittest.TestCase):
     """Cunning unit test where methods are added at run time."""
 
@@ -664,6 +637,8 @@ tests = [
     ("GenBank/NC_005816.fna", "fasta", generic_dna),
     ("GenBank/NC_005816.gb", "gb", None),
     ("GenBank/cor6_6.gb", "genbank", None),
+    ("GenBank/empty_accession.gbk", "gb", None),
+    ("GenBank/empty_version.gbk", "gb", None),
     ("IntelliGenetics/vpu_nucaligned.txt", "ig", generic_nucleotide),
     ("IntelliGenetics/TAT_mase_nuc.txt", "ig", None),
     ("IntelliGenetics/VIF_mase-pro.txt", "ig", generic_protein),


### PR DESCRIPTION
This should resolve #1344, building on the test cases contributed by Kai, for the special case of indexing a GenBank file missing usable ACCESSION or VERSION lines.

Does this work for you @kblin?