### PR TITLE
flake8: Fix and enforce D100 (module docstrings) on Tests/

### DIFF
--- a/Tests/.flake8
+++ b/Tests/.flake8
@@ -19,14 +19,12 @@ ignore =
     # =====================================
     # pydocstyle: D1## - Missing Docstrings
     # =====================================
-    # D100	Missing docstring in public module
     # D101	Missing docstring in public class
     # D102	Missing docstring in public method
     # D103	Missing docstring in public function
-    # D104	Missing docstring in public package
     # D105	Missing docstring in magic method
     # TODO: Fix some of these?
-    D100,D101,D102,D103,D105,
+    D101,D102,D103,D105,
     # ====================================
     # pydocstyle: D2## - Whitespace Issues
     # ====================================

--- a/Tests/PAML/gen_results.py
+++ b/Tests/PAML/gen_results.py
@@ -3,6 +3,8 @@
 # license. Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Generate output for PAML tests."""
+
 from __future__ import print_function
 
 import os.path

--- a/Tests/requires_internet.py
+++ b/Tests/requires_internet.py
@@ -9,6 +9,8 @@
 # import statement succeeds.  If it is not, then the statement will
 # result in a MissingExternalDependencyError exception.
 
+"""Common code to check if the internet is available."""
+
 from Bio import MissingExternalDependencyError
 
 

--- a/Tests/requires_wise.py
+++ b/Tests/requires_wise.py
@@ -5,6 +5,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Code to check if command line tool wise is installed."""
+
 import sys
 
 from Bio import MissingExternalDependencyError

--- a/Tests/search_tests_common.py
+++ b/Tests/search_tests_common.py
@@ -4,6 +4,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Common code for SearchIO tests."""
+
 from __future__ import print_function
 
 import os

--- a/Tests/seq_tests_common.py
+++ b/Tests/seq_tests_common.py
@@ -2,6 +2,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Common code for SeqRecord object tests."""
+
 from Bio._py3k import range
 from Bio._py3k import basestring
 

--- a/Tests/test_Ace.py
+++ b/Tests/test_Ace.py
@@ -5,6 +5,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for Ace module."""
+
 import unittest
 
 from Bio.Sequencing import Ace

--- a/Tests/test_Affy.py
+++ b/Tests/test_Affy.py
@@ -2,6 +2,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for Affy module."""
+
 import unittest
 
 import struct

--- a/Tests/test_AlignIO.py
+++ b/Tests/test_AlignIO.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for AlignIO module."""
+
 from __future__ import print_function
 
 import os

--- a/Tests/test_BWA_tool.py
+++ b/Tests/test_BWA_tool.py
@@ -5,6 +5,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for calling BWA."""
+
 from Bio import MissingExternalDependencyError
 import sys
 import os

--- a/Tests/test_CAPS.py
+++ b/Tests/test_CAPS.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for CAPS module."""
+
 import unittest
 
 from Bio import CAPS

--- a/Tests/test_CelFile.py
+++ b/Tests/test_CelFile.py
@@ -3,6 +3,8 @@
 # license. Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for CelFile module."""
+
 import unittest
 
 try:

--- a/Tests/test_Chi2.py
+++ b/Tests/test_Chi2.py
@@ -3,6 +3,8 @@
 # license. Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for Chi2 module."""
+
 import unittest
 from Bio.Phylo.PAML import chi2
 

--- a/Tests/test_ClustalOmega_tool.py
+++ b/Tests/test_ClustalOmega_tool.py
@@ -5,6 +5,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for ClustalOmega tool."""
+
 import sys
 import os
 import unittest

--- a/Tests/test_Clustalw_tool.py
+++ b/Tests/test_Clustalw_tool.py
@@ -7,6 +7,8 @@
 
 # TODO - Clean up the extra files created by clustalw?  e.g. *.dnd
 # and *.aln where we have not requested an explicit name?
+"""Tests for Clustalw tool."""
+
 from __future__ import print_function
 
 from Bio import MissingExternalDependencyError

--- a/Tests/test_Cluster.py
+++ b/Tests/test_Cluster.py
@@ -2,6 +2,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for Cluster module."""
+
 import unittest
 
 try:

--- a/Tests/test_CodonTable.py
+++ b/Tests/test_CodonTable.py
@@ -5,6 +5,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for CodonTable module."""
+
 import unittest
 
 from Bio.Data import IUPACData

--- a/Tests/test_CodonUsage.py
+++ b/Tests/test_CodonUsage.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for CodonUsage module."""
+
 from __future__ import print_function
 
 from Bio.SeqUtils import CodonUsage

