### PR TITLE
Remove the symlinks for historic filenames.

### DIFF
--- a/CONTRIB
+++ b/CONTRIB
@@ -1,1 +1,0 @@
-CONTRIB.rst

--- a/DEPRECATED
+++ b/DEPRECATED
@@ -1,1 +1,0 @@
-DEPRECATED.rst

--- a/NEWS
+++ b/NEWS
@@ -1,1 +1,0 @@
-NEWS.rst

--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-README.rst


### PR DESCRIPTION
People will be able to work out that ``CONTRIB`` is now ``CONTRIB.rst`` etc.

However, there is the possibility of breaking packaging scripts depending on the old names ``README`` or ``LICENSE``. Is this a real risk?

Opening as a pull request for comment.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
