### PR TITLE
Speed up simple FASTA parsers 

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -56,9 +56,8 @@ def SimpleFastaParser(handle):
     lines = []
     for line in handle:
         if line[0] == '>':
-            if lines:
-                yield title, ''.join(lines).replace(" ", "").replace("\r", "")
-                lines = []
+            yield title, ''.join(lines).replace(" ", "").replace("\r", "")
+            lines = []
             title = line[1:].rstrip()
             continue
         lines.append(line.rstrip())

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -128,6 +128,7 @@ def FastaTwoLineParser(handle):
     if idx % 2 == 0:  # on a header line
         raise ValueError("Should be at end of file, but line= '{}'".format(line))
 
+
 def FastaIterator(handle, alphabet=single_letter_alphabet, title2ids=None):
     """Iterate over Fasta records as SeqRecord objects.
 

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -41,37 +41,28 @@ def SimpleFastaParser(handle):
 
     """
     # Skip any text before the first record (e.g. blank lines, comments)
-    while True:
-        line = handle.readline()
-        if line == "":
-            return  # Premature end of file, or just empty?
-        if line[0] == ">":
+    # This matches the previous implementation where .readline() was used
+    for line in handle:
+        if line[0] == '>':
+            title = line[1:].rstrip()
             break
 
-    while True:
-        if line[0] != ">":
-            raise ValueError(
-                "Records in Fasta files should start with '>' character")
-        title = line[1:].rstrip()
-        lines = []
-        line = handle.readline()
-        while True:
-            if not line:
-                break
-            if line[0] == ">":
-                break
-            lines.append(line.rstrip())
-            line = handle.readline()
+    # Main logic
+    # Note, remove trailing whitespace, and any internal spaces
+    # (and any embedded \r which are possible in mangled files
+    # when not opened in universal read lines mode)
+    lines = []
+    for line in handle:
+        if line[0] == '>':
+            if lines:
+                yield title, ''.join(lines).replace(" ", "").replace("\r", "")
+                lines = []
+            title = line[1:].rstrip()
+            continue
+        lines.append(line.rstrip())
 
-        # Remove trailing whitespace, and any internal spaces
-        # (and any embedded \r which are possible in mangled files
-        # when not opened in universal read lines mode)
-        yield title, "".join(lines).replace(" ", "").replace("\r", "")
-
-        if not line:
-            return  # StopIteration
-
-    assert False, "Should not reach this line"
+    if lines:
+        yield title, ''.join(lines).replace(" ", "").replace("\r", "")
 
 
 def FastaTwoLineParser(handle):
