### PR TITLE
add an aligned property to PairwiseAlignment objects

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1141,6 +1141,22 @@ class PairwiseAlignment(object):
         line = "\t".join(words) + "\n"
         return line
 
+    @property
+    def aligned(self):
+        """Return the indices of subsequences aligned to each other."""
+        segments1 = []
+        segments2 = []
+        i1, i2 = self.path[0]
+        for node in self.path[1:]:
+            j1, j2 = node
+            if j1 > i1 and j2 > i2:
+                segment1 = (i1, j1)
+                segment2 = (i2, j2)
+                segments1.append(segment1)
+                segments2.append(segment2)
+            i1, i2 = j1, j2
+        return tuple(segments1), tuple(segments2)
+
 
 class PairwiseAlignments(object):
     """Implements an iterator over pairwise alignments returned by the aligner.

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1143,7 +1143,58 @@ class PairwiseAlignment(object):
 
     @property
     def aligned(self):
-        """Return the indices of subsequences aligned to each other."""
+        """Return the indices of subsequences aligned to each other.
+
+        This property returns the start and end indices of subsequences
+        in the target and query sequence that were aligned to each other.
+        For example,
+
+        >>> from Bio import Align
+        >>> aligner = Align.PairwiseAligner()
+        >>> alignments = aligner.align("GAACT", "GAT")
+        >>> alignment = alignments[0]
+        >>> print(alignment)
+        GAACT
+        ||--|
+        GA--T
+        <BLANKLINE>
+        >>> alignment.aligned
+        (((0, 2), (4, 5)), ((0, 2), (2, 3)))
+        >>> alignment = alignments[1]
+        >>> print(alignment)
+        GAACT
+        |-|-|
+        G-A-T
+        <BLANKLINE>
+        >>> alignment.aligned
+        (((0, 1), (2, 3), (4, 5)), ((0, 1), (1, 2), (2, 3)))
+
+        Note that different alignments may have the same subsequences
+        aligned to each other. In particular, this may occur if alignments
+        differ from each other in terms of their gap placement only:
+
+        >>> aligner.mismatch = -10
+        >>> alignments = aligner.align("AAACAAA", "AAAGAAA")
+        >>> len(alignments)
+        2
+        >>> print(alignments[0])
+        AAAC-AAA
+        |||--|||
+        AAA-GAAA
+        <BLANKLINE>
+        >>> alignments[0].aligned
+        (((0, 3), (4, 7)), ((0, 3), (4, 7)))
+        >>> print(alignments[1])
+        AAA-CAAA
+        |||--|||
+        AAAG-AAA
+        <BLANKLINE>
+        >>> alignments[1].aligned
+        (((0, 3), (4, 7)), ((0, 3), (4, 7)))
+
+        The property can be used to identify alignments that are identical
+        to each other in terms of their aligned sequences.
+        """
         segments1 = []
         segments2 = []
         i1, i2 = self.path[0]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1147,6 +1147,12 @@ class PairwiseAlignment(object):
 
         This property returns the start and end indices of subsequences
         in the target and query sequence that were aligned to each other.
+        If the alignment between target (t) and query (q) consists of N
+        chunks, you get two tuples of length N:
+
+            (((t_start1, t_end1), (t_start2, t_end2), ..., (t_startN, t_endN)),
+             ((q_start1, q_end1), (q_start2, q_end2), ..., (q_startN, q_endN)))
+
         For example,
 
         >>> from Bio import Align

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2030,6 +2030,44 @@ You can also represent the alignment as a string in PSL (Pattern Space Layout, a
 '3\t0\t0\t0\t0\t0\t1\t2\t+\tquery\t3\t0\t3\ttarget\t5\t0\t5\t2\t2,1,\t0,2,\t0,4,\n'
 \end{verbatim}
 
+Use the \verb+aligned+ property to find the start and end indices of subsequences in the target and query sequence that were aligned to each other:
+%cont-doctest
+\begin{verbatim}
+>>> alignment.aligned
+(((0, 2), (4, 5)), ((0, 2), (2, 3)))
+>>> alignment = alignments[1]
+>>> print(alignment)
+GAACT
+|-|-|
+G-A-T
+<BLANKLINE>
+>>> alignment.aligned
+(((0, 1), (2, 3), (4, 5)), ((0, 1), (1, 2), (2, 3)))
+\end{verbatim}
+Note that different alignments may have the same subsequences aligned to each other. In particular, this may occur if alignments differ from each other in terms of their gap placement only:
+%cont-doctest
+\begin{verbatim}
+>>> aligner.mismatch = -10
+>>> alignments = aligner.align("AAACAAA", "AAAGAAA")
+>>> len(alignments)
+2
+>>> print(alignments[0])
+AAAC-AAA
+|||--|||
+AAA-GAAA
+<BLANKLINE>
+>>> alignments[0].aligned
+(((0, 3), (4, 7)), ((0, 3), (4, 7)))
+>>> print(alignments[1])
+AAA-CAAA
+|||--|||
+AAAG-AAA
+<BLANKLINE>
+>>> alignments[1].aligned
+(((0, 3), (4, 7)), ((0, 3), (4, 7)))
+\end{verbatim}
+The \verb+aligned+ property can be used to identify alignments that are identical to each other in terms of their aligned sequences.
+
 \subsubsection{Example}
 \label{sec:pairwise-examples}
 

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -536,7 +536,7 @@ AlignIO.convert("PF05371_seed.sth", "stockholm", "PF05371_seed.phy", "phylip-rel
 \end{verbatim}
 
 This time the output looks like this, using a longer indentation to
-allow all the identifers to be given in full::
+allow all the identifers to be given in full:
 
 \begin{verbatim}
  7 52
@@ -1554,7 +1554,7 @@ part has not been extended:
 Instead of supplying a complete match/mismatch matrix, the match code
 \texttt{m} allows for easy defining general match/mismatch values. The next
 example uses match/mismatch scores of 5/-4 and gap penalties (open/extend)
-of 2/0.5 using \verb|localms|):
+of 2/0.5 using \verb|localms|:
 
 %cont-doctest
 \begin{verbatim}
@@ -2030,11 +2030,24 @@ You can also represent the alignment as a string in PSL (Pattern Space Layout, a
 '3\t0\t0\t0\t0\t0\t1\t2\t+\tquery\t3\t0\t3\ttarget\t5\t0\t5\t2\t2,1,\t0,2,\t0,4,\n'
 \end{verbatim}
 
-Use the \verb+aligned+ property to find the start and end indices of subsequences in the target and query sequence that were aligned to each other:
+Use the \verb+aligned+ property to find the start and end indices of subsequences in the target and query sequence that were aligned to each other.
+Generally, if the alignment between target (t) and query (q) consists of N
+chunks, you get two tuples of length N:
+
+\begin{verbatim}
+(((t_start1, t_end1), (t_start2, t_end2), ..., (t_startN, t_endN)),
+ ((q_start1, q_end1), (q_start2, q_end2), ..., (q_startN, q_endN)))
+\end{verbatim}
+
+In the current example, `alignment.aligned` returns two tuples of length 2:
 %cont-doctest
 \begin{verbatim}
 >>> alignment.aligned
 (((0, 2), (4, 5)), ((0, 2), (2, 3)))
+\end{verbatim}
+while for the alternative alignment, two tuples of length 3 are returned:
+%cont-doctest
+\begin{verbatim}
 >>> alignment = alignments[1]
 >>> print(alignment)
 GAACT

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -199,6 +199,7 @@ GAACT
 ||--|
 GA--T
 """)
