### PR TITLE
Disallow input of Seq objects as data to MutableSeq()

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1858,6 +1858,10 @@ class MutableSeq(object):
             self.array_indicator = "c"
         if isinstance(data, str):  # TODO - What about unicode?
             self.data = array.array(self.array_indicator, data)
+        elif isinstance(data, Seq):
+            raise TypeError("The sequence data given to a MutableSeq object "
+                            "should be a string or an array "
+                            "(not a Seq object etc)")
         else:
             self.data = data   # assumes the input is an array
         self.alphabet = alphabet

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -28,6 +28,7 @@ Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
 - Bernhard Thiel
+- Chris Rands
 - Lenna Peterson
 - Nick Negretti
 - Peter Cock

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -737,6 +737,11 @@ class StringMethodTests(unittest.TestCase):
         self.assertRaises(TypeError, Seq, (1066))
         self.assertRaises(TypeError, Seq, (Seq("ACGT", generic_dna)))
 
+    def test_MutableSeq_init_typeerror(self):
+        """Check MutableSeq __init__ gives TypeError exceptions."""
+        self.assertRaises(TypeError, MutableSeq, (Seq("A")))
+        self.assertRaises(TypeError, MutableSeq, (UnknownSeq(1)))
+
     # TODO - Addition...
 
 


### PR DESCRIPTION
This pull request addresses issue #1918. Following Peter's suggestion, I went with the exception being raised (it is trivial for the user to convert their data if they need to).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
