### PR TITLE
Default to 'latin-1' encoding for HTTP text requests.

### DIFF
--- a/Bio/_py3k/__init__.py
+++ b/Bio/_py3k/__init__.py
@@ -106,6 +106,13 @@ if sys.version_info[0] >= 3:
         except AttributeError:
             encoding = None
         if encoding is None:
+            # The W3C recommendation is:
+            # When no explicit charset parameter is provided by the sender,
+            # media subtypes of the "text" type are defined to have a default
+            # charset value of "ISO-8859-1" when received via HTTP.
+            # "ISO-8859-1" is also known as 'latin-1'
+            # See the following for more detail:
+            # https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7.1
             encoding = 'latin-1'
         wrapped = io.TextIOWrapper(io.BufferedReader(handle), encoding=encoding)
         try:

--- a/Bio/_py3k/__init__.py
+++ b/Bio/_py3k/__init__.py
@@ -104,7 +104,9 @@ if sys.version_info[0] >= 3:
             # the HTTP headers may tell us the encoding.
             encoding = handle.headers.get_content_charset()
         except AttributeError:
-            encoding = locale.getpreferredencoding(False)
+            encoding = None
+        if encoding is None:
+            encoding = 'latin-1'
         wrapped = io.TextIOWrapper(io.BufferedReader(handle), encoding=encoding)
         try:
             # If wrapping an online handle, this is nice to have:


### PR DESCRIPTION
This is following the W3C protocol documentation here:

https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7.1

This pull request addresses issue #1546 ...

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
