### PR TITLE
Deprecate obsolete Bio.KDTrees module

### DIFF
--- a/Bio/KDTree/__init__.py
+++ b/Bio/KDTree/__init__.py
@@ -3,7 +3,7 @@
 # as part of this package.
 #
 
-"""KD tree data structure for searching N-dimensional vectors (OBSOLETE).
+"""KD tree data structure for searching N-dimensional vectors (DEPRECATED).
 
 The KD tree data structure can be used for all kinds of searches that
 involve N-dimensional vectors. For example, neighbor searches (find all points
@@ -12,7 +12,14 @@ that are within a certain radius of each other. See "Computational Geometry:
 Algorithms and Applications" (Mark de Berg, Marc van Kreveld, Mark Overmars,
 Otfried Schwarzkopf).
 
-This module is OBSOLETE; its replacement is Bio.PDB.kdtrees.
+This module is DEPRECATED; its replacement is Bio.PDB.kdtrees.
 """
 
 from .KDTree import KDTree
+
+import warnings
+from Bio import BiopythonDeprecationWarning
+warnings.warn("Bio.KDTree has been deprecated, and we intend to remove it"
+              " in a future release of Biopython. Please use Bio.PDB.kdtrees"
+              " instead, which is functionally very similar.",
+              BiopythonDeprecationWarning)

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -751,9 +751,10 @@ removed in Release 1.61.
 
 Bio.KDTree
 ==========
-This module was declared obsolete in Release 1.72. As of Release 1.72, KDTree
-data structures and the functionality previously available in Bio.KDTree are
-provided in a new module ``Bio.PDB.kdtrees``.
+This module was declared obsolete in Release 1.72, and deprecated in Release
+1.74. As of Release 1.72, KDTree data structures and the functionality
+previously available in ``Bio.KDTree`` are provided in a new module
+``Bio.PDB.kdtrees``.
 
 Bio.trie, Bio.triefind
 ======================

--- a/Tests/test_KDTree.py
+++ b/Tests/test_KDTree.py
@@ -12,17 +12,22 @@ except ImportError:
     raise MissingExternalDependencyError(
         "Install NumPy if you want to use Bio.KDTree.")
 
-try:
-    from Bio.KDTree import _CKDTree
-    del _CKDTree
-except ImportError:
-    from Bio import MissingExternalDependencyError
-    raise MissingExternalDependencyError(
-            "C module in Bio.KDTree not compiled")
-
-from Bio.KDTree.KDTree import KDTree
 from numpy import sum, sqrt, array
 from numpy import random
+
+import warnings
+from Bio import BiopythonDeprecationWarning
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', BiopythonDeprecationWarning)
+    try:
+        from Bio.KDTree import _CKDTree
+        del _CKDTree
+    except ImportError:
+        from Bio import MissingExternalDependencyError
+        raise MissingExternalDependencyError(
+            "C module in Bio.KDTree not compiled")
+    from Bio.KDTree.KDTree import KDTree
+
 
 nr_points = 5000
 dim = 3


### PR DESCRIPTION
Follow up from #1636 which declared this obsolete. See also https://biopython.org/wiki/Deprecation_policy

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
