### PR TITLE
Several PEP8 and PEP257 issues in folder Scripts

### DIFF
--- a/Scripts/.flake8
+++ b/Scripts/.flake8
@@ -7,7 +7,7 @@ ignore =
     # =======================
     # pycodestyle v2.4.0 default ignore is E121,E123,E126,E226,E24,E704,W503,W504
     # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
-    W503,
+    W503,W504,
     # ====================
     # flake8-bugbear: B###
     # ====================

--- a/Scripts/.flake8
+++ b/Scripts/.flake8
@@ -7,25 +7,7 @@ ignore =
     # =======================
     # pycodestyle v2.4.0 default ignore is E121,E123,E126,E226,E24,E704,W503,W504
     # flake8 v3.3.0 default ignore is      E121,E123,E126,E226,E24,E704,W503,W504
-    W503,W504,
-    # =====================================
-    # pydocstyle: D### - Missing Docstrings
-    # =====================================
-    # D100	Missing docstring in public module
-    # D101	Missing docstring in public class
-    # D102	Missing docstring in public method
-    # D103	Missing docstring in public function
-    # D104	Missing docstring in public package
-    # D105	Missing docstring in magic method
-    # D107	Missing docstring in __init__
-    # TODO: Fix some of these?
-    D101,D102,D103,D105,D107,
-    # ====================================
-    # pydocstyle: D### - Whitespace Issues
-    # ====================================
-    # D412	No blank lines allowed between a section header and its content
-    # We ignore D412 deliberately:
-    D412,
+    W503,
     # ====================
     # flake8-bugbear: B###
     # ====================

--- a/Scripts/GenBank/check_output.py
+++ b/Scripts/GenBank/check_output.py
@@ -4,7 +4,6 @@
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
-
 """Check for the ability to read and write identical GenBank records.
 
 This script takes as input a single file to be tested for reading records.
@@ -33,7 +32,7 @@ from Bio import GenBank
 def do_comparison(good_record, test_record):
     """Compare two records to see if they are the same.
 
-    Ths compares the two GenBank record, and will raise an AssertionError
+    This compares the two GenBank record, and will raise an AssertionError
     if two lines do not match, showing the non-matching lines.
     """
     good_handle = StringIO(good_record)
@@ -60,6 +59,7 @@ def do_comparison(good_record, test_record):
 
 
 def write_format(file):
+    """Write a GenBank record from a Genbank file and compare them."""
     record_parser = GenBank.RecordParser(debug_level=2)
 
     print("Testing GenBank writing for %s..." % os.path.basename(file))

--- a/Scripts/PDB/generate_three_to_one_dict.py
+++ b/Scripts/PDB/generate_three_to_one_dict.py
@@ -91,7 +91,8 @@ while line:
                 three_to_one_buf_noq.append('%s\n' % (current_line_noq,))
                 current_line_noq = '    '
 
-            current_line_noq = '%s\'%s\':\'%s\',' % (current_line_noq, three, one)
+            current_line_noq = '%s\'%s\':\'%s\',' % (current_line_noq, three,
+                                                     one)
             counter_noq += 1
 
         found_one = False
@@ -112,9 +113,11 @@ else:
     three_to_one_buf_noq.append('%s }' % (current_line_noq[:-1]))
 
 # Find path of current script
-_scriptPath = os.path.abspath(os.path.split(inspect.getfile(inspect.currentframe()))[0])
+_scriptPath = os.path.abspath(
+    os.path.split(inspect.getfile(inspect.currentframe()))[0])
 # Path to SCOP module
-_rafPath = os.path.normpath(os.path.join(_scriptPath, "..", "..", "Bio", "SCOP"))
+_rafPath = os.path.normpath(os.path.join(_scriptPath,
+                                         "..", "..", "Bio", "SCOP"))
 _threeAllPath = os.path.join(_rafPath, 'three_to_one_all.py')
 _threePath = os.path.join(_rafPath, 'three_to_one_dict.py')
 

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -130,9 +130,10 @@ def LocalTime():
 
 
 class newenzyme(object):
-    """construct the attributes of the enzyme corresponding to 'name'."""
+    """Construct the attributes of the enzyme corresponding to 'name'."""
 
     def __init__(cls, name):
+        """Set up the enzyme's attributes."""
         cls.opt_temp = 37
         cls.inact_temp = 65
         cls.substrat = 'DNA'
