### PR TITLE
Setup on MacOS now only adds clang-specific flags if needed

### DIFF
--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -164,6 +164,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Leszek Pryszcz <https://github.com/lpryszcz>
 - Lewis A. Marshall <https://github.com/lewisamarshall>
 - Lucas Sinclair <https://github.com/xapple>
+- Manuel Nuno Melo <https://github.com/mnmelo>
 - Marc Colosimo <mcolosimo at domain mitre.org>
 - Marcin Magnus <https://github.com/mmagnus>
 - Marco Galardini <https://github.com/mgalardini>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -59,6 +59,7 @@ possible, especially the following contributors:
 - Juraj Szász (first contribution)
 - Kai Blin
 - Konstantin Vdovkin (first contribution)
+- Manuel Nuno Melo (first contribution)
 - Maximilian Greil
 - Nick Negretti (first contribution)
 - Peter Cock

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,12 @@ def osx_clang_fix():
         from subprocess import getoutput
     else:
         from commands import getoutput
-    cc = getoutput("cc -v")
+    from distutils.ccompiler import new_compiler
+    from distutils.sysconfig import customize_compiler
+    # The compiler test should be made on the actual compiler that'll be used
+    compiler = new_compiler()
+    customize_compiler(compiler)
+    cc = getoutput("{} -v".format(compiler.compiler[0]))
     if "gcc" in cc or "clang" not in cc:
         return
     for flag in ["CFLAGS", "CPPFLAGS"]:


### PR DESCRIPTION
Fixes #1287 

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
