### PR TITLE
Update the GenBank parser for extra long accession

### DIFF
--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1407,8 +1407,8 @@ class GenBankScanner(InsdcScanner):
             if int(splitline[2]) > sys.maxsize:
                 raise ValueError("Tried to load a sequence with a length %s, "
                                  "your installation of python can only load "
-                                 "sesquences of length %s" % splitline[2],
-                                 sys.maxsize)
+                                 "sesquences of length %s" % (splitline[2],
+                                 sys.maxsize))
             else:
                 consumer.size(splitline[2])
 

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1177,6 +1177,15 @@ class GenBankScanner(InsdcScanner):
         the column based layout.
 
         We also try to cope with GenBank like files with partial LOCUS lines.
+
+        As of release 229.0, the columns are no longer strictly in a given
+        position. See:
+          Historically, the LOCUS line has had a fixed length and its elements
+          have been presented at specific column positions...
+          But with the anticipated increases in the lengths of accession
+          numbers, and the advent of sequences that are gigabases long,
+          maintaining the column positions will not always be possible and the
+          overall length of the LOCUS line could exceed 79 characters.
         """
         #####################################
         # LOCUS line                        #
@@ -1387,6 +1396,8 @@ class GenBankScanner(InsdcScanner):
                 and line.split()[5] in ('linear', 'circular'):
             # Cope with invalidly spaced GenBank LOCUS lines like
             # LOCUS       AB070938          6497 bp    DNA     linear   BCT 11-OCT-2001
+            # This will also cope with extra long accession numbers and
+            # sequence lengths
             splitline = line.split()
             consumer.locus(splitline[1])
             consumer.size(splitline[2])
@@ -1394,7 +1405,8 @@ class GenBankScanner(InsdcScanner):
             consumer.topology(splitline[5])
             consumer.data_file_division(splitline[6])
             consumer.date(splitline[7])
-            warnings.warn("Attempting to parse malformed locus line:\n%r\n"
+            warnings.warn("Attempting to parse locus line that is extra "
+                          "long or malformed  :\n%r\n"
                           "Found locus %r size %r residue_type %r\n"
                           "Some fields may be wrong."
                           % (line, splitline[1], splitline[2], splitline[4]),

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1179,14 +1179,15 @@ class GenBankScanner(InsdcScanner):
         We also try to cope with GenBank like files with partial LOCUS lines.
 
         As of release 229.0, the columns are no longer strictly in a given
-        position. See:
+        position. See GenBank format release notes:
 
-        Historically, the LOCUS line has had a fixed length and its elements
-        have been presented at specific column positions...
-        But with the anticipated increases in the lengths of accession
-        numbers, and the advent of sequences that are gigabases long,
-        maintaining the column positions will not always be possible and the
-        overall length of the LOCUS line could exceed 79 characters.
+            "Historically, the LOCUS line has had a fixed length and its
+            elements have been presented at specific column positions...
+            But with the anticipated increases in the lengths of accession
+            numbers, and the advent of sequences that are gigabases long,
+            maintaining the column positions will not always be possible and
+            the overall length of the LOCUS line could exceed 79 characters."
+
         """
         #####################################
         # LOCUS line                        #

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1401,7 +1401,17 @@ class GenBankScanner(InsdcScanner):
             # sequence lengths
             splitline = line.split()
             consumer.locus(splitline[1])
-            consumer.size(splitline[2])
+            # Provide descriptive error message if the sequence is too long
+            # for python to handle
+            import sys
+            if int(splitline[2]) > sys.maxsize:
+                raise ValueError("Tried to load a sequence with a length %s, "
+                                 "your installation of python can only load "
+                                 "sesquences of length %s" % splitline[2],
+                                 sys.maxsize)
+            else:
+                consumer.size(splitline[2])
+
             consumer.residue_type(splitline[4])
             consumer.topology(splitline[5])
             consumer.data_file_division(splitline[6])

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1180,12 +1180,13 @@ class GenBankScanner(InsdcScanner):
 
         As of release 229.0, the columns are no longer strictly in a given
         position. See:
