### PR TITLE
Extract PDB ID in Bio/PDB/parse_pdb_header.py

### DIFF
--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -183,6 +183,7 @@ def _parse_pdb_header_list(header):
     dict = {
         'name': "",
         'head': '',
+        'idcode': '',
         'deposition_date': "1909-01-08",
         'release_date': "1909-01-08",
         'structure_method': "unknown",
@@ -219,6 +220,9 @@ def _parse_pdb_header_list(header):
             rr = re.search(r"\d\d-\w\w\w-\d\d", tail)
             if rr is not None:
                 dict['deposition_date'] = _format_date(_nice_case(rr.group()))
+            rr = re.search(r"\s+\w\w\w\w\s*\Z",tail)
+            if rr is not None:
+                dict['idcode'] = rr.group(0)
             head = _chop_end_misc(tail).lower()
             dict['head'] = head
         elif key == "COMPND":

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -220,7 +220,7 @@ def _parse_pdb_header_list(header):
             rr = re.search(r"\d\d-\w\w\w-\d\d", tail)
             if rr is not None:
                 dict['deposition_date'] = _format_date(_nice_case(rr.group()))
-            rr = re.search(r"\s+\w\w\w\w\s*\Z",tail)
+            rr = re.search(r"\s+\w\w\w\w\s*\Z", tail)
             if rr is not None:
                 dict['idcode'] = rr.group(0)
             head = _chop_end_misc(tail).lower()

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -220,9 +220,9 @@ def _parse_pdb_header_list(header):
             rr = re.search(r"\d\d-\w\w\w-\d\d", tail)
             if rr is not None:
                 dict['deposition_date'] = _format_date(_nice_case(rr.group()))
-            rr = re.search(r"\s+\w\w\w\w\s*\Z", tail)
+            rr = re.search(r"\s+([1-9][0-9A-Z]{3})\s*\Z", tail)
             if rr is not None:
-                dict['idcode'] = rr.group(0)
+                dict['idcode'] = rr.group(1)
             head = _chop_end_misc(tail).lower()
             dict['head'] = head
         elif key == "COMPND":

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -205,6 +205,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Rasmus Fonseca <https://github.com/RasmusFonseca>
 - rht <https://github.com/rht>
 - Richard Neher <https://github.com/rneher>
+- Rob Miller <https://github.com/rob-miller>
 - Robert Ernst <https://github.com/rernst>
 - Rodrigo Dorantes-Gilardi <https://github.com/rodogi>
 - Rona Costello <https://github.com/RonaCostello>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -26,6 +26,8 @@ no longer give a warning when parsing these. We now allow writing such files
 
 Support for the mysqlclient package, a fork of MySQLdb, has been added.
 
+We now capture the IDcode field from PDB Header records. 
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -26,7 +26,7 @@ no longer give a warning when parsing these. We now allow writing such files
 
 Support for the mysqlclient package, a fork of MySQLdb, has been added.
 
-We now capture the IDcode field from PDB Header records. 
+We now capture the IDcode field from PDB Header records.
 
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+This is Rob Miller's Biopython branch
+=====================================
+
 .. image:: https://img.shields.io/pypi/v/biopython.svg
    :alt: Biopython on the Python Package Index (PyPI)
    :target: https://pypi.python.org/pypi/biopython

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-This is Rob Miller's Biopython branch
-=====================================
-
 .. image:: https://img.shields.io/pypi/v/biopython.svg
    :alt: Biopython on the Python Package Index (PyPI)
    :target: https://pypi.python.org/pypi/biopython

--- a/Tests/test_PDB_parse_pdb_header.py
+++ b/Tests/test_PDB_parse_pdb_header.py
@@ -26,9 +26,9 @@ class ParseReal(unittest.TestCase):
     def test_parse_pdb_with_remark_465(self):
         """Tests that parse_pdb_header now can identify some REMARK 465 entries."""
         header = parse_pdb_header("PDB/2XHE.pdb")
+        self.assertEqual(header['idcode'], '2XHE')
         self.assertTrue(header["has_missing_residues"])
         self.assertEqual(len(header["missing_residues"]), 142)
-        self.assertEqual(header['idcode'], '2XHE')
         self.assertIn({"model": None, "res_name": "GLN", "chain": "B", "ssseq": 267, "insertion": None},
                       header["missing_residues"])
         header = parse_pdb_header("PDB/1A8O.pdb")

--- a/Tests/test_PDB_parse_pdb_header.py
+++ b/Tests/test_PDB_parse_pdb_header.py
@@ -28,6 +28,7 @@ class ParseReal(unittest.TestCase):
         header = parse_pdb_header("PDB/2XHE.pdb")
         self.assertTrue(header["has_missing_residues"])
         self.assertEqual(len(header["missing_residues"]), 142)
+        self.assertEqual(header['idcode'], '2XHE')
         self.assertIn({"model": None, "res_name": "GLN", "chain": "B", "ssseq": 267, "insertion": None},
                       header["missing_residues"])
         header = parse_pdb_header("PDB/1A8O.pdb")


### PR DESCRIPTION
This pull request addresses issue #1921 

Add the idCode (a.k.a. PDBid) to the header dictionary when loaded by PDBParser()

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
