### PR TITLE
Show matches vs mismatches in pairwise2 printing

### DIFF
--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -214,7 +214,7 @@ To see a description of the parameters for a function, please look at
 the docstring for the function via the help function, e.g.
 type ``help(pairwise2.align.localds``) at the Python prompt.
 
-"""
+"""  # noqa: W291
 from __future__ import print_function
 
 import warnings

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -56,7 +56,7 @@ printout, use the ``format_alignment`` method of the module:
     >>> from Bio.pairwise2 import format_alignment
     >>> print(format_alignment(*alignments[0]))
     ACCGT
-    |||||
+    |.||.
     A-CG-
       Score=3
     <BLANKLINE>
@@ -103,12 +103,12 @@ Some examples:
     >>> for a in pairwise2.align.globalxx("ACCGT", "ACG"):
     ...     print(format_alignment(*a))
     ACCGT
-    |||||
+    |.||.
     A-CG-
       Score=3
     <BLANKLINE>
     ACCGT
-    |||||
+    ||.|.
     AC-G-
       Score=3
     <BLANKLINE>
@@ -118,12 +118,12 @@ Some examples:
     >>> for a in pairwise2.align.localxx("ACCGT", "ACG"):
     ...     print(format_alignment(*a))
     ACCGT
-    ||||
+    |.||
     A-CG-
       Score=3
     <BLANKLINE>
     ACCGT
-    ||||
+    ||.|
     AC-G-
       Score=3
     <BLANKLINE>
@@ -134,12 +134,12 @@ Some examples:
     >>> for a in pairwise2.align.globalmx("ACCGT", "ACG", 2, -1):
     ...     print(format_alignment(*a))
     ACCGT
-    |||||
+    |.||.
     A-CG-
       Score=6
     <BLANKLINE>
     ACCGT
-    |||||
+    ||.|.
     AC-G-
       Score=6
     <BLANKLINE>
@@ -150,12 +150,12 @@ Some examples:
     >>> for a in pairwise2.align.globalms("ACCGT", "ACG", 2, -1, -.5, -.1):
     ...     print(format_alignment(*a))
     ACCGT
-    |||||
+    |.||.
     A-CG-
       Score=5
     <BLANKLINE>
     ACCGT
-    |||||
+    ||.|.
     AC-G-
       Score=5
     <BLANKLINE>
@@ -167,14 +167,14 @@ Some examples:
     >>> for a in pairwise2.align.globalms("A", "T", 5, -4, -1, -.1):
     ...     print(format_alignment(*a))
     A-
-    ||
+    ..
     -T
       Score=-2
     <BLANKLINE>
     >>> for a in pairwise2.align.globalms("A", "T", 5, -4, -3, -.1):
     ...	    print(format_alignment(*a))
     A
-    |
+    .
     T
       Score=-4
     <BLANKLINE>
@@ -187,7 +187,7 @@ Some examples:
     >>> for a in pairwise2.align.globaldx("KEVLA", "EVL", matrix):
     ...     print(format_alignment(*a))
     KEVLA
-    |||||
+    .|||.
     -EVL-
       Score=13
     <BLANKLINE>
@@ -1026,10 +1026,17 @@ def print_matrix(matrix):
 
 
 def format_alignment(align1, align2, score, begin, end):
-    """Format the alignment prettily into a string."""
+    """Format the alignment prettily into a string.
+
+    Since Biopython 1.71 identical matches are shown with a pipe
+    character, with a colon for mismatches. Prior releases always
+    used a pipe.
+    """
     s = []
     s.append("%s\n" % align1)
-    s.append("%s%s\n" % (" " * begin, "|" * (end - begin)))
+    matches = "".join("|" if a == b else "." for a, b in
+                      zip(align1[begin:end], align2[begin:end]))
+    s.append("%s%s\n" % (" " * begin, matches))
     s.append("%s\n" % align2)
     s.append("  Score=%g\n" % score)
     return ''.join(s)
@@ -1044,3 +1051,7 @@ try:
 except ImportError:
     warnings.warn('Import of C module failed. Falling back to pure Python ' +
                   'implementation. This may be slooow...', BiopythonWarning)
+
+if __name__ == "__main__":
+    from Bio._utils import run_doctest
+    run_doctest()

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -56,7 +56,7 @@ printout, use the ``format_alignment`` method of the module:
     >>> from Bio.pairwise2 import format_alignment
     >>> print(format_alignment(*alignments[0]))
     ACCGT
-    |.||.
+    | || 
     A-CG-
       Score=3
     <BLANKLINE>
