### PR TITLE
Typo in pairwise2 docs

### DIFF
--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -64,7 +64,7 @@ printout, use the ``format_alignment`` method of the module:
 All alignment functions have the following arguments:
 
 - Two sequences: strings, Biopython sequence objects or lists.
-  Lists are useful for suppling sequences which contain residues that are
+  Lists are useful for supplying sequences which contain residues that are
   encoded by more than one letter.
 
 - ``penalize_extend_when_opening``: boolean (default: False).


### PR DESCRIPTION
This pull request addresses a typo.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
