### PR TITLE
Fix and enforce flake8 D202 on Tests/

### DIFF
--- a/Tests/.flake8
+++ b/Tests/.flake8
@@ -32,9 +32,6 @@ ignore =
     # ====================================
     # pydocstyle: D2## - Whitespace Issues
     # ====================================
-    # D202	No blank lines allowed after function docstring
-    # TODO: Fix this:
-    D202,
     # We ignore D203 deliberately in favour of passing D211,
     D203,
     # ====================

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -138,7 +138,6 @@ def _do_db_cleanup():
 
     Relevant for MySQL and PostgreSQL.
     """
-
     if DBDRIVER in ["psycopg2", "pgdb"]:
         # first open a connection the database
         # notice that postgres doesn't have createdb privileges, so

--- a/Tests/test_Clustalw_tool.py
+++ b/Tests/test_Clustalw_tool.py
@@ -235,7 +235,6 @@ class ClustalWTestNormalConditions(ClustalWTestCase):
 
     def test_large_input_file(self):
         """Test a large input file."""
-
         # Create a large input file by converting another example file
         # (See Bug 2804, this will produce so much output on stdout that
         # subprocess could suffer a deadlock and hang).  Using all the

--- a/Tests/test_Emboss.py
+++ b/Tests/test_Emboss.py
@@ -859,7 +859,6 @@ class TranslationTests(unittest.TestCase):
 
     def test_simple(self):
         """Run transeq vs Bio.Seq for simple translations (including alt tables)."""
-
         examples = [Seq("ACGTGACTGACGTAGCATGCCACTAGG"),
                     # Unamibguous TA? codons:
                     Seq("TAATACTATTAG", generic_dna),

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -252,7 +252,6 @@ KEYWORDS    """ in gb, gb)
 
     def test_qualifier_escaping_read(self):
         """Check qualifier escaping is preserved when parsing."""
-
         # Make sure parsing improperly escaped qualifiers raises a warning
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
@@ -276,7 +275,6 @@ KEYWORDS    """ in gb, gb)
 
     def test_qualifier_escaping_write(self):
         """Check qualifier escaping is preserved when writing."""
-
         # Write some properly escaped qualifiers and test
         genbank_out = "GenBank/qualifier_escaping_write.gb"
         record = SeqIO.read(genbank_out, "gb")
@@ -344,7 +342,6 @@ KEYWORDS    """ in gb, gb)
 
     def test_genbank_date_default(self):
         """Check if default date is handled correctly."""
-
         sequence_object = Seq("ATGC", generic_dna)
         # check if default value is inserted correctly
         record = SeqRecord(sequence_object,
@@ -359,7 +356,6 @@ KEYWORDS    """ in gb, gb)
 
     def test_genbank_date_correct(self):
         """Check if user provided date is inserted correctly."""
-
         sequence_object = Seq("ATGC", generic_dna)
         record = SeqRecord(sequence_object,
                            id='123456789',
@@ -374,7 +370,6 @@ KEYWORDS    """ in gb, gb)
 
     def test_genbank_date_list(self):
         """Check if date lists are handled correctly."""
-
         sequence_object = Seq("ATGC", generic_dna)
         record = SeqRecord(sequence_object,
                            id='123456789',
@@ -400,7 +395,6 @@ KEYWORDS    """ in gb, gb)
 
     def test_genbank_date_datetime(self):
         """Check if datetime objects are handled correctly."""
-
         sequence_object = Seq("ATGC", generic_dna)
         record = SeqRecord(sequence_object,
                            id='123456789',
@@ -415,7 +409,6 @@ KEYWORDS    """ in gb, gb)
 
     def test_genbank_date_invalid(self):
         """Check if invalid dates are treated as default."""
