### PR TITLE
Add integer multiplication methods for Seq, UnknownSeq and MutableSeq

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1393,6 +1393,54 @@ class UnknownSeq(Seq):
         # Offload to the base class...
         return other + Seq(str(self), self.alphabet)
 
+    def __mul__(self, other):
+        """Multiply UnknownSeq by integer
+
+        >>> from Bio.Seq import UnknownSeq
+        >>> from Bio.Alphabet import generic_dna
+        >>> UnknownSeq(3) * 2
+        UnknownSeq(6, alphabet = Alphabet(), character = '?')
+        >>> UnknownSeq(3, generic_dna) * 2
+        UnknownSeq(6, alphabet = DNAAlphabet(), character = 'N')
+        """
+
+        if not isinstance(other, int):
+            raise TypeError("can't multiply UnknownSeq by non-int type")
+        return self.__class__(len(self) * other, self.alphabet)
+
+    def __rmul__(self, other):
+        """Multiply integer by UnknownSeq
+
+        >>> from Bio.Seq import UnknownSeq
+        >>> from Bio.Alphabet import generic_dna
+        >>> 2 * UnknownSeq(3)
+        UnknownSeq(6, alphabet = Alphabet(), character = '?')
+        >>> 2 * UnknownSeq(3, generic_dna)
+        UnknownSeq(6, alphabet = DNAAlphabet(), character = 'N')
+        """
+
+        if not isinstance(other, int):
+            raise TypeError("can't multiply UnknownSeq by non-int type")
+        return self.__class__(len(self) * other, self.alphabet)
+
+    def __imul__(self, other):
+        """Multiply UnknownSeq in-place
+
+        Note although UnknownSeq is immutable, the in-place method is
+        included to match the behaviour for regular Python strings
+
+        >>> from Bio.Seq import UnknownSeq
+        >>> from Bio.Alphabet import generic_dna
+        >>> seq = UnknownSeq(3, generic_dna)
+        >>> seq *= 2
+        >>> seq
+        UnknownSeq(6, alphabet = DNAAlphabet(), character = 'N')
+        """
+
+        if not isinstance(other, int):
+            raise TypeError("can't multiply UnknownSeq by non-int type")
+        return self.__class__(len(self) * other, self.alphabet)
+
     def __getitem__(self, index):
         """Get a subsequence from the UnknownSeq object.
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2078,7 +2078,7 @@ class MutableSeq(object):
         return self.__class__(self.data * other, self.alphabet)
 
     def __imul__(self, other):
-        """Multiply MutableSeq in-place
+        """Multiply MutableSeq in-place.
 
         >>> from Bio.Seq import MutableSeq
         >>> from Bio.Alphabet import generic_dna

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2058,7 +2058,7 @@ class MutableSeq(object):
         """
         if not isinstance(other, int):
             raise TypeError("can't multiply MutableSeq by non-int type")
-        return self.__class__(str(self) * other, self.alphabet)
+        return self.__class__(self.data * other, self.alphabet)
 
     def __rmul__(self, other):
         """Multiply integer by MutableSeq.
@@ -2075,7 +2075,7 @@ class MutableSeq(object):
         """
         if not isinstance(other, int):
             raise TypeError("can't multiply MutableSeq by non-int type")
-        return self.__class__(str(self) * other, self.alphabet)
+        return self.__class__(self.data * other, self.alphabet)
 
     def __imul__(self, other):
         """Multiply MutableSeq in-place
@@ -2089,7 +2089,7 @@ class MutableSeq(object):
         """
         if not isinstance(other, int):
             raise TypeError("can't multiply MutableSeq by non-int type")
-        return self.__class__(str(self) * other, self.alphabet)
+        return self.__class__(self.data * other, self.alphabet)
 
     def append(self, c):
         """Add a subsequence to the mutable sequence object.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -346,7 +346,7 @@ class Seq(object):
             raise TypeError
 
     def __mul__(self, other):
-        """Multiply Seq by integer
+        """Multiply Seq by integer.
 
         >>> from Bio.Seq import Seq
         >>> from Bio.Alphabet import generic_dna
@@ -355,13 +355,12 @@ class Seq(object):
         >>> Seq('ATG', generic_dna) * 2
         Seq('ATGATG', DNAAlphabet())
         """
-
         if not isinstance(other, int):
             raise TypeError("can't multiply Seq by non-int type")
         return self.__class__(str(self) * other, self.alphabet)
 
     def __rmul__(self, other):
-        """Multiply integer by Seq
+        """Multiply integer by Seq.
 
         >>> from Bio.Seq import Seq
         >>> from Bio.Alphabet import generic_dna
