### PR TITLE
Remove Bio.ExPASy.sprot_search_ful and ..._de

### DIFF
--- a/Bio/ExPASy/__init__.py
+++ b/Bio/ExPASy/__init__.py
@@ -13,8 +13,6 @@ Functions:
  - get_prosite_entry Interface to the get-prosite-entry CGI script.
  - get_prosite_raw   Interface to the get-prosite-raw CGI script.
  - get_sprot_raw     Interface to the get-sprot-raw CGI script.
- - sprot_search_ful  Interface to the sprot-search-ful CGI script.
- - sprot_search_de   Interface to the sprot-search-de CGI script.
 
 """
 
@@ -113,35 +111,3 @@ def get_sprot_raw(id):
     """
     url = "http://www.uniprot.org/uniprot/%s.txt" % id
     return _binary_to_string_handle(_urlopen(url))
-
-
-def sprot_search_ful(text, make_wild=None, swissprot=1, trembl=None,
-                     cgi='https://www.expasy.org/cgi-bin/sprot-search-ful'):
-    """Search SwissProt by full text (BROKEN)."""
-    variables = {'SEARCH': text}
-    if make_wild:
-        variables['makeWild'] = 'on'
-    if swissprot:
-        variables['S'] = 'on'
-    if trembl:
-        variables['T'] = 'on'
-    options = _urlencode(variables)
-    fullcgi = "%s?%s" % (cgi, options)
-    handle = _binary_to_string_handle(_urlopen(fullcgi))
-    return handle
-
-
-def sprot_search_de(text, swissprot=1, trembl=None,
-                    cgi='https://www.expasy.org/cgi-bin/sprot-search-de'):
-    """Search SwissProt (BROKEN).
-
-    Search by name, description, gene name, species, or organelle.
-    """
-    variables = {'SEARCH': text}
-    if swissprot:
-        variables['S'] = 'on'
-    if trembl:
-        variables['T'] = 'on'
-    options = _urlencode(variables)
-    fullcgi = "%s?%s" % (cgi, options)
-    return _binary_to_string_handle(_urlopen(fullcgi))

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -43,6 +43,11 @@ Jython
 Biopython is mostly working under Jython 2.7.0, but support for Jython
 is deprecated as of Release 1.70.
 
+Bio.ExPASy.sprot_search_ful and ExPASy.sprot_search_de
+======================================================
+These two functions were labelled as broken in Release 1.70, and removed in
+Release 1.73, since the underlying web-server API no longer exists.
+
 Bio.GA
 ======
 This was deprecated in Biopython 1.70, and removed in Release 1.73.

--- a/Doc/Tutorial/chapter_uniprot.tex
+++ b/Doc/Tutorial/chapter_uniprot.tex
@@ -381,32 +381,10 @@ If the accession number you provided to \verb|ExPASy.get_sprot_raw| does not exi
 
 Now, you may remark that I knew the records' accession numbers
 beforehand. Indeed, \verb|get_sprot_raw()| needs either the entry name
-or an accession number. When you don't have them handy, you can use
-one of the \verb|sprot_search_de()| or \verb|sprot_search_ful()|
-functions.
-
-\verb|sprot_search_de()| searches in the ID, DE, GN, OS and OG lines;
-\verb|sprot_search_ful()| searches in (nearly) all the fields. They
-are detailed on
-\url{http://www.expasy.org/cgi-bin/sprot-search-de} and
-\url{http://www.expasy.org/cgi-bin/sprot-search-ful}
-respectively. Note that they don't search in TrEMBL by default
-(argument \verb|trembl|). Note also that they return HTML pages;
-however, accession numbers are quite easily extractable:
-
-\begin{verbatim}
->>> from Bio import ExPASy
->>> import re
-
->>> handle = ExPASy.sprot_search_de("Orchid Chalcone Synthase")
->>> # or:
->>> # handle = ExPASy.sprot_search_ful("Orchid and {Chalcone Synthase}")
->>> html_results = handle.read()
->>> if "Number of sequences found" in html_results:
-...     ids = re.findall(r'HREF="/uniprot/(\w+)"', html_results)
-... else:
-...     ids = re.findall(r'href="/cgi-bin/niceprot\.pl\?(\w+)"', html_results)
-\end{verbatim}
+or an accession number. When you don't have them handy, right now you
+could ise \url{https://www.uniprot.org/} but we do not have a Python
+wrapper for searching this from a script. Perhaps you could contribute
+here?
 
 \subsection{Retrieving Prosite and Prosite documentation records}
 

--- a/Doc/Tutorial/chapter_uniprot.tex
+++ b/Doc/Tutorial/chapter_uniprot.tex
@@ -332,14 +332,12 @@ We can now iterate over the records one at a time. For example, we can make a li
 
 \section{Accessing the ExPASy server}
 
-Swiss-Prot, Prosite, and Prosite documentation records can be downloaded from the ExPASy web server at \url{http://www.expasy.org}. Six kinds of queries are available from ExPASy:
+Swiss-Prot, Prosite, and Prosite documentation records can be downloaded from the ExPASy web server at \url{http://www.expasy.org}. Four kinds of queries are available from ExPASy:
 \begin{description}
 \item[get\_prodoc\_entry]To download a Prosite documentation record in HTML format
 \item[get\_prosite\_entry]To download a Prosite record in HTML format
 \item[get\_prosite\_raw]To download a Prosite or Prosite documentation record in raw format
 \item[get\_sprot\_raw]To download a Swiss-Prot record in raw format
-\item[sprot\_search\_ful]To search for a Swiss-Prot record
-\item[sprot\_search\_de]To search for a Swiss-Prot record
 \end{description}
 To access this web server from a Python script, we use the \verb|Bio.ExPASy| module.
 
@@ -382,7 +380,7 @@ If the accession number you provided to \verb|ExPASy.get_sprot_raw| does not exi
 Now, you may remark that I knew the records' accession numbers
 beforehand. Indeed, \verb|get_sprot_raw()| needs either the entry name
 or an accession number. When you don't have them handy, right now you
-could ise \url{https://www.uniprot.org/} but we do not have a Python
+could use \url{https://www.uniprot.org/} but we do not have a Python
 wrapper for searching this from a script. Perhaps you could contribute
 here?
 


### PR DESCRIPTION
This will close #253 and remove some of the dead URLs noted on #1826.

This has not followed the letter of our deprecation policy (since there was no ``BiopythonDeprecationWarning`` issued on attempted use, but attempted use would just fail), but I think it followed the spirit at least - see https://biopython.org/wiki/Deprecation_policy

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
