### PR TITLE
memory-efficient version of the pairwise aligner

### DIFF
--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -6,6 +6,7 @@
  */
 
 
+
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "float.h"
@@ -14,15 +15,23 @@
 #define HORIZONTAL 0x1
 #define VERTICAL 0x2
 #define DIAGONAL 0x4
+#define ENDPOINT 0x8
 #define M_MATRIX 0x1
 #define Ix_MATRIX 0x2
 #define Iy_MATRIX 0x4
 #define DONE 0x8
+#define NONE 0x7
 
 #define OVERFLOW_ERROR -1
 #define MEMORY_ERROR -2
 
 #define CHARINDEX(s) (c = s, c >= 'a' ? c - 'a' : c - 'A')
+
+#define SAFE_ADD(t, s) \
+{   term = t; \
+    if (term > PY_SSIZE_T_MAX - s) { count = OVERFLOW_ERROR; goto exit; } \
+    s += term; \
+}
 
 
 typedef enum {NeedlemanWunschSmithWaterman,
@@ -33,23 +42,21 @@ typedef enum {NeedlemanWunschSmithWaterman,
 typedef enum {Global, Local} Mode;
 
 typedef struct {
-    double score;
-    unsigned int trace : 3;
-    unsigned int path : 4;
-} Cell;
+    unsigned char trace : 4;
+    unsigned char path : 4;
+} Trace;
 
 typedef struct {
-    double score;
-    unsigned int trace : 3;
-    struct {int i; int j;} path;
-} CellM; /* Used for the Waterman-Smith-Beyer algorithm. */
+    unsigned char Ix : 4;
+    unsigned char Iy : 4;
+} TraceGapsGotoh;
 
 typedef struct {
-    double score;
-    int* traceM;
-    int* traceXY;
-    struct {int i; int j;} path;
-} CellXY; /* Used for the Waterman-Smith-Beyer algorithm. */
+    int* MIx;
+    int* IyIx;
+    int* MIy;
+    int* IxIy;
+} TraceGapsWatermanSmithBeyer;
 
 static int _convert_single_letter(PyObject* item)
 {
@@ -80,13 +87,17 @@ static int _convert_single_letter(PyObject* item)
 #endif
     {
         if (!PyObject_CheckBuffer(item)
-         || PyObject_GetBuffer(item, &view, PyBUF_FORMAT) == -1
-         || strcmp(view.format, "B") != 0
-         || view.len != 1) {
+         || PyObject_GetBuffer(item, &view, PyBUF_FORMAT) == -1) {
+            PyErr_SetString(PyExc_ValueError, "expected a single letter");
+            return -1;
+        }
+        if (strcmp(view.format, "B") != 0 || view.len != 1) {
+            PyBuffer_Release(&view);
             PyErr_SetString(PyExc_ValueError, "expected a single letter");
             return -1;
         }
         letter = *((char*)(view.buf));
+        PyBuffer_Release(&view);
     }
     if (letter >= 'a' && letter <= 'z') i = letter - 'a';
     else if (letter >= 'A' && letter <= 'Z') i = letter - 'A';
@@ -98,7 +109,7 @@ static int _convert_single_letter(PyObject* item)
 }
 
 static PyObject*
-_create_path_needleman_wunsch_smith_waterman(Cell** M, int i, int j) {
+_create_path(Trace** M, int i, int j) {
     PyObject* tuple;
     PyObject* row;
     PyObject* value;
@@ -165,201 +176,1543 @@ _create_path_needleman_wunsch_smith_waterman(Cell** M, int i, int j) {
         }
     }
     Py_DECREF(tuple); /* all references were stolen */
-    return NULL;
-}
-
-static PyObject*
-_create_path_gotoh(Cell** M, Cell** Ix, Cell** Iy, int i, int j) {
-    PyObject* tuple;
-    PyObject* row;
-    PyObject* value;
-    int path;
-    const int ii = i;
-    const int jj = j;
-    int n = 1;
-    int direction = 0;
-
-    path = M[i][j].path;
-    while (path) {
-        if (path != direction) {
-            n++;
-            direction = path;
-        }
-        switch (path) {
-            case HORIZONTAL: path = Iy[i][++j].path; break;
-            case VERTICAL: path = Ix[++i][j].path; break;
-            case DIAGONAL: path = M[++i][++j].path; break;
-        }
-    }
-    i = ii;
-    j = jj;
-
-    direction = 0;
-    tuple = PyTuple_New(n);
-    if (!tuple) return NULL;
-    n = 0;
-    path = M[i][j].path;
-    while (1) {
-        if (path != direction) {
-            row = PyTuple_New(2);
-            if (!row) break;
-#if PY_MAJOR_VERSION >= 3
-            value = PyLong_FromLong(i);
-#else
-            value = PyInt_FromLong(i);
-#endif
-            if (!value) {
-                Py_DECREF(row); /* all references were stolen */
-                break;
-            }
-            PyTuple_SET_ITEM(row, 0, value);
-#if PY_MAJOR_VERSION >= 3
-            value = PyLong_FromLong(j);
-#else
-            value = PyInt_FromLong(j);
-#endif
-            if (!value) {
-                Py_DECREF(row); /* all references were stolen */
-                break;
-            }
-            PyTuple_SET_ITEM(row, 1, value);
-            PyTuple_SET_ITEM(tuple, n, row);
-            n++;
-            direction = path;
-        }
-        switch (path) {
-            case HORIZONTAL: path = Iy[i][++j].path; break;
-            case VERTICAL: path = Ix[++i][j].path; break;
-            case DIAGONAL: path = M[++i][++j].path; break;
-            default: return tuple;
-        }
-    }
-    Py_DECREF(tuple); /* all references were stolen */
-    return NULL;
-}
-
-static PyObject*
-_create_path_waterman_smith_beyer(CellM** M, CellXY** Ix, CellXY** Iy,
-                                  int i, int j) {
-    PyObject* tuple;
-    PyObject* row;
-    PyObject* value;
-    int i1 = i;
-    int j1 = j;
-    int i2 = M[i1][j1].path.i;
-    int j2 = M[i1][j1].path.j;
-    int n = 1;
-    int direction = 0;
-
-    while (1) {
-        if (i2 < 0) break;
-        else if (i1==i2) {
-            i1 = i2;
-            j1 = j2;
-            i2 = Iy[i1][j1].path.i;
-            j2 = Iy[i1][j1].path.j;
-            if (direction != HORIZONTAL) {
-                n++;
-                direction = HORIZONTAL;
-            }
-        }
-        else if (j1==j2) {
-            i1 = i2;
-            j1 = j2;
-            i2 = Ix[i1][j1].path.i;
-            j2 = Ix[i1][j1].path.j;
-            if (direction != VERTICAL) {
-                n++;
-                direction = VERTICAL;
-            }
-        }
-        else {
-            i1 = i2;
-            j1 = j2;
-            i2 = M[i1][j1].path.i;
-            j2 = M[i1][j1].path.j;
-            if (direction != DIAGONAL) {
-                n++;
-                direction = DIAGONAL;
-            }
-        }
-    }
-
-    i1 = i;
-    j1 = j;
-    i2 = M[i1][j1].path.i;
-    j2 = M[i1][j1].path.j;
-    tuple = PyTuple_New(n);
-    if (!tuple) return NULL;
-    n = 0;
-    direction = 0;
-    while (1) {
-        if ((i1==i2 && direction != HORIZONTAL)
-         || (j1==j2 && direction != VERTICAL)
-         || (direction != DIAGONAL)
-         || (i2 == -1)) {
-            row = PyTuple_New(2);
-            if (!row) break;
-#if PY_MAJOR_VERSION >= 3
-            value = PyLong_FromLong(i1);
-#else
-            value = PyInt_FromLong(i1);
-#endif
-            if (!value) {
-                Py_DECREF(row); /* all references were stolen */
-                break;
-            }
-            PyTuple_SET_ITEM(row, 0, value);
-#if PY_MAJOR_VERSION >= 3
-            value = PyLong_FromLong(j1);
-#else
-            value = PyInt_FromLong(j1);
-#endif
-            PyTuple_SET_ITEM(row, 1, value);
-            PyTuple_SET_ITEM(tuple, n, row);
-            n++;
-        }
-        if (i2 < 0) return tuple;
-        else if (i1==i2) {
-            i1 = i2;
-            j1 = j2;
-            i2 = Iy[i1][j1].path.i;
-            j2 = Iy[i1][j1].path.j;
-            direction = HORIZONTAL;
-        }
-        else if (j1==j2) {
-            i1 = i2;
-            j1 = j2;
-            i2 = Ix[i1][j1].path.i;
-            j2 = Ix[i1][j1].path.j;
-            direction = VERTICAL;
-        }
-        else {
-            i1 = i2;
-            j1 = j2;
-            i2 = M[i1][j1].path.i;
-            j2 = M[i1][j1].path.j;
-            direction = DIAGONAL;
-        }
-    }
-    Py_DECREF(tuple); /* all references were stolen */
-    return NULL;
+    return PyErr_NoMemory();
 }
 
 typedef struct {
     PyObject_HEAD
-    union { Cell** affine; CellM** general; } M; 
-    union { Cell** affine; CellXY** general; } Ix; 
-    union { Cell** affine; CellXY** general; } Iy; 
+    Trace** M;
+    union { TraceGapsGotoh** gotoh;
+            TraceGapsWatermanSmithBeyer** waterman_smith_beyer; } gaps;
     int nA;
     int nB;
     int iA;
     int iB;
     Mode mode;
     Algorithm algorithm;
-    double threshold;
     Py_ssize_t length;
 } PathGenerator;
