### PR TITLE
Fix indentation for SeqRecord le unit test

### DIFF
--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -387,7 +387,7 @@ class SeqRecordMethodsMore(unittest.TestCase):
     def test_le_exception(self):
         def le():
             SeqRecord(Seq("A")) <= SeqRecord(Seq("A"))
-            self.assertRaises(NotImplementedError, le)
+        self.assertRaises(NotImplementedError, le)
 
     def test_eq_exception(self):
         def equality():


### PR DESCRIPTION
The `test_le_exception` function included `self.assertRaises(NotImplementedError, le)` *inside* the `le` function so the unit test was not actually working as intended. The indentation is fixed here.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
