### PR TITLE
Hack in Bio.Restriction for Sphinx api-doc support

### DIFF
--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -346,9 +346,10 @@ class RestrictionType(type):
         try:
             return cls.size
         except AttributeError:
-            # Happens if the instance was not initialised as expected,
+            # Happens if the instance was not initialised as expected.
             # e.g. if instance created by a documentation framework
-            # like Sphinx trying to inspect the class automatically.
+            # like Sphinx trying to inspect the class automatically,
+            # Also seen within IPython.
             return 0
 
     def __hash__(cls):

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -260,6 +260,8 @@ class RestrictionType(type):
             cls.compsite = re.compile(cls.compsite)
         except AttributeError:
             # Can happen if initialised wrongly.
+            # (This was seen when Sphinx api-doc imports the classes, and
+            # tried to automatically general documentation for them)
             pass
         except Exception:
             raise ValueError("Problem with regular expression, re.compiled(%s)"

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -258,6 +258,9 @@ class RestrictionType(type):
         # super(RestrictionType, cls).__init__(cls, name, bases, dct)
         try:
             cls.compsite = re.compile(cls.compsite)
+        except AttributeError:
+            # Can happen if initialised wrongly.
+            pass
         except Exception:
             raise ValueError("Problem with regular expression, re.compiled(%s)"
                              % repr(cls.compsite))
@@ -338,7 +341,13 @@ class RestrictionType(type):
 
     def __len__(cls):
         """Return length of recognition site of enzyme as int."""
-        return cls.size
+        try:
+            return cls.size
+        except AttributeError:
+            # Happens if the instance was not initialised as expected,
+            # e.g. if instance created by a documentation framework
+            # like Sphinx trying to inspect the class automatically.
+            return 0
 
     def __hash__(cls):
         # Python default is to use id(...)


### PR DESCRIPTION
This pull request addresses an issue found in #1388 under Sphinx and api-doc, but which otherwise I have not seen triggered other than in an artificial example like this, which now "works":

```
$ python3 -c "from Bio.Restriction.Restriction import RestrictionType; print(len(RestrictionType('RestrictionType', tuple(), {})))"
0
```

This hack was needed when using Sphinx and api-doc to build our API documentation.

@MarkusPiotrowski - can you see any downsides to this?