### PR TITLE
Fix/fsa detection error

### DIFF
--- a/Bio/SeqIO/AbiIO.py
+++ b/Bio/SeqIO/AbiIO.py
@@ -401,7 +401,7 @@ def AbiIterator(handle, alphabet=None, trim=False):
     annot['abif_raw'] = raw
 
     # fsa check
-    is_fsa_file = set(['SpNm1', 'LIMS1', 'CTID1']).issubset(raw)
+    is_fsa_file = set(['SpNm1', 'LIMS1']).issubset(raw)
 
     if is_fsa_file:
         try:
@@ -409,7 +409,7 @@ def AbiIterator(handle, alphabet=None, trim=False):
         except AttributeError:
             file_name = ""
         sample_id = raw['LIMS1']
-        description = raw['CTID1']
+        description = raw.get('CTID1', '<unknown description>')
         record = SeqRecord(Seq(''),
                            id=sample_id,
                            name=file_name,

--- a/Bio/SeqIO/AbiIO.py
+++ b/Bio/SeqIO/AbiIO.py
@@ -401,14 +401,14 @@ def AbiIterator(handle, alphabet=None, trim=False):
     annot['abif_raw'] = raw
 
     # fsa check
-    is_fsa_file = set(['SpNm1', 'LIMS1']).issubset(raw)
+    is_fsa_file = all([tn not in raw for tn in ('PBAS1', 'PBAS2')])
 
     if is_fsa_file:
         try:
             file_name = basename(handle.name).replace('.fsa', '')
         except AttributeError:
             file_name = ""
-        sample_id = raw['LIMS1']
+        sample_id = raw.get('LIMS1', '<unknown id>')
         description = raw.get('CTID1', '<unknown description>')
         record = SeqRecord(Seq(''),
                            id=sample_id,


### PR DESCRIPTION
This pull request addresses issue #1444

As discussed there, this pull request updates the check for `fsa` files, which are essentially ABIF files without sequences.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ AND the _BSD 3-Clause License_.

I am happy to be thanked by name in the ``NEWS.rst`` and
``CONTRIB.rst`` files.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.