### PR TITLE
Raise exception for blast-tab when comment argument and actual file mismatches

### DIFF
--- a/Bio/SearchIO/BlastIO/blast_tab.py
+++ b/Bio/SearchIO/BlastIO/blast_tab.py
@@ -216,6 +216,10 @@ class BlastTabParser(object):
         elif self.has_comments:
             iterfunc = self._parse_commented_qresult
         else:
+            if self.line.startswith("#"):
+                raise ValueError("Encountered unexpected character '#' at the"
+                                 " beginning of a line. Set comments=True if"
+                                 " the file is a commented file.")
             iterfunc = self._parse_qresult
 
         for qresult in iterfunc():

--- a/Tests/test_SearchIO_blast_tab.py
+++ b/Tests/test_SearchIO_blast_tab.py
@@ -407,6 +407,17 @@ class BlastTabCases(unittest.TestCase):
         self.assertRaises(StopIteration, next, qresults)
         self.assertEqual(3, counter)
 
+    def test_tab_2226_tblastn_005_comments_false(self):
+        "Test parsing TBLASTN 2.2.26+ tabular output with comments (tab_2226_tblastn_005)"
+
+        tab_file = get_file('tab_2226_tblastn_005.txt')
+        exc_msg = ("Encountered unexpected character '#' at the beginning of"
+                   " a line. Set comments=True if the file is a commented"
+                   " file.")
+        qresults = parse(tab_file, FMT)
+        with self.assertRaises(ValueError, msg=exc_msg):
+            next(qresults)
+
     def test_tab_2226_tblastn_006(self):
         "Test parsing TBLASTN 2.2.26+ tabular output with comments (tab_2226_tblastn_006)"
 


### PR DESCRIPTION
This pull request addresses issue #1598.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)