### PR TITLE
Dual license emboss

### DIFF
--- a/Bio/Emboss/Primer3.py
+++ b/Bio/Emboss/Primer3.py
@@ -2,9 +2,11 @@
 # Revisions copyright 2009 Leighton Pritchard.
 # Revisions copyright 2010 Peter Cock.
 # All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 """Code to parse output from the EMBOSS eprimer3 program.
 
 As elsewhere in Biopython there are two input functions, read and parse,

--- a/Bio/Emboss/PrimerSearch.py
+++ b/Bio/Emboss/PrimerSearch.py
@@ -1,7 +1,9 @@
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+# Copyright 2008 Michiel de Hoon. All rights reserved.
 #
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Code to interact with the primersearch program from EMBOSS."""
 

--- a/Bio/Emboss/__init__.py
+++ b/Bio/Emboss/__init__.py
@@ -1,6 +1,8 @@
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+# Copyright 2001 Brad Chapman. All rights reserved.
 #
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Code to interact with the ever-so-useful EMBOSS programs."""

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -111,7 +111,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Iddo Friedberg <idoerg at domain burnham.org>
 - Jacek Śmietański <https://github.com/dadoskawina>
 - Jack Twilley <https://github.com/mathuin>
-- James Casbon <j.a.casbon at domain qmul.ac.uk>
+- James Casbon <https://github.com/jamescasbon>
 - James Jeffryes <https://github.com/JamesJeffryes>
 - Jared Andrews <https://github.com/j-andrews7>
 - Jason A. Hackney <jhackney at domain stanford.edu>

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -170,7 +170,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Michael Hoffman <https://github.com/michaelmhoffman>
 - Michal Kurowski <michal at domain genesilico.pl>
 - Michał J. Gajda <https://github.com/mgajda>
-- Michiel de Hoon <mdehoon at domain c2b2.columbia.edu>
+- Michiel de Hoon <https://github.com/mdehoon>
 - Mike Poidinger <Michael.Poidinger at domain eBioinformatics.com>
 - Milind Luthra <https://github.com/milindl>
 - morrme <https://github.com/morrme>


### PR DESCRIPTION
This pull request helps address issue #898, by dual licensing ``Bio.Emboss``

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
