### PR TITLE
Catch import errors during run_tests.py doctest

### DIFF
--- a/Bio/.flake8
+++ b/Bio/.flake8
@@ -45,4 +45,9 @@ ignore =
     # ================================================
     # C812	missing trailing comma
     # C815	missing trailing comma in Python 3.5+
-    C812,C815
+    C812,C815,
+    # ========================================
+    # flake8-black (in case installed locally)
+    # ========================================
+    # BLK100 Black would make changes.
+    BLK100,

--- a/Bio/Graphics/KGML_vis.py
+++ b/Bio/Graphics/KGML_vis.py
@@ -18,10 +18,20 @@ import os
 import tempfile
 from io import BytesIO
 
-from reportlab.lib import colors
-from reportlab.pdfgen import canvas
+try:
+    from reportlab.lib import colors
+    from reportlab.pdfgen import canvas
+except ImportError:
+    from Bio import MissingPythonDependencyError
+    raise MissingPythonDependencyError(
+        "Install reportlab if you want to use KGML_vis.")
 
-from PIL import Image
+try:
+    from PIL import Image
+except ImportError:
+    from Bio import MissingPythonDependencyError
+    raise MissingPythonDependencyError(
+        "Install pillow if you want to use KGML_vis.")
 
 from Bio._py3k import urlopen as _urlopen
 

--- a/BioSQL/.flake8
+++ b/BioSQL/.flake8
@@ -24,3 +24,8 @@ ignore =
     # B007	Loop control variable not used within the loop body.
     #           If this is intended, start the name with an underscore.
     B007,
+    # ========================================
+    # flake8-black (in case installed locally)
+    # ========================================
+    # BLK100 Black would make changes.
+    BLK100,

--- a/Doc/examples/.flake8
+++ b/Doc/examples/.flake8
@@ -15,3 +15,8 @@ ignore =
     # flake8-bugbear: B###
     # ====================
     B007,
+    # ========================================
+    # flake8-black (in case installed locally)
+    # ========================================
+    # BLK100 Black would make changes.
+    BLK100,

--- a/Scripts/.flake8
+++ b/Scripts/.flake8
@@ -25,4 +25,9 @@ ignore =
     # ====================================
     # D412	No blank lines allowed between a section header and its content
     # We ignore D412 deliberately:
-    D412
+    D412,
+    # ========================================
+    # flake8-black (in case installed locally)
+    # ========================================
+    # BLK100 Black would make changes.
+    BLK100,

--- a/Tests/.flake8
+++ b/Tests/.flake8
@@ -67,4 +67,9 @@ ignore =
     # flake8-commas (in case installed locally)
     # =========================================
     # C812	missing trailing comma
-    C812
+    C812,
+    # ========================================
+    # flake8-black (in case installed locally)
+    # ========================================
+    # BLK100 Black would make changes.
+    BLK100,

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -637,6 +637,7 @@ class TestRunner(unittest.TextTestRunner):
                                          verbosity=verbosity)
 
     def runTest(self, name):
+        from Bio import MissingPythonDependencyError
         from Bio import MissingExternalDependencyError
         result = self._makeResult()
         output = StringIO()
@@ -679,7 +680,16 @@ class TestRunner(unittest.TextTestRunner):
             else:
                 # It's a doc test
                 sys.stderr.write("%s docstring test ... " % name)
-                module = __import__(name, fromlist=name.split("."))
+                try:
+                    module = __import__(name, fromlist=name.split("."))
+                except MissingPythonDependencyError:
+                    sys.stderr.write("skipped, missing Python dependency\n")
+                    return True
+                except ImportError as e:
+                    sys.stderr.write("FAIL, ImportError\n")
+                    result.stream.write("ERROR while importing %s: %s\n" % (name, e))
+                    result.printErrors()
+                    return False
                 suite = doctest.DocTestSuite(module,
                                              optionflags=doctest.ELLIPSIS)
                 del module


### PR DESCRIPTION
This addresses recent AppVeyor failures apparently linked to the inclusion of ``Bio.Graphics.KGML_vis`` in the doctests run by ``run_tests.py`` since #1900, and the version of ``pillow`` installed under AppVeyor 64bit Windows Python 2.7, see: https://github.com/biopython/biopython/pull/1906#issuecomment-457516404

I could also "fix" this by explicitly installing ``pillow==4.2`` which might be worth doing as well? See e.g.
https://ci.appveyor.com/project/peterjc/biopython/builds/21865494

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
