### PR TITLE
NEWS.rst: be clearer about PEP 519 support added in #1476

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -54,10 +54,10 @@ In this release more of our code is now explicitly available under either our
 original "Biopython License Agreement", or the very similar but more commonly
 used "3-Clause BSD License".  See the ``LICENSE.rst`` file for more details.
 
-IO functions such as SeqIO.read now support objects conforming to
-`PEP 519 <https://www.python.org/dev/peps/pep-0519/>`_, allowing users to pass
-``pathlib.Path`` objects to these functions in addition to strings and open
-file handles.
+IO functions such as ``SeqIO.parse`` now accept any objects which can be passed
+to the builtin ``open`` function. Specifically, this allows using
+``pathlib.Path`` objects under Python 3.6 and newer, as per `PEP 519
+<https://www.python.org/dev/peps/pep-0519/>`_.
 
 Additionally, a number of small bugs and typos have been fixed with further
 additions to the test suite, and there has been further work to follow the


### PR DESCRIPTION
It isn't quite accurate to say that "BioPython I/O methods support `pathlib.Path` objects" -- it's more like "BioPython no longer second-guesses whether an object can be passed to `__builtins__.open`.

Clarify that using `pathlib.Path` objects in these I/O functions requires Python 3.6 or newer, to avoid any bug reports from users who might expect this to work under 3.4 or 3.5.

<hr>

I hereby agree to dual licence this and any previous contributions under both the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style checks pass with these changes.