### PR TITLE
Add optional authentication for qblast

### DIFF
--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -127,6 +127,17 @@ def qblast(program, database, sequence, url_base=NCBI_BLAST_URL,
     query = [x for x in parameters if x[1] is not None]
     message = _as_bytes(_urlencode(query))
 
+    # handle authentication for BLAST cloud
+    if username is not None and password is not None:
+        # create a password manager
+        password_mgr = _HTTPPasswordMgrWithDefaultRealm()
+
+        # Add the username and password.
+        password_mgr.add_password(None, url_base, username, password)
+        handler = _HTTPBasicAuthHandler(password_mgr)
+        opener = _build_opener(handler)
+        _install_opener(opener)
+
     # Send off the initial query to qblast.
     # Note the NCBI do not currently impose a rate limit here, other
     # than the request not to make say 50 queries at once using multiple

--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -19,6 +19,10 @@ from Bio._py3k import _as_string, _as_bytes
 from Bio._py3k import urlopen as _urlopen
 from Bio._py3k import urlencode as _urlencode
 from Bio._py3k import Request as _Request
+from Bio._py3k import HTTPPasswordMgrWithDefaultRealm as _HTTPPasswordMgrWithDefaultRealm
+from Bio._py3k import HTTPBasicAuthHandler as _HTTPBasicAuthHandler
+from Bio._py3k import build_opener as _build_opener
+from Bio._py3k import install_opener as _install_opener
 
 
 NCBI_BLAST_URL = "https://blast.ncbi.nlm.nih.gov/Blast.cgi"
@@ -38,7 +42,7 @@ def qblast(program, database, sequence, url_base=NCBI_BLAST_URL,
            entrez_links_new_window=None, expect_low=None, expect_high=None,
            format_entrez_query=None, format_object=None, format_type='XML',
            ncbi_gi=None, results_file=None, show_overview=None, megablast=None,
-           template_type=None, template_length=None,
+           template_type=None, template_length=None, username=None, password=None
            ):
     """BLAST search using NCBI's QBLAST server or a cloud service provider.
 

--- a/Bio/_py3k/__init__.py
+++ b/Bio/_py3k/__init__.py
@@ -131,7 +131,7 @@ if sys.version_info[0] >= 3:
     from io import StringIO
 
     # On Python 3 urllib, urllib2, and urlparse were merged:
-    from urllib.request import urlopen, Request, urlretrieve, urlparse, urlcleanup
+    from urllib.request import urlopen, Request, urlretrieve, urlparse, urlcleanup, HTTPPasswordMgrWithDefaultRealm, HTTPBasicAuthHandler, build_opener, install_opener
     from urllib.parse import urlencode, quote
     from urllib.error import HTTPError
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -212,6 +212,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Shyam Saladi <https://github.com/smsaladi>
 - Siong Kong <https://github.com/siongkong>
 - Sjoerd de Vries <sjoerd at domain nmr.chem.uu.nl>
+- Soroush Saffari <https://github.com/sorsaffari>
 - Sourav Singh <https://github.com/souravsingh>
 - Spencer Bliven <https://github.com/sbliven>
 - Stefans Mezulis <https://github.com/StefansM/>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -43,6 +43,7 @@ possible, especially the following contributors:
 - Nick Negretti (first contribution)
 - Peter Cock
 - Rona Costello (first contribution)
+- Soroush Saffari (first contribution)
 - Spencer Bliven
 - Wibowo 'Bow' Arindrarto
 


### PR DESCRIPTION
[NSBI BLAST on the cloud](https://aws.amazon.com/marketplace/pp/B00N44P7L6?qid=1525720065294&sr=0-1&ref_=srh_res_product_title) by default requires authentication.

This pull request allows the developer to pass the `username` and `password` as parameters of the `qblast()` method. The credentials are then used in creating an [HTTPBasicAuthHandler](https://docs.python.org/3.1/howto/urllib2.html#id6) that in turn creates and authenticated `opener` for requests against a BLAST instance on the cloud.

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
