### PR TITLE
Declare Bio.Aplhabet obsolete with PendingDeprecationWarning

### DIFF
--- a/Bio/Alphabet/__init__.py
+++ b/Bio/Alphabet/__init__.py
@@ -6,10 +6,24 @@
 # choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
 # Please see the LICENSE file that should have been included as part of this
 # package.
-"""Alphabets used in Seq objects etc to declare sequence type and letters.
+"""Alphabets used in Seq objects etc to declare sequence type and letters (OBSOLETE).
 
 This is used by sequences which contain a finite number of similar words.
+
+The design of Bio.Aphabet included a number of historic design choices
+which, with the benefit of hindsight, were regretable. While the details
+remain to be agreed, we intend to remove or replace Bio.Alphabet in 2020.
+Please avoid using this module explicitly in your code. See also:
+https://github.com/biopython/biopython/issues/2046
 """
+
+import warnings
+
+warnings.warn("We intend to remove or replace Bio.Alphabet in 2020, "
+              "ideally avoid using it explicitly in your code. Please "
+              "get in touch if you will be adversely affected by this. "
+              "https://github.com/biopython/biopython/issues/2046",
+              PendingDeprecationWarning)
 
 
 class Alphabet(object):

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -47,6 +47,15 @@ Jython
 Biopython is mostly working under Jython 2.7.0, but support for Jython
 is deprecated as of Release 1.70.
 
+Bio.Alphabet
+============
+Declared obsolete in Biopython 1.74, please avoid using this module
+explicitly in your code.
+
+The design of Bio.Aphabet included a number of historic design choices
+which, with the benefit of hindsight, were regretable. While the details
+remain to be agreed, we intend to remove or replace Bio.Alphabet in 2020.
+
 Bio.ExPASy.sprot_search_ful and ExPASy.sprot_search_de
 ======================================================
 These two functions were labelled as broken in Release 1.70, and removed in


### PR DESCRIPTION
This pull request addresses issue #2046

TODO: Follow up with changes to the tutorial to downplay usage of Bio.Aphabet

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
