### PR TITLE
Update of CodonTable

### DIFF
--- a/Bio/Data/CodonTable.py
+++ b/Bio/Data/CodonTable.py
@@ -201,6 +201,7 @@ class AmbiguousCodonTable(CodonTable):
     # This lets us get the names, if the original table is an NCBI
     # table.
     def __getattr__(self, name):
+        """Forward attribute lookups to the original table."""
         return getattr(self._codon_table, name)
 
 
@@ -344,7 +345,10 @@ class AmbiguousForwardTable(object):
         self._cache = {}
 
     def __contains__(self, codon):
-        """Check if codon works as key for ambiguous forward_table."""
+        """Check if codon works as key for ambiguous forward_table.
+
+        Only returns 'True' if forward_table[codon] returns a value.
+        """
         try:
             self.__getitem__(codon)
             return True
@@ -352,12 +356,21 @@ class AmbiguousForwardTable(object):
             return False
 
     def get(self, codon, failobj=None):
+        """Implement get for dictionary-like behaviour."""
         try:
             return self.__getitem__(codon)
         except KeyError:
             return failobj
 
     def __getitem__(self, codon):
+        """Implement dictionary-like behaviour for AmbiguousForwardTable.
+
+        forward_table[codon] will either return an amino acid letter,
+        or throws a KeyError (if codon does not encode an amino acid)
+        or a TranslationError (if codon does encode for an amino acid,
+        but either is also a stop codon or does encode several amino acids,
+        for which no unique letter is available in the given alphabet.
+        """
         try:
             x = self._cache[codon]
         except KeyError:

--- a/Bio/Data/CodonTable.py
+++ b/Bio/Data/CodonTable.py
@@ -343,6 +343,14 @@ class AmbiguousForwardTable(object):
 
         self._cache = {}
 
+    def __contains__(self, codon):
+        """Check if codon works as key for ambiguous forward_table."""
+        try:
+            self.__getitem__(codon)
+            return True
+        except (KeyError, TranslationError):
+            return False
+
     def get(self, codon, failobj=None):
         try:
             return self.__getitem__(codon)

--- a/Bio/Data/CodonTable.py
+++ b/Bio/Data/CodonTable.py
@@ -7,10 +7,8 @@ These tables are based on parsing the NCBI file
 ftp://ftp.ncbi.nih.gov/entrez/misc/data/gc.prt
 using Scripts/update_ncbi_codon_table.py
 
-Last updated at Version 4.0
+Last updated at Version 4.2 (January 2018)
 """
-
-from __future__ import print_function
 
 from Bio import Alphabet
 from Bio.Alphabet import IUPAC
@@ -35,12 +33,15 @@ ambiguous_generic_by_id = {}  # ambiguous DNA or RNA
 standard_dna_table = None
 standard_rna_table = None
 
+
 # In the future, the back_table could return a statistically
 # appropriate distribution of codons, so do not cache the results of
 # back_table lookups!
 
 
 class TranslationError(Exception):
+    """Container for translation specific exceptions."""
+
     pass
 
 
@@ -69,13 +70,13 @@ class CodonTable(object):
         self.stop_codons = stop_codons
 
     def __str__(self):
-        """Returns a simple text representation of the codon table.
+        """Return a simple text representation of the codon table.
 
-        e.g.
+        e.g.::
 
-        >>> import Bio.Data.CodonTable
-        >>> print(Bio.Data.CodonTable.standard_dna_table)
-        >>> print(Bio.Data.CodonTable.generic_by_id[1])
+            >>> import Bio.Data.CodonTable
+            >>> print(Bio.Data.CodonTable.standard_dna_table)
+            >>> print(Bio.Data.CodonTable.generic_by_id[1])
         """
         if self.id:
             answer = "Table %i" % self.id
@@ -87,8 +88,8 @@ class CodonTable(object):
         # Use the main four letters (and the conventional ordering)
         # even for ambiguous tables
         letters = self.nucleotide_alphabet.letters
-        if isinstance(self.nucleotide_alphabet, Alphabet.DNAAlphabet) \
-        or (letters is not None and "T" in letters):
+        if isinstance(self.nucleotide_alphabet, Alphabet.DNAAlphabet) or \
+           (letters is not None and "T" in letters):
             letters = "TCAG"
         else:
             # Should be either RNA or generic nucleotides,
@@ -96,7 +97,8 @@ class CodonTable(object):
             letters = "UCAG"
 
         # Build the table...
-        answer += "\n\n  |" + "|".join("  %s      " % c2 for c2 in letters) + "|"
+        answer += "\n\n"
+        answer += "  |" + "|".join("  %s      " % c2 for c2 in letters) + "|"
         answer += "\n--+" + "+".join("---------" for c2 in letters) + "+--"
         for c1 in letters:
             for c3 in letters:
@@ -139,6 +141,8 @@ def make_back_table(table, default_stop_codon):
 
 
 class NCBICodonTable(CodonTable):
+    """Codon table for generic nucleotide sequences."""
+
     nucleotide_alphabet = Alphabet.generic_nucleotide
     protein_alphabet = IUPAC.protein
 
@@ -153,16 +157,22 @@ class NCBICodonTable(CodonTable):
 
 
 class NCBICodonTableDNA(NCBICodonTable):
+    """Codon table for unambiguous DNA sequences."""
+
     nucleotide_alphabet = IUPAC.unambiguous_dna
 
 
 class NCBICodonTableRNA(NCBICodonTable):
+    """Codon table for unambiguous RNA sequences."""
+
     nucleotide_alphabet = IUPAC.unambiguous_rna
 
 
 # ########  Deal with ambiguous forward translations
 
 class AmbiguousCodonTable(CodonTable):
+    """Base codon table for ambiguous sequences."""
+
     def __init__(self, codon_table,
                  ambiguous_nucleotide_alphabet,
                  ambiguous_nucleotide_values,
@@ -180,8 +190,10 @@ class AmbiguousCodonTable(CodonTable):
                             # These two are WRONG!  I need to get the
                             # list of ambiguous codons which code for
                             # the stop codons  XXX
-                            list_ambiguous_codons(codon_table.start_codons, ambiguous_nucleotide_values),
-                            list_ambiguous_codons(codon_table.stop_codons, ambiguous_nucleotide_values)
+                            list_ambiguous_codons(codon_table.start_codons,
+                                                  ambiguous_nucleotide_values),
+                            list_ambiguous_codons(codon_table.stop_codons,
+                                                  ambiguous_nucleotide_values)
                             )
         self._codon_table = codon_table
 
@@ -193,38 +205,40 @@ class AmbiguousCodonTable(CodonTable):
 
 
 def list_possible_proteins(codon, forward_table, ambiguous_nucleotide_values):
-        c1, c2, c3 = codon
-        x1 = ambiguous_nucleotide_values[c1]
-        x2 = ambiguous_nucleotide_values[c2]
-        x3 = ambiguous_nucleotide_values[c3]
-        possible = {}
-        stops = []
-        for y1 in x1:
-            for y2 in x2:
-                for y3 in x3:
-                    try:
-                        possible[forward_table[y1 + y2 + y3]] = 1
-                    except KeyError:
-                        # If tripping over a stop codon
-                        stops.append(y1 + y2 + y3)
-        if stops:
-            if possible:
-                raise TranslationError("ambiguous codon %r codes for both"
-                                       " proteins and stop codons" % codon)
-            # This is a true stop codon - tell the caller about it
-            raise KeyError(codon)
-        return list(possible)
+    """Return all possible encoded amino acids for ambiguous codon."""
+    c1, c2, c3 = codon
+    x1 = ambiguous_nucleotide_values[c1]
+    x2 = ambiguous_nucleotide_values[c2]
+    x3 = ambiguous_nucleotide_values[c3]
+    possible = {}
+    stops = []
+    for y1 in x1:
+        for y2 in x2:
+            for y3 in x3:
+                try:
+                    possible[forward_table[y1 + y2 + y3]] = 1
+                except KeyError:
+                    # If tripping over a stop codon
+                    stops.append(y1 + y2 + y3)
+    if stops:
+        if possible:
+            raise TranslationError("ambiguous codon %r codes for both"
+                                   " proteins and stop codons" % codon)
+        # This is a true stop codon - tell the caller about it
+        raise KeyError(codon)
+    return list(possible)
 
 
 def list_ambiguous_codons(codons, ambiguous_nucleotide_values):
-    """Extends a codon list to include all possible ambigous codons.
+    """Extend a codon list to include all possible ambigous codons.
 
     e.g.::
 
          ['TAG', 'TAA'] -> ['TAG', 'TAA', 'TAR']
          ['UAG', 'UGA'] -> ['UAG', 'UGA', 'URA']
 
-    Note that ['TAG', 'TGA'] -> ['TAG', 'TGA'], this does not add 'TRR'.
+    Note that ['TAG', 'TGA'] -> ['TAG', 'TGA'], this does not add 'TRR'
+    (which could also mean 'TAA' or 'TGG').
     Thus only two more codons are added in the following:
 
     e.g.::
@@ -237,14 +251,17 @@ def list_ambiguous_codons(codons, ambiguous_nucleotide_values):
     # This will generate things like 'TRR' from ['TAG', 'TGA'], which
     # we don't want to include:
     c1_list = sorted(letter for (letter, meanings)
-               in ambiguous_nucleotide_values.items()
-               if set(codon[0] for codon in codons).issuperset(set(meanings)))
+                     in ambiguous_nucleotide_values.items()
+                     if set(codon[0]
+                            for codon in codons).issuperset(set(meanings)))
     c2_list = sorted(letter for (letter, meanings)
-               in ambiguous_nucleotide_values.items()
-               if set(codon[1] for codon in codons).issuperset(set(meanings)))
+                     in ambiguous_nucleotide_values.items()
+                     if set(codon[1]
+                            for codon in codons).issuperset(set(meanings)))
     c3_list = sorted(letter for (letter, meanings)
-               in ambiguous_nucleotide_values.items()
-               if set(codon[2] for codon in codons).issuperset(set(meanings)))
+                     in ambiguous_nucleotide_values.items()
+                     if set(codon[2]
+                            for codon in codons).issuperset(set(meanings)))
     # candidates is a list (not a set) to preserve the iteration order
     candidates = []
     for c1 in c1_list:
@@ -272,12 +289,21 @@ def list_ambiguous_codons(codons, ambiguous_nucleotide_values):
     return answer
 
 
-assert list_ambiguous_codons(['TGA', 'TAA'], IUPACData.ambiguous_dna_values) == ['TGA', 'TAA', 'TRA']
-assert list_ambiguous_codons(['TAG', 'TGA'], IUPACData.ambiguous_dna_values) == ['TAG', 'TGA']
-assert list_ambiguous_codons(['TAG', 'TAA'], IUPACData.ambiguous_dna_values) == ['TAG', 'TAA', 'TAR']
-assert list_ambiguous_codons(['UAG', 'UAA'], IUPACData.ambiguous_rna_values) == ['UAG', 'UAA', 'UAR']
+assert list_ambiguous_codons(['TGA', 'TAA'],
+                             IUPACData.ambiguous_dna_values) == ['TGA', 'TAA',
+                                                                 'TRA']
+assert list_ambiguous_codons(['TAG', 'TGA'],
+                             IUPACData.ambiguous_dna_values) == ['TAG', 'TGA']
+assert list_ambiguous_codons(['TAG', 'TAA'],
+                             IUPACData.ambiguous_dna_values) == ['TAG', 'TAA',
+                                                                 'TAR']
+assert list_ambiguous_codons(['UAG', 'UAA'],
+                             IUPACData.ambiguous_rna_values) == ['UAG', 'UAA',
+                                                                 'UAR']
 assert list_ambiguous_codons(['TGA', 'TAA', 'TAG'],
-                                 IUPACData.ambiguous_dna_values) == ['TGA', 'TAA', 'TAG', 'TAR', 'TRA']
+                             IUPACData.ambiguous_dna_values) == ['TGA', 'TAA',
+                                                                 'TAG', 'TAR',
+                                                                 'TRA']
 
 # Forward translation is "onto", that is, any given codon always maps
 # to the same protein, or it doesn't map at all.  Thus, I can build
