### PR TITLE
Enable T-Coffee in TravisCI

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -46,6 +46,7 @@ passenv =
     TRAVIS_*
     TOXENV
     CODECOV_*
+    HOME_4_TCOFFEE
 whitelist_externals =
     bash
     echo

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ addons:
     - probcons
     - samtools
     - wise
+    - t-coffee
 
 # We setup $HOME/bin and add it to the $PATH for extra binaries we're using.
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,9 @@ before_install:
   - curl -L -O https://anaconda.org/bioconda/genepop/4.5.1/download/linux-64/genepop-4.5.1-0.tar.bz2
   # This will create ./bin/Genepop and a harmless ./info/ folder.
   - tar -jxvf genepop-4.5.1-0.tar.bz2
+  # Setup environment for t-coffee
+  - mkdir -p $HOME/tcoffee_temp
+  - export HOME_4_TCOFFEE=$HOME/tcoffee_temp
   # There are TravisCI provided versions of PyPy and PyPy3, but currently too old.
   # We therefore deactivate that, and download and unzip portable PyPy binaries.
   - |


### PR DESCRIPTION
This pull request addresses issue #465

I wasn't able to replicate the same TravisCI failure as seen in 2015, although getting T-Coffee to work required setting and passing a specific environmental variable.

This lets `test_TCoffee_tools` run in TravisCI.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
