### PR TITLE
E731 issues (Don't assign lambda...) in /Bio

### DIFF
--- a/Bio/.flake8
+++ b/Bio/.flake8
@@ -10,11 +10,10 @@ ignore =
     E122,E123,E126,W503,W504,
     # These are not ignored by default:
     # E501	line too long (XX > 79 characters)
-    # E731	do not assign a lambda expression, use a def
     # F401	module imported but unused
     # F841	local variable name is assigned to but never used
     # TODO: Fix some of these?
-    E501,E731,F401,F841,
+    E501,F401,F841,
     # =====================================
     # pydocstyle: D1## - Missing Docstrings
     # =====================================

--- a/Bio/SearchIO/BlastIO/blast_tab.py
+++ b/Bio/SearchIO/BlastIO/blast_tab.py
@@ -69,10 +69,17 @@ _LONG_SHORT_MAP = {
     '% hsp coverage': 'qcovhsp',
 }
 
+
 # function to create a list from semicolon-delimited string
 # used in BlastTabParser._parse_result_row
-_list_semicol = lambda x: x.split(';')
-_list_diamond = lambda x: x.split('<>')
+def _list_semicol(s):
+    return s.split(';')
+
+
+def _list_diamond(s):
+    return s.split('<>')
+
+
 # column to class attribute map
 _COLUMN_QRESULT = {
     'qseqid': ('id', str),

--- a/Bio/SeqIO/NibIO.py
+++ b/Bio/SeqIO/NibIO.py
@@ -43,30 +43,33 @@ import sys
 try:
     hex2bytes = bytes.fromhex  # python3
 except AttributeError:
-    hex2bytes = lambda s: s.decode('hex')  # python2
+    # python 2
+    hex2bytes = lambda s: s.decode('hex')  # noqa: E731
 
 if sys.version_info < (3, ):
     # python2
     import binascii
     bytes2hex = binascii.hexlify
 elif sys.version_info < (3, 5):
-    # python3.4
+    # python 3.4
     import binascii
-    bytes2hex = lambda b: binascii.hexlify(b).decode('ascii')
+    bytes2hex = lambda b: binascii.hexlify(b).decode('ascii')  # noqa: E731
 else:
-    # python3.5 and later
-    bytes2hex = lambda b: b.hex()  # python3 later than python2.4
+    # python 3.5 and later
+    bytes2hex = lambda b: b.hex()  # noqa: E731
 
 try:
     int.from_bytes  # python3
 except AttributeError:
     def byte2int(b, byteorder):
+        """Convert byte array to integer."""
         if byteorder == 'little':
             return struct.unpack("<i", b)[0]
         elif byteorder == 'big':
             return struct.unpack(">i", b)[0]
 else:
-    byte2int = lambda b, byteorder: int.from_bytes(b, byteorder)  # python3
+    # python 3
+    byte2int = lambda b, byteorder: int.from_bytes(b, byteorder)  # noqa: E731
 
 
 try:

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -800,8 +800,11 @@ def to_dict(sequences, key_function=None):
     Biopython 1.72, on older versions of Python we explicitly use an
     OrderedDict so that you can always assume the record order is preserved.
     """
+    def _default_key_function(rec):
+        return rec.id
+
     if key_function is None:
-        key_function = lambda rec: rec.id
+        key_function = _default_key_function
 
     d = _dict()
     for record in sequences:


### PR DESCRIPTION
This pull request is related to  issue #2014.

It removes or silences the last E731 issues (don't assign a lambda expression, use def) in `/Bio`, so we can stop ignoring it in our style checks.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