-          Historically, the LOCUS line has had a fixed length and its elements
-          have been presented at specific column positions...
-          But with the anticipated increases in the lengths of accession
-          numbers, and the advent of sequences that are gigabases long,
-          maintaining the column positions will not always be possible and the
-          overall length of the LOCUS line could exceed 79 characters.
+        
+        Historically, the LOCUS line has had a fixed length and its elements
+        have been presented at specific column positions...
+        But with the anticipated increases in the lengths of accession
+        numbers, and the advent of sequences that are gigabases long,
+        maintaining the column positions will not always be possible and the
+        overall length of the LOCUS line could exceed 79 characters.
         """
         #####################################
         # LOCUS line                        #

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1408,7 +1408,7 @@ class GenBankScanner(InsdcScanner):
                 raise ValueError("Tried to load a sequence with a length %s, "
                                  "your installation of python can only load "
                                  "sesquences of length %s" % (splitline[2],
-                                 sys.maxsize))
+                                                              sys.maxsize))
             else:
                 consumer.size(splitline[2])
 

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1417,12 +1417,12 @@ class GenBankScanner(InsdcScanner):
             consumer.topology(splitline[5])
             consumer.data_file_division(splitline[6])
             consumer.date(splitline[7])
-            warnings.warn("Attempting to parse locus line that is extra "
-                          "long or malformed  :\n%r\n"
-                          "Found locus %r size %r residue_type %r\n"
-                          "Some fields may be wrong."
-                          % (line, splitline[1], splitline[2], splitline[4]),
-                          BiopythonParserWarning)
+            if len(line) < 80:
+                warnings.warn("Attempting to parse malformed locus line:\n%r\n"
+                              "Found locus %r size %r residue_type %r\n"
+                              "Some fields may be wrong."
+                              % (line, splitline[1], splitline[2], splitline[4]),
+                              BiopythonParserWarning)
         elif len(line.split()) == 7 and line.split()[3] in ["aa", "bp"]:
             # Cope with EnsEMBL genbank files which use space separation rather
             # than the expected column based layout. e.g.

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1180,7 +1180,7 @@ class GenBankScanner(InsdcScanner):
 
         As of release 229.0, the columns are no longer strictly in a given
         position. See:
-        
+
         Historically, the LOCUS line has had a fixed length and its elements
         have been presented at specific column positions...
         But with the anticipated increases in the lengths of accession

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -618,8 +618,9 @@ class GenBankWriter(_InsdcWriter):
                 tmp = tmp[1:]
             raise ValueError("Invalid whitespace in %s for LOCUS line" % tmp)
         if len(record) > 99999999999:
-            # Currently GenBank only officially support up to 350000, but
-            # the length field can take eleven digits
+            # As of the GenBank release notes 229.0, the locus line can be
+            # any length. However, long locus lines may not be compatible
+            # with all software.
             warnings.warn("The sequence length is very long. The LOCUS "
                           "line will be increased in length to compensate. "
                           "This may cause unexpected behavior.",

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -695,8 +695,8 @@ class GenBankWriter(_InsdcWriter):
                                  'expected position:\n' + line)
 
             if not (splitline[4].strip() == ""
-                    or 'DNA' in line[47:54].strip().upper()
-                    or 'RNA' in line[47:54].strip().upper()):
+                    or 'DNA' in splitline[4].strip().upper()
+                    or 'RNA' in splitline[4].strip().upper()):
                 raise ValueError('LOCUS line does not contain valid '
                                  'sequence type (DNA, RNA, ...):\n' + line)
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -19,11 +19,17 @@ either our original "Biopython License Agreement", or the very similar but
 more commonly used "3-Clause BSD License".  See the ``LICENSE.rst`` file for
 more details.
 
+The NCBI now allows longer accessions in the GenBank file LOCUS line, meaning
+the fields may not always follow the historical column based positions. We
+no longer give a warning when parsing these. We now allow writing such files
+(although with a warning as support for reading them is not yet widespread).
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
 - Bernhard Thiel
 - Lenna Peterson
+- Nick Negretti
 - Peter Cock
 
 18 December 2018: Biopython 1.73

--- a/Tests/output/test_SeqIO
+++ b/Tests/output/test_SeqIO
@@ -67,7 +67,7 @@ Testing reading clustal format file Clustalw/cw02.aln as an alignment
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|671626|emb|CAA85685.1|).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|671626|emb|CAA85685.1|' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -118,7 +118,7 @@ Testing reading clustal format file Clustalw/opuntia.aln as an alignment
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|6273291|gb|AF191665.1|AF191).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|6273291|gb|AF191665.1|AF191' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -169,7 +169,7 @@ Testing reading clustal format file Clustalw/hedgehog.aln as an alignment
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|56122354|gb|AAV74328.1|).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|56122354|gb|AAV74328.1|' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -253,7 +253,7 @@ Testing reading fasta format file Fasta/lupine.nu
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5049839|gb|AI730987.1|AI730987).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|5049839|gb|AI730987.1|AI730987' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -289,7 +289,7 @@ Testing reading fasta format file Fasta/elderberry.nu
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4218935|gb|AF074388.1|AF074388).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|4218935|gb|AF074388.1|AF074388' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -325,7 +325,7 @@ Testing reading fasta format file Fasta/phlox.nu
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5052071|gb|AF067555.1|AF067555).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|5052071|gb|AF067555.1|AF067555' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -361,7 +361,7 @@ Testing reading fasta format file Fasta/centaurea.nu
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4104054|gb|AH007193.1|SEG_CVIGS).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|4104054|gb|AH007193.1|SEG_CVIGS' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -397,7 +397,7 @@ Testing reading fasta format file Fasta/wisteria.nu
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5817701|gb|AF142731.1|AF142731).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|5817701|gb|AF142731.1|AF142731' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -433,7 +433,7 @@ Testing reading fasta format file Fasta/sweetpea.nu
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3176602|gb|U78617.1|LOU78617).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|3176602|gb|U78617.1|LOU78617' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -469,7 +469,7 @@ Testing reading fasta format file Fasta/lavender.nu
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5690369|gb|AF158246.1|AF158246).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|5690369|gb|AF158246.1|AF158246' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -505,7 +505,7 @@ Testing reading fasta format file Fasta/aster.pro
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|3298468|dbj|BAA31520.1|' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -541,7 +541,7 @@ Testing reading fasta format file Fasta/aster_no_wrap.pro
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|3298468|dbj|BAA31520.1|' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -577,7 +577,7 @@ Testing reading fasta-2line format file Fasta/aster_no_wrap.pro
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|3298468|dbj|BAA31520.1|' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -649,7 +649,7 @@ Testing reading fasta format file Fasta/rose.pro
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4959044|gb|AAD34209.1|AF069992_1).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|4959044|gb|AAD34209.1|AF069992_1' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -685,7 +685,7 @@ Testing reading fasta format file Fasta/rosemary.pro
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|671626|emb|CAA85685.1|).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|671626|emb|CAA85685.1|' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -765,7 +765,7 @@ Testing reading fasta format file Fasta/f002
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|1592936|gb|G29385|G29385).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|1592936|gb|G29385|G29385' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -849,7 +849,7 @@ Testing reading fasta format file GenBank/NC_005816.fna
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478711|ref|NC_005816.1|).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|45478711|ref|NC_005816.1|' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -896,7 +896,7 @@ Testing reading fasta format file GenBank/NC_005816.ffn
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=ref|NC_005816.1|:c8360-8088).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'ref|NC_005816.1|:c8360-8088' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -946,7 +946,7 @@ Testing reading fasta format file GenBank/NC_005816.faa
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478721|ref|NP_995576.1|).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|45478721|ref|NP_995576.1|' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -996,7 +996,7 @@ Testing reading fasta format file GenBank/NC_000932.faa
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|7525099|ref|NP_051123.1|).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|7525099|ref|NP_051123.1|' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -1046,7 +1046,7 @@ Testing reading tab format file GenBank/NC_005816.tsv
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478721|ref|NP_995576.1|).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|45478721|ref|NP_995576.1|' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -1085,7 +1085,7 @@ Testing reading fasta format file GFF/NC_001802.fna
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|NC_001802.1|).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|9629357|ref|NC_001802.1|' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -1121,7 +1121,7 @@ Testing reading fasta format file GFF/NC_001802lc.fna
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|nc_001802.1|).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|9629357|ref|nc_001802.1|' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -1211,7 +1211,7 @@ Testing reading fasta format file Registry/seqs.fasta
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=gi|129628|sp|P07175|PARA_AGRTU).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'gi|129628|sp|P07175|PARA_AGRTU' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -1266,7 +1266,7 @@ Testing reading nexus format file Nexus/test_Nexus_input.nex as an alignment
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=t9).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'one should be punished, for (that)!' is too long
+ Failed: Invalid whitespace in 'one should be punished, for (that)!' for LOCUS line
  Checking can write/read as 'imgt' format
  Failed: Cannot have spaces in EMBL accession, 'one should be punished, for (that)!'
  Checking can write/read as 'phd' format
@@ -3308,7 +3308,7 @@ Testing reading stockholm format file Stockholm/funny.sth as an alignment
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=363253|refseq_protein.50.proto_past_mitoc_micro_vira|gi|94986659|ref|YP_594592.1|awsonia_intraceuaris_PHE/MN1-00).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier '363253|refseq_protein.50.proto_past_mitoc_micro_vira|gi|94986659|ref|YP_594592.1|awsonia_intraceuaris_PHE/MN1-00' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -3850,7 +3850,6 @@ Testing reading phd format file Phd/phd1
  Checking can write/read as 'fastq-illumina' format
  Checking can write/read as 'fastq-solexa' format
  Checking can write/read as 'genbank' format
- Failed: Locus identifier '425_103_(81-A03-19).g.ab1' is too long
  Checking can write/read as 'imgt' format
  Checking can write/read as 'phd' format
  Checking can write/read as 'pir' format
@@ -4398,7 +4397,6 @@ Testing reading pir format file NBRF/clustalw.pir as an alignment
  Checking can write/read as 'fastq-solexa' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=815Parelaphostrongylus_odocoil).
  Checking can write/read as 'genbank' format
- Failed: Locus identifier '815Parelaphostrongylus_odocoil' is too long
  Checking can write/read as 'imgt' format
  Checking can write/read as 'phd' format
  Failed: No suitable quality scores found in letter_annotations of SeqRecord (id=815Parelaphostrongylus_odocoil).
@@ -4620,7 +4618,7 @@ Testing reading fastq format file Quality/tricky.fastq as an alignment
  Checking can write/read as 'fastq-illumina' format
  Checking can write/read as 'fastq-solexa' format
  Checking can write/read as 'genbank' format
- Failed: Locus identifier '071113_EAS56_0053:1:3:990:501' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format
@@ -4792,7 +4790,7 @@ Testing reading fastq-solexa format file Quality/solexa_example.fastq as an alig
  Checking can write/read as 'fastq-illumina' format
  Checking can write/read as 'fastq-solexa' format
  Checking can write/read as 'genbank' format
- Failed: Locus identifier 'SLXA-B3_649_FC8437_R1_1_1_183_714' is too long
+ Failed: Need a Nucleotide or Protein alphabet
  Checking can write/read as 'imgt' format
  Failed: Need a DNA, RNA or Protein alphabet
  Checking can write/read as 'phd' format

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -518,6 +518,18 @@ KEYWORDS    """ in gb, gb)
                 self.assertEqual(record_in.name, "AZZZAA02123456789")
                 self.assertEqual(len(record_in.seq), 10000000000)
 
