### PR TITLE
removing deprecated code from Bio.PDB

### DIFF
--- a/Bio/PDB/AbstractPropertyMap.py
+++ b/Bio/PDB/AbstractPropertyMap.py
@@ -63,35 +63,6 @@ class AbstractPropertyMap(object):
         """
         return len(self.property_dict)
 
-    def has_key(self, id):
-        """Check if the mapping has a property for this residue.
-
-        :param chain_id: chain id
-        :type chain_id: char
-
-        :param res_id: residue id
-        :type res_id: char
-
-        (Obsolete; use "id in mapping" instead.)
-
-        Examples
-        --------
-        >>> if apmap.has_key((chain_id, res_id)):
-        ...     res, prop = apmap[(chain_id, res_id)]
-
-        Is equivalent to:
-
-        >>> if (chain_id, res_id) in apmap:
-        ...     res, prop = apmap[(chain_id, res_id)]
-        ...
-
-        """
-        import warnings
-        from Bio import BiopythonDeprecationWarning
-        warnings.warn("This function is deprecated; use 'id in mapping' "
-                      "instead", BiopythonDeprecationWarning)
-        return id in self
-
     def keys(self):
         """Return the list of residues.
 

--- a/Bio/PDB/FragmentMapper.py
+++ b/Bio/PDB/FragmentMapper.py
@@ -295,16 +295,6 @@ class FragmentMapper(object):
                     raise PDBException(why)
         return fd
 
-    def has_key(self, res):
-        """Is this residue present? (DEPRECATED).
-
-        :type res: L{Residue}
-        """
-        import warnings
-        from Bio import BiopythonDeprecationWarning
-        warnings.warn("has_key is deprecated; use 'res in object' instead", BiopythonDeprecationWarning)
-        return res in self
-
     def __contains__(self, res):
         """Check if the given residue is in any of the mapped fragments.
 


### PR DESCRIPTION
This pull request removes code from Bio.PDB that has been deprecated since Biopython 1.66 or earlier.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
