### PR TITLE
Enforce flake8 checks on setup.up

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -94,6 +94,7 @@ deps =
     flake8-rst-docstrings
     restructuredtext_lint
 commands =
+    flake8 --max-line-length 82 setup.py
     # These folders each have their own .flake8 file:
     flake8 BioSQL/
     flake8 Scripts/

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ osx_clang_fix()
 
 
 def is_pypy():
+    """Check if running under the PyPy implementation of Python."""
     import platform
     try:
         if platform.python_implementation() == 'PyPy':
@@ -107,6 +108,7 @@ def is_pypy():
 
 
 def is_jython():
+    """Check if running under the Jython implementation of Python."""
     import platform
     try:
         if platform.python_implementation() == 'Jython':
@@ -119,6 +121,7 @@ def is_jython():
 
 
 def is_ironpython():
+    """Check if running under the IronPython implementation of Python."""
     return sys.platform == "cli"
     # TODO - Use platform as in Pypy test?
 
@@ -138,6 +141,7 @@ if is_jython():
 
 
 def check_dependencies_once():
+    """Check dependencies, will cache and re-use the result."""
     # Call check_dependencies, but cache the result for subsequent
     # calls.
     global _CHECKED
@@ -168,13 +172,17 @@ class install_biopython(install):
     """
 
     def run(self):
+        """Run the installation."""
         if check_dependencies_once():
             # Run the normal install.
             install.run(self)
 
 
 class build_py_biopython(build_py):
+    """Biopython builder."""
+
     def run(self):
+        """Run the build."""
         if not check_dependencies_once():
             return
         if is_jython() and "Bio.Restriction" in self.packages:
@@ -191,7 +199,10 @@ class build_py_biopython(build_py):
 
 
 class build_ext_biopython(build_ext):
+    """Biopython extension builder."""
+
     def run(self):
+        """Run the build."""
         if not check_dependencies_once():
             return
         build_ext.run(self)
@@ -208,16 +219,20 @@ class test_biopython(Command):
     python setup.py test
 
     """
+
     description = "Automatically run the test suite for Biopython."
     user_options = []
 
     def initialize_options(self):
+        """No-op, initialise options."""
         pass
 
     def finalize_options(self):
+        """No-op, finalise options."""
         pass
 
     def run(self):
+        """Run the tests."""
         this_dir = os.getcwd()
 
         # change to the test dir and run the tests
@@ -231,7 +246,7 @@ class test_biopython(Command):
 
 
 def can_import(module_name):
-    """can_import(module_name) -> module or None"""
+    """Check we can import the requested module."""
     try:
         return __import__(module_name)
     except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -35,13 +35,15 @@ try:
     from setuptools.command.build_ext import build_ext
     from setuptools import Extension
 except ImportError:
-    sys.exit("We need the Python library setuptools to be installed. Try runnning: python -m ensurepip")
+    sys.exit("We need the Python library setuptools to be installed. "
+             "Try runnning: python -m ensurepip")
 
 if "bdist_wheel" in sys.argv:
     try:
-        import wheel
+        import wheel  # noqa: F401
     except ImportError:
-        sys.exit("We need both setuptools AND wheel packages installed for bdist_wheel to work. Try running: pip install wheel")
+        sys.exit("We need both setuptools AND wheel packages installed "
+                 "for bdist_wheel to work. Try running: pip install wheel")
 
 _CHECKED = None
 
@@ -176,8 +178,8 @@ class build_py_biopython(build_py):
         if not check_dependencies_once():
             return
         if is_jython() and "Bio.Restriction" in self.packages:
-            # Evil hack to work on Jython 2.7
-            # This is to avoid java.lang.RuntimeException: Method code too large!
+            # Evil hack to work on Jython 2.7 to avoid
+            # java.lang.RuntimeException: Method code too large!
             # from Bio/Restriction/Restriction_Dictionary.py
             self.packages.remove("Bio.Restriction")
         # Add software that requires Numpy to be installed.
