### PR TITLE
PDBList local_dtd bug and other minor flake8-bugbear issues

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -83,11 +83,18 @@ class PDBList(object):
     http://www.pdb.org/.
     """
 
-    def __init__(self, server='ftp://ftp.wwpdb.org', pdb=os.getcwd(),
+    def __init__(self, server='ftp://ftp.wwpdb.org', pdb=None,
                  obsolete_pdb=None, verbose=True):
-        """Initialize the class with the default server or a custom one."""
+        """Initialize the class with the default server or a custom one.
+
+        Argument pdb is the local path to use, defaulting to the current
+        directory at the moment of initialisation.
+        """
         self.pdb_server = server  # remote pdb server
-        self.local_pdb = pdb  # local pdb file tree
+        if pdb:
+            self.local_pdb = pdb  # local pdb file tree
+        else:
+            self.local_pdb = os.getcwd()
 
         # enable or disable verbose
         self._verbose = verbose

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -233,7 +233,7 @@ class QueryResult(_BaseSearchObject):
 
         def iterhits(self):
             """Return an iterator over the Hit objects."""
-            for hit in self._items.itervalues():
+            for hit in self._items.itervalues():  # noqa: B301
                 yield hit
 
         def iterhit_keys(self):
@@ -243,7 +243,7 @@ class QueryResult(_BaseSearchObject):
 
         def iteritems(self):
             """Return an iterator yielding tuples of Hit ID and Hit objects."""
-            for item in self._items.iteritems():
+            for item in self._items.iteritems():  # noqa: B301
                 yield item
 
     else:

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -39,7 +39,7 @@ NS = "{http://uniprot.org/uniprot}"
 REFERENCE_JOURNAL = "%(name)s %(volume)s:%(first)s-%(last)s(%(pub_date)s)"
 
 
-def UniprotIterator(handle, alphabet=Alphabet.ProteinAlphabet(), return_raw_comments=False):
+def UniprotIterator(handle, alphabet=Alphabet.generic_protein, return_raw_comments=False):
     """Iterate over UniProt XML as SeqRecord objects.
 
     parses an XML entry at a time from any UniProt XML file
@@ -87,7 +87,7 @@ class Parser(object):
     alphabet=Alphabet.ProteinAlphabet()    can be modified if needed, default is protein alphabet.
     """
 
-    def __init__(self, elem, alphabet=Alphabet.ProteinAlphabet(), return_raw_comments=False):
+    def __init__(self, elem, alphabet=Alphabet.generic_protein, return_raw_comments=False):
         """Initialize the class."""
         self.entry = elem
         self.alphabet = alphabet


### PR DESCRIPTION
This pull request addresses some minor issues noticed from running ``flake8-bugbear``,

https://github.com/PyCQA/flake8-bugbear

I have ignored all the B007 warnings about loop variable names, and there are still 8 cases of B008 but they looked harmless.

Building on this, we could enable these checks on TravisCI (ignoring B007 and whitelisting the current B008 cases)?

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
