### PR TITLE
Use https://doi.org/ consistently

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -109,6 +109,10 @@ commands =
     bash -c \'grep "1999-`date +'%Y'`" LICENSE.rst\'
     # Check no __docformat__ lines
     bash -c "if grep --include '*.py' -rn '^__docformat__ ' Bio BioSQL Tests Scripts Doc ; then echo 'Remove __docformat__ line(s), we assume restructuredtext.'; false; fi"
+    # Check DOI link style, see https://www.crossref.org/display-guidelines/
+    bash -c "if grep --include '*.py' --include '*.rst' --include '*.tex' -rni 'doi:' Bio BioSQL Scripts Doc ; then echo 'Please use https://doi.org/... not the doi: or DOI: style.'; false; fi"
+    bash -c "if grep --include '*.py' --include '*.rst' --include '*.tex' -rn 'dx\.doi\.org' Bio BioSQL Tests Scripts Doc ; then echo 'Please use https://doi.org/... not the dx.doi.org style.'; false; fi"
+    bash -c "if grep --include '*.py' --include '*.rst' --include '*.tex' -rn 'http://doi\.org' Bio BioSQL Tests Scripts Doc ; then echo 'Please use https://doi.org/... not http://doi.org/...'; false; fi"
 
 [testenv:sdist]
 # This does not need to install Biopython or any of its dependencies

--- a/Bio/Align/Applications/_ClustalOmega.py
+++ b/Bio/Align/Applications/_ClustalOmega.py
@@ -30,7 +30,7 @@ class ClustalOmegaCommandline(AbstractCommandline):
     McWilliam H, Remmert M, Söding J, Thompson JD, Higgins DG (2011).
     Fast, scalable generation of high-quality protein multiple
     sequence alignments using Clustal Omega.
-    Molecular Systems Biology 7:539 doi:10.1038/msb.2011.75
+    Molecular Systems Biology 7:539 https://doi.org/10.1038/msb.2011.75
 
     Examples
     --------

--- a/Bio/Blast/Applications.py
+++ b/Bio/Blast/Applications.py
@@ -24,7 +24,7 @@ For further details, see:
 
 Camacho et al. BLAST+: architecture and applications
 BMC Bioinformatics 2009, 10:421
-doi:10.1186/1471-2105-10-421
+https://doi.org/10.1186/1471-2105-10-421
 """
 from __future__ import print_function
 

--- a/Bio/CAPS/__init__.py
+++ b/Bio/CAPS/__init__.py
@@ -9,7 +9,7 @@ A CAPS marker is a location a DifferentialCutsite as described below and a
 set of primers that can be used to visualize this.  More information can
 be found in the paper `Konieczny and Ausubel (1993)`_ (PMID 8106085).
 
-.. _`Konieczny and Ausubel (1993)`: http://dx.doi.org/10.1046/j.1365-313X.1993.04020403.x
+.. _`Konieczny and Ausubel (1993)`: https://doi.org/10.1046/j.1365-313X.1993.04020403.x
 
 """
 

--- a/Bio/Cluster/__init__.py
+++ b/Bio/Cluster/__init__.py
@@ -9,7 +9,7 @@ designed with the application to gene expression data in mind. However,
 this module can also be used for cluster analysis of other types of data.
 
 Bio.Cluster and the underlying C Clustering Library is described in
-M. de Hoon et al. (2004) http://dx.doi.org/10.1093/bioinformatics/bth078
+M. de Hoon et al. (2004) https://doi.org/10.1093/bioinformatics/bth078
 """
 
 import numpy

--- a/Bio/Graphics/ColorSpiral.py
+++ b/Bio/Graphics/ColorSpiral.py
@@ -11,7 +11,7 @@ and returning the output in RGB colour space, suitable for use with ReportLab
 and other graphics packages.
 
 This approach to colour choice was inspired by Bang Wong's Points of View
-article: Color Coding, in Nature Methods _7_ 573 (doi:10.1038/nmeth0810-573).
+article: Color Coding, in Nature Methods _7_ 573 (https://doi.org/10.1038/nmeth0810-573).
 
 The module also provides helper functions that return a list for colours, or
 a dictionary of colours (if passed an iterable containing the names of

--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -12,11 +12,11 @@ The following Accessible surface area (ASA) values can be used, defaulting
 to the Sander and Rost values:
 
     Miller
-        Miller et al. 1987 http://dx.doi.org/10.1016/0022-2836(87)90038-6
+        Miller et al. 1987 https://doi.org/10.1016/0022-2836(87)90038-6
     Sander
-        Sander and Rost 1994 http://dx.doi.org/10.1002/prot.340200303
+        Sander and Rost 1994 https://doi.org/10.1002/prot.340200303
     Wilke
-        Tien et al. 2013 http://dx.doi.org/10.1371/journal.pone.0080635
+        Tien et al. 2013 https://doi.org/10.1371/journal.pone.0080635
 
 The DSSP codes for secondary structure used here are:
 
@@ -105,9 +105,9 @@ _dssp_cys = re.compile('[a-z]')
 # Used for relative accessibility
 
 residue_max_acc = {
-    # Miller max acc: Miller et al. 1987 http://dx.doi.org/10.1016/0022-2836(87)90038-6
-    # Wilke: Tien et al. 2013 http://dx.doi.org/10.1371/journal.pone.0080635
-    # Sander: Sander & Rost 1994 http://dx.doi.org/10.1002/prot.340200303
+    # Miller max acc: Miller et al. 1987 https://doi.org/10.1016/0022-2836(87)90038-6
+    # Wilke: Tien et al. 2013 https://doi.org/10.1371/journal.pone.0080635
+    # Sander: Sander & Rost 1994 https://doi.org/10.1002/prot.340200303
     'Miller': {
         'ALA': 113.0, 'ARG': 241.0, 'ASN': 158.0, 'ASP': 151.0,
         'CYS': 140.0, 'GLN': 189.0, 'GLU': 183.0, 'GLY': 85.0,

--- a/Bio/Phylo/Applications/_Fasttree.py
+++ b/Bio/Phylo/Applications/_Fasttree.py
@@ -37,7 +37,7 @@ class FastTreeCommandline(AbstractCommandline):
     ----------
     Price, M.N., Dehal, P.S., and Arkin, A.P. (2010) FastTree 2 -- Approximately
     Maximum-Likelihood Trees for Large Alignments. PLoS ONE, 5(3):e9490.
-    doi:10.1371/journal.pone.0009490.
+    https://doi.org/10.1371/journal.pone.0009490.
 
     Examples
     --------

--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -10,7 +10,7 @@ See Also
 Official specification:
    http://phyloxml.org/
 Journal article:
-    Han and Zmasek (2009), doi:10.1186/1471-2105-10-356
+    Han and Zmasek (2009), https://doi.org/10.1186/1471-2105-10-356
 
 """
 

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -44,7 +44,7 @@ please read this open access publication::
     P.J.A.Cock (Biopython), C.J.Fields (BioPerl), N.Goto (BioRuby),
     M.L.Heuer (BioJava) and P.M. Rice (EMBOSS).
     Nucleic Acids Research 2010 38(6):1767-1771
