### PR TITLE
Style check: Ignore W503

### DIFF
--- a/Bio/.flake8
+++ b/Bio/.flake8
@@ -7,7 +7,7 @@ ignore =
     # =======================
     # pycodestyle v2.3.1 default ignore is E121,E123,E126,E226,E24,E704,W503
     # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
-    E122,E123,E126,E127,E128,E501,E731,F401,F812,F841,
+    E122,E123,E126,E127,E128,E501,E731,F401,F812,F841,W503,
     # =====================================
     # pydocstyle: D1## - Missing Docstrings
     # =====================================

--- a/BioSQL/.flake8
+++ b/BioSQL/.flake8
@@ -3,6 +3,12 @@
 # doctests = True
 max-line-length = 92
 ignore =
+    # =======================
+    # flake: E###, F###, W###
+    # =======================
+    # pycodestyle v2.3.1 default ignore is E121,E123,E126,E226,E24,E704,W503
+    # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
+    W503,
     # =====================================
     # pydocstyle: D### - Missing Docstrings
     # =====================================

--- a/Doc/examples/.flake8
+++ b/Doc/examples/.flake8
@@ -7,7 +7,7 @@ ignore =
     # =======================
     # pycodestyle v2.3.1 default ignore is E121,E123,E126,E226,E24,E704,W503
     # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
-    E122,E123,E126,E127,E128,E501,E731,F401,F812,F841,
+    E122,E123,E126,E127,E128,E501,E731,F401,F812,F841,W503,
     # =====================================
     # pydocstyle: D### - Missing Docstrings
     # =====================================

--- a/Scripts/.flake8
+++ b/Scripts/.flake8
@@ -7,7 +7,6 @@ ignore =
     # =======================
     # pycodestyle v2.3.1 default ignore is E121,E123,E126,E226,E24,E704,W503
     # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
-    # E122,E123,E126,E127,E128,E241,E402,E501,E731,F401,F405,F821,F841,
     W503,
     # =====================================
     # pydocstyle: D### - Missing Docstrings

--- a/Scripts/.flake8
+++ b/Scripts/.flake8
@@ -8,6 +8,7 @@ ignore =
     # pycodestyle v2.3.1 default ignore is E121,E123,E126,E226,E24,E704,W503
     # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
     # E122,E123,E126,E127,E128,E241,E402,E501,E731,F401,F405,F821,F841,
+    W503,
     # =====================================
     # pydocstyle: D### - Missing Docstrings
     # =====================================
@@ -19,7 +20,7 @@ ignore =
     # D105	Missing docstring in magic method
     # D107	Missing docstring in __init__
     # TODO: Fix some of these?
-    D101,D102,D103,D105,D107
+    D101,D102,D103,D105,D107,
     # ====================================
     # pydocstyle: D### - Whitespace Issues
     # ====================================

--- a/Tests/.flake8
+++ b/Tests/.flake8
@@ -6,7 +6,7 @@ ignore =
     # =======================
     # pycodestyle v2.3.1 default ignore is E121,E123,E126,E226,E24,E704,W503
     # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
-    E122,E123,E126,E127,E128,E241,E402,E501,E731,F401,F405,F821,F841,
+    E122,E123,E126,E127,E128,E241,E402,E501,E731,F401,F405,F821,F841,W503,
     # =====================================
     # pydocstyle: D1## - Missing Docstrings
     # =====================================
@@ -41,7 +41,7 @@ ignore =
     # D400	First line should end with a period
     # D401	First line should be in imperative mood
     # D412	No blank lines allowed between a section header and its content
-    D400,D401
+    D400,D401,
     # We ignore D412 deliberately:
     D412,
     # =========================================


### PR DESCRIPTION
```PEP8``` now recommends to break lines *before* binary operators. Thus we should ignore ```flake8```'s warning W503: Line break before binary operator.