### PR TITLE
remove deprecated code

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -156,28 +156,7 @@ class MultipleSeqAlignment(object):
         {'tool': 'demo'}
         >>> align.column_annotations
         {'stats': 'CCCXCCC'}
-
-        NOTE - The older Bio.Align.Generic.Alignment class only accepted a
-        single argument, an alphabet.  This is still supported via a backwards
-        compatible "hack" so as not to disrupt existing scripts and users, but
-        is deprecated and will be removed in a future release.
         """
-        if isinstance(records, (Alphabet.Alphabet, Alphabet.AlphabetEncoder)):
-            if alphabet is None:
-                # TODO - Remove this backwards compatible mode!
-                alphabet = records
-                records = []
-                import warnings
-                from Bio import BiopythonDeprecationWarning
-                warnings.warn("Invalid records argument: While the old "
-                              "Bio.Align.Generic.Alignment class only "
-                              "accepted a single argument (the alphabet), the "
-                              "newer Bio.Align.MultipleSeqAlignment class "
-                              "expects a list/iterator of SeqRecord objects "
-                              "(which can be an empty list) and an optional "
-                              "alphabet argument", BiopythonDeprecationWarning)
-            else:
-                raise ValueError("Invalid records argument")
         if alphabet is not None:
             if not isinstance(alphabet, (Alphabet.Alphabet, Alphabet.AlphabetEncoder)):
                 raise ValueError("Invalid alphabet argument")


### PR DESCRIPTION
This pull request removes code from Bio.Align that has been deprecated at least since version 1.65.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
