### PR TITLE
Fix various typos 

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -445,7 +445,7 @@ class MultipleSeqAlignment(object):
               By default, all sequences have the same weight. (0.0 =>
               no weight, 1.0 => highest weight)
 
-        In general providing a SeqRecord and calling .append is prefered.
+        In general providing a SeqRecord and calling .append is preferred.
         """
         new_seq = Seq(sequence, self._alphabet)
 

--- a/Bio/Graphics/Distribution.py
+++ b/Bio/Graphics/Distribution.py
@@ -244,5 +244,5 @@ class LineDistribution(object):
         pass
 
     def draw(self, cur_drawing, start_x, start_y, end_x, end_y):
-        """Draw a line distrubution into the current drawing."""
+        """Draw a line distribution into the current drawing."""
         pass

--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -198,7 +198,7 @@ def dssp_dict_from_pdb_file(in_file, DSSP="dssp"):
 
 
 def make_dssp_dict(filename):
-    """DSSP dictionary mapping identifers to properties.
+    """DSSP dictionary mapping identifiers to properties.
 
     Return a DSSP dictionary that maps (chainid, resid) to
     aa, ss and accessibility, from a DSSP file.

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -337,7 +337,7 @@ class RestrictionType(type):
         return "%s" % cls.__name__
 
     def __len__(cls):
-        """Return lenght of recognition site of enzyme as int."""
+        """Return length of recognition site of enzyme as int."""
         return cls.size
 
     def __hash__(cls):

--- a/Bio/TogoWS/__init__.py
+++ b/Bio/TogoWS/__init__.py
@@ -289,7 +289,7 @@ def search(db, query, offset=None, limit=None, format=None):
 
 
 def convert(data, in_format, out_format):
-    """Call TogoWS for file format convertion.
+    """Call TogoWS for file format conversion.
 
     Arguments:
      - data - string or handle containing input record(s)

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -777,7 +777,7 @@ def _recover_alignments(sequenceA, sequenceB, starts, score_matrix,
 
             # If trace is empty we have reached at least one border of the
             # matrix or the end of a local aligment. Just add the rest of
-            # the sequence(s) and fill with gaps if neccessary.
+            # the sequence(s) and fill with gaps if necessary.
             if not trace:
                 if col and col_gap:
                     dead_end = True
@@ -892,7 +892,7 @@ def _clean_alignments(alignments):
 
 def _finish_backtrace(sequenceA, sequenceB, ali_seqA, ali_seqB, row, col,
                       gap_char):
-    """Add remaining sequences and fill with gaps if neccessary (PRIVATE)."""
+    """Add remaining sequences and fill with gaps if necessary (PRIVATE)."""
     if row:
         ali_seqA += sequenceA[row - 1::-1]
     if col:

--- a/Bio/phenotype/phen_micro.py
+++ b/Bio/phenotype/phen_micro.py
@@ -583,7 +583,7 @@ class WellRecord(object):
     >>> print(well.slope, well.model)
     (61.853516785566917, 'logistic')
 
-    If not sigmoid function is specified, the first one that is succesfully
+    If not sigmoid function is specified, the first one that is successfully
     fitted is used. The user can also specify a specific function.
 
     >>> well.fit('gompertz')
@@ -799,7 +799,7 @@ class WellRecord(object):
          - logistic
          - richards
 
-        The first function that is succesfuly fitted to the signals will
+        The first function that is successfully fitted to the signals will
         be used to extract the curve parameters and update ``.area`` and
         ``.model``. If no function can be fitted an exception is raised.
 

--- a/Bio/phenotype/phen_micro.py
+++ b/Bio/phenotype/phen_micro.py
@@ -89,7 +89,7 @@ class PlateRecord(object):
     >>> 'A01' in plate
     True
 
-    All the wells belonging to a "row" (identified by the first charachter of
+    All the wells belonging to a "row" (identified by the first character of
     the well id) in the plate can be obtained:
 
     >>> for well in plate.get_row('H'):

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -890,7 +890,7 @@ class BioSeqDatabase(object):
         global _POSTGRES_RULES_PRESENT
         for cur_record in record_iterator:
             num_records += 1
-            # Hack to work arround BioSQL Bug 2839 - If using PostgreSQL and
+            # Hack to work around BioSQL Bug 2839 - If using PostgreSQL and
             # the RULES are present check for a duplicate record before loading
             if _POSTGRES_RULES_PRESENT:
                 # Recreate what the Loader's _load_bioentry_table will do:

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -1053,7 +1053,7 @@ class DatabaseLoader(object):
         """
         # NOTE - In older versions of Biopython, we would map the GenBank
         # db_xref "name", for example "GI" to "GeneIndex", and give a warning
