### PR TITLE
Update news for mmCIF writer

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -36,6 +36,10 @@ for its existing reverse_complement method etc.
 The output of function ``format_alignment`` in ``Bio.pairwise2`` for displaying
 a pairwise sequence alignment as text now indicates gaps and mis-matches.
 
+Bio.PDB now contains a writer for the mmCIF file format, which has been the
+standard PDB archive format since 2014. This allows structural objects to be
+written out and facilitates conversion between the PDB and mmCIF file formats.
+
 In this release more of our code is now explicitly available under either our
 original "Biopython License Agreement", or the very similar but more commonly
 used "3-Clause BSD License".  See the ``LICENSE.rst`` file for more details.


### PR DESCRIPTION
As discussed in #1393.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ AND the _BSD 3-Clause License_.

I am happy to be thanked by name in the ``NEWS.rst`` and
``CONTRIB.rst`` files.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.