+            def read_longer_than_maxsize():
+                with open(path.join("GenBank", "DS830848.gb"), 'r') as inhandle:
+                    data2 = inhandle.readlines()
+                    data2[0] = "LOCUS       AZZZAA02123456789 " + str(sys.maxsize + 1) + " bp    DNA     linear   PRI 15-OCT-2018\n"
+
+                long_in_tmp = StringIO()
+                long_in_tmp.writelines(data2)
+                long_in_tmp.seek(0)
+                record = SeqIO.read(long_in_tmp, 'genbank')
+
+            self.assertRaises(ValueError, read_longer_than_maxsize)
+
 
 class LineOneTests(unittest.TestCase):
     """Check GenBank/EMBL topology / molecule_type parsing."""

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -330,7 +330,7 @@ KEYWORDS    """ in gb, gb)
             self.assertIn(" %i bp " % seq_len, line)
             # Splitting based on whitespace rather than position due to
             # updated GenBank specification
-            name_and_length = [line.split()[1], line.split()[2]]
+            name_and_length = line.split()[1:3]
             self.assertEqual(name_and_length, [name, str(seq_len)], line)
             handle.seek(0)
             with warnings.catch_warnings():

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -432,7 +432,7 @@ KEYWORDS    """ in gb, gb)
             handle.seek(0)
             gb = SeqIO.read(handle, "gb")
             self.assertEqual(gb.annotations["date"], "01-JAN-1980")
