### PR TITLE
Strict four line FASTQ parser

### DIFF
--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -820,14 +820,14 @@ def FastqStrictIterator(handle):
     """
     try:
         first_line_1 = next(handle).rstrip()
-    except StopIteration:
-        raise ValueError('Empty file') from None
+    except StopIteration as e:
+        raise ValueError('Empty file')
     try:
         first_line_2 = next(handle).rstrip()
         first_line_3 = next(handle).rstrip()
         first_line_4 = next(handle).rstrip()
-    except StopIteration:
-        raise ValueError('Incomplete record encountered') from None
+    except StopIteration as e:
+        raise ValueError('Incomplete record encountered')
 
     # check if file is in binary format
     if first_line_1[0].isdigit():
@@ -868,8 +868,8 @@ def FastqStrictIterator(handle):
                                  % (line_1[1:], len(line_2, len(line_4))))
             # Return the record and then continue
             yield (line_1[1:], line_2, line_4)
-        except StopIteration:
-            raise ValueError('Incomplete record encountered') from None
+        except StopIteration as e:
+            raise ValueError('Incomplete record encountered')
 
 
 # TODO - Default to nucleotide or even DNA?

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -797,10 +797,12 @@ def _get_solexa_quality_str(record):
 
 
 def FastqStrictIterator(handle):
-    """In contrast to the FastqGeneralIterator, this iterator does allow for the
+    """Iterate over strictly four line Fastq records as string tuples.
+
+    In contrast to the FastqGeneralIterator, this iterator does allow for the
     splitting of records over multiple lines.  Line wrapping is out of vogue and
     hence this iterator provides a faster but stricter alternative to the
-    FastqGeneralIterator
+    FastqGeneralIterator.
 
     Iterate over Fastq records as string tuples (not as SeqRecord objects).
 
@@ -839,8 +841,8 @@ def FastqStrictIterator(handle):
             # Ensure the sequence and quality are of same length
             if len(line_2) != len(line_4):
                 raise ValueError("Lengths of sequence and quality values differs "
-                             " for %s (%i and %i)."
-                             % (line_1[1:], len(line_2, len(line_4))))
+                                 " for %s (%i and %i)."
+                                 % (line_1[1:], len(line_2, len(line_4))))
             # Return the record and then continue
             yield (line_1[1:], line_2, line_4)
         except IOError:

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -2052,12 +2052,5 @@ def PairedFastaQualIterator(fasta_handle, qual_handle, alphabet=single_letter_al
 
 
 if __name__ == "__main__":
-    in_file = '../../../chr1_big.fq'
-
-    def use_parser(parser):
-        with open(in_file) as handle:
-            return list(parser(handle))
-    use_parser(FastqFourLineIterator)
-    use_parser(FastqPhredIterator)
     from Bio._utils import run_doctest
     run_doctest(verbose=0)

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -821,7 +821,7 @@ def FastqStrictIterator(handle):
     try:
         first_line_1 = next(handle).rstrip()
     except StopIteration as e:
-        raise ValueError('Empty file')
+        return
     try:
         first_line_2 = next(handle).rstrip()
         first_line_3 = next(handle).rstrip()

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -372,9 +372,9 @@ import warnings
 from Bio import BiopythonWarning, BiopythonParserWarning
 import sys
 from itertools import islice, tee
-if sys.version_info[0] == 3:
+try:
     from itertools import zip_longest
-if sys.version_info[0] == 2:
+except ImportError:
     from itertools import izip_longest as zip_longest
 
 # define score offsets. See discussion for differences between Sanger and
@@ -834,7 +834,6 @@ def FastqStrictIterator(handle):
     raise an Incomplete Record error in case the record is incomplete.
 
     """
-
     def suppress_context(exc):
         """Hide the secondary cause/context of the exception raised.
 
@@ -857,13 +856,11 @@ def FastqStrictIterator(handle):
         space within the sequence. Next, the length of the read sequence and
         the quality sequence must be equal.
         """
-
         # Record level check 1: Check if start of title line is @
         if line_1[0] != "@":
             raise ValueError("FASTQ records should start with '@' character.")
         # Record level check 2: Check if start of second title line is +
         if line_3[0] != "+":
-        # if line_3 == "":
             raise ValueError("Quality title should start with '+' character.")
         # Record level check 3: If quality caption exists, check for equality
         second_title = line_3[1:].rstrip()
@@ -886,7 +883,7 @@ def FastqStrictIterator(handle):
     # File level check 2: check if file is in binary format
     if first_1[0].isdigit():
         raise ValueError("Is this handle in binary mode not text mode?")
-    
+
     # Record level check 0: Ensure the first record is complete
     try:
         first_2 = next(handle).rstrip()
