### PR TITLE
declare the trie and triefind modules obsolete

### DIFF
--- a/Bio/triefind.py
+++ b/Bio/triefind.py
@@ -19,6 +19,9 @@ Functions:
  - match_all     Find all keys in a trie matching the beginning of the string.
  - find          Find keys in a trie matching anywhere in a string.
  - find_words    Find keys in a trie matching whole words in a string.
+
+This module is OBSOLETE. We encourage users to switch to alternative libraries
+implementing a trie data structure, for example pygtrie.
 """
 
 import string

--- a/Bio/triemodule.c
+++ b/Bio/triemodule.c
@@ -808,6 +808,8 @@ trie    Create a new trie object.\n\
 save    Save a trie to a handle.\n\
 load    Load a trie from a handle.\n\
 \n\
+This module is OBSOLETE. We encourage users to switch to alternative\n\
+libraries implementing a trie data structure, for example pygtrie.\n\
 ";
 
 #if PY_MAJOR_VERSION >= 3

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -742,3 +742,9 @@ Bio.KDTree
 This module was declared obsolete in Release 1.72. As of Release 1.72, KDTree
 data structures and the functionality previously available in Bio.KDTree are
 provided in a new module ``Bio.PDB.kdtrees``.
+
+Bio.trie, Bio.triefind
+======================
+These modules were declared obsolete in Release 1.72. We encourage users to
+switch to alternative libraries implementing a trie data structure, for example
+pygtrie.


### PR DESCRIPTION
This pull request declares the `Bio.trie` and `Bio.triefind` modules obsolete. Please write a comment on this pull request if you would like to continue to use `Bio.trie` or `Bio.triefind`. Note that the pygtrie library provides an implementation of trie data structures.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
