### PR TITLE
Adding missing DocString D103 on Bio.UniGene 

### DIFF
--- a/Bio/UniGene/__init__.py
+++ b/Bio/UniGene/__init__.py
@@ -251,6 +251,7 @@ class Record(object):
 
 
 def parse(handle):
+    """Read and load a UniGene records, for files containing multiple records."""
     while True:
         record = _read(handle)
         if not record:
@@ -259,6 +260,7 @@ def parse(handle):
 
 
 def read(handle):
+    """Read and load a UniGene record, one record per file."""
     record = _read(handle)
     if not record:
         raise ValueError("No SwissProt record found")


### PR DESCRIPTION
This pull request addresses issue #1960

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
