### PR TITLE
Fixed variable typo

### DIFF
--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -357,7 +357,7 @@ class MarkovModelBuilder(object):
 
             # set the initial pseudocounts
             if pseudocount is None:
-                pseudcount = self.DEFAULT_PSEUDO
+                pseudocount = self.DEFAULT_PSEUDO
             self.transition_pseudo[(from_state, to_state)] = pseudocount
         else:
             raise KeyError("Transition from %s to %s is already allowed."

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -181,6 +181,7 @@ please open an issue on GitHub or mention it on the development mailing list.
 - Peter Bienstman <Peter.Bienstman at domain rug.ac.be>
 - Peter Cock <https://github.com/peterjc>
 - Peter Slickers <piet at domain clondiag.com>
+- Philip Bergstrom <https://github.com/phber>
 - Phillip Garland <pgarland at gmail>
 - Rasmus Fonseca <https://github.com/RasmusFonseca>
 - rht <https://github.com/rht>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -85,6 +85,7 @@ possible, especially the following contributors:
 - Michiel de Hoon
 - Nicolas Fontrodona (first contribution)
 - Peter Cock
+- Philip Bergstrom (first contribution)
 - rht (first contribution)
 - Saket Choudhary
 - Shuichiro MAKIGAKI (first contribution)


### PR DESCRIPTION
Fixed a variable typo causing 'pseudocount' to be None when calling 'allow_transition' with default arguments, causing an error when calling the method 'train' in the class 'KnownStateTrainer'.
  