### PR TITLE
flake8: Enforce E731 (no lambda expressions) on Tests/

### DIFF
--- a/Tests/.flake8
+++ b/Tests/.flake8
@@ -11,11 +11,10 @@ ignore =
     E122,E123,E126,W503,W504,
     # These are not ignored by default:
     # E501	line too long (XX > 79 characters)
-    # E731	do not assign a lambda expression, use a def
     # F401	module imported but unused
     # F841	local variable name is assigned to but never used
     # TODO: Fix some of these?
-    E501,E731,F401,F841,
+    E501,F401,F841,
     # =====================================
     # pydocstyle: D1## - Missing Docstrings
     # =====================================

--- a/Tests/test_AlignIO_convert.py
+++ b/Tests/test_AlignIO_convert.py
@@ -63,7 +63,7 @@ output_formats = ["fasta"] + sorted(AlignIO._FormatToWriter)
 for filename, in_format, alphabet in tests:
     for out_format in output_formats:
         def funct(fn, fmt1, fmt2, alpha):
-            f = lambda x: x.simple_check(fn, fmt1, fmt2, alpha)
+            f = lambda x: x.simple_check(fn, fmt1, fmt2, alpha)  # noqa: E731
             f.__doc__ = "Convert %s from %s to %s" % (fn, fmt1, fmt2)
             return f
         setattr(ConvertTests, "test_%s_%s_to_%s"

--- a/Tests/test_Clustalw_tool.py
+++ b/Tests/test_Clustalw_tool.py
@@ -98,7 +98,7 @@ class ClustalWTestCase(unittest.TestCase):
         """Shared test procedure used by all tests."""
         self.assertTrue(str(eval(repr(cline))) == str(cline))
         input_records = SeqIO.to_dict(SeqIO.parse(cline.infile, "fasta"),
-                                      lambda rec: rec.id.replace(":", "_"))
+                                      lambda rec: rec.id.replace(":", "_"))  # noqa: E731
 
         # Determine name of tree file
         if cline.newtree:

--- a/Tests/test_KEGG.py
+++ b/Tests/test_KEGG.py
@@ -141,7 +141,7 @@ class MapTests(unittest.TestCase):
         self.assertEqual(len(rxs), 56)
         # sort the reaction output by the string names, so that the
         # output will be consistent between python versions
-        rxs.sort(key=lambda x: str(x))
+        rxs.sort(key=lambda x: str(x))  # noqa: E731
         self.assertEqual(str(rxs[0]),
                          "(R)-N-Methylcoclaurine + (S)-Coclaurine + NADPH + O2 "
                          "<=> 2'-Norberbamunine + 2 H2O + NADP")

--- a/Tests/test_Muscle_tool.py
+++ b/Tests/test_Muscle_tool.py
@@ -189,7 +189,7 @@ class SimpleAlignTest(unittest.TestCase):
         input_file = "Fasta/f002"
         self.assertTrue(os.path.isfile(input_file))
         records = list(SeqIO.parse(input_file, "fasta"))
-        records.sort(key=lambda rec: rec.id)
+        records.sort(key=lambda rec: rec.id)  # noqa: E731
         # Prepare the command... use Clustal output (with a MUSCLE header)
         cmdline = MuscleCommandline(muscle_exe, input=input_file, clw=True)
         self.assertEqual(str(cmdline).rstrip(), _escape_filename(muscle_exe) +
@@ -219,7 +219,7 @@ class SimpleAlignTest(unittest.TestCase):
         input_file = "Fasta/f002"
         self.assertTrue(os.path.isfile(input_file))
         records = list(SeqIO.parse(input_file, "fasta"))
-        records.sort(key=lambda rec: rec.id)
+        records.sort(key=lambda rec: rec.id)  # noqa: E731
         # Prepare the command...
         cmdline = MuscleCommandline(muscle_exe)
         cmdline.set_parameter("in", input_file)
@@ -276,7 +276,7 @@ class SimpleAlignTest(unittest.TestCase):
                                  shell=(sys.platform != "win32"))
         align = AlignIO.read(child.stdout, "clustal")
         align.sort()
