### PR TITLE
Add makeblastdb wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ addons:
     - samtools
     - wise
     - t-coffee
+    - ncbi-blast+
 
 # We setup $HOME/bin and add it to the $PATH for extra binaries we're using.
 #

--- a/Bio/Blast/Applications.py
+++ b/Bio/Blast/Applications.py
@@ -1341,11 +1341,7 @@ class NcbimakeblastdbCommandline(AbstractCommandline):
         AbstractCommandline.__init__(self, cmd, **kwargs)
 
     def _input_type_checker(command, x):
-        expression = (x == 'asn1_bin' or
-                      x == 'asn1_txt' or
-                      x == 'blastdb' or
-                      x == 'fasta')
-        return expression
+        return x in ('asn1_bin', 'asn1_txt', 'blastdb', 'fasta')
 
     def _validate(self):
         incompatibles = {"mask_id": ["gi_mask"],

--- a/Bio/Blast/Applications.py
+++ b/Bio/Blast/Applications.py
@@ -19,6 +19,7 @@ Wrappers for the new NCBI BLAST+ tools (written in C++):
  - NcbirpstblastnCommandline - Translated Reverse Position Specific BLAST
  - NcbideltablastCommandline - Protein-Protein domain enhanced lookup time accelerated blast
  - NcbiblastformatterCommandline - Convert ASN.1 to other BLAST output formats
+ - NcbimakeblastdbCommandline - Application to create BLAST databases
 
 For further details, see:
 
@@ -1232,6 +1233,54 @@ class NcbideltablastCommandline(_Ncbiblast2SeqCommandline):
                     Incompatible with:  remote, subject""")
         ]
         _Ncbiblast2SeqCommandline.__init__(self, cmd, **kwargs)
+
+
+class NcbimakeblastdbCommandline(_NcbibaseblastCommandline):
+    """Wrapper for the NCBI BLAST+ program makeblastdb.
+
+    Application to create BLAST databases.
+
+    Need to add these commands:
+    USAGE
+    makeblastdb
+    # [-h]
+    # [-help]
+    # [-in input_file]
+    [-input_type type]
+
+    -dbtype molecule_type
+
+    [-title database_title]
+    [-parse_seqids]
+    [-hash_index]
+    [-mask_data mask_data_files]
+    [-mask_id mask_algo_ids]
+    [-mask_desc mask_algo_descriptions]
+    [-gi_mask]
+    [-gi_mask_name gi_based_mask_names]
+    # [-out database_name]
+    [-max_file_sz number_of_bytes]
+    [-logfile File_Name]
+    [-taxid TaxID]
+    [-taxid_map TaxIDMapFile]
+    # [-version]
+    """
+
+    def __init__(self, cmd="blast_formatter", **kwargs):
+        """Initialize the class."""
+        self.parameters = [
+            # Input options
+            _Option(["-dbtype", "dbtype"],
+                    "Molecule type of target db ('nucl' or 'prot')",
+                    equate=False,
+                    is_required=True,
+                    checker_function=lambda x: x == 'nucl' or x == 'prot'),
+            _Option(["-in", "input_file"],
+                    "input_file",
+                    filename=True,
+                    equate=False),
+        ]
+        _NcbibaseblastCommandline.__init__(self, cmd, **kwargs)
 
 
 def _test():

--- a/Bio/Blast/Applications.py
+++ b/Bio/Blast/Applications.py
@@ -1351,8 +1351,17 @@ class NcbimakeblastdbCommandline(AbstractCommandline):
         incompatibles = {"mask_id": ["gi_mask"],
                          "gi_mask": ["mask_id"],
                          "taxid": ["taxid_map"]}
-        _NcbibaseblastCommandline._validate_incompatibilities(self,
-                                                              incompatibles)
+
+        # Copied from _NcbibaseblastCommandline class above.
+        # Code repeated here for python2 and 3 comptaibility,
+        # because this is not a _NcbibaseblastCommandline subclass.
+        for a in incompatibles:
+            if self._get_parameter(a):
+                for b in incompatibles[a]:
+                    if self._get_parameter(b):
+                        raise ValueError("Options %s and %s are incompatible."
+                                         % (a, b))
+
         if self.mask_id and not self.mask_data:
             raise ValueError("Option mask_id requires mask_data to be set.")
         if self.mask_desc and not self.mask_id:

--- a/Tests/test_NCBI_BLAST_tools.py
+++ b/Tests/test_NCBI_BLAST_tools.py
@@ -386,9 +386,11 @@ class CheckCompleteArgList(unittest.TestCase):
             extra = extra.difference(["-save_each_pssm", "-save_pssm_after_last_round"])
         if exe_name == "makeblastdb":
             # -input_type is new in BLAST+ 2.2.26+ so will look like extra
-            # arg on older versions.
+            # arg on older versions. -mask_desc and -mask_id were added after
+            # 2.2.28+, but not documented in changelog.
             # -dbtype also ignored here, as it was set to initialize class.
-            extra = extra.difference(["-input_type", "-dbtype"])
+            extra = extra.difference(["-input_type", "-mask_desc",
+                                      "-mask_id", "-dbtype"])
         # This was added in BLAST+ 2.7.1 (or maybe 2.7.0) to most/all the tools,
         # so will be seen as an extra argument on older versions:
         if "-negative_seqidlist" in extra:

--- a/Tests/test_NCBI_BLAST_tools.py
+++ b/Tests/test_NCBI_BLAST_tools.py
@@ -10,9 +10,11 @@
 from __future__ import print_function
 
 import os
+import os.path
 import sys
 import subprocess
 import unittest
+import re
 
 from Bio.Application import _escape_filename
 from Bio import MissingExternalDependencyError
@@ -22,7 +24,7 @@ from Bio.Blast import Applications
 wanted = ["blastx", "blastp", "blastn", "tblastn", "tblastx",
           "rpsblast+",  # For Debian
           "rpsblast", "rpstblastn", "psiblast", "blast_formatter",
-          "deltablast"]
+          "deltablast", "makeblastdb"]
 exe_names = {}
 
 if sys.platform == "win32":
@@ -170,12 +172,110 @@ class Pairwise(unittest.TestCase):
         # TODO - Parse it?
 
 
+class BlastDB(unittest.TestCase):
+    def test_requires_dbtype(self):
+        """Check that dbtype throws error if not set"""
+        global exe_names
+        cline = Applications.NcbimakeblastdbCommandline(
+            exe_names["makeblastdb"],
+            input_file="GenBank/NC_005816.faa")
+        with self.assertRaises(ValueError):
+            str(cline)
+
+    def test_fasta_db_prot(self):
+        """Test makeblastdb wrapper with protein database"""
+        global exe_names
+        cline = Applications.NcbimakeblastdbCommandline(
+            exe_names["makeblastdb"],
+            input_file="GenBank/NC_005816.faa",
+            dbtype="prot",
+            hash_index=True,
+            max_file_sz="20MB",
+            parse_seqids=True,
+            taxid=10)
+
+        self.assertEqual(str(cline),
+                         _escape_filename(exe_names["makeblastdb"]) +
+                         " -dbtype prot -in GenBank/NC_005816.faa"
+                         " -parse_seqids -hash_index -max_file_sz 20MB"
+                         " -taxid 10")
+
+        child = subprocess.Popen(str(cline),
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE,
+                                 universal_newlines=True,
+                                 shell=(sys.platform != "win32"))
+        stdoutdata, stderrdata = child.communicate()
+        return_code = child.returncode
+
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.phd"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.phi"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.phr"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.pin"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.pog"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.psd"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.psi"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.psq"))
+
+    def test_fasta_db_nucl(self):
+        """Test makeblastdb wrapper with nucleotide database"""
+        global exe_names
+        cline = Applications.NcbimakeblastdbCommandline(
+            exe_names["makeblastdb"],
+            input_file="GenBank/NC_005816.fna",
+            dbtype="nucl",
+            hash_index=True,
+            max_file_sz="20MB",
+            parse_seqids=True,
+            taxid=10)
+
+        self.assertEqual(str(cline),
+                         _escape_filename(exe_names["makeblastdb"]) +
+                         " -dbtype nucl -in GenBank/NC_005816.fna"
+                         " -parse_seqids -hash_index -max_file_sz 20MB"
+                         " -taxid 10")
+
+        child = subprocess.Popen(str(cline),
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE,
+                                 universal_newlines=True,
+                                 shell=(sys.platform != "win32"))
+        stdoutdata, stderrdata = child.communicate()
+        return_code = child.returncode
+
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nhd"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nhi"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nhr"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nin"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nog"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nsd"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nsi"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nsq"))
+
+    # makeblastdb makes files in the same dir as the input, clean these up
+    def tearDown(self):
+        blastdb_matcher_prot = re.compile(r'NC_005816\.faa\.p.+')
+        for file in os.listdir('GenBank/'):
+            if blastdb_matcher_prot.match(file):
+                path = os.path.join('GenBank/', file)
+                os.remove(path)
+
+        blastdb_matcher_nucl = re.compile(r'NC_005816\.fna\.n.+')
+        for file in os.listdir('GenBank/'):
+            if blastdb_matcher_nucl.match(file):
+                path = os.path.join('GenBank/', file)
+                os.remove(path)
+
+
 class CheckCompleteArgList(unittest.TestCase):
     def check(self, exe_name, wrapper):
         global exe_names
         exe = exe_names[exe_name]
-        cline = wrapper(exe, h=True)
-
+        # dbtype must be set to initialize NcbimakeblastdbCommandline
+        if exe_name == 'makeblastdb':
+            cline = wrapper(exe, h=True, dbtype='prot')
+        else:
+            cline = wrapper(exe, h=True)
         names = set(parameter.names[0]
                     for parameter in cline.parameters)
 
@@ -284,6 +384,11 @@ class CheckCompleteArgList(unittest.TestCase):
         if exe_name in ["deltablast", "psiblast"]:
             # New in BLAST+ 2.3.0 so will look like extra args on older verions
             extra = extra.difference(["-save_each_pssm", "-save_pssm_after_last_round"])
+        if exe_name == "makeblastdb":
+            # -input_type is new in BLAST+ 2.2.26+ so will look like extra
+            # arg on older versions.
+            # -dbtype also ignored here, as it was set to initialize class.
+            extra = extra.difference(["-input_type", "-dbtype"])
         # This was added in BLAST+ 2.7.1 (or maybe 2.7.0) to most/all the tools,
         # so will be seen as an extra argument on older versions:
         if "-negative_seqidlist" in extra:
@@ -336,6 +441,10 @@ class CheckCompleteArgList(unittest.TestCase):
     def test_rpstblastn(self):
         """Check all rpstblastn arguments are supported"""
         self.check("rpstblastn", Applications.NcbirpstblastnCommandline)
+
+    def test_makeblastdb(self):
+        """Check all makeblastdb arguments are supported"""
+        self.check("makeblastdb", Applications.NcbimakeblastdbCommandline)
 
     if "blast_formatter" in exe_names:
         def test_blast_formatter(self):


### PR DESCRIPTION
This pull request addresses issue #1788, with the purpose of adding a makeblastdb wrapper.

In this pull request I have added ncbi-blast+ to the TravisCI checks. It doesn't seem to add more than a few seconds to the build time, but I'm happy to turn these off if the build time starts to get too high.

When I added the `NcbimakeblastdbCommandline` class, I didn't subclass from `_NcbibaseblastCommandline` because so few of the command line arguments were the same between them. The other option would have been to split `_NcbibaseblastCommandline` into another superseding class with only `-h` `-help` `-version` and `-out`. I thought this was a little more convoluted than not subclassing at all but it doesn't fit with the existing style as nicely, I'm happy to change this if needed.

This should show up in the generated docs, but is there anywhere else that this should be documented? 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
