### PR TITLE
Ensure aniso value is a list

### DIFF
--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -67,6 +67,12 @@ class MMCIFParser(object):
 
     # Private methods
 
+    def _ensure_list(self, val):
+        if isinstance(val, list):
+            return val
+        else:
+            return [val]
+
     def _build_structure(self, structure_id):
 
         # two special chars as placeholders in the mmCIF format
@@ -99,12 +105,12 @@ class MMCIFParser(object):
             # Invalid model number (malformed file)
             raise PDBConstructionException("Invalid model number")
         try:
-            aniso_u11 = mmcif_dict["_atom_site_anisotrop.U[1][1]"]
-            aniso_u12 = mmcif_dict["_atom_site_anisotrop.U[1][2]"]
-            aniso_u13 = mmcif_dict["_atom_site_anisotrop.U[1][3]"]
-            aniso_u22 = mmcif_dict["_atom_site_anisotrop.U[2][2]"]
-            aniso_u23 = mmcif_dict["_atom_site_anisotrop.U[2][3]"]
-            aniso_u33 = mmcif_dict["_atom_site_anisotrop.U[3][3]"]
+            aniso_u11 = self._ensure_list(mmcif_dict["_atom_site_anisotrop.U[1][1]"])
+            aniso_u12 = self._ensure_list(mmcif_dict["_atom_site_anisotrop.U[1][2]"])
+            aniso_u13 = self._ensure_list(mmcif_dict["_atom_site_anisotrop.U[1][3]"])
+            aniso_u22 = self._ensure_list(mmcif_dict["_atom_site_anisotrop.U[2][2]"])
+            aniso_u23 = self._ensure_list(mmcif_dict["_atom_site_anisotrop.U[2][3]"])
+            aniso_u33 = self._ensure_list(mmcif_dict["_atom_site_anisotrop.U[3][3]"])
             aniso_flag = 1
         except KeyError:
             # no anisotropic B factors


### PR DESCRIPTION
This pull request addresses issue #1884.

The issue here was that the anisotropic values would be read in as strings if they only had a single value. Indexing into the string and converting to a float then errors when the first character of the string is "-".

This change ensures the value is a list before continuing. It means the failing PDB entries in the issue are all read in without throwing an error. I think the mmCIF files are incorrect in these instances, as there is only a single anisotropic value. This gets mapped to the first atom. But I guess that's a PDB problem, not our problem?

This is also related to discussion at https://github.com/biopython/biopython/issues/1533. It's an example of running into the list v string problem.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
