### PR TITLE
Documentation to the build() function

### DIFF
--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -41,16 +41,17 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char='-', unknown='X',
      - complete_protein - whether the sequence begins with a start
        codon
 
-    Return a CodonAlignment object
-    
-    This example answers this Biostarts question: https://www.biostars.org/p/89741/
-    >>> from Bio.Alphabet import IUPAC, generic_protein
+    Return a CodonAlignment object.
+
+    The example below answers this Biostars question: https://www.biostars.org/p/89741/
+
+    >>> from Bio.Alphabet import generic_dna, generic_protein
     >>> from Bio.Seq import Seq
     >>> from Bio.SeqRecord import SeqRecord
     >>> from Bio.Align import MultipleSeqAlignment
     >>> from Bio.codonalign import build
-    >>> seq1 = SeqRecord(Seq('ATGTCTCGT', alphabet=IUPAC.IUPACUnambiguousDNA()), id='pro1')
-    >>> seq2 = SeqRecord(Seq('ATGCGT', alphabet=IUPAC.IUPACUnambiguousDNA()), id='pro2')
+    >>> seq1 = SeqRecord(Seq('ATGTCTCGT', alphabet=generic_dna), id='pro1')
+    >>> seq2 = SeqRecord(Seq('ATGCGT', alphabet=generic_dna), id='pro2')
     >>> pro1 = SeqRecord(Seq('MSR', alphabet=generic_protein), id='pro1')
     >>> pro2 = SeqRecord(Seq('M-R', alphabet=generic_protein), id='pro2')
     >>> aln = MultipleSeqAlignment([pro1, pro2])

--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -34,32 +34,31 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char='-', unknown='X',
 
     Arguments:
      - pro_align  - a protein MultipleSeqAlignment object
-     - nucl_align - an object returned by SeqIO.parse or SeqIO.index
+     - nucl_seqs - an object returned by SeqIO.parse or SeqIO.index
        or a collection of SeqRecord.
      - alphabet   - alphabet for the returned codon alignment
      - corr_dict  - a dict that maps protein id to nucleotide id
      - complete_protein - whether the sequence begins with a start
        codon
-     - frameshift - whether to apply frameshift detection
 
     Return a CodonAlignment object
-
-    >>> from Bio.Alphabet import IUPAC
+    
+    This example answers this Biostarts question: https://www.biostars.org/p/89741/
+    >>> from Bio.Alphabet import IUPAC, generic_protein
     >>> from Bio.Seq import Seq
     >>> from Bio.SeqRecord import SeqRecord
     >>> from Bio.Align import MultipleSeqAlignment
-    >>> seq1 = SeqRecord(Seq('TCAGGGACTGCGAGAACCAAGCTACTGCTGCTGCTGGCTGCGCTCTGCGCCGCAGGTGGGGCGCTGGAG',
-    ...     alphabet=IUPAC.IUPACUnambiguousDNA()), id='pro1')
-    >>> seq2 = SeqRecord(Seq('TCAGGGACTTCGAGAACCAAGCGCTCCTGCTGCTGGCTGCGCTCGGCGCCGCAGGTGGAGCACTGGAG',
-    ...     alphabet=IUPAC.IUPACUnambiguousDNA()), id='pro2')
-    >>> pro1 = SeqRecord(Seq('SGTARTKLLLLLAALCAAGGALE', alphabet=IUPAC.protein),id='pro1')
-    >>> pro2 = SeqRecord(Seq('SGTSRTKRLLLLAALGAAGGALE', alphabet=IUPAC.protein),id='pro2')
+    >>> from Bio.codonalign import build
+    >>> seq1 = SeqRecord(Seq('ATGTCTCGT', alphabet=IUPAC.IUPACUnambiguousDNA()), id='pro1')
+    >>> seq2 = SeqRecord(Seq('ATGCGT', alphabet=IUPAC.IUPACUnambiguousDNA()), id='pro2')
+    >>> pro1 = SeqRecord(Seq('MSR', alphabet=generic_protein), id='pro1')
+    >>> pro2 = SeqRecord(Seq('M-R', alphabet=generic_protein), id='pro2')
     >>> aln = MultipleSeqAlignment([pro1, pro2])
     >>> codon_aln = build(aln, [seq1, seq2])
     >>> print(codon_aln)
-    CodonAlphabet(Standard) CodonAlignment with 2 rows and 69 columns (23 codons)
-    TCAGGGACTGCGAGAACCAAGCTACTGCTGCTGCTGGCTGCGCTCTGCGCCGCAGGT...GAG pro1
-    TCAGGGACTTCGAGAACCAAGCG-CTCCTGCTGCTGGCTGCGCTCGGCGCCGCAGGT...GAG pro2
+    CodonAlphabet(Standard) CodonAlignment with 2 rows and 9 columns (3 codons)
+    ATGTCTCGT pro1
+    ATG---CGT pro2
 
     """
     # TODO


### PR DESCRIPTION
* A more relevant example (taken from https://www.biostars.org/p/89741/ ) is used in the function documentation
* The argument list documentation was updated to match the function definition -- `nucl_align` was changed to `nucl_seqs`; `frameshift` argument was removed

This pull request addresses issue #1840

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
