### PR TITLE
TravisCI: Move to Xenial and add Python 3.7 Linux testing

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -34,8 +34,8 @@ envlist =
     sdist
     bdist_wheel
     api
-    {py27,py34,py35,py36,pypy,pypy3}-cover
-    {py27,py34,py35,py36,pypy,pypy3}-nocov
+    {py27,py34,py35,py36,py37,pypy,pypy3}-cover
+    {py27,py34,py35,py36,py37,pypy,pypy3}-nocov
 
 [testenv]
 # TODO: Try tox default sdist based install instead:
@@ -65,16 +65,16 @@ deps =
     # https://bitbucket.org/rptlab/reportlab/issues/176/incompatibility-with-pillow-600
     py27,py35: reportlab
     py27,py35: pillow==5.4
-    py27,py34,py35,py36: psycopg2-binary
+    py27,py34,py35,py36,py37: psycopg2-binary
     py27,py34,py35,py35: mysql-connector-python-rf
     py35,py36: mysqlclient
     py27,py35,pypy: rdflib
     pypy,pypy3: numpy==1.12.1
     pypy,pypy3: mysqlclient
-    py27,py34,py36: numpy
-    py36: scipy
+    py27,py34,py36,py37: numpy
+    py37: scipy
     py27: networkx
-    py36: matplotlib
+    py37: matplotlib
 commands =
     #The bash call is a work around for special characters
     #The /dev/null is to hide the verbose output but leave warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@
 # - test - the actual functional tests which are slow
 
 dist: xenial
+services:
+  - mysql
+  - postgresql
 language: python
 cache: pip
 matrix:
@@ -21,6 +24,7 @@ matrix:
     - stage: basics
       python: 2.7
       env: TOXENV=style
+      services:
       addons:
         apt:
           packages:
@@ -28,12 +32,14 @@ matrix:
     - stage: basics
       python: 3.7
       env: TOXENV=style
+      services:
       addons:
         apt:
           packages:
       before_install: echo "Going to run basic checks"
     - stage: basics
       env: TOXENV=sdist,bdist_wheel
+      services:
       addons:
         apt:
           packages:
@@ -41,6 +47,7 @@ matrix:
     - stage: test
       python: 2.7
       env: TOXENV=api
+      services:
       addons:
         apt:
           packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@
 # - basics - quick things like style and packaging
 # - test - the actual functional tests which are slow
 
-dist: trusty
+dist: xenial
 language: python
 cache: pip
 matrix:
@@ -26,7 +26,7 @@ matrix:
           packages:
       before_install: echo "Going to run basic checks"
     - stage: basics
-      python: 3.6
+      python: 3.7
       env: TOXENV=style
       addons:
         apt:
@@ -57,6 +57,9 @@ matrix:
     - stage: test
       python: 3.6
       env: TOXENV=py36-cover
+    - stage: test
+      python: 3.7
+      env: TOXENV=py37-cover
     - stage: test
       python: pypy
       env: TOXENV=pypy-nocov


### PR DESCRIPTION
Currently not testing Python 3.7 on TravisCI, doing so requires moving from Ubuntu Trusty to Ubuntu Xenial.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