-            
+
     def test_longer_locus_line(self):
         """Check that we can read and write files with longer locus lines"""
         # Create file
@@ -469,6 +469,7 @@ KEYWORDS    """ in gb, gb)
             remove(path.join("GenBank", "long_header_genbank_test.gb"))
         if path.exists(path.join("GenBank", "long_header_genbank_test_out.gb")):
             remove(path.join("GenBank", "long_header_genbank_test_out.gb"))
+
 
 class LineOneTests(unittest.TestCase):
     """Check GenBank/EMBL topology / molecule_type parsing."""

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -301,12 +301,11 @@ KEYWORDS    """ in gb, gb)
                 ("max_length_of_16", 1000, True),
                 ("overly_long_at_17", 1000, True),
                 ("excessively_long_at_22", 99999, True),
-                # ("excessively_long_at_22", 100000, False),
+                ("excessively_long_at_22", 100000, True),
                 ("pushing_the_limits_at_24", 999, True),
-                # ("pushing_the_limits_at_24", 1000, False),
-                # ("longest_possible_len_of_26", 10, False),  # 2 digits
-                ("longest_possible_len_of_26", 9, True),  # 1 digit
-                ]:
+                ("pushing_the_limits_at_24", 1000, True),
+                ("old_max_name_length_was_26", 10, True),  # 2 digits
+                ("old_max_name_length_was_26", 9, True)]:  # 1 digit
             # Make the length match the desired target
             record = original[:]
             # TODO - Implement Seq * int
