### PR TITLE
Fixing '>', '>=', '<' and '<=' operators for Seq, MutableSeq and UnknownSeq

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -219,7 +219,10 @@ class Seq(object):
                 warnings.warn("Incompatible alphabets {0!r} and {1!r}".format(
                               self.alphabet, other.alphabet),
                               BiopythonWarning)
-        return str(self) < str(other)
+        if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
+            return str(self) < str(other)
+        raise TypeError("'<' not supported between instances of '{}' and '{}'"
+                        .format(type(self).__name__, type(other).__name__))
 
     def __le__(self, other):
         """Implement the less-than or equal operand."""
@@ -229,7 +232,36 @@ class Seq(object):
                 warnings.warn("Incompatible alphabets {0!r} and {1!r}".format(
                               self.alphabet, other.alphabet),
                               BiopythonWarning)
-        return str(self) <= str(other)
+        if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
+            return str(self) <= str(other)
+        raise TypeError("'<=' not supported between instances of '{}' and '{}'"
+                        .format(type(self).__name__, type(other).__name__))
+
+    def __gt__(self, other):
+        """Implement the greater-than operand."""
+        if hasattr(other, "alphabet"):
+            if not Alphabet._check_type_compatible([self.alphabet,
+                                                    other.alphabet]):
+                warnings.warn("Incompatible alphabets {0!r} and {1!r}".format(
+                              self.alphabet, other.alphabet),
+                              BiopythonWarning)
+        if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
+            return str(self) > str(other)
+        raise TypeError("'>' not supported between instances of '{}' and '{}'"
+                        .format(type(self).__name__, type(other).__name__))
+
+    def __ge__(self, other):
+        """Implement the greater-than or equal operand."""
+        if hasattr(other, "alphabet"):
+            if not Alphabet._check_type_compatible([self.alphabet,
+                                                    other.alphabet]):
+                warnings.warn("Incompatible alphabets {0!r} and {1!r}".format(
+                              self.alphabet, other.alphabet),
+                              BiopythonWarning)
+        if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
+            return str(self) >= str(other)
+        raise TypeError("'>=' not supported between instances of '{}' and '{}'"
+                        .format(type(self).__name__, type(other).__name__))
 
     def __len__(self):
         """Return the length of the sequence, use len(my_seq)."""
@@ -1853,13 +1885,13 @@ class MutableSeq(object):
             # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
             return "{0}('{1}...{2}'{3!s})".format(self.__class__.__name__,
-                                                  str(self[:54]),
-                                                  str(self[-3:]),
-                                                  a)
+                                                    str(self[:54]),
+                                                    str(self[-3:]),
+                                                    a)
         else:
             return "{0}('{1}'{2!s})".format(self.__class__.__name__,
-                                            str(self),
-                                            a)
+                                              str(self),
+                                              a)
 
     def __str__(self):
         """Return the full sequence as a python string.
@@ -1929,7 +1961,10 @@ class MutableSeq(object):
                               BiopythonWarning)
             if isinstance(other, MutableSeq):
                 return self.data < other.data
-        return str(self) < str(other)
+        if isinstance(other, (str, Seq, UnknownSeq)):
+            return str(self) < str(other)
+        raise TypeError("'<' not supported between instances of '{}' and '{}'"
+                        .format(type(self).__name__, type(other).__name__))
 
     def __le__(self, other):
         """Implement the less-than or equal operand."""
@@ -1941,7 +1976,40 @@ class MutableSeq(object):
                               BiopythonWarning)
             if isinstance(other, MutableSeq):
                 return self.data <= other.data
-        return str(self) <= str(other)
+        if isinstance(other, (str, Seq, UnknownSeq)):
+            return str(self) <= str(other)
+        raise TypeError("'<=' not supported between instances of '{}' and '{}'"
+                        .format(type(self).__name__, type(other).__name__))
+
+    def __gt__(self, other):
+        """Implement the greater-than operand."""
+        if hasattr(other, "alphabet"):
+            if not Alphabet._check_type_compatible([self.alphabet,
+                                                    other.alphabet]):
+                warnings.warn("Incompatible alphabets {0!r} and {1!r}".format(
+                              self.alphabet, other.alphabet),
+                              BiopythonWarning)
+            if isinstance(other, MutableSeq):
+                return self.data > other.data
+        if isinstance(other, (str, Seq, UnknownSeq)):
+            return str(self) > str(other)
+        raise TypeError("'>' not supported between instances of '{}' and '{}'"
+                        .format(type(self).__name__, type(other).__name__))
+
+    def __ge__(self, other):
+        """Implement the greater-than or equal operand."""
+        if hasattr(other, "alphabet"):
+            if not Alphabet._check_type_compatible([self.alphabet,
+                                                    other.alphabet]):
+                warnings.warn("Incompatible alphabets {0!r} and {1!r}".format(
+                              self.alphabet, other.alphabet),
+                              BiopythonWarning)
+            if isinstance(other, MutableSeq):
+                return self.data >= other.data
+        if isinstance(other, (str, Seq, UnknownSeq)):
+            return str(self) >= str(other)
+        raise TypeError("'>=' not supported between instances of '{}' and '{}'"
+                        .format(type(self).__name__, type(other).__name__))
 
     def __len__(self):
         """Return the length of the sequence, use len(my_seq)."""

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1885,13 +1885,13 @@ class MutableSeq(object):
             # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
             return "{0}('{1}...{2}'{3!s})".format(self.__class__.__name__,
-                                                    str(self[:54]),
-                                                    str(self[-3:]),
-                                                    a)
+                                                  str(self[:54]),
+                                                  str(self[-3:]),
+                                                  a)
         else:
             return "{0}('{1}'{2!s})".format(self.__class__.__name__,
-                                              str(self),
-                                              a)
+                                            str(self),
+                                            a)
 
     def __str__(self):
         """Return the full sequence as a python string.

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -242,19 +242,69 @@ class TestSeqStringMethods(unittest.TestCase):
         self.assertNotEqual(Seq.Seq("TCAAA", IUPAC.ambiguous_dna),
                             Seq.Seq("TCAAAA", IUPAC.ambiguous_dna))
 
