### PR TITLE
Reduce a number of virtuanl machine in Travis CI to save the resource.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,7 @@ matrix:
           packages:
       before_install: echo "Going to run basic checks"
     - stage: basics
-      env: TOXENV=sdist
-      addons:
-        apt:
-          packages:
-      before_install: echo "Going to run basic checks"
-    - stage: basics
-      env: TOXENV=bdist_wheel
+      env: TOXENV=sdist,bdist_wheel
       addons:
         apt:
           packages:


### PR DESCRIPTION
I know reducing a number of virtual machine is effective to save Travis CI's resource in my experience.
I think we can summarize `sdist`, `bdist_wheel` test on default Python (2.7) for that.

The result message is also helpful for us to know the result.

```
TOXENV='style,sdist,bdist_wheel' tox -c .travis-tox.ini
...
  style: commands succeeded
  sdist: commands succeeded
  bdist_wheel: commands succeeded
  congratulations :)
```
