### PR TITLE
Avoid unusual multiple variable assignment in NMR code

### DIFF
--- a/Bio/NMR/xpktools.py
+++ b/Bio/NMR/xpktools.py
@@ -114,7 +114,7 @@ class Peaklist(object):
             self.data = [line.split("\012")[0] for line in infile]
 
     def residue_dict(self, index):
-        """Return a dict of lines in "data" indexed by residue number or a nucleus.
+        """Return a dict of lines in \`data\` indexed by residue number or a nucleus.
 
         The nucleus should be given as the input argument in the same form as
         it appears in the xpk label line (H1, 15N for example)
@@ -274,7 +274,7 @@ def data_table(fn_list, datalabel, keyatom):
     # TODO - Clarify this docstring, add an example?
     outlist = []
 
-    [dict_list, label_line_list] = _read_dicts(fn_list, keyatom)
+    dict_list, label_line_list = _read_dicts(fn_list, keyatom)
 
     # Find global max and min residue numbers
     minr = dict_list[0]["minres"]

--- a/Bio/SCOP/__init__.py
+++ b/Bio/SCOP/__init__.py
@@ -359,12 +359,12 @@ class Scop(object):
                 cur.execute("select sid, residues, pdbid from cla where sunid=%s",
                                sunid)
 
-                [n.sid, n.residues, pdbid] = cur.fetchone()
+                n.sid, n.residues, pdbid = cur.fetchone()
                 n.residues = Residues.Residues(n.residues)
                 n.residues.pdbid = pdbid
                 self._sidDict[n.sid] = n
 
-            [n.sunid, n.type, n.sccs, n.description] = data
+            n.sunid, n.type, n.sccs, n.description = data
 
             if data[1] != 'ro':
                 cur.execute("SELECT parent FROM hie WHERE child=%s", sunid)
@@ -414,7 +414,7 @@ class Scop(object):
             for d in data:
                 if int(d[0]) not in self._sunidDict:
                     n = Node(scop=self)
-                    [n.sunid, n.type, n.sccs, n.description] = d
+                    n.sunid, n.type, n.sccs, n.description = d
                     n.sunid = int(n.sunid)
                     self._sunidDict[n.sunid] = n
 
@@ -438,10 +438,7 @@ class Scop(object):
             for d in data:
                 if int(d[0]) not in self._sunidDict:
                     n = Domain(scop=self)
-                    # [n.sunid, n.sid, n.pdbid, n.residues, n.sccs, n.type,
-                    # n.description,n.parent] = data
-                    [n.sunid, n.sid, pdbid, n.residues, n.sccs, n.type, n.description,
-                     n.parent] = d[0:8]
+                    n.sunid, n.sid, pdbid, n.residues, n.sccs, n.type, n.description, n.parent = d[0:8]
                     n.residues = Residues.Residues(n.residues)
                     n.residues.pdbid = pdbid
                     n.sunid = int(n.sunid)


### PR DESCRIPTION
This lead to the discovery of a minor bug in Sphinx's code parsing, see https://github.com/sphinx-doc/sphinx/pull/4138