-    def test_less_than_comparison_of_incompatible_alphabets(self):
+    def test_less_than_comparison(self):
         """Test __lt__ comparison method"""
+        self.assertTrue(self.s[:-1] < self.s)
+
+    def test_less_than_comparison_of_incompatible_alphabets(self):
+        """Test incompatible alphabet __lt__ comparison method"""
         seq1 = Seq.Seq("TCAAA", IUPAC.ambiguous_dna)
         seq2 = Seq.Seq("UCAAAA", IUPAC.ambiguous_rna)
         with self.assertWarns(BiopythonWarning):
             self.assertTrue(seq1 < seq2)
 
+    def test_less_than_comparison_of_incompatible_types(self):
+        """Test incompatible types __lt__ comparison method"""
+        with self.assertRaises(TypeError):
+            self.s < 1
+
+    def test_less_than_or_equal_comparison(self):
+        """Test __le__ comparison method"""
+        self.assertTrue(self.s <= self.s)
+
     def test_less_than_or_equal_comparison_of_incompatible_alphabets(self):
-        """Test __lt__ comparison method"""
+        """Test incompatible alphabet __le__ comparison method"""
         seq1 = Seq.Seq("TCAAA", IUPAC.ambiguous_dna)
         seq2 = Seq.Seq("UCAAAA", IUPAC.ambiguous_rna)
         with self.assertWarns(BiopythonWarning):
             self.assertTrue(seq1 <= seq2)
+
+    def test_less_than_or_equal_comparison_of_incompatible_types(self):
+        """Test incompatible types __le__ comparison method"""
+        with self.assertRaises(TypeError):
+            self.s <= 1
+
+    def test_greater_than_comparison(self):
+        """Test __gt__ comparison method"""
+        self.assertTrue(self.s > self.s[:-1])
+
+    def test_greater_than_comparison_of_incompatible_alphabets(self):
+        """Test incompatible alphabet __gt__ comparison method"""
+        seq1 = Seq.Seq("TCAAA", IUPAC.ambiguous_dna)
+        seq2 = Seq.Seq("UCAAAA", IUPAC.ambiguous_rna)
+        with self.assertWarns(BiopythonWarning):
+            self.assertTrue(seq2 > seq1)
+
+    def test_greater_than_comparison_of_incompatible_types(self):
+        """Test incompatible types __gt__ comparison method"""
+        with self.assertRaises(TypeError):
+            self.s > 1
+
+    def test_greater_than_or_equal_comparison(self):
+        """Test __ge__ comparison method"""
+        self.assertTrue(self.s >= self.s)
+
+    def test_greater_than_or_equal_comparison_of_incompatible_alphabets(self):
+        """Test incompatible alphabet __ge__ comparison method"""
+        seq1 = Seq.Seq("TCAAA", IUPAC.ambiguous_dna)
+        seq2 = Seq.Seq("UCAAAA", IUPAC.ambiguous_rna)
+        with self.assertWarns(BiopythonWarning):
+            self.assertTrue(seq2 >= seq1)
+
+    def test_greater_than_or_equal_comparison_of_incompatible_types(self):
+        """Test incompatible types __ge__ comparison method"""
+        with self.assertRaises(TypeError):
+            self.s >= 1
 
     def test_add_method_using_wrong_object(self):
         with self.assertRaises(TypeError):
