### PR TITLE
Seq: Pass on the gap character from UnknownSeq.ungap to Seq.ungap

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1690,7 +1690,7 @@ class UnknownSeq(Seq):
         explicit gap character declaration.
         """
         # Offload the alphabet stuff
-        s = Seq(self._character, self.alphabet).ungap()
+        s = Seq(self._character, self.alphabet).ungap(gap)
         if s:
             return UnknownSeq(self._length, s.alphabet, self._character)
         else:

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -11,6 +11,7 @@ import unittest
 import sys
 
 from Bio import BiopythonWarning
+from Bio import SeqIO
 from Bio.Alphabet import generic_protein, generic_nucleotide
 from Bio.Alphabet import generic_dna, generic_rna
 from Bio.Alphabet.IUPAC import protein, extended_protein
@@ -737,6 +738,18 @@ class StringMethodTests(unittest.TestCase):
         self.assertRaises(TypeError, Seq, (Seq("ACGT", generic_dna)))
 
     # TODO - Addition...
+
+
+class FileBasedTests(unittest.TestCase):
+    """Test Seq objects created from files by SeqIO."""
+
+    def test_unknown_seq_ungap(self):
+        """Test ungap() works properly on UnknownSeq instances."""
+        rec = SeqIO.read('GenBank/NT_019265.gb', 'genbank')
+        self.assertIsInstance(rec.seq, UnknownSeq)
+
+        ungapped_seq = rec.features[1].extract(rec.seq).ungap('-')
+        self.assertIsInstance(ungapped_seq, UnknownSeq)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This avoids the "Gap character not given and not defined in alphabet" Value Error
that otherwise happens even if a gap character is given. Fixes issue #1512.

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>

This pull request addresses issue #1512

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
