### PR TITLE
SeqRecord: Don't have a hard dependency on BioSQL (fixes #1471)

### DIFF
--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -437,8 +437,13 @@ class SeqRecord(object):
             if self.seq is None:
                 raise ValueError("If the sequence is None, we cannot slice it.")
             parent_length = len(self)
-            from BioSQL.BioSeq import DBSeqRecord
-            if isinstance(self, DBSeqRecord):
+            try:
+                from BioSQL.BioSeq import DBSeqRecord
+                biosql_available = True
+            except ImportError:
+                biosql_available = False
+
+            if biosql_available and isinstance(self, DBSeqRecord):
                 answer = SeqRecord(self.seq[index],
                                         id=self.id,
                                         name=self.name,


### PR DESCRIPTION
Currently, SeqRecord expects BioSQL to always be importable. That is not true on Debian packages,
where the -sql package is needed to have BioSQL around.

When BioSQL is not available, the instance in question should not be a DBSeqRecord, though.
That means the else branch of that check should be safe.

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>

This pull request addresses issue #1471 

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
