### PR TITLE
Support PEP 519 in IO functions (anything using `File.as_handle`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ Doc/*/*/hevea.sty
 #Ignore IntelliJ IDEA directory and project files
 .idea
 *.iml
+
+#Ignore unittest cache dirctory
+.cache/

--- a/Bio/File.py
+++ b/Bio/File.py
@@ -46,16 +46,20 @@ except ImportError:
 def as_handle(handleish, mode='r', **kwargs):
     r"""Context manager to ensure we are using a handle.
 
-    Context manager for arguments that can be passed to
-    SeqIO and AlignIO read, write, and parse methods: either file objects or strings.
+    Context manager for arguments that can be passed to SeqIO and AlignIO read, write,
+    and parse methods: either file objects or path-like objects (strings, pathlib.Path
+    instances, or more generally, anything that can be handled by the builtin 'open'
+    function).
 
-    When given a string, returns a file handle open to handleish with provided
-    mode which will be closed when the manager exits.
+    When given a path-like object, returns an open file handle to that path, with provided
+    mode, which will be closed when the manager exits.
 
     All other inputs are returned, and are *not* closed.
 
     Arguments:
-     - handleish  - Either a string or file handle
+     - handleish  - Either a file handle or path-like object (anything which can be
+                    passed to the builtin 'open' function: str, bytes, and under
+                    Python >= 3.6, pathlib.Path, os.DirEntry)
      - mode       - Mode to open handleish (used only if handleish is a string)
      - kwargs     - Further arguments to pass to open(...)
 
@@ -78,7 +82,7 @@ def as_handle(handleish, mode='r', **kwargs):
     been deprecated (this happens automatically in text mode).
 
     """
-    if isinstance(handleish, basestring):
+    try:
         if sys.version_info[0] >= 3 and "U" in mode:
             mode = mode.replace("U", "")
         if 'encoding' in kwargs:
@@ -87,7 +91,7 @@ def as_handle(handleish, mode='r', **kwargs):
         else:
             with open(handleish, mode, **kwargs) as fp:
                 yield fp
-    else:
+    except TypeError:
         yield handleish
 
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -50,6 +50,11 @@ In this release more of our code is now explicitly available under either our
 original "Biopython License Agreement", or the very similar but more commonly
 used "3-Clause BSD License".  See the ``LICENSE.rst`` file for more details.
 
+IO functions such as SeqIO.read now support objects conforming to
+`PEP 519 <https://www.python.org/dev/peps/pep-0519/>`_, allowing users to pass
+``pathlib.Path`` objects to these functions in addition to strings and open
+file handles.
+
 Additionally, a number of small bugs and typos have been fixed with further
 additions to the test suite, and there has been further work to follow the
 Python PEP8, PEP257 and best practice standard coding style.

--- a/Tests/test_File.py
+++ b/Tests/test_File.py
@@ -120,7 +120,7 @@ class AsHandleTestCase(unittest.TestCase):
     def test_stringio(self):
         s = StringIO()
         with File.as_handle(s) as handle:
-            self.assertEqual(s, handle)
+            self.assertIs(s, handle)
 
 
 if __name__ == "__main__":

--- a/Tests/test_File.py
+++ b/Tests/test_File.py
@@ -6,13 +6,13 @@
 from __future__ import print_function
 
 import os.path
-import unittest
 import shutil
-from Bio._py3k import StringIO
+import sys
 import tempfile
+import unittest
 
 from Bio import File
-
+from Bio._py3k import StringIO
 
 data = """This
 is
@@ -92,12 +92,27 @@ class AsHandleTestCase(unittest.TestCase):
                     "Exiting as_handle given a file-like object should not "
                     "close the file")
 
-    def test_path(self):
-        "Test as_handle with a path argument"
+    def test_string_path(self):
+        "Test as_handle with a string path argument"
         p = self._path('test_file.fasta')
         mode = 'wb'
         with File.as_handle(p, mode=mode) as handle:
             self.assertEqual(p, handle.name)
+            self.assertEqual(mode, handle.mode)
+            self.assertFalse(handle.closed)
+        self.assertTrue(handle.closed)
+
+    @unittest.skipIf(
+        sys.version_info < (3, 6),
+        'Passing Path objects to File.as_handle requires Python >= 3.6',
+    )
+    def test_path_object(self):
+        "Test as_handle with a pathlib.Path object"
+        from pathlib import Path
+        p = Path(self._path('test_file.fasta'))
+        mode = 'wb'
+        with File.as_handle(p, mode=mode) as handle:
+            self.assertEqual(str(p.absolute()), handle.name)
             self.assertEqual(mode, handle.mode)
             self.assertFalse(handle.closed)
         self.assertTrue(handle.closed)


### PR DESCRIPTION
This pull request is similar to others I made in PyTables (https://github.com/PyTables/PyTables/pull/640) and SciPy (https://github.com/scipy/scipy/issues/6854, https://github.com/scipy/scipy/pull/6855). This allows users to pass `pathlib.Path` objects to things like `SeqIO.parse`, and the logic changes required for this were quite small. As described in https://github.com/scipy/scipy/issues/6854, we can simply pass any unknown objects to `open` instead of checking for membership in a small set of predefined types. As before, `File.as_handle` ignores (returns unchanged) any objects it doesn't understand.

All tests passed locally under Python 3.6, and I'm going to depend on the Travis CI service to test other versions after I submit this pull request.

----------

I hereby agree to dual licence this and any previous contributions under both the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files, but this isn't very important to me, and though I already described this change in ``NEWS.rst``, I didn't feel compelled to add myself to the contributors for this release.