### PR TITLE
Fix and enforce flake8 E402 + F405 in Tests (top level imports)

### DIFF
--- a/Bio/NaiveBayes.py
+++ b/Bio/NaiveBayes.py
@@ -30,7 +30,12 @@ Functions:
 
 from __future__ import print_function
 
-import numpy
+try:
+    import numpy
+except ImportError:
+    from Bio import MissingPythonDependencyError
+    raise MissingPythonDependencyError(
+        "Install NumPy if you want to use Bio.MaxEntropy.")
 
 
 def _contents(items):

--- a/Tests/.flake8
+++ b/Tests/.flake8
@@ -10,14 +10,13 @@ ignore =
     # These are ignored by default:
     E122,E123,E126,E241,W503,W504,
     # These are not ignored by default:
-    # E402	module level import not at top of file
     # E501	line too long (XX > 79 characters)
     # E731	do not assign a lambda expression, use a def
     # F401	module imported but unused
     # F405	name may be undefined, or defined from star imports: module
     # F841	local variable name is assigned to but never used
     # TODO: Fix some of these?
-    E402,E501,E731,F401,F405,F841,
+    E501,E731,F401,F405,F841,
     # =====================================
     # pydocstyle: D1## - Missing Docstrings
     # =====================================

--- a/Tests/.flake8
+++ b/Tests/.flake8
@@ -13,10 +13,9 @@ ignore =
     # E501	line too long (XX > 79 characters)
     # E731	do not assign a lambda expression, use a def
     # F401	module imported but unused
-    # F405	name may be undefined, or defined from star imports: module
     # F841	local variable name is assigned to but never used
     # TODO: Fix some of these?
-    E501,E731,F401,F405,F841,
+    E501,E731,F401,F841,
     # =====================================
     # pydocstyle: D1## - Missing Docstrings
     # =====================================

--- a/Tests/requires_wise.py
+++ b/Tests/requires_wise.py
@@ -5,15 +5,18 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
-from Bio import MissingExternalDependencyError
 import sys
+
+from Bio import MissingExternalDependencyError
+from Bio._py3k import getoutput
+
+
 if sys.platform == "win32":
     # Someone needs to find out if dnal works nicely on windows,
     # and if so where it is typically installed.
     raise MissingExternalDependencyError(
         "Don't know how to find the Wise2 tool dnal on Windows.")
 
-from Bio._py3k import getoutput
 not_found_types = ["command not found", "dnal: not found", "not recognized"]
 dnal_output = getoutput("dnal")
 

--- a/Tests/test_BioSQL_MySQLdb.py
+++ b/Tests/test_BioSQL_MySQLdb.py
@@ -7,7 +7,11 @@
 
 import unittest
 
-from common_BioSQL import *  # noqa
+# Really do want "import *" to get all the test clases:
+from common_BioSQL import *  # noqa: F403
+
+# Import these explicitly to avoid flake8 F405 below:
+from common_BioSQL import load_biosql_ini, check_config
 
 DBDRIVER = 'MySQLdb'
 DBTYPE = 'mysql'

--- a/Tests/test_BioSQL_MySQLdb_online.py
+++ b/Tests/test_BioSQL_MySQLdb_online.py
@@ -7,8 +7,13 @@
 
 import unittest
 
-from common_BioSQL import *  # noqa
-from common_BioSQL_online import *  # noqa
+# Really do want "import *" to get all the test clases:
+from common_BioSQL import *  # noqa: F403
+from common_BioSQL_online import *  # noqa: F403
+
+# Import these explicitly to avoid flake8 F405 below:
+from common_BioSQL import load_biosql_ini, check_config
+from common_BioSQL_online import share_config
 
 import requires_internet
 requires_internet.check()

--- a/Tests/test_BioSQL_mysql_connector.py
+++ b/Tests/test_BioSQL_mysql_connector.py
@@ -7,7 +7,12 @@
 
 import unittest
 
-from common_BioSQL import *  # noqa
+# Really do want "import *" to get all the test clases:
+from common_BioSQL import *  # noqa: F403
+
+# Import these explicitly to avoid flake8 F405 below:
+from common_BioSQL import load_biosql_ini, check_config
+
 
 DBDRIVER = 'mysql.connector'
 DBTYPE = 'mysql'

--- a/Tests/test_BioSQL_mysql_connector_online.py
+++ b/Tests/test_BioSQL_mysql_connector_online.py
@@ -7,8 +7,13 @@
 
 import unittest
 
-from common_BioSQL import *  # noqa
-from common_BioSQL_online import *  # noqa
+# Really do want "import *" to get all the test clases:
+from common_BioSQL import *  # noqa: F403
+from common_BioSQL_online import *  # noqa: F403
+
+# Import these explicitly to avoid flake8 F405 below:
+from common_BioSQL import load_biosql_ini, check_config
+from common_BioSQL_online import share_config
 
 import requires_internet
 requires_internet.check()

