### PR TITLE
Avoid 'DEFINITION  ..\n' in GenBank output.

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -834,7 +834,7 @@ class GenBankWriter(_InsdcWriter):
 
         descr = record.description
         if descr == "<unknown description>":
-            descr = "."
+            descr = ""  # Trailing dot will be added later
 
         # The DEFINITION field must end with a period
         # see ftp://ftp.ncbi.nih.gov/genbank/gbrel.txt [3.4.5]

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -374,6 +374,20 @@ class OutputTests(unittest.TestCase):
             self.assertEqual(old.description, new.description)
             self.assertEqual(old.seq, new.seq)
 
+    def test_seqrecord_default_description(self):
+        """Read in file using SeqRecord default description."""
+        old = SeqRecord(Seq("ACGT", generic_dna),
+                        id="example",
+                        name="short")
+        self.assertEqual(old.description, "<unknown description>")
+        txt = old.format("gb")
+        self.assertIn("DEFINITION  .\n", txt)
+        new = SeqIO.read(StringIO(txt), "gb")
+        self.assertEqual(old.id, new.id)
+        self.assertEqual(old.name, new.name)
+        self.assertEqual("", new.description)
+        self.assertEqual(old.seq, new.seq)
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
This pull request addresses in part issue #1663 

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
