### PR TITLE
Minor changes to Seq integer multiplication methods and tests for inplace addition methods

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -361,7 +361,7 @@ class Seq(object):
         Seq('ATGATG', DNAAlphabet())
         """
         if not isinstance(other, int):
-            raise TypeError("can't multiply Seq by non-int type")
+            raise TypeError("can't multiply {} by non-int type".format(self.__class__.__name__))
         return self.__class__(str(self) * other, self.alphabet)
 
     def __rmul__(self, other):
@@ -375,7 +375,7 @@ class Seq(object):
         Seq('ATGATG', DNAAlphabet())
         """
         if not isinstance(other, int):
-            raise TypeError("can't multiply Seq by non-int type")
+            raise TypeError("can't multiply {} by non-int type".format(self.__class__.__name__))
         return self.__class__(str(self) * other, self.alphabet)
 
     def __imul__(self, other):
@@ -392,7 +392,7 @@ class Seq(object):
         Seq('ATGATG', DNAAlphabet())
         """
         if not isinstance(other, int):
-            raise TypeError("can't multiply Seq by non-int type")
+            raise TypeError("can't multiply {} by non-int type".format(self.__class__.__name__))
         return self.__class__(str(self) * other, self.alphabet)
 
     def tostring(self):  # Seq API requirement
@@ -1411,7 +1411,7 @@ class UnknownSeq(Seq):
         UnknownSeq(6, alphabet=DNAAlphabet(), character='N')
         """
         if not isinstance(other, int):
-            raise TypeError("can't multiply UnknownSeq by non-int type")
+            raise TypeError("can't multiply {} by non-int type".format(self.__class__.__name__))
         return self.__class__(len(self) * other, self.alphabet)
 
     def __rmul__(self, other):
@@ -1425,7 +1425,7 @@ class UnknownSeq(Seq):
         UnknownSeq(6, alphabet=DNAAlphabet(), character='N')
         """
         if not isinstance(other, int):
-            raise TypeError("can't multiply UnknownSeq by non-int type")
+            raise TypeError("can't multiply {} by non-int type".format(self.__class__.__name__))
         return self.__class__(len(self) * other, self.alphabet)
 
     def __imul__(self, other):
@@ -1442,7 +1442,7 @@ class UnknownSeq(Seq):
         UnknownSeq(6, alphabet=DNAAlphabet(), character='N')
         """
         if not isinstance(other, int):
-            raise TypeError("can't multiply UnknownSeq by non-int type")
+            raise TypeError("can't multiply {} by non-int type".format(self.__class__.__name__))
         return self.__class__(len(self) * other, self.alphabet)
 
     def __getitem__(self, index):
@@ -2072,7 +2072,7 @@ class MutableSeq(object):
         MutableSeq('ATGATG', DNAAlphabet())
         """
         if not isinstance(other, int):
-            raise TypeError("can't multiply MutableSeq by non-int type")
+            raise TypeError("can't multiply {} by non-int type".format(self.__class__.__name__))
         return self.__class__(self.data * other, self.alphabet)
 
     def __rmul__(self, other):
@@ -2089,7 +2089,7 @@ class MutableSeq(object):
         MutableSeq('ATGATG', DNAAlphabet())
         """
         if not isinstance(other, int):
-            raise TypeError("can't multiply MutableSeq by non-int type")
+            raise TypeError("can't multiply {} by non-int type".format(self.__class__.__name__))
         return self.__class__(self.data * other, self.alphabet)
 
     def __imul__(self, other):