@@ -370,16 +369,15 @@ class Seq(object):
         >>> 2 * Seq('ATG', generic_dna)
         Seq('ATGATG', DNAAlphabet())
         """
-
         if not isinstance(other, int):
             raise TypeError("can't multiply Seq by non-int type")
         return self.__class__(str(self) * other, self.alphabet)
 
     def __imul__(self, other):
-        """Multiply Seq in-place
+        """Multiply Seq in-place.
 
         Note although Seq is immutable, the in-place method is
-        included to match the behaviour for regular Python strings
+        included to match the behaviour for regular Python strings.
 
         >>> from Bio.Seq import Seq
         >>> from Bio.Alphabet import generic_dna
@@ -388,7 +386,6 @@ class Seq(object):
         >>> seq
         Seq('ATGATG', DNAAlphabet())
         """
-
         if not isinstance(other, int):
             raise TypeError("can't multiply Seq by non-int type")
         return self.__class__(str(self) * other, self.alphabet)
@@ -1394,7 +1391,7 @@ class UnknownSeq(Seq):
         return other + Seq(str(self), self.alphabet)
 
     def __mul__(self, other):
-        """Multiply UnknownSeq by integer
+        """Multiply UnknownSeq by integer.
 
         >>> from Bio.Seq import UnknownSeq
         >>> from Bio.Alphabet import generic_dna
@@ -1403,13 +1400,12 @@ class UnknownSeq(Seq):
         >>> UnknownSeq(3, generic_dna) * 2
         UnknownSeq(6, alphabet = DNAAlphabet(), character = 'N')
         """
-
         if not isinstance(other, int):
             raise TypeError("can't multiply UnknownSeq by non-int type")
         return self.__class__(len(self) * other, self.alphabet)
 
     def __rmul__(self, other):
-        """Multiply integer by UnknownSeq
+        """Multiply integer by UnknownSeq.
 
         >>> from Bio.Seq import UnknownSeq
         >>> from Bio.Alphabet import generic_dna
@@ -1418,16 +1414,15 @@ class UnknownSeq(Seq):
         >>> 2 * UnknownSeq(3, generic_dna)
         UnknownSeq(6, alphabet = DNAAlphabet(), character = 'N')
         """
-
         if not isinstance(other, int):
             raise TypeError("can't multiply UnknownSeq by non-int type")
         return self.__class__(len(self) * other, self.alphabet)
 
     def __imul__(self, other):
-        """Multiply UnknownSeq in-place
+        """Multiply UnknownSeq in-place.
 
         Note although UnknownSeq is immutable, the in-place method is
-        included to match the behaviour for regular Python strings
+        included to match the behaviour for regular Python strings.
 
         >>> from Bio.Seq import UnknownSeq
         >>> from Bio.Alphabet import generic_dna
@@ -1436,7 +1431,6 @@ class UnknownSeq(Seq):
         >>> seq
         UnknownSeq(6, alphabet = DNAAlphabet(), character = 'N')
         """
-
         if not isinstance(other, int):
             raise TypeError("can't multiply UnknownSeq by non-int type")
         return self.__class__(len(self) * other, self.alphabet)
@@ -2050,10 +2044,10 @@ class MutableSeq(object):
             raise TypeError
 
     def __mul__(self, other):
-        """Multiply MutableSeq by integer
+        """Multiply MutableSeq by integer.
 
         Note this is not in-place and returns a new object,
-        matching native Python list multiplication
+        matching native Python list multiplication.
 
         >>> from Bio.Seq import MutableSeq
         >>> from Bio.Alphabet import generic_dna
@@ -2062,16 +2056,15 @@ class MutableSeq(object):
         >>> MutableSeq('ATG', generic_dna) * 2
         MutableSeq('ATGATG', DNAAlphabet())
         """
-
         if not isinstance(other, int):
             raise TypeError("can't multiply MutableSeq by non-int type")
         return self.__class__(str(self) * other, self.alphabet)
 
     def __rmul__(self, other):
-        """Multiply integer by MutableSeq
+        """Multiply integer by MutableSeq.
 
         Note this is not in-place and returns a new object,
-        matching native Python list multiplication
+        matching native Python list multiplication.
 
         >>> from Bio.Seq import MutableSeq
         >>> from Bio.Alphabet import generic_dna
@@ -2080,7 +2073,6 @@ class MutableSeq(object):
         >>> 2 * MutableSeq('ATG', generic_dna)
         MutableSeq('ATGATG', DNAAlphabet())
         """
-
         if not isinstance(other, int):
             raise TypeError("can't multiply MutableSeq by non-int type")
         return self.__class__(str(self) * other, self.alphabet)
@@ -2095,7 +2087,6 @@ class MutableSeq(object):
         >>> seq
         MutableSeq('ATGATG', DNAAlphabet())
         """