+        self.assertEqual(alignment.aligned, (((0, 2), (4, 5)), ((0, 2), (2, 3))))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(str(alignment), """\
@@ -206,6 +207,7 @@ GAACT
 |-|-|
 G-A-T
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (2, 3), (4, 5)), ((0, 1), (1, 2), (2, 3))))
 
     def test_align_affine1_score(self):
         aligner = Align.PairwiseAligner()
@@ -273,6 +275,7 @@ Pairwise sequence aligner with parameters
 .|-|.
 zA-Bz
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((1, 2), (2, 3))))
 
     def test_gotoh_local(self):
         aligner = Align.PairwiseAligner()
@@ -309,6 +312,7 @@ Pairwise sequence aligner with parameters
 .|-|.
 zA-Bz
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((1, 2), (2, 3))))
 
 
 class TestPairwiseOpenPenalty(unittest.TestCase):
@@ -352,6 +356,7 @@ AA
 -|
 -A
 """)
+        self.assertEqual(alignment.aligned, (((1, 2),), ((0, 1),)))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.9)
         self.assertEqual(str(alignment), """\
@@ -359,6 +364,7 @@ AA
 |-
 A-
 """)
+        self.assertEqual(alignment.aligned, (((0, 1),), ((0, 1),)))
 
     def test_match_score_open_penalty2(self):
         aligner = Align.PairwiseAligner()
