### PR TITLE
Change single to double quotes on Doc/Tutorial

### DIFF
--- a/Doc/Tutorial/chapter_advanced.tex
+++ b/Doc/Tutorial/chapter_advanced.tex
@@ -290,8 +290,8 @@ Any one of the following may be done to geerate the frequency table (ftab):
 >>> from SubsMat import *
 >>> ftab = FreqTable.FreqTable(my_frequency_dictionary, FreqTable.FREQ)
 >>> ftab = FreqTable.FreqTable(my_count_dictionary, FreqTable.COUNT)
->>> ftab = FreqTable.read_count(open('myCountFile'))
->>> ftab = FreqTable.read_frequency(open('myFrequencyFile'))
+>>> ftab = FreqTable.read_count(open("myCountFile"))
+>>> ftab = FreqTable.read_frequency(open("myFrequencyFile"))
 \end{verbatim}
 
 \end{enumerate}

--- a/Doc/Tutorial/chapter_blast.tex
+++ b/Doc/Tutorial/chapter_blast.tex
@@ -413,13 +413,13 @@ threshold. The following code does this:
 >>> for alignment in blast_record.alignments:
 ...     for hsp in alignment.hsps:
 ...         if hsp.expect < E_VALUE_THRESH:
-...             print('****Alignment****')
-...             print('sequence:', alignment.title)
-...             print('length:', alignment.length)
-...             print('e value:', hsp.expect)
-...             print(hsp.query[0:75] + '...')
-...             print(hsp.match[0:75] + '...')
-...             print(hsp.sbjct[0:75] + '...')
+...             print("****Alignment****")
+...             print("sequence:", alignment.title)
+...             print("length:", alignment.length)
+...             print("e value:", hsp.expect)
+...             print(hsp.query[0:75] + "...")
+...             print(hsp.match[0:75] + "...")
+...             print(hsp.sbjct[0:75] + "...")
 \end{verbatim}
 
 This will print out summary reports like the following:
