### PR TITLE
Escape rank in BioSQL for MySQL 8 support

### DIFF
--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -252,7 +252,7 @@ def _retrieve_dbxrefs(adaptor, primary_id):
         "SELECT dbname, accession, version"
         " FROM bioentry_dbxref join dbxref using (dbxref_id)"
         " WHERE bioentry_id = %s"
-        " ORDER BY rank", (primary_id,))
+        " ORDER BY \"rank\"", (primary_id,))
     for dbname, accession, version in dbxrefs:
         if version and version != "0":
             v = "%s.%s" % (accession, version)
@@ -263,10 +263,10 @@ def _retrieve_dbxrefs(adaptor, primary_id):
 
 
 def _retrieve_features(adaptor, primary_id):
-    sql = "SELECT seqfeature_id, type.name, rank" \
+    sql = "SELECT seqfeature_id, type.name, \"rank\"" \
           " FROM seqfeature join term type on (type_term_id = type.term_id)" \
           " WHERE bioentry_id = %s" \
-          " ORDER BY rank"
+          " ORDER BY \"rank\""
     results = adaptor.execute_and_fetchall(sql, (primary_id,))
     seq_feature_list = []
     for seqfeature_id, seqfeature_type, seqfeature_rank in results:
@@ -275,7 +275,7 @@ def _retrieve_features(adaptor, primary_id):
             "SELECT name, value"
             " FROM seqfeature_qualifier_value  join term using (term_id)"
             " WHERE seqfeature_id = %s"
-            " ORDER BY rank", (seqfeature_id,))
+            " ORDER BY \"rank\"", (seqfeature_id,))
         qualifiers = {}
         for qv_name, qv_value in qvs:
             qualifiers.setdefault(qv_name, []).append(qv_value)
@@ -284,7 +284,7 @@ def _retrieve_features(adaptor, primary_id):
             "SELECT dbxref.dbname, dbxref.accession"
             " FROM dbxref join seqfeature_dbxref using (dbxref_id)"
             " WHERE seqfeature_dbxref.seqfeature_id = %s"
-            " ORDER BY rank", (seqfeature_id,))
+            " ORDER BY \"rank\"", (seqfeature_id,))
         for qv_name, qv_value in qvs:
             value = "%s:%s" % (qv_name, qv_value)
             qualifiers.setdefault("db_xref", []).append(value)
@@ -293,7 +293,7 @@ def _retrieve_features(adaptor, primary_id):
             "SELECT location_id, start_pos, end_pos, strand"
             " FROM location"
             " WHERE seqfeature_id = %s"
-            " ORDER BY rank", (seqfeature_id,))
+            " ORDER BY \"rank\"", (seqfeature_id,))
         locations = []
         # convert to Python standard form
         # Convert strand = 0 to strand = None
@@ -423,7 +423,7 @@ def _retrieve_qualifier_value(adaptor, primary_id):
         "SELECT name, value"
         " FROM bioentry_qualifier_value JOIN term USING (term_id)"
         " WHERE bioentry_id = %s"
-        " ORDER BY rank", (primary_id,))
+        " ORDER BY \"rank\"", (primary_id,))
     qualifiers = {}
     for name, value in qvs:
         if name == "keyword":
@@ -448,7 +448,7 @@ def _retrieve_reference(adaptor, primary_id):
         " JOIN reference USING (reference_id)"
         " LEFT JOIN dbxref USING (dbxref_id)"
         " WHERE bioentry_id = %s"
-        " ORDER BY rank", (primary_id,))
+        " ORDER BY \"rank\"", (primary_id,))
     references = []
     for start, end, location, title, authors, dbname, accession in refs:
         reference = SeqFeature.Reference()
@@ -526,7 +526,7 @@ def _retrieve_comment(adaptor, primary_id):
     qvs = adaptor.execute_and_fetchall(
         "SELECT comment_text FROM comment"
         " WHERE bioentry_id=%s"
-        " ORDER BY rank", (primary_id,))
+        " ORDER BY \"rank\"", (primary_id,))
     comments = [comm[0] for comm in qvs]
     # Don't want to add an empty list...
     if comments:

--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -249,10 +249,10 @@ def _retrieve_dbxrefs(adaptor, primary_id):
     """Retrieve the database cross references for the sequence (PRIVATE)."""
     _dbxrefs = []
     dbxrefs = adaptor.execute_and_fetchall(
-        "SELECT dbname, accession, version"
-        " FROM bioentry_dbxref join dbxref using (dbxref_id)"
-        " WHERE bioentry_id = %s"
-        " ORDER BY \"rank\"", (primary_id,))
+        'SELECT dbname, accession, version'
+        ' FROM bioentry_dbxref join dbxref using (dbxref_id)'
+        ' WHERE bioentry_id = %s'
+        ' ORDER BY "rank"', (primary_id,))
     for dbname, accession, version in dbxrefs:
         if version and version != "0":
             v = "%s.%s" % (accession, version)
@@ -263,37 +263,37 @@ def _retrieve_dbxrefs(adaptor, primary_id):
 
 
 def _retrieve_features(adaptor, primary_id):
