### PR TITLE
fixed PDB header tail trim to match comment.

### DIFF
--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -93,7 +93,7 @@ def _chop_end_codes(line):
 
 def _chop_end_misc(line):
     """Chops lines ending with  '     14-JUL-97  1CSA' and the like (PRIVATE)."""
-    return re.sub(r"\s\s\s\s+.*\Z", "", line)
+    return re.sub(r"\s+\d\d-\w\w\w-\d\d\s+[1-9][0-9A-Z]{3}\s*\Z", "", line)
 
 
 def _nice_case(line):

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -60,6 +60,7 @@ possible, especially the following contributors:
 - Nick Negretti
 - Peter Cock
 - Ralf Stephan
+- Rob Miller
 - Sergio Valqui
 - Antony Lee
 - Wibowo 'Bow' Arindrarto

--- a/Tests/PDB/header.pdb
+++ b/Tests/PDB/header.pdb
@@ -1,0 +1,5 @@
+HEADER    STRUCTURAL GENOMICS, UNKNOWN FUNCTION   08-SEP-08   3EFG              
+TITLE     STRUCTURE OF SLYX PROTEIN FROM XANTHOMONAS CAMPESTRIS PV. CAMPESTRIS  
+TITLE    2 STR. ATCC 33913                                                      
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: PROTEIN SLYX HOMOLOG;                                      

--- a/Tests/test_PDB_parse_pdb_header.py
+++ b/Tests/test_PDB_parse_pdb_header.py
@@ -49,6 +49,13 @@ class ParseReal(unittest.TestCase):
         self.assertEqual(info, {"model": None, "res_name": "A",
                                 "chain": "2", "ssseq": 11, "insertion": None})
 
+    def test_parse_header_line(self):
+        """Unit test for parsing and converting fields in HEADER record"""
+        header = parse_pdb_header("PDB/header.pdb")
+        self.assertEqual(header['head'], 'structural genomics, unknown function')
+        self.assertEqual(header['idcode'], '3EFG')
+        self.assertEqual(header['deposition_date'], '2008-09-08')
+
 
 if __name__ == '__main__':
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
This pull request changes _chop_end_misc in parse_pdb_header.py to match the docline better.  

The current implementation is very general (matching 4 spaces optionally followed by anything at the end of the line, `r"\s\s\s\s+.*\Z"`) and fails on pdb2yxy.ent.  Alternatively just change the '+' to a '*' in the current implementation, but this matches the specification in the routine's docline better (`"Chops lines ending with  '     14-JUL-97  1CSA' and the like (PRIVATE)."`)


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

*Peter: Fixed checkboxes by removing spaces*