### PR TITLE
SearchIO/hmmer2-text: Deal with line breaks in the end of sequence marker

### DIFF
--- a/Tests/Hmmer/README.txt
+++ b/Tests/Hmmer/README.txt
@@ -52,6 +52,7 @@ text_22_hmmpfam_001.out     single query, one match, bioperl's L77119.hmmer file
 text_23_hmmpfam_001.out     single query, multiple matches, bioperl's hmmpfam_cs.out file
 text_23_hmmpfam_002.out     single query, no match
 text_23_hmmpfam_003.out     single query, one match, missing some consensus content
+text_23_hmmpfam_004.out     single query, one match, line break in the end of sequence marker
 text_24_hmmpfam_001.out     multiple queries
 text_20_hmmsearch_001.out   single query, multiple matches, bioperl's hmmsearch.out file
 text_22_hmmsearch_001.out   single query, multiple matches, bioperl's cysprot1b.hmmsearch file

--- a/Tests/Hmmer/text_23_hmmpfam_004.out
+++ b/Tests/Hmmer/text_23_hmmpfam_004.out
@@ -1,0 +1,54 @@
+hmmpfam - search one or more sequences against HMM database
+HMMER 2.3.2 (Oct 2003)
+Copyright (C) 1992-2003 HHMI/Washington University School of Medicine
+Freely distributed under the GNU General Public License (GPL)
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+HMM file:                 antismash/modules/active_site_finder/data/PKSI-KS_N.hmm2
+Sequence file:            -
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+Query sequence: 0
+Accession:      [none]
+Description:    [none]
+
+Scores for sequence family classification (score includes all domains):
+Model    Description                                    Score    E-value  N 
+-------- -----------                                    -----    ------- ---
+PKSI-KS                                                 211.2    2.7e-64   1
+
+Parsed for domains:
+Model    Domain  seq-f seq-t    hmm-f hmm-t      score  E-value
+-------- ------- ----- -----    ----- -----      -----  -------
+PKSI-KS    1/1       1   275 [.     1   264 []   211.2  2.7e-64
+
+Alignments of top-scoring domains:
+PKSI-KS: domain 1 of 1, from 1 to 275: score 211.2, E = 2.7e-64
+                   *->epIAIVGmacRFPGgAdspeaFWelLleGrdaisevPadRwdadafy
+                        +A+VG +   PG A++++ +W+    Grd+i+evPa+Rw ++++y
+           0     1    --VAVVGVGALVPG-ATDAAGYWRVVTGGRDLITEVPASRWRVEDHY 44   
+
+                   dPdgerpGktytrwGgFLddvdlFDAaFFgISPrEAeaMDPQQRLLLEva
+                   dPd+++p+kty+r+G+FL++  +FD+   g++P+   a+D  Q L+L+va
+           0    45 DPDPAAPDKTYARRGAFLPE-VDFDPMAYGVPPANLPATDTSQLLALMVA 93   
+
+                   wEALEdAGippeslrGArhgerlgsrtGVFvGasssDYgdllplrdapdd
+                    + L dAG + + +           rtGV  Ga+  + +  +        
+           0    94 DQVLRDAGGT-SGIDR--------DRTGVVLGAAALELLPHM-YG----- 128  
+
+                   pedidaya...............................atGtarsilAN
+                   + + +a+  + ++++ ++ + +   ++   + ++ ++++ +G   +++A+
+           0   129 RSQRPAWLaglresgldeakaqavcdriaarfepwrestFPGLLGNVVAG 178  
+
+                   RiSYffdLrGPSltVDTACSSSLVAlHlACqsLrlsGEcdmAlaGGVNLi
+                   Ri+  fdL+G   t D+AC+SSL+Al  A+  L   + +d+ + GGV   
+           0   179 RIANRFDLHGVNHTTDAACASSLAALSTAVGELS-LHRADLVISGGVDTG 227  
+
+                   lsPdmfialsklgmLSPdGrCktFDarADGYvRGEGvGvVvLKRLsDA<-
+                    + +mf+++sk  +LSP G C++F ++ADG+  GE+v++  LKRLsDA  
+           0   228 NDIGMFLCFSKTPALSPSGDCRPFAEAADGTMLGEAVVMYALKRLSDA   275  
+
+                   *
+                    
+           0     -   -    
+
+//

--- a/Tests/Hmmer/text_23_hmmpfam_004.out
+++ b/Tests/Hmmer/text_23_hmmpfam_004.out
@@ -15,11 +15,13 @@ Scores for sequence family classification (score includes all domains):
 Model    Description                                    Score    E-value  N 
 -------- -----------                                    -----    ------- ---
 PKSI-KS                                                 211.2    2.7e-64   1
+PKSI-FK  Fake hit to test other line break              211.2    2.7e-64   1
 
 Parsed for domains:
 Model    Domain  seq-f seq-t    hmm-f hmm-t      score  E-value
 -------- ------- ----- -----    ----- -----      -----  -------
 PKSI-KS    1/1       1   275 [.     1   264 []   211.2  2.7e-64
+PKSI-FK    1/1       1   276 [.     1   265 []   211.2  2.7e-64
 
 Alignments of top-scoring domains:
 PKSI-KS: domain 1 of 1, from 1 to 275: score 211.2, E = 2.7e-64
@@ -50,5 +52,34 @@ PKSI-KS: domain 1 of 1, from 1 to 275: score 211.2, E = 2.7e-64
                    *
                     
            0     -   -    
+
+PKSI-FK: domain 1 of 1, from 1 to 276: score 211.2, E = 2.7e-64
+                   *->epIAIVGmacRFPGgAdspeaFWelLleGrdaisevPadRwdadafy
+                        +A+VG +   PG A++++ +W+    Grd+i+evPa+Rw ++++y
+           0     1    --VAVVGVGALVPG-ATDAAGYWRVVTGGRDLITEVPASRWRVEDHY 44   
+
+                   dPdgerpGktytrwGgFLddvdlFDAaFFgISPrEAeaMDPQQRLLLEva
+                   dPd+++p+kty+r+G+FL++  +FD+   g++P+   a+D  Q L+L+va
+           0    45 DPDPAAPDKTYARRGAFLPE-VDFDPMAYGVPPANLPATDTSQLLALMVA 93   
+
+                   wEALEdAGippeslrGArhgerlgsrtGVFvGasssDYgdllplrdapdd
+                    + L dAG + + +           rtGV  Ga+  + +  +        
+           0    94 DQVLRDAGGT-SGIDR--------DRTGVVLGAAALELLPHM-YG----- 128  
+
+                   pedidaya...............................atGtarsilAN
+                   + + +a+  + ++++ ++ + +   ++   + ++ ++++ +G   +++A+
+           0   129 RSQRPAWLaglresgldeakaqavcdriaarfepwrestFPGLLGNVVAG 178  
+
+                   RiSYffdLrGPSltVDTACSSSLVAlHlACqsLrlsGEcdmAlaGGVNLi
+                   Ri+  fdL+G   t D+AC+SSL+Al  A+  L   + +d+ + GGV   
+           0   179 RIANRFDLHGVNHTTDAACASSLAALSTAVGELS-LHRADLVISGGVDTG 227  
+
+                   lsPdmfialsklgmLSPdGrCktFDarADGYvRGEGvGvVvLKRLsDAR<
+                    + +mf+++sk  +LSP G C++F ++ADG+  GE+v++  LKRLsDAR 
+           0   228 NDIGMFLCFSKTPALSPSGDCRPFAEAADGTMLGEAVVMYALKRLSDAR  276  
+
+                   -*
+                     
+           0     -    -    
 
 //

--- a/Tests/test_SearchIO_hmmer2_text.py
+++ b/Tests/test_SearchIO_hmmer2_text.py
@@ -212,6 +212,14 @@ class HmmpfamTests(unittest.TestCase):
         self.assertEqual('-------CFL---------------------------GCLVTNWVLNRS-----------------',
                          str(hsp.query.seq))
 
+    def test_hmmpfam_23_break_in_end_of_seq(self):
+        """Test parsing hmmpfam 2.3 file with a line break in the end of seq marker.
+
+        file (text_23_hmmpfam_004.out)
+        """
+        results = list(parse(path.join("Hmmer", "text_23_hmmpfam_004.out"), self.fmt))
+        self.assertEqual(1, len(results))
+
     def test_hmmpfam_24(self):
         """Test parsing hmmpfam 2.4 file (text_24_hmmpfam_001.out)"""
         results = list(parse(path.join("Hmmer", "text_24_hmmpfam_001.out"), self.fmt))

--- a/Tests/test_SearchIO_hmmer2_text.py
+++ b/Tests/test_SearchIO_hmmer2_text.py
@@ -217,8 +217,10 @@ class HmmpfamTests(unittest.TestCase):
 
         file (text_23_hmmpfam_004.out)
         """
-        results = list(parse(path.join("Hmmer", "text_23_hmmpfam_004.out"), self.fmt))
-        self.assertEqual(1, len(results))
+        results = parse(path.join("Hmmer", "text_23_hmmpfam_004.out"), self.fmt)
+        res = next(results)
+        self.assertEqual('PKSI-KS', res[0].id)
+        self.assertEqual('PKSI-FK', res[1].id)
 
     def test_hmmpfam_24(self):
         """Test parsing hmmpfam 2.4 file (text_24_hmmpfam_001.out)"""


### PR DESCRIPTION
Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>

This pull request addresses issue #1564

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