@@ -399,6 +405,7 @@ GAA
 |-|
 G-A
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((0, 1), (1, 2))))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.9)
         self.assertEqual(str(alignment), """\
@@ -406,6 +413,7 @@ GAA
 ||-
 GA-
 """)
+        self.assertEqual(alignment.aligned, (((0, 2),), ((0, 2),)))
 
     def test_match_score_open_penalty3(self):
         aligner = Align.PairwiseAligner()
@@ -444,6 +452,7 @@ GAACT
 ||--|
 GA--T
 """)
+        self.assertEqual(alignment.aligned, (((0, 2), (4, 5)), ((0, 2), (2, 3))))
 
     def test_match_score_open_penalty4(self):
         aligner = Align.PairwiseAligner()
@@ -483,6 +492,7 @@ G-CT-
 |--|-
 GA-TA
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((0, 1), (2, 3))))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.7)
         self.assertEqual(str(alignment), """\
@@ -490,6 +500,7 @@ GC-T-
 |--|-
 G-ATA
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((0, 1), (2, 3))))
 
 
 class TestPairwiseExtendPenalty(unittest.TestCase):
@@ -531,6 +542,7 @@ GACT
 |--|
 G--T
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (3, 4)), ((0, 1), (1, 2))))
 
     def test_extend_penalty2(self):
         aligner = Align.PairwiseAligner()
@@ -569,6 +581,7 @@ GACT
 -X-|
 -G-T
 """)
+        self.assertEqual(alignment.aligned, (((1, 2), (3, 4)), ((0, 1), (1, 2))))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 0.6)
         self.assertEqual(str(alignment), """\
@@ -576,6 +589,7 @@ GACT
 |-X-
 G-T-
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((0, 1), (1, 2))))
 
 
 class TestPairwisePenalizeExtendWhenOpening(unittest.TestCase):
@@ -617,6 +631,7 @@ GACT
 |--|
 G--T
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (3, 4)), ((0, 1), (1, 2))))
 
 
 class TestPairwisePenalizeEndgaps(unittest.TestCase):
@@ -661,6 +676,7 @@ GACT
 --X|
 --GT
 """)
+        self.assertEqual(alignment.aligned, (((2, 4),), ((0, 2),)))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(str(alignment), """\
@@ -668,6 +684,7 @@ GACT
 |--|
 G--T
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (3, 4)), ((0, 1), (1, 2))))
         alignment = alignments[2]
         self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(str(alignment), """\
@@ -675,6 +692,7 @@ GACT
 |X--
 GT--
 """)
+        self.assertEqual(alignment.aligned, (((0, 2),), ((0, 2),)))
 
 
 class TestPairwiseSeparateGapPenalties(unittest.TestCase):
@@ -724,6 +742,7 @@ G-AT
 |-X|
 GTCT
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (1, 3)), ((0, 1), (2, 4))))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.7)
         self.assertEqual(str(alignment), """\
@@ -731,6 +750,7 @@ GA-T
 |X-|
 GTCT
 """)
+        self.assertEqual(alignment.aligned, (((0, 2), (2, 3)), ((0, 2), (3, 4))))
 
     def test_separate_gap_penalties2(self):
         aligner = Align.PairwiseAligner()
@@ -771,6 +791,7 @@ GAT..
 |-|..
 G-TCT
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((0, 1), (1, 2))))
 
 
 class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
@@ -818,6 +839,7 @@ G-AAT
 |-XX|
 GTCCT
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (1, 4)), ((0, 1), (2, 5))))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.9)
         self.assertEqual(str(alignment), """\
@@ -825,6 +847,7 @@ GA-AT
 |X-X|
 GTCCT
 """)
+        self.assertEqual(alignment.aligned, (((0, 2), (2, 4)), ((0, 2), (3, 5))))
         alignment = alignments[2]
         self.assertAlmostEqual(alignment.score, 1.9)
         self.assertEqual(str(alignment), """\
@@ -832,6 +855,7 @@ GAA-T
 |XX-|
 GTCCT
 """)
+        self.assertEqual(alignment.aligned, (((0, 3), (3, 4)), ((0, 3), (4, 5))))
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
@@ -841,6 +865,7 @@ G-AAT
 |-XX|
 GTCCT
 """)
+        self.assertEqual(alignment.aligned, (((0, 1), (1, 4)), ((0, 1), (2, 5))))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.9)
         self.assertEqual(str(alignment), """\
