### PR TITLE
Add support for mysqlclient package

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -65,8 +65,10 @@ deps =
     py27,py35: reportlab
     py27,py34,py35,py36: psycopg2-binary
     py27,py34,py35,py35: mysql-connector-python-rf
+    py34,py35,py36: mysqlclient
     py27,py35,pypy: rdflib
     pypy,pypy3: numpy==1.12.1
+    pypy3: mysqlclient
     py27,py34,py36: numpy
     py36: scipy
     py27: networkx

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -65,10 +65,10 @@ deps =
     py27,py35: reportlab
     py27,py34,py35,py36: psycopg2-binary
     py27,py34,py35,py35: mysql-connector-python-rf
-    py34,py35,py36: mysqlclient
+    py35,py36: mysqlclient
     py27,py35,pypy: rdflib
     pypy,pypy3: numpy==1.12.1
-    pypy3: mysqlclient
+    pypy,pypy3: mysqlclient
     py27,py34,py36: numpy
     py36: scipy
     py27: networkx

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -650,6 +650,7 @@ class MysqlConnectorAdaptor(Adaptor):
 _interface_specific_adaptors = {
     # If SQL interfaces require a specific adaptor, use this to map the adaptor
     "mysql.connector": MysqlConnectorAdaptor,
+    "MySQLdb": MysqlConnectorAdaptor
 }
 
 _allowed_lookups = {

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -24,6 +24,8 @@ the fields may not always follow the historical column based positions. We
 no longer give a warning when parsing these. We now allow writing such files
 (although with a warning as support for reading them is not yet widespread).
 
+Support for the mysqlclient package, a fork of MySQLdb, has been added.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 

--- a/README.rst
+++ b/README.rst
@@ -140,9 +140,10 @@ other optional Python dependencies, which can be installed later if needed:
   This package is used by ``BioSQL`` to access a MySQL database, and is
   supported on Python 2 and 3 and PyPy too.
 
-- MySQLdb, see http://sourceforge.net/projects/mysql-python (optional)
-  This is an older alternative package used by ``BioSQL`` to access a MySQL
-  database, but it is not available for Python 3 or PyPy.
+- mysqlclient, see https://github.com/PyMySQL/mysqlclient-python (optional)
+  This is a fork of the older MySQLdb and is used by ``BioSQL`` to access a 
+  MySQL database. It is supported by Python 2.7, Python 3.5 and above, PyPy 2,
+  and PyPy 3.
 
 Note that some of these libraries are not available for PyPy or Jython,
 and not all are available for Python 3 yet either.

--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,7 @@ other optional Python dependencies, which can be installed later if needed:
   supported on Python 2 and 3 and PyPy too.
 
 - mysqlclient, see https://github.com/PyMySQL/mysqlclient-python (optional)
-  This is a fork of the older MySQLdb and is used by ``BioSQL`` to access a 
+  This is a fork of the older MySQLdb and is used by ``BioSQL`` to access a
   MySQL database. It is supported by Python 2.7, Python 3.5 and above, PyPy 2,
   and PyPy 3.
 

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -107,7 +107,10 @@ def check_config(dbdriver, dbtype, dbhost, dbuser, dbpasswd, testdb):
         try:
             __import__(DBDRIVER)
         except ImportError:
-            message = "Install %s if you want to use %s with BioSQL " % (DBDRIVER, DBTYPE)
+            if DBDRIVER in ["MySQLdb"]:
+                message = "Install MySQLdb or mysqlclient if you want to use %s with BioSQL " % (DBTYPE)
+            else:
+                message = "Install %s if you want to use %s with BioSQL " % (DBDRIVER, DBTYPE)
             raise MissingExternalDependencyError(message)
 
     try:


### PR DESCRIPTION
This pull request addresses issue #1928 and possibly #821 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This pull request adds support for the `mysqlclient` package, see package github page [here](https://github.com/PyMySQL/mysqlclient-python). This is an updated and actively developed version of the old `MySQLdb` package that supports python 2.7, 3.5+, pypy 2 and pypy 3.

Note that this does not support python 3.4, however 3.4 is scheduled to [read end-of-life next month](https://devguide.python.org/#branchstatus). I've enabled testing `mysqlclient` in the supported python versions in TravisCI, except python 2.7 which is using the old `MySQLdb (mysql-python)`.