-        records.sort(key=lambda rec: rec.id)
+        records.sort(key=lambda rec: rec.id)  # noqa: E731
         self.assertEqual(len(records), len(align))
         for old, new in zip(records, align):
             self.assertEqual(old.id, new.id)
@@ -311,7 +311,7 @@ class SimpleAlignTest(unittest.TestCase):
         # Alignment will now run...
         align = AlignIO.read(child.stdout, "clustal")
         align.sort()
-        records.sort(key=lambda rec: rec.id)
+        records.sort(key=lambda rec: rec.id)  # noqa: E731
         self.assertEqual(len(records), len(align))
         for old, new in zip(records, align):
             self.assertEqual(old.id, new.id)
@@ -328,7 +328,7 @@ class SimpleAlignTest(unittest.TestCase):
         output_clwstrict = "temp_f002.clw"
         self.assertTrue(os.path.isfile(input_file))
         records = list(SeqIO.parse(input_file, "fasta"))
-        records.sort(key=lambda rec: rec.id)
+        records.sort(key=lambda rec: rec.id)  # noqa: E731
         # Prepare the command... use Clustal output (with a MUSCLE header)
         cmdline = MuscleCommandline(muscle_exe, input=input_file,
                                     clw=True, htmlout=output_html,

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -1618,7 +1618,7 @@ class DsspTests(unittest.TestCase):
                     xtra_list_ref = list(map(will_it_float, xtra_list_ref))
                     # The xtra attribute is a dict.
                     # To compare with the pre-comouted values first sort according to keys:
-                    xtra_itemts = sorted(res.xtra.items(), key=lambda s: s[0])
+                    xtra_itemts = sorted(res.xtra.items(), key=lambda s: s[0])  # noqa: E731
                     # Then extract the list of xtra values for the residue
                     # and convert to floats where possible:
                     xtra_list = [t[1] for t in xtra_itemts]

--- a/Tests/test_PDB_KDTree.py
+++ b/Tests/test_PDB_KDTree.py
@@ -92,7 +92,7 @@ class KDTreeTest(unittest.TestCase):
                 center = random(3)
                 kdt = kdtrees.KDTree(coords, bucket_size)
                 points1 = kdt.search(center, radius)
-                points1.sort(key=lambda point: point.index)
+                points1.sort(key=lambda point: point.index)  # noqa: E731
                 # manual search
                 points2 = []
                 for i in range(0, nr_points):
@@ -127,7 +127,7 @@ class KDTreeTest(unittest.TestCase):
             neighbors2 = kdt.neighbor_simple_search(radius)
             # compare results
             self.assertEqual(len(neighbors1), len(neighbors2))
-            key = lambda neighbor: (neighbor.index1, neighbor.index2)
+            key = lambda neighbor: (neighbor.index1, neighbor.index2)  # noqa: E731
             neighbors1.sort(key=key)
             neighbors2.sort(key=key)
             for neighbor1, neighbor2 in zip(neighbors1, neighbors2):
@@ -170,7 +170,7 @@ class KDTreeTest(unittest.TestCase):
                             neighbor = kdtrees.Neighbor(i1, i2, r)
                             neighbors2.append(neighbor)
                 self.assertEqual(len(neighbors1), len(neighbors2))
-                key = lambda neighbor: (neighbor.index1, neighbor.index2)
+                key = lambda neighbor: (neighbor.index1, neighbor.index2)  # noqa: E731
                 neighbors1.sort(key=key)
                 neighbors2.sort(key=key)
                 for neighbor1, neighbor2 in zip(neighbors1, neighbors2):

--- a/Tests/test_Phylo.py
+++ b/Tests/test_Phylo.py
@@ -435,7 +435,7 @@ class MixinTests(unittest.TestCase):
         tree = Phylo.read(EX_APAF, 'phyloxml')
         d1 = tree.depths()
         internal_node_ct = len(tree.get_nonterminals())
-        tree.collapse_all(lambda c: c.branch_length < 0.1)
+        tree.collapse_all(lambda c: c.branch_length < 0.1)  # noqa: E731
         d2 = tree.depths()
         # Should have collapsed 7 internal nodes
         self.assertEqual(len(tree.get_nonterminals()), internal_node_ct - 7)

--- a/Tests/test_PhyloXML.py
+++ b/Tests/test_PhyloXML.py
@@ -698,7 +698,7 @@ class MethodTests(unittest.TestCase):
         self.assertEqual('duplications' in evts, False)
         # Attribute access: __get/set/delitem__
         self.assertEqual(evts['speciations'], 1)
-        self.assertRaises(KeyError, lambda k: evts[k], 'duplications')
+        self.assertRaises(KeyError, lambda k: evts[k], 'duplications')  # noqa: E731
         evts['duplications'] = 3
         self.assertEqual(evts.duplications, 3)
         self.assertEqual(len(evts), 2)

--- a/Tests/test_Phylo_matplotlib.py
+++ b/Tests/test_Phylo_matplotlib.py
@@ -49,7 +49,7 @@ class UtilTests(unittest.TestCase):
         Phylo.draw(apaf, do_show=False)
         # Fancier options
         Phylo.draw(apaf, do_show=False, branch_labels={apaf.root: 'Root'})
-        Phylo.draw(apaf, do_show=False, branch_labels=lambda c: c.branch_length)
+        Phylo.draw(apaf, do_show=False, branch_labels=lambda c: c.branch_length)  # noqa: E731
 
     def test_draw_with_label_colors_dict(self):
         """Layout tree with label colors as dict.
@@ -81,8 +81,8 @@ class UtilTests(unittest.TestCase):
         dollo = Phylo.read(EX_DOLLO, 'phyloxml')
         apaf = Phylo.read(EX_APAF, 'phyloxml')
 
-        label_colors_dollo = lambda label: 'r' if label == 'f_50' else 'k'
-        label_colors_apaf = lambda label: 'r'
+        label_colors_dollo = lambda label: 'r' if label == 'f_50' else 'k'  # noqa: E731
+        label_colors_apaf = lambda label: 'r'  # noqa: E731
 
         Phylo.draw(dollo, label_colors=label_colors_dollo, do_show=False)
         Phylo.draw(apaf, label_colors=label_colors_apaf, do_show=False)

--- a/Tests/test_SearchIO_legacy.py
+++ b/Tests/test_SearchIO_legacy.py
@@ -47,8 +47,10 @@ tc.end_section()    # '***** end_section\n'
 
 print("Running tests on is_blank_line")
 
-is_blank_line = lambda *args, **keywds: \
-                pb(ParserSupport.is_blank_line(*args, **keywds))
+
+def is_blank_line(*args, **keywds):
+    return pb(ParserSupport.is_blank_line(*args, **keywds))
+
 
 print(is_blank_line('\n'))                              # 1
 print(is_blank_line('\r\n'))                            # 1
@@ -177,6 +179,15 @@ else:
 
 print("Running tests on attempt_read_and_call")
 
+
+def arac(*args, **keywds):
+    return pb(ParserSupport.attempt_read_and_call(*args, **keywds))
+
+
+def m(line):
+    lines.append(line)
+
+
 data = """>gi|132871|sp|P19947|RL30_BACSU 50S RIBOSOMAL PROTEIN L30 (BL27)
 MAKLEITLKRSVIGRPEDQRVTVRTLGLKKTNQTVVHEDNAAIRGMINKVSHLVSVKEQ
 >gi|132679|sp|P19946|RL15_BACSU 50S RIBOSOMAL PROTEIN L15
@@ -185,15 +196,7 @@ RKEYAVVNLDKLNGFAEGTEVTPELLLETGVISKLNAGVKILGNGKLEKKLTVKANKFSASAKEAVEAAG
 GTAEVI"""
 
 h = File.UndoHandle(StringIO(data))
-
-arac = lambda *args, **keywds: \
-       pb(ParserSupport.attempt_read_and_call(*args, **keywds))
 lines = []
-
-
-def m(line):
-    lines.append(line)
-
 
 print(arac(h, m, contains="RIBOSOMAL PROTEIN"))   # 1
 print(arac(h, m, start="foobar"))                 # 0

--- a/Tests/test_SearchIO_model.py
+++ b/Tests/test_SearchIO_model.py
@@ -447,7 +447,7 @@ class QueryResultCases(unittest.TestCase):
 
     def test_append_custom_hit_key_function_ok(self):
         """Test QueryResult.append, with custom hit key function."""
-        self.qresult._hit_key_function = lambda hit: hit.id + '_custom'
+        self.qresult._hit_key_function = lambda hit: hit.id + '_custom'  # noqa: E731
         # append should assign hit keys according to _hit_key_function
         self.assertEqual(['hit1', 'hit2', 'hit3'], list(self.qresult.hit_keys))
         self.qresult.append(hit41)
@@ -483,7 +483,7 @@ class QueryResultCases(unittest.TestCase):
         self.assertEqual([hit11, hit21, hit31], list(self.qresult.hits))
         # filter func: min hit length == 2
         # this would filter out hit21, since it only has 1 HSP
-        filter_func = lambda hit: len(hit) >= 2
+        filter_func = lambda hit: len(hit) >= 2  # noqa: E731
         filtered = self.qresult.hit_filter(filter_func)
         self.assertEqual([hit11, hit31], list(filtered.hits))
         # make sure all remaining hits return True for the filter function
@@ -505,7 +505,7 @@ class QueryResultCases(unittest.TestCase):
         """Test QueryResult.hit_filter, all hits filtered out."""
         # when the filter filters out all hits, hit_filter should return an
         # empty QueryResult object
-        filter_func = lambda hit: len(hit) > 50
+        filter_func = lambda hit: len(hit) > 50  # noqa: E731
         filtered = self.qresult.hit_filter(filter_func)
         self.assertEqual(0, len(filtered))
         self.assertTrue(isinstance(filtered, QueryResult))
@@ -552,7 +552,7 @@ class QueryResultCases(unittest.TestCase):
         self.assertEqual([hit11, hit21, hit31], list(self.qresult.hits))
         # filter func: no '-' in hsp query sequence
         # this would filter out hsp113 and hsp211, effectively removing hit21
-        filter_func = lambda hsp: '-' not in str(hsp.fragments[0].query)
+        filter_func = lambda hsp: '-' not in str(hsp.fragments[0].query)  # noqa: E731
         filtered = self.qresult.hsp_filter(filter_func)
         self.assertIn('hit1', filtered)
         self.assertNotIn('hit2', filtered)
@@ -578,7 +578,7 @@ class QueryResultCases(unittest.TestCase):
         """Test QueryResult.hsp_filter, all hits filtered out."""
         # when the filter filters out all hits, hsp_filter should return an
         # empty QueryResult object
-        filter_func = lambda hsp: len(hsp) > 50
+        filter_func = lambda hsp: len(hsp) > 50  # noqa: E731
         filtered = self.qresult.hsp_filter(filter_func)
         self.assertEqual(0, len(filtered))
         self.assertTrue(isinstance(filtered, QueryResult))
@@ -728,7 +728,7 @@ class QueryResultCases(unittest.TestCase):
     def test_sort_key_ok(self):
         """Test QueryResult.sort, with custom key."""
         # if custom key is given, sort using it
-        key = lambda hit: len(hit)
+        key = lambda hit: len(hit)  # noqa: E731
         self.assertEqual([hit11, hit21, hit31], list(self.qresult.hits))
         self.qresult.sort(key=key)
         self.assertEqual([hit21, hit31, hit11], list(self.qresult.hits))
@@ -736,7 +736,7 @@ class QueryResultCases(unittest.TestCase):
     def test_sort_key_not_in_place_ok(self):
         """Test QueryResult.sort, with custom key, not in place."""
         # if custom key is given, sort using it
-        key = lambda hit: len(hit)
+        key = lambda hit: len(hit)  # noqa: E731
         self.assertEqual([hit11, hit21, hit31], list(self.qresult.hits))
         sorted_qresult = self.qresult.sort(key=key, in_place=False)
         self.assertEqual([hit21, hit31, hit11], list(sorted_qresult.hits))
@@ -950,7 +950,7 @@ class HitCases(unittest.TestCase):
         # filter should return a new QueryResult object (shallow copy),
         self.assertEqual([hsp111, hsp112, hsp113], self.hit.hsps)
         # filter func: min hsp length == 4
-        filter_func = lambda hsp: len(hsp[0]) >= 4
+        filter_func = lambda hsp: len(hsp[0]) >= 4  # noqa: E731
         filtered = self.hit.filter(filter_func)
         self.assertEqual([hsp111, hsp113], filtered.hsps)
         # make sure all remaining hits return True for the filter function
@@ -971,7 +971,7 @@ class HitCases(unittest.TestCase):
     def test_filter_no_filtered(self):
         """Test Hit.hit_filter, all hits filtered out."""
         # when the filter filters out all hits, it should return None
-        filter_func = lambda hsp: len(hsp[0]) > 50
+        filter_func = lambda hsp: len(hsp[0]) > 50  # noqa: E731
         filtered = self.hit.filter(filter_func)
         self.assertTrue(filtered is None)
 
@@ -1035,7 +1035,7 @@ class HitCases(unittest.TestCase):
         """Test Hit.sort."""
         self.assertEqual([hsp111, hsp112, hsp113], self.hit.hsps)
         # sort by hsp length
-        key = lambda batch_hsp: len(batch_hsp[0])
+        key = lambda batch_hsp: len(batch_hsp[0])  # noqa: E731
         self.hit.sort(key=key)
         self.assertEqual([hsp112, hsp113, hsp111], self.hit.hsps)
 
@@ -1043,7 +1043,7 @@ class HitCases(unittest.TestCase):
         """Test Hit.sort, not in place."""
         self.assertEqual([hsp111, hsp112, hsp113], self.hit.hsps)
         # sort by hsp length
-        key = lambda hsp: len(hsp[0])
+        key = lambda hsp: len(hsp[0])  # noqa: E731
         sorted_hit = self.hit.sort(key=key, in_place=False)
         self.assertEqual([hsp112, hsp113, hsp111], sorted_hit.hsps)
         self.assertEqual([hsp111, hsp112, hsp113], self.hit.hsps)

--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -196,7 +196,7 @@ tests = [("diff_ids", 2),
          ("trunc_at_qual", 4)]
 for base_name, good_count in tests:
     def funct(name, c):
-        f = lambda x: x.check_all_fail("Quality/error_%s.fastq" % name, c)
+        f = lambda x: x.check_all_fail("Quality/error_%s.fastq" % name, c)  # noqa: E731
         f.__doc__ = "Reject FASTQ with %s" % name.replace("_", " ")
         return f
     setattr(TestFastqErrors, "test_%s" % (base_name),
@@ -214,7 +214,7 @@ tests = [("del", 3, 5),
          ("null", 0, 5)]
 for base_name, good_count, full_count in tests:
     def funct(name, c1, c2):
-        f = lambda x: x.check_qual_char("Quality/error_qual_%s.fastq" % name, c1, c2)
+        f = lambda x: x.check_qual_char("Quality/error_qual_%s.fastq" % name, c1, c2)  # noqa: E731
         f.__doc__ = "Reject FASTQ with %s in quality" % name.replace("_", " ")
         return f
     setattr(TestFastqErrors, "test_qual_%s" % (base_name),
@@ -316,7 +316,7 @@ for base_name, variant in tests:
     assert variant in ["sanger", "solexa", "illumina"]
 
     def funct(bn, var):
-        f = lambda x: x.simple_check(bn, var)
+        f = lambda x: x.simple_check(bn, var)  # noqa: E731
         f.__doc__ = "Reference conversions of %s file %s" % (var, bn)
         return f
 

--- a/Tests/test_SeqIO_convert.py
+++ b/Tests/test_SeqIO_convert.py
@@ -188,7 +188,7 @@ for filename, format, alphabet in tests:
             continue
 
         def funct(fn, fmt1, fmt2, alpha):
-            f = lambda x: x.simple_check(fn, fmt1, fmt2, alpha)
+            f = lambda x: x.simple_check(fn, fmt1, fmt2, alpha)  # noqa: E731
             f.__doc__ = "Convert %s from %s to %s" % (fn, fmt1, fmt2)
             return f
 
@@ -233,7 +233,7 @@ for filename, format, alphabet in tests:
             continue
 
         def funct(fn, fmt1, fmt2, alpha):
-            f = lambda x: x.failure_check(fn, fmt1, fmt2, alpha)
+            f = lambda x: x.failure_check(fn, fmt1, fmt2, alpha)  # noqa: E731
             f.__doc__ = "Convert %s from %s to %s" % (fn, fmt1, fmt2)
             return f
 

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -516,16 +516,16 @@ class IndexDictTests(unittest.TestCase):
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore', BiopythonParserWarning)
                 rec_dict = SeqIO.index(filename, format, alphabet,
-                                       key_function=lambda x: x.lower())
+                                       key_function=lambda x: x.lower())  # noqa: E731
                 if sqlite3:
                     rec_dict_db = SeqIO.index_db(":memory:", filename, format, alphabet,
-                                                 key_function=lambda x: x.lower())
+                                                 key_function=lambda x: x.lower())  # noqa: E731
         else:
             rec_dict = SeqIO.index(filename, format, alphabet,
-                                   key_function=lambda x: x.lower())
+                                   key_function=lambda x: x.lower())  # noqa: E731
             if sqlite3:
                 rec_dict_db = SeqIO.index_db(":memory:", filename, format, alphabet,
-                                             key_function=lambda x: x.lower())
+                                             key_function=lambda x: x.lower())  # noqa: E731
 
         self.assertEqual(set(id_list), set(rec_dict))
         if sqlite3:
@@ -711,7 +711,7 @@ for filename1, format, alphabet in tests:
     for filename2, comp in tasks:
 
         def funct(fn, fmt, alpha, c):
-            f = lambda x: x.simple_check(fn, fmt, alpha, c)
+            f = lambda x: x.simple_check(fn, fmt, alpha, c)  # noqa: E731
             f.__doc__ = "Index %s file %s defaults" % (fmt, fn)
             return f
         setattr(IndexDictTests, "test_%s_%s_simple"
@@ -720,7 +720,7 @@ for filename1, format, alphabet in tests:
         del funct
 
         def funct(fn, fmt, alpha, c):
-            f = lambda x: x.key_check(fn, fmt, alpha, c)
+            f = lambda x: x.key_check(fn, fmt, alpha, c)  # noqa: E731
             f.__doc__ = "Index %s file %s with key function" % (fmt, fn)
             return f
         setattr(IndexDictTests, "test_%s_%s_keyf"
@@ -729,7 +729,7 @@ for filename1, format, alphabet in tests:
         del funct
 
         def funct(fn, fmt, alpha, c):
-            f = lambda x: x.get_raw_check(fn, fmt, alpha, c)
+            f = lambda x: x.get_raw_check(fn, fmt, alpha, c)  # noqa: E731
             f.__doc__ = "Index %s file %s get_raw" % (fmt, fn)
             return f
         setattr(IndexDictTests, "test_%s_%s_get_raw"

--- a/Tests/test_SeqIO_online.py
+++ b/Tests/test_SeqIO_online.py
@@ -86,7 +86,7 @@ for database, formats, entry, length, checksum in [
         ]:
 
     def funct(d, f, e, l, c):
-        method = lambda x: x.simple(d, f, e, l, c)
+        method = lambda x: x.simple(d, f, e, l, c)  # noqa: E731
         method.__doc__ = "Bio.Entrez.efetch(%r, id=%r, ...)" % (d, e)
         return method
 

--- a/Tests/test_SeqIO_write.py
+++ b/Tests/test_SeqIO_write.py
@@ -164,7 +164,7 @@ for (records, descr, errs) in test_records:
     for format in test_write_read_alignment_formats:
         # Assume no errors expected...
         def funct(records, format, descr):
-            f = lambda x: x.check(records, format)
+            f = lambda x: x.check(records, format)  # noqa: E731
             f.__doc__ = "%s for %s" % (format, descr)
             return f
         setattr(WriterTests,
@@ -174,7 +174,7 @@ for (records, descr, errs) in test_records:
         for err_formats, err_type, err_msg in errs:
             if format in err_formats:
                 def funct_e(records, format, descr, err_type, err_msg):
-                    f = lambda x: x.check_write_fails(
+                    f = lambda x: x.check_write_fails(  # noqa: E731
                         records,
                         format,
                         err_type,

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -409,21 +409,21 @@ class StringMethodTests(unittest.TestCase):
         # Calling (r)split should return a list of Seq-like objects, we'll
         # just apply str() to each of them so it matches the string method
         self._test_method("rstrip",
-                          pre_comp_function=lambda x: [str(y) for y in x])
+                          pre_comp_function=lambda x: [str(y) for y in x])  # noqa: E731
 
     def test_str_rsplit(self):
         """Check matches the python string rstrip method."""
         # Calling (r)split should return a list of Seq-like objects, we'll
         # just apply str() to each of them so it matches the string method
         self._test_method("rstrip",
-                          pre_comp_function=lambda x: [str(y) for y in x])
+                          pre_comp_function=lambda x: [str(y) for y in x])  # noqa: E731
 
     def test_str_lsplit(self):
         """Check matches the python string rstrip method."""
         # Calling (r)split should return a list of Seq-like objects, we'll
         # just apply str() to each of them so it matches the string method
         self._test_method("rstrip",
-                          pre_comp_function=lambda x: [str(y) for y in x])
+                          pre_comp_function=lambda x: [str(y) for y in x])  # noqa: E731
 
     def test_str_length(self):
         """Check matches the python string __len__ method."""

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -222,7 +222,7 @@ for latex in files:
 
         def funct(n, d, f):
             global tutorial_base
-            method = lambda x: None
+            method = lambda x: None  # noqa: E731
             if f:
                 p = os.path.join(tutorial_base, f)
                 method.__doc__ = "%s\n\n>>> import os\n>>> os.chdir(%r)\n%s\n" \

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -1189,9 +1189,9 @@ class TestPerSiteGapPenalties(unittest.TestCase):
         seq2 = "AABBBAAAACCCCAAAABBBAA"
         breaks = [0, 11, len(seq2)]
         # Very expensive to open a gap in seq1:
-        nogaps = lambda x, y: -2000 - y
+        nogaps = lambda x, y: -2000 - y  # noqa: E731
         # Very expensive to open a gap in seq2 unless it is in one of the allowed positions
-        specificgaps = lambda x, y: (-2 - y) if x in breaks else (-2000 - y)
+        specificgaps = lambda x, y: (-2 - y) if x in breaks else (-2000 - y)  # noqa: E731
         aligner = Align.PairwiseAligner()
         aligner.mode = 'global'
         aligner.match_score = 1
@@ -1231,9 +1231,9 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         seq2 = "AABBBAAAACCCCAAAABBBAA"
         breaks = [0, 3, len(seq2)]
         # Very expensive to open a gap in seq1:
-        nogaps = lambda x, y: -2000 - y
+        nogaps = lambda x, y: -2000 - y  # noqa: E731
         # Very expensive to open a gap in seq2 unless it is in one of the allowed positions:
-        specificgaps = lambda x, y: (-2 - y) if x in breaks else (-2000 - y)
+        specificgaps = lambda x, y: (-2 - y) if x in breaks else (-2000 - y)  # noqa: E731
         aligner = Align.PairwiseAligner()
         aligner.mode = 'global'
         aligner.match_score = 1
@@ -1365,9 +1365,9 @@ TTG--GAA
         seq2 = "AABBBAAAACCCCAAAABBBAA"
         breaks = [0, 11, len(seq2)]
         # Very expensive to open a gap in seq1:
-        nogaps = lambda x, y: -2000 - y
+        nogaps = lambda x, y: -2000 - y  # noqa: E731
         # Very expensive to open a gap in seq2 unless it is in one of the allowed positions
-        specificgaps = lambda x, y: (-2 - y) if x in breaks else (-2000 - y)
+        specificgaps = lambda x, y: (-2 - y) if x in breaks else (-2000 - y)  # noqa: E731
         aligner = Align.PairwiseAligner()
         aligner.mode = 'local'
         aligner.match_score = 1
@@ -1415,9 +1415,9 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         seq2 = "AABBBAAAACCCCAAAABBBAA"
         breaks = [0, 3, len(seq2)]
         # Very expensive to open a gap in seq1:
-        nogaps = lambda x, y: -2000 - y
+        nogaps = lambda x, y: -2000 - y  # noqa: E731
         # Very expensive to open a gap in seq2 unless it is in one of the allowed positions:
-        specificgaps = lambda x, y: (-2 - y) if x in breaks else (-2000 - y)
+        specificgaps = lambda x, y: (-2 - y) if x in breaks else (-2000 - y)  # noqa: E731
         aligner = Align.PairwiseAligner()
         aligner.mode = 'local'
         aligner.match_score = 1

--- a/Tests/test_phenotype.py
+++ b/Tests/test_phenotype.py
@@ -213,9 +213,9 @@ class TestPhenoMicro(unittest.TestCase):
         self.assertEqual(len(w), 384)
         self.assertEqual(max(w), (95.75, 217.0))
         self.assertEqual(min(w), (0.0, 37.0))
-        self.assertEqual(max(w, key=lambda x: x[1]),
+        self.assertEqual(max(w, key=lambda x: x[1]),  # noqa: E731
                          (16.75, 313.0))
-        self.assertEqual(min(w, key=lambda x: x[1]),
+        self.assertEqual(min(w, key=lambda x: x[1]),  # noqa: E731
                          (0.25, 29.0))
         self.assertEqual(len(w[:]), 96)
         self.assertEqual(w[1], 29.)
@@ -260,9 +260,9 @@ class TestPhenoMicro(unittest.TestCase):
         self.assertEqual(len(w2), 384)
         self.assertEqual(max(w2), (95.75, 327.0))
         self.assertEqual(min(w2), (0.0, 63.0))
-        self.assertEqual(max(w2, key=lambda x: x[1]),
+        self.assertEqual(max(w2, key=lambda x: x[1]),  # noqa: E731
                          (18.25, 357.0))
-        self.assertEqual(min(w2, key=lambda x: x[1]),
+        self.assertEqual(min(w2, key=lambda x: x[1]),  # noqa: E731
                          (0.25, 55.0))
         self.assertEqual(w2[1], 71.)
         self.assertEqual(w2[12], 316.)
@@ -284,9 +284,9 @@ class TestPhenoMicro(unittest.TestCase):
         self.assertEqual(len(w2), 384)
         self.assertEqual(max(w2), (95.75, 107.0))
         self.assertEqual(min(w2), (0.0, 11.0))
-        self.assertEqual(max(w2, key=lambda x: x[1]),
+        self.assertEqual(max(w2, key=lambda x: x[1]),  # noqa: E731
                          (15.75, 274.0))
-        self.assertEqual(min(w2, key=lambda x: x[1]),
+        self.assertEqual(min(w2, key=lambda x: x[1]),  # noqa: E731
                          (3.25, -20.0))
         self.assertEqual(w2[1], -13.)
         self.assertEqual(w2[12], 228.)


### PR DESCRIPTION
Like #2016 and #2017, this pull request is somewhat related to issue #883 / #2014 and the goal of having universal flake8 settings for the entire project.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
