### PR TITLE
Deprecate Python 3.4 support

### DIFF
--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -38,6 +38,10 @@ Python 3.3
 No longer supported as of Release 1.70, having triggered a warning with
 release 1.67 onwards.
 
+Python 3.4
+==========
+Deprecated as of release 1.74.
+
 Jython
 ======
 Biopython is mostly working under Jython 2.7.0, but support for Jython

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -11,7 +11,8 @@ The latest news is at the top of this file.
 (In progress, not yet released): Biopython 1.74
 ===============================================
 
-This release of Biopython supports Python 2.7, 3.4, 3.5, 3.6 and 3.7.
+This release of Biopython supports Python 2.7, 3.4, 3.5, 3.6 and 3.7. However,
+it will be the last release to support Python 3.4 which is now at end-of-life.
 It has also been tested on PyPy2.7 v6.0.0 and PyPy3.5 v6.0.0.
 
 As in recent releases, more of our code is now explicitly available under

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,8 @@ elif sys.version_info[0] == 3 and sys.version_info[:2] < (3, 4):
     sys.stderr.write("Biopython requires Python 3.4 or later (or Python 2.7). "
                      "Python %d.%d detected.\n" % sys.version_info[:2])
     sys.exit(1)
+if sys.version_info[:2] == (3, 4):
+    print("WARNING: Biopython support for Python 3.4 is now deprecated.")
 
 if is_jython():
     sys.stderr.write("WARNING: Biopython support for Jython is now deprecated.\n")


### PR DESCRIPTION
This pull request addresses https://mailman.open-bio.org/pipermail/biopython/2018-December/016579.html by declaring Biopython 1.74 will be the last release to support Python 3.4 (with a warning on install).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
