### PR TITLE
No missing docstrings in BioSQL, enforce in flake8

### DIFF
--- a/BioSQL/.flake8
+++ b/BioSQL/.flake8
@@ -8,16 +8,6 @@ ignore =
     # pycodestyle v2.4.0 default ignore is E121,E123,E126,E226,E24,E704,W503,W504
     # flake8 v3.6.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
     W504,
-    # =====================================
-    # pydocstyle: D### - Missing Docstrings
-    # =====================================
-    # D100	Missing docstring in public module
-    # D101	Missing docstring in public class
-    # D102	Missing docstring in public method
-    # D103	Missing docstring in public function
-    # D104	Missing docstring in public package
-    # D105	Missing docstring in magic method
-    D101,D102,D103,D105,
     # ====================
     # flake8-bugbear: B###
     # ====================


### PR DESCRIPTION
This pull request addresses part of issue #1203

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