--- a/Tests/test_Crystal.py
+++ b/Tests/test_Crystal.py
@@ -4,6 +4,8 @@
 # as part of this package.
 
 # python unittest framework
+"""Tests for Crystal module."""
+
 import unittest
 import copy
 

--- a/Tests/test_EMBL_unittest.py
+++ b/Tests/test_EMBL_unittest.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for EMBL module (using unittest framework)."""
+
 import unittest
 import warnings
 from os import path

--- a/Tests/test_EmbossPhylipNew.py
+++ b/Tests/test_EmbossPhylipNew.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for EmbossPhylipNew module."""
+
 import os
 import sys
 import unittest

--- a/Tests/test_Enzyme.py
+++ b/Tests/test_Enzyme.py
@@ -4,6 +4,8 @@
 # as part of this package.
 
 
+"""Tests for Enzyme module."""
+
 import os
 import unittest
 

--- a/Tests/test_FSSP.py
+++ b/Tests/test_FSSP.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for FSSP module."""
+
 from Bio import FSSP
 from Bio.FSSP import FSSPTools
 import sys

--- a/Tests/test_Fasttree_tool.py
+++ b/Tests/test_Fasttree_tool.py
@@ -6,6 +6,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for Fasttree tool."""
+
 from __future__ import print_function
 
 from Bio import MissingExternalDependencyError

--- a/Tests/test_GenBank_unittest.py
+++ b/Tests/test_GenBank_unittest.py
@@ -5,6 +5,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for GenBank module (using unittest framework)."""
+
 import unittest
 from os import path
 import warnings

--- a/Tests/test_KDTree.py
+++ b/Tests/test_KDTree.py
@@ -2,6 +2,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for KDTree module."""
+
 import unittest
 
 try:

--- a/Tests/test_LogisticRegression.py
+++ b/Tests/test_LogisticRegression.py
@@ -6,6 +6,8 @@
 # See the Biopython Tutorial for an explanation of the biological
 # background of these tests.
 
+"""Tests for LogisticRegression module."""
+
 try:
     import numpy
     from numpy import linalg  # missing in PyPy's micronumpy

--- a/Tests/test_MSAProbs_tool.py
+++ b/Tests/test_MSAProbs_tool.py
@@ -4,6 +4,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for MSAProbs tool."""
+
 import os
 import sys
 import unittest

--- a/Tests/test_MarkovModel.py
+++ b/Tests/test_MarkovModel.py
@@ -9,6 +9,8 @@
 # Please see the LICENSE file that should have been included as part of this
 # package.
 
+"""Tests for MarkovModel module."""
+
 import warnings
 import unittest
 

--- a/Tests/test_Medline.py
+++ b/Tests/test_Medline.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for Medline module."""
+
 import unittest
 
 from Bio import Medline

--- a/Tests/test_Muscle_tool.py
+++ b/Tests/test_Muscle_tool.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for Muscle tool."""
+
 from __future__ import print_function
 from Bio._py3k import _universal_read_mode
 

--- a/Tests/test_NCBI_BLAST_tools.py
+++ b/Tests/test_NCBI_BLAST_tools.py
@@ -6,6 +6,8 @@
 # This unit test attempts to locate the blastall executable and the nr
 # database.
 
+"""Tests for NCBI BLAST tools module."""
+
 from __future__ import print_function
 
 import os

--- a/Tests/test_NaiveBayes.py
+++ b/Tests/test_NaiveBayes.py
@@ -3,6 +3,8 @@
 # as part of this package.
 
 # coding=utf-8
+"""Tests for NaiveBayes module."""
+
 import copy
 import unittest
 

--- a/Tests/test_Nexus.py
+++ b/Tests/test_Nexus.py
@@ -6,6 +6,8 @@
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
+"""Tests for Nexus module."""
+
 from __future__ import print_function
 
 import os.path

--- a/Tests/test_PAML_baseml.py
+++ b/Tests/test_PAML_baseml.py
@@ -3,6 +3,8 @@
 # license. Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for PAML baseml module."""
+
 import unittest
 import os
 import os.path

--- a/Tests/test_PAML_codeml.py
+++ b/Tests/test_PAML_codeml.py
@@ -3,6 +3,8 @@
 # license. Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for PAML codeml module."""
+
 import unittest
 import os
 import os.path

