### PR TITLE
Testing Bio.Cluster without NumPy

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -65,7 +65,7 @@ deps =
     {py27,py34,py35,py35}: mysql-connector-python-rf
     {py27,py35,pypy}: rdflib
     {pypy,pypy3}: numpy==1.12.1
-    {py27,py34,py35,py36}: numpy
+    {py27,py34,py36}: numpy
     {py36}: scipy
     {py27}: networkx
     {py36}: matplotlib

--- a/Bio/Cluster/__init__.py
+++ b/Bio/Cluster/__init__.py
@@ -12,8 +12,15 @@ Bio.Cluster and the underlying C Clustering Library is described in
 M. de Hoon et al. (2004) https://doi.org/10.1093/bioinformatics/bth078
 """
 
-import numpy
 import numbers
+
+try:
+    import numpy
+except ImportError:
+    from Bio import MissingPythonDependencyError
+    raise MissingPythonDependencyError(
+        "Please install numpy if you want to use Bio.Cluster. "
+        "See http://www.numpy.org/")
 
 from . import _cluster
 

--- a/Doc/Tutorial/chapter_cluster.tex
+++ b/Doc/Tutorial/chapter_cluster.tex
@@ -414,7 +414,7 @@ Here, \verb|left| and \verb|right| are integers referring to the two items or su
 
 To create a new \verb|Node| object, we need to specify \verb|left| and \verb|right|; \verb|distance| is optional.
 
-%doctest
+%doctest . lib:numpy
 \begin{verbatim}
 >>> from Bio.Cluster import Node
 >>> Node(2, 3)
@@ -438,7 +438,7 @@ An error is raised if \verb|left| and \verb|right| are not integers, or if \verb
 
 The Python class \verb|Tree| represents a full hierarchical clustering solution. A \verb|Tree| object can be created from a list of \verb|Node| objects:
 
-%doctest
+%doctest . lib:numpy
 \begin{verbatim}
 >>> from Bio.Cluster import Node, Tree
 >>> nodes = [Node(1, 2, 0.2), Node(0, 3, 0.5), Node(-2, 4, 0.6), Node(-1, -3, 0.9)]

--- a/README.rst
+++ b/README.rst
@@ -176,10 +176,6 @@ deprecated).
   This will offer to install Apple's XCode development suite - you can, but it
   is not needed and takes a lot of disk space.
 
-- NumPy, see http://www.numpy.org - this package is used in ``Bio.Cluster``,
-  ``Bio.PDB`` and a few other modules. We use the NumPy C API, which means it
-  must be installed *before* compiling Biopython's C code.
-
 Then either download and decompress our source code, or fetch it using git.
 Now change directory to the Biopython source code folder and run::
 

--- a/Tests/test_Cluster.py
+++ b/Tests/test_Cluster.py
@@ -1,6 +1,11 @@
 import unittest
 
-import numpy
+try:
+    import numpy
+except ImportError:
+    from Bio import MissingPythonDependencyError
+    raise MissingPythonDependencyError(
+        "Install NumPy if you want to use Bio.Cluster.")
 
 
 class TestCluster(unittest.TestCase):

--- a/Tests/test_PDB_vectors.py
+++ b/Tests/test_PDB_vectors.py
@@ -9,6 +9,14 @@
 import unittest
 import warnings
 
+try:
+    import numpy
+    del numpy
+except ImportError:
+    from Bio import MissingPythonDependencyError
+    raise MissingPythonDependencyError(
+        "Install NumPy if you want to use Bio.PDB.")
+
 from Bio import BiopythonDeprecationWarning
 
 


### PR DESCRIPTION
With the recent changes meaning we don't need NumPy at compile time,
for the test suite ``test_Cluster.py`` needs to test for this at run-time.
Following ``Bio.Graphics`` etc, doing this in the main ``__init__.py`` file.

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
