### PR TITLE
Set random seed in scatter plot test

### DIFF
--- a/Tests/test_GraphicsGeneral.py
+++ b/Tests/test_GraphicsGeneral.py
@@ -48,6 +48,7 @@ class ComparativeTest(unittest.TestCase):
     def _make_random_points(self, num_two_d_lists):
         """Make a bunch of random points for testing plots."""
         plot_info = []
+        random.seed(num_two_d_lists)  # for reproducibility
         for two_d_list in range(num_two_d_lists):
             cur_list = []
             num_points = random.randrange(self.min_num_points,


### PR DESCRIPTION
This should solve #2040, where sometimes the scatter plots
are such that we get a ZeroDivisionError exception.

This pull request addresses issue #...

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
