### PR TITLE
Also use NumPy 1.13 on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,7 +40,7 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install setuptools numpy mysql-connector-python psycopg2 matplotlib networkx reportlab scipy coverage
+  - conda install setuptools numpy==1.13 mysql-connector-python psycopg2 matplotlib networkx reportlab scipy coverage
   - if "PY_MAJOR_VER"=="2" conda install unittest2
   - python setup.py build
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,7 +40,7 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install setuptools numpy==1.13 mysql-connector-python psycopg2 matplotlib networkx reportlab scipy coverage
+  - conda install setuptools numpy==1.13.1 mysql-connector-python psycopg2 matplotlib networkx reportlab scipy coverage
   - if "PY_MAJOR_VER"=="2" conda install unittest2
   - python setup.py build
 


### PR DESCRIPTION
Right now NumPy 1.14 changes break some doctests.

This pull request partly addresses issue #1496, following on from #1500 which only did this for TravisCI