### PR TITLE
Use setuptools include_package_data=True

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -63,3 +63,4 @@ global-exclude *.pyc *.pyo *.py{} *.py-e
 include Bio/Entrez/DTDs/*.dtd  # Include DTD files for Entrez
 include Bio/Entrez/DTDs/*.ent  # Include DTD files for Entrez
 include Bio/Entrez/DTDs/*.mod  # Include DTD files for Entrez
+include Bio/Entrez/XSDs/*.xsd  # Include XSD files for Entrez

--- a/setup.py
+++ b/setup.py
@@ -446,6 +446,6 @@ setup(name='biopython',
       },
       packages=PACKAGES,
       ext_modules=EXTENSIONS,
-      include_package_data=True,  # done via MANIFEST.ini under setuptools
+      include_package_data=True,  # done via MANIFEST.in under setuptools
       install_requires=REQUIRES,
       )

--- a/setup.py
+++ b/setup.py
@@ -446,11 +446,6 @@ setup(name='biopython',
       },
       packages=PACKAGES,
       ext_modules=EXTENSIONS,
-      package_data={
-          'Bio.Entrez': ['DTDs/*.dtd',
-                         'DTDs/*.ent',
-                         'DTDs/*.mod',
-                         'XSDs/*.xsd'],
-      },
+      include_package_data=True,  # done via MANIFEST.ini under setuptools
       install_requires=REQUIRES,
       )


### PR DESCRIPTION
The idea here is rather than having ``package_data=...`` in ``setup.py`` repeating information from ``MANIFEST.ini`` (which was I think was the required way to do this under ``distutils``), ``setuptools`` makes this easier: https://blog.ionelmc.ro/presentations/packaging/#slide:15

(We first required setuptools back in Biopython 1.70)

This only affects the XSD and DTD files for ``Bio.Entrez`` (and as part of this adds the XSD files to the manifest which previously only had the DTD files), over to @mdehoon to review.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