@@ -329,8 +328,10 @@ KEYWORDS    """ in gb, gb)
             line = handle.readline()
             self.assertIn(" %s " % name, line)
             self.assertIn(" %i bp " % seq_len, line)
-            name_and_length = line[12:40]
-            self.assertEqual(name_and_length.split(), [name, str(seq_len)], line)
+            # Splitting based on whitespace rather than position due to
+            # updated GenBank specification
+            name_and_length = [line.split()[1], line.split()[2]]
+            self.assertEqual(name_and_length, [name, str(seq_len)], line)
             handle.seek(0)
             with warnings.catch_warnings():
                 # e.g. BiopythonParserWarning: GenBank LOCUS line

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -441,7 +441,7 @@ KEYWORDS    """ in gb, gb)
             data[0] = "LOCUS       AZZZAA02123456789 10000000000 bp    DNA     linear   PRI 15-OCT-2018\n"
 
         # Create memory file from modified genbank file
-        in_tmp = StringIO('w+t')
+        in_tmp = StringIO()
         in_tmp.writelines(data)
         in_tmp.seek(0)
 
@@ -463,7 +463,7 @@ KEYWORDS    """ in gb, gb)
             record = SeqIO.read(in_tmp, 'genbank')
 
             # Create temporary output memory file
-            out_tmp = StringIO('w+t')
+            out_tmp = StringIO()
             SeqIO.write(record, out_tmp, 'genbank')
 
             # Check that the written file can be read back in

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -450,7 +450,6 @@ KEYWORDS    """ in gb, gb)
             warnings.simplefilter("error", BiopythonParserWarning)
             try:
                 record = SeqIO.read(in_tmp, 'genbank')