@@ -296,6 +322,8 @@ assert list_ambiguous_codons(['TGA', 'TAA', 'TAG'],
 
 
 class AmbiguousForwardTable(object):
+    """Forward table for translation of ambiguous nucleotide sequences."""
+
     def __init__(self, forward_table, ambiguous_nucleotide, ambiguous_protein):
         """Initialize the class."""
         self.forward_table = forward_table
@@ -395,15 +423,20 @@ class AmbiguousForwardTable(object):
 
 def register_ncbi_table(name, alt_name, id,
                         table, start_codons, stop_codons):
-    """Turns codon table data into objects, and stores them in the dictionaries (PRIVATE)."""
+    """Turn codon table data into objects (PRIVATE).
+
+    The data is stored in the dictionaries.
+    """
     # In most cases names are divided by "; ", however there is also
     # Table 11 'Bacterial, Archaeal and Plant Plastid Code', previously
     # 'Bacterial and Plant Plastid' which used to be just 'Bacterial'
-    names = [x.strip() for x in name.replace(" and ", "; ").replace(", ", "; ").split("; ")]
+    names = [x.strip() for x in name
+             .replace(" and ", "; ")
+             .replace(", ", "; ")
+             .split("; ")]
 
     dna = NCBICodonTableDNA(id, names + [alt_name], table, start_codons,
                             stop_codons)
-
     ambig_dna = AmbiguousCodonTable(dna,
                                     IUPAC.ambiguous_dna,
                                     IUPACData.ambiguous_dna_values,
@@ -422,15 +455,19 @@ def register_ncbi_table(name, alt_name, id,
     generic_start_codons = []
     for codon in start_codons:
         generic_start_codons.append(codon)
-        codon = codon.replace("T", "U")
-        generic_start_codons.append(codon)
+        # We need to check if 'T' is in the codon, otherwise
+        # generic_start_codons may contain duplicates
+        if "T" in codon:
+            codon = codon.replace("T", "U")
+            generic_start_codons.append(codon)
         rna_start_codons.append(codon)
     rna_stop_codons = []
     generic_stop_codons = []
     for codon in stop_codons:
         generic_stop_codons.append(codon)
-        codon = codon.replace("T", "U")
-        generic_stop_codons.append(codon)
+        if "T" in codon:
+            codon = codon.replace("T", "U")
+            generic_stop_codons.append(codon)
         rna_stop_codons.append(codon)
 
     generic = NCBICodonTable(id, names + [alt_name], generic_table,
@@ -483,438 +520,536 @@ def register_ncbi_table(name, alt_name, id,
 ##########################################################################
 
 
+# Data from NCBI genetic code table version 4.2
+
 register_ncbi_table(name='Standard',
                     alt_name='SGC0', id=1,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
-     'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P', 'CCA': 'P',
-     'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q',
-     'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R', 'ATT': 'I',
-     'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
-     'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N', 'AAA': 'K',
-     'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R', 'AGG': 'R',
-     'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V', 'GCT': 'A',
-     'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
-     'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G', 'GGA': 'G',
-     'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGG': 'W', 'CTT': 'L', 'CTC': 'L', 'CTA': 'L',
+                           'CTG': 'L', 'CCT': 'P', 'CCC': 'P', 'CCA': 'P',
+                           'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
+                           'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R',
+                           'CGG': 'R', 'ATT': 'I', 'ATC': 'I', 'ATA': 'I',
+                           'ATG': 'M', 'ACT': 'T', 'ACC': 'T', 'ACA': 'T',
+                           'ACG': 'T', 'AAT': 'N', 'AAC': 'N', 'AAA': 'K',
+                           'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R',
+                           'AGG': 'R', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V',
+                           'GTG': 'V', 'GCT': 'A', 'GCC': 'A', 'GCA': 'A',
+                           'GCG': 'A', 'GAT': 'D', 'GAC': 'D', 'GAA': 'E',
+                           'GAG': 'E', 'GGT': 'G', 'GGC': 'G', 'GGA': 'G',
+                           'GGG': 'G'},
                     stop_codons=['TAA', 'TAG', 'TGA'],
                     start_codons=['TTG', 'CTG', 'ATG'])
 
 register_ncbi_table(name='Vertebrate Mitochondrial',
                     alt_name='SGC1', id=2,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGA': 'W', 'TGG': 'W', 'CTT': 'L',
-     'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
-     'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
-     'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
-     'ATT': 'I', 'ATC': 'I', 'ATA': 'M', 'ATG': 'M', 'ACT': 'T',
-     'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
-     'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'GTT': 'V',
-     'GTC': 'V', 'GTA': 'V', 'GTG': 'V', 'GCT': 'A', 'GCC': 'A',
-     'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D', 'GAA': 'E',
-     'GAG': 'E', 'GGT': 'G', 'GGC': 'G', 'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGA': 'W', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
+                           'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
+                           'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
+                           'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R',
+                           'CGA': 'R', 'CGG': 'R', 'ATT': 'I', 'ATC': 'I',
+                           'ATA': 'M', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
+                           'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
+                           'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
+                           'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
+                           'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A',
+                           'GAT': 'D', 'GAC': 'D', 'GAA': 'E', 'GAG': 'E',
+                           'GGT': 'G', 'GGC': 'G', 'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TAA', 'TAG', 'AGA', 'AGG'],
                     start_codons=['ATT', 'ATC', 'ATA', 'ATG', 'GTG'])
 
 register_ncbi_table(name='Yeast Mitochondrial',
                     alt_name='SGC2', id=3,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGA': 'W', 'TGG': 'W', 'CTT': 'T',
-     'CTC': 'T', 'CTA': 'T', 'CTG': 'T', 'CCT': 'P', 'CCC': 'P',
-     'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
-     'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
-     'ATT': 'I', 'ATC': 'I', 'ATA': 'M', 'ATG': 'M', 'ACT': 'T',
-     'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
-     'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R',
-     'AGG': 'R', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
-     'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
-     'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
-     'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGA': 'W', 'TGG': 'W', 'CTT': 'T', 'CTC': 'T',
+                           'CTA': 'T', 'CTG': 'T', 'CCT': 'P', 'CCC': 'P',
+                           'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
+                           'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R',
+                           'CGA': 'R', 'CGG': 'R', 'ATT': 'I', 'ATC': 'I',
+                           'ATA': 'M', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
+                           'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
+                           'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
+                           'AGA': 'R', 'AGG': 'R', 'GTT': 'V', 'GTC': 'V',
+                           'GTA': 'V', 'GTG': 'V', 'GCT': 'A', 'GCC': 'A',
+                           'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
+                           'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
+                           'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TAA', 'TAG'],
                     start_codons=['ATA', 'ATG'])
 
-register_ncbi_table(name='Mold Mitochondrial; Protozoan Mitochondrial; Coelenterate Mitochondrial; Mycoplasma; Spiroplasma',
+register_ncbi_table(name='Mold Mitochondrial; Protozoan Mitochondrial; '
+                    'Coelenterate Mitochondrial; Mycoplasma; Spiroplasma',
                     alt_name='SGC3', id=4,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGA': 'W', 'TGG': 'W', 'CTT': 'L',
-     'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
-     'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
-     'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
-     'ATT': 'I', 'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T',
-     'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
-     'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R',
-     'AGG': 'R', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
-     'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
-     'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
-     'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGA': 'W', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
+                           'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
+                           'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
+                           'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R',
+                           'CGA': 'R', 'CGG': 'R', 'ATT': 'I', 'ATC': 'I',
+                           'ATA': 'I', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
+                           'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
+                           'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
+                           'AGA': 'R', 'AGG': 'R', 'GTT': 'V', 'GTC': 'V',
+                           'GTA': 'V', 'GTG': 'V', 'GCT': 'A', 'GCC': 'A',
+                           'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
+                           'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
+                           'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TAA', 'TAG'],
                     start_codons=['TTA', 'TTG', 'CTG', 'ATT', 'ATC', 'ATA',
                                   'ATG', 'GTG'])
 
 register_ncbi_table(name='Invertebrate Mitochondrial',
                     alt_name='SGC4', id=5,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGA': 'W', 'TGG': 'W', 'CTT': 'L',
-     'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
-     'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
-     'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
-     'ATT': 'I', 'ATC': 'I', 'ATA': 'M', 'ATG': 'M', 'ACT': 'T',
-     'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
-     'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'S',
-     'AGG': 'S', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
-     'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
-     'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
-     'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGA': 'W', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
+                           'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
+                           'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
+                           'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R',
+                           'CGA': 'R', 'CGG': 'R', 'ATT': 'I', 'ATC': 'I',
+                           'ATA': 'M', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
+                           'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
+                           'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
+                           'AGA': 'S', 'AGG': 'S', 'GTT': 'V', 'GTC': 'V',
+                           'GTA': 'V', 'GTG': 'V', 'GCT': 'A', 'GCC': 'A',
+                           'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
+                           'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
+                           'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TAA', 'TAG'],
                     start_codons=['TTG', 'ATT', 'ATC', 'ATA', 'ATG', 'GTG'])
 
-register_ncbi_table(name='Ciliate Nuclear; Dasycladacean Nuclear; Hexamita Nuclear',
+register_ncbi_table(name='Ciliate Nuclear; Dasycladacean Nuclear; Hexamita '
+                    'Nuclear',
                     alt_name='SGC5', id=6,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TAA': 'Q', 'TAG': 'Q', 'TGT': 'C', 'TGC': 'C', 'TGG': 'W',
-     'CTT': 'L', 'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P',
-     'CCC': 'P', 'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
-     'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R',
-     'CGG': 'R', 'ATT': 'I', 'ATC': 'I', 'ATA': 'I', 'ATG': 'M',
-     'ACT': 'T', 'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N',
-     'AAC': 'N', 'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
-     'AGA': 'R', 'AGG': 'R', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V',
-     'GTG': 'V', 'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A',
-     'GAT': 'D', 'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G',
-     'GGC': 'G', 'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TAA': 'Q', 'TAG': 'Q',
+                           'TGT': 'C', 'TGC': 'C', 'TGG': 'W', 'CTT': 'L',
+                           'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P',
+                           'CCC': 'P', 'CCA': 'P', 'CCG': 'P', 'CAT': 'H',
+                           'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R',
+                           'CGC': 'R', 'CGA': 'R', 'CGG': 'R', 'ATT': 'I',
+                           'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T',
+                           'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N',
+                           'AAC': 'N', 'AAA': 'K', 'AAG': 'K', 'AGT': 'S',
+                           'AGC': 'S', 'AGA': 'R', 'AGG': 'R', 'GTT': 'V',
+                           'GTC': 'V', 'GTA': 'V', 'GTG': 'V', 'GCT': 'A',
+                           'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
+                           'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G',
+                           'GGC': 'G', 'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TGA'],
                     start_codons=['ATG'])
 
 register_ncbi_table(name='Echinoderm Mitochondrial; Flatworm Mitochondrial',
                     alt_name='SGC8', id=9,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGA': 'W', 'TGG': 'W', 'CTT': 'L',
-     'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
-     'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
-     'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
-     'ATT': 'I', 'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T',
-     'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
-     'AAA': 'N', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'S',
-     'AGG': 'S', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
-     'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
-     'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
-     'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGA': 'W', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
+                           'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
+                           'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
+                           'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R',
+                           'CGA': 'R', 'CGG': 'R', 'ATT': 'I', 'ATC': 'I',
+                           'ATA': 'I', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
+                           'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
+                           'AAA': 'N', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
+                           'AGA': 'S', 'AGG': 'S', 'GTT': 'V', 'GTC': 'V',
+                           'GTA': 'V', 'GTG': 'V', 'GCT': 'A', 'GCC': 'A',
+                           'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
+                           'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
+                           'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TAA', 'TAG'],
                     start_codons=['ATG', 'GTG'])
 
 register_ncbi_table(name='Euplotid Nuclear',
                     alt_name='SGC9', id=10,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGA': 'C', 'TGG': 'W', 'CTT': 'L',
-     'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
-     'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
-     'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
-     'ATT': 'I', 'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T',
-     'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
-     'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R',
-     'AGG': 'R', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
-     'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
-     'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
-     'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGA': 'C', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
+                           'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
+                           'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
+                           'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R',
+                           'CGA': 'R', 'CGG': 'R', 'ATT': 'I', 'ATC': 'I',
+                           'ATA': 'I', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
+                           'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
+                           'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
+                           'AGA': 'R', 'AGG': 'R', 'GTT': 'V', 'GTC': 'V',
+                           'GTA': 'V', 'GTG': 'V', 'GCT': 'A', 'GCC': 'A',
+                           'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
+                           'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
+                           'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TAA', 'TAG'],
                     start_codons=['ATG'])
 
 register_ncbi_table(name='Bacterial, Archaeal and Plant Plastid',
                     alt_name=None, id=11,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
-     'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P', 'CCA': 'P',
-     'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q',
-     'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R', 'ATT': 'I',
-     'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
-     'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N', 'AAA': 'K',
-     'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R', 'AGG': 'R',
-     'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V', 'GCT': 'A',
-     'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
-     'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G', 'GGA': 'G',
-     'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGG': 'W', 'CTT': 'L', 'CTC': 'L', 'CTA': 'L',
+                           'CTG': 'L', 'CCT': 'P', 'CCC': 'P', 'CCA': 'P',
+                           'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
+                           'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R',
+                           'CGG': 'R', 'ATT': 'I', 'ATC': 'I', 'ATA': 'I',
+                           'ATG': 'M', 'ACT': 'T', 'ACC': 'T', 'ACA': 'T',
+                           'ACG': 'T', 'AAT': 'N', 'AAC': 'N', 'AAA': 'K',
+                           'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R',
+                           'AGG': 'R', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V',
+                           'GTG': 'V', 'GCT': 'A', 'GCC': 'A', 'GCA': 'A',
+                           'GCG': 'A', 'GAT': 'D', 'GAC': 'D', 'GAA': 'E',
+                           'GAG': 'E', 'GGT': 'G', 'GGC': 'G', 'GGA': 'G',
+                           'GGG': 'G'},
                     stop_codons=['TAA', 'TAG', 'TGA'],
                     start_codons=['TTG', 'CTG', 'ATT', 'ATC', 'ATA', 'ATG',
                                   'GTG'])
 
 register_ncbi_table(name='Alternative Yeast Nuclear',
                     alt_name=None, id=12,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
-     'CTA': 'L', 'CTG': 'S', 'CCT': 'P', 'CCC': 'P', 'CCA': 'P',
-     'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q',
-     'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R', 'ATT': 'I',
-     'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
-     'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N', 'AAA': 'K',
-     'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R', 'AGG': 'R',
-     'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V', 'GCT': 'A',
-     'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
-     'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G', 'GGA': 'G',
-     'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGG': 'W', 'CTT': 'L', 'CTC': 'L', 'CTA': 'L',
+                           'CTG': 'S', 'CCT': 'P', 'CCC': 'P', 'CCA': 'P',
+                           'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
+                           'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R',
+                           'CGG': 'R', 'ATT': 'I', 'ATC': 'I', 'ATA': 'I',
+                           'ATG': 'M', 'ACT': 'T', 'ACC': 'T', 'ACA': 'T',
+                           'ACG': 'T', 'AAT': 'N', 'AAC': 'N', 'AAA': 'K',
+                           'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R',
+                           'AGG': 'R', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V',
+                           'GTG': 'V', 'GCT': 'A', 'GCC': 'A', 'GCA': 'A',
+                           'GCG': 'A', 'GAT': 'D', 'GAC': 'D', 'GAA': 'E',
+                           'GAG': 'E', 'GGT': 'G', 'GGC': 'G', 'GGA': 'G',
+                           'GGG': 'G'},
                     stop_codons=['TAA', 'TAG', 'TGA'],
                     start_codons=['CTG', 'ATG'])
 
 register_ncbi_table(name='Ascidian Mitochondrial',
                     alt_name=None, id=13,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGA': 'W', 'TGG': 'W', 'CTT': 'L',
-     'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
-     'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
-     'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
-     'ATT': 'I', 'ATC': 'I', 'ATA': 'M', 'ATG': 'M', 'ACT': 'T',
-     'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
-     'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'G',
-     'AGG': 'G', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
-     'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
-     'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
-     'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGA': 'W', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
+                           'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
+                           'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
+                           'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R',
+                           'CGA': 'R', 'CGG': 'R', 'ATT': 'I', 'ATC': 'I',
+                           'ATA': 'M', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
+                           'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
+                           'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
+                           'AGA': 'G', 'AGG': 'G', 'GTT': 'V', 'GTC': 'V',
+                           'GTA': 'V', 'GTG': 'V', 'GCT': 'A', 'GCC': 'A',
+                           'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
+                           'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
+                           'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TAA', 'TAG'],
                     start_codons=['TTG', 'ATA', 'ATG', 'GTG'])
 
 register_ncbi_table(name='Alternative Flatworm Mitochondrial',
                     alt_name=None, id=14,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TAA': 'Y', 'TGT': 'C', 'TGC': 'C', 'TGA': 'W', 'TGG': 'W',
-     'CTT': 'L', 'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P',
-     'CCC': 'P', 'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
-     'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R',
-     'CGG': 'R', 'ATT': 'I', 'ATC': 'I', 'ATA': 'I', 'ATG': 'M',
-     'ACT': 'T', 'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N',
-     'AAC': 'N', 'AAA': 'N', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
-     'AGA': 'S', 'AGG': 'S', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V',
-     'GTG': 'V', 'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A',
-     'GAT': 'D', 'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G',
-     'GGC': 'G', 'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TAA': 'Y', 'TGT': 'C',
+                           'TGC': 'C', 'TGA': 'W', 'TGG': 'W', 'CTT': 'L',
+                           'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P',
+                           'CCC': 'P', 'CCA': 'P', 'CCG': 'P', 'CAT': 'H',
+                           'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R',
+                           'CGC': 'R', 'CGA': 'R', 'CGG': 'R', 'ATT': 'I',
+                           'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T',
+                           'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N',
+                           'AAC': 'N', 'AAA': 'N', 'AAG': 'K', 'AGT': 'S',
+                           'AGC': 'S', 'AGA': 'S', 'AGG': 'S', 'GTT': 'V',
+                           'GTC': 'V', 'GTA': 'V', 'GTG': 'V', 'GCT': 'A',
+                           'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
+                           'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G',
+                           'GGC': 'G', 'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TAG'],
                     start_codons=['ATG'])
 
 register_ncbi_table(name='Blepharisma Macronuclear',
                     alt_name=None, id=15,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TAG': 'Q', 'TGT': 'C', 'TGC': 'C', 'TGG': 'W', 'CTT': 'L',
-     'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
-     'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
-     'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
-     'ATT': 'I', 'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T',
-     'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
-     'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R',
-     'AGG': 'R', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
-     'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
-     'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
-     'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TAG': 'Q', 'TGT': 'C',
+                           'TGC': 'C', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
+                           'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
+                           'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
+                           'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R',
+                           'CGA': 'R', 'CGG': 'R', 'ATT': 'I', 'ATC': 'I',
+                           'ATA': 'I', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
+                           'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
+                           'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
+                           'AGA': 'R', 'AGG': 'R', 'GTT': 'V', 'GTC': 'V',
+                           'GTA': 'V', 'GTG': 'V', 'GCT': 'A', 'GCC': 'A',
+                           'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
+                           'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
+                           'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TAA', 'TGA'],
                     start_codons=['ATG'])
 
 register_ncbi_table(name='Chlorophycean Mitochondrial',
                     alt_name=None, id=16,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TAG': 'L', 'TGT': 'C', 'TGC': 'C', 'TGG': 'W', 'CTT': 'L',
-     'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
-     'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
-     'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
-     'ATT': 'I', 'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T',
-     'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
-     'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R',
-     'AGG': 'R', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
-     'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
-     'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
-     'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TAG': 'L', 'TGT': 'C',
+                           'TGC': 'C', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
+                           'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
+                           'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
+                           'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R',
+                           'CGA': 'R', 'CGG': 'R', 'ATT': 'I', 'ATC': 'I',
+                           'ATA': 'I', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
+                           'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
+                           'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
+                           'AGA': 'R', 'AGG': 'R', 'GTT': 'V', 'GTC': 'V',
+                           'GTA': 'V', 'GTG': 'V', 'GCT': 'A', 'GCC': 'A',
+                           'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
+                           'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
+                           'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TAA', 'TGA'],
                     start_codons=['ATG'])
 
 register_ncbi_table(name='Trematode Mitochondrial',
                     alt_name=None, id=21,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGA': 'W', 'TGG': 'W', 'CTT': 'L',
-     'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
-     'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
-     'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
-     'ATT': 'I', 'ATC': 'I', 'ATA': 'M', 'ATG': 'M', 'ACT': 'T',
-     'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
-     'AAA': 'N', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'S',
-     'AGG': 'S', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
-     'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
-     'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
-     'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGA': 'W', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
+                           'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
+                           'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
+                           'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R',
+                           'CGA': 'R', 'CGG': 'R', 'ATT': 'I', 'ATC': 'I',
+                           'ATA': 'M', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
+                           'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
+                           'AAA': 'N', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
+                           'AGA': 'S', 'AGG': 'S', 'GTT': 'V', 'GTC': 'V',
+                           'GTA': 'V', 'GTG': 'V', 'GCT': 'A', 'GCC': 'A',
+                           'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
+                           'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
+                           'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TAA', 'TAG'],
                     start_codons=['ATG', 'GTG'])
 
 register_ncbi_table(name='Scenedesmus obliquus Mitochondrial',
                     alt_name=None, id=22,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y', 'TAG': 'L',
-     'TGT': 'C', 'TGC': 'C', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
-     'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P', 'CCA': 'P',
-     'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q',
-     'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R', 'ATT': 'I',
-     'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
-     'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N', 'AAA': 'K',
-     'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R', 'AGG': 'R',
-     'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V', 'GCT': 'A',
-     'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
-     'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G', 'GGA': 'G',
-     'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCG': 'S', 'TAT': 'Y',
+                           'TAC': 'Y', 'TAG': 'L', 'TGT': 'C', 'TGC': 'C',
+                           'TGG': 'W', 'CTT': 'L', 'CTC': 'L', 'CTA': 'L',
+                           'CTG': 'L', 'CCT': 'P', 'CCC': 'P', 'CCA': 'P',
+                           'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
+                           'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R',
+                           'CGG': 'R', 'ATT': 'I', 'ATC': 'I', 'ATA': 'I',
+                           'ATG': 'M', 'ACT': 'T', 'ACC': 'T', 'ACA': 'T',
+                           'ACG': 'T', 'AAT': 'N', 'AAC': 'N', 'AAA': 'K',
+                           'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R',
+                           'AGG': 'R', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V',
+                           'GTG': 'V', 'GCT': 'A', 'GCC': 'A', 'GCA': 'A',
+                           'GCG': 'A', 'GAT': 'D', 'GAC': 'D', 'GAA': 'E',
+                           'GAG': 'E', 'GGT': 'G', 'GGC': 'G', 'GGA': 'G',
+                           'GGG': 'G'},
                     stop_codons=['TCA', 'TAA', 'TGA'],
                     start_codons=['ATG'])
 
 register_ncbi_table(name='Thraustochytrium Mitochondrial',
                     alt_name=None, id=23,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTG': 'L', 'TCT': 'S', 'TCC': 'S',
-     'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C',
-     'TGC': 'C', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L', 'CTA': 'L',
-     'CTG': 'L', 'CCT': 'P', 'CCC': 'P', 'CCA': 'P', 'CCG': 'P',
-     'CAT': 'H', 'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R',
-     'CGC': 'R', 'CGA': 'R', 'CGG': 'R', 'ATT': 'I', 'ATC': 'I',
-     'ATA': 'I', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T', 'ACA': 'T',
-     'ACG': 'T', 'AAT': 'N', 'AAC': 'N', 'AAA': 'K', 'AAG': 'K',
-     'AGT': 'S', 'AGC': 'S', 'AGA': 'R', 'AGG': 'R', 'GTT': 'V',
-     'GTC': 'V', 'GTA': 'V', 'GTG': 'V', 'GCT': 'A', 'GCC': 'A',
-     'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D', 'GAA': 'E',
-     'GAG': 'E', 'GGT': 'G', 'GGC': 'G', 'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTG': 'L', 'TCT': 'S',
+                           'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y',
+                           'TAC': 'Y', 'TGT': 'C', 'TGC': 'C', 'TGG': 'W',
+                           'CTT': 'L', 'CTC': 'L', 'CTA': 'L', 'CTG': 'L',
+                           'CCT': 'P', 'CCC': 'P', 'CCA': 'P', 'CCG': 'P',
+                           'CAT': 'H', 'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q',
+                           'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
+                           'ATT': 'I', 'ATC': 'I', 'ATA': 'I', 'ATG': 'M',
+                           'ACT': 'T', 'ACC': 'T', 'ACA': 'T', 'ACG': 'T',
+                           'AAT': 'N', 'AAC': 'N', 'AAA': 'K', 'AAG': 'K',
+                           'AGT': 'S', 'AGC': 'S', 'AGA': 'R', 'AGG': 'R',
+                           'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
+                           'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A',
+                           'GAT': 'D', 'GAC': 'D', 'GAA': 'E', 'GAG': 'E',
+                           'GGT': 'G', 'GGC': 'G', 'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TTA', 'TAA', 'TAG', 'TGA'],
                     start_codons=['ATT', 'ATG', 'GTG'])
 
 register_ncbi_table(name='Pterobranchia Mitochondrial',
                     alt_name=None, id=24,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGA': 'W', 'TGG': 'W', 'CTT': 'L',
-     'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
-     'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
-     'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
-     'ATT': 'I', 'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T',
-     'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
-     'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'S',
-     'AGG': 'K', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
-     'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
-     'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
-     'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGA': 'W', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
+                           'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
+                           'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
+                           'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R',
+                           'CGA': 'R', 'CGG': 'R', 'ATT': 'I', 'ATC': 'I',
+                           'ATA': 'I', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
+                           'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
+                           'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
+                           'AGA': 'S', 'AGG': 'K', 'GTT': 'V', 'GTC': 'V',
+                           'GTA': 'V', 'GTG': 'V', 'GCT': 'A', 'GCC': 'A',
+                           'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
+                           'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
+                           'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TAA', 'TAG'],
                     start_codons=['TTG', 'CTG', 'ATG', 'GTG'])
 
 register_ncbi_table(name='Candidate Division SR1 and Gracilibacteria',
                     alt_name=None, id=25,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGA': 'G', 'TGG': 'W', 'CTT': 'L',
-     'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
-     'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
-     'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
-     'ATT': 'I', 'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T',
-     'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
-     'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R',
-     'AGG': 'R', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
-     'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
-     'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
-     'GGA': 'G', 'GGG': 'G', },
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGA': 'G', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
+                           'CTA': 'L', 'CTG': 'L', 'CCT': 'P', 'CCC': 'P',
+                           'CCA': 'P', 'CCG': 'P', 'CAT': 'H', 'CAC': 'H',
+                           'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R', 'CGC': 'R',
+                           'CGA': 'R', 'CGG': 'R', 'ATT': 'I', 'ATC': 'I',
+                           'ATA': 'I', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
+                           'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N',
+                           'AAA': 'K', 'AAG': 'K', 'AGT': 'S', 'AGC': 'S',
+                           'AGA': 'R', 'AGG': 'R', 'GTT': 'V', 'GTC': 'V',
+                           'GTA': 'V', 'GTG': 'V', 'GCT': 'A', 'GCC': 'A',
+                           'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
+                           'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G',
+                           'GGA': 'G', 'GGG': 'G'},
                     stop_codons=['TAA', 'TAG'],
                     start_codons=['TTG', 'ATG', 'GTG'])
