### PR TITLE
Currently ReportLab breaks with Pillow 6.0.0

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -62,7 +62,9 @@ deps =
     py27: unittest2
     py27: mysql-python
     py27,py36: mmtf-python
+    # https://bitbucket.org/rptlab/reportlab/issues/176/incompatibility-with-pillow-600
     py27,py35: reportlab
+    py27,py35: pillow==5.4
     py27,py34,py35,py36: psycopg2-binary
     py27,py34,py35,py35: mysql-connector-python-rf
     py35,py36: mysqlclient

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -758,6 +758,7 @@ class DupLoadTest(unittest.TestCase):
             # Note we don't do a specific exception handler because the
             # exception class will depend on which DB back end is in use.
             self.assertTrue(err.__class__.__name__ in ["IntegrityError",
+                                                       "UniqueViolation",
                                                        "AttributeError",
                                                        "OperationalError"],
                             err.__class__.__name__)
@@ -775,6 +776,7 @@ class DupLoadTest(unittest.TestCase):
         except Exception as err:
             # Good!
             self.assertTrue(err.__class__.__name__ in ["IntegrityError",
+                                                       "UniqueViolation",
                                                        "AttributeError"],
                             err.__class__.__name__)
             return
@@ -791,6 +793,7 @@ class DupLoadTest(unittest.TestCase):
         except Exception as err:
             # Good!
             self.assertTrue(err.__class__.__name__ in ["IntegrityError",
+                                                       "UniqueViolation",
                                                        "AttributeError"],
                             err.__class__.__name__)
             return
@@ -1005,6 +1008,7 @@ class InDepthLoadTest(unittest.TestCase):
         except Exception as err:
             # Good!
             self.assertTrue(err.__class__.__name__ in ["IntegrityError",
+                                                       "UniqueViolation",
                                                        "AttributeError"],
                             err.__class__.__name__)
             return


### PR DESCRIPTION
This pull request should address issue #1995

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
