### PR TITLE
fixed documentation typo in Bio.SearchIo.BlastIO

### DIFF
--- a/Bio/SearchIO/BlastIO/__init__.py
+++ b/Bio/SearchIO/BlastIO/__init__.py
@@ -263,9 +263,9 @@ blast-tab provides the following attributes for each SearchIO objects:
 |             +-------------------+--------------+
 |             | gap_num           | gaps         |
 |             +-------------------+--------------+
-|             | ident_pct         | nident       |
+|             | ident_num         | nident       |
 |             +-------------------+--------------+
-|             | ident_num         | pident       |
+|             | ident_pct         | pident       |
 |             +-------------------+--------------+
 |             | mismatch_num      | mismatch     |
 |             +-------------------+--------------+


### PR DESCRIPTION
This pull request addresses issue #1592 