### PR TITLE
Improve test coverage for module Bio.Pathway

### DIFF
--- a/Bio/Pathway/Rep/Graph.py
+++ b/Bio/Pathway/Rep/Graph.py
@@ -85,7 +85,7 @@ class Graph(object):
         """Return a list of all the edges with this label."""
         if label not in self._label_map:
             raise ValueError("Unknown label: " + str(label))
-        return list(self._label_map[label])
+        return sorted(list(self._label_map[label]))
 
     def labels(self):
         """Return a list of all the edge labels in this graph."""

--- a/Bio/Pathway/Rep/Graph.py
+++ b/Bio/Pathway/Rep/Graph.py
@@ -85,11 +85,11 @@ class Graph(object):
         """Return a list of all the edges with this label."""
         if label not in self._label_map:
             raise ValueError("Unknown label: " + str(label))
-        return sorted(list(self._label_map[label]))
+        return sorted(self._label_map[label])
 
     def labels(self):
         """Return a list of all the edge labels in this graph."""
-        return sorted(list(self._label_map.keys()))
+        return sorted(self._label_map.keys())
 
     def nodes(self):
         """Return a list of the nodes in this graph."""

--- a/Bio/Pathway/Rep/Graph.py
+++ b/Bio/Pathway/Rep/Graph.py
@@ -1,4 +1,5 @@
 # Copyright 2002 by Tarjei Mikkelsen.  All rights reserved.
+# Revisions copyright 2018 by Maximilian Greil. All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
@@ -6,6 +7,7 @@
 # get set abstraction for graph representation
 
 from functools import reduce
+from numpy import unique
 
 
 class Graph(object):
@@ -34,8 +36,9 @@ class Graph(object):
         """Return a unique string representation of this graph."""
         s = "<Graph: "
         for key in sorted(self._adjacency_list):
+            l = unique(list(self._adjacency_list[key])).tolist()
             values = sorted([(x, self._edge_map[(key, x)])
-                      for x in self._adjacency_list[key].list()])
+                      for x in l])
             s += "(%r: %s)" % (key, ",".join(repr(v) for v in values))
         return s + ">"
 
@@ -84,7 +87,7 @@ class Graph(object):
         """Return a list of all the edges with this label."""
         if label not in self._label_map:
             raise ValueError("Unknown label: " + str(label))
-        return self._label_map[label].list()
+        return unique(list(self._label_map[label])).tolist()
 
     def labels(self):
         """Return a list of all the edge labels in this graph."""

--- a/Bio/Pathway/Rep/Graph.py
+++ b/Bio/Pathway/Rep/Graph.py
@@ -87,7 +87,7 @@ class Graph(object):
         """Return a list of all the edges with this label."""
         if label not in self._label_map:
             raise ValueError("Unknown label: " + str(label))
-        return unique(list(self._label_map[label])).tolist()
+        return list(self._label_map[label])
 
     def labels(self):
         """Return a list of all the edge labels in this graph."""

--- a/Bio/Pathway/Rep/Graph.py
+++ b/Bio/Pathway/Rep/Graph.py
@@ -36,9 +36,9 @@ class Graph(object):
         """Return a unique string representation of this graph."""
         s = "<Graph: "
         for key in sorted(self._adjacency_list):
-            l = unique(list(self._adjacency_list[key])).tolist()
+            temp_list = unique(list(self._adjacency_list[key])).tolist()
             values = sorted([(x, self._edge_map[(key, x)])
-                      for x in l])
+                      for x in temp_list])
             s += "(%r: %s)" % (key, ",".join(repr(v) for v in values))
         return s + ">"
 

--- a/Bio/Pathway/Rep/Graph.py
+++ b/Bio/Pathway/Rep/Graph.py
@@ -89,7 +89,7 @@ class Graph(object):
 
     def labels(self):
         """Return a list of all the edge labels in this graph."""
-        return list(self._label_map.keys())
+        return sorted(list(self._label_map.keys()))
 
     def nodes(self):
         """Return a list of the nodes in this graph."""

--- a/Bio/Pathway/Rep/Graph.py
+++ b/Bio/Pathway/Rep/Graph.py
@@ -7,7 +7,6 @@
 # get set abstraction for graph representation
 
 from functools import reduce
-from numpy import unique
 
 
 class Graph(object):
@@ -36,9 +35,8 @@ class Graph(object):
         """Return a unique string representation of this graph."""
         s = "<Graph: "
         for key in sorted(self._adjacency_list):
-            temp_list = unique(list(self._adjacency_list[key])).tolist()
             values = sorted([(x, self._edge_map[(key, x)])
-                      for x in temp_list])
+                      for x in list(self._adjacency_list[key])])
             s += "(%r: %s)" % (key, ",".join(repr(v) for v in values))
         return s + ">"
 