-
         if not isinstance(other, int):
             raise TypeError("can't multiply MutableSeq by non-int type")
         return self.__class__(str(self) * other, self.alphabet)

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2049,6 +2049,57 @@ class MutableSeq(object):
         else:
             raise TypeError
 
+    def __mul__(self, other):
+        """Multiply MutableSeq by integer
+
+        Note this is not in-place and returns a new object,
+        matching native Python list multiplication
+
+        >>> from Bio.Seq import MutableSeq
+        >>> from Bio.Alphabet import generic_dna
+        >>> MutableSeq('ATG') * 2
+        MutableSeq('ATGATG', Alphabet())
+        >>> MutableSeq('ATG', generic_dna) * 2
+        MutableSeq('ATGATG', DNAAlphabet())
+        """
+
+        if not isinstance(other, int):
+            raise TypeError("can't multiply MutableSeq by non-int type")
+        return self.__class__(str(self) * other, self.alphabet)
+
+    def __rmul__(self, other):
+        """Multiply integer by MutableSeq
+
+        Note this is not in-place and returns a new object,
+        matching native Python list multiplication
+
+        >>> from Bio.Seq import MutableSeq
+        >>> from Bio.Alphabet import generic_dna
+        >>> 2 * MutableSeq('ATG')
+        MutableSeq('ATGATG', Alphabet())
+        >>> 2 * MutableSeq('ATG', generic_dna)
+        MutableSeq('ATGATG', DNAAlphabet())
+        """
+
+        if not isinstance(other, int):
+            raise TypeError("can't multiply MutableSeq by non-int type")
+        return self.__class__(str(self) * other, self.alphabet)
+
+    def __imul__(self, other):
+        """Multiply MutableSeq in-place
+
+        >>> from Bio.Seq import MutableSeq
+        >>> from Bio.Alphabet import generic_dna
+        >>> seq = MutableSeq('ATG', generic_dna)
+        >>> seq *= 2
+        >>> seq
+        MutableSeq('ATGATG', DNAAlphabet())
+        """
+
+        if not isinstance(other, int):
+            raise TypeError("can't multiply MutableSeq by non-int type")
+        return self.__class__(str(self) * other, self.alphabet)
+
     def append(self, c):
         """Add a subsequence to the mutable sequence object.
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -345,6 +345,54 @@ class Seq(object):
         else:
             raise TypeError
 
+    def __mul__(self, other):
+        """Multiply Seq by integer
+
+        >>> from Bio.Seq import Seq
+        >>> from Bio.Alphabet import generic_dna
+        >>> Seq('ATG') * 2
+        Seq('ATGATG', Alphabet())
+        >>> Seq('ATG', generic_dna) * 2
+        Seq('ATGATG', DNAAlphabet())
+        """
+
+        if not isinstance(other, int):
+            raise TypeError("can't multiply Seq by non-int type")
+        return self.__class__(str(self) * other, self.alphabet)
+
+    def __rmul__(self, other):
+        """Multiply integer by Seq
+
+        >>> from Bio.Seq import Seq
+        >>> from Bio.Alphabet import generic_dna
+        >>> 2 * Seq('ATG')
+        Seq('ATGATG', Alphabet())
+        >>> 2 * Seq('ATG', generic_dna)
+        Seq('ATGATG', DNAAlphabet())
+        """
+
+        if not isinstance(other, int):
+            raise TypeError("can't multiply Seq by non-int type")
+        return self.__class__(str(self) * other, self.alphabet)
+
+    def __imul__(self, other):
+        """Multiply Seq in-place
+
+        Note although Seq is immutable, the in-place method is
+        included to match the behaviour for regular Python strings
+
+        >>> from Bio.Seq import Seq
+        >>> from Bio.Alphabet import generic_dna
+        >>> seq = Seq('ATG', generic_dna)
+        >>> seq *= 2
+        >>> seq
+        Seq('ATGATG', DNAAlphabet())
+        """
+
+        if not isinstance(other, int):
+            raise TypeError("can't multiply Seq by non-int type")
+        return self.__class__(str(self) * other, self.alphabet)
+
     def tostring(self):  # Seq API requirement
         """Return the full sequence as a python string (DEPRECATED).
 

--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -160,7 +160,7 @@ class DBSeq(Seq):
         # Let the Seq object deal with the alphabet issues etc
         return self.toseq() * other
 
