### PR TITLE
Updated NEWS.rst with Entrez custom directory

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -22,10 +22,15 @@ In this release more of our code is now explicitly available under either our
 original "Biopython License Agreement", or the very similar but more commonly
 used "3-Clause BSD License".  See the ``LICENSE.rst`` file for more details.
 
+The Entrez module now allows users to set a custom directory location for DTD
+and XSD files. This change allows Entrez to be used in code deployments
+such as AWS Lambda, which restricts write access to specific directories.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
 - Blaise Li
+- Chad Parmet
 - Chris Rands
 - Peter Cock
 - Wibowo 'Bow' Arindrarto


### PR DESCRIPTION
This pull request follows PR #1522 

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
