### PR TITLE
fix memory leak (C Clustering Library 1.57)

### DIFF
--- a/Bio/Cluster/cluster.c
+++ b/Bio/Cluster/cluster.c
@@ -2732,8 +2732,8 @@ number of clusters is larger than the number of elements being clustered,
     if (npass>1)
     { free(tclusterid);
       free(mapping);
-      return;
     }
+    return;
   }
 
   if (method=='m')
@@ -3859,6 +3859,7 @@ If a memory error occurs, treecluster returns NULL.
     { distmatrix[i] = malloc(i*sizeof(double));
       if (distmatrix[i]==NULL) /* Not enough memory available */
       { while (--i > 0) free(distmatrix[i]);
+        free(distmatrix);
         return NULL;
       }
     }


### PR DESCRIPTION
This pull request fixes two memory leaks in Bio.Cluster.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
