### PR TITLE
Added custom Entrez directory to NEWS.rst

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -18,6 +18,10 @@ The MAF alignment indexing in Bio.AlignIO.MafIO has been updated to use
 inclusive end co-ordindates to better handle searches at end points. This
 will require you to rebuild any existing MAF index files.
 
+The Entrez module now allows users to set a custom directory location for DTD
+and XSD files. This change allows Entrez to be used in code deployments
+such as AWS Lambda, which restricts write access to specific directories.
+
 In this release more of our code is now explicitly available under either our
 original "Biopython License Agreement", or the very similar but more commonly
 used "3-Clause BSD License".  See the ``LICENSE.rst`` file for more details.


### PR DESCRIPTION
This pull request addresses issue #...

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
