### PR TITLE
Consistent error messages for empty file parsing in SeqIO

### DIFF
--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -255,6 +255,8 @@ def PdbAtomIterator(handle):
     from Bio.File import UndoHandle
     undo_handle = UndoHandle(handle)
     firstline = undo_handle.peekline()
+    if undo_handle.readlines() == []:
+        raise ValueError("Empty file.")
     if firstline.startswith("HEADER"):
         pdb_id = firstline[62:66]
     else:
@@ -458,6 +460,8 @@ def CifAtomIterator(handle):
 
     buffer.seek(0)
     mmcif_dict = MMCIF2Dict(buffer)
+    if mmcif_dict == {}:
+        raise ValueError("Empty file.")
     if "_entry.id" in mmcif_dict:
         pdb_id = mmcif_dict["_entry.id"]
         if isinstance(pdb_id, list):

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -255,8 +255,11 @@ def PdbAtomIterator(handle):
     from Bio.File import UndoHandle
     undo_handle = UndoHandle(handle)
     firstline = undo_handle.peekline()
+
+    # check if file is empty
     if firstline == '':
         raise ValueError("Empty file.")
+
     if firstline.startswith("HEADER"):
         pdb_id = firstline[62:66]
     else:
@@ -458,10 +461,12 @@ def CifAtomIterator(handle):
     buffer = StringIO()
     shutil.copyfileobj(handle, buffer)
 
+    # check if file is empty
+    if len(buffer.getvalue()) == 0:
+        raise ValueError("Empty file.")
+
     buffer.seek(0)
     mmcif_dict = MMCIF2Dict(buffer)
-    if mmcif_dict == {}:
-        raise ValueError("Empty file.")
     if "_entry.id" in mmcif_dict:
         pdb_id = mmcif_dict["_entry.id"]
         if isinstance(pdb_id, list):

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -255,7 +255,7 @@ def PdbAtomIterator(handle):
     from Bio.File import UndoHandle
     undo_handle = UndoHandle(handle)
     firstline = undo_handle.peekline()
-    if undo_handle.readlines() == []:
+    if firstline == '':
         raise ValueError("Empty file.")
     if firstline.startswith("HEADER"):
         pdb_id = firstline[62:66]

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -50,6 +50,11 @@ def UniprotIterator(handle, alphabet=Alphabet.generic_protein, return_raw_commen
     return_raw_comments = True --> comment fields are returned as complete XML to allow further processing
     skip_parsing_errors = True --> if parsing errors are found, skip to next entry
     """
+    # check if file is empty
+    from Bio.File import UndoHandle
+    if UndoHandle(handle).readlines() == []:
+      raise ValueError("Empty file.")
+
     if isinstance(alphabet, Alphabet.NucleotideAlphabet):
         raise ValueError("Wrong alphabet %r" % alphabet)
     if isinstance(alphabet, Alphabet.Gapped):

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -53,7 +53,7 @@ def UniprotIterator(handle, alphabet=Alphabet.generic_protein, return_raw_commen
     # check if file is empty
     from Bio.File import UndoHandle
     if UndoHandle(handle).readlines() == []:
-      raise ValueError("Empty file.")
+        raise ValueError("Empty file.")
 
     if isinstance(alphabet, Alphabet.NucleotideAlphabet):
         raise ValueError("Wrong alphabet %r" % alphabet)

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -52,7 +52,7 @@ def UniprotIterator(handle, alphabet=Alphabet.generic_protein, return_raw_commen
     """
     # check if file is empty
     from Bio.File import UndoHandle
-    if UndoHandle(handle).readlines() == []:
+    if UndoHandle(handle).peekline() == '':
         raise ValueError("Empty file.")
 
     if isinstance(alphabet, Alphabet.NucleotideAlphabet):

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -51,8 +51,7 @@ def UniprotIterator(handle, alphabet=Alphabet.generic_protein, return_raw_commen
     skip_parsing_errors = True --> if parsing errors are found, skip to next entry
     """
     # check if file is empty
-    from Bio.File import UndoHandle
-    if UndoHandle(handle).peekline() == '':
+    if handle.readline() == '':
         raise ValueError("Empty file.")
 
     if isinstance(alphabet, Alphabet.NucleotideAlphabet):
@@ -70,7 +69,7 @@ def UniprotIterator(handle, alphabet=Alphabet.generic_protein, return_raw_commen
             handle = StringIO(handle)
         else:
             raise TypeError("Requires an XML-containing handle"
-                            " (or XML as a string, but that's deprectaed)")
+                            " (or XML as a string, but that's deprecated)")
 
     if ElementTree is None:
         from Bio import MissingExternalDependencyError

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -82,6 +82,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - David Nicholson <https://github.com/danich1>
 - David Weisman <david.weisman at domain acm.org>
 - David Winter <david dot winter at gmail dot com>
+- Devang Thakkar <https://github.com/devangthakkar>
 - Diana Jaunzeikare
 - Diego Brouard <diego at domain conysis.com>
 - Edward Liaw <https://github.com/edliaw>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -46,6 +46,7 @@ possible, especially the following contributors:
 - Catherine Lesuisse
 - Chris Rands
 - Darcy Mason (first contribution)
+- Devang Thakkar (first contribution)
 - Ivan Antonov (first contribution)
 - Juraj Szász (first contribution)
 - Jeremy LaBarage (first contribution)


### PR DESCRIPTION
This pull request addresses Issue #1838. Current SeqIO code does not optimally handle empty files for certain formats. This pull request raises a standard `ValueError("Empty file.")` error message on encountering an empty file instead of the current non standard errors. Formats worked on are as
follows: cif-atom, pdb-atom, uniprot-xml. The other formats either do not print anything thing or raise a `ValueError("Empty file.")` error message.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
