### PR TITLE
Ignore ABIF tags with unicode encoding problems

### DIFF
--- a/Bio/SeqIO/AbiIO.py
+++ b/Bio/SeqIO/AbiIO.py
@@ -18,9 +18,11 @@ http://www6.appliedbiosystems.com/support/software_community/ABIF_File_Format.pd
 
 import datetime
 import struct
+import warnings
 
 from os.path import basename
 
+from Bio import BiopythonParserWarning
 from Bio import Alphabet
 from Bio.Alphabet.IUPAC import ambiguous_dna, unambiguous_dna
 from Bio.Seq import Seq
@@ -480,8 +482,12 @@ def _abi_parse_header(header, handle):
             data_offset = tag_offset + 20
         handle.seek(data_offset)
         data = handle.read(data_size)
-        yield tag_name, tag_number, \
-            _parse_tag_data(elem_code, elem_num, data)
+        try:
+            yield tag_name, tag_number, \
+                _parse_tag_data(elem_code, elem_num, data)
+        except UnicodeDecodeError:
+            warnings.warn("Ignoring tag %s %i due to unicode problem"
+                          % (tag_name, tag_number), BiopythonParserWarning)
 
 
 def _abi_trim(seq_record):


### PR DESCRIPTION
Instead, just give a warning. Unless in a critical tag like sequence identifier, should be OK.

This pull request is a partial work around for issue #1982

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