-    http://dx.doi.org/10.1093/nar/gkp1137
+    https://doi.org/10.1093/nar/gkp1137
 
 The good news is that Roche 454 sequencers can output files in the QUAL format,
 and sensibly they use PHREP style scores like Sanger.  Converting a pair of

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -9,7 +9,7 @@ You are expected to use this module via the Bio.SeqIO functions.
 
 SeqXML is a lightweight XML format which is supposed be an alternative for
 FASTA files. For more Information see http://www.seqXML.org and Schmitt et al
-(2011), http://dx.doi.org/10.1093/bib/bbr025
+(2011), https://doi.org/10.1093/bib/bbr025
 """
 
 from __future__ import print_function

--- a/Bio/SeqUtils/CheckSum.py
+++ b/Bio/SeqUtils/CheckSum.py
@@ -132,7 +132,7 @@ def seguid(seq):
 
     For more information about SEGUID, see:
     http://bioinformatics.anl.gov/seguid/
-    DOI: 10.1002/pmic.200600032
+    https://doi.org/10.1002/pmic.200600032
     """
     import hashlib
     import base64

--- a/Bio/SeqUtils/lcc.py
+++ b/Bio/SeqUtils/lcc.py
@@ -131,7 +131,7 @@ def lcc_simp(seq):
 
     Reference:
     Andrzej K Konopka (2005) Sequence Complexity and Composition
-    DOI: 10.1038/npg.els.0005260
+    https://doi.org/10.1038/npg.els.0005260
     """
     wsize = len(seq)
     try:

--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -307,7 +307,7 @@ def cal_dn_ds(codon_seq1, codon_seq2, method="NG86",
     .. _`Nei and Gojobori (1986)`: http://www.ncbi.nlm.nih.gov/pubmed/3444411
     .. _`Li et al. (1985)`: http://www.ncbi.nlm.nih.gov/pubmed/3916709
     .. _`Goldman and Yang (1994)`: http://mbe.oxfordjournals.org/content/11/5/725
-    .. _`Yang and Nielsen (2000)`: http://dx.doi.org/10.1093/oxfordjournals.molbev.a026236
+    .. _`Yang and Nielsen (2000)`: https://doi.org/10.1093/oxfordjournals.molbev.a026236
 
     Arguments:
      - codon_seq1 - CodonSeq or or SeqRecord that contains a CodonSeq
@@ -832,8 +832,8 @@ def _count_site_YN00(codon_lst1, codon_lst2, pi, k,
     and base frequencies in each category. The function is equivalent to
     the ``CountSites()`` function in ``yn00.c`` of PAML.
 
-    .. _`Ina (1995)`: http://dx.doi.org/10.1007/BF00167113
-    .. _`Yang and Nielsen (2000)`: http://dx.doi.org/10.1093/oxfordjournals.molbev.a026236
+    .. _`Ina (1995)`: https://doi.org/10.1007/BF00167113
+    .. _`Yang and Nielsen (2000)`: https://doi.org/10.1093/oxfordjournals.molbev.a026236
 
     """
     if len(codon_lst1) != len(codon_lst2):

--- a/Doc/Tutorial.tex
+++ b/Doc/Tutorial.tex
@@ -186,85 +186,85 @@ Michiel de Hoon, Peter Cock, Tiago Antao, Eric Talevich, Bartek Wilczy\'{n}ski}
 
 \begin{thebibliography}{99}
 \bibitem{cock2009}
