### PR TITLE
Fix BWA tests

### DIFF
--- a/Tests/test_BWA_tool.py
+++ b/Tests/test_BWA_tool.py
@@ -91,20 +91,15 @@ class BwaTestCase(unittest.TestCase):
         cmdline = BwaIndexCommandline(bwa_exe)
         cmdline.set_parameter("infile", self.reference_file)
         cmdline.set_parameter("algorithm", "bwtsw")
-        try:
-            stdout, stderr = cmdline()
-        except ApplicationError as err:
-            self.assertTrue(err.returncode == 0,
-                            "FASTA indexing failed:\n%s\nStdout:%s\nStderr:%s\n"
-                            % (cmdline, stdout, stderr))
-
-
         stdout, stderr = cmdline()
         for extension in self.reference_extensions:
             index_file = self.reference_file + "." + extension
             self.assertTrue(os.path.exists(index_file),
                             "Index File %s not found"
                             % (index_file))
+        self.assertTrue('Finished constructing BWT' in str(stdout) + str(stderr),
+                        "FASTA indexing failed:\n%s\nStdout:%s\nStderr:%s\n"
+                        % (cmdline, stdout, stderr))
 
     def do_aln(self, in_file, out_file):
         """Test for generating sai files given the reference and read file"""
@@ -112,15 +107,13 @@ class BwaTestCase(unittest.TestCase):
         cmdline.set_parameter("reference", self.reference_file)
         cmdline.read_file = in_file
         self.assertTrue(os.path.isfile(in_file))
-        try:
-            stdout, stderr = cmdline(stdout=out_file)
-        except ApplicationError as err:
-            self.assertTrue(err.returncode == 0,
-                            "Error aligning sequence to reference:\n%s\nStdout:%s\nStderr:%s\n"
-                            % (cmdline, stdout, stderr))
+        stdout, stderr = cmdline(stdout=out_file)
+        self.assertTrue("fail to locate the index" not in str(stderr) + str(stdout),
+                        "Error aligning sequence to reference:\n%s\nStdout:%s\nStderr:%s\n"
+                        % (cmdline, stdout, stderr))
 
     def create_fasta_index(self):
-        """Creates index for fasta file.
+        """Test for generating index for fasta file.
 
         BWA requires an indexed fasta for each alignment operation.
         This should be called to create an index before any alignment

--- a/Tests/test_BWA_tool.py
+++ b/Tests/test_BWA_tool.py
@@ -91,15 +91,20 @@ class BwaTestCase(unittest.TestCase):
         cmdline = BwaIndexCommandline(bwa_exe)
         cmdline.set_parameter("infile", self.reference_file)
         cmdline.set_parameter("algorithm", "bwtsw")
+        try:
+            stdout, stderr = cmdline()
+        except ApplicationError as err:
+            self.assertTrue(err.returncode == 0,
+                            "FASTA indexing failed:\n%s\nStdout:%s\nStderr:%s\n"
+                            % (cmdline, stdout, stderr))
+
+
         stdout, stderr = cmdline()
         for extension in self.reference_extensions:
             index_file = self.reference_file + "." + extension
             self.assertTrue(os.path.exists(index_file),
                             "Index File %s not found"
                             % (index_file))
-        self.assertTrue(stdout.startswith("[bwt_gen]"),
-                        "FASTA indexing failed:\n%s\nStdout:%s"
-                        % (cmdline, stdout))
 
     def do_aln(self, in_file, out_file):
         """Test for generating sai files given the reference and read file"""
@@ -107,11 +112,12 @@ class BwaTestCase(unittest.TestCase):
         cmdline.set_parameter("reference", self.reference_file)
         cmdline.read_file = in_file
         self.assertTrue(os.path.isfile(in_file))
-        stdout, stderr = cmdline(stdout=out_file)
-
-        self.assertTrue("fail to locate the index" not in stderr,
-                        "Error aligning sequence to reference:\n%s\nStderr:%s"
-                        % (cmdline, stderr))
+        try:
+            stdout, stderr = cmdline(stdout=out_file)
+        except ApplicationError as err:
+            self.assertTrue(err.returncode == 0,
+                            "Error aligning sequence to reference:\n%s\nStdout:%s\nStderr:%s\n"
+                            % (cmdline, stdout, stderr))
 
     def create_fasta_index(self):
         """Creates index for fasta file.


### PR DESCRIPTION
Upstream changes to stdout and stderr are flaky and hence
returncodes should be checked instead.


This pull request addresses issue #1431

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ AND the _BSD 3-Clause License_.

I *am* happy to be thanked by name in the ``NEWS.rst`` and
``CONTRIB.rst`` files.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.
