### PR TITLE
Remove D400 docstring error in test_PDB_parse_pdb_header

### DIFF
--- a/Tests/test_PDB_parse_pdb_header.py
+++ b/Tests/test_PDB_parse_pdb_header.py
@@ -8,10 +8,9 @@
 
 
 import unittest
-import warnings
 
 try:
-    import numpy
+    import numpy  # noqa F401
 except ImportError:
     from Bio import MissingPythonDependencyError
     raise MissingPythonDependencyError(
@@ -50,7 +49,7 @@ class ParseReal(unittest.TestCase):
                                 "chain": "2", "ssseq": 11, "insertion": None})
 
     def test_parse_header_line(self):
-        """Unit test for parsing and converting fields in HEADER record"""
+        """Unit test for parsing and converting fields in HEADER record."""
         header = parse_pdb_header("PDB/header.pdb")
         self.assertEqual(header['head'], 'structural genomics, unknown function')
         self.assertEqual(header['idcode'], '3EFG')


### PR DESCRIPTION
This pull request removes a docstring error in a commit that somehow bypassed style-checking.

A recent commit (https://github.com/biopython/biopython/commit/8ad8ddb57d8c4e3c2a8b7f17f1a93b74b071a93d) introduced a D400 docstring error in the codebase that makes all PR's fail.

https://github.com/biopython/biopython/blob/ead409e6cb342cff68ed079c4c1d3bdc3c23e653/Tests/test_PDB_parse_pdb_header.py#L52-L53

<pre>
Tests/test_PDB_parse_pdb_header.py:53:1: D400 First line should end with a period
ERROR: InvocationError for command /home/travis/build/biopython/biopython/.tox/style/bin/flake8 Tests/ (exited with code 1)
</pre>