### PR TITLE
deprecating Bio.trie

### DIFF
--- a/Bio/triefind.py
+++ b/Bio/triefind.py
@@ -20,12 +20,18 @@ Functions:
  - find          Find keys in a trie matching anywhere in a string.
  - find_words    Find keys in a trie matching whole words in a string.
 
-This module is OBSOLETE. We encourage users to switch to alternative libraries
+This module is DEPRECATED. We encourage users to switch to alternative libraries
 implementing a trie data structure, for example pygtrie.
 """
 
 import string
 import re
+
+from Bio import BiopythonDeprecationWarning
+import warnings
+warnings.warn("This module has been deprecated. We encourage users to switch "
+              "to alternative libraries implementing a trie data structure, "
+              "for example pygtrie.", BiopythonDeprecationWarning)
 
 
 def match(string, trie):

--- a/Bio/triemodule.c
+++ b/Bio/triemodule.c
@@ -836,6 +836,11 @@ void inittrie(void)
 {
     Py_TYPE(&Trie_Type) = &PyType_Type;
 
+    PyErr_WarnEx(NULL,
+"This module has been deprecated. We encourage users to switch "
+"to alternative libraries implementing a trie data structure, "
+"for example pygtrie.", 1);
+
     if (PyType_Ready(&Trie_Type) < 0)
 #if PY_MAJOR_VERSION >= 3
         return NULL;

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -754,6 +754,6 @@ provided in a new module ``Bio.PDB.kdtrees``.
 
 Bio.trie, Bio.triefind
 ======================
-These modules were declared obsolete in Release 1.72. We encourage users to
-switch to alternative libraries implementing a trie data structure, for example
-pygtrie.
+These modules were declared obsolete in Release 1.72, and deprecated in
+Release 1.73. We encourage users to switch to alternative libraries
+implementing a trie data structure, for example pygtrie.

--- a/Tests/test_trie.py
+++ b/Tests/test_trie.py
@@ -10,17 +10,22 @@ import unittest
 from string import ascii_lowercase
 from io import BytesIO
 
-try:
-    from Bio import trie
-    from Bio import triefind
-except ImportError:
-    import os
-    from Bio import MissingPythonDependencyError
-    if os.name == "java":
-        message = "Not available on Jython, Bio.trie requires compiled C code."
-    else:
-        message = "Could not import Bio.trie, check C code was compiled."
-    raise MissingPythonDependencyError(message)
+import warnings
+from Bio import BiopythonDeprecationWarning
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', BiopythonDeprecationWarning)
+    warnings.simplefilter('ignore', RuntimeWarning) # for the trie module
+    try:
+        from Bio import trie
+        from Bio import triefind
+    except ImportError:
+        import os
+        from Bio import MissingPythonDependencyError
+        if os.name == "java":
+            message = "Not available on Jython, Bio.trie requires compiled C code."
+        else:
+            message = "Could not import Bio.trie, check C code was compiled."
+        raise MissingPythonDependencyError(message)
 
 
 class TestTrie(unittest.TestCase):

--- a/Tests/test_trie.py
+++ b/Tests/test_trie.py
@@ -14,7 +14,7 @@ import warnings
 from Bio import BiopythonDeprecationWarning
 with warnings.catch_warnings():
     warnings.simplefilter('ignore', BiopythonDeprecationWarning)
-    warnings.simplefilter('ignore', RuntimeWarning) # for the trie module
+    warnings.simplefilter('ignore', RuntimeWarning)  # for the trie module
     try:
         from Bio import trie
         from Bio import triefind


### PR DESCRIPTION
This pull request downgrades Bio.trie and Bio.triefind from obsolete to deprecated.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