-        # for any unknown terms.  This was a long term maintainance problem,
+        # for any unknown terms.  This was a long term maintenance problem,
         # and differed from BioPerl and BioJava's implementation.  See bug 2405
         for rank, value in enumerate(dbxrefs):
             # Split the DB:accession format string at colons.  We have to

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -44,9 +44,9 @@ In this release more of our code is now explicitly available under either our
 original "Biopython License Agreement", or the very similar but more commonly
 used "3-Clause BSD License".  See the ``LICENSE.rst`` file for more details.
 
-Additionally, a number of small bugs have been fixed with further additions to
-the test suite, and there has been further work to follow the Python PEP8,
-PEP257 and best practice standard coding style.
+Additionally, a number of small bugs and typos have been fixed with further 
+additions to the test suite, and there has been further work to follow the 
+Python PEP8, PEP257 and best practice standard coding style.
 
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -806,7 +806,7 @@ class DictionaryBuilder(object):
                 ovhgseq = site[fst3:] + (fst5 - size) * 'N'
             else:
                 #
-                #   should not happend
+                #   should not happen
                 #
                 raise ValueError('Error in #1')
         elif fst3 < 0 and size < fst5:

--- a/Scripts/SeqGui/SeqGui.py
+++ b/Scripts/SeqGui/SeqGui.py
@@ -64,7 +64,7 @@ codon_list.selection_set(0)
 codon_list.configure(exportselection=False)
 codon_scroller.config(command=codon_list.yview)
 
-# Radiobuttons are more appropiate than another listbox here:
+# Radiobuttons are more appropriate than another listbox here:
 transform_panel = ttk.LabelFrame(param_panel, text='Transformation')
 
 transform_var = tk.StringVar()

--- a/Scripts/xbbtools/xbb_help.py
+++ b/Scripts/xbbtools/xbb_help.py
@@ -53,7 +53,7 @@ as part of this package.\n
         t.insert(tk.END, 'thomas@biopython.org\n\n', 'blue')
         t.insert(tk.END, '* Goto Field\n', 'bold')
         t.insert(tk.END, '\tinserting one position moves cursor to position\n')
-        t.insert(tk.END, "\tinserting two positions, seperated by ':' ")
+        t.insert(tk.END, "\tinserting two positions, separated by ':' ")
         t.insert(tk.END, 'highlights', 'highlight')
         t.insert(tk.END, ' selected range\n')
         t.insert(tk.END, '\n')

--- a/Tests/test_GAMutation.py
+++ b/Tests/test_GAMutation.py
@@ -58,7 +58,7 @@ class MutationHelper(object):
 
         percent_mutants = float(num_mutations) / float(self.num_trials)
         assert percent_mutants > expected_percent, \
