### PR TITLE
Access these IUPACData values directly

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -34,6 +34,8 @@ from Bio import Alphabet
 from Bio.Alphabet import IUPAC
 from Bio.Data.IUPACData import (ambiguous_dna_complement,
                                 ambiguous_rna_complement)
+from Bio.Data.IUPACData import ambiguous_dna_letters as _ambiguous_dna_letters
+from Bio.Data.IUPACData import ambiguous_rna_letters as _ambiguous_rna_letters
 from Bio.Data import CodonTable
 
 
@@ -2603,8 +2605,8 @@ def _translate_str(sequence, table, stop_symbol="*", to_stop=False,
         valid_letters = set(table.nucleotide_alphabet.letters.upper())
     else:
         # Assume the worst case, ambiguous DNA or RNA:
-        valid_letters = set(IUPAC.ambiguous_dna.letters.upper() +
-                            IUPAC.ambiguous_rna.letters.upper())
+        valid_letters = set(_ambiguous_dna_letters.upper() +
+                            _ambiguous_rna_letters.upper())
     n = len(sequence)
 
     # Check for tables with 'ambiguous' (dual-coding) stop codons:


### PR DESCRIPTION
Avoid needlessly going via Bio.Alphabet classes here, noted while looking at wider issue of ``Bio.Alphabet`` removal and/or replacement.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
