### PR TITLE
TravisCI/Tox - Avoid numpy 1.14 for doctests

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -65,7 +65,7 @@ deps =
     {py27,py34,py35,py35,pypy}: mysql-connector-python-rf
     {py27,py35,pypy}: rdflib
     {pypy,pypy3}: numpy==1.12.1
-    {py27,py34,py35,py36}: numpy
+    {py27,py34,py35,py36}: numpy<1.14
     {py36}: scipy
     {py27}: networkx
     {py36}: matplotlib


### PR DESCRIPTION
This is a temporary solution to changes in NumPy 1.14 which break some of our doctests, see GitHub issue #1496.
