### PR TITLE
changed atom coordinates to numpy array to allow distance calculation

### DIFF
--- a/Bio/PDB/mmtf/DefaultParser.py
+++ b/Bio/PDB/mmtf/DefaultParser.py
@@ -1,5 +1,5 @@
 from Bio.PDB.StructureBuilder import StructureBuilder
-
+import numpy
 
 class StructureDecoder(object):
     """Class to pass the data from mmtf-python into a Biopython data structure."""
@@ -50,7 +50,7 @@ class StructureDecoder(object):
             alternative_location_id = " "
 
         # Atom_name is in twice - the full_name is with spaces
-        self.structure_bulder.init_atom(str(atom_name), [x, y, z],
+        self.structure_bulder.init_atom(str(atom_name), numpy.array((x, y, z), "f"),
                                         temperature_factor, occupancy,
                                         alternative_location_id, str(atom_name),
                                         serial_number=serial_number,

--- a/Bio/PDB/mmtf/DefaultParser.py
+++ b/Bio/PDB/mmtf/DefaultParser.py
@@ -1,6 +1,7 @@
 from Bio.PDB.StructureBuilder import StructureBuilder
 import numpy
 
+
 class StructureDecoder(object):
     """Class to pass the data from mmtf-python into a Biopython data structure."""
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -157,6 +157,7 @@ please open an issue on GitHub or mention it on the development mailing list.
 - Matt Shirley <https://github.com/mdshw5>
 - Matteo Sticco <https://github.com/sticken88/>
 - Maximilian Greil <https://github.com/MaxGreil>
+- Maximilian Peters <maximili.peters at mail.huji.ac.il>
 - Melissa Gymrek <https://github.com/mgymrek>
 - Michael Hoffman <https://github.com/michaelmhoffman>
 - Michal Kurowski <michal at domain genesilico.pl>

--- a/Tests/test_mmtf.py
+++ b/Tests/test_mmtf.py
@@ -33,6 +33,8 @@ class ParseMMTF(unittest.TestCase):
                                    mmcif_atom.full_id)  # (structure id, model id, chain id, residue id, atom id)
             self.assertEqual(mmtf_atom.id, mmcif_atom.name)  # id of atom is the atom name (e.g. "CA")
             # self.assertEqual(mmtf_atom.serial_number,mmcif_atom.serial_number) # mmCIF serial number is none
+            self.assertEqual(mmtf_atom - mmtf_atom, 0)
+            self.assertEqual(mmtf_atom - mmcif_atom, 0)
 
     def check_residues(self):
         """Check all residues in self.mmcif_res and self.mmtf_res are equivalent"""


### PR DESCRIPTION
This pull request addresses an issue reported on stackoverflow: https://stackoverflow.com/questions/47359764/biopython-mmtfparser-cant-find-distances-between-atoms

Atoms imported via MMTFParser have the coordinates stored as a list and not as a Numpy array which breaks the `__sub__` implementation.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
