### PR TITLE
Modify ImportError traceback for _aligners

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -22,9 +22,11 @@ from Bio import Alphabet
 try:
     from Bio.Align import _aligners
 except ImportError as e:
-    raise ImportError("""{}: you should not try to import directly from the
+    new_exc =  ImportError("""{}: you should not import directly from the
                          biopython source directory; please exit the source
                          tree and re-launch your code from there""".format(e))
+    new_exc.__cause__ = None
+    raise new_exc
 
 
 class MultipleSeqAlignment(object):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -22,9 +22,9 @@ from Bio import Alphabet
 try:
     from Bio.Align import _aligners
 except ImportError as e:
-    new_exc = ImportError("""{}: you should not import directly from the
-                          biopython source directory; please exit the source
-                          tree and re-launch your code from there""".format(e))
+    new_exc = ImportError("{}: you should not import directly from the"
+                          "biopython source directory; please exit the source"
+                          "tree and re-launch your code from there".format(e))
     new_exc.__cause__ = None
     raise new_exc
 

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -22,8 +22,8 @@ from Bio import Alphabet
 try:
     from Bio.Align import _aligners
 except ImportError as e:
-    new_exc = ImportError("{}: you should not import directly from the"
-                          "biopython source directory; please exit the source"
+    new_exc = ImportError("{}: you should not import directly from the "
+                          "biopython source directory; please exit the source "
                           "tree and re-launch your code from there".format(e))
     new_exc.__cause__ = None
     raise new_exc

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -22,9 +22,9 @@ from Bio import Alphabet
 try:
     from Bio.Align import _aligners
 except ImportError as e:
-    new_exc =  ImportError("""{}: you should not import directly from the
-                         biopython source directory; please exit the source
-                         tree and re-launch your code from there""".format(e))
+    new_exc = ImportError("""{}: you should not import directly from the
+                          biopython source directory; please exit the source
+                          tree and re-launch your code from there""".format(e))
     new_exc.__cause__ = None
     raise new_exc
 

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -19,7 +19,12 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord, _RestrictedDict
 from Bio import Alphabet
 
-from Bio.Align import _aligners
+try:
+    from Bio.Align import _aligners
+except ImportError as e:
+    raise ImportError("""{}: you should not try to import directly from the
+                         biopython source directory; please exit the source
+                         tree and re-launch your code from there""".format(e))
 
 
 class MultipleSeqAlignment(object):


### PR DESCRIPTION
This pull request relates to an issue raised on the mailing list [here](http://mailman.open-bio.org/pipermail/biopython/2018-June/016485.html). I also saw the same question asked on Stack overflow [here](https://stackoverflow.com/questions/51296034/importerror-cannot-import-name-aligners-biopython), and I then later independently encountered the issue myself because I had used some soft links rather than doing a proper install. The error can occur on a few imports, for example:

```
>>> from Bio import SeqIO
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/biopython/Bio/SeqIO/__init__.py", line 375, in <module>
    from Bio.Align import MultipleSeqAlignment
  File "path/biopython/Bio/Align/__init__.py", line 22, in <module>
    from Bio.Align import _aligners
ImportError: cannot import name '_aligners'
```

I found the error slightly cryptic until I read through the mailing list thread, and perhaps I am not alone. Michiel noted in the mailing list thread [here](http://mailman.open-bio.org/pipermail/biopython/2018-June/016492.html) that `numpy` have a more informative traceback, I suggest modifying the traceback in this case in a similar way:

```
>>> from Bio import SeqIO
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/biopython/Bio/SeqIO/__init__.py", line 375, in <module>
    from Bio.Align import MultipleSeqAlignment
  File "/path/biopython/Bio/Align/__init__.py", line 29, in <module>
    raise new_exc
ImportError: cannot import name '_aligners': you should not import directly from the
                         biopython source directory; please exit the source
                         tree and re-launch your code from there
```

Thoughts?

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
