### PR TITLE
Vector division broken in python 3.x #1914

### DIFF
--- a/Bio/PDB/vectors.py
+++ b/Bio/PDB/vectors.py
@@ -6,6 +6,7 @@
 """Vector class, including rotation-related functions."""
 
 from __future__ import print_function
+from __future__ import division
 
 import numpy
 
@@ -276,11 +277,11 @@ class Vector(object):
         """Return Vector.Vector (dot product)."""
         return sum(self._ar * other._ar)
 
-    def __div__(self, x):
+    def __truediv__(self, x):
         """Return Vector(coords/a)."""
         a = self._ar / numpy.array(x)
         return Vector(a)
-
+    
     def __pow__(self, other):
         """Return VectorxVector (cross product) or Vectorxscalar."""
         if isinstance(other, Vector):


### PR DESCRIPTION
Support division operator in Python 3. If users use `Vector.__div__(x)` to perform division,  they should modify their codes.

This pull request addresses issue #1914 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
