### PR TITLE
Dual license Bio/UniGene/__init__.py

### DIFF
--- a/Bio/UniGene/__init__.py
+++ b/Bio/UniGene/__init__.py
@@ -1,15 +1,10 @@
-# Copyright 2006 by Sean Davis.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+# Copyright 2006 by Sean Davis, National Cancer Institute, NIH.
+# All rights reserved.
 #
-# $Id: __init__.py,v 1.12 2009-04-24 12:03:45 mdehoon Exp $
-# Sean Davis <sdavis2 at mail dot nih dot gov>
-# National Cancer Institute
-# National Institutes of Health
-# Bethesda, MD, USA
-#
-
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 """Parse Unigene flat file format files such as the Hs.data file.
 
 Here is an overview of the flat file format that this parser deals with:


### PR DESCRIPTION
We have not yet been able to contact Katharine Lindner (CVS username katel) who wrote the original code which was initially in ``Bio/UniGene/UniGene.py`` (back in 2001).

However, the modele was completely rewritten in 2006 https://github.com/biopython/biopython/commit/33f706c65816d1ab4e6c3481c5900f8332b90789 by Sean Davis (CVS username sdavis, now on GitHub as @seandavi) and he and all the other contributors have agreed to the license change:

 - Adhemar Zerlotini (@azneto)
   https://github.com/biopython/biopython/pull/1412#issue-147372599
 - Andrew Dalke (@adalke)
   http://mailman.open-bio.org/pipermail/biopython-dev/2013-August/019941.html
 - Brad Chapman (@chapmanb)
   http://mailman.open-bio.org/pipermail/biopython-dev/2013-July/019903.html
 - Christian Brueffer (@cbrueffer)
   https://github.com/biopython/biopython/issues/898#issuecomment-236922857
 - Connor McCoy (@cmccoy)
   https://github.com/biopython/biopython/issues/898#issuecomment-380478091
 - jchang (@jefftc)
   https://github.com/biopython/biopython/issues/898#issuecomment-236968522
 - Michiel de Hoon (@mdehoon)
   https://github.com/biopython/biopython/issues/898#issuecomment-237122630
 - Nick Negretti (@nimne)
   https://github.com/biopython/biopython/pull/1768#issue-210631196
 - Peter Cock (@peterjc)
   https://github.com/biopython/biopython/issues/898#issue-167420613
 - Sean Davis (@seandavi)
   https://github.com/biopython/biopython/issues/898#issuecomment-424399275
 - Travis Wrightsman (@twrightsman)
   https://github.com/biopython/biopython/issues/898#issuecomment-237625470

This pull request addresses in part issue #898