### PR TITLE
Fix test failure when running test_SearchIO_blast_xml alone

### DIFF
--- a/Bio/SearchIO/BlastIO/__init__.py
+++ b/Bio/SearchIO/BlastIO/__init__.py
@@ -407,11 +407,17 @@ The blast-text parser provides the following object attributes:
    present as well. It is recommended that you use these instead of 'frames' directly.
 
 """
+import warnings
+from Bio import BiopythonWarning
 
 from .blast_tab import BlastTabParser, BlastTabIndexer, BlastTabWriter
 from .blast_xml import BlastXmlParser, BlastXmlIndexer, BlastXmlWriter
-from .blast_text import BlastTextParser
 
+# Suppress the NCBIStandalone depreciation warning when importing this module
+with warnings.catch_warnings():
+    warnings.filterwarnings('ignore', r'.*Parsing BLAST plain text output '
+                            'file is not a well supported.*', BiopythonWarning)
+    from .blast_text import BlastTextParser
 
 # if not used as a module, run the doctest
 if __name__ == "__main__":

--- a/Bio/SearchIO/BlastIO/__init__.py
+++ b/Bio/SearchIO/BlastIO/__init__.py
@@ -407,17 +407,10 @@ The blast-text parser provides the following object attributes:
    present as well. It is recommended that you use these instead of 'frames' directly.
 
 """
-import warnings
-from Bio import BiopythonWarning
 
 from .blast_tab import BlastTabParser, BlastTabIndexer, BlastTabWriter
 from .blast_xml import BlastXmlParser, BlastXmlIndexer, BlastXmlWriter
-
-# Suppress the NCBIStandalone depreciation warning when importing this module
-with warnings.catch_warnings():
-    warnings.filterwarnings('ignore', r'.*Parsing BLAST plain text output '
-                            'file is not a well supported.*', BiopythonWarning)
-    from .blast_text import BlastTextParser
+from .blast_text import BlastTextParser
 
 # if not used as a module, run the doctest
 if __name__ == "__main__":

--- a/Bio/SearchIO/BlastIO/blast_text.py
+++ b/Bio/SearchIO/BlastIO/blast_text.py
@@ -14,12 +14,7 @@ parser (which is now deprecated).
 
 from Bio.Alphabet import generic_dna, generic_protein
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
-
-import warnings
-from Bio import BiopythonDeprecationWarning
-with warnings.catch_warnings():
-    warnings.simplefilter('ignore', BiopythonDeprecationWarning)
-    from Bio.SearchIO._legacy import NCBIStandalone
+from Bio.SearchIO._legacy import NCBIStandalone
 
 
 __all__ = ('BlastTextParser', )

--- a/Bio/SearchIO/_legacy/NCBIStandalone.py
+++ b/Bio/SearchIO/_legacy/NCBIStandalone.py
@@ -38,13 +38,6 @@ from Bio.Blast import Record
 
 from Bio import BiopythonWarning
 import warnings
-warnings.warn(
-    "Parsing BLAST plain text output file is not a well supported"
-    " functionality anymore. Consider generating your BLAST output for parsing"
-    " as XML or tabular format instead.",
-    BiopythonWarning
-)
-
 
 _score_e_re = re.compile(r'Score +E')
 
@@ -87,6 +80,15 @@ class _Scanner(object):
      - feed     Feed data into the scanner.
 
     """
+
+    def __init__(self):
+        """Raise warning that this module is outdated."""
+        warnings.warn(
+            "Parsing BLAST plain text output file is not a well supported"
+            " functionality anymore. Consider generating your BLAST output for parsing"
+            " as XML or tabular format instead.",
+            BiopythonWarning
+        )
 
     def feed(self, handle, consumer):
         """Feed in a BLAST report for scanning.

--- a/Tests/test_NCBITextParser.py
+++ b/Tests/test_NCBITextParser.py
@@ -8,9 +8,12 @@ import unittest
 
 import warnings
 from Bio import BiopythonWarning
-with warnings.catch_warnings():
-    warnings.simplefilter('ignore', BiopythonWarning)
-    from Bio.SearchIO._legacy import NCBIStandalone
+from Bio.SearchIO._legacy import NCBIStandalone
+
+# This prevents the NCBIStandalone usage warning from
+# printing to screen when running the test suite
+warnings.filterwarnings('ignore', r'Parsing BLAST plain text output '
+                        'file is not a well supported.*', BiopythonWarning)
 
 
 class TestBlastRecord(unittest.TestCase):

