### PR TITLE
Add API key usage on Bio.Entrez module

### DIFF
--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -110,6 +110,7 @@ from Bio._py3k import _binary_to_string_handle, _as_bytes
 
 email = None
 tool = "biopython"
+api_key = None
 
 
 # XXX retmode?
@@ -509,24 +510,14 @@ def _open(cgi, params=None, post=None, ecitmatch=False):
     # Equivalently, at least a third of second between queries
     params = _construct_params(params)
     options = _encode_options(ecitmatch, params)
-    if params['api_key'] is None:
-        delay = 0.333333334
-        current = time.time()
-        wait = _open.previous + delay - current
-        if wait > 0:
-            time.sleep(wait)
-            _open.previous = current + wait
-        else:
-            _open.previous = current
+    delay = 0.1 if api_key else 0.333333334
+    current = time.time()
+    wait = _open.previous + delay - current
+    if wait > 0:
+        time.sleep(wait)
+        _open.previous = current + wait
     else:
-        delay = 0.1
-        current = time.time()
-        wait = _open.previous + delay - current
-        if wait > 0:
-            time.sleep(wait)
-            _open.previous = current + wait
-        else:
-            _open.previous = current
+        _open.previous = current
 
     # By default, post is None. Set to a boolean to over-ride length choice:
     if post is None and len(options) > 1000:
