### PR TITLE
Nexus interleave

### DIFF
--- a/Bio/AlignIO/NexusIO.py
+++ b/Bio/AlignIO/NexusIO.py
@@ -1,4 +1,4 @@
-# Copyright 2008-2010, 2012-2014, 2016 by Peter Cock.  All rights reserved.
+# Copyright 2008-2010, 2012-2014, 2016-2017 by Peter Cock.  All rights reserved.
 #
 # This file is part of the Biopython distribution and governed by your
 # choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
@@ -50,7 +50,7 @@ def NexusIterator(handle, seq_count=None):
 
     if seq_count and seq_count != len(n.unaltered_taxlabels):
         raise ValueError("Found %i sequences, but seq_count=%i"
-               % (len(n.unaltered_taxlabels), seq_count))
+                         % (len(n.unaltered_taxlabels), seq_count))
 
     # TODO - Can we extract any annotation too?
     records = (SeqRecord(n.matrix[new_name], id=new_name,
@@ -100,9 +100,14 @@ class NexusWriter(AlignmentWriter):
         self.write_alignment(first_alignment)
         return 1  # we only support writing one alignment!
 
-    def write_alignment(self, alignment):
-        # Creates an empty Nexus object, adds the sequences,
-        # and then gets Nexus to prepare the output.
+    def write_alignment(self, alignment, interleave=None):
+        """Write an alignment to file.
+
+        Creates an empty Nexus object, adds the sequences
+        and then gets Nexus to prepare the output.
+        Default interleave behaviour: Interleave if columns > 1000
+        --> Override with interleave=[True/False]
+        """
         if len(alignment) == 0:
             raise ValueError("Must have at least one sequence")
         columns = alignment.get_alignment_length()
@@ -115,11 +120,11 @@ class NexusWriter(AlignmentWriter):
         n.alphabet = alignment._alphabet
         for record in alignment:
             n.add_sequence(record.id, str(record.seq))
-        # For smaller alignments, don't bother to interleave.
-        # For larger alginments, interleave to avoid very long lines
-        # in the output - something MrBayes can't handle.
-        # TODO - Default to always interleaving?
-        n.write_nexus_data(self.handle, interleave=(columns > 1000))
+
+        # Note: MrBayes may choke on large alignments if not interleaved
+        if interleave is None:
+            interleave = False if columns <= 1000 else True
+        n.write_nexus_data(self.handle, interleave=interleave)
 
     def _classify_alphabet_for_nexus(self, alphabet):
         """Return 'protein', 'dna', or 'rna' based on the alphabet (PRIVATE).

--- a/Bio/AlignIO/NexusIO.py
+++ b/Bio/AlignIO/NexusIO.py
@@ -123,7 +123,7 @@ class NexusWriter(AlignmentWriter):
 
         # Note: MrBayes may choke on large alignments if not interleaved
         if interleave is None:
-            interleave = False if columns <= 1000 else True
+            interleave = (columns > 1000)
         n.write_nexus_data(self.handle, interleave=interleave)
 
     def _classify_alphabet_for_nexus(self, alphabet):

--- a/Tests/test_Nexus.py
+++ b/Tests/test_Nexus.py
@@ -363,8 +363,7 @@ usertype matrix_test stepmatrix=5
 ;
 """)  # noqa : W291
 
-    @staticmethod
-    def test_write_alignment():
+    def test_write_alignment(self):
         # Default causes no interleave (columns <= 1000)
         records = [SeqRecord(Seq("ATGCTGCTGA" * 90, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
         a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
@@ -373,7 +372,7 @@ usertype matrix_test stepmatrix=5
         NexusWriter(handle).write_alignment(a)
         handle.seek(0)
         data = handle.read()
-        assert "ATGCTGCTGA" * 90 in data
+        self.assertIn("ATGCTGCTGA" * 90, data)
 
         # Default causes interleave (columns > 1000)
         records = [SeqRecord(Seq("ATGCTGCTGA" * 110, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
@@ -382,8 +381,8 @@ usertype matrix_test stepmatrix=5
         NexusWriter(handle).write_alignment(a)
         handle.seek(0)
         data = handle.read()
-        assert "ATGCTGCTGA" * 90 not in data
-        assert "ATGCTGCTGA" * 7 in data
+        self.assertNotIn("ATGCTGCTGA" * 90, data)
+        self.assertIn("ATGCTGCTGA" * 7, data)
 
         # Override interleave: True
         records = [SeqRecord(Seq("ATGCTGCTGA" * 9, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
@@ -392,8 +391,8 @@ usertype matrix_test stepmatrix=5
         NexusWriter(handle).write_alignment(a, interleave=True)
         handle.seek(0)
         data = handle.read()
-        assert "ATGCTGCTGA" * 9 not in data
-        assert "ATGCTGCTGA" * 7 in data
+        self.assertNotIn("ATGCTGCTGA" * 9, data)
+        self.assertIn("ATGCTGCTGA" * 7, data)
 
         # Override interleave: False
         records = [SeqRecord(Seq("ATGCTGCTGA" * 110, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
@@ -402,7 +401,7 @@ usertype matrix_test stepmatrix=5
         NexusWriter(handle).write_alignment(a, interleave=False)
         handle.seek(0)
         data = handle.read()
-        assert "ATGCTGCTGA" * 110 in data
+        self.assertIn("ATGCTGCTGA" * 110, data)
 
     def test_TreeTest1(self):
         """Test Tree module."""

--- a/Tests/test_Nexus.py
+++ b/Tests/test_Nexus.py
@@ -363,6 +363,47 @@ usertype matrix_test stepmatrix=5
 ;
 """)  # noqa : W291
 
+    @staticmethod
+    def test_write_alignment():
+        # Default causes no interleave (columns <= 1000)
+        records = [SeqRecord(Seq("ATGCTGCTGA" * 90, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
+        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+
+        handle = StringIO()
+        NexusWriter(handle).write_alignment(a)
+        handle.seek(0)
+        data = handle.read()
+        assert "ATGCTGCTGA" * 90 in data
+
+        # Default causes interleave (columns > 1000)
+        records = [SeqRecord(Seq("ATGCTGCTGA" * 110, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
+        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+        handle = StringIO()
+        NexusWriter(handle).write_alignment(a)
+        handle.seek(0)
+        data = handle.read()
+        assert "ATGCTGCTGA" * 90 not in data
+        assert "ATGCTGCTGA" * 7 in data
+
+        # Override interleave: True
+        records = [SeqRecord(Seq("ATGCTGCTGA" * 9, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
+        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+        handle = StringIO()
+        NexusWriter(handle).write_alignment(a, interleave=True)
+        handle.seek(0)
+        data = handle.read()
+        assert "ATGCTGCTGA" * 9 not in data
+        assert "ATGCTGCTGA" * 7 in data
+
+        # Override interleave: False
+        records = [SeqRecord(Seq("ATGCTGCTGA" * 110, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
+        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+        handle = StringIO()
+        NexusWriter(handle).write_alignment(a, interleave=False)
+        handle.seek(0)
+        data = handle.read()
+        assert "ATGCTGCTGA" * 110 in data
+
     def test_TreeTest1(self):
         """Test Tree module."""
         n = Nexus.Nexus(self.handle)


### PR DESCRIPTION
This pull request supersedes pull request #362

The original pull request seems stuck, because @theboocock has not replied to requests to accept the license agreement and incorporate suggestions by @PamelaM.

This new request is a modification of 362, in that it implements a full override mechanism instead of a partial (negative only) override. A full override allows users to force interleave alignments where 70<columns<1000

**************
I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