@@ -848,6 +873,7 @@ GA-AT
 |X-X|
 GTCCT
 """)
+        self.assertEqual(alignment.aligned, (((0, 2), (2, 4)), ((0, 2), (3, 5))))
         alignment = alignments[2]
         self.assertAlmostEqual(alignment.score, 1.9)
         self.assertEqual(str(alignment), """\
@@ -855,6 +881,7 @@ GAA-T
 |XX-|
 GTCCT
 """)
+        self.assertEqual(alignment.aligned, (((0, 3), (3, 4)), ((0, 3), (4, 5))))
 
 
 class TestPairwiseMatchDictionary(unittest.TestCase):
@@ -896,18 +923,22 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 2)
-        self.assertAlmostEqual(alignments[0].score, 3.0)
-        self.assertEqual(str(alignments[0]), """\
+        alignment = alignments[0]
+        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertEqual(str(alignment), """\
 ATAT
 ||X.
 ATT.
 """)
-        self.assertAlmostEqual(alignments[1].score, 3.0)
-        self.assertEqual(str(alignments[1]), """\
+        self.assertEqual(alignment.aligned, (((0, 3),), ((0, 3),)))
+        alignment = alignments[1]
+        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertEqual(str(alignment), """\
 ATAT
 ||-|
 AT-T
 """)
+        self.assertEqual(alignment.aligned, (((0, 2), (3, 4)), ((0, 2), (2, 3))))
 
     def test_match_dictionary2(self):
         seq1 = "ATAT"
@@ -938,12 +969,14 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
-        self.assertAlmostEqual(alignments[0].score, 3.0)
-        self.assertEqual(str(alignments[0]), """\
+        alignment = alignments[0]
+        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertEqual(str(alignment), """\
 ATAT
 ||X.
 ATT.
 """)
+        self.assertEqual(alignment.aligned, (((0, 3),), ((0, 3),)))
 
     def test_match_dictionary3(self):
         seq1 = "ATT"
@@ -974,12 +1007,14 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
-        self.assertAlmostEqual(alignments[0].score, 3.0)
-        self.assertEqual(str(alignments[0]), """\
+        alignment = alignments[0]
+        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertEqual(str(alignment), """\
 ATT.
 ||X.
 ATAT
 """)
+        self.assertEqual(alignment.aligned, (((0, 3),), ((0, 3),)))
 
 
 class TestPairwiseOneCharacter(unittest.TestCase):
@@ -1019,6 +1054,7 @@ abcde
 ..|..
 ..c..
 """)
+        self.assertEqual(alignment.aligned, (((2, 3),), ((0, 1),)))
 
     def test_align_one_char2(self):
         aligner = Align.PairwiseAligner()
@@ -1055,6 +1091,7 @@ abcce
 ..|..
 ..c..
 """)
+        self.assertEqual(alignment.aligned, (((2, 3),), ((0, 1),)))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1)
         self.assertEqual(str(alignment), """\
@@ -1062,6 +1099,7 @@ abcce
 ...|.
 ...c.
 """)
+        self.assertEqual(alignment.aligned, (((3, 4),), ((0, 1),)))
 
     def test_align_one_char3(self):
         aligner = Align.PairwiseAligner()
@@ -1100,6 +1138,7 @@ abcde
 --|--
 --c--
 """)
+        self.assertEqual(alignment.aligned, (((2, 3),), ((0, 1),)))
 
     def test_align_one_char_score3(self):
         aligner = Align.PairwiseAligner()
@@ -1171,6 +1210,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 --|||||||||||----------|||||||||||--
 --AABBBAAAACC----------CCAAAABBBAA--
 """)
+        self.assertEqual(alignment.aligned, (((2, 13), (23, 34)), ((0, 11), (11, 22))))
 
     def test_gap_here_only_2(self):
         # Force a bad alignment.
@@ -1212,6 +1252,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 --|||----------XXXXXX|||||||||||||--
 --AAB----------BBAAAACCCCAAAABBBAA--
 """)
+        self.assertEqual(alignment.aligned, (((2, 5), (15, 34)), ((0, 3), (3, 22))))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, -10)
         self.assertEqual(str(alignment), """\
@@ -1219,6 +1260,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 ||X------------XXXXXX|||||||||||||--
 AAB------------BBAAAACCCCAAAABBBAA--
 """)
