### PR TITLE
change single to double quote in leftover doctest parts in Doc/Tutorial

### DIFF
--- a/Doc/Tutorial/chapter_appendix.tex
+++ b/Doc/Tutorial/chapter_appendix.tex
@@ -96,7 +96,7 @@ string into a handle. The following example shows how to do this using
 
 %doctest
 \begin{verbatim}
->>> my_info = 'A string\n with multiple lines.'
+>>> my_info = "A string\n with multiple lines."
 >>> print(my_info)
 A string
  with multiple lines.

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -726,7 +726,7 @@ comparison itself only the string of letters in the sequence is used:
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import generic_dna, generic_protein
 >>> dna_seq = Seq("ACGT", generic_dna)
->>> prot_seq = Seq(``ACGT'', generic_protein)
+>>> prot_seq = Seq("ACGT", generic_protein)
 >>> dna_seq == prot_seq
 BiopythonWarning: Incompatible alphabets DNAAlphabet() and ProteinAlphabet()
 True

--- a/Doc/Tutorial/chapter_seqio.tex
+++ b/Doc/Tutorial/chapter_seqio.tex
@@ -859,7 +859,7 @@ You can use the index as a read only Python dictionary - without having to worry
 about which file the sequence comes from, e.g.
 
 \begin{verbatim}
->>> print(gb_vrl[``AB811634.1''].description)
+>>> print(gb_vrl["AB811634.1"].description)
 Equine encephalosis virus NS3 gene, complete cds, isolate: Kimron1.
 \end{verbatim}
 
@@ -872,10 +872,10 @@ get at the raw bytes of each record:
 % TODO - Under Python 3 you'd get the bytes string representation with
 % leading b single-quote, escaped newlines, and closing single-quote:
 %
-% >>> print(gb_vrl.get_raw(``GQ333173.1''))
+% >>> print(gb_vrl.get_raw("GQ333173.1"))
 % b'LOCUS       GQ333173                 459 bp    DNA     linear   VRL 21-OCT-2009\nDEFINITION...'
 \begin{verbatim}
->>> print(gb_vrl.get_raw(``AB811634.1''))
+>>> print(gb_vrl.get_raw("AB811634.1"))
 LOCUS       AB811634                 723 bp    RNA     linear   VRL 17-JUN-2015
 DEFINITION  Equine encephalosis virus NS3 gene, complete cds, isolate: Kimron1.
 ACCESSION   AB811634


### PR DESCRIPTION
This pull request addresses issue #1651

I took care of the leftover examples and the `chapter_seqio.tex` errors.