@@ -103,12 +103,12 @@ Some examples:
     >>> for a in pairwise2.align.globalxx("ACCGT", "ACG"):
     ...     print(format_alignment(*a))
     ACCGT
-    |.||.
+    | || 
     A-CG-
       Score=3
     <BLANKLINE>
     ACCGT
-    ||.|.
+    || | 
     AC-G-
       Score=3
     <BLANKLINE>
@@ -118,12 +118,12 @@ Some examples:
     >>> for a in pairwise2.align.localxx("ACCGT", "ACG"):
     ...     print(format_alignment(*a))
     ACCGT
-    |.||
+    | ||
     A-CG-
       Score=3
     <BLANKLINE>
     ACCGT
-    ||.|
+    || |
     AC-G-
       Score=3
     <BLANKLINE>
@@ -134,12 +134,12 @@ Some examples:
     >>> for a in pairwise2.align.globalmx("ACCGT", "ACG", 2, -1):
     ...     print(format_alignment(*a))
     ACCGT
-    |.||.
+    | || 
     A-CG-
       Score=6
     <BLANKLINE>
     ACCGT
-    ||.|.
+    || | 
     AC-G-
       Score=6
     <BLANKLINE>
@@ -150,12 +150,12 @@ Some examples:
     >>> for a in pairwise2.align.globalms("ACCGT", "ACG", 2, -1, -.5, -.1):
     ...     print(format_alignment(*a))
     ACCGT
-    |.||.
+    | || 
     A-CG-
       Score=5
     <BLANKLINE>
     ACCGT
-    ||.|.
+    || | 
     AC-G-
       Score=5
     <BLANKLINE>
@@ -167,7 +167,7 @@ Some examples:
     >>> for a in pairwise2.align.globalms("A", "T", 5, -4, -1, -.1):
     ...     print(format_alignment(*a))
     A-
-    ..
+    <BLANKLINE>
     -T
       Score=-2
     <BLANKLINE>
@@ -187,7 +187,7 @@ Some examples:
     >>> for a in pairwise2.align.globaldx("KEVLA", "EVL", matrix):
     ...     print(format_alignment(*a))
     KEVLA
-    .|||.
+     ||| 
     -EVL-
       Score=13
     <BLANKLINE>
@@ -1029,14 +1029,25 @@ def format_alignment(align1, align2, score, begin, end):
     """Format the alignment prettily into a string.
 
     Since Biopython 1.71 identical matches are shown with a pipe
-    character, with a colon for mismatches. Prior releases always
-    used a pipe.
+    character, mismatches as a dot, and gaps as a space.
+
+    Note that spaces are also used at the start/end of a local
+    alignment.
+
+    Prior releases just used the pipe character to indicate the
+    aligned region (matches, mismatches and gaps).
     """
     s = []
     s.append("%s\n" % align1)
-    matches = "".join("|" if a == b else "." for a, b in
-                      zip(align1[begin:end], align2[begin:end]))
-    s.append("%s%s\n" % (" " * begin, matches))
+    s.append(" " * begin)
+    for a, b in zip(align1[begin:end], align2[begin:end]):
+        if a == b:
+            s.append("|")  # match
+        elif a == "-" or b == "-":
+            s.append(" ")  # gap
+        else:
+            s.append(".")  # mismatch
+    s.append("\n")
     s.append("%s\n" % align2)
     s.append("  Score=%g\n" % score)
     return ''.join(s)

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1513,7 +1513,7 @@ of 2/0.5 using \verb|localms|):
 >>> alignments = pairwise2.align.localms("AGAACT", "GAC", 5, -4, -2, -0.5)
 >>> print(pairwise2.format_alignment(*alignments[0]))
 AGAACT
- |.||
+ | ||
 -G-AC-
   Score=13
 <BLANKLINE>

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1497,7 +1497,7 @@ where again XX stands for a two letter code for the match and gap functions:
 >>> alignments = pairwise2.align.localds("LSPADKTNVKAA", "PEEKSAV", blosum62, -10, -1)
 >>> print(pairwise2.format_alignment(*alignments[0]))
 LSPADKTNVKAA
-  |||||||
+  |..|..|
 --PEEKSAV---
   Score=16
 <BLANKLINE>
@@ -1513,7 +1513,7 @@ of 2/0.5 using \verb|localms|):
 >>> alignments = pairwise2.align.localms("AGAACT", "GAC", 5, -4, -2, -0.5)
 >>> print(pairwise2.format_alignment(*alignments[0]))
 AGAACT
