### PR TITLE
Vector division broken in python 3.x #1914

### DIFF
--- a/Bio/PDB/Vector.py
+++ b/Bio/PDB/Vector.py
@@ -27,6 +27,8 @@ old and new versions of Biopython:
 
 """
 
+from __future__ import division
+
 import warnings
 
 from .vectors import m2rotaxis, vector_to_axis, rotaxis2m

--- a/Bio/PDB/vectors.py
+++ b/Bio/PDB/vectors.py
@@ -6,6 +6,7 @@
 """Vector class, including rotation-related functions."""
 
 from __future__ import print_function
+from __future__ import division
 
 import numpy
 
@@ -276,7 +277,7 @@ class Vector(object):
         """Return Vector.Vector (dot product)."""
         return sum(self._ar * other._ar)
 
-    def __div__(self, x):
+    def __truediv__(self, x):
         """Return Vector(coords/a)."""
         a = self._ar / numpy.array(x)
         return Vector(a)

--- a/Tests/test_PDB_vectors.py
+++ b/Tests/test_PDB_vectors.py
@@ -35,6 +35,14 @@ class LegacyImportTests(unittest.TestCase):
             del m2rotaxis, refmat, rotaxis2m, rotmat
             del vector_to_axis, Vector
 
+class VectorTests(unittest.TestCase):
+    """Tests for the Vector class."""
+
+    def test_division(self):
+        """Confirm division works."""
+        from Bio.PDB.Vector import Vector
+        v = Vector(2, 2, 2) / 2
+        self.assertEqual(repr(v), "<Vector 1.00, 1.00, 1.00>")
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)

--- a/Tests/test_PDB_vectors.py
+++ b/Tests/test_PDB_vectors.py
@@ -35,6 +35,7 @@ class LegacyImportTests(unittest.TestCase):
             del m2rotaxis, refmat, rotaxis2m, rotmat
             del vector_to_axis, Vector
 
+
 class VectorTests(unittest.TestCase):
     """Tests for the Vector class."""
 
@@ -43,6 +44,7 @@ class VectorTests(unittest.TestCase):
         from Bio.PDB.Vector import Vector
         v = Vector(2, 2, 2) / 2
         self.assertEqual(repr(v), "<Vector 1.00, 1.00, 1.00>")
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
This pull request addresses issue #1914

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