--- a/Tests/test_BioSQL_psycopg2.py
+++ b/Tests/test_BioSQL_psycopg2.py
@@ -7,7 +7,11 @@
 
 import unittest
 
-from common_BioSQL import *  # noqa
+# Really do want "import *" to get all the test clases:
+from common_BioSQL import *  # noqa: F403
+
+# Import these explicitly to avoid flake8 F405
+from common_BioSQL import load_biosql_ini, check_config
 
 DBDRIVER = 'psycopg2'
 DBTYPE = 'pg'

--- a/Tests/test_BioSQL_psycopg2_online.py
+++ b/Tests/test_BioSQL_psycopg2_online.py
@@ -7,8 +7,13 @@
 
 import unittest
 
-from common_BioSQL import *  # noqa
-from common_BioSQL_online import *  # noqa
+# Really do want "import *" to get all the test clases:
+from common_BioSQL import *  # noqa: F403
+from common_BioSQL_online import *  # noqa: F403
+
+# Import these explicitly to avoid flake8 F405 below:
+from common_BioSQL import load_biosql_ini, check_config
+from common_BioSQL_online import share_config
 
 import requires_internet
 requires_internet.check()

--- a/Tests/test_BioSQL_sqlite3.py
+++ b/Tests/test_BioSQL_sqlite3.py
@@ -11,7 +11,11 @@ import unittest
 from Bio import SeqIO
 from BioSQL import BioSeqDatabase
 
-from common_BioSQL import *  # noqa
+# Really do want "import *" to get all the test clases:
+from common_BioSQL import *  # noqa: F403
+
+# Import these explicitly to avoid flake8 F405 below:
+from common_BioSQL import load_biosql_ini, check_config, compare_records, temp_db_filename
 
 # Constants for the database driver
 DBDRIVER = 'sqlite3'

--- a/Tests/test_BioSQL_sqlite3_online.py
+++ b/Tests/test_BioSQL_sqlite3_online.py
@@ -7,8 +7,13 @@
 
 import unittest
 
-from common_BioSQL import *  # noqa
-from common_BioSQL_online import *  # noqa
+# Really do want "import *" to get all the test clases:
+from common_BioSQL import *  # noqa: F403
+from common_BioSQL_online import *  # noqa: F403
+
+# Import these explicitly to avoid flake8 F405 below
+from common_BioSQL import load_biosql_ini, check_config, temp_db_filename
+from common_BioSQL_online import share_config
 
 import requires_internet
 requires_internet.check()

--- a/Tests/test_ClustalOmega_tool.py
+++ b/Tests/test_ClustalOmega_tool.py
@@ -5,11 +5,13 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
-from Bio import MissingExternalDependencyError
-
 import sys
 import os
 import unittest
+
+from Bio._py3k import getoutput
+
+from Bio import MissingExternalDependencyError
 from Bio import SeqIO
 from Bio import AlignIO
 from Bio.Align.Applications import ClustalOmegaCommandline
@@ -21,7 +23,6 @@ from Bio.Application import ApplicationError
 os.environ['LANG'] = 'C'
 
 clustalo_exe = None
-from Bio._py3k import getoutput
 try:
     output = getoutput("clustalo --help")
     if output.startswith("Clustal Omega"):

--- a/Tests/test_Entrez_parser.py
+++ b/Tests/test_Entrez_parser.py
@@ -9,6 +9,12 @@
 import unittest
 import sys
 import os
+
+from io import BytesIO
+
+from Bio._py3k import StringIO
+from Bio import Entrez
+
 if os.name == 'java':
     try:
         from xml.parsers.expat import XML_PARAM_ENTITY_PARSING_ALWAYS
@@ -17,10 +23,6 @@ if os.name == 'java':
         from Bio import MissingPythonDependencyError
         raise MissingPythonDependencyError("The Bio.Entrez XML parser fails on "
                                            "Jython, see http://bugs.jython.org/issue1447")
-
-from io import BytesIO
-from Bio._py3k import StringIO
-from Bio import Entrez
 
 
 class GeneralTests(unittest.TestCase):

--- a/Tests/test_ExPASy.py
+++ b/Tests/test_ExPASy.py
@@ -7,9 +7,6 @@
 
 import unittest
 
-import requires_internet
-requires_internet.check()
-
 # We want to test these:
 from Bio import ExPASy
 
@@ -17,8 +14,11 @@ from Bio import ExPASy
 from Bio.ExPASy import Prodoc
 from Bio.ExPASy import Prosite
 
