### PR TITLE
fix handling of whitespace-only SeqRecord descriptions

### DIFF
--- a/Bio/AlignIO/StockholmIO.py
+++ b/Bio/AlignIO/StockholmIO.py
@@ -454,7 +454,16 @@ class StockholmIterator(AlignmentIterator):
                 elif line[:5] == '#=GS ':
                     # Generic per-Sequence annotation, free text
                     # Format: "#=GS <seqname> <feature> <free text>"
-                    seq_id, feature, text = line[5:].strip().split(None, 2)
+                    parts = line[5:].strip().split(None, 2)
+                    if len(parts) not in (2, 3):
+                        raise ValueError(
+                            "Could not split line in seqname, "
+                            "feature, and text:\n" + line)
+                    seq_id, feature = parts[:2]
+                    if len(parts) == 3:
+                        text = parts[2]
+                    else:
+                        text = ""
                     # if seq_id not in ids:
                     #    ids.append(seq_id)
                     if seq_id not in gs:

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -93,7 +93,7 @@ def _get_seq_string(record):
 # Function variant of the SequenceWriter method.
 def _clean(text):
     """Use this to avoid getting newlines in the output."""
-    return text.replace("\n", " ").replace("\r", " ").replace("  ", " ")
+    return text.replace("\n", " ").replace("\r", " ").replace("  ", " ").strip()
 
 
 class SequenceWriter(object):
@@ -126,7 +126,7 @@ class SequenceWriter(object):
 
     def clean(self, text):
         """Use this to avoid getting newlines in the output."""
-        return text.replace("\n", " ").replace("\r", " ").replace("  ", " ")
+        return text.replace("\n", " ").replace("\r", " ").replace("  ", " ").strip()
 
     def write_file(self, records):
         """Use this to write an entire file containing the given records.

--- a/Tests/test_SeqIO_write.py
+++ b/Tests/test_SeqIO_write.py
@@ -60,6 +60,7 @@ test_records = [
      [(["stockholm"], ValueError, "Duplicate record identifier: Beta"),
       (["maf"], ValueError, "Identifiers in each MultipleSeqAlignment must be unique"),
       (["phylip", "phylip-relaxed", "phylip-sequential"], ValueError, "Repeated name 'Beta' (originally 'Beta'), possibly due to truncation")]),
+    ([SeqRecord(Seq("TCGAGAGATCTC", Alphabet.generic_dna), id="X", description="  ")], "Whitespace-only description", []),
     ]
 # Meddle with the annotation too:
 assert test_records[4][1] == "3 DNA seq alignment with CR/LF in name/descr"


### PR DESCRIPTION
This pull request addresses issue #1624 

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