-Peter J. A. Cock, Tiago Antao, Jeffrey T. Chang, Brad A. Chapman, Cymon J. Cox, Andrew Dalke, Iddo Friedberg, Thomas Hamelryck, Frank Kauff, Bartek Wilczynski, Michiel J. L. de Hoon: ``Biopython: freely available Python tools for computational molecular biology and bioinformatics''. {\it Bioinformatics} {\bf 25} (11), 1422--1423 (2009). \href{http://dx.doi.org/10.1093/bioinformatics/btp163}{doi:10.1093/bioinformatics/btp163},
+Peter J. A. Cock, Tiago Antao, Jeffrey T. Chang, Brad A. Chapman, Cymon J. Cox, Andrew Dalke, Iddo Friedberg, Thomas Hamelryck, Frank Kauff, Bartek Wilczynski, Michiel J. L. de Hoon: ``Biopython: freely available Python tools for computational molecular biology and bioinformatics''. {\it Bioinformatics} {\bf 25} (11), 1422--1423 (2009). \href{https://doi.org/10.1093/bioinformatics/btp163}{doi:10.1093/bioinformatics/btp163},
 \bibitem{pritchard2006}
 Leighton Pritchard, Jennifer A. White, Paul R.J. Birch, Ian K. Toth: ``GenomeDiagram: a python package for the visualization of large-scale genomic data''.  {\it Bioinformatics} {\bf 22} (5): 616--617 (2006).
-\href{http://dx.doi.org/10.1093/bioinformatics/btk021}{doi:10.1093/bioinformatics/btk021},
+\href{https://doi.org/10.1093/bioinformatics/btk021}{doi:10.1093/bioinformatics/btk021},
 \bibitem{toth2006}
 Ian K. Toth, Leighton Pritchard, Paul R. J. Birch: ``Comparative genomics reveals what makes an enterobacterial plant pathogen''. {\it Annual Review of Phytopathology} {\bf 44}: 305--336 (2006).
-\href{http://dx.doi.org/10.1146/annurev.phyto.44.070505.143444}{doi:10.1146/annurev.phyto.44.070505.143444},
+\href{https://doi.org/10.1146/annurev.phyto.44.070505.143444}{doi:10.1146/annurev.phyto.44.070505.143444},
 \bibitem{vanderauwera2009}
 G\'eraldine A. van der Auwera, Jaroslaw E. Kr\'ol, Haruo Suzuki, Brian Foster, Rob van Houdt, Celeste J. Brown, Max Mergeay, Eva M. Top: ``Plasmids captured in C. metallidurans CH34: defining the PromA family of broad-host-range plasmids''.
 \textit{Antonie van Leeuwenhoek} {\bf 96} (2): 193--204 (2009).
-\href{http://dx.doi.org/10.1007/s10482-009-9316-9}{doi:10.1007/s10482-009-9316-9}
+\href{https://doi.org/10.1007/s10482-009-9316-9}{doi:10.1007/s10482-009-9316-9}
 \bibitem{proux2002}
 Caroline Proux, Douwe van Sinderen, Juan Suarez, Pilar Garcia, Victor Ladero, Gerald F. Fitzgerald, Frank Desiere, Harald Br\"ussow:
 ``The dilemma of phage taxonomy illustrated by comparative genomics of Sfi21-Like Siphoviridae in lactic acid bacteria''.  \textit{Journal of Bacteriology} {\bf 184} (21): 6026--6036 (2002).
-\href{http://dx.doi.org/10.1128/JB.184.21.6026-6036.2002}{http://dx.doi.org/10.1128/JB.184.21.6026-6036.2002}
+\href{https://doi.org/10.1128/JB.184.21.6026-6036.2002}{https://doi.org/10.1128/JB.184.21.6026-6036.2002}
 \bibitem{jupe2012}
 Florian Jupe, Leighton Pritchard, Graham J. Etherington, Katrin MacKenzie, Peter JA Cock, Frank Wright, Sanjeev Kumar Sharma1, Dan Bolser, Glenn J Bryan, Jonathan DG Jones, Ingo Hein: ``Identification and localisation of the NB-LRR gene family within the potato genome''. \textit{BMC Genomics} {\bf 13}: 75 (2012).
-\href{http://dx.doi.org/10.1186/1471-2164-13-75}{http://dx.doi.org/10.1186/1471-2164-13-75}
+\href{https://doi.org/10.1186/1471-2164-13-75}{https://doi.org/10.1186/1471-2164-13-75}
 \bibitem{cock2010}
-Peter J. A. Cock, Christopher J. Fields, Naohisa Goto, Michael L. Heuer, Peter M. Rice: ``The Sanger FASTQ file format for sequences with quality scores, and the Solexa/Illumina FASTQ variants''.  \textit{Nucleic Acids Research} {\bf 38} (6): 1767--1771 (2010). \href{http://dx.doi.org/10.1093/nar/gkp1137}{doi:10.1093/nar/gkp1137}
+Peter J. A. Cock, Christopher J. Fields, Naohisa Goto, Michael L. Heuer, Peter M. Rice: ``The Sanger FASTQ file format for sequences with quality scores, and the Solexa/Illumina FASTQ variants''.  \textit{Nucleic Acids Research} {\bf 38} (6): 1767--1771 (2010). \href{https://doi.org/10.1093/nar/gkp1137}{doi:10.1093/nar/gkp1137}
 \bibitem{brown1999}
-Patrick O. Brown, David Botstein: ``Exploring the new world of the genome with DNA microarrays''. \textit{Nature Genetics} {\bf 21} (Supplement 1), 33--37 (1999). \href{http://dx.doi.org/10.1038/4462}{doi:10.1038/4462}
+Patrick O. Brown, David Botstein: ``Exploring the new world of the genome with DNA microarrays''. \textit{Nature Genetics} {\bf 21} (Supplement 1), 33--37 (1999). \href{https://doi.org/10.1038/4462}{doi:10.1038/4462}
 \bibitem{talevich2012}
-Eric Talevich, Brandon M. Invergo, Peter J.A. Cock, Brad A. Chapman: ``Bio.Phylo: A unified toolkit for processing, analyzing and visualizing phylogenetic trees in Biopython''.  \textit{BMC Bioinformatics} {\bf 13}: 209 (2012).  \href{http://dx.doi.org/10.1186/1471-2105-13-209}{doi:10.1186/1471-2105-13-209}
+Eric Talevich, Brandon M. Invergo, Peter J.A. Cock, Brad A. Chapman: ``Bio.Phylo: A unified toolkit for processing, analyzing and visualizing phylogenetic trees in Biopython''.  \textit{BMC Bioinformatics} {\bf 13}: 209 (2012).  \href{https://doi.org/10.1186/1471-2105-13-209}{doi:10.1186/1471-2105-13-209}
 \bibitem{cornish1985}
-Athel Cornish-Bowden: ``Nomenclature for incompletely specified bases in nucleic acid sequences: Recommendations 1984.'' \textit{Nucleic Acids Research} {\bf 13} (9): 3021--3030 (1985). \href{http://dx.doi.org/10.1093/nar/13.9.3021}{doi:10.1093/nar/13.9.3021}
+Athel Cornish-Bowden: ``Nomenclature for incompletely specified bases in nucleic acid sequences: Recommendations 1984.'' \textit{Nucleic Acids Research} {\bf 13} (9): 3021--3030 (1985). \href{https://doi.org/10.1093/nar/13.9.3021}{doi:10.1093/nar/13.9.3021}
 \bibitem{cavener1987}
-Douglas R. Cavener: ``Comparison of the consensus sequence flanking translational start sites in Drosophila and vertebrates.'' \textit{Nucleic Acids Research} {\bf 15} (4): 1353--1361 (1987). \href{http://dx.doi.org/10.1093/nar/15.4.1353}{doi:10.1093/nar/15.4.1353}
+Douglas R. Cavener: ``Comparison of the consensus sequence flanking translational start sites in Drosophila and vertebrates.'' \textit{Nucleic Acids Research} {\bf 15} (4): 1353--1361 (1987). \href{https://doi.org/10.1093/nar/15.4.1353}{doi:10.1093/nar/15.4.1353}
 \bibitem{bailey1994}
 Timothy L. Bailey and Charles Elkan: ``Fitting a mixture model by expectation maximization to discover motifs in biopolymers'', \textit{Proceedings of the Second International Conference on Intelligent Systems for Molecular Biology} 28--36. AAAI Press, Menlo Park, California (1994).
 \bibitem{chapman2000}
 Brad Chapman and Jeff Chang: ``Biopython: Python tools for computational biology''. \textit{ACM SIGBIO Newsletter} {\bf 20} (2): 15--19 (August 2000).
 \bibitem{dehoon2004}
-Michiel J. L. de Hoon, Seiya Imoto, John Nolan, Satoru Miyano: ``Open source clustering software''. \textit{Bioinformatics} {\bf 20} (9): 1453--1454 (2004). \href{http://dx.doi.org/10.1093/bioinformatics/bth078}{doi:10.1093/bioinformatics/bth078}
+Michiel J. L. de Hoon, Seiya Imoto, John Nolan, Satoru Miyano: ``Open source clustering software''. \textit{Bioinformatics} {\bf 20} (9): 1453--1454 (2004). \href{https://doi.org/10.1093/bioinformatics/bth078}{doi:10.1093/bioinformatics/bth078}
 \bibitem{eisen1998}
-Michiel B. Eisen, Paul T. Spellman, Patrick O. Brown, David Botstein: ``Cluster analysis and display of genome-wide expression patterns''. \textit{Proceedings of the National Academy of Science USA} {\bf 95} (25): 14863--14868 (1998). \href{http://dx.doi.org/10.1073/pnas.96.19.10943-c}{doi:10.1073/pnas.96.19.10943-c}
+Michiel B. Eisen, Paul T. Spellman, Patrick O. Brown, David Botstein: ``Cluster analysis and display of genome-wide expression patterns''. \textit{Proceedings of the National Academy of Science USA} {\bf 95} (25): 14863--14868 (1998). \href{https://doi.org/10.1073/pnas.96.19.10943-c}{doi:10.1073/pnas.96.19.10943-c}
 \bibitem{golub1971}
 Gene H. Golub, Christian Reinsch: ``Singular value decomposition and least squares solutions''. In \textit{Handbook for Automatic Computation}, {\bf 2}, (Linear Algebra) (J. H. Wilkinson and C. Reinsch, eds), 134--151. New York: Springer-Verlag (1971).
 \bibitem{golub1989}
 Gene H. Golub, Charles F. Van Loan: \textit{Matrix computations}, 2nd edition (1989).
 \bibitem{hamelryck2003a}
 Thomas Hamelryck and  Bernard Manderick: 11PDB parser and structure class
-implemented in Python''. \textit{Bioinformatics}, \textbf{19} (17): 2308--2310 (2003) \href{http://dx.doi.org/10.1093/bioinformatics/btg299}{doi: 10.1093/bioinformatics/btg299}. 
+implemented in Python''. \textit{Bioinformatics}, \textbf{19} (17): 2308--2310 (2003) \href{https://doi.org/10.1093/bioinformatics/btg299}{doi: 10.1093/bioinformatics/btg299}. 
 \bibitem{hamelryck2003b}
-Thomas Hamelryck: ``Efficient identification of side-chain patterns using a multidimensional index tree''. \textit{Proteins} {\bf 51} (1): 96--108 (2003). \href{http://dx.doi.org/10.1002/prot.10338}{doi:10.1002/prot.10338}
+Thomas Hamelryck: ``Efficient identification of side-chain patterns using a multidimensional index tree''. \textit{Proteins} {\bf 51} (1): 96--108 (2003). \href{https://doi.org/10.1002/prot.10338}{doi:10.1002/prot.10338}
 \bibitem{hamelryck2005}
-Thomas Hamelryck: ``An amino acid has two sides; A new 2D measure provides a different view of solvent exposure''. \textit{Proteins} {\bf 59} (1): 29--48 (2005). \href{http://dx.doi.org/10.1002/prot.20379}{doi:10.1002/prot.20379}.
+Thomas Hamelryck: ``An amino acid has two sides; A new 2D measure provides a different view of solvent exposure''. \textit{Proteins} {\bf 59} (1): 29--48 (2005). \href{https://doi.org/10.1002/prot.20379}{doi:10.1002/prot.20379}.
 \bibitem{hartigan1975}
 John A. Hartiga. \textit{Clustering algorithms}. New York: Wiley (1975).
 \bibitem{hihara2001}
-Yukako Hiharaa, Ayako Kameib, Minoru Kanehisac, Aaron Kapland and Masahiko Ikeuchib: ``DNA microarray analysis of cyanobacterial gene expression during acclimation to high light''. \textit{Plant Cell} {\bf 13} (4): 793--806 (2001). \href{http://dx.doi.org/10.1105/tpc.13.4.793}{doi:10.1105/tpc.13.4.793}.
+Yukako Hiharaa, Ayako Kameib, Minoru Kanehisac, Aaron Kapland and Masahiko Ikeuchib: ``DNA microarray analysis of cyanobacterial gene expression during acclimation to high light''. \textit{Plant Cell} {\bf 13} (4): 793--806 (2001). \href{https://doi.org/10.1105/tpc.13.4.793}{doi:10.1105/tpc.13.4.793}.
 \bibitem{jain1988}
 Anil L. Jain, Richard C. Dubes: \textit{Algorithms for clustering data}. Englewood Cliffs, N.J.: Prentice Hall (1988).
 \bibitem{kachitvichyanukul1988}
-Voratas Kachitvichyanukul, Bruce W. Schmeiser: Binomial Random Variate Generation. \textit{Communications of the ACM} {\bf 31} (2): 216--222 (1988). \href{http://dx.doi.org/10.1145/42372.42381}{doi:10.1145/42372.42381}
+Voratas Kachitvichyanukul, Bruce W. Schmeiser: Binomial Random Variate Generation. \textit{Communications of the ACM} {\bf 31} (2): 216--222 (1988). \href{https://doi.org/10.1145/42372.42381}{doi:10.1145/42372.42381}
 \bibitem{kohonen1997}
 Teuvo Kohonen: ``Self-organizing maps'', 2nd Edition. Berlin; New York: Springer-Verlag (1997).
 \bibitem{lecuyer1988}
 Pierre L'Ecuyer: ``Efficient and Portable Combined Random Number Generators.''
-\textit{Communications of the ACM} {\bf 31} (6): 742--749,774 (1988). \href{http://dx.doi.org/10.1145/62959.62969}{doi:10.1145/62959.62969}
+\textit{Communications of the ACM} {\bf 31} (6): 742--749,774 (1988). \href{https://doi.org/10.1145/62959.62969}{doi:10.1145/62959.62969}
 \bibitem{majumdar2005}
-Indraneel Majumdar, S. Sri Krishna, Nick V. Grishin: ``PALSSE: A program to delineate linear secondary structural elements from protein structures.'' \textit{BMC Bioinformatics}, {\bf 6}: 202 (2005). \href{http://dx.doi.org/10.1186/1471-2105-6-202}{doi:10.1186/1471-2105-6-202}.
+Indraneel Majumdar, S. Sri Krishna, Nick V. Grishin: ``PALSSE: A program to delineate linear secondary structural elements from protein structures.'' \textit{BMC Bioinformatics}, {\bf 6}: 202 (2005). \href{https://doi.org/10.1186/1471-2105-6-202}{doi:10.1186/1471-2105-6-202}.
 \bibitem{matys2003}
-V. Matys, E. Fricke, R. Geffers, E. G\"ossling, M. Haubrock, R. Hehl, K. Hornischer, D. Karas, A.E. Kel, O.V. Kel-Margoulis, D.U. Kloos, S. Land, B. Lewicki-Potapov, H. Michael, R. M\"unch, I. Reuter, S. Rotert, H. Saxel, M. Scheer, S. Thiele, E. Wingender E: ``TRANSFAC: transcriptional regulation, from patterns to profiles.'' Nucleic Acids Research {\bf 31} (1): 374--378 (2003). \href{http://dx.doi.org/10.1093/nar/gkg108}{doi:10.1093/nar/gkg108}
+V. Matys, E. Fricke, R. Geffers, E. G\"ossling, M. Haubrock, R. Hehl, K. Hornischer, D. Karas, A.E. Kel, O.V. Kel-Margoulis, D.U. Kloos, S. Land, B. Lewicki-Potapov, H. Michael, R. M\"unch, I. Reuter, S. Rotert, H. Saxel, M. Scheer, S. Thiele, E. Wingender E: ``TRANSFAC: transcriptional regulation, from patterns to profiles.'' Nucleic Acids Research {\bf 31} (1): 374--378 (2003). \href{https://doi.org/10.1093/nar/gkg108}{doi:10.1093/nar/gkg108}
 \bibitem{sibson1973}
-Robin Sibson: ``SLINK: An optimally efficient algorithm for the single-link cluster method''. \textit{The Computer Journal} {\bf 16} (1): 30--34 (1973). \href{http://dx.doi.org/10.1093/comjnl/16.1.30}{doi:10.1093/comjnl/16.1.30}
+Robin Sibson: ``SLINK: An optimally efficient algorithm for the single-link cluster method''. \textit{The Computer Journal} {\bf 16} (1): 30--34 (1973). \href{https://doi.org/10.1093/comjnl/16.1.30}{doi:10.1093/comjnl/16.1.30}
 \bibitem{snedecor1989}
 George W. Snedecor, William G. Cochran: \textit{Statistical methods}. Ames, Iowa: Iowa State University Press (1989).
 \bibitem{tamayo1999}
-Pablo Tamayo, Donna Slonim, Jill Mesirov, Qing Zhu, Sutisak Kitareewan, Ethan Dmitrovsky, Eric S. Lander, Todd R. Golub: ``Interpreting patterns of gene expression with self-organizing maps: Methods and application to hematopoietic differentiation''. \textit{Proceedings of the National Academy of Science USA} {\bf 96} (6): 2907--2912 (1999). \href{http://dx.doi.org/10.1073/pnas.96.6.2907}{doi:10.1073/pnas.96.6.2907}
+Pablo Tamayo, Donna Slonim, Jill Mesirov, Qing Zhu, Sutisak Kitareewan, Ethan Dmitrovsky, Eric S. Lander, Todd R. Golub: ``Interpreting patterns of gene expression with self-organizing maps: Methods and application to hematopoietic differentiation''. \textit{Proceedings of the National Academy of Science USA} {\bf 96} (6): 2907--2912 (1999). \href{https://doi.org/10.1073/pnas.96.6.2907}{doi:10.1073/pnas.96.6.2907}
 \bibitem{tryon1970}
 Robert C. Tryon, Daniel E. Bailey: \textit{Cluster analysis}. New York: McGraw-Hill (1970).
 \bibitem{tukey1977}
 John W. Tukey: ``Exploratory data analysis''. Reading, Mass.: Addison-Wesley Pub. Co. (1977).
 \bibitem{yeung2001}
-Ka Yee Yeung, Walter L. Ruzzo: ``Principal Component Analysis for clustering gene expression data''. \textit{Bioinformatics} {\bf 17} (9): 763--774 (2001). \href{http://dx.doi.org/10.1093/bioinformatics/17.9.763}{doi:10.1093/bioinformatics/17.9.763}
+Ka Yee Yeung, Walter L. Ruzzo: ``Principal Component Analysis for clustering gene expression data''. \textit{Bioinformatics} {\bf 17} (9): 763--774 (2001). \href{https://doi.org/10.1093/bioinformatics/17.9.763}{doi:10.1093/bioinformatics/17.9.763}
 \bibitem{saldanha2004}
 Alok Saldanha: ``Java Treeview---extensible visualization of microarray data''. \textit{Bioinformatics} {\bf 20} (17): 3246--3248 (2004). 
-\href{http://dx.doi.org/10.1093/bioinformatics/bth349}{http://dx.doi.org/10.1093/bioinformatics/bth349}
+\href{https://doi.org/10.1093/bioinformatics/bth349}{https://doi.org/10.1093/bioinformatics/bth349}
 \end{thebibliography}
 \end{document}
 

--- a/Doc/Tutorial.tex
+++ b/Doc/Tutorial.tex
@@ -186,85 +186,97 @@ Michiel de Hoon, Peter Cock, Tiago Antao, Eric Talevich, Bartek Wilczy\'{n}ski}
 
 \begin{thebibliography}{99}
 \bibitem{cock2009}
-Peter J. A. Cock, Tiago Antao, Jeffrey T. Chang, Brad A. Chapman, Cymon J. Cox, Andrew Dalke, Iddo Friedberg, Thomas Hamelryck, Frank Kauff, Bartek Wilczynski, Michiel J. L. de Hoon: ``Biopython: freely available Python tools for computational molecular biology and bioinformatics''. {\it Bioinformatics} {\bf 25} (11), 1422--1423 (2009). \href{https://doi.org/10.1093/bioinformatics/btp163}{doi:10.1093/bioinformatics/btp163},
+Peter J. A. Cock, Tiago Antao, Jeffrey T. Chang, Brad A. Chapman, Cymon J. Cox, Andrew Dalke, Iddo Friedberg, Thomas Hamelryck, Frank Kauff, Bartek Wilczynski, Michiel J. L. de Hoon: ``Biopython: freely available Python tools for computational molecular biology and bioinformatics''. {\it Bioinformatics} {\bf 25} (11), 1422--1423 (2009).
+\url{https://doi.org/10.1093/bioinformatics/btp163}
 \bibitem{pritchard2006}
 Leighton Pritchard, Jennifer A. White, Paul R.J. Birch, Ian K. Toth: ``GenomeDiagram: a python package for the visualization of large-scale genomic data''.  {\it Bioinformatics} {\bf 22} (5): 616--617 (2006).
-\href{https://doi.org/10.1093/bioinformatics/btk021}{doi:10.1093/bioinformatics/btk021},
+\url{https://doi.org/10.1093/bioinformatics/btk021}
 \bibitem{toth2006}
 Ian K. Toth, Leighton Pritchard, Paul R. J. Birch: ``Comparative genomics reveals what makes an enterobacterial plant pathogen''. {\it Annual Review of Phytopathology} {\bf 44}: 305--336 (2006).
-\href{https://doi.org/10.1146/annurev.phyto.44.070505.143444}{doi:10.1146/annurev.phyto.44.070505.143444},
+\url{https://doi.org/10.1146/annurev.phyto.44.070505.143444}
 \bibitem{vanderauwera2009}
 G\'eraldine A. van der Auwera, Jaroslaw E. Kr\'ol, Haruo Suzuki, Brian Foster, Rob van Houdt, Celeste J. Brown, Max Mergeay, Eva M. Top: ``Plasmids captured in C. metallidurans CH34: defining the PromA family of broad-host-range plasmids''.
 \textit{Antonie van Leeuwenhoek} {\bf 96} (2): 193--204 (2009).
-\href{https://doi.org/10.1007/s10482-009-9316-9}{doi:10.1007/s10482-009-9316-9}
+\url{https://doi.org/10.1007/s10482-009-9316-9}
 \bibitem{proux2002}
 Caroline Proux, Douwe van Sinderen, Juan Suarez, Pilar Garcia, Victor Ladero, Gerald F. Fitzgerald, Frank Desiere, Harald Br\"ussow:
 ``The dilemma of phage taxonomy illustrated by comparative genomics of Sfi21-Like Siphoviridae in lactic acid bacteria''.  \textit{Journal of Bacteriology} {\bf 184} (21): 6026--6036 (2002).
-\href{https://doi.org/10.1128/JB.184.21.6026-6036.2002}{https://doi.org/10.1128/JB.184.21.6026-6036.2002}
+\url{https://doi.org/10.1128/JB.184.21.6026-6036.2002}
 \bibitem{jupe2012}
 Florian Jupe, Leighton Pritchard, Graham J. Etherington, Katrin MacKenzie, Peter JA Cock, Frank Wright, Sanjeev Kumar Sharma1, Dan Bolser, Glenn J Bryan, Jonathan DG Jones, Ingo Hein: ``Identification and localisation of the NB-LRR gene family within the potato genome''. \textit{BMC Genomics} {\bf 13}: 75 (2012).
-\href{https://doi.org/10.1186/1471-2164-13-75}{https://doi.org/10.1186/1471-2164-13-75}
+\url{https://doi.org/10.1186/1471-2164-13-75}
 \bibitem{cock2010}
-Peter J. A. Cock, Christopher J. Fields, Naohisa Goto, Michael L. Heuer, Peter M. Rice: ``The Sanger FASTQ file format for sequences with quality scores, and the Solexa/Illumina FASTQ variants''.  \textit{Nucleic Acids Research} {\bf 38} (6): 1767--1771 (2010). \href{https://doi.org/10.1093/nar/gkp1137}{doi:10.1093/nar/gkp1137}
+Peter J. A. Cock, Christopher J. Fields, Naohisa Goto, Michael L. Heuer, Peter M. Rice: ``The Sanger FASTQ file format for sequences with quality scores, and the Solexa/Illumina FASTQ variants''.  \textit{Nucleic Acids Research} {\bf 38} (6): 1767--1771 (2010). \url{https://doi.org/10.1093/nar/gkp1137}
 \bibitem{brown1999}
-Patrick O. Brown, David Botstein: ``Exploring the new world of the genome with DNA microarrays''. \textit{Nature Genetics} {\bf 21} (Supplement 1), 33--37 (1999). \href{https://doi.org/10.1038/4462}{doi:10.1038/4462}
+Patrick O. Brown, David Botstein: ``Exploring the new world of the genome with DNA microarrays''. \textit{Nature Genetics} {\bf 21} (Supplement 1), 33--37 (1999). \url{https://doi.org/10.1038/4462}
 \bibitem{talevich2012}
-Eric Talevich, Brandon M. Invergo, Peter J.A. Cock, Brad A. Chapman: ``Bio.Phylo: A unified toolkit for processing, analyzing and visualizing phylogenetic trees in Biopython''.  \textit{BMC Bioinformatics} {\bf 13}: 209 (2012).  \href{https://doi.org/10.1186/1471-2105-13-209}{doi:10.1186/1471-2105-13-209}
+Eric Talevich, Brandon M. Invergo, Peter J.A. Cock, Brad A. Chapman: ``Bio.Phylo: A unified toolkit for processing, analyzing and visualizing phylogenetic trees in Biopython''.  \textit{BMC Bioinformatics} {\bf 13}: 209 (2012).
+\url{https://doi.org/10.1186/1471-2105-13-209}
 \bibitem{cornish1985}
-Athel Cornish-Bowden: ``Nomenclature for incompletely specified bases in nucleic acid sequences: Recommendations 1984.'' \textit{Nucleic Acids Research} {\bf 13} (9): 3021--3030 (1985). \href{https://doi.org/10.1093/nar/13.9.3021}{doi:10.1093/nar/13.9.3021}
+Athel Cornish-Bowden: ``Nomenclature for incompletely specified bases in nucleic acid sequences: Recommendations 1984.'' \textit{Nucleic Acids Research} {\bf 13} (9): 3021--3030 (1985).
+\url{https://doi.org/10.1093/nar/13.9.3021}
 \bibitem{cavener1987}
-Douglas R. Cavener: ``Comparison of the consensus sequence flanking translational start sites in Drosophila and vertebrates.'' \textit{Nucleic Acids Research} {\bf 15} (4): 1353--1361 (1987). \href{https://doi.org/10.1093/nar/15.4.1353}{doi:10.1093/nar/15.4.1353}
+Douglas R. Cavener: ``Comparison of the consensus sequence flanking translational start sites in Drosophila and vertebrates.'' \textit{Nucleic Acids Research} {\bf 15} (4): 1353--1361 (1987).
+\url{https://doi.org/10.1093/nar/15.4.1353}
 \bibitem{bailey1994}
 Timothy L. Bailey and Charles Elkan: ``Fitting a mixture model by expectation maximization to discover motifs in biopolymers'', \textit{Proceedings of the Second International Conference on Intelligent Systems for Molecular Biology} 28--36. AAAI Press, Menlo Park, California (1994).
 \bibitem{chapman2000}
 Brad Chapman and Jeff Chang: ``Biopython: Python tools for computational biology''. \textit{ACM SIGBIO Newsletter} {\bf 20} (2): 15--19 (August 2000).
 \bibitem{dehoon2004}
-Michiel J. L. de Hoon, Seiya Imoto, John Nolan, Satoru Miyano: ``Open source clustering software''. \textit{Bioinformatics} {\bf 20} (9): 1453--1454 (2004). \href{https://doi.org/10.1093/bioinformatics/bth078}{doi:10.1093/bioinformatics/bth078}
+Michiel J. L. de Hoon, Seiya Imoto, John Nolan, Satoru Miyano: ``Open source clustering software''. \textit{Bioinformatics} {\bf 20} (9): 1453--1454 (2004).
+\url{https://doi.org/10.1093/bioinformatics/bth078}
 \bibitem{eisen1998}
-Michiel B. Eisen, Paul T. Spellman, Patrick O. Brown, David Botstein: ``Cluster analysis and display of genome-wide expression patterns''. \textit{Proceedings of the National Academy of Science USA} {\bf 95} (25): 14863--14868 (1998). \href{https://doi.org/10.1073/pnas.96.19.10943-c}{doi:10.1073/pnas.96.19.10943-c}
+Michiel B. Eisen, Paul T. Spellman, Patrick O. Brown, David Botstein: ``Cluster analysis and display of genome-wide expression patterns''. \textit{Proceedings of the National Academy of Science USA} {\bf 95} (25): 14863--14868 (1998). \url{https://doi.org/10.1073/pnas.96.19.10943-c}
 \bibitem{golub1971}
 Gene H. Golub, Christian Reinsch: ``Singular value decomposition and least squares solutions''. In \textit{Handbook for Automatic Computation}, {\bf 2}, (Linear Algebra) (J. H. Wilkinson and C. Reinsch, eds), 134--151. New York: Springer-Verlag (1971).
 \bibitem{golub1989}
 Gene H. Golub, Charles F. Van Loan: \textit{Matrix computations}, 2nd edition (1989).
 \bibitem{hamelryck2003a}
 Thomas Hamelryck and  Bernard Manderick: 11PDB parser and structure class
-implemented in Python''. \textit{Bioinformatics}, \textbf{19} (17): 2308--2310 (2003) \href{https://doi.org/10.1093/bioinformatics/btg299}{doi: 10.1093/bioinformatics/btg299}. 
+implemented in Python''. \textit{Bioinformatics}, \textbf{19} (17): 2308--2310 (2003) \url{https://doi.org/10.1093/bioinformatics/btg299}. 
 \bibitem{hamelryck2003b}
-Thomas Hamelryck: ``Efficient identification of side-chain patterns using a multidimensional index tree''. \textit{Proteins} {\bf 51} (1): 96--108 (2003). \href{https://doi.org/10.1002/prot.10338}{doi:10.1002/prot.10338}
+Thomas Hamelryck: ``Efficient identification of side-chain patterns using a multidimensional index tree''. \textit{Proteins} {\bf 51} (1): 96--108 (2003).
+\url{https://doi.org/10.1002/prot.10338}
 \bibitem{hamelryck2005}
-Thomas Hamelryck: ``An amino acid has two sides; A new 2D measure provides a different view of solvent exposure''. \textit{Proteins} {\bf 59} (1): 29--48 (2005). \href{https://doi.org/10.1002/prot.20379}{doi:10.1002/prot.20379}.
+Thomas Hamelryck: ``An amino acid has two sides; A new 2D measure provides a different view of solvent exposure''. \textit{Proteins} {\bf 59} (1): 29--48 (2005).
+\url{https://doi.org/10.1002/prot.20379}.
 \bibitem{hartigan1975}
 John A. Hartiga. \textit{Clustering algorithms}. New York: Wiley (1975).
 \bibitem{hihara2001}
-Yukako Hiharaa, Ayako Kameib, Minoru Kanehisac, Aaron Kapland and Masahiko Ikeuchib: ``DNA microarray analysis of cyanobacterial gene expression during acclimation to high light''. \textit{Plant Cell} {\bf 13} (4): 793--806 (2001). \href{https://doi.org/10.1105/tpc.13.4.793}{doi:10.1105/tpc.13.4.793}.
+Yukako Hiharaa, Ayako Kameib, Minoru Kanehisac, Aaron Kapland and Masahiko Ikeuchib: ``DNA microarray analysis of cyanobacterial gene expression during acclimation to high light''. \textit{Plant Cell} {\bf 13} (4): 793--806 (2001). \url{https://doi.org/10.1105/tpc.13.4.793}.
 \bibitem{jain1988}
 Anil L. Jain, Richard C. Dubes: \textit{Algorithms for clustering data}. Englewood Cliffs, N.J.: Prentice Hall (1988).
 \bibitem{kachitvichyanukul1988}
-Voratas Kachitvichyanukul, Bruce W. Schmeiser: Binomial Random Variate Generation. \textit{Communications of the ACM} {\bf 31} (2): 216--222 (1988). \href{https://doi.org/10.1145/42372.42381}{doi:10.1145/42372.42381}
+Voratas Kachitvichyanukul, Bruce W. Schmeiser: Binomial Random Variate Generation. \textit{Communications of the ACM} {\bf 31} (2): 216--222 (1988). \url{https://doi.org/10.1145/42372.42381}
 \bibitem{kohonen1997}
 Teuvo Kohonen: ``Self-organizing maps'', 2nd Edition. Berlin; New York: Springer-Verlag (1997).
 \bibitem{lecuyer1988}
 Pierre L'Ecuyer: ``Efficient and Portable Combined Random Number Generators.''
-\textit{Communications of the ACM} {\bf 31} (6): 742--749,774 (1988). \href{https://doi.org/10.1145/62959.62969}{doi:10.1145/62959.62969}
+\textit{Communications of the ACM} {\bf 31} (6): 742--749,774 (1988).
+\url{https://doi.org/10.1145/62959.62969}
 \bibitem{majumdar2005}
-Indraneel Majumdar, S. Sri Krishna, Nick V. Grishin: ``PALSSE: A program to delineate linear secondary structural elements from protein structures.'' \textit{BMC Bioinformatics}, {\bf 6}: 202 (2005). \href{https://doi.org/10.1186/1471-2105-6-202}{doi:10.1186/1471-2105-6-202}.
+Indraneel Majumdar, S. Sri Krishna, Nick V. Grishin: ``PALSSE: A program to delineate linear secondary structural elements from protein structures.'' \textit{BMC Bioinformatics}, {\bf 6}: 202 (2005).
+\url{https://doi.org/10.1186/1471-2105-6-202}.
 \bibitem{matys2003}
-V. Matys, E. Fricke, R. Geffers, E. G\"ossling, M. Haubrock, R. Hehl, K. Hornischer, D. Karas, A.E. Kel, O.V. Kel-Margoulis, D.U. Kloos, S. Land, B. Lewicki-Potapov, H. Michael, R. M\"unch, I. Reuter, S. Rotert, H. Saxel, M. Scheer, S. Thiele, E. Wingender E: ``TRANSFAC: transcriptional regulation, from patterns to profiles.'' Nucleic Acids Research {\bf 31} (1): 374--378 (2003). \href{https://doi.org/10.1093/nar/gkg108}{doi:10.1093/nar/gkg108}
+V. Matys, E. Fricke, R. Geffers, E. G\"ossling, M. Haubrock, R. Hehl, K. Hornischer, D. Karas, A.E. Kel, O.V. Kel-Margoulis, D.U. Kloos, S. Land, B. Lewicki-Potapov, H. Michael, R. M\"unch, I. Reuter, S. Rotert, H. Saxel, M. Scheer, S. Thiele, E. Wingender E: ``TRANSFAC: transcriptional regulation, from patterns to profiles.'' Nucleic Acids Research {\bf 31} (1): 374--378 (2003).
+\url{https://doi.org/10.1093/nar/gkg108}
 \bibitem{sibson1973}
-Robin Sibson: ``SLINK: An optimally efficient algorithm for the single-link cluster method''. \textit{The Computer Journal} {\bf 16} (1): 30--34 (1973). \href{https://doi.org/10.1093/comjnl/16.1.30}{doi:10.1093/comjnl/16.1.30}
+Robin Sibson: ``SLINK: An optimally efficient algorithm for the single-link cluster method''. \textit{The Computer Journal} {\bf 16} (1): 30--34 (1973).
+\url{https://doi.org/10.1093/comjnl/16.1.30}
 \bibitem{snedecor1989}
 George W. Snedecor, William G. Cochran: \textit{Statistical methods}. Ames, Iowa: Iowa State University Press (1989).
 \bibitem{tamayo1999}
-Pablo Tamayo, Donna Slonim, Jill Mesirov, Qing Zhu, Sutisak Kitareewan, Ethan Dmitrovsky, Eric S. Lander, Todd R. Golub: ``Interpreting patterns of gene expression with self-organizing maps: Methods and application to hematopoietic differentiation''. \textit{Proceedings of the National Academy of Science USA} {\bf 96} (6): 2907--2912 (1999). \href{https://doi.org/10.1073/pnas.96.6.2907}{doi:10.1073/pnas.96.6.2907}
+Pablo Tamayo, Donna Slonim, Jill Mesirov, Qing Zhu, Sutisak Kitareewan, Ethan Dmitrovsky, Eric S. Lander, Todd R. Golub: ``Interpreting patterns of gene expression with self-organizing maps: Methods and application to hematopoietic differentiation''. \textit{Proceedings of the National Academy of Science USA} {\bf 96} (6): 2907--2912 (1999). \url{https://doi.org/10.1073/pnas.96.6.2907}
 \bibitem{tryon1970}
 Robert C. Tryon, Daniel E. Bailey: \textit{Cluster analysis}. New York: McGraw-Hill (1970).
 \bibitem{tukey1977}
 John W. Tukey: ``Exploratory data analysis''. Reading, Mass.: Addison-Wesley Pub. Co. (1977).
 \bibitem{yeung2001}
-Ka Yee Yeung, Walter L. Ruzzo: ``Principal Component Analysis for clustering gene expression data''. \textit{Bioinformatics} {\bf 17} (9): 763--774 (2001). \href{https://doi.org/10.1093/bioinformatics/17.9.763}{doi:10.1093/bioinformatics/17.9.763}
+Ka Yee Yeung, Walter L. Ruzzo: ``Principal Component Analysis for clustering gene expression data''. \textit{Bioinformatics} {\bf 17} (9): 763--774 (2001).
+\url{https://doi.org/10.1093/bioinformatics/17.9.763}
 \bibitem{saldanha2004}
 Alok Saldanha: ``Java Treeview---extensible visualization of microarray data''. \textit{Bioinformatics} {\bf 20} (17): 3246--3248 (2004). 
-\href{https://doi.org/10.1093/bioinformatics/bth349}{https://doi.org/10.1093/bioinformatics/bth349}
+\url{https://doi.org/10.1093/bioinformatics/bth349}
 \end{thebibliography}
 \end{document}
 

--- a/Doc/examples/Proux_et_al_2002_Figure_6.py
+++ b/Doc/examples/Proux_et_al_2002_Figure_6.py
@@ -10,7 +10,7 @@ You can use the Entrez module to download the 3 required GenBank files
 This is an extended version of the example in the Biopython Tutorial
 which produces a GenomeDiagram figure close to Proux et al 2002 Figure 6.
 
-See http://dx.doi.org/10.1128/JB.184.21.6026-6036.2002
+See https://doi.org/10.1128/JB.184.21.6026-6036.2002
 """
 from reportlab.lib import colors
 from reportlab.lib.colors import red, grey, orange, green, brown


### PR DESCRIPTION
This addresses a style inconsistency in how we have written DOI references, noticed while reviewing #1367

With this change we now use ``https://doi.org/...`` as per https://www.crossref.org/display-guidelines/ (and avoid HTTP, ``dx.doi.org``, and the text-only variants ``DOI: ...`` and ``doi: ...`` in favour of showing the HTTPS URL).

This would then be enforced by the TravisCI/Tox style checks.