### PR TITLE
Replace shlex dependency in mmCIF parsing

### DIFF
--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -67,6 +67,7 @@ class MMCIF2Dict(dict):
         in_token = False
         # quote character of the currently open quote, or None if no quote open
         quote_open_char = None
+        start_i = 0
         for (i, c) in enumerate(line):
             if c in self.whitespace_chars:
                 if in_token and not quote_open_char:
@@ -76,8 +77,8 @@ class MMCIF2Dict(dict):
                 if not quote_open_char:
                     quote_open_char = c
                     in_token = True
-                    start_i = i+1
-                elif c == quote_open_char and (i+1 == len(line) or line[i+1] in self.whitespace_chars):
+                    start_i = i + 1
+                elif c == quote_open_char and (i + 1 == len(line) or line[i + 1] in self.whitespace_chars):
                     quote_open_char = None
                     in_token = False
                     yield line[start_i:i]
@@ -87,7 +88,7 @@ class MMCIF2Dict(dict):
         if in_token:
             yield line[start_i:]
         if quote_open_char:
-            raise ValueError("Line ended with quote open: "+line)
+            raise ValueError("Line ended with quote open: " + line)
 
     def _tokenize(self, handle):
         for line in handle:

--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -7,8 +7,6 @@
 
 from __future__ import print_function
 
-import shlex
-
 from Bio.File import as_handle
 
 
