### PR TITLE
TravisCI/Tox: Switch to psycopg2-binary from PyPI

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -61,7 +61,7 @@ deps =
     {py27}: mysql-python
     {py27,py36}: mmtf-python
     {py27,py35}: reportlab
-    {py27,py34,py35,py36}: psycopg2
+    {py27,py34,py35,py36}: psycopg2-binary
     {py27,py34,py35,py35,pypy}: mysql-connector-python-rf
     {py27,py35,pypy}: rdflib
     {pypy,pypy3}: numpy==1.12.1


### PR DESCRIPTION
Was getting a warning recommending using the PyPI package psycopg2-binary instead.

http://initd.org/psycopg/docs/install.html#binary-install-from-pypi

e.g.

```
test_BioSQL_psycopg2 ... /home/travis/build/biopython/biopython/.tox/py34-cover/lib/python3.4/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)
ok
```