### PR TITLE
Adding comment on "X" nucleotide in IUPACData

### DIFF
--- a/Bio/Data/IUPACData.py
+++ b/Bio/Data/IUPACData.py
@@ -63,6 +63,9 @@ extended_dna_letters = "GATCBDSW"
 # are there extended forms?
 # extended_rna_letters = "GAUCBDSW"
 
+# "X" is included in the following _values and _complement dictionaries,
+# for historical reasons although it is not an IUPAC nucleotide,
+# and so is not in the corresponding _letters strings above
 ambiguous_dna_values = {
     "A": "A",
     "C": "C",

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -196,7 +196,7 @@ possible, especially the following contributors:
 - Ariel Aptekmann (first contribution)
 - Ben Fulton
 - Bertrand Caron (first contribution)
-- Chris Rands
+- Chris Rands (first contribution)
 - Connor T. Skennerton
 - Eric Rasche
 - Eric Talevich

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -26,6 +26,7 @@ Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
 - Blaise Li
+- Chris Rands
 - Peter Cock
 - Wibowo 'Bow' Arindrarto
 


### PR DESCRIPTION
A minor one this, but as noted in issue #1538 the `"X"` nucleotide is included in  several `IUPACData` dictionaries (such as `ambiguous_dna_values`) but not in the corresponding strings (such as `ambiguous_dna_letters`). This likely for historical reasons and in the issue Peter suggested not to change the behaviour but instead add a comment like this. Note, this does not close the issue, which is more complex.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
