### PR TITLE
Update meme.py

### DIFF
--- a/Bio/motifs/meme.py
+++ b/Bio/motifs/meme.py
@@ -10,7 +10,7 @@ from Bio.Alphabet import IUPAC
 from Bio import Seq
 from Bio import motifs
 
-
+supported = ['4.11.4', '4.12.0']	#
 def read(handle):
     """Parses the text output of the MEME program into a meme.Record object.
 
@@ -33,7 +33,7 @@ def read(handle):
     for line in handle:
         if line.startswith('MOTIF  1'):
             break
-        if record.version == '4.11.4' and line.startswith('MOTIF '):
+        if record.version in supported and line.startswith('MOTIF '):
             break
     else:
         raise ValueError('Unexpected end of stream')

--- a/Bio/motifs/meme.py
+++ b/Bio/motifs/meme.py
@@ -10,7 +10,7 @@ from Bio.Alphabet import IUPAC
 from Bio import Seq
 from Bio import motifs
 
-supported = ['4.11.4', '4.12.0']	#
+supported=['4.11.4','4.12.0']
 def read(handle):
     """Parses the text output of the MEME program into a meme.Record object.
 

--- a/Bio/motifs/meme.py
+++ b/Bio/motifs/meme.py
@@ -10,7 +10,6 @@ from Bio.Alphabet import IUPAC
 from Bio import Seq
 from Bio import motifs
 
-supported=['4.11.4','4.12.0']
 def read(handle):
     """Parses the text output of the MEME program into a meme.Record object.
 
@@ -24,6 +23,7 @@ def read(handle):
     ...         print(instance.motif_name, instance.sequence_name, instance.strand, instance.pvalue)
 
     """
+    supported = ['4.11.4', '4.12.0']
     record = Record()
     __read_version(record, handle)
     __read_datafile(record, handle)

--- a/Bio/motifs/meme.py
+++ b/Bio/motifs/meme.py
@@ -12,16 +12,13 @@ from Bio import motifs
 
 def read(handle):
     """Parses the text output of the MEME program into a meme.Record object.
-
     Example:
-
     >>> from Bio.motifs import meme
     >>> with open("meme.output.txt") as f:
     ...     record = meme.read(f)
     >>> for motif in record:
     ...     for instance in motif.instances:
     ...         print(instance.motif_name, instance.sequence_name, instance.strand, instance.pvalue)
-
     """
     supported = ['4.11.4', '4.12.0']
     record = Record()

--- a/Bio/motifs/meme.py
+++ b/Bio/motifs/meme.py
@@ -21,7 +21,6 @@ def read(handle):
     ...     for instance in motif.instances:
     ...         print(instance.motif_name, instance.sequence_name, instance.strand, instance.pvalue)
     """
-    supported = ['4.11.4', '4.12.0']
     record = Record()
     __read_version(record, handle)
     __read_datafile(record, handle)
@@ -29,9 +28,7 @@ def read(handle):
     __read_sequences(record, handle)
     __read_command(record, handle)
     for line in handle:
-        if line.startswith('MOTIF  1'):
-            break
-        if record.version in supported and line.startswith('MOTIF '):
+        if line.startswith('MOTIF '):
             break
     else:
         raise ValueError('Unexpected end of stream')

--- a/Bio/motifs/meme.py
+++ b/Bio/motifs/meme.py
@@ -10,6 +10,7 @@ from Bio.Alphabet import IUPAC
 from Bio import Seq
 from Bio import motifs
 
+
 def read(handle):
     """Parses the text output of the MEME program into a meme.Record object.
     Example:


### PR DESCRIPTION
Supports version 4.12.0, should be easier to modify to add newer versions if they keep the same format. 
Would still raise an error with a not included version.

This pull request addresses issue #1372

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ AND the _BSD 3-Clause License_.

I (*am*) happy to be thanked by name in the ``NEWS.rst`` and
``CONTRIB.rst`` files.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.