--- a/Tests/test_SearchIO_blast_text.py
+++ b/Tests/test_SearchIO_blast_text.py
@@ -7,13 +7,19 @@
 
 import os
 import unittest
+import warnings
 
 from Bio.SearchIO import parse
-
+from Bio import BiopythonWarning
 
 # test case files are in the Blast directory
 TEST_DIR = 'Blast'
 FMT = 'blast-text'
+
+# This prevents the NCBIStandalone usage warning from
+# printing to screen when running the test suite
+warnings.filterwarnings('ignore', r'Parsing BLAST plain text output '
+                        'file is not a well supported.*', BiopythonWarning)
 
 
 def get_file(filename):
@@ -34,6 +40,21 @@ class BaseBlastCases(unittest.TestCase):
 
 
 class BlastnCases(BaseBlastCases):
+    def test_000_unsupported_warning(self):
+        """Test that the 'unsupported' warning is generated."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiopythonWarning)
+            try:
+                blast_file = get_file('text_2226_blastn_001.txt')
+                qresults = list(parse(blast_file, FMT))
+            except BiopythonWarning as e:
+                self.assertEqual(str(e),
+                                 "Parsing BLAST plain text output file is not "
+                                 "a well supported functionality anymore. "
+                                 "Consider generating your BLAST output for "
+                                 "parsing as XML or tabular format instead.")
+            else:
+                self.assertTrue(False, "Expected BiopythonWarning here on usage of NCBIStandalone.")
 
     def test_text_2226_blastn_001(self):
         """Test parsing blastn output (text_2226_blastn_001.txt)"""

--- a/Tests/test_SearchIO_blast_text.py
+++ b/Tests/test_SearchIO_blast_text.py
@@ -40,21 +40,6 @@ class BaseBlastCases(unittest.TestCase):
 
 
 class BlastnCases(BaseBlastCases):
-    def test_000_unsupported_warning(self):
-        """Test that the 'unsupported' warning is generated."""
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", BiopythonWarning)
-            try:
-                blast_file = get_file('text_2226_blastn_001.txt')
-                qresults = list(parse(blast_file, FMT))
-            except BiopythonWarning as e:
-                self.assertEqual(str(e),
-                                 "Parsing BLAST plain text output file is not "
-                                 "a well supported functionality anymore. "
-                                 "Consider generating your BLAST output for "
-                                 "parsing as XML or tabular format instead.")
-            else:
-                self.assertTrue(False, "Expected BiopythonWarning here on usage of NCBIStandalone.")
 
     def test_text_2226_blastn_001(self):
         """Test parsing blastn output (text_2226_blastn_001.txt)"""

--- a/Tests/test_SearchIO_blast_xml.py
+++ b/Tests/test_SearchIO_blast_xml.py
@@ -10,12 +10,8 @@ import sys
 import unittest
 import warnings
 
-from Bio import BiopythonParserWarning, BiopythonWarning
+from Bio import BiopythonParserWarning
 from Bio.SearchIO import parse
-
-with warnings.catch_warnings():
-    warnings.simplefilter('ignore', BiopythonWarning)
-    from Bio.SearchIO._legacy import NCBIStandalone
 
 
 # test case files are in the Blast directory

--- a/Tests/test_SearchIO_blast_xml.py
+++ b/Tests/test_SearchIO_blast_xml.py
@@ -10,8 +10,12 @@ import sys
 import unittest
 import warnings
 
-from Bio import BiopythonParserWarning
+from Bio import BiopythonParserWarning, BiopythonWarning
 from Bio.SearchIO import parse
+
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', BiopythonWarning)
+    from Bio.SearchIO._legacy import NCBIStandalone
 
 
 # test case files are in the Blast directory


### PR DESCRIPTION
NCBIStandalone causes a warning when imported, suppress that warning.

This pull request addresses issue #1889

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This fix suppresses the warning raised by `NCBIStandalone` on import causing the `test_SearchIO_blast_xml` to fail when running standalone.