-    sql = "SELECT seqfeature_id, type.name, \"rank\"" \
-          " FROM seqfeature join term type on (type_term_id = type.term_id)" \
-          " WHERE bioentry_id = %s" \
-          " ORDER BY \"rank\""
+    sql = 'SELECT seqfeature_id, type.name, "rank"' \
+          ' FROM seqfeature join term type on (type_term_id = type.term_id)' \
+          ' WHERE bioentry_id = %s' \
+          ' ORDER BY "rank"'
     results = adaptor.execute_and_fetchall(sql, (primary_id,))
     seq_feature_list = []
     for seqfeature_id, seqfeature_type, seqfeature_rank in results:
         # Get qualifiers [except for db_xref which is stored separately]
         qvs = adaptor.execute_and_fetchall(
-            "SELECT name, value"
-            " FROM seqfeature_qualifier_value  join term using (term_id)"
-            " WHERE seqfeature_id = %s"
-            " ORDER BY \"rank\"", (seqfeature_id,))
+            'SELECT name, value'
+            ' FROM seqfeature_qualifier_value  join term using (term_id)'
+            ' WHERE seqfeature_id = %s'
+            ' ORDER BY "rank"', (seqfeature_id,))
         qualifiers = {}
         for qv_name, qv_value in qvs:
             qualifiers.setdefault(qv_name, []).append(qv_value)
         # Get db_xrefs [special case of qualifiers]
         qvs = adaptor.execute_and_fetchall(
-            "SELECT dbxref.dbname, dbxref.accession"
-            " FROM dbxref join seqfeature_dbxref using (dbxref_id)"
-            " WHERE seqfeature_dbxref.seqfeature_id = %s"
-            " ORDER BY \"rank\"", (seqfeature_id,))
+            'SELECT dbxref.dbname, dbxref.accession'
+            ' FROM dbxref join seqfeature_dbxref using (dbxref_id)'
+            ' WHERE seqfeature_dbxref.seqfeature_id = %s'
+            ' ORDER BY "rank"', (seqfeature_id,))
         for qv_name, qv_value in qvs:
             value = "%s:%s" % (qv_name, qv_value)
             qualifiers.setdefault("db_xref", []).append(value)
         # Get locations
         results = adaptor.execute_and_fetchall(
-            "SELECT location_id, start_pos, end_pos, strand"
-            " FROM location"
-            " WHERE seqfeature_id = %s"
-            " ORDER BY \"rank\"", (seqfeature_id,))
+            'SELECT location_id, start_pos, end_pos, strand'
+            ' FROM location'
+            ' WHERE seqfeature_id = %s'
+            ' ORDER BY "rank"', (seqfeature_id,))
         locations = []
         # convert to Python standard form
         # Convert strand = 0 to strand = None
@@ -420,10 +420,10 @@ def _make_unicode_into_string(text):
 
 def _retrieve_qualifier_value(adaptor, primary_id):
     qvs = adaptor.execute_and_fetchall(
-        "SELECT name, value"
-        " FROM bioentry_qualifier_value JOIN term USING (term_id)"
-        " WHERE bioentry_id = %s"
-        " ORDER BY \"rank\"", (primary_id,))
+        'SELECT name, value'
+        ' FROM bioentry_qualifier_value JOIN term USING (term_id)'
+        ' WHERE bioentry_id = %s'
+        ' ORDER BY "rank"', (primary_id,))
     qualifiers = {}
     for name, value in qvs:
         if name == "keyword":
@@ -441,14 +441,14 @@ def _retrieve_reference(adaptor, primary_id):
     # XXX dbxref_qualifier_value
 
     refs = adaptor.execute_and_fetchall(
-        "SELECT start_pos, end_pos, "
-        " location, title, authors,"
-        " dbname, accession"
-        " FROM bioentry_reference"
-        " JOIN reference USING (reference_id)"
-        " LEFT JOIN dbxref USING (dbxref_id)"
-        " WHERE bioentry_id = %s"
-        " ORDER BY \"rank\"", (primary_id,))
+        'SELECT start_pos, end_pos, '
+        ' location, title, authors,'
+        ' dbname, accession'
+        ' FROM bioentry_reference'
+        ' JOIN reference USING (reference_id)'
+        ' LEFT JOIN dbxref USING (dbxref_id)'
+        ' WHERE bioentry_id = %s'
+        ' ORDER BY "rank"', (primary_id,))
     references = []
     for start, end, location, title, authors, dbname, accession in refs:
         reference = SeqFeature.Reference()
@@ -524,9 +524,9 @@ def _retrieve_taxon(adaptor, primary_id, taxon_id):
 
 def _retrieve_comment(adaptor, primary_id):
     qvs = adaptor.execute_and_fetchall(
-        "SELECT comment_text FROM comment"
-        " WHERE bioentry_id=%s"
-        " ORDER BY \"rank\"", (primary_id,))
+        'SELECT comment_text FROM comment'
+        ' WHERE bioentry_id=%s'
+        ' ORDER BY "rank"', (primary_id,))
     comments = [comm[0] for comm in qvs]
     # Don't want to add an empty list...
     if comments:

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -107,6 +107,10 @@ def open_database(driver="MySQLdb", **kwargs):
     else:
         server = DBServer(conn, module)
 