--- a/Tests/test_PAML_tools.py
+++ b/Tests/test_PAML_tools.py
@@ -3,6 +3,8 @@
 # license. Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for PAML tools module."""
+
 import unittest
 import os
 import sys

--- a/Tests/test_PAML_yn00.py
+++ b/Tests/test_PAML_yn00.py
@@ -3,6 +3,8 @@
 # license. Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for PAML yn00 module."""
+
 import unittest
 import os
 import os.path

--- a/Tests/test_PDB_FragmentMapper.py
+++ b/Tests/test_PDB_FragmentMapper.py
@@ -6,6 +6,8 @@
 # Please see the LICENSE file that should have been included as part of this
 # package.
 
+"""Tests for PDB FragmentMapper module."""
+
 import unittest
 
 try:

--- a/Tests/test_Pathway.py
+++ b/Tests/test_Pathway.py
@@ -5,6 +5,8 @@
 # as part of this package.
 
 # python unittest framework
+"""Tests for Pathway module."""
+
 import unittest
 
 # modules to be tested

--- a/Tests/test_Phd.py
+++ b/Tests/test_Phd.py
@@ -2,6 +2,8 @@
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
+"""Tests for Phd module."""
+
 import unittest
 
 from Bio import SeqIO

--- a/Tests/test_PopGen_GenePop_nodepend.py
+++ b/Tests/test_PopGen_GenePop_nodepend.py
@@ -4,6 +4,8 @@
 # as part of this package.
 
 
+"""Tests for PopGen GenePop nodepend module."""
+
 import os
 import unittest
 from Bio.PopGen import GenePop

--- a/Tests/test_QCPSuperimposer.py
+++ b/Tests/test_QCPSuperimposer.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for QCPSuperimposer module."""
+
 import unittest
 
 try:

--- a/Tests/test_SVDSuperimposer.py
+++ b/Tests/test_SVDSuperimposer.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for SVDSuperimposer module."""
+
 import unittest
 
 try:

--- a/Tests/test_SearchIO_hmmer2_text.py
+++ b/Tests/test_SearchIO_hmmer2_text.py
@@ -4,6 +4,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for SearchIO hmmer2 text module."""
+
 import unittest
 from os import path
 

--- a/Tests/test_SearchIO_legacy.py
+++ b/Tests/test_SearchIO_legacy.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for SearchIO legacy module."""
+
 from __future__ import print_function
 
 import string

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for SeqIO module."""
+
 from __future__ import print_function
 from Bio._py3k import basestring
 

--- a/Tests/test_SeqIO_AbiIO.py
+++ b/Tests/test_SeqIO_AbiIO.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for SeqIO AbiIO module."""
+
 import unittest
 
 from os.path import join, basename

--- a/Tests/test_SeqIO_Insdc.py
+++ b/Tests/test_SeqIO_Insdc.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for SeqIO Insdc module."""
+
 import unittest
 from Bio._py3k import StringIO
 

--- a/Tests/test_SeqIO_NibIO.py
+++ b/Tests/test_SeqIO_NibIO.py
@@ -1,3 +1,5 @@
+"""Tests for SeqIO NibIO module."""
+
 import unittest
 
 from io import BytesIO

--- a/Tests/test_SeqIO_PdbIO.py
+++ b/Tests/test_SeqIO_PdbIO.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for SeqIO PdbIO module."""
+
 import unittest
 import warnings
 

--- a/Tests/test_SeqIO_SeqXML.py
+++ b/Tests/test_SeqIO_SeqXML.py
@@ -2,6 +2,8 @@
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
+"""Tests for SeqIO SeqXML module."""
+
 import unittest
 import sys
 

--- a/Tests/test_SeqIO_write.py
+++ b/Tests/test_SeqIO_write.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for SeqIO write module."""
+
 import os
 import unittest
 import warnings

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for SeqUtils module."""
+
 import os
 import unittest
 

--- a/Tests/test_SffIO.py
+++ b/Tests/test_SffIO.py
@@ -4,6 +4,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for SffIO module."""
+
 import sys
 import re
 import unittest

--- a/Tests/test_SubsMat.py
+++ b/Tests/test_SubsMat.py
@@ -2,6 +2,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for SubsMat module."""
+
 try:
     from numpy import corrcoef
     del corrcoef

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -48,6 +48,8 @@
 
 
 # This future import will apply to all the doctests too:
+"""Tests for Tutorial module."""
+
 from __future__ import print_function
 from Bio._py3k import _universal_read_mode
 

