### PR TITLE
Fix bug in mmCIF parsing for mid-line comments

### DIFF
--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -84,7 +84,7 @@ class MMCIF2Dict(dict):
                     quote_open_char = None
                     in_token = False
                     yield line[start_i:i]
-            elif c == "#" and not quote_open_char:
+            elif not quote_open_char and c == "#" and ((i == 0) or (i > 0 and line[i - 1] in self.whitespace_chars)):
                 return
             elif not in_token:
                 in_token = True

--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -84,7 +84,10 @@ class MMCIF2Dict(dict):
                     quote_open_char = None
                     in_token = False
                     yield line[start_i:i]
-            elif not quote_open_char and c == "#" and ((i == 0) or (i > 0 and line[i - 1] in self.whitespace_chars)):
+            elif c == "#" and not in_token:
+                # Skip comments. "#" is a valid non-comment char inside of a
+                # quote and inside of an unquoted token (!?!?), so we need to
+                # check that the current char is not in a token.
                 return
             elif not in_token:
                 in_token = True

--- a/Tests/test_PDB_MMCIF2Dict.py
+++ b/Tests/test_PDB_MMCIF2Dict.py
@@ -75,6 +75,7 @@ class MMCIF2dictTests(unittest.TestCase):
         # https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax#lex
         self.assertEqual(list(mmcif._splitline("foo#bar")), ["foo#bar"])
         self.assertEqual(list(mmcif._splitline("foo #bar")), ["foo"])
+        self.assertEqual(list(mmcif._splitline("foo# bar")), ["foo#", "bar"])
         self.assertEqual(list(mmcif._splitline("#foo bar")), [])
 
         self.assertRaises(ValueError, list, mmcif._splitline("foo 'bar"))

--- a/Tests/test_PDB_MMCIF2Dict.py
+++ b/Tests/test_PDB_MMCIF2Dict.py
@@ -69,6 +69,14 @@ class MMCIF2dictTests(unittest.TestCase):
         self.assertEqual(list(mmcif._splitline("foo 'bar'a' b")), ["foo", "bar'a", "b"])
         self.assertEqual(list(mmcif._splitline("foo \"bar' a\" b")), ["foo", "bar' a", "b"])
         self.assertEqual(list(mmcif._splitline("foo '' b")), ["foo", "", "b"])
+
+        # A hash (#) starts a comment iff it is preceded by whitespace or is at
+        # the beginning of a line:
+        # https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax#lex
+        self.assertEqual(list(mmcif._splitline("foo#bar")), ["foo#bar"])
+        self.assertEqual(list(mmcif._splitline("foo #bar")), ["foo"])
+        self.assertEqual(list(mmcif._splitline("#foo bar")), [])
+
         self.assertRaises(ValueError, list, mmcif._splitline("foo 'bar"))
         self.assertRaises(ValueError, list, mmcif._splitline("foo 'ba'r  "))
         self.assertRaises(ValueError, list, mmcif._splitline("foo \"bar'"))
@@ -94,17 +102,19 @@ class MMCIF2dictTests(unittest.TestCase):
             "First line\n    Second line\nThird line")
 
     def test_inline_comments(self):
-        """Comments may begin outside of column 1."""
+        """Comments may begin outside of column 1 if preceded by whitespace."""
         mmcif_dict = MMCIF2Dict(io.StringIO(textwrap.dedent(u"""\
             data_verbatim_test
-            _test_key_value foo # Ignore this comment
+            _test_key_value_1 foo # Ignore this comment
+            _test_key_value_2 foo#NotIgnored
             loop_
             _test_loop
             a b c d # Ignore this comment
             e f g
 
         """)))
-        self.assertEqual(mmcif_dict["_test_key_value"], "foo")
+        self.assertEqual(mmcif_dict["_test_key_value_1"], "foo")
+        self.assertEqual(mmcif_dict["_test_key_value_2"], "foo#NotIgnored")
         self.assertEqual(mmcif_dict["_test_loop"], list("abcdefg"))
 
     def test_loop_keyword_case_insensitive(self):


### PR DESCRIPTION
Comments in mmCIF files are only started if the "#" character is at the
beginning of a line or preceded by whitespace:
https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax#lex.
This means that an unquoted valid token can contain a "#".

This commit adds a check to the `Bio.PDB.MMCIF2Dict.MMCIF2Dict._splitline`
method to account for this. Previously, a "#" character would always
start a mid-line comment, which broke the parsing of (e.g.) 1EMB at the
line `_entity_src_gen.pdbx_host_org_vector TU#58`. I have also added
some tests to hopefully prevent regressions here.

I introduced this bug in 781441b :)

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