@@ -904,9 +901,9 @@ def FastqStrictIterator(handle):
     try:
         # zip the four iterators, one for each line, and iterate over them
         for line_1, line_2, line_3, line_4 in zip_longest(
-            islice(handles[0], 0, None, 4), islice(handles[1], 1, None, 4),
-            islice(handles[2], 2, None, 4), islice(handles[3], 3, None, 4)):
-            
+                islice(handles[0], 0, None, 4), islice(handles[1], 1, None, 4),
+                islice(handles[2], 2, None, 4), islice(handles[3], 3, None, 4)):
+
             line_1, line_2 = line_1.rstrip(), line_2.rstrip()
             line_3, line_4 = line_3.rstrip(), line_4.rstrip()
             # Record level checks 1, 2, 3, 4: Defined within check()

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -286,6 +286,8 @@ names are also used in Bio.AlignIO and include the following:
       two lines per record (no line wrapping).
     - fastq   - A "FASTA like" format used by Sanger which also stores PHRED
       sequence quality values (with an ASCII offset of 33).
+    - fastq-4line - Stricter interpretation of the FASTQ format using exactly
+      two lines per record (no line wrapping).
     - fastq-sanger - An alias for "fastq" for consistency with BioPerl and EMBOSS
     - fastq-solexa - Original Solexa/Illumnia variant of the FASTQ format which
       encodes Solexa quality scores (not PHRED quality scores) with an
@@ -425,6 +427,7 @@ _FormatToIterator = {"fasta": FastaIO.FastaIterator,
                      "tab": TabIO.TabIterator,
                      "pir": PirIO.PirIterator,
                      "fastq": QualityIO.FastqPhredIterator,
+                     "fastq-4line": QualityIO.FastqFourLineIterator,
                      "fastq-sanger": QualityIO.FastqPhredIterator,
                      "fastq-solexa": QualityIO.FastqSolexaIterator,
                      "fastq-illumina": QualityIO.FastqIlluminaIterator,

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -46,7 +46,7 @@ possible, especially the following contributors:
 - Catherine Lesuisse
 - Chris Rands
 - Darcy Mason (first contribution)
-- Devang Thakkar (first contribution)
+- Devang Thakkar
 - Ivan Antonov (first contribution)
 - Juraj Szász (first contribution)
 - Jeremy LaBarage (first contribution)


### PR DESCRIPTION
This pull request addresses issue #1812 

The current FASTQ parser allows for line wrapping in records, however this is not
used very often and a replacement for this parser was suggested in #1812. This
parser would be stricter, in the sense that it would not allow the breaking of lines
within a record. This would imply that the resulting parser would be faster than the
existing one. The FastqStrictIterator function is the new parser compared with the
old parser FastqGeneralIterator, currently used downstream by FastqPhredIterator,
FastqSolexaIterator, and FastqIlluminaIterator.

The timings point favorably towards the new parser, though there might of course
be opportunities for further improvement.

```
(Old parser) Mean time: 131.98; Std dev: 6.87
(New parser) Mean time: 122.74; Std dev: 7.47
(Change) Mean time: 9.25; Std dev: 1.28
```

The bare essence of the new parser is as shown below, the actual code can be 
found in the commits to this request.
```
for line in handle:
    line_1 = line.strip()
    line_2 = next(handle).strip()
    line_3 = next(handle).strip()
    line_4 = next(handle).strip()
    '''
    sanity checking and testing code here
    '''
    yield (line_1[1:], line_2, line_4)
```
Code to reproduce results:
```
import os
import sys
import Bio
from timeit import timeit

SEQ_LINE = '@dummy\n' + 'ATCGN'*10 + '\n' + '+dummy\n' + 'IFG?W'*10 + '\n'

# Make test file
if not os.path.isfile('file.fastq'):
    with open('file.fastq', 'w') as out_f:
        for _ in range(1000000):
            out_f.write(SEQ_LINE)

def use_parser(parser, filename):
    with open(filename) as handle:
        return list(parser(handle))

print('Python version: {}\n'
      'Biopython version: {}'.
       format(sys.version_info, Bio.__version__))

for _ in range(10):
    print('\nIteration '+str(_))
    a = timeit(
            'use_parser(FastqGeneralIterator, "file.fastq")',
            setup='from Bio.SeqIO.QualityIO import FastqGeneralIterator; from __main__ import use_parser',
            number = 20)
    b = timeit(
            'use_parser(FastqStrictIterator, "file.fastq")',
            setup='from Bio.SeqIO.QualityIO import FastqStrictIterator; from __main__ import use_parser',
            number = 20)
    print('Old: %.2f' % a)
    print('New: %.2f' % b)
    print('Change: %.2f' % (a-b))
```
Output:
```
Python version: sys.version_info(major=3, minor=5, micro=2, releaselevel='final', serial=0)
Biopython version: 1.73.dev0

Iteration 1
Old: 132.31
New: 121.59
Change: 10.72

Iteration 2
Old: 130.38
New: 121.13
Change: 9.25

Iteration 3
Old: 129.47
New: 120.49
Change: 8.98

Iteration 4
Old: 127.83
New: 118.51
Change: 9.32

Iteration 5
Old: 127.85
New: 118.46
Change: 9.39

Iteration 6
Old: 127.01
New: 118.55
Change: 8.46

Iteration 7
Old: 126.81
New: 118.53
Change: 8.28

Iteration 8
Old: 149.38
New: 142.53
Change: 6.85

Iteration 9
Old: 137.23
New: 127.49
Change: 9.74

Iteration 10
Old: 131.56
New: 120.10
Change: 11.46
```

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
