### PR TITLE
Adding new entries for the Biopython 1.73 release news

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -35,8 +35,8 @@ warning on parsing.
 
 There is a new command line wrapper for the BWA-MEM sequence mapper.
 
-FASTA files are now parsed slightly faster with ``SeqIO.parse()`` due to
-internal changes in ``SimpleFastaParser``.
+The string-based FASTA parsers in ``Bio.SeqIO.FastaIO`` have been optimised,
+which also speeds up parsing FASTA files using ``Bio.SeqIO.parse()``.
 
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -33,6 +33,11 @@ Double-quote characters in GenBank feature qualifier values in ``Bio.SeqIO``
 are now escaped as per the NCBI standard. Improperly escaped values trigger a
 warning on parsing.
 
+There is a new command line wrapper for the BWA-MEM sequence mapper.
+
+FASTA files are now parsed slightly faster with ``SeqIO.parse()`` due to
+internal changes in ``SimpleFastaParser``.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 


### PR DESCRIPTION
I didn't want to clog up the mailing list with this suggestion, but I propose adding a couple of lines to the Biopython 1.73 release news. Note that I just added additional timings to #1808 that show the new FASTA parser is slightly faster with `SeqIO.parse()`, at least with Python 3.6 on my system.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
