### PR TITLE
ValueError if _open_for_random_access given gzipped file

### DIFF
--- a/Tests/test_File.py
+++ b/Tests/test_File.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import unittest
 
+from Bio import bgzf
 from Bio import File
 from Bio._py3k import StringIO
 
@@ -65,6 +66,23 @@ class UndoHandleTests(unittest.TestCase):
                 new += tmp
             self.assertEqual(data, new)
             h.close()
+
+
+class RandomAccess(unittest.TestCase):
+
+    def test_plain(self):
+        with File._open_for_random_access("Quality/example.fastq") as handle:
+            self.assertTrue("r" in handle.mode)
+            self.assertTrue("b" in handle.mode)
+
+    def test_bgzf(self):
+        with File._open_for_random_access("Quality/example.fastq.bgz") as handle:
+            self.assertIsInstance(handle, bgzf.BgzfReader)
+
+    def test_gzip(self):
+        self.assertRaises(ValueError,
+                          File._open_for_random_access,
+                          "Quality/example.fastq.gz")
 
 
 class AsHandleTestCase(unittest.TestCase):


### PR DESCRIPTION
Still accepts BGZF, but will now error on other gzipped files (previously would just open them in rb mode).

This is intended to close #1666

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