@@ -2103,7 +2103,7 @@ class MutableSeq(object):
         MutableSeq('ATGATG', DNAAlphabet())
         """
         if not isinstance(other, int):
-            raise TypeError("can't multiply MutableSeq by non-int type")
+            raise TypeError("can't multiply {} by non-int type".format(self.__class__.__name__))
         return self.__class__(self.data * other, self.alphabet)
 
     def append(self, c):

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -18,6 +18,7 @@ Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
 - Brandon Invergo
+- Chris Rands
 - Kai Blin
 - Maximilian Greil
 - Peter Cock

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -431,6 +431,8 @@ class TestSeqAddition(unittest.TestCase):
         """Test resulting sequence has gap types '-' and '.'"""
         with self.assertRaises(ValueError):
             self.rna[3] + self.rna[4]
+        with self.assertRaises(ValueError):
+            self.rna[3] += self.rna[4]
 
     def test_addition_dna_with_dna(self):
         for a in self.dna:
@@ -454,6 +456,10 @@ class TestSeqAddition(unittest.TestCase):
                     a + b
                 with self.assertRaises(TypeError):
                     b + a
+                with self.assertRaises(TypeError):
+                    a += b
+                with self.assertRaises(TypeError):
+                    b += a
 
     def test_addition_proteins(self):
         self.protein.pop(2)
@@ -476,6 +482,8 @@ class TestSeqAddition(unittest.TestCase):
         b = Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-"))
         with self.assertRaises(ValueError):
             a + b
+        with self.assertRaises(ValueError):
+            a += b
 
     def test_exception_when_added_protein_has_several_stop_codon_types(self):
         """Test resulting protein has stop codon types '*' and '@'"""
@@ -485,12 +493,16 @@ class TestSeqAddition(unittest.TestCase):
             Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"))
         with self.assertRaises(ValueError):
             a + b
+        with self.assertRaises(ValueError):
+            a += b
 
     def test_exception_when_adding_protein_with_nucleotides(self):
         for a in self.protein[0:5]:
             for b in self.dna[0:3] + self.rna[0:4]:
                 with self.assertRaises(TypeError):
                     a + b
+                with self.assertRaises(TypeError):
+                    a += b
 
     def test_adding_generic_nucleotide_with_other_nucleotides(self):
         for a in self.nuc:

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -498,6 +498,13 @@ class TestSeqAddition(unittest.TestCase):
                 c = a + b
                 self.assertEqual(str(c), str(a) + str(b))
 
+    def test_adding_generic_nucleotide_with_other_nucleotides_inplace(self):
+        for a in self.nuc:
+            for b in self.dna + self.rna + self.nuc:
+                c = b + a
+                b += a  # can't change 'a' as need value next iteration
+                self.assertEqual(c, b)
+
 
 class TestSeqMultiplication(unittest.TestCase):
     def test_mul_method(self):

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -408,9 +408,9 @@ class TestSeqAddition(unittest.TestCase):
     def test_addition_dna_rna_with_generic_nucleotides_inplace(self):
         for a in self.dna + self.rna:
             for b in self.nuc:
-                c = a + b
-                a += b
-                self.assertEqual(c, a)
+                c = b + a
+                b += a  # can't change 'a' as need value next iteration
+                self.assertEqual(c, b)
 
     def test_addition_rna_with_rna(self):
         self.rna.pop(3)
@@ -423,9 +423,9 @@ class TestSeqAddition(unittest.TestCase):
         self.rna.pop(3)
         for a in self.rna:
             for b in self.rna:
-                c = a + b
-                a += b
-                self.assertEqual(c, a)
+                c = b + a
+                b += a
+                self.assertEqual(c, b)
 
     def test_exception_when_added_rna_has_more_than_one_gap_type(self):
         """Test resulting sequence has gap types '-' and '.'"""
@@ -443,9 +443,9 @@ class TestSeqAddition(unittest.TestCase):
     def test_addition_dna_with_dna_inplace(self):
         for a in self.dna:
             for b in self.dna:
-                c = a + b
-                a += b
-                self.assertEqual(c, a)
+                c = b + a
+                b += a
+                self.assertEqual(c, b)
 
     def test_addition_dna_with_rna(self):
         self.dna.pop(4)
@@ -472,9 +472,9 @@ class TestSeqAddition(unittest.TestCase):
         self.protein.pop(2)
         for a in self.protein:
             for b in self.protein:
-                c = a + b
-                a += b
-                self.assertEqual(c, a)
+                c = b + a
+                b += a
+                self.assertEqual(c, b)
 
     def test_exception_when_added_protein_has_more_than_one_gap_type(self):
         """Test resulting protein has gap types '-' and '.'"""
@@ -514,7 +514,7 @@ class TestSeqAddition(unittest.TestCase):
         for a in self.nuc:
             for b in self.dna + self.rna + self.nuc:
                 c = b + a
-                b += a  # can't change 'a' as need value next iteration
+                b += a
                 self.assertEqual(c, b)
 
 

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -405,12 +405,27 @@ class TestSeqAddition(unittest.TestCase):
                 c = a + b
                 self.assertEqual(str(c), str(a) + str(b))
 
+    def test_addition_dna_rna_with_generic_nucleotides_inplace(self):
+        for a in self.dna + self.rna:
+            for b in self.nuc:
+                c = a + b
+                a += b
+                self.assertEqual(c, a)
+
     def test_addition_rna_with_rna(self):
         self.rna.pop(3)
         for a in self.rna:
             for b in self.rna:
                 c = a + b
                 self.assertEqual(str(c), str(a) + str(b))
+
+    def test_addition_rna_with_rna_inplace(self):
+        self.rna.pop(3)
+        for a in self.rna:
+            for b in self.rna:
+                c = a + b
+                a += b
+                self.assertEqual(c, a)
 
     def test_exception_when_added_rna_has_more_than_one_gap_type(self):
         """Test resulting sequence has gap types '-' and '.'"""
@@ -422,6 +437,13 @@ class TestSeqAddition(unittest.TestCase):
             for b in self.dna:
                 c = a + b
                 self.assertEqual(str(c), str(a) + str(b))
+
+    def test_addition_dna_with_dna_inplace(self):
+        for a in self.dna:
+            for b in self.dna:
+                c = a + b
+                a += b
+                self.assertEqual(c, a)
 
     def test_addition_dna_with_rna(self):
         self.dna.pop(4)
@@ -439,6 +461,14 @@ class TestSeqAddition(unittest.TestCase):
             for b in self.protein:
                 c = a + b
                 self.assertEqual(str(c), str(a) + str(b))
+
+    def test_addition_proteins_inplace(self):
+        self.protein.pop(2)
+        for a in self.protein:
+            for b in self.protein:
+                c = a + b
+                a += b
+                self.assertEqual(c, a)
 
     def test_exception_when_added_protein_has_more_than_one_gap_type(self):
         """Test resulting protein has gap types '-' and '.'"""


### PR DESCRIPTION
This pull request relates to pull request #1669 and corresponding issue #1659 where we introduced integer multiplication methods for Seq-like objects, I propose 2 small changes.

1) A small improvement to the trackback for `Seq`, `UnknownSeq`, and `MutableSeq` multiplication methods when subclassing, here is an example:

```
>>> from Bio.Seq import Seq
>>> class MySeq(Seq): pass
...
>>> MySeq('A') * 2.0
# TypeError: can't multiply Seq by non-int type # Old behaviour
# TypeError: can't multiply MySeq by non-int type # New behaviour
``` 

2) Adding unit tests for in-place `Seq`, `UnknownSeq`, and `MutableSeq` addition methods. These `+=` operations are available even though the `__iadd__` methods are never defined, so I thought they should be tested.

I'd be grateful for review of the changes, any thoughts?

One related point, `__imul__` methods are defined but `__iadd__` methods are not. Does this matter? Probably we should ideally be consistent, but it is likely inconsequential?


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