-
         invalid_dates = ("invalid date",
                          "29-2-1981",
                          "35-1-2018",
@@ -696,7 +689,6 @@ class GenBankScannerTests(unittest.TestCase):
 
     def gb_to_l_cds_f(self, filename, tags2id=None):
         """Gb file to Seq list parse CDS features."""
-
         with open(filename) as handle:
             if tags2id:
                 l_cds_f = list(self.gb_s.parse_cds_features(handle, tags2id=tags2id))
@@ -706,14 +698,12 @@ class GenBankScannerTests(unittest.TestCase):
 
     def gb_to_l_r(self, filename, do_features=False):
         """Gb file to Seq list parse records."""
-
         with open(filename) as handle:
             l_gb_r = list(self.gb_s.parse_records(handle, do_features=do_features))
         return l_gb_r
 
     def test_genbank_cds_interaction(self):
         """Test CDS interaction, parse CDS features on gb(k) files."""
-
         # Test parse CDS features on NC_000932.gb
         l_cds_f = self.gb_to_l_cds_f("GenBank/NC_000932.gb")
         # number of records, should be 85
@@ -747,7 +737,6 @@ class GenBankScannerTests(unittest.TestCase):
 
     def test_genbank_interaction(self):
         """Test GenBank records interaction on gbk files."""
-
         # Test parse records, on NC_005816, do_features False
         l_r = self.gb_to_l_r("GenBank/NC_005816.gb", do_features=False)
         # number of records, should be 1
@@ -792,7 +781,6 @@ class GenBankScannerTests(unittest.TestCase):
 
     def test_embl_cds_interaction(self):
         """Test EMBL CDS interaction, parse CDS features on embl files."""
-
         embl_s = Scanner.EmblScanner()
 
         # Test parse CDS features on embl_file
@@ -806,7 +794,6 @@ class GenBankScannerTests(unittest.TestCase):
 
     def test_embl_record_interaction(self):
         """Test EMBL Record interaction on embl files."""
-
         embl_s = Scanner.EmblScanner()
 
         #  Test parse records on embl_file

--- a/Tests/test_MSAProbs_tool.py
+++ b/Tests/test_MSAProbs_tool.py
@@ -45,7 +45,6 @@ class MSAProbsTestCase(unittest.TestCase):
 
     def standard_test_procedure(self, cline):
         """Shared testing procedure used by all tests."""
-
         # Mark output files for later cleanup.
         self.add_file_to_clean(cline.outfile)
 

--- a/Tests/test_MafIO_index.py
+++ b/Tests/test_MafIO_index.py
@@ -287,7 +287,6 @@ if sqlite3:
 
         def test_correct_retrieval_1(self):
             """Correct retrieval of Cnksr3 in mouse."""
-
             search = self.idx.search((3014742, 3018161), (3015028, 3018644))
             results = [x for x in search]
 

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -547,7 +547,6 @@ class ParseTest(unittest.TestCase):
     # Tests for sorting methods
     def test_comparison_entities(self):
         """Test comparing and sorting the several SMCRA objects."""
-
         struct = self.structure
         # Test deepcopy of a structure with disordered atoms
         struct2 = deepcopy(struct)

--- a/Tests/test_PDB_MMCIFParser.py
+++ b/Tests/test_PDB_MMCIFParser.py
@@ -38,7 +38,6 @@ class ParseReal(unittest.TestCase):
 
     def test_parsers(self):
         """Extract polypeptides from 1A80."""
-
         parser = MMCIFParser()
         fast_parser = FastMMCIFParser()
 
@@ -170,7 +169,6 @@ class ParseReal(unittest.TestCase):
 
     def testModels(self):
         """Test file with multiple models."""
-
         parser = MMCIFParser(QUIET=1)
         f_parser = FastMMCIFParser(QUIET=1)
         with warnings.catch_warnings():
@@ -310,7 +308,6 @@ class CIFtoPDB(unittest.TestCase):
 
     def test_conversion(self):
         """Parse 1A8O.cif, write 1A8O.pdb, parse again and compare."""
-
         cif_parser = MMCIFParser(QUIET=1)
         cif_struct = cif_parser.get_structure("example", "PDB/1LCD.cif")
 

--- a/Tests/test_RCSBFormats.py
+++ b/Tests/test_RCSBFormats.py
@@ -47,7 +47,6 @@ class CompareStructures(unittest.TestCase):
 
     def test_compare_models(self):
         """Compared parsed models."""
-
         cif_models = [(m.id, len(m.child_list)) for m in self.cifo.get_models()]
         pdb_models = [(m.id, len(m.child_list)) for m in self.pdbo.get_models()]
 
@@ -57,7 +56,6 @@ class CompareStructures(unittest.TestCase):
 
     def test_compare_chains(self):
         """Compare parsed chains."""
-
         cif_chains = [(c.id, len(c.child_list)) for c in self.cifo.get_chains()]
         pdb_chains = [(c.id, len(c.child_list)) for c in self.pdbo.get_chains()]
 

--- a/Tests/test_SearchIO_blast_text.py
+++ b/Tests/test_SearchIO_blast_text.py
@@ -43,7 +43,6 @@ class BlastnCases(BaseBlastCases):
 
     def test_text_2226_blastn_001(self):
         """Test parsing blastn output (text_2226_blastn_001.txt)."""
-
         blast_file = get_file('text_2226_blastn_001.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -61,7 +60,6 @@ class BlastnCases(BaseBlastCases):
 
     def test_text_2226_blastn_002(self):
         """Test parsing blastn output (text_2226_blastn_002.txt)."""
-
         blast_file = get_file('text_2226_blastn_002.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -137,7 +135,6 @@ class BlastnCases(BaseBlastCases):
 
     def test_text_2226_blastn_003(self):
         """Test parsing blastn output (text_2226_blastn_003.txt)."""
-
         blast_file = get_file('text_2226_blastn_003.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -236,7 +233,6 @@ class BlastnCases(BaseBlastCases):
 
     def test_text_2226_blastn_004(self):
         """Test parsing blastn output (text_2226_blastn_004.txt)."""
-
         blast_file = get_file('text_2226_blastn_004.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(3, len(qresults))
@@ -416,7 +412,6 @@ class BlastpCases(BaseBlastCases):
 
     def test_text_2226_blastp_001(self):
         """Test parsing blastp output (text_2226_blastp_001.txt)."""
-
         blast_file = get_file('text_2226_blastp_001.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -434,7 +429,6 @@ class BlastpCases(BaseBlastCases):
 
     def test_text_2226_blastp_002(self):
         """Test parsing blastp output (text_2226_blastp_002.txt)."""
-
         blast_file = get_file('text_2226_blastp_002.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -510,7 +504,6 @@ class BlastpCases(BaseBlastCases):
 
     def test_text_2226_blastp_003(self):
         """Test parsing blastp output (text_2226_blastp_003.txt)."""
-
         blast_file = get_file('text_2226_blastp_003.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -632,7 +625,6 @@ class BlastpCases(BaseBlastCases):
 
     def test_text_2226_blastp_004(self):
         """Test parsing blastp output (text_2226_blastp_004.txt)."""
-
         blast_file = get_file('text_2226_blastp_004.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(3, len(qresults))
@@ -835,7 +827,6 @@ class BlastxCases(BaseBlastCases):
 
     def test_text_2226_blastx_001(self):
         """Test parsing blastx output (text_2226_blastx_001.txt)."""
-
         blast_file = get_file('text_2226_blastx_001.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -853,7 +844,6 @@ class BlastxCases(BaseBlastCases):
 
     def test_text_2226_blastx_002(self):
         """Test parsing blastx output (text_2226_blastx_002.txt)."""
-
         blast_file = get_file('text_2226_blastx_002.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -929,7 +919,6 @@ class BlastxCases(BaseBlastCases):
 
     def test_text_2226_blastx_003(self):
         """Test parsing blastx output (text_2226_blastx_003.txt)."""
-
         blast_file = get_file('text_2226_blastx_003.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -1051,7 +1040,6 @@ class BlastxCases(BaseBlastCases):
 
     def test_text_2226_blastx_004(self):
         """Test parsing blastx output (text_2226_blastx_004.txt)."""
-
         blast_file = get_file('text_2226_blastx_004.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(2, len(qresults))
@@ -1186,7 +1174,6 @@ class TblastnCases(BaseBlastCases):
 
     def test_text_2226_tblastn_001(self):
         """Test parsing tblastn output (text_2226_tblastn_001.txt)."""
-
         blast_file = get_file('text_2226_tblastn_001.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -1204,7 +1191,6 @@ class TblastnCases(BaseBlastCases):
 
     def test_text_2226_tblastn_002(self):
         """Test parsing tblastn output (text_2226_tblastn_002.txt)."""
-
         blast_file = get_file('text_2226_tblastn_002.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -1280,7 +1266,6 @@ class TblastnCases(BaseBlastCases):
 
     def test_text_2226_tblastn_003(self):
         """Test parsing tblastn output (text_2226_tblastn_003.txt)."""
-
         blast_file = get_file('text_2226_tblastn_003.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -1402,7 +1387,6 @@ class TblastnCases(BaseBlastCases):
 
     def test_text_2226_tblastn_004(self):
         """Test parsing tblastn output (text_2226_tblastn_004.txt)."""
-
         blast_file = get_file('text_2226_tblastn_004.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(3, len(qresults))
@@ -1605,7 +1589,6 @@ class TblastxCases(BaseBlastCases):
 
     def test_text_2226_tblastx_001(self):
         """Test parsing tblastx output (text_2226_tblastx_001.txt)."""
-
         blast_file = get_file('text_2226_tblastx_001.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -1623,7 +1606,6 @@ class TblastxCases(BaseBlastCases):
 
     def test_text_2226_tblastx_002(self):
         """Test parsing tblastx output (text_2226_tblastx_002.txt)."""
-
         blast_file = get_file('text_2226_tblastx_002.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -1699,7 +1681,6 @@ class TblastxCases(BaseBlastCases):
 
     def test_text_2226_tblastx_003(self):
         """Test parsing tblastx output (text_2226_tblastx_003.txt)."""
-
         blast_file = get_file('text_2226_tblastx_003.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -1821,7 +1802,6 @@ class TblastxCases(BaseBlastCases):
 
     def test_text_2226_tblastx_004(self):
         """Test parsing tblastx output (text_2226_tblastx_004.txt)."""
-
         blast_file = get_file('text_2226_tblastx_004.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(2, len(qresults))
@@ -1950,7 +1930,6 @@ class TblastxCases(BaseBlastCases):
 
     def test_text_2230_blastp_001(self):
         """Test parsing blastp output (text_2230_blastp_001.txt)."""
-
         blast_file = get_file('text_2230_blastp_001.txt')
         qresults = list(parse(blast_file, FMT))
         self.assertEqual(1, len(qresults))

--- a/Tests/test_SearchIO_exonerate.py
+++ b/Tests/test_SearchIO_exonerate.py
@@ -69,7 +69,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_m_affine_local(self):
         """Test parsing exonerate output (exn_22_m_affine_local.exn)."""
-
         exn_file = get_file('exn_22_m_affine_local.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -174,7 +173,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_m_cdna2genome(self):
         """Test parsing exonerate output (exn_22_m_cdna2genome.exn)."""
-
         exn_file = get_file('exn_22_m_cdna2genome.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -282,7 +280,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_m_coding2coding(self):
         """Test parsing exonerate output (exn_22_m_coding2coding.exn)."""
-
         exn_file = get_file('exn_22_m_coding2coding.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -382,7 +379,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_m_coding2genome(self):
         """Test parsing exonerate output (exn_22_m_coding2genome.exn)."""
-
         exn_file = get_file('exn_22_m_coding2genome.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -482,7 +478,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_m_dna2protein(self):
         """Test parsing exonerate output (exn_22_m_dna2protein.exn)."""
-
         exn_file = get_file('exn_22_m_dna2protein.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -520,7 +515,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_m_est2genome(self):
         """Test parsing exonerate output (exn_22_m_est2genome.exn)."""
-
         exn_file = get_file('exn_22_m_est2genome.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -633,7 +627,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_m_genome2genome(self):
         """Test parsing exonerate output (exn_22_m_genome2genome.exn)."""
-
         exn_file = get_file('exn_22_m_genome2genome.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -772,7 +765,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_m_ungapped(self):
         """Test parsing exonerate output (exn_22_m_ungapped.exn)."""
-
         exn_file = get_file('exn_22_m_ungapped.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -872,7 +864,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_m_ungapped_trans(self):
         """Test parsing exonerate output (exn_22_m_ungapped_trans.exn)."""
-
         exn_file = get_file('exn_22_m_ungapped_trans.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -967,7 +958,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_m_ner(self):
         """Test parsing exonerate output (exn_22_m_ner.exn)."""
-
         exn_file = get_file('exn_22_m_ner.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -1065,7 +1055,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_q_multiple(self):
         """Test parsing exonerate output (exn_22_q_multiple.exn)."""
-
         exn_file = get_file('exn_22_q_multiple.exn')
         qresults = list(parse(exn_file, self.fmt))
         self.assertEqual(2, len(qresults))
@@ -1267,7 +1256,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_m_coding2coding_fshifts(self):
         """Test parsing exonerate output (exn_22_m_coding2coding_fshifts.exn)."""
-
         exn_file = get_file('exn_22_m_coding2coding_fshifts.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -1347,7 +1335,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_m_protein2dna_fshifts(self):
         """Test parsing exonerate output (exn_22_m_protein2dna_fshifts.exn)."""
-
         exn_file = get_file('exn_22_m_protein2dna_fshifts.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -1420,7 +1407,6 @@ class ExonerateTextCases(unittest.TestCase):
 
     def test_exn_22_m_protein2genome(self):
         """Test parsing exonerate output (exn_22_m_protein2genome.exn)."""
-
         exn_file = get_file('exn_22_m_protein2genome.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -1501,7 +1487,6 @@ class ExonerateVulgarCases(unittest.TestCase):
 
     def test_exn_22_o_vulgar(self):
         """Test parsing exonerate output (exn_22_o_vulgar.exn)."""
-
         exn_file = get_file('exn_22_o_vulgar.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -1590,7 +1575,6 @@ class ExonerateVulgarCases(unittest.TestCase):
 
     def test_exn_22_o_vulgar_fshifts(self):
         """Test parsing exonerate output (exn_22_o_vulgar_fshifts.exn)."""
-
         exn_file = get_file('exn_22_o_vulgar_fshifts.exn')
         qresult = read(exn_file, self.fmt)
 
@@ -1646,7 +1630,6 @@ class ExonerateCigarCases(unittest.TestCase):
 
     def test_exn_22_o_vulgar_cigar(self):
         """Test parsing exonerate output (exn_22_o_vulgar_cigar.exn)."""
-
         exn_file = get_file('exn_22_o_vulgar_cigar.exn')
         qresult = read(exn_file, self.fmt)
 

--- a/Tests/test_SearchIO_fasta_m10.py
+++ b/Tests/test_SearchIO_fasta_m10.py
@@ -25,7 +25,6 @@ class Fasta34Cases(unittest.TestCase):
 
     def test_output002(self):
         """Test parsing fasta34 output (output002.m10)."""
-
         m10_file = get_file('output002.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(3, len(qresults))
@@ -225,7 +224,6 @@ class Fasta34Cases(unittest.TestCase):
 
     def test_output003(self):
         """Test parsing fasta34 output (output003.m10)."""
-
         m10_file = get_file('output003.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(5, len(qresults))
@@ -370,7 +368,6 @@ class Fasta35Cases(unittest.TestCase):
 
     def test_output001(self):
         """Test parsing fasta35 output (output001.m10)."""
-
         m10_file = get_file('output001.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(3, len(qresults))
@@ -518,7 +515,6 @@ class Fasta35Cases(unittest.TestCase):
 
     def test_output004(self):
         """Test parsing fasta35 output (output004.m10)."""
-
         m10_file = get_file('output004.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(3, len(qresults))
@@ -587,7 +583,6 @@ class Fasta35Cases(unittest.TestCase):
 
     def test_output005(self):
         """Test parsing ssearch35 output (output005.m10)."""
-
         m10_file = get_file('output005.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(3, len(qresults))
@@ -655,7 +650,6 @@ class Fasta35Cases(unittest.TestCase):
 
     def test_output006(self):
         """Test parsing fasta35 output (output006.m10)."""
-
         m10_file = get_file('output006.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -707,7 +701,6 @@ class Fasta36Cases(unittest.TestCase):
 
     def test_output007(self):
         """Test parsing fasta36 output (output007.m10)."""
-
         m10_file = get_file('output007.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(3, len(qresults))
@@ -985,7 +978,6 @@ class Fasta36Cases(unittest.TestCase):
 
     def test_output008(self):
         """Test parsing tfastx36 output (output008.m10)."""
-
         m10_file = get_file('output008.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(4, len(qresults))
@@ -1320,7 +1312,6 @@ class Fasta36Cases(unittest.TestCase):
 
     def test_output009(self):
         """Test parsing fasta36 output (output009.m10)."""
-
         m10_file = get_file('output009.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(3, len(qresults))
@@ -1526,7 +1517,6 @@ class Fasta36Cases(unittest.TestCase):
 
     def test_output010(self):
         """Test parsing fasta36 output (output010.m10)."""
-
         m10_file = get_file('output010.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -1550,7 +1540,6 @@ class Fasta36Cases(unittest.TestCase):
 
     def test_output011(self):
         """Test parsing fasta36 output (output011.m10)."""
-
         m10_file = get_file('output011.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -1694,7 +1683,6 @@ class Fasta36Cases(unittest.TestCase):
 
     def test_output012(self):
         """Test parsing fasta36 output (output012.m10)."""
-
         m10_file = get_file('output012.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -1946,7 +1934,6 @@ class Fasta36Cases(unittest.TestCase):
 
     def test_output013(self):
         """Test parsing fasta36 output (output013.m10)."""
-
         m10_file = get_file('output013.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(3, len(qresults))
@@ -2115,7 +2102,6 @@ class Fasta36Cases(unittest.TestCase):
 
     def test_output014(self):
         """Test parsing fasta36 output (output014.m10)."""
-
         m10_file = get_file('output014.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -2139,7 +2125,6 @@ class Fasta36Cases(unittest.TestCase):
 
     def test_output015(self):
         """Test parsing fasta36 output (output015.m10)."""
-
         m10_file = get_file('output015.m10')
         qresults = list(parse(m10_file, FMT))
         self.assertEqual(1, len(qresults))
@@ -2213,7 +2198,6 @@ class Fasta36Cases(unittest.TestCase):
 
     def test_output016(self):
         """Test parsing fasta36 output (output016.m10)."""
-
         m10_file = get_file('output016.m10')
         # only check 8, 10 is too many
         qresults = list(parse(m10_file, FMT))[:8]

--- a/Tests/test_SeqIO_PdbIO.py
+++ b/Tests/test_SeqIO_PdbIO.py
@@ -35,7 +35,6 @@ def SeqresTestGenerator(extension, parser):
         parser:
             The name of the SeqIO parser to use (e.g. ``pdb-atom``).
     """
-
     class SeqresTests(unittest.TestCase):
         """Use "parser" to parse sequence records from a structure file.
 
@@ -95,7 +94,6 @@ def AtomTestGenerator(extension, parser):
 
     See SeqresTestGenerator for more information.
     """
-
     class AtomTests(unittest.TestCase):
         def test_atom_parse(self):
             """Parse a multi-chain structure by ATOM entries.

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -184,7 +184,6 @@ class StringMethodTests(unittest.TestCase):
 
     def test_str_count_overlap_GG(self):
         """Check our count_overlap method using GG."""
-
         # Testing with self._examples
         expected = [3, 3, 3, 3, 1, 1, 1, 1, 0, 0, 0, 0,  # Seq() Tests
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  # UnknownSeq() Tests
@@ -265,7 +264,6 @@ class StringMethodTests(unittest.TestCase):
 
     def test_str_count_overlap_NN(self):
         """Check our count_overlap method using NN."""
-
         # Testing with self._examples
         expected = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  # Seq() Tests
                     0, 0, 0, 0, 0, 11, 11, 11, 0, 0, 0]  # UnknownSeq() Tests
@@ -777,21 +775,18 @@ class StringMethodTests(unittest.TestCase):
 
     def test_join_Seq_TypeError(self):
         """Checks that a TypeError is thrown for incompatible alphabets."""
-
         spacer = Seq('NNNNN', generic_dna)
         self.assertRaises(TypeError, spacer.join, [Seq('NNNNN', generic_rna), Seq('NNNNN', generic_rna)])
         self.assertRaises(TypeError, spacer.join, [Seq('NNNNN', generic_protein), Seq('NNNNN', generic_protein)])
 
     def test_join_UnknownSeq_TypeError(self):
         """Checks that a TypeError is thrown for incompatible alphabets."""
-
         spacer = UnknownSeq(5, character="-", alphabet=generic_dna)
         self.assertRaises(TypeError, spacer.join, [UnknownSeq(5, character="-", alphabet=generic_rna), UnknownSeq(5, character="-", alphabet=generic_rna)])
         self.assertRaises(TypeError, spacer.join, [Seq('NNNNN', generic_protein), UnknownSeq(5, character="-", alphabet=generic_protein)])
 
     def test_join_MutableSeq_TypeError(self):
         """Checks that a TypeError is thrown for incompatible alphabets."""
-
         spacer = MutableSeq('NNNNN', generic_dna)
         self.assertRaises(TypeError, spacer.join, [MutableSeq('NNNNN', generic_rna), MutableSeq('NNNNN', generic_rna)])
         self.assertRaises(TypeError, spacer.join, [Seq('NNNNN', generic_protein), MutableSeq('NNNNN', generic_protein)])

--- a/Tests/test_samtools_tool.py
+++ b/Tests/test_samtools_tool.py
@@ -116,7 +116,6 @@ class SamtoolsTestCase(unittest.TestCase):
 
     def test_view(self):
         """Test for samtools view."""
-
         cmdline = SamtoolsViewCommandline(samtools_exe)
         cmdline.set_parameter("input_file", self.bamfile1)
         stdout_bam, stderr_bam = cmdline()

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -155,7 +155,6 @@ class TestSeq(unittest.TestCase):
 
     def test_concatenation_error(self):
         """DNA Seq objects cannot be concatenated with Protein Seq objects."""
-
         with self.assertRaises(TypeError):
             self.s + Seq.Seq("T", IUPAC.protein)
 


### PR DESCRIPTION
Like #2016, #2017, #2019, and #2024 this pull request is somewhat related to issue #883 / #2014 and the goal of having universal flake8 settings for the entire project.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
