### PR TITLE
Add parse_index attribute to HSPs

### DIFF
--- a/Bio/SearchIO/_model/hsp.py
+++ b/Bio/SearchIO/_model/hsp.py
@@ -211,7 +211,7 @@ class HSP(_BaseHSP):
     +------------+---------------------------------------------------+
 
     In addition to the objects listed above, HSP objects also provide the
-    following properties:
+    following properties and/or attributes:
 
     +--------------------+------------------------------------------------------+
     | Property           | Value                                                |
@@ -230,6 +230,9 @@ class HSP(_BaseHSP):
     |                    | between fragments                                    |
     +--------------------+------------------------------------------------------+
     | hit_inter_spans    | list of lengths of the regions between hit fragments |
+    +--------------------+------------------------------------------------------+
+    | parse_index        | 0-based index for storing the order by which the HSP |
+    |                    | appears in the output file (default: -1).            |
     +--------------------+------------------------------------------------------+
     | query_id           | ID of the query sequence                             |
     +--------------------+------------------------------------------------------+
@@ -250,11 +253,14 @@ class HSP(_BaseHSP):
     # from this one
     _NON_STICKY_ATTRS = ('_items', )
 
-    def __init__(self, fragments=()):
+    def __init__(self, fragments=(), parse_index=-1):
         """Initialize an HSP object.
 
         :param fragments: fragments contained in the HSP object
         :type fragments: iterable yielding HSPFragment
+        :param parse_index: optional index / ordering of the HSP fragment in
+            the original input file.
+        :type parse_index: integer
 
         HSP objects must be initialized with a list containing at least one
         HSPFragment object. If multiple HSPFragment objects are used for
@@ -275,6 +281,7 @@ class HSP(_BaseHSP):
                 raise ValueError("HSP object can not contain fragments with "
                                  "more than one %s." % attr)
 
+        self.parse_index = parse_index
         self._items = []
         for fragment in fragments:
             self._validate_fragment(fragment)

--- a/Bio/SearchIO/_model/hsp.py
+++ b/Bio/SearchIO/_model/hsp.py
@@ -231,7 +231,7 @@ class HSP(_BaseHSP):
     +--------------------+------------------------------------------------------+
     | hit_inter_spans    | list of lengths of the regions between hit fragments |
     +--------------------+------------------------------------------------------+
-    | parse_index        | 0-based index for storing the order by which the HSP |
+    | output_index       | 0-based index for storing the order by which the HSP |
     |                    | appears in the output file (default: -1).            |
     +--------------------+------------------------------------------------------+
     | query_id           | ID of the query sequence                             |
@@ -253,14 +253,14 @@ class HSP(_BaseHSP):
     # from this one
     _NON_STICKY_ATTRS = ('_items', )
 
-    def __init__(self, fragments=(), parse_index=-1):
+    def __init__(self, fragments=(), output_index=-1):
         """Initialize an HSP object.
 
         :param fragments: fragments contained in the HSP object
         :type fragments: iterable yielding HSPFragment
-        :param parse_index: optional index / ordering of the HSP fragment in
+        :param output_index: optional index / ordering of the HSP fragment in
             the original input file.
-        :type parse_index: integer
+        :type output_index: integer
 
         HSP objects must be initialized with a list containing at least one
         HSPFragment object. If multiple HSPFragment objects are used for
@@ -281,7 +281,7 @@ class HSP(_BaseHSP):
                 raise ValueError("HSP object can not contain fragments with "
                                  "more than one %s." % attr)
 
-        self.parse_index = parse_index
+        self.output_index = output_index
         self._items = []
         for fragment in fragments:
             self._validate_fragment(fragment)

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -457,7 +457,7 @@ class QueryResult(_BaseSearchObject):
         """Access the HSP objects contained in the QueryResult."""
         return sorted(
             [hsp for hsp in chain(*self.hits)],
-            key=lambda hsp: hsp.parse_index)
+            key=lambda hsp: hsp.output_index)
 
     @property
     def fragments(self):

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -455,7 +455,9 @@ class QueryResult(_BaseSearchObject):
     @property
     def hsps(self):
         """Access the HSP objects contained in the QueryResult."""
-        return [hsp for hsp in chain(*self.hits)]
+        return sorted(
+            [hsp for hsp in chain(*self.hits)],
+            key=lambda hsp: hsp.parse_index)
 
     @property
     def fragments(self):

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -38,6 +38,11 @@ only the aligned section of the sequences are shown, together with the start
 positions of the sequences (in 1-based notation). Alignments of lists will now
 also be prettily printed.
 
+``Bio.SearchIO`` HSP objects has a new attribute called ``output_index``. This
+attribute is meant for capturing the order by which the HSP were output in the
+parsed file and is set with a default value of -1 for all HSP objects. It is
+also used for sorting the output of ``QueryResult.hsps``.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
@@ -52,6 +57,7 @@ possible, especially the following contributors:
 - Ralf Stephan
 - Sergio Valqui
 - Antony Lee
+- Wibowo 'Bow' Arindrarto
 
 18 December 2018: Biopython 1.73
 ================================


### PR DESCRIPTION
This pull request is related to #1965 and adds an HSP attribute for SearchIO objects to store the order by which the HSP appears in the output file given to SearchIO.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
