### PR TITLE
 Replace multiline assert statements in HMM module and add tests

### DIFF
--- a/Bio/HMM/Trainer.py
+++ b/Bio/HMM/Trainer.py
@@ -38,9 +38,8 @@ class TrainingSequence(object):
            the sequence of states should be an empty string.
 
         """
-        if len(state_path) > 0:
-            assert len(emissions) == len(state_path), \
-                   "State path does not match associated emissions."
+        if len(state_path) > 0 and len(emissions) != len(state_path):
+            raise ValueError('State path does not match associated emissions.')
         self.emissions = emissions
         self.states = state_path
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -90,6 +90,7 @@ possible, especially the following contributors:
 - Saket Choudhary
 - Shuichiro MAKIGAKI (first contribution)
 - Shyam Saladi (first contribution)
+- Siong Kong
 - Spencer Bliven
 - Stefans Mezulis
 - Steve Bond

--- a/Tests/test_HMMGeneral.py
+++ b/Tests/test_HMMGeneral.py
@@ -3,6 +3,8 @@
 
 Also tests Training methods.
 """
+
+
 # standard modules
 from __future__ import print_function
 
@@ -39,6 +41,28 @@ def test_assertion(name, result, expected):
     """
     assert result == expected, "Expected %s, got %s for %s" \
            % (expected, result, name)
+
+
+class TrainingSequenceTest(unittest.TestCase):
+    def test_empty_state_training_sequence(self):
+        emission_seq = Seq('AB', LetterAlphabet())
+        state_seq = Seq('', NumberAlphabet())
+        training_seq = Trainer.TrainingSequence(emission_seq, state_seq)
+        assert training_seq.emissions == emission_seq
+        assert training_seq.states == state_seq
+
+    def test_valid_training_sequence(self):
+        emission_seq = Seq('AB', LetterAlphabet())
+        state_seq = Seq('12', NumberAlphabet())
+        training_seq = Trainer.TrainingSequence(emission_seq, state_seq)
+        assert training_seq.emissions == emission_seq
+        assert training_seq.states == state_seq
+
+    def test_invalid_training_sequence(self):
+        emission_seq = Seq('AB', LetterAlphabet())
+        state_seq = Seq('1', NumberAlphabet())
+        with self.assertRaises(ValueError):
+            Trainer.TrainingSequence(emission_seq, state_seq)
 
 
 class MarkovModelBuilderTest(unittest.TestCase):

--- a/Tests/test_HMMGeneral.py
+++ b/Tests/test_HMMGeneral.py
@@ -3,8 +3,6 @@
 
 Also tests Training methods.
 """
-
-
 # standard modules
 from __future__ import print_function
 
@@ -401,8 +399,6 @@ class ScaledDPAlgorithmsTest(unittest.TestCase):
         previous_vars = {('1', 0): .5,
                          ('2', 0): .7}
         s_value = self.dp._calculate_s_value(1, previous_vars)
-
-        # print(s_value)
 
 
 class AbstractTrainerTest(unittest.TestCase):


### PR DESCRIPTION
This pull request addresses issue #1515 

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