+    # Sets MySQL to allow double quotes, rather than only backticks
+    if driver in ['MySQLdb', 'mysql.connector']:
+        server.adaptor.execute("SET sql_mode='ANSI_QUOTES';")
+
     # TODO - Remove the following once BioSQL Bug 2839 is fixed.
     # Test for RULES in PostgreSQL schema, see also Bug 2833.
     if driver in ["psycopg2", "pgdb"]:

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -671,9 +671,9 @@ class DatabaseLoader(object):
             date = date[0]
         annotation_tags_id = self._get_ontology_id("Annotation Tags")
         date_id = self._get_term_id("date_changed", annotation_tags_id)
-        sql = "INSERT INTO bioentry_qualifier_value" \
-              " (bioentry_id, term_id, value, \"rank\")" \
-              " VALUES (%s, %s, %s, 1)"
+        sql = 'INSERT INTO bioentry_qualifier_value' \
+              ' (bioentry_id, term_id, value, "rank")' \
+              ' VALUES (%s, %s, %s, 1)'
         self.adaptor.execute(sql, (bioentry_id, date_id, date))
 
     def _load_biosequence(self, record, bioentry_id):
@@ -731,8 +731,8 @@ class DatabaseLoader(object):
             comment = comment.replace('\n', ' ')
             # TODO - Store each line as a separate entry?  This would preserve
             # the newlines, but we should check BioPerl etc to be consistent.
-            sql = "INSERT INTO comment (bioentry_id, comment_text, \"rank\")" \
-                  " VALUES (%s, %s, %s)"
+            sql = 'INSERT INTO comment (bioentry_id, comment_text, "rank")' \
+                  ' VALUES (%s, %s, %s)'
             self.adaptor.execute(sql, (bioentry_id, comment, index + 1))
 
     def _load_annotations(self, record, bioentry_id):
@@ -750,9 +750,9 @@ class DatabaseLoader(object):
         mono_sql = "INSERT INTO bioentry_qualifier_value" \
                    "(bioentry_id, term_id, value)" \
                    " VALUES (%s, %s, %s)"
-        many_sql = "INSERT INTO bioentry_qualifier_value" \
-                   "(bioentry_id, term_id, value, \"rank\")" \
-                   " VALUES (%s, %s, %s, %s)"
+        many_sql = 'INSERT INTO bioentry_qualifier_value'\
+                   '(bioentry_id, term_id, value, "rank")' \
+                   ' VALUES (%s, %s, %s, %s)'
         tag_ontology_id = self._get_ontology_id('Annotation Tags')
         for key, value in record.annotations.items():
             if key in ["references", "comment", "ncbi_taxid", "date"]:
@@ -839,8 +839,8 @@ class DatabaseLoader(object):
             start = None
             end = None
 
-        sql = "INSERT INTO bioentry_reference (bioentry_id, reference_id," \
-              " start_pos, end_pos, \"rank\") VALUES (%s, %s, %s, %s, %s)"
+        sql = 'INSERT INTO bioentry_reference (bioentry_id, reference_id,' \
+              ' start_pos, end_pos, "rank") VALUES (%s, %s, %s, %s, %s)'
         self.adaptor.execute(sql, (bioentry_id, reference_id,
                                    start, end, rank + 1))
 
@@ -881,8 +881,8 @@ class DatabaseLoader(object):
         source_term_id = self._get_term_id(source,
                                            ontology_id=source_cat_id)
 
-        sql = "INSERT INTO seqfeature (bioentry_id, type_term_id, " \
-              "source_term_id, \"rank\") VALUES (%s, %s, %s, %s)"
+        sql = 'INSERT INTO seqfeature (bioentry_id, type_term_id, ' \
+              'source_term_id, "rank") VALUES (%s, %s, %s, %s)'
         self.adaptor.execute(sql, (bioentry_id, seqfeature_key_id,
                                    source_term_id, feature_rank + 1))
         seqfeature_id = self.adaptor.last_id('seqfeature')
@@ -971,9 +971,9 @@ class DatabaseLoader(object):
         else:
             dbxref_id = None
 
-        sql = "INSERT INTO location (seqfeature_id, dbxref_id, term_id," \
-              "start_pos, end_pos, strand, \"rank\") " \
-              "VALUES (%s, %s, %s, %s, %s, %s, %s)"
+        sql = 'INSERT INTO location (seqfeature_id, dbxref_id, term_id,' \
+              'start_pos, end_pos, strand, "rank") ' \
+              'VALUES (%s, %s, %s, %s, %s, %s, %s)'
         self.adaptor.execute(sql, (seqfeature_id, dbxref_id, loc_term_id,
                                    start, end, strand, rank))
 
@@ -1022,9 +1022,9 @@ class DatabaseLoader(object):
                     entries = [entries]
                 for qual_value_rank in range(len(entries)):
                     qualifier_value = entries[qual_value_rank]
