### PR TITLE
Patch 1

### DIFF
--- a/Bio/Align/Applications/_Muscle.py
+++ b/Bio/Align/Applications/_Muscle.py
@@ -52,6 +52,11 @@ class MuscleCommandline(AbstractCommandline):
             ["pctid_kimura", "pctid_log"]
         OBJECTIVE_SCORES = ["sp", "ps", "dp", "xp", "spf", "spm"]
         TREE_ROOT_METHODS = ["pseudo", "midlongestspan", "minavgleafdist"]
+        
+        # The mucleotide arguments for  the sequence type parameter in MUSCLE (-seqtype) 
+        #   were updated at somepoint in MUSCLE version 3.8. Prior to the update
+        #   'nucleo' was used for nucleotide. This has been updated to 'rna' and 'dna'. 'nucleo' kept for 
+        #   backwards compatibility with older MUSCLE versions.
         SEQUENCE_TYPES = ["protein", "rna", "dna", "nucleo", "auto"]
         WEIGHTING_SCHEMES = ["none", "clustalw", "henikoff", "henikoffpb",
                              "gsc", "threeway"]
@@ -304,8 +309,10 @@ class MuscleCommandline(AbstractCommandline):
                     filename=True,
                     equate=False),
             # seqtype         protein              auto     Sequence type.
-            #                nucleo
-            #                auto
+            #                 dna (MUSCLE version > 3.8)
+            #                 rna (MUSCLE version > 3.8)
+            #                 auto
+            #                 nucleo (only valid for MUSCLE versions < 3.8)
             _Option(["-seqtype", "seqtype"],
                     "Sequence type",
                     checker_function=lambda x: x in SEQUENCE_TYPES,

--- a/Bio/Align/Applications/_Muscle.py
+++ b/Bio/Align/Applications/_Muscle.py
@@ -54,9 +54,9 @@ class MuscleCommandline(AbstractCommandline):
         TREE_ROOT_METHODS = ["pseudo", "midlongestspan", "minavgleafdist"]
         
         # The mucleotide arguments for  the sequence type parameter in MUSCLE (-seqtype) 
-        #   were updated at somepoint in MUSCLE version 3.8. Prior to the update
-        #   'nucleo' was used for nucleotide. This has been updated to 'rna' and 'dna'. 'nucleo' kept for 
-        #   backwards compatibility with older MUSCLE versions.
+        # were updated at somepoint in MUSCLE version 3.8. Prior to the update
+        # 'nucleo' was used for nucleotide. This has been updated to 'rna' and 'dna'. 'nucleo' kept for 
+        # backwards compatibility with older MUSCLE versions.
         SEQUENCE_TYPES = ["protein", "rna", "dna", "nucleo", "auto"]
         WEIGHTING_SCHEMES = ["none", "clustalw", "henikoff", "henikoffpb",
                              "gsc", "threeway"]

--- a/Bio/Align/Applications/_Muscle.py
+++ b/Bio/Align/Applications/_Muscle.py
@@ -52,10 +52,10 @@ class MuscleCommandline(AbstractCommandline):
             ["pctid_kimura", "pctid_log"]
         OBJECTIVE_SCORES = ["sp", "ps", "dp", "xp", "spf", "spm"]
         TREE_ROOT_METHODS = ["pseudo", "midlongestspan", "minavgleafdist"]
-        
-        # The mucleotide arguments for  the sequence type parameter in MUSCLE (-seqtype) 
+
+        # The mucleotide arguments for  the sequence type parameter in MUSCLE (-seqtype)
         # were updated at somepoint in MUSCLE version 3.8. Prior to the update
-        # 'nucleo' was used for nucleotide. This has been updated to 'rna' and 'dna'. 'nucleo' kept for 
+        # 'nucleo' was used for nucleotide. This has been updated to 'rna' and 'dna'. 'nucleo' kept for
         # backwards compatibility with older MUSCLE versions.
         SEQUENCE_TYPES = ["protein", "rna", "dna", "nucleo", "auto"]
         WEIGHTING_SCHEMES = ["none", "clustalw", "henikoff", "henikoffpb",

--- a/Bio/Align/Applications/_Muscle.py
+++ b/Bio/Align/Applications/_Muscle.py
@@ -52,7 +52,7 @@ class MuscleCommandline(AbstractCommandline):
             ["pctid_kimura", "pctid_log"]
         OBJECTIVE_SCORES = ["sp", "ps", "dp", "xp", "spf", "spm"]
         TREE_ROOT_METHODS = ["pseudo", "midlongestspan", "minavgleafdist"]
-        SEQUENCE_TYPES = ["protein", "nucleo", "auto"]
+        SEQUENCE_TYPES = ["protein", "rna", "dna", "nucleo", "auto"]
         WEIGHTING_SCHEMES = ["none", "clustalw", "henikoff", "henikoffpb",
                              "gsc", "threeway"]
         self.parameters = [

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -224,6 +224,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Stefans Mezulis <https://github.com/StefansM/>
 - Steve Bond <https://github.com/biologyguy>
 - Steve Marshall <https://github.com/hungryhoser>
+- Stuart Nelis <https://github.com/biostu24>
 - Sunhwan Jo <https://github.com/sunhwan>
 - Tarcisio Fedrizzi <https://github.com/hcraT>
 - Tarjei Mikkelsen <tarjei at domain genome.wi.mit.edu>


### PR DESCRIPTION
This pull request addresses issue #1911

The the arguments foe the MUSCLE -seqtype argument for nucleotide sequences have changed from 'nucleo' to 'rna'/'dna'. This pull request updates the allowable MuscleCommandline parameter arguments.

I have attempted to identify the version of MUSCLE where this change took place - however, I have not been able find this information.

Version data is not readily available online (no version histories or source code for intermediate versions and not previous references or manuals). I have contacted the author, who replied but he was unable to help me. All I can surmise is the -seqtype arguments changed either in 1) a version after 3.8.0 or 2) from 3.8.0. The 3.8.0 user manual (which I found online) uses the old notation - however, I suspect this may be an error but I do not have any evidence for this.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

*Edit: Added leading hash for issue number (so that GitHub links it), removed spaces on the check boxes (so that GitHub renders them nicely). Peter.*