@@ -512,13 +512,13 @@ This will parse the BLAST report into a Blast Record class (either a Blast or a 
 >>> for alignment in blast_record.alignments:
 ...     for hsp in alignment.hsps:
 ...         if hsp.expect < E_VALUE_THRESH:
-...             print('****Alignment****')
-...             print('sequence:', alignment.title)
-...             print('length:', alignment.length)
-...             print('e value:', hsp.expect)
-...             print(hsp.query[0:75] + '...')
-...             print(hsp.match[0:75] + '...')
-...             print(hsp.sbjct[0:75] + '...')
+...             print("****Alignment****")
+...             print("sequence:", alignment.title)
+...             print("length:", alignment.length)
+...             print("e value:", hsp.expect)
+...             print(hsp.query[0:75] + "...")
+...             print(hsp.match[0:75] + "...")
+...             print(hsp.sbjct[0:75] + "...")
 \end{verbatim}
 
 If you also read the section~\ref{sec:parsing-blast} on parsing BLAST XML output, you'll notice that the above code is identical to what is found in that section. Once you parse something into a record class you can deal with it independent of the format of the original BLAST info you were parsing. Pretty snazzy!
@@ -558,14 +558,14 @@ Each call to next will return a new record that we can deal with. Now we can ite
 ...     for alignment in blast_record.alignments:
 ...         for hsp in alignment.hsps:
 ...             if hsp.expect < E_VALUE_THRESH:
-...                 print('****Alignment****')
-...                 print('sequence:', alignment.title)
-...                 print('length:', alignment.length)
-...                 print('e value:', hsp.expect)
+...                 print("****Alignment****")
+...                 print("sequence:", alignment.title)
+...                 print("length:", alignment.length)
+...                 print("e value:", hsp.expect)
 ...                 if len(hsp.query) > 75:
-...                     dots = '...'
+...                     dots = "..."
 ...                 else:
-...                     dots = ''
+...                     dots = ""
 ...                 print(hsp.query[0:75] + dots)
 ...                 print(hsp.match[0:75] + dots)
 ...                 print(hsp.sbjct[0:75] + dots)

--- a/Doc/Tutorial/chapter_cluster.tex
+++ b/Doc/Tutorial/chapter_cluster.tex
@@ -960,9 +960,9 @@ The example data \verb|cyano.txt| can be found in Biopython's \verb|Tests/Cluste
 >>> with open("cyano.txt") as handle:
 ...     record = Cluster.read(handle)
 ...
->>> genetree = record.treecluster(method='s')
+>>> genetree = record.treecluster(method="s")
 >>> genetree.scale()
->>> exptree = record.treecluster(dist='u', transpose=1)
+>>> exptree = record.treecluster(dist="u", transpose=1)
 >>> record.save("cyano_result", genetree, exptree)
 \end{verbatim}
 

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -228,11 +228,11 @@ Note that instead of a species name like \texttt{Cypripedioideae[Orgn]}, you can
 
 As a final example, let's get a list of computational journal titles:
 \begin{verbatim}
->>> handle = Entrez.esearch(db="nlmcatalog", term="computational[Journal]", retmax='20')
+>>> handle = Entrez.esearch(db="nlmcatalog", term="computational[Journal]", retmax="20")
 >>> record = Entrez.read(handle)
 >>> print("{} computational journals found".format(record["Count"]))
 117 computational Journals found
->>> print("The first 20 are\n{}".format(record['IdList']))
+>>> print("The first 20 are\n{}".format(record["IdList"]))
 ['101660833', '101664671', '101661657', '101659814', '101657941',
  '101653734', '101669877', '101649614', '101647835', '101639023',
  '101627224', '101647801', '101589678', '101585369', '101645372',
@@ -294,7 +294,7 @@ ESummary retrieves document summaries from a list of primary IDs (see the  \href
 >>> Entrez.email = "A.N.Other@example.com"     # Always tell NCBI who you are
 >>> handle = Entrez.esummary(db="nlmcatalog", id="101660833")
 >>> record = Entrez.read(handle)
->>> info = record[0]['TitleMainList'][0]
+>>> info = record[0]["TitleMainList"][0]
 >>> print("Journal info\nid: {}\nTitle: {}".format(record[0]["Id"], info["Title"]))
 Journal info
 id: 101660833
@@ -842,7 +842,7 @@ For comparison, here we show an example using the XML format:
 \begin{verbatim}
 >>> handle = Entrez.efetch(db="pubmed", id=idlist, rettype="medline", retmode="xml")
 >>> records = Entrez.read(handle)
->>> for record in records['PubmedArticle']:
+>>> for record in records["PubmedArticle"]:
 ...     print(record["MedlineCitation"]["Article"]["ArticleTitle"])
 Biopython: freely available Python tools for computational molecular biology and
  bioinformatics.

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -604,11 +604,11 @@ The XML file \verb+Homo_sapiens.xml+ consists of a list of Entrez gene records, 
 >>> handle = open("Homo_sapiens.xml")
 >>> records = Entrez.parse(handle)
 >>> for record in records:
-...     status = record['Entrezgene_track-info']['Gene-track']['Gene-track_status']
-...     if status.attributes['value']=='discontinued':
+...     status = record["Entrezgene_track-info"]["Gene-track"]["Gene-track_status"]
+...     if status.attributes["value"]=="discontinued":
 ...         continue
-...     geneid = record['Entrezgene_track-info']['Gene-track']['Gene-track_geneid']
-...     genename = record['Entrezgene_gene']['Gene-ref']['Gene-ref_locus']
+...     geneid = record["Entrezgene_track-info"]["Gene-track"]["Gene-track_geneid"]
+...     genename = record["Entrezgene_gene"]["Gene-ref"]["Gene-ref_locus"]
 ...     print(geneid, genename)
 ...
 \end{verbatim}

--- a/Doc/Tutorial/chapter_kegg.tex
+++ b/Doc/Tutorial/chapter_kegg.tex
@@ -45,7 +45,7 @@ First, here is how to extend the above example by downloading the relevant enzym
 >>> from Bio.KEGG import REST
 >>> from Bio.KEGG import Enzyme
 >>> request = REST.kegg_get("ec:5.4.2.2")
->>> open("ec_5.4.2.2.txt", 'w').write(request.read())
+>>> open("ec_5.4.2.2.txt", "w").write(request.read())
 >>> records = Enzyme.parse(open("ec_5.4.2.2.txt"))
 >>> record = list(records)[0]
 >>> record.classname

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -90,18 +90,18 @@ T:   4.00   0.00   2.00   0.00   0.00
 You can access these counts as a dictionary:
 %cont-doctest
 \begin{verbatim}
->>> m.counts['A']
+>>> m.counts["A"]
 [3, 7, 0, 2, 1]
 \end{verbatim}
 but you can also think of it as a 2D array with the nucleotide as the first
 dimension and the position as the second dimension:
 %cont-doctest
 \begin{verbatim}
->>> m.counts['T', 0]
+>>> m.counts["T", 0]
 4
->>> m.counts['T', 2]
+>>> m.counts["T", 2]
 2
->>> m.counts['T', 3]
+>>> m.counts["T", 3]
 0
 \end{verbatim}
 You can also directly access columns of the counts matrix
@@ -120,7 +120,7 @@ IUPACUnambiguousDNA()
 'GATC'
 >>> sorted(m.alphabet.letters)
 ['A', 'C', 'G', 'T']
->>> m.counts['A',:]
+>>> m.counts["A",:]
 (3, 7, 0, 2, 1)
 >>> m.counts[0,:]
 (3, 7, 0, 2, 1)
@@ -625,7 +625,7 @@ In addition to using an index into the record, as we did above,
 you can also find it by its name:
 %cont-doctest
 \begin{verbatim}
->>> motif = record['Motif 1']
+>>> motif = record["Motif 1"]
 \end{verbatim}
 Each motif has an attribute \verb+.instances+ with the sequence instances
 in which the motif was found, providing some information on each instance:
@@ -725,7 +725,7 @@ store any additional information about the motif:
 >>> motif = record[0]
 >>> motif.degenerate_consensus # Using the Bio.motifs.Motif method
 Seq('SRACAGGTGKYG', IUPACAmbiguousDNA())
->>> motif['ID'] # Using motif as a dictionary
+>>> motif["ID"] # Using motif as a dictionary
 'motif1'
 \end{verbatim}
 
@@ -822,7 +822,7 @@ You can export the motifs in the TRANSFAC format by capturing this output
 in a string and saving it in a file:
 \begin{verbatim}
 >>> text = str(record)
->>> with open("mytransfacfile.dat", 'w') as out_handle:
+>>> with open("mytransfacfile.dat", "w") as out_handle:
 ...     out_handle.write(text)
 ...
 \end{verbatim}
@@ -869,7 +869,7 @@ This function can be used regardless of whether the motifs originated from a TRA
 %cont-doctest
 \begin{verbatim}
 >>> two_motifs = [arnt, srf]
->>> print(motifs.write(two_motifs, 'transfac'))
+>>> print(motifs.write(two_motifs, "transfac"))
 P0      A      C      G      T
 01      4     16      0      0      C
 02     19      0      1      0      A
@@ -947,7 +947,7 @@ the human genome is about 40\%, you may want to choose the
 pseudocounts accordingly:
 %cont-doctest
 \begin{verbatim}
->>> pwm = m.counts.normalize(pseudocounts={'A':0.6, 'C': 0.4, 'G': 0.4, 'T': 0.6})
+>>> pwm = m.counts.normalize(pseudocounts={"A":0.6, "C": 0.4, "G": 0.4, "T": 0.6})
 >>> print(pwm)
         0      1      2      3      4
 A:   0.40   0.84   0.07   0.29   0.18
@@ -1018,7 +1018,7 @@ unequal probabilities for A, C, G, T, use the \verb+background+ argument.
 For example, against a background with a 40\% GC content, use
 %cont-doctest
 \begin{verbatim}
->>> background = {'A':0.3,'C':0.2,'G':0.2,'T':0.3}
+>>> background = {"A":0.3,"C":0.2,"G":0.2,"T":0.3}
 >>> pssm = pwm.log_odds(background)
 >>> print(pssm)
         0      1      2      3      4
@@ -1300,7 +1300,7 @@ T: 0.25
 Again, if you modify the background distribution, the position-specific scoring matrix is recalculated:
 %cont-doctest
 \begin{verbatim}
->>> motif.background = {'A': 0.2, 'C': 0.3, 'G': 0.3, 'T': 0.2}
+>>> motif.background = {"A": 0.2, "C": 0.3, "G": 0.3, "T": 0.2}
 >>> print(motif.pssm)
         0      1      2      3      4      5
 A:   0.13   1.78  -1.09  -1.09  -1.09  -1.09
@@ -1400,8 +1400,8 @@ T:  10.00 100.00 100.00   0.00   0.00   0.00   0.00  40.00  15.00
 To make the motifs comparable, we choose the same values for the pseudocounts and the background distribution as our motif \verb|m|:
 %cont-doctest
 \begin{verbatim}
->>> m_reb1.pseudocounts = {'A':0.6, 'C': 0.4, 'G': 0.4, 'T': 0.6}
->>> m_reb1.background = {'A':0.3,'C':0.2,'G':0.2,'T':0.3}
+>>> m_reb1.pseudocounts = {"A":0.6, "C": 0.4, "G": 0.4, "T": 0.6}
+>>> m_reb1.background = {"A":0.3,"C":0.2,"G":0.2,"T":0.3}
 >>> pssm_reb1 = m_reb1.pssm
 >>> print(pssm_reb1)
         0      1      2      3      4      5      6      7      8

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -460,10 +460,10 @@ T:   0.00   0.00   0.00   0.00  20.00   0.00
 The \verb+fetch_motifs+ method allows you to fetch motifs which match a specified set of criteria. These criteria include any of the above described meta information as well as certain matrix properties such as the minimum information content (\verb+min_ic+ in the example below), the minimum length of the matrix or the minimum number of sites used to construct the matrix. Only motifs which pass ALL the specified criteria are returned. Note that selection criteria which correspond to meta information which allow for multiple values may be specified as either a single value or a list of values, e.g. \verb+tax_group+ and \verb+tf_family+ in the example below.
 \begin{verbatim}
 >>> motifs = jdb.fetch_motifs(
-...     collection = 'CORE',
-...     tax_group = ['vertebrates', 'insects'],
-...     tf_class = 'Winged Helix-Turn-Helix',
-...     tf_family = ['Forkhead', 'Ets'],
+...     collection = "CORE",
+...     tax_group = ["vertebrates", "insects"],
+...     tf_class = "Winged Helix-Turn-Helix",
+...     tf_family = ["Forkhead", "Ets"],
 ...     min_ic = 12
 ... )
 >>> for motif in motifs:
@@ -1213,7 +1213,7 @@ To facilitate searching for potential TFBSs using PSSMs, both the position-weigh
 \begin{verbatim}
 >>> from Bio import motifs
 >>> with open("Arnt.sites") as handle:
-...     motif = motifs.read(handle, 'sites')
+...     motif = motifs.read(handle, "sites")
 ...
 >>> print(motif.counts)
         0      1      2      3      4      5

--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -41,8 +41,8 @@ a Python dictionary that maps header records to their values.
 Example:
 
 \begin{verbatim}
->>> resolution = structure.header['resolution']
->>> keywords = structure.header['keywords']
+>>> resolution = structure.header["resolution"]
+>>> keywords = structure.header["keywords"]
 \end{verbatim}
 The available keys are \verb+name+, \verb+head+, \verb+deposition_date+, \verb+release_date+, \verb+structure_method+, \verb+resolution+, \verb+structure_reference+ (which maps to a list of references), \verb+journal_reference+, \verb+author+, and \verb+compound+ (which maps to a dictionary with various information about the crystallized compound).
 
@@ -51,7 +51,7 @@ object, ie. directly from the PDB file:
 
 \begin{verbatim}
 >>> from Bio.PDB import parse_pdb_header
->>> with open(filename, 'r') as handle:
+>>> with open(filename, "r") as handle:
 ...     header_dict = parse_pdb_header(handle)
 ...
 \end{verbatim}
@@ -66,7 +66,7 @@ Similarly to the case of PDB files, first create an \texttt{MMCIFParser} object:
 \end{verbatim}
 Then use this parser to create a structure object from the mmCIF file:
 \begin{verbatim}
->>> structure = parser.get_structure('1fat', '1fat.cif')
+>>> structure = parser.get_structure("1fat", "1fat.cif")
 \end{verbatim}
 
 To have some more low level access to an mmCIF file, you can use the \verb+MMCIF2Dict+ class to create a Python dictionary that maps all mmCIF
@@ -77,17 +77,17 @@ The dictionary is created from the mmCIF file as follows:
 
 \begin{verbatim}
 >>> from Bio.PDB.MMCIF2Dict import MMCIF2Dict
->>> mmcif_dict = MMCIF2Dict('1FAT.cif')
+>>> mmcif_dict = MMCIF2Dict("1FAT.cif")
 \end{verbatim}
 
 Example: get the solvent content from an mmCIF file:
 \begin{verbatim}
->>> sc = mmcif_dict['_exptl_crystal.density_percent_sol']
+>>> sc = mmcif_dict["_exptl_crystal.density_percent_sol"]
 \end{verbatim}
 
 Example: get the list of the $y$ coordinates of all atoms
 \begin{verbatim}
->>> y_list = mmcif_dict['_atom_site.Cartn_y']
+>>> y_list = mmcif_dict["_atom_site.Cartn_y"]
 \end{verbatim}
 
 
@@ -138,7 +138,7 @@ Example: saving a structure
 \begin{verbatim}
 >>> io = PDBIO()
 >>> io.set_structure(s)
->>> io.save('out.pdb')
+>>> io.save("out.pdb")
 \end{verbatim}
 If you want to write out a part of the structure, make use of the
 \texttt{Select} class (also in \texttt{PDBIO}). Select has four methods:
@@ -165,7 +165,7 @@ out glycine residues:
 ...
 >>> io = PDBIO()
 >>> io.set_structure(s)
->>> io.save('gly_only.pdb', GlySelect())
+>>> io.save("gly_only.pdb", GlySelect())
 \end{verbatim}
 If this is all too complicated for you, the \texttt{Dice} module contains
 a handy \texttt{extract} function that writes out all residues in
@@ -178,7 +178,7 @@ A similar interface can be used to write structures to the mmCIF file format:
 \begin{verbatim}
 >>> io = MMCIFIO()
 >>> io.set_structure(s)
->>> io.save('out.cif')
+>>> io.save("out.cif")
 \end{verbatim}
 The \texttt{Select} class can be used in a similar way to \texttt{PDBIO} above.
 mmCIF dictionaries read using \texttt{MMCIF2Dict} can also be written:
@@ -186,7 +186,7 @@ mmCIF dictionaries read using \texttt{MMCIF2Dict} can also be written:
 \begin{verbatim}
 >>> io = MMCIFIO()
 >>> io.set_dict(d)
->>> io.save('out.cif')
+>>> io.save("out.cif")
 \end{verbatim}
 
 \section{Structure representation}
@@ -363,7 +363,7 @@ identifier alone can be used:
 
 \begin{verbatim}
 # Full id
->>> residue=chain[(' ', 100, ' ')]
+>>> residue=chain[(" ", 100, " ")]
 # Shortcut id
 >>> residue=chain[100]
 \end{verbatim}
@@ -389,7 +389,7 @@ id:
 
 \begin{verbatim}
 # use full id
->>> res10 = chain[(' ', 10, ' ')]
+>>> res10 = chain[(" ", 10, " ")]
 # use shortcut
 >>> res10 = chain[10]
 \end{verbatim}
@@ -476,9 +476,9 @@ module:
 
 \begin{verbatim}
 # get atom coordinates as vectors
->>> n = residue['N'].get_vector()
->>> c = residue['C'].get_vector()
->>> ca = residue['CA'].get_vector()
+>>> n = residue["N"].get_vector()
+>>> c = residue["C"].get_vector()
+>>> ca = residue["CA"].get_vector()
 # center at origin
 >>> n = n - ca
 >>> c = c - ca
@@ -505,14 +505,14 @@ These are some examples:
 
 \begin{verbatim}
 >>> model = structure[0]
->>> chain = model['A']
+>>> chain = model["A"]
 >>> residue = chain[100]
->>> atom = residue['CA']
+>>> atom = residue["CA"]
 \end{verbatim}
 Note that you can use a shortcut:
 
 \begin{verbatim}
->>> atom = structure[0]['A'][100]['CA']
+>>> atom = structure[0]["A"][100]["CA"]
 \end{verbatim}
 
 \section{Disorder}
@@ -553,10 +553,10 @@ specify that a \texttt{Disordered\-Atom} object should behave like
 the \texttt{Atom} object associated with a specific altloc identifier:
 
 \begin{verbatim}
->>> atom.disordered_select('A') # select altloc A atom
+>>> atom.disordered_select("A") # select altloc A atom
 >>> print(atom.get_altloc())
 "A"
->>> atom.disordered_select('B') # select altloc B atom
+>>> atom.disordered_select("B") # select altloc B atom
 >>> print(atom.get_altloc())
 "B"
 \end{verbatim}
@@ -599,7 +599,7 @@ consisting of a Ser and a Cys residue. Make sure that residue 10 of
 this chain behaves as the Cys residue.
 \begin{verbatim}
 >>> residue = chain[10]
->>> residue.disordered_select('CYS')
+>>> residue.disordered_select("CYS")
 \end{verbatim}
 In addition, you can get a list of all \texttt{Atom} objects (ie.
 all \texttt{DisorderedAtom} objects are 'unpacked' to their individual
@@ -650,7 +650,7 @@ would have hetfield ``H\_GLC''. Its residue id could e.g. be (``H\_GLC'',
 
 \begin{verbatim}
 >>> p = PDBParser()
->>> structure = p.get_structure('X', 'pdb1fat.ent')
+>>> structure = p.get_structure("X", "pdb1fat.ent")
 >>> for model in structure:
 ...     for chain in model:
 ...         for residue in chain:
@@ -687,11 +687,11 @@ or if you want to iterate over all residues in a model:
 
 You can also use the \verb+Selection.unfold_entities+ function to get all residues from a structure:
 \begin{verbatim}
->>> res_list = Selection.unfold_entities(structure, 'R')
+>>> res_list = Selection.unfold_entities(structure, "R")
 \end{verbatim}
 or to get all atoms from a chain:
 \begin{verbatim}
->>> atom_list = Selection.unfold_entities(chain, 'A')
+>>> atom_list = Selection.unfold_entities(chain, "A")
 \end{verbatim}
 Obviously, \verb+A=atom, R=residue, C=chain, M=model, S=structure+.
 You can use this to go up in the hierarchy, e.g. to get a list of
@@ -699,8 +699,8 @@ You can use this to go up in the hierarchy, e.g. to get a list of
 \verb+Atoms+:
 
 \begin{verbatim}
->>> residue_list = Selection.unfold_entities(atom_list, 'R')
->>> chain_list = Selection.unfold_entities(atom_list, 'C')
+>>> residue_list = Selection.unfold_entities(atom_list, "R")
+>>> chain_list = Selection.unfold_entities(atom_list, "C")
 \end{verbatim}
 For more info, see the API documentation.
 
@@ -822,8 +822,8 @@ Seq('SNVVE...', <class Bio.Alphabet.ProteinAlphabet>)
 The minus operator for atoms has been overloaded to return the distance between two atoms.
 \begin{verbatim}
 # Get some atoms
->>> ca1 = residue1['CA']
->>> ca2 = residue2['CA']
+>>> ca1 = residue1["CA"]
+>>> ca2 = residue2["CA"]
 # Simply subtract the atoms to get their distance
 >>> distance = ca1-ca2
 \end{verbatim}
@@ -915,9 +915,9 @@ Example:
 >>> model = structure[0]
 >>> hse = HSExposure()
 # Calculate HSEalpha
->>> exp_ca = hse.calc_hs_exposure(model, option='CA3')
+>>> exp_ca = hse.calc_hs_exposure(model, option="CA3")
 # Calculate HSEbeta
->>> exp_cb=hse.calc_hs_exposure(model, option='CB')
+>>> exp_cb=hse.calc_hs_exposure(model, option="CB")
 # Calculate classical coordination number
 >>> exp_fs = hse.calc_fs_exposure(model)
 # Print HSEalpha for a residue
@@ -1127,7 +1127,7 @@ The argument for this method is the PDB identifier of the structure.
 
 \begin{verbatim}
 >>> pdbl = PDBList()
->>> pdbl.retrieve_pdb_file('1FAT')
+>>> pdbl.retrieve_pdb_file("1FAT")
 \end{verbatim}
 
 The \texttt{PDBList} class can also be used as a command-line tool:
@@ -1171,7 +1171,7 @@ the local copy of the PDB is present) and calls the \texttt{update\_pdb}
 method:
 
 \begin{verbatim}
->>> pl = PDBList(pdb='/data/pdb')
+>>> pl = PDBList(pdb="/data/pdb")
 >>> pl.update_pdb()
 \end{verbatim}
 One can of course make a weekly \texttt{cronjob} out of this to keep

--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -158,7 +158,7 @@ out glycine residues:
 \begin{verbatim}
 >>> class GlySelect(Select):
 ...     def accept_residue(self, residue):
-...         if residue.get_name()=='GLY':
+...         if residue.get_name()=="GLY":
 ...             return True
 ...         else:
 ...             return False

--- a/Doc/Tutorial/chapter_phenotype.tex
+++ b/Doc/Tutorial/chapter_phenotype.tex
@@ -60,7 +60,7 @@ There are several ways to access WellRecord objects from a PlateRecord objects:
   \item[Well identifier]
     If you know the well identifier (row + column identifiers) you can access the desired well directly.
     \begin{verbatim}
-    >>> record['A02']
+    >>> record["A02"]
     \end{verbatim}
 
   \item[Well plate coordinates]
@@ -116,7 +116,7 @@ in the example below only the first ten time points are shown.
 \begin{verbatim}
 >>> from Bio import phenotype
 >>> record = list(phenotype.parse("Plates.csv", "pm-csv"))[-1]
->>> well = record['A02']  
+>>> well = record["A02"]
 \end{verbatim}
 %rest of code snippet output is truncated
 \begin{verbatim}
@@ -183,10 +183,10 @@ with the corrected data.
 
 %cont-doctest
 \begin{verbatim}
->>> corrected = record.subtract_control(control='A01')
->>> record['A01'][63]
+>>> corrected = record.subtract_control(control="A01")
+>>> record["A01"][63]
 336.0
->>> corrected['A01'][63]
+>>> corrected["A01"][63]
 0.0
 \end{verbatim}
 
@@ -242,7 +242,7 @@ the logistic and then the richards function. The user can also specify one of th
 \begin{verbatim}
 >>> from Bio import phenotype
 >>> record = list(phenotype.parse("Plates.csv", "pm-csv"))[-1]
->>> well = record['A02'] 
+>>> well = record["A02"]
 >>> well.fit()
 >>> print("Function fitted: %s" % well.model)
 Function fitted: gompertz

--- a/Doc/Tutorial/chapter_phylo.tex
+++ b/Doc/Tutorial/chapter_phylo.tex
@@ -375,10 +375,10 @@ Fig.~\ref{fig:phylo-dot}):
 
 \begin{verbatim}
 >>> tree = Phylo.read("example.xml", "phyloxml")
->>> Phylo.draw_graphviz(tree, prog='dot')
+>>> Phylo.draw_graphviz(tree, prog="dot")
 >>> import pylab
 >>> pylab.show()                    # Displays the tree in an interactive viewer
->>> pylab.savefig('phylo-dot.png')  # Creates a PNG file of the same graphic
+>>> pylab.savefig("phylo-dot.png")  # Creates a PNG file of the same graphic
 \end{verbatim}
 
 \begin{htmlonly}
@@ -807,7 +807,7 @@ on taxon names) and a variety of options. A quick example:
 \begin{verbatim}
 >>> from Bio import Phylo
 >>> from Bio.Phylo.Applications import PhymlCommandline
->>> cmd = PhymlCommandline(input='Tests/Phylip/random.phy')
+>>> cmd = PhymlCommandline(input="Tests/Phylip/random.phy")
 >>> out_log, err_log = cmd()
 \end{verbatim}
 
@@ -816,7 +816,7 @@ This generates a tree file and a stats file with the names
 [\textit{input~filename}]\verb|_phyml_stats.txt|. The tree file is in Newick format:
 
 \begin{verbatim}
->>> tree = Phylo.read('Tests/Phylip/random.phy_phyml_tree.txt', 'newick')
+>>> tree = Phylo.read("Tests/Phylip/random.phy_phyml_tree.txt", "newick")
 >>> Phylo.draw_ascii(tree)
 \end{verbatim}
 

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -511,7 +511,7 @@ check all the features one by one in a loop:
 >>> record = SeqIO.read("NC_005816.gb", "genbank")
 >>> for feature in record.features:
 ...     if my_snp in feature:
-...         print("%s %s" % (feature.type, feature.qualifiers.get('db_xref')))
+...         print("%s %s" % (feature.type, feature.qualifiers.get("db_xref")))
 ...
 source ['taxon:229193']
 gene ['GeneID:2767712']

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -111,7 +111,7 @@ makes no difference:
 \begin{verbatim}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
->>> my_seq = Seq('GATCGATGGGCCTATATAGGATCGAAAATCGC', IUPAC.unambiguous_dna)
+>>> my_seq = Seq("GATCGATGGGCCTATATAGGATCGAAAATCGC", IUPAC.unambiguous_dna)
 >>> len(my_seq)
 32
 >>> my_seq.count("G")
@@ -127,7 +127,7 @@ While you could use the above snippet of code to calculate a GC\%, note that  th
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> from Bio.SeqUtils import GC
->>> my_seq = Seq('GATCGATGGGCCTATATAGGATCGAAAATCGC', IUPAC.unambiguous_dna)
+>>> my_seq = Seq("GATCGATGGGCCTATATAGGATCGAAAATCGC", IUPAC.unambiguous_dna)
 >>> GC(my_seq)
 46.875
 \end{verbatim}

--- a/Doc/Tutorial/chapter_uniprot.tex
+++ b/Doc/Tutorial/chapter_uniprot.tex
@@ -174,8 +174,8 @@ The entries in this file can be parsed by the \verb+parse+ function in the \verb
 >>> handle = open("keywlist.txt")
 >>> records = KeyWList.parse(handle)
 >>> for record in records:
-...     print(record['ID'])
-...     print(record['DE'])
+...     print(record["ID"])
+...     print(record["DE"])
 \end{verbatim}
 
 This prints

--- a/Doc/Tutorial/chapter_uniprot.tex
+++ b/Doc/Tutorial/chapter_uniprot.tex
@@ -416,7 +416,7 @@ To retrieve a Prosite or Prosite documentation record in raw format, use \verb|g
 
 \begin{verbatim}
 >>> from Bio import ExPASy
->>> handle = ExPASy.get_prosite_raw('PS00001')
+>>> handle = ExPASy.get_prosite_raw("PS00001")
 >>> text = handle.read()
 >>> print(text)
 \end{verbatim}
@@ -426,7 +426,7 @@ To retrieve a Prosite record and parse it into a \verb|Bio.Prosite.Record| objec
 \begin{verbatim}
 >>> from Bio import ExPASy
 >>> from Bio import Prosite
->>> handle = ExPASy.get_prosite_raw('PS00001')
+>>> handle = ExPASy.get_prosite_raw("PS00001")
 >>> record = Prosite.read(handle)
 \end{verbatim}
 
@@ -435,7 +435,7 @@ The same function can be used to retrieve a Prosite documentation record and par
 \begin{verbatim}
 >>> from Bio import ExPASy
 >>> from Bio.ExPASy import Prodoc
->>> handle = ExPASy.get_prosite_raw('PDOC00001')
+>>> handle = ExPASy.get_prosite_raw("PDOC00001")
 >>> record = Prodoc.read(handle)
 \end{verbatim}
 
@@ -445,7 +445,7 @@ The functions \verb|get_prosite_entry()| and \verb|get_prodoc_entry()| are used 
 
 \begin{verbatim}
 >>> from Bio import ExPASy
->>> handle = ExPASy.get_prosite_entry('PS00001')
+>>> handle = ExPASy.get_prosite_entry("PS00001")
 >>> html = handle.read()
 >>> with open("myprositerecord.html", "w") as out_handle:
 ...     out_handle.write(html)
@@ -456,7 +456,7 @@ and similarly for a Prosite documentation record:
 
 \begin{verbatim}
 >>> from Bio import ExPASy
->>> handle = ExPASy.get_prodoc_entry('PDOC00001')
+>>> handle = ExPASy.get_prodoc_entry("PDOC00001")
 >>> html = handle.read()
 >>> with open("myprodocrecord.html", "w") as out_handle:
 ...     out_handle.write(html)


### PR DESCRIPTION
This pull request addresses issue #1651

Some single quotes were used for Regex function (ex: `re.findall` in `Doc/Tutorial/uniprot.tex`, line 406 and 408).
I left them like so in case the function was compromised.

