### PR TITLE
use the buffer protocol instead of numpy arrays directly

### DIFF
--- a/Bio/motifs/_pwm.c
+++ b/Bio/motifs/_pwm.c
@@ -1,36 +1,17 @@
 #include <Python.h>
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include "numpy/arrayobject.h"
 
 
-
-static PyObject*
-calculate(const char sequence[], int s, PyObject* matrix, npy_intp m)
+static void
+calculate(const char sequence[], int s, Py_ssize_t m, double* matrix,
+          Py_ssize_t n, float* scores)
 {
-    npy_intp n = s - m + 1;
-    npy_intp i, j;
+    Py_ssize_t i, j;
     char c;
     double score;
     int ok;
-    PyObject* result;
-    PyArrayObject* array;
-    float* p;
-    npy_intp shape = (npy_intp)n;
+    float* p = scores;
     float nan = 0.0;
     nan /= nan;
-    if ((int)shape!=n)
-    {
-        PyErr_SetString(PyExc_ValueError, "integer overflow");
-        return NULL;
-    }
-    result = PyArray_SimpleNew(1, &shape, NPY_FLOAT32);
-    if (!result)
-    {
-        PyErr_SetString(PyExc_MemoryError, "failed to create output data");
-        return NULL;
-    }
-    p = PyArray_DATA((PyArrayObject*)result);
-    array = (PyArrayObject*)matrix;
     for (i = 0; i < n; i++)
     {
         score = 0.0;
@@ -46,16 +27,16 @@ calculate(const char sequence[], int s, PyObject* matrix, npy_intp m)
                  plasmid). */
                 case 'A':
                 case 'a':
-                    score += *((double*)PyArray_GETPTR2(array, j, 0)); break;
+                    score += matrix[j*4+0]; break;
                 case 'C':
                 case 'c':
-                    score += *((double*)PyArray_GETPTR2(array, j, 1)); break;
+                    score += matrix[j*4+1]; break;
                 case 'G':
                 case 'g':
-                    score += *((double*)PyArray_GETPTR2(array, j, 2)); break;
+                    score += matrix[j*4+2]; break;
                 case 'T':
                 case 't':
-                    score += *((double*)PyArray_GETPTR2(array, j, 3)); break;
+		    score += matrix[j*4+3]; break;
                 default:
                     ok = 0;
             }
@@ -64,7 +45,79 @@ calculate(const char sequence[], int s, PyObject* matrix, npy_intp m)
         else *p = nan;
         p++;
     }
-    return result;
+}
+
+static int
+matrix_converter(PyObject* object, void* address)
+{
+    const int flags = PyBUF_C_CONTIGUOUS | PyBUF_FORMAT;
+    char datatype;
+    Py_buffer* view = address;
+    if (PyObject_GetBuffer(object, view, flags) == -1) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "position-weight matrix is not an array");
+        return 0;
+    }
+    datatype = view->format[0];
+    switch (datatype) {
+        case '@':
+        case '=':
+        case '<':
+        case '>':
+        case '!': datatype = view->format[1]; break;
+        default: break;
+    }
+    if (datatype != 'd') {
+        PyErr_Format(PyExc_RuntimeError,
+            "position-weight matrix data format incorrect ('%c', expected 'd')",
+            datatype);
+        return 0;
+    }
+    if (view->ndim != 2) {
+        PyErr_Format(PyExc_RuntimeError,
+            "position-weight matrix has incorrect rank (%d expected 2)",
+            view->ndim);
+        return 0;
+    }
+    if (view->shape[1] != 4) {
+        PyErr_Format(PyExc_RuntimeError,
+            "position-weight matrix should have four columns "
+            "(%zd columns found)", view->shape[1]);
+        return 0;
+    }
+    return 1;
+}
+
+static int
+scores_converter(PyObject* object, void* address)
+{
+    const int flags = PyBUF_C_CONTIGUOUS | PyBUF_FORMAT;
+    char datatype;
+    Py_buffer* view = address;
+    if (PyObject_GetBuffer(object, view, flags) == -1)
+        return 0;
+    datatype = view->format[0];
+    switch (datatype) {
+        case '@':
+        case '=':
+        case '<':
+        case '>':
+        case '!': datatype = view->format[1]; break;
+        default: break;
+    }
+    if (datatype != 'f') {
+        PyErr_Format(PyExc_RuntimeError,
+            "scores array has incorrect data format ('%c', expected 'f')",
+            datatype);
+        return 0;
+    }
+    if (view->ndim != 1) {
+        PyErr_Format(PyExc_ValueError,
+            "scores array has incorrect rank (%d expected 1)",
+            view->ndim);
+        return 0;
+    }
+    return 1;
 }
 
 static char calculate__doc__[] =
