### PR TITLE
Update Bio/motifs/__init__.py weblogo

### DIFF
--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -402,7 +402,7 @@ class Motif(object):
         for more information::
 
             'stack_width' : 'medium',
-            'stack_per_line' : '40',
+            'stacks_per_line' : '40',
             'alphabet' : 'alphabet_dna',
             'ignore_lower_case' : True,
             'unit_name' : "bits",
@@ -453,7 +453,7 @@ class Motif(object):
         values = {'sequences': frequencies,
                   'format': format.lower(),
                   'stack_width': 'medium',
-                  'stack_per_line': '40',
+                  'stacks_per_line': '40',
                   'alphabet': alpha,
                   'ignore_lower_case': True,
                   'unit_name': "bits",

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -165,6 +165,7 @@ please open an issue on GitHub or mention it on the development mailing list.
 - Nader Morshed <https://github.com/naderm>
 - Nate Sutton <https://github.com/nmsutton>
 - Nathan J. Edwards <nje5 at edu domain georgetown>
+- Nicolas Fontrodona <https://github.com/NFontrodona>
 - Nigel Delaney <https://github.com/evolvedmicrobe/>
 - Noam Kremen <https://github.com/noamkremen>
 - Olivier Morelle <https://github.com/Oli4>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -58,6 +58,7 @@ possible, especially the following contributors:
 - Kai Blin
 - Kozo Nishida
 - Michiel de Hoon
+- Nicolas Fontrodona (first contribution)
 - Peter Cock
 - rht (first contribution)
 - Shuichiro MAKIGAKI (first contribution)


### PR DESCRIPTION
in weblogo function, the parameter stack_per_line seems not to work. The real name seems to be  stacks_per_line

This pull request addresses issue #...

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ AND the _BSD 3-Clause License_.

I (*am/am not*) happy to be thanked by name in the ``NEWS.rst`` and
``CONTRIB.rst`` files.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.
