### PR TITLE
Check README.rst is plain ASCII

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -430,9 +430,19 @@ for line in open('Bio/__init__.py'):
 
 # We now load in our reStructuredText README.rst file to pass
 # explicitly in the metadata since at time of writing PyPI
-# did not do this for us:
-with open("README.rst") as handle:
-    readme_rst = handle.read()
+# did not do this for us.
+#
+# Without declaring an encoding, if there was a problematic
+# character in the file, it would work on Python 2 but might
+# fail on Python 3 depending on the user's locale. By explicitly
+# checking ASCII (could use latin1 or UTF8 if needed later),
+# if any invalid character does appear in our README, this will
+# fail and alert us immediately on either platform.
+with open("README.rst", "rb") as handle:
+    # Only Python 3's open has an encoding argument.
+    # Opening in binary and doing decoding like this to work
+    # on both Python 2 and 3.
+    readme_rst = handle.read().decode("ascii")
 
 setup(name='biopython',
       version=__version__,


### PR DESCRIPTION
This would prevent issues like #1600 (also reported during the Debian packaging of Biopython 1.71).

I hereby agree to dual licence this and any previous contributions under both the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files ``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed already, or do not wish to be listed. (*This acknowledgement is optional.*)