@@ -78,46 +131,35 @@ static PyObject*
 py_calculate(PyObject* self, PyObject* args, PyObject* keywords)
 {
     const char* sequence;
-    PyObject* matrix = NULL;
-    static char* kwlist[] = {"sequence", "matrix", NULL};
-    npy_intp m;
+    static char* kwlist[] = {"sequence", "matrix", "scores", NULL};
+    Py_ssize_t m;
+    Py_ssize_t n;
     int s;
-    PyObject* result;
-    PyArrayObject* array;
-    if(!PyArg_ParseTupleAndKeywords(args, keywords, "s#O&", kwlist,
+    PyObject* result = NULL;
+    Py_buffer scores;
+    Py_buffer matrix;
+    matrix.obj = NULL;
+    scores.obj = NULL;
+    if(!PyArg_ParseTupleAndKeywords(args, keywords, "s#O&O&", kwlist,
                                     &sequence,
                                     &s,
-                                    PyArray_Converter,
-                                    &matrix)) return NULL;
-
-    array = (PyArrayObject*) matrix;
-    if (PyArray_TYPE(array) != NPY_DOUBLE)
-    {
-        PyErr_SetString(PyExc_ValueError,
-            "position-weight matrix should contain floating-point values");
-        result = NULL;
+                                    matrix_converter, &matrix,
+                                    scores_converter, &scores)) goto exit;
+    m = matrix.shape[0];
+    n = scores.shape[0];
+    if (n != s - m + 1) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "size of scores array is inconsistent");
+        goto exit;
     }
-    else if (PyArray_NDIM(array) != 2) /* Checking number of dimensions */
-    {
-        result = PyErr_Format(PyExc_ValueError,
-            "position-weight matrix has incorrect rank (%d expected 2)",
-            PyArray_NDIM(array));
-    }
-    else if(PyArray_DIM(array, 1) != 4)
-    {
-        result = PyErr_Format(PyExc_ValueError,
-            "position-weight matrix should have four columns (%" NPY_INTP_FMT
-            " columns found)", PyArray_DIM(array, 1));
-    }
-    else
-    {
-        m = PyArray_DIM(array, 0);
-        result = calculate(sequence, s, matrix, m);
-    }
-    Py_DECREF(matrix);
+    calculate(sequence, s, m, matrix.buf, n, scores.buf);
+    Py_INCREF(Py_None);
+    result = Py_None;
+exit:
+    if (matrix.obj) PyBuffer_Release(&matrix);
+    if (scores.obj) PyBuffer_Release(&scores);
     return result;
 }
