### PR TITLE
Make SeqRecord unhashable

### DIFF
--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -750,10 +750,10 @@ class SeqRecord(object):
     def __ge__(self, other):
         raise NotImplementedError(_NO_SEQRECORD_COMPARISON)
 
-    # Note Python 3 does not use __cmp__ and there is no need to
-    # define __cmp__ on Python 2 as have all of  _lt__ etc defined.
+    # Make SeqRecord unhashable explicit, required for Python 2.
+    # See github issue 929 for related discussion.
+    __hash__ = None
 
-    # Python 3:
     def __bool__(self):
         """Boolean value of an instance of this class (True).
 

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -754,6 +754,10 @@ class SeqRecord(object):
     # See github issue 929 for related discussion.
     __hash__ = None
 
+    # Note Python 3 does not use __cmp__ and there is no need to
+    # define __cmp__ on Python 2 as have all of  _lt__ etc defined.
+
+    # Python 3:
     def __bool__(self):
         """Boolean value of an instance of this class (True).
 

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -409,6 +409,15 @@ class SeqRecordMethodsMore(unittest.TestCase):
             SeqRecord(Seq("A")) >= SeqRecord(Seq("A"))
         self.assertRaises(NotImplementedError, ge)
 
+    def test_hash_exception(self):
+        def hash1():
+            hash(SeqRecord(Seq("A")))
+        self.assertRaises(TypeError, hash1)
+
+        def hash2():
+            SeqRecord(Seq("A")).__hash__()
+        self.assertRaises(TypeError, hash2)
+
 
 class TestTranslation(unittest.TestCase):
 


### PR DESCRIPTION
Currently `SeqRecord` is unhashable in Python 3 but not in Python 2, this pull request address this inconsistency. This pull request addresses issue #929 

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)

Hope this looks ok?