### PR TITLE
pairwise2: Improved format_alignment for local alignments and alignments of lists

### DIFF
--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1456,7 +1456,7 @@ function \verb|format_alignment| for a nicer printout:
 \begin{verbatim}
 >>> print(pairwise2.format_alignment(*alignment[0]))
 MV-LSPADKTNV---K-A--A-WGKVGAHAG---EY-GA-EALE-RMFLSF----PTTK-TY--F...YR-
-|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||...|||
+|| |     |     | |  | ||||        |  |  |||  |  |      |    |   |   |  
 MVHL-----T--PEEKSAVTALWGKV-----NVDE-VG-GEAL-GR--L--LVVYP---WT-QRF...Y-H
   Score=72
 \end{verbatim}
@@ -1483,8 +1483,8 @@ and a gap extension penalty of 0.5 (using \verb|globalds|):
 \begin{verbatim}
 >>> print(pairwise2.format_alignment(*alignments[0]))
 MV-LSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTY...KYR
-||||||||||||||||||||||||||||||||||||||||||||...|||
-MVHLTPEEKSAVTALWGKV-NVDEVGGEALGRLLVVYPWTQRFF...KYH
+|| |.|..|..|.|.||||  ...|.|.|||.|.....|.....   ||.
+MVHLTPEEKSAVTALWGKV--NVDEVGGEALGRLLVVYPWTQRF...KYH
   Score=292.5
 \end{verbatim}
 
@@ -1500,9 +1500,9 @@ where again XX stands for a two letter code for the match and gap functions:
 >>> from Bio.SubsMat.MatrixInfo import blosum62
 >>> alignments = pairwise2.align.localds("LSPADKTNVKAA", "PEEKSAV", blosum62, -10, -1)
 >>> print(pairwise2.format_alignment(*alignments[0]))
-LSPADKTNVKAA
+3 PADKTNV
   |..|..|
---PEEKSAV---
+1 PEEKSAV
   Score=16
 <BLANKLINE>
 \end{verbatim}
@@ -1516,9 +1516,9 @@ of 2/0.5 using \verb|localms|):
 \begin{verbatim}
 >>> alignments = pairwise2.align.localms("AGAACT", "GAC", 5, -4, -2, -0.5)
 >>> print(pairwise2.format_alignment(*alignments[0]))
-AGAACT
- | ||
--G-AC-
+2 GAAC
+  | ||
+1 G-AC
   Score=13
 <BLANKLINE>
 \end{verbatim}

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -187,7 +187,10 @@ The SeqRecord object now has a translate method, following the approach used
 for its existing reverse_complement method etc.
 
 The output of function ``format_alignment`` in ``Bio.pairwise2`` for displaying
-a pairwise sequence alignment as text now indicates gaps and mis-matches.
+a pairwise sequence alignment as text now indicates gaps and mis-matches. For
+local alignments, if they do not consist of the whole sequences, only the
+aligned section of the sequences are shown, together with the start positions
+of the sequences. Alignments of list will now also be prettily printed.
 
 Bio.SeqIO now supports reading and writing two-line-per-record FASTA files
 under the format name "fasta-2line", useful if you wish to work without

--- a/Tests/test_pairwise2.py
+++ b/Tests/test_pairwise2.py
@@ -126,17 +126,17 @@ class TestPairwiseLocal(unittest.TestCase):
         seq1, seq2, score, begin, end = aligns[0]
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
--AxBx
- | |
-zA-Bz
+1 AxB
+  | |
+2 A-B
   Score=1.9
 """)
         seq1, seq2, score, begin, end = aligns[1]
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
--AxBx
- | |.
-zA-Bz
+1 AxBx
+  | |.
+2 A-Bz
   Score=1.9
 """)
 
@@ -146,16 +146,16 @@ zA-Bz
                                                 -0.5, -3, -1))
         alignment = pairwise2.format_alignment(*aligns[0])
         self.assertEqual(alignment, """\
---xxxABCDxxx
-       ||
-zzzABzzCDz--
+6 CD
+  ||
+8 CD
   Score=2
 """)
         alignment = pairwise2.format_alignment(*aligns[1])
         self.assertEqual(alignment, """\
-xxxABCDxxx
-   ||
-zzzABzzCDz
+4 AB
+  ||
+4 AB
   Score=2
 """)
 