@@ -22,6 +20,8 @@ class MMCIF2Dict(dict):
          - file - name of the PDB file OR an open filehandle
 
         """
+        self.quote_chars = ['\'', '\"']
+        self.whitespace_chars = [' ', '\t']
         with as_handle(filename) as handle:
             loop_flag = False
             key = None
@@ -62,6 +62,33 @@ class MMCIF2Dict(dict):
 
     # Private methods
 
+    def _splitline(self, line):
+        # See https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax for the syntax
+        in_token = False
+        # quote character of the currently open quote, or None if no quote open
+        quote_open_char = None
+        for (i, c) in enumerate(line):
+            if c in self.whitespace_chars:
+                if in_token and not quote_open_char:
+                    in_token = False
+                    yield line[start_i:i]
+            elif c in self.quote_chars:
+                if not quote_open_char:
+                    quote_open_char = c
+                    in_token = True
+                    start_i = i+1
+                elif c == quote_open_char and (i+1 == len(line) or line[i+1] in self.whitespace_chars):
+                    quote_open_char = None
+                    in_token = False
+                    yield line[start_i:i]
+            elif not in_token:
+                in_token = True
+                start_i = i
+        if in_token:
+            yield line[start_i:]
+        if quote_open_char:
+            raise ValueError("Line ended with quote open: "+line)
+
     def _tokenize(self, handle):
         for line in handle:
             if line.startswith("#"):
@@ -75,6 +102,5 @@ class MMCIF2Dict(dict):
                     token += line
                 yield token
             else:
-                tokens = shlex.split(line)
-                for token in tokens:
+                for token in self._splitline(line.strip()):
                     yield token

--- a/Tests/PDB/1MOM_min.cif
+++ b/Tests/PDB/1MOM_min.cif
@@ -1,0 +1,45 @@
+data_1MOM
+loop_
+_struct_conf.conf_type_id
+_struct_conf.id
+_struct_conf.pdbx_PDB_helix_id
+_struct_conf.beg_label_comp_id
+_struct_conf.beg_label_asym_id
+_struct_conf.beg_label_seq_id
+_struct_conf.pdbx_beg_PDB_ins_code
+_struct_conf.end_label_comp_id
+_struct_conf.end_label_asym_id
+_struct_conf.end_label_seq_id
+_struct_conf.pdbx_end_PDB_ins_code
+_struct_conf.beg_auth_comp_id
+_struct_conf.beg_auth_asym_id
+_struct_conf.beg_auth_seq_id
+_struct_conf.end_auth_comp_id
+_struct_conf.end_auth_asym_id
+_struct_conf.end_auth_seq_id
+_struct_conf.pdbx_PDB_helix_class
+_struct_conf.details
+_struct_conf.pdbx_PDB_helix_length
+HELX_P HELX_P1  A     PRO A 11  ? ASN A 23  ? PRO A 11  ASN A 23  1 ?                         13
+HELX_P HELX_P2  "A'"  ALA A 44  ? ARG A 46  ? ALA A 44  ARG A 46  5 ?                         3
+HELX_P HELX_P3  B     PRO A 86  ? SER A 92  ? PRO A 86  SER A 92  1 ?                         7
+HELX_P HELX_P4  C     TYR A 111 ? ALA A 118 ? TYR A 111 ALA A 118 1 ?                         8
+HELX_P HELX_P5  "B'"  ARG A 122 ? LYS A 124 ? ARG A 122 LYS A 124 5 ?                         3
+HELX_P HELX_P6  D     LEU A 129 ? LEU A 139 ? LEU A 129 LEU A 139 1 ?                         11
+HELX_P HELX_P7  E     SER A 144 ? ILE A 155 ? SER A 144 ILE A 155 1 ?                         12
+HELX_P HELX_P8  "C'"  THR A 158 ? ARG A 163 ? THR A 158 ARG A 163 1 ?                         6
+HELX_P HELX_P9  F     LYS A 165 ? GLU A 173 ? LYS A 165 GLU A 173 1 ?                         9
+HELX_P HELX_P10 G     LEU A 183 ? SER A 191 ? LEU A 183 SER A 191 1 ?                         9
+HELX_P HELX_P11 H     TRP A 192 ? LEU A 201 ? TRP A 192 LEU A 201 1 ?                         10
+HELX_P HELX_P12 "D'"  LYS A 231 ? ASN A 236 ? LYS A 231 ASN A 236 3 ?                         6
+HELX_P HELX_P13 "E'"  THR A 243 ? ILE A 246 ? THR A 243 ILE A 246 5 ?                         4
+TURN_P TURN_P1  'A'"' ASP A 1   ? ILE A 34  ? ASP A 1   ILE A 34  5
+;TYPE I'
+;
+?
+TURN_P TURN_P2  BC    ASP A 1   ? GLY A 57  ? ASP A 1   GLY A 57  5 'TYPE I'                  ?
+TURN_P TURN_P3  CD    ASP A 1   ? ASN A 68  ? ASP A 1   ASN A 68  5 'TYPE I (H-BOND O65-N69)' ?
+TURN_P TURN_P4  DE    ASP A 1   ? THR A 79  ? ASP A 1   THR A 79  5
+;TYPE II'
+;
+?

--- a/Tests/test_PDB_MMCIF2Dict.py
+++ b/Tests/test_PDB_MMCIF2Dict.py
@@ -56,6 +56,7 @@ class MMCIF2dictTests(unittest.TestCase):
         self.assertEqual(list(mmcif._splitline("foo 'bar a' b")), ["foo", "bar a", "b"])
         self.assertEqual(list(mmcif._splitline("foo 'bar'a' b")), ["foo", "bar'a", "b"])
         self.assertEqual(list(mmcif._splitline("foo \"bar' a\" b")), ["foo", "bar' a", "b"])
+        self.assertEqual(list(mmcif._splitline("foo '' b")), ["foo", "", "b"])
         self.assertRaises(ValueError, list, mmcif._splitline("foo 'bar"))
         self.assertRaises(ValueError, list, mmcif._splitline("foo 'ba'r  "))
         self.assertRaises(ValueError, list, mmcif._splitline("foo \"bar'"))

--- a/Tests/test_PDB_MMCIF2Dict.py
+++ b/Tests/test_PDB_MMCIF2Dict.py
@@ -39,6 +39,13 @@ class MMCIF2dictTests(unittest.TestCase):
         self.assertEqual(len(mmcif.keys()), 5)
         self.assertEqual(mmcif['_pdbx_audit_revision_item.item'], ['_atom_site.B_iso_or_equiv', '_atom_site.Cartn_x', '_atom_site.Cartn_y', '_atom_site.Cartn_z'])
 
+    def test_quotefix(self):
+        # Test quote characters parse correctly
+        filename = "PDB/1MOM_min.cif"
+        mmcif = MMCIF2Dict(filename)
+        self.assertEqual(len(mmcif.keys()), 21)
+        self.assertEqual(mmcif['_struct_conf.pdbx_PDB_helix_id'], ['A', 'A\'', 'B', 'C', 'B\'', 'D', 'E', 'C\'', 'F', 'G', 'H', 'D\'', 'E\'', 'A\'"', 'BC', 'CD', 'DE'])
+
     def test_splitline(self):
         filename = "PDB/4Q9R_min.cif"
         mmcif = MMCIF2Dict(filename)

--- a/Tests/test_PDB_MMCIF2Dict.py
+++ b/Tests/test_PDB_MMCIF2Dict.py
@@ -51,7 +51,7 @@ class MMCIF2dictTests(unittest.TestCase):
         self.assertEqual(list(mmcif._splitline("foo \"bar' a\" b")), ["foo", "bar' a", "b"])
         self.assertRaises(ValueError, list, mmcif._splitline("foo 'bar"))
         self.assertRaises(ValueError, list, mmcif._splitline("foo 'ba'r  "))
-        self.assertRaises(ValueError ,list, mmcif._splitline("foo \"bar'"))
+        self.assertRaises(ValueError, list, mmcif._splitline("foo \"bar'"))
 
 
 if __name__ == '__main__':

--- a/Tests/test_PDB_MMCIF2Dict.py
+++ b/Tests/test_PDB_MMCIF2Dict.py
@@ -39,6 +39,20 @@ class MMCIF2dictTests(unittest.TestCase):
         self.assertEqual(len(mmcif.keys()), 5)
         self.assertEqual(mmcif['_pdbx_audit_revision_item.item'], ['_atom_site.B_iso_or_equiv', '_atom_site.Cartn_x', '_atom_site.Cartn_y', '_atom_site.Cartn_z'])
 
+    def test_splitline(self):
+        filename = "PDB/4Q9R_min.cif"
+        mmcif = MMCIF2Dict(filename)
+        self.assertEqual(list(mmcif._splitline("foo bar")), ["foo", "bar"])
+        self.assertEqual(list(mmcif._splitline("  foo bar  ")), ["foo", "bar"])
+        self.assertEqual(list(mmcif._splitline("'foo' bar")), ["foo", "bar"])
+        self.assertEqual(list(mmcif._splitline("foo \"bar\"")), ["foo", "bar"])
+        self.assertEqual(list(mmcif._splitline("foo 'bar a' b")), ["foo", "bar a", "b"])
+        self.assertEqual(list(mmcif._splitline("foo 'bar'a' b")), ["foo", "bar'a", "b"])
+        self.assertEqual(list(mmcif._splitline("foo \"bar' a\" b")), ["foo", "bar' a", "b"])
+        self.assertRaises(ValueError, list, mmcif._splitline("foo 'bar"))
+        self.assertRaises(ValueError, list, mmcif._splitline("foo 'ba'r  "))
+        self.assertRaises(ValueError ,list, mmcif._splitline("foo \"bar'"))
+
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
I have seen in some comments on here that the use of `shlex` to split the lines in mmCIF parsing is slow, and I also found an error due to this.

This PR replaces `shlex.split` with a custom function to split lines. On my machine it gives 3-4x speedups in the construction of `MMCIF2Dict`.

Let me know if this is suitable and if any changes are required.

This pull request addresses issue #1357.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ AND the _BSD 3-Clause License_.

I am happy to be thanked by name in the ``NEWS.rst`` and
``CONTRIB.rst`` files.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.