+
+static Py_ssize_t
+PathGenerator_needlemanwunsch_length(PathGenerator* self)
+{
+    int i;
+    int j;
+    int trace;
+    const int nA = self->nA;
+    const int nB = self->nB;
+    Trace** M = self->M;
+    Py_ssize_t term;
+    Py_ssize_t count;
+    Py_ssize_t temp;
+    Py_ssize_t* counts;
+    counts = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+    if (!counts) return MEMORY_ERROR;
+    counts[0] = 1;
+    for (j = 1; j <= nB; j++) {
+        trace = M[0][j].trace;
+        count = 0;
+        if (trace & HORIZONTAL) SAFE_ADD(counts[j-1], count);
+        counts[j] = count;
+    }
+    for (i = 1; i <= nA; i++) {
+        trace = M[i][0].trace;
+        count = 0;
+        if (trace & VERTICAL) SAFE_ADD(counts[0], count);
+        temp = counts[0];
+        counts[0] = count;
+        for (j = 1; j <= nB; j++) {
+            trace = M[i][j].trace;
+            count = 0;
+            if (trace & HORIZONTAL) SAFE_ADD(counts[j-1], count);
+            if (trace & VERTICAL) SAFE_ADD(counts[j], count);
+            if (trace & DIAGONAL) SAFE_ADD(temp, count);
+            temp = counts[j];
+            counts[j] = count;
+        }
+    }
+exit:
+    PyMem_Free(counts);
+    return count;
+}
+
+static Py_ssize_t
+PathGenerator_smithwaterman_length(PathGenerator* self)
+{
+    int i;
+    int j;
+    int trace;
+    const int nA = self->nA;
+    const int nB = self->nB;
+    Trace** M = self->M;
+    Py_ssize_t term;
+    Py_ssize_t count;
+    Py_ssize_t total = 0;
+    Py_ssize_t temp;
+    Py_ssize_t* counts;
+    counts = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+    if (!counts) return MEMORY_ERROR;
+    counts[0] = 1;
+    for (j = 1; j <= nB; j++) counts[j] = 1;
+    for (i = 1; i <= nA; i++) {
+        temp = counts[0];
+        counts[0] = 1;
+        for (j = 1; j <= nB; j++) {
+            trace = M[i][j].trace;
+            count = 0;
+            if (trace & DIAGONAL) SAFE_ADD(temp, count);
+            if (M[i][j].trace & ENDPOINT) SAFE_ADD(count, total);
+            if (trace & HORIZONTAL) SAFE_ADD(counts[j-1], count);
+            if (trace & VERTICAL) SAFE_ADD(counts[j], count);
+            temp = counts[j];
+            if (count == 0) count = 1;
+            counts[j] = count;
+        }
+    }
+    count = total;
+exit:
+    PyMem_Free(counts);
+    return count;
+}
+
+static Py_ssize_t
+PathGenerator_gotoh_global_length(PathGenerator* self)
+{
+    int i;
+    int j;
+    int trace;
+    const int nA = self->nA;
+    const int nB = self->nB;
+    Trace** M = self->M;
+    TraceGapsGotoh** gaps = self->gaps.gotoh;
+    Py_ssize_t count = MEMORY_ERROR;
+    Py_ssize_t term;
+    Py_ssize_t M_temp;
+    Py_ssize_t Ix_temp;
+    Py_ssize_t Iy_temp;
+    Py_ssize_t* M_counts = NULL;
+    Py_ssize_t* Ix_counts = NULL;
+    Py_ssize_t* Iy_counts = NULL;
+    M_counts = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+    if (!M_counts) goto exit;
+    Ix_counts = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+    if (!Ix_counts) goto exit;
+    Iy_counts = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+    if (!Iy_counts) goto exit;
+    M_counts[0] = 1;
+    Ix_counts[0] = 0;
+    Iy_counts[0] = 0;
+    for (j = 1; j <= nB; j++) {
+        M_counts[j] = 0;
+        Ix_counts[j] = 0;
+        Iy_counts[j] = 1;
+    }
+    for (i = 1; i <= nA; i++) {
+        M_temp = M_counts[0];
+        M_counts[0] = 0;
+        Ix_temp = Ix_counts[0];
+        Ix_counts[0] = 1;
+        Iy_temp = Iy_counts[0];
+        Iy_counts[0] = 0;
+        for (j = 1; j <= nB; j++) {
+            count = 0;
+            trace = M[i][j].trace;
+            if (trace & M_MATRIX) SAFE_ADD(M_temp, count);
+            if (trace & Ix_MATRIX) SAFE_ADD(Ix_temp, count);
+            if (trace & Iy_MATRIX) SAFE_ADD(Iy_temp, count);
+            M_temp = M_counts[j];
+            M_counts[j] = count;
+            count = 0;
+            trace = gaps[i][j].Ix;
+            if (trace & M_MATRIX) SAFE_ADD(M_temp, count);
+            if (trace & Ix_MATRIX) SAFE_ADD(Ix_counts[j], count);
+            if (trace & Iy_MATRIX) SAFE_ADD(Iy_counts[j], count);
+            Ix_temp = Ix_counts[j];
+            Ix_counts[j] = count;
+            count = 0;
+            trace = gaps[i][j].Iy;
+            if (trace & M_MATRIX) SAFE_ADD(M_counts[j-1], count);
+            if (trace & Ix_MATRIX) SAFE_ADD(Ix_counts[j-1], count);
+            if (trace & Iy_MATRIX) SAFE_ADD(Iy_counts[j-1], count);
+            Iy_temp = Iy_counts[j];
+            Iy_counts[j] = count;
+        }
+    }
+    count = 0;
+    if (M[nA][nB].trace) SAFE_ADD(M_counts[nB], count);
+    if (gaps[nA][nB].Ix) SAFE_ADD(Ix_counts[nB], count);
+    if (gaps[nA][nB].Iy) SAFE_ADD(Iy_counts[nB], count);
+exit:
+    if (M_counts) PyMem_Free(M_counts);
+    if (Ix_counts) PyMem_Free(Ix_counts);
+    if (Iy_counts) PyMem_Free(Iy_counts);
+    return count;
+}
+
+static Py_ssize_t
+PathGenerator_gotoh_local_length(PathGenerator* self)
+{
+    int i;
+    int j;
+    int trace;
+    const int nA = self->nA;
+    const int nB = self->nB;
+    Trace** M = self->M;
+    TraceGapsGotoh** gaps = self->gaps.gotoh;
+    Py_ssize_t term;
+    Py_ssize_t count = MEMORY_ERROR;
+    Py_ssize_t total = 0;
+    Py_ssize_t M_temp;
+    Py_ssize_t Ix_temp;
+    Py_ssize_t Iy_temp;
+    Py_ssize_t* M_counts = NULL;
+    Py_ssize_t* Ix_counts = NULL;
+    Py_ssize_t* Iy_counts = NULL;
+    M_counts = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+    if (!M_counts) goto exit;
+    Ix_counts = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+    if (!Ix_counts) goto exit;
+    Iy_counts = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+    if (!Iy_counts) goto exit;
+    M_counts[0] = 1;
+    Ix_counts[0] = 0;
+    Iy_counts[0] = 0;
+    for (j = 1; j <= nB; j++) {
+        M_counts[j] = 1;
+        Ix_counts[j] = 0;
+        Iy_counts[j] = 0;
+    }
+    for (i = 1; i <= nA; i++) {
+        M_temp = M_counts[0];
+        M_counts[0] = 1;
+        Ix_temp = Ix_counts[0];
+        Ix_counts[0] = 0;
+        Iy_temp = Iy_counts[0];
+        Iy_counts[0] = 0;
+        for (j = 1; j <= nB; j++) {
+            count = 0;
+            trace = M[i][j].trace;
+            if (trace & M_MATRIX) SAFE_ADD(M_temp, count);
+            if (trace & Ix_MATRIX) SAFE_ADD(Ix_temp, count);
+            if (trace & Iy_MATRIX) SAFE_ADD(Iy_temp, count);
+            if (count == 0) count = 1;
+            M_temp = M_counts[j];
+            M_counts[j] = count;
+            if (M[i][j].trace & ENDPOINT) SAFE_ADD(count, total);
+            count = 0;
+            trace = gaps[i][j].Ix;
+            if (trace & M_MATRIX) SAFE_ADD(M_temp, count);
+            if (trace & Ix_MATRIX) SAFE_ADD(Ix_counts[j], count);
+            if (trace & Iy_MATRIX) SAFE_ADD(Iy_counts[j], count);
+            Ix_temp = Ix_counts[j];
+            Ix_counts[j] = count;
+            count = 0;
+            trace = gaps[i][j].Iy;
+            if (trace & M_MATRIX) SAFE_ADD(M_counts[j-1], count);
+            if (trace & Ix_MATRIX) SAFE_ADD(Ix_counts[j-1], count);
+            if (trace & Iy_MATRIX) SAFE_ADD(Iy_counts[j-1], count);
+            Iy_temp = Iy_counts[j];
+            Iy_counts[j] = count;
+        }
+    }
+    count = total;
+exit:
+    if (M_counts) PyMem_Free(M_counts);
+    if (Ix_counts) PyMem_Free(Ix_counts);
+    if (Iy_counts) PyMem_Free(Iy_counts);
+    return count;
+}
+
+static Py_ssize_t
+PathGenerator_waterman_smith_beyer_global_length(PathGenerator* self)
+{
+    int i;
+    int j;
+    int trace;
+    int* p;
+    int gap;
+    const int nA = self->nA;
+    const int nB = self->nB;
+    Trace** M = self->M;
+    TraceGapsWatermanSmithBeyer** gaps = self->gaps.waterman_smith_beyer;
+    Py_ssize_t count = MEMORY_ERROR;
+    Py_ssize_t term;
+    Py_ssize_t** M_count = NULL;
+    Py_ssize_t** Ix_count = NULL;
+    Py_ssize_t** Iy_count = NULL;
+    M_count = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
+    if (!M_count) goto exit;
+    Ix_count = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
+    if (!Ix_count) goto exit;
+    Iy_count = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
+    if (!Iy_count) goto exit;
+    for (i = 0; i <= nA; i++) {
+        M_count[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+        if (!M_count[i]) goto exit;
+        Ix_count[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+        if (!Ix_count[i]) goto exit;
+        Iy_count[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+        if (!Iy_count[i]) goto exit;
+    }
+    for (i = 0; i <= nA; i++) {
+        for (j = 0; j <= nB; j++) {
+            count = 0;
+            trace = M[i][j].trace;
+            if (trace & M_MATRIX) SAFE_ADD(M_count[i-1][j-1], count);
+            if (trace & Ix_MATRIX) SAFE_ADD(Ix_count[i-1][j-1], count);
+            if (trace & Iy_MATRIX) SAFE_ADD(Iy_count[i-1][j-1], count);
+            if (count == 0) count = 1; /* happens at M[0][0] only */
+            M_count[i][j] = count;
+            count = 0;
+            p = gaps[i][j].MIx;
+            if (p) {
+                while (1) {
+                    gap = *p;
+                    if (!gap) break;
+                    SAFE_ADD(M_count[i-gap][j], count);
+                    p++;
+                }
+            }
+            p = gaps[i][j].IyIx;
+            if (p) {
+                while (1) {
+                    gap = *p;
+                    if (!gap) break;
+                    SAFE_ADD(Iy_count[i-gap][j], count);
+                    p++;
+                }
+            }
+            Ix_count[i][j] = count;
+            count = 0;
+            p = gaps[i][j].MIy;
+            if (p) {
+                while (1) {
+                    gap = *p;
+                    if (!gap) break;
+                    SAFE_ADD(M_count[i][j-gap], count);
+                    p++;
+                }
+            }
+	    p = gaps[i][j].IxIy;
+            if (p) {
+                while (1) {
+                    gap = *p;
+                    if (!gap) break;
+                    SAFE_ADD(Ix_count[i][j-gap], count);
+                    p++;
+                }
+            }
+            Iy_count[i][j] = count;
+        }
+    }
+    count = 0;
+    if (M[nA][nB].trace)
+        SAFE_ADD(M_count[nA][nB], count);
+    if (gaps[nA][nB].MIx[0] || gaps[nA][nB].IyIx[0])
+        SAFE_ADD(Ix_count[nA][nB], count);
+    if (gaps[nA][nB].MIy[0] || gaps[nA][nB].IxIy[0])
+        SAFE_ADD(Iy_count[nA][nB], count);
+exit:
+    if (M_count) {
+        if (Ix_count) {
+            if (Iy_count) {
+                for (i = 0; i <= nA; i++) {
+                    if (!M_count[i]) break;
+                    PyMem_Free(M_count[i]);
+                    if (!Ix_count[i]) break;
+                    PyMem_Free(Ix_count[i]);
+                    if (!Iy_count[i]) break;
+                    PyMem_Free(Iy_count[i]);
+                }
+                PyMem_Free(Iy_count);
+            }
+            PyMem_Free(Ix_count);
+        }
+        PyMem_Free(M_count);
+    }
+    return count;
+}
+
+static Py_ssize_t
+PathGenerator_waterman_smith_beyer_local_length(PathGenerator* self)
+{
+    int i;
+    int j;
+    int trace;
+    int* p;
+    int gap;
+    const int nA = self->nA;
+    const int nB = self->nB;
+    Trace** M = self->M;
+    TraceGapsWatermanSmithBeyer** gaps = self->gaps.waterman_smith_beyer;
+    Py_ssize_t term;
+    Py_ssize_t count = MEMORY_ERROR;
+    Py_ssize_t total = 0;
+    Py_ssize_t** M_count = NULL;
+    Py_ssize_t** Ix_count = NULL;
+    Py_ssize_t** Iy_count = NULL;
+    M_count = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
+    if (!M_count) goto exit;
+    Ix_count = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
+    if (!Ix_count) goto exit;
+    Iy_count = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
+    if (!Iy_count) goto exit;
+    for (i = 0; i <= nA; i++) {
+        M_count[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+        if (!M_count[i]) goto exit;
+        Ix_count[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+        if (!Ix_count[i]) goto exit;
+        Iy_count[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
+        if (!Iy_count[i]) goto exit;
+    }
+    for (i = 0; i <= nA; i++) {
+        for (j = 0; j <= nB; j++) {
+            count = 0;
+            trace = M[i][j].trace;
+            if (trace & M_MATRIX) SAFE_ADD(M_count[i-1][j-1], count);
+            if (trace & Ix_MATRIX) SAFE_ADD(Ix_count[i-1][j-1], count);
+            if (trace & Iy_MATRIX) SAFE_ADD(Iy_count[i-1][j-1], count);
+            if (count == 0) count = 1;
+            M_count[i][j] = count;
+            if (M[i][j].trace & ENDPOINT) SAFE_ADD(count, total);
+            count = 0;
+            p = gaps[i][j].MIx;
+            if (p) {
+                while (1) {
+                    gap = *p;
+                    if (!gap) break;
+                    SAFE_ADD(M_count[i-gap][j], count);
+                    p++;
+                }
+            }
+            p = gaps[i][j].IyIx;
+            if (p) {
+                while (1) {
+                    gap = *p;
+                    if (!gap) break;
+                    SAFE_ADD(Iy_count[i-gap][j], count);
+                    p++;
+                }
+            }
+            if (count == 0) count = 1;
+            Ix_count[i][j] = count;
+            count = 0;
+            p = gaps[i][j].MIy;
+            if (p) {
+                while (1) {
+                    gap = *p;
+                    if (!gap) break;
+                    SAFE_ADD(M_count[i][j-gap], count);
+                    p++;
+                }
+            }
+            p = gaps[i][j].IxIy;
+            if (p) {
+                while (1) {
+                    gap = *p;
+                    if (!gap) break;
+                    SAFE_ADD(Ix_count[i][j-gap], count);
+                    p++;
+                }
+            }
+            if (count == 0) count = 1;
+            Iy_count[i][j] = count;
+        }
+    }
+    count = total;
+exit:
+    if (M_count) {
+        if (Ix_count) {
+            if (Iy_count) {
+                for (i = 0; i <= nA; i++) {
+                    if (!M_count[i]) break;
+                    PyMem_Free(M_count[i]);
+                    if (!Ix_count[i]) break;
+                    PyMem_Free(Ix_count[i]);
+                    if (!Iy_count[i]) break;
+                    PyMem_Free(Iy_count[i]);
+                }
+                PyMem_Free(Iy_count);
+            }
+            PyMem_Free(Ix_count);
+        }
+        PyMem_Free(M_count);
+    }
+    return count;
+}
+
+static Py_ssize_t PathGenerator_length(PathGenerator* self) {
+    Py_ssize_t length = self->length;
+    if (length == 0) {
+        switch (self->algorithm) {
+            case NeedlemanWunschSmithWaterman:
+                switch (self->mode) {
+                    case Global:
+                        length = PathGenerator_needlemanwunsch_length(self);
+                        break;
+                    case Local:
+                        length = PathGenerator_smithwaterman_length(self);
+                        break;
+                    default:
+                        /* should not happen, but some compilers complain that
+                         * that length can be used uninitialized.
+                         */
+                        PyErr_SetString(PyExc_RuntimeError, "Unknown mode");
+                        return -1;
+                }
+                break;
+            case Gotoh:
+                switch (self->mode) {
+                    case Global:
+                        length = PathGenerator_gotoh_global_length(self);
+                        break;
+                    case Local:
+                        length = PathGenerator_gotoh_local_length(self);
+                        break;
+                    default:
+                        /* should not happen, but some compilers complain that
+                         * that length can be used uninitialized.
+                         */
+                        PyErr_SetString(PyExc_RuntimeError, "Unknown mode");
+                        return -1;
+                }
+                break;
+            case WatermanSmithBeyer:
+                switch (self->mode) {
+                    case Global:
+                        length = PathGenerator_waterman_smith_beyer_global_length(self);
+                        break;
+                    case Local:
+                        length = PathGenerator_waterman_smith_beyer_local_length(self);
+                        break;
+                    default:
+                        /* should not happen, but some compilers complain that
+                         * that length can be used uninitialized.
+                         */
+                        PyErr_SetString(PyExc_RuntimeError, "Unknown mode");
+                        return -1;
+                }
+                break;
+            case Unknown:
+            default:
+                PyErr_SetString(PyExc_RuntimeError, "Unknown algorithm");
+                return -1;
+        }
+        self->length = length;
+    }
+    switch (length) {
+        case OVERFLOW_ERROR:
+            PyErr_Format(PyExc_OverflowError,
+                         "number of optimal alignments is larger than %zd",
+                         PY_SSIZE_T_MAX);
+            break;
+        case MEMORY_ERROR:
+            PyErr_SetNone(PyExc_MemoryError);
+            break;
+        default:
+            break;
+    }
+    return length;
+}
+
+static void
+PathGenerator_dealloc(PathGenerator* self)
+{
+    int i;
+    const int nA = self->nA;
+    const Algorithm algorithm = self->algorithm;
+    Trace** M = self->M;
+    if (M) {
+        for (i = 0; i <= nA; i++) {
+            if (!M[i]) break;
+            PyMem_Free(M[i]);
+        }
+        PyMem_Free(M);
+    }
+    switch (algorithm) {
+        case NeedlemanWunschSmithWaterman:
+            break;
+        case Gotoh: {
+            TraceGapsGotoh** gaps = self->gaps.gotoh;
+            if (gaps) {
+                for (i = 0; i <= nA; i++) {
+                    if (!gaps[i]) break;
+                    PyMem_Free(gaps[i]);
+                }
+                PyMem_Free(gaps);
+            }
+            break;
+        }
+        case WatermanSmithBeyer: {
+            TraceGapsWatermanSmithBeyer** gaps = self->gaps.waterman_smith_beyer;
+            if (gaps) {
+                int j;
+                const int nB = self->nB;
+                int* trace;
+                for (i = 0; i <= nA; i++) {
+                    if (!gaps[i]) break;
+                    for (j = 0; j <= nB; j++) {
+                        trace = gaps[i][j].MIx;
+                        if (trace) PyMem_Free(trace);
+                        trace = gaps[i][j].IyIx;
+                        if (trace) PyMem_Free(trace);
+                        trace = gaps[i][j].MIy;
+                        if (trace) PyMem_Free(trace);
+                        trace = gaps[i][j].IxIy;
+                        if (trace) PyMem_Free(trace);
+                    }
+                    PyMem_Free(gaps[i]);
+                }
+                PyMem_Free(gaps);
+            }
+            break;
+        }
+        case Unknown:
+        default:
+            PyErr_WriteUnraisable((PyObject*)self);
+            break;
+    }
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static PyObject* PathGenerator_next_needlemanwunsch(PathGenerator* self)
+{
+    int i = 0;
+    int j = 0;
+    int path;
+    int trace = 0;
+    const int nA = self->nA;
+    const int nB = self->nB;
+    Trace** M = self->M;
+
+    path = M[i][j].path;
+    if (path == DONE) return NULL;
+    if (path == 0) {
+        /* Generate the first path. */
+        i = nA;
+        j = nB;
+    }
+    else {
+        /* We already have a path. Prune the path to see if there are
+         * any alternative paths. */
+        while (1) {
+            if (path == HORIZONTAL) {
+                trace = M[i][++j].trace;
+                if (trace & VERTICAL) {
+                    M[--i][j].path = VERTICAL;
+                    break;
+                }
+                if (trace & DIAGONAL) {
+                    M[--i][--j].path = DIAGONAL;
+                    break;
+                }
+            }
+            else if (path == VERTICAL) {
+                trace = M[++i][j].trace;
+                if (trace & DIAGONAL) {
+                    M[--i][--j].path = DIAGONAL;
+                    break;
+                }
+            }
+            else /* DIAGONAL */ {
+                i++;
+                j++;
+            }
+            path = M[i][j].path;
+            if (!path) {
+                /* we reached the end of the alignment without finding
+                 * an alternative path */
+                M[0][0].path = DONE;
+                return NULL;
+            }
+        }
+    }
+    /* Follow the traceback until we reach the origin. */
+    while (1) {
+        trace = M[i][j].trace;
+        if (trace & HORIZONTAL) M[i][--j].path = HORIZONTAL;
+        else if (trace & VERTICAL) M[--i][j].path = VERTICAL;
+        else if (trace & DIAGONAL) M[--i][--j].path = DIAGONAL;
+        else break;
+    }
+    return _create_path(M, 0, 0);
+}
+
+static PyObject* PathGenerator_next_smithwaterman(PathGenerator* self)
+{
+    int trace = 0;
+    int i = self->iA;
+    int j = self->iB;
+    const int nA = self->nA;
+    const int nB = self->nB;
+    Trace** M = self->M;
+    int path = M[0][0].path;
+
+    if (path == DONE || path == NONE) return NULL;
+
+    path = M[i][j].path;
+    if (path) {
+        /* We already have a path. Prune the path to see if there are
+         * any alternative paths. */
+        while (1) {
+            if (path == HORIZONTAL) {
+                trace = M[i][++j].trace;
+                if (trace & VERTICAL) {
+                    M[--i][j].path = VERTICAL;
+                    break;
+                }
+                else if (trace & DIAGONAL) {
+                    M[--i][--j].path = DIAGONAL;
+                    break;
+                }
+            }
+            else if (path == VERTICAL) {
+                trace = M[++i][j].trace;
+                if (trace & DIAGONAL) {
+                    M[--i][--j].path = DIAGONAL;
+                    break;
+                }
+            }
+            else /* DIAGONAL */ {
+                i++;
+                j++;
+            }
+            path = M[i][j].path;
+            if (!path) break;
+        }
+    }
+
+    if (path) {
+        trace = M[i][j].trace;
+    } else {
+        /* Find a suitable end point for a path.
+         * Only allow start points ending at the M matrix. */
+        while (1) {
+            if (j < nB) j++;
+            else if (i < nA) {
+                i++;
+                j = 0;
+            }
+            else {
+                /* we reached the end of the sequences without finding
+                 * an alternative path */
+                M[0][0].path = DONE;
+                return NULL;
+            }
+            trace = M[i][j].trace;
+            if (trace & ENDPOINT) {
+                trace &= DIAGONAL; /* exclude paths ending in a gap */
+                break;
+            }
+        }
+        M[i][j].path = 0;
+    }
+
+    /* Follow the traceback until we reach the origin. */
+    while (1) {
+        if (trace & HORIZONTAL) M[i][--j].path = HORIZONTAL;
+        else if (trace & VERTICAL) M[--i][j].path = VERTICAL;
+        else if (trace & DIAGONAL) M[--i][--j].path = DIAGONAL;
+        else break;
+        trace = M[i][j].trace;
+    }
+    self->iA = i;
+    self->iB = j;
+    return _create_path(M, i, j);
+}
+
+static PyObject* PathGenerator_next_gotoh_global(PathGenerator* self)
+{
+    int i = 0;
+    int j = 0;
+    int m;
+    int path;
+    int trace = 0;
+    const int nA = self->nA;
+    const int nB = self->nB;
+    Trace** M = self->M;
+    TraceGapsGotoh** gaps = self->gaps.gotoh;
+
+    m = M_MATRIX;
+    path = M[i][j].path;
+    if (path == DONE) return NULL;
+    if (path == 0) {
+        i = nA;
+        j = nB;
+    }
+    else {
+        /* We already have a path. Prune the path to see if there are
+         * any alternative paths. */
+        while (1) {
+            path = M[i][j].path;
+            if (path == 0) {
+                switch (m) {
+                    case M_MATRIX: m = Ix_MATRIX; break;
+                    case Ix_MATRIX: m = Iy_MATRIX; break;
+                    case Iy_MATRIX: m = 0; break;
+                }
+                break;
+            }
+            switch (path) {
+                case HORIZONTAL: trace = gaps[i][++j].Iy; break;
+                case VERTICAL: trace = gaps[++i][j].Ix; break;
+                case DIAGONAL: trace = M[++i][++j].trace; break;
+            }
+            switch (m) {
+                case M_MATRIX:
+                    if (trace & Ix_MATRIX) {
+                        m = Ix_MATRIX;
+                        break;
+                    }
+                case Ix_MATRIX:
+                    if (trace & Iy_MATRIX) {
+                        m = Iy_MATRIX;
+                        break;
+                    }
+                case Iy_MATRIX:
+                default:
+                    switch (path) {
+                        case HORIZONTAL: m = Iy_MATRIX; break;
+                        case VERTICAL: m = Ix_MATRIX; break;
+                        case DIAGONAL: m = M_MATRIX; break;
+                    }
+                    continue;
+            }
+            switch (path) {
+                case HORIZONTAL: j--; break;
+                case VERTICAL: i--; break;
+                case DIAGONAL: i--; j--; break;
+            }
+            M[i][j].path = path;
+            break;
+        }
+    }
+
+    if (path == 0) {
+        /* Generate a new path. */
+        switch (m) {
+            case M_MATRIX:
+                if (M[nA][nB].trace) {
+                   /* m = M_MATRIX; */
+                   break;
+                }
+            case Ix_MATRIX:
+                if (gaps[nA][nB].Ix) {
+                   m = Ix_MATRIX;
+                   break;
+                }
+            case Iy_MATRIX:
+                if (gaps[nA][nB].Iy) {
+                   m = Iy_MATRIX;
+                   break;
+                }
+            default:
+                /* exhausted this generator */
+                M[0][0].path = DONE;
+                return NULL;
+        }
+    }
+
+    switch (m) {
+        case M_MATRIX:
+            trace = M[i][j].trace;
+            path = DIAGONAL;
+            i--; j--;
+            break;
+        case Ix_MATRIX:
+            trace = gaps[i][j].Ix;
+            path = VERTICAL;
+            i--;
+            break;
+        case Iy_MATRIX:
+            trace = gaps[i][j].Iy;
+            path = HORIZONTAL;
+            j--;
+            break;
+    }
+
+    while (1) {
+        if (trace & M_MATRIX) {
+            trace = M[i][j].trace;
+            M[i][j].path = path;
+            path = DIAGONAL;
+            i--; j--;
+        }
+        else if (trace & Ix_MATRIX) {
+            M[i][j].path = path;
+            trace = gaps[i][j].Ix;
+            path = VERTICAL;
+            i--;
+        }
+        else if (trace & Iy_MATRIX) {
+            M[i][j].path = path;
+            trace = gaps[i][j].Iy;
+            path = HORIZONTAL;
+            j--;
+        }
+        else break;
+    }
+    return _create_path(M, 0, 0);
+}
+
+static PyObject* PathGenerator_next_gotoh_local(PathGenerator* self)
+{
+    int trace = 0;
+    int i;
+    int j;
+    int m = M_MATRIX;
+    int iA = self->iA;
+    int iB = self->iB;
+    const int nA = self->nA;
+    const int nB = self->nB;
+    Trace** M = self->M;
+    TraceGapsGotoh** gaps = self->gaps.gotoh;
+    int path = M[0][0].path;
+
+    if (path == DONE) return NULL;
+
+    path = M[iA][iB].path;
+
+    if (path) {
+        i = iA;
+        j = iB;
+        while (1) {
+            /* We already have a path. Prune the path to see if there are
+             * any alternative paths. */
+            path = M[i][j].path;
+            if (path == 0) {
+                m = M_MATRIX;
+                iA = i;
+                iB = j;
+                break;
+            }
+            switch (path) {
+                case HORIZONTAL: trace = gaps[i][++j].Iy; break;
+                case VERTICAL: trace = gaps[++i][j].Ix; break;
+                case DIAGONAL: trace = M[++i][++j].trace; break;
+            }
+            switch (m) {
+                case M_MATRIX:
+                    if (trace & Ix_MATRIX) {
+                        m = Ix_MATRIX;
+                        break;
+                    }
+                case Ix_MATRIX:
+                    if (trace & Iy_MATRIX) {
+                        m = Iy_MATRIX;
+                        break;
+                    }
+                case Iy_MATRIX:
+                default:
+                    switch (path) {
+                        case HORIZONTAL: m = Iy_MATRIX; break;
+                        case VERTICAL: m = Ix_MATRIX; break;
+                        case DIAGONAL: m = M_MATRIX; break;
+                    }
+                    continue;
+            }
+            switch (path) {
+                case HORIZONTAL: j--; break;
+                case VERTICAL: i--; break;
+                case DIAGONAL: i--; j--; break;
+            }
+            M[i][j].path = path;
+            break;
+        }
+    }
+
+    if (path == 0) {
+        /* Find the end point for a new path. */
+        while (1) {
+            if (iB < nB) iB++;
+            else if (iA < nA) {
+                iA++;
+                iB = 0;
+            }
+            else {
+                /* we reached the end of the alignment without finding
+                 * an alternative path */
+                M[0][0].path = DONE;
+                return NULL;
+            }
+            if (M[iA][iB].trace & ENDPOINT) {
+                M[iA][iB].path = 0;
+                break;
+            }
+        }
+        m = M_MATRIX;
+        i = iA;
+        j = iB;
+    }
+
+    while (1) {
+        switch (m) {
+            case M_MATRIX: trace = M[i][j].trace; break;
+            case Ix_MATRIX: trace = gaps[i][j].Ix; break;
+            case Iy_MATRIX: trace = gaps[i][j].Iy; break;
+        }
+        if (trace == 0) {
+            self->iA = i;
+            self->iB = j;
+            return _create_path(M, i, j);
+        }
+        switch (m) {
+            case M_MATRIX:
+                path = DIAGONAL;
+                i--;
+                j--;
+                break;
+            case Ix_MATRIX:
+                path = VERTICAL;
+                i--;
+                break;
+            case Iy_MATRIX:
+                path = HORIZONTAL;
+                j--;
+                break;
+        }
+        if (trace & M_MATRIX) m = M_MATRIX;
+        else if (trace & Ix_MATRIX) m = Ix_MATRIX;
+        else if (trace & Iy_MATRIX) m = Iy_MATRIX;
+        M[i][j].path = path;
+    }
+    return NULL;
+}
+
+static PyObject*
+PathGenerator_next_waterman_smith_beyer_global(PathGenerator* self)
+{
+    int i = 0, j = 0;
+    int iA, iB;
+    int trace;
+    int* gapM;
+    int* gapXY;
+
+    int m = M_MATRIX;
+    const int nA = self->nA;
+    const int nB = self->nB;
+    Trace** M = self->M;
+    TraceGapsWatermanSmithBeyer** gaps = self->gaps.waterman_smith_beyer;
+
+    int gap;
+    int path = M[0][0].path;
+
+    if (path == DONE) return NULL;
+
+    if (path) {
+        /* We already have a path. Prune the path to see if there are
+         * any alternative paths. */
+        while (1) {
+            if (!path) {
+                m <<= 1;
+                break;
+            }
+            switch (path) {
+                case HORIZONTAL:
+                    iA = i;
+                    iB = j;
+                    while (M[i][iB].path == HORIZONTAL) iB++;
+                    break;
+                case VERTICAL:
+                    iA = i;
+                    while (M[iA][j].path == VERTICAL) iA++;
+                    iB = j;
+                    break;
+                case DIAGONAL:
+                    iA = i + 1;
+                    iB = j + 1;
+                    break;
+                default:
+                    PyErr_SetString(PyExc_RuntimeError,
+                        "Unexpected path in PathGenerator_next_waterman_smith_beyer_global");
+                    return NULL;
+            }
+            if (i == iA) { /* HORIZONTAL */
+                gapM = gaps[iA][iB].MIy;
+                gapXY = gaps[iA][iB].IxIy;
+                if (m == M_MATRIX) {
+                    gap = iB - j;
+                    while (*gapM != gap) gapM++;
+                    gapM++;
+                    gap = *gapM;
+                    if (gap) {
+                        j = iB - gap;
+                        while (j < iB) M[i][--iB].path = HORIZONTAL;
+                        break;
+                    }
+                } else if (m == Ix_MATRIX) {
+                    gap = iB - j;
+                    while (*gapXY != gap) gapXY++;
+                    gapXY++;
+                }
+                gap = *gapXY;
+                if (gap) {
+                    m = Ix_MATRIX;
+                    j = iB - gap;
+                    while (j < iB) M[i][--iB].path = HORIZONTAL;
+                    break;
+                }
+                /* no alternative found; continue pruning */
+                m = Iy_MATRIX;
+                j = iB;
+            }
+            else if (j == iB) { /* VERTICAL */
+                gapM = gaps[iA][iB].MIx;
+                gapXY = gaps[iA][iB].IyIx;
+                if (m == M_MATRIX) {
+                    gap = iA - i;
+                    while (*gapM != gap) gapM++;
+                    gapM++;
+                    gap = *gapM;
+                    if (gap) {
+                        i = iA - gap;
+                        while (i < iA) M[--iA][j].path = VERTICAL;
+                        break;
+                    }
+                } else if (m == Iy_MATRIX) {
+                    gap = iA - i;
+                    while (*gapXY != gap) gapXY++;
+                    gapXY++;
+                }
+                gap = *gapXY;
+                if (gap) {
+                    m = Iy_MATRIX;
+                    i = iA - gap;
+                    while (i < iA) M[--iA][j].path = VERTICAL;
+                    break;
+                }
+                /* no alternative found; continue pruning */
+                m = Ix_MATRIX;
+                i = iA;
+            }
+            else { /* DIAGONAL */
+                i = iA - 1;
+                j = iB - 1;
+                trace = M[iA][iB].trace;
+                switch (m) {
+                    case M_MATRIX:
+                        if (trace & Ix_MATRIX) {
+                            m = Ix_MATRIX;
+                            M[i][j].path = DIAGONAL;
+                            break;
+                        }
+                    case Ix_MATRIX:
+                        if (trace & Iy_MATRIX) {
+                            m = Iy_MATRIX;
+                            M[i][j].path = DIAGONAL;
+                            break;
+                        }
+                    case Iy_MATRIX:
+                    default:
+                        /* no alternative found; continue pruning */
+                        m = M_MATRIX;
+                        i = iA;
+                        j = iB;
+                        path = M[i][j].path;
+                        continue;
+                }
+                /* alternative found; build path until starting point */
+                break;
+            }
+            path = M[i][j].path;
+        }
+    }
+
+    if (!path) {
+        /* Find a suitable end point for a path. */
+        switch (m) {
+            case M_MATRIX:
+                if (M[nA][nB].trace) {
+                    /* m = M_MATRIX; */
+                    break;
+                }
+            case Ix_MATRIX:
+                if (gaps[nA][nB].MIx[0] || gaps[nA][nB].IyIx[0]) {
+                    m = Ix_MATRIX;
+                    break;
+                }
+            case Iy_MATRIX:
+                if (gaps[nA][nB].MIy[0] || gaps[nA][nB].IxIy[0]) {
+                    m = Iy_MATRIX;
+                    break;
+                }
+            default:
+                M[0][0].path = DONE;
+                return NULL;
+        }
+        i = nA;
+        j = nB;
+    }
+
+    /* Follow the traceback until we reach the origin. */
+    while (1) {
+        switch (m) {
+            case M_MATRIX:
+                trace = M[i][j].trace;
+                if (trace & M_MATRIX) m = M_MATRIX;
+                else if (trace & Ix_MATRIX) m = Ix_MATRIX;
+                else if (trace & Iy_MATRIX) m = Iy_MATRIX;
+                else return _create_path(M, i, j);
+                i--;
+                j--;
+                M[i][j].path = DIAGONAL;
+                break;
+            case Ix_MATRIX:
+                gap = gaps[i][j].MIx[0];
+                if (gap) m = M_MATRIX;
+                else {
+                    gap = gaps[i][j].IyIx[0];
+                    m = Iy_MATRIX;
+                }
+                iA = i - gap;
+                while (iA < i) M[--i][j].path = VERTICAL;
+                M[i][j].path = VERTICAL;
+                break;
+            case Iy_MATRIX:
+                gap = gaps[i][j].MIy[0];
+                if (gap) m = M_MATRIX;
+                else {
+                    gap = gaps[i][j].IxIy[0];
+                    m = Ix_MATRIX;
+                }
+                iB = j - gap;
+                while (iB < j) M[i][--j].path = HORIZONTAL;
+                M[i][j].path = HORIZONTAL;
+                break;
+        }
+    }
+}
+
+static PyObject*
+PathGenerator_next_waterman_smith_beyer_local(PathGenerator* self)
+{
+    int i, j, m;
+    int trace = 0;
+    int* gapM;
+    int* gapXY;
+
+    int iA = self->iA;
+    int iB = self->iB;
+    const int nA = self->nA;
+    const int nB = self->nB;
+    Trace** M = self->M;
+    TraceGapsWatermanSmithBeyer** gaps = self->gaps.waterman_smith_beyer;
+
+    int gap;
+    int path = M[0][0].path;
+
+    if (path == DONE) return NULL;
+    m = 0;
+    path = M[iA][iB].path;
+    if (path) {
+        /* We already have a path. Prune the path to see if there are
+         * any alternative paths. */
+        m = M_MATRIX;
+        i = iA;
+        j = iB;
+        while (1) {
+            path = M[i][j].path;
+            switch (path) {
+                case HORIZONTAL:
+                    iA = i;
+                    iB = j;
+                    while (M[i][iB].path == HORIZONTAL) iB++;
+                    break;
+                case VERTICAL:
+                    iA = i;
+                    iB = j;
+                    while (M[iA][j].path == VERTICAL) iA++;
+                    break;
+                case DIAGONAL:
+                    iA = i + 1;
+                    iB = j + 1;
+                    break;
+                default:
+                    iA = -1;
+                    break;
+            }
+            if (iA < 0) {
+                m = 0;
+                iA = i;
+                iB = j;
+                break;
+            }
+            if (i == iA) { /* HORIZONTAL */
+                gapM = gaps[iA][iB].MIy;
+                gapXY = gaps[iA][iB].IxIy;
+                if (m == M_MATRIX) {
+                    gap = iB - j;
+                    while (*gapM != gap) gapM++;
+                    gapM++;
+                    gap = *gapM;
+                    if (gap) {
+                        j = iB - gap;
+                        while (j < iB) M[i][--iB].path = HORIZONTAL;
+                        break;
+                    }
+                } else if (m == Ix_MATRIX) {
+                    gap = iB - j;
+                    while (*gapXY != gap) gapXY++;
+                    gapXY++;
+                }
+                gap = *gapXY;
+                if (gap) {
+                    m = Ix_MATRIX;
+                    j = iB - gap;
+                    M[i][j].path = HORIZONTAL;
+                    while (iB > j) M[i][--iB].path = HORIZONTAL;
+                    break;
+                }
+                /* no alternative found; continue pruning */
+                m = Iy_MATRIX;
+                j = iB;
+            }
+            else if (j == iB) { /* VERTICAL */
+                gapM = gaps[iA][iB].MIx;
+                gapXY = gaps[iA][iB].IyIx;
+                if (m == M_MATRIX) {
+                    gap = iA - i;
+                    while (*gapM != gap) gapM++;
+                    gapM++;
+                    gap = *gapM;
+                    if (gap) {
+                        i = iA - gap;
+                        while (i < iA) M[--iA][j].path = VERTICAL;
+                        break;
+                    }
+                } else if (m == Iy_MATRIX) {
+                    gap = iA - i;
+                    while (*gapXY != gap) gapXY++;
+                    gapXY++;
+                }
+                gap = *gapXY;
+                if (gap) {
+                    m = Iy_MATRIX;
+                    i = iA - gap;
+                    M[i][j].path = VERTICAL;
+                    while (iA > i) M[--iA][j].path = VERTICAL;
+                    break;
+                }
+                /* no alternative found; continue pruning */
+                m = Ix_MATRIX;
+                i = iA;
+            }
+            else { /* DIAGONAL */
+                i = iA - 1;
+                j = iB - 1;
+                trace = M[iA][iB].trace;
+                switch (m) {
+                    case M_MATRIX:
+                        if (trace & Ix_MATRIX) {
+                            m = Ix_MATRIX;
+                            M[i][j].path = DIAGONAL;
+                            break;
+                        }
+                    case Ix_MATRIX:
+                        if (trace & Iy_MATRIX) {
+                            m = Iy_MATRIX;
+                            M[i][j].path = DIAGONAL;
+                            break;
+                        }
+                    case Iy_MATRIX:
+                    default:
+                        /* no alternative found; continue pruning */
+                        m = M_MATRIX;
+                        i = iA;
+                        j = iB;
+                        continue;
+                }
+                /* alternative found; build path until starting point */
+                break;
+            }
+        }
+    }
+ 
+    if (m == 0) {
+        /* We are at [nA][nB]. Find a suitable end point for a path. */
+        while (1) {
+            if (iB < nB) iB++;
+            else if (iA < nA) {
+                iA++;
+                iB = 0;
+            }
+            else {
+                /* exhausted this generator */
+                M[0][0].path = DONE;
+                return NULL;
+            }
+            if (M[iA][iB].trace & ENDPOINT) break;
+        }
+        M[iA][iB].path = 0;
+        m = M_MATRIX;
+        i = iA;
+        j = iB;
+    }
+
+    /* Follow the traceback until we reach the origin. */
+    while (1) {
+        switch (m) {
+            case Ix_MATRIX:
+                gapM = gaps[i][j].MIx;
+                gapXY = gaps[i][j].IyIx;
+                iB = j;
+                gap = *gapM;
+                if (gap) m = M_MATRIX;
+                else {
+                    gap = *gapXY;
+                    m = Iy_MATRIX;
+                }
+                iA = i - gap;
+                while (i > iA) M[--i][iB].path = VERTICAL;
+                break;
+            case Iy_MATRIX:
+                gapM = gaps[i][j].MIy;
+                gapXY = gaps[i][j].IxIy;
+                iA = i;
+                gap = *gapM;
+                if (gap) m = M_MATRIX;
+                else {
+                    gap = *gapXY;
+                    m = Ix_MATRIX;
+                }
+                iB = j - gap;
+                while (j > iB) M[iA][--j].path = HORIZONTAL;
+                break;
+            case M_MATRIX:
+                iA = i-1;
+                iB = j-1;
+                trace = M[i][j].trace;
+                if (trace & M_MATRIX) m = M_MATRIX;
+                else if (trace & Ix_MATRIX) m = Ix_MATRIX;
+                else if (trace & Iy_MATRIX) m = Iy_MATRIX;
+                else {
+                    self->iA = i;
+                    self->iB = j;
+                    return _create_path(M, i, j);
+                }
+                M[iA][iB].path = DIAGONAL;
+                break;
+        }
+        i = iA;
+        j = iB;
+    }
+}
+
+static PyObject *
+PathGenerator_next(PathGenerator* self)
+{
+    const Mode mode = self->mode;
+    const Algorithm algorithm = self->algorithm;
+    switch (algorithm) {
+        case NeedlemanWunschSmithWaterman:
+            switch (mode) {
+                case Global:
+                    return PathGenerator_next_needlemanwunsch(self);
+                case Local:
+                    return PathGenerator_next_smithwaterman(self);
+            }
+        case Gotoh:
+            switch (mode) {
+                case Global:
+                    return PathGenerator_next_gotoh_global(self);
+                case Local:
+                    return PathGenerator_next_gotoh_local(self);
+            }
+        case WatermanSmithBeyer:
+            switch (mode) {
+                case Global:
+                    return PathGenerator_next_waterman_smith_beyer_global(self);
+                case Local:
+                    return PathGenerator_next_waterman_smith_beyer_local(self);
+            }
+        case Unknown:
+        default:
+            PyErr_SetString(PyExc_RuntimeError, "Unknown algorithm");
+            return NULL;
+    }
+}
+
+static const char PathGenerator_reset__doc__[] = "reset the iterator";
+
+static PyObject*
+PathGenerator_reset(PathGenerator* self)
+{
+    switch (self->mode) {
+        case Local:
+            self->iA = 0;
+            self->iB = 0;
+        case Global: {
+            Trace** M = self->M;
+            switch (self->algorithm) {
+                case NeedlemanWunschSmithWaterman:
+                case Gotoh: {
+                    if (M[0][0].path != NONE) M[0][0].path = 0;
+                    break;
+                }
+                case WatermanSmithBeyer: {
+                    M[0][0].path = 0;
+                    break;
+                }
+                case Unknown:
+                default:
+                    break;
+            }
+        }
+    }
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyMethodDef PathGenerator_methods[] = {
+    {"reset",
+     (PyCFunction)PathGenerator_reset,
+     METH_NOARGS,
+     PathGenerator_reset__doc__
+    },
+    {NULL}  /* Sentinel */
+};
+
+static PySequenceMethods PathGenerator_as_sequence = {
+    (lenfunc)PathGenerator_length,  /* sq_length */
+    NULL,                           /* sq_concat */
+    NULL,                           /* sq_repeat */
+    NULL,                           /* sq_item */
+    NULL,                           /* sq_ass_item */
+    NULL,                           /* sq_contains */
+    NULL,                           /* sq_inplace_concat */
+    NULL,                           /* sq_inplace_repeat */
+};
+
+static PyTypeObject PathGenerator_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "Path generator",               /* tp_name */
+    sizeof(PathGenerator),          /* tp_basicsize */
+    0,                              /* tp_itemsize */
+    (destructor)PathGenerator_dealloc,  /* tp_dealloc */
+    0,                              /* tp_print */
+    0,                              /* tp_getattr */
+    0,                              /* tp_setattr */
+    0,                              /* tp_reserved */
+    0,                              /* tp_repr */
+    0,                              /* tp_as_number */
+    &PathGenerator_as_sequence,     /* tp_as_sequence */
+    0,                              /* tp_as_mapping */
+    0,                              /* tp_hash */
+    0,                              /* tp_call */
+    0,                              /* tp_str */
+    0,                              /* tp_getattro */
+    0,                              /* tp_setattro */
+    0,                              /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT,             /* tp_flags */
+    0,                              /* tp_doc */
+    0,                              /* tp_traverse */
+    0,                              /* tp_clear */
+    0,                              /* tp_richcompare */
+    0,                              /* tp_weaklistoffset */
+    PyObject_SelfIter,              /* tp_iter */
+    (iternextfunc)PathGenerator_next,      /* tp_iternext */
+    PathGenerator_methods,          /* tp_methods */
+};
 
 typedef struct {
     PyObject_HEAD
@@ -471,10 +1824,7 @@ Aligner_str(Aligner* self)
 #else
         char* s;
         PyObject* representation = PyObject_Repr(self->target_gap_function);
-        if (!representation) {
-            PyErr_SetString(PyExc_MemoryError, "Out of memory");
-            return NULL;
-        }
+        if (!representation) return PyErr_NoMemory();
         s = PyString_AsString(representation);
         n = sprintf(p, "  target gap function: %s\n", s);
         p += n;
@@ -508,10 +1858,7 @@ Aligner_str(Aligner* self)
 #else
         char* s;
         PyObject* representation = PyObject_Repr(self->query_gap_function);
-        if (!representation) {
-            PyErr_SetString(PyExc_MemoryError, "Out of memory");
-            return NULL;
-        }
+        if (!representation) return PyErr_NoMemory();
         s = PyString_AsString(representation);
         n = sprintf(p, "  query gap function: %s\n", s);
         p += n;
@@ -557,7 +1904,7 @@ Aligner_str(Aligner* self)
 #endif
 }
 
-static char Aligner_mode__doc__[] = "alignment mode (global or local)";
+static char Aligner_mode__doc__[] = "alignment mode ('global' or 'local')";
 
 static PyObject*
 Aligner_get_mode(Aligner* self, void* closure)
@@ -577,29 +1924,35 @@ static int
 Aligner_set_mode(Aligner* self, PyObject* value, void* closure)
 {
 #if PY_MAJOR_VERSION >= 3
-    if (!PyUnicode_Check(value)) {
+    if (PyUnicode_Check(value)) {
 #else
     char* mode;
-    if (!PyString_Check(value)) {
+    if (PyString_Check(value)) {
 #endif
-        PyErr_SetString(PyExc_TypeError, "invalid mode");
-        return -1;
-    }
 #if PY_MAJOR_VERSION >= 3
-    if (PyUnicode_CompareWithASCIIString(value, "global") == 0)
-       self->mode = Global;
-    else if (PyUnicode_CompareWithASCIIString(value, "local") == 0)
-       self->mode = Local;
+        if (PyUnicode_CompareWithASCIIString(value, "global") == 0) {
+            self->mode = Global;
+            return 0;
+        }
+        if (PyUnicode_CompareWithASCIIString(value, "local") == 0) {
+            self->mode = Local;
+            return 0;
+        }
 #else
-    mode = PyString_AsString(value);
-    if (strcmp(mode, "global")==0) self->mode = Global;
-    else if (strcmp(mode, "local")==0) self->mode = Local;
+        mode = PyString_AsString(value);
+        if (strcmp(mode, "global") == 0) {
+            self->mode = Global;
+            return 0;
+        }
+        if (strcmp(mode, "local") == 0) {
+            self->mode = Local;
+            return 0;
+        }
 #endif
-    else {
-        PyErr_SetString(PyExc_ValueError, "invalid mode");
-        return -1;
     }
-    return 0;
+    PyErr_SetString(PyExc_ValueError,
+                    "invalid mode (expected 'global' or 'local'");
+    return -1;
 }
 
 static char Aligner_match__doc__[] = "match score";
@@ -701,6 +2054,9 @@ Aligner_get_substitution_matrix(Aligner* self, void* closure)
                 value = PyFloat_FromDouble(self->substitution_matrix[i][j]);
                 if (!value) goto exit;
                 if (PyDict_SetItem(matrix, key, value) == -1) goto exit;
+                Py_DECREF(key);
+                Py_DECREF(value);
+                value = NULL;
             }
         }
         return matrix;
@@ -764,7 +2120,7 @@ Aligner_set_substitution_matrix(Aligner* self, PyObject* values, void* closure)
     }
     if (!self->letters) self->letters = PyMem_Malloc(n*sizeof(int));
     if (!self->letters) {
-        PyErr_SetString(PyExc_MemoryError, "Out of memory");
+        PyErr_SetNone(PyExc_MemoryError);
         return -1;
     }
     /* No errors - store the new substitution matrix */
@@ -790,8 +2146,12 @@ static PyObject*
 Aligner_get_gap_score(Aligner* self, void* closure)
 {   
     if (self->target_gap_function || self->query_gap_function) {
-        PyErr_SetString(PyExc_ValueError, "using a gap score function");
-        return NULL;
+        if (self->target_gap_function != self->query_gap_function) {
+            PyErr_SetString(PyExc_ValueError, "gap scores are different");
+            return NULL;
+        }
+        Py_INCREF(self->target_gap_function);
+        return self->target_gap_function;
     }
     else {
         const double score = self->target_open_gap_score;
@@ -1479,8 +2839,8 @@ static char Aligner_target_gap_score__doc__[] = "target gap score";
 static PyObject*
 Aligner_get_target_gap_score(Aligner* self, void* closure)
 {   if (self->target_gap_function) {
-        PyErr_SetString(PyExc_ValueError, "using a gap score function");
-        return NULL;
+        Py_INCREF(self->target_gap_function);
+        return self->target_gap_function;
     }
     else {
         const double score = self->target_open_gap_score;
@@ -1599,8 +2959,8 @@ static char Aligner_query_gap_score__doc__[] = "query gap score";
 static PyObject*
 Aligner_get_query_gap_score(Aligner* self, void* closure)
 {   if (self->query_gap_function) {
-        PyErr_SetString(PyExc_ValueError, "using a gap score function");
-        return NULL;
+        Py_INCREF(self->query_gap_function);
+        return self->query_gap_function;
     }
     else {
         const double score = self->query_open_gap_score;
@@ -2676,59 +4036,82 @@ static PyGetSetDef Aligner_getset[] = {
     if (score < 0) score = 0; \
     else if (score > maximum) maximum = score;
 
-#define SELECT_TRACE_NEEDLEMAN_WUNSCH(cell, score1, score2, score3) \
-    score = score1; \
-    trace = HORIZONTAL; \
-    temp = score2; \
+#define SELECT_TRACE_NEEDLEMAN_WUNSCH(hgap, vgap) \
+    score = temp + self->substitution_matrix[kA][kB]; \
+    trace = DIAGONAL; \
+    temp = scores[j-1] + hgap; \
+    if (temp > score + epsilon) { \
+        score = temp; \
+        trace = HORIZONTAL; \
+    } \
+    else if (temp > score - epsilon) trace |= HORIZONTAL; \
+    temp = scores[j] + vgap; \
     if (temp > score + epsilon) { \
         score = temp; \
         trace = VERTICAL; \
     } \
     else if (temp > score - epsilon) trace |= VERTICAL; \
-    temp = score3; \
-    if (temp > score + epsilon) { \
-        score = temp; \
-        trace = DIAGONAL; \
-    } \
-    else if (temp > score - epsilon) trace |= DIAGONAL; \
-    cell.score = score; \
-    cell.trace = trace;
+    temp = scores[j]; \
+    scores[j] = score; \
+    M[i][j].trace = trace;
 
-#define SELECT_TRACE_SMITH_WATERMAN_HVD(cell, score1, score2, score3) \
-    trace = HORIZONTAL; \
-    score = score1; \
-    temp = score2; \
+#define SELECT_TRACE_SMITH_WATERMAN_HVD(hgap, vgap) \
+    trace = DIAGONAL; \
+    score = temp + self->substitution_matrix[kA][kB]; \
+    temp = scores[j-1] + hgap; \
+    if (temp > score + epsilon) { \
+        score = temp; \
+        trace = HORIZONTAL; \
+    } \
+    else if (temp > score - epsilon) trace |= HORIZONTAL; \
+    temp = scores[j] + vgap; \
     if (temp > score + epsilon) { \
         score = temp; \
         trace = VERTICAL; \
     } \
     else if (temp > score - epsilon) trace |= VERTICAL; \
-    temp = score3; \
-    if (temp > score + epsilon) { \
-        score = temp; \
-        trace = DIAGONAL; \
-    } \
-    else if (temp > score - epsilon) trace |= DIAGONAL; \
     if (score < epsilon) { \
         score = 0; \
         trace = 0; \
     } \
-    cell.score = score; \
-    cell.trace = trace; \
-    if (score > maximum) maximum = score;
+    else if (trace & DIAGONAL && score > maximum - epsilon) { \
+        if (score > maximum + epsilon) { \
+            for ( ; im < i; im++, jm = 0) \
+                for ( ; jm <= nB; jm++) M[im][jm].trace &= ~ENDPOINT; \
+            for ( ; jm < j; jm++) M[im][jm].trace &= ~ENDPOINT; \
+            im = i; \
+            jm = j; \
+        } \
+        trace |= ENDPOINT; \
+    } \
+    M[i][j].trace = trace; \
+    if (score > maximum) maximum = score; \
+    temp = scores[j]; \
+    scores[j] = score;
 
-#define SELECT_TRACE_SMITH_WATERMAN_D(cell, score1) \
-    score = score1; \
+#define SELECT_TRACE_SMITH_WATERMAN_D \
+    score = temp + self->substitution_matrix[kA][kB]; \
     trace = DIAGONAL; \
     if (score < epsilon) { \
         score = 0; \
         trace = 0; \
     } \
-    cell.score = score; \
-    cell.trace = trace; \
-    if (score > maximum) maximum = score;
+    else if (trace & DIAGONAL && score > maximum - epsilon) { \
+        if (score > maximum + epsilon) { \
+            for ( ; im < i; im++, jm = 0) \
+                for ( ; jm <= nB; jm++) M[im][jm].trace &= ~ENDPOINT; \
+            for ( ; jm < j; jm++) M[im][jm].trace &= ~ENDPOINT; \
+            im = i; \
+            jm = j; \
+        } \
+        trace |= ENDPOINT; \
+    } \
+    M[i][j].trace = trace; \
+    if (score > maximum) maximum = score; \
+    temp = scores[j]; \
+    scores[j] = score
 
-#define SELECT_TRACE_GOTOH_GLOBAL_GAP(cell, score1, score2, score3) \
+#define SELECT_TRACE_GOTOH_GLOBAL_GAP(matrix, score1, score2, score3) \
     trace = M_MATRIX; \
     score = score1; \
     temp = score2; \
@@ -2743,10 +4126,57 @@ static PyGetSetDef Aligner_getset[] = {
         trace = Iy_MATRIX; \
     } \
     else if (temp > score - epsilon) trace |= Iy_MATRIX; \
-    cell.score = score; \
-    cell.trace = trace;
+    gaps[i][j].matrix = trace;
 
-#define SELECT_TRACE_GOTOH_GLOBAL_ALIGN(cell, score1, score2, score3, score4) \
+#define SELECT_TRACE_GOTOH_GLOBAL_ALIGN \
+    trace = M_MATRIX; \
+    score = M_temp; \
+    temp = Ix_temp; \
+    if (temp > score + epsilon) { \
+        score = Ix_temp; \
+        trace = Ix_MATRIX; \
+    } \
+    else if (temp > score - epsilon) trace |= Ix_MATRIX; \
+    temp = Iy_temp; \
+    if (temp > score + epsilon) { \
+        score = temp; \
+        trace = Iy_MATRIX; \
+    } \
+    else if (temp > score - epsilon) trace |= Iy_MATRIX; \
+    M[i][j].trace = trace;
+
+#define SELECT_TRACE_GOTOH_LOCAL_ALIGN \
+    trace = M_MATRIX; \
+    score = M_temp; \
+    if (Ix_temp > score + epsilon) { \
+        score = Ix_temp; \
+        trace = Ix_MATRIX; \
+    } \
+    else if (Ix_temp > score - epsilon) trace |= Ix_MATRIX; \
+    if (Iy_temp > score + epsilon) { \
+        score = Iy_temp; \
+        trace = Iy_MATRIX; \
+    } \
+    else if (Iy_temp > score - epsilon) trace |= Iy_MATRIX; \
+    score += self->substitution_matrix[kA][kB]; \
+    if (score < epsilon) { \
+        score = 0; \
+        trace = 0; \
+    } \
+    else if (score > maximum - epsilon) { \
+        if (score > maximum + epsilon) { \
+            maximum = score; \
+            for ( ; im < i; im++, jm = 0) \
+                for ( ; jm <= nB; jm++) M[im][jm].trace &= ~ENDPOINT; \
+            for ( ; jm < j; jm++) M[im][jm].trace &= ~ENDPOINT; \
+            im = i; \
+            jm = j; \
+        } \
+        trace |= ENDPOINT; \
+    } \
+    M[i][j].trace = trace;
+
+#define SELECT_TRACE_GOTOH_LOCAL_GAP(matrix, score1, score2, score3) \
     trace = M_MATRIX; \
     score = score1; \
     temp = score2; \
@@ -2761,31 +4191,53 @@ static PyGetSetDef Aligner_getset[] = {
         trace = Iy_MATRIX; \
     } \
     else if (temp > score - epsilon) trace |= Iy_MATRIX; \
-    cell.score = score + score4; \
-    cell.trace = trace;
-
-#define SELECT_TRACE_GOTOH_LOCAL_GAP(cell, score1, score2, score3) \
-    trace = M_MATRIX; \
-    score = score1; \
-    if (score2 > score + epsilon) { \
-        score = score2; \
-        trace = Ix_MATRIX; \
-    } \
-    else if (score2 > score - epsilon) trace |= Ix_MATRIX; \
-    if (score3 > score + epsilon) { \
-        score = score3; \
-        trace = Iy_MATRIX; \
-    } \
-    else if (score3 > score - epsilon) trace |= Iy_MATRIX; \
     if (score < epsilon) { \
         score = -DBL_MAX; \
         trace = 0; \
     } \
-    else if (score > maximum) maximum = score; \
-    cell.score = score; \
-    cell.trace = trace;
+    gaps[i][j].matrix = trace;
 
-#define SELECT_TRACE_GOTOH_LOCAL_ALIGN(cell, score1, score2, score3, score4) \
+#define SELECT_TRACE_WATERMAN_SMITH_BEYER_GLOBAL_ALIGN(score4) \
+    trace = M_MATRIX; \
+    score = M_scores[i-1][j-1]; \
+    temp = Ix_scores[i-1][j-1]; \
+    if (temp > score + epsilon) { \
+        score = temp; \
+        trace = Ix_MATRIX; \
+    } \
+    else if (temp > score - epsilon) trace |= Ix_MATRIX; \
+    temp = Iy_scores[i-1][j-1]; \
+    if (temp > score + epsilon) { \
+        score = temp; \
+        trace = Iy_MATRIX; \
+    } \
+    else if (temp > score - epsilon) trace |= Iy_MATRIX; \
+    M_scores[i][j] = score + score4; \
+    M[i][j].trace = trace;
+
+#define SELECT_TRACE_WATERMAN_SMITH_BEYER_GAP(score1, score2) \
+    temp = score1 + gapscore; \
+    if (temp > score - epsilon) { \
+        if (temp > score + epsilon) { \
+            score = temp; \
+            nm = 0; \
+            ng = 0; \
+        } \
+        gapM[nm] = gap; \
+        nm++; \
+    } \
+    temp = score2 + gapscore; \
+    if (temp > score - epsilon) { \
+        if (temp > score + epsilon) { \
+            score = temp; \
+            nm = 0; \
+            ng = 0; \
+        } \
+        gapXY[ng] = gap; \
+        ng++; \
+    }
+
+#define SELECT_TRACE_WATERMAN_SMITH_BEYER_ALIGN(score1, score2, score3, score4) \
     trace = M_MATRIX; \
     score = score1; \
     if (score2 > score + epsilon) { \
@@ -2803,252 +4255,212 @@ static PyGetSetDef Aligner_getset[] = {
         score = 0; \
         trace = 0; \
     } \
-    else if (score > maximum) maximum = score; \
-    cell.score = score; \
-    cell.trace = trace;
-
-#define SELECT_TRACE_WATERMAN_SMITH_BEYER_GAP(score1, score2, gap) \
-    temp = score1 + gapscore; \
-    if (temp > score - epsilon) { \
-        if (temp > score + epsilon) { \
-            score = temp; \
-            nm = 0; \
-            ng = 0; \
+    else if (score > maximum - epsilon) { \
+        if (score > maximum + epsilon) { \
+            maximum = score; \
+            for ( ; im < i; im++, jm = 0) \
+                for ( ; jm <= nB; jm++) M[im][jm].trace &= ~ENDPOINT; \
+            for ( ; jm < j; jm++) M[im][jm].trace &= ~ENDPOINT; \
+            im = i; \
+            jm = j; \
         } \
-        traceM[nm] = gap; \
-        nm++; \
+        trace |= ENDPOINT; \
     } \
-    temp = score2 + gapscore; \
-    if (temp > score - epsilon) { \
-        if (temp > score + epsilon) { \
-            score = temp; \
-            nm = 0; \
-            ng = 0; \
-        } \
-        traceXY[ng] = gap; \
-        ng++; \
-    }
+    M_scores[i][j] = score; \
+    M[i][j].trace = trace;
 
 /* -------------- allocation & deallocation ------------- */
 
-static void
-_deallocate_needlemanwunsch_smithwaterman_matrix(Py_ssize_t nA, Cell** M)
+static PathGenerator*
+PathGenerator_create_NWSW(Py_ssize_t nA, Py_ssize_t nB, Mode mode)
 {
     int i;
-    if (!M) return;
-    for (i = 0; i <= nA; i++) {
-        if (!M[i]) break;
-        PyMem_Free(M[i]);
-    }
-    PyMem_Free(M);
-}
+    unsigned char trace = 0;
+    Trace** M;
+    PathGenerator* paths;
 
-static Cell**
-_allocate_needlemanwunsch_smithwaterman_matrix(Py_ssize_t nA, Py_ssize_t nB)
-{
-    int i;
-    Cell** M = PyMem_Malloc((nA+1)*sizeof(Cell*));
-    if (!M) return NULL;
+    paths = (PathGenerator*)PyType_GenericAlloc(&PathGenerator_Type, 0);
+    if (!paths) return NULL;
+
+    paths->iA = 0;
+    paths->iB = 0;
+    paths->nA = nA;
+    paths->nB = nB;
+    paths->M = NULL;
+    paths->gaps.gotoh = NULL;
+    paths->gaps.waterman_smith_beyer = NULL;
+    paths->algorithm = NeedlemanWunschSmithWaterman;
+    paths->mode = mode;
+    paths->length = 0;
+
+    M = PyMem_Malloc((nA+1)*sizeof(Trace*));
+    paths->M = M;
+    if (!M) goto exit;
+    if (mode == Global) trace = VERTICAL;
     for (i = 0; i <= nA; i++) {
-        M[i] = PyMem_Malloc((nB+1)*sizeof(Cell));
+        M[i] = PyMem_Malloc((nB+1)*sizeof(Trace));
         if (!M[i]) goto exit;
+        M[i][0].trace = trace;
     }
-    return M;
+    M[0][0].trace = 0;
+    if (mode == Global) trace = HORIZONTAL;
+    for (i = 1; i <= nB; i++) M[0][i].trace = trace;
+    M[0][0].path = 0;
+    return paths;
 exit:
-    _deallocate_needlemanwunsch_smithwaterman_matrix(nA, M);
+    Py_DECREF(paths);
+    PyErr_SetNone(PyExc_MemoryError);
     return NULL;
 }
 
-static void
-_deallocate_gotoh_matrices(Py_ssize_t nA, Cell** M, Cell** Ix, Cell** Iy)
+static PathGenerator*
+PathGenerator_create_Gotoh(Py_ssize_t nA, Py_ssize_t nB, Mode mode)
 {
     int i;
-    if (M) {
-        if (Ix) {
-            if (Iy) {
-                for (i = 0; i <= nA; i++) {
-                    if (!M[i]) break;
-                    PyMem_Free(M[i]);
-                    if (!Ix[i]) break;
-                    PyMem_Free(Ix[i]);
-                    if (!Iy[i]) break;
-                    PyMem_Free(Iy[i]);
-                }
-                PyMem_Free(Iy);
-            }
-            PyMem_Free(Ix);
-        }
-        PyMem_Free(M);
-    }
-}
+    Trace** M;
+    TraceGapsGotoh** gaps;
+    PathGenerator* paths;
 
-static int
-_allocate_gotoh_matrices(Py_ssize_t nA, Py_ssize_t nB,
-                         Cell*** pM, Cell*** pIx, Cell*** pIy)
-{
-    int i;
-    Cell** M = NULL;
-    Cell** Ix = NULL;
-    Cell** Iy = NULL;
-    M = PyMem_Malloc((nA+1)*sizeof(Cell*));
+    paths = (PathGenerator*)PyType_GenericAlloc(&PathGenerator_Type, 0);
+    if (!paths) return NULL;
+
+    paths->iA = 0;
+    paths->iB = 0;
+    paths->nA = nA;
+    paths->nB = nB;
+    paths->M = NULL;
+    paths->gaps.gotoh = NULL;
+    paths->algorithm = Gotoh;
+    paths->mode = mode;
+    paths->length = 0;
+
+    M = PyMem_Malloc((nA+1)*sizeof(Trace*));
     if (!M) goto exit;
-    Ix = PyMem_Malloc((nA+1)*sizeof(Cell*));
-    if (!Ix) goto exit;
-    Iy = PyMem_Malloc((nA+1)*sizeof(Cell*));
-    if (!Iy) goto exit;
+    paths->M = M;
     for (i = 0; i <= nA; i++) {
-        M[i] = PyMem_Malloc((nB+1)*sizeof(Cell));
+        M[i] = PyMem_Malloc((nB+1)*sizeof(Trace));
         if (!M[i]) goto exit;
-        Ix[i] = PyMem_Malloc((nB+1)*sizeof(Cell));
-        if (!Ix[i]) goto exit;
-        Iy[i] = PyMem_Malloc((nB+1)*sizeof(Cell));
-        if (!Iy[i]) goto exit;
+        M[i][0].trace = 0;
     }
-    *pM = M;
-    *pIx = Ix;
-    *pIy = Iy;
-    return 1;
+    gaps = PyMem_Malloc((nA+1)*sizeof(TraceGapsGotoh*));
+    if (!gaps) goto exit;
+    paths->gaps.gotoh = gaps;
+    for (i = 0; i <= nA; i++) {
+        gaps[i] = PyMem_Malloc((nB+1)*sizeof(TraceGapsGotoh));
+        if (!gaps[i]) goto exit;
+    }
+
+    gaps[0][0].Ix = 0;
+    gaps[0][0].Iy = 0;
+    if (mode == Global) {
+        for (i = 1; i <= nA; i++) {
+            gaps[i][0].Ix = Ix_MATRIX;
+            gaps[i][0].Iy = 0;
+        }
+        gaps[1][0].Ix = M_MATRIX;
+        for (i = 1; i <= nB; i++) {
+            M[0][i].trace = 0;
+            gaps[0][i].Ix = 0;
+            gaps[0][i].Iy = Iy_MATRIX;
+        }
+        gaps[0][1].Iy = M_MATRIX;
+    }
+    else if (mode == Local) {
+        for (i = 1; i < nA; i++) {
+            gaps[i][0].Ix = 0;
+            gaps[i][0].Iy = 0;
+        }
+        for (i = 1; i <= nB; i++) {
+            M[0][i].trace = 0;
+            gaps[0][i].Ix = 0;
+            gaps[0][i].Iy = 0;
+        }
+    }
+    M[0][0].path = 0;
+
+    return paths;
 exit:
-    _deallocate_gotoh_matrices(nA, M, Ix, Iy);
-    return 0;
+    Py_DECREF(paths);
+    PyErr_SetNone(PyExc_MemoryError);
+    return NULL;
 }
 
-static void
-_deallocate_watermansmithbeyer_matrices(Py_ssize_t nA, Py_ssize_t nB,
-                                        CellM** M, CellXY** Ix, CellXY** Iy,
-                                        Mode mode)
+static PathGenerator*
+PathGenerator_create_WSB(Py_ssize_t nA, Py_ssize_t nB, Mode mode)
 {
     int i, j;
     int* trace;
-    if (M) {
-        if (Ix) {
-            if (Iy) {
-                for (i = 0; i <= nA; i++) {
-                    if (!M[i]) break;
-                    PyMem_Free(M[i]);
-                    if (Ix[i]) {
-                        if (Iy[i]) {
-                            for (j = 0; j <= nB; j++) {
-                                trace = Ix[i][j].traceM;
-                                if (trace) PyMem_Free(trace);
-                                trace = Ix[i][j].traceXY;
-                                if (trace) PyMem_Free(trace);
-                                trace = Iy[i][j].traceM;
-                                if (trace) PyMem_Free(trace);
-                                trace = Iy[i][j].traceXY;
-                                if (trace) PyMem_Free(trace);
-                            }
-                            PyMem_Free(Iy[i]);
-                        } else break;
-                        PyMem_Free(Ix[i]);
-                    } else break;
-                }
-                PyMem_Free(Iy);
-            }
-            PyMem_Free(Ix);
-        }
-        PyMem_Free(M);
-    }
-}
+    Trace** M = NULL;
+    TraceGapsWatermanSmithBeyer** gaps = NULL;
+    PathGenerator* paths;
 
-static int
-_allocate_watermansmithbeyer_matrices(Py_ssize_t nA, Py_ssize_t nB,
-                                      CellM*** pM, CellXY*** pIx, CellXY*** pIy,
-                                      Mode mode)
-{
-    int i, j;
-    int* trace;
-    CellM** M = NULL;
-    CellXY** Ix = NULL;
-    CellXY** Iy = NULL;
-    M = PyMem_Malloc((nA+1)*sizeof(CellM*));
+    paths = (PathGenerator*)PyType_GenericAlloc(&PathGenerator_Type, 0);
+    if (!paths) return NULL;
+
+    paths->iA = 0;
+    paths->iB = 0;
+    paths->nA = nA;
+    paths->nB = nB;
+    paths->M = NULL;
+    paths->gaps.waterman_smith_beyer = NULL;
+    paths->algorithm = WatermanSmithBeyer;
+    paths->mode = mode;
+    paths->length = 0;
+
+    M = PyMem_Malloc((nA+1)*sizeof(Trace*));
     if (!M) goto exit;
-    Ix = PyMem_Malloc((nA+1)*sizeof(CellXY*));
-    if (!Ix) goto exit;
-    Iy = PyMem_Malloc((nA+1)*sizeof(CellXY*));
-    if (!Iy) goto exit;
+    paths->M = M;
     for (i = 0; i <= nA; i++) {
-        M[i] = PyMem_Malloc((nB+1)*sizeof(CellM));
+        M[i] = PyMem_Malloc((nB+1)*sizeof(Trace));
         if (!M[i]) goto exit;
-        Ix[i] = PyMem_Malloc((nB+1)*sizeof(CellXY));
-        if (!Ix[i]) goto exit;
-        Iy[i] = PyMem_Malloc((nB+1)*sizeof(CellXY));
-        if (!Iy[i]) goto exit;
+    }
+    gaps = PyMem_Malloc((nA+1)*sizeof(TraceGapsWatermanSmithBeyer*));
+    if (!gaps) goto exit;
+    paths->gaps.waterman_smith_beyer = gaps;
+    for (i = 0; i <= nA; i++) gaps[i] = NULL;
+    for (i = 0; i <= nA; i++) {
+        gaps[i] = PyMem_Malloc((nB+1)*sizeof(TraceGapsWatermanSmithBeyer));
+        if (!gaps[i]) goto exit;
         for (j = 0; j <= nB; j++) {
-            Ix[i][j].traceM = NULL;
-            Ix[i][j].traceXY = NULL;
-            Iy[i][j].traceM = NULL;
-            Iy[i][j].traceXY = NULL;
+            gaps[i][j].MIx = NULL;
+            gaps[i][j].IyIx = NULL;
+            gaps[i][j].MIy = NULL;
+            gaps[i][j].IxIy = NULL;
         }
         M[i][0].trace = 0;
-        M[i][0].path.i = -1;
-        Ix[i][0].path.i = -1;
-        Iy[i][0].path.i = -1;
-        Iy[i][0].score = -DBL_MAX;
-        if (i==0) {
-            M[0][0].score = 0;
-            Ix[0][0].score = -DBL_MAX;
-        }
-        else {
-            switch (mode) {
-                case Global:
-                    M[i][0].score = -DBL_MAX;
-                    Ix[i][0].score = 0;
-                    trace = PyMem_Malloc(2*sizeof(int));
-                    if (!trace) goto exit;
-                    Ix[i][0].traceM = trace;
-                    trace[0] = 0;
-                    trace[1] = -1;
-                    trace = PyMem_Malloc(sizeof(int));
-                    if (!trace) goto exit;
-                    Ix[i][0].traceXY = trace;
-                    trace[0] = -1;
-                    break;
-                case Local:
-                    M[i][0].score = 0;
-                    Ix[i][0].score = -DBL_MAX;
-                    Ix[i][0].traceM = NULL;
-                    Ix[i][0].traceXY = NULL;
-                    break;
-            }
+        M[i][0].path = 0;
+        if (mode == Global) {
+            trace = PyMem_Malloc(2*sizeof(int));
+            if (!trace) goto exit;
+            gaps[i][0].MIx = trace;
+            trace[0] = i;
+            trace[1] = 0;
+            trace = PyMem_Malloc(sizeof(int));
+            if (!trace) goto exit;
+            gaps[i][0].IyIx = trace;
+            trace[0] = 0;
         }
     }
     for (i = 1; i <= nB; i++) {
         M[0][i].trace = 0;
-        Ix[0][i].traceM = NULL;
-        Ix[0][i].traceXY = NULL;
-        Ix[0][i].score = -DBL_MAX;
-        switch (mode) {
-            case Global:
-                M[0][i].score = -DBL_MAX;
-                Iy[0][i].score = 0;
-                trace = PyMem_Malloc(2*sizeof(int));
-                if (!trace) goto exit;
-                Iy[0][i].traceM = trace;
-                trace[0] = 0;
-                trace[1] = -1;
-                trace = PyMem_Malloc(sizeof(int));
-                if (!trace) goto exit;
-                Iy[0][i].traceXY = trace;
-                trace[0] = -1;
-                break;
-            case Local:
-                M[0][i].score = 0;
-                Iy[0][i].score = -DBL_MAX;
-                Iy[0][i].traceM = NULL;
-                Iy[0][i].traceXY = NULL;
-                break;
+        if (mode == Global) {
+            trace = PyMem_Malloc(2*sizeof(int));
+            if (!trace) goto exit;
+            gaps[0][i].MIy = trace;
+            trace[0] = i;
+            trace[1] = 0;
+            trace = PyMem_Malloc(sizeof(int));
+            if (!trace) goto exit;
+            gaps[0][i].IxIy = trace;
+            trace[0] = 0;
         }
     }
-    M[0][0].path.j = 0;
-    *pM = M;
-    *pIx = Ix;
-    *pIy = Iy;
-    return 1;
+    M[0][0].path = 0;
+    return paths;
 exit:
-    _deallocate_watermansmithbeyer_matrices(nA, nB, M, Ix, Iy, mode);
-    PyErr_SetString(PyExc_MemoryError, "Out of memory");
-    return 0;
+    Py_DECREF(paths);
+    PyErr_SetNone(PyExc_MemoryError);
+    return NULL;
 }
 
 /* ----------------- alignment algorithms ----------------- */
@@ -3068,66 +4480,56 @@ Aligner_needlemanwunsch_score(Aligner* self, const char* sA, Py_ssize_t nA,
     const double right_gap_extend_A = self->target_right_extend_gap_score;
     const double left_gap_extend_B = self->query_left_extend_gap_score;
     const double right_gap_extend_B = self->query_right_extend_gap_score;
-    double** F;
     double score;
     double temp;
-    PyObject* result = NULL;
+
+    double* scores;
 
     /* Needleman-Wunsch algorithm */
-    F = PyMem_Malloc((nA+1)*sizeof(double*));
-    if (!F) goto exit;
-    for (i = 0; i <= nA; i++) {
-        F[i] = PyMem_Malloc((nB+1)*sizeof(double));
-        if (!F[i]) goto exit;
-    }
+    scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!scores) return PyErr_NoMemory();
 
     /* The top row of the score matrix is a special case,
      * as there are no previously aligned characters.
      */
-    F[0][0] = 0.0;
-    for (j = 1; j <= nB; j++)
-        F[0][j] = j * left_gap_extend_A;
+    scores[0] = 0.0;
+    for (j = 1; j <= nB; j++) scores[j] = j * left_gap_extend_A;
     for (i = 1; i < nA; i++) {
         kA = CHARINDEX(sA[i-1]);
-        F[i][0] = i * left_gap_extend_B;
+        temp = scores[0];
+        scores[0] = i * left_gap_extend_B;
         for (j = 1; j < nB; j++) {
             kB = CHARINDEX(sB[j-1]);
-            SELECT_SCORE_GLOBAL(F[i-1][j-1] + self->substitution_matrix[kA][kB],
-                                F[i-1][j] + gap_extend_B,
-                                F[i][j-1] + gap_extend_A);
-            F[i][j] = score;
+            SELECT_SCORE_GLOBAL(temp + self->substitution_matrix[kA][kB],
+                                scores[j] + gap_extend_B,
+                                scores[j-1] + gap_extend_A);
+            temp = scores[j];
+            scores[j] = score;
         }
         kB = CHARINDEX(sB[nB-1]);
-        SELECT_SCORE_GLOBAL(F[i-1][nB-1] + self->substitution_matrix[kA][kB],
-                            F[i-1][nB] + right_gap_extend_B,
-                            F[i][nB-1] + gap_extend_A);
-        F[i][nB] = score;
+        SELECT_SCORE_GLOBAL(temp + self->substitution_matrix[kA][kB],
+                            scores[nB] + right_gap_extend_B,
+                            scores[nB-1] + gap_extend_A);
+        temp = scores[nB];
+        scores[nB] = score;
     }
     kA = CHARINDEX(sA[nA-1]);
-    F[nA][0] = nA * right_gap_extend_B;
+    temp = scores[0];
+    scores[0] = nA * right_gap_extend_B;
     for (j = 1; j < nB; j++) {
         kB = CHARINDEX(sB[j-1]);
-        SELECT_SCORE_GLOBAL(F[nA-1][j-1] + self->substitution_matrix[kA][kB],
-                            F[nA-1][j] + gap_extend_B,
-                            F[nA][j-1] + right_gap_extend_A);
-        F[nA][j] = score;
+        SELECT_SCORE_GLOBAL(temp + self->substitution_matrix[kA][kB],
+                            scores[j] + gap_extend_B,
+                            scores[j-1] + right_gap_extend_A);
+        temp = scores[j];
+        scores[j] = score;
     }
     kB = CHARINDEX(sB[nB-1]);
-    SELECT_SCORE_GLOBAL(F[nA-1][nB-1] + self->substitution_matrix[kA][kB],
-                        F[nA-1][nB] + right_gap_extend_B,
-                        F[nA][nB-1] + right_gap_extend_A);
-    F[nA][nB] = score;
-    result = PyFloat_FromDouble(score);
-exit:
-    if (F) {
-        for (i = 0; i <= nA; i++) {
-            if (!F[i]) break;
-            PyMem_Free(F[i]);
-        }
-        PyMem_Free(F);
-    }
-    if (!result) PyErr_SetString(PyExc_MemoryError, "Out of memory");
-    return result;
+    SELECT_SCORE_GLOBAL(temp + self->substitution_matrix[kA][kB],
+                        scores[nB] + right_gap_extend_B,
+                        scores[nB-1] + right_gap_extend_A);
+    PyMem_Free(scores);
+    return PyFloat_FromDouble(score);
 }
 
 static PyObject*
@@ -3141,1660 +4543,48 @@ Aligner_smithwaterman_score(Aligner* self, const char* sA, Py_ssize_t nA,
     int kB;
     const double gap_extend_A = self->target_extend_gap_score;
     const double gap_extend_B = self->query_extend_gap_score;
-    double** F;
     double score;
+    double* scores;
     double temp;
     double maximum = 0;
-    PyObject* result = NULL;
 
     /* Smith-Waterman algorithm */
-    F = PyMem_Malloc((nA+1)*sizeof(double*));
-    if (!F) goto exit;
-    for (i = 0; i <= nA; i++) {
-        F[i] = PyMem_Malloc((nB+1)*sizeof(double));
-        if (!F[i]) goto exit;
-    }
+    scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!scores) return PyErr_NoMemory();
 
     /* The top row of the score matrix is a special case,
      * as there are no previously aligned characters.
      */
     for (j = 0; j <= nB; j++)
-        F[0][j] = 0;
+        scores[j] = 0;
     for (i = 1; i < nA; i++) {
         kA = CHARINDEX(sA[i-1]);
-        F[i][0] = 0;
+        temp = 0;
         for (j = 1; j < nB; j++) {
             kB = CHARINDEX(sB[j-1]);
-            SELECT_SCORE_LOCAL3(F[i-1][j-1] + self->substitution_matrix[kA][kB],
-                                F[i-1][j] + gap_extend_B,
-                                F[i][j-1] + gap_extend_A);
-            F[i][j] = score;
+            SELECT_SCORE_LOCAL3(temp + self->substitution_matrix[kA][kB],
+                                scores[j] + gap_extend_B,
+                                scores[j-1] + gap_extend_A);
+            temp = scores[j];
+            scores[j] = score;
         }
         kB = CHARINDEX(sB[nB-1]);
-        SELECT_SCORE_LOCAL1(F[i-1][nB-1] + self->substitution_matrix[kA][kB]);
-        F[i][nB] = score;
+        SELECT_SCORE_LOCAL1(temp + self->substitution_matrix[kA][kB]);
+        temp = scores[nB];
+        scores[nB] = score;
     }
     kA = CHARINDEX(sA[nA-1]);
-    F[nA][0] = 0;
+    temp = 0;
     for (j = 1; j < nB; j++) {
         kB = CHARINDEX(sB[j-1]);
-        SELECT_SCORE_LOCAL1(F[nA-1][j-1] + self->substitution_matrix[kA][kB]);
-        F[nA][j] = score;
+        SELECT_SCORE_LOCAL1(temp + self->substitution_matrix[kA][kB]);
+        temp = scores[j];
+        scores[j] = score;
     }
     kB = CHARINDEX(sB[nB-1]);
-    SELECT_SCORE_LOCAL1(F[nA-1][nB-1] + self->substitution_matrix[kA][kB]);
-    F[nA][nB] = score;
-    result = PyFloat_FromDouble(maximum);
-exit:
-    if (F) {
-        for (i = 0; i <= nA; i++) {
-            if (!F[i]) break;
-            PyMem_Free(F[i]);
-        }
-        PyMem_Free(F);
-    }
-    if (!result) PyErr_SetString(PyExc_MemoryError, "Out of memory");
-    return result;
-}
-
-static PyObject* _next_needlemanwunsch(PathGenerator* self)
-{
-    int i = 0;
-    int j = 0;
-    int path;
-    int trace = 0;
-    const int nA = self->nA;
-    const int nB = self->nB;
-    Cell** M = self->M.affine;
-
-    path = M[i][j].path;
-    if (path == DONE) return NULL;
-    if (path == 0) {
-        /* Generate the first path. */
-        i = nA;
-        j = nB;
-    }
-    else {
-        /* We already have a path. Prune the path to see if there are
-         * any alternative paths. */
-        while (1) {
-            if (path == HORIZONTAL) {
-                trace = M[i][++j].trace;
-                if (trace & VERTICAL) {
-                    M[--i][j].path = VERTICAL;
-                    break;
-                }
-                if (trace & DIAGONAL) {
-                    M[--i][--j].path = DIAGONAL;
-                    break;
-                }
-            }
-            else if (path == VERTICAL) {
-                trace = M[++i][j].trace;
-                if (trace & DIAGONAL) {
-                    M[--i][--j].path = DIAGONAL;
-                    break;
-                }
-            }
-            else /* DIAGONAL */ {
-                i++;
-                j++;
-            }
-            path = M[i][j].path;
-            if (!path) {
-                /* we reached the end of the alignment without finding
-                 * an alternative path */
-                M[0][0].path = DONE;
-                return NULL;
-            }
-        }
-    }
-    /* Follow the traceback until we reach the origin. */
-    while (1) {
-        trace = M[i][j].trace;
-        if (trace & HORIZONTAL) M[i][--j].path = HORIZONTAL;
-        else if (trace & VERTICAL) M[--i][j].path = VERTICAL;
-        else if (trace & DIAGONAL) M[--i][--j].path = DIAGONAL;
-        else break;
-    }
-    return _create_path_needleman_wunsch_smith_waterman(M, 0, 0);
-}
-
-static PyObject* _next_smithwaterman(PathGenerator* self)
-{
-    int trace = 0;
-    int i = self->iA;
-    int j = self->iB;
-    const int nA = self->nA;
-    const int nB = self->nB;
-    const double threshold = self->threshold;
-    Cell** M = self->M.affine;
-    int path = M[0][0].path;
-
-    if (path == DONE) return NULL;
-
-    path = M[i][j].path;
-    if (path) {
-        /* We already have a path. Prune the path to see if there are
-         * any alternative paths. */
-        while (1) {
-            if (path == HORIZONTAL) {
-                trace = M[i][++j].trace;
-                if (trace & VERTICAL) {
-                    M[--i][j].path = VERTICAL;
-                    break;
-                }
-                else if (trace & DIAGONAL) {
-                    M[--i][--j].path = DIAGONAL;
-                    break;
-                }
-            }
-            else if (path == VERTICAL) {
-                trace = M[++i][j].trace;
-                if (trace & DIAGONAL) {
-                    M[--i][--j].path = DIAGONAL;
-                    break;
-                }
-            }
-            else /* DIAGONAL */ {
-                i++;
-                j++;
-            }
-            path = M[i][j].path;
-            if (!path) break;
-        }
-    }
-
-    if (!path) {
-        /* Find a suitable end point for a path.
-         * Only allow start points ending at the M matrix. */
-        while (1) {
-            if (j < nB) j++;
-            else if (i < nA) {
-                i++;
-                j = 0;
-            }
-            else {
-                /* we reached the end of the alignment without finding
-                 * an alternative path */
-                M[0][0].path = DONE;
-                return NULL;
-            }
-            if (M[i][j].score >= threshold) break;
-        }
-        M[i][j].path = 0;
-    }
-
-    /* Follow the traceback until we reach the origin. */
-    while (1) {
-        trace = M[i][j].trace;
-        if (trace & HORIZONTAL) M[i][--j].path = HORIZONTAL;
-        else if (trace & VERTICAL) M[--i][j].path = VERTICAL;
-        else if (trace & DIAGONAL) M[--i][--j].path = DIAGONAL;
-        else break;
-    }
-    self->iA = i;
-    self->iB = j;
-    return _create_path_needleman_wunsch_smith_waterman(M, i, j);
-}
-
-static PyObject* _next_gotoh_global(PathGenerator* self)
-{
-    int i = 0;
-    int j = 0;
-    int m;
-    int path;
-    int trace = 0;
-    const int nA = self->nA;
-    const int nB = self->nB;
-    Cell** M = self->M.affine;
-    Cell** Ix = self->Ix.affine;
-    Cell** Iy = self->Iy.affine;
-    const double threshold = self->threshold;
-
-    m = M_MATRIX;
-    path = M[i][j].path;
-    if (path == DONE) return NULL;
-    if (path == 0) {
-        i = nA;
-        j = nB;
-    }
-    else {
-        /* We already have a path. Prune the path to see if there are
-         * any alternative paths. */
-        while (1) {
-            switch (m) {
-                case M_MATRIX: path = M[i][j].path; break;
-                case Ix_MATRIX: path = Ix[i][j].path; break;
-                case Iy_MATRIX: path = Iy[i][j].path; break;
-            }
-            if (path == 0) {
-                switch (m) {
-                    case M_MATRIX: m = Ix_MATRIX; break;
-                    case Ix_MATRIX: m = Iy_MATRIX; break;
-                    case Iy_MATRIX: m = 0; break;
-                }
-                break;
-            }
-            switch (path) {
-                case HORIZONTAL: trace = Iy[i][++j].trace; break;
-                case VERTICAL: trace = Ix[++i][j].trace; break;
-                case DIAGONAL: trace = M[++i][++j].trace; break;
-            }
-            switch (m) {
-                case M_MATRIX:
-                    if (trace & Ix_MATRIX) {
-                        m = Ix_MATRIX;
-                        break;
-                    }
-                case Ix_MATRIX:
-                    if (trace & Iy_MATRIX) {
-                        m = Iy_MATRIX;
-                        break;
-                    }
-                case Iy_MATRIX:
-                default:
-                    switch (path) {
-                        case HORIZONTAL: m = Iy_MATRIX; break;
-                        case VERTICAL: m = Ix_MATRIX; break;
-                        case DIAGONAL: m = M_MATRIX; break;
-                    }
-                    continue;
-            }
-            switch (path) {
-                case HORIZONTAL: j--; break;
-                case VERTICAL: i--; break;
-                case DIAGONAL: i--; j--; break;
-            }
-            switch (m) {
-                case M_MATRIX: M[i][j].path = path; break;
-                case Ix_MATRIX: Ix[i][j].path = path; break;
-                case Iy_MATRIX: Iy[i][j].path = path; break;
-            }
-            break;
-        }
-    }
-
-    if (path == 0) {
-        /* Generate a new path. */
-        switch (m) {
-            case M_MATRIX:
-                if (M[nA][nB].score >= threshold) {
-                   /* m = M_MATRIX; */
-                   break;
-                }
-            case Ix_MATRIX:
-                if (Ix[nA][nB].score >= threshold) {
-                   m = Ix_MATRIX;
-                   break;
-                }
-            case Iy_MATRIX:
-                if (Iy[nA][nB].score >= threshold) {
-                   m = Iy_MATRIX;
-                   break;
-                }
-            default:
-                /* exhausted this generator */
-                M[0][0].path = DONE;
-                return NULL;
-        }
-    }
-
-    switch (m) {
-        case M_MATRIX:
-            trace = M[i][j].trace;
-            path = DIAGONAL;
-            i--; j--;
-            break;
-        case Ix_MATRIX:
-            trace = Ix[i][j].trace;
-            path = VERTICAL;
-            i--;
-            break;
-        case Iy_MATRIX:
-            trace = Iy[i][j].trace;
-            path = HORIZONTAL;
-            j--;
-            break;
-    }
-
-    while (1) {
-        if (trace & M_MATRIX) {
-            M[i][j].path = path;
-            trace = M[i][j].trace;
-            path = DIAGONAL;
-            i--; j--;
-        }
-        else if (trace & Ix_MATRIX) {
-            Ix[i][j].path = path;
-            trace = Ix[i][j].trace;
-            path = VERTICAL;
-            i--;
-        }
-        else if (trace & Iy_MATRIX) {
-            Iy[i][j].path = path;
-            trace = Iy[i][j].trace;
-            path = HORIZONTAL;
-            j--;
-        }
-        else break;
-    }
-    return _create_path_gotoh(M, Ix, Iy, 0, 0);
-}
-
-static PyObject* _next_gotoh_local(PathGenerator* self)
-{
-    int trace = 0;
-    int i;
-    int j;
-    int m = M_MATRIX;
-    int iA = self->iA;
-    int iB = self->iB;
-    const int nA = self->nA;
-    const int nB = self->nB;
-    const double threshold = self->threshold;
-    Cell** M = self->M.affine;
-    Cell** Ix = self->Ix.affine;
-    Cell** Iy = self->Iy.affine;
-    int path = M[0][0].path;
-
-    if (path == DONE) return NULL;
-
-    path = M[iA][iB].path;
-
-    if (path) {
-        i = iA;
-        j = iB;
-        while (1) {
-            /* We already have a path. Prune the path to see if there are
-             * any alternative paths. */
-            switch (m) {
-                case M_MATRIX: path = M[i][j].path; break;
-                case Ix_MATRIX: path = Ix[i][j].path; break;
-                case Iy_MATRIX: path = Iy[i][j].path; break;
-            }
-            if (path == 0) {
-                m = M_MATRIX;
-                iA = i;
-                iB = j;
-                break;
-            }
-            switch (path) {
-                case HORIZONTAL: trace = Iy[i][++j].trace; break;
-                case VERTICAL: trace = Ix[++i][j].trace; break;
-                case DIAGONAL: trace = M[++i][++j].trace; break;
-            }
-            switch (m) {
-                case M_MATRIX:
-                    if (trace & Ix_MATRIX) {
-                        m = Ix_MATRIX;
-                        break;
-                    }
-                case Ix_MATRIX:
-                    if (trace & Iy_MATRIX) {
-                        m = Iy_MATRIX;
-                        break;
-                    }
-                case Iy_MATRIX:
-                default:
-                    switch (path) {
-                        case HORIZONTAL: m = Iy_MATRIX; break;
-                        case VERTICAL: m = Ix_MATRIX; break;
-                        case DIAGONAL: m = M_MATRIX; break;
-                    }
-                    continue;
-            }
-            switch (path) {
-                case HORIZONTAL: j--; break;
-                case VERTICAL: i--; break;
-                case DIAGONAL: i--; j--; break;
-            }
-            switch (m) {
-                case M_MATRIX: M[i][j].path = path; break;
-                case Ix_MATRIX: Ix[i][j].path = path; break;
-                case Iy_MATRIX: Iy[i][j].path = path; break;
-            }
-            break;
-        }
-    }
-
-    if (path == 0) {
-        /* Find the starting point for a new path. */
-        while (1) {
-            if (iB < nB) iB++;
-            else if (iA < nA) {
-                iA++;
-                iB = 0;
-            }
-            else {
-                /* we reached the end of the alignment without finding
-                 * an alternative path */
-                M[0][0].path = DONE;
-                return NULL;
-            }
-            if (M[iA][iB].score >= threshold) {
-                M[iA][iB].path = 0;
-                break;
-            }
-        }
-        m = M_MATRIX;
-        i = iA;
-        j = iB;
-    }
-
-    while (1) {
-        switch (m) {
-            case M_MATRIX: trace = M[i][j].trace; break;
-            case Ix_MATRIX: trace = Ix[i][j].trace; break;
-            case Iy_MATRIX: trace = Iy[i][j].trace; break;
-        }
-        if (trace==0) {
-            self->iA = i;
-            self->iB = j;
-            return _create_path_gotoh(M, Ix, Iy, i, j);
-        }
-        switch (m) {
-            case M_MATRIX:
-                path = DIAGONAL;
-                i--;
-                j--;
-                break;
-            case Ix_MATRIX:
-                path = VERTICAL;
-                i--;
-                break;
-            case Iy_MATRIX:
-                path = HORIZONTAL;
-                j--;
-                break;
-        }
-        if (trace & M_MATRIX) m = M_MATRIX;
-        else if (trace & Ix_MATRIX) m = Ix_MATRIX;
-        else if (trace & Iy_MATRIX) m = Iy_MATRIX;
-        switch (m) {
-            case M_MATRIX: M[i][j].path = path; break;
-            case Ix_MATRIX: Ix[i][j].path = path; break;
-            case Iy_MATRIX: Iy[i][j].path = path; break;
-        }
-    }
-    return NULL;
-}
-
-static PyObject* _next_waterman_smith_beyer_global(PathGenerator* self)
-{
-    int i, j;
-    int iA, iB;
-    int trace;
-    int* traceXY;
-    int* traceM;
-
-    int m = M_MATRIX;
-    const int nA = self->nA;
-    const int nB = self->nB;
-    CellM** M = self->M.general;
-    CellXY** Ix = self->Ix.general;
-    CellXY** Iy = self->Iy.general;
-    const double threshold = self->threshold;
-
-    iB = M[0][0].path.j;
-    if (iB < 0) return NULL;
-
-    iA = M[0][0].path.i;
-    if (iA >= 0) {
-        /* We already have a path. Prune the path to see if there are
-         * any alternative paths. */
-        i = 0;
-        j = 0;
-        while (1) {
-            switch (m) {
-                case M_MATRIX:
-                    iA = M[i][j].path.i;
-                    iB = M[i][j].path.j;
-                    break;
-                case Ix_MATRIX:
-                    iA = Ix[i][j].path.i;
-                    iB = Ix[i][j].path.j;
-                    break;
-                case Iy_MATRIX:
-                    iA = Iy[i][j].path.i;
-                    iB = Iy[i][j].path.j;
-                    break;
-            }
-            if (iA < 0) {
-                m <<= 1;
-                break;
-            }
-            if (i == iA) { /* HORIZONTAL */
-                traceXY = Iy[iA][iB].traceXY;
-                traceM = Iy[iA][iB].traceM;
-                if (m==M_MATRIX) {
-                    while (*traceM != j) traceM++;
-                    traceM++;
-                    j = *traceM;
-                    if (j >= 0) {
-                        M[i][j].path.i = iA;
-                        M[i][j].path.j = iB;
-                        break;
-                    }
-                } else if (m==Ix_MATRIX) {
-                    while (*traceXY != j) traceXY++;
-                    traceXY++;
-                }
-                j = *traceXY;
-                if (j >= 0) {
-                    m = Ix_MATRIX;
-                    Ix[i][j].path.i = iA;
-                    Ix[i][j].path.j = iB;
-                    break;
-                }
-                /* no alternative found; continue pruning */
-                m = Iy_MATRIX;
-                j = iB;
-            }
-            else if (j==iB) { /* VERTICAL */
-                traceXY = Ix[iA][iB].traceXY;
-                traceM = Ix[iA][iB].traceM;
-                if (m==M_MATRIX) {
-                    while (*traceM != i) traceM++;
-                    traceM++;
-                    i = *traceM;
-                    if (i >= 0) {
-                        M[i][j].path.i = iA;
-                        M[i][j].path.j = iB;
-                        break;
-                    }
-                } else if (m==Iy_MATRIX) {
-                    while (*traceXY != i) traceXY++;
-                    traceXY++;
-                }
-                i = *traceXY;
-                if (i >= 0) {
-                    m = Iy_MATRIX;
-                    Iy[i][j].path.i = iA;
-                    Iy[i][j].path.j = iB;
-                    break;
-                }
-                /* no alternative found; continue pruning */
-                m = Ix_MATRIX;
-                i = iA;
-            }
-            else { /* DIAGONAL */
-                i = iA - 1;
-                j = iB - 1;
-                trace = M[iA][iB].trace;
-               switch (m) {
-                    case M_MATRIX:
-                        if (trace & Ix_MATRIX) {
-                            m = Ix_MATRIX;
-                            Ix[i][j].path.i = iA;
-                            Ix[i][j].path.j = iB;
-                            break;
-                        }
-                    case Ix_MATRIX:
-                        if (trace & Iy_MATRIX) {
-                            m = Iy_MATRIX;
-                            Iy[i][j].path.i = iA;
-                            Iy[i][j].path.j = iB;
-                            break;
-                        }
-                    case Iy_MATRIX:
-                    default:
-                        /* no alternative found; continue pruning */
-                        m = M_MATRIX;
-                        i = iA;
-                        j = iB;
-                        continue;
-                }
-                /* alternative found; build path until starting point */
-                break;
-            }
-        }
-    }
-
-    if (iA < 0) {
-        /* Find a suitable end point for a path. */
-        switch (m) {
-            case M_MATRIX:
-                if (M[nA][nB].score >= threshold) {
-                    /* m = M_MATRIX; */
-                    break;
-                }
-            case Ix_MATRIX:
-                if (Ix[nA][nB].score >= threshold) {
-                    m = Ix_MATRIX;
-                    break;
-                }
-            case Iy_MATRIX:
-                if (Iy[nA][nB].score >= threshold) {
-                    m = Iy_MATRIX;
-                    break;
-                }
-            default:
-                M[0][0].path.j = -1;
-                return NULL;
-        }
-        i = nA;
-        j = nB;
-    }
-
-    /* Follow the traceback until we reach the origin. */
-    while (1) {
-        switch (m) {
-            case M_MATRIX:
-                iA = i-1;
-                iB = j-1;
-                trace = M[i][j].trace;
-                if (trace & M_MATRIX) {
-                    m = M_MATRIX;
-                    M[iA][iB].path.i = i;
-                    M[iA][iB].path.j = j;
-                }
-                else if (trace & Ix_MATRIX) {
-                    m = Ix_MATRIX;
-                    Ix[iA][iB].path.i = i;
-                    Ix[iA][iB].path.j = j;
-                }
-                else if (trace & Iy_MATRIX) {
-                    m = Iy_MATRIX;
-                    Iy[iA][iB].path.i = i;
-                    Iy[iA][iB].path.j = j;
-                } else {
-                    return _create_path_waterman_smith_beyer(M, Ix, Iy, i, j);
-                }
-                i = iA;
-                j = iB;
-                continue;
-            case Ix_MATRIX:
-                traceXY = Ix[i][j].traceXY;
-                traceM = Ix[i][j].traceM;
-                iB = j;
-                iA = *traceM;
-                if (iA >= 0) m = M_MATRIX;
-                else {
-                    iA = *traceXY;
-                    m = Iy_MATRIX;
-                }
-                break;
-            case Iy_MATRIX:
-                traceXY = Iy[i][j].traceXY;
-                traceM = Iy[i][j].traceM;
-                iA = i;
-                iB = *traceM;
-                if (iB >= 0) m = M_MATRIX;
-                else {
-                    iB = *traceXY;
-                    m = Ix_MATRIX;
-                }
-                break;
-        }
-        switch (m) {
-            case M_MATRIX:
-                M[iA][iB].path.i = i;
-                M[iA][iB].path.j = j;
-                break;
-            case Ix_MATRIX:
-                Ix[iA][iB].path.i = i;
-                Ix[iA][iB].path.j = j;
-                break;
-            case Iy_MATRIX:
-                Iy[iA][iB].path.i = i;
-                Iy[iA][iB].path.j = j;
-                break;
-        }
-        i = iA;
-        j = iB;
-    }
-}
-
-static PyObject* _next_waterman_smith_beyer_local(PathGenerator* self)
-{
-    int i, j, m;
-    int trace = 0;
-    int* traceXY;
-    int* traceM;
-
-    int iA = self->iA;
-    int iB = self->iB;
-    const int nA = self->nA;
-    const int nB = self->nB;
-    CellM** M = self->M.general;
-    CellXY** Ix = self->Ix.general;
-    CellXY** Iy = self->Iy.general;
-    const double threshold = self->threshold;
-
-    if (M[0][0].path.j < 0) return NULL; /* DONE */
-    m = 0;
-    if (M[iA][iB].path.i >= 0) {
-        /* We already have a path. Prune the path to see if there are
-         * any alternative paths. */
-        m = M_MATRIX;
-        i = iA;
-        j = iB;
-        while (1) {
-            switch (m) {
-                case M_MATRIX:
-                    iA = M[i][j].path.i;
-                    iB = M[i][j].path.j;
-                    break;
-                case Ix_MATRIX:
-                    iA = Ix[i][j].path.i;
-                    iB = Ix[i][j].path.j;
-                    break;
-                case Iy_MATRIX:
-                    iA = Iy[i][j].path.i;
-                    iB = Iy[i][j].path.j;
-                    break;
-            }
-            if (iA < 0) {
-                m = 0;
-                iA = i;
-                iB = j;
-                break;
-            }
-            if (i == iA) { /* HORIZONTAL */
-                traceXY = Iy[iA][iB].traceXY;
-                traceM = Iy[iA][iB].traceM;
-                if (m==M_MATRIX) {
-                    while (*traceM != j) traceM++;
-                    traceM++;
-                    j = *traceM;
-                    if (j >= 0) {
-                        M[i][j].path.i = iA;
-                        M[i][j].path.j = iB;
-                        break;
-                    }
-                } else if (m==Ix_MATRIX) {
-                    while (*traceXY != j) traceXY++;
-                    traceXY++;
-                }
-                j = *traceXY;
-                if (j >= 0) {
-                    m = Ix_MATRIX;
-                    Ix[i][j].path.i = iA;
-                    Ix[i][j].path.j = iB;
-                    break;
-                }
-                /* no alternative found; continue pruning */
-                m = Iy_MATRIX;
-                j = iB;
-            }
-            else if (j == iB) { /* VERTICAL */
-                traceXY = Ix[iA][iB].traceXY;
-                traceM = Ix[iA][iB].traceM;
-                if (m==M_MATRIX) {
-                    while (*traceM != i) traceM++;
-                    traceM++;
-                    i = *traceM;
-                    if (i >= 0) {
-                        M[i][j].path.i = iA;
-                        M[i][j].path.j = iB;
-                        break;
-                    }
-                } else if (m==Iy_MATRIX) {
-                    while (*traceXY != i) traceXY++;
-                    traceXY++;
-                }
-                i = *traceXY;
-                if (i >= 0) {
-                    m = Iy_MATRIX;
-                    Iy[i][j].path.i = iA;
-                    Iy[i][j].path.j = iB;
-                    break;
-                }
-                /* no alternative found; continue pruning */
-                m = Ix_MATRIX;
-                i = iA;
-            }
-            else { /* DIAGONAL */
-                i = iA - 1;
-                j = iB - 1;
-                trace = M[iA][iB].trace;
-                switch (m) {
-                    case M_MATRIX:
-                        if (trace & Ix_MATRIX) {
-                            m = Ix_MATRIX;
-                            Ix[i][j].path.i = iA;
-                            Ix[i][j].path.j = iB;
-                            break;
-                        }
-                    case Ix_MATRIX:
-                        if (trace & Iy_MATRIX) {
-                            m = Iy_MATRIX;
-                            Iy[i][j].path.i = iA;
-                            Iy[i][j].path.j = iB;
-                            break;
-                        }
-                    case Iy_MATRIX:
-                    default:
-                        /* no alternative found; continue pruning */
-                        m = M_MATRIX;
-                        i = iA;
-                        j = iB;
-                        continue;
-                }
-                /* alternative found; build path until starting point */
-                break;
-            }
-        }
-    }
- 
-    if (m == 0) {
-        /* We are at [nA][nB]. Find a suitable end point for a path.
-         * Only allow start points ending at the M matrix. */
-        while (1) {
-            if (iB < nB) iB++;
-            else if (iA < nA) {
-                iA++;
-                iB = 0;
-            }
-            else {
-                /* exhausted this generator */
-                M[0][0].path.j = -1;
-                return NULL;
-            }
-            if (M[iA][iB].score >= threshold) break;
-        }
-        M[iA][iB].path.i = -1;
-        M[iA][iB].path.j = -1;
-        m = M_MATRIX;
-        i = iA;
-        j = iB;
-    }
-
-    /* Follow the traceback until we reach the origin. */
-    while (1) {
-        switch (m) {
-            case Ix_MATRIX:
-                traceXY = Ix[i][j].traceXY;
-                traceM = Ix[i][j].traceM;
-                iB = j;
-                iA = *traceM;
-                if (iA >= 0) m = M_MATRIX;
-                else {
-                    iA = *traceXY;
-                    m = Iy_MATRIX;
-                }
-                break;
-            case Iy_MATRIX:
-                traceXY = Iy[i][j].traceXY;
-                traceM = Iy[i][j].traceM;
-                iA = i;
-                iB = *traceM;
-                if (iB >= 0) m = M_MATRIX;
-                else {
-                    iB = *traceXY;
-                    m = Ix_MATRIX;
-                }
-                break;
-            case M_MATRIX:
-                iA = i-1;
-                iB = j-1;
-                trace = M[i][j].trace;
-                if (trace & M_MATRIX) m = M_MATRIX;
-                else if (trace & Ix_MATRIX) m = Ix_MATRIX;
-                else if (trace & Iy_MATRIX) m = Iy_MATRIX;
-                else {
-                    self->iA = i;
-                    self->iB = j;
-                    return _create_path_waterman_smith_beyer(M, Ix, Iy, i, j);
-                }
-        }
-        switch (m) {
-            case M_MATRIX:
-                M[iA][iB].path.i = i;
-                M[iA][iB].path.j = j;
-                break;
-            case Ix_MATRIX:
-                Ix[iA][iB].path.i = i;
-                Ix[iA][iB].path.j = j;
-                break;
-            case Iy_MATRIX:
-                Iy[iA][iB].path.i = i;
-                Iy[iA][iB].path.j = j;
-                break;
-        }
-        i = iA;
-        j = iB;
-    }
-}
-
-static PyObject *
-PathGenerator_next(PathGenerator* self)
-{
-    const Mode mode = self->mode;
-    const Algorithm algorithm = self->algorithm;
-    switch (algorithm) {
-        case NeedlemanWunschSmithWaterman:
-            switch (mode) {
-                case Global:
-                    return _next_needlemanwunsch(self);
-                case Local:
-                    return _next_smithwaterman(self);
-            }
-        case Gotoh:
-            switch (mode) {
-                case Global:
-                    return _next_gotoh_global(self);
-                case Local:
-                    return _next_gotoh_local(self);
-            }
-        case WatermanSmithBeyer:
-            switch (mode) {
-                case Global:
-                    return _next_waterman_smith_beyer_global(self);
-                case Local:
-                    return _next_waterman_smith_beyer_local(self);
-            }
-        case Unknown:
-        default:
-            PyErr_SetString(PyExc_RuntimeError, "Unknown algorithm");
-            return NULL;
-    }
-}
-
-static void
-PathGenerator_dealloc(PathGenerator* self)
-{
-    const int nA = self->nA;
-    const Algorithm algorithm = self->algorithm;
-    switch (algorithm) {
-        case NeedlemanWunschSmithWaterman: {
-            Cell** M = self->M.affine;
-            _deallocate_needlemanwunsch_smithwaterman_matrix(nA, M);
-            break;
-        }
-        case Gotoh: {
-            Cell** M = self->M.affine;
-            Cell** Ix = self->Ix.affine;
-            Cell** Iy = self->Iy.affine;
-            _deallocate_gotoh_matrices(nA, M, Ix, Iy);
-            break;
-        }
-        case WatermanSmithBeyer: {
-            CellM** M = self->M.general;
-            CellXY** Ix = self->Ix.general;
-            CellXY** Iy = self->Iy.general;
-            const Mode mode = self->mode;
-            const int nB = self->nB;
-            _deallocate_watermansmithbeyer_matrices(nA, nB, M, Ix, Iy, mode);
-            break;
-        }
-        case Unknown:
-        default:
-            PyErr_WriteUnraisable((PyObject*)self);
-            return;
-    }
-    Py_TYPE(self)->tp_free((PyObject*)self);
-}
-
-static const char PathGenerator_reset__doc__[] = "reset the iterator";
-
-static PyObject*
-PathGenerator_reset(PathGenerator* self)
-{
-    switch (self->mode) {
-        case Local:
-            if (self->threshold <= 0) /* no solutions were found */ break;
-            self->iA = 0;
-            self->iB = 0;
-        case Global:
-            switch (self->algorithm) {
-                case NeedlemanWunschSmithWaterman:
-                case Gotoh: {
-                    Cell** M = self->M.affine;
-                    M[0][0].path = 0;
-                    break;
-                }
-                case WatermanSmithBeyer: {
-                    CellM** M = self->M.general;
-                    M[0][0].path.i = -1;
-                    M[0][0].path.j = 0;
-                    break;
-                }
-                case Unknown:
-                default:
-                    break;
-        }
-    }
-    Py_INCREF(Py_None);
-    return Py_None;
-}
-
-static PyMethodDef PathGenerator_methods[] = {
-    {"reset",
-     (PyCFunction)PathGenerator_reset,
-     METH_NOARGS,
-     PathGenerator_reset__doc__
-    },
-    {NULL}  /* Sentinel */
-};
-
-#define SAFE_ADD(t, s) \
-{   term = t; \
-    if (term > PY_SSIZE_T_MAX - s) { count = OVERFLOW_ERROR; goto exit; } \
-    s += term; \
-}
-
-static Py_ssize_t
-PathGenerator_needlemanwunsch_length(PathGenerator* self)
-{
-    int i;
-    int j;
-    int trace;
-    const int nA = self->nA;
-    const int nB = self->nB;
-    Cell** M = self->M.affine;
-    Py_ssize_t term;
-    Py_ssize_t count;
-    Py_ssize_t temp;
-    Py_ssize_t* counts;
-    counts = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-    if (!counts) return MEMORY_ERROR;
-    counts[0] = 1;
-    for (j = 1; j <= nB; j++) {
-        trace = M[0][j].trace;
-        count = 0;
-        if (trace & HORIZONTAL) SAFE_ADD(counts[j-1], count);
-        counts[j] = count;
-    }
-    for (i = 1; i <= nA; i++) {
-        trace = M[i][0].trace;
-        count = 0;
-        if (trace & VERTICAL) SAFE_ADD(counts[0], count);
-        temp = counts[0];
-        counts[0] = count;
-        for (j = 1; j <= nB; j++) {
-            trace = M[i][j].trace;
-            count = 0;
-            if (trace & HORIZONTAL) SAFE_ADD(counts[j-1], count);
-            if (trace & VERTICAL) SAFE_ADD(counts[j], count);
-            if (trace & DIAGONAL) SAFE_ADD(temp, count);
-            temp = counts[j];
-            counts[j] = count;
-        }
-    }
-exit:
-    PyMem_Free(counts);
-    return count;
-}
-
-static Py_ssize_t
-PathGenerator_smithwaterman_length(PathGenerator* self)
-{
-    int i;
-    int j;
-    int trace;
-    const int nA = self->nA;
-    const int nB = self->nB;
-    Cell** M = self->M.affine;
-    const double threshold = self->threshold;
-    Py_ssize_t term;
-    Py_ssize_t count;
-    Py_ssize_t total = 0;
-    Py_ssize_t temp;
-    Py_ssize_t* counts;
-    counts = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-    if (!counts) return MEMORY_ERROR;
-    counts[0] = 1;
-    for (j = 1; j <= nB; j++) {
-        trace = M[0][j].trace;
-        count = 0;
-        if (trace & HORIZONTAL) SAFE_ADD(counts[j-1], count);
-        if (count==0) count = 1;
-        counts[j] = count;
-        if (trace && M[0][j].score >= threshold) SAFE_ADD(count, total);
-    }
-    for (i = 1; i <= nA; i++) {
-        trace = M[i][0].trace;
-        count = 0;
-        if (trace & VERTICAL) SAFE_ADD(counts[0], count);
-        if (count == 0) count = 1;
-        temp = counts[0];
-        counts[0] = count;
-        for (j = 1; j <= nB; j++) {
-            trace = M[i][j].trace;
-            count = 0;
-            if (trace & HORIZONTAL) SAFE_ADD(counts[j-1], count);
-            if (trace & VERTICAL) SAFE_ADD(counts[j], count);
-            if (trace & DIAGONAL) SAFE_ADD(temp, count);
-            temp = counts[j];
-            if (count==0) count = 1;
-            counts[j] = count;
-            if (trace && M[i][j].score >= threshold) SAFE_ADD(count, total);
-        }
-    }
-    count = total;
-exit:
-    PyMem_Free(counts);
-    return count;
-}
-
-static Py_ssize_t
-PathGenerator_gotoh_global_length(PathGenerator* self)
-{
-    int i;
-    int j;
-    int trace;
-    const int nA = self->nA;
-    const int nB = self->nB;
-    Cell** M = self->M.affine;
-    Cell** Ix = self->Ix.affine;
-    Cell** Iy = self->Iy.affine;
-    const double threshold = self->threshold;
-    Py_ssize_t count = MEMORY_ERROR;
-    Py_ssize_t term;
-    Py_ssize_t tempM;
-    Py_ssize_t tempIx;
-    Py_ssize_t tempIy;
-    Py_ssize_t* countsM = NULL;
-    Py_ssize_t* countsIx = NULL;
-    Py_ssize_t* countsIy = NULL;
-    countsM = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-    if (!countsM) goto exit;
-    countsIx = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-    if (!countsIx) goto exit;
-    countsIy = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-    if (!countsIy) goto exit;
-    countsM[0] = 1;
-    countsIx[0] = 0;
-    countsIy[0] = 0;
-    for (j = 1; j <= nB; j++) {
-        countsM[j] = 0;
-        countsIx[j] = 0;
-        countsIy[j] = 1;
-    }
-    for (i = 1; i <= nA; i++) {
-        tempM = countsM[0];
-        countsM[0] = 0;
-        tempIx = countsIx[0];
-        countsIx[0] = 1;
-        tempIy = countsIy[0];
-        countsIy[0] = 0;
-        for (j = 1; j <= nB; j++) {
-            count = 0;
-            trace = M[i][j].trace;
-            if (trace & M_MATRIX) SAFE_ADD(tempM, count);
-            if (trace & Ix_MATRIX) SAFE_ADD(tempIx, count);
-            if (trace & Iy_MATRIX) SAFE_ADD(tempIy, count);
-            tempM = countsM[j];
-            countsM[j] = count;
-            count = 0;
-            trace = Ix[i][j].trace;
-            if (trace & M_MATRIX) SAFE_ADD(tempM, count);
-            if (trace & Ix_MATRIX) SAFE_ADD(countsIx[j], count);
-            if (trace & Iy_MATRIX) SAFE_ADD(countsIy[j], count);
-            tempIx = countsIx[j];
-            countsIx[j] = count;
-            count = 0;
-            trace = Iy[i][j].trace;
-            if (trace & M_MATRIX) SAFE_ADD(countsM[j-1], count);
-            if (trace & Ix_MATRIX) SAFE_ADD(countsIx[j-1], count);
-            if (trace & Iy_MATRIX) SAFE_ADD(countsIy[j-1], count);
-            tempIy = countsIy[j];
-            countsIy[j] = count;
-        }
-    }
-    count = 0;
-    if (M[nA][nB].score >= threshold) SAFE_ADD(countsM[nB], count);
-    if (Ix[nA][nB].score >= threshold) SAFE_ADD(countsIx[nB], count);
-    if (Iy[nA][nB].score >= threshold) SAFE_ADD(countsIy[nB], count);
-exit:
-    if (countsM) PyMem_Free(countsM);
-    if (countsIx) PyMem_Free(countsIx);
-    if (countsIy) PyMem_Free(countsIy);
-    return count;
-}
-
-static Py_ssize_t
-PathGenerator_gotoh_local_length(PathGenerator* self)
-{
-    int i;
-    int j;
-    int trace;
-    const int nA = self->nA;
-    const int nB = self->nB;
-    Cell** M = self->M.affine;
-    Cell** Ix = self->Ix.affine;
-    Cell** Iy = self->Iy.affine;
-    const double threshold = self->threshold;
-    Py_ssize_t term;
-    Py_ssize_t count = MEMORY_ERROR;
-    Py_ssize_t total = 0;
-    Py_ssize_t tempM;
-    Py_ssize_t tempIx;
-    Py_ssize_t tempIy;
-    Py_ssize_t* countsM = NULL;
-    Py_ssize_t* countsIx = NULL;
-    Py_ssize_t* countsIy = NULL;
-    countsM = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-    if (!countsM) goto exit;
-    countsIx = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-    if (!countsIx) goto exit;
-    countsIy = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-    if (!countsIy) goto exit;
-    countsM[0] = 1;
-    countsIx[0] = 0;
-    countsIy[0] = 0;
-    for (j = 1; j <= nB; j++) {
-        countsM[j] = 1;
-        countsIx[j] = 0;
-        countsIy[j] = 0;
-    }
-    for (i = 1; i <= nA; i++) {
-        tempM = countsM[0];
-        countsM[0] = 1;
-        tempIx = countsIx[0];
-        countsIx[0] = 0;
-        tempIy = countsIy[0];
-        countsIy[0] = 0;
-        for (j = 1; j <= nB; j++) {
-            count = 0;
-            trace = M[i][j].trace;
-            if (trace & M_MATRIX) SAFE_ADD(tempM, count);
-            if (trace & Ix_MATRIX) SAFE_ADD(tempIx, count);
-            if (trace & Iy_MATRIX) SAFE_ADD(tempIy, count);
-            if (count==0) count = 1;
-            tempM = countsM[j];
-            countsM[j] = count;
-            if (trace && M[i][j].score >= threshold) SAFE_ADD(count, total);
-            count = 0;
-            trace = Ix[i][j].trace;
-            if (trace & M_MATRIX) SAFE_ADD(tempM, count);
-            if (trace & Ix_MATRIX) SAFE_ADD(countsIx[j], count);
-            if (trace & Iy_MATRIX) SAFE_ADD(countsIy[j], count);
-            tempIx = countsIx[j];
-            countsIx[j] = count;
-            if (trace && Ix[i][j].score >= threshold) SAFE_ADD(count, total);
-            count = 0;
-            trace = Iy[i][j].trace;
-            if (trace & M_MATRIX) SAFE_ADD(countsM[j-1], count);
-            if (trace & Ix_MATRIX) SAFE_ADD(countsIx[j-1], count);
-            if (trace & Iy_MATRIX) SAFE_ADD(countsIy[j-1], count);
-            tempIy = countsIy[j];
-            countsIy[j] = count;
-            if (trace && Iy[i][j].score >= threshold) SAFE_ADD(count, total);
-        }
-    }
-    count = total;
-exit:
-    if (countsM) PyMem_Free(countsM);
-    if (countsIx) PyMem_Free(countsIx);
-    if (countsIy) PyMem_Free(countsIy);
-    return count;
-}
-
-static Py_ssize_t
-PathGenerator_waterman_smith_beyer_global_length(PathGenerator* self)
-{
-    int i;
-    int j;
-    int k;
-    int trace;
-    int* tracep;
-    const int nA = self->nA;
-    const int nB = self->nB;
-    CellM** M = self->M.general;
-    CellXY** Ix = self->Ix.general;
-    CellXY** Iy = self->Iy.general;
-    const double threshold = self->threshold;
-    Py_ssize_t count = MEMORY_ERROR;
-    Py_ssize_t term;
-    Py_ssize_t** countM = NULL;
-    Py_ssize_t** countIx = NULL;
-    Py_ssize_t** countIy = NULL;
-    countM = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
-    if (!countM) goto exit;
-    countIx = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
-    if (!countIx) goto exit;
-    countIy = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
-    if (!countIy) goto exit;
-    for (i = 0; i <= nA; i++) {
-        countM[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-        if (!M[i]) goto exit;
-        countIx[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-        if (!Ix[i]) goto exit;
-        countIy[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-        if (!Iy[i]) goto exit;
-    }
-    for (i = 0; i <= nA; i++) {
-        for (j = 0; j <= nB; j++) {
-            count = 0;
-            trace = M[i][j].trace;
-            if (trace & M_MATRIX) SAFE_ADD(countM[i-1][j-1], count);
-            if (trace & Ix_MATRIX) SAFE_ADD(countIx[i-1][j-1], count);
-            if (trace & Iy_MATRIX) SAFE_ADD(countIy[i-1][j-1], count);
-            if (count == 0) count = 1; /* happens at M[0][0] only */
-            countM[i][j] = count;
-            count = 0;
-            tracep = Ix[i][j].traceM;
-            if (tracep) {
-                while (1) {
-                    k = *tracep;
-                    if (k < 0) break;
-                    SAFE_ADD(countM[k][j], count);
-                    tracep++;
-                }
-            }
-            tracep = Ix[i][j].traceXY;
-            if (tracep) {
-                while (1) {
-                    k = *tracep;
-                    if (k < 0) break;
-                    SAFE_ADD(countIy[k][j], count);
-                    tracep++;
-                }
-            }
-            countIx[i][j] = count;
-            count = 0;
-            tracep = Iy[i][j].traceM;
-            if (tracep) {
-                while (1) {
-                    k = *tracep;
-                    if (k < 0) break;
-                    SAFE_ADD(countM[i][k], count);
-                    tracep++;
-                }
-            }
-            tracep = Iy[i][j].traceXY;
-            if (tracep) {
-                while (1) {
-                    k = *tracep;
-                    if (k < 0) break;
-                    SAFE_ADD(countIx[i][k], count);
-                    tracep++;
-                }
-            }
-            countIy[i][j] = count;
-        }
-    }
-    count = 0;
-    if (M[nA][nB].score > threshold) SAFE_ADD(countM[nA][nB], count);
-    if (Ix[nA][nB].score > threshold) SAFE_ADD(countIx[nA][nB], count);
-    if (Iy[nA][nB].score > threshold) SAFE_ADD(countIy[nA][nB], count);
-exit:
-    if (countM) {
-        if (countIx) {
-            if (countIy) {
-                for (i = 0; i <= nA; i++) {
-                    if (!countM[i]) break;
-                    PyMem_Free(countM[i]);
-                    if (!countIx[i]) break;
-                    PyMem_Free(countIx[i]);
-                    if (!countIy[i]) break;
-                    PyMem_Free(countIy[i]);
-                }
-                PyMem_Free(countIy);
-            }
-            PyMem_Free(countIx);
-        }
-        PyMem_Free(countM);
-    }
-    return count;
-}
-
-static Py_ssize_t
-PathGenerator_waterman_smith_beyer_local_length(PathGenerator* self)
-{
-    int i;
-    int j;
-    int k;
-    int trace;
-    int* tracep;
-    const int nA = self->nA;
-    const int nB = self->nB;
-    CellM** M = self->M.general;
-    CellXY** Ix = self->Ix.general;
-    CellXY** Iy = self->Iy.general;
-    const double threshold = self->threshold;
-    Py_ssize_t term;
-    Py_ssize_t count = MEMORY_ERROR;
-    Py_ssize_t total = 0;
-    Py_ssize_t** countM = NULL;
-    Py_ssize_t** countIx = NULL;
-    Py_ssize_t** countIy = NULL;
-    if (threshold < 0) return 0;
-    countM = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
-    if (!countM) goto exit;
-    countIx = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
-    if (!countIx) goto exit;
-    countIy = PyMem_Malloc((nA+1)*sizeof(Py_ssize_t*));
-    if (!countIy) goto exit;
-    for (i = 0; i <= nA; i++) {
-        countM[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-        if (!M[i]) goto exit;
-        countIx[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-        if (!Ix[i]) goto exit;
-        countIy[i] = PyMem_Malloc((nB+1)*sizeof(Py_ssize_t));
-        if (!Iy[i]) goto exit;
-    }
-    for (i = 0; i <= nA; i++) {
-        for (j = 0; j <= nB; j++) {
-            count = 0;
-            trace = M[i][j].trace;
-            if (trace & M_MATRIX) SAFE_ADD(countM[i-1][j-1], count);
-            if (trace & Ix_MATRIX) SAFE_ADD(countIx[i-1][j-1], count);
-            if (trace & Iy_MATRIX) SAFE_ADD(countIy[i-1][j-1], count);
-            if (count==0) count = 1;
-            countM[i][j] = count;
-            if (trace && M[i][j].score >= threshold) SAFE_ADD(count, total);
-            count = 0;
-            tracep = Ix[i][j].traceM;
-            if (tracep) {
-                while (1) {
-                    k = *tracep;
-                    if (k < 0) break;
-                    SAFE_ADD(countM[k][j], count);
-                    tracep++;
-                }
-            }
-            tracep = Ix[i][j].traceXY;
-            if (tracep) {
-                while (1) {
-                    k = *tracep;
-                    if (k < 0) break;
-                    SAFE_ADD(countIy[k][j], count);
-                    tracep++;
-                }
-            }
-            if (count == 0) count = 1;
-            countIx[i][j] = count;
-            count = 0;
-            tracep = Iy[i][j].traceM;
-            if (tracep) {
-                while (1) {
-                    k = *tracep;
-                    if (k < 0) break;
-                    SAFE_ADD(countM[i][k], count);
-                    tracep++;
-                }
-            }
-            tracep = Iy[i][j].traceXY;
-            if (tracep) {
-                while (1) {
-                    k = *tracep;
-                    if (k < 0) break;
-                    SAFE_ADD(countIx[i][k], count);
-                    tracep++;
-                }
-            }
-            if (count == 0) count = 1;
-            countIy[i][j] = count;
-        }
-    }
-    count = total;
-exit:
-    if (countM) {
-        if (countIx) {
-            if (countIy) {
-                for (i = 0; i <= nA; i++) {
-                    if (!countM[i]) break;
-                    PyMem_Free(countM[i]);
-                    if (!countIx[i]) break;
-                    PyMem_Free(countIx[i]);
-                    if (!countIy[i]) break;
-                    PyMem_Free(countIy[i]);
-                }
-                PyMem_Free(countIy);
-            }
-            PyMem_Free(countIx);
-        }
-        PyMem_Free(countM);
-    }
-    return count;
-}
-
-static Py_ssize_t PathGenerator_length(PathGenerator* self) {
-    Py_ssize_t length = self->length;
-    if (length == 0) {
-        switch (self->algorithm) {
-            case NeedlemanWunschSmithWaterman:
-                switch (self->mode) {
-                    case Global:
-                        length = PathGenerator_needlemanwunsch_length(self);
-                        break;
-                    case Local:
-                        length = PathGenerator_smithwaterman_length(self);
-                        break;
-                    default:
-                        /* should not happen, but some compilers complain that
-                         * that length can be used uninitialized.
-                         */
-                        PyErr_SetString(PyExc_RuntimeError, "Unknown mode");
-                        return -1;
-                }
-                break;
-            case Gotoh:
-                switch (self->mode) {
-                    case Global:
-                        length = PathGenerator_gotoh_global_length(self);
-                        break;
-                    case Local:
-                        length = PathGenerator_gotoh_local_length(self);
-                        break;
-                    default:
-                        /* should not happen, but some compilers complain that
-                         * that length can be used uninitialized.
-                         */
-                        PyErr_SetString(PyExc_RuntimeError, "Unknown mode");
-                        return -1;
-                }
-                break;
-            case WatermanSmithBeyer:
-                switch (self->mode) {
-                    case Global:
-                        length = PathGenerator_waterman_smith_beyer_global_length(self);
-                        break;
-                    case Local:
-                        length = PathGenerator_waterman_smith_beyer_local_length(self);
-                        break;
-                    default:
-                        /* should not happen, but some compilers complain that
-                         * that length can be used uninitialized.
-                         */
-                        PyErr_SetString(PyExc_RuntimeError, "Unknown mode");
-                        return -1;
-                }
-                break;
-            case Unknown:
-            default:
-                PyErr_SetString(PyExc_RuntimeError, "Unknown algorithm");
-                return -1;
-        }
-        self->length = length;
-    }
-    switch (length) {
-        case OVERFLOW_ERROR:
-            PyErr_Format(PyExc_OverflowError,
-                         "number of optimal alignments is larger than %zd",
-                         PY_SSIZE_T_MAX);
-            break;
-        case MEMORY_ERROR:
-            PyErr_SetString(PyExc_MemoryError, "Out of memory");
-            break;
-        default:
-            break;
-    }
-    return length;
-}
-
-static PySequenceMethods PathGenerator_as_sequence = {
-    (lenfunc)PathGenerator_length,  /* sq_length */
-    NULL,                           /* sq_concat */
-    NULL,                           /* sq_repeat */
-    NULL,                           /* sq_item */
-    NULL,                           /* sq_ass_item */
-    NULL,                           /* sq_contains */
-    NULL,                           /* sq_inplace_concat */
-    NULL,                           /* sq_inplace_repeat */
-};
-
-static PyTypeObject PathGenerator_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "Path generator",               /* tp_name */
-    sizeof(PathGenerator),          /* tp_basicsize */
-    0,                              /* tp_itemsize */
-    (destructor)PathGenerator_dealloc,  /* tp_dealloc */
-    0,                              /* tp_print */
-    0,                              /* tp_getattr */
-    0,                              /* tp_setattr */
-    0,                              /* tp_reserved */
-    0,                              /* tp_repr */
-    0,                              /* tp_as_number */
-    &PathGenerator_as_sequence,     /* tp_as_sequence */
-    0,                              /* tp_as_mapping */
-    0,                              /* tp_hash */
-    0,                              /* tp_call */
-    0,                              /* tp_str */
-    0,                              /* tp_getattro */
-    0,                              /* tp_setattro */
-    0,                              /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT,             /* tp_flags */
-    0,                              /* tp_doc */
-    0,                              /* tp_traverse */
-    0,                              /* tp_clear */
-    0,                              /* tp_richcompare */
-    0,                              /* tp_weaklistoffset */
-    PyObject_SelfIter,              /* tp_iter */
-    (iternextfunc)PathGenerator_next,      /* tp_iternext */
-    PathGenerator_methods,          /* tp_methods */
-};
-
-static PathGenerator*
-_create_path_generator(const Aligner* aligner, int nA, int nB, double epsilon)
-{
-    Algorithm algorithm = aligner->algorithm;
-    PathGenerator* generator;
-    generator = (PathGenerator*)PyType_GenericAlloc(&PathGenerator_Type, 0);
-    if (!generator) return NULL;
-
-    generator->iA = 0;
-    generator->iB = 0;
-    generator->nA = nA;
-    generator->nB = nB;
-    switch (algorithm) {
-        case NeedlemanWunschSmithWaterman:
-        case Gotoh:
-            generator->M.affine = NULL;
-            generator->Ix.affine = NULL;
-            generator->Iy.affine = NULL;
-            break;
-        case WatermanSmithBeyer:
-            generator->M.general = NULL;
-            generator->Ix.general = NULL;
-            generator->Iy.general = NULL;
-            break;
-        case Unknown:
-        default:
-            Py_DECREF(generator);
-            PyErr_SetString(PyExc_RuntimeError, "unknown algorithm");
-            return NULL;
-    }
-    generator->algorithm = algorithm;
-    generator->mode = aligner->mode;
-    generator->threshold = 0;
-    generator->length = 0;
-
-    return generator;
+    SELECT_SCORE_LOCAL1(temp + self->substitution_matrix[kA][kB]);
+    PyMem_Free(scores);
+    return PyFloat_FromDouble(maximum);
 }
 
 static PyObject*
@@ -4813,70 +4603,48 @@ Aligner_needlemanwunsch_align(Aligner* self, const char* sA, Py_ssize_t nA,
     const double right_gap_extend_A = self->target_right_extend_gap_score;
     const double right_gap_extend_B = self->query_right_extend_gap_score;
     const double epsilon = self->epsilon;
-    Cell** M = NULL;
+    Trace** M;
     double score;
     int trace;
     double temp;
-    PathGenerator* paths = NULL;
+    double* scores = NULL;
+    PathGenerator* paths;
 
     /* Needleman-Wunsch algorithm */
-    M = _allocate_needlemanwunsch_smithwaterman_matrix(nA, nB);
-    if (!M) goto exit;
-    M[0][0].score = 0;
-    M[0][0].trace = 0;
-    for (j = 1; j <= nB; j++) {
-        M[0][j].score = j * left_gap_extend_A;
-        M[0][j].trace = HORIZONTAL;
+    paths = PathGenerator_create_NWSW(nA, nB, Global);
+    if (!paths) return NULL;
+    scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!scores) {
+        Py_DECREF(paths);
+        return PyErr_NoMemory();
     }
+    M = paths->M;
+    scores[0] = 0;
+    for (j = 1; j <= nB; j++) scores[j] = j * left_gap_extend_A;
     for (i = 1; i < nA; i++) {
-        M[i][0].score = i * left_gap_extend_B;
-        M[i][0].trace = VERTICAL;
+        temp = scores[0];
+        scores[0] = i * left_gap_extend_B;
         kA = CHARINDEX(sA[i-1]);
         for (j = 1; j < nB; j++) {
             kB = CHARINDEX(sB[j-1]);
-            SELECT_TRACE_NEEDLEMAN_WUNSCH(M[i][j],
-                M[i][j-1].score + gap_extend_A,
-                M[i-1][j].score + gap_extend_B,
-                M[i-1][j-1].score + self->substitution_matrix[kA][kB]);
+            SELECT_TRACE_NEEDLEMAN_WUNSCH(gap_extend_A, gap_extend_B);
         }
-        kB = CHARINDEX(sB[nB-1]);
-        SELECT_TRACE_NEEDLEMAN_WUNSCH(M[i][nB],
-            M[i][nB-1].score + gap_extend_A,
-            M[i-1][nB].score + right_gap_extend_B,
-            M[i-1][nB-1].score + self->substitution_matrix[kA][kB]);
+        kB = CHARINDEX(sB[j-1]);
+        SELECT_TRACE_NEEDLEMAN_WUNSCH(gap_extend_A, right_gap_extend_B);
     }
-    M[nA][0].score = i * left_gap_extend_B;
-    M[nA][0].trace = VERTICAL;
+    temp = scores[0];
+    scores[0] = i * left_gap_extend_B;
     kA = CHARINDEX(sA[nA-1]);
     for (j = 1; j < nB; j++) {
         kB = CHARINDEX(sB[j-1]);
-        SELECT_TRACE_NEEDLEMAN_WUNSCH(M[nA][j],
-            M[nA][j-1].score + right_gap_extend_A,
-            M[nA-1][j].score + gap_extend_B,
-            M[nA-1][j-1].score + self->substitution_matrix[kA][kB]);
+        SELECT_TRACE_NEEDLEMAN_WUNSCH(right_gap_extend_A, gap_extend_B);
     }
-    kB = CHARINDEX(sB[nB-1]);
-    SELECT_TRACE_NEEDLEMAN_WUNSCH(M[nA][nB],
-        M[nA][nB-1].score + right_gap_extend_A,
-        M[nA-1][nB].score + right_gap_extend_B,
-        M[nA-1][nB-1].score + self->substitution_matrix[kA][kB]);
-    M[0][0].path = 0;
+    kB = CHARINDEX(sB[j-1]);
+    SELECT_TRACE_NEEDLEMAN_WUNSCH(right_gap_extend_A, right_gap_extend_B);
+    PyMem_Free(scores);
     M[nA][nB].path = 0;
 
-    paths = _create_path_generator(self, nA, nB, epsilon);
-    if (paths) {
-        PyObject* result;
-        paths->M.affine = M;
-        paths->threshold = score - epsilon;
-        result = Py_BuildValue("fO", score, paths);
-        Py_DECREF(paths);
-        return result;
-    }
-    else _deallocate_needlemanwunsch_smithwaterman_matrix(nA, M);
-
-exit:
-    PyErr_SetString(PyExc_MemoryError, "Out of memory");
-    return NULL;
+    return Py_BuildValue("fN", score, paths);
 }
 
 static PyObject*
@@ -4886,70 +4654,55 @@ Aligner_smithwaterman_align(Aligner* self, const char* sA, Py_ssize_t nA,
     char c;
     int i;
     int j;
+    int im = nA;
+    int jm = nB;
     int kA;
     int kB;
     const double gap_extend_A = self->target_extend_gap_score;
     const double gap_extend_B = self->query_extend_gap_score;
     const double epsilon = self->epsilon;
-    Cell** M = NULL;
+    Trace** M = NULL;
     double maximum = 0;
     double score = 0;
+    double* scores = NULL;
     double temp;
     int trace;
     PathGenerator* paths = NULL;
 
     /* Smith-Waterman algorithm */
-    M = _allocate_needlemanwunsch_smithwaterman_matrix(nA, nB);
-    if (!M) goto exit;
-    M[0][0].score = 0;
-    M[0][0].trace = 0;
-    M[0][0].path = 0;
-    for (j = 1; j <= nB; j++) {
-        M[0][j].score = 0;
-        M[0][j].trace = 0;
+    paths = PathGenerator_create_NWSW(nA, nB, Local);
+    if (!paths) return NULL;
+    scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!scores) {
+        Py_DECREF(paths);
+        return PyErr_NoMemory();
     }
+    M = paths->M;
+    for (j = 0; j <= nB; j++) scores[j] = 0;
     for (i = 1; i < nA; i++) {
-        M[i][0].score = 0;
-        M[i][0].trace = 0;
+        temp = 0;
         kA = CHARINDEX(sA[i-1]);
         for (j = 1; j < nB; j++) {
             kB = CHARINDEX(sB[j-1]);
-            SELECT_TRACE_SMITH_WATERMAN_HVD(M[i][j],
-                M[i][j-1].score + gap_extend_A,
-                M[i-1][j].score + gap_extend_B,
-                M[i-1][j-1].score + self->substitution_matrix[kA][kB]);
+            SELECT_TRACE_SMITH_WATERMAN_HVD(gap_extend_A, gap_extend_B);
         }
         kB = CHARINDEX(sB[nB-1]);
-        SELECT_TRACE_SMITH_WATERMAN_D(M[i][nB],
-            M[i-1][nB-1].score + self->substitution_matrix[kA][kB]);
+        SELECT_TRACE_SMITH_WATERMAN_D;
     }
-    M[nA][0].score = 0;
-    M[nA][0].trace = 0;
+    temp = 0;
     kA = CHARINDEX(sA[nA-1]);
     for (j = 1; j < nB; j++) {
         kB = CHARINDEX(sB[j-1]);
-        SELECT_TRACE_SMITH_WATERMAN_D(M[nA][j],
-            M[nA-1][j-1].score + self->substitution_matrix[kA][kB]);
+        SELECT_TRACE_SMITH_WATERMAN_D;
     }
     kB = CHARINDEX(sB[nB-1]);
-    SELECT_TRACE_SMITH_WATERMAN_D(M[nA][nB],
-        M[nA-1][nB-1].score + self->substitution_matrix[kA][kB]);
+    SELECT_TRACE_SMITH_WATERMAN_D;
+    PyMem_Free(scores);
 
-    paths = _create_path_generator(self, nA, nB, epsilon);
-    if (paths) {
-        PyObject* result;
-        paths->M.affine = M;
-        paths->threshold = maximum - epsilon;
-        if (maximum==0) M[0][0].path = DONE;
-        result = Py_BuildValue("fO", maximum, paths);
-        Py_DECREF(paths);
-        return result;
-    }
-    else _deallocate_needlemanwunsch_smithwaterman_matrix(nA, M);
+    if (maximum == 0) M[0][0].path = NONE;
+    else M[0][0].path = 0;
 
-exit:
-    PyErr_SetString(PyExc_MemoryError, "Out of memory");
-    return NULL;
+    return Py_BuildValue("fN", maximum, paths);
 }
 
 static PyObject*
@@ -4973,135 +4726,131 @@ Aligner_gotoh_global_score(Aligner* self, const char* sA, Py_ssize_t nA,
     const double right_gap_open_B = self->query_right_open_gap_score;
     const double right_gap_extend_A = self->target_right_extend_gap_score;
     const double right_gap_extend_B = self->query_right_extend_gap_score;
-    double** M = NULL;
-    double** Ix = NULL;
-    double** Iy = NULL;
+    double* M_scores = NULL;
+    double* Ix_scores = NULL;
+    double* Iy_scores = NULL;
     double score;
     double temp;
-    PyObject* result = NULL;
+    double M_temp;
+    double Ix_temp;
+    double Iy_temp;
 
     /* Gotoh algorithm with three states */
-    M = PyMem_Malloc((nA+1)*sizeof(double*));
-    if (!M) goto exit;
-    Ix = PyMem_Malloc((nA+1)*sizeof(double*));
-    if (!Ix) goto exit;
-    Iy = PyMem_Malloc((nA+1)*sizeof(double*));
-    if (!Iy) goto exit;
-    for (i = 0; i <= nA; i++) {
-        M[i] = PyMem_Malloc((nB+1)*sizeof(double));
-        if (!M[i]) goto exit;
-        Ix[i] = PyMem_Malloc((nB+1)*sizeof(double));
-        if (!Ix[i]) goto exit;
-        Iy[i] = PyMem_Malloc((nB+1)*sizeof(double));
-        if (!Iy[i]) goto exit;
-    }
+    M_scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!M_scores) goto exit;
+    Ix_scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!Ix_scores) goto exit;
+    Iy_scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!Iy_scores) goto exit;
 
     /* The top row of the score matrix is a special case,
      * as there are no previously aligned characters.
      */
-    M[0][0] = 0;
-    Ix[0][0] = -DBL_MAX;
-    Iy[0][0] = -DBL_MAX;
-    for (i = 1; i <= nA; i++) {
-        M[i][0] = -DBL_MAX;
-        Ix[i][0] = left_gap_open_B + left_gap_extend_B * (i-1);
-        Iy[i][0] = -DBL_MAX;
-    }
+    M_scores[0] = 0;
+    Ix_scores[0] = -DBL_MAX;
+    Iy_scores[0] = -DBL_MAX;
     for (j = 1; j <= nB; j++) {
-        M[0][j] = -DBL_MAX;
-        Ix[0][j] = -DBL_MAX;
-        Iy[0][j] = left_gap_open_A + left_gap_extend_A * (j-1);
+        M_scores[j] = -DBL_MAX;
+        Ix_scores[j] = -DBL_MAX;
+        Iy_scores[j] = left_gap_open_A + left_gap_extend_A * (j-1);
     }
 
     for (i = 1; i < nA; i++) {
+        M_temp = M_scores[0];
+        Ix_temp = Ix_scores[0];
+        Iy_temp = Iy_scores[0];
+        M_scores[0] = -DBL_MAX;
+        Ix_scores[0] = left_gap_open_B + left_gap_extend_B * (i-1);
+        Iy_scores[0] = -DBL_MAX;
         kA = CHARINDEX(sA[i-1]);
         for (j = 1; j < nB; j++) {
             kB = CHARINDEX(sB[j-1]);
-            SELECT_SCORE_GLOBAL(M[i-1][j] + gap_open_B,
-                                Ix[i-1][j] + gap_extend_B,
-                                Iy[i-1][j] + gap_open_B);
-            Ix[i][j] = score;
-            SELECT_SCORE_GLOBAL(M[i][j-1] + gap_open_A,
-                                Iy[i][j-1] + gap_extend_A,
-                                Ix[i][j-1] + gap_open_A);
-            Iy[i][j] = score;
-            SELECT_SCORE_GLOBAL(M[i-1][j-1],
-                                Ix[i-1][j-1],
-                                Iy[i-1][j-1]);
-            M[i][j] = score + self->substitution_matrix[kA][kB];
+            SELECT_SCORE_GLOBAL(M_temp,
+                                Ix_temp,
+                                Iy_temp);
+            M_temp = M_scores[j];
+            M_scores[j] = score + self->substitution_matrix[kA][kB];
+            SELECT_SCORE_GLOBAL(M_temp + gap_open_B,
+                                Ix_scores[j] + gap_extend_B,
+                                Iy_scores[j] + gap_open_B);
+            Ix_temp = Ix_scores[j];
+            Ix_scores[j] = score;
+            SELECT_SCORE_GLOBAL(M_scores[j-1] + gap_open_A,
+                                Ix_scores[j-1] + gap_open_A,
+                                Iy_scores[j-1] + gap_extend_A);
+            Iy_temp = Iy_scores[j];
+            Iy_scores[j] = score;
         }
         kB = CHARINDEX(sB[nB-1]);
-        SELECT_SCORE_GLOBAL(M[i-1][nB] + right_gap_open_B,
-                            Ix[i-1][nB] + right_gap_extend_B,
-                            Iy[i-1][nB] + right_gap_open_B);
-        Ix[i][nB] = score;
-        SELECT_SCORE_GLOBAL(M[i][nB-1] + gap_open_A,
-                            Iy[i][nB-1] + gap_extend_A,
-                            Ix[i][nB-1] + gap_open_A);
-        Iy[i][nB] = score;
-        SELECT_SCORE_GLOBAL(M[i-1][nB-1],
-                            Ix[i-1][nB-1],
-                            Iy[i-1][nB-1]);
-        M[i][nB] = score + self->substitution_matrix[kA][kB];
+        SELECT_SCORE_GLOBAL(M_temp,
+                            Ix_temp,
+                            Iy_temp);
+        M_temp = M_scores[nB];
+        M_scores[nB] = score + self->substitution_matrix[kA][kB];
+        SELECT_SCORE_GLOBAL(M_temp + right_gap_open_B,
+                            Ix_scores[nB] + right_gap_extend_B,
+                            Iy_scores[nB] + right_gap_open_B);
+        Ix_scores[nB] = score;
+        SELECT_SCORE_GLOBAL(M_scores[nB-1] + gap_open_A,
+                            Iy_scores[nB-1] + gap_extend_A,
+                            Ix_scores[nB-1] + gap_open_A);
+        Iy_scores[nB] = score;
     }
 
+    M_temp = M_scores[0];
+    Ix_temp = Ix_scores[0];
+    Iy_temp = Iy_scores[0];
+    M_scores[0] = -DBL_MAX;
+    Ix_scores[0] = left_gap_open_B + left_gap_extend_B * (i-1);
+    Iy_scores[0] = -DBL_MAX;
     kA = CHARINDEX(sA[nA-1]);
     for (j = 1; j < nB; j++) {
         kB = CHARINDEX(sB[j-1]);
-        SELECT_SCORE_GLOBAL(M[nA-1][j] + gap_open_B,
-                            Ix[nA-1][j] + gap_extend_B,
-                            Iy[nA-1][j] + gap_open_B);
-        Ix[nA][j] = score;
-        SELECT_SCORE_GLOBAL(M[nA][j-1] + right_gap_open_A,
-                            Iy[nA][j-1] + right_gap_extend_A,
-                            Ix[nA][j-1] + right_gap_open_A);
-        Iy[nA][j] = score;
-        SELECT_SCORE_GLOBAL(M[nA-1][j-1],
-                            Ix[nA-1][j-1],
-                            Iy[nA-1][j-1]);
-        M[nA][j] = score + self->substitution_matrix[kA][kB];
+        SELECT_SCORE_GLOBAL(M_temp,
+                            Ix_temp,
+                            Iy_temp);
+        M_temp = M_scores[j];
+        M_scores[j] = score + self->substitution_matrix[kA][kB];
+        SELECT_SCORE_GLOBAL(M_temp + gap_open_B,
+                            Ix_scores[j] + gap_extend_B,
+                            Iy_scores[j] + gap_open_B);
+        Ix_temp = Ix_scores[j];
+        Ix_scores[j] = score;
+        SELECT_SCORE_GLOBAL(M_scores[j-1] + right_gap_open_A,
+                            Iy_scores[j-1] + right_gap_extend_A,
+                            Ix_scores[j-1] + right_gap_open_A);
+        Iy_temp = Iy_scores[j];
+        Iy_scores[j] = score;
     }
 
     kB = CHARINDEX(sB[nB-1]);
-    SELECT_SCORE_GLOBAL(M[nA-1][nB] + right_gap_open_B,
-                        Ix[nA-1][nB] + right_gap_extend_B,
-                        Iy[nA-1][nB] + right_gap_open_B);
-    Ix[nA][nB] = score;
-    SELECT_SCORE_GLOBAL(M[nA][nB-1] + right_gap_open_A,
-                        Iy[nA][nB-1] + right_gap_extend_A,
-                        Ix[nA][nB-1] + right_gap_open_A);
-    Iy[nA][nB] = score;
-    SELECT_SCORE_GLOBAL(M[nA-1][nB-1],
-                        Ix[nA-1][nB-1],
-                        Iy[nA-1][nB-1]);
-    M[nA][nB] = score + self->substitution_matrix[kA][kB];
+    SELECT_SCORE_GLOBAL(M_temp,
+                        Ix_temp,
+                        Iy_temp);
+    M_temp = M_scores[nB];
+    M_scores[nB] = score + self->substitution_matrix[kA][kB];
+    SELECT_SCORE_GLOBAL(M_temp + right_gap_open_B,
+                        Ix_scores[nB] + right_gap_extend_B,
+                        Iy_scores[nB] + right_gap_open_B);
+    Ix_temp = Ix_scores[nB];
+    Ix_scores[nB] = score;
+    SELECT_SCORE_GLOBAL(M_scores[nB-1] + right_gap_open_A,
+                        Ix_scores[nB-1] + right_gap_open_A,
+                        Iy_scores[nB-1] + right_gap_extend_A);
+    Iy_temp = Iy_scores[nB];
+    Iy_scores[nB] = score;
 
-    SELECT_SCORE_GLOBAL(M[nA][nB], Ix[nA][nB], Iy[nA][nB]);
-    result = PyFloat_FromDouble(score);
+    SELECT_SCORE_GLOBAL(M_scores[nB], Ix_scores[nB], Iy_scores[nB]);
+    PyMem_Free(M_scores);
+    PyMem_Free(Ix_scores);
+    PyMem_Free(Iy_scores);
+    return PyFloat_FromDouble(score);
 
 exit:
-    if (M) {
-        /* If M is NULL, then Ix is also NULL. */
-        if (Ix) {
-            /* If Ix is NULL, then Iy is also NULL. */
-            if (Iy) {
-                /* If Iy is NULL, then M[i], Ix[i], and Iy[i] are also NULL. */
-                for (i = 0; i <= nA; i++) {
-                    if (!M[i]) break;
-                    PyMem_Free(M[i]);
-                    if (!Ix[i]) break;
-                    PyMem_Free(Ix[i]);
-                    if (!Iy[i]) break;
-                    PyMem_Free(Iy[i]);
-                }
-                PyMem_Free(Iy);
-            }
-            PyMem_Free(Ix);
-        }
-        PyMem_Free(M);
-    }
-    if (!result) PyErr_SetString(PyExc_MemoryError, "Out of memory");
-    return result;
+    if (M_scores) PyMem_Free(M_scores);
+    if (Ix_scores) PyMem_Free(Ix_scores);
+    if (Iy_scores) PyMem_Free(Iy_scores);
+    return PyErr_NoMemory();
 }
 
 static PyObject*
@@ -5117,123 +4866,113 @@ Aligner_gotoh_local_score(Aligner* self, const char* sA, Py_ssize_t nA,
     const double gap_open_B = self->query_open_gap_score;
     const double gap_extend_A = self->target_extend_gap_score;
     const double gap_extend_B = self->query_extend_gap_score;
-    double** M = NULL;
-    double** Ix = NULL;
-    double** Iy = NULL;
+    double* M_scores = NULL;
+    double* Ix_scores = NULL;
+    double* Iy_scores = NULL;
     double score;
     double temp;
+    double M_temp;
+    double Ix_temp;
+    double Iy_temp;
     double maximum = 0.0;
-    PyObject* result = NULL;
 
     /* Gotoh algorithm with three states */
-    M = PyMem_Malloc((nA+1)*sizeof(double*));
-    if (!M) goto exit;
-    Ix = PyMem_Malloc((nA+1)*sizeof(double*));
-    if (!Ix) goto exit;
-    Iy = PyMem_Malloc((nA+1)*sizeof(double*));
-    if (!Iy) goto exit;
-    for (i = 0; i <= nA; i++) {
-        M[i] = PyMem_Malloc((nB+1)*sizeof(double));
-        if (!M[i]) goto exit;
-        Ix[i] = PyMem_Malloc((nB+1)*sizeof(double));
-        if (!Ix[i]) goto exit;
-        Iy[i] = PyMem_Malloc((nB+1)*sizeof(double));
-        if (!Iy[i]) goto exit;
-    }
+    M_scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!M_scores) goto exit;
+    Ix_scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!Ix_scores) goto exit;
+    Iy_scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!Iy_scores) goto exit;
 
     /* The top row of the score matrix is a special case,
      * as there are no previously aligned characters.
      */
-    M[0][0] = 0;
-    Ix[0][0] = -DBL_MAX;
-    Iy[0][0] = -DBL_MAX;
-    for (i = 1; i <= nA; i++) {
-        M[i][0] = -DBL_MAX;
-        Ix[i][0] = 0;
-        Iy[i][0] = -DBL_MAX;
-    }
+    M_scores[0] = 0;
+    Ix_scores[0] = -DBL_MAX;
+    Iy_scores[0] = -DBL_MAX;
     for (j = 1; j <= nB; j++) {
-        M[0][j] = -DBL_MAX;
-        Ix[0][j] = -DBL_MAX;
-        Iy[0][j] = 0;
+        M_scores[j] = -DBL_MAX;
+        Ix_scores[j] = -DBL_MAX;
+        Iy_scores[j] = 0;
     }
 
     for (i = 1; i < nA; i++) {
+        M_temp = M_scores[0];
+        Ix_temp = Ix_scores[0];
+        Iy_temp = Iy_scores[0];
+        M_scores[0] = -DBL_MAX;
+        Ix_scores[0] = 0;
+        Iy_scores[0] = -DBL_MAX;
         kA = CHARINDEX(sA[i-1]);
         for (j = 1; j < nB; j++) {
             kB = CHARINDEX(sB[j-1]);
-            SELECT_SCORE_LOCAL3(M[i-1][j] + gap_open_B,
-                                Ix[i-1][j] + gap_extend_B,
-                                Iy[i-1][j] + gap_open_B);
-            Ix[i][j] = score;
-            SELECT_SCORE_LOCAL3(M[i][j-1] + gap_open_A,
-                                Iy[i][j-1] + gap_extend_A,
-                                Ix[i][j-1] + gap_open_A);
-            Iy[i][j] = score;
-            SELECT_SCORE_GOTOH_LOCAL_ALIGN(M[i-1][j-1],
-                                           Ix[i-1][j-1],
-                                           Iy[i-1][j-1],
+            SELECT_SCORE_GOTOH_LOCAL_ALIGN(M_temp,
+                                           Ix_temp,
+                                           Iy_temp,
                                            self->substitution_matrix[kA][kB]);
-            M[i][j] = score;
+            M_temp = M_scores[j];
+            M_scores[j] = score;
+            SELECT_SCORE_LOCAL3(M_temp + gap_open_B,
+                                Ix_scores[j] + gap_extend_B,
+                                Iy_scores[j] + gap_open_B);
+            Ix_temp = Ix_scores[j];
+            Ix_scores[j] = score;
+            SELECT_SCORE_LOCAL3(M_scores[j-1] + gap_open_A,
+                                Ix_scores[j-1] + gap_open_A,
+                                Iy_scores[j-1] + gap_extend_A);
+            Iy_temp = Iy_scores[j];
+            Iy_scores[j] = score;
         }
 
         kB = CHARINDEX(sB[nB-1]);
 
-        Ix[i][nB] = 0;
-        Iy[i][nB] = 0;
-        SELECT_SCORE_GOTOH_LOCAL_ALIGN(M[i-1][nB-1],
-                                       Ix[i-1][nB-1],
-                                       Iy[i-1][nB-1],
+        Ix_scores[nB] = 0;
+        Iy_scores[nB] = 0;
+        SELECT_SCORE_GOTOH_LOCAL_ALIGN(M_temp,
+                                       Ix_temp,
+                                       Iy_temp,
                                        self->substitution_matrix[kA][kB]);
-        M[i][nB] = score;
+        M_temp = M_scores[nB];
+        M_scores[nB] = score;
     }
 
+    M_temp = M_scores[0];
+    Ix_temp = Ix_scores[0];
+    Iy_temp = Iy_scores[0];
+    M_scores[0] = -DBL_MAX;
+    Ix_scores[0] = 0;
+    Iy_scores[0] = -DBL_MAX;
     kA = CHARINDEX(sA[nA-1]);
     for (j = 1; j < nB; j++) {
         kB = CHARINDEX(sB[j-1]);
-        Ix[nA][j] = 0;
-        Iy[nA][j] = 0;
-        SELECT_SCORE_GOTOH_LOCAL_ALIGN(M[nA-1][j-1],
-                                       Ix[nA-1][j-1],
-                                       Iy[nA-1][j-1],
+        SELECT_SCORE_GOTOH_LOCAL_ALIGN(M_temp,
+                                       Ix_temp,
+                                       Iy_temp,
                                        self->substitution_matrix[kA][kB]);
-        M[nA][j] = score;
+        M_temp = M_scores[j];
+        M_scores[j] = score;
+        Ix_temp = Ix_scores[j];
+        Iy_temp = Iy_scores[j];
+        Ix_scores[j] = 0;
+        Iy_scores[j] = 0;
     }
 
     kB = CHARINDEX(sB[nB-1]);
-    Ix[nA][nB] = 0;
-    Iy[nA][nB] = 0;
-    SELECT_SCORE_GOTOH_LOCAL_ALIGN(M[nA-1][nB-1],
-                                   Ix[nA-1][nB-1],
-                                   Iy[nA-1][nB-1],
+    SELECT_SCORE_GOTOH_LOCAL_ALIGN(M_temp,
+                                   Ix_temp,
+                                   Iy_temp,
                                    self->substitution_matrix[kA][kB]);
-    M[nA][nB] = score;
 
-    result = PyFloat_FromDouble(maximum);
+    PyMem_Free(M_scores);
+    PyMem_Free(Ix_scores);
+    PyMem_Free(Iy_scores);
+    return PyFloat_FromDouble(maximum);
 
 exit:
-    if (M) {
-        /* If M is NULL, then Ix is also NULL. */
-        if (Ix) {
-            /* If Ix is NULL, then Iy is also NULL. */
-            if (Iy) {
-                /* If Iy is NULL, then M[i], Ix[i], and Iy[i] are also NULL. */
-                for (i = 0; i <= nA; i++) {
-                    if (!M[i]) break;
-                    PyMem_Free(M[i]);
-                    if (!Ix[i]) break;
-                    PyMem_Free(Ix[i]);
-                    if (!Iy[i]) break;
-                    PyMem_Free(Iy[i]);
-                }
-                PyMem_Free(Iy);
-            }
-            PyMem_Free(Ix);
-        }
-        PyMem_Free(M);
-    }
-    if (!result) PyErr_SetString(PyExc_MemoryError, "Out of memory");
-    return result;
+    if (M_scores) PyMem_Free(M_scores);
+    if (Ix_scores) PyMem_Free(Ix_scores);
+    if (Iy_scores) PyMem_Free(Iy_scores);
+    return PyErr_NoMemory();
 }
 
 static PyObject*
@@ -5258,131 +4997,139 @@ Aligner_gotoh_global_align(Aligner* self, const char* sA, Py_ssize_t nA,
     const double right_gap_extend_A = self->target_right_extend_gap_score;
     const double right_gap_extend_B = self->query_right_extend_gap_score;
     const double epsilon = self->epsilon;
-    Cell** M = NULL;
-    Cell** Ix = NULL;
-    Cell** Iy = NULL;
+    TraceGapsGotoh** gaps = NULL;
+    Trace** M = NULL;
+    double* M_scores = NULL;
+    double* Ix_scores = NULL;
+    double* Iy_scores = NULL;
     double score;
     int trace;
     double temp;
-
-    PathGenerator* paths = NULL;
+    double M_temp;
+    double Ix_temp;
+    double Iy_temp;
+    PathGenerator* paths;
 
     /* Gotoh algorithm with three states */
-    if (!_allocate_gotoh_matrices(nA, nB, &M, &Ix, &Iy)) goto exit;
-    M[0][0].score = 0;
-    M[0][0].trace = 0;
-    Ix[0][0].score = -DBL_MAX;
-    Ix[0][0].trace = 0;
-    Iy[0][0].score = -DBL_MAX;
-    Iy[0][0].trace = 0;
-    for (i = 1; i <= nA; i++) {
-        M[i][0].score = -DBL_MAX;
-        M[i][0].trace = 0;
-        Ix[i][0].score = left_gap_open_B + left_gap_extend_B * (i-1);
-        Ix[i][0].trace = Ix_MATRIX;
-        Iy[i][0].score = -DBL_MAX;
-        Iy[i][0].trace = 0;
-    }
-    Ix[1][0].trace = M_MATRIX;
+    paths = PathGenerator_create_Gotoh(nA, nB, Global);
+    if (!paths) return NULL;
+
+    M_scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!M_scores) goto exit;
+    Ix_scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!Ix_scores) goto exit;
+    Iy_scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!Iy_scores) goto exit;
+    M = paths->M;
+    gaps = paths->gaps.gotoh;
+
+    /* Gotoh algorithm with three states */
+    M_scores[0] = 0;
+    Ix_scores[0] = -DBL_MAX;
+    Iy_scores[0] = -DBL_MAX;
 
     for (j = 1; j <= nB; j++) {
-        M[0][j].score = -DBL_MAX;
-        M[0][j].trace = 0;
-        Ix[0][j].score = -DBL_MAX;
-        Ix[0][j].trace = 0;
-        Iy[0][j].score = left_gap_open_A + left_gap_extend_A * (j-1);
-        Iy[0][j].trace = Iy_MATRIX;
+        M_scores[j] = -DBL_MAX;
+        Ix_scores[j] = -DBL_MAX;
+        Iy_scores[j] = left_gap_open_A + left_gap_extend_A * (j-1);
     }
-    Iy[0][1].trace = M_MATRIX;
 
     for (i = 1; i < nA; i++) {
         kA = CHARINDEX(sA[i-1]);
+        M_temp = M_scores[0];
+        Ix_temp = Ix_scores[0];
+        Iy_temp = Iy_scores[0];
+        M_scores[0] = -DBL_MAX;
+        Ix_scores[0] = left_gap_open_B + left_gap_extend_B * (i-1);
+        Iy_scores[0] = -DBL_MAX;
         for (j = 1; j < nB; j++) {
             kB = CHARINDEX(sB[j-1]);
-            SELECT_TRACE_GOTOH_GLOBAL_GAP(Ix[i][j],
-                M[i-1][j].score + gap_open_B,
-                Ix[i-1][j].score + gap_extend_B,
-                Iy[i-1][j].score + gap_open_B);
-            SELECT_TRACE_GOTOH_GLOBAL_GAP(Iy[i][j],
-                M[i][j-1].score + gap_open_A,
-                Ix[i][j-1].score + gap_open_A,
-                Iy[i][j-1].score + gap_extend_A);
-            SELECT_TRACE_GOTOH_GLOBAL_ALIGN(M[i][j],
-                M[i-1][j-1].score,
-                Ix[i-1][j-1].score,
-                Iy[i-1][j-1].score,
-                self->substitution_matrix[kA][kB]);
+            SELECT_TRACE_GOTOH_GLOBAL_ALIGN;
+            M_temp = M_scores[j];
+            M_scores[j] = score + self->substitution_matrix[kA][kB];
+            SELECT_TRACE_GOTOH_GLOBAL_GAP(Ix,
+                                          M_temp + gap_open_B,
+                                          Ix_scores[j] + gap_extend_B,
+                                          Iy_scores[j] + gap_open_B);
+            Ix_temp = Ix_scores[j];
+            Ix_scores[j] = score;
+            SELECT_TRACE_GOTOH_GLOBAL_GAP(Iy,
+                                          M_scores[j-1] + gap_open_A,
+                                          Ix_scores[j-1] + gap_open_A,
+                                          Iy_scores[j-1] + gap_extend_A);
+            Iy_temp = Iy_scores[j];
+            Iy_scores[j] = score;
         }
         kB = CHARINDEX(sB[nB-1]);
-        SELECT_TRACE_GOTOH_GLOBAL_GAP(Ix[i][nB],
-            M[i-1][nB].score + right_gap_open_B,
-            Ix[i-1][nB].score + right_gap_extend_B,
-            Iy[i-1][nB].score + right_gap_open_B);
-        SELECT_TRACE_GOTOH_GLOBAL_GAP(Iy[i][nB],
-            M[i][nB-1].score + gap_open_A,
-            Ix[i][nB-1].score + gap_open_A,
-            Iy[i][nB-1].score + gap_extend_A);
-        SELECT_TRACE_GOTOH_GLOBAL_ALIGN(M[i][nB],
-            M[i-1][nB-1].score,
-            Ix[i-1][nB-1].score,
-            Iy[i-1][nB-1].score,
-            self->substitution_matrix[kA][kB]);
+        SELECT_TRACE_GOTOH_GLOBAL_ALIGN;
+        M_temp = M_scores[nB];
+        M_scores[nB] = score + self->substitution_matrix[kA][kB];
+        SELECT_TRACE_GOTOH_GLOBAL_GAP(Ix,
+                                      M_temp + right_gap_open_B,
+                                      Ix_scores[nB] + right_gap_extend_B,
+                                      Iy_scores[nB] + right_gap_open_B);
+        Ix_temp = Ix_scores[nB];
+        Ix_scores[nB] = score;
+        SELECT_TRACE_GOTOH_GLOBAL_GAP(Iy,
+                                      M_scores[nB-1] + gap_open_A,
+                                      Ix_scores[nB-1] + gap_open_A,
+                                      Iy_scores[nB-1] + gap_extend_A);
+        Iy_temp = Iy_scores[nB];
+        Iy_scores[nB] = score;
     }
     kA = CHARINDEX(sA[nA-1]);
+    M_temp = M_scores[0];
+    Ix_temp = Ix_scores[0];
+    Iy_temp = Iy_scores[0];
+    M_scores[0] = -DBL_MAX;
+    Ix_scores[0] = left_gap_open_B + left_gap_extend_B * (nA-1);
+    Iy_scores[0] = -DBL_MAX;
     for (j = 1; j < nB; j++) {
         kB = CHARINDEX(sB[j-1]);
-        SELECT_TRACE_GOTOH_GLOBAL_GAP(Ix[nA][j],
-            M[nA-1][j].score + gap_open_B,
-            Ix[nA-1][j].score + gap_extend_B,
-            Iy[nA-1][j].score + gap_open_B);
-        SELECT_TRACE_GOTOH_GLOBAL_GAP(Iy[nA][j],
-            M[nA][j-1].score + right_gap_open_A,
-            Ix[nA][j-1].score + right_gap_open_A,
-            Iy[nA][j-1].score + right_gap_extend_A);
-        SELECT_TRACE_GOTOH_GLOBAL_ALIGN(M[nA][j],
-            M[nA-1][j-1].score,
-            Ix[nA-1][j-1].score,
-            Iy[nA-1][j-1].score,
-            self->substitution_matrix[kA][kB]);
+        SELECT_TRACE_GOTOH_GLOBAL_ALIGN;
+        M_temp = M_scores[j];
+        M_scores[j] = score + self->substitution_matrix[kA][kB];
+        SELECT_TRACE_GOTOH_GLOBAL_GAP(Ix,
+                                      M_scores[j] + gap_open_B,
+                                      Ix_scores[j] + gap_extend_B,
+                                      Iy_scores[j] + gap_open_B);
+        Ix_temp = Ix_scores[j];
+        Ix_scores[j] = score;
+        SELECT_TRACE_GOTOH_GLOBAL_GAP(Iy,
+                                      M_scores[j-1] + right_gap_open_A,
+                                      Ix_scores[j-1] + right_gap_open_A,
+                                      Iy_scores[j-1] + right_gap_extend_A);
+        Iy_temp = Iy_scores[j];
+        Iy_scores[j] = score;
     }
     kB = CHARINDEX(sB[nB-1]);
-    SELECT_TRACE_GOTOH_GLOBAL_GAP(Ix[nA][nB],
-        M[nA-1][nB].score + right_gap_open_B,
-        Ix[nA-1][nB].score + right_gap_extend_B,
-        Iy[nA-1][nB].score + right_gap_open_B);
-    SELECT_TRACE_GOTOH_GLOBAL_GAP(Iy[nA][nB],
-        M[nA][nB-1].score + right_gap_open_A,
-        Ix[nA][nB-1].score + right_gap_open_A,
-        Iy[nA][nB-1].score + right_gap_extend_A);
-    SELECT_TRACE_GOTOH_GLOBAL_ALIGN(M[nA][nB],
-        M[nA-1][nB-1].score,
-        Ix[nA-1][nB-1].score,
-        Iy[nA-1][nB-1].score,
-        self->substitution_matrix[kA][kB]);
-    M[0][0].path = 0;
+    SELECT_TRACE_GOTOH_GLOBAL_ALIGN;
+    M_temp = M_scores[j];
+    M_scores[j] = score + self->substitution_matrix[kA][kB];
+    SELECT_TRACE_GOTOH_GLOBAL_GAP(Ix,
+                                  M_temp + right_gap_open_B,
+                                  Ix_scores[j] + right_gap_extend_B,
+                                  Iy_scores[j] + right_gap_open_B);
+    Ix_scores[nB] = score;
+    SELECT_TRACE_GOTOH_GLOBAL_GAP(Iy,
+                                  M_scores[j-1] + right_gap_open_A,
+                                  Ix_scores[j-1] + right_gap_open_A,
+                                  Iy_scores[j-1] + right_gap_extend_A);
+    Iy_scores[nB] = score;
     M[nA][nB].path = 0;
-    Ix[nA][nB].path = 0;
-    Iy[nA][nB].path = 0;
 
     /* traceback */
-    paths = _create_path_generator(self, nA, nB, epsilon);
-    if (paths) {
-        PyObject* result;
-        SELECT_SCORE_GLOBAL(M[nA][nB].score,
-                            Ix[nA][nB].score,
-                            Iy[nA][nB].score);
-        paths->M.affine = M;
-        paths->Ix.affine = Ix;
-        paths->Iy.affine = Iy;
-        paths->threshold = score - epsilon;
-        result = Py_BuildValue("fO", score, paths);
-        Py_DECREF(paths);
-        return result;
-    }
-    else _deallocate_gotoh_matrices(nA, M, Ix, Iy);
+    SELECT_SCORE_GLOBAL(M_scores[nB], Ix_scores[nB], Iy_scores[nB]);
+    if (M_scores[nB] < score - epsilon) M[nA][nB].trace = 0;
+    if (Ix_scores[nB] < score - epsilon) gaps[nA][nB].Ix = 0;
+    if (Iy_scores[nB] < score - epsilon) gaps[nA][nB].Iy = 0;
+    return Py_BuildValue("fN", score, paths);
 exit:
-    PyErr_SetString(PyExc_MemoryError, "Out of memory");
-    return NULL;
+    Py_DECREF(paths);
+    if (M_scores) PyMem_Free(M_scores);
+    if (Ix_scores) PyMem_Free(Ix_scores);
+    if (Iy_scores) PyMem_Free(Iy_scores);
+    return PyErr_NoMemory();
 }
 
 static PyObject*
@@ -5392,6 +5139,8 @@ Aligner_gotoh_local_align(Aligner* self, const char* sA, Py_ssize_t nA,
     char c;
     int i;
     int j;
+    int im = nA;
+    int jm = nB;
     int kA;
     int kB;
     const double gap_open_A = self->target_open_gap_score;
@@ -5399,111 +5148,118 @@ Aligner_gotoh_local_align(Aligner* self, const char* sA, Py_ssize_t nA,
     const double gap_extend_A = self->target_extend_gap_score;
     const double gap_extend_B = self->query_extend_gap_score;
     const double epsilon = self->epsilon;
-    Cell** M = NULL;
-    Cell** Ix = NULL;
-    Cell** Iy = NULL;
+    Trace** M = NULL;
+    TraceGapsGotoh** gaps = NULL;
+    double* M_scores = NULL;
+    double* Ix_scores = NULL;
+    double* Iy_scores = NULL;
     double score;
     int trace;
+    double temp;
+    double M_temp;
+    double Ix_temp;
+    double Iy_temp;
     double maximum = 0.0;
-
-    PathGenerator* paths = NULL;
+    PathGenerator* paths;
 
     /* Gotoh algorithm with three states */
-    if (!_allocate_gotoh_matrices(nA, nB, &M, &Ix, &Iy)) goto exit;
-    M[0][0].score = 0;
-    M[0][0].trace = 0;
-    M[0][0].path = 0;
-    Ix[0][0].score = -DBL_MAX;
-    Ix[0][0].trace = 0;
-    Iy[0][0].score = -DBL_MAX;
-    Iy[0][0].trace = 0;
-    for (i = 1; i <= nA; i++) {
-        M[i][0].score = 0;
-        M[i][0].trace = 0;
-        Ix[i][0].score = -DBL_MAX;
-        Ix[i][0].trace = 0;
-        Iy[i][0].score = -DBL_MAX;
-        Iy[i][0].trace = 0;
-    }
+    paths = PathGenerator_create_Gotoh(nA, nB, Local);
+    if (!paths) return NULL;
+    M = paths->M;
+    gaps = paths->gaps.gotoh;
+
+    M_scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!M_scores) goto exit;
+    Ix_scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!Ix_scores) goto exit;
+    Iy_scores = PyMem_Malloc((nB+1)*sizeof(double));
+    if (!Iy_scores) goto exit;
+    M_scores[0] = 0;
+    Ix_scores[0] = -DBL_MAX;
+    Iy_scores[0] = -DBL_MAX;
 
     for (j = 1; j <= nB; j++) {
-        M[0][j].score = 0;
-        M[0][j].trace = 0;
-        Ix[0][j].score = -DBL_MAX;
-        Ix[0][j].trace = 0;
-        Iy[0][j].score = -DBL_MAX;
-        Iy[0][j].trace = 0;
+        M_scores[j] = 0;
+        Ix_scores[j] = -DBL_MAX;
+        Iy_scores[j] = -DBL_MAX;
     }
     for (i = 1; i < nA; i++) {
+        M_temp = M_scores[0];
+        Ix_temp = Ix_scores[0];
+        Iy_temp = Iy_scores[0];
+        M_scores[0] = 0;
+        Ix_scores[0] = -DBL_MAX;
+        Iy_scores[0] = -DBL_MAX;
         kA = CHARINDEX(sA[i-1]);
         for (j = 1; j < nB; j++) {
             kB = CHARINDEX(sB[j-1]);
-            SELECT_TRACE_GOTOH_LOCAL_GAP(Ix[i][j],
-                                     M[i-1][j].score + gap_open_B,
-                                     Ix[i-1][j].score + gap_extend_B,
-                                     Iy[i-1][j].score + gap_open_B);
-            SELECT_TRACE_GOTOH_LOCAL_GAP(Iy[i][j],
-                                     M[i][j-1].score + gap_open_A,
-                                     Ix[i][j-1].score + gap_open_A,
-                                     Iy[i][j-1].score + gap_extend_A);
-            SELECT_TRACE_GOTOH_LOCAL_ALIGN(M[i][j],
-                                           M[i-1][j-1].score,
-                                           Ix[i-1][j-1].score,
-                                           Iy[i-1][j-1].score,
-                                           self->substitution_matrix[kA][kB]);
+            SELECT_TRACE_GOTOH_LOCAL_ALIGN
+            M_temp = M_scores[j];
+            M_scores[j] = score;
+            SELECT_TRACE_GOTOH_LOCAL_GAP(Ix,
+                                     M_temp + gap_open_B,
+                                     Ix_scores[j] + gap_extend_B,
+                                     Iy_scores[j] + gap_open_B);
+            Ix_temp = Ix_scores[j];
+            Ix_scores[j] = score;
+            SELECT_TRACE_GOTOH_LOCAL_GAP(Iy,
+                                     M_scores[j-1] + gap_open_A,
+                                     Ix_scores[j-1] + gap_open_A,
+                                     Iy_scores[j-1] + gap_extend_A);
+            Iy_temp = Iy_scores[j];
+            Iy_scores[j] = score;
         }
         kB = CHARINDEX(sB[nB-1]);
-        Ix[i][nB].score = 0;
-        Ix[i][nB].trace = 0;
-        Iy[i][nB].score = 0;
-        Iy[i][nB].trace = 0;
-        SELECT_TRACE_GOTOH_LOCAL_ALIGN(M[i][nB],
-                                       M[i-1][nB-1].score,
-                                       Ix[i-1][nB-1].score,
-                                       Iy[i-1][nB-1].score,
-                                       self->substitution_matrix[kA][kB]);
+        SELECT_TRACE_GOTOH_LOCAL_ALIGN
+        M_temp = M_scores[j];
+        M_scores[j] = score;
+        Ix_temp = Ix_scores[nB];
+        Ix_scores[nB] = 0;
+        gaps[i][nB].Ix = 0;
+        Iy_temp = Iy_scores[nB];
+        Iy_scores[nB] = 0;
+        gaps[i][nB].Iy = 0;
     }
+    M_temp = M_scores[0];
+    M_scores[0] = 0;
+    M[nA][0].trace = 0;
+    Ix_temp = Ix_scores[0];
+    Ix_scores[0] = -DBL_MAX;
+    gaps[nA][0].Ix = 0;
+    gaps[nA][0].Iy = 0;
+    Iy_temp = Iy_scores[0];
+    Iy_scores[0] = -DBL_MAX;
     kA = CHARINDEX(sA[nA-1]);
     for (j = 1; j < nB; j++) {
         kB = CHARINDEX(sB[j-1]);
-        Ix[nA][j].score = 0;
-        Ix[nA][j].trace = 0;
-        Iy[nA][j].score = 0;
-        Iy[nA][j].trace = 0;
-        SELECT_TRACE_GOTOH_LOCAL_ALIGN(M[nA][j],
-                                       M[nA-1][j-1].score,
-                                       Ix[nA-1][j-1].score,
-                                       Iy[nA-1][j-1].score,
-                                       self->substitution_matrix[kA][kB]);
+        SELECT_TRACE_GOTOH_LOCAL_ALIGN
+        M_temp = M_scores[j];
+        M_scores[j] = score;
+        Ix_temp = Ix_scores[j];
+        Ix_scores[j] = 0;
+        gaps[nA][j].Ix = 0;
+        Iy_temp = Iy_scores[j];
+        Iy_scores[j] = 0;
+        gaps[nA][j].Iy = 0;
     }
     kB = CHARINDEX(sB[nB-1]);
-    Ix[nA][nB].score = 0;
-    Ix[nA][nB].trace = 0;
-    Iy[nA][nB].score = 0;
-    Iy[nA][nB].trace = 0;
-    SELECT_TRACE_GOTOH_LOCAL_ALIGN(M[nA][nB],
-                                   M[nA-1][nB-1].score,
-                                   Ix[nA-1][nB-1].score,
-                                   Iy[nA-1][nB-1].score,
-                                   self->substitution_matrix[kA][kB]);
+    SELECT_TRACE_GOTOH_LOCAL_ALIGN
+    gaps[nA][nB].Ix = 0;
+    gaps[nA][nB].Iy = 0;
+
+    PyMem_Free(M_scores);
+    PyMem_Free(Ix_scores);
+    PyMem_Free(Iy_scores);
 
     /* traceback */
-    paths = _create_path_generator(self, nA, nB, epsilon);
-    if (paths) {
-        PyObject* result;
-        paths->M.affine = M;
-        paths->Ix.affine = Ix;
-        paths->Iy.affine = Iy;
-        paths->threshold = maximum - epsilon;
-        if (maximum==0) M[0][0].path = DONE;
-        result = Py_BuildValue("fO", maximum, paths);
-        Py_DECREF(paths);
-        return result;
-    }
-    else _deallocate_gotoh_matrices(nA, M, Ix, Iy);
+    if (maximum == 0) M[0][0].path = DONE;
+    return Py_BuildValue("fN", maximum, paths);
 exit:
-    PyErr_SetString(PyExc_MemoryError, "Out of memory");
-    return NULL;
+    Py_DECREF(paths);
+    if (M_scores) PyMem_Free(M_scores);
+    if (Ix_scores) PyMem_Free(Ix_scores);
+    if (Iy_scores) PyMem_Free(Iy_scores);
+    return PyErr_NoMemory();
 }
 
 static int
@@ -5565,8 +5321,6 @@ Aligner_waterman_smith_beyer_global_score(Aligner* self,
     double temp;
     int ok = 1;
 
-    PyObject* result = NULL;
-
     /* Waterman-Smith-Beyer algorithm */
     M = PyMem_Malloc((nA+1)*sizeof(double*));
     if (!M) goto exit;
@@ -5627,7 +5381,6 @@ Aligner_waterman_smith_beyer_global_score(Aligner* self,
     }
     SELECT_SCORE_GLOBAL(M[nA][nB], Ix[nA][nB], Iy[nA][nB]);
 
-    result = PyFloat_FromDouble(score);
 exit:
     if (M) {
         /* If M is NULL, then Ix is also NULL. */
@@ -5650,8 +5403,7 @@ exit:
         PyMem_Free(M);
     }
     if (!ok) return NULL;
-    if (!result) PyErr_SetString(PyExc_MemoryError, "Out of memory");
-    return result;
+    return PyFloat_FromDouble(score);
 }
 
 static PyObject*
@@ -5662,122 +5414,181 @@ Aligner_waterman_smith_beyer_global_align(Aligner* self,
     char c;
     int i;
     int j;
-    int k;
+    int gap;
     int kA;
     int kB;
     const double epsilon = self->epsilon;
-    CellM** M = NULL;
-    CellXY** Ix = NULL;
-    CellXY** Iy = NULL;
+    Trace** M;
+    TraceGapsWatermanSmithBeyer** gaps;
+    double** M_scores = NULL;
+    double** Ix_scores = NULL;
+    double** Iy_scores = NULL;
     int ng;
     int nm;
     double score;
     double gapscore;
     double temp;
     int trace;
-    int* traceM;
-    int* traceXY;
+    int* gapM;
+    int* gapXY;
     int ok = 1;
-
     PathGenerator* paths = NULL;
 
     /* Waterman-Smith-Beyer algorithm */
-    if (!_allocate_watermansmithbeyer_matrices(nA, nB, &M, &Ix, &Iy, Global))
-        return NULL;
+    paths = PathGenerator_create_WSB(nA, nB, Global);
+    if (!paths) return NULL;
+    M = paths->M;
+    gaps = paths->gaps.waterman_smith_beyer;
+
+    M_scores = PyMem_Malloc((nA+1)*sizeof(double*));
+    if (!M_scores) goto exit;
+    Ix_scores = PyMem_Malloc((nA+1)*sizeof(double*));
+    if (!Ix_scores) goto exit;
+    Iy_scores = PyMem_Malloc((nA+1)*sizeof(double*));
+    if (!Iy_scores) goto exit;
+    for (i = 0; i <= nA; i++) {
+        M_scores[i] = PyMem_Malloc((nB+1)*sizeof(double));
+        if (!M_scores[i]) goto exit;
+        M_scores[i][0] = -DBL_MAX;
+        Ix_scores[i] = PyMem_Malloc((nB+1)*sizeof(double));
+        if (!Ix_scores[i]) goto exit;
+        Ix_scores[i][0] = 0;
+        Iy_scores[i] = PyMem_Malloc((nB+1)*sizeof(double));
+        if (!Iy_scores[i]) goto exit;
+        Iy_scores[i][0] = -DBL_MAX;
+    }
+    M_scores[0][0] = 0;
+    Ix_scores[0][0] = -DBL_MAX;
+    for (i = 1; i <= nB; i++) {
+        M_scores[0][i] = -DBL_MAX;
+        Ix_scores[0][i] = -DBL_MAX;
+        Iy_scores[0][i] = 0;
+    }
     for (i = 1; i <= nA; i++) {
         ok = _call_query_gap_function(self, 0, i, &score);
         if (!ok) goto exit;
-        Ix[i][0].score = score;
+        Ix_scores[i][0] = score;
     }
     for (j = 1; j <= nB; j++) {
         ok = _call_target_gap_function(self, 0, j, &score);
         if (!ok) goto exit;
-        Iy[0][j].score = score;
+        Iy_scores[0][j] = score;
     }
     for (i = 1; i <= nA; i++) {
         kA = CHARINDEX(sA[i-1]);
         for (j = 1; j <= nB; j++) {
             kB = CHARINDEX(sB[j-1]);
-            SELECT_TRACE_GOTOH_GLOBAL_ALIGN(M[i][j],
-                                            M[i-1][j-1].score,
-                                            Ix[i-1][j-1].score,
-                                            Iy[i-1][j-1].score,
-                                            self->substitution_matrix[kA][kB]);
-            traceM = PyMem_Malloc((i+1)*sizeof(int));
-            if (!traceM) goto exit;
-            Ix[i][j].traceM = traceM;
-            traceXY = PyMem_Malloc((i+1)*sizeof(int));
-            if (!traceXY) goto exit;
-            Ix[i][j].traceXY = traceXY;
+            SELECT_TRACE_WATERMAN_SMITH_BEYER_GLOBAL_ALIGN(self->substitution_matrix[kA][kB]);
+            gapM = PyMem_Malloc((i+1)*sizeof(int));
+            if (!gapM) goto exit;
+            gaps[i][j].MIx = gapM;
+            gapXY = PyMem_Malloc((i+1)*sizeof(int));
+            if (!gapXY) goto exit;
+            gaps[i][j].IyIx = gapXY;
             nm = 0;
             ng = 0;
             score = -DBL_MAX;
-            for (k = 1; k <= i; k++) {
-                ok = _call_query_gap_function(self, j, k, &gapscore);
+            for (gap = 1; gap <= i; gap++) {
+                ok = _call_query_gap_function(self, j, gap, &gapscore);
                 if (!ok) goto exit;
-                SELECT_TRACE_WATERMAN_SMITH_BEYER_GAP(M[i-k][j].score,
-                                                      Iy[i-k][j].score,
-                                                      i-k);
+                SELECT_TRACE_WATERMAN_SMITH_BEYER_GAP(M_scores[i-gap][j],
+                                                      Iy_scores[i-gap][j]);
             }
-            traceM = PyMem_Realloc(traceM, (nm+1)*sizeof(int));
-            if (!traceM) goto exit;
-            Ix[i][j].traceM = traceM;
-            traceM[nm] = -1;
-            traceXY = PyMem_Realloc(traceXY, (ng+1)*sizeof(int));
-            if (!traceXY) goto exit;
-            Ix[i][j].traceXY = traceXY;
-            traceXY[ng] = -1;
-            Ix[i][j].score = score;
-            traceM = PyMem_Malloc((j+1)*sizeof(int));
-            if (!traceM) goto exit;
-            Iy[i][j].traceM = traceM;
-            traceXY = PyMem_Malloc((j+1)*sizeof(int));
-            if (!traceXY) goto exit;
-            Iy[i][j].traceXY = traceXY;
+            gapM = PyMem_Realloc(gapM, (nm+1)*sizeof(int));
+            if (!gapM) goto exit;
+            gaps[i][j].MIx = gapM;
+            gapM[nm] = 0;
+            gapXY = PyMem_Realloc(gapXY, (ng+1)*sizeof(int));
+            if (!gapXY) goto exit;
+            gapXY[ng] = 0;
+            gaps[i][j].IyIx = gapXY;
+            Ix_scores[i][j] = score;
+            gapM = PyMem_Malloc((j+1)*sizeof(int));
+            if (!gapM) goto exit;
+            gaps[i][j].MIy = gapM;
+            gapXY = PyMem_Malloc((j+1)*sizeof(int));
+            if (!gapXY) goto exit;
+            gaps[i][j].IxIy = gapXY;
             nm = 0;
             ng = 0;
             score = -DBL_MAX;
-            for (k = 1; k <= j; k++) {
-                ok = _call_target_gap_function(self, i, k, &gapscore);
+            for (gap = 1; gap <= j; gap++) {
+                ok = _call_target_gap_function(self, i, gap, &gapscore);
                 if (!ok) goto exit;
-                SELECT_TRACE_WATERMAN_SMITH_BEYER_GAP(M[i][j-k].score,
-                                                      Ix[i][j-k].score,
-                                                      j-k);
+                SELECT_TRACE_WATERMAN_SMITH_BEYER_GAP(M_scores[i][j-gap],
+                                                      Ix_scores[i][j-gap]);
             }
-            Iy[i][j].score = score;
-            traceM = PyMem_Realloc(traceM, (nm+1)*sizeof(int));
-            if (!traceM) goto exit;
-            Iy[i][j].traceM = traceM;
-            traceM[nm] = -1;
-            traceXY = PyMem_Realloc(traceXY, (ng+1)*sizeof(int));
-            if (!traceXY) goto exit;
-            Iy[i][j].traceXY = traceXY;
-            traceXY[ng] = -1;
+            Iy_scores[i][j] = score;
+            gapM = PyMem_Realloc(gapM, (nm+1)*sizeof(int));
+            if (!gapM) goto exit;
+            gaps[i][j].MIy = gapM;
+            gapM[nm] = 0;
+            gapXY = PyMem_Realloc(gapXY, (ng+1)*sizeof(int));
+            if (!gapXY) goto exit;
+            gaps[i][j].IxIy = gapXY;
+            gapXY[ng] = 0;
         }
     }
 
     /* traceback */
-    SELECT_SCORE_GLOBAL(M[nA][nB].score, Ix[nA][nB].score, Iy[nA][nB].score);
-    M[nA][nB].path.i = -1;
-    M[nA][nB].path.j = -1;
-    Ix[nA][nB].path.i = -1;
-    Iy[nA][nB].path.i = -1;
-    paths = _create_path_generator(self, nA, nB, epsilon);
-    if (paths) {
-        PyObject* result;
-        paths->M.general = M;
-        paths->Ix.general = Ix;
-        paths->Iy.general = Iy;
-        paths->threshold = score - epsilon;
-        result = Py_BuildValue("fO", score, paths);
-        Py_DECREF(paths);
-        return result;
+    SELECT_SCORE_GLOBAL(M_scores[nA][nB], Ix_scores[nA][nB], Iy_scores[nA][nB]);
+    M[nA][nB].path = 0;
+
+    if (M_scores[nA][nB] < score - epsilon) M[nA][nB].trace = 0;
+    if (Ix_scores[nA][nB] < score - epsilon) {
+        gapM = PyMem_Realloc(gaps[nA][nB].MIx, sizeof(int));
+        if (!gapM) goto exit;
+        gapM[0] = 0;
+        gaps[nA][nB].MIx = gapM;
+        gapXY = PyMem_Realloc(gaps[nA][nB].IyIx, sizeof(int));
+        if (!gapXY) goto exit;
+        gapXY[0] = 0;
+        gaps[nA][nB].IyIx = gapXY;
     }
+    if (Iy_scores[nA][nB] < score - epsilon) {
+        gapM = PyMem_Realloc(gaps[nA][nB].MIy, sizeof(int));
+        if (!gapM) goto exit;
+        gapM[0] = 0;
+        gaps[nA][nB].MIy = gapM;
+        gapXY = PyMem_Realloc(gaps[nA][nB].IxIy, sizeof(int));
+        if (!gapXY) goto exit;
+        gapXY[0] = 0;
+        gaps[nA][nB].IxIy = gapXY;
+    }
+    for (i = 0; i <= nA; i++) {
+        PyMem_Free(M_scores[i]);
+        PyMem_Free(Ix_scores[i]);
+        PyMem_Free(Iy_scores[i]);
+    }
+    PyMem_Free(M_scores);
+    PyMem_Free(Ix_scores);
+    PyMem_Free(Iy_scores);
+    return Py_BuildValue("fN", score, paths);
 
 exit:
     if (ok) /* otherwise, an exception was already set */
-        PyErr_SetString(PyExc_MemoryError, "Out of memory");
-    _deallocate_watermansmithbeyer_matrices(nA, nB, M, Ix, Iy, Global);
+        PyErr_SetNone(PyExc_MemoryError);
+    Py_DECREF(paths);
+    if (M_scores) {
+        /* If M is NULL, then Ix is also NULL. */
+        if (Ix_scores) {
+            /* If Ix is NULL, then Iy is also NULL. */
+            if (Iy_scores) {
+                /* If Iy is NULL, then M[i], Ix[i], and Iy[i] are also NULL. */
+                for (i = 0; i <= nA; i++) {
+                    if (!M_scores[i]) break;
+                    PyMem_Free(M_scores[i]);
+                    if (!Ix_scores[i]) break;
+                    PyMem_Free(Ix_scores[i]);
+                    if (!Iy_scores[i]) break;
+                    PyMem_Free(Iy_scores[i]);
+                }
+                PyMem_Free(Iy_scores);
+            }
+            PyMem_Free(Ix_scores);
+        }
+        PyMem_Free(M_scores);
+    }
     return NULL;
 }
 
@@ -5789,7 +5600,7 @@ Aligner_waterman_smith_beyer_local_score(Aligner* self,
     char c;
     int i;
     int j;
-    int k;
+    int gap;
     int kA;
     int kB;
     double** M = NULL;
@@ -5850,18 +5661,18 @@ Aligner_waterman_smith_beyer_local_score(Aligner* self,
                 continue;
             }
             score = 0.0;
-            for (k = 1; k <= i; k++) {
-                ok = _call_query_gap_function(self, j, k, &gapscore);
-                SELECT_SCORE_WATERMAN_SMITH_BEYER(M[i-k][j], Iy[i-k][j]);
+            for (gap = 1; gap <= i; gap++) {
+                ok = _call_query_gap_function(self, j, gap, &gapscore);
+                SELECT_SCORE_WATERMAN_SMITH_BEYER(M[i-gap][j], Iy[i-gap][j]);
                 if (!ok) goto exit;
             }
             if (score > maximum) maximum = score;
             Ix[i][j] = score;
             score = 0.0;
-            for (k = 1; k <= j; k++) {
-                ok = _call_target_gap_function(self, i, k, &gapscore);
+            for (gap = 1; gap <= j; gap++) {
+                ok = _call_target_gap_function(self, i, gap, &gapscore);
                 if (!ok) goto exit;
-                SELECT_SCORE_WATERMAN_SMITH_BEYER(M[i][j-k], Ix[i][j-k]);
+                SELECT_SCORE_WATERMAN_SMITH_BEYER(M[i][j-gap], Ix[i][j-gap]);
             }
             if (score > maximum) maximum = score;
             Iy[i][j] = score;
@@ -5872,32 +5683,29 @@ Aligner_waterman_smith_beyer_local_score(Aligner* self,
 
     result = PyFloat_FromDouble(maximum);
 exit:
-    if (!result) {
-        /* otherwise the alignment generator will PyMem_Free the matrices */
-        if (M) {
-            /* If M is NULL, then Ix is also NULL. */
-            if (Ix) {
-                /* If Ix is NULL, then Iy is also NULL. */
-                if (Iy) {
-                    /* If Iy is NULL, then M[i], Ix[i], and Iy[i] are
-                     * also NULL. */
-                    for (i = 0; i <= nA; i++) {
-                        if (!M[i]) break;
-                        PyMem_Free(M[i]);
-                        if (!Ix[i]) break;
-                        PyMem_Free(Ix[i]);
-                        if (!Iy[i]) break;
-                        PyMem_Free(Iy[i]);
-                    }
-                    PyMem_Free(Iy);
+    if (M) {
+        /* If M is NULL, then Ix is also NULL. */
+        if (Ix) {
+            /* If Ix is NULL, then Iy is also NULL. */
+            if (Iy) {
+                /* If Iy is NULL, then M[i], Ix[i], and Iy[i] are
+                 * also NULL. */
+                for (i = 0; i <= nA; i++) {
+                    if (!M[i]) break;
+                    PyMem_Free(M[i]);
+                    if (!Ix[i]) break;
+                    PyMem_Free(Ix[i]);
+                    if (!Iy[i]) break;
+                    PyMem_Free(Iy[i]);
                 }
-                PyMem_Free(Ix);
+                PyMem_Free(Iy);
             }
-            PyMem_Free(M);
+            PyMem_Free(Ix);
         }
+        PyMem_Free(M);
     }
     if (!ok) return NULL;
-    if (!result) PyErr_SetString(PyExc_MemoryError, "Out of memory");
+    if (!result) return PyErr_NoMemory();
     return result;
 }
 
@@ -5909,19 +5717,23 @@ Aligner_waterman_smith_beyer_local_align(Aligner* self,
     char c;
     int i;
     int j;
-    int k;
+    int im = nA;
+    int jm = nB;
+    int gap;
     int kA;
     int kB;
     const double epsilon = self->epsilon;
-    CellM** M = NULL;
-    CellXY** Ix = NULL;
-    CellXY** Iy = NULL;
+    Trace** M = NULL;
+    TraceGapsWatermanSmithBeyer** gaps;
+    double** M_scores;
+    double** Ix_scores;
+    double** Iy_scores;
     double score;
     double gapscore;
     double temp;
     int trace;
-    int* traceM;
-    int* traceXY;
+    int* gapM;
+    int* gapXY;
     int nm;
     int ng;
     int ok = 1;
@@ -5930,43 +5742,66 @@ Aligner_waterman_smith_beyer_local_align(Aligner* self,
     PathGenerator* paths = NULL;
 
     /* Waterman-Smith-Beyer algorithm */
-    if (!_allocate_watermansmithbeyer_matrices(nA, nB, &M, &Ix, &Iy, Local))
-        return NULL;
+    paths = PathGenerator_create_WSB(nA, nB, Local);
+    if (!paths) return NULL;
+    M = paths->M;
+    gaps = paths->gaps.waterman_smith_beyer;
 
+    M_scores = PyMem_Malloc((nA+1)*sizeof(double*));
+    if (!M_scores) goto exit;
+    Ix_scores = PyMem_Malloc((nA+1)*sizeof(double*));
+    if (!Ix_scores) goto exit;
+    Iy_scores = PyMem_Malloc((nA+1)*sizeof(double*));
+    if (!Iy_scores) goto exit;
+    for (i = 0; i <= nA; i++) {
+        M_scores[i] = PyMem_Malloc((nB+1)*sizeof(double));
+        if (!M_scores[i]) goto exit;
+        M_scores[i][0] = 0;
+        Ix_scores[i] = PyMem_Malloc((nB+1)*sizeof(double));
+        if (!Ix_scores[i]) goto exit;
+        Ix_scores[i][0] = -DBL_MAX;
+        Iy_scores[i] = PyMem_Malloc((nB+1)*sizeof(double));
+        if (!Iy_scores[i]) goto exit;
+        Iy_scores[i][0] = -DBL_MAX;
+    }
+    for (i = 1; i <= nB; i++) {
+        M_scores[0][i] = 0;
+        Ix_scores[0][i] = -DBL_MAX;
+        Iy_scores[0][i] = -DBL_MAX;
+    }
     for (i = 1; i <= nA; i++) {
         kA = CHARINDEX(sA[i-1]);
         for (j = 1; j <= nB; j++) {
             kB = CHARINDEX(sB[j-1]);
             nm = 0;
             ng = 0;
-            SELECT_TRACE_GOTOH_LOCAL_ALIGN(M[i][j],
-                                           M[i-1][j-1].score,
-                                           Ix[i-1][j-1].score,
-                                           Iy[i-1][j-1].score,
+            SELECT_TRACE_WATERMAN_SMITH_BEYER_ALIGN(
+                                           M_scores[i-1][j-1],
+                                           Ix_scores[i-1][j-1],
+                                           Iy_scores[i-1][j-1],
                                            self->substitution_matrix[kA][kB]);
-            M[i][j].path.i = -1;
+            M[i][j].path = 0;
             if (i == nA || j == nB) {
-                Ix[i][j].score = score;
-                Ix[i][j].traceM = NULL;
-                Ix[i][j].traceXY = NULL;
-                Iy[i][j].score = score;
-                Iy[i][j].traceM = NULL;
-                Iy[i][j].traceXY = NULL;
+                Ix_scores[i][j] = score;
+                gaps[i][j].MIx = NULL;
+                gaps[i][j].IyIx = NULL;
+                gaps[i][j].MIy = NULL;
+                gaps[i][j].IxIy = NULL;
+                Iy_scores[i][j] = score;
                 continue;
             }
-            traceM = PyMem_Malloc((i+1)*sizeof(int));
-            if (!traceM) goto exit;
-            Ix[i][j].traceM = traceM;
-            traceXY = PyMem_Malloc((i+1)*sizeof(int));
-            if (!traceXY) goto exit;
-            Ix[i][j].traceXY = traceXY;
+            gapM = PyMem_Malloc((i+1)*sizeof(int));
+            if (!gapM) goto exit;
+            gaps[i][j].MIx = gapM;
+            gapXY = PyMem_Malloc((i+1)*sizeof(int));
+            if (!gapXY) goto exit;
+            gaps[i][j].IyIx = gapXY;
             score = -DBL_MAX;
-            for (k = 1; k <= i; k++) {
-                ok = _call_query_gap_function(self, j, k, &gapscore);
+            for (gap = 1; gap <= i; gap++) {
+                ok = _call_query_gap_function(self, j, gap, &gapscore);
                 if (!ok) goto exit;
-                SELECT_TRACE_WATERMAN_SMITH_BEYER_GAP(M[i-k][j].score,
-                                                      Iy[i-k][j].score,
-                                                      i-k);
+                SELECT_TRACE_WATERMAN_SMITH_BEYER_GAP(M_scores[i-gap][j],
+                                                      Iy_scores[i-gap][j]);
             }
             if (score < epsilon) {
                 score = -DBL_MAX;
@@ -5974,33 +5809,33 @@ Aligner_waterman_smith_beyer_local_align(Aligner* self,
                 ng = 0;
             }
             else if (score > maximum) maximum = score;
-            traceM[nm] = -1;
-            traceXY[ng] = -1;
-            Ix[i][j].score = score;
-            Ix[i][j].path.i = -1;
-            traceM = PyMem_Realloc(traceM, (nm+1)*sizeof(int));
-            if (!traceM) goto exit;
-            Ix[i][j].traceM = traceM;
-            traceM[nm] = -1;
-            traceXY = PyMem_Realloc(traceXY, (ng+1)*sizeof(int));
-            if (!traceXY) goto exit;
-            Ix[i][j].traceXY = traceXY;
-            traceXY[ng] = -1;
-            traceM = PyMem_Malloc((j+1)*sizeof(int));
-            if (!traceM) goto exit;
-            Iy[i][j].traceM = traceM;
-            traceXY = PyMem_Malloc((j+1)*sizeof(int));
-            if (!traceXY) goto exit;
-            Iy[i][j].traceXY = traceXY;
+            gapM[nm] = 0;
+            gapXY[ng] = 0;
+            Ix_scores[i][j] = score;
+            M[i][j].path = 0;
+            gapM = PyMem_Realloc(gapM, (nm+1)*sizeof(int));
+            if (!gapM) goto exit;
+            gaps[i][j].MIx = gapM;
+            gapM[nm] = 0;
+            gapXY = PyMem_Realloc(gapXY, (ng+1)*sizeof(int));
+            if (!gapXY) goto exit;
+            gaps[i][j].IyIx = gapXY;
+            gapXY[ng] = 0;
+            gapM = PyMem_Malloc((j+1)*sizeof(int));
+            if (!gapM) goto exit;
+            gaps[i][j].MIy = gapM;
+            gapXY = PyMem_Malloc((j+1)*sizeof(int));
+            if (!gapXY) goto exit;
+            gaps[i][j].IxIy = gapXY;
             nm = 0;
             ng = 0;
             score = -DBL_MAX;
-            for (k = 1; k <= j; k++) {
-                ok = _call_target_gap_function(self, i, k, &gapscore);
+            gapM[0] = 0;
+            for (gap = 1; gap <= j; gap++) {
+                ok = _call_target_gap_function(self, i, gap, &gapscore);
                 if (!ok) goto exit;
-                SELECT_TRACE_WATERMAN_SMITH_BEYER_GAP(M[i][j-k].score,
-                                                      Ix[i][j-k].score,
-                                                      j-k);
+                SELECT_TRACE_WATERMAN_SMITH_BEYER_GAP(M_scores[i][j-gap],
+                                                      Ix_scores[i][j-gap]);
             }
             if (score < epsilon) {
                 score = -DBL_MAX;
@@ -6008,37 +5843,53 @@ Aligner_waterman_smith_beyer_local_align(Aligner* self,
                 ng = 0;
             }
             else if (score > maximum) maximum = score;
-            traceM = PyMem_Realloc(traceM, (nm+1)*sizeof(int));
-            if (!traceM) goto exit;
-            Iy[i][j].traceM = traceM;
-            traceXY = PyMem_Realloc(traceXY, (ng+1)*sizeof(int));
-            if (!traceXY) goto exit;
-            Iy[i][j].traceXY = traceXY;
-            traceM[nm] = -1;
-            traceXY[ng] = -1;
-            Iy[i][j].score = score;
-            Iy[i][j].path.i = -1;
+            gapM = PyMem_Realloc(gapM, (nm+1)*sizeof(int));
+            if (!gapM) goto exit;
+            gaps[i][j].MIy = gapM;
+            gapXY = PyMem_Realloc(gapXY, (ng+1)*sizeof(int));
+            if (!gapXY) goto exit;
+            gaps[i][j].IxIy = gapXY;
+            gapM[nm] = 0;
+            gapXY[ng] = 0;
+            Iy_scores[i][j] = score;
+            M[i][j].path = 0;
         }
     }
+    for (i = 0; i <= nA; i++) PyMem_Free(M_scores[i]);
+    PyMem_Free(M_scores);
+    for (i = 0; i <= nA; i++) PyMem_Free(Ix_scores[i]);
+    PyMem_Free(Ix_scores);
+    for (i = 0; i <= nA; i++) PyMem_Free(Iy_scores[i]);
+    PyMem_Free(Iy_scores);
 
     /* traceback */
-    paths = _create_path_generator(self, nA, nB, epsilon);
-    if (paths) {
-        PyObject* result;
-        paths->M.general = M;
-        paths->Ix.general = Ix;
-        paths->Iy.general = Iy;
-        paths->threshold = maximum - epsilon;
-        if (maximum==0) M[0][0].path.j = -1; /* DONE */
-        result = Py_BuildValue("fO", maximum, paths);
-        Py_DECREF(paths);
-        return result;
-    }
+    if (maximum == 0) M[0][0].path = DONE;
+    return Py_BuildValue("fN", maximum, paths);
 
 exit:
     if (ok) /* otherwise, an exception was already set */
-        PyErr_SetString(PyExc_MemoryError, "Out of memory");
-    _deallocate_watermansmithbeyer_matrices(nA, nB, M, Ix, Iy, Local);
+        PyErr_SetNone(PyExc_MemoryError);
+    Py_DECREF(paths);
+    if (M_scores) {
+        /* If M is NULL, then Ix is also NULL. */
+        if (Ix_scores) {
+            /* If Ix is NULL, then Iy is also NULL. */
+            if (Iy_scores) {
+                /* If Iy is NULL, then M[i], Ix[i], and Iy[i] are also NULL. */
+                for (i = 0; i <= nA; i++) {
+                    if (!M_scores[i]) break;
+                    PyMem_Free(M_scores[i]);
+                    if (!Ix_scores[i]) break;
+                    PyMem_Free(Ix_scores[i]);
+                    if (!Iy_scores[i]) break;
+                    PyMem_Free(Iy_scores[i]);
+                }
+                PyMem_Free(Iy_scores);
+            }
+            PyMem_Free(Ix_scores);
+        }
+        PyMem_Free(M_scores);
+    }
     return NULL;
 }
  
@@ -6099,6 +5950,7 @@ Aligner_align(Aligner* self, PyObject* args, PyObject* keywords)
     Py_ssize_t nB;
     const Mode mode = self->mode;
     const Algorithm algorithm = _get_algorithm(self);
+
     static char *kwlist[] = {"sequenceA", "sequenceB", NULL};
     if(!PyArg_ParseTupleAndKeywords(args, keywords, "s#s#", kwlist,
                                     &sA, &nA, &sB, &nB))


### PR DESCRIPTION
This pull request implements memory-efficient versions of the Needleman-Wunsch, Smith-Waterman, Gotoh global and local, and Waterman-Smith-Beyer global and local algorithm. Alignable sequences 

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
