### PR TITLE
Avoid blank PHYLIP lines if length multiple of 50

### DIFF
--- a/Bio/AlignIO/PhylipIO.py
+++ b/Bio/AlignIO/PhylipIO.py
@@ -145,7 +145,7 @@ class PhylipWriter(SequentialAlignmentWriter):
                         break
                 handle.write("\n")
             block += 1
-            if block * 50 > length_of_seqs:
+            if block * 50 >= length_of_seqs:
                 break
             handle.write("\n")
 


### PR DESCRIPTION
This closes issue #1556.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.