@@ -168,7 +168,7 @@ zzzABzzCDz
                                              blosum62, -4, -4)
         for a in alignments:
             self.assertEqual(pairwise2.format_alignment(*a),
-                             "VKAHGKKV\n .||\nFQAHCAGV\n  Score=13\n")
+                             "2 KAH\n  .||\n2 QAH\n  Score=13\n")
 
 
 class TestScoreOnly(unittest.TestCase):
@@ -402,9 +402,9 @@ GTCT
         seq1, seq2, score, begin, end = aligns[0]
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
-GAT--
-| |
-G-TCT
+1 GAT
+  | |
+1 G-T
   Score=1.8
 """)  # noqa: W291
 
@@ -419,27 +419,27 @@ class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
         seq1, seq2, score, begin, end = aligns[0]
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
-['G', '-', 'A', 'A', 'T']
-| ..|
-['G', 'T', 'C', 'C', 'T']
+G - A A T 
+|   . . | 
+G T C C T 
   Score=1.9
-""")
+""")  # noqa: W291
         seq1, seq2, score, begin, end = aligns[1]
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
-['G', 'A', '-', 'A', 'T']
-|. .|
-['G', 'T', 'C', 'C', 'T']
+G A - A T 
+| .   . | 
+G T C C T 
   Score=1.9
-""")
+""")  # noqa: W291
         seq1, seq2, score, begin, end = aligns[2]
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
-['G', 'A', 'A', '-', 'T']
-|.. |
-['G', 'T', 'C', 'C', 'T']
+G A A - T 
+| . .   | 
+G T C C T 
   Score=1.9
-""")
+""")  # noqa: W291
 
 
 class TestPairwiseMatchDictionary(unittest.TestCase):
@@ -466,9 +466,9 @@ AT-T
         seq1, seq2, score, begin, end = aligns[1]
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
-ATAT
-||.
-ATT-
+1 ATA
+  ||.
+1 ATT
   Score=3
 """)
 
@@ -478,9 +478,9 @@ ATT-
         seq1, seq2, score, begin, end = aligns[0]
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
-ATAT
-||.
-ATT-
+1 ATA
+  ||.
+1 ATT
   Score=3
 """)
 
@@ -490,9 +490,9 @@ ATT-
         seq1, seq2, score, begin, end = aligns[0]
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
-ATT-
-||.
-ATAT
+1 ATT
+  ||.
+1 ATA
   Score=3
 """)
 
@@ -505,9 +505,9 @@ class TestPairwiseOneCharacter(unittest.TestCase):
         seq1, seq2, score, begin, end = aligns[0]
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
-abcde
+3 c
   |
---c--
+1 c
   Score=1
 """)
 
@@ -518,17 +518,17 @@ abcde
         seq1, seq2, score, begin, end = aligns[0]
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
-abcce
-   |
----c-
+4 c
+  |
+1 c
   Score=1
 """)
         seq1, seq2, score, begin, end = aligns[1]
         alignment = pairwise2.format_alignment(seq1, seq2, score, begin, end)
         self.assertEqual(alignment, """\
-abcce
+3 c
   |
---c--
+1 c
   Score=1
 """)
 


### PR DESCRIPTION
This pull request builds upon #1352 where the pretty print output of ```pairwise2``` was already improved by changing the match line for distinguishing between matches and mismatches.

This PR addresses local alignments and alignments of lists:
 - For local alignments only the aligned part will be shown, together with the starting positions:
   ```
   Before:
   --TTTTTGGGAATTCCC-------
          ||||.|||||
   CCCCCCCGGGATTTCCCGGGGGGG
     Score=9

   Proposed:
   6 GGGAATTCCC
     ||||.|||||
   8 GGGATTTCCC
     Score=9
   ```

 - ```pairwise2``` allows to supply the sequences as lists, however, ```print_format``` was not able to print them in  a pretty way:
   ```
   Before:
   ['A', 'C', 'C', 'G', 'T', 'N97', 'C', 'T']
   |||| .||
   ['A', 'C', 'C', 'G', '-', '8DX', 'C', 'T']
     Score=1
   
   Proposed:
   A C C G T N97 C T 
   | | | |    .  | | 
   A C C G - 8DX C T 
     Score=1
   ```
   Example from SO question: https://stackoverflow.com/questions/36142371/nucleotides-separator-in-the-pairwise-sequence-alignment-bio-python


I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
