### PR TITLE
Lift SearchIO warning

### DIFF
--- a/Bio/SearchIO/__init__.py
+++ b/Bio/SearchIO/__init__.py
@@ -198,17 +198,10 @@ from __future__ import print_function
 from Bio._py3k import basestring
 
 import sys
-import warnings
 
-from Bio import BiopythonExperimentalWarning
 from Bio.File import as_handle
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 from Bio.SearchIO._utils import get_processor
-
-
-warnings.warn('Bio.SearchIO is an experimental submodule which may undergo '
-        'significant changes prior to its future official release.',
-        BiopythonExperimentalWarning)
 
 
 __all__ = ('read', 'parse', 'to_dict', 'index', 'index_db', 'write', 'convert')


### PR DESCRIPTION
This pull request lifts the BiopythonExperimentalWarning on SearchIO.

@peterjc , continuing from the [mailing list discussion](http://lists.open-bio.org/pipermail/biopython/2018-June/016449.html), this is the PR. Let's see if all the test passes and then I think this should be good to merge.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