-               "Did not recieve an acceptable number of mutations."
+               "Did not receive an acceptable number of mutations."
 
     def _never_mutate(self, mutator):
         """Test that a mutator does not cause unexpected mutations.

--- a/Tests/test_HMMCasino.py
+++ b/Tests/test_HMMCasino.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Test out HMMs using the Occasionally Dishonest Casino.
 
-This uses the ocassionally dishonest casino example from Biological
+This uses the occasionally dishonest casino example from Biological
 Sequence Analysis by Durbin et al.
 
 In this example, we are dealing with a casino that has two types of

--- a/Tests/test_NCBI_BLAST_tools.py
+++ b/Tests/test_NCBI_BLAST_tools.py
@@ -30,7 +30,7 @@ if sys.platform == "win32":
     # and by default installs to C:\Program Files\NCBI\BLAST-2.2.22+\bin
     # To keep things simple, assume BLAST+ is on the path on Windows.
     #
-    # On Windows the environment variable name isn't case senstive,
+    # On Windows the environment variable name isn't case sensitive,
     # but must split on ";" not ":"
     likely_dirs = os.environ.get("PATH", "").split(";")
 else:

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -1463,7 +1463,7 @@ class CopyTests(unittest.TestCase):
         self.assertFalse(self.a is aa)
         self.assertFalse(self.a.get_coord() is aa.get_coord())
 
-    def test_entitity_copy(self):
+    def test_entity_copy(self):
         """Make a copy of a residue."""
         for e in (self.s, self.m, self.c, self.r):
             ee = e.copy()

--- a/Tests/test_SearchIO_fasta_m10.py
+++ b/Tests/test_SearchIO_fasta_m10.py
@@ -1925,13 +1925,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(659, hsp.hit_end)
         self.assertEqual('TTTTTTTCCTCCTCC', str(hsp.hit.seq))
         self.assertEqual(-1, hsp.query_strand)
-        # first qresult, eigth hit
+        # first qresult, eighth hit
         hit = qresult[7]
         self.assertEqual('gi|332211538|ref|XM_003254827.1|', hit.id)
         self.assertEqual('PREDICTED: Nomascus leucogenys hemoglobin subunit gamma-1-like, transcript variant 1 (LOC100582529), mRNA', hit.description)
         self.assertEqual(713, hit.seq_len)
         self.assertEqual(1, len(hit))
-        # first qresult, eigth hit, first hsp
+        # first qresult, eighth hit, first hsp
         hsp = qresult[7].hsps[0]
         self.assertEqual(57, hsp.initn_score)
         self.assertEqual(57, hsp.init1_score)
@@ -2568,13 +2568,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(835, hsp.hit_end)
         self.assertEqual('VASGRTNQSIMVQWQPPP-----ETEHNGV--LRGYILRYRLAGLPGEYQQRNITSPEVNYCLVTDL', str(hsp.hit.seq))
         self.assertEqual(0, hsp.query_strand)
-        # first qresult, eigth hit
+        # first qresult, eighth hit
         hit = qresult[7]
         self.assertEqual('gi|332864595|ref|XP_518946.3|', hit.id)
         self.assertEqual('PREDICTED: protein sidekick-1 [Pan troglodytes]', hit.description)
         self.assertEqual(2213, hit.seq_len)
         self.assertEqual(2, len(hit))
-        # first qresult, eigth hit, first hsp
+        # first qresult, eighth hit, first hsp
         hsp = qresult[7].hsps[0]
         self.assertEqual(68, hsp.initn_score)
         self.assertEqual(45, hsp.init1_score)
@@ -2593,7 +2593,7 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(740, hsp.hit_end)
         self.assertEqual('LASPNSS--HSHAVVLSWVRP---FDGNS-----PILY-YIVELSENNSPWKVHLSNVGPEMTGITVSGLTPARTYQ', str(hsp.hit.seq))
         self.assertEqual(0, hsp.query_strand)
-        # first qresult, eigth hit, second hsp
+        # first qresult, eighth hit, second hsp
         hsp = qresult[7].hsps[1]
         self.assertEqual(87, hsp.initn_score)
         self.assertEqual(51, hsp.init1_score)

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -592,16 +592,16 @@ class IndexDictTests(unittest.TestCase):
 
     if sqlite3:
         def test_duplicates_index_db(self):
-            """Index file with duplicate identifers with Bio.SeqIO.index_db()"""
+            """Index file with duplicate identifiers with Bio.SeqIO.index_db()"""
             self.assertRaises(ValueError, SeqIO.index_db, ":memory:",
                               ["Fasta/dups.fasta"], "fasta")
 
     def test_duplicates_index(self):
-        """Index file with duplicate identifers with Bio.SeqIO.index()"""
+        """Index file with duplicate identifiers with Bio.SeqIO.index()"""
         self.assertRaises(ValueError, SeqIO.index, "Fasta/dups.fasta", "fasta")
 
     def test_duplicates_to_dict(self):
-        """Index file with duplicate identifers with Bio.SeqIO.to_dict()"""
+        """Index file with duplicate identifiers with Bio.SeqIO.to_dict()"""
         handle = open("Fasta/dups.fasta", _universal_read_mode)
         iterator = SeqIO.parse(handle, "fasta")
         self.assertRaises(ValueError, SeqIO.to_dict, iterator)

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -25,7 +25,7 @@ else:
     maketrans = str.maketrans
 
 # This is just the standard table with less stop codons
-# (replaced with coding for O as an artifical example)
+# (replaced with coding for O as an artificial example)
 special_table = CodonTable(forward_table={
     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
     'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -220,7 +220,7 @@ class StringMethodTests(unittest.TestCase):
             self.assertEqual(Seq(testing_seq).count_overlap("GG", start, end), exp)
             self.assertEqual(MutableSeq(testing_seq).count_overlap("GG", start, end), exp)
 
-        # Testing Seq() and MutableSeq() with a more heterogenous sequenece
+        # Testing Seq() and MutableSeq() with a more heterogeneous sequenece
         self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("GG"), 5)
         self.assertEqual(MutableSeq("GGGTGGTAGGG").count_overlap("GG"), 5)
         self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("GG", 2, 8), 1)
@@ -301,7 +301,7 @@ class StringMethodTests(unittest.TestCase):
             self.assertEqual(Seq(testing_seq).count_overlap("NN", start, end), exp)
             self.assertEqual(MutableSeq(testing_seq).count_overlap("NN", start, end), exp)
 
-        # Testing Seq() and MutableSeq() with a more heterogenous sequenece
+        # Testing Seq() and MutableSeq() with a more heterogeneous sequenece
         self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("NN"), 0)
         self.assertEqual(MutableSeq("GGGTGGTAGGG").count_overlap("NN"), 0)
         self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("NN", 2, 8), 0)

--- a/Tests/test_TogoWS.py
+++ b/Tests/test_TogoWS.py
@@ -394,7 +394,7 @@ class TogoSearch(unittest.TestCase):
     def test_pubmed_search_porin(self):
         """Bio.TogoWS.search_iter("pubmed", "human porin") etc
 
