### PR TITLE
MMCIFIO.set_structure KeyError for pdb_object.level=="R" with chain!='A'

### DIFF
--- a/Bio/PDB/mmcifio.py
+++ b/Bio/PDB/mmcifio.py
@@ -85,8 +85,8 @@ class MMCIFIO(object):
                             parent_id = pdb_object.parent.id
                             sb.structure[0]['A'].id = parent_id
                         except ValueError:
-                            pass
-                        sb.structure[0]['A'].add(pdb_object)
+                            parent_id="A"
+                        sb.structure[0][parent_id].add(pdb_object)
                     else:
                         # Atom
                         sb.init_residue('DUM', ' ', 1, ' ')

--- a/Bio/PDB/mmcifio.py
+++ b/Bio/PDB/mmcifio.py
@@ -85,7 +85,7 @@ class MMCIFIO(object):
                             parent_id = pdb_object.parent.id
                             sb.structure[0]['A'].id = parent_id
                         except ValueError:
-                            parent_id="A"
+                            parent_id = "A"
                         sb.structure[0][parent_id].add(pdb_object)
                     else:
                         # Atom

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -866,6 +866,7 @@ class WriteTest(unittest.TestCase):
             self.parser = PDBParser(PERMISSIVE=1)
             self.mmcif_parser = MMCIFParser()
             self.structure = self.parser.get_structure("example", "PDB/1A8O.pdb")
+            self.dna_structure = self.parser.get_structure("rna_example", "PDB/1LCD.pdb")
             self.mmcif_file = "PDB/1A8O.cif"
             self.mmcif_multimodel_pdb_file = "PDB/1SSU_mod.pdb"
             self.mmcif_multimodel_mmcif_file = "PDB/1SSU_mod.cif"
@@ -989,7 +990,6 @@ class WriteTest(unittest.TestCase):
             self.assertEqual(nresidues, 158)
         finally:
             os.remove(filename)
-
     def test_mmcifio_write_residue(self):
         """Write a single residue using MMCIFIO."""
         io = MMCIFIO()
@@ -1004,6 +1004,24 @@ class WriteTest(unittest.TestCase):
             struct2 = self.mmcif_parser.get_structure("1a8o", filename)
             nresidues = len(list(struct2.get_residues()))
             self.assertEqual(nresidues, 1)
+        finally:
+            os.remove(filename)
+
+    def test_mmcifio_write_dna_residue(self):
+        """Write a single dna residue using MMCIFIO."""
+        io = MMCIFIO()
+        struct1 = self.dna_structure
+        residue1 = list(struct1.get_residues())[0]
+        io.set_structure(residue1)
+        filenumber, filename = tempfile.mkstemp()
+        os.close(filenumber)
+        try:
+            io.save(filename)
+            struct2 = self.mmcif_parser.get_structure("1lcd", filename)
+            nresidues = len(list(struct2.get_residues()))
+            self.assertEqual(nresidues, 1)
+            first_atom = list(struct2.get_atoms())[0]
+            self.assertEqual(first_atom.get_name(), "O5'")
         finally:
             os.remove(filename)
 

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -990,6 +990,7 @@ class WriteTest(unittest.TestCase):
             self.assertEqual(nresidues, 158)
         finally:
             os.remove(filename)
+            
     def test_mmcifio_write_residue(self):
         """Write a single residue using MMCIFIO."""
         io = MMCIFIO()


### PR DESCRIPTION
chain.id is now a property that updates the parent's child_dict.

Before this PR, using a residue with chain!="A" in `set_structure` caused a KeyError.

- [x ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ x] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [ x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