- ||||
+ |.||
 -G-AC-
   Score=13
 <BLANKLINE>

--- a/Tests/test_pairwise2.py
+++ b/Tests/test_pairwise2.py
@@ -72,7 +72,7 @@ class TestPairwiseGlobal(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GAACT
-|||||
+|.|.|
 G-A-T
   Score=3
 """)
@@ -80,7 +80,7 @@ G-A-T
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GAACT
-|||||
+||..|
 GA--T
   Score=3
 """)
@@ -94,7 +94,7 @@ GA--T
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 G-A-T
-|||||
+|.|.|
 GAACT
   Score=3
 """)
@@ -102,7 +102,7 @@ GAACT
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GA--T
-|||||
+||..|
 GAACT
   Score=3
 """)
@@ -127,7 +127,7 @@ class TestPairwiseLocal(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 -AxBx
- |||
+ |.|
 zA-Bz
   Score=1.9
 """)
@@ -135,7 +135,7 @@ zA-Bz
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 -AxBx
- ||||
+ |.|.
 zA-Bz
   Score=1.9
 """)
@@ -168,7 +168,7 @@ zzzABzzCDz
                                              blosum62, -4, -4)
         for a in alignments:
             self.assertEqual(pairwise2.format_alignment(*a),
-                             "VKAHGKKV\n |||\nFQAHCAGV\n  Score=13\n")
+                             "VKAHGKKV\n .||\nFQAHCAGV\n  Score=13\n")
 
 
 class TestScoreOnly(unittest.TestCase):
@@ -199,7 +199,7 @@ class TestPairwiseOpenPenalty(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 AA
-||
+.|
 -A
   Score=1.9
 """)
@@ -207,7 +207,7 @@ AA
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 AA
-||
+|.
 A-
   Score=1.9
 """)
@@ -220,7 +220,7 @@ A-
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GAA
-|||
+|.|
 G-A
   Score=2.9
 """)
@@ -228,7 +228,7 @@ G-A
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GAA
-|||
+||.
 GA-
   Score=2.9
 """)
@@ -240,7 +240,7 @@ GA-
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GAACT
-|||||
+||..|
 GA--T
   Score=2.9
 """)
@@ -252,7 +252,7 @@ GA--T
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GC-T-
-|||||
+|..|.
 G-ATA
   Score=1.7
 """)
@@ -267,7 +267,7 @@ class TestPairwiseExtendPenalty(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-||||
+|..|
 G--T
   Score=1.3
 """)
@@ -280,7 +280,7 @@ G--T
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-||||
+|..|
 G--T
   Score=0.3
 """)
@@ -296,7 +296,7 @@ class TestPairwisePenalizeExtendWhenOpening(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-||||
+|..|
 G--T
   Score=-1.2
 """)
@@ -313,7 +313,7 @@ class TestPairwisePenalizeEndgaps(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-||||
+...|
 --GT
   Score=1
 """)
@@ -321,7 +321,7 @@ GACT
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-||||
+|..|
 G--T
   Score=1
 """)
@@ -329,7 +329,7 @@ G--T
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-||||
+|...
 GT--
   Score=1
 """)
@@ -345,7 +345,7 @@ GT--
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-||||
+...|
 --GT
   Score=1
 """)
@@ -353,7 +353,7 @@ GACT
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-||||
+|..|
 G--T
   Score=1
 """)
@@ -361,7 +361,7 @@ G--T
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-||||
+|...
 GT--
   Score=1
 """)
@@ -377,7 +377,7 @@ class TestPairwiseSeparateGapPenalties(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 G-AT
-||||
+|..|
 GTCT
   Score=1.7
 """)
@@ -385,7 +385,7 @@ GTCT
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GA-T
-||||
+|..|
 GTCT
   Score=1.7
 """)
@@ -397,7 +397,7 @@ GTCT
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GAT--
-|||
+|.|
 G-TCT
   Score=1.8
 """)
@@ -414,7 +414,7 @@ class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 ['G', '-', 'A', 'A', 'T']
-|||||
+|...|
 ['G', 'T', 'C', 'C', 'T']
   Score=1.9
 """)
@@ -422,7 +422,7 @@ class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 ['G', 'A', '-', 'A', 'T']
-|||||
+|...|
 ['G', 'T', 'C', 'C', 'T']
   Score=1.9
 """)
