### PR TITLE
Fix use of flake8-bugbear on TravisCI

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -99,7 +99,7 @@ deps =
     flake8-docstrings
     flake8-blind-except
     flake8-rst-docstrings
-    py34,py35,py36: flake8-bugbear
+    flake8-bugbear;python_version>="3.5"
     restructuredtext_lint
     doc8
 commands =

--- a/Bio/.flake8
+++ b/Bio/.flake8
@@ -40,9 +40,7 @@ ignore =
     #     	it is not any safer than normal property access.
     # B010	Do not call setattr with a constant attribute value,
     #     	it is not any safer than normal property access.
-    # B011	Do not call assert False since python -O removes these calls.
-    #     	Instead callers should raise AssertionError().
-    B007,B009,B010,B011,
+    B007,B009,B010,
     # ================================================
     # flake8-commas: C#### (in case installed locally)
     # ================================================

--- a/Tests/.flake8
+++ b/Tests/.flake8
@@ -46,9 +46,7 @@ ignore =
     #     	it is not any safer than normal property access.
     # B010	Do not call setattr with a constant attribute value,
     #     	it is not any safer than normal property access.
-    # B011	Do not call assert False since python -O removes these calls.
-    #     	Instead callers should raise AssertionError().
-    B007,B009,B010,B011,
+    B007,B009,B010,
     # =========================================
     # flake8-commas (in case installed locally)
     # =========================================


### PR DESCRIPTION
This pull request addresses issue #2025, noticed as part of #2015.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
