### PR TITLE
Bugfix in the setter for the id of Bio.PDB.Entity

### DIFF
--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -165,6 +165,8 @@ class Entity(object):
 
         @raises: ValueError
         """
+        if value == self._id:
+            return
         if self.parent:
             if value in self.parent.child_dict:
                 raise ValueError(

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -42,7 +42,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Ben Morris <https://github.com/bendmorris>
 - Ben Woodcroft <https://github.com/wwood>
 - Benjamin Vaisvil <https://github.com/bvaisvil>
-- Bernhard Thiel <https://github.com/Bernhard10>
+- Bernhard C. Thiel <https://github.com/Bernhard10>
 - Bertrand Caron <https://github.com/bertrand-caron>
 - Bertrand Frottier <bertrand.frottier at domain free.fr>
 - Bertrand Néron <https://github.com/bneron>

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -1264,6 +1264,13 @@ class ChangingIdTests(unittest.TestCase):
         model = next(iter(self.struc))
         self.assertIn("R", model)
 
+    def test_change_id_to_self(self):
+        """Changing the id to itself does nothing (does not raise)."""
+        chain = next(iter(self.struc.get_chains()))
+        chain_id = chain.id
+        chain.id = chain_id
+        self.assertEqual(chain.id, chain_id)
+
     def test_change_residue_id(self):
         """Change the id of a residue."""
         chain = next(iter(self.struc.get_chains()))


### PR DESCRIPTION
Fix a bug with Bio.PDB.Entity.py

Changing an id to itself should be a no-op, but previously raised an Error.

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