@@ -430,7 +430,7 @@ class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 ['G', 'A', 'A', '-', 'T']
-|||||
+|...|
 ['G', 'T', 'C', 'C', 'T']
   Score=1.9
 """)
@@ -453,7 +453,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 ATAT
-||||
+||.|
 AT-T
   Score=3
 """)
@@ -461,7 +461,7 @@ AT-T
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 ATAT
-|||
+||.
 ATT-
   Score=3
 """)
@@ -473,7 +473,7 @@ ATT-
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 ATAT
-|||
+||.
 ATT-
   Score=3
 """)
@@ -485,7 +485,7 @@ ATT-
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 ATT-
-|||
+||.
 ATAT
   Score=3
 """)
@@ -533,7 +533,7 @@ abcce
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 abcde
-|||||
+..|..
 --c--
   Score=0.2
 """)
@@ -569,7 +569,7 @@ class TestPersiteGapPenalties(unittest.TestCase):
         formatted = pairwise2.format_alignment(*alignments[0])
         self.assertEqual(formatted, """\
 AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
-||||||||||||||||||||||||||||||||||||
+..|||||||||||..........|||||||||||..
 --AABBBAAAACC----------CCAAAABBBAA--
   Score=2
 """)
@@ -603,7 +603,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         formatted = pairwise2.format_alignment(*alignments[0])
         self.assertEqual(formatted, """\
 AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
-||||||||||||||||||||||||||||||||||||
+..|||................|||||||||||||..
 --AAB----------BBAAAACCCCAAAABBBAA--
   Score=-10
 """)

--- a/Tests/test_pairwise2.py
+++ b/Tests/test_pairwise2.py
@@ -210,7 +210,7 @@ AA
 | 
 A-
   Score=1.9
-""")
+""")  # noqa: W291
 
     def test_match_score_open_penalty2(self):
         aligns = pairwise2.align.globalms("GAA", "GA", 1.5, 0, -0.1, 0)
@@ -231,7 +231,7 @@ GAA
 || 
 GA-
   Score=2.9
-""")
+""")  # noqa: W291
 
     def test_match_score_open_penalty3(self):
         aligns = pairwise2.align.globalxs("GAACT", "GAT", -0.1, 0)
@@ -255,7 +255,7 @@ GC-T-
 |  | 
 G-ATA
   Score=1.7
-""")
+""")  # noqa: W291
 
 
 class TestPairwiseExtendPenalty(unittest.TestCase):
@@ -332,7 +332,7 @@ GACT
 |.  
 GT--
   Score=1
-""")
+""")  # noqa: W291
 
     def test_penalize_end_gaps2(self):
         """Do the same, but use the generic method (with the same result)."""
@@ -364,7 +364,7 @@ GACT
 |.  
 GT--
   Score=1
-""")
+""")  # noqa: W291
 
 
 class TestPairwiseSeparateGapPenalties(unittest.TestCase):
@@ -400,7 +400,7 @@ GAT--
 | |
 G-TCT
   Score=1.8
-""")
+""")  # noqa: W291
 
 
 class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
@@ -536,7 +536,7 @@ abcde
   |  
 --c--
   Score=0.2
-""")
+""")  # noqa: W291
 
 
 class TestPersiteGapPenalties(unittest.TestCase):
@@ -572,7 +572,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
   |||||||||||          |||||||||||  
 --AABBBAAAACC----------CCAAAABBBAA--
   Score=2
-""")
+""")  # noqa: W291
 
     def test_gap_here_only_2(self):
         """Force a bad alignment.
@@ -606,7 +606,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
   |||          ......|||||||||||||  
 --AAB----------BBAAAACCCCAAAABBBAA--
   Score=-10
-""")
+""")  # noqa: W291
 
 
 class TestOtherFunctions(unittest.TestCase):

--- a/Tests/test_pairwise2.py
+++ b/Tests/test_pairwise2.py
@@ -72,7 +72,7 @@ class TestPairwiseGlobal(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GAACT
-|.|.|
+| | |
 G-A-T
   Score=3
 """)
@@ -80,7 +80,7 @@ G-A-T
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GAACT
-||..|
+||  |
 GA--T
   Score=3
 """)
@@ -94,7 +94,7 @@ GA--T
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 G-A-T
-|.|.|
+| | |
 GAACT
   Score=3
 """)
@@ -102,7 +102,7 @@ GAACT
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GA--T
-||..|
+||  |
 GAACT
   Score=3
 """)
@@ -127,7 +127,7 @@ class TestPairwiseLocal(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 -AxBx
- |.|
+ | |
 zA-Bz
   Score=1.9
 """)
