### PR TITLE
Genomediagram Bug Fixes (squashed)

### DIFF
--- a/Bio/Graphics/GenomeDiagram/_Diagram.py
+++ b/Bio/Graphics/GenomeDiagram/_Diagram.py
@@ -36,7 +36,7 @@ from Bio.Graphics import _write
 
 
 def _first_defined(*args):
-    """Return the first non-null argument"""
+    """Return the first non-null argument (PRIVATE)."""
     for arg in args:
         if arg is not None:
             return arg

--- a/Bio/Graphics/GenomeDiagram/_Diagram.py
+++ b/Bio/Graphics/GenomeDiagram/_Diagram.py
@@ -35,6 +35,14 @@ from ._Track import Track
 from Bio.Graphics import _write
 
 
+def _first_defined(*args):
+    """Return the first non-null argument"""
+    for arg in args:
+        if arg is not None:
+            return arg
+    return None
+
+
 class Diagram(object):
     """Diagram container.
 
@@ -79,7 +87,7 @@ class Diagram(object):
     def __init__(self, name=None, format='circular', pagesize='A3',
                  orientation='landscape', x=0.05, y=0.05, xl=None,
                  xr=None, yt=None, yb=None, start=None, end=None,
-                 tracklines=False, fragments=10, fragment_size=0.9,
+                 tracklines=False, fragments=10, fragment_size=None,
                  track_size=0.75, circular=True, circle_core=0.0):
         """Initialize.
 
@@ -101,7 +109,15 @@ class Diagram(object):
         self.end = end
         self.tracklines = tracklines
         self.fragments = fragments
-        self.fragment_size = fragment_size
+        if fragment_size is not None:
+            self.fragment_size = fragment_size
+        else:
+            if self.fragments == 1:
+                # For single fragments, default to full height
+                self.fragment_size = 1
+            else:
+                # Otherwise keep a 10% gap between fragments
+                self.fragment_size = .9
         self.track_size = track_size
         self.circular = circular
         self.circle_core = circle_core
@@ -136,29 +152,37 @@ class Diagram(object):
         # Instantiation arguments, but I suspect there's a neater way to do
         # this.
         if format == 'linear':
-            drawer = LinearDrawer(self, pagesize or self.pagesize,
-                                  orientation or self.orientation,
-                                  x or self.x, y or self.y, xl or self.xl,
-                                  xr or self.xr, yt or self.yt,
-                                  yb or self.yb, start or self.start,
-                                  end or self.end,
-                                  tracklines or self.tracklines,
-                                  fragments or self.fragments,
-                                  fragment_size or self.fragment_size,
-                                  track_size or self.track_size,
-                                  cross_track_links or self.cross_track_links)
+            drawer = LinearDrawer(self, _first_defined(pagesize, self.pagesize),
+                                  _first_defined(orientation, self.orientation),
+                                  _first_defined(x, self.x),
+                                  _first_defined(y, self.y),
+                                  _first_defined(xl, self.xl),
+                                  _first_defined(xr, self.xr),
+                                  _first_defined(yt, self.yt),
+                                  _first_defined(yb, self.yb),
+                                  _first_defined(start, self.start),
+                                  _first_defined(end, self.end),
+                                  _first_defined(tracklines, self.tracklines),
+                                  _first_defined(fragments, self.fragments),
+                                  _first_defined(fragment_size, self.fragment_size),
+                                  _first_defined(track_size, self.track_size),
+                                  _first_defined(cross_track_links, self.cross_track_links))
         else:
-            drawer = CircularDrawer(self, pagesize or self.pagesize,
-                                    orientation or self.orientation,
-                                    x or self.x, y or self.y, xl or self.xl,
-                                    xr or self.xr, yt or self.yt,
-                                    yb or self.yb, start or self.start,
-                                    end or self.end,
-                                    tracklines or self.tracklines,
-                                    track_size or self.track_size,
-                                    circular or self.circular,
-                                    circle_core or self.circle_core,
-                                    cross_track_links or self.cross_track_links)
+            drawer = CircularDrawer(self, _first_defined(pagesize, self.pagesize),
+                                    _first_defined(orientation, self.orientation),
+                                    _first_defined(x, self.x),
+                                    _first_defined(y, self.y),
+                                    _first_defined(xl, self.xl),
+                                    _first_defined(xr, self.xr),
+                                    _first_defined(yt, self.yt),
+                                    _first_defined(yb, self.yb),
+                                    _first_defined(start, self.start),
+                                    _first_defined(end, self.end),
+                                    _first_defined(tracklines, self.tracklines),
+                                    _first_defined(track_size, self.track_size),
+                                    _first_defined(circular, self.circular),
+                                    _first_defined(circle_core, self.circle_core),
+                                    _first_defined(cross_track_links, self.cross_track_links))
         drawer.draw()   # Tell the drawer to complete the drawing
         self.drawing = drawer.drawing  # Get the completed drawing
 

--- a/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
@@ -82,7 +82,7 @@ class LinearDrawer(AbstractDrawer):
     def __init__(self, parent=None, pagesize='A3', orientation='landscape',
                  x=0.05, y=0.05, xl=None, xr=None, yt=None, yb=None,
                  start=None, end=None, tracklines=0, fragments=10,
-                 fragment_size=0.9, track_size=0.75, cross_track_links=None):
+                 fragment_size=None, track_size=0.75, cross_track_links=None):
         """Initialize.
 
         Arguments:
@@ -125,7 +125,15 @@ class LinearDrawer(AbstractDrawer):
 
         # Useful measurements on the page
         self.fragments = fragments
-        self.fragment_size = fragment_size
+        if fragment_size is not None:
+            self.fragment_size = fragment_size
+        else:
+            if self.fragments == 1:
+                # For single fragments, default to full height
+                self.fragment_size = 1
+            else:
+                # Otherwise keep a 10% gap between fragments
+                self.fragment_size = .9
         self.track_size = track_size
 
     def draw(self):

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -22,6 +22,7 @@ possible, especially the following contributors:
 - Kai Blin
 - Maximilian Greil
 - Peter Cock
+- Spencer Bliven
 - Wibowo 'Bow' Arindrarto
 
 


### PR DESCRIPTION
This is a cleaner version of #1329.

It squashes commits down to two main issues.

1. Allows GenomeDiagrams to be created with zero margins. Also reduces unneeded extra y padding in the case of single fragments (but this is still generated if needed).

2. Work around a bug in reportlab's PNG output of polygons with degenerate vertices. 84079c6 simplifies the approach used in #1329, so it should work with all polygons regardless of the strand or source of degeneracy (short arrow shafts, thick arrow shafts, octogons, etc).

Here are some results from running Tests/test_GenomeDiagrams.py:

BIGARROW:
![gd_sigil_bigarrow_shafts](https://user-images.githubusercontent.com/595872/30030611-68c22c54-918e-11e7-8fed-beaecc1f38f3.png)
![gd_sigil_short_bigarrow](https://user-images.githubusercontent.com/595872/30030697-c710478c-918e-11e7-9eca-06532ff207d8.png)

ARROW:
![gd_sigil_short_arrow](https://user-images.githubusercontent.com/595872/30030704-ce0c37d0-918e-11e7-8077-4e80811a955d.png)

OCTO:
![gd_sigil_short_octo](https://user-images.githubusercontent.com/595872/30030640-842793c6-918e-11e7-8088-49de2e3e5555.png)