@@ -575,6 +566,8 @@ is A.N.Other@example.com, you can specify it as follows:
 In case of excessive usage of the E-utilities, NCBI will attempt to contact
 a user at the email address provided before blocking access to the
 E-utilities.""", UserWarning)
+    if "api_key" not in params:
+        params["api_key"] = api_key
     return params
 
 

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -48,6 +48,15 @@ To paraphrase:
 \end{verbatim}
 The tool parameter will default to Biopython.
 \item For large queries, the NCBI also recommend using their session history feature (the WebEnv session cookie string, see Section~\ref{sec:entrez-webenv}).  This is only slightly more complicated.
+\item After May 1, 2018, NCBI will limit access to the E-utilities unless one have an API key (more info at \url{https://ncbiinsights.ncbi.nlm.nih.gov/2017/11/02/new-api-keys-for-the-e-utilities/}).
+Without a valid key, a maximum of 3 queries per second is allowed. With a valid key, this limit can be increased to 10 queries per second. The \verb|Bio.Entrez| module handles the limit automatically when the right parameter is specified in any E-utility (include {\tt api_key="MyAPIkey"} in the argument list):
+%doctest
+\begin{verbatim}
+>>> from Bio import Entrez
+>>> Entrez.email = "A.N.Other@example.com"
+>>> handle = Entrez.efetch(db='protein', id='15718680,157427902,119703751',
+                               retmode='xml', api_key="MyAPIkey")
+\end{verbatim}
 \end{itemize}
 
 In conclusion, be sensible with your usage levels.  If you plan to download lots of data, consider other options.  For example, if you want easy access to all the human genes, consider fetching each chromosome by FTP as a GenBank file, and importing these into your own BioSQL database (see Section~\ref{sec:BioSQL}).

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -49,13 +49,11 @@ To paraphrase:
 The tool parameter will default to Biopython.
 \item For large queries, the NCBI also recommend using their session history feature (the WebEnv session cookie string, see Section~\ref{sec:entrez-webenv}).  This is only slightly more complicated.
 \item After May 1, 2018, NCBI will limit access to the E-utilities unless one have an API key (more info at \url{https://ncbiinsights.ncbi.nlm.nih.gov/2017/11/02/new-api-keys-for-the-e-utilities/}).
-Without a valid key, a maximum of 3 queries per second is allowed. With a valid key, this limit can be increased to 10 queries per second. The \verb|Bio.Entrez| module handles the limit automatically when the right parameter is specified in any E-utility (include {\tt api_key="MyAPIkey"} in the argument list):
+Without a valid key, a maximum of 3 queries per second is allowed. With a valid key, this limit can be increased to 10 queries per second. The \verb|Bio.Entrez| module handles the limit automatically when the key is specified in any E-utility. Include {\tt api_key="MyAPIkey"} in the argument list or set it as a global variable:
 %doctest
 \begin{verbatim}
 >>> from Bio import Entrez
->>> Entrez.email = "A.N.Other@example.com"
->>> handle = Entrez.efetch(db='protein', id='15718680,157427902,119703751',
-                               retmode='xml', api_key="MyAPIkey")
+>>> Entrez.api_key = "MyAPIkey"
 \end{verbatim}
 \end{itemize}
 

--- a/Tests/test_Entrez.py
+++ b/Tests/test_Entrez.py
@@ -12,11 +12,12 @@ from Bio import Entrez
 
 
 # This lets us set the email address to be sent to NCBI Entrez:
-Entrez.email = "biopython-dev@biopython.org"
+Entrez.email = "biopython@biopython.org"
 
 URL_HEAD = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
 URL_TOOL = "tool=biopython"
-URL_EMAIL = "email=biopython-dev%40biopython.org"
+URL_EMAIL = "email=biopython%40biopython.org"
+API_KEY = "5cfd4026f9df285d6cfc723c662d74bcbe09"
 
 
 class TestURLConstruction(unittest.TestCase):
@@ -40,9 +41,11 @@ class TestURLConstruction(unittest.TestCase):
         post = False
 
         params = Entrez._construct_params(variables)
+        params['api_key'] = API_KEY
         options = Entrez._encode_options(ecitmatch=True, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
         self.assertIn("retmode=xml", result_url)
+        self.assertIn(API_KEY, result_url)
 
     def test_construct_cgi_einfo(self):
         """Test constructed url for request to Entrez."""
@@ -83,6 +86,7 @@ class TestURLConstruction(unittest.TestCase):
         post = False
 
         params = Entrez._construct_params(variables)
+        params['api_key'] = API_KEY
         options = Entrez._encode_options(ecitmatch=False, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
         self.assertTrue(result_url.startswith(URL_HEAD + "elink.fcgi?"),
@@ -90,6 +94,7 @@ class TestURLConstruction(unittest.TestCase):
         self.assertIn(URL_TOOL, result_url)
         self.assertIn(URL_EMAIL, result_url)
         self.assertIn("id=22347800%2C48526535", result_url)
+        self.assertIn(API_KEY, result_url)
 
     def test_construct_cgi_elink2(self):
         """Commas: Link from protein to gene."""
@@ -99,6 +104,7 @@ class TestURLConstruction(unittest.TestCase):
         post = False
 
         params = Entrez._construct_params(variables)
+        params['api_key'] = API_KEY
         options = Entrez._encode_options(ecitmatch=False, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
         self.assertTrue(result_url.startswith(URL_HEAD + "elink.fcgi"),
@@ -107,6 +113,7 @@ class TestURLConstruction(unittest.TestCase):
         self.assertIn(URL_EMAIL, result_url)
         self.assertTrue("id=15718680%2C157427902%2C119703751" in result_url,
                         result_url)
+        self.assertIn(API_KEY, result_url)
 
     def test_construct_cgi_elink3(self):
         """Multiple ID entries: Find one-to-one links from protein to gene."""
@@ -116,6 +123,7 @@ class TestURLConstruction(unittest.TestCase):
         post = False
 
         params = Entrez._construct_params(variables)
+        params['api_key'] = API_KEY
         options = Entrez._encode_options(ecitmatch=False, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
         self.assertTrue(result_url.startswith(URL_HEAD + "elink.fcgi"),
@@ -125,6 +133,7 @@ class TestURLConstruction(unittest.TestCase):
         self.assertIn("id=15718680", result_url)
         self.assertIn("id=157427902", result_url)
         self.assertIn("id=119703751", result_url)
+        self.assertIn(API_KEY, result_url)
 
     def test_construct_cgi_efetch(self):
         cgi = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi'
@@ -133,6 +142,7 @@ class TestURLConstruction(unittest.TestCase):
         post = False
 
         params = Entrez._construct_params(variables)
+        params['api_key'] = API_KEY
         options = Entrez._encode_options(ecitmatch=False, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
         self.assertTrue(result_url.startswith(URL_HEAD + "efetch.fcgi?"),
@@ -141,6 +151,7 @@ class TestURLConstruction(unittest.TestCase):
         self.assertIn(URL_EMAIL, result_url)
         self.assertTrue("id=15718680%2C157427902%2C119703751" in result_url,
                         result_url)
+        self.assertIn(API_KEY, result_url)
 
 
 if __name__ == "__main__":

--- a/Tests/test_Entrez.py
+++ b/Tests/test_Entrez.py
@@ -13,11 +13,12 @@ from Bio import Entrez
 
 # This lets us set the email address to be sent to NCBI Entrez:
 Entrez.email = "biopython@biopython.org"
+Entrez.api_key = "5cfd4026f9df285d6cfc723c662d74bcbe09"
 
 URL_HEAD = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
 URL_TOOL = "tool=biopython"
 URL_EMAIL = "email=biopython%40biopython.org"
-API_KEY = "5cfd4026f9df285d6cfc723c662d74bcbe09"
+URL_API_KEY = "api_key=5cfd4026f9df285d6cfc723c662d74bcbe09"
 
 
 class TestURLConstruction(unittest.TestCase):
@@ -41,11 +42,10 @@ class TestURLConstruction(unittest.TestCase):
         post = False
 
         params = Entrez._construct_params(variables)
-        params['api_key'] = API_KEY
         options = Entrez._encode_options(ecitmatch=True, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
         self.assertIn("retmode=xml", result_url)
-        self.assertIn(API_KEY, result_url)
+        self.assertIn(URL_API_KEY, result_url)
 
     def test_construct_cgi_einfo(self):
         """Test constructed url for request to Entrez."""
@@ -86,7 +86,6 @@ class TestURLConstruction(unittest.TestCase):
         post = False
 
         params = Entrez._construct_params(variables)
-        params['api_key'] = API_KEY
         options = Entrez._encode_options(ecitmatch=False, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
         self.assertTrue(result_url.startswith(URL_HEAD + "elink.fcgi?"),
@@ -94,7 +93,7 @@ class TestURLConstruction(unittest.TestCase):
         self.assertIn(URL_TOOL, result_url)
         self.assertIn(URL_EMAIL, result_url)
         self.assertIn("id=22347800%2C48526535", result_url)
-        self.assertIn(API_KEY, result_url)
+        self.assertIn(URL_API_KEY, result_url)
 
     def test_construct_cgi_elink2(self):
         """Commas: Link from protein to gene."""
@@ -104,7 +103,6 @@ class TestURLConstruction(unittest.TestCase):
         post = False
 
         params = Entrez._construct_params(variables)
-        params['api_key'] = API_KEY
         options = Entrez._encode_options(ecitmatch=False, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
         self.assertTrue(result_url.startswith(URL_HEAD + "elink.fcgi"),
@@ -113,7 +111,7 @@ class TestURLConstruction(unittest.TestCase):
         self.assertIn(URL_EMAIL, result_url)
         self.assertTrue("id=15718680%2C157427902%2C119703751" in result_url,
                         result_url)
-        self.assertIn(API_KEY, result_url)
+        self.assertIn(URL_API_KEY, result_url)
 
     def test_construct_cgi_elink3(self):
         """Multiple ID entries: Find one-to-one links from protein to gene."""
@@ -123,7 +121,6 @@ class TestURLConstruction(unittest.TestCase):
         post = False
 
         params = Entrez._construct_params(variables)
-        params['api_key'] = API_KEY
         options = Entrez._encode_options(ecitmatch=False, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
         self.assertTrue(result_url.startswith(URL_HEAD + "elink.fcgi"),
@@ -133,7 +130,7 @@ class TestURLConstruction(unittest.TestCase):
         self.assertIn("id=15718680", result_url)
         self.assertIn("id=157427902", result_url)
         self.assertIn("id=119703751", result_url)
-        self.assertIn(API_KEY, result_url)
+        self.assertIn(URL_API_KEY, result_url)
 
     def test_construct_cgi_efetch(self):
         cgi = 'http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi'
@@ -142,7 +139,6 @@ class TestURLConstruction(unittest.TestCase):
         post = False
 
         params = Entrez._construct_params(variables)
-        params['api_key'] = API_KEY
         options = Entrez._encode_options(ecitmatch=False, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
         self.assertTrue(result_url.startswith(URL_HEAD + "efetch.fcgi?"),
@@ -151,7 +147,7 @@ class TestURLConstruction(unittest.TestCase):
         self.assertIn(URL_EMAIL, result_url)
         self.assertTrue("id=15718680%2C157427902%2C119703751" in result_url,
                         result_url)
-        self.assertIn(API_KEY, result_url)
+        self.assertIn(URL_API_KEY, result_url)
 
 
 if __name__ == "__main__":

--- a/Tests/test_Entrez_online.py
+++ b/Tests/test_Entrez_online.py
@@ -37,11 +37,12 @@ if os.name == 'java':
 
 
 # This lets us set the email address to be sent to NCBI Entrez:
-Entrez.email = "biopython-dev@biopython.org"
+Entrez.email = "biopython@biopython.org"
 
 URL_HEAD = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
 URL_TOOL = "tool=biopython"
-URL_EMAIL = "email=biopython-dev%40biopython.org"
+URL_EMAIL = "email=biopython%40biopython.org"
+API_KEY = "5cfd4026f9df285d6cfc723c662d74bcbe09"
 
 
 class EntrezOnlineCase(unittest.TestCase):
@@ -62,10 +63,11 @@ class EntrezOnlineCase(unittest.TestCase):
     def test_parse_from_url(self):
         """Test Entrez.parse from URL"""
         handle = Entrez.efetch(db='protein', id='15718680,157427902,119703751',
-                               retmode='xml')
+                               retmode='xml', api_key=API_KEY)
         self.assertTrue(handle.url.startswith(URL_HEAD + "efetch.fcgi?"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
+        self.assertIn(API_KEY, handle.url)
         self.assertIn("id=15718680%2C157427902%2C119703751", handle.url)
         recs = list(Entrez.parse(handle))
         handle.close()
@@ -77,10 +79,11 @@ class EntrezOnlineCase(unittest.TestCase):
         """Test Entrez.search from link webenv history"""
         handle = Entrez.elink(db='nucleotide', dbfrom='protein',
                               id='22347800,48526535', webenv=None, query_key=None,
-                              cmd='neighbor_history')
+                              cmd='neighbor_history', api_key=API_KEY)
         self.assertTrue(handle.url.startswith(URL_HEAD + "elink.fcgi?"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
+        self.assertIn(API_KEY, handle.url)
         self.assertIn("id=22347800%2C48526535", handle.url)
         recs = Entrez.read(handle)
         handle.close()
@@ -91,10 +94,11 @@ class EntrezOnlineCase(unittest.TestCase):
         handle = Entrez.esearch(db='nucleotide', term=None,
                                 retstart=0, retmax=10,
                                 webenv=webenv, query_key=query_key,
-                                usehistory='y')
+                                usehistory='y', api_key=API_KEY)
         self.assertTrue(handle.url.startswith(URL_HEAD + "esearch.fcgi?"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
+        self.assertIn(API_KEY, handle.url)
         search_record = Entrez.read(handle)
         handle.close()
         self.assertEqual(2, len(search_record['IdList']))

--- a/Tests/test_Entrez_online.py
+++ b/Tests/test_Entrez_online.py
@@ -38,11 +38,12 @@ if os.name == 'java':
 
 # This lets us set the email address to be sent to NCBI Entrez:
 Entrez.email = "biopython@biopython.org"
+Entrez.api_key = "5cfd4026f9df285d6cfc723c662d74bcbe09"
 
 URL_HEAD = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/"
 URL_TOOL = "tool=biopython"
 URL_EMAIL = "email=biopython%40biopython.org"
-API_KEY = "5cfd4026f9df285d6cfc723c662d74bcbe09"
+URL_API_KEY = "api_key=5cfd4026f9df285d6cfc723c662d74bcbe09"
 
 
 class EntrezOnlineCase(unittest.TestCase):
@@ -53,6 +54,7 @@ class EntrezOnlineCase(unittest.TestCase):
         self.assertTrue(handle.url.startswith(URL_HEAD + "einfo.fcgi?"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
+        self.assertIn(URL_API_KEY, handle.url)
         rec = Entrez.read(handle)
         handle.close()
         self.assertTrue(isinstance(rec, dict))
@@ -63,11 +65,11 @@ class EntrezOnlineCase(unittest.TestCase):
     def test_parse_from_url(self):
         """Test Entrez.parse from URL"""
         handle = Entrez.efetch(db='protein', id='15718680,157427902,119703751',
-                               retmode='xml', api_key=API_KEY)
+                               retmode='xml')
         self.assertTrue(handle.url.startswith(URL_HEAD + "efetch.fcgi?"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
-        self.assertIn(API_KEY, handle.url)
+        self.assertIn(URL_API_KEY, handle.url)
         self.assertIn("id=15718680%2C157427902%2C119703751", handle.url)
         recs = list(Entrez.parse(handle))
         handle.close()
@@ -79,11 +81,11 @@ class EntrezOnlineCase(unittest.TestCase):
         """Test Entrez.search from link webenv history"""
         handle = Entrez.elink(db='nucleotide', dbfrom='protein',
                               id='22347800,48526535', webenv=None, query_key=None,
-                              cmd='neighbor_history', api_key=API_KEY)
+                              cmd='neighbor_history')
         self.assertTrue(handle.url.startswith(URL_HEAD + "elink.fcgi?"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
-        self.assertIn(API_KEY, handle.url)
+        self.assertIn(URL_API_KEY, handle.url)
         self.assertIn("id=22347800%2C48526535", handle.url)
         recs = Entrez.read(handle)
         handle.close()
@@ -94,11 +96,11 @@ class EntrezOnlineCase(unittest.TestCase):
         handle = Entrez.esearch(db='nucleotide', term=None,
                                 retstart=0, retmax=10,
                                 webenv=webenv, query_key=query_key,
-                                usehistory='y', api_key=API_KEY)
+                                usehistory='y')
         self.assertTrue(handle.url.startswith(URL_HEAD + "esearch.fcgi?"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
-        self.assertIn(API_KEY, handle.url)
+        self.assertIn(URL_API_KEY, handle.url)
         search_record = Entrez.read(handle)
         handle.close()
         self.assertEqual(2, len(search_record['IdList']))
@@ -110,6 +112,7 @@ class EntrezOnlineCase(unittest.TestCase):
         self.assertTrue(handle.url.startswith(URL_HEAD + "efetch.fcgi?"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
+        self.assertIn(URL_API_KEY, handle.url)
         self.assertIn("id=186972394", handle.url)
         record = SeqIO.read(handle, 'genbank')
         handle.close()
@@ -124,6 +127,7 @@ class EntrezOnlineCase(unittest.TestCase):
         self.assertTrue(handle.url.startswith(URL_HEAD + "efetch.fcgi?"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
+        self.assertIn(URL_API_KEY, handle.url)
         self.assertIn("id=19304878", handle.url)
         record = Medline.read(handle)
         handle.close()
@@ -156,6 +160,7 @@ class EntrezOnlineCase(unittest.TestCase):
         self.assertTrue(handle.url.startswith(URL_HEAD + "elink.fcgi"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
+        self.assertIn(URL_API_KEY, handle.url)
         self.assertIn("id=15718680%2C157427902%2C119703751", handle.url)
         handle.close()
 
@@ -165,6 +170,7 @@ class EntrezOnlineCase(unittest.TestCase):
         self.assertTrue(handle.url.startswith(URL_HEAD + "elink.fcgi"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
+        self.assertIn(URL_API_KEY, handle.url)
         self.assertIn("id=15718680", handle.url)
         self.assertIn("id=157427902", handle.url)
         self.assertIn("id=119703751", handle.url)
@@ -228,6 +234,7 @@ class EntrezOnlineCase(unittest.TestCase):
             self.assertTrue(handle.url.startswith(URL_HEAD + "efetch.fcgi?"), handle.url)
             self.assertIn(URL_TOOL, handle.url)
             self.assertIn(URL_EMAIL, handle.url)
+            self.assertIn(URL_API_KEY, handle.url)
             self.assertIn("id=200079209", handle.url)
             result = handle.read()
             expected_result = u'“field of injury”'  # Use of Unicode double qoutation marks U+201C and U+201D


### PR DESCRIPTION
This pull request addresses issue #1440

A test API key has been created for Biopython an associated to `biopython owner at ...`

`Bio/Entrez/__init__.py` has been modified to check the presence of `api_key` parameter. If it is present, 10 queries/seconds are allowed; the default 3 queries/second is maintained otherwise.

`Tests/test_Entrez.py` and `Tests/test_Entrez_online.py` have a couple of tests edited to check the presence of the `api_key` parameter when the URL is built and the queries are run online. 

A small warning here. Even if the online test is not run, there is an exception error:

```
======================================================================
FAIL: test_efetch_gds_utf8 (test_Entrez_online.EntrezOnlineCase)
Test correct handling of encodings in Entrez.efetch
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/gasta/Documents/GitHub/biopython/Tests/test_Entrez_online.py", line 234, in test_efetch_gds_utf8
    self.assertEqual(result[342:359], expected_result)
AssertionError: '\xe2\x80\x9cfield of injur' != u'\u201cfield of injury\u201d'

----------------------------------------------------------------------
Ran 22 tests in 17.601s

FAILED (failures=1)
[Finished in 18.014s]
```

It looks like that this test result might change with future updates. Any thoughts?