-
 
 static struct PyMethodDef methods[] = {
    {"calculate", (PyCFunction)py_calculate, METH_VARARGS | METH_KEYWORDS, calculate__doc__},
@@ -148,9 +190,6 @@ void init_pwm(void)
 #endif
 {
   PyObject *m;
-
-  import_array();
-
 #if PY_MAJOR_VERSION >= 3
   m = PyModule_Create(&moduledef);
   if (m==NULL) return NULL;

--- a/Bio/motifs/_pwm.c
+++ b/Bio/motifs/_pwm.c
@@ -36,7 +36,7 @@ calculate(const char sequence[], int s, Py_ssize_t m, double* matrix,
                     score += matrix[j*4+2]; break;
                 case 'T':
                 case 't':
-		    score += matrix[j*4+3]; break;
+                    score += matrix[j*4+3]; break;
                 default:
                     ok = 0;
             }

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -32,7 +32,7 @@ try:
         n = len(sequence)
         # Create the numpy arrays here; the C module then does not rely on numpy
         # Use a float32 for the scores array to save space
-        scores = numpy.empty(n-m+1, numpy.float32)
+        scores = numpy.empty(n - m + 1, numpy.float32)
         logodds = numpy.array([[score_dict[letter][i] for letter in "ACGT"]
                                for i in range(m)], float)
         _pwm.calculate(sequence, logodds, scores)

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -22,26 +22,35 @@ from Bio import Alphabet
 # Fall back to the slower Python implementation if Jython or IronPython.
 try:
     from . import _pwm
+    import numpy
+    # We could further generalize this code by using array objects from
+    # the Python standard library instead of numpy arrays; this would still
+    # allow us to use the C module.
 
-    def _calculate(score_dict, sequence, m, n):
+    def _calculate(score_dict, sequence, m):
         """Calculate scores using C code (PRIVATE)."""
-        logodds = [[score_dict[letter][i] for letter in "ACGT"] for i in range(m)]
-        return _pwm.calculate(sequence, logodds)
+        n = len(sequence)
+        # Create the numpy arrays here; the C module then does not rely on numpy
+        # Use a float32 for the scores array to save space
+        scores = numpy.empty(n-m+1, numpy.float32)
+        logodds = numpy.array([[score_dict[letter][i] for letter in "ACGT"]
+                               for i in range(m)], float)
+        _pwm.calculate(sequence, logodds, scores)
+        return scores
 
 except ImportError:
     if platform.python_implementation() == 'CPython':
         import warnings
         from Bio import BiopythonWarning
-        warnings.warn("Using pure-Python as missing Biopython's C code for PWM. "
-                      "This can happen if Biopython was installed without NumPy. "
-                      "Try re-installing NumPy and then Biopython.",
+        warnings.warn("Using pure-Python as missing Biopython's C code for PWM.",
                       BiopythonWarning)
 
-    def _calculate(score_dict, sequence, m, n):
+    def _calculate(score_dict, sequence, m):
         """Calculate scores using Python code (PRIVATE).
 
         The C code handles mixed case so Python version must too.
         """
+        n = len(sequence)
         sequence = sequence.upper()
         scores = []
         for i in range(n - m + 1):
@@ -394,9 +403,7 @@ class PositionSpecificScoringMatrix(GenericPositionMatrix):
         # case would impose an overhead to allocate the extra memory.
         sequence = str(sequence)
         m = self.length
-        n = len(sequence)
-
-        scores = _calculate(self, sequence, m, n)
+        scores = _calculate(self, sequence, m)
 
         if len(scores) == 1:
             return scores[0]

--- a/setup.py
+++ b/setup.py
@@ -373,6 +373,9 @@ elif is_pypy():
     Extension('Bio.Nexus.cnexus',
               ['Bio/Nexus/cnexus.c']
               ),
+    Extension('Bio.motifs._pwm',
+              ["Bio/motifs/_pwm.c"],
+              ),
     ]
 else:
     EXTENSIONS = [
@@ -386,6 +389,9 @@ else:
               ),
     Extension('Bio.Nexus.cnexus',
               ['Bio/Nexus/cnexus.c']
+              ),
+    Extension('Bio.motifs._pwm',
+              ["Bio/motifs/_pwm.c"],
               ),
     ]
 
@@ -403,11 +409,6 @@ if is_Numpy_installed():
         Extension('Bio.KDTree._CKDTree',
                   ["Bio/KDTree/KDTree.c",
                    "Bio/KDTree/KDTreemodule.c"],
-                  include_dirs=[numpy_include_dir],
-                  ))
-    EXTENSIONS.append(
-        Extension('Bio.motifs._pwm',
-                  ["Bio/motifs/_pwm.c"],
                   include_dirs=[numpy_include_dir],
                   ))
     EXTENSIONS.append(


### PR DESCRIPTION
In this pull request, the C code implementing fast position-weight matrix score calculations was changed to use Python's buffer protocol instead of using numpy arrays directly. This means that the C code can be compiled without numpy being installed. As soon as numpy is installed, the fast C code becomes available without having to recompile Biopython.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
