### PR TITLE
fixed doctest for Bio.TogoWS

### DIFF
--- a/Bio/TogoWS/__init__.py
+++ b/Bio/TogoWS/__init__.py
@@ -192,7 +192,7 @@ def search_iter(db, query, limit=None, batch=100):
     >>> from Bio import TogoWS
     >>> for id in TogoWS.search_iter("pubmed", "diabetes+human", limit=10):
     ...     print("PubMed ID: %s" %id) # maybe fetch data with entry?
-    PubMed ID: 27374092
+    PubMed ID: ...
 
     Internally this first calls the Bio.TogoWS.search_count() and then
     uses Bio.TogoWS.search() to get the results in batches.

--- a/Bio/TogoWS/__init__.py
+++ b/Bio/TogoWS/__init__.py
@@ -191,8 +191,8 @@ def search_iter(db, query, limit=None, batch=100):
     You would use this function within a for loop, e.g.
     >>> from Bio import TogoWS
     >>> for id in TogoWS.search_iter("pubmed", "diabetes+human", limit=10):
-    ...     print(id) # maybe fetch data with entry?
-    27374092
+    ...     print("PubMed ID: %s" %id) # maybe fetch data with entry?
+    PubMed ID: 27374092
 
     Internally this first calls the Bio.TogoWS.search_count() and then
     uses Bio.TogoWS.search() to get the results in batches.

--- a/Bio/TogoWS/__init__.py
+++ b/Bio/TogoWS/__init__.py
@@ -179,7 +179,7 @@ def search_count(db, query):
 
 
 def search_iter(db, query, limit=None, batch=100):
-    """Call TogoWS search iteratating over the results (generator function).
+    """Call TogoWS search iterating over the results (generator function).
 
     Arguments:
      - db - database (string), see http://togows.dbcls.jp/search
@@ -189,9 +189,10 @@ def search_iter(db, query, limit=None, batch=100):
        TogoWS (currently limited to 100).
 
     You would use this function within a for loop, e.g.
-
-    >>> for id in search_iter("pubmed", "lung+cancer+drug", limit=10):
+    >>> from Bio import TogoWS
+    >>> for id in TogoWS.search_iter("pubmed", "diabetes+human", limit=10):
     ...     print(id) # maybe fetch data with entry?
+    27374092
 
     Internally this first calls the Bio.TogoWS.search_count() and then
     uses Bio.TogoWS.search() to get the results in batches.

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -111,7 +111,6 @@ EXCLUDE_DOCTEST_MODULES = [
     'Bio.SubsMat',
     'Bio.SubsMat.FreqTable',
     'BioSQL.BioSeqDatabase',
-    'Bio.TogoWS',
 ]
 
 # Exclude modules with online activity


### PR DESCRIPTION
This pull request addresses issue #1902 
- I have changed the query so it only returns one value, and added the import; with this the doctest works, however on an online query the result is variable, so this is fragile; If I extend the code to minimize errors, then it defies the purpose of been a clean simple example of how to use TogoWS.
Looking forward to feedback.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