@@ -355,6 +356,7 @@ Used REBASE emboss files version {} ({}).
 
 
 class DictionaryBuilder(object):
+    """Builds ``Restriction_Dictionary.py`` from Rebase files."""
 
     def __init__(self, ftp_proxy=''):
         """Initialize class.
@@ -685,6 +687,7 @@ class DictionaryBuilder(object):
                 continue
 
     def parseline(self, line):
+        """Parse a line from the Rebase emboss_e.xxx file."""
         line = [line[0]] + \
             [line[1].upper()] + [int(i) for i in line[2:9]] + \
             line[9:]
@@ -884,13 +887,12 @@ class DictionaryBuilder(object):
         return line
 
     def removestart(self, file):
-        #
-        #   remove the heading of the file.
-        #
+        """Remove the heading of the file."""
         return [l for l in itertools.dropwhile(lambda l:l.startswith('#'),
                                                file)]
 
     def getblock(self, file, index):
+        """Get a block from the emboss_r file."""
         #
         #   emboss_r.txt, separation between blocks is //
         #
@@ -901,6 +903,7 @@ class DictionaryBuilder(object):
         return block, index
 
     def get(self, block):
+        """Get name, methylation information and suppliers."""
         #
         #   take what we want from the block.
         #   Each block correspond to one enzyme.
@@ -914,6 +917,7 @@ class DictionaryBuilder(object):
         return (block[0].strip(), bl3, block[5].strip())
 
     def information_mixer(self, file1, file2, file3):
+        """Combine extracted data from the the three emboss_x.xxx files."""
         #
         #   Mix all the information from the 3 files and produce a coherent
         #   restriction record.
@@ -995,6 +999,7 @@ class DictionaryBuilder(object):
 
 
 def standalone():
+    """Set up for running as main."""
     parser = optparse.OptionParser()
     add = parser.add_option
 

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -887,12 +887,12 @@ class DictionaryBuilder(object):
         return line
 
     def removestart(self, file):
-        """Remove the heading of the file."""
+        """Remove the header of the file."""
         return [l for l in itertools.dropwhile(lambda l:l.startswith('#'),
                                                file)]
 
     def getblock(self, file, index):
-        """Get a block from the emboss_r file."""
+        """Get a data block from the emboss_r file."""
         #
         #   emboss_r.txt, separation between blocks is //
         #
@@ -917,7 +917,7 @@ class DictionaryBuilder(object):
         return (block[0].strip(), bl3, block[5].strip())
 
     def information_mixer(self, file1, file2, file3):
-        """Combine extracted data from the the three emboss_x.xxx files."""
+        """Combine extracted data from the three emboss_x.xxx files."""
         #
         #   Mix all the information from the 3 files and produce a coherent
         #   restriction record.

--- a/Scripts/Restriction/rebase_update.py
+++ b/Scripts/Restriction/rebase_update.py
@@ -85,7 +85,7 @@ class RebaseUpdate(FancyURLopener):
         return
 
     def localtime(self):
-        """Generate time 'stamp' of type ymm to add to Rebase file names."""
+        """Generate 'time stamp' of type ymm to add to Rebase file names."""
         t = time.gmtime()
         year = str(t.tm_year)[-1]
         month = str(t.tm_mon)
@@ -94,7 +94,7 @@ class RebaseUpdate(FancyURLopener):
         return year + month
 
     def update(self, *files):
-        """Update filenames to recent versions (indicated by 'time stamp'."""
+        """Update filenames to recent versions (indicated by 'time stamp')."""
         if not files:
             files = [ftp_emb_e, ftp_emb_s, ftp_emb_r]
         return [x.replace('###', self.localtime()) for x in files]

--- a/Scripts/Restriction/rebase_update.py
+++ b/Scripts/Restriction/rebase_update.py
@@ -7,7 +7,6 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 #
-
 """Update the Rebase EMBOSS files.
 
 The Rebase EMBOSS files are used by `ranacompiler.py` to build the updated
@@ -33,6 +32,7 @@ from Bio.Restriction.RanaConfig import ftp_emb_e, ftp_emb_s, ftp_emb_r
 
 
 class RebaseUpdate(FancyURLopener):
+    """A class to fetch the Rebase EMBOSS files."""
 
     def __init__(self, ftpproxy=''):
         """RebaseUpdate([ftpproxy]]) -> new RebaseUpdate instance.
@@ -50,6 +50,7 @@ class RebaseUpdate(FancyURLopener):
         FancyURLopener.__init__(self, proxy)
 
     def openRebase(self, name=ftp_Rebase):
+        """Connect to Rebase ftp server."""
         print('\n Please wait, trying to connect to Rebase\n')
         try:
             self.open(name)
@@ -58,6 +59,7 @@ class RebaseUpdate(FancyURLopener):
         return
 
     def getfiles(self, *files):
+        """Download Rebase files."""
         for file in self.update(*files):
             print('copying %s' % file)
             fn = os.path.basename(file)
@@ -83,6 +85,7 @@ class RebaseUpdate(FancyURLopener):
         return
 
     def localtime(self):
+        """Generate time 'stamp' of type ymm to add to Rebase file names."""
         t = time.gmtime()
         year = str(t.tm_year)[-1]
         month = str(t.tm_mon)
@@ -91,11 +94,13 @@ class RebaseUpdate(FancyURLopener):
         return year + month
 
     def update(self, *files):
+        """Update filenames to recent versions (indicated by 'time stamp'."""
         if not files:
             files = [ftp_emb_e, ftp_emb_s, ftp_emb_r]
         return [x.replace('###', self.localtime()) for x in files]
 
     def __del__(self):
+        """Close tmpcache on exiting."""
         if hasattr(self, 'tmpcache'):
             self.close()
         #
@@ -105,16 +110,20 @@ class RebaseUpdate(FancyURLopener):
 
 
 class FtpNameError(ValueError):
+    """Error class for missing user name (usually 'anonymous')."""
 
     def __init__(self, which_server):
+        """Print the error message."""
         print(" In order to connect to %s ftp server, you must provide a name.\
         \n Please edit Bio.Restriction.RanaConfig\n" % which_server)
         sys.exit()
 
 
 class ConnectionError(IOError):
+    """Error class for failing connections to Rebase ftp server."""
 
     def __init__(self, which_server):
+        """Print the error message."""
         print('\
         \n Unable to connect to the %s ftp server, make sure your computer\
         \n is connected to the internet and that you have correctly configured\

--- a/Scripts/debug/debug_blast_parser.py
+++ b/Scripts/debug/debug_blast_parser.py
@@ -4,7 +4,6 @@
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
-
 """Script to help diagnose problems with BLAST parser."""
 
 # To do:
@@ -46,7 +45,10 @@ OPTIONS:
 
 
 class DebuggingConsumer(object):
+    """A Debugging Consumer..."""
+
     def __init__(self, decorated=None):
+        """Initialize the DebuggingConsumer."""
         self.linenum = 0
         if decorated is None:
             decorated = ParserSupport.AbstractConsumer()
@@ -61,6 +63,7 @@ class DebuggingConsumer(object):
         self.linenum += 1
 
     def __getattr__(self, attr):
+        """Override __getattr__."""
         self._prev_attr = attr
         if attr.startswith('start_') or attr.startswith('end_'):
             return self._decorated_section
@@ -69,20 +72,24 @@ class DebuggingConsumer(object):
 
 
 def chomp(line):
+    """Remove line-breaks from line."""
     return re.sub(r"[\r\n]*$", "", line)
 
 
 def choose_parser(outfile):
+    """Select corret parser automatically."""
     data = open(outfile).read()
     ldata = data.lower()
     if "<html>" in ldata or "<pre>" in ldata:
-        raise NotImplementedError("Biopython no longer has an HTML BLAST parser.")
+        raise NotImplementedError("Biopython no longer has an HTML BLAST "
+                                  "parser.")
     if "results from round)" in ldata or "converged!" in ldata:
         return NCBIStandalone.PSIBlastParser
     return NCBIStandalone.BlastParser
 
 
 def test_blast_output(outfile):
+    """Try to find BLAST parser error from output file."""
     # Try to auto-detect the format
     if 1:
         print("No parser specified.  I'll try to choose one for you based")
@@ -91,11 +98,12 @@ def test_blast_output(outfile):
 
         parser_class = choose_parser(outfile)
         print("It looks like you have given output that should be parsed")
-        print("with %s.%s.  If I'm wrong, you can select the correct parser" %
-              (parser_class.__module__, parser_class.__name__))
+        print("with %s.%s.  If I'm wrong, you can select the correct parser"
+              % (parser_class.__module__, parser_class.__name__))
         print("on the command line of this script (NOT IMPLEMENTED YET).")
     else:
-        raise NotImplementedError("Biopython no longer has an HTML BLAST parser.")
+        raise NotImplementedError("Biopython no longer has an HTML "
+                                  "BLAST parser.")
     print("")
 
     scanner_class = parser_class()._scanner.__class__
@@ -103,7 +111,7 @@ def test_blast_output(outfile):
 
     # parser_class()._scanner.feed(
     #    open(outfile), ParserSupport.TaggingConsumer())
-    print("I'm going to run the data through the parser to see what happens...")
+    print("I'm going to run the data through the parser to see what happens..")
     parser = parser_class()
     try:
         parser.parse_file(outfile)
@@ -252,7 +260,8 @@ if __name__ == '__main__':
 
     if len([x for x in (PROTEIN, NUCLEOTIDE, OUTPUT) if x is not None]) != 1:
         OUTPUT = 1
-        # sys.stderr.write("Exactly one of -p, -n, or -o should be specified.\n")
+        # sys.stderr.write("Exactly one of -p, -n, or -o should be "
+        #                  "specified.\n")
         # sys.exit(-1)
     if PROTEIN or NUCLEOTIDE:
         sys.stderr.write("-p and -n not implemented yet\n")

--- a/Scripts/query_pubmed.py
+++ b/Scripts/query_pubmed.py
@@ -16,6 +16,7 @@ from Bio import Entrez
 
 
 def print_usage():
+    """Print a help message."""
     print("""query_pubmed.py [-h] [-c] [-d delay] query
 
 This script sends a query to PubMed (via the NCBI Entrez webservice*)

--- a/Scripts/scop_pdb.py
+++ b/Scripts/scop_pdb.py
@@ -4,7 +4,6 @@
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
-
 """Extract SCOP domain ATOM and HETATOM records from PDB."""
 
 from __future__ import print_function
@@ -18,6 +17,7 @@ from Bio.SCOP import Raf, Cla
 
 
 def usage():
+    """Print a help message."""
     print("""Extract a SCOP domain's ATOM and HETATOM records from the relevant PDB file.
 
 For example:
@@ -61,10 +61,11 @@ Usage: scop_pdb [-h] [-i file] [-o file] [-p pdb_url_prefix]
 
 default_pdb_url = "http://www.rcsb.org/pdb/cgi/export.cgi/somefile.pdb?" \
     "format=PDB&pdbId=%s&compression=None"
-# default_pdb_url = "file://usr/local/db/pdb/data/010331/snapshot/all/pdb%s.ent"
+# default_pdb_url = "file://usr/local/db/pdb/data/010331/snapshot/all/pdb%s.ent"  # noqa: E501
 
 
 def open_pdb(pdbid, pdb_url=None):
+    """Make a local copy of an online pdb file and return a file handle."""
     if pdb_url is None:
         pdb_url = default_pdb_url
     url = pdb_url % pdbid
@@ -73,9 +74,11 @@ def open_pdb(pdbid, pdb_url=None):
 
 
 def main():
+    """Extract a SCOP domain's ATOM and HETATOM records from a PDB file."""
     try:
         opts, args = getopt.getopt(sys.argv[1:], "hp:o:i:",
-                                   ["help", "usage", "pdb=", "output=", "input="])
+                                   ["help", "usage", "pdb=", "output=",
+                                    "input="])
     except getopt.GetoptError:
         # show help information and exit:
         usage()
@@ -100,7 +103,8 @@ def main():
             pdb_url = a
 
     if len(args) < 2:
-        sys.stderr.write("Not enough arguments. Try --help for more details.\n")
+        sys.stderr.write("Not enough arguments. "
+                         "Try --help for more details.\n")
         sys.exit(2)
 
     raf_url = args[0]
@@ -152,7 +156,8 @@ def main():
                     finally:
                         f.close()
                 except (IOError, KeyError, RuntimeError) as e:
-                    sys.stderr.write("I cannot do SCOP domain %s : %s\n" % (id, e))
+                    sys.stderr.write("I cannot do SCOP domain %s : %s\n"
+                                     % (id, e))
             finally:
                 out_handle.close()
     finally:

--- a/Scripts/xbbtools/nextorf.py
+++ b/Scripts/xbbtools/nextorf.py
@@ -8,6 +8,7 @@
 # Authors: Thomas Sicheritz-Ponten and Jan O. Andersson
 # thomas@cbs.dtu.dk, http://www.cbs.dtu.dk/thomas
 # Jan.O.Andersson@home.se
+# flake8: noqa
 
 """Find next open reading frame in sequence data."""
 

--- a/Scripts/xbbtools/xbb_blast.py
+++ b/Scripts/xbbtools/xbb_blast.py
@@ -34,12 +34,14 @@ import xbb_blastbg
 
 
 class BlastIt(object):
+    """Local BLAST integration for xbbtools."""
 
     nin, pin = [], []
     blast_ok = False
     blast_path = ''
 
     def __init__(self, seq, parent=None):
+        """Set up new top-level window for BLAST search."""
         self.seq = seq
         self.parent = parent
         self.toplevel = tk.Toplevel(parent)
@@ -132,6 +134,7 @@ class BlastIt(object):
         return database_path
 
     def Choices(self):
+        """Set up window to select BLAST program and database."""
         self.blast_string = tk.StringVar()
         self.blast_string.set('blastn')
         self.cf = ttk.Frame(self.toplevel)
@@ -165,6 +168,7 @@ class BlastIt(object):
         self.Validate()
 
     def Validate(self, *args):
+        """Check everything and enable/disable 'Run' button."""
         db = self.convert_dbname_to_dbpath(self.dbs.get())
         prog = self.blasts.get()
         if (prog in ['blastn', 'tblastx', 'tblastn']) == (db in self.nin):
@@ -188,6 +192,7 @@ class BlastIt(object):
         self.Run()
 
     def Run(self):
+        """Open new notepad and initialize running BLAST."""
         self.notepad = NotePad()
         tid = self.notepad.tid
 

--- a/Scripts/xbbtools/xbb_blastbg.py
+++ b/Scripts/xbbtools/xbb_blastbg.py
@@ -30,11 +30,15 @@ from Bio.Blast.Applications import (NcbiblastnCommandline,
 
 
 class BlastDisplayer(object):
+    """A class for running and displaying a BLAST search."""
+
     def __init__(self, command_data, text_id=None):
+        """Take command data and notpad id."""
         self.command_data = command_data
         self.tid = text_id
 
     def RunCommand(self):
+        """Run the BLAST search."""
         self.fh_in, self.infile = tempfile.mkstemp()
         self.fh_out, self.outfile = tempfile.mkstemp()
 
@@ -86,6 +90,7 @@ class BlastDisplayer(object):
         self.UpdateResults()
 
     def UpdateResults(self):
+        """Write BLAST result data into notepad."""
         # open the oufile and displays new appended text
         self.tid.insert('end', 'BLAST is running...')
         while True:
@@ -105,6 +110,7 @@ class BlastDisplayer(object):
         self.Exit()
 
     def Exit(self):
+        """Clean up on exit."""
         if os.path.exists(self.outfile):
             os.close(self.fh_out)
             os.remove(self.outfile)
@@ -116,13 +122,16 @@ class BlastDisplayer(object):
 
 
 class BlastWorker(threading.Thread):
+    """Allows multiple BLAST searches by threading."""
 
     def __init__(self, blast_command):
+        """Initialize the worker."""
         self.com = blast_command
         threading.Thread.__init__(self)
         self.finished = 0
 
     def run(self):
+        """Start worker."""
         try:
             self.com()
         except Exception as e:

--- a/Scripts/xbbtools/xbb_help.py
+++ b/Scripts/xbbtools/xbb_help.py
@@ -20,7 +20,10 @@ except ImportError:  # Python 3
 
 
 class xbbtools_help(tk.Toplevel):
+    """Help window."""
+
     def __init__(self, *args):
+        """Make toplevel help window."""
         tk.Toplevel.__init__(self)
         self.tid = scrolledtext.ScrolledText(self)
         self.tid.pack(fill=tk.BOTH, expand=1)
@@ -28,6 +31,7 @@ class xbbtools_help(tk.Toplevel):
         self.Show()
 
     def Styles(self):
+        """Define text styles."""
         for c in ['red', 'blue', 'magenta', 'yellow', 'green', 'red4',
                   'green4', 'blue4']:
             self.tid.tag_configure(c, foreground=c)
@@ -40,6 +44,7 @@ class xbbtools_help(tk.Toplevel):
         self.tid.tag_config('highlight', background='gray')
 
     def Show(self):
+        """Display help text."""
         t = self.tid
         t.insert(tk.END, "XBBtools Help\n", 'title')
         t.insert(tk.END, """

--- a/Scripts/xbbtools/xbb_search.py
+++ b/Scripts/xbbtools/xbb_search.py
@@ -30,11 +30,15 @@ import xbb_widget
 
 
 class DNAsearch(object):
+    """Class to search a DNA sequence."""
+
     def __init__(self):
+        """Set up the alphabet."""
         self.init_alphabet()
         self.sequence = ''
 
     def init_alphabet(self):
+        """Expand alphabet values for ambiguous codes."""
         self.alphabet = ambiguous_dna_values
         other = ''.join(self.alphabet)
         self.alphabet['N'] = self.alphabet['N'] + other
@@ -46,14 +50,17 @@ class DNAsearch(object):
             self.alphabet[key] = self.alphabet[key] + key
 
     def SetSeq(self, seq):
+        """Set sequence."""
         self.sequence = seq
 
     def SetPattern(self, pattern):
+        """Convert search pattern to regular expression."""
         self.pattern = pattern
         self.rx_pattern = self.IUPAC2regex(pattern)
         self.rx = re.compile(self.rx_pattern)
 
     def IUPAC2regex(self, s):
+        """Translate search text into pattern."""
         rx = ''
         for i in s:
             r = self.alphabet.get(i, i)
@@ -64,10 +71,13 @@ class DNAsearch(object):
         return rx
 
     def _Search(self, start=0):
+        """Search and return MatchObject (PRIVAT)."""
+        # Only called from SearchAll. Is it used?
         pos = self.rx.search(self.sequence, start)
         return pos
 
     def Search(self, start=0):
+        """Search for query sequence and return position."""
         pos = self.rx.search(self.sequence, start)
         if pos:
             return pos.start()
@@ -75,6 +85,8 @@ class DNAsearch(object):
             return -1
 
     def SearchAll(self):
+        """Search the whole sequence."""
+        # Doesn't seem to be used...
         pos = -1
         positions = []
         while True:
@@ -90,7 +102,10 @@ class DNAsearch(object):
 
 
 class XDNAsearch(tk.Toplevel, DNAsearch):
+    """Graphical tools to perform the DNA search."""
+
     def __init__(self, seq='', master=None, highlight=0):
+        """Initialize the search GUI."""
         DNAsearch.__init__(self)
         self.master = master
         self.highlight = highlight
@@ -100,6 +115,7 @@ class XDNAsearch(tk.Toplevel, DNAsearch):
         self.cur_pos = 0
 
     def init_graphics(self):
+        """Build the search window."""
         tk.Toplevel.__init__(self, self.master)
         self.frame = ttk.Frame(self)
         self.frame.pack(fill=tk.BOTH, expand=1)
@@ -125,6 +141,7 @@ class XDNAsearch(tk.Toplevel, DNAsearch):
         self.config_color(self.current_color)
 
     def config_color(self, color=None):
+        """Set color for found sequence tag."""
         if not self.highlight:
             return
         if not color:
@@ -139,13 +156,16 @@ class XDNAsearch(tk.Toplevel, DNAsearch):
         self.colors.append(color)
 
     def change_color(self):
+        """Call back for color button."""
         self.config_color()
 
     def get_pattern(self):
+        """Retrieve query sequence."""
         pattern = self.search_entry.get()
         return pattern
 
     def do_search(self, other_strand=0):
+        """Start the search."""
         pattern = self.get_pattern()
         if other_strand:
             pattern = reverse_complement(pattern)
@@ -164,6 +184,7 @@ class XDNAsearch(tk.Toplevel, DNAsearch):
                 w.see('1.%d' % start)
 
     def exit(self):
+        """Clean up on exit."""
         for c in self.colors:
             self.master.tag_remove('searched_%s' % c, 1.0, tk.END)
             self.master.tag_remove('searched_%sR' % c, 1.0, tk.END)

--- a/Scripts/xbbtools/xbb_translations.py
+++ b/Scripts/xbbtools/xbb_translations.py
@@ -20,28 +20,37 @@ from Bio.SeqUtils import GC
 
 
 class xbb_translations(object):
+    """A class for doing translations."""
+
     def __init__(self):
+        """Initialize."""
         pass
 
     def frame1(self, seq, translation_table=1):
+        """Translate first reading frame."""
         return translate(seq, table=translation_table)
 
     def complement(self, seq):
+        """Return complementary DNA Seq object."""
         return Seq.complement(Seq(seq))
 
     def reverse(self, seq):
+        """Reverse the sequence."""
         return seq[::-1]
 
     def antiparallel(self, seq):
+        """Return reverse complementary sequence."""
         return reverse_complement(seq)
 
     def frame(self, seq, frame, translation_table=1):
+        """Translate DNA sequence in a choosen frame."""
         if frame < 0:
             seq = reverse_complement(seq)
         seq = seq[(abs(frame) - 1):]
         return translate(seq, table=translation_table)
 
     def header_nice(self, txt, seq):
+        """Print a short header for the translation window."""
         length = len(seq)
         if length > 20:
             short = '%s ... %s' % (seq[:10], seq[-10:])
@@ -60,6 +69,7 @@ class xbb_translations(object):
         return res
 
     def frame_nice(self, seq, frame, translation_table=1):
+        """Print a pretty print single frame translation."""
         length = len(seq)
         protein = self.frame(seq, frame, translation_table)
         protein_length = len(protein)
@@ -86,10 +96,11 @@ class xbb_translations(object):
         return res
 
     def gc(self, seq):
-        """Return a float between 0 and 100."""
+        """Calculate GC content in percent (0-100)."""
         return GC(seq)
 
     def gcframe(self, seq, translation_table=1, direction='both'):
+        """Print a pretty print tranlation in several frames."""
         # always use uppercase nt-sequence !!
         comp = self.complement(seq)
         anti = self.reverse(comp)

--- a/Scripts/xbbtools/xbb_utils.py
+++ b/Scripts/xbbtools/xbb_utils.py
@@ -42,7 +42,7 @@ class NotePad(tk.Toplevel):
         self.yscroll.pack(side='right', fill='y')
 
     def text_id(self):
-        """Get text from notepad window."""
+        """Get reference to notepad window."""
         return self.tid
 
     def insert(self, start, txt):

--- a/Scripts/xbbtools/xbb_utils.py
+++ b/Scripts/xbbtools/xbb_utils.py
@@ -22,7 +22,10 @@ except ImportError:  # Python 3
 
 
 class NotePad(tk.Toplevel):
+    """Top level window for results (translations, BLAST searches...)."""
+
     def __init__(self, master=None):
+        """Set up notepad window."""
         tk.Toplevel.__init__(self, master)
         self.menubar = tk.Menu(self)
         self.filemenu = tk.Menu(self.menubar)
@@ -39,12 +42,15 @@ class NotePad(tk.Toplevel):
         self.yscroll.pack(side='right', fill='y')
 
     def text_id(self):
+        """Get text from notepad window."""
         return self.tid
 
     def insert(self, start, txt):
+        """Add text to notepad window."""
         self.tid.insert(start, txt)
 
     def save(self):
+        """Save text from notepad to file."""
         file = filedialog.asksaveasfilename()
         if file:
             with open(file, 'w') as fid:

--- a/Scripts/xbbtools/xbb_widget.py
+++ b/Scripts/xbbtools/xbb_widget.py
@@ -178,7 +178,7 @@ class xbb_widget(object):
             self.main_frame.destroy()
 
     def create_seqinfo(self, parent):
-        """Set up top sequence information fields."""
+        """Set up two info lines at top of main window."""
         # all the sequence information in the top labels
         self.seq_info1 = ttk.Frame(parent, relief='ridge',
                                    borderwidth=5, height=30)
@@ -267,7 +267,7 @@ class xbb_widget(object):
         self.count_selection(None)
 
     def get_selection_or_sequence(self):
-        """Return selected sequence or whole sequence, if nothing selected.
+        """Return selected sequence or whole sequence (if nothing selected).
 
         Whitespaces, digits etc. are removed.
         """


### PR DESCRIPTION
This pull request is related to issue #2014.
It removes several code-style violations according to PEP-8 and PEP-257 in folder `Scripts`, so that no extra `per-file-ignores` are neccesary for this folder.
I put a whole-file `noqa: flake8` on `nextorf.py` in `xbbtools` for now. It does not seem to be used in `xbbtools` (and is causing numerous style-issues...)

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
