### PR TITLE
Add travis_wait command to prevent 10 minutes no output timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ install:
   - "tox -c .travis-tox.ini -e $TOXENV --notest"
 
 script:
-  - "tox -c .travis-tox.ini -e $TOXENV"
+  - travis_wait tox -c .travis-tox.ini -e $TOXENV
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,14 +84,13 @@ addons:
 #
 # This before_install list is only used for the test stage.
 before_install:
-  - cd $HOME
+  - pushd $HOME
   - mkdir -p bin
   - export PATH=$HOME/bin:$PATH
   - echo "Installing PhyML"
   - curl -L -O http://www.atgc-montpellier.fr/download/binaries/phyml/PhyML-3.1.zip
   - unzip PhyML-3.1.zip
   - mv PhyML-3.1/PhyML-3.1_linux64 bin/phyml
-  - cd $HOME
   - echo "Installing dssp"
   - curl -L -O ftp://ftp.cmbi.ru.nl/pub/software/dssp/dssp-2.0.4-linux-amd64
   - mv dssp-2.0.4-linux-amd64 bin/dssp
@@ -100,15 +99,15 @@ before_install:
   - curl -L -O https://anaconda.org/bioconda/genepop/4.5.1/download/linux-64/genepop-4.5.1-0.tar.bz2
   # This will create ./bin/Genepop and a harmless ./info/ folder.
   - tar -jxvf genepop-4.5.1-0.tar.bz2
-  - cd $TRAVIS_BUILD_DIR
-  - "cp Tests/biosql.ini.sample Tests/biosql.ini"
+  - popd
+  - cp Tests/biosql.ini.sample Tests/biosql.ini
 
 
 # This is minimal and used under all stages
 install:
-  - "pip install --upgrade pip setuptools"
-  - "pip install tox"
-  - "tox -c .travis-tox.ini -e $TOXENV --notest"
+  - pip install --upgrade pip setuptools
+  - pip install tox
+  - tox -c .travis-tox.ini -e $TOXENV --notest
 
 script:
   - travis_wait tox -c .travis-tox.ini -e $TOXENV


### PR DESCRIPTION
Right now Travis tests are sometimes failed because of a timeout for 10 minutes no output.

Adding `travis_wait` command extends the 10 minutes to 20 minutes.

> https://travis-ci.org/biopython/biopython/jobs/261066092#L660
> No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
> Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

See for detail https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

I also updated `.travis.yml` for refactoring.
