### PR TITLE
Add Saket to NEWS file

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -68,6 +68,7 @@ possible, especially the following contributors:
 - Nicolas Fontrodona (first contribution)
 - Peter Cock
 - rht (first contribution)
+- Saket Choudhary
 - Shuichiro MAKIGAKI (first contribution)
 - Spencer Bliven
 - Yasar L. Ahmed (first contribution)


### PR DESCRIPTION
This pull request addresses issue #1437 

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ AND the _BSD 3-Clause License_.

I *am* happy to be thanked by name in the ``NEWS.rst`` and
``CONTRIB.rst`` files.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.
