### PR TITLE
Fix Fuzznuc para and add Fuzzpro wrapper

### DIFF
--- a/Bio/Emboss/Applications.py
+++ b/Bio/Emboss/Applications.py
@@ -988,11 +988,30 @@ class FuzznucCommandline(_EmbossCommandLine):
             _Option(["-pattern", "pattern"],
                     "Search pattern, using standard IUPAC one-letter codes",
                     is_required=True),
-            _Option(["-mismatch", "mismatch"],
-                    "Number of mismatches",
-                    is_required=True),
+            _Option(["-pmismatch", "pmismatch"],
+                    "Number of mismatches"),
             _Option(["-complement", "complement"],
                     "Search complementary strand"),
+            _Option(["-rformat", "rformat"],
+                    "Specify the report format to output in."),
+            ]
+        _EmbossCommandLine.__init__(self, cmd, **kwargs)
+
+
+class FuzzproCommandline(_EmbossCommandLine):
+    """Commandline object for the fuzzpro program from EMBOSS."""
+
+    def __init__(self, cmd="fuzzpro", **kwargs):
+        """Initialize the class."""
+        self.parameters = [
+            _Option(["-sequence", "sequence"],
+                    "Sequence database USA",
+                    is_required=True),
+            _Option(["-pattern", "pattern"],
+                    "Search pattern, using standard IUPAC one-letter codes",
+                    is_required=True),
+            _Option(["-pmismatch", "pmismatch"],
+                    "Number of mismatches"),
             _Option(["-rformat", "rformat"],
                     "Specify the report format to output in."),
             ]

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -85,6 +85,7 @@ please open an issue on GitHub or mention it on the development mailing list.
 - Eric Talevich <https://github.com/etal>
 - Erick Matsen <surname at fhcrc dot org>
 - Erik Cederstrand <https://github.com/ecederstrand>
+- Fei Qi <https://github.com/qifei9>
 - Foen Peng <https://github.com/foenpeng>
 - Francesco Gastaldello <https://github.com/Gasta88>
 - Francisco Pina-Martins <https://github.com/StuntsPT>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -40,6 +40,9 @@ Bio.PDB now contains a writer for the mmCIF file format, which has been the
 standard PDB archive format since 2014. This allows structural objects to be
 written out and facilitates conversion between the PDB and mmCIF file formats.
 
+Bio.Emboss.Applications has been updated to fix a wrong parameter in fuzznuc
+wrapper and include a new wrapper for fuzzpro.
+
 In this release more of our code is now explicitly available under either our
 original "Biopython License Agreement", or the very similar but more commonly
 used "3-Clause BSD License".  See the ``LICENSE.rst`` file for more details.

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -56,6 +56,7 @@ possible, especially the following contributors:
 - Chris Rands
 - Christian Brueffer
 - Erik Cederstrand (first contribution)
+- Fei Qi (first contribution)
 - Francesco Gastaldello
 - Jerven Bolleman (first contribution)
 - Joe Greener (first contribution)


### PR DESCRIPTION
This pull request addresses issue #1451  and also add a wrapper of `fuzzpro` in `Emboss`.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ AND the _BSD 3-Clause License_.

I *am* happy to be thanked by name in the ``NEWS.rst`` and
``CONTRIB.rst`` files.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.
