### PR TITLE
qcprot does not need numpy at compile time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -373,6 +373,9 @@ elif is_pypy():
     Extension('Bio.Nexus.cnexus',
               ['Bio/Nexus/cnexus.c']
               ),
+    Extension('Bio.PDB.QCPSuperimposer.qcprotmodule',
+              ["Bio/PDB/QCPSuperimposer/qcprotmodule.c"],
+              ),
     ]
 else:
     EXTENSIONS = [
@@ -386,6 +389,9 @@ else:
               ),
     Extension('Bio.Nexus.cnexus',
               ['Bio/Nexus/cnexus.c']
+              ),
+    Extension('Bio.PDB.QCPSuperimposer.qcprotmodule',
+              ["Bio/PDB/QCPSuperimposer/qcprotmodule.c"],
               ),
     ]
 
@@ -408,11 +414,6 @@ if is_Numpy_installed():
     EXTENSIONS.append(
         Extension('Bio.motifs._pwm',
                   ["Bio/motifs/_pwm.c"],
-                  include_dirs=[numpy_include_dir],
-                  ))
-    EXTENSIONS.append(
-        Extension('Bio.PDB.QCPSuperimposer.qcprotmodule',
-                  ["Bio/PDB/QCPSuperimposer/qcprotmodule.c"],
                   include_dirs=[numpy_include_dir],
                   ))
 


### PR DESCRIPTION
The title says it all. Bio/PDB/QCPSuperimposer/qcprotmodule.c  does not need numpy to be compiled.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I am happy be thanked by name in the ``NEWS.rst`` and ``CONTRIB.rst`` files,
and have added myself to those files as part of this pull request. (*This
acknowledgement is optional. Note we list the names sorted alphabetically.*)