-
             except BiopythonParserWarning as e:
                 self.assertEqual(str(e), "Attempting to parse locus line that is extra long or malformed  :\n"
                                  "'LOCUS       AZZZAA021234567891234 2147483647 bp    DNA     linear   PRI 15-OCT-2018\\n'\n"
@@ -479,7 +478,8 @@ KEYWORDS    """ in gb, gb)
         def test_extremely_long_sequence(self):
             """Tests if extremely long sequences can be read.
 
-            This is only run if sys.maxsize > 2147483647"""
+            This is only run if sys.maxsize > 2147483647.
+            """
             # Create example file from existing file
             with open(path.join("GenBank", "DS830848.gb"), 'r') as inhandle:
                 data = inhandle.readlines()

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -448,18 +448,6 @@ KEYWORDS    """ in gb, gb)
         in_tmp.seek(0)
 
         with warnings.catch_warnings():
-            warnings.simplefilter("error", BiopythonParserWarning)
-            try:
-                record = SeqIO.read(in_tmp, 'genbank')
-            except BiopythonParserWarning as e:
-                self.assertEqual(str(e), "Attempting to parse locus line that is extra long or malformed  :\n"
-                                 "'LOCUS       AZZZAA021234567891234 2147483647 bp    DNA     linear   PRI 15-OCT-2018\\n'\n"
-                                 "Found locus 'AZZZAA021234567891234' size '2147483647' residue_type 'DNA'\n"
-                                 "Some fields may be wrong.")
-            else:
-                self.assertTrue(False, "Expected specified BiopythonParserWarning here.")
-
-        with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             in_tmp.seek(0)
             record = SeqIO.read(in_tmp, 'genbank')
@@ -490,18 +478,6 @@ KEYWORDS    """ in gb, gb)
             in_tmp = StringIO()
             in_tmp.writelines(data)
             in_tmp.seek(0)
-
-            with warnings.catch_warnings():
-                warnings.simplefilter("error", BiopythonParserWarning)
-                try:
-                    record = SeqIO.read(in_tmp, 'genbank')
-                except BiopythonParserWarning as e:
-                    self.assertEqual(str(e), "Attempting to parse locus line that is extra long or malformed  :\n"
-                                     "'LOCUS       AZZZAA02123456789 10000000000 bp    DNA     linear   PRI 15-OCT-2018\\n'\n"
-                                     "Found locus 'AZZZAA02123456789' size '10000000000' residue_type 'DNA'\n"
-                                     "Some fields may be wrong.")
-                else:
-                    self.assertTrue(False, "Expected specified BiopythonParserWarning here.")
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")


### PR DESCRIPTION
This pull request addresses issue #1870

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

The genbank parser was essentially ready to handle the extra long accession, I've changed some changes to turn errors in to warnings.

The genbank writer will also handle the longer accession length which resulted in quite a few changes in the test suite - where there was a 'name too long' error, there now is none.

There are warnings on both parsing, and writing genbank files with extra long accession numbers. I think these should stay for a while, as I expect a long accession field will cause problems in other software until it is updated.
