### PR TITLE
Fix simple bug in Bio.Cluster

### DIFF
--- a/Bio/Cluster/__init__.py
+++ b/Bio/Cluster/__init__.py
@@ -57,7 +57,8 @@ class Tree(_cluster.Tree):
         indices = numpy.ones(n, dtype='intc')
         if nclusters is None:
             nclusters = n
-        return _cluster.Tree.cut(self, indices, nclusters)
+        _cluster.Tree.cut(self, indices, nclusters)
+        return indices
 
 
 def kcluster(data, nclusters=2, mask=None, weight=None, transpose=False,


### PR DESCRIPTION
This pull request fixes a simple bug in Bio.Cluster, where the result of tree.cut was not returned to the user.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
