### PR TITLE
Improve Travis before_install part for readability.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,8 +92,31 @@ before_install:
   - unzip PhyML-3.1.zip
   - mv PhyML-3.1/PhyML-3.1_linux64 bin/phyml
   - cd $HOME
-  - "if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then deactivate && wget https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.7.1-linux_x86_64-portable.tar.bz2 && tar -jxvf pypy-5.7.1-linux_x86_64-portable.tar.bz2 && echo 'Setting up aliases...' && cd pypy-5.7.1-linux_x86_64-portable/bin/ && export PATH=$PWD:$PATH && ln -s pypy python && echo 'Setting up pip...' && ./pypy -m ensurepip ; fi"
-  - "if [[ $TRAVIS_PYTHON_VERSION == 'pypy3' ]]; then deactivate && wget https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.8-beta-linux_x86_64-portable.tar.bz2 && tar -jxvf pypy3.5-5.8-beta-linux_x86_64-portable.tar.bz2 && echo 'Setting up aliases...' && cd pypy3.5-5.8-beta-linux_x86_64-portable/bin/ && export PATH=$PWD:$PATH && ln -s pypy3 python && echo 'Setting up pip...' && ./pypy3 -m ensurepip && ln -s pip3 pip ; fi"
+  - |
+    if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then
+        deactivate
+        wget https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.7.1-linux_x86_64-portable.tar.bz2
+        tar -jxvf pypy-5.7.1-linux_x86_64-portable.tar.bz2
+        echo 'Setting up aliases...'
+        cd pypy-5.7.1-linux_x86_64-portable/bin/
+        export PATH=$PWD:$PATH
+        ln -s pypy python
+        echo 'Setting up pip...'
+        ./pypy -m ensurepip
+    fi
+  - |
+    if [[ $TRAVIS_PYTHON_VERSION == 'pypy3' ]]; then
+        deactivate
+        wget https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-5.8-beta-linux_x86_64-portable.tar.bz2
+        tar -jxvf pypy3.5-5.8-beta-linux_x86_64-portable.tar.bz2
+        echo 'Setting up aliases...'
+        cd pypy3.5-5.8-beta-linux_x86_64-portable/bin/
+        export PATH=$PWD:$PATH
+        ln -s pypy3 python
+        echo 'Setting up pip...'
+        ./pypy3 -m ensurepip
+        ln -s pip3 pip
+    fi
   - cd $HOME
   - echo "Installing dssp"
   - curl -L -O ftp://ftp.cmbi.ru.nl/pub/software/dssp/dssp-2.0.4-linux-amd64


### PR DESCRIPTION
Hello,

I updated  Travis before_install part in `.travis.yml` for readability.
YAML block style "|" helps us for that.
As Travis is run as "bash -e" mode, I think that we do not have to connect with `&&`.

