### PR TITLE
The size property of an Alphabet is defined as the number of characte…

### DIFF
--- a/Bio/Alphabet/Reduced.py
+++ b/Bio/Alphabet/Reduced.py
@@ -93,6 +93,7 @@ class Murphy15(Alphabet.ProteinAlphabet):
     """
 
     letters = "LCAGSTPFWEDNQKH"
+    size = 1
 
 
 murphy_15 = Murphy15()
@@ -127,6 +128,7 @@ class Murphy10(Alphabet.ProteinAlphabet):
     """
 
     letters = "LCAGSPFEKH"
+    size = 1
 
 
 murphy_10 = Murphy10()
@@ -161,6 +163,7 @@ class Murphy8(Alphabet.ProteinAlphabet):
     """
 
     letters = "LASPFEKH"
+    size = 1
 
 
 murphy_8 = Murphy8()
@@ -194,6 +197,7 @@ class Murphy4(Alphabet.ProteinAlphabet):
     """
 
     letters = "LAFE"
+    size = 1
 
 
 murphy_4 = Murphy4()
@@ -227,6 +231,7 @@ class HPModel(Alphabet.ProteinAlphabet):
     """
 
     letters = "HP"
+    size = 1
 
 
 hp_model = HPModel()
@@ -261,6 +266,7 @@ class PC5(Alphabet.ProteinAlphabet):
     """
 
     letters = "ARCTD"
+    size = 1
 
 
 pc5 = PC5()

--- a/Bio/Alphabet/Reduced.py
+++ b/Bio/Alphabet/Reduced.py
@@ -93,7 +93,6 @@ class Murphy15(Alphabet.ProteinAlphabet):
     """
 
     letters = "LCAGSTPFWEDNQKH"
-    size = 1
 
 
 murphy_15 = Murphy15()
@@ -128,7 +127,6 @@ class Murphy10(Alphabet.ProteinAlphabet):
     """
 
     letters = "LCAGSPFEKH"
-    size = 1
 
 
 murphy_10 = Murphy10()
@@ -163,7 +161,6 @@ class Murphy8(Alphabet.ProteinAlphabet):
     """
 
     letters = "LASPFEKH"
-    size = 1
 
 
 murphy_8 = Murphy8()
@@ -197,7 +194,6 @@ class Murphy4(Alphabet.ProteinAlphabet):
     """
 
     letters = "LAFE"
-    size = 1
 
 
 murphy_4 = Murphy4()
@@ -231,7 +227,6 @@ class HPModel(Alphabet.ProteinAlphabet):
     """
 
     letters = "HP"
-    size = 1
 
 
 hp_model = HPModel()
@@ -266,7 +261,6 @@ class PC5(Alphabet.ProteinAlphabet):
     """
 
     letters = "ARCTD"
-    size = 1
 
 
 pc5 = PC5()

--- a/Bio/Alphabet/Reduced.py
+++ b/Bio/Alphabet/Reduced.py
@@ -93,7 +93,7 @@ class Murphy15(Alphabet.ProteinAlphabet):
     """
 
     letters = "LCAGSTPFWEDNQKH"
-    size = 15
+    size = 1
 
 
 murphy_15 = Murphy15()
@@ -128,7 +128,7 @@ class Murphy10(Alphabet.ProteinAlphabet):
     """
 
     letters = "LCAGSPFEKH"
-    size = 10
+    size = 1
 
 
 murphy_10 = Murphy10()
@@ -163,7 +163,7 @@ class Murphy8(Alphabet.ProteinAlphabet):
     """
 
     letters = "LASPFEKH"
-    size = 8
+    size = 1
 
 
 murphy_8 = Murphy8()
@@ -197,7 +197,7 @@ class Murphy4(Alphabet.ProteinAlphabet):
     """
 
     letters = "LAFE"
-    size = 4
+    size = 1
 
 
 murphy_4 = Murphy4()
@@ -231,7 +231,7 @@ class HPModel(Alphabet.ProteinAlphabet):
     """
 
     letters = "HP"
-    size = 2
+    size = 1
 
 
 hp_model = HPModel()
@@ -266,7 +266,7 @@ class PC5(Alphabet.ProteinAlphabet):
     """
 
     letters = "ARCTD"
-    size = 5
+    size = 1
 
 
 pc5 = PC5()

--- a/Bio/Alphabet/__init__.py
+++ b/Bio/Alphabet/__init__.py
@@ -20,9 +20,12 @@ class Alphabet(object):
     Attributes:
         - letters - list-like object containing the letters of the alphabet.
                Usually it is a string when letters are single characters.
+        - size    - size of the alphabet's letters (e.g. 1 when letters are
+               single characters).
 
     """
 
+    size = None     # default to no fixed size for words
     letters = None  # default to no fixed alphabet
     # In general, a list-like object. However,
     # assuming letters are single characters, use a
@@ -83,6 +86,7 @@ generic_alphabet = Alphabet()
 class SingleLetterAlphabet(Alphabet):
     """Generic alphabet with letters of size one."""
 
+    size = 1
     letters = None   # string of all letters in the alphabet
 
 
@@ -146,6 +150,7 @@ class SecondaryStructure(SingleLetterAlphabet):
 class ThreeLetterProtein(Alphabet):
     """Three letter protein alphabet."""
 
+    size = 3
     letters = [
         "Ala", "Asx", "Cys", "Asp", "Glu", "Phe", "Gly", "His", "Ile",
         "Lys", "Leu", "Met", "Asn", "Pro", "Gln", "Arg", "Ser", "Thr",

--- a/Bio/Alphabet/__init__.py
+++ b/Bio/Alphabet/__init__.py
@@ -20,12 +20,9 @@ class Alphabet(object):
     Attributes:
         - letters - list-like object containing the letters of the alphabet.
                Usually it is a string when letters are single characters.
-        - size    - size of the alphabet's letters (e.g. 1 when letters are
-               single characters).
 
     """
 
-    size = None     # default to no fixed size for words
     letters = None  # default to no fixed alphabet
     # In general, a list-like object. However,
     # assuming letters are single characters, use a
@@ -86,7 +83,6 @@ generic_alphabet = Alphabet()
 class SingleLetterAlphabet(Alphabet):
     """Generic alphabet with letters of size one."""
 
-    size = 1
     letters = None   # string of all letters in the alphabet
 
 
@@ -150,7 +146,6 @@ class SecondaryStructure(SingleLetterAlphabet):
 class ThreeLetterProtein(Alphabet):
     """Three letter protein alphabet."""
 
-    size = 3
     letters = [
         "Ala", "Asx", "Cys", "Asp", "Glu", "Phe", "Gly", "His", "Ile",
         "Lys", "Leu", "Met", "Asn", "Pro", "Gln", "Arg", "Ser", "Thr",


### PR DESCRIPTION
Alphabets have a property .size, defined as the number of characters in one letter of the alphabet. However in `Bio/Alphabet/Reduced.py`, the size was set to the number of letters in the alphabet.


I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
