### PR TITLE
StopIteration fixes for Python 3.7

### DIFF
--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -444,6 +444,8 @@ def _kill_comments_and_break_lines(text):
 
     NOTE: this function is very slow for large files, and obsolete when using C extension cnexus
     """
+    if not text:
+        return ""
     contents = iter(text)
     newtext = []
     newline = []

--- a/Bio/TogoWS/__init__.py
+++ b/Bio/TogoWS/__init__.py
@@ -199,7 +199,7 @@ def search_iter(db, query, limit=None, batch=100):
     """
     count = search_count(db, query)
     if not count:
-        raise StopIteration
+        return
     # NOTE - We leave it to TogoWS to enforce any upper bound on each
     # batch, they currently return an HTTP 400 Bad Request if above 100.
     remain = count


### PR DESCRIPTION
This pull request addresses issue #1693 (or at least, the non-ARM parts of it).

As far as I can tell, the remaining instances of ``raise StopIteration`` are safe
(e.g. within ``__next__`` methods which is appropriate).

I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