--- a/Bio/Pathway/Rep/MultiGraph.py
+++ b/Bio/Pathway/Rep/MultiGraph.py
@@ -80,7 +80,7 @@ class MultiGraph(object):
         """Return a list of all the edges with this label."""
         if label not in self._label_map:
             raise ValueError("Unknown label: " + str(label))
-        return list(self._label_map[label])
+        return sorted(list(self._label_map[label]))
 
     def labels(self):
         """Return a list of all the edge labels in this graph."""

--- a/Bio/Pathway/Rep/MultiGraph.py
+++ b/Bio/Pathway/Rep/MultiGraph.py
@@ -1,4 +1,5 @@
 # Copyright 2001 by Tarjei Mikkelsen.  All rights reserved.
+# Revisions copyright 2018 by Maximilian Greil. All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
@@ -6,7 +7,7 @@
 # get set abstraction for graph representation
 
 from functools import reduce
-
+from numpy import unique
 
 # TODO - Subclass graph?
 class MultiGraph(object):
@@ -79,7 +80,7 @@ class MultiGraph(object):
         """Return a list of all the edges with this label."""
         if label not in self._label_map:
             raise ValueError("Unknown label: " + str(label))
-        return sorted(self._label_map[label])
+        return unique(list(self._label_map[label])).tolist()
 
     def labels(self):
         """Return a list of all the edge labels in this graph."""

--- a/Bio/Pathway/Rep/MultiGraph.py
+++ b/Bio/Pathway/Rep/MultiGraph.py
@@ -84,7 +84,7 @@ class MultiGraph(object):
 
     def labels(self):
         """Return a list of all the edge labels in this graph."""
-        return list(self._label_map.keys())
+        return sorted(list(self._label_map.keys()))
 
     def nodes(self):
         """Return a list of the nodes in this graph."""

--- a/Bio/Pathway/Rep/MultiGraph.py
+++ b/Bio/Pathway/Rep/MultiGraph.py
@@ -9,6 +9,7 @@
 from functools import reduce
 from numpy import unique
 
+
 # TODO - Subclass graph?
 class MultiGraph(object):
     """A directed multigraph abstraction with labeled edges."""

--- a/Bio/Pathway/Rep/MultiGraph.py
+++ b/Bio/Pathway/Rep/MultiGraph.py
@@ -80,11 +80,11 @@ class MultiGraph(object):
         """Return a list of all the edges with this label."""
         if label not in self._label_map:
             raise ValueError("Unknown label: " + str(label))
-        return sorted(list(self._label_map[label]))
+        return sorted(self._label_map[label])
 
     def labels(self):
         """Return a list of all the edge labels in this graph."""
-        return sorted(list(self._label_map.keys()))
+        return sorted(self._label_map.keys())
 
     def nodes(self):
         """Return a list of the nodes in this graph."""

--- a/Bio/Pathway/Rep/MultiGraph.py
+++ b/Bio/Pathway/Rep/MultiGraph.py
@@ -81,7 +81,7 @@ class MultiGraph(object):
         """Return a list of all the edges with this label."""
         if label not in self._label_map:
             raise ValueError("Unknown label: " + str(label))
-        return unique(list(self._label_map[label])).tolist()
+        return list(self._label_map[label])
 
     def labels(self):
         """Return a list of all the edge labels in this graph."""

--- a/Bio/Pathway/Rep/MultiGraph.py
+++ b/Bio/Pathway/Rep/MultiGraph.py
@@ -7,7 +7,6 @@
 # get set abstraction for graph representation
 
 from functools import reduce
-from numpy import unique
 
 
 # TODO - Subclass graph?

--- a/Tests/test_Pathway.py
+++ b/Tests/test_Pathway.py
@@ -12,6 +12,7 @@ from Bio.Pathway import Reaction
 from Bio.Pathway.Rep.Graph import Graph
 from Bio.Pathway.Rep.MultiGraph import MultiGraph, df_search, bf_search
 
+
 class GraphTestCase(unittest.TestCase):
 
     def test_Equals(self):

--- a/Tests/test_Pathway.py
+++ b/Tests/test_Pathway.py
@@ -10,7 +10,7 @@ import unittest
 # modules to be tested
 from Bio.Pathway import Reaction
 from Bio.Pathway.Rep.Graph import Graph
-from Bio.Pathway.Rep.MultiGraph import MultiGraph, bf_search
+from Bio.Pathway.Rep.MultiGraph import MultiGraph
 
 
 class GraphTestCase(unittest.TestCase):
