### PR TITLE
Fixed a minor bug in KDTreemodule.c

### DIFF
--- a/Bio/KDTree/KDTree.py
+++ b/Bio/KDTree/KDTree.py
@@ -101,7 +101,7 @@ class KDTree(object):
         n = self.kdt.get_count()
         if n == 0:
             return []
-        radii = empty(n, int)
+        radii = empty(n, 'f')
         self.kdt.get_radii(radii)
         return radii
 

--- a/Bio/KDTree/KDTreemodule.c
+++ b/Bio/KDTree/KDTreemodule.c
@@ -579,7 +579,7 @@ static PyObject *PyTree_get_radii(PyTree *self, PyObject* args)
         case '!': datatype = view.format[1]; break;
         default: break;
     }
-    if (datatype != 'l') {
+    if (datatype != 'f') {
         PyErr_Format(PyExc_RuntimeError,
             "array has incorrect data format ('%c', expected 'f')", datatype);
         PyBuffer_Release(&view);


### PR DESCRIPTION
This pull request addresses issue of inconsistency between the type check and the message displayed. This is a minor bug but can be fatal.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
