### PR TITLE
Fix bug in EmbossIO for full line insertion in pair alignment format

### DIFF
--- a/Bio/AlignIO/EmbossIO.py
+++ b/Bio/AlignIO/EmbossIO.py
@@ -152,7 +152,7 @@ class EmbossIterator(AlignmentIterator):
                     # (an aligned seq is broken up into multiple lines)
                     id, start = id_start
                     seq, end = seq_end
-                    if start == end:
+                    if start >= end:
                         # Special case, either a single letter is present,
                         # or no letters at all.
                         if seq.replace("-", "") == "":
@@ -177,7 +177,7 @@ class EmbossIterator(AlignmentIterator):
                         seq_starts.append(start)
 
                     # Check the start...
-                    if start == end:
+                    if start >= end:
                         assert seq.replace("-", "") == "", line
                     elif start - seq_starts[index] != len(seqs[index].replace("-", "")):
                         raise ValueError("Found %i chars so far for sequence %i (%s, %s), line says start %i:\n%s"

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -181,6 +181,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Olivier Morelle <https://github.com/Oli4>
 - Oscar G. Garcia <https://github.com/oscarmaestre>
 - Owen Solberg <https://github.com/odoublewen>
+- Pamela Russell <https://github.com/pamelarussell>
 - Patrick Kunzmann <https://github.com/padix-key>
 - Paul T. Bathen
 - Peter Bienstman <Peter.Bienstman at domain rug.ac.be>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -39,7 +39,7 @@ possible, especially the following contributors:
 - Chris Rands
 - Francesco Gastaldello
 - Michiel de Hoon
-- Pamela Russell
+- Pamela Russell (first contribution)
 - Peter Cock
 - Spencer Bliven
 - Wibowo 'Bow' Arindrarto

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -39,6 +39,7 @@ possible, especially the following contributors:
 - Chris Rands
 - Francesco Gastaldello
 - Michiel de Hoon
+- Pamela Russell
 - Peter Cock
 - Spencer Bliven
 - Wibowo 'Bow' Arindrarto

--- a/Tests/Emboss/emboss_pair_aln_full_blank_line.txt
+++ b/Tests/Emboss/emboss_pair_aln_full_blank_line.txt
@@ -1,0 +1,155 @@
+########################################
+# Program: stretcher
+# Rundate: Tue 15 May 2018 17:01:31
+# Commandline: stretcher
+#    -auto
+#    -stdout
+#    -asequence emboss_stretcher-I20180515-170128-0371-22292969-p1m.aupfile
+#    -bsequence emboss_stretcher-I20180515-170128-0371-22292969-p1m.bupfile
+#    -datafile EDNAFULL
+#    -gapopen 16
+#    -gapextend 4
+#    -aformat3 pair
+#    -snucleotide1
+#    -snucleotide2
+# Align_format: pair
+# Report_file: stdout
+########################################
+
+#=======================================
+#
+# Aligned_sequences: 2
+# 1: hg38_chrX_131691529_131830643_47210_48660
+# 2: mm10_chrX_50555743_50635321_27140_27743
+# Matrix: EDNAFULL
+# Gap_penalty: 16
+# Extend_penalty: 4
+#
+# Length: 1450
+# Identity:     441/1450 (30.4%)
+# Similarity:   441/1450 (30.4%)
+# Gaps:         847/1450 (58.4%)
+# Score: -2623
+# 
+#
+#=======================================
+
+hg38_chrX_131      1 GGCAGGTGCATAGCTTGAGCCTAGGAGTTCAAGTCCAGCCCTGACAATGT     50
+                     |                          ||||||.|||.||..||.    |
+mm10_chrX_505      1 G--------------------------TTCAAGGCCATCCGGGAT----T     20
+
+hg38_chrX_131     51 AGAGAGACCCCGTCTCTTCAAAAAATACAAAAAATAGCCAGGCATGGTGA    100
+                     |.||       ||.|..|           |.||.|...|.|  ||||.||
+mm10_chrX_505     21 AAAG-------GTGTGGT-----------AGAACTCTTCTG--ATGGAGA     50
+
+hg38_chrX_131    101 CCTACAATGGAAGCCCTAGCTACGTAGGAGGCGGAAATGGGAGGATCACC    150
+                     |    |||..|||                    ||.||.|||.||     
+mm10_chrX_505     51 C----AATATAAG--------------------GACATTGGAAGA-----     71
+
+hg38_chrX_131    151 TCAGCCCAGGGAGGCTGATGTTGCAGTGAGCCATGATCATGCCTCTACAC    200
+                            ||||||     |.||||      ||.||.||.|.|..||||. 
+mm10_chrX_505     72 -------AGGGAG-----TCTTGC------CCTTGCTCCTTCGCCTACT-    102
+
+hg38_chrX_131    201 TCCACCCTGGGCAACAGAGTAAGATGCTGTCTAAAATATATATATATGCA    250
+                                             ||||||.|||.|              
+mm10_chrX_505    103 ------------------------TGCTGTGTAAGA--------------    114
+
+hg38_chrX_131    251 TATCTGTGTGTATATATATATATATATATGTGTGTGTGTGTGTGTGTATA    300
+                        |||.||                                         
+mm10_chrX_505    115 ---CTGAGT-----------------------------------------    120
+
+hg38_chrX_131    301 TACATATGTGTGTGTATATACATATATGTGTATATATATATGTGTGTATA    350
+                                                                       
+mm10_chrX_505    121 --------------------------------------------------    120
+
+hg38_chrX_131    351 TATACATATACATATTCAGCATCACCTTATATTCTTTGAATATATCTACA    400
+                                         |.|.||| |.|..|||.||.|         
+mm10_chrX_505    121 --------------------AACTCCT-AGACCCTTGGACT---------    140
+
+hg38_chrX_131    401 TCAATACATACTTTTGAGTGCTTGAAATTTTTTATATTTTACTCTAGAAG    450
+                             |.|.|||.||..                    |||...|||.
+mm10_chrX_505    141 --------TCCATTTCAGCC--------------------ACTACTGAAC    162
+
+hg38_chrX_131    451 AACTGTAAGAAATTATAAAGTAGAAAACTTGTGGTAGGTCAAACATAGTA    500
+                     .|.|||..|.||||..   |..|.|.|||    |||.||||...|||   
+mm10_chrX_505    163 CATTGTTGGGAATTGG---GCTGCAGACT----GTAAGTCATCAATA---    202
+
+hg38_chrX_131    501 AGAAGAAATAATCACTTTTTAAAGGTCTGTGCTAGGTACTATGATCTGTT    550
+                              |||..||||                   |||||.       
+mm10_chrX_505    203 ---------AATTCCTTT-------------------ACTATA-------    217
+
+hg38_chrX_131    551 CCCTATATATACATAATATGGACTTTTATAAACTAATGTTCAAATTCCCC    600
+                                               ||.|.||||          |||  
+mm10_chrX_505    218 --------------------------TAGAGACTA----------TCC--    229
+
+hg38_chrX_131    601 TGTAGTATAACTTCTTGTTGTTGTTTATTTTTTTTTTTTTGTATTTTTCA    650
+                           ||||.||||.                               |.|
+mm10_chrX_505    230 ------ATAAATTCTG-------------------------------TGA    242
+
+hg38_chrX_131    651 TTTTAGATATGGGGTTTCACTCTGTTGACCAGGCTGATCTCGAACCACTG    700
+                     .|.||||.|         ||.||   |||.|.           ||.||||
+mm10_chrX_505    243 CTCTAGAGA---------ACCCT---GACAAT-----------ACAACTG    269
+
+hg38_chrX_131    701 GTCTCAAGCGATCCTCCCATCTTGGACTCCCAAAGTGCTAGGATTACAGG    750
+                     |                                                 
+mm10_chrX_505    270 G-------------------------------------------------    270
+
+hg38_chrX_131    751 CACGAGGCACCTTGACTGGCCACCATGTACTATAGCTGTTAAAACAAGTT    800
+                        ||.||||       ||.||.|.|.|                      
+mm10_chrX_505    271 ---GAAGCAC-------GGACATCCTCT----------------------    288
+
+hg38_chrX_131    801 TGTTTCACTGATAACTGGAGTACTTTTCAAATATAATTAATAATTCATGG    850
+                                              ||.|.|||||||||     |||   
+mm10_chrX_505    289 -------------------------TTGAGATATAATTA-----TCA---    305
+
+hg38_chrX_131    851 AAATAATGATAGCTTTAAAAGTATTGGCACTTTTAAAAACTGAGTTTGTA    900
+                         |.||   ||     ||||.||.|    ||||          ||| |
+mm10_chrX_505    306 ----ACTG---GC-----AAGTGTTTG----TTTA----------TTG-A    328
+
+hg38_chrX_131    901 AACTTCATATAACATAAAATTAACCATTAAAATGTATTAATTTCAATGGC    950
+                     .|.||.|..|||.|.|||.||||.|.|            |.|.|  ||.|
+mm10_chrX_505    329 TATTTTACTTAAGACAAAGTTAAACCT------------ACTCC--TGTC    364
+
+hg38_chrX_131    951 ATTTAGGACACTCACAATGCAGTGCAAGCATTACCACTATGTAGTGGCAA   1000
+                     .|.|.||     ||        ||..|||||..  ||| |.|..|||   
+mm10_chrX_505    365 CTCTGGG-----CA--------TGGTAGCATGG--ACT-TATTCTGG---    395
+
+hg38_chrX_131   1001 ATCATTTTCACTACCACAAAAGAAAATCCTGGACCCATTAGTTAGTCATT   1050
+                             .|||||||.|.  |||||..|.|.|.||      ||      
+mm10_chrX_505    396 --------AACTACCAGAG--GAAAAGACAGAAGCC------TA------    423
+
+hg38_chrX_131   1051 CCCCATTCCACTCTCTGCCCAGCCCCTGGCAAACACTCATCTGATTTCCC   1100
+                                   |||...||.|||.|||       ||||         
+mm10_chrX_505    424 --------------CTGGAAAGGCCCAGGC-------CATC---------    443
+
+hg38_chrX_131   1101 TCACTACTGATCATCACAACAAGTGGCCTTGTTCATCTTGTTGTGGGAAC   1150
+                           |||                        |.||||||.||      
+mm10_chrX_505    444 ------CTG------------------------CCTCTTGTAGT------    457
+
+hg38_chrX_131   1151 CAGGAGACCAGAGAGACCAATGGGTGGAACAGGAGGATTTTACTAGGTGG   1200
+                                                            |.||||||   
+mm10_chrX_505    458 ---------------------------------------TCACTAGG---    465
+
+hg38_chrX_131   1201 TCACCGACTCAGCAGATTAACATCCAAAGGCTGAGCCCCAAACCAAGAGA   1250
+                               |.|||             ||||.|||           |.|
+mm10_chrX_505    466 ----------ACCAG-------------GGCTCAGC-----------ATA    481
+
+hg38_chrX_131   1251 GGGCTTGACTTTTATACATATATCTGAAAAGGGCCCAAAACCTGTAAGGC   1300
+                     |..||||.|||.|      |.|||||..|      |.|.|.||.||.  |
+mm10_chrX_505    482 GTCCTTGGCTTCT------AAATCTGCTA------CCATATCTTTAT--C    517
+
+hg38_chrX_131   1301 CGGTAAGCAAGCTTACAGCAGAACAAAGGCAGTTTATCAAACAGTGACAG   1350
+                     ..|||   ||.||.|||..|.|..|||  ||   |||||||         
+mm10_chrX_505    518 ATGTA---AAACTGACACAAAATTAAA--CA---TATCAAA---------    550
+
+hg38_chrX_131   1351 GTTTTACAGTTCAGGCATGTCTTGTGACCTTTGCCATAACTGCACAGCTG   1400
+                            |.||.|.|.|.        |||.|     |||.|    |.|||
+mm10_chrX_505    551 -------ATTTTATGAAA--------ACCAT-----TAAGT----ATCTG    576
+
+hg38_chrX_131   1401 GAAAACAGGAACTTACAAAATCCTTACAAGCTTGCAGAAACAGTTACAAA   1450
+                     |||||.|       |.||||||                ||||||||.|||
+mm10_chrX_505    577 GAAAAGA-------AAAAAATC----------------AACAGTTATAAA    603
+
+
+#---------------------------------------
+#---------------------------------------

--- a/Tests/output/test_AlignIO
+++ b/Tests/output/test_AlignIO
@@ -527,6 +527,21 @@ Testing reading emboss format file Emboss/matcher_pair.txt with 5 alignments
  Checking can write/read as 'stockholm' format
  Checking can write/read as 'fasta' format
  Checking can write/read as 'tab' format
+Testing reading emboss format file Emboss/emboss_pair_aln_full_blank_line.txt with 1 alignments
+ Alignment 0, with 2 sequences of length 1450
+  GGCAGGTGCATAGCTTGAGCCTAGGAGTTCAAGTCC...AAA hg38_chrX_131691529_131830643_47210_48660
+  G--------------------------TTCAAGGCC...AAA mm10_chrX_50555743_50635321_27140_27743
+ Checking can write/read as 'clustal' format
+ Checking can write/read as 'maf' format
+ Checking can write/read as 'mauve' format
+ Checking can write/read as 'nexus' format
+ Failed: Need a DNA, RNA or Protein alphabet
+ Checking can write/read as 'phylip' format
+ Checking can write/read as 'phylip-relaxed' format
+ Checking can write/read as 'phylip-sequential' format
+ Checking can write/read as 'stockholm' format
+ Checking can write/read as 'fasta' format
+ Checking can write/read as 'tab' format
 Testing reading fasta-m10 format file Fasta/output001.m10 with 4 alignments
  Alignment 0, with 2 sequences of length 108
   SGSNT-RRRAISRPVRLTAEED---QEIRKRAAECG...LSR gi|10955263|ref|NP_052604.1|

--- a/Tests/test_AlignIO.py
+++ b/Tests/test_AlignIO.py
@@ -57,6 +57,7 @@ test_files = [
     ("emboss", 2, 1, 'Emboss/water2.txt'),
     ("emboss", 2, 1, 'Emboss/matcher_simple.txt'),
     ("emboss", 2, 5, 'Emboss/matcher_pair.txt'),
+    ("emboss", 2, 1, 'Emboss/emboss_pair_aln_full_blank_line.txt'),
     ("fasta-m10", 2, 4, 'Fasta/output001.m10'),
     ("fasta-m10", 2, 6, 'Fasta/output002.m10'),
     ("fasta-m10", 2, 3, 'Fasta/output003.m10'),


### PR DESCRIPTION

This pull request addresses issue #1652. I have handled the case where a full line in EMBOSS pair format contains no letters, which can be reported by the Stretcher program with the start coordinate of the line equal to 1 + the end coordinate of the line.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.