-     def __rmull__(self, other):
+    def __rmull__(self, other):
         """Multiply integer by a sequence.
 
         The sequence is first converted to a Seq object before multiplication.
@@ -169,7 +169,7 @@ class DBSeq(Seq):
         # Let the Seq object deal with the alphabet issues etc
         return other * self.toseq()
 
-     def __imull__(self, other):
+    def __imull__(self, other):
         """Multiply sequence by integer in-place.
 
         The sequence is first converted to a Seq object before multiplication.

--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -137,7 +137,7 @@ class DBSeq(Seq):
         """Add another sequence or string to this sequence.
 
         The sequence is first converted to a Seq object before the addition.
-        The returned object is a Seq object, not a DBSeq object
+        The returned object is a Seq object, not a DBSeq object.
         """
         # Let the Seq object deal with the alphabet issues etc
         return self.toseq() + other
@@ -146,10 +146,37 @@ class DBSeq(Seq):
         """Add another sequence or string to the left.
 
         The sequence is first converted to a Seq object before the addition.
-        The returned object is a Seq object, not a DBSeq object
+        The returned object is a Seq object, not a DBSeq object.
         """
         # Let the Seq object deal with the alphabet issues etc
         return other + self.toseq()
+
+    def __mull__(self, other):
+        """Multiply sequence by an integer.
+
+        The sequence is first converted to a Seq object before multiplication.
+        The returned object is a Seq object, not a DBSeq object.
+        """
+        # Let the Seq object deal with the alphabet issues etc
+        return self.toseq() * other
+
+     def __rmull__(self, other):
+        """Multiply integer by a sequence.
+
+        The sequence is first converted to a Seq object before multiplication.
+        The returned object is a Seq object, not a DBSeq object.
+        """
+        # Let the Seq object deal with the alphabet issues etc
+        return other * self.toseq()
+
+     def __imull__(self, other):
+        """Multiply sequence by integer in-place.
+
+        The sequence is first converted to a Seq object before multiplication.
+        The returned object is a Seq object, not a DBSeq object.
+        """
+        # Let the Seq object deal with the alphabet issues etc
+        return self.toseq() * other
 
 
 def _retrieve_seq_len(adaptor, primary_id):

--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -151,7 +151,7 @@ class DBSeq(Seq):
         # Let the Seq object deal with the alphabet issues etc
         return other + self.toseq()
 
-    def __mull__(self, other):
+    def __mul__(self, other):
         """Multiply sequence by an integer.
 
         The sequence is first converted to a Seq object before multiplication.
@@ -160,7 +160,7 @@ class DBSeq(Seq):
         # Let the Seq object deal with the alphabet issues etc
         return self.toseq() * other
 
-    def __rmull__(self, other):
+    def __rmul__(self, other):
         """Multiply integer by a sequence.
 
         The sequence is first converted to a Seq object before multiplication.
@@ -169,7 +169,7 @@ class DBSeq(Seq):
         # Let the Seq object deal with the alphabet issues etc
         return other * self.toseq()
 
