### PR TITLE
Improve test_KEGG.py coverage

### DIFF
--- a/Tests/test_KEGG.py
+++ b/Tests/test_KEGG.py
@@ -58,6 +58,11 @@ class EnzymeTests(unittest.TestCase):
                           ('BRENDA, the Enzyme Database', ['1.1.1.1']),
                           ('CAS', ['9031-72-5'])])
         self.assertEqual(records[-1].entry, "2.7.2.1")
+        self.assertEqual(records[-1].__str__().replace(" ","").split("\n")[:10],
+                         ['ENTRYEC2.7.2.1','NAMEacetatekinase', 'acetokinase',
+                          'AckA', 'AK', 'acetickinase', 'acetatekinase(phosphorylating)',
+                          'CLASSTransferases;', 'Transferringphosphorus-containinggroups;',
+                          'Phosphotransferaseswithacarboxygroupasacceptor'])
 
     def test_irregular(self):
         with open("KEGG/enzyme.irregular") as handle:
@@ -81,6 +86,19 @@ class EnzymeTests(unittest.TestCase):
                          ('HSA', ['5236', '55276']))
         self.assertEqual(records[0].genes[8],
                          ('CSAB', ['103224690', '103246223']))
+        
+    def test_exceptions(self):
+        with open("KEGG/enzyme.sample") as handle:
+            with self.assertRaises(ValueError) as context:
+                list(Enzyme.read(handle))
+            self.assertTrue("More than one record found in handle" in str(context.exception))
+            records = Enzyme.parse(handle)
+            for i in range (0, 6):
+                next(records)
+            self.assertRaises(StopIteration, next, records)
+            
+    
+        
 
 
 class CompoundTests(unittest.TestCase):

--- a/Tests/test_KEGG.py
+++ b/Tests/test_KEGG.py
@@ -58,8 +58,8 @@ class EnzymeTests(unittest.TestCase):
                           ('BRENDA, the Enzyme Database', ['1.1.1.1']),
                           ('CAS', ['9031-72-5'])])
         self.assertEqual(records[-1].entry, "2.7.2.1")
-        self.assertEqual(records[-1].__str__().replace(" ","").split("\n")[:10],
-                         ['ENTRYEC2.7.2.1','NAMEacetatekinase', 'acetokinase',
+        self.assertEqual(records[-1].__str__().replace(" ", "").split("\n")[:10],
+                         ['ENTRYEC2.7.2.1', 'NAMEacetatekinase', 'acetokinase',
                           'AckA', 'AK', 'acetickinase', 'acetatekinase(phosphorylating)',
                           'CLASSTransferases;', 'Transferringphosphorus-containinggroups;',
                           'Phosphotransferaseswithacarboxygroupasacceptor'])
@@ -86,19 +86,16 @@ class EnzymeTests(unittest.TestCase):
                          ('HSA', ['5236', '55276']))
         self.assertEqual(records[0].genes[8],
                          ('CSAB', ['103224690', '103246223']))
-        
+
     def test_exceptions(self):
         with open("KEGG/enzyme.sample") as handle:
             with self.assertRaises(ValueError) as context:
                 list(Enzyme.read(handle))
             self.assertTrue("More than one record found in handle" in str(context.exception))
             records = Enzyme.parse(handle)
-            for i in range (0, 6):
+            for i in range(0, 6):
                 next(records)
             self.assertRaises(StopIteration, next, records)
-            
-    
-        
 
 
 class CompoundTests(unittest.TestCase):
@@ -119,7 +116,7 @@ class CompoundTests(unittest.TestCase):
         self.assertEqual(records[1].enzyme[0], ('2.3.2.6'))
         self.assertEqual(records[1].structures, [])
         self.assertEqual(records[1].dblinks[0], ('PubChem', ['3319']))
-        self.assertEqual(records[-1].__str__().replace(" ","").split("\n")[:10],
+        self.assertEqual(records[-1].__str__().replace(" ", "").split("\n")[:10],
                          ['ENTRYC01386', 'NAMENH2Mec', '7-Amino-4-methylcoumarin',
                           'FORMULAC10H9NO2', 'DBLINKSCAS:26093-31-2',
                           'PubChem:4580', 'ChEBI:51771', 'ChEMBL:CHEMBL270672',

--- a/Tests/test_KEGG.py
+++ b/Tests/test_KEGG.py
@@ -119,6 +119,11 @@ class CompoundTests(unittest.TestCase):
         self.assertEqual(records[1].enzyme[0], ('2.3.2.6'))
         self.assertEqual(records[1].structures, [])
         self.assertEqual(records[1].dblinks[0], ('PubChem', ['3319']))
+        self.assertEqual(records[-1].__str__().replace(" ","").split("\n")[:10],
+                         ['ENTRYC01386', 'NAMENH2Mec', '7-Amino-4-methylcoumarin',
+                          'FORMULAC10H9NO2', 'DBLINKSCAS:26093-31-2',
+                          'PubChem:4580', 'ChEBI:51771', 'ChEMBL:CHEMBL270672',
+                          'KNApSAcK:C00048593', 'PDB-CCD:MCM'])
 
     def test_irregular(self):
         with open("KEGG/compound.irregular") as handle:

--- a/Tests/test_KEGG.py
+++ b/Tests/test_KEGG.py
@@ -58,7 +58,7 @@ class EnzymeTests(unittest.TestCase):
                           ('BRENDA, the Enzyme Database', ['1.1.1.1']),
                           ('CAS', ['9031-72-5'])])
         self.assertEqual(records[-1].entry, "2.7.2.1")
-        self.assertEqual(records[-1].__str__().replace(" ", "").split("\n")[:10],
+        self.assertEqual(str(records[-1]).replace(" ", "").split("\n")[:10],
                          ['ENTRYEC2.7.2.1', 'NAMEacetatekinase', 'acetokinase',
                           'AckA', 'AK', 'acetickinase', 'acetatekinase(phosphorylating)',
                           'CLASSTransferases;', 'Transferringphosphorus-containinggroups;',
@@ -116,7 +116,7 @@ class CompoundTests(unittest.TestCase):
         self.assertEqual(records[1].enzyme[0], ('2.3.2.6'))
         self.assertEqual(records[1].structures, [])
         self.assertEqual(records[1].dblinks[0], ('PubChem', ['3319']))
-        self.assertEqual(records[-1].__str__().replace(" ", "").split("\n")[:10],
+        self.assertEqual(str(records[-1]).replace(" ", "").split("\n")[:10],
                          ['ENTRYC01386', 'NAMENH2Mec', '7-Amino-4-methylcoumarin',
                           'FORMULAC10H9NO2', 'DBLINKSCAS:26093-31-2',
                           'PubChem:4580', 'ChEBI:51771', 'ChEMBL:CHEMBL270672',


### PR DESCRIPTION
This pull request addresses issue #1288 

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ AND the _BSD 3-Clause License_.

I am happy to be thanked by name in the ``NEWS.rst`` and
``CONTRIB.rst`` files.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.
