### PR TITLE
Python 3.1 doctest prolem resolved in Python 3.2 onwards

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1107,7 +1107,7 @@ class Seq(object):
         >>> coding_dna.translate(table=1, cds=True)
         Traceback (most recent call last):
             ...
-        TranslationError: First codon 'GTG' is not a start codon
+        Bio.Data.CodonTable.TranslationError: First codon 'GTG' is not a start codon
 
         If the sequence has no in-frame stop codon, then the to_stop argument
         has no effect:
@@ -2573,7 +2573,7 @@ def _translate_str(sequence, table, stop_symbol="*", to_stop=False,
     >>> _translate_str("TA?", table)
     Traceback (most recent call last):
        ...
-    TranslationError: Codon 'TA?' is invalid
+    Bio.Data.CodonTable.TranslationError: Codon 'TA?' is invalid
 
     In a change to older versions of Biopython, partial codons are now
     always regarded as an error (previously only checked if cds=True)
@@ -2589,11 +2589,11 @@ def _translate_str(sequence, table, stop_symbol="*", to_stop=False,
     >>> _translate_str("AAACCCTAG", table, cds=True)
     Traceback (most recent call last):
        ...
-    TranslationError: First codon 'AAA' is not a start codon
+    Bio.Data.CodonTable.TranslationError: First codon 'AAA' is not a start codon
     >>> _translate_str("ATGCCCTAGCCCTAG", table, cds=True)
     Traceback (most recent call last):
        ...
-    TranslationError: Extra in frame stop codon found.
+    Bio.Data.CodonTable.TranslationError: Extra in frame stop codon found.
     """
     sequence = sequence.upper()
     amino_acids = []

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -173,8 +173,9 @@ except ImportError:
     DOCTEST_MODULES.remove("Bio.SeqIO")
     DOCTEST_MODULES.remove("Bio.SearchIO")
 
-# Skip Bio.Seq doctest under Python 3, see http://bugs.python.org/issue7490
-if sys.version_info[0] == 3:
+# Skip Bio.Seq doctest under Python 2, see http://bugs.python.org/issue7490
+# Can't easily write exceptions with consistent class name in python 2 and 3
+if sys.version_info[0] == 2:
     DOCTEST_MODULES.remove("Bio.Seq")
 
 

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -173,10 +173,6 @@ except ImportError:
     DOCTEST_MODULES.remove("Bio.SeqIO")
     DOCTEST_MODULES.remove("Bio.SearchIO")
 
-# Skip Bio.Seq doctest under Python 3, see http://bugs.python.org/issue7490
-if sys.version_info[0] == 3:
-    DOCTEST_MODULES.remove("Bio.Seq")
-
 
 # Skip Bio.bgzf doctest for broken gzip, see http://bugs.python.org/issue17666
 def _have_bug17666():

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -173,6 +173,10 @@ except ImportError:
     DOCTEST_MODULES.remove("Bio.SeqIO")
     DOCTEST_MODULES.remove("Bio.SearchIO")
 
+# Skip Bio.Seq doctest under Python 3, see http://bugs.python.org/issue7490
+if sys.version_info[0] == 3:
+    DOCTEST_MODULES.remove("Bio.Seq")
+
 
 # Skip Bio.bgzf doctest for broken gzip, see http://bugs.python.org/issue17666
 def _have_bug17666():


### PR DESCRIPTION
We no longer care about Python 3.0 and 3.1, so can now always run the Bio.Seq docstring tests.

With IGNORE_EXCEPTION_DETAIL enabled, Python 3.2 onwards will ignore the module name differences from the Python 2 to 3 migration, see http://bugs.python.org/issue7490

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Noticed while reviewing #1746