@@ -107,32 +98,37 @@ def FastaTwoLineParser(handle):
     ValueError: Expected FASTA record starting with '>' character. Perhaps this file is using FASTA line wrapping? Got: 'MTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI'
 
     """
-    line = handle.readline()
-    # If this is an empty file, while loop is skipped.
-    while line:
-        if line[0] != ">":
-            if line.strip():
-                raise ValueError("Expected FASTA record starting with '>' character. "
-                                 "Perhaps this file is using FASTA line wrapping? "
-                                 "Got: %r" % line)
-            else:
-                raise ValueError("Expected FASTA record starting with '>' character. "
-                                 "If using two-lines-per-record, there should be no "
-                                 "blank lines between records, or at the end of file.")
-        title = line[1:].rstrip()
-        line = handle.readline()
-        if not line:
-            raise ValueError("Premature end of FASTA file (or this is not strict "
-                             "two-line-per-record FASTA format), expected one line "
-                             "of sequence following: '>%s'" % title)
-        elif line[0] == ">":
-            raise ValueError("Two '>' FASTA lines in a row. Missing sequence line "
-                             "if this is strict two-line-per-record FASTA format. "
-                             "Have '>%s' and '%s'" % (title, line))
-        yield title, line.strip()
-        line = handle.readline()
+    idx = None
+    for idx, line in enumerate(handle):
+        if idx % 2 == 0:  # title line
+            if line[0] != '>':
+                if line.strip():
+                    raise ValueError("Expected FASTA record starting with '>' character. "
+                                     "Perhaps this file is using FASTA line wrapping? "
+                                     "Got: '{}'".format(line))
+                else:
+                    raise ValueError("Expected FASTA record starting with '>' character. "
+                                     "If using two-lines-per-record, there should be no "
+                                     "blank lines between records, or at the end of file.")
+            title = line[1:].rstrip()
 
-    assert not line, "Should be at end of file, but line=%r" % line
+        else:  # sequence line
+            line = line.strip()
+            if not line:
+                raise ValueError("Premature end of FASTA file (or this is not strict "
+                                 "two-line-per-record FASTA format), expected one line "
+                                 "of sequence following: '{}'".format(title))
+            elif line[0] == '>':
+                raise ValueError("Two '>' FASTA lines in a row. Missing sequence line "
+                                 "if this is strict two-line-per-record FASTA format. "
+                                 "Have '>{}' and '{}'".format(title, line))
+            yield title, line
+
+    if idx is None:
+        # empty file
+        pass
+    elif idx % 2 == 0:
+        raise ValueError("Should be at end of file, but line= '{}'".format(line))
 
 
 def FastaIterator(handle, alphabet=single_letter_alphabet, title2ids=None):

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -46,6 +46,8 @@ def SimpleFastaParser(handle):
         if line[0] == '>':
             title = line[1:].rstrip()
             break
+    else:   # no break encountered
+        return  # Premature end of file, or just empty?
 
     # Main logic
     # Note, remove trailing whitespace, and any internal spaces
@@ -61,8 +63,7 @@ def SimpleFastaParser(handle):
             continue
         lines.append(line.rstrip())
 
-    if lines:
-        yield title, ''.join(lines).replace(" ", "").replace("\r", "")
+    yield title, ''.join(lines).replace(" ", "").replace("\r", "")
 
 
 def FastaTwoLineParser(handle):
@@ -98,7 +99,7 @@ def FastaTwoLineParser(handle):
     ValueError: Expected FASTA record starting with '>' character. Perhaps this file is using FASTA line wrapping? Got: 'MTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI'
 
     """
-    idx = None
+    idx = -1  # for empty file
     for idx, line in enumerate(handle):
         if idx % 2 == 0:  # title line
             if line[0] != '>':
@@ -124,12 +125,8 @@ def FastaTwoLineParser(handle):
                                  "Have '>{}' and '{}'".format(title, line))
             yield title, line
 
-    if idx is None:
-        # empty file
-        pass
-    elif idx % 2 == 0:
+    if idx % 2 == 0:  # on a header line
         raise ValueError("Should be at end of file, but line= '{}'".format(line))
-
 
 def FastaIterator(handle, alphabet=single_letter_alphabet, title2ids=None):
     """Iterate over Fasta records as SeqRecord objects.


### PR DESCRIPTION
This pull request addresses issue #1805

Basically, the PR replaces `.readline()` calls by iterating over file handles for FASTA parsing with the `SimpleFastaParser` and `FastaTwoLineParser `. This speeds up the parsers, at least on my system, maybe someone else can test this independently also?

Here are timings *before* the PR, suggesting a speed improvement for the new implementation:

```
Timings: 1 large sequence
old simple parser 76.89216220937669
new simple parser 57.97007081564516
regular parser 76.77094562910497

Timings: 1,000,000 small sequences
old simple parser 43.77311799954623
new simple parser 34.3902100995183
regular parser 206.45853164047003

Timings 1,000,000 small sequences, 2 line parsers
old simple two-line parser 43.24465982336551
new simple two-line parser 23.533120669424534
```

Here are timings after the PR, old and new timings should be the same here since the new methods are now implemented (I am not sure why they are not for the 2-line parser case, but there is still a speed improvement):
```
Timings: 1 large sequence
old simple parser 58.63168554287404
new simple parser 58.73430686816573
regular parser 58.55501845944673

Timings: 1,000,000 small sequences
old simple parser 34.61581619922072
new simple parser 34.34436380956322
regular parser 191.3278057463467

Timings 1,000,000 small sequences, 2 line parsers
old simple two-line parser 34.29244772717357
new simple two-line parser 23.71209624875337
```

The code is on pastebin for reproducibility:
https://pastebin.com/MmhBVfFu 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