@@ -613,6 +663,10 @@ class TestMutableSeq(unittest.TestCase):
             self.mutable_s[:-1] < MutableSeq("UCAAAAGGAUGCAUCAUG",
                                              IUPAC.ambiguous_rna)
 
+    def test_less_than_comparison_of_incompatible_types(self):
+        with self.assertRaises(TypeError):
+            self.mutable_s < 1
+
     def test_less_than_comparison_without_alphabet(self):
         self.assertTrue(self.mutable_s[:-1] < "TCAAAAGGATGCATCATG")
 
@@ -625,8 +679,44 @@ class TestMutableSeq(unittest.TestCase):
             self.mutable_s[:-1] <= MutableSeq("UCAAAAGGAUGCAUCAUG",
                                               IUPAC.ambiguous_rna)
 
+    def test_less_than_or_equal_comparison_of_incompatible_types(self):
+        with self.assertRaises(TypeError):
+            self.mutable_s <= 1
+
     def test_less_than_or_equal_comparison_without_alphabet(self):
         self.assertTrue(self.mutable_s[:-1] <= "TCAAAAGGATGCATCATG")
+
+    def test_greater_than_comparison(self):
+        """Test __gt__ comparison method"""
+        self.assertTrue(self.mutable_s > self.mutable_s[:-1])
+
+    def test_greater_than_comparison_of_incompatible_alphabets(self):
+        with self.assertWarns(BiopythonWarning):
+            self.mutable_s[:-1] > MutableSeq("UCAAAAGGAUGCAUCAUG",
+                                             IUPAC.ambiguous_rna)
+
+    def test_greater_than_comparison_of_incompatible_types(self):
+        with self.assertRaises(TypeError):
+            self.mutable_s > 1
+
+    def test_greater_than_comparison_without_alphabet(self):
+        self.assertTrue(self.mutable_s > "TCAAAAGGATGCATCAT")
+
+    def test_greater_than_or_equal_comparison(self):
+        """Test __ge__ comparison method"""
+        self.assertTrue(self.mutable_s >= self.mutable_s)
+
+    def test_greater_than_or_equal_comparison_of_incompatible_alphabets(self):
+        with self.assertWarns(BiopythonWarning):
+            self.mutable_s[:-1] >= MutableSeq("UCAAAAGGAUGCAUCAUG",
+                                              IUPAC.ambiguous_rna)
+
+    def test_greater_than_or_equal_comparison_of_incompatible_types(self):
+        with self.assertRaises(TypeError):
+            self.mutable_s >= 1
+
+    def test_greater_than_or_equal_comparison_without_alphabet(self):
+        self.assertTrue(self.mutable_s >= "TCAAAAGGATGCATCATG")
 
     def test_add_method(self):
         """Test adding wrong type to MutableSeq"""


### PR DESCRIPTION
This pull request addresses issue #1750

The issue has the background and context. Basically I implemented the greater-than `>` (`__gt__`) and greater-than or equal to `>=` (`__ge__`) methods for `Seq` and `MutableSeq`. I also slightly modified the `<`/`<=` (`__lt__`, `__le__`) methods to raise `TypeError`s for 'invalid' comparisons, trying to match the behaviour of Python's native strings.

I also added unit tests for all the methods to give a more comphrensive test suite.

Note I did't add methods or tests for `UnknownSeq`, but they should apply and work the same as `Seq` since they are inherited (`UnknownSeq` sub-classes `Seq`).

Here are some examples of the new behavior:
```
>>> from Bio.Seq import Seq, MutableSeq, UnknownSeq
>>> s = Seq('A')
>>> s > 'A'; s < 'A'; 'A' < s; 'A' > s
False
False
False
False
>>> s >= 'A'; s <= 'A'; 'A' <= s; 'A' >= s
True
True
True
True
>>> s >= MutableSeq('A')
True
>>> s >= UnknownSeq(1, character='A')
True
>>> s >= UnknownSeq(2, character='A')
False
>>> s > 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/chrisrands/Applications/BIOPYTHON/biopython/Bio/Seq.py", line 251, in __gt__
    .format(type(self).__name__, type(other).__name__))
TypeError: '>' not supported between instances of 'Seq' and 'int'
>>> s > 1.0
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/chrisrands/Applications/BIOPYTHON/biopython/Bio/Seq.py", line 251, in __gt__
    .format(type(self).__name__, type(other).__name__))
TypeError: '>' not supported between instances of 'Seq' and 'float'

```

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