+
+register_ncbi_table(name='Pachysolen tannophilus Nuclear',
+                    alt_name=None, id=26,
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TGT': 'C', 'TGC': 'C',
+                           'TGG': 'W', 'CTT': 'L', 'CTC': 'L', 'CTA': 'L',
+                           'CTG': 'A', 'CCT': 'P', 'CCC': 'P', 'CCA': 'P',
+                           'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q',
+                           'CAG': 'Q', 'CGT': 'R', 'CGC': 'R', 'CGA': 'R',
+                           'CGG': 'R', 'ATT': 'I', 'ATC': 'I', 'ATA': 'I',
+                           'ATG': 'M', 'ACT': 'T', 'ACC': 'T', 'ACA': 'T',
+                           'ACG': 'T', 'AAT': 'N', 'AAC': 'N', 'AAA': 'K',
+                           'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R',
+                           'AGG': 'R', 'GTT': 'V', 'GTC': 'V', 'GTA': 'V',
+                           'GTG': 'V', 'GCT': 'A', 'GCC': 'A', 'GCA': 'A',
+                           'GCG': 'A', 'GAT': 'D', 'GAC': 'D', 'GAA': 'E',
+                           'GAG': 'E', 'GGT': 'G', 'GGC': 'G', 'GGA': 'G',
+                           'GGG': 'G'},
+                    stop_codons=['TAA', 'TAG', 'TGA'],
+                    start_codons=['CTG', 'ATG'])
+
+register_ncbi_table(name='Karyorelict Nuclear',
+                    alt_name=None, id=27,
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TAA': 'Q', 'TAG': 'Q',
+                           'TGT': 'C', 'TGC': 'C', 'TGA': 'W', 'TGG': 'W',
+                           'CTT': 'L', 'CTC': 'L', 'CTA': 'L', 'CTG': 'L',
+                           'CCT': 'P', 'CCC': 'P', 'CCA': 'P', 'CCG': 'P',
+                           'CAT': 'H', 'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q',
+                           'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
+                           'ATT': 'I', 'ATC': 'I', 'ATA': 'I', 'ATG': 'M',
+                           'ACT': 'T', 'ACC': 'T', 'ACA': 'T', 'ACG': 'T',
+                           'AAT': 'N', 'AAC': 'N', 'AAA': 'K', 'AAG': 'K',
+                           'AGT': 'S', 'AGC': 'S', 'AGA': 'R', 'AGG': 'R',
+                           'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
+                           'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A',
+                           'GAT': 'D', 'GAC': 'D', 'GAA': 'E', 'GAG': 'E',
+                           'GGT': 'G', 'GGC': 'G', 'GGA': 'G', 'GGG': 'G'},
+                    stop_codons=['TGA'],
+                    start_codons=['ATG'])
+
+register_ncbi_table(name='Condylostoma Nuclear',
+                    alt_name=None, id=28,
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TAA': 'Q', 'TAG': 'Q',
+                           'TGT': 'C', 'TGC': 'C', 'TGA': 'W', 'TGG': 'W',
+                           'CTT': 'L', 'CTC': 'L', 'CTA': 'L', 'CTG': 'L',
+                           'CCT': 'P', 'CCC': 'P', 'CCA': 'P', 'CCG': 'P',
+                           'CAT': 'H', 'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q',
+                           'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
+                           'ATT': 'I', 'ATC': 'I', 'ATA': 'I', 'ATG': 'M',
+                           'ACT': 'T', 'ACC': 'T', 'ACA': 'T', 'ACG': 'T',
+                           'AAT': 'N', 'AAC': 'N', 'AAA': 'K', 'AAG': 'K',
+                           'AGT': 'S', 'AGC': 'S', 'AGA': 'R', 'AGG': 'R',
+                           'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
+                           'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A',
+                           'GAT': 'D', 'GAC': 'D', 'GAA': 'E', 'GAG': 'E',
+                           'GGT': 'G', 'GGC': 'G', 'GGA': 'G', 'GGG': 'G'},
+                    stop_codons=['TAA', 'TAG', 'TGA'],
+                    start_codons=['ATG'])
+
+register_ncbi_table(name='Mesodinium Nuclear',
+                    alt_name=None, id=29,
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TAA': 'Y', 'TAG': 'Y',
+                           'TGT': 'C', 'TGC': 'C', 'TGG': 'W', 'CTT': 'L',
+                           'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P',
+                           'CCC': 'P', 'CCA': 'P', 'CCG': 'P', 'CAT': 'H',
+                           'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R',
+                           'CGC': 'R', 'CGA': 'R', 'CGG': 'R', 'ATT': 'I',
+                           'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T',
+                           'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N',
+                           'AAC': 'N', 'AAA': 'K', 'AAG': 'K', 'AGT': 'S',
+                           'AGC': 'S', 'AGA': 'R', 'AGG': 'R', 'GTT': 'V',
+                           'GTC': 'V', 'GTA': 'V', 'GTG': 'V', 'GCT': 'A',
+                           'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
+                           'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G',
+                           'GGC': 'G', 'GGA': 'G', 'GGG': 'G'},
+                    stop_codons=['TGA'],
+                    start_codons=['ATG'])
+
+register_ncbi_table(name='Peritrich Nuclear',
+                    alt_name=None, id=30,
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TAA': 'E', 'TAG': 'E',
+                           'TGT': 'C', 'TGC': 'C', 'TGG': 'W', 'CTT': 'L',
+                           'CTC': 'L', 'CTA': 'L', 'CTG': 'L', 'CCT': 'P',
+                           'CCC': 'P', 'CCA': 'P', 'CCG': 'P', 'CAT': 'H',
+                           'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q', 'CGT': 'R',
+                           'CGC': 'R', 'CGA': 'R', 'CGG': 'R', 'ATT': 'I',
+                           'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T',
+                           'ACC': 'T', 'ACA': 'T', 'ACG': 'T', 'AAT': 'N',
+                           'AAC': 'N', 'AAA': 'K', 'AAG': 'K', 'AGT': 'S',
+                           'AGC': 'S', 'AGA': 'R', 'AGG': 'R', 'GTT': 'V',
+                           'GTC': 'V', 'GTA': 'V', 'GTG': 'V', 'GCT': 'A',
+                           'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D',
+                           'GAC': 'D', 'GAA': 'E', 'GAG': 'E', 'GGT': 'G',
+                           'GGC': 'G', 'GGA': 'G', 'GGG': 'G'},
+                    stop_codons=['TGA'],
+                    start_codons=['ATG'])
+
+register_ncbi_table(name='Blastocrithidia Nuclear',
+                    alt_name=None, id=31,
+                    table={'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L',
+                           'TCT': 'S', 'TCC': 'S', 'TCA': 'S', 'TCG': 'S',
+                           'TAT': 'Y', 'TAC': 'Y', 'TAA': 'E', 'TAG': 'E',
+                           'TGT': 'C', 'TGC': 'C', 'TGA': 'W', 'TGG': 'W',
+                           'CTT': 'L', 'CTC': 'L', 'CTA': 'L', 'CTG': 'L',
+                           'CCT': 'P', 'CCC': 'P', 'CCA': 'P', 'CCG': 'P',
+                           'CAT': 'H', 'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q',
+                           'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R',
+                           'ATT': 'I', 'ATC': 'I', 'ATA': 'I', 'ATG': 'M',
+                           'ACT': 'T', 'ACC': 'T', 'ACA': 'T', 'ACG': 'T',
+                           'AAT': 'N', 'AAC': 'N', 'AAA': 'K', 'AAG': 'K',
+                           'AGT': 'S', 'AGC': 'S', 'AGA': 'R', 'AGG': 'R',
+                           'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V',
+                           'GCT': 'A', 'GCC': 'A', 'GCA': 'A', 'GCG': 'A',
+                           'GAT': 'D', 'GAC': 'D', 'GAA': 'E', 'GAG': 'E',
+                           'GGT': 'G', 'GGC': 'G', 'GGA': 'G', 'GGG': 'G'},
+                    stop_codons=['TAA', 'TAG'],
+                    start_codons=['ATG'])
 
 
 ########################################################################
 # End of auto-generated output from Scripts/update_ncbi_codon_table.py #
 ########################################################################