-        Count was 357 at time of writing, this was choosen to
+        Count was 357 at time of writing, this was chosen to
         be larger than the default chunk size for iteration,
         but still not too big to download the full list.
         """

--- a/Tests/test_prosite1.py
+++ b/Tests/test_prosite1.py
@@ -3,7 +3,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 #
-# NOTE - This file has been split in two as a work around for Jython JVM limits.
+# NOTE - This file has been split in two as a workaround for Jython JVM limits.
 
 import os
 import unittest

--- a/Tests/test_prosite1.py
+++ b/Tests/test_prosite1.py
@@ -3,7 +3,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 #
-# NOTE - This file has been split in two as a work arround for Jython JVM limits.
+# NOTE - This file has been split in two as a work around for Jython JVM limits.
 
 import os
 import unittest

--- a/Tests/test_prosite2.py
+++ b/Tests/test_prosite2.py
@@ -3,7 +3,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 #
-# NOTE - This file has been split in two as a work arround for Jython JVM limits.
+# NOTE - This file has been split in two as a workaround for Jython JVM limits.
 
 import os
 import unittest

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ def check_dependencies():
     if is_Numpy_installed():
         return True
     if is_jython():
-        return True  # NumPy is not avaliable for Jython (for now)
+        return True  # NumPy is not available for Jython (for now)
     if is_ironpython():
         return True  # We're ignoring NumPy under IronPython (for now)
 


### PR DESCRIPTION
This pull request replaces #1435 

It fixes various typos and should now give a clean merge.

----

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ AND the _BSD 3-Clause License_.

I have updated ``NEWS.rst`` and am already mentioned in ``CONTRIB.rst``.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.
