### PR TITLE
Addresses #1497: FeatureLocation invalid input exception

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -669,10 +669,10 @@ class FeatureLocation(object):
             self._end = ExactPosition(end)
         else:
             raise TypeError("end=%r %s" % (end, type(end)))
-        if self._start > self._end:
+        if self.start.position and self.end.position and self.start > self.end:
             raise ValueError('End location ({}) must be greater than or equal '
-                             'to start location ({})'.format(int(self._end),
-                                                             int(self._start)))
+                             'to start location ({})'.format(self.end,
+                                                             self.start))
         self.strand = strand
         self.ref = ref
         self.ref_db = ref_db

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -669,6 +669,10 @@ class FeatureLocation(object):
             self._end = ExactPosition(end)
         else:
             raise TypeError("end=%r %s" % (end, type(end)))
+        if self._start > self._end:
+            raise ValueError('End location ({}) must be greater than or equal '
+                             'to start location ({})'.format(int(self._end),
+                                                             int(self._start)))
         self.strand = strand
         self.ref = ref
         self.ref_db = ref_db

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -669,7 +669,8 @@ class FeatureLocation(object):
             self._end = ExactPosition(end)
         else:
             raise TypeError("end=%r %s" % (end, type(end)))
-        if self.start.position and self.end.position and self.start > self.end:
+        if isinstance(self.start.position, int) and \
+                isinstance(self.end.position, int) and self.start > self.end:
             raise ValueError('End location ({}) must be greater than or equal '
                              'to start location ({})'.format(self.end,
                                                              self.start))

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -109,6 +109,7 @@ please open an issue on GitHub or mention it on the development mailing list.
 - Jacek Śmietański <https://github.com/dadoskawina>
 - Jack Twilley <https://github.com/mathuin>
 - James Casbon <j.a.casbon at domain qmul.ac.uk>
+- James Jeffryes <https://github.com/JamesJeffryes>
 - Jared Andrews <https://github.com/j-andrews7>
 - Jason A. Hackney <jhackney at domain stanford.edu>
 - Jeff Hussmann <first dot last at gmail dot com>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -73,6 +73,7 @@ possible, especially the following contributors:
 - Erik Cederstrand (first contribution)
 - Fei Qi (first contribution)
 - Francesco Gastaldello
+- James Jeffryes (first contribution)
 - Jerven Bolleman (first contribution)
 - Joe Greener (first contribution)
 - João Rodrigues

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -8,8 +8,8 @@
 import unittest
 from os import path
 from Bio import SeqIO
-from Bio.SeqFeature import FeatureLocation, AfterPosition, BeforePosition, \
-    CompoundLocation, UnknownPosition
+from Bio.SeqFeature import FeatureLocation, AfterPosition, BeforePosition
+from Bio.SeqFeature import CompoundLocation, UnknownPosition
 
 
 class TestReference(unittest.TestCase):
@@ -78,19 +78,29 @@ class TestFeatureLocation(unittest.TestCase):
         self.assertNotEqual(loc1, loc2)
 
     def test_start_before_end(self):
-        err = "must be greater than or equal to start location"
-        with self.assertRaisesRegex(ValueError, err):
+        expected = "must be greater than or equal to start location"
+        with self.assertRaises(ValueError) as err:
             FeatureLocation(42, 23, 1)
+        assert expected in str(err.exception)
 
-        with self.assertRaisesRegex(ValueError, err):
+        with self.assertRaises(ValueError) as err:
             FeatureLocation(42, 0, 1)
+        assert expected in str(err.exception)
 
-        with self.assertRaisesRegex(ValueError, err):
+        with self.assertRaises(ValueError) as err:
             FeatureLocation(BeforePosition(42), AfterPosition(23), -1)
+        assert expected in str(err.exception)
+
+        with self.assertRaises(ValueError) as err:
+            FeatureLocation(42, AfterPosition(0), 1)
+        assert expected in str(err.exception)
 
         # Features with UnknownPositions should pass check
         FeatureLocation(42, UnknownPosition())
         FeatureLocation(UnknownPosition(), 42)
+
+        # Same start and end should pass check
+        FeatureLocation(42, 42)
 
 
 class TestCompoundLocation(unittest.TestCase):

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -76,6 +76,14 @@ class TestFeatureLocation(unittest.TestCase):
         loc2 = FeatureLocation(23, 42, 1, 'foo', 'baz')
         self.assertNotEqual(loc1, loc2)
 
+    def test_start_before_end(self):
+        err = "must be greater than or equal to start location"
+        with self.assertRaisesRegex(ValueError, err):
+            FeatureLocation(42, 23, 1)
+
+        with self.assertRaisesRegex(ValueError, err):
+            FeatureLocation(BeforePosition(42), AfterPosition(23), -1)
+
 
 class TestCompoundLocation(unittest.TestCase):
     """Tests for the SeqFeature.CompoundLocation class"""

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -8,7 +8,8 @@
 import unittest
 from os import path
 from Bio import SeqIO
-from Bio.SeqFeature import FeatureLocation, AfterPosition, BeforePosition, CompoundLocation
+from Bio.SeqFeature import FeatureLocation, AfterPosition, BeforePosition, \
+    CompoundLocation, UnknownPosition
 
 
 class TestReference(unittest.TestCase):
@@ -83,6 +84,10 @@ class TestFeatureLocation(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, err):
             FeatureLocation(BeforePosition(42), AfterPosition(23), -1)
+
+        # Features with UnknownPositions should pass test
+        FeatureLocation(42, UnknownPosition())
+        FeatureLocation(UnknownPosition(), 42)
 
 
 class TestCompoundLocation(unittest.TestCase):

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -83,9 +83,12 @@ class TestFeatureLocation(unittest.TestCase):
             FeatureLocation(42, 23, 1)
 
         with self.assertRaisesRegex(ValueError, err):
+            FeatureLocation(42, 0, 1)
+
+        with self.assertRaisesRegex(ValueError, err):
             FeatureLocation(BeforePosition(42), AfterPosition(23), -1)
 
-        # Features with UnknownPositions should pass test
+        # Features with UnknownPositions should pass check
         FeatureLocation(42, UnknownPosition())
         FeatureLocation(UnknownPosition(), 42)
 


### PR DESCRIPTION
FeatureLocation will now raise a value error if supplied an start location greater than the specified end location

This pull request addresses issue #1497 

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
