### PR TITLE
weight should be checked before calling distancematrix

### DIFF
--- a/Bio/Cluster/__init__.py
+++ b/Bio/Cluster/__init__.py
@@ -494,9 +494,14 @@ def distancematrix(data, mask=None, weight=None, transpose=False, dist='e'):
         [4., 2., 6., 0.]
     """
     data = __check_data(data)
-    mask = __check_mask(mask, data.shape)
-    n = data.shape[1] if transpose else data.shape[0]
-    matrix = [numpy.empty(i, dtype='d') for i in range(n)]
+    shape = data.shape
+    mask = __check_mask(mask, shape)
+    if transpose:
+        ndata, nitems = shape
+    else:
+        nitems, ndata = shape
+    weight = __check_weight(weight, ndata)
+    matrix = [numpy.empty(i, dtype='d') for i in range(nitems)]
     _cluster.distancematrix(data, mask, weight, transpose, dist, matrix)
     return matrix
 

--- a/Tests/test_Cluster.py
+++ b/Tests/test_Cluster.py
@@ -1163,6 +1163,54 @@ class TestCluster(unittest.TestCase):
         self.assertEqual(clusterid[8], 2)
         self.assertAlmostEqual(error, 7.680, places=3)
 
+        # check if default weights can be used
+        matrix = distancematrix(data, mask=mask)
+        self.assertAlmostEqual(matrix[1][0], 1.687, places=3)
+
+        self.assertAlmostEqual(matrix[2][0], 21.365, places=3)
+        self.assertAlmostEqual(matrix[2][1], 38.560, places=3)
+
+        self.assertAlmostEqual(matrix[3][0], 4.900, places=3)
+        self.assertAlmostEqual(matrix[3][1], 7.793, places=3)
+        self.assertAlmostEqual(matrix[3][2], 22.490, places=3)
+
+        self.assertAlmostEqual(matrix[4][0], 3.687, places=3)
+        self.assertAlmostEqual(matrix[4][1], 6.367, places=3)
+        self.assertAlmostEqual(matrix[4][2], 22.025, places=3)
+        self.assertAlmostEqual(matrix[4][3], 0.087, places=3)
+
+        self.assertAlmostEqual(matrix[5][0], 0.040, places=3)
+        self.assertAlmostEqual(matrix[5][1], 2.890, places=3)
+        self.assertAlmostEqual(matrix[5][2], 34.810, places=3)
+        self.assertAlmostEqual(matrix[5][3], 0.640, places=3)
+        self.assertAlmostEqual(matrix[5][4], 0.490, places=3)
+
+        self.assertAlmostEqual(matrix[6][0], 1.557, places=3)
+        self.assertAlmostEqual(matrix[6][1], 0.990, places=3)
+        self.assertAlmostEqual(matrix[6][2], 34.065, places=3)
+        self.assertAlmostEqual(matrix[6][3], 3.937, places=3)
+        self.assertAlmostEqual(matrix[6][4], 3.017, places=3)
+        self.assertAlmostEqual(matrix[6][5], 3.610, places=3)
+
+        self.assertAlmostEqual(matrix[7][0], 14.005, places=3)
+        self.assertAlmostEqual(matrix[7][1], 9.050, places=3)
+        self.assertAlmostEqual(matrix[7][2], 65.610, places=3)
+        self.assertAlmostEqual(matrix[7][3], 30.465, places=3)
+        self.assertAlmostEqual(matrix[7][4], 27.380, places=3)
+        self.assertAlmostEqual(matrix[7][5], 0.000, places=3)
+        self.assertAlmostEqual(matrix[7][6], 16.385, places=3)
+
+        self.assertAlmostEqual(matrix[8][0], 14.167, places=3)
+        self.assertAlmostEqual(matrix[8][1], 25.553, places=3)
+        self.assertAlmostEqual(matrix[8][2], 0.010, places=3)
+        self.assertAlmostEqual(matrix[8][3], 17.187, places=3)
+        self.assertAlmostEqual(matrix[8][4], 16.380, places=3)
+        self.assertAlmostEqual(matrix[8][5], 33.640, places=3)
+        self.assertAlmostEqual(matrix[8][6], 22.497, places=3)
+        self.assertAlmostEqual(matrix[8][7], 36.745, places=3)
+
+
+
     def test_pca(self):
         if TestCluster.module == 'Bio.Cluster':
             from Bio.Cluster import pca

--- a/Tests/test_Cluster.py
+++ b/Tests/test_Cluster.py
@@ -1209,8 +1209,6 @@ class TestCluster(unittest.TestCase):
         self.assertAlmostEqual(matrix[8][6], 22.497, places=3)
         self.assertAlmostEqual(matrix[8][7], 36.745, places=3)
 
-
-
     def test_pca(self):
         if TestCluster.module == 'Bio.Cluster':
             from Bio.Cluster import pca


### PR DESCRIPTION
This pull request addresses issue #1856 . Weight parameter should be checked before calling distancematrix.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
