### PR TITLE
reserved word loop_ should be case insensitive

### DIFF
--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -31,7 +31,7 @@ class MMCIF2Dict(dict):
             i = 0
             n = 0
             for token in tokens:
-                if token == "loop_":
+                if token.lower() == "loop_":
                     loop_flag = True
                     keys = []
                     i = 0

--- a/Tests/test_PDB_MMCIF2Dict.py
+++ b/Tests/test_PDB_MMCIF2Dict.py
@@ -107,6 +107,31 @@ class MMCIF2dictTests(unittest.TestCase):
         self.assertEqual(mmcif_dict["_test_key_value"], "foo")
         self.assertEqual(mmcif_dict["_test_loop"], list("abcdefg"))
 
+    def test_loop_keyword_case_insensitive(self):
+        """Comments may begin outside of column 1."""
+        test_data = u"""\
+            data_verbatim_test
+            _test_key_value foo # Ignore this comment
+            loop_
+            _test_loop
+            a b c d # Ignore this comment
+            e f g
+
+        """
+        mmcif_dict = MMCIF2Dict(io.StringIO(textwrap.dedent(test_data)))
+
+        mmcif_dict2 = MMCIF2Dict(io.StringIO(textwrap.dedent(test_data.replace("loop_", "LOOP_"))))
+        self.assertDictEqual(mmcif_dict,
+                             mmcif_dict2)
+
+        mmcif_dict2 = MMCIF2Dict(io.StringIO(textwrap.dedent(test_data.replace("loop_", "looP_"))))
+        self.assertDictEqual(mmcif_dict,
+                             mmcif_dict2)
+
+        mmcif_dict2 = MMCIF2Dict(io.StringIO(textwrap.dedent(test_data.replace("_loop", "_LOOP"))))
+        self.assertNotEqual(mmcif_dict,
+                            mmcif_dict2)
+
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
Probably a minor issue but the reserved word loop_ should case insensitive. The code was changed accordingly and a few unit tests were added.

https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax
> In addition the following case-insensitive reserved words may not occur as unquoted data values.
> loop_ | identifies looped list of data







I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
