### PR TITLE
Declare Bio.Statistics obsolete.

### DIFF
--- a/Bio/Statistics/__init__.py
+++ b/Bio/Statistics/__init__.py
@@ -4,3 +4,7 @@
 # package.
 """Basic statistics module."""
 # TODO: Remove empty __init__.py once we drop Python 2 support
+
+import warnings
+warnings.warn("The Bio.Statistics module is obsolete.",
+              PendingDeprecationWarning)

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -765,3 +765,7 @@ Bio.trie, Bio.triefind
 These modules were declared obsolete in Release 1.72, and deprecated in
 Release 1.73. We encourage users to switch to alternative libraries
 implementing a trie data structure, for example pygtrie.
+
+Bio.statistics
+==============
+This module was declared obsolete in Release 1.74.

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -39,6 +39,7 @@ possible, especially the following contributors:
 - Peter Cock
 - Ralf Stephan
 - Sergio Valqui
+- Antony Lee
 
 18 December 2018: Biopython 1.73
 ================================


### PR DESCRIPTION
Its only functionality (lowess) suffers from known bugs since 2014 and
has seen no activity (other than style fixes) since 2008.

This pull request addresses issue #344 (where the deprecation was suggested).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
