### PR TITLE
Add missing docstrings for public functions in Bio/

### DIFF
--- a/Bio/.flake8
+++ b/Bio/.flake8
@@ -19,10 +19,9 @@ ignore =
     # =====================================
     # D101	Missing docstring in public class
     # D102	Missing docstring in public method
-    # D103	Missing docstring in public function
     # D105	Missing docstring in magic method
     # TODO: Fix some of these?
-    D101,D102,D103,D105,
+    D101,D102,D105,
     # ====================================
     # pydocstyle: D2## - Whitespace Issues
     # ====================================

--- a/Bio/Geo/Record.py
+++ b/Bio/Geo/Record.py
@@ -85,6 +85,7 @@ class Record(object):
 
 
 def out_block(text, prefix=''):
+    """Format text in blocks of 80 chars with an additional optional prefix."""
     output = ''
     for j in range(0, len(text), 80):
         output += '%s%s\n' % (prefix, text[j:j + 80])

--- a/Bio/Geo/__init__.py
+++ b/Bio/Geo/__init__.py
@@ -25,6 +25,10 @@ def _read_key_value(line):
 
 
 def parse(handle):
+    """Read Gene Expression Omnibus records from file handle.
+
+    Returns a generator object which yields Bio.Geo.Record() objects.
+    """
     record = None
     for line in handle:
         line = line.strip('\n').strip('\r')

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -110,6 +110,7 @@ class TabWriter(SequentialSequenceWriter):
 
 
 def as_tab(record):
+    """Return record as tab separated (id(tab)seq) string."""
     title = _clean(record.id)
     seq = _get_seq_string(record)  # Catches sequence being None
     assert "\t" not in title

--- a/Bio/SwissProt/KeyWList.py
+++ b/Bio/SwissProt/KeyWList.py
@@ -53,6 +53,11 @@ class Record(dict):
 
 
 def parse(handle):
+    """Parse the keyword list from file handle.
+
+    Returns a generator object which yields keyword entries as
+    Bio.SwissProt.KeyWList.Record() object.
+    """
     record = Record()
     # First, skip the header - look for start of a record
     for line in handle:

--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -132,6 +132,10 @@ class Reference(object):
 
 
 def parse(handle):
+    """Read multiple SwissProt records from file handle.
+
+    Returns a generator object which yields Bio.SwissProt.Record() objects.
+    """
     while True:
         record = _read(handle)
         if not record:
@@ -140,6 +144,10 @@ def parse(handle):
 
 
 def read(handle):
+    """Read one SwissProt record from file handle.
+
+    Returns a Record() object.
+    """
     record = _read(handle)
     if not record:
         raise ValueError("No SwissProt record found")
@@ -306,9 +314,9 @@ def _read_dt(record, line):
     value = line[5:]
     uprline = value.upper()
     cols = value.rstrip().split()
-    if 'CREATED' in uprline \
-    or 'LAST SEQUENCE UPDATE' in uprline \
-    or 'LAST ANNOTATION UPDATE' in uprline:
+    if ('CREATED' in uprline
+            or 'LAST SEQUENCE UPDATE' in uprline
+            or 'LAST ANNOTATION UPDATE' in uprline):
         # Old style DT line
         # =================
         # e.g.
@@ -352,9 +360,9 @@ def _read_dt(record, line):
             record.annotation_update = date, version
         else:
             raise ValueError("Unrecognised DT (DaTe) line.")
-    elif 'INTEGRATED INTO' in uprline \
-    or 'SEQUENCE VERSION' in uprline \
-    or 'ENTRY VERSION' in uprline:
+    elif ('INTEGRATED INTO' in uprline
+          or 'SEQUENCE VERSION' in uprline
+          or 'ENTRY VERSION' in uprline):
         # New style DT line
         # =================
         # As of UniProt Knowledgebase release 7.0 (including

--- a/Bio/codonalign/codonalphabet.py
+++ b/Bio/codonalign/codonalphabet.py
@@ -33,6 +33,7 @@ class CodonAlphabet(Alphabet):
 
 
 def get_codon_alphabet(codon_table, gap_char="-"):
+    """Construct a CodonAlphabet from a given codon table."""
     letters = list(codon_table.forward_table.keys())
     letters.extend(codon_table.stop_codons)
     letters.extend(codon_table.start_codons)


### PR DESCRIPTION
This pull request addresses issue #1960 and added the last missing docstrings for public functions in the `Bio` module.

Important: One missing docstring in `Bio.SeqIO.NibIO` is part of PR #2065. Thus this PR should not be merged before PR #2065.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
