### PR TITLE
Avoid creating a variable just for return value

### DIFF
--- a/Bio/Blast/ParseBlastTable.py
+++ b/Bio/Blast/ParseBlastTable.py
@@ -96,9 +96,7 @@ class BlastTableReader(object):
     def _consume_header(self, inline):
         for keyword in reader_keywords:
             if keyword in inline:
-                in_header = self._Parse('_parse_%s' % reader_keywords[keyword], inline)
-                break
-        return in_header
+                return self._Parse('_parse_%s' % reader_keywords[keyword], inline)
 
     def _parse_version(self, inline):
         program, version, date = inline.split()[1:]

--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -21,9 +21,7 @@ def _gen_random_array(n):
     """Return an array of n random numbers summing to 1.0 (PRIVATE)."""
     randArray = [random.random() for i in range(n)]
     total = sum(randArray)
-    normalizedRandArray = [x / total for x in randArray]
-
-    return normalizedRandArray
+    return [x / total for x in randArray]
 
 
 def _calculate_emissions(emission_probs):

--- a/Bio/SubsMat/FreqTable.py
+++ b/Bio/SubsMat/FreqTable.py
@@ -84,8 +84,7 @@ def read_count(f):
     for line in f:
         key, value = line.strip().split()
         count[key] = int(value)
-    freq_table = FreqTable(count, COUNT)
-    return freq_table
+    return FreqTable(count, COUNT)
 
 
 def read_freq(f):

--- a/Bio/TogoWS/__init__.py
+++ b/Bio/TogoWS/__init__.py
@@ -173,10 +173,9 @@ def search_count(db, query):
     if not data:
         raise ValueError("TogoWS returned no data from URL %s" % url)
     try:
-        count = int(data.strip())
+        return int(data.strip())
     except ValueError:
         raise ValueError("Expected an integer from URL %s, got: %r" % (url, data))
-    return count
 
 
 def search_iter(db, query, limit=None, batch=100):

--- a/Bio/Wise/__init__.py
+++ b/Bio/Wise/__init__.py
@@ -63,9 +63,7 @@ def _build_align_cmdline(cmdline, pair, output_filename, kbyte=None, force_type=
     cmdline.extend((">", output_filename))
     if quiet:
         cmdline.extend(("2>", "/dev/null"))
-    cmdline_str = ' '.join(cmdline)
-
-    return cmdline_str
+    return ' '.join(cmdline)
 
 
 def align(cmdline, pair, kbyte=None, force_type=None, dry_run=False, quiet=False, debug=False):

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -653,9 +653,7 @@ class DatabaseLoader(object):
                                    description,
                                    version))
         # now retrieve the id for the bioentry
-        bioentry_id = self.adaptor.last_id('bioentry')
-
-        return bioentry_id
+        return self.adaptor.last_id('bioentry')
 
     def _load_bioentry_date(self, record, bioentry_id):
         """Add the effective date of the entry into the database (PRIVATE).
@@ -885,9 +883,7 @@ class DatabaseLoader(object):
               'source_term_id, "rank") VALUES (%s, %s, %s, %s)'
         self.adaptor.execute(sql, (bioentry_id, seqfeature_key_id,
                                    source_term_id, feature_rank + 1))
-        seqfeature_id = self.adaptor.last_id('seqfeature')
-
-        return seqfeature_id
+        return self.adaptor.last_id('seqfeature')
 
     def _load_seqfeature_locations(self, feature, seqfeature_id):
         """Load all of the locations for a SeqFeature into tables (PRIVATE).


### PR DESCRIPTION
This fixes a sample of cases spotted with ``flake8-return`` error ``R504``, but sadly have concluded that tool has too many false positives to be worth trying to enforce for Biopython. See https://pypi.org/project/flake8-return/

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