+import requires_internet
+requires_internet.check()
 
 # TODO - Use with statement when drop Python 2
+
 
 class ExPASyOnlineTests(unittest.TestCase):
     """Test ExPASy online resources."""

--- a/Tests/test_HMMCasino.py
+++ b/Tests/test_HMMCasino.py
@@ -19,15 +19,8 @@ loaded dice is .05 and the probability of switching from loaded to fair is
 
 from __future__ import print_function
 
-import os
-if os.name == 'java':
-    from Bio import MissingExternalDependencyError
-    # This is a slight miss-use of MissingExternalDependencyError,
-    # but it will do in the short term to skip this unit test on Jython
-    raise MissingExternalDependencyError("This test can cause a fatal error "
-                                         "on Jython with some versions of Java")
-
 # standard modules
+import os
 import random
 
 # biopython
@@ -39,6 +32,15 @@ from Bio.Seq import Seq
 from Bio.HMM import MarkovModel
 from Bio.HMM import Trainer
 from Bio.HMM import Utilities
+
+
+if os.name == 'java':
+    from Bio import MissingExternalDependencyError
+    # This is a slight miss-use of MissingExternalDependencyError,
+    # but it will do in the short term to skip this unit test on Jython
+    raise MissingExternalDependencyError("This test can cause a fatal error "
+                                         "on Jython with some versions of Java")
+
 
 # whether we should print everything out. Set this to zero for
 # regression testing

--- a/Tests/test_KGML_graphics_online.py
+++ b/Tests/test_KGML_graphics_online.py
@@ -12,9 +12,6 @@ from __future__ import with_statement
 import os
 import unittest
 
-import requires_internet
-requires_internet.check()
-
 # Biopython
 from Bio.Graphics.ColorSpiral import ColorSpiral
 
@@ -42,6 +39,9 @@ from Bio.Graphics.KGML_vis import KGMLCanvas
 
 # test_KGML_graphics module
 from test_KGML_graphics import PathwayData
+
+import requires_internet
+requires_internet.check()
 
 
 class KGMLPathwayOnlineTest(unittest.TestCase):

--- a/Tests/test_NaiveBayes.py
+++ b/Tests/test_NaiveBayes.py
@@ -8,13 +8,9 @@ import unittest
 
 from Bio import NaiveBayes
 
-
-try:
-    import numpy
-except ImportError:
-    from Bio import MissingPythonDependencyError
-    raise MissingPythonDependencyError(
-        "Install NumPy if you want to use Bio.NaiveBayes.")
+# Importing NaiveBayes will itself raise MissingPythonDependencyError
+# if NumPy is unavailable.
+import numpy
 try:
     hash(numpy.float64(123.456))
 except TypeError:

--- a/Tests/test_NaiveBayes.py
+++ b/Tests/test_NaiveBayes.py
@@ -6,6 +6,9 @@
 import copy
 import unittest
 
+from Bio import NaiveBayes
+
+
 try:
     import numpy
 except ImportError:
@@ -22,8 +25,6 @@ except TypeError:
         "Please update NumPy if you want to use Bio.NaiveBayes "
         "(under this version numpy.float64 is unhashable).")
 del numpy
-
-from Bio import NaiveBayes
 
 
 class CarTest(unittest.TestCase):

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -12,11 +12,11 @@ import shutil
 import tempfile
 import unittest
 
-import requires_internet
-requires_internet.check()
-
 # We want to test this module:
 from Bio.PDB.PDBList import PDBList
+
+import requires_internet
+requires_internet.check()
 
 
 class TestPBDListGetList(unittest.TestCase):

--- a/Tests/test_PDB_ResidueDepth.py
+++ b/Tests/test_PDB_ResidueDepth.py
@@ -15,8 +15,8 @@ from Bio.PDB import PDBParser, ResidueDepth
 from Bio import MissingExternalDependencyError
 from Bio.PDB.PDBExceptions import PDBConstructionWarning
 
-msms_exe = None
 from Bio._py3k import getoutput
+msms_exe = None
 try:
     output = getoutput("msms -h")
     if output.startswith("Usage : msms parameters"):

--- a/Tests/test_SCOP_online.py
+++ b/Tests/test_SCOP_online.py
@@ -7,10 +7,10 @@
 
 import unittest
 
+from Bio import SCOP
+
 import requires_internet
 requires_internet.check()
-
-from Bio import SCOP
 
 
 class ScopSearch(unittest.TestCase):