-    def __imull__(self, other):
+    def __imul__(self, other):
         """Multiply sequence by integer in-place.
 
         The sequence is first converted to a Seq object before multiplication.

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -33,6 +33,9 @@ Improved support for parsing NCBI Entrez XML files that use XSD schemas.
 Internal changes to our C code mean that NumPy is no longer required at
 compile time - only at run time (and only for those modules which use NumPy).
 
+Seq, UnknownSeq, MutableSeq and derived classes now support integer
+multiplication methods, matching native Python string methods.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -543,11 +543,13 @@ class SeqInterfaceTest(unittest.TestCase):
         tripled = test_seq * 3
         # Test DBSeq.__mul__
         self.assertTrue(isinstance(tripled, Seq))
+        self.assertFalse(isinstance(tripled, BioSeq.DBSeq))
         self.assertEqual(tripled, str(test_seq) * 3)
         self.assertEqual(tripled.alphabet, alphabet)
         # Test DBSeq.__rmul__
         tripled = 3 * test_seq
         self.assertTrue(isinstance(tripled, Seq))
+        self.assertFalse(isinstance(tripled, BioSeq.DBSeq))
         self.assertEqual(tripled, str(test_seq) * 3)
         self.assertEqual(tripled.alphabet, alphabet)
         # Test DBSeq.__imul__
@@ -555,6 +557,7 @@ class SeqInterfaceTest(unittest.TestCase):
         tripled = test_seq
         tripled *= 3
         self.assertTrue(isinstance(tripled, Seq))
+        self.assertFalse(isinstance(tripled, BioSeq.DBSeq))
         self.assertEqual(tripled, str(original) * 3)
         self.assertEqual(tripled.alphabet, alphabet)
 

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -536,6 +536,28 @@ class SeqInterfaceTest(unittest.TestCase):
             test = other + test_seq
             self.assertEqual(str(test), str(other) + str(test_seq))
 
+    def test_multiplication(self):
+        """Check can multiply DBSeq objects by integers."""
+        test_seq = self.item.seq
+        alphabet = test_seq.alphabet
+        tripled = test_seq * 3
+        # Test DBSeq.__mul__
+        self.assertTrue(isinstance(tripled, Seq))
+        self.assertEqual(tripled, str(test_seq) * 3)
+        self.assertEqual(tripled.alphabet, alphabet)
+        # Test DBSeq.__rmul__
+        tripled = 3 * test_seq
+        self.assertTrue(isinstance(tripled, Seq))
+        self.assertEqual(tripled, str(test_seq) * 3)
+        self.assertEqual(tripled.alphabet, alphabet)
+        # Test DBSeq.__imul__
+        original = self.item.seq
+        tripled = test_seq
+        tripled *= 3
+        self.assertTrue(isinstance(tripled, Seq))
+        self.assertEqual(tripled, str(original) * 3)
+        self.assertEqual(tripled.alphabet, alphabet)
+
     def test_seq_slicing(self):
         """Check that slices of sequences are retrieved properly."""
         test_seq = self.item.seq

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -496,6 +496,22 @@ class TestSeqMultiplication(unittest.TestCase):
             with self.assertRaises(TypeError):
                 '' * seq
 
+    def test_imul_method(self):
+        """Test imul method; relies on addition and mull methods"""
+        for seq in test_seqs + protein_seqs:
+            original_seq = seq * 1  # make a copy
+            seq *= 3
+            self.assertEqual(seq, original_seq + original_seq + original_seq)
+
+    def test_imul_method_exceptions(self):
+        """Test imul method exceptions; relies on mull method"""
+        for seq in test_seqs + protein_seqs:
+            original_seq = seq * 1  # make a copy
+            with self.assertRaises(TypeError):
+                seq *= 3.0
+            with self.assertRaises(TypeError):
+                seq *= ''
+
 
 class TestMutableSeq(unittest.TestCase):
     def setUp(self):

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -469,6 +469,34 @@ class TestSeqAddition(unittest.TestCase):
                 self.assertEqual(str(c), str(a) + str(b))
 
 
+class TestSeqMultiplication(unittest.TestCase):
+    def test_mul_method(self):
+        """Test mul method; relies on addition method"""
+        for seq in test_seqs + protein_seqs:
+            self.assertEqual(seq * 3, seq + seq + seq)
+
+    def test_mul_method_exceptions(self):
+        """Test mul method exceptions"""
+        for seq in test_seqs + protein_seqs:
+            with self.assertRaises(TypeError):
+                seq * 3.0
+            with self.assertRaises(TypeError):
+                seq * ''
+
+    def test_rmul_method(self):
+        """Test rmul method; relies on addition method"""
+        for seq in test_seqs + protein_seqs:
+            self.assertEqual(3 * seq, seq + seq + seq)
+
+    def test_rmul_method_exceptions(self):
+        """Test rmul method exceptions"""
+        for seq in test_seqs + protein_seqs:
+            with self.assertRaises(TypeError):
+                3.0 * seq
+            with self.assertRaises(TypeError):
+                '' * seq
+
+
 class TestMutableSeq(unittest.TestCase):
     def setUp(self):
         self.s = Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna)

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -504,9 +504,8 @@ class TestSeqMultiplication(unittest.TestCase):
             self.assertEqual(seq, original_seq + original_seq + original_seq)
 
     def test_imul_method_exceptions(self):
-        """Test imul method exceptions; relies on mull method"""
+        """Test imul method exceptions"""
         for seq in test_seqs + protein_seqs:
-            original_seq = seq * 1  # make a copy
             with self.assertRaises(TypeError):
                 seq *= 3.0
             with self.assertRaises(TypeError):


### PR DESCRIPTION
This pull request addresses issue #1659

The issue explains the rationale, but here is a small example of the utility of the new methods:

```
>>> from Bio.Seq import Seq
>>> Seq('AT') * 2
Seq('ATAT', Alphabet())
>>> 2 * Seq('AT')    
Seq('ATAT', Alphabet())
>>> seq = Seq('AT')
>>> seq *= 2
>>> seq
Seq('ATAT', Alphabet())
```

The methods should work with all the `Seq`, `UnknownSeq`, and `MutableSeq` objects and with any alphabet. I also implemented some unit tests.

Let me know if this looks ok?

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