+        self.assertEqual(alignment.aligned, (((0, 3), (15, 34)), ((0, 3), (3, 22))))
 
     def test_gap_here_only_3(self):
         # Check if gap open and gap extend penalties are handled correctly.
@@ -1262,6 +1304,7 @@ TT-CC-AA
 ||----||
 TTG--GAA
 """)
+        self.assertEqual(alignment.aligned, (((0, 2), (4, 6)), ((0, 2), (4, 6))))
         aligner.query_gap_score = gap_score
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
@@ -1282,6 +1325,7 @@ TT-CCAA
 ||-X-||
 TTGG-AA
 """)
+        self.assertEqual(alignment.aligned, (((0, 2), (2, 3), (4, 6)), ((0, 2), (3, 4), (4, 6))))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, -8.0)
         self.assertEqual(str(alignment), """\
@@ -1289,6 +1333,7 @@ TTC--CAA
 ||----||
 TT-GG-AA
 """)
+        self.assertEqual(alignment.aligned, (((0, 2), (4, 6)), ((0, 2), (4, 6))))
         alignment = alignments[2]
         self.assertAlmostEqual(alignment.score, -8.0)
         self.assertEqual(str(alignment), """\
@@ -1296,6 +1341,7 @@ TTCC-AA
 ||-X-||
 TT-GGAA
 """)
+        self.assertEqual(alignment.aligned, (((0, 2), (3, 4), (4, 6)), ((0, 2), (2, 3), (4, 6))))
         alignment = alignments[3]
         self.assertAlmostEqual(alignment.score, -8.0)
         self.assertEqual(str(alignment), """\
@@ -1303,6 +1349,7 @@ TT-CC-AA
 ||----||
 TTG--GAA
 """)
+        self.assertEqual(alignment.aligned, (((0, 2), (4, 6)), ((0, 2), (4, 6))))
 
     def test_gap_here_only_local_1(self):
         seq1 = "AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA"
@@ -1339,6 +1386,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 ..|||||||||||||.....................
 ..AABBBAAAACCCCAAAABBBAA............
 """)
+        self.assertEqual(alignment.aligned, (((2, 15),), ((0, 13),)))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 13)
         self.assertEqual(str(alignment), """\
@@ -1346,6 +1394,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 .....................|||||||||||||..
 ............AABBBAAAACCCCAAAABBBAA..
 """)
+        self.assertEqual(alignment.aligned, (((21, 34),), ((9, 22),)))
 
     def test_gap_here_only_local_2(self):
         # Force a bad alignment.
@@ -1387,6 +1436,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 ..|||||||||||||.....................
 ..AABBBAAAACCCCAAAABBBAA............
 """)
+        self.assertEqual(alignment.aligned, (((2, 15),), ((0, 13),)))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 13)
         self.assertEqual(str(alignment), """\
@@ -1394,6 +1444,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 .....................|||||||||||||..
 ............AABBBAAAACCCCAAAABBBAA..
 """)
+        self.assertEqual(alignment.aligned, (((21, 34),), ((9, 22),)))
 
     def test_gap_here_only_local_3(self):
         # Check if gap open and gap extend penalties are handled correctly.
@@ -1437,6 +1488,7 @@ TTCCAA
 ||....
 TTGGAA
 """)
+        self.assertEqual(alignment.aligned, (((0, 2),), ((0, 2),)))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.0)
         self.assertEqual(str(alignment), """\
@@ -1444,6 +1496,7 @@ TTCCAA
 ....||
 TTGGAA
 """)
+        self.assertEqual(alignment.aligned, (((4, 6),), ((4, 6),)))
         aligner.query_gap = gap_score
         self.assertEqual(str(aligner), """\
 Pairwise sequence aligner with parameters
@@ -1469,6 +1522,7 @@ TTCCAA
 ||....
 TTGGAA
 """)
+        self.assertEqual(alignment.aligned, (((0, 2),), ((0, 2),)))
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.0)
         self.assertEqual(str(alignment), """\
@@ -1476,6 +1530,7 @@ TTCCAA
 ....||
 TTGGAA
 """)
+        self.assertEqual(alignment.aligned, (((4, 6),), ((4, 6),)))
 
     def test_broken_gap_function(self):
         # Check if an Exception is propagated if the gap function raises one


### PR DESCRIPTION
Add an `aligned` property to PairwiseAlignment objects to identify the subsequences that were aligned to each other. This can be used to identify alignments that are only trivially different from each other.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
