### PR TITLE
Poll cloud ncbi every ten seconds

### DIFF
--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -211,7 +211,6 @@ def qblast(program, database, sequence, url_base=NCBI_BLAST_URL,
 qblast._previous = 0
 
 
-
 def _parse_qblast_ref_page(handle):
     """Extract a tuple of RID, RTOE from the 'please wait' page (PRIVATE).
 

--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -207,15 +207,14 @@ def qblast(program, database, sequence, url_base=NCBI_BLAST_URL,
         # NCBI Cloud (private) instance until the results are ready.
         # Sends a request every 10 seconds
         delay = 10
-        previous = 0
         while True:
             current = time.time()
-            wait = previous + delay - current
+            wait = qblast._previous + delay - current
             if wait > 0:
                 time.sleep(wait)
-                previous = current + wait
+                qblast._previous = current + wait
             else:
-                previous = current
+                qblast._previous = current
 
             request = _Request(url_base,
                                message,

--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -159,8 +159,6 @@ def qblast(program, database, sequence, url_base=NCBI_BLAST_URL,
     query = [x for x in parameters if x[1] is not None]
     message = _as_bytes(_urlencode(query))
 
-
-
     # Poll NCBI until the results are ready.
     # https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=DeveloperInfo
     # 1. Do not contact the server more often than once every 10 seconds.
@@ -188,8 +186,8 @@ def qblast(program, database, sequence, url_base=NCBI_BLAST_URL,
             delay = 60
 
         request = _Request(url_base,
-                            message,
-                            {"User-Agent": "BiopythonClient"})
+                           message,
+                           {"User-Agent": "BiopythonClient"})
         handle = _urlopen(request)
         results = _as_string(handle.read())
 

--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -159,86 +159,57 @@ def qblast(program, database, sequence, url_base=NCBI_BLAST_URL,
     query = [x for x in parameters if x[1] is not None]
     message = _as_bytes(_urlencode(query))
 
-    if url_base == NCBI_BLAST_URL:
-        # Poll NCBI until the results are ready.
-        # https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=DeveloperInfo
-        # 1. Do not contact the server more often than once every 10 seconds.
-        # 2. Do not poll for any single RID more often than once a minute.
-        # 3. Use the URL parameter email and tool, so that the NCBI
-        #    can contact you if there is a problem.
-        # 4. Run scripts weekends or between 9 pm and 5 am Eastern time
-        #    on weekdays if more than 50 searches will be submitted.
-        # --
-        # Could start with a 10s delay, but expect most short queries
-        # will take longer thus at least 70s with delay. Therefore,
-        # start with 20s delay, thereafter once a minute.
-        delay = 20  # seconds
-        while True:
-            current = time.time()
-            wait = qblast._previous + delay - current
-            if wait > 0:
-                time.sleep(wait)
-                qblast._previous = current + wait
-            else:
-                qblast._previous = current
-            if delay < 60:
-                # Wasn't a quick return, must wait at least a minute
-                delay = 60
 
-            request = _Request(url_base,
-                               message,
-                               {"User-Agent": "BiopythonClient"})
-            handle = _urlopen(request)
-            results = _as_string(handle.read())
 
-            # Can see an "\n\n" page while results are in progress,
-            # if so just wait a bit longer...
-            if results == "\n\n":
-                continue
-            # XML results don't have the Status tag when finished
-            if "Status=" not in results:
-                break
-            i = results.index("Status=")
-            j = results.index("\n", i)
-            status = results[i + len("Status="):j].strip()
-            if status.upper() == "READY":
-                break
-    else:
-        # NCBI Cloud (private) instance until the results are ready.
-        # Sends a request every 10 seconds
-        delay = 10
-        while True:
-            current = time.time()
-            wait = qblast._previous + delay - current
-            if wait > 0:
-                time.sleep(wait)
-                qblast._previous = current + wait
-            else:
-                qblast._previous = current
+    # Poll NCBI until the results are ready.
+    # https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=DeveloperInfo
+    # 1. Do not contact the server more often than once every 10 seconds.
+    # 2. Do not poll for any single RID more often than once a minute.
+    # 3. Use the URL parameter email and tool, so that the NCBI
+    #    can contact you if there is a problem.
+    # 4. Run scripts weekends or between 9 pm and 5 am Eastern time
+    #    on weekdays if more than 50 searches will be submitted.
+    # --
+    # Could start with a 10s delay, but expect most short queries
+    # will take longer thus at least 70s with delay. Therefore,
+    # start with 20s delay, thereafter once a minute.
+    delay = 20  # seconds
+    while True:
+        current = time.time()
+        wait = qblast._previous + delay - current
+        if wait > 0:
+            time.sleep(wait)
+            qblast._previous = current + wait
+        else:
+            qblast._previous = current
+        # delay by at least 60 seconds only if running the request against the public NCBI API
+        if delay < 60 and url_base == NCBI_BLAST_URL:
+            # Wasn't a quick return, must wait at least a minute
+            delay = 60
 
-            request = _Request(url_base,
-                               message,
-                               {"User-Agent": "BiopythonClient"})
-            handle = _urlopen(request)
-            results = _as_string(handle.read())
+        request = _Request(url_base,
+                            message,
+                            {"User-Agent": "BiopythonClient"})
+        handle = _urlopen(request)
+        results = _as_string(handle.read())
 
-            # Can see an "\n\n" page while results are in progress,
-            # if so just wait a bit longer...
-            if results == "\n\n":
-                continue
-            # XML results don't have the Status tag when finished
-            if "Status=" not in results:
-                break
-            i = results.index("Status=")
-            j = results.index("\n", i)
-            status = results[i + len("Status="):j].strip()
-            if status.upper() == "READY":
-                break
-
+        # Can see an "\n\n" page while results are in progress,
+        # if so just wait a bit longer...
+        if results == "\n\n":
+            continue
+        # XML results don't have the Status tag when finished
+        if "Status=" not in results:
+            break
+        i = results.index("Status=")
+        j = results.index("\n", i)
+        status = results[i + len("Status="):j].strip()
+        if status.upper() == "READY":
+            break
     return StringIO(results)
 
 
 qblast._previous = 0
+
 
 
 def _parse_qblast_ref_page(handle):


### PR DESCRIPTION
[NSBI BLAST on the cloud](https://aws.amazon.com/marketplace/pp/B00N44P7L6?qid=1525720065294&sr=0-1&ref_=srh_res_product_title) has no limitations on the frequency of requests sent at it. Therefore, to output the result quicker, this pull request changes the behaviour of `qblast()` method to send the `GET` request every 10 seconds until the results are ready.

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
