### PR TITLE
Fix GenePop v4.7 compatibility

### DIFF
--- a/Bio/PopGen/GenePop/Controller.py
+++ b/Bio/PopGen/GenePop/Controller.py
@@ -109,7 +109,7 @@ def _hw_func(stream, is_locus, has_fisher=False):
     if is_locus:
         hook = "Locus "
     else:
-        hook = " Pop : "
+        hook = "Pop : "
     while line != "":
         if line.startswith(hook):
             stream.readline()

--- a/Bio/PopGen/GenePop/Controller.py
+++ b/Bio/PopGen/GenePop/Controller.py
@@ -111,7 +111,7 @@ def _hw_func(stream, is_locus, has_fisher=False):
     else:
         hook = "Pop : "
     while line != "":
-        if line.startswith(hook):
+        if line.lstrip().startswith(hook):
             stream.readline()
             stream.readline()
             stream.readline()


### PR DESCRIPTION
This pull request addresses issue #1777 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

It appears that GenePop v4.7 (released August 23, 2017) removed a space before ` POP : ` in the output. This results in a test failure.

This fixes the issue by removing any whitespace proceeding ` POP :`. I chose this route rather than explicitly checking the GenePop version in the output, so that any future changes in the version line formatting wouldn't break this feature.

I've only been able to test this with GenePop v4.7 and v4.2.