### PR TITLE
Monkey patch to enforce --offline switch in run_tests.py

### DIFF
--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -38,7 +38,6 @@ import doctest
 import distutils.util
 import gc
 from io import BytesIO
-from Bio import MissingExternalDependencyError
 
 
 # Note, we want to be able to call run_tests.py BEFORE
@@ -256,11 +255,14 @@ def main(argv):
             return 0
         if opt == "--offline":
             print("Skipping any tests requiring internet access")
+            # This is a bit of a hack...
+            import requires_internet
+            requires_internet.check.available = False
             # Monkey patch for urlopen()
             import Bio._py3k
 
             def dummy_urlopen(url):
-                raise MissingExternalDependencyError("internet not available")
+                raise RuntimeError("internet not available")
 
             Bio._py3k.urlopen = dummy_urlopen
         if opt == "-g" or opt == "--generate":

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -262,7 +262,7 @@ def main(argv):
             import Bio._py3k
 
             def dummy_urlopen(url):
-                raise RuntimeError("internet not available")
+                raise RuntimeError("Internal test suite error, attempting to use internet despite --offline setting")
 
             Bio._py3k.urlopen = dummy_urlopen
         if opt == "-g" or opt == "--generate":

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -38,6 +38,8 @@ import doctest
 import distutils.util
 import gc
 from io import BytesIO
+from Bio import MissingExternalDependencyError
+
 
 # Note, we want to be able to call run_tests.py BEFORE
 # Biopython is installed, so we can't use this:
@@ -254,10 +256,13 @@ def main(argv):
             return 0
         if opt == "--offline":
             print("Skipping any tests requiring internet access")
-            # This is a bit of a hack...
-            import requires_internet
-            requires_internet.check.available = False
-            # The check() function should now report internet not available
+            # Monkey patch for urlopen()
+            import Bio._py3k
+
+            def dummy_urlopen(url):
+                raise MissingExternalDependencyError("internet not available")
+
+            Bio._py3k.urlopen = dummy_urlopen
         if opt == "-g" or opt == "--generate":
             if len(args) > 1:
                 print("Only one argument (the test name) needed for generate")


### PR DESCRIPTION
This pull request addresses issue #846

This is far from being the final version because I'm not sure about the end result.

Monkey patching `urlopen()` throws a `MissingExternalDependencyError` each time the method is called inside the unittest script.

The end result via a `run_tests --offline` call, is a `FAIL` flag associated to the online test.

Is this informative enough or would it be better to have again a message that explain why the test has failed? (ex: like before `skipping. No internet available`)