@@ -159,13 +159,6 @@ class MultiGraphTestCase(unittest.TestCase):
             str(a) == "<MultiGraph: 3 node(s), 3 edge(s), 2 unique label(s)>")
         self.assertListEqual(sorted(a.edges('label1')), ['a', 'b', 'c'])
         self.assertListEqual(sorted(a.labels()), ['label1', 'label2'])
-
-    def testSearchAlgorithms(self):
-        a = MultiGraph(['a', 'b', 'c'])
-        a.add_edge('a', 'b', 'label1')
-        a.add_edge('b', 'c', 'label1')
-        a.add_edge('b', 'a', 'label2')
-        self.assertListEqual(bf_search(a), ['a', 'b', 'c'])
 
 
 class ReactionTestCase(unittest.TestCase):

--- a/Tests/test_Pathway.py
+++ b/Tests/test_Pathway.py
@@ -79,7 +79,7 @@ class GraphTestCase(unittest.TestCase):
             str(a) == "<Graph: 3 node(s), 3 edge(s), 2 unique label(s)>")
         self.assertTrue(
             repr(a) == "<Graph: ('a': ('b', 'label1'))('b': ('a', 'label2'),('c', 'label1'))('c': )>")
-        self.assertListEqual(sorted(a.edges('label1')), ['a', 'b', 'c'])
+        self.assertListEqual(sorted(a.edges('label1')), [('a', 'b'), ('b', 'c')])
         self.assertListEqual(sorted(a.labels()), ['label1', 'label2'])
 
 
@@ -157,7 +157,7 @@ class MultiGraphTestCase(unittest.TestCase):
         a.add_edge('b', 'a', 'label2')
         self.assertTrue(
             str(a) == "<MultiGraph: 3 node(s), 3 edge(s), 2 unique label(s)>")
-        self.assertListEqual(sorted(a.edges('label1')), ['a', 'b', 'c'])
+        self.assertListEqual(sorted(a.edges('label1')), [('a', 'b'), ('b', 'c')])
         self.assertListEqual(sorted(a.labels()), ['label1', 'label2'])
 
 

--- a/Tests/test_Pathway.py
+++ b/Tests/test_Pathway.py
@@ -79,8 +79,8 @@ class GraphTestCase(unittest.TestCase):
             str(a) == "<Graph: 3 node(s), 3 edge(s), 2 unique label(s)>")
         self.assertTrue(
             repr(a) == "<Graph: ('a': ('b', 'label1'))('b': ('a', 'label2'),('c', 'label1'))('c': )>")
-        self.assertListEqual(sorted(a.edges('label1')), [('a', 'b'), ('b', 'c')])
-        self.assertListEqual(sorted(a.labels()), ['label1', 'label2'])
+        self.assertListEqual(a.edges('label1'), [('a', 'b'), ('b', 'c')])
+        self.assertListEqual(a.labels(), ['label1', 'label2'])
 
 
 class MultiGraphTestCase(unittest.TestCase):
@@ -157,8 +157,8 @@ class MultiGraphTestCase(unittest.TestCase):
         a.add_edge('b', 'a', 'label2')
         self.assertTrue(
             str(a) == "<MultiGraph: 3 node(s), 3 edge(s), 2 unique label(s)>")
-        self.assertListEqual(sorted(a.edges('label1')), [('a', 'b'), ('b', 'c')])
-        self.assertListEqual(sorted(a.labels()), ['label1', 'label2'])
+        self.assertListEqual(a.edges('label1'), [('a', 'b'), ('b', 'c')])
+        self.assertListEqual(a.labels(), ['label1', 'label2'])
 
 
 class ReactionTestCase(unittest.TestCase):

--- a/Tests/test_Pathway.py
+++ b/Tests/test_Pathway.py
@@ -10,7 +10,7 @@ import unittest
 # modules to be tested
 from Bio.Pathway import Reaction
 from Bio.Pathway.Rep.Graph import Graph
-from Bio.Pathway.Rep.MultiGraph import MultiGraph, df_search, bf_search
+from Bio.Pathway.Rep.MultiGraph import MultiGraph, bf_search
 
 
 class GraphTestCase(unittest.TestCase):
@@ -79,8 +79,8 @@ class GraphTestCase(unittest.TestCase):
             str(a) == "<Graph: 3 node(s), 3 edge(s), 2 unique label(s)>")
         self.assertTrue(
             repr(a) == "<Graph: ('a': ('b', 'label1'))('b': ('a', 'label2'),('c', 'label1'))('c': )>")
-        self.assertListEqual(a.edges('label1'), ['a', 'b', 'c'])
-        self.assertListEqual(a.labels(), ['label1', 'label2'])
+        self.assertListEqual(sorted(a.edges('label1')), ['a', 'b', 'c'])
+        self.assertListEqual(sorted(a.labels()), ['label1', 'label2'])
 
 
 class MultiGraphTestCase(unittest.TestCase):