-
-
-# This is currently missing in Version 4.0 of
-# ftp://ftp.ncbi.nih.gov/entrez/misc/data/gc.prt
-# and was entered by hand based on
-# http://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi#SG26
-#
-# Code 26 is used so far only for the ascomycete fungus Pachysolen
-# tannophilus. The only difference to the standard code is the
-# translation of CUG as alanine (as opposed to leucine). As of
-# April 2016, there is no publication documenting this code.
-register_ncbi_table(name='Pachysolen tannophilus Nuclear Code',
-                    alt_name=None, id=26,
-                    table={
-     'TTT': 'F', 'TTC': 'F', 'TTA': 'L', 'TTG': 'L', 'TCT': 'S',
-     'TCC': 'S', 'TCA': 'S', 'TCG': 'S', 'TAT': 'Y', 'TAC': 'Y',
-     'TGT': 'C', 'TGC': 'C', 'TGG': 'W', 'CTT': 'L', 'CTC': 'L',
-     'CTA': 'L', 'CTG': 'A', 'CCT': 'P', 'CCC': 'P', 'CCA': 'P',
-     'CCG': 'P', 'CAT': 'H', 'CAC': 'H', 'CAA': 'Q', 'CAG': 'Q',
-     'CGT': 'R', 'CGC': 'R', 'CGA': 'R', 'CGG': 'R', 'ATT': 'I',
-     'ATC': 'I', 'ATA': 'I', 'ATG': 'M', 'ACT': 'T', 'ACC': 'T',
-     'ACA': 'T', 'ACG': 'T', 'AAT': 'N', 'AAC': 'N', 'AAA': 'K',
-     'AAG': 'K', 'AGT': 'S', 'AGC': 'S', 'AGA': 'R', 'AGG': 'R',
-     'GTT': 'V', 'GTC': 'V', 'GTA': 'V', 'GTG': 'V', 'GCT': 'A',
-     'GCC': 'A', 'GCA': 'A', 'GCG': 'A', 'GAT': 'D', 'GAC': 'D',
-     'GAA': 'E', 'GAG': 'E', 'GGT': 'G', 'GGC': 'G', 'GGA': 'G',
-     'GGG': 'G', },
-                    stop_codons=['TAA', 'TAG', 'TGA'],
-                    start_codons=['TTG', 'CTG', 'ATG'])
-
-
-# Basic sanity test,
-for key, val in generic_by_name.items():
-    assert key in ambiguous_generic_by_name[key].names
-for key, val in generic_by_id.items():
-    assert ambiguous_generic_by_id[key].id == key
-del key, val
-
-for n in ambiguous_generic_by_id:
-    assert ambiguous_rna_by_id[n].forward_table["GUU"] == "V"
-    assert ambiguous_rna_by_id[n].forward_table["GUN"] == "V"
-    if n != 23:
-        # For table 23, UUN = F, L or stop.
-        assert ambiguous_rna_by_id[n].forward_table["UUN"] == "X"  # F or L
-    # R = A or G, so URR = UAA or UGA / TRA = TAA or TGA = stop codons
-    if "UAA" in unambiguous_rna_by_id[n].stop_codons \
-    and "UGA" in unambiguous_rna_by_id[n].stop_codons:
-        try:
-            print(ambiguous_dna_by_id[n].forward_table["TRA"])
-            assert False, "Should be a stop only"
-        except KeyError:
-            pass
-        assert "URA" in ambiguous_generic_by_id[n].stop_codons
-        assert "URA" in ambiguous_rna_by_id[n].stop_codons
-        assert "TRA" in ambiguous_generic_by_id[n].stop_codons
-        assert "TRA" in ambiguous_dna_by_id[n].stop_codons
-del n
-assert ambiguous_generic_by_id[1] == ambiguous_generic_by_name["Standard"]
-assert ambiguous_generic_by_id[4] == ambiguous_generic_by_name["SGC3"]
-assert ambiguous_generic_by_id[11] == ambiguous_generic_by_name["Bacterial"]
-assert ambiguous_generic_by_id[11] == ambiguous_generic_by_name["Archaeal"]
-assert ambiguous_generic_by_id[11] == ambiguous_generic_by_name["Plant Plastid"]
-assert ambiguous_generic_by_id[15] == ambiguous_generic_by_name['Blepharisma Macronuclear']
-assert ambiguous_generic_by_id[24] == ambiguous_generic_by_name["Pterobranchia Mitochondrial"]
-assert generic_by_id[1] == generic_by_name["Standard"]
-assert generic_by_id[4] == generic_by_name["SGC3"]
-assert generic_by_id[11] == generic_by_name["Bacterial"]
-assert generic_by_id[11] == generic_by_name["Plant Plastid"]
-assert generic_by_id[15] == generic_by_name['Blepharisma Macronuclear']
-assert generic_by_id[24] == generic_by_name["Pterobranchia Mitochondrial"]

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2387,19 +2387,20 @@ def _translate_str(sequence, table, stop_symbol="*", to_stop=False,
     n = len(sequence)
 
     # Check for tables with 'ambiguous' (dual-coding) stop codons:
-    for codon in (c for c in stop_codons if c in forward_table):
+    dual_coding = [c for c in stop_codons if c in forward_table]
+    if dual_coding:
+        c = dual_coding[0]
         if to_stop:
-            raise ValueError("This table contains at least one stop codon "
-                             "('{}') which codes for both 'STOP' and an "
-                             "amino acid ('{}'). You can not use 'to_stop="
-                             "True' with this table."
-                             .format(codon, forward_table[codon]))
-        warnings.warn("This table contains at least one stop codon ('{}') "
-                      "which codes for both 'STOP' and an amino acid ('{}'). "
+            raise ValueError("You cannot use 'to_stop=True' with this table "
+                             "as it contains {} codon(s) which can be both "
+                             " STOP and an  amino acid (e.g. '{}' -> '{}' or "
+                             "STOP)."
+                             .format(len(dual_coding), c, forward_table[c]))
+        warnings.warn("This table contains {} codon(s) which code(s) for both "
+                      "STOP and an amino acid (e.g. '{}' -> '{}' or STOP). "
                       "Such codons will be translated as amino acid."
-                      .format(codon, forward_table[codon]),
+                      .format(len(dual_coding), c, forward_table[c]),
                       BiopythonWarning)
-        break
 
     if cds:
         if str(sequence[:3]).upper() not in table.start_codons:
@@ -2543,7 +2544,7 @@ def translate(sequence, table="Standard", stop_symbol="*", to_stop=False,
     >>> translate(coding_dna3, table=27, to_stop=True)
     Traceback (most recent call last):
        ...
-    ValueError: ... You can not use 'to_stop=True' with this table.
+    ValueError: You cannot use 'to_stop=True' with this table ...
     """
     if isinstance(sequence, Seq):
         return sequence.translate(table, stop_symbol, to_stop, cds)

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2387,26 +2387,19 @@ def _translate_str(sequence, table, stop_symbol="*", to_stop=False,
     n = len(sequence)
 
     # Check for tables with 'ambiguous' (dual-coding) stop codons:
-    for codon in stop_codons:
-            try:
-                forward_table[codon]
-                if to_stop:
-                    raise ValueError("This table contains at least one stop "
-                                     "codon ('{}') which codes for both "
-                                     "'STOP' and an amino acid ('{}'). You "
-                                     "can not use 'to_stop=True' with this "
-                                     "table."
-                                     .format(codon, forward_table[codon]))
-                else:
-                    warnings.warn("This table contains at least one stop "
-                                  "codon ('{}') which codes for both 'STOP' "
-                                  "and an amino acid ('{}'). Such codons will "
-                                  "be translated as amino acid."
-                                  .format(codon, forward_table[codon]),
-                                  BiopythonWarning)
-                break
-            except KeyError:
-                pass  # KeyError is the expected behaviour for most tables
+    for codon in (c for c in stop_codons if c in forward_table):
+        if to_stop:
+            raise ValueError("This table contains at least one stop codon "
+                             "('{}') which codes for both 'STOP' and an "
+                             "amino acid ('{}'). You can not use 'to_stop="
+                             "True' with this table."
+                             .format(codon, forward_table[codon]))
+        warnings.warn("This table contains at least one stop codon ('{}') "
+                      "which codes for both 'STOP' and an amino acid ('{}'). "
+                      "Such codons will be translated as amino acid."
+                      .format(codon, forward_table[codon]),
+                      BiopythonWarning)
+        break
 
     if cds:
         if str(sequence[:3]).upper() not in table.start_codons:

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2550,9 +2550,7 @@ def translate(sequence, table="Standard", stop_symbol="*", to_stop=False,
     >>> translate(coding_dna3, table=27, to_stop=True)
     Traceback (most recent call last):
        ...
-    ValueError: This table contains at least one stop codon ('TGA') which codes
-    for both 'STOP' and an amino acid ('W'). You can not use 'to_stop=True'
-    with this table.
+    ValueError: ... You can not use 'to_stop=True' with this table.
     """
     if isinstance(sequence, Seq):
         return sequence.translate(table, stop_symbol, to_stop, cds)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -50,6 +50,11 @@ wrapper and include a new wrapper for fuzzpro.
 The restriction enzyme list in Bio.Restriction has been updated to the
 November 2017 release of REBASE.
 
+New codon tables 27-31 from NCBI (NCBI genetic code table version 4.2) 
+were added to Bio.Data.CodonTable. Note that tables 27, 28 and 31 contain
+no dedicated stop codons; the stop codons in these codes have a context
+dependent encoding as either STOP or as amino acid. 
+
 In this release more of our code is now explicitly available under either our
 original "Biopython License Agreement", or the very similar but more commonly
 used "3-Clause BSD License".  See the ``LICENSE.rst`` file for more details.

--- a/Tests/output/test_CodonTable
+++ b/Tests/output/test_CodonTable
@@ -1,2 +1,0 @@
-test_CodonTable
-Done

--- a/Tests/test_CodonTable.py
+++ b/Tests/test_CodonTable.py
@@ -1,139 +1,765 @@
-# Copyright 2008 by Peter Cock.  All rights reserved.
+# Copyright 2008 by Peter Cock.
+# Revision copyright 2017 by Markus Piotrowski.
+# All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
-from __future__ import print_function
+import unittest
 
 from Bio.Data import IUPACData
-from Bio.Data.CodonTable import ambiguous_generic_by_id, ambiguous_generic_by_name
-from Bio.Data.CodonTable import ambiguous_rna_by_id, ambiguous_dna_by_id
-from Bio.Data.CodonTable import unambiguous_rna_by_id
-from Bio.Data.CodonTable import list_ambiguous_codons, TranslationError
+from Bio.Data.CodonTable import (generic_by_id, generic_by_name,
+                                 ambiguous_generic_by_id,
+                                 ambiguous_generic_by_name,
+                                 ambiguous_rna_by_id, ambiguous_dna_by_id,
+                                 ambiguous_dna_by_name, ambiguous_rna_by_name,
+                                 unambiguous_rna_by_id,
+                                 unambiguous_rna_by_name,
+                                 unambiguous_dna_by_id,
+                                 unambiguous_dna_by_name)
+from Bio.Data.CodonTable import list_ambiguous_codons, list_possible_proteins
+from Bio.Data.CodonTable import TranslationError
 
-# Check the extension of stop codons to include well defined ambiguous ones
-assert list_ambiguous_codons(['TGA', 'TAA'], IUPACData.ambiguous_dna_values) == ['TGA', 'TAA', 'TRA']
-assert list_ambiguous_codons(['TAG', 'TGA'], IUPACData.ambiguous_dna_values) == ['TAG', 'TGA']
-assert list_ambiguous_codons(['TAG', 'TAA'], IUPACData.ambiguous_dna_values) == ['TAG', 'TAA', 'TAR']
-assert list_ambiguous_codons(['UAG', 'UAA'], IUPACData.ambiguous_rna_values) == ['UAG', 'UAA', 'UAR']
-assert list_ambiguous_codons(['TGA', 'TAA', 'TAG'], IUPACData.ambiguous_dna_values) == ['TGA', 'TAA', 'TAG', 'TAR', 'TRA']
+exception_list = []
+ids = [key for key in unambiguous_dna_by_id]
+
+# Find codon tables with 'ambiguous' stop codons (coding both for stop and
+# an amino acid) and put them into exception_list
+for id in ids:
+    table = unambiguous_dna_by_id[id]
+    for codon in table.stop_codons:
+        if codon not in table.forward_table:
+            continue
+        else:
+            exception_list.append(table.id)
+            break
 
 
-# Basic sanity test,
-for n in ambiguous_generic_by_id:
-    assert ambiguous_rna_by_id[n].forward_table["GUU"] == "V"
-    assert ambiguous_rna_by_id[n].forward_table["GUN"] == "V"
-    if n != 23:
-        assert ambiguous_rna_by_id[n].forward_table["UUN"] == "X"  # F or L
+class BasicSanityTests(unittest.TestCase):
+    """Basic tests."""
 
-    assert ambiguous_dna_by_id[n].forward_table["GTT"] == "V"
-    if n != 23:
-        assert ambiguous_dna_by_id[n].forward_table["TTN"] == "X"  # F or L
-    assert ambiguous_dna_by_id[n].forward_table["GTN"] == "V"
+    def test_number_of_tables(self):
+        """Check if we have the same number of tables for each type."""
+        self.assertTrue(len(unambiguous_dna_by_id)
+                        == len(unambiguous_rna_by_id)
+                        == len(generic_by_id)
+                        == len(ambiguous_dna_by_id)
+                        == len(ambiguous_rna_by_id)
+                        == len(ambiguous_generic_by_id))
+        self.assertTrue(len(unambiguous_dna_by_name)
+                        == len(unambiguous_rna_by_name)
+                        == len(generic_by_name)
+                        == len(ambiguous_dna_by_name)
+                        == len(ambiguous_rna_by_name)
+                        == len(ambiguous_generic_by_name))
 
-    if n != 23:
-        assert ambiguous_generic_by_id[n].forward_table.get("TTN") == "X"
-    assert ambiguous_generic_by_id[n].forward_table["ACN"] == "T"
-    assert ambiguous_generic_by_id[n].forward_table["GUU"] == "V"
-    assert ambiguous_generic_by_id[n].forward_table["GUN"] == "V"
-    if n != 23:
-        assert ambiguous_generic_by_id[n].forward_table["UUN"] == "X"  # F or L
-    assert ambiguous_generic_by_id[n].forward_table["GTT"] == "V"
-    if n != 23:
-        assert ambiguous_generic_by_id[n].forward_table["TTN"] == "X"  # F or L
-    assert ambiguous_generic_by_id[n].forward_table["GTN"] == "V"
-    # And finally something evil, an RNA-DNA mixture:
-    if n != 23:
-        assert ambiguous_generic_by_id[n].forward_table["UTN"] == "X"  # F or L
-    assert ambiguous_generic_by_id[n].forward_table["UTU"] == "F"
+    def test_complete_tables(self):
+        """Check if all unambiguous codon tables have all entries.
 
-    # R = A or G, so URR = UAA or UGA / TRA = TAA or TGA = stop codons
-    if "UAA" in unambiguous_rna_by_id[n].stop_codons \
-    and "UGA" in unambiguous_rna_by_id[n].stop_codons:
-        try:
-            print(ambiguous_dna_by_id[n].forward_table["TRA"])
-            assert False, "Should be a stop only"
-        except KeyError:
-            pass
-        try:
-            print(ambiguous_rna_by_id[n].forward_table["URA"])
-            assert False, "Should be a stop only"
-        except KeyError:
-            pass
-        try:
-            print(ambiguous_generic_by_id[n].forward_table["URA"])
-            assert False, "Should be a stop only"
-        except KeyError:
-            pass
-        assert "URA" in ambiguous_generic_by_id[n].stop_codons
-        assert "URA" in ambiguous_rna_by_id[n].stop_codons
-        assert "TRA" in ambiguous_generic_by_id[n].stop_codons
-        assert "TRA" in ambiguous_dna_by_id[n].stop_codons
+        For DNA/RNA tables each of the 64 codons must be either in
+        the forward_table or in the stop_codons list.
+        For DNA+RNA (generic) tables the number of possible codons is 101.
 
-    if "UAG" in unambiguous_rna_by_id[n].stop_codons \
-    and "UAA" in unambiguous_rna_by_id[n].stop_codons \
-    and "UGA" in unambiguous_rna_by_id[n].stop_codons:
-        try:
-            print(ambiguous_dna_by_id[n].forward_table["TAR"])
-            assert False, "Should be a stop only"
-        except KeyError:
-            pass
-        try:
-            print(ambiguous_rna_by_id[n].forward_table["UAR"])
-            assert False, "Should be a stop only"
-        except KeyError:
-            pass
-        try:
-            print(ambiguous_generic_by_id[n].forward_table["UAR"])
-            assert False, "Should be a stop only"
-        except KeyError:
-            pass
-        try:
-            print(ambiguous_generic_by_id[n].forward_table["URR"])
-            assert False, "Should be a stop OR an amino"
-        except TranslationError:
-            pass
-        assert "UAR" in ambiguous_generic_by_id[n].stop_codons
-        assert "UAR" in ambiguous_rna_by_id[n].stop_codons
-        assert "TAR" in ambiguous_generic_by_id[n].stop_codons
-        assert "TAR" in ambiguous_dna_by_id[n].stop_codons
-        assert "URA" in ambiguous_generic_by_id[n].stop_codons
-        assert "URA" in ambiguous_rna_by_id[n].stop_codons
-        assert "TRA" in ambiguous_generic_by_id[n].stop_codons
-        assert "TRA" in ambiguous_dna_by_id[n].stop_codons
+        There must be at least one start codon and one stop codon.
 
-    if "UUG" in unambiguous_rna_by_id[n].start_codons \
-    and "CUG" in unambiguous_rna_by_id[n].start_codons \
-    and "AUG" in unambiguous_rna_by_id[n].start_codons \
-    and "UUG" not in unambiguous_rna_by_id[n].start_codons:
-        assert "NUG" not in ambiguous_dna_by_id[n].start_codons
-        assert "RUG" not in ambiguous_dna_by_id[n].start_codons
-        assert "WUG" not in ambiguous_dna_by_id[n].start_codons
-        assert "KUG" not in ambiguous_dna_by_id[n].start_codons
-        assert "SUG" not in ambiguous_dna_by_id[n].start_codons
-        assert "DUG" not in ambiguous_dna_by_id[n].start_codons
-del n
+        The back_tables must have 21 entries (20 amino acids and one
+        stop symbol).
+        """
+        for id in ids:
+            nuc_table = generic_by_id[id]
+            dna_table = unambiguous_dna_by_id[id]
+            rna_table = unambiguous_rna_by_id[id]
 
-# Table 2 Vertebrate Mitochondrial has
-# TAA and TAG -> TAR, plus AGA and AGG -> AGR
-assert "AGR" in ambiguous_dna_by_id[2].stop_codons
-assert "TAR" in ambiguous_dna_by_id[2].stop_codons
-assert "AGR" in ambiguous_rna_by_id[2].stop_codons
-assert "UAR" in ambiguous_rna_by_id[2].stop_codons
-assert "AGR" in ambiguous_generic_by_id[2].stop_codons
-assert "UAR" in ambiguous_generic_by_id[2].stop_codons
-assert "TAR" in ambiguous_generic_by_id[2].stop_codons
-assert "UGA" not in ambiguous_rna_by_id[24].stop_codons
-assert "UGA" not in ambiguous_rna_by_id[25].stop_codons
-assert ambiguous_generic_by_id[1].stop_codons == ambiguous_generic_by_name["Standard"].stop_codons
-assert ambiguous_generic_by_id[4].stop_codons == ambiguous_generic_by_name["SGC3"].stop_codons
-assert ambiguous_generic_by_id[15].stop_codons == ambiguous_generic_by_name['Blepharisma Macronuclear'].stop_codons
-assert ambiguous_generic_by_id[24].stop_codons == ambiguous_generic_by_name["Pterobranchia Mitochondrial"].stop_codons
+            if id not in exception_list:
+                self.assertEqual(len(dna_table.forward_table)
+                                 + len(dna_table.stop_codons), 64)
+                self.assertEqual(len(rna_table.forward_table)
+                                 + len(rna_table.stop_codons), 64)
+                self.assertEqual(len(nuc_table.forward_table)
+                                 + len(nuc_table.stop_codons), 101)
+                self.assertTrue(dna_table.stop_codons)
+                self.assertTrue(dna_table.start_codons)
+                self.assertTrue(rna_table.stop_codons)
+                self.assertTrue(rna_table.start_codons)
+                self.assertTrue(nuc_table.start_codons)
+                self.assertTrue(nuc_table.stop_codons)
+                self.assertEqual(len(dna_table.back_table), 21)
+                self.assertEqual(len(rna_table.back_table), 21)
+                self.assertEqual(len(nuc_table.back_table), 21)
 
-assert ambiguous_generic_by_id[24].forward_table["AGA"] == "S"  # Ser not Arg
-assert ambiguous_generic_by_id[24].forward_table["AGG"] == "K"  # Lys not Arg
-assert ambiguous_generic_by_id[24].forward_table["UGA"] == "W"  # Trp not stop
-assert ambiguous_generic_by_id[25].forward_table["UGA"] == "G"  # Gly not stop
-assert ambiguous_generic_by_id[26].forward_table["CUG"] == "A"  # Ala not Leu
+    def test_ambiguous_tables(self):
+        """Check if all IDs and all names are present in ambiguous tables."""
+        for key, val in generic_by_name.items():
+            self.assertTrue(key in ambiguous_generic_by_name[key].names)
+        for key, val in generic_by_id.items():
+            self.assertEqual(ambiguous_generic_by_id[key].id, key)
 
-print("Done")
+
+class AmbiguousCodonsTests(unittest.TestCase):
+    """Tests for ambiguous codons."""
+
+    def test_list_ambiguous_codons(self):
+        """Check if stop codons are properly extended."""
+        self.assertEqual(list_ambiguous_codons(['TGA', 'TAA'],
+                                               IUPACData.ambiguous_dna_values),
+                         ['TGA', 'TAA', 'TRA'])
+        self.assertEqual(list_ambiguous_codons(['TAG', 'TGA'],
+                                               IUPACData.ambiguous_dna_values),
+                         ['TAG', 'TGA'])
+        self.assertEqual(list_ambiguous_codons(['TAG', 'TAA'],
+                                               IUPACData.ambiguous_dna_values),
+                         ['TAG', 'TAA', 'TAR'])
+        self.assertEqual(list_ambiguous_codons(['UAG', 'UAA'],
+                                               IUPACData.ambiguous_rna_values),
+                         ['UAG', 'UAA', 'UAR'])
+        self.assertEqual(list_ambiguous_codons(['TGA', 'TAA', 'TAG'],
+                                               IUPACData.ambiguous_dna_values),
+                         ['TGA', 'TAA', 'TAG', 'TAR', 'TRA'])
+
+    def test_coding(self):
+        """Check a few ambiguous codons for correct coding."""
+        for id in ids:
+            amb_dna = ambiguous_dna_by_id[id]
+            amb_rna = ambiguous_rna_by_id[id]
+            amb_nuc = ambiguous_generic_by_id[id]
+
+            self.assertEqual(amb_rna.forward_table["GUU"], "V")
+            self.assertEqual(amb_rna.forward_table["GUN"], "V")
+            self.assertEqual(amb_dna.forward_table["GTT"], "V")
+            self.assertEqual(amb_dna.forward_table["GTN"], "V")
+            self.assertEqual(amb_rna.forward_table["ACN"], "T")
+            self.assertEqual(amb_nuc.forward_table["GUU"], "V")
+            self.assertEqual(amb_nuc.forward_table["GUN"], "V")
+            self.assertEqual(amb_nuc.forward_table["GTT"], "V")
+            self.assertEqual(amb_nuc.forward_table["GTN"], "V")
+            # And finally something evil, an RNA-DNA mixture:
+            self.assertEqual(amb_nuc.forward_table["UTU"], "F")
+            if id != 23:
+                self.assertEqual(amb_rna.forward_table["UUN"], "X")  # F or L
+                self.assertEqual(amb_dna.forward_table["TTN"], "X")  # F or L
+                self.assertEqual(amb_nuc.forward_table.get("TTN"), "X")
+                self.assertEqual(amb_nuc.forward_table["UUN"], "X")  # F or L
+                self.assertEqual(amb_nuc.forward_table["TTN"], "X")  # F or L
+                self.assertEqual(amb_nuc.forward_table["UTN"], "X")  # F or L
+
+    def test_stop_codons(self):
+        """Test various ambiguous codons as stop codon.
+
+        Stop codons should not appear in forward tables. This should give a
+        KeyError. If an ambiguous codon may code for both (stop codon and
+        amino acid, this should raise a TranslationError.
+        """
+        for id in ids:
+            rna = unambiguous_rna_by_id[id]
+            amb_dna = ambiguous_dna_by_id[id]
+            amb_rna = ambiguous_rna_by_id[id]
+            amb_nuc = ambiguous_generic_by_id[id]
+
+            # R = A or G, so URR = UAA or UGA / TRA = TAA or TGA = stop codons
+            if "UAA" in amb_rna.stop_codons and "UGA" in amb_rna.stop_codons \
+               and id != 28:
+                self.assertEqual(amb_dna.forward_table.get("TRA", "X"), "X")
+                with self.assertRaises(KeyError):
+                    amb_dna.forward_table["TRA"]
+                    amb_rna.forward_table["URA"]
+                    amb_nuc.forward_table["URA"]
+                self.assertIn("URA", amb_nuc.stop_codons)
+                self.assertIn("URA", amb_rna.stop_codons)
+                self.assertIn("TRA", amb_nuc.stop_codons)
+                self.assertIn("TRA", amb_dna.stop_codons)
+
+            if "UAG" in rna.stop_codons and "UAA" in rna.stop_codons \
+               and "UGA" in rna.stop_codons and id != 28:
+                with self.assertRaises(KeyError):
+                    amb_dna.forward_table["TAR"]
+                    amb_rna.forward_table["UAR"]
+                    amb_nuc.forward_table["UAR"]
+                with self.assertRaises(TranslationError):
+                    amb_nuc.forward_table["URR"]
+                self.assertIn("UAR", amb_nuc.stop_codons)
+                self.assertIn("UAR", amb_rna.stop_codons)
+                self.assertIn("TAR", amb_nuc.stop_codons)
+                self.assertIn("TAR", amb_dna.stop_codons)
+                self.assertIn("URA", amb_nuc.stop_codons)
+                self.assertIn("URA", amb_rna.stop_codons)
+                self.assertIn("TRA", amb_nuc.stop_codons)
+                self.assertIn("TRA", amb_dna.stop_codons)
+
+    def test_start_codons(self):
+        """Test various ambiguous codons as start codon."""
+        for id in ids:
+            rna = unambiguous_rna_by_id[id]
+            amb_dna = ambiguous_dna_by_id[id]
+            amb_rna = ambiguous_rna_by_id[id]
+
+            if "UUG" in rna.start_codons and "CUG" in rna.start_codons and \
+               "AUG" in rna.start_codons and "UUG" not in rna.start_codons:
+                self.assertNotIn("NUG", amb_rna.start_codons)
+                self.assertNotIn("RUG", amb_rna.start_codons)
+                self.assertNotIn("WUG", amb_rna.start_codons)
+                self.assertNotIn("KUG", amb_rna.start_codons)
+                self.assertNotIn("SUG", amb_rna.start_codons)
+                self.assertNotIn("DUG", amb_rna.start_codons)
+
+                self.assertNotIn("NTG", amb_dna.start_codons)
+                self.assertNotIn("RTG", amb_dna.start_codons)
+                self.assertNotIn("WTG", amb_dna.start_codons)
+                self.assertNotIn("KTG", amb_dna.start_codons)
+                self.assertNotIn("STG", amb_dna.start_codons)
+                self.assertNotIn("DTG", amb_dna.start_codons)
+
+
+class SingleTableTests(unittest.TestCase):
+    """Several test for individual codon tables.
+
+    In general we want to check:
+        - that we can call the codon table by its name(s) or id
+        - the number of start and stop codons
+        - deviations from the standard code
+        - that stop codons do not appear in the forward_table (except in
+          tables 27, 28, 31).
+    """
+
+    def test_table01(self):
+        """Check table 1: Standard."""
+        self.assertEqual(ambiguous_dna_by_id[1].names, ["Standard", "SGC0"])
+        self.assertEqual(ambiguous_dna_by_name["Standard"].stop_codons,
+                         ambiguous_dna_by_id[1].stop_codons)
+        self.assertEqual(generic_by_id[1].start_codons,
+                         ["TTG", "UUG", "CTG", "CUG", "ATG", "AUG"])
+        self.assertEqual(len(unambiguous_dna_by_id[1].start_codons), 3)
+        self.assertEqual(len(unambiguous_dna_by_id[1].stop_codons), 3)
+
+    def test_table02(self):
+        """Check table 2: Vertebrate Mitochondrial.
+
+        Table 2 Vertebrate Mitochondrial has TAA and TAG -> TAR,
+        plus AGA and AGG -> AGR as stop codons.
+        """
+        self.assertEqual(generic_by_name["Vertebrate Mitochondrial"].id, 2)
+        self.assertEqual(generic_by_name["SGC1"].id, 2)
+        self.assertIn("SGC1", generic_by_id[2].names)
+        self.assertIn("AGR", ambiguous_dna_by_id[2].stop_codons)
+        self.assertIn("TAR", ambiguous_dna_by_id[2].stop_codons)
+        self.assertIn("AGR", ambiguous_rna_by_id[2].stop_codons)
+        self.assertIn("UAR", ambiguous_rna_by_id[2].stop_codons)
+        self.assertIn("AGR", ambiguous_generic_by_id[2].stop_codons)
+        self.assertIn("UAR", ambiguous_generic_by_id[2].stop_codons)
+        self.assertIn("TAR", ambiguous_generic_by_id[2].stop_codons)
+        self.assertEqual(len(unambiguous_dna_by_id[2].start_codons), 5)
+        self.assertEqual(len(unambiguous_dna_by_id[2].stop_codons), 4)
+
+    def test_table03(self):
+        """Check table 3: Yeast Mitochondrial.
+
+        Start codons ATG and ATA -> ATR
+        Stop codons TAA and TAG -> TAR
+        TGA codes for W (instead of stop) and CTN codes for T (instead of L).
+        """
+        self.assertEqual(generic_by_name["Yeast Mitochondrial"].id, 3)
+        self.assertEqual(generic_by_name["SGC2"].id, 3)
+        self.assertIn("SGC2", generic_by_id[3].names)
+        self.assertEqual(len(unambiguous_dna_by_id[3].start_codons), 2)
+        self.assertEqual(len(unambiguous_dna_by_id[3].stop_codons), 2)
+        self.assertIn("ATR", ambiguous_dna_by_id[3].start_codons)
+        self.assertIn("TAR", ambiguous_dna_by_id[3].stop_codons)
+        self.assertNotIn("TGA", ambiguous_dna_by_id[3].stop_codons)
+        self.assertEqual(generic_by_id[3].forward_table["UGA"],
+                         "W")
+        self.assertEqual(ambiguous_rna_by_id[3].forward_table["CUN"], "T")
+
+    def test_table04(self):
+        """Check table 4: Mold Mitochondrial and others.
+
+        Stop codons TAA and TAG -> TAR
+        TGA codes for W (instead of stop).
+        """
+        self.assertEqual(generic_by_name["Mold Mitochondrial"].id, 4)
+        self.assertEqual(generic_by_name["Mycoplasma"].id, 4)
+        self.assertIn("SGC3", generic_by_id[4].names)
+        self.assertEqual(len(unambiguous_dna_by_id[4].start_codons), 8)
+        self.assertEqual(len(unambiguous_dna_by_id[4].stop_codons), 2)
+        self.assertIn("ATN", ambiguous_dna_by_id[4].start_codons)
+        self.assertIn("TAR", ambiguous_dna_by_id[4].stop_codons)
+        self.assertNotIn("TGA", ambiguous_dna_by_id[4].stop_codons)
+        self.assertEqual(ambiguous_rna_by_id[4].forward_table["UGA"], "W")
+
+    def test_table05(self):
+        """Check table 5: Invertebrate Mitochondrial.
+
+        Stop codons TAA and TAG -> TAR
+        TGA codes for W (instead of stop), AGR codes for S (instead of R),
+        ATA for M (instead of I).
+        """
+        self.assertEqual(generic_by_name["Invertebrate Mitochondrial"].id, 5)
+        self.assertEqual(generic_by_name["SGC4"].id, 5)
+        self.assertIn("SGC4", generic_by_id[5].names)
+        self.assertEqual(len(unambiguous_dna_by_id[5].start_codons), 6)
+        self.assertEqual(len(unambiguous_dna_by_id[5].stop_codons), 2)
+        self.assertIn("ATN", ambiguous_dna_by_id[5].start_codons)
+        self.assertIn("KTG", ambiguous_dna_by_id[5].start_codons)
+        self.assertIn("TAR", ambiguous_dna_by_id[5].stop_codons)
+        self.assertNotIn("TGA", ambiguous_dna_by_id[5].stop_codons)
+        self.assertEqual(ambiguous_rna_by_id[5].forward_table["UGA"], "W")
+        self.assertEqual(ambiguous_dna_by_id[5].forward_table["AGR"], "S")
+        self.assertEqual(generic_by_id[5].forward_table["AUA"], "M")
+
+    def test_table06(self):
+        """Check table 6: Ciliate and Other Nuclear.
+
+        Only one stop codon TGA. TAA and TAG code for Q.
+        """
+        dna_table = unambiguous_dna_by_id[6]
+        nuc_table = generic_by_id[6]
+        amb_rna_table = ambiguous_rna_by_id[6]
+        amb_nuc_table = ambiguous_generic_by_id[6]
+
+        self.assertEqual(generic_by_name["Ciliate Nuclear"].id, 6)
+        self.assertEqual(generic_by_name["Hexamita Nuclear"].id, 6)
+        self.assertIn("SGC5", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 1)
+        self.assertEqual(len(dna_table.stop_codons), 1)
+        self.assertNotIn("UAR", amb_rna_table.stop_codons)
+        self.assertEqual(amb_nuc_table.forward_table["UAR"], "Q")
+
+    def test_table09(self):
+        """Check table 9: Echinoderm and Flatworm Mitochondrial.
+
+        Stop codons TAA and TAG -> TAR
+        TGA codes for W (instead of stop), AGR codes for S (instead of R),
+        AAA for N (instead of K).
+        """
+        dna_table = unambiguous_dna_by_id[9]
+        rna_table = unambiguous_rna_by_id[9]
+        nuc_table = generic_by_id[9]
+        amb_rna_table = ambiguous_rna_by_id[9]
+        amb_nuc_table = ambiguous_generic_by_id[9]
+
+        self.assertEqual(generic_by_name["Echinoderm Mitochondrial"].id, 9)
+        self.assertEqual(generic_by_name["Flatworm Mitochondrial"].id, 9)
+        self.assertIn("SGC8", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 2)
+        self.assertEqual(len(dna_table.stop_codons), 2)
+        self.assertIn("UAR", amb_rna_table.stop_codons)
+        self.assertNotIn("TGA", dna_table.stop_codons)
+        self.assertEqual(nuc_table.forward_table["UGA"], "W")
+        self.assertEqual(amb_nuc_table.forward_table["AGR"], "S")
+        self.assertEqual(rna_table.forward_table["AAA"], "N")
+
+    def test_table10(self):
+        """Check table 10: Euplotid Nuclear.
+
+        Stop codons TAA and TAG -> TAR
+        TGA codes for C (instead of stop).
+        """
+        dna_table = unambiguous_dna_by_id[10]
+        nuc_table = generic_by_id[10]
+        amb_rna_table = ambiguous_rna_by_id[10]
+
+        self.assertEqual(generic_by_name["Euplotid Nuclear"].id, 10)
+        self.assertIn("SGC9", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 1)
+        self.assertEqual(len(dna_table.stop_codons), 2)
+        self.assertIn("UAR", amb_rna_table.stop_codons)
+        self.assertNotIn("TGA", dna_table.stop_codons)
+        self.assertEqual(nuc_table.forward_table["UGA"], "C")
+
+    def test_table11(self):
+        """Check table 11: Bacterial, Archaeal and Plant Plastid."""
+        dna_table = unambiguous_dna_by_id[11]
+        nuc_table = generic_by_id[11]
+
+        self.assertEqual(generic_by_name["Bacterial"].id, 11)
+        self.assertEqual(generic_by_name["Archaeal"].id, 11)
+        self.assertIn("Plant Plastid", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 7)
+        self.assertEqual(len(dna_table.stop_codons), 3)
+
+    def test_table12(self):
+        """Check table 12: Alternative Yeast Nuclear.
+
+        CTG codes for S (instead of L).
+        """
+        dna_table = unambiguous_dna_by_id[12]
+        nuc_table = generic_by_id[12]
+
+        self.assertEqual(generic_by_name["Alternative Yeast Nuclear"].id, 12)
+        self.assertIn("Alternative Yeast Nuclear", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 2)
+        self.assertEqual(len(dna_table.stop_codons), 3)
+        self.assertEqual(nuc_table.forward_table["CUG"], "S")
+
+    def test_table13(self):
+        """Check table 13: Ascidian Mitochondrial.
+
+        Stop codons TAA and TAG -> TAR
+        TGA codes for W (instead of stop), AGR codes for G (instead of R),
+        ATA for M (instead of I).
+        """
+        dna_table = unambiguous_dna_by_id[13]
+        nuc_table = generic_by_id[13]
+        amb_rna_table = ambiguous_rna_by_id[13]
+        amb_nuc_table = ambiguous_generic_by_id[13]
+
+        self.assertEqual(generic_by_name["Ascidian Mitochondrial"].id, 13)
+        self.assertIn("Ascidian Mitochondrial", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 4)
+        self.assertEqual(len(dna_table.stop_codons), 2)
+        self.assertIn("UAR", amb_rna_table.stop_codons)
+        self.assertNotIn("TGA", dna_table.stop_codons)
+        self.assertEqual(nuc_table.forward_table["UGA"], "W")
+        self.assertEqual(amb_nuc_table.forward_table["AGR"], "G")
+        self.assertEqual(amb_rna_table.forward_table["AUR"], "M")
+
+    def test_table14(self):
+        """Check table 14: Alternative Flatworm Mitochondrial.
+
+        Only one stop codon TAG. TAA and TGA code for Y and W, respecitively
+        (instead of stop). AGR codes for S (instead of R), AAA for N (instead
+        of K).
+        """
+        dna_table = unambiguous_dna_by_id[14]
+        rna_table = unambiguous_rna_by_id[14]
+        nuc_table = generic_by_id[14]
+        amb_rna_table = ambiguous_rna_by_id[14]
+        amb_nuc_table = ambiguous_generic_by_id[14]
+
+        self.assertEqual(generic_by_name["Alternative Flatworm "
+                                         "Mitochondrial"].id, 14)
+        self.assertIn("Alternative Flatworm Mitochondrial", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 1)
+        self.assertEqual(len(dna_table.stop_codons), 1)
+        self.assertNotIn("URA", amb_rna_table.stop_codons)
+        self.assertEqual(nuc_table.forward_table["UAA"], "Y")
+        self.assertEqual(rna_table.forward_table["UGA"], "W")
+        self.assertEqual(amb_nuc_table.forward_table["AGR"], "S")
+        self.assertEqual(rna_table.forward_table["AAA"], "N")
+
+    def test_table16(self):
+        """Check table 16: Chlorophycean Mitochondrial.
+
+        Stop codons TAA and TGA -> TRA
+        TAG codes for L (instead of stop).
+        """
+        dna_table = unambiguous_dna_by_id[16]
+        nuc_table = generic_by_id[16]
+        amb_rna_table = ambiguous_rna_by_id[16]
+
+        self.assertEqual(generic_by_name["Chlorophycean Mitochondrial"].id, 16)
+        self.assertIn("Chlorophycean Mitochondrial", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 1)
+        self.assertEqual(len(dna_table.stop_codons), 2)
+        self.assertIn("URA", amb_rna_table.stop_codons)
+        self.assertNotIn("TAG", dna_table.stop_codons)
+        self.assertEqual(nuc_table.forward_table["UAG"], "L")
+
+    def test_table21(self):
+        """Check table 21: Trematode Mitochondrial.
+
+        Stop codons TAA and TAG -> TAR
+        TGA codes for W (instead of stop), ATA codes for M (instead of I),
+        AGR codes for S (instead of R), AAA for N (instead of K).
+        """
+        dna_table = unambiguous_dna_by_id[21]
+        rna_table = unambiguous_rna_by_id[21]
+        nuc_table = generic_by_id[21]
+        amb_rna_table = ambiguous_rna_by_id[21]
+        amb_nuc_table = ambiguous_generic_by_id[21]
+
+        self.assertEqual(generic_by_name["Trematode Mitochondrial"].id, 21)
+        self.assertIn("Trematode Mitochondrial", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 2)
+        self.assertEqual(len(dna_table.stop_codons), 2)
+        self.assertIn("UAR", amb_rna_table.stop_codons)
+        self.assertNotIn("TGA", dna_table.stop_codons)
+        self.assertEqual(rna_table.forward_table["AUA"], "M")
+        self.assertEqual(nuc_table.forward_table["UGA"], "W")
+        self.assertEqual(amb_nuc_table.forward_table["AGR"], "S")
+        self.assertEqual(rna_table.forward_table["AAA"], "N")
+
+    def test_table22(self):
+        """Check table 22: Scenedesmus obliquus Mitochondrial.
+
+        Stop codons TAA, TCA and TGA -> TVA
+        TAG codes for L (instead of stop).
+        """
+        dna_table = unambiguous_dna_by_id[22]
+        nuc_table = generic_by_id[22]
+        amb_rna_table = ambiguous_rna_by_id[22]
+
+        self.assertEqual(generic_by_name["Scenedesmus obliquus "
+                                         "Mitochondrial"].id, 22)
+        self.assertIn("Scenedesmus obliquus Mitochondrial", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 1)
+        self.assertEqual(len(dna_table.stop_codons), 3)
+        self.assertIn("UVA", amb_rna_table.stop_codons)
+        self.assertNotIn("TAG", dna_table.stop_codons)
+        self.assertEqual(nuc_table.forward_table["UAG"], "L")
+
+    def test_table23(self):
+        """Check table 9: Thraustochytrium Mitochondrial.
+
+        TTA codes for stop (instead of L).
+        """
+        dna_table = unambiguous_dna_by_id[23]
+        nuc_table = generic_by_id[23]
+        amb_rna_table = ambiguous_rna_by_id[23]
+
+        self.assertEqual(generic_by_name["Thraustochytrium Mitochondrial"].id,
+                         23)
+        self.assertIn("Thraustochytrium Mitochondrial", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 3)
+        self.assertEqual(len(dna_table.stop_codons), 4)
+        self.assertIn("UUA", amb_rna_table.stop_codons)
+        self.assertNotIn("TTA", dna_table.forward_table.keys())
+
+    def test_table24(self):
+        """Check table 24: Pterobranchia Mitochondrial.
+
+        Stop codons TAA and TAG -> TAR
+        TGA codes for W (instead of stop), AGA codes for S (instead of R),
+        AGG for K (instead of R).
+        """
+        dna_table = unambiguous_dna_by_id[24]
+        nuc_table = generic_by_id[24]
+        amb_rna_table = ambiguous_rna_by_id[24]
+        amb_nuc_table = ambiguous_generic_by_id[24]
+
+        self.assertEqual(generic_by_name["Pterobranchia Mitochondrial"].id, 24)
+        self.assertIn("Pterobranchia Mitochondrial", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 4)
+        self.assertEqual(len(dna_table.stop_codons), 2)
+        self.assertIn("UAR", amb_rna_table.stop_codons)
+        self.assertNotIn("TGA", dna_table.stop_codons)
+        self.assertEqual(nuc_table.forward_table["UGA"], "W")
+        self.assertEqual(amb_nuc_table.forward_table["AGA"], "S")
+        self.assertEqual(dna_table.forward_table["AGG"], "K")
+
+    def test_table25(self):
+        """Check table 25: Candidate Division SR1 and Gracilibacteria.
+
+        Stop codons TAA and TAG -> TAR
+        TGA codes for G (instead of stop).
+        """
+        dna_table = unambiguous_dna_by_id[25]
+        nuc_table = generic_by_id[25]
+        amb_rna_table = ambiguous_rna_by_id[25]
+
+        self.assertEqual(generic_by_name["Candidate Division SR1"].id, 25)
+        self.assertEqual(generic_by_name["Gracilibacteria"].id, 25)
+        self.assertIn("Candidate Division SR1", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 3)
+        self.assertEqual(len(dna_table.stop_codons), 2)
+        self.assertIn("UAR", amb_rna_table.stop_codons)
+        self.assertNotIn("TGA", dna_table.stop_codons)
+        self.assertEqual(nuc_table.forward_table["UGA"], "G")
+
+    def test_table26(self):
+        """Check table 26: Pachysolen tannophilus Nuclear.
+
+        CTG codes for A (instead of L).
+        """
+        dna_table = unambiguous_dna_by_id[26]
+        nuc_table = generic_by_id[26]
+
+        self.assertEqual(generic_by_name["Pachysolen tannophilus "
+                                         "Nuclear"].id, 26)
+        self.assertIn("Pachysolen tannophilus Nuclear", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 2)
+        self.assertEqual(len(dna_table.stop_codons), 3)
+        self.assertEqual(nuc_table.forward_table["CTG"], "A")
+
+    def test_table27(self):
+        """Check table 27: Karyorelict Nuclear.
+
+        NOTE: This code has no unambiguous stop codon! TGA codes for either
+        stop or W, dependent on the context.
+        TAR codes for Q (instead of stop)
+        """
+        dna_table = unambiguous_dna_by_id[27]
+        nuc_table = generic_by_id[27]
+        amb_rna_table = ambiguous_rna_by_id[27]
+        amb_nuc_table = ambiguous_generic_by_id[27]
+
+        self.assertEqual(generic_by_name["Karyorelict Nuclear"].id, 27)
+        self.assertIn("Karyorelict Nuclear", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 1)
+        self.assertEqual(len(dna_table.stop_codons), 1)
+        self.assertNotIn("UAR", amb_rna_table.stop_codons)
+        self.assertEqual(amb_nuc_table.forward_table["UAR"], "Q")
+        self.assertEqual(nuc_table.forward_table["UGA"], "W")
+        self.assertIn("TGA", dna_table.stop_codons)
+
+    def test_table28(self):
+        """Check table 28: Condylostoma Nuclear.
+
+        NOTE: This code has no unambiguous stop codon! TAR codes for either
+        stop or Q, TGA for stop or W, dependent on the context.
+        """
+        dna_table = unambiguous_dna_by_id[28]
+        nuc_table = generic_by_id[28]
+        amb_dna_table = ambiguous_dna_by_id[28]
+        amb_rna_table = ambiguous_rna_by_id[28]
+
+        self.assertEqual(generic_by_name["Condylostoma Nuclear"].id, 28)
+        self.assertIn("Condylostoma Nuclear", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 1)
+        self.assertEqual(len(dna_table.stop_codons), 3)
+        self.assertIn("UAR", amb_rna_table.stop_codons)
+        self.assertIn("TGA", amb_dna_table.stop_codons)
+        self.assertEqual(amb_dna_table.forward_table["TAR"], "Q")
+        self.assertEqual(nuc_table.forward_table["UGA"], "W")
+
+    def test_table29(self):
+        """Check table 29: Mesodinium Nuclear.
+
+        TAR codes for Y (instead of stop).
+        """
+        dna_table = unambiguous_dna_by_id[29]
+        nuc_table = generic_by_id[29]
+        amb_rna_table = ambiguous_rna_by_id[29]
+        amb_nuc_table = ambiguous_generic_by_id[29]
+
+        self.assertEqual(generic_by_name["Mesodinium Nuclear"].id, 29)
+        self.assertIn("Mesodinium Nuclear", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 1)
+        self.assertEqual(len(dna_table.stop_codons), 1)
+        self.assertNotIn("UAR", amb_rna_table.stop_codons)
+        self.assertEqual(amb_nuc_table.forward_table["UAR"], "Y")
+
+    def test_table30(self):
+        """Check table 30: Peritrich Nuclear.
+
+        TAR codes for E (instead of stop).
+        """
+        dna_table = unambiguous_dna_by_id[30]
+        nuc_table = generic_by_id[30]
+        amb_rna_table = ambiguous_rna_by_id[30]
+        amb_nuc_table = ambiguous_generic_by_id[30]
+
+        self.assertEqual(generic_by_name["Peritrich Nuclear"].id, 30)
+        self.assertIn("Peritrich Nuclear", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 1)
+        self.assertEqual(len(dna_table.stop_codons), 1)
+        self.assertNotIn("UAR", amb_rna_table.stop_codons)
+        self.assertEqual(amb_nuc_table.forward_table["UAR"], "E")
+
+    def test_table31(self):
+        """Check table 31: Blastocrithidia Nuclear.
+
+        NOTE: This code has no unambiguous stop codon! TAR codes for either
+        stop or E, dependent on the context.
+        TGA codes for W (instead of stop)
+        """
+        dna_table = unambiguous_dna_by_id[31]
+        nuc_table = generic_by_id[31]
+        amb_dna_table = ambiguous_dna_by_id[31]
+        amb_rna_table = ambiguous_rna_by_id[31]
+
+        self.assertEqual(generic_by_name["Blastocrithidia Nuclear"].id, 31)
+        self.assertIn("Blastocrithidia Nuclear", nuc_table.names)
+        self.assertEqual(len(dna_table.start_codons), 1)
+        self.assertEqual(len(dna_table.stop_codons), 2)
+        self.assertIn("UAR", amb_rna_table.stop_codons)
+        self.assertNotIn("TGA", amb_dna_table.stop_codons)
+        self.assertEqual(amb_dna_table.forward_table["TAR"], "E")
+        self.assertEqual(nuc_table.forward_table["UGA"], "W")
+
+
+class ErrorConditions(unittest.TestCase):
+    """Tests for module specific errors."""
+
+    def test_list_possible_proteins(self):
+        """Raise errors in list_possible proteins."""
+        table = unambiguous_dna_by_id[1]
+        amb_values = {'T': 'T', 'G': 'G', 'A': 'A', 'R': ('A', 'G')}
+        with self.assertRaises(TranslationError):
+            # Can be stop or amino acid:
+            codon = ['T', 'R', 'R']
+            list_possible_proteins(codon, table.forward_table, amb_values)
+        with self.assertRaises(KeyError):
+            # Is a stop codon:
+            codon = ['T', 'G', 'A']
+            list_possible_proteins(codon, table.forward_table, amb_values)
+
+    def test_ambiguous_forward_table(self):
+        """Raise errors in AmbiguousForwardTable."""
+        table = ambiguous_dna_by_id[1]
+        self.assertEqual(table.forward_table.get("ZZZ"), None)
+        with self.assertRaises(KeyError):
+            table.forward_table["ZZZ"]  # KeyError it's a stop codon
+            table.forward_table['TGA']  # KeyError stop codon
+        with self.assertRaises(TranslationError):
+            table.forward_table["WWW"]  # Translation error does not code
+
+
+class PrintTable(unittest.TestCase):
+    """Test for __str__ in CodonTable."""
+
+    def test_print_table(self):
+        """Test output of __str__ function."""
+        table = generic_by_id[1]
+        output = table.__str__()
+
+        expected_output = """Table 1 Standard, SGC0
+
+  |  U      |  C      |  A      |  G      |
+--+---------+---------+---------+---------+--
+U | UUU F   | UCU S   | UAU Y   | UGU C   | U
+U | UUC F   | UCC S   | UAC Y   | UGC C   | C
+U | UUA L   | UCA S   | UAA Stop| UGA Stop| A
+U | UUG L(s)| UCG S   | UAG Stop| UGG W   | G
+--+---------+---------+---------+---------+--
+C | CUU L   | CCU P   | CAU H   | CGU R   | U
+C | CUC L   | CCC P   | CAC H   | CGC R   | C
+C | CUA L   | CCA P   | CAA Q   | CGA R   | A
+C | CUG L(s)| CCG P   | CAG Q   | CGG R   | G
+--+---------+---------+---------+---------+--
+A | AUU I   | ACU T   | AAU N   | AGU S   | U
+A | AUC I   | ACC T   | AAC N   | AGC S   | C
+A | AUA I   | ACA T   | AAA K   | AGA R   | A
+A | AUG M(s)| ACG T   | AAG K   | AGG R   | G
+--+---------+---------+---------+---------+--
+G | GUU V   | GCU A   | GAU D   | GGU G   | U
+G | GUC V   | GCC A   | GAC D   | GGC G   | C
+G | GUA V   | GCA A   | GAA E   | GGA G   | A
+G | GUG V   | GCG A   | GAG E   | GGG G   | G
+--+---------+---------+---------+---------+--"""
+
+        self.assertEqual(output, expected_output)
+
+        table = unambiguous_dna_by_id[1]
+        table.id = ""
+        output = table.__str__()
+
+        expected_output = """Table ID unknown Standard, SGC0
+
+  |  T      |  C      |  A      |  G      |
+--+---------+---------+---------+---------+--
+T | TTT F   | TCT S   | TAT Y   | TGT C   | T
+T | TTC F   | TCC S   | TAC Y   | TGC C   | C
+T | TTA L   | TCA S   | TAA Stop| TGA Stop| A
+T | TTG L(s)| TCG S   | TAG Stop| TGG W   | G
+--+---------+---------+---------+---------+--
+C | CTT L   | CCT P   | CAT H   | CGT R   | T
+C | CTC L   | CCC P   | CAC H   | CGC R   | C
+C | CTA L   | CCA P   | CAA Q   | CGA R   | A
+C | CTG L(s)| CCG P   | CAG Q   | CGG R   | G
+--+---------+---------+---------+---------+--
+A | ATT I   | ACT T   | AAT N   | AGT S   | T
+A | ATC I   | ACC T   | AAC N   | AGC S   | C
+A | ATA I   | ACA T   | AAA K   | AGA R   | A
+A | ATG M(s)| ACG T   | AAG K   | AGG R   | G
+--+---------+---------+---------+---------+--
+G | GTT V   | GCT A   | GAT D   | GGT G   | T
+G | GTC V   | GCC A   | GAC D   | GGC G   | C
+G | GTA V   | GCA A   | GAA E   | GGA G   | A
+G | GTG V   | GCG A   | GAG E   | GGG G   | G
+--+---------+---------+---------+---------+--"""
+
+        self.assertEqual(output, expected_output)
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -1274,6 +1274,24 @@ class TestTranslating(unittest.TestCase):
         with self.assertRaises(TranslationError):
             Seq.translate(seq, table=2, cds=True)
 
+    def test_translation_using_tables_with_ambiguous_stop_codons(self):
+        """Check for error and warning messages.
+
+        Here, 'ambiguous stop codons' means codons of unambiguous sequence
+        but with a context sensitive encoding as STOP or an amino acid.
+        Thus, these codons appear within the codon table in the forward
+        table as well as in the list of stop codons.
+        """
+        seq = "ATGGGCTGA"
+        with self.assertRaises(ValueError):
+            Seq.translate(seq, table=28, to_stop=True)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Seq.translate(seq, table=28)
+            message = str(w[-1].message)
+            self.assertTrue(message.startswith("This table contains at"))
+            self.assertTrue(message.endswith("be translated as amino acid."))
+
 
 class TestStopCodons(unittest.TestCase):
     def setUp(self):

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -1289,7 +1289,7 @@ class TestTranslating(unittest.TestCase):
             warnings.simplefilter("always")
             Seq.translate(seq, table=28)
             message = str(w[-1].message)
-            self.assertTrue(message.startswith("This table contains at"))
+            self.assertTrue(message.startswith("This table contains"))
             self.assertTrue(message.endswith("be translated as amino acid."))
 
 


### PR DESCRIPTION
 - Small changes in ```update_ncbi_codon_table.py``` to give a PEP8 compliant output
 - Added codon tables 27 - 31 in ```Bio.Data.CodonTable.py``` (and some coding style issues)
 - Removed a bunch of ```assert``` statements in ```Bio.Data.Codon.Table.py```. They were moved to ```test_CodonTable.py```
 - Complete re-write of ```test_CodonTable.py``` to use the ```unittest``` framework. Added tests for each codon table.
 - Small change in ```Seq.py``` to raise a warning or exception when codon tables with 'dual coding' stop codons are used (see #1224). The use of such tables during translation will generally raise a ```BiopythonWarning```. If ```to_stop=True``` a ```ValueError``` is raised.
 - Small update in ```test_Seq.py``` to include these cases.
 - Small update in ```NEWS.rst``` for the addition of the new codon tables.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. 

  