### PR TITLE
Catch uppercase PROTEIN when converting from EMBL to GenBank

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -632,7 +632,7 @@ class GenBankWriter(_InsdcWriter):
                 warnings.warn("Molecule type %r too long" % mol_type,
                               BiopythonWarning)
                 mol_type = None
-        if mol_type == "protein":
+        if mol_type in ["protein", "PROTEIN"]:
             mol_type = ""
 
         if mol_type:


### PR DESCRIPTION
This an unreported issue.
GenBankWriter was crashing out when converting protein from EMBL format, because the mol_type variable in GenBankWriter._write_the_first_line() was only looking for 'protein' instead of ['protein', 'PROTEIN'].

Previous behaviour:

```python
from Bio import SeqIO
from Bio.Alphabet import IUPAC
from io import StringIO

input_file = """>XP_012056384.1
MNRKDREQIDHCCESIVSKIDLTKLLPKLLENKVYNRDDVNIPRWQENLLDHHIYSDEFF
SEPLIIEVCKATKFLDCEYDLIERYPMRSKPRGLVLIITNIYYELSYEKPRFSAKYDNNN
LKKLFEEMGFIVVIYQNLTGQAMKDIIKEFSKRDDLNKVDSCFVIVTSHGMEDEESNTEI
QGTDYHIASRQANYEKVLCTEVCDYFTAEACPQLAEKPKIFIFQLCRGKKKQNGVIHSRI
TTDSCAMKSTNEANIEIPRIQTIRNYSDMLIVQSTLPGYVSYRDSKTGSWFIQILCKIFM
KHAHENHVQDLFNMIDAELKNLRTTNHECQTSSVQSLGFNKHCYLNPGLFMES"""

input_file = StringIO(input_file)
fasta = next(SeqIO.parse(input_file, format="fasta", alphabet=IUPAC.protein))

embl_file = StringIO(fasta.format("embl"))
embl = next(SeqIO.parse(embl_file, format="embl", alphabet=IUPAC.protein))

gb_file = StringIO(embl.format("gb"))
print(next(SeqIO.parse(gb_file, format="gb", alphabet=IUPAC.protein)))
```

```text
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-1-71530c9f6fd1> in <module>()
     17 embl = next(SeqIO.parse(embl_file, format="embl", alphabet=IUPAC.protein))
     18 
---> 19 gb_file = StringIO(embl.format("gb"))
     20 next(SeqIO.parse(gb_file, format="gb", alphabet=IUPAC.protein))

~/anaconda/lib/python3.6/site-packages/Bio/SeqRecord.py in format(self, format)
    692         # See also the __format__ added for Python 2.6 / 3.0, PEP 3101
    693         # See also the Bio.Align.Generic.Alignment class and its format()
--> 694         return self.__format__(format)
    695 
    696     def __format__(self, format_spec):

~/anaconda/lib/python3.6/site-packages/Bio/SeqRecord.py in __format__(self, format_spec)
    716             from Bio._py3k import StringIO
    717             handle = StringIO()
--> 718         SeqIO.write(self, handle, format_spec)
    719         return handle.getvalue()
    720 

~/anaconda/lib/python3.6/site-packages/Bio/SeqIO/__init__.py in write(sequences, handle, format)
    495         if format in _FormatToWriter:
    496             writer_class = _FormatToWriter[format]
--> 497             count = writer_class(fp).write_file(sequences)
    498         elif format in AlignIO._FormatToWriter:
    499             # Try and turn all the records into a single alignment,

~/anaconda/lib/python3.6/site-packages/Bio/SeqIO/Interfaces.py in write_file(self, records)
    213         """
    214         self.write_header()
--> 215         count = self.write_records(records)
    216         self.write_footer()
    217         return count

~/anaconda/lib/python3.6/site-packages/Bio/SeqIO/Interfaces.py in write_records(self, records)
    198         count = 0
    199         for record in records:
--> 200             self.write_record(record)
    201             count += 1
    202         # Mark as true, even if there where no records

~/anaconda/lib/python3.6/site-packages/Bio/SeqIO/InsdcIO.py in write_record(self, record)
    813         """Write a single record to the output file."""
    814         handle = self.handle
--> 815         self._write_the_first_line(record)
    816 
    817         default = record.id

~/anaconda/lib/python3.6/site-packages/Bio/SeqIO/InsdcIO.py in _write_the_first_line(self, record)
    687             or 'DNA' in line[47:54].strip() \
    688             or 'RNA' in line[47:54].strip(), \
--> 689                'LOCUS line does not contain valid sequence type (DNA, RNA, ...):\n' + line
    690         assert line[54:55] == ' ', \
    691             'LOCUS line does not contain space at position 55:\n' + line

AssertionError: LOCUS line does not contain valid sequence type (DNA, RNA, ...):
LOCUS       XP_012056384             353 aa    PROTEIN          UNK 01-JAN-1980
```

After the fix, the expected output is given:
```text
ID: XP_012056384.1
Name: XP_012056384
Description: XP_012056384.1
Number of features: 0
/data_file_division=UNK
/date=01-JAN-1980
/accessions=['XP_012056384']
/sequence_version=1
/keywords=['']
/source=
/organism=.
/taxonomy=[]
Seq('MNRKDREQIDHCCESIVSKIDLTKLLPKLLENKVYNRDDVNIPRWQENLLDHHI...MES', IUPACProtein())
```

---

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
