### PR TITLE
Update IUPAC alphabet for Selenocysteine. 'U' now translates to 'Sec'

### DIFF
--- a/Bio/Data/IUPACData.py
+++ b/Bio/Data/IUPACData.py
@@ -39,7 +39,7 @@ protein_letters_1to3 = {
 }
 protein_letters_1to3_extended = dict(list(protein_letters_1to3.items()) + list({
     'B': 'Asx', 'X': 'Xaa', 'Z': 'Glx', 'J': 'Xle',
-    'U': 'Sel', 'O': 'Pyl',
+    'U': 'Sec', 'O': 'Pyl',
 }.items()))
 
 protein_letters_3to1 = dict((x[1], x[0]) for x in


### PR DESCRIPTION
This is according with the comments (line 26) and the provided link: biopython/blob/c60067476b4fe84b43df985cf81140d32f70e319/Bio/Data/IUPACData.py

This pull request addresses issue #...

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
