### PR TITLE
Public class docstrings for Bio.Alphabet

### DIFF
--- a/Bio/Alphabet/__init__.py
+++ b/Bio/Alphabet/__init__.py
@@ -171,6 +171,8 @@ class ThreeLetterProtein(Alphabet):
 
 
 class AlphabetEncoder(object):
+    """A class to construct a new, extended alphabet from an existing one."""
+
     def __init__(self, alphabet, new_letters):
         """Initialize the class."""
         self.alphabet = alphabet
@@ -209,6 +211,8 @@ class AlphabetEncoder(object):
 
 
 class Gapped(AlphabetEncoder):
+    """Alphabets which contain a gap character."""
+
     def __init__(self, alphabet, gap_char="-"):
         """Initialize the class."""
         AlphabetEncoder.__init__(self, alphabet, gap_char)
@@ -234,6 +238,8 @@ class Gapped(AlphabetEncoder):
 
 
 class HasStopCodon(AlphabetEncoder):
+    """Alphabets which contain a stop symbol."""
+
     def __init__(self, alphabet, stop_symbol="*"):
         """Initialize the class."""
         AlphabetEncoder.__init__(self, alphabet, stop_symbol)


### PR DESCRIPTION
This pull request addresses issue #1961, missing docstrings in public classes.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