-                    sql = "INSERT INTO seqfeature_qualifier_value "\
-                          " (seqfeature_id, term_id, \"rank\", value) VALUES"\
-                          " (%s, %s, %s, %s)"
+                    sql = 'INSERT INTO seqfeature_qualifier_value '\
+                          ' (seqfeature_id, term_id, "rank", value) VALUES'\
+                          ' (%s, %s, %s, %s)'
                     self.adaptor.execute(sql, (seqfeature_id,
                                                qualifier_key_id,
                                                qual_value_rank + 1,
@@ -1121,7 +1121,7 @@ class DatabaseLoader(object):
         dbxref_id
         """
         sql = 'INSERT INTO seqfeature_dbxref ' \
-              '(seqfeature_id, dbxref_id, \"rank\") VALUES' \
+              '(seqfeature_id, dbxref_id, "rank") VALUES' \
               '(%s, %s, %s)'
         self.adaptor.execute(sql, (seqfeature_id, dbxref_id, rank))
         return (seqfeature_id, dbxref_id)
@@ -1176,7 +1176,7 @@ class DatabaseLoader(object):
         Returns the seqfeature_id and dbxref_id (PRIVATE).
         """
         sql = 'INSERT INTO bioentry_dbxref ' \
-              '(bioentry_id,dbxref_id,\"rank\") VALUES ' \
+              '(bioentry_id,dbxref_id,"rank") VALUES ' \
               '(%s, %s, %s)'
         self.adaptor.execute(sql, (bioentry_id, dbxref_id, rank))
         return (bioentry_id, dbxref_id)

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -671,9 +671,9 @@ class DatabaseLoader(object):
             date = date[0]
         annotation_tags_id = self._get_ontology_id("Annotation Tags")
         date_id = self._get_term_id("date_changed", annotation_tags_id)
-        sql = r"INSERT INTO bioentry_qualifier_value" \
-              r" (bioentry_id, term_id, value, rank)" \
-              r" VALUES (%s, %s, %s, 1)"
+        sql = "INSERT INTO bioentry_qualifier_value" \
+              " (bioentry_id, term_id, value, \"rank\")" \
+              " VALUES (%s, %s, %s, 1)"
         self.adaptor.execute(sql, (bioentry_id, date_id, date))
 
     def _load_biosequence(self, record, bioentry_id):
@@ -731,7 +731,7 @@ class DatabaseLoader(object):
             comment = comment.replace('\n', ' ')
             # TODO - Store each line as a separate entry?  This would preserve
             # the newlines, but we should check BioPerl etc to be consistent.
-            sql = "INSERT INTO comment (bioentry_id, comment_text, rank)" \
+            sql = "INSERT INTO comment (bioentry_id, comment_text, \"rank\")" \
                   " VALUES (%s, %s, %s)"
             self.adaptor.execute(sql, (bioentry_id, comment, index + 1))
 
@@ -751,7 +751,7 @@ class DatabaseLoader(object):
                    "(bioentry_id, term_id, value)" \
                    " VALUES (%s, %s, %s)"
         many_sql = "INSERT INTO bioentry_qualifier_value" \
-                   "(bioentry_id, term_id, value, rank)" \
+                   "(bioentry_id, term_id, value, \"rank\")" \
                    " VALUES (%s, %s, %s, %s)"
         tag_ontology_id = self._get_ontology_id('Annotation Tags')
         for key, value in record.annotations.items():
@@ -840,7 +840,7 @@ class DatabaseLoader(object):
             end = None
 
         sql = "INSERT INTO bioentry_reference (bioentry_id, reference_id," \
-              " start_pos, end_pos, rank) VALUES (%s, %s, %s, %s, %s)"
+              " start_pos, end_pos, \"rank\") VALUES (%s, %s, %s, %s, %s)"
         self.adaptor.execute(sql, (bioentry_id, reference_id,
                                    start, end, rank + 1))
 
@@ -881,8 +881,8 @@ class DatabaseLoader(object):
         source_term_id = self._get_term_id(source,
                                            ontology_id=source_cat_id)
 
-        sql = r"INSERT INTO seqfeature (bioentry_id, type_term_id, " \
-              r"source_term_id, rank) VALUES (%s, %s, %s, %s)"
+        sql = "INSERT INTO seqfeature (bioentry_id, type_term_id, " \
+              "source_term_id, \"rank\") VALUES (%s, %s, %s, %s)"
         self.adaptor.execute(sql, (bioentry_id, seqfeature_key_id,
                                    source_term_id, feature_rank + 1))
         seqfeature_id = self.adaptor.last_id('seqfeature')
@@ -971,9 +971,9 @@ class DatabaseLoader(object):
         else:
             dbxref_id = None
 
-        sql = r"INSERT INTO location (seqfeature_id, dbxref_id, term_id," \
-              r"start_pos, end_pos, strand, rank) " \
-              r"VALUES (%s, %s, %s, %s, %s, %s, %s)"
+        sql = "INSERT INTO location (seqfeature_id, dbxref_id, term_id," \
+              "start_pos, end_pos, strand, \"rank\") " \
+              "VALUES (%s, %s, %s, %s, %s, %s, %s)"
         self.adaptor.execute(sql, (seqfeature_id, dbxref_id, loc_term_id,
                                    start, end, strand, rank))
 
@@ -1022,9 +1022,9 @@ class DatabaseLoader(object):
                     entries = [entries]
                 for qual_value_rank in range(len(entries)):
                     qualifier_value = entries[qual_value_rank]
-                    sql = r"INSERT INTO seqfeature_qualifier_value "\
-                          r" (seqfeature_id, term_id, rank, value) VALUES"\
-                          r" (%s, %s, %s, %s)"
+                    sql = "INSERT INTO seqfeature_qualifier_value "\
+                          " (seqfeature_id, term_id, \"rank\", value) VALUES"\
+                          " (%s, %s, %s, %s)"
                     self.adaptor.execute(sql, (seqfeature_id,
                                                qualifier_key_id,
                                                qual_value_rank + 1,
@@ -1120,9 +1120,9 @@ class DatabaseLoader(object):
         Insert a seqfeature_dbxref row and return the seqfeature_id and
         dbxref_id
         """
-        sql = r'INSERT INTO seqfeature_dbxref ' \
-              '(seqfeature_id, dbxref_id, rank) VALUES' \
-              r'(%s, %s, %s)'
+        sql = 'INSERT INTO seqfeature_dbxref ' \
+              '(seqfeature_id, dbxref_id, \"rank\") VALUES' \
+              '(%s, %s, %s)'
         self.adaptor.execute(sql, (seqfeature_id, dbxref_id, rank))
         return (seqfeature_id, dbxref_id)
 
@@ -1175,8 +1175,8 @@ class DatabaseLoader(object):
 
         Returns the seqfeature_id and dbxref_id (PRIVATE).
         """
-        sql = r'INSERT INTO bioentry_dbxref ' \
-              '(bioentry_id,dbxref_id,rank) VALUES ' \
+        sql = 'INSERT INTO bioentry_dbxref ' \
+              '(bioentry_id,dbxref_id,\"rank\") VALUES ' \
               '(%s, %s, %s)'
         self.adaptor.execute(sql, (bioentry_id, dbxref_id, rank))
         return (bioentry_id, dbxref_id)

--- a/Tests/BioSQL/biosqldb-mysql.sql
+++ b/Tests/BioSQL/biosqldb-mysql.sql
@@ -45,6 +45,7 @@
 -- (there is no concept of versions of database). There is a concept of
 -- versions of entries. Versions of databases deserve their own table and
 -- join to bioentry table for tracking with versions of entries 
+SET sql_mode='ANSI_QUOTES';
 
 CREATE TABLE biodatabase (
   	biodatabase_id 	INT(10) UNSIGNED NOT NULL auto_increment,
@@ -142,7 +143,7 @@ CREATE TABLE term_synonym (
 CREATE TABLE term_dbxref (
        	term_id	          INT(10) UNSIGNED NOT NULL,
        	dbxref_id         INT(10) UNSIGNED NOT NULL,
-	rank		  SMALLINT,
+	"rank"		  SMALLINT,
 	PRIMARY KEY (term_id, dbxref_id)
 ) ENGINE=INNODB;
 
@@ -274,7 +275,7 @@ CREATE TABLE bioentry_relationship (
         object_bioentry_id 	 INT(10) UNSIGNED NOT NULL,
    	subject_bioentry_id 	 INT(10) UNSIGNED NOT NULL,
    	term_id 		 INT(10) UNSIGNED NOT NULL,
-   	rank 			 INT(5),
+   	"rank" 			 INT(5),
    	PRIMARY KEY (bioentry_relationship_id),
 	UNIQUE (object_bioentry_id,subject_bioentry_id,term_id)
 ) ENGINE=INNODB;
@@ -349,9 +350,9 @@ CREATE INDEX dbxref_db  ON dbxref(dbname);
 CREATE TABLE dbxref_qualifier_value (
        	dbxref_id 		INT(10) UNSIGNED NOT NULL,
        	term_id 		INT(10) UNSIGNED NOT NULL,
-  	rank  		   	SMALLINT NOT NULL DEFAULT 0,
+  	"rank"  		   	SMALLINT NOT NULL DEFAULT 0,
        	value			TEXT,
-	PRIMARY KEY (dbxref_id,term_id,rank)
+	PRIMARY KEY (dbxref_id,term_id,"rank")
 ) ENGINE=INNODB;
 
 CREATE INDEX dbxrefqual_dbx ON dbxref_qualifier_value(dbxref_id);
@@ -366,7 +367,7 @@ CREATE INDEX dbxrefqual_trm ON dbxref_qualifier_value(term_id);
 CREATE TABLE bioentry_dbxref ( 
        	bioentry_id        INT(10) UNSIGNED NOT NULL,
        	dbxref_id          INT(10) UNSIGNED NOT NULL,
-  	rank  		   SMALLINT,
+  	"rank"  		   SMALLINT,
 	PRIMARY KEY (bioentry_id,dbxref_id)
 ) ENGINE=INNODB;
 
@@ -396,8 +397,8 @@ CREATE TABLE bioentry_reference (
   	reference_id 	INT(10) UNSIGNED NOT NULL,
   	start_pos	INT(10),
   	end_pos	  	INT(10),
-  	rank  		SMALLINT NOT NULL DEFAULT 0,
-  	PRIMARY KEY(bioentry_id,reference_id,rank)
+  	"rank"  		SMALLINT NOT NULL DEFAULT 0,
+  	PRIMARY KEY(bioentry_id,reference_id,"rank")
 ) ENGINE=INNODB;
 
 CREATE INDEX bioentryref_ref ON bioentry_reference(reference_id);
@@ -410,9 +411,9 @@ CREATE TABLE comment (
   	comment_id  	INT(10) UNSIGNED NOT NULL auto_increment,
   	bioentry_id    	INT(10) UNSIGNED NOT NULL,
   	comment_text   	TEXT NOT NULL,
-  	rank   		SMALLINT NOT NULL DEFAULT 0,
+  	"rank"   		SMALLINT NOT NULL DEFAULT 0,
 	PRIMARY KEY (comment_id),
-  	UNIQUE(bioentry_id, rank)
+  	UNIQUE(bioentry_id, "rank")
 ) ENGINE=INNODB;
 
 
@@ -421,8 +422,8 @@ CREATE TABLE bioentry_qualifier_value (
 	bioentry_id   		INT(10) UNSIGNED NOT NULL,
    	term_id  		INT(10) UNSIGNED NOT NULL,
    	value         		TEXT,
-	rank			INT(5) NOT NULL DEFAULT 0,
-	UNIQUE (bioentry_id,term_id,rank)
+	"rank"			INT(5) NOT NULL DEFAULT 0,
+	UNIQUE (bioentry_id,term_id,"rank")
 ) ENGINE=INNODB;
 
 CREATE INDEX bioentryqual_trm ON bioentry_qualifier_value(term_id);
@@ -438,9 +439,9 @@ CREATE TABLE seqfeature (
    	type_term_id		INT(10) UNSIGNED NOT NULL,
    	source_term_id  	INT(10) UNSIGNED NOT NULL,
 	display_name		VARCHAR(64),
-   	rank 			SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+   	"rank" 			SMALLINT UNSIGNED NOT NULL DEFAULT 0,
 	PRIMARY KEY (seqfeature_id),
-	UNIQUE (bioentry_id,type_term_id,source_term_id,rank)
+	UNIQUE (bioentry_id,type_term_id,source_term_id,"rank")
 ) ENGINE=INNODB;
 
 CREATE INDEX seqfeature_trm  ON seqfeature(type_term_id);
@@ -458,7 +459,7 @@ CREATE TABLE seqfeature_relationship (
    	object_seqfeature_id	INT(10) UNSIGNED NOT NULL,
    	subject_seqfeature_id 	INT(10) UNSIGNED NOT NULL,
    	term_id 	        INT(10) UNSIGNED NOT NULL,
-   	rank 			INT(5),
+   	"rank" 			INT(5),
    	PRIMARY KEY (seqfeature_relationship_id),
 	UNIQUE (object_seqfeature_id,subject_seqfeature_id,term_id)
 ) ENGINE=INNODB;
@@ -489,9 +490,9 @@ CREATE INDEX seqfeaturepath_child ON seqfeature_path(subject_seqfeature_id);
 CREATE TABLE seqfeature_qualifier_value (
 	seqfeature_id 		INT(10) UNSIGNED NOT NULL,
    	term_id 		INT(10) UNSIGNED NOT NULL,
-   	rank 			SMALLINT NOT NULL DEFAULT 0,
+   	"rank" 			SMALLINT NOT NULL DEFAULT 0,
    	value  			TEXT NOT NULL,
-   	PRIMARY KEY (seqfeature_id,term_id,rank)
+   	PRIMARY KEY (seqfeature_id,term_id,"rank")
 ) ENGINE=INNODB;
 
 CREATE INDEX seqfeaturequal_trm ON seqfeature_qualifier_value(term_id);
@@ -504,7 +505,7 @@ CREATE INDEX seqfeaturequal_trm ON seqfeature_qualifier_value(term_id);
 CREATE TABLE seqfeature_dbxref ( 
        	seqfeature_id      INT(10) UNSIGNED NOT NULL,
        	dbxref_id          INT(10) UNSIGNED NOT NULL,
-  	rank  		   SMALLINT,
+  	"rank"  		   SMALLINT,
 	PRIMARY KEY (seqfeature_id,dbxref_id)
 ) ENGINE=INNODB;
 
@@ -533,9 +534,9 @@ CREATE TABLE location (
    	start_pos              	INT(10),
    	end_pos                	INT(10),
    	strand             	TINYINT NOT NULL DEFAULT 0,
-   	rank          		SMALLINT NOT NULL DEFAULT 0,
+   	"rank"          		SMALLINT NOT NULL DEFAULT 0,
 	PRIMARY KEY (location_id),
-   	UNIQUE (seqfeature_id, rank)
+   	UNIQUE (seqfeature_id, "rank")
 ) ENGINE=INNODB;
 
 CREATE INDEX seqfeatureloc_start ON location(start_pos, end_pos);
@@ -778,5 +779,3 @@ ALTER TABLE location_qualifier_value ADD CONSTRAINT FKfeatloc_locqual
 	ON DELETE CASCADE;
 ALTER TABLE location_qualifier_value ADD CONSTRAINT FKterm_locqual
 	FOREIGN KEY (term_id) REFERENCES term(term_id);
-
-

--- a/Tests/BioSQL/biosqldb-mysql.sql
+++ b/Tests/BioSQL/biosqldb-mysql.sql
@@ -1,4 +1,4 @@
--- $Id: biosqldb-mysql.sql,v 1.5 2008-09-26 12:31:42 peterc Exp $
+-- $Id$
 --
 -- Copyright 2002-2003 Ewan Birney, Elia Stupka, Chris Mungall
 -- Copyright 2003-2008 Hilmar Lapp 
@@ -45,7 +45,6 @@
 -- (there is no concept of versions of database). There is a concept of
 -- versions of entries. Versions of databases deserve their own table and
 -- join to bioentry table for tracking with versions of entries 
-SET sql_mode='ANSI_QUOTES';
 
 CREATE TABLE biodatabase (
   	biodatabase_id 	INT(10) UNSIGNED NOT NULL auto_increment,
@@ -143,7 +142,7 @@ CREATE TABLE term_synonym (
 CREATE TABLE term_dbxref (
        	term_id	          INT(10) UNSIGNED NOT NULL,
        	dbxref_id         INT(10) UNSIGNED NOT NULL,
-	"rank"		  SMALLINT,
+	`rank`		  SMALLINT,
 	PRIMARY KEY (term_id, dbxref_id)
 ) ENGINE=INNODB;
 
@@ -275,7 +274,7 @@ CREATE TABLE bioentry_relationship (
         object_bioentry_id 	 INT(10) UNSIGNED NOT NULL,
    	subject_bioentry_id 	 INT(10) UNSIGNED NOT NULL,
    	term_id 		 INT(10) UNSIGNED NOT NULL,
-   	"rank" 			 INT(5),
+   	`rank` 			 INT(5),
    	PRIMARY KEY (bioentry_relationship_id),
 	UNIQUE (object_bioentry_id,subject_bioentry_id,term_id)
 ) ENGINE=INNODB;
@@ -350,9 +349,9 @@ CREATE INDEX dbxref_db  ON dbxref(dbname);
 CREATE TABLE dbxref_qualifier_value (
        	dbxref_id 		INT(10) UNSIGNED NOT NULL,
        	term_id 		INT(10) UNSIGNED NOT NULL,
-  	"rank"  		   	SMALLINT NOT NULL DEFAULT 0,
+  	`rank`  		   	SMALLINT NOT NULL DEFAULT 0,
        	value			TEXT,
-	PRIMARY KEY (dbxref_id,term_id,"rank")
+	PRIMARY KEY (dbxref_id,term_id,`rank`)
 ) ENGINE=INNODB;
 
 CREATE INDEX dbxrefqual_dbx ON dbxref_qualifier_value(dbxref_id);
@@ -367,7 +366,7 @@ CREATE INDEX dbxrefqual_trm ON dbxref_qualifier_value(term_id);
 CREATE TABLE bioentry_dbxref ( 
        	bioentry_id        INT(10) UNSIGNED NOT NULL,
        	dbxref_id          INT(10) UNSIGNED NOT NULL,
-  	"rank"  		   SMALLINT,
+  	`rank`  		   SMALLINT,
 	PRIMARY KEY (bioentry_id,dbxref_id)
 ) ENGINE=INNODB;
 
@@ -397,8 +396,8 @@ CREATE TABLE bioentry_reference (
   	reference_id 	INT(10) UNSIGNED NOT NULL,
   	start_pos	INT(10),
   	end_pos	  	INT(10),
-  	"rank"  		SMALLINT NOT NULL DEFAULT 0,
-  	PRIMARY KEY(bioentry_id,reference_id,"rank")
+  	`rank`  		SMALLINT NOT NULL DEFAULT 0,
+  	PRIMARY KEY(bioentry_id,reference_id,`rank`)
 ) ENGINE=INNODB;
 
 CREATE INDEX bioentryref_ref ON bioentry_reference(reference_id);
@@ -411,9 +410,9 @@ CREATE TABLE comment (
   	comment_id  	INT(10) UNSIGNED NOT NULL auto_increment,
   	bioentry_id    	INT(10) UNSIGNED NOT NULL,
   	comment_text   	TEXT NOT NULL,
-  	"rank"   		SMALLINT NOT NULL DEFAULT 0,
+  	`rank`   		SMALLINT NOT NULL DEFAULT 0,
 	PRIMARY KEY (comment_id),
-  	UNIQUE(bioentry_id, "rank")
+  	UNIQUE(bioentry_id, `rank`)
 ) ENGINE=INNODB;
 
 
@@ -422,8 +421,8 @@ CREATE TABLE bioentry_qualifier_value (
 	bioentry_id   		INT(10) UNSIGNED NOT NULL,
    	term_id  		INT(10) UNSIGNED NOT NULL,
    	value         		TEXT,
-	"rank"			INT(5) NOT NULL DEFAULT 0,
-	UNIQUE (bioentry_id,term_id,"rank")
+	`rank`			INT(5) NOT NULL DEFAULT 0,
+	UNIQUE (bioentry_id,term_id,`rank`)
 ) ENGINE=INNODB;
 
 CREATE INDEX bioentryqual_trm ON bioentry_qualifier_value(term_id);
@@ -439,9 +438,9 @@ CREATE TABLE seqfeature (
    	type_term_id		INT(10) UNSIGNED NOT NULL,
    	source_term_id  	INT(10) UNSIGNED NOT NULL,
 	display_name		VARCHAR(64),
-   	"rank" 			SMALLINT UNSIGNED NOT NULL DEFAULT 0,
+   	`rank` 			SMALLINT UNSIGNED NOT NULL DEFAULT 0,
 	PRIMARY KEY (seqfeature_id),
-	UNIQUE (bioentry_id,type_term_id,source_term_id,"rank")
+	UNIQUE (bioentry_id,type_term_id,source_term_id,`rank`)
 ) ENGINE=INNODB;
 
 CREATE INDEX seqfeature_trm  ON seqfeature(type_term_id);
@@ -459,7 +458,7 @@ CREATE TABLE seqfeature_relationship (
    	object_seqfeature_id	INT(10) UNSIGNED NOT NULL,
    	subject_seqfeature_id 	INT(10) UNSIGNED NOT NULL,
    	term_id 	        INT(10) UNSIGNED NOT NULL,
-   	"rank" 			INT(5),
+   	`rank` 			INT(5),
    	PRIMARY KEY (seqfeature_relationship_id),
 	UNIQUE (object_seqfeature_id,subject_seqfeature_id,term_id)
 ) ENGINE=INNODB;
@@ -490,9 +489,9 @@ CREATE INDEX seqfeaturepath_child ON seqfeature_path(subject_seqfeature_id);
 CREATE TABLE seqfeature_qualifier_value (
 	seqfeature_id 		INT(10) UNSIGNED NOT NULL,
    	term_id 		INT(10) UNSIGNED NOT NULL,
-   	"rank" 			SMALLINT NOT NULL DEFAULT 0,
+   	`rank` 			SMALLINT NOT NULL DEFAULT 0,
    	value  			TEXT NOT NULL,
-   	PRIMARY KEY (seqfeature_id,term_id,"rank")
+   	PRIMARY KEY (seqfeature_id,term_id,`rank`)
 ) ENGINE=INNODB;
 
 CREATE INDEX seqfeaturequal_trm ON seqfeature_qualifier_value(term_id);
@@ -505,7 +504,7 @@ CREATE INDEX seqfeaturequal_trm ON seqfeature_qualifier_value(term_id);
 CREATE TABLE seqfeature_dbxref ( 
        	seqfeature_id      INT(10) UNSIGNED NOT NULL,
        	dbxref_id          INT(10) UNSIGNED NOT NULL,
-  	"rank"  		   SMALLINT,
+  	`rank`  		   SMALLINT,
 	PRIMARY KEY (seqfeature_id,dbxref_id)
 ) ENGINE=INNODB;
 
@@ -534,9 +533,9 @@ CREATE TABLE location (
    	start_pos              	INT(10),
    	end_pos                	INT(10),
    	strand             	TINYINT NOT NULL DEFAULT 0,
-   	"rank"          		SMALLINT NOT NULL DEFAULT 0,
+   	`rank`          		SMALLINT NOT NULL DEFAULT 0,
 	PRIMARY KEY (location_id),
-   	UNIQUE (seqfeature_id, "rank")
+   	UNIQUE (seqfeature_id, `rank`)
 ) ENGINE=INNODB;
 
 CREATE INDEX seqfeatureloc_start ON location(start_pos, end_pos);
@@ -779,3 +778,5 @@ ALTER TABLE location_qualifier_value ADD CONSTRAINT FKfeatloc_locqual
 	ON DELETE CASCADE;
 ALTER TABLE location_qualifier_value ADD CONSTRAINT FKterm_locqual
 	FOREIGN KEY (term_id) REFERENCES term(term_id);
+
+


### PR DESCRIPTION
This pull request addresses issue #1882

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

These changes escape the new MySQL keyword `rank`. This works locally on MySQL 8.0.15 installed on  linux. Unfortunately I don't think that it is simple or straightforward to enable MySQL 8 on Travis CI.

Changes were needed to the BioSQL file itself. I've chosen to put `rank` in double quotes, this required adding `SET sql_mode='ANSI_QUOTES';` to the top of the file. Alternatively, `rank` could go in backticks without needing to set `ANSI_QUOTES` as this is a MySQL specific file. I'm not sure what is the best style.