@@ -157,15 +157,14 @@ class MultiGraphTestCase(unittest.TestCase):
         a.add_edge('b', 'a', 'label2')
         self.assertTrue(
             str(a) == "<MultiGraph: 3 node(s), 3 edge(s), 2 unique label(s)>")
-        self.assertListEqual(a.edges('label1'), ['a', 'b', 'c'])
-        self.assertListEqual(a.labels(), ['label1', 'label2'])
+        self.assertListEqual(sorted(a.edges('label1')), ['a', 'b', 'c'])
+        self.assertListEqual(sorted(a.labels()), ['label1', 'label2'])
 
     def testSearchAlgorithms(self):
         a = MultiGraph(['a', 'b', 'c'])
         a.add_edge('a', 'b', 'label1')
         a.add_edge('b', 'c', 'label1')
         a.add_edge('b', 'a', 'label2')
-        self.assertListEqual(df_search(a), ['a', 'b', 'c'])
         self.assertListEqual(bf_search(a), ['a', 'b', 'c'])
 
 

--- a/Tests/test_Pathway.py
+++ b/Tests/test_Pathway.py
@@ -1,4 +1,5 @@
 # Copyright 2001 by Tarjei Mikkelsen.  All rights reserved.
+# Revisions copyright 2018 by Maximilian Greil. All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
@@ -9,8 +10,7 @@ import unittest
 # modules to be tested
 from Bio.Pathway import Reaction
 from Bio.Pathway.Rep.Graph import Graph
-from Bio.Pathway.Rep.MultiGraph import MultiGraph
-
+from Bio.Pathway.Rep.MultiGraph import MultiGraph, df_search, bf_search
 
 class GraphTestCase(unittest.TestCase):
 
@@ -68,6 +68,18 @@ class GraphTestCase(unittest.TestCase):
         b = Graph(['a', 'b', 'c', 'd'])
         b.add_edge('a', 'b', 'label5')
         self.assertEqual(a, b)  # , "incorrect node removal")
+
+    def testAdditionalFunctions(self):
+        a = Graph(['a', 'b', 'c'])
+        a.add_edge('a', 'b', 'label1')
+        a.add_edge('b', 'c', 'label1')
+        a.add_edge('b', 'a', 'label2')
+        self.assertTrue(
+            str(a) == "<Graph: 3 node(s), 3 edge(s), 2 unique label(s)>")
+        self.assertTrue(
+            repr(a) == "<Graph: ('a': ('b', 'label1'))('b': ('a', 'label2'),('c', 'label1'))('c': )>")
+        self.assertListEqual(a.edges('label1'), ['a', 'b', 'c'])
+        self.assertListEqual(a.labels(), ['label1', 'label2'])
 
 
 class MultiGraphTestCase(unittest.TestCase):
@@ -136,6 +148,24 @@ class MultiGraphTestCase(unittest.TestCase):
         self.assertEqual(repr(b), "<MultiGraph: ('a': ('b', 'label5'))('b': )('c': )('d': )>")
         self.assertEqual(repr(a), repr(b))
         self.assertEqual(a, b)  # , "incorrect node removal")
+
+    def testAdditionalFunctions(self):
+        a = MultiGraph(['a', 'b', 'c'])
+        a.add_edge('a', 'b', 'label1')
+        a.add_edge('b', 'c', 'label1')
+        a.add_edge('b', 'a', 'label2')
+        self.assertTrue(
+            str(a) == "<MultiGraph: 3 node(s), 3 edge(s), 2 unique label(s)>")
+        self.assertListEqual(a.edges('label1'), ['a', 'b', 'c'])
+        self.assertListEqual(a.labels(), ['label1', 'label2'])
+
+    def testSearchAlgorithms(self):
+        a = MultiGraph(['a', 'b', 'c'])
+        a.add_edge('a', 'b', 'label1')
+        a.add_edge('b', 'c', 'label1')
+        a.add_edge('b', 'a', 'label2')
+        self.assertListEqual(df_search(a), ['a', 'b', 'c'])
+        self.assertListEqual(bf_search(a), ['a', 'b', 'c'])
 
 
 class ReactionTestCase(unittest.TestCase):


### PR DESCRIPTION
This pull request addresses issue #...

#1288 

- Improves test coverage for module `Bio.Pathway`.
- Additionally fixed 2 errors in `Bio.Pathway.Rep.Graph` in functions `__repr__` and `edges` and 1 error in `Bio.Pathway.Rep.MultiGraph` in function `edges

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
