### PR TITLE
Pairwise aligner savemem

### DIFF
--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -42,7 +42,6 @@ typedef struct {
     double score;
     unsigned int trace : 3;
     struct {int i; int j;} path;
-    Py_ssize_t count;
 } CellM; /* Used for the Waterman-Smith-Beyer algorithm. */
 
 typedef struct {
@@ -50,7 +49,6 @@ typedef struct {
     int* traceM;
     int* traceXY;
     struct {int i; int j;} path;
-    Py_ssize_t count;
 } CellXY; /* Used for the Waterman-Smith-Beyer algorithm. */
 
 static int _convert_single_letter(PyObject* item)

--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -4441,6 +4441,24 @@ PathGenerator_waterman_smith_beyer_global_length(PathGenerator* self)
     const double threshold = self->threshold;
     Py_ssize_t count = MEMORY_ERROR;
     Py_ssize_t term;
+
+    Py_ssize_t** countM = NULL;
+    Py_ssize_t** countIx = NULL;
+    Py_ssize_t** countIy = NULL;
+    countM = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
+    if (!countM) goto exit;
+    countIx = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
+    if (!countIx) goto exit;
+    countIy = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
+    if (!countIy) goto exit;
+    for (i = 0; i <= nA; i++) {
+        countM[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+        if (!M[i]) goto exit;
+        countIx[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+        if (!Ix[i]) goto exit;
+        countIy[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+        if (!Iy[i]) goto exit;
+    }
     for (i = 0; i <= nA; i++) {
         for (j = 0; j <= nB; j++) {
             count = 0;
@@ -4497,6 +4515,23 @@ PathGenerator_waterman_smith_beyer_global_length(PathGenerator* self)
     if (Ix[nA][nB].score > threshold) SAFE_ADD(Ix[nA][nB].count, count);
     if (Iy[nA][nB].score > threshold) SAFE_ADD(Iy[nA][nB].count, count);
 exit:
+    if (countM) {
+        if (countIx) {
+            if (countIy) {
+                for (i = 0; i <= nA; i++) {
+                    if (!countM[i]) break;
+                    PyMem_Free(countM[i]);
+                    if (!countIx[i]) break;
+                    PyMem_Free(countIx[i]);
+                    if (!countIy[i]) break;
+                    PyMem_Free(countIy[i]);
+                }
+                PyMem_Free(countIy);
+            }
+            PyMem_Free(countIx);
+        }
+        PyMem_Free(countM);
+    }
     return count;
 }
 


### PR DESCRIPTION
Reduce the memory requirements of the pairwise aligners by

- Calculating the number of alignments only when asked for;
- For Needleman-Wunsch, Smith-Waterman, and Gotoh global and local, keep only one row of the count matrix in memory at a time.

This reduces the size per matrix element from 24 bytes to 16 bytes for Needleman-Wunsch, Smith-Waterman, and Gotoh global and local, and from 32 bytes to 24 bytes (M matrix) and from 40 bytes to 32 bytes (X and Y matrix) for Waterman-Smith-Beyer global and local.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
