### PR TITLE
removes files created during run of test_Tutorial.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,10 +53,12 @@ Tests/biosql.ini
 #TODO - The unit tests shouldn't leave temp files after running:
 Tests/BioSQL/temp_sqlite.db
 Tests/BioSQL/temp_sqlite.db-journal
+Tests/Cluster/cyano_result*
 
 #TODO - The Tutorial doctests should leave example files after
 #running Tests/test_Tutorial.py
 Doc/examples/other_trees.nwk
+Doc/examples/tree1.nwk
 
 #Ignore LaTeX temp files, and compiled output
 Doc/*.aux

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -57,6 +57,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Bryan Lunt <https://github.com/bryan-lunt>
 - Carlos Pena <https://github.com/carlosp420>
 - Carlos Ríos <https://github.com/Crosvera>
+- Catherine Lesuisse <https://github.com/kaskales>
 - Cecilia Alsmark <Cecilia.Alsmark at domain ebc.uu.se>
 - Chad Parmet <https://github.com/cparmet>
 - Chaitanya Gupta <https://github.com/iCHAIT>

--- a/Doc/Tutorial/chapter_cluster.tex
+++ b/Doc/Tutorial/chapter_cluster.tex
@@ -954,6 +954,8 @@ This is an example of a hierarchical clustering calculation, using single linkag
 
 The example data \verb|cyano.txt| can be found in Biopython's \verb|Tests/Cluster| subdirectory and is from the paper \cite[Hihara \textit{et al.}, 2001]{hihara2001}.
 
+%all cyano_result* files created here during the run of test_Tutorial.py are 
+%after automatically deleted at the end of the test run.
 %doctest ../Tests/Cluster lib:numpy
 \begin{verbatim}
 >>> from Bio import Cluster

--- a/Doc/Tutorial/chapter_phylo.tex
+++ b/Doc/Tutorial/chapter_phylo.tex
@@ -276,7 +276,8 @@ through each of the trees in the given file:
 
 Write a tree or iterable of trees back to file with the \verb|write| function:
 
-%the files tree1.nwk and other_trees.nwk are created and then deleted during the run of test_Tutorial.py
+%the files tree1.nwk and other_trees.nwk are created and then deleted during the
+%run of test_Tutorial.py
 %cont-doctest
 \begin{verbatim}
 >>> trees = list(Phylo.parse("../../Tests/PhyloXML/phyloxml_examples.xml", "phyloxml"))

--- a/Doc/Tutorial/chapter_phylo.tex
+++ b/Doc/Tutorial/chapter_phylo.tex
@@ -276,6 +276,7 @@ through each of the trees in the given file:
 
 Write a tree or iterable of trees back to file with the \verb|write| function:
 
+%the files tree1.nwk and other_trees.nwk are created and then deleted during the run of test_Tutorial.py
 %cont-doctest
 \begin{verbatim}
 >>> trees = list(Phylo.parse("../../Tests/PhyloXML/phyloxml_examples.xml", "phyloxml"))

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -18,6 +18,7 @@ Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
 - Brandon Invergo
+- Catherine Lesuisse
 - Chris Rands
 - Kai Blin
 - Maximilian Greil

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -259,12 +259,12 @@ class TutorialTestCase(unittest.TestCase):
     def tearDown(self):
         global original_path
         os.chdir(original_path)
-        #  remove files created from chapter_phylo.tex
-        # files don't get created during test with python3.5
+        # files currently don't get created during test with python3.5 and pypy
+        # remove files created from chapter_phylo.tex
         if os.path.exists(os.path.join(tutorial_base, "examples/tree1.nwk")):
             os.remove(os.path.join(tutorial_base, "examples/tree1.nwk"))
             os.remove(os.path.join(tutorial_base, "examples/other_trees.nwk"))
-        #  remove files created from chapter_cluster.tex
+        # remove files created from chapter_cluster.tex
         tutorial_cluster_base = os.path.abspath("../Tests/")
         if os.path.exists(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.atr")):
             os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.atr"))

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -55,7 +55,6 @@ import unittest
 import doctest
 import os
 import sys
-import platform
 import warnings
 from Bio import BiopythonExperimentalWarning, MissingExternalDependencyError
 
@@ -261,18 +260,22 @@ class TutorialTestCase(unittest.TestCase):
         os.chdir(original_path)
         # files currently don't get created during test with python3.5 and pypy
         # remove files created from chapter_phylo.tex
-        if os.path.exists(os.path.join(tutorial_base, "examples/tree1.nwk")):
-            os.remove(os.path.join(tutorial_base, "examples/tree1.nwk"))
-            os.remove(os.path.join(tutorial_base, "examples/other_trees.nwk"))
+        delete_phylo_tutorial = [
+            "examples/tree1.nwk", "examples/other_trees.nwk"
+            ]
+        for file in delete_phylo_tutorial:
+            if os.path.exists(os.path.join(tutorial_base, file)):
+                os.remove(os.path.join(tutorial_base, file))
         # remove files created from chapter_cluster.tex
         tutorial_cluster_base = os.path.abspath("../Tests/")
-        if os.path.exists(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.atr")):
-            os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.atr"))
-            os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.cdt"))
-            os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.gtr"))
-            os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result_K_A2.kag"))
-            os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result_K_G5.kgg"))
-            os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result_K_G5_A2.cdt"))
+        delete_cluster_tutorial = [
+            "Cluster/cyano_result.atr", "Cluster/cyano_result.cdt",
+            "Cluster/cyano_result.gtr", "Cluster/cyano_result_K_A2.kag",
+            "Cluster/cyano_result_K_G5.kgg", "Cluster/cyano_result_K_G5_A2.cdt"
+            ]
+        for file in delete_cluster_tutorial:
+            if os.path.exists(os.path.join(tutorial_cluster_base, file)):
+                os.remove(os.path.join(tutorial_cluster_base, file))
 
 
 # This is to run the doctests if the script is called directly:

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -258,6 +258,17 @@ class TutorialTestCase(unittest.TestCase):
     def tearDown(self):
         global original_path
         os.chdir(original_path)
+        #  remove files created from chapter_phylo.tex
+        os.remove(os.path.join(tutorial_base, "examples/tree1.nwk"))
+        os.remove(os.path.join(tutorial_base, "examples/other_trees.nwk"))
+        #  remove files created from chapter_cluster.tex
+        tutorial_cluster_base = os.path.abspath("../Tests/")
+        os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.atr"))
+        os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.cdt"))
+        os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.gtr"))
+        os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result_K_A2.kag"))
+        os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result_K_G5.kgg"))
+        os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result_K_G5_A2.cdt"))
 
 
 # This is to run the doctests if the script is called directly:

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -55,6 +55,7 @@ import unittest
 import doctest
 import os
 import sys
+import platform
 import warnings
 from Bio import BiopythonExperimentalWarning, MissingExternalDependencyError
 
@@ -259,16 +260,19 @@ class TutorialTestCase(unittest.TestCase):
         global original_path
         os.chdir(original_path)
         #  remove files created from chapter_phylo.tex
-        os.remove(os.path.join(tutorial_base, "examples/tree1.nwk"))
-        os.remove(os.path.join(tutorial_base, "examples/other_trees.nwk"))
+        # files don't get created during test with python3.5
+        if os.path.exists(os.path.join(tutorial_base, "examples/tree1.nwk")):
+            os.remove(os.path.join(tutorial_base, "examples/tree1.nwk"))
+            os.remove(os.path.join(tutorial_base, "examples/other_trees.nwk"))
         #  remove files created from chapter_cluster.tex
         tutorial_cluster_base = os.path.abspath("../Tests/")
-        os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.atr"))
-        os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.cdt"))
-        os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.gtr"))
-        os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result_K_A2.kag"))
-        os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result_K_G5.kgg"))
-        os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result_K_G5_A2.cdt"))
+        if os.path.exists(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.atr")):
+            os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.atr"))
+            os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.cdt"))
+            os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result.gtr"))
+            os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result_K_A2.kag"))
+            os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result_K_G5.kgg"))
+            os.remove(os.path.join(tutorial_cluster_base, "Cluster/cyano_result_K_G5_A2.cdt"))
 
 
 # This is to run the doctests if the script is called directly:


### PR DESCRIPTION
This pull request addresses issue discussed in the comments of a previous pull request, 1746.

Removes two from created from chapter_phylo.tex and six from chapter_cluster.tex during the run of test_Tutorial.py

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