--- a/Tests/test_UniGene.py
+++ b/Tests/test_UniGene.py
@@ -2,6 +2,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for UniGene module."""
+
 from Bio import UniGene
 import unittest
 

--- a/Tests/test_Wise.py
+++ b/Tests/test_Wise.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for Wise module."""
+
 import doctest
 import sys
 import unittest

--- a/Tests/test_XXmotif_tool.py
+++ b/Tests/test_XXmotif_tool.py
@@ -4,6 +4,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for XXmotif tool."""
+
 import glob
 import os
 import shutil

--- a/Tests/test_cellosaurus.py
+++ b/Tests/test_cellosaurus.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for cellosaurus module."""
+
 import os
 import unittest
 

--- a/Tests/test_kNN.py
+++ b/Tests/test_kNN.py
@@ -6,6 +6,8 @@
 # See the Biopython Tutorial for an explanation of the biological
 # background of these tests.
 
+"""Tests for kNN module."""
+
 import unittest
 
 try:

--- a/Tests/test_lowess.py
+++ b/Tests/test_lowess.py
@@ -2,6 +2,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for lowess module."""
+
 try:
     from numpy import array, median
 except ImportError:

--- a/Tests/test_mmtf.py
+++ b/Tests/test_mmtf.py
@@ -5,6 +5,8 @@
 # Please see the LICENSE file that should have been included as part of this
 # package.
 
+"""Tests for mmtf module."""
+
 import unittest
 import warnings
 from Bio.PDB.mmtf import MMTFParser

--- a/Tests/test_mmtf_online.py
+++ b/Tests/test_mmtf_online.py
@@ -4,6 +4,8 @@
 # Please see the LICENSE file that should have been included as part of this
 # package.
 
+"""Tests for mmtf online module."""
+
 import unittest
 import warnings
 

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -4,6 +4,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for motifs module."""
+
 import os
 import unittest
 import math

--- a/Tests/test_pairwise2.py
+++ b/Tests/test_pairwise2.py
@@ -3,6 +3,8 @@
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
+"""Tests for pairwise2 module."""
+
 import unittest
 import warnings
 

--- a/Tests/test_pairwise2_no_C.py
+++ b/Tests/test_pairwise2_no_C.py
@@ -7,6 +7,8 @@
 # This test file prevents loading of the cpairwise2.pyd C extension of
 # pairwise2 to allow for testing the fallback Python implementation of
 # the _make_score_matrix_fast method.
+"""Tests for pairwise2 module (pure Python, no C)."""
+
 import unittest
 import sys
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -5,6 +5,8 @@
 # as part of this package.
 
 
+"""Tests for pairwise aligner module."""
+
 import unittest
 
 from Bio import Align

--- a/Tests/test_prosite1.py
+++ b/Tests/test_prosite1.py
@@ -5,6 +5,8 @@
 #
 # NOTE - This file has been split in two as a workaround for Jython JVM limits.
 
+"""Tests for prosite1 module."""
+
 import os
 import unittest
 

--- a/Tests/test_prosite2.py
+++ b/Tests/test_prosite2.py
@@ -5,6 +5,8 @@
 #
 # NOTE - This file has been split in two as a workaround for Jython JVM limits.
 
+"""Tests for prosite2 module."""
+
 import os
 import unittest
 

--- a/Tests/test_psw.py
+++ b/Tests/test_psw.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for psw module."""
+
 import doctest
 import unittest
 import random

--- a/Tests/test_samtools_tool.py
+++ b/Tests/test_samtools_tool.py
@@ -7,6 +7,8 @@
 
 # Last Checked with samtools [0.1.18 (r982:295)]
 
+"""Tests for samtools tool."""
+
 from Bio import MissingExternalDependencyError
 import sys
 import os

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -2,6 +2,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for seq module."""
+
 from __future__ import print_function
 import array
 import copy

--- a/Tests/test_translate.py
+++ b/Tests/test_translate.py
@@ -5,6 +5,8 @@
 # Make sure the translation functions work.
 # Start simple - unambiguous DNA to unambiguous protein
 
+"""Tests for translate module."""
+
 from __future__ import print_function
 
 from Bio import Seq

--- a/Tests/test_trie.py
+++ b/Tests/test_trie.py
@@ -4,6 +4,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Tests for trie module."""
+
 import random
 import tempfile
 import unittest


### PR DESCRIPTION
Like #2016, #2017, #2019, #2024, and #2027 this pull request is somewhat related to issue #883 / #2014 and the goal of having universal flake8 settings for the entire project.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
