### PR TITLE
allow weight to be None in case the distance matrix is used

### DIFF
--- a/Bio/Cluster/__init__.py
+++ b/Bio/Cluster/__init__.py
@@ -294,13 +294,22 @@ def treecluster(data, mask=None, weight=None, transpose=False, method='m',
     treecluster returns a Tree object describing the hierarchical clustering
     result. See the description of the Tree class for more information.
     """
+    if data is None and distancematrix is None:
+        raise ValueError('use either data or distancematrix')
+    if data is not None and distancematrix is not None:
+        raise ValueError('use either data or distancematrix; do not use both')
     if data is not None:
         data = __check_data(data)
         shape = data.shape
         ndata = shape[0] if transpose else shape[1]
         mask = __check_mask(mask, shape)
         weight = __check_weight(weight, ndata)
-    distancematrix = __check_distancematrix(distancematrix)
+    if distancematrix is not None:
+        distancematrix = __check_distancematrix(distancematrix)
+        if mask is not None:
+            raise ValueError('mask is ignored if distancematrix is used')
+        if weight is not None:
+            raise ValueError('weight is ignored if distancematrix is used')
     tree = Tree()
     _cluster.treecluster(tree, data, mask, weight, transpose, method, dist,
                          distancematrix)

--- a/Bio/Cluster/cluster.c
+++ b/Bio/Cluster/cluster.c
@@ -33,20 +33,6 @@
 #include <limits.h>
 #include <string.h>
 #include "cluster.h"
-#ifdef WINDOWS
-#  include <windows.h>
-#endif
-
-/* ************************************************************************ */
-
-#ifdef WINDOWS
-/* Then we make a Windows DLL */
-int WINAPI
-clusterdll_init(HANDLE h, DWORD reason, void* foo)
-{
-  return 1;
-}
-#endif
 
 /* ************************************************************************ */
 

--- a/Bio/Cluster/cluster.h
+++ b/Bio/Cluster/cluster.h
@@ -38,7 +38,7 @@
 #  include <windows.h>
 #endif
 
-#define CLUSTERVERSION "1.55"
+#define CLUSTERVERSION "1.58"
 
 /* Chapter 2 */
 double clusterdistance(int nrows, int ncolumns, double** data, int** mask,

--- a/Bio/Cluster/cluster.h
+++ b/Bio/Cluster/cluster.h
@@ -34,10 +34,6 @@
 #define	max(x, y)	((x) > (y) ? (x) : (y))
 #endif
 
-#ifdef WINDOWS
-#  include <windows.h>
-#endif
-
 #define CLUSTERVERSION "1.58"
 
 /* Chapter 2 */

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -83,7 +83,6 @@ VERBOSITY = 0
 # please remove here!
 EXCLUDE_DOCTEST_MODULES = [
     'Bio.AlignIO.MauveIO',
-    'Bio.Cluster',
     'Bio.Data.CodonTable',
     'Bio.ExPASy',
     'Bio.ExPASy.cellosaurus',

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -125,6 +125,7 @@ EXCLUDE_DOCTEST_MODULES.extend([
 if numpy is None:
     EXCLUDE_DOCTEST_MODULES.extend([
         "Bio.Affy.CelFile",
+        "Bio.Cluster",
         "Bio.KDTree",
         "Bio.KDTree.KDTree",
         "Bio.kNN",


### PR DESCRIPTION
This pull request allows the weight argument to the treecluster routine to be None if the distance matrix is provided.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
