### PR TITLE
Update MAST parser for MEME>=4.11.4

### DIFF
--- a/Bio/motifs/mast.py
+++ b/Bio/motifs/mast.py
@@ -91,19 +91,23 @@ def __read_database_and_motifs(record, handle):
     elif words[2] == '(peptide)':
         record.alphabet = IUPAC.protein
     for line in handle:
-        if 'MOTIF WIDTH' in line:
+        if 'WIDTH BEST POSSIBLE MATCH' in line:
             break
     line = next(handle)
     if '----' not in line:
         raise ValueError("Line does not contain '----':\n%s" % line)
+    has_motif_ids = (len(line.strip().split()) == 5)
     for line in handle:
         if not line.strip():
             break
         words = line.strip().split()
         motif = meme.Motif(record.alphabet)
         motif.name = words[0]
-        motif.length = int(words[1])
-        # words[2] contains the best possible match
+        if has_motif_ids:
+            motif.id = words[1]
+            motif.alt_id = words[2]
+        motif.length = int(words[-2])
+        # words[-1] contains the best possible match
         record.append(motif)
 
 

--- a/Bio/motifs/meme.py
+++ b/Bio/motifs/meme.py
@@ -85,6 +85,8 @@ class Motif(motifs.Motif):
         self.evalue = 0.0
         self.num_occurrences = 0
         self.name = None
+        self.id = None
+        self.alt_id = None
 
 
 class Instance(Seq.Seq):

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -244,6 +244,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Uri Laserson <https://github.com/laserson>
 - Uwe Schmitt <https://github.com/uweschmitt>
 - Veronika Berman <https://github.com/NikiB>
+- Victor Lin <https://github.com/victorlin>
 - Walter Gillett <https://github.com/wgillett>
 - Wayne Decatur <https://github.com/fomightez>
 - Wibowo Arindrarto <https://github.com/bow>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -80,6 +80,7 @@ possible, especially the following contributors:
 - Ralf Stephan
 - Rob Miller
 - Sergio Valqui
+- Victor Lin
 - Wibowo 'Bow' Arindrarto
 
 


### PR DESCRIPTION
From [MEME Suite Release Notes](http://meme-suite.org/doc/release-notes.html) under version 4.11.4:

> **MEME** motif names are now their **consensus sequence**, rather than a number, and the alternate ID is "MEME-i", where "i" = 1, 2, 3,... is the old motif name.

Newer versions of MEME contain motif ID and alternate ID. This commit updates the MAST parser to account for those additions. Older files without the `ID`/`ALT ID` are still supported.

I can add tests with newer MAST output files in another pull request.

---

This pull request addresses issue #1980.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)