@@ -135,7 +135,7 @@ zA-Bz
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 -AxBx
- |.|.
+ | |.
 zA-Bz
   Score=1.9
 """)
@@ -199,7 +199,7 @@ class TestPairwiseOpenPenalty(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 AA
-.|
+ |
 -A
   Score=1.9
 """)
@@ -207,7 +207,7 @@ AA
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 AA
-|.
+| 
 A-
   Score=1.9
 """)
@@ -220,7 +220,7 @@ A-
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GAA
-|.|
+| |
 G-A
   Score=2.9
 """)
@@ -228,7 +228,7 @@ G-A
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GAA
-||.
+|| 
 GA-
   Score=2.9
 """)
@@ -240,7 +240,7 @@ GA-
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GAACT
-||..|
+||  |
 GA--T
   Score=2.9
 """)
@@ -252,7 +252,7 @@ GA--T
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GC-T-
-|..|.
+|  | 
 G-ATA
   Score=1.7
 """)
@@ -267,7 +267,7 @@ class TestPairwiseExtendPenalty(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-|..|
+|  |
 G--T
   Score=1.3
 """)
@@ -280,7 +280,7 @@ G--T
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-|..|
+|  |
 G--T
   Score=0.3
 """)
@@ -296,7 +296,7 @@ class TestPairwisePenalizeExtendWhenOpening(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-|..|
+|  |
 G--T
   Score=-1.2
 """)
@@ -313,7 +313,7 @@ class TestPairwisePenalizeEndgaps(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-...|
+  .|
 --GT
   Score=1
 """)
@@ -321,7 +321,7 @@ GACT
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-|..|
+|  |
 G--T
   Score=1
 """)
@@ -329,7 +329,7 @@ G--T
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-|...
+|.  
 GT--
   Score=1
 """)
@@ -345,7 +345,7 @@ GT--
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-...|
+  .|
 --GT
   Score=1
 """)
@@ -353,7 +353,7 @@ GACT
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-|..|
+|  |
 G--T
   Score=1
 """)
@@ -361,7 +361,7 @@ G--T
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GACT
-|...
+|.  
 GT--
   Score=1
 """)
@@ -377,7 +377,7 @@ class TestPairwiseSeparateGapPenalties(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 G-AT
-|..|
+| .|
 GTCT
   Score=1.7
 """)
@@ -385,7 +385,7 @@ GTCT
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GA-T
-|..|
+|. |
 GTCT
   Score=1.7
 """)
@@ -397,7 +397,7 @@ GTCT
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 GAT--
-|.|
+| |
 G-TCT
   Score=1.8
 """)
@@ -414,7 +414,7 @@ class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 ['G', '-', 'A', 'A', 'T']
-|...|
+| ..|
 ['G', 'T', 'C', 'C', 'T']
   Score=1.9
 """)
@@ -422,7 +422,7 @@ class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 ['G', 'A', '-', 'A', 'T']
-|...|
+|. .|
 ['G', 'T', 'C', 'C', 'T']
   Score=1.9
 """)
@@ -430,7 +430,7 @@ class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 ['G', 'A', 'A', '-', 'T']
-|...|
+|.. |
 ['G', 'T', 'C', 'C', 'T']
   Score=1.9
 """)
@@ -453,7 +453,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 ATAT
-||.|
+|| |
 AT-T
   Score=3
 """)
@@ -533,7 +533,7 @@ abcce
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
 abcde
-..|..
+  |  
 --c--
   Score=0.2
 """)
@@ -569,7 +569,7 @@ class TestPersiteGapPenalties(unittest.TestCase):
         formatted = pairwise2.format_alignment(*alignments[0])
         self.assertEqual(formatted, """\
 AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
-..|||||||||||..........|||||||||||..
+  |||||||||||          |||||||||||  
 --AABBBAAAACC----------CCAAAABBBAA--
   Score=2
 """)
@@ -603,7 +603,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         formatted = pairwise2.format_alignment(*alignments[0])
         self.assertEqual(formatted, """\
 AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
-..|||................|||||||||||||..
+  |||          ......|||||||||||||  
 --AAB----------BBAAAACCCCAAAABBBAA--
   Score=-10
 """)


### PR DESCRIPTION
This would help with situations like https://www.biostars.org/p/265338/#265624 by making the matches and mismatches of the aligned region easier to see.

Note space is already used to mean an unaligned region, thus I picked ``:`` to go with ``|``.

@MarkusPiotrowski and @bow: Could you review this please (eg is there any convention in ``Bio.SearchIO`` we could follow here)?