@@ -350,38 +352,30 @@ elif is_ironpython():
     EXTENSIONS = []
 else:
     EXTENSIONS = [
-    Extension('Bio.Align._aligners',
-              ['Bio/Align/_aligners.c'],
-              ),
-    Extension('Bio.cpairwise2',
-              ['Bio/cpairwise2module.c'],
-              ),
-    Extension('Bio.Nexus.cnexus',
-              ['Bio/Nexus/cnexus.c']
-              ),
-    Extension('Bio.PDB.QCPSuperimposer.qcprotmodule',
-              ["Bio/PDB/QCPSuperimposer/qcprotmodule.c"],
-              ),
-    Extension('Bio.motifs._pwm',
-              ["Bio/motifs/_pwm.c"],
-              ),
-    Extension('Bio.Cluster._cluster',
-              ['Bio/Cluster/cluster.c', 'Bio/Cluster/clustermodule.c'],
-              ),
-    Extension('Bio.PDB.kdtrees',
-              ["Bio/PDB/kdtrees.c"],
-              ),
-    Extension('Bio.KDTree._CKDTree',
-              ["Bio/KDTree/KDTree.c", "Bio/KDTree/KDTreemodule.c"],
-              ),
-    ]
+        Extension('Bio.Align._aligners',
+                  ['Bio/Align/_aligners.c']),
+        Extension('Bio.cpairwise2',
+                  ['Bio/cpairwise2module.c']),
+        Extension('Bio.Nexus.cnexus',
+                  ['Bio/Nexus/cnexus.c']),
+        Extension('Bio.PDB.QCPSuperimposer.qcprotmodule',
+                  ["Bio/PDB/QCPSuperimposer/qcprotmodule.c"]),
+        Extension('Bio.motifs._pwm',
+                  ["Bio/motifs/_pwm.c"]),
+        Extension('Bio.Cluster._cluster',
+                  ['Bio/Cluster/cluster.c', 'Bio/Cluster/clustermodule.c']),
+        Extension('Bio.PDB.kdtrees',
+                  ["Bio/PDB/kdtrees.c"]),
+        Extension('Bio.KDTree._CKDTree',
+                  ["Bio/KDTree/KDTree.c", "Bio/KDTree/KDTreemodule.c"]),
+        ]
     if not is_pypy():
         # Bio.trie has a problem under PyPy2 v5.6 and 5.7
-        extension = Extension('Bio.trie',
-                              ['Bio/triemodule.c', 'Bio/trie.c'],
-                              include_dirs=["Bio"]
-                             )
-        EXTENSIONS.append(extension)
+        EXTENSIONS.extend([
+                Extension('Bio.trie',
+                          ['Bio/triemodule.c', 'Bio/trie.c'],
+                          include_dirs=["Bio"]),
+                ])
 
 
 # We now define the Biopython version number in Bio/__init__.py
@@ -446,7 +440,10 @@ setup(name='biopython',
       packages=PACKAGES,
       ext_modules=EXTENSIONS,
       package_data={
-          'Bio.Entrez': ['DTDs/*.dtd', 'DTDs/*.ent', 'DTDs/*.mod', 'XSDs/*.xsd'],
+          'Bio.Entrez': ['DTDs/*.dtd',
+                         'DTDs/*.ent',
+                         'DTDs/*.mod',
+                         'XSDs/*.xsd'],
       },
       install_requires=REQUIRES,
       )


### PR DESCRIPTION
This does some minimal cleanup of ``setup.py`` and starts to enforce PEP8 checks with flake8 via TravisCI/Tox, using defaults other than line length (there are still a few slightly long lines, but they did not look easy to shorten nicely).

(This does mean another corner case to update for the recommended git pre-commit flake8 script)

I hereby agree to dual licence this and any previous contributions under both the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files ``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed already, or do not wish to be listed. (*This acknowledgement is optional.*)
