### PR TITLE
Fixed multiline assert statements in Bio folder, issue #1515

### DIFF
--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -597,7 +597,7 @@ class EmblScanner(InsdcScanner):
     def parse_footer(self):
         """Return a tuple containing a list of any misc strings, and the sequence."""
         if self.line[:self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
-            raise ValueError("Eh? '%s'" % self.line)
+            raise ValueError("Footer format unexpected: '%s'" % self.line)
 
         # Note that the SQ line can be split into several lines...
         misc_lines = []
@@ -623,8 +623,9 @@ class EmblScanner(InsdcScanner):
                 raise ValueError("Blank line in sequence data")
             if line == '//':
                 break
-            assert self.line[:self.HEADER_WIDTH] == " " * self.HEADER_WIDTH, \
-                repr(self.line)
+            if self.line[:self.HEADER_WIDTH] != (" " * self.HEADER_WIDTH):
+                raise ValueError("Problem with characters in header line, "
+                                 " or incorrect header width: " + self.line)
             # Remove tailing number now, remove spaces later
             linersplit = line.rsplit(None, 1)
             if len(linersplit) == 2 and linersplit[1].isdigit():
@@ -1117,7 +1118,7 @@ class GenBankScanner(InsdcScanner):
     def parse_footer(self):
         """Return a tuple containing a list of any misc strings, and the sequence."""
         if self.line[:self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
-            raise ValueError("Eh? '%s'" % self.line)
+            raise ValueError("Footer format unexpected:  '%s'" % self.line)
 
         misc_lines = []
         while self.line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS \

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -113,8 +113,8 @@ class InsdcScanner(object):
 
         Assumes you have just read in the ID/LOCUS line.
         """
-        assert self.line[:self.HEADER_WIDTH] == self.RECORD_START, \
-            "Not at start of record"
+        if self.line[:self.HEADER_WIDTH] != self.RECORD_START:
+            raise ValueError("Not at start of record")
 
         header_lines = []
         while True:
@@ -353,8 +353,8 @@ class InsdcScanner(object):
                     raise ValueError("Premature end of file")
                 self.line = self.line.rstrip()
 
-        assert self.line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS, \
-            "Not at start of sequence"
+        if self.line[:self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
+            raise ValueError("Not at start of sequence")
         while True:
             line = self.handle.readline()
             if not line:
@@ -596,8 +596,8 @@ class EmblScanner(InsdcScanner):
 
     def parse_footer(self):
         """Return a tuple containing a list of any misc strings, and the sequence."""
-        assert self.line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS, \
-            "Eh? '%s'" % self.line
+        if self.line[:self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
+            raise ValueError("Eh? '%s'" % self.line)
 
         # Note that the SQ line can be split into several lines...
         misc_lines = []
@@ -608,8 +608,10 @@ class EmblScanner(InsdcScanner):
                 raise ValueError("Premature end of file")
             self.line = self.line.rstrip()
 
-        assert self.line[:self.HEADER_WIDTH] == " " * self.HEADER_WIDTH \
-            or self.line.strip() == '//', "Unexpected content after SQ or CO line: %r" % self.line
+        if not (self.line[:self.HEADER_WIDTH] == " " * self.HEADER_WIDTH
+                or self.line.strip() == '//'):
+            raise ValueError("Unexpected content after SQ or CO "
+                             "line: %r" % self.line)
 
         seq_lines = []
         line = self.line
@@ -1114,8 +1116,8 @@ class GenBankScanner(InsdcScanner):
 
     def parse_footer(self):
         """Return a tuple containing a list of any misc strings, and the sequence."""
-        assert self.line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS, \
-            "Eh? '%s'" % self.line
+        if self.line[:self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
+            raise ValueError("Eh? '%s'" % self.line)
 
         misc_lines = []
         while self.line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS \
@@ -1127,8 +1129,8 @@ class GenBankScanner(InsdcScanner):
                 raise ValueError("Premature end of file")
             self.line = self.line
 
-        assert self.line[:self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS, \
-            "Eh? '%s'" % self.line
+        if self.line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
+            raise ValueError("Eh? '%s'" % self.line)
 
         # Now just consume the sequence lines until reach the // marker
         # or a CONTIG line
@@ -1178,8 +1180,8 @@ class GenBankScanner(InsdcScanner):
         #####################################
         # LOCUS line                        #
         #####################################
-        assert line[0:self.GENBANK_INDENT] == 'LOCUS       ', \
-            'LOCUS line does not start correctly:\n' + line
+        if line[0:self.GENBANK_INDENT] != 'LOCUS       ':
+            raise ValueError('LOCUS line does not start correctly:\n' + line)
 
         # Have to break up the locus line, and handle the different bits of it.
         # There are at least two different versions of the locus line...
@@ -1205,28 +1207,35 @@ class GenBankScanner(InsdcScanner):
             #
             # assert line[29:33] in [' bp ', ' aa ',' rc '] , \
             #       'LOCUS line does not contain size units at expected position:\n' + line
-            assert line[41:42] == ' ', \
-                'LOCUS line does not contain space at position 42:\n' + line
-            assert line[42:51].strip() in ['', 'linear', 'circular'], \
-                'LOCUS line does not contain valid entry (linear, circular, ...):\n' + line
-            assert line[51:52] == ' ', \
-                'LOCUS line does not contain space at position 52:\n' + line
-            # assert line[55:62] == '       ', \
-            #      'LOCUS line does not contain spaces from position 56 to 62:\n' + line
+            if line[41:42] != ' ':
+                raise ValueError('LOCUS line does not contain space at '
+                                 'position 42:\n' + line)
+            if line[42:51].strip() not in ['', 'linear', 'circular']:
+                raise ValueError('LOCUS line does not contain valid entry '
+                                 '(linear, circular, ...):\n' + line)
+            if line[51:52] != ' ':
+                raise ValueError('LOCUS line does not contain space at '
+                                 'position 52:\n' + line)
+            # if line[55:62] != '       ':
+            #      raise ValueError('LOCUS line does not contain spaces from position 56 to 62:\n' + line)
             if line[62:73].strip():
-                assert line[64:65] == '-', \
-                    'LOCUS line does not contain - at position 65 in date:\n' + line
-                assert line[68:69] == '-', \
-                    'LOCUS line does not contain - at position 69 in date:\n' + line
+                if line[64:65] != '-':
+                    raise ValueError('LOCUS line does not contain - at '
+                                     'position 65 in date:\n' + line)
+                if line[68:69] != '-':
+                    raise ValueError('LOCUS line does not contain - at '
+                                     'position 69 in date:\n' + line)
 
             name_and_length_str = line[self.GENBANK_INDENT:29]
             while '  ' in name_and_length_str:
                 name_and_length_str = name_and_length_str.replace('  ', ' ')
             name_and_length = name_and_length_str.split(' ')
-            assert len(name_and_length) <= 2, \
-                'Cannot parse the name and length in the LOCUS line:\n' + line
-            assert len(name_and_length) != 1, \
-                'Name and length collide in the LOCUS line:\n' + line
+            if len(name_and_length) > 2:
+                raise ValueError('Cannot parse the name and length in '
+                                 'the LOCUS line:\n' + line)
+            if len(name_and_length) == 1:
+                raise ValueError('Name and length collide in the LOCUS '
+                                 'line:\n' + line)
             # Should be possible to split them based on position, if
             # a clear definition of the standard exists THAT AGREES with
             # existing files.
@@ -1287,36 +1296,48 @@ class GenBankScanner(InsdcScanner):
                 padding = " " * padding_len
                 line += padding
 
-            assert line[40:44] in [' bp ', ' aa ', ' rc '], \
-                'LOCUS line does not contain size units at expected position:\n' + line
-            assert line[44:47] in ['   ', 'ss-', 'ds-', 'ms-'], \
-                'LOCUS line does not have valid strand type (Single stranded, ...):\n' + line
-            assert line[47:54].strip() == "" \
-                or 'DNA' in line[47:54].strip().upper() \
-                or 'RNA' in line[47:54].strip().upper(), \
-                   'LOCUS line does not contain valid sequence type (DNA, RNA, ...):\n' + line
-            assert line[54:55] == ' ', \
-                'LOCUS line does not contain space at position 55:\n' + line
-            assert line[55:63].strip() in ['', 'linear', 'circular'], \
-                'LOCUS line does not contain valid entry (linear, circular, ...):\n' + line
-            assert line[63:64] == ' ', \
-                'LOCUS line does not contain space at position 64:\n' + line
-            assert line[67:68] == ' ', \
-                'LOCUS line does not contain space at position 68:\n' + line
+            if line[40:44] not in [' bp ', ' aa ', ' rc ']:
+                raise ValueError('LOCUS line does not contain size units at '
+                                 'expected position:\n' + line)
+            if line[44:47] not in ['   ', 'ss-', 'ds-', 'ms-']:
+                raise ValueError('LOCUS line does not have valid strand '
+                                 'type (Single stranded, ...):\n' + line)
+
+            if not (line[47:54].strip() == ""
+                    or 'DNA' in line[47:54].strip().upper()
+                    or 'RNA' in line[47:54].strip().upper()):
+                raise ValueError('LOCUS line does not contain valid '
+                                 'sequence type (DNA, RNA, ...):\n' + line)
+            if line[54:55] != ' ':
+                raise ValueError('LOCUS line does not contain space at '
+                                 'position 55:\n' + line)
+            if line[55:63].strip() not in ['', 'linear', 'circular']:
+                raise ValueError('LOCUS line does not contain valid '
+                                 'entry (linear, circular, ...):\n' + line)
+            if line[63:64] != ' ':
+                raise ValueError('LOCUS line does not contain space at '
+                                 'position 64:\n' + line)
+            if line[67:68] != ' ':
+                raise ValueError('LOCUS line does not contain space at '
+                                 'position 68:\n' + line)
             if line[68:79].strip():
-                assert line[70:71] == '-', \
-                    'LOCUS line does not contain - at position 71 in date:\n' + line
-                assert line[74:75] == '-', \
-                    'LOCUS line does not contain - at position 75 in date:\n' + line
+                if line[70:71] != '-':
+                    raise ValueError('LOCUS line does not contain - at '
+                                     'position 71 in date:\n' + line)
+                if line[74:75] != '-':
+                    raise ValueError('LOCUS line does not contain - at '
+                                     'position 75 in date:\n' + line)
 
             name_and_length_str = line[self.GENBANK_INDENT:40]
             while '  ' in name_and_length_str:
                 name_and_length_str = name_and_length_str.replace('  ', ' ')
             name_and_length = name_and_length_str.split(' ')
-            assert len(name_and_length) <= 2, \
-                'Cannot parse the name and length in the LOCUS line:\n' + line
-            assert len(name_and_length) != 1, \
-                'Name and length collide in the LOCUS line:\n' + line
+            if len(name_and_length) > 2:
+                raise ValueError('Cannot parse the name and length in '
+                                 'the LOCUS line:\n' + line)
+            if len(name_and_length) == 1:
+                raise ValueError('Name and length collide in the LOCUS '
+                                 'line:\n' + line)
             # Should be possible to split them based on position, if
             # a clear definition of the stand exists THAT AGREES with
             # existing files.

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -1241,8 +1241,9 @@ class _FeatureConsumer(_BaseGenBankConsumer):
 
         # Try and append the version number to the accession for the full id
         if not self.data.id:
-            assert 'accessions' not in self.data.annotations, \
-                   self.data.annotations['accessions']
+            if 'accessions' in self.data.annotations:
+                raise ValueError("Problem adding version number to accession: "
+                                 + str(self.data.annotations['accessions']))
             self.data.id = self.data.name  # Good fall back?
         elif self.data.id.count('.') == 0:
             try:

--- a/Bio/Graphics/BasicChromosome.py
+++ b/Bio/Graphics/BasicChromosome.py
@@ -69,8 +69,9 @@ class _ChromosomeComponent(Widget):
 
     def add(self, component):
         """Add a sub_component to the list of components under this item."""
-        assert isinstance(component, _ChromosomeComponent), \
-            "Expected a _ChromosomeComponent object, got %s" % component
+        if not isinstance(component, _ChromosomeComponent):
+            raise TypeError("Expected a _ChromosomeComponent "
+                            "object, got %s" % component)
 
         self._sub_components.append(component)
 

--- a/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
@@ -1191,7 +1191,10 @@ class CircularDrawer(AbstractDrawer):
             headangle = max(min(headangle, startangle), endangle)
         if not (startangle <= headangle <= endangle
                 or endangle <= headangle <= startangle):
-            raise RuntimeError(startangle, headangle, endangle, angle)
+            raise RuntimeError("Problem drawing arrow, invalid positions. "
+                               "Start angle: %s, Head angle: %s, "
+                               "End angle: %s, Angle: %s"
+                               % (startangle, headangle, endangle, angle))
 
         # Calculate trig values for angle and coordinates
         startcos, startsin = cos(startangle), sin(startangle)
@@ -1326,8 +1329,12 @@ class CircularDrawer(AbstractDrawer):
             tailangle = min(startangle + min(height * tail_length_ratio / (center * teeth), angle), endangle)
 
         if not startangle <= tailangle <= headangle <= endangle:
-            raise RuntimeError(startangle, tailangle,
-                               headangle, endangle, angle)
+            raise RuntimeError("Problem drawing jaggy sigil, invalid "
+                               "positions. Start angle: %s, "
+                               "Tail angle: %s, Head angle: %s, End angle %s, "
+                               "Angle: %s" % (startangle, tailangle, headangle,
+                                              endangle, angle))
+
 
         # Calculate trig values for angle and coordinates
         startcos, startsin = cos(startangle), sin(startangle)

--- a/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
@@ -1335,7 +1335,6 @@ class CircularDrawer(AbstractDrawer):
                                "Angle: %s" % (startangle, tailangle, headangle,
                                               endangle, angle))
 
-
         # Calculate trig values for angle and coordinates
         startcos, startsin = cos(startangle), sin(startangle)
         headcos, headsin = cos(headangle), sin(headangle)

--- a/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
@@ -1189,9 +1189,9 @@ class CircularDrawer(AbstractDrawer):
             headangle = max(min(headangle, endangle), startangle)
         else:
             headangle = max(min(headangle, startangle), endangle)
-        assert startangle <= headangle <= endangle \
-            or endangle <= headangle <= startangle, \
-            (startangle, headangle, endangle, angle)
+        if not (startangle <= headangle <= endangle
+                or endangle <= headangle <= startangle):
+            raise RuntimeError(startangle, headangle, endangle, angle)
 
         # Calculate trig values for angle and coordinates
         startcos, startsin = cos(startangle), sin(startangle)
@@ -1325,8 +1325,9 @@ class CircularDrawer(AbstractDrawer):
             headangle = endangle
             tailangle = min(startangle + min(height * tail_length_ratio / (center * teeth), angle), endangle)
 
-        assert startangle <= tailangle <= headangle <= endangle, \
-            (startangle, tailangle, headangle, endangle, angle)
+        if not startangle <= tailangle <= headangle <= endangle:
+            raise RuntimeError(startangle, tailangle,
+                               headangle, endangle, angle)
 
         # Calculate trig values for angle and coordinates
         startcos, startsin = cos(startangle), sin(startangle)

--- a/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
@@ -315,13 +315,13 @@ class LinearDrawer(AbstractDrawer):
 
         Returns a drawing element that is the tick on the scale
         """
-        assert self.start <= tickpos and tickpos <= self.end, \
-               "Tick at %i, but showing %i to %i" \
-               % (tickpos, self.start, self.end)
-        assert (track.start is None or track.start <= tickpos) and \
-               (track.end is None or tickpos <= track.end), \
-               "Tick at %i, but showing %r to %r for track" \
-               % (tickpos, track.start, track.end)
+        if self.start >= tickpos and tickpos >= self.end:
+            raise RuntimeError("Tick at %i, but showing %i to %i"
+                               % (tickpos, self.start, self.end))
+        if not ((track.start is None or track.start <= tickpos)
+                and (track.end is None or tickpos <= track.end)):
+            raise RuntimeError("Tick at %i, but showing %r to %r for track"
+                               % (tickpos, track.start, track.end))
         fragment, tickx = self.canvas_location(tickpos)  # Tick co-ordinates
         assert fragment >= 0, "Fragment %i, tickpos %i" % (fragment, tickpos)
         tctr = ctr + self.fragment_lines[fragment][0]   # Center line of the track

--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -194,8 +194,9 @@ class MarkovModelBuilder(object):
 
         # ensure that all referenced states are valid
         for state in initial_prob:
-            assert state in self._state_alphabet.letters, \
-                   "State %s was not found in the sequence alphabet" % state
+            if state not in self._state_alphabet.letters:
+                raise ValueError("State %s was not found in the sequence "
+                                 "alphabet" % state)
 
         # distribute the residual probability, if any
         num_states_not_set =\
@@ -344,8 +345,9 @@ class MarkovModelBuilder(object):
         """
         # check the sanity of adding these states
         for state in [from_state, to_state]:
-            assert state in self._state_alphabet.letters, \
-                   "State %s was not found in the sequence alphabet" % state
+            if state not in self._state_alphabet.letters:
+                raise ValueError("State %s was not found in the sequence "
+                                 "alphabet" % state)
 
         # ensure that the states are not already set
         if (from_state, to_state) not in self.transition_prob and \

--- a/Bio/KEGG/KGML/KGML_pathway.py
+++ b/Bio/KEGG/KGML/KGML_pathway.py
@@ -89,17 +89,17 @@ class Pathway(object):
     def add_entry(self, entry):
         """Add an Entry element to the pathway."""
         # We insist that the node ID is an integer
-        assert _is_int_or_long(entry.id), \
-            "Node ID must be an integer, got %s (%s)" % (type(entry.id),
-                                                         entry.id)
+        if not _is_int_or_long(entry.id):
+            raise TypeError("Node ID must be an integer, got %s (%s)"
+                            % (type(entry.id), entry.id))
         entry._pathway = self           # Let the entry know about the pathway
         self.entries[entry.id] = entry
 
     def remove_entry(self, entry):
         """Remove an Entry element from the pathway."""
-        assert _is_int_or_long(entry.id), \
-            "Node ID must be an integer, got %s (%s)" % (type(entry.id),
-                                                         entry.id)
+        if not _is_int_or_long(entry.id):
+            raise TypeError("Node ID must be an integer, got %s (%s)"
+                            % (type(entry.id), entry.id))
         # We need to remove the entry from any other elements that may
         # contain it, which means removing those elements
         # TODO
@@ -108,19 +108,20 @@ class Pathway(object):
     def add_reaction(self, reaction):
         """Add a Reaction element to the pathway."""
         # We insist that the node ID is an integer and corresponds to an entry
-        assert _is_int_or_long(reaction.id), \
-            "Node ID must be an integer, got %s (%s)" % (type(reaction.id),
-                                                         reaction.id)
-        assert reaction.id in self.entries, \
-            "Reaction ID %d has no corresponding entry" % reaction.id
+        if not _is_int_or_long(reaction.id):
+            raise ValueError("Node ID must be an integer, got %s (%s)"
+                             % (type(reaction.id), reaction.id))
+        if reaction.id not in self.entries:
+            raise ValueError("Reaction ID %d has no corresponding"
+                             " entry" % reaction.id)
         reaction._pathway = self    # Let the reaction know about the pathway
         self._reactions[reaction.id] = reaction
 
     def remove_reaction(self, reaction):
         """Remove a Reaction element from the pathway."""
-        assert _is_int_or_long(reaction.id), \
-            "Node ID must be an integer, got %s (%s)" % (type(reaction.id),
-                                                         reaction.id)
+        if not _is_int_or_long(reaction.id):
+            raise TypeError("Node ID must be an integer, got %s (%s)"
+                            % (type(reaction.id), reaction.id))
         # We need to remove the reaction from any other elements that may
         # contain it, which means removing those elements
         # TODO
@@ -155,8 +156,9 @@ class Pathway(object):
         return self._name
 
     def _setname(self, value):
-        assert value.startswith('path:'), \
-            "Pathway name should begin with 'path:', got %s" % value
+        if not value.startswith('path:'):
+            raise ValueError("Pathway name should begin with 'path:', "
+                             "got %s" % value)
         self._name = value
 
     def _delname(self):
@@ -302,8 +304,9 @@ class Entry(object):
         the component already exists.
         """
         if self._pathway is not None:
-            assert element.id in self._pathway.entries, \
-                "Component %s is not an entry in the pathway" % element.id
+            if element.id not in self._pathway.entries:
+                raise ValueError("Component %s is not an entry in the "
+                                 "pathway" % element.id)
         self.components.add(element)
 
     def remove_component(self, value):
@@ -653,16 +656,17 @@ class Reaction(object):
     def add_substrate(self, substrate_id):
         """Add a substrate, identified by its node ID, to the reaction."""
         if self._pathway is not None:
-            assert int(substrate_id) in self._pathway.entries, \
-                "Couldn't add substrate, no node ID %d in Pathway" % \
-                int(substrate_id)
+            if int(substrate_id) not in self._pathway.entries:
+                raise ValueError("Couldn't add substrate, no node ID %d in "
+                                 "Pathway" % int(substrate_id))
         self._substrates.add(substrate_id)
 
     def add_product(self, product_id):
         """Add a product, identified by its node ID, to the reaction."""
         if self._pathway is not None:
-            assert int(product_id) in self._pathway.entries, \
-                "Couldn't add product, no node ID %d in Pathway" % product_id
+            if int(product_id) not in self._pathway.entries:
+                raise ValueError("Couldn't add product, no node ID %d in "
+                                 "Pathway" % product_id)
         self._products.add(int(product_id))
 
     # The node ID is also the node ID of the Entry that corresponds to the

--- a/Bio/NeuralNetwork/Gene/Signature.py
+++ b/Bio/NeuralNetwork/Gene/Signature.py
@@ -74,9 +74,9 @@ class SignatureFinder(object):
         for seq_record in seq_records:
             # if we are working with alphabets, make sure we are consistent
             if alphabet is not None:
-                assert seq_record.seq.alphabet == alphabet, \
-                       "Working with alphabet %s and got %s" % \
-                       (alphabet, seq_record.seq.alphabet)
+                if seq_record.seq.alphabet != alphabet:
+                    raise TypeError("Working with alphabet %s and got %s" %
+                                    (alphabet, seq_record.seq.alphabet))
 
             # now start finding signatures in the sequence
             largest_sig_size = sig_size * 2 + max_gap

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -1049,9 +1049,10 @@ class Nexus(object):
         # check that taxlabels is identical with matrix.keys. If not, it's a problem
         matrixkeys = sorted(self.matrix)
         taxlabelssort = sorted(self.taxlabels[:])
-        assert matrixkeys == taxlabelssort, \
-            "ERROR: TAXLABELS must be identical with MATRIX. " + \
-            "Please Report this as a bug, and send in data file."
+        if matrixkeys != taxlabelssort:
+            raise ValueError("ERROR: TAXLABELS must be identical with MATRIX. "
+                             "Please Report this as a bug, "
+                             "and send in data file.")
 
     def _translate(self, options):
         """Translate a Nexus file (PRIVATE)."""
@@ -1772,8 +1773,9 @@ class Nexus(object):
         else:
             unique_name = name
 
-        assert unique_name not in self.matrix, \
-            "ERROR. There is a discrepancy between taxlabels and matrix keys. Report this as a bug."
+        if unique_name in self.matrix:
+            raise ValueError("ERROR. There is a discrepancy between taxlabels "
+                             "and matrix keys. Report this as a bug.")
 
         self.matrix[unique_name] = Seq(sequence, self.alphabet)
         self.ntax += 1
@@ -1888,8 +1890,10 @@ class Nexus(object):
             else:
                 sequence = sequence[:end + 1] + missing * (length - end - 1)
                 sequence = start * missing + sequence[start:]
-            assert length == len(sequence), \
-                "Illegal sequence manipulation in Nexus.terminal_gap_to_missing in taxon %s" % taxon
+            if length != len(sequence):
+                raise RuntimeError("Illegal sequence manipulation in "
+                                   "Nexus.terminal_gap_to_missing in taxon %s"
+                                   % taxon)
             self.matrix[taxon] = Seq(sequence, self.alphabet)
 
 

--- a/Bio/PDB/ResidueDepth.py
+++ b/Bio/PDB/ResidueDepth.py
@@ -481,8 +481,9 @@ def get_surface(model, PDB_TO_XYZR=None, MSMS="msms"):
     make_surface = MSMS % (xyz_tmp, surface_tmp)
     os.system(make_surface)
     surface_file = surface_tmp + ".vert"
-    assert os.path.isfile(surface_file), \
-        "Failed to generate surface file using command:\n%s" % make_surface
+    if not os.path.isfile(surface_file):
+        raise RuntimeError("Failed to generate surface file using "
+                           "command:\n%s" % make_surface)
 
     # read surface vertices from vertex file
     surface = _read_vertex_array(surface_file)

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -835,9 +835,10 @@ class Tree(TreeElement, TreeMixin):
         # Hideous kludge because Py2.x doesn't allow keyword args after *args
         outgroup_branch_length = kwargs.get('outgroup_branch_length')
         if outgroup_branch_length is not None:
-            assert 0 <= outgroup_branch_length <= prev_blen, \
-                "outgroup_branch_length must be between 0 and the " \
-                "original length of the branch leading to the outgroup."
+            if not (0 <= outgroup_branch_length <= prev_blen):
+                raise ValueError("outgroup_branch_length must be between 0 "
+                                 "and the original length of the branch "
+                                 "leading to the outgroup.")
 
         if outgroup.is_terminal() or outgroup_branch_length is not None:
             # Create a new root with a 0-length branch to the outgroup

--- a/Bio/Phylo/PhyloXMLIO.py
+++ b/Bio/Phylo/PhyloXMLIO.py
@@ -350,8 +350,9 @@ class Parser(object):
         for event, elem in self.context:
             namespace, tag = _split_namespace(elem.tag)
             if event == 'start' and tag == 'clade':
-                assert phylogeny.root is None, \
-                    "Phylogeny object should only have 1 clade"
+                if phylogeny.root is not None:
+                    raise ValueError("Phylogeny object should only have "
+                                     "1 clade")
                 phylogeny.root = self._parse_clade(elem)
                 continue
             if event == 'end':

--- a/Bio/Phylo/_utils.py
+++ b/Bio/Phylo/_utils.py
@@ -377,8 +377,9 @@ def draw(tree, label_func=str, do_show=True, show_confidence=True,
         def format_branch_label(clade):
             return branch_labels.get(clade)
     else:
-        assert callable(branch_labels), \
-            "branch_labels must be either a dict or a callable (function)"
+        if not callable(branch_labels):
+            raise TypeError("branch_labels must be either a "
+                            "dict or a callable (function)")
         format_branch_label = branch_labels
 
     # options for displaying label colors.

--- a/Bio/SearchIO/BlastIO/blast_tab.py
+++ b/Bio/SearchIO/BlastIO/blast_tab.py
@@ -321,8 +321,9 @@ class BlastTabParser(object):
         """Return a dictionary of parsed row values (PRIVATE)."""
         fields = self.fields
         columns = self.line.strip().split('\t')
-        assert len(fields) == len(columns), "Expected %i columns, found: " \
-            "%i" % (len(fields), len(columns))
+        if len(fields) != len(columns):
+            raise ValueError("Expected %i columns, found: "
+                             "%i" % (len(fields), len(columns)))
 
         qresult, hit, hsp, frag = {}, {}, {}, {}
         for idx, value in enumerate(columns):

--- a/Bio/SearchIO/BlastIO/blast_xml.py
+++ b/Bio/SearchIO/BlastIO/blast_xml.py
@@ -783,8 +783,9 @@ class BlastXmlWriter(object):
                 content = str(getattr(obj, attr))
             except AttributeError:
                 # ensure attrs that is not present is optional
-                assert elem in _DTD_OPT, "Element %r (attribute %r) not " \
-                    "found" % (elem, attr)
+                if elem not in _DTD_OPT:
+                    raise ValueError("Element %r (attribute %r) not "
+                                     "found" % (elem, attr))
             else:
                 # custom element-attribute mapping, for fallback values
                 if elem in opt_dict:
@@ -805,8 +806,9 @@ class BlastXmlWriter(object):
             try:
                 content = str(getattr(qresult, attr))
             except AttributeError:
-                assert elem in _DTD_OPT, "Element %s (attribute %s) not " \
-                    "found" % (elem, attr)
+                if elem not in _DTD_OPT:
+                    raise ValueError("Element %s (attribute %s) not "
+                                     "found" % (elem, attr))
             else:
                 if elem == 'BlastOutput_version':
                     content = '%s %s' % (qresult.program.upper(),
@@ -909,8 +911,9 @@ class BlastXmlWriter(object):
                 # make sure any elements that is not present is optional
                 # in the DTD
                 except AttributeError:
-                    assert elem in _DTD_OPT, "Element %s (attribute %s) not found" \
-                            % (elem, attr)
+                    if elem not in _DTD_OPT:
+                        raise ValueError("Element %s (attribute %s) not found"
+                                         % (elem, attr))
                 else:
                     xml.simpleElement(elem, str(content))
             self.hsp_counter += 1

--- a/Bio/SearchIO/BlatIO.py
+++ b/Bio/SearchIO/BlatIO.py
@@ -229,8 +229,8 @@ def _reorient_starts(starts, blksizes, seqlen, strand):
 
     """
     if len(starts) != len(blksizes):
-            raise RuntimeError("Unequal start coordinates and block sizes list"
-                               " (%r vs %r)" % (len(starts), len(blksizes)))
+        raise RuntimeError("Unequal start coordinates and block sizes list"
+                           " (%r vs %r)" % (len(starts), len(blksizes)))
     # see: http://genome.ucsc.edu/goldenPath/help/blatSpec.html
     # no need to reorient if it's already the positive strand
     if strand >= 0:

--- a/Bio/SearchIO/BlatIO.py
+++ b/Bio/SearchIO/BlatIO.py
@@ -228,9 +228,9 @@ def _reorient_starts(starts, blksizes, seqlen, strand):
     :type strand: int, choice of -1, 0, or 1
 
     """
-    assert len(starts) == len(blksizes), \
-            "Unequal start coordinates and block sizes list (%r vs %r)" \
-            % (len(starts), len(blksizes))
+    if len(starts) != len(blksizes):
+            raise RuntimeError("Unequal start coordinates and block sizes list"
+                               " (%r vs %r)" % (len(starts), len(blksizes)))
     # see: http://genome.ucsc.edu/goldenPath/help/blatSpec.html
     # no need to reorient if it's already the positive strand
     if strand >= 0:
@@ -443,11 +443,15 @@ class BlatPslParser(object):
 
     def _validate_cols(self, cols):
         if not self.pslx:
-            assert len(cols) == 21, "Invalid PSL line: %r. " \
-            "Expected 21 tab-separated columns, found %i" % (self.line, len(cols))
+            if len(cols) != 21:
+                raise ValueError("Invalid PSL line: %r. Expected 21 "
+                                 "tab-separated columns, found %i"
+                                 % (self.line, len(cols)))
         else:
-            assert len(cols) == 23, "Invalid PSLX line: %r. " \
-            "Expected 23 tab-separated columns, found %i" % (self.line, len(cols))
+            if len(cols) != 23:
+                raise ValueError("Invalid PSLX line: %r. Expected 23 "
+                                 "tab-separated columns, found %i"
+                                 % (self.line, len(cols)))
 
     def _parse_qresult(self):
         """Yield QueryResult objects (PRIVATE)."""

--- a/Bio/SearchIO/ExonerateIO/exonerate_text.py
+++ b/Bio/SearchIO/ExonerateIO/exonerate_text.py
@@ -405,8 +405,9 @@ class ExonerateTextParser(_BaseExonerateParser):
                         re.findall(_RE_NER_LEN, cmbn_rows[row_dict[seq_type]])]
 
             # check that inter_lens's length is len opp_type block - 1
-            assert len(inter_lens) == len(hsp[opp_type]) - 1, \
-                    "%r vs %r" % (len(inter_lens), len(hsp[opp_type]) - 1)
+            if len(inter_lens) != len(hsp[opp_type]) - 1:
+                raise ValueError("Length mismatch: %r vs %r"
+                                 % (len(inter_lens), len(hsp[opp_type]) - 1))
             # fill the hsp query and hit coordinates
             hsp['%s_ranges' % opp_type] = _comp_coords(hsp, opp_type, inter_lens)
             # and fill the split codon coordinates, if model != ner

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1683,9 +1683,9 @@ class WithinPosition(int, AbstractPosition):
 
     def __new__(cls, position, left, right):
         """Create a WithinPosition object."""
-        assert position == left or position == right, \
-            "WithinPosition: %r should match left %r or right %r" \
-            % (position, left, right)
+        if not (position == left or position == right):
+            raise RuntimeError("WithinPosition: %r should match left %r or "
+                               "right %r" % (position, left, right))
         obj = int.__new__(cls, position)
         obj._left = left
         obj._right = right
@@ -2033,8 +2033,9 @@ class OneOfPosition(int, AbstractPosition):
 
         position is an integer specifying the default behaviour.
         """
-        assert position in choices, \
-            "OneOfPosition: %r should match one of %r" % (position, choices)
+        if position not in choices:
+            raise ValueError("OneOfPosition: %r should match one "
+                             "of %r" % (position, choices))
         obj = int.__new__(cls, position)
         obj.position_choices = choices
         return obj

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -681,27 +681,35 @@ class GenBankWriter(_InsdcWriter):
         assert line[12:40].split() == [locus, str(len(record))], line
 
         # Tests copied from Bio.GenBank.Scanner
-        assert line[40:44] in [' bp ', ' aa '], \
-            'LOCUS line does not contain size units at expected position:\n' + \
-            line
-        assert line[44:47] in ['   ', 'ss-', 'ds-', 'ms-'], \
-            'LOCUS line does not have valid strand type (Single stranded, ...):\n' + line
-        assert line[47:54].strip() == "" \
-            or 'DNA' in line[47:54].strip().upper() \
-            or 'RNA' in line[47:54].strip().upper(), \
-               'LOCUS line does not contain valid sequence type (DNA, RNA, ...):\n' + line
-        assert line[54:55] == ' ', \
-            'LOCUS line does not contain space at position 55:\n' + line
-        assert line[55:63].strip() in ['', 'linear', 'circular'], \
-            'LOCUS line does not contain valid entry (linear, circular, ...):\n' + line
-        assert line[63:64] == ' ', \
-            'LOCUS line does not contain space at position 64:\n' + line
-        assert line[67:68] == ' ', \
-            'LOCUS line does not contain space at position 68:\n' + line
-        assert line[70:71] == '-', \
-            'LOCUS line does not contain - at position 71 in date:\n' + line
-        assert line[74:75] == '-', \
-            'LOCUS line does not contain - at position 75 in date:\n' + line
+        if line[40:44] not in [' bp ', ' aa ']:
+            raise ValueError('LOCUS line does not contain size units at '
+                             'expected position:\n' + line)
+        if line[44:47] not in ['   ', 'ss-', 'ds-', 'ms-']:
+            raise ValueError('LOCUS line does not have valid strand '
+                             'type (Single stranded, ...):\n' + line)
+        if not (line[47:54].strip() == ""
+                or 'DNA' in line[47:54].strip().upper()
+                or 'RNA' in line[47:54].strip().upper()):
+            raise ValueError('LOCUS line does not contain valid '
+                             'sequence type (DNA, RNA, ...):\n' + line)
+        if line[54:55] != ' ':
+            raise ValueError('LOCUS line does not contain space at '
+                             'position 55:\n' + line)
+        if line[55:63].strip() not in ['', 'linear', 'circular']:
+            raise ValueError('LOCUS line does not contain valid '
+                             'entry (linear, circular, ...):\n' + line)
+        if line[63:64] != ' ':
+            raise ValueError('LOCUS line does not contain space at '
+                             'position 64:\n' + line)
+        if line[67:68] != ' ':
+            raise ValueError('LOCUS line does not contain space at '
+                             'position 68:\n' + line)
+        if line[70:71] != '-':
+            raise ValueError('LOCUS line does not contain - at '
+                             'position 71 in date:\n' + line)
+        if line[74:75] != '-':
+            raise ValueError('LOCUS line does not contain - at '
+                             'position 75 in date:\n' + line)
 
         self.handle.write(line)
 

--- a/Bio/SeqIO/PhdIO.py
+++ b/Bio/SeqIO/PhdIO.py
@@ -106,11 +106,13 @@ class PhdWriter(SequentialSequenceWriter):
         # 'solexa_quality' scores if present, else raises a value error
         phred_qualities = QualityIO._get_phred_quality(record)
         peak_locations = record.letter_annotations.get("peak_location")
-        assert len(record.seq) == len(phred_qualities), "Number of " + \
-            "phd quality scores does not match length of sequence"
+        if len(record.seq) != len(phred_qualities):
+            raise ValueError("Number of phd quality scores does not match "
+                             "length of sequence")
         if peak_locations:
-            assert len(record.seq) == len(peak_locations), "Number " + \
-                "of peak location scores does not match length of sequence"
+            if len(record.seq) != len(peak_locations):
+                raise ValueError("Number of peak location scores does not "
+                                 "match length of sequence")
         if None in phred_qualities:
             raise ValueError("A quality value of None was found")
         if record.description.startswith("%s " % record.id):

--- a/Bio/SeqIO/PirIO.py
+++ b/Bio/SeqIO/PirIO.py
@@ -264,8 +264,9 @@ class PirWriter(SequentialSequenceWriter):
             else:
                 code = "XX"
 
-        assert code in _pir_alphabets, "Sequence code must be one of " + \
-                                       _pir_alphabets.keys() + "."
+        if code not in _pir_alphabets:
+            raise TypeError("Sequence code must be one of " +
+                            _pir_alphabets.keys() + ".")
         assert "\n" not in title
         assert "\r" not in description
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -520,9 +520,10 @@ def write(sequences, handle, format):
             # and write that using Bio.AlignIO
             alignment = MultipleSeqAlignment(sequences)
             alignment_count = AlignIO.write([alignment], fp, format)
-            assert alignment_count == 1, \
-                "Internal error - the underlying writer " \
-                " should have returned 1, not %r" % alignment_count
+            if alignment_count != 1:
+                raise RuntimeError("Internal error - the underlying writer "
+                                   "should have returned 1, not %r"
+                                   % alignment_count)
             count = len(alignment)
             del alignment_count, alignment
         elif format in _FormatToIterator or format in AlignIO._FormatToIterator:
@@ -531,9 +532,10 @@ def write(sequences, handle, format):
         else:
             raise ValueError("Unknown format '%s'" % format)
 
-        assert isinstance(count, int), "Internal error - the underlying %s " \
-            "writer should have returned the record count, not %r" \
-            % (format, count)
+        if not isinstance(count, int):
+            raise RuntimeError("Internal error - the underlying %s writer "
+                               "should have returned the record count, not %r"
+                               % (format, count))
 
     return count
 

--- a/Bio/SeqIO/_index.py
+++ b/Bio/SeqIO/_index.py
@@ -105,9 +105,9 @@ class SffRandomAccess(SeqFileRandomAccess):
                     max_offset = max(max_offset, offset)
                     yield name, offset, 0
                     count += 1
-                assert count == number_of_reads, \
-                    "Indexed %i records, expected %i" \
-                    % (count, number_of_reads)
+                if count != number_of_reads:
+                    raise ValueError("Indexed %i records, expected %i"
+                                     % (count, number_of_reads))
                 # If that worked, call _check_eof ...
             except ValueError as err:
                 import warnings
@@ -134,8 +134,9 @@ class SffRandomAccess(SeqFileRandomAccess):
         for name, offset in SeqIO.SffIO._sff_do_slow_index(handle):
             yield name, offset, 0
             count += 1
-        assert count == number_of_reads, \
-            "Indexed %i records, expected %i" % (count, number_of_reads)
+        if count != number_of_reads:
+            raise ValueError("Indexed %i records, expected %i"
+                             % (count, number_of_reads))
         SeqIO.SffIO._check_eof(handle, index_offset, index_length)
 
     def get(self, offset):

--- a/Bio/motifs/transfac.py
+++ b/Bio/motifs/transfac.py
@@ -114,8 +114,10 @@ def read(handle):
             record.version = value
         elif key in ('P0', 'PO'):  # Old TRANSFAC files use PO instead of P0
             counts = {}
-            assert value.split()[:4] == ['A', 'C', 'G', 'T'], \
-                'A TRANSFAC matrix "{0:s}" line should be followed by "A C G T": "{0:s}"'.format(key, line)
+            if value.split()[:4] != ['A', 'C', 'G', 'T']:
+                raise ValueError('A TRANSFAC matrix "{0:s}" line should be '
+                                 'followed by "A C G T": '
+                                 '"{0:s}"'.format(key, line))
             length = 0
             for c in "ACGT":
                 counts[c] = []
@@ -141,8 +143,10 @@ def read(handle):
                         BiopythonParserWarning)
                 else:
                     length += 1
-                assert i == length, \
-                    'The TRANSFAC matrix row number does not match the position in the matrix: "{0:s}"'.format(line)
+                if i != length:
+                    raise ValueError('The TRANSFAC matrix row number does not '
+                                     'match the position in the matrix: '
+                                     '"{0:s}"'.format(line))
                 if len(key) == 1:
                     warnings.warn(
                         'A TRANSFAC matrix line should have a 2 digit key at the start of the lin ("{0:02d}"), '
@@ -150,23 +154,29 @@ def read(handle):
                         BiopythonParserWarning)
                 assert len(key_value) == 2, 'A TRANSFAC matrix line should have a key and a value: "{0:s}"'.format(line)
                 values = value.split()[:4]
-                assert len(values) == 4, \
-                    'A TRANSFAC matrix line should have a value for each nucleotide (A, C, G and T): "{0:s}"'.format(
-                        line)
+                if len(values) != 4:
+                    raise ValueError('A TRANSFAC matrix line should have a '
+                                     'value for each nucleotide '
+                                     '(A, C, G and T): "{0:s}"'.format(line))
                 for c, v in zip("ACGT", values):
                     counts[c].append(float(v))
         if line == 'XX':
             pass
         elif key == 'RN':
             index, separator, accession = value.partition(";")
-            assert index[0] == '[', \
-                'The index "{0:s}" in a TRANSFAC RN line should start with a "[": "{0:s}"'.format(index, line)
-            assert index[-1] == ']', \
-                'The index "{0:s}" in a TRANSFAC RN line should end with a "]": "{0:s}"'.format(index, line)
+            if index[0] != '[':
+                raise ValueError('The index "{0:s}" in a TRANSFAC RN line '
+                                 'should start with a '
+                                 '"[": "{0:s}"'.format(index, line))
+            if index[-1] != ']':
+                raise ValueError('The index "{0:s}" in a TRANSFAC RN line '
+                                 'should end with a '
+                                 '"]": "{0:s}"'.format(index, line))
             index = int(index[1:-1])
-            assert len(references) == index - 1, \
-                'The index "{0:d}" of the TRANSFAC RN line does not match the current number ' \
-                'of seen references "{1:d}": "{2:s}"'.format(index, len(references) + 1, line)
+            if len(references) != index - 1:
+                raise ValueError('The index "{0:d}" of the TRANSFAC RN line '
+                                 'does not match the current number of seen '
+                                 'references ''"{1:d}": "{2:s}"'.format(index, len(references) + 1, line))
             reference = {key: value}
             references.append(reference)
         elif key == '//':

--- a/Bio/phenotype/__init__.py
+++ b/Bio/phenotype/__init__.py
@@ -141,9 +141,10 @@ def write(plates, handle, format):
         else:
             raise ValueError("Unknown format '%s'" % format)
 
-        assert isinstance(count, int), "Internal error - the underlying %s " \
-            "writer should have returned the record count, not %s" \
-            % (format, repr(count))
+        if not isinstance(count, int):
+            raise TypeError("Internal error - the underlying %s "
+                            "writer should have returned the record count, "
+                            "not %s" % (format, repr(count)))
 
     return count
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -175,6 +175,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Nader Morshed <https://github.com/naderm>
 - Nate Sutton <https://github.com/nmsutton>
 - Nathan J. Edwards <nje5 at edu domain georgetown>
+- Nick Negretti <https://github.com/nimne/>
 - Nicolas Fontrodona <https://github.com/NFontrodona>
 - Nigel Delaney <https://github.com/evolvedmicrobe/>
 - Noam Kremen <https://github.com/noamkremen>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -21,7 +21,7 @@ possible, especially the following contributors:
 - Chris Rands
 - Kai Blin
 - Maximilian Greil
-- Nick Negretti
+- Nick Negretti (first contribution)
 - Peter Cock
 - Spencer Bliven
 - Wibowo 'Bow' Arindrarto

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -21,6 +21,7 @@ possible, especially the following contributors:
 - Chris Rands
 - Kai Blin
 - Maximilian Greil
+- Nick Negretti
 - Peter Cock
 - Spencer Bliven
 - Wibowo 'Bow' Arindrarto
@@ -121,10 +122,10 @@ wrapper and include a new wrapper for fuzzpro.
 The restriction enzyme list in Bio.Restriction has been updated to the
 November 2017 release of REBASE.
 
-New codon tables 27-31 from NCBI (NCBI genetic code table version 4.2) 
+New codon tables 27-31 from NCBI (NCBI genetic code table version 4.2)
 were added to Bio.Data.CodonTable. Note that tables 27, 28 and 31 contain
 no dedicated stop codons; the stop codons in these codes have a context
-dependent encoding as either STOP or as amino acid. 
+dependent encoding as either STOP or as amino acid.
 
 IO functions such as ``SeqIO.parse`` now accept any objects which can be passed
 to the builtin ``open`` function. Specifically, this allows using

--- a/Tests/test_EMBL_unittest.py
+++ b/Tests/test_EMBL_unittest.py
@@ -13,15 +13,15 @@ from Bio import BiopythonParserWarning
 
 class EMBLTests(unittest.TestCase):
     def test_embl_content_after_co(self):
-        """Test an AssertionError is thrown by content after a CO line"""
+        """Test a ValueError is thrown by content after a CO line"""
         def parse_content_after_co():
             rec = SeqIO.read(path.join('EMBL', 'xx_after_co.embl'), 'embl')
 
-        self.assertRaises(AssertionError, parse_content_after_co)
+        self.assertRaises(ValueError, parse_content_after_co)
 
         try:
             parse_content_after_co()
-        except AssertionError as e:
+        except ValueError as e:
             self.assertEqual(str(e), "Unexpected content after SQ or CO line: 'XX'")
         else:
             self.assertTrue(False, "Error message without explanation raised by content after CO line")


### PR DESCRIPTION
This pull request addresses issue #1515 

Most of the multi-line assert statements in the Bio folder were changed to errors. The few that remain are either in comments, or I couldn't determine an obvious substitution.

Unit tests (that I was able to install dependences for) passed locally, with the exception of test_partial_diagram, but that appears to be related to ReportLab 3.5.0.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