--- a/Tests/test_SeqIO_online.py
+++ b/Tests/test_SeqIO_online.py
@@ -16,9 +16,6 @@ Goals:
 """
 import unittest
 
-import requires_internet
-requires_internet.check()
-
 # We want to test these:
 from Bio import Entrez
 from Bio import ExPASy
@@ -30,6 +27,9 @@ from Bio.SeqUtils.CheckSum import seguid
 
 from Bio.File import UndoHandle
 from Bio._py3k import _as_string
+
+import requires_internet
+requires_internet.check()
 
 # This lets us set the email address to be sent to NCBI Entrez:
 Entrez.email = "biopython@biopython.org"

--- a/Tests/test_TogoWS.py
+++ b/Tests/test_TogoWS.py
@@ -12,9 +12,6 @@ import unittest
 from Bio._py3k import StringIO
 from Bio._py3k import HTTPError
 
-import requires_internet
-requires_internet.check()
-
 # We want to test these:
 from Bio import TogoWS
 
@@ -22,6 +19,9 @@ from Bio import TogoWS
 from Bio import SeqIO
 from Bio.SeqUtils.CheckSum import seguid
 from Bio import Medline
+
+import requires_internet
+requires_internet.check()
 
 #####################################################################
 

--- a/Tests/test_Uniprot.py
+++ b/Tests/test_Uniprot.py
@@ -12,15 +12,17 @@ import unittest
 from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord
 
+from seq_tests_common import compare_reference, compare_record
+
+
 # Left as None if the import within UniProtIO fails
 if SeqIO.UniprotIO.ElementTree is None:
     from Bio import MissingPythonDependencyError
+    # TODO: Can this fail on Python 2.7 onwards?
     raise MissingPythonDependencyError("No ElementTree module was found. "
                                        "Use Python 2.5+, lxml or elementtree "
                                        "if you want to use "
                                        "Bio.SeqIO.UniprotIO.")
-
-from seq_tests_common import compare_reference, compare_record
 
 
 class TestUniprot(unittest.TestCase):

--- a/Tests/test_Wise.py
+++ b/Tests/test_Wise.py
@@ -7,13 +7,13 @@ import doctest
 import sys
 import unittest
 
-if 'requires_wise' in sys.modules:
-    del sys.modules['requires_wise']
-import requires_wise
-
 from Bio._py3k import StringIO
 
 from Bio import Wise
+
+if 'requires_wise' in sys.modules:
+    del sys.modules['requires_wise']
+import requires_wise  # noqa: E402
 
 
 class TestWiseDryRun(unittest.TestCase):

--- a/Tests/test_phyml_tool.py
+++ b/Tests/test_phyml_tool.py
@@ -9,6 +9,8 @@ import sys
 import os
 import unittest
 
+from Bio._py3k import getoutput
+
 from Bio import Phylo
 from Bio.Phylo.Applications import PhymlCommandline
 from Bio import MissingExternalDependencyError
@@ -18,7 +20,6 @@ os.environ['LANG'] = 'C'
 
 phyml_exe = None
 exe_name = "PhyML-3.1_win32.exe" if sys.platform == "win32" else "phyml"
-from Bio._py3k import getoutput
 try:
     output = getoutput(exe_name + " --version")
     if "not found" not in output and ("20" in output or "PhyML" in output):

--- a/Tests/test_psw.py
+++ b/Tests/test_psw.py
@@ -8,11 +8,11 @@ import unittest
 import random
 import sys
 
+from Bio.Wise import psw
+
 if 'requires_wise' in sys.modules:
     del sys.modules['requires_wise']
-import requires_wise
-
-from Bio.Wise import psw
+import requires_wise  # noqa: E402
 
 
 class TestPSW(unittest.TestCase):

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -8,16 +8,6 @@ import copy
 import sys
 import warnings
 
-# Remove unittest2 import after dropping support for Python 2
-if sys.version_info[0] < 3:
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        from Bio import MissingPythonDependencyError
-        raise MissingPythonDependencyError("Under Python 2 this test needs the unittest2 library")
-else:
-    import unittest
-
 from Bio import BiopythonWarning
 from Bio import Alphabet
 from Bio import Seq
@@ -28,6 +18,15 @@ from Bio.Data.IUPACData import (ambiguous_dna_complement,
 from Bio.Data.CodonTable import TranslationError, standard_dna_table
 from Bio.Seq import MutableSeq
 
+# Remove unittest2 import after dropping support for Python 2
+if sys.version_info[0] < 3:
+    try:
+        import unittest2 as unittest
+    except ImportError:
+        from Bio import MissingPythonDependencyError
+        raise MissingPythonDependencyError("Under Python 2 this test needs the unittest2 library")
+else:
+    import unittest
 
 if sys.version_info[0] == 3:
     array_indicator = "u"


### PR DESCRIPTION
Like #2016, #2017 and #2019, this pull request is somewhat related to issue #883 / #2014 and the goal of having universal flake8 settings for the entire project.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
