### PR TITLE
removing deprecated code

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -429,18 +429,6 @@ class Seq(object):
             raise TypeError("can't multiply {} by non-int type".format(self.__class__.__name__))
         return self.__class__(str(self) * other, self.alphabet)
 
-    def tostring(self):  # Seq API requirement
-        """Return the full sequence as a python string (DEPRECATED).
-
-        You are now encouraged to use str(my_seq) instead of
-        my_seq.tostring().
-        """
-        from Bio import BiopythonDeprecationWarning
-        warnings.warn("This method is obsolete; please use str(my_seq) "
-                      "instead of my_seq.tostring().",
-                      BiopythonDeprecationWarning)
-        return str(self)
-
     def tomutable(self):  # Needed?  Or use a function?
         """Return the full sequence as a MutableSeq object.
 
@@ -2444,31 +2432,6 @@ class MutableSeq(object):
         else:
             for c in other:
                 self.data.append(c)
-
-    def tostring(self):
-        """Return the full sequence as a python string (DEPRECATED).
-
-        You are now encouraged to use str(my_seq) instead of my_seq.tostring()
-        as this method is officially deprecated.
-
-        Because str(my_seq) will give you the full sequence as a python string,
-        there is often no need to make an explicit conversion.  For example,
-
-        >>> my_seq = Seq("ATCGTG")
-        >>> my_name = "seq_1"
-        >>> print("ID={%s}, sequence={%s}" % (my_name, my_seq))
-        ID={seq_1}, sequence={ATCGTG}
-
-        On Biopython 1.44 or older you would have to have done this:
-
-        >>> print("ID={%s}, sequence={%s}" % (my_name, my_seq.tostring()))
-        ID={seq_1}, sequence={ATCGTG}
-        """
-        from Bio import BiopythonDeprecationWarning
-        warnings.warn("This method is obsolete; please use str(my_seq) "
-                      "instead of my_seq.tostring().",
-                      BiopythonDeprecationWarning)
-        return "".join(self.data)
 
     def toseq(self):
         """Return the full sequence as a new immutable Seq object.

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -103,8 +103,9 @@ id(seq1) == id(seq2), as required.
 
 Bio.Seq.Seq.tostring() and Bio.Seq.MutableSeq.tostring()
 ========================================================
-Deprecated as of Release 1.64. You should now use str(Bio.Seq.Seq) or
-str(Bio.Seq.MutableSeq) instead of the tostring() methods.
+Deprecated in release 1.64, and removed in release 1.73.
+You should now use str(Bio.Seq.Seq) or str(Bio.Seq.MutableSeq) instead of
+the tostring() methods.
 
 Iterator .next() methods
 ========================


### PR DESCRIPTION
This pull request removes the tostring methods from Bio.Seq; these were deprecated in Biopython 1.64.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
