### PR TITLE
Syntax coloring in Tutorial (PDF only, using minted + Pygments)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ Doc/*/*/*.out
 Doc/*/*/*.toc
 Doc/*/*/*.haux
 Doc/*/*/*.htoc
+Doc/_minted-Tutorial/
 Doc/Tutorial.txt
 Doc/Tutorial.pdf
 Doc/Tutorial.html

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -5,9 +5,9 @@ all:  Tutorial.html Tutorial.txt pdf $(subdirs)
 pdf:  Tutorial.pdf biopdb_faq.pdf
 
 Tutorial.pdf: Tutorial.tex Tutorial/chapter_*.tex
-	pdflatex Tutorial.tex
-	pdflatex Tutorial.tex
-	pdflatex Tutorial.tex
+	pdflatex --shell-escape Tutorial.tex
+	pdflatex --shell-escape Tutorial.tex
+	pdflatex --shell-escape Tutorial.tex
 
 biopdb_faq.pdf: biopdb_faq.tex
 	pdflatex biopdb_faq.tex

--- a/Doc/Tutorial.tex
+++ b/Doc/Tutorial.tex
@@ -47,7 +47,7 @@
 \usepackage{fullpage}
 \usepackage{hevea}
 \usepackage{graphicx}
-\usepackage{listings}
+\usepackage{minted}
 
 % make everything have section numbers
 \setcounter{secnumdepth}{4}

--- a/Doc/Tutorial.tex
+++ b/Doc/Tutorial.tex
@@ -47,7 +47,12 @@
 \usepackage{fullpage}
 \usepackage{hevea}
 \usepackage{graphicx}
+
+% For syntax coloring of python, pycon, bash etc in pdflatex:
 \usepackage{minted}
+% Minted fails on hevea, https://github.com/gpoore/minted/issues/234
+% silently fall back on verbatim - ignore the language argument:
+%HEVEA \newenvironment{minted}[1]{\verbatim}{\endverbatim}
 
 % make everything have section numbers
 \setcounter{secnumdepth}{4}

--- a/Doc/Tutorial/chapter_advanced.tex
+++ b/Doc/Tutorial/chapter_advanced.tex
@@ -36,9 +36,9 @@ into \verb|SeqRecord| objects.
 \subsection{SubsMat}
 
 This module provides a class and a few routines for generating substitution matrices, similar to BLOSUM or PAM matrices, but based on user-provided data. Additionally, you may select a matrix from MatrixInfo.py, a collection of established substitution matrices. The \verb+SeqMat+ class derives from a dictionary:
-\begin{verbatim}
+\begin{minted}{python}
 class SeqMat(dict)
-\end{verbatim}
+\end{minted}
 The dictionary is of the form \verb|{(i1,j1):n1, (i1,j2):n2,...,(ik,jk):nk}| where i, j are alphabet letters, and n is a value.
 
 \begin{enumerate}
@@ -54,9 +54,9 @@ The dictionary is of the form \verb|{(i1,j1):n1, (i1,j2):n2,...,(ik,jk):nk}| whe
   \begin{enumerate}
 
     \item
-\begin{verbatim}
+\begin{minted}{python}
 __init__(self,data=None,alphabet=None, mat_name='', build_later=0):
-\end{verbatim}
+\end{minted}
 
     \begin{enumerate}
 
@@ -70,18 +70,18 @@ __init__(self,data=None,alphabet=None, mat_name='', build_later=0):
     \end{enumerate}
 
     \item
-\begin{verbatim}
+\begin{minted}{python}
 entropy(self,obs_freq_mat)
-\end{verbatim}
+\end{minted}
 
     \begin{enumerate}
       \item \verb|obs_freq_mat|: an observed frequency matrix. Returns the matrix's entropy, based on the frequency in  \verb|obs_freq_mat|. The matrix instance should be LO or SUBS.
     \end{enumerate}
 
     \item
-\begin{verbatim}
+\begin{minted}{python}
 sum(self)
-\end{verbatim}
+\end{minted}
     Calculates the sum of values for each letter in the matrix's alphabet, and returns it as a dictionary of the form \verb|{i1: s1, i2: s2,...,in:sn}|, where:
     \begin{itemize}
       \item i: an alphabet letter;
@@ -90,9 +90,9 @@ sum(self)
     \end{itemize}
 
     \item
-\begin{verbatim}
+\begin{minted}{python}
 print_mat(self,f,format="%4d",bottomformat="%4s",alphabet=None)
-\end{verbatim}
+\end{minted}
 
     prints the matrix to file handle f. \verb|format| is the format field for the matrix values; \verb|bottomformat| is the format field for the bottom row, containing matrix letters. Example output for a 3-letter alphabet matrix:
 
@@ -145,9 +145,9 @@ At this point, if all you wish to do is generate a log-odds matrix, please go to
 \item Generating the observed frequency matrix (OFM)
 
 Use:
-\begin{verbatim}
+\begin{minted}{python}
 OFM = SubsMat._build_obs_freq_mat(ARM)
-\end{verbatim}
+\end{minted}
 
   The OFM is generated from the ARM, only instead of replacement counts, it contains replacement frequencies.
 
@@ -155,9 +155,9 @@ OFM = SubsMat._build_obs_freq_mat(ARM)
 
 Use:
 
-\begin{verbatim}
+\begin{minted}{python}
 EFM = SubsMat._build_exp_freq_mat(OFM,exp_freq_table)
-\end{verbatim}
+\end{minted}
 
   \begin{enumerate}
     \item \verb|exp_freq_table|: should be a FreqTable instance. See section~\ref{sec:freq_table} for detailed information on FreqTable. Briefly, the expected frequency table has the frequencies of appearance for each member of the alphabet. It is
@@ -166,10 +166,10 @@ EFM = SubsMat._build_exp_freq_mat(OFM,exp_freq_table)
 
 The expected frequency table can (and generally should) be generated from the observed frequency matrix. So in most cases you will generate \verb|exp_freq_table| using:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> exp_freq_table = SubsMat._exp_freq_table_from_obs_freq(OFM)
 >>> EFM = SubsMat._build_exp_freq_mat(OFM, exp_freq_table)
-\end{verbatim}
+\end{minted}
 
 But you can supply your own \verb|exp_freq_table|, if you wish
 
@@ -177,18 +177,18 @@ But you can supply your own \verb|exp_freq_table|, if you wish
 
 Use:
 
-\begin{verbatim}
+\begin{minted}{python}
 SFM = SubsMat._build_subs_mat(OFM,EFM)
-\end{verbatim}
+\end{minted}
 
   Accepts an OFM, EFM. Provides the division product of the corresponding values.
 
 \item Generating a log-odds matrix (LOM)
 
    Use:
-\begin{verbatim}
+\begin{minted}{python}
 LOM=SubsMat._build_log_odds_mat(SFM[,logbase=10,factor=10.0,round_digit=1])
-\end{verbatim}
+\end{minted}
 
    \begin{enumerate}
      \item Accepts an SFM.
@@ -205,10 +205,10 @@ LOM=SubsMat._build_log_odds_mat(SFM[,logbase=10,factor=10.0,round_digit=1])
 
 As most people would want to generate a log-odds matrix, with minimum hassle, SubsMat provides one function which does it all:
 
-\begin{verbatim}
+\begin{minted}{python}
 make_log_odds_matrix(acc_rep_mat,exp_freq_table=None,logbase=10,
                       factor=10.0,round_digit=0):
-\end{verbatim}
+\end{minted}
 
 \begin{enumerate}
   \item \verb|acc_rep_mat|: user provided accepted replacements matrix
@@ -222,9 +222,9 @@ make_log_odds_matrix(acc_rep_mat,exp_freq_table=None,logbase=10,
 \subsection{FreqTable}
 \label{sec:freq_table}
 
-\begin{verbatim}
+\begin{minted}{python}
 FreqTable.FreqTable(UserDict.UserDict)
-\end{verbatim}
+\end{minted}
 
 \begin{enumerate}
 
@@ -265,9 +265,9 @@ C  0.5
 Conversely, the residue frequencies or counts can be passed as a dictionary.
 Example of a count dictionary (3-letter alphabet):
 
-\begin{verbatim}
+\begin{minted}{python}
 {'A': 35, 'B': 65, 'C': 100}
-\end{verbatim}
+\end{minted}
 
 Which means that an expected data count would give a 0.5 frequency
 for 'C', a 0.325 probability of 'B' and a 0.175 probability of 'A'
@@ -275,9 +275,9 @@ out of 200 total, sum of A, B and C)
 
  A frequency dictionary for the same data would be:
 
-\begin{verbatim}
+\begin{minted}{python}
 {'A': 0.175, 'B': 0.325, 'C': 0.5}
-\end{verbatim}
+\end{minted}
 
 Summing up to 1.
 
@@ -286,13 +286,13 @@ When passing a dictionary as an argument, you should indicate whether it is a co
 Read expected counts. readCount will already generate the frequencies
 Any one of the following may be done to geerate the frequency table (ftab):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from SubsMat import *
 >>> ftab = FreqTable.FreqTable(my_frequency_dictionary, FreqTable.FREQ)
 >>> ftab = FreqTable.FreqTable(my_count_dictionary, FreqTable.COUNT)
 >>> ftab = FreqTable.read_count(open("myCountFile"))
 >>> ftab = FreqTable.read_frequency(open("myFrequencyFile"))
-\end{verbatim}
+\end{minted}
 
 \end{enumerate}
 

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -72,15 +72,15 @@ COATB_BPIF1/22-73             FAADDATSQAKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKLFKKFVS
 This is the seed alignment for the Phage\_Coat\_Gp8 (PF05371) PFAM entry, downloaded from a now out of date release of PFAM from \url{https://pfam.xfam.org/}.  We can load this file as follows (assuming it has been saved to disk as ``PF05371\_seed.sth'' in the current working directory):
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import AlignIO
 >>> alignment = AlignIO.read("PF05371_seed.sth", "stockholm")
-\end{verbatim}
+\end{minted}
 
 \noindent This code will print out a summary of the alignment:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignment)
 SingleLetterAlphabet() alignment with 7 rows and 52 columns
 AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRL...SKA COATB_BPIKE/30-81
@@ -90,12 +90,12 @@ AEGDDP---AKAAFNSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPM13/24-72
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPZJ2/1-49
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA Q9T0Q9_BPFD/1-49
 FAADDATSQAKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKL...SRA COATB_BPIF1/22-73
-\end{verbatim}
+\end{minted}
 
 You'll notice in the above output the sequences have been truncated.  We could instead write our own code to format this as we please by iterating over the rows as \verb|SeqRecord| objects:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import AlignIO
 >>> alignment = AlignIO.read("PF05371_seed.sth", "stockholm")
 >>> print("Alignment length %i" % alignment.get_alignment_length())
@@ -110,14 +110,14 @@ AEGDDP---AKAAFNSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFTSKA - COATB_BPM13/24-72
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFASKA - COATB_BPZJ2/1-49
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFTSKA - Q9T0Q9_BPFD/1-49
 FAADDATSQAKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKLFKKFVSRA - COATB_BPIF1/22-73
-\end{verbatim}
+\end{minted}
 
 You could also use the alignment object's \verb|format| method to show it in a particular file format  -- see Section~\ref{sec:alignment-format-method} for details.
 
 Did you notice in the raw file above that several of the sequences include database cross-references to the PDB and the associated known secondary structure?  Try this:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for record in alignment:
 ...     if record.dbxrefs:
 ...         print("%s %s" % (record.id, record.dbxrefs))
@@ -126,15 +126,15 @@ COATB_BPIKE/30-81 ['PDB; 1ifl ; 1-52;']
 COATB_BPM13/24-72 ['PDB; 2cpb ; 1-49;', 'PDB; 2cps ; 1-49;']
 Q9T0Q9_BPFD/1-49 ['PDB; 1nh4 A; 1-49;']
 COATB_BPIF1/22-73 ['PDB; 1ifk ; 1-50;']
-\end{verbatim}
+\end{minted}
 
 \noindent To have a look at all the sequence annotation, try this:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for record in alignment:
 ...     print(record)
 ...
-\end{verbatim}
+\end{minted}
 
 PFAM provide a nice web interface at \url{ http://pfam.xfam.org/family/PF05371} which will actually let you download this alignment in several other formats.  This is what the file looks like in the FASTA file format:
 
@@ -157,11 +157,11 @@ FAADDATSQAKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKLFKKFVSRA
 
 \noindent Note the website should have an option about showing gaps as periods (dots) or dashes, we've shown dashes above.  Assuming you download and save this as file ``PF05371\_seed.faa'' then you can load it with almost exactly the same code:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import AlignIO
 alignment = AlignIO.read("PF05371_seed.faa", "fasta")
 print(alignment)
-\end{verbatim}
+\end{minted}
 
 All that has changed in this code is the filename and the format string.  You'll get the same output as before, the sequences and record identifiers are the same.
 However, as you should expect, if you check each \verb|SeqRecord| there is no annotation nor database cross-references because these are not included in the FASTA file format.
@@ -170,11 +170,11 @@ Note that rather than using the Sanger website, you could have used \verb|Bio.Al
 
 With any supported file format, you can load an alignment in exactly the same way just by changing the format string.  For example, use ``phylip'' for PHYLIP files, ``nexus'' for NEXUS files or ``emboss'' for the alignments output by the EMBOSS tools.  There is a full listing on the wiki page (\url{http://biopython.org/wiki/AlignIO}) and in the built in documentation (also \href{http://biopython.org/DIST/docs/api/Bio.AlignIO-module.html}{online}):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import AlignIO
 >>> help(AlignIO)
 ...
-\end{verbatim}
+\end{minted}
 
 \subsection{Multiple Alignments}
 
@@ -224,13 +224,13 @@ Epsilon   CAAACC
 If you wanted to read this in using \verb|Bio.AlignIO| you could use:
 
 %TODO - Replace the print blank line with print()?
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import AlignIO
 alignments = AlignIO.parse("resampled.phy", "phylip")
 for alignment in alignments:
     print(alignment)
     print("")
-\end{verbatim}
+\end{minted}
 
 \noindent This would give the following output, again abbreviated for display:
 
@@ -269,12 +269,12 @@ CAAACC Epsilon
 As with the function \verb|Bio.SeqIO.parse()|, using \verb|Bio.AlignIO.parse()| returns an iterator.
 If you want to keep all the alignments in memory at once, which will allow you to access them in any order, then turn the iterator into a list:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import AlignIO
 alignments = list(AlignIO.parse("resampled.phy", "phylip"))
 last_align = alignments[-1]
 first_align = alignments[0]
-\end{verbatim}
+\end{minted}
 
 \subsection{Ambiguous Alignments}
 \label{sec:AlignIO-count-argument}
@@ -342,13 +342,13 @@ To interpret these FASTA examples as several separate alignments, we can use \ve
 For example, using the third example as the input data:
 
 %TODO - Replace the print blank line with print()?
-\begin{verbatim}
+\begin{minted}{python}
 for alignment in AlignIO.parse(handle, "fasta", seq_count=2):
     print("Alignment length %i" % alignment.get_alignment_length())
     for record in alignment:
         print("%s - %s" % (record.seq, record.id))
     print("")
-\end{verbatim}
+\end{minted}
 
 \noindent giving:
 
@@ -379,7 +379,7 @@ We've talked about using \verb|Bio.AlignIO.read()| and \verb|Bio.AlignIO.parse()
 Here is an example, where we start by creating a few \verb|MultipleSeqAlignment| objects the hard way (by hand, rather than by loading them from a file).
 Note we create some \verb|SeqRecord| objects to construct the alignment from.
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.Alphabet import generic_dna
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
@@ -404,14 +404,14 @@ align3 = MultipleSeqAlignment([
          ])
 
 my_alignments = [align1, align2, align3]
-\end{verbatim}
+\end{minted}
 
 \noindent Now we have a list of \verb|Alignment| objects, we'll write them to a PHYLIP format file:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import AlignIO
 AlignIO.write(my_alignments, "my_example.phy", "phylip")
-\end{verbatim}
+\end{minted}
 
 \noindent And if you open this file in your favourite text editor it should look like this:
 
@@ -448,30 +448,30 @@ in the same way as converting between sequence file formats with \verb|Bio.SeqIO
 
 For this example, we'll load the PFAM/Stockholm format file used earlier and save it as a Clustal W format file:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import AlignIO
 count = AlignIO.convert("PF05371_seed.sth", "stockholm", "PF05371_seed.aln", "clustal")
 print("Converted %i alignments" % count)
-\end{verbatim}
+\end{minted}
 
 Or, using \verb|Bio.AlignIO.parse()| and \verb|Bio.AlignIO.write()|:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import AlignIO
 alignments = AlignIO.parse("PF05371_seed.sth", "stockholm")
 count = AlignIO.write(alignments, "PF05371_seed.aln", "clustal")
 print("Converted %i alignments" % count)
-\end{verbatim}
+\end{minted}
 
 The \verb|Bio.AlignIO.write()| function expects to be given multiple alignment objects.  In the example above we gave it the alignment iterator returned by \verb|Bio.AlignIO.parse()|.
 
 In this case, we know there is only one alignment in the file so we could have used \verb|Bio.AlignIO.read()| instead, but notice we have to pass this alignment to \verb|Bio.AlignIO.write()| as a single element list:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import AlignIO
 alignment = AlignIO.read("PF05371_seed.sth", "stockholm")
 AlignIO.write([alignment], "PF05371_seed.aln", "clustal")
-\end{verbatim}
+\end{minted}
 
 Either way, you should end up with the same new Clustal W format file ``PF05371\_seed.aln'' with the following content:
 
@@ -498,10 +498,10 @@ COATB_BPIF1/22-73                   RA
 
 Alternatively, you could make a PHYLIP format file which we'll name ``PF05371\_seed.phy'':
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import AlignIO
 AlignIO.convert("PF05371_seed.sth", "stockholm", "PF05371_seed.phy", "phylip")
-\end{verbatim}
+\end{minted}
 
 This time the output looks like this:
 
@@ -530,10 +530,10 @@ In this example, as you can see the resulting names are still unique -
 but they are not very readable. As a result, a more relaxed variant of
 the original PHYLIP format is now quite widely used:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import AlignIO
 AlignIO.convert("PF05371_seed.sth", "stockholm", "PF05371_seed.phy", "phylip-relaxed")
-\end{verbatim}
+\end{minted}
 
 This time the output looks like this, using a longer indentation to
 allow all the identifers to be given in full:
@@ -561,7 +561,7 @@ If you have to work with the original strict PHYLIP format, then you may need to
 compress the identifers somehow -- or assign your own names or numbering system.
 This following bit of code manipulates the record identifiers before saving the output:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import AlignIO
 alignment = AlignIO.read("PF05371_seed.sth", "stockholm")
 name_mapping = {}
@@ -571,12 +571,12 @@ for i, record in enumerate(alignment):
 print(name_mapping)
 
 AlignIO.write([alignment], "PF05371_seed.phy", "phylip")
-\end{verbatim}
+\end{minted}
 
 \noindent This code used a Python dictionary to record a simple mapping from the new sequence system to the original identifier:
-\begin{verbatim}
+\begin{minted}{python}
 {0: 'COATB_BPIKE/30-81', 1: 'Q9T0Q8_BPIKE/1-52', 2: 'COATB_BPI22/32-83', ...}
-\end{verbatim}
+\end{minted}
 
 \noindent Here is the new (strict) PHYLIP format output:
 \begin{verbatim}
@@ -608,11 +608,11 @@ The \verb|Bio.AlignIO| interface is based on handles, which means if you want to
 However, you will probably prefer to take advantage of the alignment object's \verb|format()| method.
 This takes a single mandatory argument, a lower case string which is supported by \verb|Bio.AlignIO| as an output format.  For example:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import AlignIO
 alignment = AlignIO.read("PF05371_seed.sth", "stockholm")
 print(alignment.format("clustal"))
-\end{verbatim}
+\end{minted}
 
 As described in Section~\ref{sec:SeqRecord-format}, the \verb|SeqRecord| object has a similar method using output formats supported by \verb|Bio.SeqIO|.
 
@@ -620,7 +620,7 @@ Internally the \verb|format()| method is using the \verb|StringIO| string based 
 \verb|Bio.AlignIO.write()|.  You can do this in your own code if for example you are using an
 older version of Biopython:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import AlignIO
 from StringIO import StringIO
 
@@ -631,7 +631,7 @@ AlignIO.write(alignments, out_handle, "clustal")
 clustal_data = out_handle.getvalue()
 
 print(clustal_data)
-\end{verbatim}
+\end{minted}
 
 \section{Manipulating Alignments}
 \label{sec:manipulating-alignments}
@@ -646,7 +646,7 @@ of \verb|len()| (the number of rows) and iteration (each row as a \verb|SeqRecor
 make sense:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import AlignIO
 >>> alignment = AlignIO.read("PF05371_seed.sth", "stockholm")
 >>> print("Number of rows: %i" % len(alignment))
@@ -661,7 +661,7 @@ AEGDDP---AKAAFNSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFTSKA - COATB_BPM13/24-72
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFASKA - COATB_BPZJ2/1-49
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFTSKA - Q9T0Q9_BPFD/1-49
 FAADDATSQAKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKLFKKFVSRA - COATB_BPIF1/22-73
-\end{verbatim}
+\end{minted}
 
 You can also use the list-like \verb|append| and \verb|extend| methods to add
 more rows to the alignment (as \verb|SeqRecord| objects). Keeping the list
@@ -669,7 +669,7 @@ metaphor in mind, simple slicing of the alignment should also make sense -
 it selects some of the rows giving back another alignment object:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignment)
 SingleLetterAlphabet() alignment with 7 rows and 52 columns
 AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRL...SKA COATB_BPIKE/30-81
@@ -685,49 +685,49 @@ AEGDDP---AKAAFNSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPM13/24-72
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPZJ2/1-49
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA Q9T0Q9_BPFD/1-49
 FAADDATSQAKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKL...SRA COATB_BPIF1/22-73
-\end{verbatim}
+\end{minted}
 
 What if you wanted to select by column? Those of you who have used the NumPy
 matrix or array objects won't be surprised at this - you use a double index.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignment[2, 6])
 T
-\end{verbatim}
+\end{minted}
 
 \noindent Using two integer indices pulls out a single letter, short hand for this:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignment[2].seq[6])
 T
-\end{verbatim}
+\end{minted}
 
 You can pull out a single column as a string like this:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignment[:, 6])
 TTT---T
-\end{verbatim}
+\end{minted}
 
 You can also select a range of columns. For example, to pick out those same
 three rows we extracted earlier, but take just their first six columns:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignment[3:6, :6])
 SingleLetterAlphabet() alignment with 3 rows and 6 columns
 AEGDDP COATB_BPM13/24-72
 AEGDDP COATB_BPZJ2/1-49
 AEGDDP Q9T0Q9_BPFD/1-49
-\end{verbatim}
+\end{minted}
 
 Leaving the first index as \verb|:| means take all the rows:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignment[:, :6])
 SingleLetterAlphabet() alignment with 7 rows and 6 columns
 AEPNAA COATB_BPIKE/30-81
@@ -737,13 +737,13 @@ AEGDDP COATB_BPM13/24-72
 AEGDDP COATB_BPZJ2/1-49
 AEGDDP Q9T0Q9_BPFD/1-49
 FAADDA COATB_BPIF1/22-73
-\end{verbatim}
+\end{minted}
 
 This brings us to a neat way to remove a section. Notice columns
 7, 8 and 9 which are gaps in three of the seven sequences:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignment[:, 6:9])
 SingleLetterAlphabet() alignment with 7 rows and 3 columns
 TNY COATB_BPIKE/30-81
@@ -753,12 +753,12 @@ TSY COATB_BPI22/32-83
 --- COATB_BPZJ2/1-49
 --- Q9T0Q9_BPFD/1-49
 TSQ COATB_BPIF1/22-73
-\end{verbatim}
+\end{minted}
 
 \noindent Again, you can slice to get everything after the ninth column:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignment[:, 9:])
 SingleLetterAlphabet() alignment with 7 rows and 43 columns
 ATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRLFKKFSSKA COATB_BPIKE/30-81
@@ -768,13 +768,13 @@ AKAAFNSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFTSKA COATB_BPM13/24-72
 AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFASKA COATB_BPZJ2/1-49
 AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFTSKA Q9T0Q9_BPFD/1-49
 AKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKLFKKFVSRA COATB_BPIF1/22-73
-\end{verbatim}
+\end{minted}
 
 \noindent Now, the interesting thing is that addition of alignment objects works
 by column. This lets you do this as a way to remove a block of columns:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> edited = alignment[:, :6] + alignment[:, 9:]
 >>> print(edited)
 SingleLetterAlphabet() alignment with 7 rows and 49 columns
@@ -785,7 +785,7 @@ AEGDDPAKAAFNSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFTSKA COATB_BPM13/24-72
 AEGDDPAKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFASKA COATB_BPZJ2/1-49
 AEGDDPAKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFTSKA Q9T0Q9_BPFD/1-49
 FAADDAAKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKLFKKFVSRA COATB_BPIF1/22-73
-\end{verbatim}
+\end{minted}
 
 Another common use of alignment addition would be to combine alignments for
 several different genes into a meta-alignment. Watch out though - the identifiers
@@ -794,7 +794,7 @@ need to match up (see Section~\ref{sec:SeqRecord-addition} for how adding
 alignment rows alphabetically by id:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> edited.sort()
 >>> print(edited)
 SingleLetterAlphabet() alignment with 7 rows and 49 columns
@@ -805,7 +805,7 @@ AEGDDPAKAAFNSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFTSKA COATB_BPM13/24-72
 AEGDDPAKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFASKA COATB_BPZJ2/1-49
 AEPNAAATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIKLFKKFVSRA Q9T0Q8_BPIKE/1-52
 AEGDDPAKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKLFKKFTSKA Q9T0Q9_BPFD/1-49
-\end{verbatim}
+\end{minted}
 
 \noindent Note that you can only add two alignments together if they
 have the same number of rows.
@@ -816,21 +816,21 @@ object into an array of letters -- and you can do this with NumPy:
 
 %This example fails under PyPy 2.0, https://bugs.pypy.org/issue1546
 %doctest examples lib:numpy
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> import numpy as np
 >>> from Bio import AlignIO
 >>> alignment = AlignIO.read("PF05371_seed.sth", "stockholm")
 >>> align_array = np.array([list(rec) for rec in alignment], np.character)
 >>> print("Array shape %i by %i" % align_array.shape)
 Array shape 7 by 52
-\end{verbatim}
+\end{minted}
 
 If you will be working heavily with the columns, you can tell NumPy to store
 the array by column (as in Fortran) rather then its default of by row (as in C):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> align_array = np.array([list(rec) for rec in alignment], np.character, order="F")
-\end{verbatim}
+\end{minted}
 
 Note that this leaves the original Biopython alignment object and the NumPy array
 in memory as separate objects - editing one will not update the other!
@@ -860,13 +860,13 @@ using the \texttt{subprocess} module).
 
 Most of these wrappers are defined in the \verb|Bio.Align.Applications| module:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> import Bio.Align.Applications
 >>> dir(Bio.Align.Applications)
 ...
 ['ClustalwCommandline', 'DialignCommandline', 'MafftCommandline', 'MuscleCommandline',
 'PrankCommandline', 'ProbconsCommandline', 'TCoffeeCommandline' ...]
-\end{verbatim}
+\end{minted}
 
 \noindent (Ignore the entries starting with an underscore -- these have
 special meaning in Python.)
@@ -892,11 +892,11 @@ the ClustalW tool yourself by hand at the command line, to familiarise
 yourself the other options. You'll find the Biopython wrapper is very
 faithful to the actual command line API:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Align.Applications import ClustalwCommandline
 >>> help(ClustalwCommandline)
 ...
-\end{verbatim}
+\end{minted}
 
 For the most basic usage, all you need is to have a FASTA input file, such as
 \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/opuntia.fasta}{opuntia.fasta}
@@ -909,12 +909,12 @@ based on the input FASTA file, in this case \texttt{opuntia.aln} and
 \texttt{opuntia.dnd}, but you can override this or make it explicit:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Align.Applications import ClustalwCommandline
 >>> cline = ClustalwCommandline("clustalw2", infile="opuntia.fasta")
 >>> print(cline)
 clustalw2 -infile=opuntia.fasta
-\end{verbatim}
+\end{minted}
 
 Notice here we have given the executable name as \texttt{clustalw2},
 indicating we have version two installed, which has a different filename to
@@ -931,17 +931,17 @@ ClustalW tools (how you do this will depend on your OS), or simply type in
 the full path of the tool. For example:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> import os
 >>> from Bio.Align.Applications import ClustalwCommandline
 >>> clustalw_exe = r"C:\Program Files\new clustal\clustalw2.exe"
 >>> clustalw_cline = ClustalwCommandline(clustalw_exe, infile="opuntia.fasta")
-\end{verbatim}
+\end{minted}
 %Don't run it in the doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> assert os.path.isfile(clustalw_exe), "Clustal W executable missing"
 >>> stdout, stderr = clustalw_cline()
-\end{verbatim}
+\end{minted}
 
 \noindent Remember, in Python strings \verb|\n| and \verb|\t| are by default
 interpreted as a new line and a tab -- which is why we're put a letter
@@ -980,7 +980,7 @@ You should be able to work out how to read in the alignment using
 \verb|Bio.AlignIO| by now:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import AlignIO
 >>> align = AlignIO.read("opuntia.aln", "clustal")
 >>> print(align)
@@ -992,7 +992,7 @@ TATACATAAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273286|gb|AF191660.1|AF19
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273290|gb|AF191664.1|AF191
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273289|gb|AF191663.1|AF191
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273291|gb|AF191665.1|AF191
-\end{verbatim}
+\end{minted}
 
 In case you are interested (and this is an aside from the main thrust of this
 chapter), the \texttt{opuntia.dnd} file ClustalW creates is just a standard
@@ -1000,7 +1000,7 @@ Newick tree file, and \verb|Bio.Phylo| can parse these:
 
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Phylo
 >>> tree = Phylo.read("opuntia.dnd", "newick")
 >>> Phylo.draw_ascii(tree)
@@ -1018,7 +1018,7 @@ _|_________________ gi|6273287|gb|AF191661.1|AF191661
  |___|
      | gi|6273284|gb|AF191658.1|AF191658
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 \noindent Chapter \ref{sec:Phylo} covers Biopython's support for phylogenetic trees in more
 depth.
@@ -1030,11 +1030,11 @@ module. As before, we recommend you try using MUSCLE from the command line befor
 trying it from within Python, as the Biopython wrapper is very faithful to the
 actual command line API:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Align.Applications import MuscleCommandline
 >>> help(MuscleCommandline)
 ...
-\end{verbatim}
+\end{minted}
 
 For the most basic usage, all you need is to have a FASTA input file, such as
 \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/opuntia.fasta}{opuntia.fasta}
@@ -1043,12 +1043,12 @@ code). You can then tell MUSCLE to read in this FASTA file, and write the
 alignment to an output file:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Align.Applications import MuscleCommandline
 >>> cline = MuscleCommandline(input="opuntia.fasta", out="opuntia.txt")
 >>> print(cline)
 muscle -in opuntia.fasta -out opuntia.txt
-\end{verbatim}
+\end{minted}
 
 Note that MUSCLE uses ``-in'' and ``-out'' but in Biopython we have to use
 ``input'' and ``out'' as the keyword arguments or property names. This is
@@ -1060,23 +1060,23 @@ alignment using \texttt{format="fasta"}.
 You can also ask for ClustalW-like output:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Align.Applications import MuscleCommandline
 >>> cline = MuscleCommandline(input="opuntia.fasta", out="opuntia.aln", clw=True)
 >>> print(cline)
 muscle -in opuntia.fasta -out opuntia.aln -clw
-\end{verbatim}
+\end{minted}
 
 Or, strict ClustalW output where the original ClustalW header line is
 used for maximum compatibility:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Align.Applications import MuscleCommandline
 >>> cline = MuscleCommandline(input="opuntia.fasta", out="opuntia.aln", clwstrict=True)
 >>> print(cline)
 muscle -in opuntia.fasta -out opuntia.aln -clwstrict
-\end{verbatim}
+\end{minted}
 
 \noindent The \verb|Bio.AlignIO| module should be able to read these alignments
 using \texttt{format="clustal"}.
@@ -1101,18 +1101,18 @@ MUSCLE will write the alignment to standard output (stdout). We can take
 advantage of this to avoid having a temporary output file! For example:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Align.Applications import MuscleCommandline
 >>> muscle_cline = MuscleCommandline(input="opuntia.fasta")
 >>> print(muscle_cline)
 muscle -in opuntia.fasta
-\end{verbatim}
+\end{minted}
 
 If we run this via the wrapper, we get back the output as a string. In order
 to parse this we can use \verb|StringIO| to turn it into a handle.
 Remember that MUSCLE defaults to using FASTA as the output format:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Align.Applications import MuscleCommandline
 >>> muscle_cline = MuscleCommandline(input="opuntia.fasta")
 >>> stdout, stderr = muscle_cline()
@@ -1128,14 +1128,14 @@ TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF19
 TATACATAAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273286|gb|AF191660.1|AF191660
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273285|gb|AF191659.1|AF191659
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273284|gb|AF191658.1|AF191658
-\end{verbatim}
+\end{minted}
 
 The above approach is fairly simple, but if you are dealing with very large output
 text the fact that all of stdout and stderr is loaded into memory as a string can
 be a potential drawback. Using the \verb|subprocess| module we can work directly
 with handles instead:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> import subprocess
 >>> from Bio.Align.Applications import MuscleCommandline
 >>> muscle_cline = MuscleCommandline(input="opuntia.fasta")
@@ -1155,7 +1155,7 @@ TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF19
 TATACATAAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273286|gb|AF191660.1|AF191660
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273285|gb|AF191659.1|AF191659
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273284|gb|AF191658.1|AF191658
-\end{verbatim}
+\end{minted}
 
 \subsection{MUSCLE using stdin and stdout}
 
@@ -1169,26 +1169,26 @@ For this demonstration I'm going to use a filtered version of the original FASTA
 file (using a generator expression), taking just six of the seven sequences:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> records = (r for r in SeqIO.parse("opuntia.fasta", "fasta") if len(r) < 900)
-\end{verbatim}
+\end{minted}
 
 Then we create the MUSCLE command line, leaving the input and output to their
 defaults (stdin and stdout). I'm also going to ask for strict ClustalW format
 as for the output.
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Align.Applications import MuscleCommandline
 >>> muscle_cline = MuscleCommandline(clwstrict=True)
 >>> print(muscle_cline)
 muscle -clwstrict
-\end{verbatim}
+\end{minted}
 
 Now for the fiddly bits using the \verb|subprocess| module, stdin and stdout:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> import subprocess
 >>> import sys
 >>> child = subprocess.Popen(str(cline),
@@ -1197,23 +1197,23 @@ Now for the fiddly bits using the \verb|subprocess| module, stdin and stdout:
 ...                          stderr=subprocess.PIPE,
 ...                          universal_newlines=True,
 ...                          shell=(sys.platform!="win32"))
-\end{verbatim}
+\end{minted}
 
 That should start MUSCLE, but it will be sitting waiting for its FASTA input
 sequences, which we must supply via its stdin handle:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> SeqIO.write(records, child.stdin, "fasta")
 6
 >>> child.stdin.close()
-\end{verbatim}
+\end{minted}
 
 After writing the six sequences to the handle, MUSCLE will still be waiting
 to see if that is all the FASTA sequences or not -- so we must signal that
 this is all the input data by closing the handle. At that point MUSCLE should
 start to run, and we can ask for the output:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import AlignIO
 >>> align = AlignIO.read(child.stdout, "clustal")
 >>> print(align)
@@ -1224,7 +1224,7 @@ TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF19
 TATACATAAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273286|gb|AF191660.1|AF19166
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273285|gb|AF191659.1|AF19165
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273284|gb|AF191658.1|AF19165
-\end{verbatim}
+\end{minted}
 
 Wow! There we are with a new alignment of just the six records, without having created
 a temporary FASTA input file, or a temporary alignment output file. However, a word of
@@ -1245,7 +1245,7 @@ provided your data isn't very big, you can prepare the FASTA input in memory as
 a string using \texttt{StringIO} (see Section~\ref{sec:appendix-handles}):
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> records = (r for r in SeqIO.parse("opuntia.fasta", "fasta") if len(r) < 900)
 >>> from StringIO import StringIO
@@ -1253,12 +1253,12 @@ a string using \texttt{StringIO} (see Section~\ref{sec:appendix-handles}):
 >>> SeqIO.write(records, handle, "fasta")
 6
 >>> data = handle.getvalue()
-\end{verbatim}
+\end{minted}
 
 \noindent You can then run the tool and parse the alignment as follows:
 
 %not a doctest as can't assume the MUSCLE binary is present
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> stdout, stderr = muscle_cline(stdin=data)
 >>> from Bio import AlignIO
 >>> align = AlignIO.read(StringIO(stdout), "clustal")
@@ -1270,7 +1270,7 @@ TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF19
 TATACATAAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273286|gb|AF191660.1|AF19166
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273285|gb|AF191659.1|AF19165
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273284|gb|AF191658.1|AF19165
-\end{verbatim}
+\end{minted}
 
 You might find this easier, but it does require more memory (RAM) for the strings
 used for the input FASTA and output Clustal formatted data.
@@ -1307,13 +1307,13 @@ under the \verb|Doc/examples/| directory.
 Let's start by creating a complete \texttt{needle} command line object in one go:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Emboss.Applications import NeedleCommandline
 >>> needle_cline = NeedleCommandline(asequence="alpha.faa", bsequence="beta.faa",
 ...                                  gapopen=10, gapextend=0.5, outfile="needle.txt")
 >>> print(needle_cline)
 needle -outfile=needle.txt -asequence=alpha.faa -bsequence=beta.faa -gapopen=10 -gapextend=0.5
-\end{verbatim}
+\end{minted}
 
 Why not try running this by hand at the command prompt? You should see it does a
 pairwise comparison and records the output in the file \texttt{needle.txt} (in the
@@ -1326,12 +1326,12 @@ variable. You can either update your PATH setting, or simply tell Biopython
 the full path to the tool, for example:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Emboss.Applications import NeedleCommandline
 >>> needle_cline = NeedleCommandline(r"C:\EMBOSS\needle.exe",
 ...                                  asequence="alpha.faa", bsequence="beta.faa",
 ...                                  gapopen=10, gapextend=0.5, outfile="needle.txt")
-\end{verbatim}
+\end{minted}
 
 \noindent Remember in Python that for a default string \verb|\n| or \verb|\t| means a
 new line or a tab -- which is why we're put a letter ``r'' at the start for a raw string.
@@ -1340,16 +1340,16 @@ At this point it might help to try running the EMBOSS tools yourself by hand at 
 command line, to familiarise yourself the other options and compare them to the
 Biopython help text:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Emboss.Applications import NeedleCommandline
 >>> help(NeedleCommandline)
 ...
-\end{verbatim}
+\end{minted}
 
 Note that you can also specify (or change or look at) the settings like this:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Emboss.Applications import NeedleCommandline
 >>> needle_cline = NeedleCommandline()
 >>> needle_cline.asequence="alpha.faa"
@@ -1361,29 +1361,29 @@ Note that you can also specify (or change or look at) the settings like this:
 needle -outfile=needle.txt -asequence=alpha.faa -bsequence=beta.faa -gapopen=10 -gapextend=0.5
 >>> print(needle_cline.outfile)
 needle.txt
-\end{verbatim}
+\end{minted}
 
 Next we want to use Python to run this command for us. As explained above,
 for full control, we recommend you use the built in Python \texttt{subprocess}
 module, but for simple usage the wrapper object usually suffices:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> stdout, stderr = needle_cline()
 >>> print(stdout + stderr)
 Needleman-Wunsch global alignment of two sequences
-\end{verbatim}
+\end{minted}
 
 Next we can load the output file with \verb|Bio.AlignIO| as
 discussed earlier in this chapter, as the \texttt{emboss} format:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import AlignIO
 >>> align = AlignIO.read("needle.txt", "emboss")
 >>> print(align)
 SingleLetterAlphabet() alignment with 2 rows and 149 columns
 MV-LSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTY...KYR HBA_HUMAN
 MVHLTPEEKSAVTALWGKV--NVDEVGGEALGRLLVVYPWTQRF...KYH HBB_HUMAN
-\end{verbatim}
+\end{minted}
 
 In this example, we told EMBOSS to write the output to a file, but you
 \emph{can} tell it to write the output to stdout instead (useful if you
@@ -1434,13 +1434,13 @@ hemoglobin sequences from above (\texttt{HBA\_HUMAN}, \texttt{HBB\_HUMAN})
 stored in \texttt{alpha.faa} and \texttt{beta.faa}:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import pairwise2
 >>> from Bio import SeqIO
 >>> seq1 = SeqIO.read("alpha.faa", "fasta")
 >>> seq2 = SeqIO.read("beta.faa", "fasta")
 >>> alignments = pairwise2.align.globalxx(seq1.seq, seq2.seq)
-\end{verbatim}
+\end{minted}
 
 As you see, we call the alignment function with \verb|align.globalxx|. The tricky
 part are the last two letters of the function name (here: \texttt{xx}), which are
@@ -1459,16 +1459,16 @@ different alignments with the score 72 (\verb|Bio.pairwise2| will return up to 1
 alignments). Have a look at one of these alignments:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(alignments)
 80
-\end{verbatim}
+\end{minted}
 %This has been abbreviated, can't use as doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignments[0])
 ('MV-LSPADKTNV---K-A--A-WGKVGAHAG...YR-', 'MVHL-----T--PEEKSAVTALWGKV----...Y-H',
 72.0, 0, 217)
-\end{verbatim}
+\end{minted}
 
 Each alignment is a tuple consisting of the two aligned sequences, the score, the
 start and the end positions of the alignment (in global alignments the start is
@@ -1476,13 +1476,13 @@ always 0 and the end the length of the alignment). \verb|Bio.pairwise2| has a
 function \verb|format_alignment| for a nicer printout:
 
 %This has been abbreviated, can't use as doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(pairwise2.format_alignment(*alignment[0]))
 MV-LSPADKTNV---K-A--A-WGKVGAHAG---EY-GA-EALE-RMFLSF----PTTK-TY--F...YR-
 || |     |     | |  | ||||        |  |  |||  |  |      |    |   |...|  
 MVHL-----T--PEEKSAVTALWGKV-----NVDE-VG-GEAL-GR--L--LVVYP---WT-QRF...Y-H
   Score=72
-\end{verbatim}
+\end{minted}
 
 Better alignments are usually obtained by penalizing gaps: higher costs
 for opening a gap and lower costs for extending an existing gap. For amino
@@ -1492,7 +1492,7 @@ obtained by using the BLOSUM62 matrix, together with a gap open penalty of 10
 and a gap extension penalty of 0.5 (using \verb|globalds|):
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import pairwise2
 >>> from Bio import SeqIO
 >>> from Bio.SubsMat.MatrixInfo import blosum62
@@ -1501,15 +1501,15 @@ and a gap extension penalty of 0.5 (using \verb|globalds|):
 >>> alignments = pairwise2.align.globalds(seq1.seq, seq2.seq, blosum62, -10, -0.5)
 >>> len(alignments)
 2
-\end{verbatim}
+\end{minted}
 %This has been abbreviated, can't use as doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(pairwise2.format_alignment(*alignments[0]))
 MV-LSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTY...KYR
 || |.|..|..|.|.|||| ......|............|.......||.
 MVHLTPEEKSAVTALWGKV-NVDEVGGEALGRLLVVYPWTQRFF...KYH
   Score=292.5
-\end{verbatim}
+\end{minted}
 
 This alignment has the same score that we obtained earlier with EMBOSS needle
 using the same sequences and the same parameters.
@@ -1518,7 +1518,7 @@ Local alignments are called similarly with the function \verb|align.localXX|,
 where again XX stands for a two letter code for the match and gap functions:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import pairwise2
 >>> from Bio.SubsMat.MatrixInfo import blosum62
 >>> alignments = pairwise2.align.localds("LSPADKTNVKAA", "PEEKSAV", blosum62, -10, -1)
@@ -1528,7 +1528,7 @@ where again XX stands for a two letter code for the match and gap functions:
 1 PEEKSAV
   Score=16
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 Note that local alignments must, as defined by Smith \& Waterman, have a 
 positive score (\textgreater 0). Thus, \verb|pairwise2| may return no
@@ -1539,7 +1539,7 @@ and lysin/asparagin (K/N) both have a match score of 0. As you see, the aligned
 part has not been extended:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import pairwise2
 >>> from Bio.SubsMat.MatrixInfo import blosum62
 >>> alignments = pairwise2.align.localds("LSSPADKTNVKKAA", "DDPEEKSAVNN", blosum62, -10, -1)
@@ -1549,7 +1549,7 @@ part has not been extended:
 3 PEEKSAV
   Score=16
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 Instead of supplying a complete match/mismatch matrix, the match code
 \texttt{m} allows for easy defining general match/mismatch values. The next
@@ -1557,7 +1557,7 @@ example uses match/mismatch scores of 5/-4 and gap penalties (open/extend)
 of 2/0.5 using \verb|localms|:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> alignments = pairwise2.align.localms("AGAACT", "GAC", 5, -4, -2, -0.5)
 >>> print(pairwise2.format_alignment(*alignments[0]))
 2 GAAC
@@ -1565,7 +1565,7 @@ of 2/0.5 using \verb|localms|:
 1 G-AC
   Score=13
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 One useful keyword argument of the \verb|Bio.pairwise2.align| functions is
 \texttt{score\_only}. When set to \texttt{True} it will only return the score
@@ -1596,10 +1596,10 @@ We refer to Durbin {\it et al.} \cite{durbin1998} for in-depth information on se
 
 To generate pairwise alignments, first create a \verb+PairwiseAligner+ object:
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Align
 >>> aligner = Align.PairwiseAligner()
-\end{verbatim}
+\end{minted}
 The \verb+PairwiseAligner+ object \verb+aligner+
 (see Section~\ref{sec:pairwise-aligner})
 stores the alignment parameters to be used for the pairwise alignments.
@@ -1607,17 +1607,17 @@ stores the alignment parameters to be used for the pairwise alignments.
 Use the \verb+aligner.score+ method to calculate the alignment score between
 two sequences:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> seq1 = "GAACT"
 >>> seq2 = "GAT"
 >>> score = aligner.score(seq1, seq2)
 >>> score
 3.0
-\end{verbatim}
+\end{minted}
 
 To see the actual alignments, use the \verb+aligner.align+ method and iterate over the \verb+PairwiseAlignment+ objects returned:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> alignments = aligner.align(seq1, seq2)
 >>> for alignment in alignments:
 ...     print(alignment)
@@ -1630,7 +1630,7 @@ GAACT
 |-|-|
 G-A-T
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 By default, a global pairwise alignment is performed, which finds the optimal
 alignment over the whole length of \verb+seq1+ and \verb+seq2+.
@@ -1640,7 +1640,7 @@ Local alignments can be generated by setting \verb+aligner.mode+ to
 \verb+"local"+:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> aligner.mode = 'local'
 >>> seq1 = "AGAACTC"
 >>> seq2 = "GAACT"
@@ -1655,7 +1655,7 @@ AGAACTC
 .|||||.
 .GAACT.
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 Note that there is some ambiguity in the definition of the best local alignments if segments with a score 0 can be added to the alignment. We follow the suggestion by Waterman \& Eggert \cite{waterman1987} and disallow such extensions.
 
@@ -1665,7 +1665,7 @@ Note that there is some ambiguity in the definition of the best local alignments
 The \verb+PairwiseAligner+ object stores all alignment parameters to be used
 for the pairwise alignments. To see an overview of the values for all parameters, use
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(aligner)
 Pairwise sequence aligner with parameters
   match_score: 1.000000
@@ -1684,7 +1684,7 @@ Pairwise sequence aligner with parameters
   query_right_extend_gap_score: 0.000000
   mode: local
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 See Sections~\ref{sec:pairwise-matchscores}, \ref{sec:pairwise-affine-gapscores}, and \ref{sec:pairwise-general-gapscores} below for the definition of these
 parameters. The attribute \verb+mode+ (described above in Section~\ref{sec:pairwise-basic}) can be set equal to \verb+"global"+ or \verb+"local"+ to specify global or local pairwise alignment, respectively.
 
@@ -1693,18 +1693,18 @@ Depending on the gap scoring parameters
 \ref{sec:pairwise-general-gapscores}) and mode, a \verb+PairwiseAligner+ object
 automatically chooses the appropriate algorithm to use for pairwise sequence alignment. To verify the selected algorithm, use
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> aligner.algorithm
 'Smith-Waterman'
-\end{verbatim}
+\end{minted}
 This attribute is read-only.
 
 A \verb+PairwiseAligner+ object also stores the precision $\epsilon$ to be used during alignment. The value of $\epsilon$ is stored in the attribute \verb+aligner.epsilon+, and by default is equal to $10^{-6}$:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> aligner.epsilon
 1e-06
-\end{verbatim}
+\end{minted}
 Two scores will be considered equal to each other for the purpose of the alignment if the absolute difference between them is less than $\epsilon$.
 
 \subsubsection{Match and mismatch scores}
@@ -1713,7 +1713,7 @@ Two scores will be considered equal to each other for the purpose of the alignme
 The match and mismatch scores are stored as attributes of an \verb+PairwiseAligner+
 object:
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Align
 >>> aligner = Align.PairwiseAligner()
 >>> aligner.match_score
@@ -1727,14 +1727,14 @@ object:
 >>> score = aligner.score("AAA","AAC")
 >>> print(score)
 4.0
-\end{verbatim}
+\end{minted}
 
 Alternatively, you can specify a substitution matrix as follows:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> matrix = {('A','A'): 1.0, ('A','B'): -1.0, ('B','B'): 2.0}
 >>> aligner.substitution_matrix = matrix
-\end{verbatim}
+\end{minted}
 
 The attributes \verb+aligner.match_score+ and \verb+aligner.mismatch_score+ are
 ignored if \verb+aligner.substitution_matrix+ is specified. Likewise, after
@@ -1745,11 +1745,11 @@ Note that \verb+aligner.substitution_matrix+ will return a copy of the
 substitution matrix stored in the \verb+PairwiseAligner+ object. Therefore,
 modifying the substitution matrix directly has no effect:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> aligner.substitution_matrix[('A','A')] = 5.0 # does nothing
 >>> aligner.substitution_matrix[('A','A')]
 1.0
-\end{verbatim}
+\end{minted}
 
 In all cases, the character \verb+X+ is used to denote unknown characters,
 which will always get a zero score in alignments, irrespective of the match or
@@ -1862,7 +1862,7 @@ For convenience, \verb+PairwiseAligner+ objects have additional attributes that 
 For even more fine-grained control over the gap scores, you can specify a gap scoring function. For example, the gap scoring function below disallows a gap after two nucleotides in the query sequence:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Align
 >>> aligner = Align.PairwiseAligner()
 >>> def my_gap_score_function(start, length):
@@ -1892,7 +1892,7 @@ AACTT
 ||X|-
 AATT-
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 \subsubsection{Iterating over alignments}
 
@@ -1902,16 +1902,16 @@ You can perform the following operations on \verb+alignments+:
 \begin{itemize}
 \item \verb+len(alignments)+ returns the number of alignments stored. This function returns quickly, even if the number of alignments is huge. If the number of alignments is extremely large (typically, larger than 9,223,372,036,854,775,807, which is the largest integer that can be stored as a \verb+long int+ on 64 bit machines), \verb+len(alignments)+ will raise an \verb+OverflowError+. A large number of alignments suggests that the alignment quality is low.
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Align
 >>> aligner = Align.PairwiseAligner()
 >>> alignments = aligner.align("AAA", "AA")
 >>> len(alignments)
 3
-\end{verbatim}
+\end{minted}
 \item You can extract a specific alignment by index:
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Align
 >>> aligner = Align.PairwiseAligner()
 >>> alignments = aligner.align("AAA", "AA")
@@ -1925,16 +1925,16 @@ AAA
 ||-
 AA-
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 \item You can iterate over alignments, for example as in
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for alignment in alignments:
 ...     print(alignment)
 ...
-\end{verbatim}
+\end{minted}
 Note that \verb+alignments+ can be reused, i.e. you can iterate over alignments multiple times:
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Align
 >>> aligner = Align.PairwiseAligner()
 >>> alignments = aligner.align("AAA", "AA")
@@ -1968,86 +1968,86 @@ AAA
 -||
 -AA
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 You can also convert the \verb+alignments+ iterator into a \verb+list+ or \verb+tuple+:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> alignments = list(alignments)
-\end{verbatim}
+\end{minted}
 It is wise to check the number of alignments by calling \verb+len(alignments)+ before attempting to call \verb+list(alignments)+ to save all alignments as a list.
 \item The alignment score (which has the same value for each alignment in \verb+alignments+), is stored as an attribute. This allows you to check the alignment score before proceeding to extract individual alignments:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignments.score)
 2.0
-\end{verbatim}
+\end{minted}
 \end{itemize}
 
 \subsubsection{Alignment objects}
 The \verb+aligner.align+ method returns \verb+PairwiseAlignment+ objects, each representing one alignment between the two sequences.
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Align
 >>> aligner = Align.PairwiseAligner()
 >>> seq1 = "GAACT"
 >>> seq2 = "GAT"
 >>> alignments = aligner.align(seq1, seq2)
 >>> alignment = alignments[0]
-\end{verbatim}
-\begin{verbatim}
+\end{minted}
+\begin{minted}{pycon}
 >>> alignment
 <Bio.Align.PairwiseAlignment object at 0x10204d250>
-\end{verbatim}
+\end{minted}
 
 Each alignment stores the alignment score:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> alignment.score
 3.0
-\end{verbatim}
+\end{minted}
 as well as pointers to the sequences that were aligned:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> alignment.target
 'GAACT'
 >>> alignment.query
 'GAT'
-\end{verbatim}
+\end{minted}
 
 Print the \verb+PairwiseAlignment+ object to show the alignment explicitly:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignment)
 GAACT
 ||--|
 GA--T
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 You can also represent the alignment as a string in PSL (Pattern Space Layout, as generated by BLAT \cite{kent2002}) format:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> format(alignment, 'psl')
 '3\t0\t0\t0\t0\t0\t1\t2\t+\tquery\t3\t0\t3\ttarget\t5\t0\t5\t2\t2,1,\t0,2,\t0,4,\n'
-\end{verbatim}
+\end{minted}
 
 Use the \verb+aligned+ property to find the start and end indices of subsequences in the target and query sequence that were aligned to each other.
 Generally, if the alignment between target (t) and query (q) consists of N
 chunks, you get two tuples of length N:
 
-\begin{verbatim}
+\begin{minted}{python}
 (((t_start1, t_end1), (t_start2, t_end2), ..., (t_startN, t_endN)),
  ((q_start1, q_end1), (q_start2, q_end2), ..., (q_startN, q_endN)))
-\end{verbatim}
+\end{minted}
 
 In the current example, `alignment.aligned` returns two tuples of length 2:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> alignment.aligned
 (((0, 2), (4, 5)), ((0, 2), (2, 3)))
-\end{verbatim}
+\end{minted}
 while for the alternative alignment, two tuples of length 3 are returned:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> alignment = alignments[1]
 >>> print(alignment)
 GAACT
@@ -2056,10 +2056,10 @@ G-A-T
 <BLANKLINE>
 >>> alignment.aligned
 (((0, 1), (2, 3), (4, 5)), ((0, 1), (1, 2), (2, 3)))
-\end{verbatim}
+\end{minted}
 Note that different alignments may have the same subsequences aligned to each other. In particular, this may occur if alignments differ from each other in terms of their gap placement only:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> aligner.mismatch_score = -10
 >>> alignments = aligner.align("AAACAAA", "AAAGAAA")
 >>> len(alignments)
@@ -2078,7 +2078,7 @@ AAAG-AAA
 <BLANKLINE>
 >>> alignments[1].aligned
 (((0, 3), (4, 7)), ((0, 3), (4, 7)))
-\end{verbatim}
+\end{minted}
 The \verb+aligned+ property can be used to identify alignments that are identical to each other in terms of their aligned sequences.
 
 \subsubsection{Example}
@@ -2089,7 +2089,7 @@ hemoglobin sequences from above (\texttt{HBA\_HUMAN}, \texttt{HBB\_HUMAN})
 stored in \texttt{alpha.faa} and \texttt{beta.faa}:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Align
 >>> from Bio import SeqIO
 >>> seq1 = SeqIO.read("alpha.faa", "fasta")
@@ -2098,39 +2098,39 @@ stored in \texttt{alpha.faa} and \texttt{beta.faa}:
 >>> score = aligner.score(seq1.seq, seq2.seq)
 >>> print(score)
 72.0
-\end{verbatim}
+\end{minted}
 
 showing an alignment score of 72.0. To see the individual alignments, do
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> alignments = aligner.align(seq1.seq, seq2.seq)
-\end{verbatim}
+\end{minted}
 In this example, the total number of optimal alignments is huge (more than $4 \times 10^{37}$), and calling \verb+len(alignments)+ will raise an \verb+OverflowError+:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(alignments)
 ...
 OverflowError: number of optimal alignments is larger than 9223372036854775807
-\end{verbatim}
+\end{minted}
 Let's have a look at the first alignment:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> alignment = alignments[0]
-\end{verbatim}
+\end{minted}
 
 The alignment object stores the alignment score, as well as the alignment
 itself:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignment.score)
 72.0
-\end{verbatim}
+\end{minted}
 %This has been abbreviated, can't use as doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignment)
 MV-LS-PAD--KTN--VK-AA-WGKV-----GAHAGEYGAEALE-RMFLSF----P-TTKTY--FPHF--...
 ||-|--|----|----|--|--||||-----|---||--|--|--|--|------|-|------|--|--...
 MVHL-TP--EEK--SAV-TA-LWGKVNVDEVG---GE--A--L-GR--L--LVVYPWT----QRF--FES...
-\end{verbatim}
+\end{minted}
 
 Better alignments are usually obtained by penalizing gaps: higher costs
 for opening a gap and lower costs for extending an existing gap. For amino
@@ -2140,7 +2140,7 @@ obtained by using the BLOSUM62 matrix, together with a gap open penalty of 10
 and a gap extension penalty of 0.5:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Align
 >>> from Bio import SeqIO
 >>> from Bio.SubsMat.MatrixInfo import blosum62
@@ -2158,21 +2158,21 @@ and a gap extension penalty of 0.5:
 2
 >>> print(alignments[0].score)
 292.5
-\end{verbatim}
+\end{minted}
 %This has been abbreviated, can't use as doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(alignments[0])
 MV-LSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTYFPHF-DLS-----HGSAQVKGHGKKV...
 ||-|X|XX|XX|X|X||||--XXX|X|X|||X|XXXXX|X|XXX|XX|-|||---- X|XXX||X|||||...
 MVHLTPEEKSAVTALWGKV--NVDEVGGEALGRLLVVYPWTQRFFESFGDLSTPDAVMGNPKVKAHGKKV...
-\end{verbatim}
+\end{minted}
 
 This alignment has the same score that we obtained earlier with EMBOSS needle
 using the same sequences and the same parameters.
 
 To perform a local alignment, set \verb+aligner.mode+ to \verb+'local'+:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> aligner.mode = 'local'
 >>> aligner.open_gap_score = -10
 >>> aligner.extend_gap_score = -1
@@ -2187,4 +2187,4 @@ LSPADKTNVKAA
 <BLANKLINE>
 >>> print(alignment.score)
 16.0
-\end{verbatim}
+\end{minted}

--- a/Doc/Tutorial/chapter_appendix.tex
+++ b/Doc/Tutorial/chapter_appendix.tex
@@ -43,44 +43,44 @@ we handle to the file {\tt m\_cold.fasta} which you can download
 \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/m\_cold.fasta}{here}
 (or find included in the Biopython source code as {\tt Doc/examples/m\_cold.fasta}).
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> handle = open("m_cold.fasta", "r")
 >>> handle.readline()
 ">gi|8332116|gb|BE037100.1|BE037100 MP14H09 MP Mesembryanthemum ...\n"
-\end{verbatim}
+\end{minted}
 
 Handles are regularly used in Biopython for passing information to parsers.
 For example, since Biopython 1.54 the main functions in \verb|Bio.SeqIO|
 and \verb|Bio.AlignIO| have allowed you to use a filename instead of a
 handle:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 for record in SeqIO.parse("m_cold.fasta", "fasta"):
     print(record.id, len(record))
-\end{verbatim}
+\end{minted}
 
 On older versions of Biopython you had to use a handle, e.g.
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 handle = open("m_cold.fasta", "r")
 for record in SeqIO.parse(handle, "fasta"):
     print(record.id, len(record))
 handle.close()
-\end{verbatim}
+\end{minted}
 
 This pattern is still useful - for example suppose you have a gzip
 compressed FASTA file you want to parse:
 
-\begin{verbatim}
+\begin{minted}{python}
 import gzip
 from Bio import SeqIO
 handle = gzip.open("m_cold.fasta.gz", "rt")
 for record in SeqIO.parse(handle, "fasta"):
     print(record.id, len(record))
 handle.close()
-\end{verbatim}
+\end{minted}
 
 With our parsers for plain text files, under Python 3 it is
 essential to use gzip in text mode.
@@ -95,7 +95,7 @@ string into a handle. The following example shows how to do this using
 \verb|cStringIO| from the Python standard library:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> my_info = "A string\n with multiple lines."
 >>> print(my_info)
 A string
@@ -109,4 +109,4 @@ A string
 >>> second_line = my_info_handle.readline()
 >>> print(second_line)
  with multiple lines.
-\end{verbatim}
+\end{minted}

--- a/Doc/Tutorial/chapter_blast.tex
+++ b/Doc/Tutorial/chapter_blast.tex
@@ -62,11 +62,11 @@ described in section~\ref{sec:parsing-blast} below.
 For more about the optional BLAST arguments, we refer you to the NCBI's own
 documentation, or that built into Biopython:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Blast import NCBIWWW
 >>> help(NCBIWWW.qblast)
 ...
-\end{verbatim}
+\end{minted}
 
 Note that the default settings on the NCBI BLAST website are not quite
 the same as the defaults on QBLAST. If you get different results, you'll
@@ -77,42 +77,42 @@ For example, if you have a nucleotide sequence you want to search against
 the nucleotide database (nt) using BLASTN, and you know the GI number of your
 query sequence, you can use:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Blast import NCBIWWW
 >>> result_handle = NCBIWWW.qblast("blastn", "nt", "8332116")
-\end{verbatim}
+\end{minted}
 
 Alternatively, if we have our query sequence already in a FASTA formatted
 file, we just need to open the file and read in this record as a string,
 and use that as the query argument:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Blast import NCBIWWW
 >>> fasta_string = open("m_cold.fasta").read()
 >>> result_handle = NCBIWWW.qblast("blastn", "nt", fasta_string)
-\end{verbatim}
+\end{minted}
 
 We could also have read in the FASTA file as a \verb|SeqRecord| and then
 supplied just the sequence itself:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Blast import NCBIWWW
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("m_cold.fasta", format="fasta")
 >>> result_handle = NCBIWWW.qblast("blastn", "nt", record.seq)
-\end{verbatim}
+\end{minted}
 
 Supplying just the sequence means that BLAST will assign an identifier
 for your sequence automatically.  You might prefer to use the
 \verb|SeqRecord| object's format method to make a FASTA string
 (which will include the existing identifier):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Blast import NCBIWWW
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("m_cold.fasta", format="fasta")
 >>> result_handle = NCBIWWW.qblast("blastn", "nt", record.format("fasta"))
-\end{verbatim}
+\end{minted}
 
 This approach makes more sense if you have your sequence(s) in a
 non-FASTA file format which you can extract using \verb|Bio.SeqIO|
@@ -133,12 +133,12 @@ We need to be a bit careful since we can use \verb|result_handle.read()| to
 read the BLAST output only once -- calling \verb|result_handle.read()| again
 returns an empty string.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> with open("my_blast.xml", "w") as out_handle:
 ...     out_handle.write(result_handle.read())
 ...
 >>> result_handle.close()
-\end{verbatim}
+\end{minted}
 
 After doing this, the results are in the file \verb|my_blast.xml| and the
 original handle has had all its data extracted (so we closed it). However,
@@ -146,9 +146,9 @@ the \verb|parse| function of the BLAST parser (described
 in~\ref{sec:parsing-blast}) takes a file-handle-like object, so
 we can just open the saved file for input:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> result_handle = open("my_blast.xml")
-\end{verbatim}
+\end{minted}
 
 Now that we've got the BLAST results back into a handle again, we are ready
 to do something with them, so this leads us right into the parsing section
@@ -199,9 +199,9 @@ run a BLASTX (translation) search against the non-redundant (NR) protein databas
 Assuming you (or your systems administrator) has downloaded and installed the NR
 database, you might run:
 
-\begin{verbatim}
-blastx -query opuntia.fasta -db nr -out opuntia.xml -evalue 0.001 -outfmt 5
-\end{verbatim}
+\begin{minted}{bash}
+$ blastx -query opuntia.fasta -db nr -out opuntia.xml -evalue 0.001 -outfmt 5
+\end{minted}
 
 This should run BLASTX against the NR database, using an expectation cut-off value
 of $0.001$ and produce XML output to the specified file (which we can then parse).
@@ -212,7 +212,7 @@ From within Biopython we can use the NCBI BLASTX wrapper from the
 \verb|Bio.Blast.Applications| module to build the command line string,
 and run it:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Blast.Applications import NcbiblastxCommandline
 >>> help(NcbiblastxCommandline)
 ...
@@ -224,7 +224,7 @@ db='nr', evalue=0.001)
 >>> print(blastx_cline)
 blastx -out opuntia.xml -outfmt 5 -query opuntia.fasta -db nr -evalue 0.001
 >>> stdout, stderr = blastx_cline()
-\end{verbatim}
+\end{minted}
 
 In this example there shouldn't be any output from BLASTX to the terminal,
 so stdout and stderr should be empty. You may want to check the output file
@@ -302,34 +302,34 @@ If you followed the code above for interacting with BLAST through a
 script, then you already have \verb|result_handle|, the handle to the
 BLAST results.  For example, using a GI number to do an online search:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Blast import NCBIWWW
 >>> result_handle = NCBIWWW.qblast("blastn", "nt", "8332116")
-\end{verbatim}
+\end{minted}
 
 If instead you ran BLAST some other way, and have the
 BLAST output (in XML format) in the file \verb|my_blast.xml|, all you
 need to do is to open the file for reading:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> result_handle = open("my_blast.xml")
-\end{verbatim}
+\end{minted}
 
 Now that we've got a handle, we are ready to parse the output. The
 code to parse it is really quite small.  If you expect a single
 BLAST result (i.e., you used a single query):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Blast import NCBIXML
 >>> blast_record = NCBIXML.read(result_handle)
-\end{verbatim}
+\end{minted}
 
 \noindent or, if you have lots of results (i.e., multiple query sequences):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Blast import NCBIXML
 >>> blast_records = NCBIXML.parse(result_handle)
-\end{verbatim}
+\end{minted}
 
 Just like \verb|Bio.SeqIO| and \verb|Bio.AlignIO|
 (see Chapters~\ref{chapter:Bio.SeqIO} and~\ref{chapter:Bio.AlignIO}),
@@ -345,7 +345,7 @@ iterator. In plain English, an iterator allows you to step through
 the BLAST output, retrieving BLAST records one by one for each BLAST
 search result:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Blast import NCBIXML
 >>> blast_records = NCBIXML.parse(result_handle)
 >>> blast_record = next(blast_records)
@@ -359,37 +359,37 @@ Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 StopIteration
 # No further records
-\end{verbatim}
+\end{minted}
 
 Or, you can use a \verb|for|-loop:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for blast_record in blast_records:
 ...     # Do something with blast_record
-\end{verbatim}
+\end{minted}
 
 Note though that you can step through the BLAST records only once.
 Usually, from each BLAST record you would save the information that
 you are interested in. If you want to save all returned BLAST records,
 you can convert the iterator into a list:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blast_records = list(blast_records)
-\end{verbatim}
+\end{minted}
 Now you can access each BLAST record in the list with an index as usual.
 If your BLAST file is huge though, you may run into memory problems trying to
 save them all in a list.
 
 Usually, you'll be running one BLAST search at a time. Then, all you need
 to do is to pick up the first (and only) BLAST record in \verb|blast_records|:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Blast import NCBIXML
 >>> blast_records = NCBIXML.parse(result_handle)
 >>> blast_record = next(blast_records)
-\end{verbatim}
+\end{minted}
 \noindent or more elegantly:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Blast import NCBIXML
 >>> blast_record = NCBIXML.read(result_handle)
-\end{verbatim}
+\end{minted}
 
 I guess by now you're wondering what is in a BLAST record.
 
@@ -407,7 +407,7 @@ To continue with our example, let's just print out some summary info
 about all hits in our blast report greater than a particular
 threshold. The following code does this:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> E_VALUE_THRESH = 0.04
 
 >>> for alignment in blast_record.alignments:
@@ -420,7 +420,7 @@ threshold. The following code does this:
 ...             print(hsp.query[0:75] + "...")
 ...             print(hsp.match[0:75] + "...")
 ...             print(hsp.sbjct[0:75] + "...")
-\end{verbatim}
+\end{minted}
 
 This will print out summary reports like the following:
 

--- a/Doc/Tutorial/chapter_cluster.tex
+++ b/Doc/Tutorial/chapter_cluster.tex
@@ -164,10 +164,10 @@ For most of the distance functions available in \verb|Bio.Cluster|, a weight vec
 \label{subsec:distancematrix}
 
 The distance matrix is a square matrix with all pairwise distances between the items in \verb|data|, and can be calculated by the function \verb|distancematrix| in the \verb|Bio.Cluster| module:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Cluster import distancematrix
 >>> matrix = distancematrix(data)
-\end{verbatim}
+\end{minted}
 where the following arguments are defined:
 \begin{itemize}
 \item \verb|data| (required)\\
@@ -185,7 +185,7 @@ Defines the distance function to be used (see \ref{sec:distancefunctions}).
 To save memory, the distance matrix is returned as a list of 1D arrays.
 The number of columns in each row is equal to the row number. Hence, the first row has zero elements. For example,
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from numpy import array
 >>> from Bio.Cluster import distancematrix
 >>> data = array([[0, 1,  2,  3],
@@ -193,20 +193,20 @@ The number of columns in each row is equal to the row number. Hence, the first r
 ...               [8, 9, 10, 11],
 ...               [1, 2,  3,  4]])
 >>> distances = distancematrix(data, dist='e')
-\end{verbatim}
+\end{minted}
 yields a distance matrix
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> distances
 [array([], dtype=float64), array([ 16.]), array([ 64.,  16.]), array([  1.,   9.,  49.])]
-\end{verbatim}
+\end{minted}
 which can be rewritten as
-\begin{verbatim}
+\begin{minted}{python}
 [array([], dtype=float64),
  array([ 16.]),
  array([ 64.,  16.]),
  array([  1.,   9.,  49.])
 ]
-\end{verbatim}
+\end{minted}
 This corresponds to the distance matrix:
 $$
 \left(
@@ -226,10 +226,10 @@ $$
 
 The centroid of a cluster can be defined either as the mean or as the median of each dimension over all cluster items. The function \verb|clustercentroids| in \verb|Bio.Cluster| can be used to calculate either:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Cluster import clustercentroids
 >>> cdata, cmask = clustercentroids(data)
-\end{verbatim}
+\end{minted}
 where the following arguments are defined:
 \begin{itemize}
 \item \verb|data| (required) \\
@@ -251,10 +251,10 @@ This function returns the tuple \verb|(cdata, cmask)|. The centroid data are sto
 Given a distance function between \emph{items}, we can define the distance between two \emph{clusters} in several ways. The distance between the arithmetic means of the two clusters is used in pairwise centroid-linkage clustering and in $k$-means clustering. In $k$-medoids clustering, the distance between the medians of the two clusters is used instead. The shortest pairwise distance between items of the two clusters is used in pairwise single-linkage clustering, while the longest pairwise distance is used in pairwise maximum-linkage clustering. In pairwise average-linkage clustering, the distance between two clusters is defined as the average over the pairwise distances.
 
 To calculate the distance between two clusters, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Cluster import clusterdistance
 >>> distance = clusterdistance(data)
-\end{verbatim}
+\end{minted}
 where the following arguments are defined:
 \begin{itemize}
 \item \verb|data| (required)\\
@@ -319,10 +319,10 @@ The EM algorithm terminates when no further reassignments take place.  We notice
 
 The $k$-means and $k$-medians algorithms are implemented as the function \verb|kcluster| in \verb|Bio.Cluster|:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Cluster import kcluster
 >>> clusterid, error, nfound = kcluster(data)
-\end{verbatim}
+\end{minted}
 where the following arguments are defined:
 \begin{itemize}
 \item \verb|data| (required)\\
@@ -356,10 +356,10 @@ This function returns a tuple \verb|(clusterid, error, nfound)|, where \verb|clu
 \subsection*{$k$-medoids clustering}
 
 The \verb+kmedoids+ routine performs $k$-medoids clustering on a given set of items, using the distance matrix and the number of clusters passed by the user:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Cluster import kmedoids
 >>> clusterid, error, nfound = kmedoids(distance)
-\end{verbatim}
+\end{minted}
 where the following arguments are defined:
 , nclusters=2, npass=1, initialid=None)|
 
@@ -368,22 +368,22 @@ where the following arguments are defined:
 The matrix containing the distances between the items; this matrix can be specified in three ways:
 \begin{itemize}
 \item as a 2D Numerical Python array (in which only the left-lower part of the array will be accessed):
-\begin{verbatim}
+\begin{minted}{python}
 distance = array([[0.0, 1.1, 2.3],
                   [1.1, 0.0, 4.5],
                   [2.3, 4.5, 0.0]])
-\end{verbatim}
+\end{minted}
 \item as a 1D Numerical Python array containing consecutively the distances in the left-lower part of the distance matrix:
-\begin{verbatim}
+\begin{minted}{python}
 distance = array([1.1, 2.3, 4.5])
-\end{verbatim}
+\end{minted}
 \item as a list containing the rows of the left-lower part of the distance matrix:
-\begin{verbatim}
+\begin{minted}{python}
 distance = [array([]|,
             array([1.1]),
             array([2.3, 4.5])
            ]
-\end{verbatim}
+\end{minted}
 \end{itemize}
 These three expressions correspond to the same distance matrix.
 \item \verb|nclusters| (default: \verb|2|) \\
@@ -432,31 +432,31 @@ Here, \verb|left| and \verb|right| are integers referring to the two items or su
 To create a new \verb|Node| object, we need to specify \verb|left| and \verb|right|; \verb|distance| is optional.
 
 %doctest . lib:numpy
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Cluster import Node
 >>> Node(2, 3)
 (2, 3): 0
 >>> Node(2, 3, 0.91)
 (2, 3): 0.91
-\end{verbatim}
+\end{minted}
 
 The attributes \verb|left|, \verb|right|, and \verb|distance| of an existing \verb|Node| object can be modified directly:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> node = Node(4, 5)
 >>> node.left = 6
 >>> node.right = 2
 >>> node.distance = 0.73
 >>> node
 (6, 2): 0.73
-\end{verbatim}
+\end{minted}
 An error is raised if \verb|left| and \verb|right| are not integers, or if \verb|distance| cannot be converted to a floating-point value.
 
 The Python class \verb|Tree| represents a full hierarchical clustering solution. A \verb|Tree| object can be created from a list of \verb|Node| objects:
 
 %doctest . lib:numpy
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Cluster import Node, Tree
 >>> nodes = [Node(1, 2, 0.2), Node(0, 3, 0.5), Node(-2, 4, 0.6), Node(-1, -3, 0.9)]
 >>> tree = Tree(nodes)
@@ -465,23 +465,23 @@ The Python class \verb|Tree| represents a full hierarchical clustering solution.
 (0, 3): 0.5
 (-2, 4): 0.6
 (-1, -3): 0.9
-\end{verbatim}
+\end{minted}
 
 The \verb|Tree| initializer checks if the list of nodes is a valid hierarchical clustering result:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> nodes = [Node(1, 2, 0.2), Node(0, 2, 0.5)]
 >>> Tree(nodes)
 Traceback (most recent call last):
   File "<stdin>", line 1, in ?
 ValueError: Inconsistent tree
-\end{verbatim}
+\end{minted}
 
 Individual nodes in a \verb|Tree| object can be accessed using square brackets:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> nodes = [Node(1, 2, 0.2), Node(0, -1, 0.5)]
 >>> tree = Tree(nodes)
 >>> tree[0]
@@ -490,12 +490,12 @@ Individual nodes in a \verb|Tree| object can be accessed using square brackets:
 (0, -1): 0.5
 >>> tree[-1]
 (0, -1): 0.5
-\end{verbatim}
+\end{minted}
 
 As a \verb|Tree| object is immutable, we cannot change individual nodes in a \verb|Tree| object. However, we can convert the tree to a list of nodes, modify this list, and create a new tree from this list:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> tree = Tree([Node(1, 2, 0.1), Node(0, -1, 0.5), Node(-2, 3, 0.9)])
 >>> print(tree)
 (1, 2): 0.1
@@ -509,26 +509,26 @@ As a \verb|Tree| object is immutable, we cannot change individual nodes in a \ve
 (0, 1): 0.2
 (2, -1): 0.5
 (-2, 3): 0.9
-\end{verbatim}
+\end{minted}
 
 This guarantees that any \verb|Tree| object is always well-formed.
 
 To display a hierarchical clustering solution with visualization programs such as Java Treeview, it is better to scale all node distances such that they are between zero and one. This can be accomplished by calling the \verb|scale| method on an existing \verb|Tree| object:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> tree.scale()
-\end{verbatim}
+\end{minted}
 This method takes no arguments, and returns \verb|None|.
 
 Before drawing the tree, you may also want to reorder the tree nodes. A hierarchical clustering solution of $n$ items can be drawn as $2^{n-1}$ different but equivalent dendrograms by switching the left and right subnode at each node. The \verb|tree.sort(order)| method visits each node in the hierarchical clustering tree and verifies if the average order value of the left subnode is less than or equal to the average order value of the right subnode. If not, the left and right subnodes are exchanged. Here, the order values of the items are given by the user. In the resulting dendrogram, items in the left-to-right order will tend to have increasing order values. The method will return the indices of the elements in the left-to-right order after sorting:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> indices = tree.sort(order)
-\end{verbatim}
+\end{minted}
 such that item \verb|indices[i]| will occur at position $i$ in the dendrogram.
 
 After hierarchical clustering, the items can be grouped into $k$ clusters based on the tree structure stored in the \verb|Tree| object by cutting the tree:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> clusterid = tree.cut(nclusters=1)
-\end{verbatim}
+\end{minted}
 where \verb|nclusters| (defaulting to \verb|1|) is the desired number of clusters $k$.
 This method ignores the top $k-1$ linking events in the tree structure, resulting in $k$ separated clusters of items. The number of clusters $k$ should be positive, and less than or equal to the number of items.
 This method returns an array \verb|clusterid| containing the number of the cluster to which each item is assigned. Clusters are numbered $0$ to $k-1$ in their left-to-right order in the dendrogram.
@@ -536,10 +536,10 @@ This method returns an array \verb|clusterid| containing the number of the clust
 \subsection*{Performing hierarchical clustering}
 
 To perform hierarchical clustering, use the \verb|treecluster| function in \verb|Bio.Cluster|.
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Cluster import treecluster
 >>> tree = treecluster(data)
-\end{verbatim}
+\end{minted}
 where the following arguments are defined:
 
 \begin{itemize}
@@ -564,31 +564,31 @@ Defines the distance function to be used (see \ref{sec:distancefunctions}).
 \end{itemize}
 
 To apply hierarchical clustering on a precalculated distance matrix, specify the \verb|distancematrix| argument when calling \verb|treecluster| function instead of the \verb|data| argument:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Cluster import treecluster
 >>> tree = treecluster(distancematrix=distance)
-\end{verbatim}
+\end{minted}
 In this case, the following arguments are defined:
 \begin{itemize}
 \item \verb|distancematrix| \\
 The distance matrix, which can be specified in three ways:
 \begin{itemize}
 \item as a 2D Numerical Python array (in which only the left-lower part of the array will be accessed):
-\begin{verbatim}
+\begin{minted}{python}
 distance = array([[0.0, 1.1, 2.3],
                   [1.1, 0.0, 4.5],
                   [2.3, 4.5, 0.0]])
-\end{verbatim}
+\end{minted}
 \item as a 1D Numerical Python array containing consecutively the distances in the left-lower part of the distance matrix:
-\begin{verbatim}
+\begin{minted}{python}
 distance = array([1.1, 2.3, 4.5])
-\end{verbatim}
+\end{minted}
 \item as a list containing the rows of the left-lower part of the distance matrix:
-\begin{verbatim}
+\begin{minted}{python}
 distance = [array([]),
             array([1.1]),
             array([2.3, 4.5])
-\end{verbatim}
+\end{minted}
 \end{itemize}
 These three expressions correspond to the same distance matrix.
 As \verb|treecluster| may shuffle the values in the distance matrix as part of the clustering algorithm, be sure to save this array in a different variable before calling \verb|treecluster| if you need it later.
@@ -634,10 +634,10 @@ are the dimensions of the rectangle defining the topology.
 The function \verb|somcluster| implements the complete algorithm to calculate a Self-Organizing Map on a rectangular grid. First it initializes the random number generator. The node data are then initialized using the random number generator. The order in which genes or samples are used to modify the SOM is also randomized. The total number of iterations in the SOM algorithm is specified by the user.
 
 To run \verb|somcluster|, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Cluster import somcluster
 >>> clusterid, celldata = somcluster(data)
-\end{verbatim}
+\end{minted}
 where the following arguments are defined:
 \begin{itemize}
 \item \verb|data| (required) \\
@@ -679,10 +679,10 @@ Before applying principal component analysis, typically the mean is subtracted f
 The function \verb|pca| below first uses the singular value decomposition to calculate the eigenvalues and eigenvectors of the data matrix. The singular value decomposition is implemented as a translation in C of the Algol procedure \verb|svd| \cite{golub1971}, which uses Householder bidiagonalization and a variant of the QR algorithm. The principal components, the coordinates of each data vector along the principal components, and the eigenvalues corresponding to the principal components are then evaluated and returned in decreasing order of the magnitude of the eigenvalue. If data centering is desired, the mean should be subtracted from each column in the data matrix before calling the \verb|pca| routine.
 
 To apply Principal Component Analysis to a rectangular matrix \verb|data|, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Cluster import pca
 >>> columnmean, coordinates, components, eigenvalues = pca(data)
-\end{verbatim}
+\end{minted}
 This function returns a tuple \verb|columnmean, coordinates, components, eigenvalues|:
 \begin{itemize}
 \item \verb|columnmean| \\
@@ -702,34 +702,34 @@ Cluster/TreeView are GUI-based codes for clustering gene expression data. They w
 
 An object of the class \verb|Record| contains all information stored in a Cluster/TreeView-type data file. To store the information contained in the data file in a \verb|Record| object, we first open the file and then read it:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Cluster
 >>> with open("mydatafile.txt") as handle:
 ...     record = Cluster.read(handle)
 ...
-\end{verbatim}
+\end{minted}
 This two-step process gives you some flexibility in the source of the data.
 For example, you can use
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> import gzip # Python standard library
 >>> handle = gzip.open("mydatafile.txt.gz", "rt")
-\end{verbatim}
+\end{minted}
 to open a gzipped file, or
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from urllib.request import urlopen # Python 3 only
 >>> from io import TextIOWrapper
 >>>
 >>> handle = TextIOWrapper(urlopen("https://raw.githubusercontent.com/biopython/biopython/master/Tests/Cluster/cyano.txt"))
-\end{verbatim}
+\end{minted}
 to open a file stored on the Internet before calling \verb|read|.
 
 Note for Python 2 this can be done by using:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from urllib import urlopen # Python 2 only
 >>>
 >>> handle = urlopen("https://raw.githubusercontent.com/biopython/biopython/master/Tests/Cluster/cyano.txt")
-\end{verbatim}
+\end{minted}
 
 The \verb|read| command reads the tab-delimited text file \verb|mydatafile.txt| containing gene expression data in the format specified for Michael Eisen's Cluster/TreeView program. In this file format, rows represent genes and columns represent samples or observations. For a simple time course, a minimal input file would look like this:
 
@@ -809,9 +809,9 @@ After loading a \verb|Record| object, each of these attributes can be accessed a
 \subsection*{Calculating the distance matrix}
 
 To calculate the distance matrix between the items stored in the record, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> matrix = record.distancematrix()
-\end{verbatim}
+\end{minted}
 where the following arguments are defined:
 \begin{itemize}
 \item \verb|transpose| (default: \verb|0|) \\
@@ -825,9 +825,9 @@ This function returns the distance matrix as a list of rows, where the number of
 \subsection*{Calculating the cluster centroids}
 
 To calculate the centroids of clusters of items stored in the record, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> cdata, cmask = record.clustercentroids()
-\end{verbatim}
+\end{minted}
 
 \begin{itemize}
 \item \verb|clusterid| (default: \verb|None|) \\
@@ -842,9 +842,9 @@ This function returns the tuple \verb|cdata, cmask|; see section \ref{subsec:clu
 
 \subsection*{Calculating the distance between clusters}
 To calculate the distance between clusters of items stored in the record, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> distance = record.clusterdistance()
-\end{verbatim}
+\end{minted}
 where the following arguments are defined:
 \begin{itemize}
 \item \verb|index1| (default: \verb|0|) \\
@@ -870,9 +870,9 @@ If \verb|transpose| is \verb|True|, calculate the distance between the columns o
 \subsection*{Performing hierarchical clustering}
 
 To perform hierarchical clustering on the items stored in the record, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> tree = record.treecluster()
-\end{verbatim}
+\end{minted}
 where the following arguments are defined:
 \begin{itemize}
 \item \verb|transpose| (default: \verb|0|) \\
@@ -896,9 +896,9 @@ This function returns a \verb|Tree| object. This object contains $\left(\textrm{
 \subsection*{Performing $k$-means or $k$-medians clustering}
 
 To perform $k$-means or $k$-medians clustering on the items stored in the record, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> clusterid, error, nfound = record.kcluster()
-\end{verbatim}
+\end{minted}
 where the following arguments are defined:
 \begin{itemize}
 \item \verb|nclusters| (default: \verb|2|) \\
@@ -923,9 +923,9 @@ This function returns a tuple \verb|(clusterid, error, nfound)|, where \verb|clu
 \subsection*{Calculating a Self-Organizing Map}
 
 To calculate a Self-Organizing Map of the items stored in the record, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> clusterid, celldata = record.somcluster()
-\end{verbatim}
+\end{minted}
 where the following arguments are defined:
 \begin{itemize}
 \item \verb|transpose| (default: \verb|0|) \\
@@ -951,9 +951,9 @@ An array with dimensions $\left(\verb|nxgrid|, \verb|nygrid|, \textrm{number of 
 \subsection*{Saving the clustering result}
 
 To save the clustering result, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.save(jobname, geneclusters, expclusters)
-\end{verbatim}
+\end{minted}
 where the following arguments are defined:
 \begin{itemize}
 \item \verb|jobname| \\
@@ -974,7 +974,7 @@ The example data \verb|cyano.txt| can be found in Biopython's \verb|Tests/Cluste
 %all cyano_result* files created here during the run of test_Tutorial.py are 
 %after automatically deleted at the end of the test run.
 %doctest ../Tests/Cluster lib:numpy
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Cluster
 >>> with open("cyano.txt") as handle:
 ...     record = Cluster.read(handle)
@@ -983,14 +983,14 @@ The example data \verb|cyano.txt| can be found in Biopython's \verb|Tests/Cluste
 >>> genetree.scale()
 >>> exptree = record.treecluster(dist="u", transpose=1)
 >>> record.save("cyano_result", genetree, exptree)
-\end{verbatim}
+\end{minted}
 
 This will create the files \verb|cyano_result.cdt|, \verb|cyano_result.gtr|, and \verb|cyano_result.atr|.
 
 Similarly, we can save a $k$-means clustering solution:
 
 %doctest ../Tests/Cluster lib:numpy
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Cluster
 >>> with open("cyano.txt") as handle:
 ...     record = Cluster.read(handle)
@@ -998,6 +998,6 @@ Similarly, we can save a $k$-means clustering solution:
 >>> (geneclusters, error, ifound) = record.kcluster(nclusters=5, npass=1000)
 >>> (expclusters, error, ifound) = record.kcluster(nclusters=2, npass=100, transpose=1)
 >>> record.save("cyano_result", geneclusters, expclusters)
-\end{verbatim}
+\end{minted}
 
 This will create the files \verb|cyano_result_K_G2_A2.cdt|, \verb|cyano_result_K_G2.kgg|, and \verb|cyano_result_K_A2.kag|.

--- a/Doc/Tutorial/chapter_contributing.tex
+++ b/Doc/Tutorial/chapter_contributing.tex
@@ -50,9 +50,9 @@ You must first make sure you have a C compiler on your Windows computer, and tha
 
 Once you are setup with a C compiler, making the installer just requires doing:
 
-\begin{verbatim}
-python setup.py bdist_wininst
-\end{verbatim}
+\begin{minted}{bash}
+$ python setup.py bdist_wininst
+\end{minted}
 
 Now you've got a Windows installer. Congrats!  At the moment we have no trouble shipping installers built on 32 bit windows.  If anyone would like to look into supporting 64 bit Windows that would be great.
 
@@ -60,9 +60,9 @@ Now you've got a Windows installer. Congrats!  At the moment we have no trouble 
 
 To make the RPM, you just need to do:
 
-\begin{verbatim}
-python setup.py bdist_rpm
-\end{verbatim}
+\begin{minted}{bash}
+$ python setup.py bdist_rpm
+\end{minted}
 
 This will create an RPM for your specific platform and a source RPM in the directory \verb|dist|. This RPM should be good and ready to go, so this is all you need to do! Nice and easy.
 

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -34,7 +34,7 @@ Try something like this:
 
 %not a doctest to avoid temp files being left behind, also no >>>
 %makes it easier to copy and paste the example to a script file.
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 
 input_file = "big_file.sff"
@@ -50,7 +50,7 @@ count = SeqIO.write(records, output_file, "sff")
 print("Saved %i records from %s to %s" % (count, input_file, output_file))
 if count < len(wanted):
     print("Warning %i IDs not found in %s" % (len(wanted) - count, input_file))
-\end{verbatim}
+\end{minted}
 
 Note that we use a Python \verb|set| rather than a \verb|list|, this makes
 testing membership faster.
@@ -62,7 +62,7 @@ example shows how to do this with FASTQ files -- it is more complicated:
 
 %not a doctest to avoid temp files being left behind, also no >>>
 %makes it easier to copy and paste the example to a script file.
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.SeqIO.QualityIO import FastqGeneralIterator
 
 input_file = "big_file.fastq"
@@ -85,7 +85,7 @@ with open(input_file) as in_handle:
 print("Saved %i records from %s to %s" % (count, input_file, output_file))
 if count < len(wanted):
     print("Warning %i IDs not found in %s" % (len(wanted) - count, input_file))
-\end{verbatim}
+\end{minted}
 
 \subsection{Producing randomised genomes}
 
@@ -105,10 +105,10 @@ This file contains one and only one record, so we can read it in as a
 \verb|SeqRecord| using the \verb|Bio.SeqIO.read()| function:
 
 %doctest ../Tests/GenBank
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> original_rec = SeqIO.read("NC_005816.gb", "genbank")
-\end{verbatim}
+\end{minted}
 
 So, how can we generate a shuffled versions of the original sequence?  I would
 use the built in Python \verb|random| module for this, in particular the function
@@ -116,11 +116,11 @@ use the built in Python \verb|random| module for this, in particular the functio
 \verb|Seq| object, so in order to shuffle it we need to turn it into a list:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> import random
 >>> nuc_list = list(original_rec.seq)
 >>> random.shuffle(nuc_list)  # acts in situ!
-\end{verbatim}
+\end{minted}
 
 Now, in order to use \verb|Bio.SeqIO| to output the shuffled sequence, we need
 to construct a new \verb|SeqRecord| with a new \verb|Seq| object using this
@@ -129,13 +129,13 @@ shuffled list.  In order to do this, we need to turn the list of nucleotides
 this is with the string object's join method.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.SeqRecord import SeqRecord
 >>> shuffled_rec = SeqRecord(Seq("".join(nuc_list), original_rec.seq.alphabet),
 ...                          id="Shuffled", description="Based on %s" % original_rec.id)
 ...
-\end{verbatim}
+\end{minted}
 
 Let's put all these pieces together to make a complete Python script which
 generates a single FASTA file containing 30 randomly shuffled versions of
@@ -145,7 +145,7 @@ This first version just uses a big for loop and writes out the records one by on
 (using the \verb|SeqRecord|'s format method described in
 Section~\ref{sec:Bio.SeqIO-and-StringIO}):
 
-\begin{verbatim}
+\begin{minted}{python}
 import random
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
@@ -161,12 +161,12 @@ with open("shuffled.fasta", "w") as output_handle:
                                  id="Shuffled%i" % (i+1),
                                  description="Based on %s" % original_rec.id)
         out_handle.write(shuffled_rec.format("fasta"))
-\end{verbatim}
+\end{minted}
 
 Personally I prefer the following version using a function to shuffle the record
 and a generator expression instead of the for loop:
 
-\begin{verbatim}
+\begin{minted}{python}
 import random
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
@@ -182,7 +182,7 @@ original_rec = SeqIO.read("NC_005816.gb","genbank")
 shuffled_recs = (make_shuffle_record(original_rec, "Shuffled%i" % (i+1))
                  for i in range(30))
 SeqIO.write(shuffled_recs, "shuffled.fasta", "fasta")
-\end{verbatim}
+\end{minted}
 
 \subsection{Translating a FASTA file of CDS entries}
 \label{sec:SeqIO-translate}
@@ -202,25 +202,25 @@ You can write you own function to do this, choosing suitable protein identifiers
 for your sequences, and the appropriate genetic code.  In this example we just
 use the default table and add a prefix to the identifier:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.SeqRecord import SeqRecord
 def make_protein_record(nuc_record):
     """Returns a new SeqRecord with the translated sequence (default table)."""
     return SeqRecord(seq = nuc_record.seq.translate(cds=True), \
                      id = "trans_" + nuc_record.id, \
                      description = "translation of CDS, using default table")
-\end{verbatim}
+\end{minted}
 
 We can then use this function to turn the input nucleotide records into protein
 records ready for output.  An elegant way and memory efficient way to do this
 is with a generator expression:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 proteins = (make_protein_record(nuc_rec) for nuc_rec in \
             SeqIO.parse("coding_sequences.fasta", "fasta"))
 SeqIO.write(proteins, "translations.fasta", "fasta")
-\end{verbatim}
+\end{minted}
 
 This should work on any FASTA file of complete coding sequences.
 If you are working on partial coding sequences, you may prefer to use
@@ -236,12 +236,12 @@ important. You may want to edit the file to make everything consistent (e.g.
 all upper case), and you can do this easily using the \verb|upper()| method
 of the \verb|SeqRecord| object (added in Biopython 1.55):
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 records = (rec.upper() for rec in SeqIO.parse("mixed.fas", "fasta"))
 count = SeqIO.write(records, "upper.fas", "fasta")
 print("Converted %i records to upper case" % count)
-\end{verbatim}
+\end{minted}
 
 How does this work? The first line is just importing the \verb|Bio.SeqIO|
 module. The second line is the interesting bit -- this is a Python
@@ -265,24 +265,24 @@ FASTA or FASTQ which \verb|Bio.SeqIO| can read, write (and index).
 If the file is small enough, you can load it all into memory at once
 as a list of \verb|SeqRecord| objects, sort the list, and save it:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 records = list(SeqIO.parse("ls_orchid.fasta", "fasta"))
 records.sort(key=lambda r: len(r))
 SeqIO.write(records, "sorted_orchids.fasta", "fasta")
-\end{verbatim}
+\end{minted}
 
 The only clever bit is specifying a comparison method for how to
 sort the records (here we sort them by length). If you wanted the
 longest records first, you could flip the comparison or use the
 reverse argument:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 records = list(SeqIO.parse("ls_orchid.fasta", "fasta"))
 records.sort(key=lambda r: -len(r))
 SeqIO.write(records, "sorted_orchids.fasta", "fasta")
-\end{verbatim}
+\end{minted}
 
 Now that's pretty straight forward - but what happens if you have a
 very large file and you can't load it all into memory like this?
@@ -290,7 +290,7 @@ For example, you might have some next-generation sequencing reads
 to sort by length. This can be solved using the
 \verb|Bio.SeqIO.index()| function.
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 # Get the lengths and ids, and sort on length
 len_and_ids = sorted((len(rec), rec.id) for rec in
@@ -300,7 +300,7 @@ del len_and_ids  # free this memory
 record_index = SeqIO.index("ls_orchid.fasta", "fasta")
 records = (record_index[id] for id in ids)
 SeqIO.write(records, "sorted.fasta", "fasta")
-\end{verbatim}
+\end{minted}
 
 First we scan through the file once using \verb|Bio.SeqIO.parse()|,
 recording the record identifiers and their lengths in a list of tuples.
@@ -316,7 +316,7 @@ support, like the plain text SwissProt format? Here is an alternative
 solution using the \verb|get_raw()| method added to \verb|Bio.SeqIO.index()|
 in Biopython 1.54 (see Section~\ref{sec:seqio-index-getraw}).
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 
 # Get the lengths and ids, and sort on length
@@ -329,7 +329,7 @@ record_index = SeqIO.index("ls_orchid.fasta", "fasta")
 with open("sorted.fasta", "wb") as out_handle:
     for id in ids:
         out_handle.write(record_index.get_raw(id))
-\end{verbatim}
+\end{minted}
 
 Note with Python 3 onwards, we have to open the file for writing in
 binary mode because the \verb|get_raw()| method returns bytes strings.
@@ -339,7 +339,7 @@ a second time it should be faster. If you only want to use this with FASTA
 format, we can speed this up one step further by using the low-level FASTA
 parser to get the record identifiers and lengths:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 from Bio import SeqIO
 
@@ -354,7 +354,7 @@ record_index = SeqIO.index("ls_orchid.fasta", "fasta")
 with open("sorted.fasta", "wb") as out_handle:
     for id in ids:
         out_handle.write(record_index.get_raw(id))
-\end{verbatim}
+\end{minted}
 
 \subsection{Simple quality filtering for FASTQ files}
 \label{sec:FASTQ-filtering-example}
@@ -383,24 +383,24 @@ Roche 454 GS FLX single end data from virus infected California sea lions
 
 First, let's count the reads:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 count = 0
 for rec in SeqIO.parse("SRR020192.fastq", "fastq"):
     count += 1
 print("%i reads" % count)
-\end{verbatim}
+\end{minted}
 
 \noindent Now let's do a simple filtering for a minimum PHRED quality of 20:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 good_reads = (rec for rec in \
               SeqIO.parse("SRR020192.fastq", "fastq") \
               if min(rec.letter_annotations["phred_quality"]) >= 20)
 count = SeqIO.write(good_reads, "good_quality.fastq", "fastq")
 print("Saved %i reads" % count)
-\end{verbatim}
+\end{minted}
 
 \noindent This pulled out only $14580$ reads out of the $41892$ present.
 A more sensible thing to do would be to quality trim the reads, but this
@@ -432,14 +432,14 @@ This code uses \verb|Bio.SeqIO| with a generator expression (to avoid loading
 all the sequences into memory at once), and the \verb|Seq| object's
 \verb|startswith| method to see if the read starts with the primer sequence:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 primer_reads = (rec for rec in \
                 SeqIO.parse("SRR020192.fastq", "fastq") \
                 if rec.seq.startswith("GATGACGGTGT"))
 count = SeqIO.write(primer_reads, "with_primer.fastq", "fastq")
 print("Saved %i reads" % count)
-\end{verbatim}
+\end{minted}
 
 \noindent That should find $13819$ reads from \texttt{SRR014849.fastq} and save them to
 a new FASTQ file, \texttt{with\_primer.fastq}.
@@ -449,14 +449,14 @@ but with the primer sequence removed?  That's just a small change as we can slic
 \verb|SeqRecord| (see Section~\ref{sec:SeqRecord-slicing}) to remove the first eleven
 letters (the length of our primer):
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 trimmed_primer_reads = (rec[11:] for rec in \
                         SeqIO.parse("SRR020192.fastq", "fastq") \
                         if rec.seq.startswith("GATGACGGTGT"))
 count = SeqIO.write(trimmed_primer_reads, "with_primer_trimmed.fastq", "fastq")
 print("Saved %i reads" % count)
-\end{verbatim}
+\end{minted}
 
 \noindent Again, that should pull out the $13819$ reads from \texttt{SRR020192.fastq},
 but this time strip off the first ten characters, and save them to another new
@@ -467,7 +467,7 @@ their primer removed, but all the other reads are kept as they were?
 If we want to still use a generator expression, it is probably clearest to
 define our own trim function:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 def trim_primer(record, primer):
     if record.seq.startswith(primer):
@@ -479,14 +479,14 @@ trimmed_reads = (trim_primer(record, "GATGACGGTGT") for record in \
                  SeqIO.parse("SRR020192.fastq", "fastq"))
 count = SeqIO.write(trimmed_reads, "trimmed.fastq", "fastq")
 print("Saved %i reads" % count)
-\end{verbatim}
+\end{minted}
 
 This takes longer, as this time the output file contains all $41892$ reads.
 Again, we're used a generator expression to avoid any memory problems.
 You could alternatively use a generator function rather than a generator
 expression.
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 def trim_primers(records, primer):
     """Removes perfect primer sequences at start of reads.
@@ -505,7 +505,7 @@ original_reads = SeqIO.parse("SRR020192.fastq", "fastq")
 trimmed_reads = trim_primers(original_reads, "GATGACGGTGT")
 count = SeqIO.write(trimmed_reads, "trimmed.fastq", "fastq")
 print("Saved %i reads" % count)
-\end{verbatim}
+\end{minted}
 
 This form is more flexible if you want to do something more complicated
 where only some of the records are retained -- as shown in the next example.
@@ -521,7 +521,7 @@ formatted read data, again the \texttt{SRR020192.fastq} file from the NCBI
 This time however, we will look for the sequence \emph{anywhere} in the reads,
 not just at the very beginning:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 
 def trim_adaptors(records, adaptor):
@@ -544,7 +544,7 @@ original_reads = SeqIO.parse("SRR020192.fastq", "fastq")
 trimmed_reads = trim_adaptors(original_reads, "GATGACGGTGT")
 count = SeqIO.write(trimmed_reads, "trimmed.fastq", "fastq")
 print("Saved %i reads" % count)
-\end{verbatim}
+\end{minted}
 
 Because we are using a FASTQ input file in this example, the \verb|SeqRecord|
 objects have per-letter-annotation for the quality scores. By slicing the
@@ -557,7 +557,7 @@ trimmed reads are quite short after trimming (e.g. if the adaptor was
 found in the middle rather than near the start). So, let's add a minimum
 length requirement as well:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 
 def trim_adaptors(records, adaptor, min_len):
@@ -584,7 +584,7 @@ original_reads = SeqIO.parse("SRR020192.fastq", "fastq")
 trimmed_reads = trim_adaptors(original_reads, "GATGACGGTGT", 100)
 count = SeqIO.write(trimmed_reads, "trimmed.fastq", "fastq")
 print("Saved %i reads" % count)
-\end{verbatim}
+\end{minted}
 
 By changing the format names, you could apply this to FASTA files instead.
 This code also could be extended to do a fuzzy match instead of an exact
@@ -649,19 +649,19 @@ in the \verb|Bio.SeqIO.QualityIO| module, which are called if you use
 \verb|Bio.SeqIO| to convert an old Solexa/Illumina file into a standard Sanger
 FASTQ file:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 SeqIO.convert("solexa.fastq", "fastq-solexa", "standard.fastq", "fastq")
-\end{verbatim}
+\end{minted}
 
 If you want to convert a new Illumina 1.3+ FASTQ file, all that gets changed
 is the ASCII offset because although encoded differently the scores are all
 PHRED qualities:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 SeqIO.convert("illumina.fastq", "fastq-illumina", "standard.fastq", "fastq")
-\end{verbatim}
+\end{minted}
 
 Note that using \verb|Bio.SeqIO.convert()| like this is \emph{much} faster
 than combining \verb|Bio.SeqIO.parse()| and \verb|Bio.SeqIO.write()|
@@ -679,11 +679,11 @@ the NCBI, and elsewhere (format name \texttt{fastq} or \texttt{fastq-sanger}).
 
 For more details, see the built in help (also \href{http://www.biopython.org/DIST/docs/api/Bio.SeqIO.QualityIO-module.html}{online}):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.SeqIO import QualityIO
 >>> help(QualityIO)
 ...
-\end{verbatim}
+\end{minted}
 
 \subsection{Converting FASTA and QUAL files into FASTQ files}
 \label{sec:SeqIO-fasta-qual-conversion}
@@ -695,17 +695,17 @@ the qualities. Therefore a single FASTQ file can be converted to or from
 
 Going from FASTQ to FASTA is easy:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 SeqIO.convert("example.fastq", "fastq", "example.fasta", "fasta")
-\end{verbatim}
+\end{minted}
 
 Going from FASTQ to QUAL is also easy:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 SeqIO.convert("example.fastq", "fastq", "example.qual", "qual")
-\end{verbatim}
+\end{minted}
 
 However, the reverse is a little more tricky. You can use \verb|Bio.SeqIO.parse()|
 to iterate over the records in a \emph{single} file, but in this case we have
@@ -716,25 +716,25 @@ together. The code is a little fiddly, so we provide a function called
 this. This takes two handles (the FASTA file and the QUAL file) and returns
 a \verb|SeqRecord| iterator:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.SeqIO.QualityIO import PairedFastaQualIterator
 for record in PairedFastaQualIterator(open("example.fasta"), open("example.qual")):
    print(record)
-\end{verbatim}
+\end{minted}
 
 This function will check that the FASTA and QUAL files are consistent (e.g.
 the records are in the same order, and have the same sequence length).
 You can combine this with the \verb|Bio.SeqIO.write()| function to convert a
 pair of FASTA and QUAL files into a single FASTQ files:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 from Bio.SeqIO.QualityIO import PairedFastaQualIterator
 with open("example.fasta") as f_handle, open("example.qual") as q_handle:
     records = PairedFastaQualIterator(f_handle, q_handle)
     count = SeqIO.write(records, "temp.fastq", "fastq")
 print("Converted %i records" % count)
-\end{verbatim}
+\end{minted}
 
 \subsection{Indexing a FASTQ file}
 \label{sec:fastq-indexing}
@@ -753,7 +753,7 @@ Again we'll use the \texttt{SRR020192.fastq} file from the ENA
 (\url{ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR020/SRR020192/SRR020192.fastq.gz}),
 although this is actually quite a small FASTQ file with less than $50,000$ reads:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> fq_dict = SeqIO.index("SRR020192.fastq", "fastq")
 >>> len(fq_dict)
@@ -762,7 +762,7 @@ although this is actually quite a small FASTQ file with less than $50,000$ reads
 ['SRR020192.38240', 'SRR020192.23181', 'SRR020192.40568', 'SRR020192.23186']
 >>> fq_dict["SRR020192.23186"].seq
 Seq('GTCCCAGTATTCGGATTTGTCTGCCAAAACAATGAAATTGACACAGTTTACAAC...CCG', SingleLetterAlphabet())
-\end{verbatim}
+\end{minted}
 
 When testing this on a FASTQ file with seven million reads,
 indexing took about a minute, but record access was almost instant.
@@ -787,7 +787,7 @@ A common task is to convert from SFF to a pair of FASTA and QUAL files,
 or to a single FASTQ file. These operations are trivial using the
 \verb|Bio.SeqIO.convert()| function (see Section~\ref{sec:SeqIO-conversion}):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> SeqIO.convert("E3MFGYR02_random_10_reads.sff", "sff", "reads.fasta", "fasta")
 10
@@ -795,7 +795,7 @@ or to a single FASTQ file. These operations are trivial using the
 10
 >>> SeqIO.convert("E3MFGYR02_random_10_reads.sff", "sff", "reads.fastq", "fastq")
 10
-\end{verbatim}
+\end{minted}
 
 \noindent Remember the convert function returns the number of records, in
 this example just ten. This will give you the \emph{untrimmed} reads, where
@@ -803,7 +803,7 @@ the leading and trailing poor quality sequence or adaptor will be in lower
 case. If you want the \emph{trimmed} reads (using the clipping information
 recorded within the SFF file) use this:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> SeqIO.convert("E3MFGYR02_random_10_reads.sff", "sff-trim", "trimmed.fasta", "fasta")
 10
@@ -811,30 +811,30 @@ recorded within the SFF file) use this:
 10
 >>> SeqIO.convert("E3MFGYR02_random_10_reads.sff", "sff-trim", "trimmed.fastq", "fastq")
 10
-\end{verbatim}
+\end{minted}
 
 If you run Linux, you could ask Roche for a copy of their ``off instrument''
 tools (often referred to as the Newbler tools). This offers an alternative way to
 do SFF to FASTA or QUAL conversion at the command line (but currently FASTQ output
 is not supported), e.g.
 
-\begin{verbatim}
+\begin{minted}{bash}
 $ sffinfo -seq -notrim E3MFGYR02_random_10_reads.sff > reads.fasta
 $ sffinfo -qual -notrim E3MFGYR02_random_10_reads.sff > reads.qual
 $ sffinfo -seq -trim E3MFGYR02_random_10_reads.sff > trimmed.fasta
 $ sffinfo -qual -trim E3MFGYR02_random_10_reads.sff > trimmed.qual
-\end{verbatim}
+\end{minted}
 
 \noindent The way Biopython uses mixed case sequence strings to represent
 the trimming points deliberately mimics what the Roche tools do.
 
 For more information on the Biopython SFF support, consult the built in help:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.SeqIO import SffIO
 >>> help(SffIO)
 ...
-\end{verbatim}
+\end{minted}
 
 \subsection{Identifying open reading frames}
 
@@ -855,18 +855,18 @@ this time we'll start with a plain FASTA file with no pre-marked genes:
 NCBI codon table 11 (see Section~\ref{sec:translation} about translation).
 
 %doctest ../Tests/GenBank
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.fna", "fasta")
 >>> table = 11
 >>> min_pro_len = 100
-\end{verbatim}
+\end{minted}
 
 Here is a neat trick using the \verb|Seq| object's \verb|split| method to
 get a list of all the possible ORF translations in the six reading frames:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for strand, nuc in [(+1, record.seq), (-1, record.seq.reverse_complement())]:
 ...     for frame in range(3):
 ...         length = 3 * ((len(record)-frame) // 3) #Multiple of three
@@ -888,7 +888,7 @@ RGIFMSDTMVVNGSGGVPAFLFSGSTLSSY...LLK - length 361, strand -1, frame 1
 WDVKTVTGVLHHPFHLTFSLCPEGATQSGR...VKR - length 111, strand -1, frame 1
 LSHTVTDFTDQMAQVGLCQCVNVFLDEVTG...KAA - length 107, strand -1, frame 2
 RALTGLSAPGIRSQTSCDRLRELRYVPVSL...PLQ - length 119, strand -1, frame 2
-\end{verbatim}
+\end{minted}
 
 Note that here we are counting the frames from the 5' end (start) of
 \emph{each} strand. It is sometimes easier to always count from the 5' end
@@ -903,7 +903,7 @@ the locations in terms of the protein counting, and converts back to the
 parent sequence by multiplying by three, then adjusting for the frame and
 strand:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 record = SeqIO.read("NC_005816.gb","genbank")
 table = 11
@@ -939,7 +939,7 @@ orf_list = find_orfs_with_trans(record.seq, table, min_pro_len)
 for start, end, strand, pro in orf_list:
     print("%s...%s - length %i, strand %i, %i:%i" \
           % (pro[:30], pro[-3:], len(pro), strand, start, end))
-\end{verbatim}
+\end{minted}
 
 \noindent And the output:
 
@@ -1000,19 +1000,19 @@ First of all, we will use \verb|Bio.SeqIO| to parse the FASTA file and compile a
 of all the sequence lengths.  You could do this with a for loop, but I find a list
 comprehension more pleasing:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> sizes = [len(rec) for rec in SeqIO.parse("ls_orchid.fasta", "fasta")]
 >>> len(sizes), min(sizes), max(sizes)
 (94, 572, 789)
 >>> sizes
 [740, 753, 748, 744, 733, 718, 730, 704, 740, 709, 700, 726, ..., 592]
-\end{verbatim}
+\end{minted}
 
 Now that we have the lengths of all the genes (as a list of integers), we can use the
 matplotlib histogram function to display it.
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 sizes = [len(rec) for rec in SeqIO.parse("ls_orchid.fasta", "fasta")]
 
@@ -1023,7 +1023,7 @@ pylab.title("%i orchid sequences\nLengths %i to %i" \
 pylab.xlabel("Sequence length (bp)")
 pylab.ylabel("Count")
 pylab.show()
-\end{verbatim}
+\end{minted}
 
 %
 % Have a HTML version and a PDF version to display nicely...
@@ -1069,17 +1069,17 @@ transfer.  Again, for this example we'll reuse our orchid FASTA file
 First of all, we will use \verb|Bio.SeqIO| to parse the FASTA file and compile a list
 of all the GC percentages.  Again, you could do this with a for loop, but I prefer this:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 from Bio.SeqUtils import GC
 
 gc_values = sorted(GC(rec.seq) for rec in SeqIO.parse("ls_orchid.fasta", "fasta"))
-\end{verbatim}
+\end{minted}
 
 Having read in each sequence and calculated the GC\%, we then sorted them into ascending
 order. Now we'll take this list of floating point values and plot them with matplotlib:
 
-\begin{verbatim}
+\begin{minted}{python}
 import pylab
 pylab.plot(gc_values)
 pylab.title("%i orchid sequences\nGC%% %0.1f to %0.1f" \
@@ -1087,7 +1087,7 @@ pylab.title("%i orchid sequences\nGC%% %0.1f to %0.1f" \
 pylab.xlabel("Genes")
 pylab.ylabel("GC%")
 pylab.show()
-\end{verbatim}
+\end{minted}
 
 %
 % Have an HTML version and a PDF version to display nicely...
@@ -1145,13 +1145,13 @@ in the plot below).
 To start off, we'll need two sequences.  For the sake of argument, we'll just take
 the first two from our orchid FASTA file \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/ls_orchid.fasta}{\tt ls\_orchid.fasta}:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 with open("ls_orchid.fasta") as in_handle:
     record_iterator = SeqIO.parse(in_handle, "fasta")
     rec_one = next(record_iterator)
     rec_two = next(record_iterator)
-\end{verbatim}
+\end{minted}
 
 We're going to show two approaches.  Firstly, a simple naive implementation
 which compares all the window sized sub-sequences to each other to compiles a
@@ -1159,21 +1159,21 @@ similarity matrix.  You could construct a matrix or array object, but here we
 just use a list of lists of booleans created with a nested list
 comprehension:
 
-\begin{verbatim}
+\begin{minted}{python}
 window = 7
 seq_one = str(rec_one.seq).upper()
 seq_two = str(rec_two.seq).upper()
 data = [[(seq_one[i:i + window] != seq_two[j:j + window])
          for j in range(len(seq_one) - window)]
         for i in range(len(seq_two) - window)]
-\end{verbatim}
+\end{minted}
 
 Note that we have \emph{not} checked for reverse complement matches here.
 Now we'll use the matplotlib's \verb|pylab.imshow()| function to display this
 data, first requesting the gray color scheme so this is done in black and
 white:
 
-\begin{verbatim}
+\begin{minted}{python}
 import pylab
 pylab.gray()
 pylab.imshow(data)
@@ -1181,7 +1181,7 @@ pylab.xlabel("%s (length %i bp)" % (rec_one.id, len(rec_one)))
 pylab.ylabel("%s (length %i bp)" % (rec_two.id, len(rec_two)))
 pylab.title("Dot plot using window size %i\n(allowing no mis-matches)" % window)
 pylab.show()
-\end{verbatim}
+\end{minted}
 %pylab.savefig("dot_plot.png", dpi=75)
 %pylab.savefig("dot_plot.pdf")
 
@@ -1216,7 +1216,7 @@ in the size of matrix it can display.  As an alternative, we'll use the
 \verb|pylab.scatter()| function.
 
 We start by creating dictionaries mapping the window-sized sub-sequences to locations:
-\begin{verbatim}
+\begin{minted}{python}
 window = 7
 dict_one = {}
 dict_two = {}
@@ -1232,10 +1232,10 @@ for (seq, section_dict) in [(str(rec_one.seq).upper(), dict_one),
 #(Python 2.3 would require slightly different code here)
 matches = set(dict_one).intersection(dict_two)
 print("%i unique matches" % len(matches))
-\end{verbatim}
+\end{minted}
 \noindent In order to use the \verb|pylab.scatter()| we need separate lists for the $x$ and $y$ co-ordinates:
-\begin{verbatim}
-#Create lists of x and y co-ordinates for scatter plot
+\begin{minted}{python}
+# Create lists of x and y co-ordinates for scatter plot
 x = []
 y = []
 for section in matches:
@@ -1243,9 +1243,9 @@ for section in matches:
         for j in dict_two[section]:
             x.append(i)
             y.append(j)
-\end{verbatim}
+\end{minted}
 \noindent We are now ready to draw the revised dot plot as a scatter plot:
-\begin{verbatim}
+\begin{minted}{python}
 import pylab
 pylab.cla() #clear any prior graph
 pylab.gray()
@@ -1256,7 +1256,7 @@ pylab.xlabel("%s (length %i bp)" % (rec_one.id, len(rec_one)))
 pylab.ylabel("%s (length %i bp)" % (rec_two.id, len(rec_two)))
 pylab.title("Dot plot using window size %i\n(allowing no mis-matches)" % window)
 pylab.show()
-\end{verbatim}
+\end{minted}
 %pylab.savefig("dot_plot.png", dpi=75)
 %pylab.savefig("dot_plot.pdf")
 %
@@ -1297,7 +1297,7 @@ In the following code the \verb|pylab.subplot(...)| function is used in order to
 the forward and reverse qualities on two subplots, side by side. There is also a little
 bit of code to only plot the first fifty reads.
 
-\begin{verbatim}
+\begin{minted}{python}
 import pylab
 from Bio import SeqIO
 for subfigure in [1,2]:
@@ -1311,7 +1311,7 @@ for subfigure in [1,2]:
     pylab.xlabel("Position")
 pylab.savefig("SRR001666.png")
 print("Done")
-\end{verbatim}
+\end{minted}
 
 You should note that we are using the \verb|Bio.SeqIO| format name \texttt{fastq}
 here because the NCBI has saved these reads using the standard Sanger FASTQ format
@@ -1349,10 +1349,10 @@ Once you have an alignment, you are very likely going to want to find out inform
 
 Getting ready to calculate summary information about an object is quick to do. Let's say we've got an alignment object called \verb|alignment|, for example read in using \verb|Bio.AlignIO.read(...)| as described in Chapter~\ref{chapter:Bio.AlignIO}. All we need to do to get an object that will calculate summary information is:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.Align import AlignInfo
 summary_align = AlignInfo.SummaryInfo(alignment)
-\end{verbatim}
+\end{minted}
 
 The \verb|summary_align| object is very useful, and will do the following neat things for you:
 
@@ -1368,9 +1368,9 @@ The \verb|summary_align| object is very useful, and will do the following neat t
 
 The \verb|SummaryInfo| object, described in section~\ref{sec:summary_info}, provides functionality to calculate a quick consensus of an alignment. Assuming we've got a \verb|SummaryInfo| object called \verb|summary_align| we can calculate a consensus by doing:
 
-\begin{verbatim}
+\begin{minted}{python}
 consensus = summary_align.dumb_consensus()
-\end{verbatim}
+\end{minted}
 
 As the name suggests, this is a really simple consensus calculator, and will just add up all of the residues at each point in the consensus, and if the most common value is higher than some threshold value will add the common residue to the consensus. If it doesn't reach the threshold, it adds an ambiguity character to the consensus. The returned consensus object is Seq object whose alphabet is inferred from the alphabets of the sequences making up the consensus. So doing a \verb|print consensus| would give:
 
@@ -1413,17 +1413,17 @@ CTGTC
 
 Let's assume we've got an alignment object called \verb|c_align|. To get a PSSM with the consensus sequence along the side we first get a summary object and calculate the consensus sequence:
 
-\begin{verbatim}
+\begin{minted}{python}
 summary_align = AlignInfo.SummaryInfo(c_align)
 consensus = summary_align.dumb_consensus()
-\end{verbatim}
+\end{minted}
 
 Now, we want to make the PSSM, but ignore any \verb|N| ambiguity residues when calculating this:
 
-\begin{verbatim}
+\begin{minted}{python}
 my_pssm = summary_align.pos_specific_score_matrix(consensus,
                                                   chars_to_ignore = ['N'])
-\end{verbatim}
+\end{minted}
 
 Two notes should be made about this:
 
@@ -1432,11 +1432,11 @@ Two notes should be made about this:
 
   \item The sequence passed to be displayed along the left side of the axis does not need to be the consensus. For instance, if you wanted to display the second sequence in  the alignment along this axis, you would need to do:
 
-\begin{verbatim}
+\begin{minted}{python}
 second_seq = alignment.get_seq_by_num(1)
 my_pssm = summary_align.pos_specific_score_matrix(second_seq
                                                   chars_to_ignore = ['N'])
-\end{verbatim}
+\end{minted}
 
 \end{enumerate}
 
@@ -1459,10 +1459,10 @@ T  1.0 0.0 0.0 6.0
 
 You can access any element of the PSSM by subscripting like \verb|your_pssm[sequence_number][residue_count_name]|. For instance, to get the counts for the 'A' residue in the second element of the above PSSM you would do:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(my_pssm[1]["A"])
 7.0
-\end{verbatim}
+\end{minted}
 
 The structure of the PSSM class hopefully makes it easy both to access elements and to pretty print the matrix.
 
@@ -1496,59 +1496,59 @@ Well, now that we have an idea what information content is being calculated in B
 
 First, we need to use our alignment to get an alignment summary object, which we'll assume is called \verb|summary_align| (see section~\ref{sec:summary_info}) for instructions on how to get this. Once we've got this object, calculating the information content for a region is as easy as:
 
-\begin{verbatim}
+\begin{minted}{python}
 info_content = summary_align.information_content(5, 30,
                                                  chars_to_ignore = ['N'])
-\end{verbatim}
+\end{minted}
 
 Wow, that was much easier then the formula above made it look! The variable \verb|info_content| now contains a float value specifying the information content over the specified region (from 5 to 30 of the alignment). We specifically ignore the ambiguity residue 'N' when calculating the information content, since this value is not included in our alphabet (so we shouldn't be interested in looking at it!).
 
 As mentioned above, we can also calculate relative information content by supplying the expected frequencies:
 
-\begin{verbatim}
+\begin{minted}{python}
 expect_freq = {
     'A' : .3,
     'G' : .2,
     'T' : .3,
     'C' : .2}
-\end{verbatim}
+\end{minted}
 
 The expected should not be passed as a raw dictionary, but instead by passed as a \verb|SubsMat.FreqTable| object (see section~\ref{sec:freq_table} for more information about FreqTables). The FreqTable object provides a standard for associating the dictionary with an Alphabet, similar to how the Biopython Seq class works.
 
 To create a FreqTable object, from the frequency dictionary you just need to do:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.Alphabet import IUPAC
 from Bio.SubsMat import FreqTable
 
 e_freq_table = FreqTable.FreqTable(expect_freq, FreqTable.FREQ,
                                    IUPAC.unambiguous_dna)
-\end{verbatim}
+\end{minted}
 
 Now that we've got that, calculating the relative information content for our region of the alignment is as simple as:
 
-\begin{verbatim}
+\begin{minted}{python}
 info_content = summary_align.information_content(5, 30,
                                                  e_freq_table = e_freq_table,
                                                  chars_to_ignore = ['N'])
-\end{verbatim}
+\end{minted}
 
 Now, \verb|info_content| will contain the relative information content over the region in relation to the expected frequencies.
 
 The value return is calculated using base 2 as the logarithm base in the formula above. You can modify this by passing the parameter \verb|log_base| as the base you want:
 
-\begin{verbatim}
+\begin{minted}{python}
 info_content = summary_align.information_content(5, 30, log_base = 10,
                                                  chars_to_ignore = ['N'])
-\end{verbatim}
+\end{minted}
 
 By default nucleotide or amino acid residues with a frequency of 0 in a column are not take into account when the relative information column for that column is computed. If this is not the desired result, you can use \verb|pseudo_count| instead.
 
-\begin{verbatim}
+\begin{minted}{python}
 info_content = summary_align.information_content(5, 30,
                                                  chars_to_ignore = ['N'],
                                                  pseudo_count = 1)
-\end{verbatim}
+\end{minted}
 
 In this case, the observed frequency $P_{ij}$ of a particular letter $i$ in the $j$-th column is computed as follow :
 
@@ -1589,7 +1589,7 @@ alignment. The file containing \href{examples/protein.aln}{protein.aln}
 contains the Clustalw alignment output.
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import AlignIO
 >>> from Bio import Alphabet
 >>> from Bio.Alphabet import IUPAC
@@ -1598,7 +1598,7 @@ contains the Clustalw alignment output.
 >>> alpha = Alphabet.Gapped(IUPAC.protein)
 >>> c_align = AlignIO.read(filename, "clustal", alphabet=alpha)
 >>> summary_align = AlignInfo.SummaryInfo(c_align)
-\end{verbatim}
+\end{minted}
 
 Sections~\ref{sec:align_clustal} and~\ref{sec:summary_info} contain
 more information on doing this.
@@ -1612,16 +1612,16 @@ characters that should be ignored. Thus we'll create a dictionary of
 replacements for only charged polar amino acids using:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> replace_info = summary_align.replacement_dictionary(["G", "A", "V", "L", "I",
 ...                                                      "M", "P", "F", "W", "S",
 ...                                                      "T", "N", "Q", "Y", "C"])
-\end{verbatim}
+\end{minted}
 
 This information about amino acid replacements is represented as a
 python dictionary which will look something like (the order can vary):
 
-\begin{verbatim}
+\begin{minted}{python}
 {('R', 'R'): 2079.0, ('R', 'H'): 17.0, ('R', 'K'): 103.0, ('R', 'E'): 2.0,
 ('R', 'D'): 2.0, ('H', 'R'): 0, ('D', 'H'): 15.0, ('K', 'K'): 3218.0,
 ('K', 'H'): 24.0, ('H', 'K'): 8.0, ('E', 'H'): 15.0, ('H', 'H'): 1235.0,
@@ -1629,7 +1629,7 @@ python dictionary which will look something like (the order can vary):
 ('D', 'R'): 48.0, ('E', 'R'): 2.0, ('D', 'K'): 1.0, ('E', 'K'): 45.0,
 ('K', 'R'): 130.0, ('E', 'D'): 241.0, ('E', 'E'): 3305.0,
 ('D', 'E'): 270.0, ('D', 'D'): 2360.0}
-\end{verbatim}
+\end{minted}
 
 This information gives us our accepted number of replacements, or how
 often we expect different things to substitute for each other. It
@@ -1639,18 +1639,18 @@ replacement dictionary information to create an Accepted Replacement
 Matrix (ARM):
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SubsMat
 >>> my_arm = SubsMat.SeqMat(replace_info)
-\end{verbatim}
+\end{minted}
 
 With this accepted replacement matrix, we can go right ahead and
 create our log odds matrix (i.~e.~a standard type Substitution Matrix):
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> my_lom = SubsMat.make_log_odds_matrix(my_arm)
-\end{verbatim}
+\end{minted}
 
 The log odds matrix you create is customizable with the following
 optional arguments:
@@ -1678,7 +1678,7 @@ using the function \verb|print_mat|. Doing this on our created matrix
 gives:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> my_lom.print_mat()
 D   2
 E  -1   1
@@ -1686,7 +1686,7 @@ H  -5  -4   3
 K -10  -5  -4   1
 R  -4  -8  -4  -2   2
    D   E   H   K   R
-\end{verbatim}
+\end{minted}
 
 Very nice. Now we've got our very own substitution matrix to play with!
 

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -36,23 +36,23 @@ To paraphrase:
 This is automatically enforced by Biopython.
 Include \verb|api_key="MyAPIkey"| in the argument list or set it as a module level variable:
 %DO NOT run this as a doctest, will set an invalid API key!
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.api_key = "MyAPIkey"
-\end{verbatim}
+\end{minted}
 \item Use the optional email parameter so the NCBI can contact you if there is a problem.  You can either explicitly set this as a parameter with each call to Entrez (e.g. include {\tt email="A.N.Other@example.com"} in the argument list), or you can set a global email address:
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"
-\end{verbatim}
+\end{minted}
 {\tt Bio.Entrez} will then use this email address with each call to Entrez.  The {\tt example.com} address is a reserved domain name specifically for documentation (RFC 2606).  Please DO NOT use a random email -- it's better not to give an email at all. The email parameter has been mandatory since June 1, 2010. In case of excessive usage, NCBI will attempt to contact a user at the e-mail address provided prior to blocking access to the E-utilities.
 \item If you are using Biopython within some larger software suite, use the tool parameter to specify this.  You can either explicitly set the tool name as a parameter with each call to Entrez (e.g. include {\tt tool="MyLocalScript"} in the argument list), or you can set a global tool name:
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.tool = "MyLocalScript"
-\end{verbatim}
+\end{minted}
 The tool parameter will default to Biopython.
 \item For large queries, the NCBI also recommend using their session history feature (the WebEnv session cookie string, see Section~\ref{sec:entrez-webenv}).  This is only slightly more complicated.
 \end{itemize}
@@ -64,15 +64,15 @@ In conclusion, be sensible with your usage levels.  If you plan to download lots
 EInfo provides field index term counts, last update, and available links for each of NCBI's databases. In addition, you can use EInfo to obtain a list of all database names accessible through the Entrez utilities:
 %Run this as a doctest in current directory, requires internet access!
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.einfo()
 >>> result = handle.read()
 >>> handle.close()
-\end{verbatim}
+\end{minted}
 The variable \verb+result+ now contains a list of databases in XML format:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(result)
 <?xml version="1.0"?>
 <!DOCTYPE eInfoResult PUBLIC "-//NLM//DTD eInfoResult, 11 May 2002//EN"
@@ -118,24 +118,24 @@ The variable \verb+result+ now contains a list of databases in XML format:
         <DbName>unists</DbName>
 </DbList>
 </eInfoResult>
-\end{verbatim}
+\end{minted}
 
 Since this is a fairly simple XML file, we could extract the information it contains simply by string searching. Using \verb+Bio.Entrez+'s parser instead, we can directly parse this XML file into a Python object:
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> handle = Entrez.einfo()
 >>> record = Entrez.read(handle)
-\end{verbatim}
+\end{minted}
 Now \verb+record+ is a dictionary with exactly one key:
 %Not continuing doctest due as only Python 2 will show a u'string' prefix...
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.keys()
 ['DbList']
-\end{verbatim}
+\end{minted}
 The values stored in this key is the list of database names shown in the XML above:
 %Line-wrapping for display so not using for doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record["DbList"]
 ['pubmed', 'protein', 'nucleotide', 'nuccore', 'nucgss', 'nucest',
  'structure', 'genome', 'books', 'cancerchromosomes', 'cdd', 'gap',
@@ -143,30 +143,30 @@ The values stored in this key is the list of database names shown in the XML abo
  'journals', 'mesh', 'ncbisearch', 'nlmcatalog', 'omia', 'omim', 'pmc',
  'popset', 'probe', 'proteinclusters', 'pcassay', 'pccompound',
  'pcsubstance', 'snp', 'taxonomy', 'toolkit', 'unigene', 'unists']
-\end{verbatim}
+\end{minted}
 
 For each of these databases, we can use EInfo again to obtain more information:
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.einfo(db="pubmed")
 >>> record = Entrez.read(handle)
 >>> record["DbInfo"]["Description"]
 'PubMed bibliographic record'
-\end{verbatim}
+\end{minted}
 %These are too changable to use in doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record["DbInfo"]["Count"]
 '17989604'
 >>> record["DbInfo"]["LastUpdate"]
 '2008/05/24 06:45'
-\end{verbatim}
+\end{minted}
 Try \verb+record["DbInfo"].keys()+ for other information stored in this record.
 One of the most useful is a list of possible search fields for use with ESearch:
 
 %Output is truncated so can't easily use in doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for field in record["DbInfo"]["FieldList"]:
 ...     print("%(Name)s, %(FullName)s, %(Description)s" % field)
 ...
@@ -181,7 +181,7 @@ AUTH, Author, Author(s) of publication
 JOUR, Journal, Journal abbreviation of publication
 AFFL, Affiliation, Author's institutional affiliation and address
 ...
-\end{verbatim}
+\end{minted}
 
 That's a long list, but indirectly this tells you that for the PubMed
 database, you can do things like \texttt{Jones[AUTH]} to search the
@@ -193,19 +193,19 @@ familiar with a particular database.
 \label{sec:entrez-esearch}
 To search any of these databases, we use \verb+Bio.Entrez.esearch()+. For example, let's search in PubMed for publications related to Biopython:
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"     # Always tell NCBI who you are
 >>> handle = Entrez.esearch(db="pubmed", term="biopython")
 >>> record = Entrez.read(handle)
 >>> "19304878" in record["IdList"]
 True
-\end{verbatim}
+\end{minted}
 %truncted for display, so not in doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(record["IdList"])
 ['28011774', '24929426', '24497503', '24267035', '24194598', ..., '14871861']
-\end{verbatim}
+\end{minted}
 In this output, you see lots of PubMed IDs (including 19304878 which is the PMID for the Biopython application note), which can be retrieved by EFetch (see section \ref{sec:efetch}).
 
 You can also use ESearch to search GenBank. Here we'll do a quick
@@ -214,14 +214,14 @@ search for the \emph{matK} gene in \emph{Cypripedioideae} orchids
 find out which fields you can search in each Entrez database):
 
 % Search results too changable for use in doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> handle = Entrez.esearch(db="nucleotide", term="Cypripedioideae[Orgn] AND matK[Gene]", idtype="acc")
 >>> record = Entrez.read(handle)
 >>> record["Count"]
 '348'
 >>> record["IdList"]
 ['JQ660909.1', 'JQ660908.1', 'JQ660907.1', 'JQ660906.1', ..., 'JQ660890.1']
-\end{verbatim}
+\end{minted}
 
 \noindent Each of the IDs (JQ660909.1, JQ660908.1, JQ660907.1, \ldots) is a GenBank identifier (Accession number).
 See section~\ref{sec:efetch} for information on how to actually download these GenBank records.
@@ -229,7 +229,7 @@ See section~\ref{sec:efetch} for information on how to actually download these G
 Note that instead of a species name like \texttt{Cypripedioideae[Orgn]}, you can restrict the search using an NCBI taxon identifier, here this would be \texttt{txid158330[Orgn]}.  This isn't currently documented on the ESearch help page - the NCBI explained this in reply to an email query.  You can often deduce the search term formatting by playing with the Entrez web interface.  For example, including \texttt{complete[prop]} in a genome search restricts to just completed genomes.
 
 As a final example, let's get a list of computational journal titles:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> handle = Entrez.esearch(db="nlmcatalog", term="computational[Journal]", retmax="20")
 >>> record = Entrez.read(handle)
 >>> print("{} computational journals found".format(record["Count"]))
@@ -239,7 +239,7 @@ As a final example, let's get a list of computational journal titles:
  '101653734', '101669877', '101649614', '101647835', '101639023',
  '101627224', '101647801', '101589678', '101585369', '101645372',
  '101586429', '101582229', '101574747', '101564639', '101671907']
-\end{verbatim}
+\end{minted}
 Again, we could use EFetch to obtain more information for each of these journal IDs.
 
 ESearch has many useful options --- see the \href{https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch}{ESearch help page} for more information.
@@ -262,7 +262,7 @@ getting round the long URL problem).  With the history support, you can then
 refer to this long list of IDs, and download the associated data with EFetch.
 
 Let's look at a simple example to see how EPost works -- uploading some PubMed identifiers:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"     # Always tell NCBI who you are
 >>> id_list = ["19304878", "18606172", "16403221", "16377612", "14871861", "14630660"]
@@ -274,24 +274,24 @@ Let's look at a simple example to see how EPost works -- uploading some PubMed i
 	<QueryKey>1</QueryKey>
 	<WebEnv>NCID_01_206841095_130.14.22.101_9001_1242061629</WebEnv>
 </ePostResult>
-\end{verbatim}
+\end{minted}
 \noindent The returned XML includes two important strings, \verb|QueryKey| and \verb|WebEnv| which together define your history session.
 You would extract these values for use with another Entrez call such as EFetch:
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"     # Always tell NCBI who you are
 >>> id_list = ["19304878", "18606172", "16403221", "16377612", "14871861", "14630660"]
 >>> search_results = Entrez.read(Entrez.epost("pubmed", id=",".join(id_list)))
 >>> webenv = search_results["WebEnv"]
 >>> query_key = search_results["QueryKey"]
-\end{verbatim}
+\end{minted}
 \noindent Section~\ref{sec:entrez-webenv} shows how to use the history feature.
 
 \section{ESummary: Retrieving summaries from primary IDs}
 ESummary retrieves document summaries from a list of primary IDs (see the  \href{https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESummary}{ESummary help page} for more information). In Biopython, ESummary is available as \verb+Bio.Entrez.esummary()+. Using the search result above, we can for example find out more about the journal with ID 30367:
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.esummary(db="nlmcatalog", id="101660833")
@@ -301,7 +301,7 @@ ESummary retrieves document summaries from a list of primary IDs (see the  \href
 Journal info
 id: 101660833
 Title: IEEE transactions on computational imaging.
-\end{verbatim}
+\end{minted}
 
 \section{EFetch: Downloading full records from Entrez}
 \label{sec:efetch}
@@ -314,7 +314,7 @@ For most of their databases, the NCBI support several different file formats. Re
 One common usage is downloading sequences in the FASTA or GenBank/GenPept plain text formats (which can then be parsed with \verb|Bio.SeqIO|, see Sections~\ref{sec:SeqIO_GenBank_Online} and~\ref{sec:efetch}). From the \emph{Cypripedioideae} example above, we can download GenBank record EU490707 using \verb+Bio.Entrez.efetch+:
 
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.efetch(db="nucleotide", id="EU490707", rettype="gb", retmode="text")
@@ -391,7 +391,7 @@ ORIGIN
 //
 <BLANKLINE>
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 Please be aware that as of October 2016 GI identifiers are discontinued in favour of accession numbers. You can still fetch sequences based on their GI, but new sequences are no longer given this identifier. You should instead refer to them by the ``Accession number'' as done in the example.
 
@@ -408,7 +408,7 @@ Alternatively, you could for example use \verb+rettype="fasta"+ to get the Fasta
 If you fetch the record in one of the formats accepted by \verb+Bio.SeqIO+ (see Chapter~\ref{chapter:Bio.SeqIO}), you could directly parse it into a \verb+SeqRecord+:
 
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
@@ -425,11 +425,11 @@ Selenipedium aequinoctiale maturase K (matK) gene, partial cds; chloroplast
 3
 >>> print(repr(record.seq))
 Seq('ATTTTTTACGAACCTGTGGAAATTTTTGGTTATGACAATAAATCTAGTTTAGTA...GAA', IUPACAmbiguousDNA())
-\end{verbatim}
+\end{minted}
 
 Note that a more typical use would be to save the sequence data to a local file, and \emph{then} parse it with \verb|Bio.SeqIO|.  This can save you having to re-download the same file repeatedly while working on your script, and places less load on the NCBI's servers.  For example:
 
-\begin{verbatim}
+\begin{minted}{python}
 import os
 from Bio import SeqIO
 from Bio import Entrez
@@ -447,12 +447,12 @@ if not os.path.isfile(filename):
 print("Parsing...")
 record = SeqIO.read(filename, "genbank")
 print(record)
-\end{verbatim}
+\end{minted}
 
 To get the output in XML format, which you can parse using the \verb+Bio.Entrez.read()+ function, use \verb+retmode="xml"+:
 
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.efetch(db="nucleotide", id="EU490707", retmode="xml")
@@ -462,7 +462,7 @@ To get the output in XML format, which you can parse using the \verb+Bio.Entrez.
 'Selenipedium aequinoctiale maturase K (matK) gene, partial cds; chloroplast'
 >>> record[0]["GBSeq_source"]
 'chloroplast Selenipedium aequinoctiale'
-\end{verbatim}
+\end{minted}
 
 So, that dealt with sequences. For examples of parsing file formats specific to the other databases (e.g. the \verb+MEDLINE+ format used in PubMed), see Section~\ref{sec:entrez-specialized-parsers}.
 
@@ -477,32 +477,32 @@ and other cool stuff.
 Let's use ELink to find articles related to the Biopython application note published in \textit{Bioinformatics} in 2009. The PubMed ID of this article is 19304878:
 
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> pmid = "19304878"
 >>> record = Entrez.read(Entrez.elink(dbfrom="pubmed", id=pmid))
-\end{verbatim}
+\end{minted}
 
 The \verb+record+ variable consists of a Python list, one for each database in which we searched. Since we specified only one PubMed ID to search for, \verb+record+ contains only one item. This item is a dictionary containing information about our search term, as well as all the related items that were found:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record[0]["DbFrom"]
 'pubmed'
 >>> record[0]["IdList"]
 ['19304878']
-\end{verbatim}
+\end{minted}
 
 The \verb+"LinkSetDb"+ key contains the search results, stored as a list consisting of one item for each target database. In our search results, we only find hits in the PubMed database (although sub-divided into categories):
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(record[0]["LinkSetDb"])
 8
-\end{verbatim}
+\end{minted}
 \noindent The exact numbers should increase over time:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for linksetdb in record[0]["LinkSetDb"]:
 ...     print(linksetdb["DbTo"], linksetdb["LinkName"], len(linksetdb["Link"]))
 ...
@@ -514,27 +514,27 @@ pubmed pubmed_pubmed_five 6
 pubmed pubmed_pubmed_refs 17
 pubmed pubmed_pubmed_reviews 7
 pubmed pubmed_pubmed_reviews_five 6
-\end{verbatim}
+\end{minted}
 
 The actual search results are stored as under the \verb+"Link"+ key.
 
 Let's now at the first search result:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record[0]["LinkSetDb"][0]["Link"][0]
 {'Id': '19304878'}
-\end{verbatim}
+\end{minted}
 
 \noindent This is the article we searched for, which doesn't help us much, so let's look at the second search result:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record[0]["LinkSetDb"][0]["Link"][1]
 {'Id': '14630660'}
-\end{verbatim}
+\end{minted}
 
 \noindent This paper, with PubMed ID 14630660, is about the Biopython PDB parser.
 
 We can use a loop to print out all PubMed IDs:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for link in record[0]["LinkSetDb"][0]["Link"]:
 ...     print(link["Id"])
 19304878
@@ -544,7 +544,7 @@ We can use a loop to print out all PubMed IDs:
 16377612
 12368254
 ......
-\end{verbatim}
+\end{minted}
 
 Now that was nice, but personally I am often more interested to find out if a paper has been cited.
 Well, ELink can do that too -- at least for journals in Pubmed Central (see Section~\ref{sec:elink-citations}).
@@ -557,7 +557,7 @@ EGQuery provides counts for a search term in each of the Entrez databases (i.e. 
 
 In this example, we use \verb+Bio.Entrez.egquery()+ to obtain the counts for ``Biopython'':
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.egquery(term="biopython")
@@ -569,14 +569,14 @@ pubmed 6
 pmc 62
 journals 0
 ...
-\end{verbatim}
+\end{minted}
 See the \href{https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.EGQuery}{EGQuery help page} for more information.
 
 \section{ESpell: Obtaining spelling suggestions}
 ESpell retrieves spelling suggestions. In this example, we use \verb+Bio.Entrez.espell()+ to obtain the correct spelling of Biopython:
 
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.espell(term="biopythooon")
@@ -585,7 +585,7 @@ ESpell retrieves spelling suggestions. In this example, we use \verb+Bio.Entrez.
 'biopythooon'
 >>> record["CorrectedQuery"]
 'biopython'
-\end{verbatim}
+\end{minted}
 See the \href{https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESpell}{ESpell help page} for more information.
 The main use of this is for GUI tools to provide automatic suggestions for search terms.
 
@@ -595,15 +595,15 @@ The \verb+Entrez.read+ function reads the entire XML file returned by Entrez int
 
 For example, you can download the entire Entrez Gene database for a given organism as a file from NCBI's ftp site. These files can be very large. As an example, on September 4, 2009, the file \verb+Homo_sapiens.ags.gz+, containing the Entrez Gene database for human, had a size of 116576 kB. This file, which is in the \verb+ASN+ format, can be converted into an XML file using NCBI's \verb+gene2xml+ program (see NCBI's ftp site for more information):
 
-\begin{verbatim}
-gene2xml -b T -i Homo_sapiens.ags -o Homo_sapiens.xml
-\end{verbatim}
+\begin{minted}{bash}
+$ gene2xml -b T -i Homo_sapiens.ags -o Homo_sapiens.xml
+\end{minted}
 
 The resulting XML file has a size of 6.1 GB. Attempting \verb+Entrez.read+ on this file will result in a \verb+MemoryError+ on many computers.
 
 The XML file \verb+Homo_sapiens.xml+ consists of a list of Entrez gene records, each corresponding to one Entrez gene in human. \verb+Entrez.parse+ retrieves these gene records one by one. You can then print out or store the relevant information in each record by iterating over the records. For example, this script iterates over the Entrez gene records and prints out the gene numbers and names for all current genes:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = open("Homo_sapiens.xml")
@@ -616,10 +616,6 @@ The XML file \verb+Homo_sapiens.xml+ consists of a list of Entrez gene records, 
 ...     genename = record["Entrezgene_gene"]["Gene-ref"]["Gene-ref_locus"]
 ...     print(geneid, genename)
 ...
-\end{verbatim}
-
-This will print:
-\begin{verbatim}
 1 A1BG
 2 A2M
 3 A2MP
@@ -634,7 +630,7 @@ This will print:
 16 AARS
 17 AAVS1
 ...
-\end{verbatim}
+\end{minted}
 
 \section{HTML escape characters}
 
@@ -647,9 +643,9 @@ in the XML returned by Entrez, is converted to the Python string
 '<i>P</i> < 0.05'
 \end{verbatim}
 by the \verb+Bio.Entrez+ parser. While this is more human-readable, it is not valid HTML due to the less-than sign, and makes further processing of the text e.g. by an HTML parser impractical. To ensure that all strings returned by the parser are valid HTML, call \verb+Entrez.read+ or \verb+Entrez.parse+ with the \verb+escape+ argument set to \verb+True+:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record = Entrez.read(handle, escape=True)
-\end{verbatim}
+\end{minted}
 The parser will then replace all characters disallowed in HTML by their HTML-escaped equivalent; in the example above, the parser will generate
 \begin{verbatim}
 '<i>P</i> &lt; 0.05'
@@ -667,14 +663,14 @@ Three things can go wrong when parsing an XML file:
 
 The first case occurs if, for example, you try to parse a Fasta file as if it were an XML file:
 %doctest ../Tests/GenBank
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> handle = open("NC_005816.fna") # a Fasta file
 >>> record = Entrez.read(handle)
 Traceback (most recent call last):
   ...
 Bio.Entrez.Parser.NotXMLError: Failed to parse the XML data (syntax error: line 1, column 0). Please make sure that the input data are in XML format.
-\end{verbatim}
+\end{minted}
 Here, the parser didn't find the \verb|<?xml ...| tag with which an XML file is supposed to start, and therefore decides (correctly) that the file is not an XML file.
 
 When your file is in the XML format but is corrupted (for example, by ending prematurely), the parser will raise a CorruptedXMLError.
@@ -697,12 +693,12 @@ Here is an example of an XML file that ends prematurely:
         <DbName>cdd</DbName>
 \end{verbatim}
 which will generate the following traceback:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> Entrez.read(handle)
 Traceback (most recent call last):
   ...
 Bio.Entrez.Parser.CorruptedXMLError: Failed to parse the XML data (no element found: line 16, column 0). Please make sure that the input data are not corrupted.
-\end{verbatim}
+\end{minted}
 Note that the error message tells you at what point in the XML file the error was detected.
 
 The third type of error occurs if the XML file contains tags that do not have a description in the corresponding DTD file. This is an example of such an XML file:
@@ -738,22 +734,22 @@ The third type of error occurs if the XML file contains tags that do not have a 
 In this file, for some reason the tag \verb|<DocsumList>| (and several others) are not listed in the DTD file \verb|eInfo_020511.dtd|, which is specified on the second line as the DTD for this XML file. By default, the parser will stop and raise a ValidationError if it cannot find some tag in the DTD:
 
 %doctest ../Tests/Entrez/
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> handle = open("einfo3.xml")
 >>> record = Entrez.read(handle)
 Traceback (most recent call last):
   ...
 Bio.Entrez.Parser.ValidationError: Failed to find tag 'DocsumList' in the DTD. To skip all tags that are not represented in the DTD, please call Bio.Entrez.read or Bio.Entrez.parse with validate=False.
-\end{verbatim}
+\end{minted}
 Optionally, you can instruct the parser to skip such tags instead of raising a ValidationError. This is done by calling \verb|Entrez.read| or \verb|Entrez.parse| with the argument \verb|validate| equal to False:
 %doctest ../Tests/Entrez/
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> handle = open("einfo3.xml")
 >>> record = Entrez.read(handle, validate=False)
 >>> handle.close()
-\end{verbatim}
+\end{minted}
 Of course, the information contained in the XML tags that are not in the DTD are not present in the record returned by \verb|Entrez.read|.
 
 
@@ -790,20 +786,20 @@ AB  - Bioinformatics research is often difficult to do with commercial software.
 \end{verbatim}
 We first open the file and then parse it:
 %doctest ../Tests/Medline
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Medline
 >>> with open("pubmed_result1.txt") as handle:
 ...    record = Medline.read(handle)
 ...
-\end{verbatim}
+\end{minted}
 The \verb+record+ now contains the Medline record as a Python dictionary:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record["PMID"]
 '12230038'
-\end{verbatim}
+\end{minted}
 %TODO - doctest wrapping?
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record["AB"]
 'Bioinformatics research is often difficult to do with commercial software.
 The Open Source BioPerl, BioPython and Biojava projects provide toolkits with
@@ -812,16 +808,16 @@ analysis. This review briefly compares the quirks of the underlying languages
 and the functionality, documentation, utility and relative advantages of the
 Bio counterparts, particularly from the point of view of the beginning
 biologist programmer.'
-\end{verbatim}
+\end{minted}
 The key names used in a Medline record can be rather obscure; use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> help(record)
-\end{verbatim}
+\end{minted}
 for a brief summary.
 
 To parse a file containing multiple Medline records, you can use the \verb+parse+ function instead:
 %doctest ../Tests/Medline
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Medline
 >>> with open("pubmed_result2.txt") as handle:
 ...     for record in Medline.parse(handle):
@@ -831,24 +827,24 @@ A high level interface to SCOP and ASTRAL implemented in python.
 GenomeDiagram: a python package for the visualization of large-scale genomic data.
 Open source clustering software.
 PDB file parser and structure class implemented in Python.
-\end{verbatim}
+\end{minted}
 
 Instead of parsing Medline records stored in files, you can also parse Medline records downloaded by \verb+Bio.Entrez.efetch+. For example, let's look at all Medline records in PubMed related to Biopython:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.esearch(db="pubmed", term="biopython")
 >>> record = Entrez.read(handle)
 >>> record["IdList"]
 ['19304878', '18606172', '16403221', '16377612', '14871861', '14630660', '12230038']
-\end{verbatim}
+\end{minted}
 We now use \verb+Bio.Entrez.efetch+ to download these Medline records:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> idlist = record["IdList"]
 >>> handle = Entrez.efetch(db="pubmed", id=idlist, rettype="medline", retmode="text")
-\end{verbatim}
+\end{minted}
 Here, we specify \verb+rettype="medline", retmode="text"+ to obtain the Medline records in plain-text Medline format. Now we use \verb+Bio.Medline+ to parse these records:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Medline
 >>> records = Medline.parse(handle)
 >>> for record in records:
@@ -860,10 +856,10 @@ Here, we specify \verb+rettype="medline", retmode="text"+ to obtain the Medline 
 ['de Hoon MJ', 'Imoto S', 'Nolan J', 'Miyano S']
 ['Hamelryck T', 'Manderick B']
 ['Mangalam H']
-\end{verbatim}
+\end{minted}
 
 For comparison, here we show an example using the XML format:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> handle = Entrez.efetch(db="pubmed", id=idlist, rettype="medline", retmode="xml")
 >>> records = Entrez.read(handle)
 >>> for record in records["PubmedArticle"]:
@@ -877,7 +873,7 @@ GenomeDiagram: a python package for the visualization of large-scale genomic dat
 Open source clustering software.
 PDB file parser and structure class implemented in Python.
 The Bio* toolkits--a brief overview.
-\end{verbatim}
+\end{minted}
 
 Note that in both of these examples, for simplicity we have naively combined ESearch and EFetch.
 In this situation, the NCBI would expect you to use their history feature,
@@ -894,18 +890,18 @@ data.
 The following code fragment shows how to parse the example GEO file
 \verb|GSE16.txt| into a record and print the record:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Geo
 >>> handle = open("GSE16.txt")
 >>> records = Geo.parse(handle)
 >>> for record in records:
 ...     print(record)
-\end{verbatim}
+\end{minted}
 
 You can search the ``gds'' database (GEO datasets) with ESearch:
 
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.esearch(db="gds", term="GSE16")
@@ -913,11 +909,11 @@ You can search the ``gds'' database (GEO datasets) with ESearch:
 >>> handle.close()
 >>> record["Count"]
 '27'
-\end{verbatim}
-\begin{verbatim}
+\end{minted}
+\begin{minted}{pycon}
 >>> record["IdList"]
 ['200000016', '100000028', ...]
-\end{verbatim}
+\end{minted}
 
 From the Entrez website, UID ``200000016'' is GDS16 while the other hit
 ``100000028'' is for the associated platform, GPL28.  Unfortunately, at the
@@ -972,43 +968,43 @@ SEQUENCE    ACC=AU099534.1; NID=g13550663; CLONE=HSI08034; END=5'; LID=8800; SEQ
 This particular record shows the set of transcripts (shown in the \verb+SEQUENCE+ lines) that originate from the human gene NAT2, encoding en N-acetyltransferase. The \verb+PROTSIM+ lines show proteins with significant similarity to NAT2, whereas the \verb+STS+ lines show the corresponding sequence-tagged sites in the genome.
 
 To parse UniGene files, use the \verb+Bio.UniGene+ module:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import UniGene
 >>> input = open("myunigenefile.data")
 >>> record = UniGene.read(input)
-\end{verbatim}
+\end{minted}
 
 The \verb+record+ returned by \verb+UniGene.read+ is a Python object with attributes corresponding to the fields in the UniGene record. For example,
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.ID
 "Hs.2"
 >>> record.title
 "N-acetyltransferase 2 (arylamine N-acetyltransferase)"
-\end{verbatim}
+\end{minted}
 
 The \verb+EXPRESS+ and \verb+RESTR_EXPR+ lines are stored as Python lists of strings:
-\begin{verbatim}
+\begin{minted}{python}
 ['bone', 'connective tissue', 'intestine', 'liver', 'liver tumor', 'normal', 'soft tissue/muscle tissue tumor', 'adult']
-\end{verbatim}
+\end{minted}
 
 Specialized objects are returned for the \verb+STS+, \verb+PROTSIM+, and \verb+SEQUENCE+ lines, storing the keys shown in each line as attributes:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.sts[0].acc
 'PMC310725P3'
 >>> record.sts[0].unists
 '272646'
-\end{verbatim}
+\end{minted}
 and similarly for the \verb+PROTSIM+ and \verb+SEQUENCE+ lines.
 
 To parse a file containing more than one UniGene record, use the \verb+parse+ function in \verb+Bio.UniGene+:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import UniGene
 >>> input = open("unigenerecords.data")
 >>> records = UniGene.parse(input)
 >>> for record in records:
 ...     print(record.ID)
-\end{verbatim}
+\end{minted}
 
 \section{Using a proxy}
 
@@ -1023,10 +1019,10 @@ You may choose to set the \verb|http_proxy| environment variable once (how you
 do this will depend on your operating system).  Alternatively you can set this
 within Python at the start of your script, for example:
 
-\begin{verbatim}
+\begin{minted}{python}
 import os
 os.environ["http_proxy"] = "http://proxyhost.example.com:8080"
-\end{verbatim}
+\end{minted}
 
 \noindent See the \href{https://docs.python.org/2/library/urllib.html}
 {urllib documentation} for more details.
@@ -1041,7 +1037,7 @@ If you are in the medical field or interested in human issues (and many times ev
 
 In this example, we will query PubMed for all articles having to do with orchids (see section~\ref{sec:orchids} for our motivation). We first check how many of such articles there are:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.egquery(term="orchid")
@@ -1050,54 +1046,54 @@ In this example, we will query PubMed for all articles having to do with orchids
 ...     if row["DbName"]=="pubmed":
 ...         print(row["Count"])
 463
-\end{verbatim}
+\end{minted}
 
 Now we use the \verb+Bio.Entrez.efetch+ function to download the PubMed IDs of these 463 articles:
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.esearch(db="pubmed", term="orchid", retmax=463)
 >>> record = Entrez.read(handle)
 >>> handle.close()
 >>> idlist = record["IdList"]
-\end{verbatim}
+\end{minted}
 
 This returns a Python list containing all of the PubMed IDs of articles related to orchids:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(idlist)
 ['18680603', '18665331', '18661158', '18627489', '18627452', '18612381',
 '18594007', '18591784', '18589523', '18579475', '18575811', '18575690',
 ...
-\end{verbatim}
+\end{minted}
 
 Now that we've got them, we obviously want to get the corresponding Medline records and extract the information from them. Here, we'll download the Medline records in the Medline flat-file format, and use the \verb+Bio.Medline+ module to parse them:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Medline
 >>> handle = Entrez.efetch(db="pubmed", id=idlist, rettype="medline",
 ...                        retmode="text")
 >>> records = Medline.parse(handle)
-\end{verbatim}
+\end{minted}
 
 NOTE - We've just done a separate search and fetch here, the NCBI much prefer you to take advantage of their history support in this situation.  See Section~\ref{sec:entrez-webenv}.
 
 Keep in mind that \verb+records+ is an iterator, so you can iterate through the records only once. If you want to save the records, you can convert them to a list:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> records = list(records)
-\end{verbatim}
+\end{minted}
 
 Let's now iterate over the records to print out some information about each record:
 %TODO - Replace the print blank line with print()?
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for record in records:
 ...     print("title:", record.get("TI", "?"))
 ...     print("authors:", record.get("AU", "?"))
 ...     print("source:", record.get("SO", "?"))
 ...     print("")
 ...
-\end{verbatim}
+\end{minted}
 
 The output for this looks like:
 \begin{verbatim}
@@ -1110,7 +1106,7 @@ source: J Comp Physiol [A] 2000 Jun;186(6):567-74
 \end{verbatim}
 
 Especially interesting to note is the list of authors, which is returned as a standard Python list. This makes it easy to manipulate and search using standard Python tools. For instance, we could loop through a whole bunch of entries searching for a particular author with code like the following:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> search_author = "Waits T"
 >>> for record in records:
 ...     if not "AU" in record:
@@ -1118,7 +1114,7 @@ Especially interesting to note is the list of authors, which is returned as a st
 ...     if search_author in record["AU"]:
 ...         print("Author %s found: %s" % (search_author, record["SO"]))
 ...
-\end{verbatim}
+\end{minted}
 
 Hopefully this section gave you an idea of the power and flexibility of the Entrez and Medline interfaces and how they can be used together.
 
@@ -1128,7 +1124,7 @@ Hopefully this section gave you an idea of the power and flexibility of the Entr
 Here we'll show a simple example of performing a remote Entrez query. In section~\ref{sec:orchids} of the parsing examples, we talked about using NCBI's Entrez website to search the NCBI nucleotide databases for info on Cypripedioideae, our friends the lady slipper orchids. Now, we'll look at how to automate that process using a Python script. In this example, we'll just show how to connect, get the results, and parse them, with the Entrez module doing all of the work.
 
 First, we use EGQuery to find out the number of results we will get before actually downloading them.  EGQuery will tell us how many search results were found in each of the databases, but for this example we are only interested in nucleotides:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.egquery(term="Cypripedioideae")
@@ -1137,49 +1133,49 @@ First, we use EGQuery to find out the number of results we will get before actua
 ...     if row["DbName"]=="nuccore":
 ...         print(row["Count"])
 4457
-\end{verbatim}
+\end{minted}
 
 So, we expect to find 4457 Entrez Nucleotide records (this increased from 814 records in 2008; it is likely to continue to increase in the future). If you find some ridiculously high number of hits, you may want to reconsider if you really want to download all of them, which is our next step. 
 Let's use the \verb+retmax+ argument to restrict the maximum number of records retrieved to the number available in 2008:
 
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.esearch(db="nucleotide", term="Cypripedioideae", retmax=814, idtype="acc")
 >>> record = Entrez.read(handle)
 >>> handle.close()
-\end{verbatim}
+\end{minted}
 
 Here, \verb+record+ is a Python dictionary containing the search results and some auxiliary information. Just for information, let's look at what is stored in this dictionary:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(record.keys())
 ['Count', 'RetMax', 'IdList', 'TranslationSet', 'RetStart', 'QueryTranslation']
-\end{verbatim}
+\end{minted}
 First, let's check how many results were found:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(record["Count"])
 '4457'
-\end{verbatim}
+\end{minted}
 You might have expected this to be 814, the maximum number of records we asked to retrieve. 
 However, \verb+Count+ represents the total number of records available for that search, not how many were retrieved.
 The retrieved records are stored in \verb+record['IdList']+, which should contain the total number we asked for:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(record["IdList"])
 814
-\end{verbatim}
+\end{minted}
 Let's look at the first five results:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record["IdList"][:5]
 ['KX265015.1', 'KX265014.1', 'KX265013.1', 'KX265012.1', 'KX265011.1']
-\end{verbatim}
+\end{minted}
 
 \label{sec:entrez-batched-efetch}
 We can download these records using \verb+efetch+.
 While you could download these records one by one, to reduce the load on NCBI's servers, it is better to fetch a bunch of records at the same time, shown below.
 However, in this situation you should ideally be using the history feature described later in Section~\ref{sec:entrez-webenv}.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> idlist = ",".join(record["IdList"][:5])
 >>> print(idlist)
 KX265015.1, KX265014.1, KX265013.1, KX265012.1, KX265011.1]
@@ -1187,9 +1183,9 @@ KX265015.1, KX265014.1, KX265013.1, KX265012.1, KX265011.1]
 >>> records = Entrez.read(handle)
 >>> len(records)
 5
-\end{verbatim}
+\end{minted}
 Each of these records corresponds to one GenBank record.
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(records[0].keys())
 ['GBSeq_moltype', 'GBSeq_source', 'GBSeq_sequence',
  'GBSeq_primary-accession', 'GBSeq_definition', 'GBSeq_accession-version',
@@ -1210,7 +1206,7 @@ mitochondrial
 
 >>> print(records[0]["GBSeq_organism"])
 Cypripedium calceolus
-\end{verbatim}
+\end{minted}
 
 You could use this to quickly set up searches -- but for heavy usage, see Section~\ref{sec:entrez-webenv}.
 
@@ -1224,7 +1220,7 @@ For simplicity, this example \emph{does not} take advantage of the WebEnv histor
 
 First, we want to make a query and find out the ids of the records to retrieve. Here we'll do a quick search for one of our favorite organisms, \emph{Opuntia} (prickly-pear cacti). We can do quick search and get back the GIs (GenBank identifiers) for all of the corresponding records. First we check how many records there are:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.egquery(term="Opuntia AND rpl16")
@@ -1234,27 +1230,27 @@ First, we want to make a query and find out the ids of the records to retrieve. 
 ...         print(row["Count"])
 ...
 9
-\end{verbatim}
+\end{minted}
 Now we download the list of GenBank identifiers:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> handle = Entrez.esearch(db="nuccore", term="Opuntia AND rpl16")
 >>> record = Entrez.read(handle)
 >>> gi_list = record["IdList"]
 >>> gi_list
 ['57240072', '57240071', '6273287', '6273291', '6273290', '6273289', '6273286',
 '6273285', '6273284']
-\end{verbatim}
+\end{minted}
 
 Now we use these GIs to download the GenBank records - note that with older versions of Biopython you had to supply a comma separated list of GI numbers to Entrez, as of Biopython 1.59 you can pass a list and this is converted for you:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> gi_str = ",".join(gi_list)
 >>> handle = Entrez.efetch(db="nuccore", id=gi_str, rettype="gb", retmode="text")
-\end{verbatim}
+\end{minted}
 
 If you want to look at the raw GenBank files, you can read from this handle and print out the result:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> text = handle.read()
 >>> print(text)
 LOCUS       AY851612                 892 bp    DNA     linear   PLN 10-APR-2007
@@ -1270,20 +1266,20 @@ SOURCE      chloroplast Austrocylindropuntia subulata
 REFERENCE   1  (bases 1 to 892)
   AUTHORS   Butterworth,C.A. and Wallace,R.S.
 ...
-\end{verbatim}
+\end{minted}
 
 In this case, we are just getting the raw records. To get the records in a more Python-friendly form, we can use \verb+Bio.SeqIO+ to parse the GenBank data into \verb|SeqRecord| objects, including \verb|SeqFeature| objects (see Chapter~\ref{chapter:Bio.SeqIO}):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> handle = Entrez.efetch(db="nuccore", id=gi_str, rettype="gb", retmode="text")
 >>> records = SeqIO.parse(handle, "gb")
-\end{verbatim}
+\end{minted}
 
 \noindent We can now step through the records and look at the information we are interested in:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for record in records:
->>> ...    print("%s, length %i, with %i features" \
+>>> ...    print("%s, length %i, with %i features"
 >>> ...           % (record.name, len(record), len(record.features)))
 AY851612, length 892, with 3 features
 AY851611, length 881, with 3 features
@@ -1294,7 +1290,7 @@ AF191663, length 899, with 3 features
 AF191660, length 893, with 3 features
 AF191659, length 894, with 3 features
 AF191658, length 896, with 3 features
-\end{verbatim}
+\end{minted}
 
 Using these automated query retrieval functionality is a big plus over doing things by hand.   Although the module should obey the NCBI's max three queries per second rule, the NCBI have other recommendations like avoiding peak hours.  See Section~\ref{sec:entrez-guidelines}.
 In particular, please note that for simplicity, this example does not use the WebEnv history feature.  You should use this for any non-trivial search and download work, see Section~\ref{sec:entrez-webenv}.
@@ -1305,7 +1301,7 @@ Finally, if plan to repeat your analysis, rather than downloading the files from
 
 Staying with a plant example, let's now find the lineage of the Cypripedioideae orchid family. First, we search the Taxonomy database for Cypripedioideae, which yields exactly one NCBI taxonomy identifier:
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> handle = Entrez.esearch(db="Taxonomy", term="Cypripedioideae")
@@ -1314,27 +1310,27 @@ Staying with a plant example, let's now find the lineage of the Cypripedioideae 
 ['158330']
 >>> record["IdList"][0]
 '158330'
-\end{verbatim}
+\end{minted}
 Now, we use \verb+efetch+ to download this entry in the Taxonomy database, and then parse it:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> handle = Entrez.efetch(db="Taxonomy", id="158330", retmode="xml")
 >>> records = Entrez.read(handle)
-\end{verbatim}
+\end{minted}
 Again, this record stores lots of information:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> records[0].keys()
 ['Lineage', 'Division', 'ParentTaxId', 'PubDate', 'LineageEx',
  'CreateDate', 'TaxId', 'Rank', 'GeneticCode', 'ScientificName',
  'MitoGeneticCode', 'UpdateDate']
-\end{verbatim}
+\end{minted}
 We can get the lineage directly from this record:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> records[0]["Lineage"]
 'cellular organisms; Eukaryota; Viridiplantae; Streptophyta; Streptophytina;
  Embryophyta; Tracheophyta; Euphyllophyta; Spermatophyta; Magnoliophyta;
  Liliopsida; Asparagales; Orchidaceae'
-\end{verbatim}
+\end{minted}
 
 The record data contains much more than just the information shown here - for example look under \texttt{"LineageEx"} instead of \texttt{"Lineage"} and you'll get the NCBI taxon identifiers of the lineage entries too.
 
@@ -1367,41 +1363,41 @@ To do this, call \verb|Bio.Entrez.esearch()| as normal, but with the
 additional argument of \verb|usehistory="y"|,
 
 %doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "history.user@example.com"  # Always tell NCBI who you are
 >>> search_handle = Entrez.esearch(db="nucleotide",term="Opuntia[orgn] and rpl16",
 ...                                usehistory="y", idtype="acc")
 >>> search_results = Entrez.read(search_handle)
 >>> search_handle.close()
-\end{verbatim}
+\end{minted}
 
 \noindent When you get the XML output back, it will still include the usual search results.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> acc_list = search_results["IdList"]
 >>> count = int(search_results["Count"])
 >>> count == len(acc_list)
 True
-\end{verbatim}
+\end{minted}
 
 \noindent (Remember from Section~\ref{subsec:entrez_example_genbank} that the number of records retrieved will not necessarily be the same as the \verb+Count+, especially if the argument \verb+retmax+ is used.)
 
 \noindent However, you also get given two additional pieces of information, the {\tt WebEnv} session cookie, and the {\tt QueryKey}:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> webenv = search_results["WebEnv"]
 >>> query_key = search_results["QueryKey"]
-\end{verbatim}
+\end{minted}
 
 Having stored these values in variables {\tt session\_cookie} and {\tt query\_key} we can use them as parameters to \verb|Bio.Entrez.efetch()| instead of giving the GI numbers as identifiers.
 
 While for small searches you might be OK downloading everything at once, it is better to download in batches.  You use the {\tt retstart} and {\tt retmax} parameters to specify which range of search results you want returned (starting entry using zero-based counting, and maximum number of results to return).  Sometimes you will get intermittent errors from Entrez, HTTPError 5XX, we use a try except pause retry block to address this.
 For example,
 
-\begin{verbatim}
+\begin{minted}{python}
 # This assumes you have already run a search as shown above,
 # and set the variables count, webenv, query_key
 
@@ -1435,14 +1431,14 @@ for start in range(0, count, batch_size):
     fetch_handle.close()
     out_handle.write(data)
 out_handle.close()
-\end{verbatim}
+\end{minted}
 
 \noindent For illustrative purposes, this example downloaded the FASTA records in batches of three.  Unless you are downloading genomes or chromosomes, you would normally pick a larger batch size.
 
 \subsection{Searching for and downloading abstracts using the history}
 Here is another history example, searching for papers published in the last year about the \textit{Opuntia}, and then downloading them into a file in MedLine format:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import Entrez
 import time
 try:
@@ -1482,7 +1478,7 @@ for start in range(0,count,batch_size):
     fetch_handle.close()
     out_handle.write(data)
 out_handle.close()
-\end{verbatim}
+\end{minted}
 
 \noindent At the time of writing, this gave 28 matches - but because this is a date dependent search, this will of course vary.  As described in Section~\ref{subsec:entrez-and-medline} above, you can then use \verb|Bio.Medline| to parse the saved records.
 
@@ -1494,7 +1490,7 @@ Unfortunately this only covers journals indexed for PubMed Central
 (doing it for all the journals in PubMed would mean a lot more work for the NIH).
 Let's try this for the Biopython PDB parser paper, PubMed ID 14630660:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 >>> pmid = "14630660"
@@ -1503,7 +1499,7 @@ Let's try this for the Biopython PDB parser paper, PubMed ID 14630660:
 >>> pmc_ids = [link["Id"] for link in results[0]["LinkSetDb"][0]["Link"]]
 >>> pmc_ids
 ['2744707', '2705363', '2682512', ..., '1190160']
-\end{verbatim}
+\end{minted}
 
 Great - eleven articles. But why hasn't the Biopython application note been
 found (PubMed ID 19304878)? Well, as you might have guessed from the variable
@@ -1518,13 +1514,13 @@ so by now you should expect to use the history feature to accomplish it
 But first, taking the more straightforward approach of making a second
 (separate) call to ELink:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> results2 = Entrez.read(Entrez.elink(dbfrom="pmc", db="pubmed", LinkName="pmc_pubmed",
 ...                                     id=",".join(pmc_ids)))
 >>> pubmed_ids = [link["Id"] for link in results2[0]["LinkSetDb"][0]["Link"]]
 >>> pubmed_ids
 ['19698094', '19450287', '19304878', ..., '15985178']
-\end{verbatim}
+\end{minted}
 
 \noindent This time you can immediately spot the Biopython application note
 as the third hit (PubMed ID 19304878).

--- a/Doc/Tutorial/chapter_graphics.tex
+++ b/Doc/Tutorial/chapter_graphics.tex
@@ -67,28 +67,28 @@ included with the Biopython unit tests under the GenBank folder, or online
 \href{https://raw.githubusercontent.com/biopython/biopython/master/Tests/GenBank/NC_005816.gb}
 {\texttt{NC\_005816.gb}} from our website.
 
-\begin{verbatim}
+\begin{minted}{python}
 from reportlab.lib import colors
 from reportlab.lib.units import cm
 from Bio.Graphics import GenomeDiagram
 from Bio import SeqIO
 record = SeqIO.read("NC_005816.gb", "genbank")
-\end{verbatim}
+\end{minted}
 
 We're using a top down approach, so after loading in our sequence we next
 create an empty diagram, then add an (empty) track, and to that add an
 (empty) feature set:
 
-\begin{verbatim}
+\begin{minted}{python}
 gd_diagram = GenomeDiagram.Diagram("Yersinia pestis biovar Microtus plasmid pPCP1")
 gd_track_for_features = gd_diagram.new_track(1, name="Annotated Features")
 gd_feature_set = gd_track_for_features.new_set()
-\end{verbatim}
+\end{minted}
 
 Now the fun part - we take each gene \verb|SeqFeature| object in our
 \verb|SeqRecord|, and use it to generate a feature on the diagram. We're
 going to color them blue, alternating between a dark blue and a light blue.
-\begin{verbatim}
+\begin{minted}{python}
 for feature in record.features:
     if feature.type != "gene":
         #Exclude this feature
@@ -98,27 +98,27 @@ for feature in record.features:
     else:
         color = colors.lightblue
     gd_feature_set.add_feature(feature, color=color, label=True)
-\end{verbatim}
+\end{minted}
 
 Now we come to actually making the output file.  This happens in two steps,
 first we call the \verb|draw| method, which creates all the shapes using
 ReportLab objects.  Then we call the \verb|write| method which renders these
 to the requested file format.  Note you can output in multiple file formats:
 
-\begin{verbatim}
+\begin{minted}{python}
 gd_diagram.draw(format="linear", orientation="landscape", pagesize='A4',
                 fragments=4, start=0, end=len(record))
 gd_diagram.write("plasmid_linear.pdf", "PDF")
 gd_diagram.write("plasmid_linear.eps", "EPS")
 gd_diagram.write("plasmid_linear.svg", "SVG")
-\end{verbatim}
+\end{minted}
 
 Also, provided you have the dependencies installed, you can also do bitmaps,
 for example:
 
-\begin{verbatim}
+\begin{minted}{python}
 gd_diagram.write("plasmid_linear.png", "PNG")
-\end{verbatim}
+\end{minted}
 
 \begin{htmlonly}
 %The blank line below is important to start a new paragraph
@@ -139,11 +139,11 @@ many pieces the genome gets broken up into.
 
 If you want to do a circular figure, then try this:
 
-\begin{verbatim}
+\begin{minted}{python}
 gd_diagram.draw(format="circular", circular=True, pagesize=(20*cm,20*cm),
                 start=0, end=len(record), circle_core=0.7)
 gd_diagram.write("plasmid_circular.pdf", "PDF")
-\end{verbatim}
+\end{minted}
 
 \begin{htmlonly}
 %The blank line below is important to start a new paragraph
@@ -166,7 +166,7 @@ Now let's produce exactly the same figures, but using the bottom up approach.
 This means we create the different objects directly (and this can be done in
 almost any order) and then combine them.
 
-\begin{verbatim}
+\begin{minted}{python}
 from reportlab.lib import colors
 from reportlab.lib.units import cm
 from Bio.Graphics import GenomeDiagram
@@ -193,7 +193,7 @@ gd_diagram = GenomeDiagram.Diagram("Yersinia pestis biovar Microtus plasmid pPCP
 #Now have to glue the bits together...
 gd_track_for_features.add_set(gd_feature_set)
 gd_diagram.add_track(gd_track_for_features, 1)
-\end{verbatim}
+\end{minted}
 
 You can now call the \verb|draw| and \verb|write| methods as before to produce
 a linear or circular diagram, using the code at the end of the top-down example
@@ -208,16 +208,16 @@ Sometimes you won't have \verb|SeqFeature| objects,
 but just the coordinates for a feature you want to draw.  You have to create
 minimal \verb|SeqFeature| object, but this is easy:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.SeqFeature import SeqFeature, FeatureLocation
 my_seq_feature = SeqFeature(FeatureLocation(50,100),strand=+1)
-\end{verbatim}
+\end{minted}
 
 For strand, use \texttt{+1} for the forward strand, \texttt{-1} for the
 reverse strand, and \texttt{None} for both.  Here is a short self contained
 example:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.SeqFeature import SeqFeature, FeatureLocation
 from Bio.Graphics import GenomeDiagram
 from reportlab.lib.units import cm
@@ -237,7 +237,7 @@ gds_features.add_feature(feature, name="Reverse", label=True)
 gdd.draw(format='linear', pagesize=(15*cm,4*cm), fragments=1,
          start=0, end=400)
 gdd.write("GD_labels_default.pdf", "pdf")
-\end{verbatim}
+\end{minted}
 
 \begin{htmlonly}
 The top part of the image in the next subsection shows the output
@@ -256,9 +256,9 @@ caption text for these features.  This is discussed in more detail next.
 Recall we used the following (where \texttt{feature} was a
 \verb|SeqFeature| object) to add a feature to the diagram:
 
-\begin{verbatim}
+\begin{minted}{python}
 gd_feature_set.add_feature(feature, color=color, label=True)
-\end{verbatim}
+\end{minted}
 
 In the example above the \verb|SeqFeature| annotation was used to pick a
 sensible caption for the features.  By default the following possible entries
@@ -266,16 +266,16 @@ under the \verb|SeqFeature| object's qualifiers dictionary are used:
 \texttt{gene}, \texttt{label}, \texttt{name}, \texttt{locus\_tag}, and
 \texttt{product}.  More simply, you can specify a name directly:
 
-\begin{verbatim}
+\begin{minted}{python}
 gd_feature_set.add_feature(feature, color=color, label=True, name="My Gene")
-\end{verbatim}
+\end{minted}
 
 In addition to the caption text for each feature's label, you can also choose
 the font, position (this defaults to the start of the sigil, you can also
 choose the middle or at the end) and orientation (for linear diagrams only,
 where this defaults to rotated by $45$ degrees):
 
-\begin{verbatim}
+\begin{minted}{python}
 #Large font, parallel with the track
 gd_feature_set.add_feature(feature, label=True, color="green",
                            label_size=25, label_angle=0)
@@ -289,7 +289,7 @@ gd_feature_set.add_feature(feature, label=True, color="purple",
 gd_feature_set.add_feature(feature, label=True, color="blue",
                            label_position="middle",
                            label_size=6, label_angle=-90)
-\end{verbatim}
+\end{minted}
 
 \noindent Combining each of these three fragments with the complete example
 in the previous section should give something like
@@ -330,7 +330,7 @@ The examples above have all just used the default sigil for the feature, a
 plain box, which was all that was available in the last publicly released standalone version of GenomeDiagram. Arrow sigils were included when
 GenomeDiagram was added to Biopython 1.50:
 
-\begin{verbatim}
+\begin{minted}{python}
 # Default uses a BOX sigil
 gd_feature_set.add_feature(feature)
 
@@ -339,12 +339,12 @@ gd_feature_set.add_feature(feature, sigil="BOX")
 
 # Or opt for an arrow:
 gd_feature_set.add_feature(feature, sigil="ARROW")
-\end{verbatim}
+\end{minted}
 
 \noindent
 Biopython 1.61 added three more sigils,
 
-\begin{verbatim}
+\begin{minted}{python}
 # Box with corners cut off (making it an octagon)
 gd_feature_set.add_feature(feature, sigil="OCTO")
 
@@ -353,7 +353,7 @@ gd_feature_set.add_feature(feature, sigil="JAGGY")
 
 # Arrow which spans the axis with strand used only for direction
 gd_feature_set.add_feature(feature, sigil="BIGARROW")
-\end{verbatim}
+\end{minted}
 
 These are shown
 \begin{htmlonly}
@@ -388,7 +388,7 @@ There are two additional options to adjust the shapes of the arrows, firstly
 the thickness of the arrow shaft, given as a proportion of the height of the
 bounding box:
 
-\begin{verbatim}
+\begin{minted}{python}
 # Full height shafts, giving pointed boxes:
 gd_feature_set.add_feature(feature, sigil="ARROW", color="brown",
                            arrowshaft_height=1.0)
@@ -398,7 +398,7 @@ gd_feature_set.add_feature(feature, sigil="ARROW", color="teal",
 # Or, very thin shafts:
 gd_feature_set.add_feature(feature, sigil="ARROW", color="darkgreen",
                            arrowshaft_height=0.1)
-\end{verbatim}
+\end{minted}
 
 \begin{htmlonly}
 \noindent The results are shown below:
@@ -420,7 +420,7 @@ gd_feature_set.add_feature(feature, sigil="ARROW", color="darkgreen",
 Secondly, the length of the arrow head - given as a proportion of the height
 of the bounding box (defaulting to $0.5$, or $50\%$):
 
-\begin{verbatim}
+\begin{minted}{python}
 # Short arrow heads:
 gd_feature_set.add_feature(feature, sigil="ARROW", color="blue",
                            arrowhead_length=0.25)
@@ -430,7 +430,7 @@ gd_feature_set.add_feature(feature, sigil="ARROW", color="orange",
 # Or, very very long arrow heads (i.e. all head, no shaft, so triangles):
 gd_feature_set.add_feature(feature, sigil="ARROW", color="red",
                            arrowhead_length=10000)
-\end{verbatim}
+\end{minted}
 
 \begin{htmlonly}
 \noindent The results are shown below:
@@ -452,10 +452,10 @@ gd_feature_set.add_feature(feature, sigil="ARROW", color="red",
 Biopython 1.61 adds a new \verb|BIGARROW| sigil which always stradles
 the axis, pointing left for the reverse strand or right otherwise:
 
-\begin{verbatim}
+\begin{minted}{python}
 # A large arrow straddling the axis:
 gd_feature_set.add_feature(feature, sigil="BIGARROW")
-\end{verbatim}
+\end{minted}
 
 \noindent All the shaft and arrow head options shown above for the
 \verb|ARROW| sigil can be used for the \verb|BIGARROW| sigil too.
@@ -470,7 +470,7 @@ we'll use arrows for the genes, and overlay them with strand-less features
 (as plain boxes) showing the position of some restriction digest sites.
 
 %NOTE - This *just* fits on one page in the PDF output :)
-\begin{verbatim}
+\begin{minted}{python}
 from reportlab.lib import colors
 from reportlab.lib.units import cm
 from Bio.Graphics import GenomeDiagram
@@ -522,7 +522,7 @@ gd_diagram.draw(format="circular", circular=True, pagesize=(20*cm,20*cm),
 gd_diagram.write("plasmid_circular_nice.pdf", "PDF")
 gd_diagram.write("plasmid_circular_nice.eps", "EPS")
 gd_diagram.write("plasmid_circular_nice.svg", "SVG")
-\end{verbatim}
+\end{minted}
 
 \begin{htmlonly}
 \noindent And the output:
@@ -575,13 +575,13 @@ features preserved, see Section~\ref{sec:SeqRecord-slicing}), and must also
 reverse complement to match the orientation of the first two phage (again
 preserving the features, see Section~\ref{sec:SeqRecord-reverse-complement}):
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 
 A_rec = SeqIO.read("NC_002703.gbk", "gb")
 B_rec = SeqIO.read("AF323668.gbk", "gb")
 C_rec = SeqIO.read("NC_003212.gbk", "gb")[2587879:2625807].reverse_complement(name=True)
-\end{verbatim}
+\end{minted}
 
 The figure we are imitating used different colors for different gene functions.
 One way to do this is to edit the GenBank file to record color preferences for
@@ -592,7 +592,7 @@ however, we'll just hard code three lists of colors.
 Note that the annotation in the GenBank files doesn't exactly match that shown
 in Proux \textit{et al.}, they have drawn some unannotated genes.
 
-\begin{verbatim}
+\begin{minted}{python}
 from reportlab.lib.colors import red, grey, orange, green, brown, blue, lightblue, purple
 
 A_colors = [red]*5 + [grey]*7 + [orange]*2 + [grey]*2 + [orange] + [grey]*11 + [green]*4 \
@@ -602,13 +602,13 @@ B_colors = [red]*6 + [grey]*8 + [orange]*2 + [grey] + [orange] + [grey]*21 + [gr
          + [grey] + [brown]*4 + [blue]*3 + [lightblue]*3 + [grey]*5 + [purple]*2
 C_colors = [grey]*30 + [green]*5 + [brown]*4 + [blue]*2 + [grey, blue] + [lightblue]*2 \
          + [grey]*5
-\end{verbatim}
+\end{minted}
 
 Now to draw them -- this time we add three tracks to the diagram, and also notice they
 are given different start/end values to reflect their different lengths (this requires
 Biopython 1.59 or later).
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.Graphics import GenomeDiagram
 
 name = "Proux Fig 6"
@@ -639,7 +639,7 @@ gd_diagram.draw(format="linear", pagesize='A4', fragments=1,
 gd_diagram.write(name + ".pdf", "PDF")
 gd_diagram.write(name + ".eps", "EPS")
 gd_diagram.write(name + ".svg", "SVG")
-\end{verbatim}
+\end{minted}
 
 \begin{htmlonly}
 \noindent The result:
@@ -684,7 +684,7 @@ My naming convention continues to refer to the three phage as A, B and C.
 Here are the links we want to show between A and B, given as a list of
 tuples (percentage similarity score, gene in A, gene in B).
 
-\begin{verbatim}
+\begin{minted}{python}
 # Tuc2009 (NC_002703) vs bIL285 (AF323668)
 A_vs_B = [
     (99, "Tuc2009_01", "int"),
@@ -713,11 +713,11 @@ A_vs_B = [
     (91, "Tuc2009_49", "orf55"),
     (95, "Tuc2009_52", "orf60"),
 ]
-\end{verbatim}
+\end{minted}
 
 Likewise for B and C:
 
-\begin{verbatim}
+\begin{minted}{python}
 # bIL285 (AF323668) vs Listeria innocua prophage 5 (in NC_003212)
 B_vs_C = [
     (42, "orf39", "lin2581"),
@@ -736,14 +736,14 @@ B_vs_C = [
     (30, "orf53", "lin2567"),
     (28, "orf54", "lin2566"),
 ]
-\end{verbatim}
+\end{minted}
 
 For the first and last phage these identifiers are locus tags, for the middle
 phage there are no locus tags so I've used gene names instead. The following
 little helper function lets us lookup a feature using either a locus tag or
 gene name:
 
-\begin{verbatim}
+\begin{minted}{python}
 def get_feature(features, id, tags=["locus_tag", "gene"]):
     """Search list of SeqFeature objects for an identifier under the given tags."""
     for f in features:
@@ -753,7 +753,7 @@ def get_feature(features, id, tags=["locus_tag", "gene"]):
                 if x == id:
                      return f
     raise KeyError(id)
-\end{verbatim}
+\end{minted}
 
 We can now turn those list of identifier pairs into SeqFeature pairs, and thus
 find their location co-ordinates. We can now add all that code and the following
@@ -763,7 +763,7 @@ line -- see the finished example script
 included in the \texttt{Doc/examples} folder of the Biopython source code)
 to add cross links to the figure:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.Graphics.GenomeDiagram import CrossLink
 from reportlab.lib import colors
 # Note it might have been clearer to assign the track numbers explicitly...
@@ -779,7 +779,7 @@ for rec_X, tn_X, rec_Y, tn_Y, X_vs_Y in [(A_rec, 3, B_rec, 2, A_vs_B),
                             (track_Y, feature_Y.location.start, feature_Y.location.end),
                             color, colors.lightgrey)
         gd_diagram.cross_track_links.append(link_xy)
-\end{verbatim}
+\end{minted}
 
 There are several important pieces to this code. First the \verb|GenomeDiagram| object
 has a \verb|cross_track_links| attribute which is just a list of \verb|CrossLink| objects.
@@ -881,30 +881,30 @@ center (colour and centre).  You will need to change to the American spellings,
 although for several years the Biopython version of GenomeDiagram supported both.
 
 For example, if you used to have:
-\begin{verbatim}
+\begin{minted}{python}
 from GenomeDiagram import GDFeatureSet, GDDiagram
 gdd = GDDiagram("An example")
 ...
-\end{verbatim}
+\end{minted}
 you could just switch the import statements like this:
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.Graphics.GenomeDiagram import FeatureSet as GDFeatureSet, Diagram as GDDiagram
 gdd = GDDiagram("An example")
 ...
-\end{verbatim}
+\end{minted}
 and hopefully that should be enough.  In the long term you might want to
 switch to the new names, but you would have to change more of your code:
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.Graphics.GenomeDiagram import FeatureSet, Diagram
 gdd = Diagram("An example")
 ...
-\end{verbatim}
+\end{minted}
 or:
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.Graphics import GenomeDiagram
 gdd = GenomeDiagram.Diagram("An example")
 ...
-\end{verbatim}
+\end{minted}
 
 If you run into difficulties, please ask on the Biopython mailing list for
 advice. One catch is that we have not included the old module
@@ -945,7 +945,7 @@ could use the GenBank files for this (and the next example uses those for
 plotting features), but if all you want is the length it is faster to use the
 FASTA files for the whole chromosomes:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 entries = [("Chr I", "CHR_I/NC_003070.fna"),
            ("Chr II", "CHR_II/NC_003071.fna"),
@@ -955,12 +955,12 @@ entries = [("Chr I", "CHR_I/NC_003070.fna"),
 for (name, filename) in entries:
     record = SeqIO.read(filename,"fasta")
     print(name, len(record))
-\end{verbatim}
+\end{minted}
 
 \noindent This gave the lengths of the five chromosomes, which we'll now use in
 the following short demonstration of the \verb|BasicChromosome| module:
 
-\begin{verbatim}
+\begin{minted}{python}
 from reportlab.lib.units import cm
 from Bio.Graphics import BasicChromosome
 
@@ -1002,7 +1002,7 @@ for name, length in entries:
     chr_diagram.add(cur_chromosome)
 
 chr_diagram.draw("simple_chrom.pdf", "Arabidopsis thaliana")
-\end{verbatim}
+\end{minted}
 
 This should create a very simple PDF file, shown
 \begin{htmlonly}
@@ -1027,7 +1027,7 @@ files from the NCBI FTP site
 \url{ftp://ftp.ncbi.nlm.nih.gov/genomes/archive/old_refseq/Arabidopsis_thaliana/},
 and preserve the subdirectory names or edit the paths below:
 
-\begin{verbatim}
+\begin{minted}{python}
 from reportlab.lib.units import cm
 from Bio import SeqIO
 from Bio.Graphics import BasicChromosome
@@ -1077,7 +1077,7 @@ for index, (name, filename) in enumerate(entries):
     chr_diagram.add(cur_chromosome)
 
 chr_diagram.draw("tRNA_chrom.pdf", "Arabidopsis thaliana")
-\end{verbatim}
+\end{minted}
 
 It might warn you about the labels being too close together - have a look
 at the forward strand (right hand side) of Chr I, but it should create a

--- a/Doc/Tutorial/chapter_introduction.tex
+++ b/Doc/Tutorial/chapter_introduction.tex
@@ -166,28 +166,28 @@ and HTML formats
 
   For example, this will only work under Python 2:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print "Hello World!"
 Hello World!
-\end{verbatim}
+\end{minted}
 
   If you try that on Python 3 you'll get a \verb|SyntaxError|.
   Under Python 3 you must write:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print("Hello World!")
 Hello World!
-\end{verbatim}
+\end{minted}
 
   Surprisingly that will also work on Python 2 -- but only for simple
   examples printing one thing. In general you need to add this magic
   line to the start of your Python scripts to use the print function
   under Python 2.6 and 2.7:
 
-\begin{verbatim}
+\begin{minted}{python}
 from __future__ import print_function
-\end{verbatim}
+\end{minted}
 
   If you forget to add this magic import, under Python 2 you'll see
   extra brackets produced by trying to use the print function when
@@ -195,11 +195,11 @@ from __future__ import print_function
 
   \item \emph{How do I find out what version of Biopython I have installed?} \\
   Use this:
-  \begin{verbatim}
-  >>> import Bio
-  >>> print(Bio.__version__)
-  ...
-  \end{verbatim}
+\begin{minted}{pycon}
+>>> import Bio
+>>> print(Bio.__version__)
+...
+\end{minted}
   If the ``\verb|import Bio|'' line fails, Biopython is not installed.
   Note that those are double underscores before and after version.
   If the second line fails, your version is \emph{very} out of date.

--- a/Doc/Tutorial/chapter_kegg.tex
+++ b/Doc/Tutorial/chapter_kegg.tex
@@ -10,7 +10,7 @@ Parsing a KEGG record is as simple as using any other file format parser in Biop
 (Before running the following codes, please open \url{http://rest.kegg.jp/get/ec:5.4.2.2} with your web browser and save it as \verb|ec_5.4.2.2.txt|.)
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.KEGG import Enzyme
 >>> records = Enzyme.parse(open("ec_5.4.2.2.txt"))
 >>> record = list(records)[0]
@@ -18,19 +18,19 @@ Parsing a KEGG record is as simple as using any other file format parser in Biop
 ['Isomerases;', 'Intramolecular transferases;', 'Phosphotransferases (phosphomutases)']
 >>> record.entry
 '5.4.2.2'
-\end{verbatim}
+\end{minted}
 
 Alternatively, if the input KEGG file has exactly one entry, you can use \verb|read|:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.KEGG import Enzyme
 >>> record = Enzyme.read(open("ec_5.4.2.2.txt"))
 >>> record.classname
 ['Isomerases;', 'Intramolecular transferases;', 'Phosphotransferases (phosphomutases)']
 >>> record.entry
 '5.4.2.2'
-\end{verbatim}
+\end{minted}
 
 The following section will shows how to download the above enzyme using the KEGG api as well as how to use the generic parser with data that does not have a custom parser implemented.
 
@@ -41,7 +41,7 @@ Biopython has full support for the querying of the KEGG api. Querying all KEGG e
 First, here is how to extend the above example by downloading the relevant enzyme and passing it through the Enzyme parser.
 
 %want online doctest here
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.KEGG import REST
 >>> from Bio.KEGG import Enzyme
 >>> request = REST.kegg_get("ec:5.4.2.2")
@@ -52,12 +52,12 @@ First, here is how to extend the above example by downloading the relevant enzym
 ['Isomerases;', 'Intramolecular transferases;', 'Phosphotransferases (phosphomutases)']
 >>> record.entry
 '5.4.2.2'
-\end{verbatim}
+\end{minted}
 
 Now, here's a more realistic example which shows a combination of querying the KEGG API. This will demonstrate how to extract a unique set of all human pathway gene symbols which relate to DNA repair. The steps that need to be taken to do so are as follows. First, we need to get a list of all human pathways. Secondly, we need to filter those for ones which relate to "repair". Lastly, we need to get a list of all the gene symbols in all repair pathways.
 
 %want online doctest here
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.KEGG import REST
 
 human_pathways = REST.kegg_list("pathway", "hsa").read()
@@ -92,7 +92,7 @@ for pathway in repair_pathways:
 print("There are %d repair pathways and %d repair genes. The genes are:" % \
       (len(repair_pathways), len(repair_genes)))
 print(", ".join(repair_genes))
-\end{verbatim}
+\end{minted}
 
 The KEGG API wrapper is compatible with all endpoints. Usage is essentially replacing all slashes in the url with commas and using that list as arguments to the corresponding method in the KEGG module. Here are a few examples from the api documentation (\url{https://www.kegg.jp/kegg/docs/keggapi.html}).
 

--- a/Doc/Tutorial/chapter_learning.tex
+++ b/Doc/Tutorial/chapter_learning.tex
@@ -76,7 +76,7 @@ Let's calculate the logistic regression model from these data:
 
 %NOTE - can't use this as a doctest in case NumPy is missing (Jython).
 %Also the ... are missing but that means the user can copy/paste the example.
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import LogisticRegression
 >>> xs = [[-53, -200.78],
           [117, -267.14],
@@ -113,21 +113,21 @@ Let's calculate the logistic regression model from these data:
           0,
           0]
 >>> model = LogisticRegression.train(xs, ys)
-\end{verbatim}
+\end{minted}
 
 Here, \verb+xs+ and \verb+ys+ are the training data: \verb+xs+ contains the predictor variables for each gene pair, and \verb+ys+ specifies if the gene pair belongs to the same operon (\verb+1+, class OP) or different operons (\verb+0+, class NOP). The resulting logistic regression model is stored in \verb+model+, which contains the weights $\beta_0$, $\beta_1$, and $\beta_2$:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> model.beta
 [8.9830290157144681, -0.035968960444850887, 0.02181395662983519]
-\end{verbatim}
+\end{minted}
 
 Note that $\beta_1$ is negative, as gene pairs with a shorter intergene distance have a higher probability of belonging to the same operon (class OP). On the other hand, $\beta_2$ is positive, as gene pairs belonging to the same operon typically have a higher similarity score of their gene expression profiles.
 The parameter $\beta_0$ is positive due to the higher prevalence of operon gene pairs than non-operon gene pairs in the training data.
 
 The function \verb+train+ has two optional arguments: \verb+update_fn+ and \verb+typecode+. The \verb+update_fn+ can be used to specify a callback function, taking as arguments the iteration number and the log-likelihood. With the callback function, we can for example track the progress of the model calculation (which uses a Newton-Raphson iteration to maximize the log-likelihood function of the logistic regression model):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> def show_progress(iteration, loglikelihood):
         print("Iteration:", iteration, "Log-likelihood function:", loglikelihood)
 >>>
@@ -174,7 +174,7 @@ Iteration: 38 Log-likelihood function: -3.01520177394
 Iteration: 39 Log-likelihood function: -3.00441242601
 Iteration: 40 Log-likelihood function: -2.99406722296
 Iteration: 41 Log-likelihood function: -2.98413867259
-\end{verbatim}
+\end{minted}
 
 The iteration stops once the increase in the log-likelihood function is less than 0.01. If no convergence is reached after 500 iterations, the \verb+train+ function returns with an \verb+AssertionError+.
 
@@ -199,29 +199,29 @@ Gene pair & Intergene distance $x_1$ & Gene expression score $x_2$ \\
 \end{table}
 
 The logistic regression model classifies {\it yxcE}, {\it yxcD} as belonging to the same operon (class OP), while {\it yxiB}, {\it yxiA} are predicted to belong to different operons:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print("yxcE, yxcD:", LogisticRegression.classify(model, [6, -173.143442352]))
 yxcE, yxcD: 1
 >>> print("yxiB, yxiA:", LogisticRegression.classify(model, [309, -271.005880394]))
 yxiB, yxiA: 0
-\end{verbatim}
+\end{minted}
 (which, by the way, agrees with the biological literature).
 
 To find out how confident we can be in these predictions, we can call the \verb+calculate+ function to obtain the probabilities (equations (\ref{eq:OP}) and \ref{eq:NOP}) for class OP and NOP. For {\it yxcE}, {\it yxcD} we find
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> q, p = LogisticRegression.calculate(model, [6, -173.143442352])
 >>> print("class OP: probability =", p, "class NOP: probability =", q)
 class OP: probability = 0.993242163503 class NOP: probability = 0.00675783649744
-\end{verbatim}
+\end{minted}
 and for {\it yxiB}, {\it yxiA}
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> q, p = LogisticRegression.calculate(model, [309, -271.005880394])
 >>> print("class OP: probability =", p, "class NOP: probability =", q)
 class OP: probability = 0.000321211251817 class NOP: probability = 0.999678788748
-\end{verbatim}
+\end{minted}
 
 To get some idea of the prediction accuracy of the logistic regression model, we can apply it to the training data:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for i in range(len(ys)):
         print("True:", ys[i], "Predicted:", LogisticRegression.classify(model, xs[i]))
 True: 1 Predicted: 1
@@ -241,9 +241,9 @@ True: 0 Predicted: 0
 True: 0 Predicted: 0
 True: 0 Predicted: 0
 True: 0 Predicted: 0
-\end{verbatim}
+\end{minted}
 showing that the prediction is correct for all but one of the gene pairs. A more reliable estimate of the prediction accuracy can be found from a leave-one-out analysis, in which the model is recalculated from the training data after removing the gene to be predicted:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for i in range(len(ys)):
         model = LogisticRegression.train(xs[:i]+xs[i+1:], ys[:i]+ys[i+1:])
         print("True:", ys[i], "Predicted:", LogisticRegression.classify(model, xs[i]))
@@ -264,7 +264,7 @@ True: 0 Predicted: 0
 True: 0 Predicted: 1
 True: 0 Predicted: 0
 True: 0 Predicted: 0
-\end{verbatim}
+\end{minted}
 The leave-one-out analysis shows that the prediction of the logistic regression model is incorrect for only two of the gene pairs, which corresponds to a prediction accuracy of 88\%.
 
 \subsection{Logistic Regression, Linear Discriminant Analysis, and Support Vector Machines}
@@ -287,11 +287,11 @@ In Biopython, the $k$-nearest neighbors method is available in \verb+Bio.kNN+. T
 
 Using the data in Table \ref{table:training}, we create and initialize a $k$-nearest neighbors model as follows:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import kNN
 >>> k = 3
 >>> model = kNN.train(xs, ys, k)
-\end{verbatim}
+\end{minted}
 
 where \verb+xs+ and \verb+ys+ are the same as in Section \ref{subsec:LogisticRegressionTraining}. Here, \verb+k+ is the number of neighbors $k$ that will be considered for the classification. For classification into two classes, choosing an odd number for $k$ lets you avoid tied votes. The function name \verb+train+ is a bit of a misnomer, since no model training is done: this function simply stores \verb+xs+, \verb+ys+, and \verb+k+ in \verb+model+.
 
@@ -300,19 +300,19 @@ where \verb+xs+ and \verb+ys+ are the same as in Section \ref{subsec:LogisticReg
 To classify new data using the $k$-nearest neighbors model, we use the \verb+classify+ function. This function takes a data point $(x_1,x_2)$ and finds the $k$-nearest neighbors in the training data set \verb+xs+. The data point $(x_1, x_2)$ is then classified based on which category (\verb+ys+) occurs most among the $k$ neighbors.
 
 For the example of the gene pairs {\it yxcE}, {\it yxcD} and {\it yxiB}, {\it yxiA}, we find:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> x = [6, -173.143442352]
 >>> print("yxcE, yxcD:", kNN.classify(model, x))
 yxcE, yxcD: 1
 >>> x = [309, -271.005880394]
 >>> print("yxiB, yxiA:", kNN.classify(model, x))
 yxiB, yxiA: 0
-\end{verbatim}
+\end{minted}
 In agreement with the logistic regression model, {\it yxcE}, {\it yxcD} are classified as belonging to the same operon (class OP), while {\it yxiB}, {\it yxiA} are predicted to belong to different operons.
 
 The \verb+classify+ function lets us specify both a distance function and a weight function as optional arguments. The distance function affects which $k$ neighbors are chosen as the nearest neighbors, as these are defined as the neighbors with the smallest distance to the query point $(x, y)$. By default, the Euclidean distance is used. Instead, we could for example use the city-block (Manhattan) distance:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> def cityblock(x1, x2):
 ...    assert len(x1)==2
 ...    assert len(x2)==2
@@ -322,11 +322,11 @@ The \verb+classify+ function lets us specify both a distance function and a weig
 >>> x = [6, -173.143442352]
 >>> print("yxcE, yxcD:", kNN.classify(model, x, distance_fn = cityblock))
 yxcE, yxcD: 1
-\end{verbatim}
+\end{minted}
 
 The weight function can be used for weighted voting. For example, we may want to give closer neighbors a higher weight than neighbors that are further away:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> def weight(x1, x2):
 ...    assert len(x1)==2
 ...    assert len(x2)==2
@@ -335,28 +335,28 @@ The weight function can be used for weighted voting. For example, we may want to
 >>> x = [6, -173.143442352]
 >>> print("yxcE, yxcD:", kNN.classify(model, x, weight_fn = weight))
 yxcE, yxcD: 1
-\end{verbatim}
+\end{minted}
 By default, all neighbors are given an equal weight.
 
 To find out how confident we can be in these predictions, we can call the \verb+calculate+ function, which will calculate the total weight assigned to the classes OP and NOP. For the default weighting scheme, this reduces to the number of neighbors in each category. For {\it yxcE}, {\it yxcD}, we find
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> x = [6, -173.143442352]
 >>> weight = kNN.calculate(model, x)
 >>> print("class OP: weight =", weight[0], "class NOP: weight =", weight[1])
 class OP: weight = 0.0 class NOP: weight = 3.0
-\end{verbatim}
+\end{minted}
 which means that all three neighbors of \verb+x1+, \verb+x2+ are in the NOP class. As another example, for {\it yesK}, {\it yesL} we find
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> x = [117, -267.14]
 >>> weight = kNN.calculate(model, x)
 >>> print("class OP: weight =", weight[0], "class NOP: weight =", weight[1])
 class OP: weight = 2.0 class NOP: weight = 1.0
-\end{verbatim}
+\end{minted}
 which means that two neighbors are operon pairs and one neighbor is a non-operon pair.
 
 To get some idea of the prediction accuracy of the $k$-nearest neighbors approach, we can apply it to the training data:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for i in range(len(ys)):
         print("True:", ys[i], "Predicted:", kNN.classify(model, xs[i]))
 True: 1 Predicted: 1
@@ -376,9 +376,9 @@ True: 0 Predicted: 0
 True: 0 Predicted: 0
 True: 0 Predicted: 0
 True: 0 Predicted: 0
-\end{verbatim}
+\end{minted}
 showing that the prediction is correct for all but two of the gene pairs. A more reliable estimate of the prediction accuracy can be found from a leave-one-out analysis, in which the model is recalculated from the training data after removing the gene to be predicted:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> k = 3
 >>> for i in range(len(ys)):
         model = kNN.train(xs[:i]+xs[i+1:], ys[:i]+ys[i+1:], k)
@@ -400,7 +400,7 @@ True: 0 Predicted: 0
 True: 0 Predicted: 0
 True: 0 Predicted: 0
 True: 0 Predicted: 1
-\end{verbatim}
+\end{minted}
 The leave-one-out analysis shows that $k$-nearest neighbors model is correct for 13 out of 17 gene pairs, which corresponds to a prediction accuracy of 76\%.
 
 \section{Na\"ive Bayes}

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -25,10 +25,12 @@ on commercial use.
 Since we are interested in motif analysis, we need to take a look at
 \verb|Motif| objects in the first place. For that we need to import
 the Bio.motifs library:
+
 %doctest ../Tests/motifs
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import motifs
-\end{verbatim}
+\end{minted}
+
 and we can start creating our first motif objects. We can either create
 a \verb+Motif+ object from a list of instances of the motif, or we can
 obtain a \verb+Motif+ object by parsing a file from a motif database
@@ -38,7 +40,7 @@ or motif finding software.
 
 Suppose we have these instances of a DNA motif:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> instances = [Seq("TACAA"),
 ...              Seq("TACGC"),
@@ -48,16 +50,16 @@ Suppose we have these instances of a DNA motif:
 ...              Seq("AATGC"),
 ...              Seq("AATGC"),
 ...             ]
-\end{verbatim}
+\end{minted}
 then we can create a Motif object as follows:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> m = motifs.create(instances)
-\end{verbatim}
+\end{minted}
 The instances are saved in an attribute \verb+m.instances+, which is essentially a Python list with some added functionality, as described below.
 Printing out the Motif object shows the instances from which it was constructed:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(m)
 TACAA
 TACGC
@@ -67,17 +69,17 @@ AACCC
 AATGC
 AATGC
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 The length of the motif is defined as the sequence length, which should be the same for all instances:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(m)
 5
-\end{verbatim}
+\end{minted}
 The Motif object has an attribute \verb+.counts+ containing the counts of each
 nucleotide at each position. Printing this counts matrix shows it in an easily readable format:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(m.counts)
         0      1      2      3      4
 A:   3.00   7.00   0.00   2.00   1.00
@@ -85,74 +87,74 @@ C:   0.00   0.00   5.00   2.00   6.00
 G:   0.00   0.00   0.00   3.00   0.00
 T:   4.00   0.00   2.00   0.00   0.00
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 You can access these counts as a dictionary:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> m.counts["A"]
 [3, 7, 0, 2, 1]
-\end{verbatim}
+\end{minted}
 but you can also think of it as a 2D array with the nucleotide as the first
 dimension and the position as the second dimension:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> m.counts["T", 0]
 4
 >>> m.counts["T", 2]
 2
 >>> m.counts["T", 3]
 0
-\end{verbatim}
+\end{minted}
 You can also directly access columns of the counts matrix
 %Don't doctest this as dictionary order is platform dependent:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> m.counts[:, 3]
 {'A': 2, 'C': 2, 'T': 0, 'G': 3}
-\end{verbatim}
+\end{minted}
 Instead of the nucleotide itself, you can also use the index of the nucleotide
 in the alphabet of the motif:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> m.alphabet
 'ACGT'
 >>> m.counts["A",:]
 (3, 7, 0, 2, 1)
 >>> m.counts[0,:]
 (3, 7, 0, 2, 1)
-\end{verbatim}
+\end{minted}
 The motif has an associated consensus sequence, defined as the sequence of
 letters along the positions of the motif for which the largest value in the
 corresponding columns of the \verb+.counts+ matrix is obtained:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> m.consensus
 Seq('TACGC')
-\end{verbatim}
+\end{minted}
 as well as an anticonsensus sequence, corresponding to the smallest values in
 the columns of the \verb+.counts+ matrix:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> m.anticonsensus
 Seq('CCATG')
-\end{verbatim}
+\end{minted}
 Note that there is some ambiguity in the definition of the consensus and anticonsensus sequence if in some columns multiple nucleotides have the maximum or minimum count.
 
 You can also ask for a degenerate consensus sequence, in which ambiguous
 nucleotides are used for positions where there are multiple nucleotides with
 high counts:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> m.degenerate_consensus
 Seq('WACVC')
-\end{verbatim}
+\end{minted}
 Here, W and R follow the IUPAC nucleotide ambiguity codes: W is either A or T,
 and V is A, C, or G \cite{cornish1985}. The degenerate consensus sequence is
 constructed following the rules specified by Cavener \cite{cavener1987}.
 
 We can also get the reverse complement of a motif:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> r = m.reverse_complement()
 >>> r.consensus
 Seq('GCGTA')
@@ -167,16 +169,16 @@ GGGTT
 GCATT
 GCATT
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 The reverse complement and the degenerate consensus sequence are
 only defined for DNA motifs.
 
 \subsection{Creating a sequence logo}
 If we have internet access, we can create a \href{https://weblogo.berkeley.edu}{weblogo}:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> m.weblogo("mymotif.png")
-\end{verbatim}
+\end{minted}
 We should get our logo saved as a PNG in the specified file.
 
 \section{Reading motifs}
@@ -231,15 +233,15 @@ The parts of the sequence in capital letters are the motif instances that were f
 
 We can create a \verb+Motif+ object from these instances as follows:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import motifs
 >>> with open("Arnt.sites") as handle:
 ...     arnt = motifs.read(handle, "sites")
 ...
-\end{verbatim}
+\end{minted}
 The instances from which this motif was created is stored in the \verb+.instances+ property:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(arnt.instances[:3])
 [Seq('CACGTG'), Seq('CACGTG'), Seq('CACGTG')]
 >>> for instance in arnt.instances:
@@ -265,10 +267,10 @@ AACGTG
 AACGTG
 AACGTG
 CGCGTG
-\end{verbatim}
+\end{minted}
 The counts matrix of this motif is automatically calculated from the instances:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(arnt.counts)
         0      1      2      3      4      5
 A:   4.00  19.00   0.00   0.00   0.00   0.00
@@ -276,7 +278,7 @@ C:  16.00   0.00  20.00   0.00   0.00   0.00
 G:   0.00   1.00   0.00  20.00   0.00  20.00
 T:   0.00   0.00   0.00   0.00  20.00   0.00
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 This format does not store any meta information.
 
 \subsubsection*{The JASPAR \texttt{pfm} format}
@@ -293,7 +295,7 @@ For example, this is the JASPAR file \verb+SRF.pfm+ containing the counts matrix
 \end{verbatim}
 We can create a motif for this count matrix as follows:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> with open("SRF.pfm") as handle:
 ...     srf = motifs.read(handle, "pfm")
 ...
@@ -304,21 +306,21 @@ C:   1.00  33.00  45.00  45.00   1.00   1.00   0.00   0.00   0.00   1.00   0.00 
 G:  39.00   2.00   1.00   0.00   0.00   0.00   0.00   0.00   0.00   0.00  44.00  43.00
 T:   4.00   2.00   0.00   0.00  13.00  42.00   0.00  45.00   3.00  30.00   0.00   0.00
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 As this motif was created from the counts matrix directly, it has no instances associated with it:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(srf.instances)
 None
-\end{verbatim}
+\end{minted}
 We can now ask for the consensus sequence of these two motifs:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(arnt.counts.consensus)
 CACGTG
 >>> print(srf.counts.consensus)
 GCCCATATATGG
-\end{verbatim}
+\end{minted}
 
 As with the instances file, no meta information is stored in this format.
 
@@ -343,7 +345,7 @@ G  [ 0  0  0  0  0  0  0  0  2 50 ]
 T  [ 7 58  0 55 49 52 21 56  0  2 ]
 \end{verbatim}
 The motifs are read as follows:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> fh = open("jaspar_motifs.txt")
 >>> for m in motifs.parse(fh, "jaspar"))
 ...     print(m)
@@ -377,14 +379,14 @@ A:   1.00   0.00  57.00   2.00   9.00   6.00  37.00   2.00  56.00   6.00
 C:  50.00   0.00   1.00   1.00   0.00   0.00   0.00   0.00   0.00   0.00
 G:   0.00   0.00   0.00   0.00   0.00   0.00   0.00   0.00   2.00  50.00
 T:   7.00  58.00   0.00  55.00  49.00  52.00  21.00  56.00   0.00   2.00
-\end{verbatim}
+\end{minted}
 
 Note that printing a JASPAR motif yields both the counts data and the available meta-information.
 
 \subsubsection*{Accessing the JASPAR database}
 
 In addition to parsing these flat file formats, we can also retrieve motifs from a JASPAR SQL database. Unlike the flat file formats, a JASPAR database allows storing of all possible meta information defined in the JASPAR \verb+Motif+ class. It is beyond the scope of this document to describe how to set up a JASPAR database (please see the main \href{http://jaspar.genereg.net}{JASPAR} website). Motifs are read from a JASPAR database using the \verb+Bio.motifs.jaspar.db+ module.  First connect to the JASPAR database using the JASPAR5 class which models the the latest JASPAR schema:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.motifs.jaspar.db import JASPAR5
 >>>
 >>> JASPAR_DB_HOST = <hostname>
@@ -398,14 +400,14 @@ In addition to parsing these flat file formats, we can also retrieve motifs from
 ...     user=JASPAR_DB_USER,
 ...     password=JASPAR_DB_PASS
 ... )
-\end{verbatim}
+\end{minted}
 
 Now we can fetch a single motif by its unique JASPAR ID with the \verb+fetch_motif_by_id+ method. Note that a JASPAR ID conists of a base ID and a version number seperated by a decimal point, e.g. 'MA0004.1'. The \verb+fetch_motif_by_id+ method allows you to use either the fully specified ID or just the base ID. If only the base ID is provided, the latest version of the motif is returned.
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> arnt = jdb.fetch_motif_by_id("MA0004")
-\end{verbatim}
+\end{minted}
 Printing the motif reveals that the JASPAR SQL database stores much more meta-information than the flat files:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(arnt)
 TF name	Arnt
 Matrix ID	MA0004.1
@@ -427,10 +429,10 @@ G:   0.00   1.00   0.00  20.00   0.00  20.00
 T:   0.00   0.00   0.00   0.00  20.00   0.00
 
 
-\end{verbatim}
+\end{minted}
 
 We can also fetch motifs by name. The name must be an exact match (partial matches or database wildcards are not currently supported). Note that as the name is not guaranteed to be unique, the \verb+fetch_motifs_by_name+ method actually returns a list.
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> motifs = jdb.fetch_motifs_by_name("Arnt")
 >>> print(motifs[0])
 TF name	Arnt
@@ -453,10 +455,10 @@ G:   0.00   1.00   0.00  20.00   0.00  20.00
 T:   0.00   0.00   0.00   0.00  20.00   0.00
 
 
-\end{verbatim}
+\end{minted}
 
 The \verb+fetch_motifs+ method allows you to fetch motifs which match a specified set of criteria. These criteria include any of the above described meta information as well as certain matrix properties such as the minimum information content (\verb+min_ic+ in the example below), the minimum length of the matrix or the minimum number of sites used to construct the matrix. Only motifs which pass ALL the specified criteria are returned. Note that selection criteria which correspond to meta information which allow for multiple values may be specified as either a single value or a list of values, e.g. \verb+tax_group+ and \verb+tf_family+ in the example below.
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> motifs = jdb.fetch_motifs(
 ...     collection = "CORE",
 ...     tax_group = ["vertebrates", "insects"],
@@ -466,7 +468,7 @@ The \verb+fetch_motifs+ method allows you to fetch motifs which match a specifie
 ... )
 >>> for motif in motifs:
 ...     pass # do something with the motif
-\end{verbatim}
+\end{minted}
 
 \subsubsection*{Compatibility with Perl TFBS modules}
 
@@ -477,24 +479,24 @@ An important thing to note is that the JASPAR \verb+Motif+ class was designed to
 The Perl \verb+TFBS+ modules appear to allow a choice of custom background probabilities (although the documentation states that uniform background is assumed). However the default is to use a uniform background. Therefore it is recommended that you use a uniform background for computing the position-specific scoring matrix (PSSM). This is the default when using the Biopython \verb+motifs+ module.
 \item{\bf Choice of pseudocounts:} \\
 By default, the Perl \verb+TFBS+ modules use a pseudocount equal to $\sqrt{N} * \textrm{bg}[\textrm{nucleotide}]$, where $N$ represents the total number of sequences used to construct the matrix. To apply this same pseudocount formula, set the motif \verb+pseudocounts+ attribute using the \verb+jaspar.calculate\_pseudcounts()+ function:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> motif.pseudocounts = motifs.jaspar.calculate_pseudocounts(motif)
-\end{verbatim}
+\end{minted}
 Note that it is possible for the counts matrix to have an unequal number of sequences making up the columns. The pseudocount computation uses the average number of sequences making up the matrix. However, when \verb+normalize+ is called on the counts matrix, each count value in a column is divided by the total number of sequences making up that specific column, not by the average number of sequences. This differs from the Perl \verb+TFBS+ modules because the normalization is not done as a separate step and so the average number of sequences is used throughout the computation of the pssm. Therefore, for matrices with unequal column counts, the PSSM computed by the \verb+motifs+ module will differ somewhat from the pssm computed by the Perl \verb+TFBS+ modules.
 \item{\bf Computation of matrix information content:} \\
 The information content (IC) or specificity of a matrix is computed using the \verb+mean+ method of the \verb+PositionSpecificScoringMatrix+ class. However of note, in the Perl \verb+TFBS+ modules the default behaviour is to compute the IC without first applying pseudocounts, even though by default the PSSMs are computed using pseudocounts as described above.
 \item{\bf Searching for instances:} \\
 Searching for instances with the Perl \verb+TFBS+ motifs was usually performed using a relative score threshold, i.e. a score in the range 0 to 1. In order to compute the absolute PSSM score corresponding to a relative score one can use the equation:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> abs_score =  (pssm.max - pssm.min) * rel_score + pssm.min
-\end{verbatim}
+\end{minted}
 To convert the absolute score of an instance back to a relative score, one can use the equation:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> rel_score = (abs_score - pssm.min) / (pssm.max - pssm.min)
-\end{verbatim}
+\end{minted}
 For example, using the Arnt motif before, let's search a sequence with a relative score threshold of 0.8.
 %TODO - Check missing ... lines, make into a doctest?
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> test_seq=Seq("TAAGCGTGCACGCGCAACACGTGCATTA")
 >>> arnt.pseudocounts = motifs.jaspar.calculate_pseudocounts(arnt)
 >>> pssm = arnt.pssm
@@ -512,7 +514,7 @@ Position 8: score = 6.112, rel. score = 0.831
 Position -20: score = 7.103, rel. score = 0.870
 Position 17: score = 10.351, rel. score = 1.000
 Position -11: score = 10.351, rel. score = 1.000
-\end{verbatim}
+\end{minted}
 \end{itemize}
 
 \subsection{MEME}
@@ -572,16 +574,16 @@ matrix            T  aa:1::9::11:
 \end{verbatim}
 To parse this file (stored as \verb+meme.dna.oops.txt+), use
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> with open("meme.dna.oops.txt") as handle:
 ...     record = motifs.parse(handle, "meme")
 ...
-\end{verbatim}
+\end{minted}
 The \verb+motifs.parse+ command reads the complete file directly, so you can
 close the file after calling \verb+motifs.parse+.
 The header information is stored in attributes:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.version
 '3.0'
 >>> record.datafile
@@ -592,11 +594,11 @@ The header information is stored in attributes:
 'ACGT'
 >>> record.sequences
 ['CHO1', 'CHO2', 'FAS1', 'FAS2', 'ACC1', 'INO1', 'OPI3']
-\end{verbatim}
+\end{minted}
 The record is an object of the \verb+Bio.motifs.meme.Record+ class.
 The class inherits from list, and you can think of \verb+record+ as a list of Motif objects:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(record)
 2
 >>> motif = record[0]
@@ -604,11 +606,11 @@ The class inherits from list, and you can think of \verb+record+ as a list of Mo
 TTCACATGCCGC
 >>> print(motif.degenerate_consensus)
 TTCACATGSCNC
-\end{verbatim}
+\end{minted}
 In addition to these generic motif attributes, each motif also stores its
 specific information as calculated by MEME. For example,
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> motif.num_occurrences
 7
 >>> motif.length
@@ -618,17 +620,17 @@ specific information as calculated by MEME. For example,
 0.2
 >>> motif.name
 'Motif 1'
-\end{verbatim}
+\end{minted}
 In addition to using an index into the record, as we did above,
 you can also find it by its name:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> motif = record["Motif 1"]
-\end{verbatim}
+\end{minted}
 Each motif has an attribute \verb+.instances+ with the sequence instances
 in which the motif was found, providing some information on each instance:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(motif.instances)
 7
 >>> motif.instances[0]
@@ -646,7 +648,7 @@ Instance('TTCACATGCCGC', 'ACGT')
 >>> pvalue = motif.instances[0].pvalue
 >>> print("%5.3g" % pvalue)
 1.85e-08
-\end{verbatim}
+\end{minted}
 
 \subsubsection*{MAST}
 
@@ -702,36 +704,36 @@ P0      A      C      G      T
 \end{verbatim}
 To parse a TRANSFAC file, use
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> with open("transfac.dat") as handle:
 ...     record = motifs.parse(handle, "TRANSFAC")
 ...
-\end{verbatim}
+\end{minted}
 If any discrepancies between the file contents and the TRANSFAC file format are detected, a \verb+ValueError+ is raised. Note that you may encounter files that do not follow the TRANSFAC format strictly. For example, the number of spaces between columns may be different, or a tab may be used instead of spaces. Use \verb+strict=False+ to enable parsing such files without raising a \verb+ValueError+:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record = motifs.parse(handle, "TRANSFAC", strict=False)
-\end{verbatim}
+\end{minted}
 When parsing a non-compliant file, we recommend to check the record returned by \verb+motif.parse+ to ensure that it is consistent with the file contents.
 
 The overall version number, if available, is stored as \verb+record.version+:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.version
 'EXAMPLE January 15, 2013'
-\end{verbatim}
+\end{minted}
 
 Each motif in \verb+record+ is in instance of the \verb+Bio.motifs.transfac.Motif+
 class, which inherits both from the \verb+Bio.motifs.Motif+ class and
 from a Python dictionary. The dictionary uses the two-letter keys to
 store any additional information about the motif:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> motif = record[0]
 >>> motif.degenerate_consensus # Using the Bio.motifs.Motif method
 Seq('SRACAGGTGKYG')
 >>> motif["ID"] # Using motif as a dictionary
 'motif1'
-\end{verbatim}
+\end{minted}
 
 TRANSFAC files are typically much more elaborate than this example, containing
 lots of additional information about the motif. Table \ref{table:transfaccodes}
@@ -783,7 +785,7 @@ references associated with the motif, using these two-letter keys:
 
 Printing the motifs writes them out in their native TRANSFAC format:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(record)
 VV  EXAMPLE January 15, 2013
 XX
@@ -821,41 +823,41 @@ P0      A      C      G      T
 XX
 //
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 You can export the motifs in the TRANSFAC format by capturing this output
 in a string and saving it in a file:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> text = str(record)
 >>> with open("mytransfacfile.dat", "w") as out_handle:
 ...     out_handle.write(text)
 ...
-\end{verbatim}
+\end{minted}
 
 \section{Writing motifs}
 
 Speaking of exporting, let's look at export functions in general.
 We can use the \verb+format+ method to write the motif in the simple JASPAR \verb+pfm+ format:
 %the tabs in the output confuse doctest; don't test
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(arnt.format("pfm"))
   4.00  19.00   0.00   0.00   0.00   0.00
  16.00   0.00  20.00   0.00   0.00   0.00
   0.00   1.00   0.00  20.00   0.00  20.00
   0.00   0.00   0.00   0.00  20.00   0.00
-\end{verbatim}
+\end{minted}
 Similarly, we can use \verb+format+ to write the motif in the JASPAR \verb+jaspar+ format:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(arnt.format("jaspar"))
 >MA0004.1  Arnt
 A [  4.00  19.00   0.00   0.00   0.00   0.00]
 C [ 16.00   0.00  20.00   0.00   0.00   0.00]
 G [  0.00   1.00   0.00  20.00   0.00  20.00]
 T [  0.00   0.00   0.00   0.00  20.00   0.00]
-\end{verbatim}
+\end{minted}
 
 To write the motif in a TRANSFAC-like matrix format, use
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(m.format("transfac"))
 P0      A      C      G      T
 01      3      0      0      4      W
@@ -866,12 +868,12 @@ P0      A      C      G      T
 XX
 //
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 To write out multiple motifs, you can use \verb+motifs.write+.
 This function can be used regardless of whether the motifs originated from a TRANSFAC file. For example,
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> two_motifs = [arnt, srf]
 >>> print(motifs.write(two_motifs, "transfac"))
 P0      A      C      G      T
@@ -899,10 +901,10 @@ P0      A      C      G      T
 XX
 //
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 Or, to write multiple motifs in the \verb+jaspar+ format:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> two_motifs = [arnt, mef2a]
 >>> print(motifs.write(two_motifs, "jaspar"))
 >MA0004.1  Arnt
@@ -915,7 +917,7 @@ A [  1.00   0.00  57.00   2.00   9.00   6.00  37.00   2.00  56.00   6.00]
 C [ 50.00   0.00   1.00   1.00   0.00   0.00   0.00   0.00   0.00   0.00]
 G [  0.00   0.00   0.00   0.00   0.00   0.00   0.00   0.00   2.00  50.00]
 T [  7.00  58.00   0.00  55.00  49.00  52.00  21.00  56.00   0.00   2.00]
-\end{verbatim}
+\end{minted}
 
 \section{Position-Weight Matrices}
 
@@ -935,7 +937,7 @@ probabilities from becoming zero. To add a fixed pseudocount to all
 nucleotides at all positions, specify a number for the
 \verb+pseudocounts+ argument:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> pwm = m.counts.normalize(pseudocounts=0.5)
 >>> print(pwm)
         0      1      2      3      4
@@ -944,13 +946,13 @@ C:   0.06   0.06   0.61   0.28   0.72
 G:   0.06   0.06   0.06   0.39   0.06
 T:   0.50   0.06   0.28   0.06   0.06
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 Alternatively, \verb+pseudocounts+ can be a dictionary specifying the
 pseudocounts for each nucleotide. For example, as the GC content of
 the human genome is about 40\%, you may want to choose the
 pseudocounts accordingly:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> pwm = m.counts.normalize(pseudocounts={"A":0.6, "C": 0.4, "G": 0.4, "T": 0.6})
 >>> print(pwm)
         0      1      2      3      4
@@ -959,30 +961,30 @@ C:   0.04   0.04   0.60   0.27   0.71
 G:   0.04   0.04   0.04   0.38   0.04
 T:   0.51   0.07   0.29   0.07   0.07
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 The position-weight matrix has its own methods to calculate the
 consensus, anticonsensus, and degenerate consensus sequences:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> pwm.consensus
 Seq('TACGC')
 >>> pwm.anticonsensus
 Seq('CCGTG')
 >>> pwm.degenerate_consensus
 Seq('WACNC')
-\end{verbatim}
+\end{minted}
 Note that due to the pseudocounts, the degenerate consensus sequence
 calculated from the position-weight matrix is slightly different
 from the degenerate consensus sequence calculated from the instances
 in the motif:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> m.degenerate_consensus
 Seq('WACVC')
-\end{verbatim}
+\end{minted}
 The reverse complement of the position-weight matrix can be calculated directly from the \verb+pwm+:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> rpwm = pwm.reverse_complement()
 >>> print(rpwm)
         0      1      2      3      4
@@ -991,7 +993,7 @@ C:   0.04   0.38   0.04   0.04   0.04
 G:   0.71   0.27   0.60   0.04   0.04
 T:   0.18   0.29   0.07   0.84   0.40
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 \section{Position-Specific Scoring Matrices}
 
@@ -1001,7 +1003,7 @@ odds of a particular symbol to be coming from a motif against the
 background. We can use the \verb|.log_odds()| method on the position-weight
 matrix:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> pssm = pwm.log_odds()
 >>> print(pssm)
         0      1      2      3      4
@@ -1010,7 +1012,7 @@ C:  -2.49  -2.49   1.26   0.09   1.51
 G:  -2.49  -2.49  -2.49   0.60  -2.49
 T:   1.03  -1.91   0.21  -1.91  -1.91
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 Here we can see positive values for symbols more frequent in the motif
 than in the background and negative for symbols more frequent in the
 background. $0.0$ means that it's equally likely to see a symbol in the
@@ -1021,7 +1023,7 @@ calculate the position-specific scoring matrix against a background with
 unequal probabilities for A, C, G, T, use the \verb+background+ argument.
 For example, against a background with a 40\% GC content, use
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> background = {"A":0.3,"C":0.2,"G":0.2,"T":0.3}
 >>> pssm = pwm.log_odds(background)
 >>> print(pssm)
@@ -1031,27 +1033,27 @@ C:  -2.17  -2.17   1.58   0.42   1.83
 G:  -2.17  -2.17  -2.17   0.92  -2.17
 T:   0.77  -2.17  -0.05  -2.17  -2.17
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 The maximum and minimum score obtainable from the PSSM are stored in the
 \verb+.max+ and \verb+.min+ properties:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print("%4.2f" % pssm.max)
 6.59
 >>> print("%4.2f" % pssm.min)
 -10.85
-\end{verbatim}
+\end{minted}
 
 The mean and standard deviation of the PSSM scores with respect to a specific
 background are calculated by the \verb+.mean+ and \verb+.std+ methods.
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> mean = pssm.mean(background)
 >>> std = pssm.std(background)
 >>> print("mean = %0.2f, standard deviation = %0.2f" % (mean, std))
 mean = 3.21, standard deviation = 2.59
-\end{verbatim}
+\end{minted}
 A uniform background is used if \verb+background+ is not specified.
 The mean is particularly important, as its value is equal to the
 Kullback-Leibler divergence or relative entropy, and is a measure for the
@@ -1069,40 +1071,40 @@ The most frequent use for a motif is to find its instances in some
 sequence. For the sake of this section, we will use an artificial sequence like this:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> test_seq=Seq("TACACTGCATTACAACCCAAGCATTA")
 >>> len(test_seq)
 26
-\end{verbatim}
+\end{minted}
 
 \subsection{Searching for exact matches}
 
 The simplest way to find instances, is to look for exact matches of
 the true instances of the motif:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for pos, seq in m.instances.search(test_seq):
 ...     print("%i %s" % (pos, seq))
 ...
 0 TACAC
 10 TACAA
 13 AACCC
-\end{verbatim}
+\end{minted}
 We can do the same with the reverse complement (to find instances on the complementary strand):
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for pos, seq in r.instances.search(test_seq):
 ...     print("%i %s" % (pos, seq))
 ...
 6 GCATT
 20 GCATT
-\end{verbatim}
+\end{minted}
 
 \subsection{Searching for matches using the PSSM score}
 
 It's just as easy to look for positions, giving rise to high log-odds scores against our motif:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for position, score in pssm.search(test_seq, threshold=3.0):
 ...     print("Position %d: score = %5.3f" % (position, score))
 ...
@@ -1111,7 +1113,7 @@ Position -20: score = 4.601
 Position 10: score = 3.037
 Position 13: score = 5.738
 Position -6: score = 4.601
-\end{verbatim}
+\end{minted}
 The negative positions refer to instances of the motif found on the
 reverse strand of the test sequence, and follow the Python convention
 on negative indices. Therefore, the instance of the motif at \verb|pos|
@@ -1126,7 +1128,7 @@ that looks more like the motif than the background.
 
 You can also calculate the scores at all positions along the sequence:
 %Don't use a doc test for this as the spacing can differ
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> pssm.calculate(test_seq)
 array([  5.62230396,  -5.6796999 ,  -3.43177247,   0.93827754,
         -6.84962511,  -2.04066086, -10.84962463,  -3.65614533,
@@ -1134,12 +1136,12 @@ array([  5.62230396,  -5.6796999 ,  -3.43177247,   0.93827754,
         -0.6016975 ,   5.7381525 ,  -0.50977498,  -3.56422281,
         -8.73414803,  -0.09919716,  -0.6016975 ,  -2.39429784,
        -10.84962463,  -3.65614533], dtype=float32)
-\end{verbatim}
+\end{minted}
 In general, this is the fastest way to calculate PSSM scores.
 The scores returned by \verb+pssm.calculate+ are for the forward strand
 only. To obtain the scores on the reverse strand, you can take the reverse
 complement of the PSSM:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> rpssm = pssm.reverse_complement()
 >>> rpssm.calculate(test_seq)
 array([ -9.43458748,  -3.06172252,  -7.18665981,  -7.76216221,
@@ -1148,7 +1150,7 @@ array([ -9.43458748,  -3.06172252,  -7.18665981,  -7.76216221,
         -8.73414803, -10.84962463,  -4.82356262,  -4.82356262,
         -5.64668512,  -8.73414803,  -4.15613794,  -5.6796999 ,
          4.60124254,  -4.2480607 ], dtype=float32)
-\end{verbatim}
+\end{minted}
 
 \subsection{Selecting a score threshold}
 
@@ -1157,46 +1159,46 @@ can explore the distribution of PSSM scores. Since the space for a score
 distribution grows exponentially with motif length, we are using an
 approximation with a given precision to keep computation cost manageable:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> distribution = pssm.distribution(background=background, precision=10**4)
-\end{verbatim}
+\end{minted}
 The \verb+distribution+ object can be used to determine a number of different thresholds.
 We can specify the requested false-positive rate (probability of ``finding'' a motif instance in background generated sequence):
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> threshold = distribution.threshold_fpr(0.01)
 >>> print("%5.3f" % threshold)
 4.009
-\end{verbatim}
+\end{minted}
 or the false-negative rate (probability of ``not finding'' an instance generated from the motif):
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> threshold = distribution.threshold_fnr(0.1)
 >>> print("%5.3f" % threshold)
 -0.510
-\end{verbatim}
+\end{minted}
 or a threshold (approximately) satisfying some relation between the false-positive rate and the false-negative rate ($\frac{\textrm{fnr}}{\textrm{fpr}}\simeq t$):
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> threshold = distribution.threshold_balanced(1000)
 >>> print("%5.3f" % threshold)
 6.241
-\end{verbatim}
+\end{minted}
 or a threshold satisfying (roughly) the equality between the $-log$ of the
 false-positive rate and the information content (as used in patser software by
 Hertz and Stormo):
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> threshold = distribution.threshold_patser()
 >>> print("%5.3f" % threshold)
 0.346
-\end{verbatim}
+\end{minted}
 
 For example, in case of our motif, you can get the threshold giving
 you exactly the same results (for this sequence) as searching for
 instances with balanced threshold with rate of $1000$.
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> threshold = distribution.threshold_fpr(0.01)
 >>> print("%5.3f" % threshold)
 4.009
@@ -1207,14 +1209,14 @@ Position 0: score = 5.622
 Position -20: score = 4.601
 Position 13: score = 5.738
 Position -6: score = 4.601
-\end{verbatim}
+\end{minted}
 
 \section{Each motif object has an associated Position-Specific Scoring Matrix}
 
 To facilitate searching for potential TFBSs using PSSMs, both the position-weight matrix and the position-specific scoring matrix are associated with each motif. Using the Arnt motif as an example:
 %TODO - Start a new doctest here?
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import motifs
 >>> with open("Arnt.sites") as handle:
 ...     motif = motifs.read(handle, "sites")
@@ -1233,9 +1235,9 @@ C:   0.80   0.00   1.00   0.00   0.00   0.00
 G:   0.00   0.05   0.00   1.00   0.00   1.00
 T:   0.00   0.00   0.00   0.00   1.00   0.00
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 %Can't use next bit in doctest, Windows Python 2.5 and 2.6 put -1.$ not -inf
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(motif.pssm)
         0      1      2      3      4      5
 A:  -0.32   1.93   -inf   -inf   -inf   -inf
@@ -1243,10 +1245,10 @@ C:   1.68   -inf   2.00   -inf   -inf   -inf
 G:   -inf  -2.32   -inf   2.00   -inf   2.00
 T:   -inf   -inf   -inf   -inf   2.00   -inf
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 The negative infinities appear here because the corresponding entry in the frequency matrix is 0, and we are using zero pseudocounts by default:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for letter in "ACGT":
 ...     print("%s: %4.2f" % (letter, motif.pseudocounts[letter]))
 ...
@@ -1254,10 +1256,10 @@ A: 0.00
 C: 0.00
 G: 0.00
 T: 0.00
-\end{verbatim}
+\end{minted}
 If you change the \verb+.pseudocounts+ attribute, the position-frequency matrix and the position-specific scoring matrix are recalculated automatically:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> motif.pseudocounts = 3.0
 >>> for letter in "ACGT":
 ...     print("%s: %4.2f" % (letter, motif.pseudocounts[letter]))
@@ -1266,10 +1268,10 @@ A: 3.00
 C: 3.00
 G: 3.00
 T: 3.00
-\end{verbatim}
+\end{minted}
 %Can't use this in doctest, Windows Python 2.5 and 2.6 give G/1 as 0.13 not 0.12
 %TODO - Check why...
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(motif.pwm)
         0      1      2      3      4      5
 A:   0.22   0.69   0.09   0.09   0.09   0.09
@@ -1277,9 +1279,9 @@ C:   0.59   0.09   0.72   0.09   0.09   0.09
 G:   0.09   0.12   0.09   0.72   0.09   0.72
 T:   0.09   0.09   0.09   0.09   0.72   0.09
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(motif.pssm)
         0      1      2      3      4      5
 A:  -0.19   1.46  -1.42  -1.42  -1.42  -1.42
@@ -1287,12 +1289,12 @@ C:   1.25  -1.42   1.52  -1.42  -1.42  -1.42
 G:  -1.42  -1.00  -1.42   1.52  -1.42   1.52
 T:  -1.42  -1.42  -1.42  -1.42   1.52  -1.42
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 You can also set the \verb+.pseudocounts+ to a dictionary over the four nucleotides if you want to use different pseudocounts for them. Setting \verb+motif.pseudocounts+ to \verb+None+ resets it to its default value of zero.
 
 The position-specific scoring matrix depends on the background distribution, which is uniform by default:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for letter in "ACGT":
 ...     print("%s: %4.2f" % (letter, motif.background[letter]))
 ...
@@ -1300,10 +1302,10 @@ A: 0.25
 C: 0.25
 G: 0.25
 T: 0.25
-\end{verbatim}
+\end{minted}
 Again, if you modify the background distribution, the position-specific scoring matrix is recalculated:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> motif.background = {"A": 0.2, "C": 0.3, "G": 0.3, "T": 0.2}
 >>> print(motif.pssm)
         0      1      2      3      4      5
@@ -1312,10 +1314,10 @@ C:   0.98  -1.68   1.26  -1.68  -1.68  -1.68
 G:  -1.68  -1.26  -1.68   1.26  -1.68   1.26
 T:  -1.09  -1.09  -1.09  -1.09   1.85  -1.09
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 Setting \verb+motif.background+ to \verb+None+ resets it to a uniform distribution:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> motif.background = None
 >>> for letter in "ACGT":
 ...     print("%s: %4.2f" % (letter, motif.background[letter]))
@@ -1324,10 +1326,10 @@ A: 0.25
 C: 0.25
 G: 0.25
 T: 0.25
-\end{verbatim}
+\end{minted}
 If you set \verb+motif.background+ equal to a single value, it will be interpreted as the GC content:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> motif.background = 0.8
 >>> for letter in "ACGT":
 ...     print("%s: %4.2f" % (letter, motif.background[letter]))
@@ -1336,32 +1338,32 @@ A: 0.10
 C: 0.40
 G: 0.40
 T: 0.10
-\end{verbatim}
+\end{minted}
 Note that you can now calculate the mean of the PSSM scores over the background against which it was computed:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print("%f" % motif.pssm.mean(motif.background))
 4.703928
-\end{verbatim}
+\end{minted}
 as well as its standard deviation:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print("%f" % motif.pssm.std(motif.background))
 3.290900
-\end{verbatim}
+\end{minted}
 and its distribution:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> distribution = motif.pssm.distribution(background=motif.background)
 >>> threshold = distribution.threshold_fpr(0.01)
 >>> print("%f" % threshold)
 3.854375
-\end{verbatim}
+\end{minted}
 
 Note that the position-weight matrix and the position-specific scoring matrix are recalculated each time you call \verb+motif.pwm+ or \verb+motif.pssm+, respectively. If speed is an issue and you want to use the PWM or PSSM repeatedly, you can save them as a variable, as in
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> pssm = motif.pssm
-\end{verbatim}
+\end{minted}
 
 \section{Comparing motifs}
 \label{sec:comp}
@@ -1386,7 +1388,7 @@ To give an example, let us first load another motif,
 which is similar to our test motif \verb|m|:
 %TODO - Start a new doctest here?
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> with open("REB1.pfm") as handle:
 ...    m_reb1 = motifs.read(handle, "pfm")
 ...
@@ -1399,11 +1401,11 @@ C:  10.00   0.00   0.00   0.00 100.00 100.00 100.00   0.00  15.00
 G:  50.00   0.00   0.00   0.00   0.00   0.00   0.00  60.00  55.00
 T:  10.00 100.00 100.00   0.00   0.00   0.00   0.00  40.00  15.00
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 To make the motifs comparable, we choose the same values for the pseudocounts and the background distribution as our motif \verb|m|:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> m_reb1.pseudocounts = {"A":0.6, "C": 0.4, "G": 0.4, "T": 0.6}
 >>> m_reb1.background = {"A":0.3,"C":0.2,"G":0.2,"T":0.3}
 >>> pssm_reb1 = m_reb1.pssm
@@ -1414,18 +1416,18 @@ C:  -0.97  -5.67  -5.67  -5.67   2.30   2.30   2.30  -5.67  -0.41
 G:   1.30  -5.67  -5.67  -5.67  -5.67  -5.67  -5.67   1.57   1.44
 T:  -1.53   1.72   1.72  -5.67  -5.67  -5.67  -5.67   0.41  -0.97
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 We'll compare these motifs using the Pearson correlation.
 Since we want it to resemble a distance measure, we actually take
 $1-r$, where $r$ is the Pearson correlation coefficient (PCC):
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> distance, offset = pssm.dist_pearson(pssm_reb1)
 >>> print("distance = %5.3g" % distance)
 distance = 0.239
 >>> print(offset)
 -2
-\end{verbatim}
+\end{minted}
 This means that the best PCC between motif \verb|m| and  \verb|m_reb1| is obtained with the following alignment:
 \begin{verbatim}
 m:      bbTACGCbb
@@ -1451,16 +1453,16 @@ favorite parameters and saved the output in the file
 running the following piece of code:
 
 %doctest ../Tests/motifs
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import motifs
 >>> with open("meme.out") as handle:
 ...     motifsM = motifs.parse(handle, "meme")
 ...
-\end{verbatim}
-\begin{verbatim}
+\end{minted}
+\begin{minted}{pycon}
 >>> motifsM
 [<Bio.motifs.meme.Motif object at 0xc356b0>]
-\end{verbatim}
+\end{minted}
 
 Besides the most wanted list of motifs, the result object contains more useful information, accessible through properties with self-explanatory names:
 \begin{itemize}
@@ -1476,7 +1478,7 @@ Motif objects (with instances), they also provide some extra
 functionality, by adding additional information about the instances.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> motifsM[0].consensus
 Seq('CTCAATCGTA')
 >>> motifsM[0].instances[0].sequence_name
@@ -1485,11 +1487,11 @@ Seq('CTCAATCGTA')
 3
 >>> motifsM[0].instances[0].strand
 '+'
-\end{verbatim}
-\begin{verbatim}
+\end{minted}
+\begin{minted}{pycon}
 >>> motifsM[0].instances[0].pvalue
 8.71e-07
-\end{verbatim}
+\end{minted}
 
 
 \section{Useful links}

--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -10,14 +10,14 @@ Bio.PDB is a Biopython module that focuses on working with crystal structures of
 
 Similarly to the case of PDB files, first create an \texttt{MMCIFParser} object:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.PDB.MMCIFParser import MMCIFParser
 >>> parser = MMCIFParser()
-\end{verbatim}
+\end{minted}
 Then use this parser to create a structure object from the mmCIF file:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> structure = parser.get_structure("1fat", "1fat.cif")
-\end{verbatim}
+\end{minted}
 
 To have some more low level access to an mmCIF file, you can use the \verb+MMCIF2Dict+ class to create a Python dictionary that maps all mmCIF
 tags in an mmCIF file to their values. If there are multiple values
@@ -25,20 +25,20 @@ tags in an mmCIF file to their values. If there are multiple values
 the $y$ coordinates of all atoms), the tag is mapped to a list of values.
 The dictionary is created from the mmCIF file as follows:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.PDB.MMCIF2Dict import MMCIF2Dict
 >>> mmcif_dict = MMCIF2Dict("1FAT.cif")
-\end{verbatim}
+\end{minted}
 
 Example: get the solvent content from an mmCIF file:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> sc = mmcif_dict["_exptl_crystal.density_percent_sol"]
-\end{verbatim}
+\end{minted}
 
 Example: get the list of the $y$ coordinates of all atoms
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> y_list = mmcif_dict["_atom_site.Cartn_y"]
-\end{verbatim}
+\end{minted}
 
 
 \subsection{Reading files in the MMTF format}
@@ -46,50 +46,50 @@ Example: get the list of the $y$ coordinates of all atoms
 You can use the direct MMTFParser to read a structure from a file:
 %want to use doctest ../Tests lib:mmtf
 %but will trigger PDBConstructionWarning
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.PDB.mmtf import MMTFParser
 >>> structure = MMTFParser.get_structure("PDB/4CUP.mmtf")
-\end{verbatim}
+\end{minted}
 
 Or you can use the same class to get a structure by its PDB ID:
 %want online doctest here
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> structure = MMTFParser.get_structure_from_url("4CUP")
-\end{verbatim}
+\end{minted}
 
 This gives you a Structure object as if read from a PDB or mmCIF file.
 
 You can also have access to the underlying data using the external
 MMTF library which Biopython is using internally:
 %want online doctest here
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from mmtf import fetch
 >>> decoded_data = fetch("4CUP")
-\end{verbatim}
+\end{minted}
 For example you can access just the X-coordinate.
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(decoded_data.x_coord_list)
 ...
-\end{verbatim}
+\end{minted}
 
 \subsection{Reading a PDB file}
 
 First we create a \texttt{PDBParser} object:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.PDB.PDBParser import PDBParser
 >>> parser = PDBParser(PERMISSIVE=1)
-\end{verbatim}
+\end{minted}
 
 The {\tt PERMISSIVE} flag indicates that a number of common problems (see \ref{problem structures}) associated with PDB files will be ignored (but note that some atoms and/or residues will be missing). If the flag is not present a {\tt PDBConstructionException} will be generated if any problems are detected during the parse operation.
 
 The Structure object is then produced by letting the \texttt{PDBParser} object parse a PDB file (the PDB file in this case is called \verb|pdb1fat.ent|, \verb|1fat| is a user defined name for the structure):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> structure_id = "1fat"
 >>> filename = "pdb1fat.ent"
 >>> structure = parser.get_structure(structure_id, filename)
-\end{verbatim}
+\end{minted}
 
 You can extract the header and trailer (simple lists of strings) of the PDB
 file from the PDBParser object with the {\tt get\_header} and {\tt get\_trailer}
@@ -106,10 +106,10 @@ a Python dictionary that maps header records to their values.
 
 Example:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> resolution = structure.header["resolution"]
 >>> keywords = structure.header["keywords"]
-\end{verbatim}
+\end{minted}
 The available keys are \verb+name+, \verb+head+, \verb+deposition_date+, 
 \verb+release_date+, \verb+structure_method+, \verb+resolution+, 
 \verb+structure_reference+ (which maps to a list of references), 
@@ -128,12 +128,12 @@ the PDB specification.}
 The dictionary can also be created without creating a \texttt{Structure}
 object, ie. directly from the PDB file:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.PDB import parse_pdb_header
 >>> with open(filename, "r") as handle:
 ...     header_dict = parse_pdb_header(handle)
 ...
-\end{verbatim}
+\end{minted}
 
 \subsection{Reading files in the PDB XML format}
 
@@ -146,19 +146,19 @@ via the mailing list if you need this.
 
 A similar interface can be used to write structures to the mmCIF file format:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> io = MMCIFIO()
 >>> io.set_structure(s)
 >>> io.save("out.cif")
-\end{verbatim}
+\end{minted}
 The \texttt{Select} class can be used in a similar way to \texttt{PDBIO} above.
 mmCIF dictionaries read using \texttt{MMCIF2Dict} can also be written:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> io = MMCIFIO()
 >>> io.set_dict(d)
 >>> io.save("out.cif")
-\end{verbatim}
+\end{minted}
 
 \subsection{Writing PDB files}
 
@@ -167,11 +167,11 @@ of a structure too, of course.
 
 Example: saving a structure
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> io = PDBIO()
 >>> io.set_structure(s)
 >>> io.save("out.pdb")
-\end{verbatim}
+\end{minted}
 If you want to write out a part of the structure, make use of the
 \texttt{Select} class (also in \texttt{PDBIO}). Select has four methods:
 
@@ -187,7 +187,7 @@ is included in the output). By subclassing \texttt{Select} and returning
 Cumbersome maybe, but very powerful. The following code only writes
 out glycine residues:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> class GlySelect(Select):
 ...     def accept_residue(self, residue):
 ...         if residue.get_name()=="GLY":
@@ -198,7 +198,7 @@ out glycine residues:
 >>> io = PDBIO()
 >>> io.set_structure(s)
 >>> io.save("gly_only.pdb", GlySelect())
-\end{verbatim}
+\end{minted}
 If this is all too complicated for you, the \texttt{Dice} module contains
 a handy \texttt{extract} function that writes out all residues in
 a chain between a start and end residue.
@@ -263,33 +263,33 @@ In general, a child Entity object (i.e. Atom, Residue, Chain, Model) can be
 extracted from its parent (i.e. Residue, Chain, Model, Structure, respectively)
 by using an id as a key.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> child_entity = parent_entity[child_id]
-\end{verbatim}
+\end{minted}
 
 You can also get a list of all child Entities of a parent Entity object. Note
 that this list is sorted in a specific way (e.g. according to chain identifier
 for Chain objects in a Model object).
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> child_list = parent_entity.get_list()
-\end{verbatim}
+\end{minted}
 
 You can also get the parent from a child:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> parent_entity = child_entity.get_parent()
-\end{verbatim}
+\end{minted}
 
 At all levels of the SMCRA hierarchy, you can also extract a \emph{full id}.
 The full id is a tuple containing all id's starting from the top object (Structure)
 down to the current object. A full id for a Residue object e.g. is something
 like:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> full_id = residue.get_full_id()
 >>> print(full_id)
 ("1abc", 0, "A", ("", 10, "A"))
-\end{verbatim}
+\end{minted}
 
 This corresponds to:
 
@@ -304,17 +304,17 @@ because it has a blank hetero field, that its sequence identifier is 10 and
 that its insertion code is \char`\"{}A\char`\"{}.
 
 To get the entity's id, use the \verb+get_id+ method:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> entity.get_id()
-\end{verbatim}
+\end{minted}
 You can check if the entity has a child with a given id by using the \verb+has_id+ method:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> entity.has_id(entity_id)
-\end{verbatim}
+\end{minted}
 The length of an entity is equal to its number of children:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> nr_children = len(entity)
-\end{verbatim}
+\end{minted}
 
 It is possible to delete, rename, add, etc. child entities from a parent entity,
 but this does not include any sanity checks (e.g. it is possible to add two
@@ -338,9 +338,9 @@ of the model in the parsed file (they are automatically numbered starting from
 Crystal structures generally have only one model (with id 0), while NMR files usually have several models. Whereas many PDB parsers assume that there is only one model, the \verb+Structure+ class in \verb+Bio.PDB+ is designed such that it can easily handle PDB files with more than one model.
 
 As an example, to get the first model from a Structure object, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> first_model = structure[0]
-\end{verbatim}
+\end{minted}
 
 The Model object stores a list of Chain children.
 
@@ -348,9 +348,9 @@ The Model object stores a list of Chain children.
 
 The id of a Chain object is derived from the chain identifier in the PDB/mmCIF
 file, and is a single character (typically a letter). Each Chain in a Model object has a unique id. As an example, to get the Chain object with identifier ``A'' from a Model object, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> chain_A = model["A"]
-\end{verbatim}
+\end{minted}
 
 The Chain object stores a list of Residue children.
 
@@ -376,12 +376,12 @@ The id of the above glucose residue would thus be \texttt{('H\_GLC',
 100, 'A')}. If the hetero-flag and insertion code are blank, the sequence
 identifier alone can be used:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 # Full id
 >>> residue=chain[(" ", 100, " ")]
 # Shortcut id
 >>> residue=chain[100]
-\end{verbatim}
+\end{minted}
 The reason for the hetero-flag is that many, many PDB files use the
 same sequence identifier for an amino acid and a hetero-residue or
 a water, which would create obvious problems if the hetero-flag was
@@ -402,24 +402,24 @@ In most cases, the hetflag and insertion code fields will be blank, e.g. {\tt ('
 In these cases, the sequence identifier can be used as a shortcut for the full
 id:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 # use full id
 >>> res10 = chain[(" ", 10, " ")]
 # use shortcut
 >>> res10 = chain[10]
-\end{verbatim}
+\end{minted}
 
 Each Residue object in a Chain object should have a unique id. However, disordered
 residues are dealt with in a special way, as described in section \ref{point mutations}.
 
 A Residue object has a number of additional methods:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> residue.get_resname()       # returns the residue name, e.g. "ASN"
 >>> residue.is_disordered()     # returns 1 if the residue has disordered atoms
 >>> residue.get_segid()	        # returns the SEGID, e.g. "CHN1"
 >>> residue.has_id(name)        # test if a residue has a certain atom
-\end{verbatim}
+\end{minted}
 
 You can use \texttt{is\_aa(residue)} to test if a Residue object is an amino acid.
 
@@ -461,7 +461,7 @@ atomic coordinates directly.
 
 An Atom object has the following additional methods:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> a.get_name()       # atom name (spaces stripped, e.g. "CA")
 >>> a.get_id()         # id (equals atom name)
 >>> a.get_coord()      # atomic coordinates
@@ -473,7 +473,7 @@ An Atom object has the following additional methods:
 >>> a.get_siguij()     # standard deviation of anisotropic B factor
 >>> a.get_anisou()     # anisotropic B factor
 >>> a.get_fullname()   # atom name (with spaces, e.g. ".CA.")
-\end{verbatim}
+\end{minted}
 
 To represent the atom coordinates, siguij, anisotropic B factor and sigatm Numpy
 arrays are used.
@@ -489,7 +489,7 @@ do it, making use of the \texttt{rotaxis} method (which can be used
 to construct a rotation around a certain axis) of the \texttt{Vector}
 module:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 # get atom coordinates as vectors
 >>> n = residue["N"].get_vector()
 >>> c = residue["C"].get_vector()
@@ -504,7 +504,7 @@ module:
 >>> cb_at_origin = n.left_multiply(rot)
 # put on top of ca atom
 >>> cb = cb_at_origin+ca
-\end{verbatim}
+\end{minted}
 This example shows that it's possible to do some quite nontrivial
 vector operations on atomic data, which can be quite useful. In addition
 to all the usual vector operations (cross (use \texttt{{*}{*}}), and
@@ -518,17 +518,17 @@ from a Structure}
 
 These are some examples:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> model = structure[0]
 >>> chain = model["A"]
 >>> residue = chain[100]
 >>> atom = residue["CA"]
-\end{verbatim}
+\end{minted}
 Note that you can use a shortcut:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> atom = structure[0]["A"][100]["CA"]
-\end{verbatim}
+\end{minted}
 
 \section{Disorder}
 
@@ -567,14 +567,14 @@ Each disordered atom has a characteristic altloc identifier. You can
 specify that a \texttt{Disordered\-Atom} object should behave like
 the \texttt{Atom} object associated with a specific altloc identifier:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> atom.disordered_select("A") # select altloc A atom
 >>> print(atom.get_altloc())
 "A"
 >>> atom.disordered_select("B") # select altloc B atom
 >>> print(atom.get_altloc())
 "B"
-\end{verbatim}
+\end{minted}
 
 \subsection{Disordered residues}
 
@@ -612,10 +612,10 @@ residue Cys 60 would have id ``CYS''. The user can select the active
 Example: suppose that a chain has a point mutation at position 10,
 consisting of a Ser and a Cys residue. Make sure that residue 10 of
 this chain behaves as the Cys residue.
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> residue = chain[10]
 >>> residue.disordered_select("CYS")
-\end{verbatim}
+\end{minted}
 In addition, you can get a list of all \texttt{Atom} objects (ie.
 all \texttt{DisorderedAtom} objects are 'unpacked' to their individual
 \texttt{Atom} objects) using the \texttt{get\_unpacked\_list} method
@@ -651,7 +651,7 @@ would have hetfield ``H\_GLC''. Its residue id could e.g. be (``H\_GLC'',
 
 \subsubsection*{Parse a PDB file, and extract some Model, Chain, Residue and Atom objects}
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.PDB.PDBParser import PDBParser
 >>> parser = PDBParser()
 >>> structure = parser.get_structure("test", "1fat.pdb")
@@ -659,11 +659,11 @@ would have hetfield ``H\_GLC''. Its residue id could e.g. be (``H\_GLC'',
 >>> chain = model["A"]
 >>> residue = chain[1]
 >>> atom = residue["CA"]
-\end{verbatim}
+\end{minted}
 
 \subsubsection*{Iterating through all atoms of a structure}
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> p = PDBParser()
 >>> structure = p.get_structure("X", "pdb1fat.ent")
 >>> for model in structure:
@@ -672,74 +672,74 @@ would have hetfield ``H\_GLC''. Its residue id could e.g. be (``H\_GLC'',
 ...             for atom in residue:
 ...                 print(atom)
 ...
-\end{verbatim}
+\end{minted}
 
 There is a shortcut if you want to iterate over all atoms in a structure:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> atoms = structure.get_atoms()
 >>> for atom in atoms:
 ...     print(atom)
 ...
-\end{verbatim}
+\end{minted}
 
 Similarly, to iterate over all atoms in a chain, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> atoms = chain.get_atoms()
 >>> for atom in atoms:
 ...     print(atom)
 ...
-\end{verbatim}
+\end{minted}
 
 \subsubsection*{Iterating over all residues of a model}
 
 or if you want to iterate over all residues in a model:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> residues = model.get_residues()
 >>> for residue in residues:
 ...     print(residue)
 ...
-\end{verbatim}
+\end{minted}
 
 You can also use the \verb+Selection.unfold_entities+ function to get all residues from a structure:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> res_list = Selection.unfold_entities(structure, "R")
-\end{verbatim}
+\end{minted}
 or to get all atoms from a chain:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> atom_list = Selection.unfold_entities(chain, "A")
-\end{verbatim}
+\end{minted}
 Obviously, \verb+A=atom, R=residue, C=chain, M=model, S=structure+.
 You can use this to go up in the hierarchy, e.g. to get a list of
 (unique) \verb+Residue+ or \verb+Chain+ parents from a list of
 \verb+Atoms+:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> residue_list = Selection.unfold_entities(atom_list, "R")
 >>> chain_list = Selection.unfold_entities(atom_list, "C")
-\end{verbatim}
+\end{minted}
 For more info, see the API documentation.
 
 \subsubsection*{Extract a hetero residue from a chain (e.g. a glucose (GLC) moiety with resseq 10)}
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> residue_id = ("H_GLC", 10, " ")
 >>> residue = chain[residue_id]
-\end{verbatim}
+\end{minted}
 
 \subsubsection*{Print all hetero residues in chain}
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for residue in chain.get_list():
 ...    residue_id = residue.get_id()
 ...    hetfield = residue_id[0]
 ...    if hetfield[0]=="H":
 ...        print(residue_id)
 ...
-\end{verbatim}
+\end{minted}
 
 \subsubsection*{Print out the coordinates of all CA atoms in a structure with B factor greater than 50}
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for model in structure.get_list():
 ...     for chain in model.get_list():
 ...         for residue in chain.get_list():
@@ -748,11 +748,11 @@ For more info, see the API documentation.
 ...                 if ca.get_bfactor() > 50.0:
 ...                     print(ca.get_coord())
 ...
-\end{verbatim}
+\end{minted}
 
 \subsubsection*{Print out all the residues that contain disordered atoms}
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for model in structure.get_list():
 ...     for chain in model.get_list():
 ...         for residue in chain.get_list():
@@ -763,13 +763,13 @@ For more info, see the API documentation.
 ...                 chain_id = chain.get_id()
 ...                 print(model_id, chain_id, resname, resseq)
 ...
-\end{verbatim}
+\end{minted}
 
 \subsubsection*{Loop over all disordered atoms, and select all atoms with altloc A (if present)}
 This will make sure that the SMCRA data structure will behave as if only the
 atoms with altloc A are present.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for model in structure.get_list():
 ...     for chain in model.get_list():
 ...         for residue in chain.get_list():
@@ -779,26 +779,26 @@ atoms with altloc A are present.
 ...                         if atom.disordered_has_id("A"):
 ...                             atom.disordered_select("A")
 ...
-\end{verbatim}
+\end{minted}
 
 \subsubsection*{Extracting polypeptides from a \texttt{Structure} object\label{subsubsec:extracting_polypeptides}}
 
 To extract polypeptides from a structure, construct a list of \texttt{Polypeptide} objects from a \texttt{Structure} object using \texttt{PolypeptideBuilder} as follows:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> model_nr = 1
 >>> polypeptide_list = build_peptides(structure, model_nr)
 >>> for polypeptide in polypeptide_list:
 ...     print(polypeptide)
 ...
-\end{verbatim}
+\end{minted}
 
 A Polypeptide object is simply a UserList of Residue objects, and is always created from a single Model (in this case model 1).
 You can use the resulting \texttt{Polypeptide} object to get the sequence as a \texttt{Seq} object or to get a list of C$\alpha$ atoms as well. Polypeptides can be built using a C-N or a C$\alpha$-C$\alpha$ distance criterion.
 
 Example:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 # Using C-N
 >>> ppb=PPBuilder()
 >>> for pp in ppb.build_peptides(structure):
@@ -809,7 +809,7 @@ Example:
 >>> for pp in ppb.build_peptides(structure):
 ...     print(pp.get_sequence())
 ...
-\end{verbatim}
+\end{minted}
 Note that in the above case only model 0 of the structure is considered
 by \texttt{PolypeptideBuilder}. However, it is possible to use \texttt{PolypeptideBuilder}
 to build \texttt{Polypeptide} objects from \texttt{Model} and \texttt{Chain}
@@ -825,44 +825,44 @@ defined by a \texttt{ProteinAlphabet} object.
 
 Example:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> seq = polypeptide.get_sequence()
 >>> print(seq)
 Seq('SNVVE...', <class Bio.Alphabet.ProteinAlphabet>)
-\end{verbatim}
+\end{minted}
 
 \section{Analyzing structures}
 
 \subsection{Measuring distances}
 The minus operator for atoms has been overloaded to return the distance between two atoms.
-\begin{verbatim}
+\begin{minted}{pycon}
 # Get some atoms
 >>> ca1 = residue1["CA"]
 >>> ca2 = residue2["CA"]
 # Simply subtract the atoms to get their distance
 >>> distance = ca1-ca2
-\end{verbatim}
+\end{minted}
 
 \subsection{Measuring angles}
 Use the vector representation of the atomic coordinates, and
 the \texttt{calc\_angle} function from the \texttt{Vector} module:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> vector1 = atom1.get_vector()
 >>> vector2 = atom2.get_vector()
 >>> vector3 = atom3.get_vector()
 >>> angle = calc_angle(vector1, vector2, vector3)
-\end{verbatim}
+\end{minted}
 
 \subsection{Measuring torsion angles}
 Use  the vector representation of the atomic coordinates, and
 the \texttt{calc\_dihedral} function from the \texttt{Vector} module:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> vector1 = atom1.get_vector()
 >>> vector2 = atom2.get_vector()
 >>> vector3 = atom3.get_vector()
 >>> vector4 = atom4.get_vector()
 >>> angle = calc_dihedral(vector1, vector2, vector3, vector4)
-\end{verbatim}
+\end{minted}
 
 \subsection{Determining atom-atom contacts}
 
@@ -886,7 +886,7 @@ The algorithm used by \texttt{Superimposer} comes from \cite[Golub \& Van Loan]{
 
 Example:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> sup = Superimposer()
 # Specify the atom lists
 # 'fixed' and 'moving' are lists of Atom objects
@@ -897,7 +897,7 @@ Example:
 >>> print(sup.rms)
 # Apply rotation/translation to the moving atoms
 >>> sup.apply(moving)
-\end{verbatim}
+\end{minted}
 
 To superimpose two structures based on their active sites, use the active site atoms to calculate the rotation/translation matrices (as above), and apply these to the whole molecule.
 
@@ -926,7 +926,7 @@ and contact number values.
 
 Example:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> model = structure[0]
 >>> hse = HSExposure()
 # Calculate HSEalpha
@@ -937,7 +937,7 @@ Example:
 >>> exp_fs = hse.calc_fs_exposure(model)
 # Print HSEalpha for a residue
 >>> print(exp_ca[some_residue])
-\end{verbatim}
+\end{minted}
 
 \subsection{Determining the secondary structure}
 
@@ -999,11 +999,11 @@ of a residue's C$\alpha$ atom to the solvent accessible surface.
 
 Example:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> model = structure[0]
 >>> rd = ResidueDepth(model, pdb_file)
 >>> residue_depth, ca_depth=rd[some_residue]
-\end{verbatim}
+\end{minted}
 You can also get access to the molecular surface itself (via the \texttt{get\_surface}
 function), in the form of a Numeric Python array with the surface points.
 
@@ -1017,13 +1017,13 @@ way, which is the default.
 
 Example:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 # Permissive parser
 >>> parser = PDBParser(PERMISSIVE=1)
 >>> parser = PDBParser() # The same (default)
 # Strict parser
 >>> strict_parser = PDBParser(PERMISSIVE=0)
-\end{verbatim}
+\end{minted}
 In the permissive state (DEFAULT), PDB files that obviously contain
 errors are ``corrected'' (i.e. some residues or atoms are left out).
 These errors include:
@@ -1140,15 +1140,15 @@ Structures can be downloaded from the PDB (Protein Data Bank)
 by using the \texttt{retrieve\_pdb\_file} method on a \texttt{PDBList} object.
 The argument for this method is the PDB identifier of the structure.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> pdbl = PDBList()
 >>> pdbl.retrieve_pdb_file("1FAT")
-\end{verbatim}
+\end{minted}
 
 The \texttt{PDBList} class can also be used as a command-line tool:
-\begin{verbatim}
+\begin{minted}{pycon}
 python PDBList.py 1fat
-\end{verbatim}
+\end{minted}
 The downloaded file will be called \texttt{pdb1fat.ent} and stored
 in the current working directory. Note that the \texttt{retrieve\_pdb\_file}
 method also has an optional argument \texttt{pdir} that specifies
@@ -1167,11 +1167,11 @@ to Kristian Rother for donating this module.
 The following commands will store all PDB files in the \texttt{/data/pdb}
 directory:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 python PDBList.py all /data/pdb
 
 python PDBList.py all /data/pdb -d
-\end{verbatim}
+\end{minted}
 \noindent The API method for this is called \texttt{download\_entire\_pdb}.
 Adding the \texttt{-d} option will store all files in the same directory.
 Otherwise, they are sorted into PDB-style subdirectories according
@@ -1185,10 +1185,10 @@ creates a \texttt{PDBList} object (specifying the directory where
 the local copy of the PDB is present) and calls the \texttt{update\_pdb}
 method:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> pl = PDBList(pdb="/data/pdb")
 >>> pl.update_pdb()
-\end{verbatim}
+\end{minted}
 One can of course make a weekly \texttt{cronjob} out of this to keep
 the local copy automatically up-to-date. The PDB ftp site can also
 be specified (see API documentation).

--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -415,10 +415,10 @@ residues are dealt with in a special way, as described in section \ref{point mut
 A Residue object has a number of additional methods:
 
 \begin{minted}{pycon}
->>> residue.get_resname()       # returns the residue name, e.g. "ASN"
->>> residue.is_disordered()     # returns 1 if the residue has disordered atoms
->>> residue.get_segid()	        # returns the SEGID, e.g. "CHN1"
->>> residue.has_id(name)        # test if a residue has a certain atom
+>>> residue.get_resname()    # returns the residue name, e.g. "ASN"
+>>> residue.is_disordered()  # returns 1 if the residue has disordered atoms
+>>> residue.get_segid()      # returns the SEGID, e.g. "CHN1"
+>>> residue.has_id(name)     # test if a residue has a certain atom
 \end{minted}
 
 You can use \texttt{is\_aa(residue)} to test if a Residue object is an amino acid.

--- a/Doc/Tutorial/chapter_phenotype.tex
+++ b/Doc/Tutorial/chapter_phenotype.tex
@@ -40,7 +40,7 @@ on whether the read or parse method is being used.
 You can test the parse function by using the \href{https://github.com/biopython/biopython/blob/master/Doc/examples/Plates.csv}{\texttt{Plates.csv}} file provided with the Biopython source code.
 
 %doctest examples lib:numpy
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import phenotype
 >>> for record in phenotype.parse("Plates.csv", "pm-csv"):
 ...     print("%s %i" % (record.id, len(record)))
@@ -49,7 +49,7 @@ PM01 96
 PM01 96
 PM09 96
 PM09 96
-\end{verbatim}
+\end{minted}
 
 The parser returns a series of PlateRecord objects, each one containing a series of WellRecord objects
 (holding each well's experimental data) arranged in 8 rows and 12 columns; each row is indicated by
@@ -59,20 +59,20 @@ There are several ways to access WellRecord objects from a PlateRecord objects:
 \begin{description}
   \item[Well identifier]
     If you know the well identifier (row + column identifiers) you can access the desired well directly.
-    \begin{verbatim}
+\begin{minted}{pycon}
     >>> record["A02"]
-    \end{verbatim}
+    \end{minted}
 
   \item[Well plate coordinates]
     The same well can be retrieved by using the row and columns numbers (0-based index).
 
 %doctest examples lib:numpy
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import phenotype
 >>> record = list(phenotype.parse("Plates.csv", "pm-csv"))[-1]
 >>> print(record[0, 1].id)
 A02
-\end{verbatim}
+\end{minted}
 
   \item[Row or column coordinates]
     A series of WellRecord objects contiguous to each other in the plate can be retrieved in bulk by
@@ -80,7 +80,7 @@ A02
     a 0-based index.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(record[0])
 Plate ID: PM09
 Well: 12
@@ -99,7 +99,7 @@ Well: 9
 Rows: 3
 Columns: 3
 PlateRecord('WellRecord['A01'], WellRecord['A02'], WellRecord['A03'], ..., WellRecord['C03']')
-\end{verbatim}
+\end{minted}
 
 \end{description}
 
@@ -113,13 +113,13 @@ experiments. The raw data can be accessed by iterating on a WellRecord object;
 in the example below only the first ten time points are shown.
 
 %doctest examples lib:numpy
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import phenotype
 >>> record = list(phenotype.parse("Plates.csv", "pm-csv"))[-1]
 >>> well = record["A02"]
-\end{verbatim}
+\end{minted}
 %rest of code snippet output is truncated
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for time, signal in well:
 ...    print(time, signal)
 ...
@@ -134,7 +134,7 @@ in the example below only the first ten time points are shown.
 (2.0, 44.0)
 (2.25, 44.0)
 [...]
-\end{verbatim}
+\end{minted}
 
 This method, while providing a way to access the raw data, doesn't allow a direct
 comparison between different WellRecord objects, which may have measurements at
@@ -150,14 +150,14 @@ Time intervals can be defined with the same syntax as list
 indexing; the default time interval is therefore one hour.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> well[:10]  
 [12.0, 37.0, 44.0, 44.0, 44.0, 44.0, 44.0, 44.0, 44.0, 44.0]
-\end{verbatim}
+\end{minted}
 
 Different time intervals can be used, for instance five minutes:
 %Rounding makes this tricky as a doctest...
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> well[63:64:0.083]
 [12.0, 37.0, 44.0, 44.0, 44.0, 44.0, 44.0, 44.0, 44.0, 44.0]
 >>> well[9.55]
@@ -173,7 +173,7 @@ Different time intervals can be used, for instance five minutes:
  140.0,
  142.0,
  nan]
-\end{verbatim}
+\end{minted}
 
 \subsubsection{Control well subtraction}
 Many Phenotype Microarray plates contain a control well (usually A01), that is a well where the media shouldn't support
@@ -182,13 +182,13 @@ The PlateRecord objects have a dedicated function for that, which returns anothe
 with the corrected data.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> corrected = record.subtract_control(control="A01")
 >>> record["A01"][63]
 336.0
 >>> corrected["A01"][63]
 0.0
-\end{verbatim}
+\end{minted}
 
 \subsubsection{Parameters extraction}
 Those wells where metabolic activity is observed show a sigmoid behavior for the colorimetric data.
@@ -239,7 +239,7 @@ The fit method by default tries first to fit the gompertz function: if it fails 
 the logistic and then the richards function. The user can also specify one of the three functions to be applied.
 
 %TODO: enable with doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import phenotype
 >>> record = list(phenotype.parse("Plates.csv", "pm-csv"))[-1]
 >>> well = record["A02"]
@@ -257,7 +257,7 @@ max     143.00
 min     12.00
 plateau 120.02
 slope   4.99
-\end{verbatim}
+\end{minted}
 
 \subsection{Writing Phenotype Microarray data}
 PlateRecord objects can be written to file in the form of
@@ -265,7 +265,7 @@ PlateRecord objects can be written to file in the form of
 files, a format compatible with other software packages such as
 \href{https://www.dsmz.de/research/microorganisms/projects/analysis-of-omnilog-phenotype-microarray-data.html}{opm}
 or \href{https://combogenomics.github.io/DuctApe/}{DuctApe}.
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> phenotype.write(record, "out.json", "pm-json")
 1
-\end{verbatim}
+\end{minted}

--- a/Doc/Tutorial/chapter_phylo.tex
+++ b/Doc/Tutorial/chapter_phylo.tex
@@ -27,9 +27,9 @@ tree file available, you can follow this demo using that instead.)
 
 Launch the Python interpreter of your choice:
 
-\begin{verbatim}
-% ipython -pylab
-\end{verbatim}
+\begin{minted}{bash}
+$ ipython -pylab
+\end{minted}
 
 For interactive work, launching the IPython interpreter with the \verb|-pylab| flag enables
 \textbf{matplotlib} integration, so graphics will pop up automatically. We'll use that during
@@ -38,15 +38,15 @@ this demo.
 Now, within Python, read the tree file, giving the file name and the name of the format.
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Phylo
 >>> tree = Phylo.read("simple.dnd", "newick")
-\end{verbatim}
+\end{minted}
 
 Printing the tree object as a string gives us a look at the entire object hierarchy.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(tree)
 Tree(rooted=False, weight=1.0)
     Clade()
@@ -61,7 +61,7 @@ Tree(rooted=False, weight=1.0)
             Clade(name='E')
             Clade(name='F')
             Clade(name='G')
-\end{verbatim}
+\end{minted}
 
 The \texttt{Tree} object contains global information about the tree, such as whether it's
 rooted or unrooted. It has one root clade, and under that, it's nested lists of clades all the
@@ -72,7 +72,7 @@ convenient visualization for interactive exploration, in case better graphical t
 available.
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Phylo
 >>> tree = Phylo.read("simple.dnd", "newick")
 >>> Phylo.draw_ascii(tree)
@@ -90,15 +90,15 @@ _|                                                 |________________________ D
                           |
                           |________________________ G
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 If you have \textbf{matplotlib} or \textbf{pylab} installed, you can create a graphic
 using the \verb|draw| function (see Fig. \ref{fig:phylo-simple-draw}):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> tree.rooted = True
 >>> Phylo.draw(tree)
-\end{verbatim}
+\end{minted}
 
 \begin{htmlonly}
 \imgsrc[width=666, height=530]{images/phylo-simple-draw.png}
@@ -131,16 +131,16 @@ object called Phylogeny, from the Bio.Phylo.PhyloXML module.
 
 In Biopython 1.55 and later, this is a convenient tree method:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> tree = tree.as_phyloxml()
-\end{verbatim}
+\end{minted}
 
 In Biopython 1.54, you can accomplish the same thing with one extra import:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Phylo.PhyloXML import Phylogeny
 >>> tree = Phylogeny.from_tree(tree)
-\end{verbatim}
+\end{minted}
 
 Note that the file formats Newick and Nexus don't support branch colors or widths, so
 if you use these attributes in Bio.Phylo, you will only be able to save the values in
@@ -152,21 +152,21 @@ First, we'll color the root clade gray.  We can do that by assigning the 24-bit 
 value as an RGB triple, an HTML-style hex string, or the name of one of the predefined
 colors.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> tree.root.color = (128, 128, 128)
-\end{verbatim}
+\end{minted}
 
 Or:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> tree.root.color = "#808080"
-\end{verbatim}
+\end{minted}
 
 Or:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> tree.root.color = "gray"
-\end{verbatim}
+\end{minted}
 
 Colors for a clade are treated as cascading down through the entire clade, so when we colorize
 the root here, it turns the whole tree gray.  We can override that by assigning a different
@@ -176,24 +176,24 @@ Let's target the most recent common ancestor (MRCA) of the nodes named ``E'' and
 \verb|common_ancestor| method returns a reference to that clade in the original tree, so when
 we color that clade ``salmon'', the color will show up in the original tree.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> mrca = tree.common_ancestor({"name": "E"}, {"name": "F"})
 >>> mrca.color = "salmon"
-\end{verbatim}
+\end{minted}
 
 If we happened to know exactly where a certain clade is in the tree, in terms of nested list
 entries, we can jump directly to that position in the tree by indexing it.  Here, the index
 \verb|[0,1]| refers to the second child of the first child of the root.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> tree.clade[0, 1].color = "blue"
-\end{verbatim}
+\end{minted}
 
 Finally, show our work (see Fig. \ref{fig:phylo-color-draw}):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> Phylo.draw(tree)
-\end{verbatim}
+\end{minted}
 
 \begin{htmlonly}
 \imgsrc[width=666, height=530]{images/phylo-color-draw.png}
@@ -219,7 +219,7 @@ would be written --- and the format \texttt{phyloxml}.  PhyloXML saves the color
 so you can open this phyloXML file in another tree viewer like Archaeopteryx, and the colors
 will show up there, too.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> import sys
 >>> Phylo.write(tree, sys.stdout, "phyloxml")
 
@@ -239,7 +239,7 @@ will show up there, too.
           <phy:clade>
             <phy:name>A</phy:name>
             ...
-\end{verbatim}
+\end{minted}
 
 The rest of this chapter covers the core functionality of Bio.Phylo in greater detail. For more
 examples of using Bio.Phylo, see the cookbook page on Biopython.org:
@@ -256,11 +256,11 @@ well as the Comparative Data Analysis Ontology (CDAO).
 The \verb|read| function parses a single tree in the given file and returns it. Careful; it
 will raise an error if the file contains more than one tree, or no trees.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Phylo
 >>> tree = Phylo.read("Tests/Nexus/int_node_labels.nwk", "newick")
 >>> print(tree)
-\end{verbatim}
+\end{minted}
 
 (Example files are available in the \texttt{Tests/Nexus/} and \texttt{Tests/PhyloXML/}
 directories of the Biopython distribution.)
@@ -268,18 +268,18 @@ directories of the Biopython distribution.)
 To handle multiple (or an unknown number of) trees, use the \verb|parse| function iterates
 through each of the trees in the given file:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> trees = Phylo.parse("../../Tests/PhyloXML/phyloxml_examples.xml", "phyloxml")
 >>> for tree in trees:
 ...     print(tree)
-\end{verbatim}
+\end{minted}
 
 Write a tree or iterable of trees back to file with the \verb|write| function:
 
 %the files tree1.nwk and other_trees.nwk are created and then deleted during the
 %run of test_Tutorial.py
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> trees = list(Phylo.parse("../../Tests/PhyloXML/phyloxml_examples.xml", "phyloxml"))
 >>> tree1 = trees[0]
 >>> others = trees[1:]
@@ -287,27 +287,27 @@ Write a tree or iterable of trees back to file with the \verb|write| function:
 1
 >>> Phylo.write(others, "other_trees.nwk", "newick")
 12
-\end{verbatim}
+\end{minted}
 
 Convert files between any of the supported formats with the \verb|convert| function:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> Phylo.convert("tree1.nwk", "newick", "tree1.xml", "nexml")
 1
 >>> Phylo.convert("other_trees.xml", "phyloxml", "other_trees.nex", "nexus")
 12
-\end{verbatim}
+\end{minted}
 
 To use strings as input or output instead of actual files, use \verb|StringIO| as you would
 with SeqIO and AlignIO:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Phylo
 >>> from StringIO import StringIO
 >>> handle = StringIO("(((A,B),(C,D)),(E,F,G));")
 >>> tree = Phylo.read(handle, "newick")
-\end{verbatim}
+\end{minted}
 
 
 \section{View and export trees}
@@ -315,7 +315,7 @@ with SeqIO and AlignIO:
 The simplest way to get an overview of a \verb|Tree| object is to \verb|print| it:
 
 %doctest ../Tests
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Phylo
 >>> tree = Phylo.read("PhyloXML/example.xml", "phyloxml")
 >>> print(tree)
@@ -325,7 +325,7 @@ Phylogeny(description='phyloXML allows to use either a "branch_length" attribute
             Clade(branch_length=0.102, name='A')
             Clade(branch_length=0.23, name='B')
         Clade(branch_length=0.4, name='C')
-\end{verbatim}
+\end{minted}
 
 This is essentially an outline of the object hierarchy Biopython uses to represent a tree. But
 more likely, you'd want to see a drawing of the tree. There are three functions to do this.
@@ -335,7 +335,7 @@ rooted phylogram) to standard output, or an open file handle if given. Not all o
 available information about the tree is shown, but it provides a way to quickly view the
 tree without relying on any external dependencies.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> tree = Phylo.read("example.xml", "phyloxml")
 >>> Phylo.draw_ascii(tree)
              __________________ A
@@ -344,16 +344,16 @@ _|          |___________________________________________ B
  |
  |___________________________________________________________________________ C
 
-\end{verbatim}
+\end{minted}
 
 The \verb|draw| function draws a more attractive image using the matplotlib
 library. See the API documentation for details on the arguments it accepts to
 customize the output.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> tree = Phylo.read("example.xml", "phyloxml")
 >>> Phylo.draw(tree, branch_labels=lambda c: c.branch_length)
-\end{verbatim}
+\end{minted}
 
 \begin{htmlonly}
 \imgsrc[width=701, height=465]{images/phylo-draw-example.png}
@@ -585,11 +585,11 @@ The rest of these methods are boolean checks:
 These methods modify the tree in-place. If you want to keep the original tree intact, make a
 complete copy of the tree first, using Python's \texttt{copy} module:
 
-\begin{verbatim}
+\begin{minted}{python}
 tree = Phylo.read('example.xml', 'phyloxml')
 import copy
 newtree = copy.deepcopy(tree)
-\end{verbatim}
+\end{minted}
 
 \begin{description}
   \item[\texttt{collapse}]
@@ -653,9 +653,8 @@ descriptions and examples of using the additional annotation features provided b
 
 % The object hierarchy still looks and behaves similarly:
 
-% \begin{verbatim}
+% \begin{minted}{pycon}
 % >>> print(tree)
-
 % Phylogeny(rooted=True, name="")
 %     Clade(branch_length=1.0)
 %         Clade(branch_length=1.0)
@@ -669,7 +668,7 @@ descriptions and examples of using the additional annotation features provided b
 %             Clade(branch_length=1.0, name="E")
 %             Clade(branch_length=1.0, name="F")
 %             Clade(branch_length=1.0, name="G")
-% \end{verbatim}
+% \end{minted}
 
 \section{Running external applications}
 \label{sec:PhyloApps}
@@ -684,21 +683,21 @@ Biopython 1.58 introduced a wrapper for PhyML
 \texttt{phylip-relaxed} format (that's Phylip format, but without the 10-character limit
 on taxon names) and a variety of options. A quick example:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import Phylo
 >>> from Bio.Phylo.Applications import PhymlCommandline
 >>> cmd = PhymlCommandline(input="Tests/Phylip/random.phy")
 >>> out_log, err_log = cmd()
-\end{verbatim}
+\end{minted}
 
 This generates a tree file and a stats file with the names
 [\textit{input~filename}]\verb|_phyml_tree.txt| and
 [\textit{input~filename}]\verb|_phyml_stats.txt|. The tree file is in Newick format:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> tree = Phylo.read("Tests/Phylip/random.phy_phyml_tree.txt", "newick")
 >>> Phylo.draw_ascii(tree)
-\end{verbatim}
+\end{minted}
 
 A similar wrapper for RAxML (\url{https://sco.h-its.org/exelixis/software.html})
 was added in Biopython 1.60, and FastTree
@@ -728,7 +727,7 @@ program is run via the \texttt{run()} method and the output file is automaticall
 to a results dictionary.
 
 Here is an example of typical usage of codeml:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Phylo.PAML import codeml
 >>> cml = codeml.Codeml()
 >>> cml.alignment = "Tests/PAML/alignment.phylip"
@@ -750,13 +749,13 @@ Here is an example of typical usage of codeml:
 >>> m0 = ns_sites.get(0)
 >>> m0_params = m0.get("parameters")
 >>> print(m0_params.get("omega"))
-\end{verbatim}
+\end{minted}
 
 Existing output files may be parsed as well using a module's \texttt{read()} function:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> results = codeml.read("Tests/PAML/Results/codeml/codeml_NSsites_all.out")
 >>> print(results.get("lnL max"))
-\end{verbatim}
+\end{minted}
 
 Detailed documentation for this new module currently lives on the Biopython wiki:
 \url{http://biopython.org/wiki/PAML}

--- a/Doc/Tutorial/chapter_popgen.tex
+++ b/Doc/Tutorial/chapter_popgen.tex
@@ -26,12 +26,12 @@ Utilities to manipulate the content of a record are also provided.
 Here is an example on how to read a GenePop file (you can find
 example GenePop data files in the Test/PopGen directory of Biopython):
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.PopGen import GenePop
 
 with open("example.gen") as handle:
     rec = GenePop.read(handle)
-\end{verbatim}
+\end{minted}
 
 This will read a file called example.gen and parse it. If you
 do print rec, the record will be output again, in GenePop format.
@@ -45,7 +45,7 @@ a list of individuals, each individual is a pair composed by individual
 name and a list of alleles (2 per marker), here is an example for
 rec.populations:
 
-\begin{verbatim}
+\begin{minted}{python}
 [
     [
         ('Ind1', [(1, 2),    (3, 3), (200, 201)],
@@ -55,7 +55,7 @@ rec.populations:
         ('Other1', [(1, 1),  (4, 3), (200, 200)],
     ]
 ]
-\end{verbatim}
+\end{minted}
 
 So we have two populations, the first with two individuals, the
 second with only one. The first individual of the first
@@ -66,7 +66,7 @@ might be missing (see as an example, Ind2 above).
 A few utility functions to manipulate GenePop records are made
 available, here is an example:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.PopGen import GenePop
 
 #Imagine that you have loaded rec, as per the code snippet above...
@@ -102,7 +102,7 @@ rec_pops =  rec.split_in_pops(pop_names)
 #  they are passed in array (pop_names).
 #  The value of each dictionary entry is the GenePop record.
 #  rec is not altered.
-\end{verbatim}
+\end{minted}
 
 GenePop does not support population names, a limitation which can be
 cumbersome at times. Functionality to enable population names is currently

--- a/Doc/Tutorial/chapter_quick_start.tex
+++ b/Doc/Tutorial/chapter_quick_start.tex
@@ -21,7 +21,7 @@ Disputably (of course!), the central object in bioinformatics is the sequence. T
 Most of the time when we think about sequences we have in my mind a string of letters like `\verb|AGTACACTGGT|'. You can create such \verb|Seq| object with this sequence as follows - the ``\verb+>>>+'' represents the Python prompt followed by what you would type in:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> my_seq = Seq("AGTACACTGGT")
 >>> my_seq
@@ -30,21 +30,21 @@ Seq('AGTACACTGGT')
 AGTACACTGGT
 >>> my_seq.alphabet
 Alphabet()
-\end{verbatim}
+\end{minted}
 
 What we have here is a sequence object with a \emph{generic} alphabet - reflecting the fact we have \emph{not} specified if this is a DNA or protein sequence (okay, a protein with a lot of Alanines, Glycines, Cysteines and Threonines!).  We'll talk more about alphabets in Chapter~\ref{chapter:Bio.Seq}.
 
 In addition to having an alphabet, the \verb|Seq| object differs from the Python string in the methods it supports.  You can't do this with a plain string:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> my_seq
 Seq('AGTACACTGGT')
 >>> my_seq.complement()
 Seq('TCATGTGACCA')
 >>> my_seq.reverse_complement()
 Seq('ACCAGTGTACT')
-\end{verbatim}
+\end{minted}
 
 The next most important class is the \verb|SeqRecord| or Sequence Record.  This holds a sequence (as a \verb|Seq| object) with additional annotation including an identifier, name and description.  The \verb|Bio.SeqIO| module for reading and writing sequence file formats works with \verb|SeqRecord| objects, which will be introduced below and covered in more detail by Chapter~\ref{chapter:Bio.SeqIO}.
 
@@ -96,13 +96,13 @@ AATCCGGAGGACCGGTGTACTCAGCTCACCGGGGGCATTGCTCCCGTGGTGACCCTGATTTGTTGTTGGG
 
 It contains 94 records, each has a line starting with ``\verb+>+'' (greater-than symbol) followed by the sequence on one or more lines.  Now try this in Python:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 for seq_record in SeqIO.parse("ls_orchid.fasta", "fasta"):
     print(seq_record.id)
     print(repr(seq_record.seq))
     print(len(seq_record))
-\end{verbatim}
+\end{minted}
 
 \noindent You should get something like this on your screen:
 
@@ -122,13 +122,13 @@ Notice that the FASTA format does not specify the alphabet, so \verb|Bio.SeqIO| 
 
 Now let's load the GenBank file \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/ls_orchid.gbk}{\tt ls\_orchid.gbk} instead - notice that the code to do this is almost identical to the snippet used above for the FASTA file - the only difference is we change the filename and the format string:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 for seq_record in SeqIO.parse("ls_orchid.gbk", "genbank"):
     print(seq_record.id)
     print(repr(seq_record.seq))
     print(len(seq_record))
-\end{verbatim}
+\end{minted}
 
 \noindent This should give:
 

--- a/Doc/Tutorial/chapter_searchio.tex
+++ b/Doc/Tutorial/chapter_searchio.tex
@@ -116,7 +116,7 @@ The QueryResult object represents a single search query and contains zero or
 more Hit objects. Let's see what it looks like using the BLAST file we have:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SearchIO
 >>> blast_qresult = SearchIO.read("my_blast.xml", "blast-xml")
 >>> print(blast_qresult)
@@ -161,7 +161,7 @@ Program: blastn (2.2.27+)
            97      1  gi|356517317|ref|XM_003527287.1|  PREDICTED: Glycine ma...
            98      1  gi|297814701|ref|XM_002875188.1|  Arabidopsis lyrata su...
            99      1  gi|397513516|ref|XM_003827011.1|  PREDICTED: Pan panisc...
-\end{verbatim}
+\end{minted}
 
 We've just begun to scratch the surface of the object model, but you can see that
 there's already some useful information. By invoking \verb|print| on the
@@ -182,7 +182,7 @@ there's already some useful information. By invoking \verb|print| on the
 Now let's check our BLAT results using the same procedure as above:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blat_qresult = SearchIO.read("my_blat.psl", "blat-psl")
 >>> print(blat_qresult)
 Program: blat (<unknown version>)
@@ -193,7 +193,7 @@ Program: blat (<unknown version>)
             #  # HSP  ID + description
          ----  -----  ----------------------------------------------------------
             0     17  chr19  <unknown description>
-\end{verbatim}
+\end{minted}
 
 You'll immediately notice that there are some differences. Some of these are
 caused by the way PSL format stores its details, as you'll see. The rest are
@@ -224,14 +224,14 @@ notation). There are also other format-specific attributes that you can access
 using the same method.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print("%s %s" % (blast_qresult.program, blast_qresult.version))
 blastn 2.2.27+
 >>> print("%s %s" % (blat_qresult.program, blat_qresult.version))
 blat <unknown version>
 >>> blast_qresult.param_evalue_threshold    # blast-xml specific
 10.0
-\end{verbatim}
+\end{minted}
 
 For a complete list of accessible attributes, you can check each format-specific
 documentation. Here are the ones
@@ -248,7 +248,7 @@ dictionaries.
 Like Python lists and dictionaries, \verb|QueryResult| objects are iterable.
 Each iteration returns a \verb|Hit| object:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for hit in blast_qresult:
 ...     hit
 Hit(id='gi|262205317|ref|NR_030195.1|', query_id='42291', 1 hsps)
@@ -257,36 +257,36 @@ Hit(id='gi|270133242|ref|NR_032573.1|', query_id='42291', 1 hsps)
 Hit(id='gi|301171322|ref|NR_035857.1|', query_id='42291', 2 hsps)
 Hit(id='gi|301171267|ref|NR_035851.1|', query_id='42291', 1 hsps)
 ...
-\end{verbatim}
+\end{minted}
 
 To check how many items (hits) a \verb|QueryResult| has, you can simply invoke
 Python's \verb|len| method:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(blast_qresult)
 100
 >>> len(blat_qresult)
 1
-\end{verbatim}
+\end{minted}
 
 Like Python lists, you can retrieve items (hits) from a \verb|QueryResult| using
 the slice notation:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blast_qresult[0]        # retrieves the top hit
 Hit(id='gi|262205317|ref|NR_030195.1|', query_id='42291', 1 hsps)
 >>> blast_qresult[-1]       # retrieves the last hit
 Hit(id='gi|397513516|ref|XM_003827011.1|', query_id='42291', 1 hsps)
-\end{verbatim}
+\end{minted}
 
 To retrieve multiple hits, you can slice \verb|QueryResult| objects using the
 slice notation as well. In this case, the slice will return a new
 \verb|QueryResult| object containing only the sliced hits:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blast_slice = blast_qresult[:3]     # slices the first three hits
 >>> print(blast_slice)
 Program: blastn (2.2.27+)
@@ -299,47 +299,47 @@ Program: blastn (2.2.27+)
             0      1  gi|262205317|ref|NR_030195.1|  Homo sapiens microRNA 52...
             1      1  gi|301171311|ref|NR_035856.1|  Pan troglodytes microRNA...
             2      1  gi|270133242|ref|NR_032573.1|  Macaca mulatta microRNA ...
-\end{verbatim}
+\end{minted}
 
 Like Python dictionaries, you can also retrieve hits using the hit's ID. This is
 particularly useful if you know a given hit ID exists within a search query
 results:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blast_qresult["gi|262205317|ref|NR_030195.1|"]
 Hit(id='gi|262205317|ref|NR_030195.1|', query_id='42291', 1 hsps)
-\end{verbatim}
+\end{minted}
 
 You can also get a full list of \verb|Hit| objects using \verb|hits| and a full
 list of \verb|Hit| IDs using \verb|hit_keys|:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blast_qresult.hits
 [...]       # list of all hits
 >>> blast_qresult.hit_keys
 [...]       # list of all hit IDs
-\end{verbatim}
+\end{minted}
 
 What if you just want to check whether a particular hit is present in the query
 results? You can do a simple Python membership test using the \verb|in| keyword:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> "gi|262205317|ref|NR_030195.1|" in blast_qresult
 True
 >>> "gi|262205317|ref|NR_030194.1|" in blast_qresult
 False
-\end{verbatim}
+\end{minted}
 
 Sometimes, knowing whether a hit is present is not enough; you also want to know
 the rank of the hit. Here, the \verb|index| method comes to the rescue:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blast_qresult.index("gi|301171437|ref|NR_035870.1|")
 22
-\end{verbatim}
+\end{minted}
 
 Remember that we're using Python's indexing style here, which is zero-based.
 This means our hit above is ranked at no. 23, not 22.
@@ -360,7 +360,7 @@ each hit's full sequence length. For this particular sort, we'll set the
 the \verb|reverse| flag to \verb|True| so that we sort in descending order.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for hit in blast_qresult[:5]:   # id and sequence length of the first five hits
 ...     print("%s %i" % (hit.id, hit.seq_len))
 ...
@@ -380,7 +380,7 @@ gi|390332045|ref|XM_776818.2| 4082
 gi|390332043|ref|XM_003723358.1| 4079
 gi|356517317|ref|XM_003527287.1| 3251
 gi|356543101|ref|XM_003539954.1| 2936
-\end{verbatim}
+\end{minted}
 
 The advantage of having the \verb|in_place| flag here is that we're preserving
 the native ordering, so we may use it again later. You should note that this is
@@ -418,7 +418,7 @@ Here is an example of using \verb|hit_filter| to filter out \verb|Hit| objects
 that only have one HSP:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> filter_func = lambda hit: len(hit.hsps) > 1     # the callback function
 >>> len(blast_qresult)      # no. of hits before filtering
 100
@@ -432,7 +432,7 @@ gi|262205330|ref|NR_030198.1| 2
 gi|301171447|ref|NR_035871.1| 2
 gi|262205298|ref|NR_030190.1| 2
 gi|270132717|ref|NR_032716.1| 2
-\end{verbatim}
+\end{minted}
 
 \verb|hsp_filter| works the same as \verb|hit_filter|, only instead of looking
 at the \verb|Hit| objects, it performs filtering on the \verb|HSP| objects in
@@ -446,7 +446,7 @@ callback function must return the modified \verb|Hit| or \verb|HSP| object
 Let's see an example where we're using \verb|hit_map| to rename the hit IDs:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> def map_func(hit):
 ...     hit.id = hit.id.split("|")[3]   # renames "gi|301171322|ref|NR_035857.1|" to "NR_035857.1"
 ...     return hit
@@ -459,7 +459,7 @@ NR_035856.1
 NR_032573.1
 NR_035857.1
 NR_035851.1
-\end{verbatim}
+\end{minted}
 
 Again, \verb|hsp_map| works the same as \verb|hit_map|, but on \verb|HSP|
 objects instead of \verb|Hit| objects.
@@ -475,7 +475,7 @@ themselves contain \verb|HSP| objects.
 Let's see what they look like, beginning with our BLAST search:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SearchIO
 >>> blast_qresult = SearchIO.read("my_blast.xml", "blast-xml")
 >>> blast_hit = blast_qresult[3]    # fourth hit from the query result
@@ -489,7 +489,7 @@ Query: 42291
        ----  --------  ---------  ------  ---------------  ---------------------
           0   8.9e-20     100.47      60           [1:61]                [13:73]
           1   3.3e-06      55.39      60           [0:60]                [13:73]
-\end{verbatim}
+\end{minted}
 
 You see that we've got the essentials covered here:
 
@@ -511,7 +511,7 @@ Now let's contrast this with the BLAT search. Remember that in the BLAT search w
 had one hit with 17 HSPs.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blat_qresult = SearchIO.read("my_blat.psl", "blat-psl")
 >>> blat_hit = blat_qresult[0]      # the only hit
 >>> print(blat_hit)
@@ -539,7 +539,7 @@ Query: mystery_seq
          14         ?          ?       ?           [8:61]    [54212018:54212071]
          15         ?          ?       ?           [8:51]    [54234278:54234321]
          16         ?          ?       ?           [8:61]    [54238143:54238196]
-\end{verbatim}
+\end{minted}
 
 Here, we've got a similar level of detail as with the BLAST hit we saw earlier.
 There are some differences worth explaining, though:
@@ -562,23 +562,23 @@ Just like Python lists, \verb|Hit| objects are iterable, and each iteration
 returns one \verb|HSP| object it contains:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for hsp in blast_hit:
 ...     hsp
 HSP(hit_id='gi|301171322|ref|NR_035857.1|', query_id='42291', 1 fragments)
 HSP(hit_id='gi|301171322|ref|NR_035857.1|', query_id='42291', 1 fragments)
-\end{verbatim}
+\end{minted}
 
 You can invoke \verb|len| on a \verb|Hit| to see how many \verb|HSP| objects it
 has:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(blast_hit)
 2
 >>> len(blat_hit)
 17
-\end{verbatim}
+\end{minted}
 
 You can use the slice notation on \verb|Hit| objects, whether to retrieve single
 \verb|HSP| or multiple \verb|HSP| objects. Like \verb|QueryResult|, if you slice
@@ -586,7 +586,7 @@ for multiple \verb|HSP|, a new \verb|Hit| object will be returned containing
 only the sliced \verb|HSP| objects:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blat_hit[0]                 # retrieve single items
 HSP(hit_id='chr19', query_id='mystery_seq', 1 fragments)
 >>> sliced_hit = blat_hit[4:9]  # retrieve multiple items
@@ -605,7 +605,7 @@ Query: mystery_seq
           2         ?          ?       ?           [0:61]    [54238143:54240175]
           3         ?          ?       ?           [0:60]    [54189735:54189795]
           4         ?          ?       ?           [0:61]    [54185425:54185486]
-\end{verbatim}
+\end{minted}
 
 You can also sort the \verb|HSP| inside a \verb|Hit|, using the exact same
 arguments like the sort method you saw in the \verb|QueryResult| object.
@@ -632,7 +632,7 @@ Let's see some examples from our BLAST and BLAT searches. We'll look at the
 BLAST HSP first:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SearchIO
 >>> blast_qresult = SearchIO.read("my_blast.xml", "blast-xml")
 >>> blast_hsp = blast_qresult[0][0]    # first hit, first hsp
@@ -646,7 +646,7 @@ Quick stats: evalue 4.9e-23; bitscore 111.29
      Query - CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTTTAGAGGG
              |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
        Hit - CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTTTAGAGGG
-\end{verbatim}
+\end{minted}
 
 Just like \verb|QueryResult| and \verb|Hit|, invoking \verb|print| on an
 \verb|HSP| shows its general details:
@@ -668,29 +668,29 @@ These details can be accessed on their own using the dot notation, just like in
 \verb|QueryResult| and \verb|Hit|:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blast_hsp.query_range
 (0, 61)
-\end{verbatim}
+\end{minted}
 %hack! since float display may be different across versions
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blast_hsp.evalue
 4.91307e-23
-\end{verbatim}
+\end{minted}
 
 They're not the only attributes available, though. \verb|HSP| objects come with
 a default set of properties that makes it easy to probe their various
 details. Here are some examples:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blast_hsp.hit_start         # start coordinate of the hit sequence
 0
 >>> blast_hsp.query_span        # how many residues in the query sequence
 61
 >>> blast_hsp.aln_span          # how long the alignment is
 61
-\end{verbatim}
+\end{minted}
 
 Check out the \verb|HSP|
 \href{http://biopython.org/DIST/docs/api/Bio.SearchIO._model.hsp-module.html}{documentation}
@@ -702,33 +702,33 @@ outputs the number of gaps and identical residues. These attributes can be
 accessed like so:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blast_hsp.gap_num       # number of gaps
 0
 >>> blast_hsp.ident_num     # number of identical residues
 61
-\end{verbatim}
+\end{minted}
 
 These details are format-specific; they may not be present in other formats.
 To see which details are available for a given sequence search tool, you
 should check the format's documentation in \verb|Bio.SearchIO|. Alternatively,
 you may also use \verb|.__dict__.keys()| for a quick list of what's available:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blast_hsp.__dict__.keys()
 ['bitscore', 'evalue', 'ident_num', 'gap_num', 'bitscore_raw', 'pos_num', '_items']
-\end{verbatim}
+\end{minted}
 
 Finally, you may have noticed that the \verb|query| and \verb|hit| attributes
 of our HSP are not just regular strings:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blast_hsp.query
 SeqRecord(seq=Seq('CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTT...GGG', DNAAlphabet()), id='42291', name='aligned query sequence', description='mystery_seq', dbxrefs=[])
 >>> blast_hsp.hit
 SeqRecord(seq=Seq('CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTT...GGG', DNAAlphabet()), id='gi|262205317|ref|NR_030195.1|', name='aligned hit sequence', description='Homo sapiens microRNA 520b (MIR520B), microRNA', dbxrefs=[])
-\end{verbatim}
+\end{minted}
 
 They are \verb|SeqRecord| objects you saw earlier in
 Section~\ref{chapter:SeqRecord}! This means that you can do all sorts of
@@ -739,19 +739,19 @@ It should not surprise you now that the \verb|HSP| object has an
 \verb|alignment| property which is a \verb|MultipleSeqAlignment| object:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(blast_hsp.aln)
 DNAAlphabet() alignment with 2 rows and 61 columns
 CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAG...GGG 42291
 CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAG...GGG gi|262205317|ref|NR_030195.1|
-\end{verbatim}
+\end{minted}
 
 Having probed the BLAST HSP, let's now take a look at HSPs from our BLAT
 results for a different kind of HSP. As usual, we'll begin by invoking
 \verb|print| on it:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blat_qresult = SearchIO.read("my_blat.psl", "blat-psl")
 >>> blat_hsp = blat_qresult[0][0]       # first hit, first hsp
 >>> print(blat_hsp)
@@ -761,7 +761,7 @@ Query range: [0:61] (1)
   Hit range: [54204480:54204541] (1)
 Quick stats: evalue ?; bitscore ?
   Fragments: 1 (? columns)
-\end{verbatim}
+\end{minted}
 
 Some of the outputs you may have already guessed. We have the query and hit IDs
 and descriptions and the sequence coordinates. Values for evalue and bitscore is
@@ -773,14 +773,14 @@ if you try to access \verb|HSP.query|, \verb|HSP.hit|, or \verb|HSP.aln|?
 You'll get the default values for these attributes, which is \verb|None|:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blat_hsp.hit is None
 True
 >>> blat_hsp.query is None
 True
 >>> blat_hsp.aln is None
 True
-\end{verbatim}
+\end{minted}
 
 This does not affect other attributes, though. For example, you can still
 access the length of the query or hit alignment. Despite not displaying any
@@ -788,22 +788,22 @@ attributes, the PSL format still have this information so \verb|Bio.SearchIO|
 can extract them:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blat_hsp.query_span     # length of query match
 61
 >>> blat_hsp.hit_span       # length of hit match
 61
-\end{verbatim}
+\end{minted}
 
 Other format-specific attributes are still present as well:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blat_hsp.score          # PSL score
 61
 >>> blat_hsp.mismatch_num   # the mismatch column
 0
-\end{verbatim}
+\end{minted}
 
 So far so good? Things get more interesting when you look at another `variant'
 of HSP present in our BLAT results. You might recall that in BLAT searches,
@@ -815,7 +815,7 @@ Let's take a look at a BLAT HSP that contains multiple blocks to see how
 \verb|Bio.SearchIO| deals with this:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blat_hsp2 = blat_qresult[0][1]      # first hit, second hsp
 >>> print(blat_hsp2)
       Query: mystery_seq <unknown description>
@@ -828,7 +828,7 @@ Quick stats: evalue ?; bitscore ?
              ---  --------------  ----------------------  ----------------------
                0               ?                  [0:18]     [54233104:54233122]
                1               ?                 [18:61]     [54264420:54264463]
-\end{verbatim}
+\end{minted}
 
 What's happening here? We still some essential details covered: the IDs and
 descriptions, the coordinates, and the quick statistics are similar to what
@@ -854,7 +854,7 @@ intervening regions), while the hit match is not.
 All these attributes are accessible from the HSP directly, by the way:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blat_hsp2.hit_range         # hit start and end coordinates of the entire HSP
 (54233104, 54264463)
 >>> blat_hsp2.hit_range_all     # hit start and end coordinates of each fragment
@@ -867,7 +867,7 @@ All these attributes are accessible from the HSP directly, by the way:
 [(54233122, 54264420)]
 >>> blat_hsp2.hit_inter_spans   # span of intervening regions in the hit sequence
 [31298]
-\end{verbatim}
+\end{minted}
 
 Most of these attributes are not readily available from the PSL file we have,
 but \verb|Bio.SearchIO| calculates them for you on the fly when you parse the
@@ -887,12 +887,12 @@ Finally, to check whether you have multiple fragments or not, you can use the
 \verb|is_fragmented| property like so:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blat_hsp2.is_fragmented     # BLAT HSP with 2 fragments
 True
 >>> blat_hsp.is_fragmented      # BLAT HSP from earlier, with one fragment
 False
-\end{verbatim}
+\end{minted}
 
 Before we move on, you should also know that we can use the slice notation on
 \verb|HSP| objects, just like \verb|QueryResult| or \verb|Hit| objects. When
@@ -918,7 +918,7 @@ These attributes are readily shown when you invoke \verb|print| on an
 \verb|HSPFragment|. Here's an example, taken from our BLAST search:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SearchIO
 >>> blast_qresult = SearchIO.read("my_blast.xml", "blast-xml")
 >>> blast_frag = blast_qresult[0][0][0]    # first hit, first hsp, first fragment
@@ -931,13 +931,13 @@ Query range: [0:61] (1)
      Query - CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTTTAGAGGG
              |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
        Hit - CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTTTAGAGGG
-\end{verbatim}
+\end{minted}
 
 At this level, the BLAT fragment looks quite similar to the BLAST fragment, save
 for the query and hit sequences which are not present:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blat_qresult = SearchIO.read("my_blat.psl", "blat-psl")
 >>> blat_frag = blat_qresult[0][0][0]    # first hit, first hsp, first fragment
 >>> print(blat_frag)
@@ -946,20 +946,20 @@ for the query and hit sequences which are not present:
 Query range: [0:61] (1)
   Hit range: [54204480:54204541] (1)
   Fragments: 1 (? columns)
-\end{verbatim}
+\end{minted}
 
 In all cases, these attributes are accessible using our favorite dot notation.
 Some examples:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> blast_frag.query_start      # query start coordinate
 0
 >>> blast_frag.hit_strand       # hit sequence strand
 1
 >>> blast_frag.hit              # hit sequence, as a SeqRecord object
 SeqRecord(seq=Seq('CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTT...GGG', DNAAlphabet()), id='gi|262205317|ref|NR_030195.1|', name='aligned hit sequence', description='Homo sapiens microRNA 520b (MIR520B), microRNA', dbxrefs=[])
-\end{verbatim}
+\end{minted}
 
 \section{A note about standards and conventions}
 \label{sec:searchio-standards}
@@ -1033,7 +1033,7 @@ keyword argument to modify so it parses the BLAST tabular variant with comments
 in it:
 
 %doctest ../Tests/Blast
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SearchIO
 >>> qresult = SearchIO.read("tab_2226_tblastn_003.txt", "blast-tab")
 >>> qresult
@@ -1041,7 +1041,7 @@ QueryResult(id='gi|16080617|ref|NP_391444.1|', 3 hits)
 >>> qresult2 = SearchIO.read("tab_2226_tblastn_007.txt", "blast-tab", comments=True)
 >>> qresult2
 QueryResult(id='gi|16080617|ref|NP_391444.1|', 3 hits)
-\end{verbatim}
+\end{minted}
 
 These keyword arguments differs among file formats. Check the format
 documentation to see if it has keyword arguments that modifies its parser's
@@ -1053,7 +1053,7 @@ yields a \verb|QueryResult| object in each iteration. Like
 \verb|Bio.SearchIO.read|, it also accepts format-specific keyword arguments:
 
 %doctest ../Tests/Blast
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SearchIO
 >>> qresults = SearchIO.parse("tab_2226_tblastn_001.txt", "blast-tab")
 >>> for qresult in qresults:
@@ -1066,7 +1066,7 @@ gi|11464971:4-101
 random_s00
 gi|16080617|ref|NP_391444.1|
 gi|11464971:4-101
-\end{verbatim}
+\end{minted}
 
 \section{Dealing with large search output files with indexing}
 \label{sec:searchio-index}
@@ -1087,7 +1087,7 @@ Here are some examples. You can use \verb|index| with just the filename and
 format name:
 
 %doctest ../Tests/Blast
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SearchIO
 >>> idx = SearchIO.index("tab_2226_tblastn_001.txt", "blast-tab")
 >>> sorted(idx.keys())
@@ -1095,24 +1095,24 @@ format name:
 >>> idx["gi|16080617|ref|NP_391444.1|"]
 QueryResult(id='gi|16080617|ref|NP_391444.1|', 3 hits)
 >>> idx.close()
-\end{verbatim}
+\end{minted}
 
 Or also with the format-specific keyword argument:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> idx = SearchIO.index("tab_2226_tblastn_005.txt", "blast-tab", comments=True)
 >>> sorted(idx.keys())
 ['gi|11464971:4-101', 'gi|16080617|ref|NP_391444.1|', 'random_s00']
 >>> idx["gi|16080617|ref|NP_391444.1|"]
 QueryResult(id='gi|16080617|ref|NP_391444.1|', 3 hits)
 >>> idx.close()
-\end{verbatim}
+\end{minted}
 
 Or with the \verb|key_function| argument, as in \verb|Bio.SeqIO|:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> key_function = lambda id: id.upper()    # capitalizes the keys
 >>> idx = SearchIO.index("tab_2226_tblastn_001.txt", "blast-tab", key_function=key_function)
 >>> sorted(idx.keys())
@@ -1120,7 +1120,7 @@ Or with the \verb|key_function| argument, as in \verb|Bio.SeqIO|:
 >>> idx["GI|16080617|REF|NP_391444.1|"]
 QueryResult(id='gi|16080617|ref|NP_391444.1|', 3 hits)
 >>> idx.close()
-\end{verbatim}
+\end{minted}
 
 \verb|Bio.SearchIO.index_db| works like as \verb|index|, only it writes the
 query offsets into an SQLite database file.
@@ -1137,12 +1137,12 @@ arguments. It returns a four-item tuple, which denotes the number or
 \verb|QueryResult|, \verb|Hit|, \verb|HSP|, and \verb|HSPFragment| objects that
 were written.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SearchIO
 >>> qresults = SearchIO.parse("mirna.xml", "blast-xml")     # read XML file
 >>> SearchIO.write(qresults, "results.tab", "blast-tab")    # write to tabular file
 (3, 239, 277, 277)
-\end{verbatim}
+\end{minted}
 
 You should note different file formats require different attributes of the
 \verb|QueryResult|, \verb|Hit|, \verb|HSP| and \verb|HSPFragment| objects. If
@@ -1161,11 +1161,11 @@ Finally, \verb|Bio.SearchIO| also provides a \verb|convert| function, which is
 simply a shortcut for \verb|Bio.SearchIO.parse| and \verb|Bio.SearchIO.write|.
 Using the convert function, our example above would be:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SearchIO
 >>> SearchIO.convert("mirna.xml", "blast-xml", "results.tab", "blast-tab")
 (3, 239, 277, 277)
-\end{verbatim}
+\end{minted}
 
 As \verb|convert| uses \verb|write|, it is only limited to format conversions
 that have all the required attributes. Here, the BLAST XML file provides all the

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -9,11 +9,11 @@ or EMBL files, this information is quite important.
 
 While this chapter should cover most things to do with the \verb|SeqRecord| and \verb|SeqFeature| objects in this chapter, you may also want to read the \verb|SeqRecord| wiki page (\url{http://biopython.org/wiki/SeqRecord}), and the built in documentation (also online -- \href{http://biopython.org/DIST/docs/api/Bio.SeqRecord.SeqRecord-class.html}{SeqRecord} and \href{http://biopython.org/DIST/docs/api/Bio.SeqFeature.SeqFeature-class.html}{SeqFeature}):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.SeqRecord import SeqRecord
 >>> help(SeqRecord)
 ...
-\end{verbatim}
+\end{minted}
 
 \section{The SeqRecord object}
 \label{sec:SeqRecord}
@@ -53,17 +53,17 @@ below).  However, creating \verb|SeqRecord| can be quite simple.
 To create a \verb|SeqRecord| at a minimum you just need a \verb|Seq| object:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> simple_seq = Seq("GATC")
 >>> from Bio.SeqRecord import SeqRecord
 >>> simple_seq_r = SeqRecord(simple_seq)
-\end{verbatim}
+\end{minted}
 
 Additionally, you can also pass the id, name and description to the initialization function, but if not they will be set as strings indicating they are unknown, and can be modified subsequently:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> simple_seq_r.id
 '<unknown id>'
 >>> simple_seq_r.id = "AC12345"
@@ -72,43 +72,43 @@ Additionally, you can also pass the id, name and description to the initializati
 Made up sequence I wish I could write a paper about
 >>> simple_seq_r.seq
 Seq('GATC')
-\end{verbatim}
+\end{minted}
 
 Including an identifier is very important if you want to output your \verb|SeqRecord| to a file.  You would normally include this when creating the object:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> simple_seq = Seq("GATC")
 >>> from Bio.SeqRecord import SeqRecord
 >>> simple_seq_r = SeqRecord(simple_seq, id="AC12345")
-\end{verbatim}
+\end{minted}
 
 As mentioned above, the \verb|SeqRecord| has an dictionary attribute \verb|annotations|. This is used
 for any miscellaneous annotations that doesn't fit under one of the other more specific attributes.
 Adding annotations is easy, and just involves dealing directly with the annotation dictionary:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> simple_seq_r.annotations["evidence"] = "None. I just made it up."
 >>> print(simple_seq_r.annotations)
 {'evidence': 'None. I just made it up.'}
 >>> print(simple_seq_r.annotations["evidence"])
 None. I just made it up.
-\end{verbatim}
+\end{minted}
 
 Working with per-letter-annotations is similar, \verb|letter_annotations| is a
 dictionary like attribute which will let you assign any Python sequence (i.e.
 a string, list or tuple) which has the same length as the sequence:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> simple_seq_r.letter_annotations["phred_quality"] = [40, 40, 38, 30]
 >>> print(simple_seq_r.letter_annotations)
 {'phred_quality': [40, 40, 38, 30]}
 >>> print(simple_seq_r.letter_annotations["phred_quality"])
 [40, 40, 38, 30]
-\end{verbatim}
+\end{minted}
 
 The \verb|dbxrefs| and \verb|features| attributes are just Python lists, and
 should be used to store strings and \verb|SeqFeature| objects (discussed later
@@ -133,7 +133,7 @@ used to loop over all the records in a file as \verb|SeqRecord| objects. The \ve
 has a sister function for use on files which contain just one record which we'll use here (see Chapter~\ref{chapter:Bio.SeqIO} for details):
 
 %TODO - line wrapping for doctest?
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.fna", "fasta")
 >>> record
@@ -141,16 +141,16 @@ SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG'
 SingleLetterAlphabet()), id='gi|45478711|ref|NC_005816.1|', name='gi|45478711|ref|NC_005816.1|',
 description='gi|45478711|ref|NC_005816.1| Yersinia pestis biovar Microtus ... sequence',
 dbxrefs=[])
-\end{verbatim}
+\end{minted}
 
 Now, let's have a look at the key attributes of this \verb|SeqRecord|
 individually -- starting with the \verb|seq| attribute which gives you a
 \verb|Seq| object:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.seq
 Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG', SingleLetterAlphabet())
-\end{verbatim}
+\end{minted}
 
 \noindent Here \verb|Bio.SeqIO| has defaulted to a generic alphabet, rather
 than guessing that this is DNA. If you know in advance what kind of sequence
@@ -159,14 +159,14 @@ your FASTA file contains, you can tell \verb|Bio.SeqIO| which alphabet to use
 
 Next, the identifiers and description:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.id
 'gi|45478711|ref|NC_005816.1|'
 >>> record.name
 'gi|45478711|ref|NC_005816.1|'
 >>> record.description
 'gi|45478711|ref|NC_005816.1| Yersinia pestis biovar Microtus ... pPCP1, complete sequence'
-\end{verbatim}
+\end{minted}
 
 As you can see above, the first word of the FASTA record's title line (after
 removing the greater than symbol) is used for both the \verb|id| and
@@ -184,7 +184,7 @@ TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGGGGGTAATCTGCTCTCC
 Note that none of the other annotation attributes get populated when reading a
 FASTA file:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.dbxrefs
 []
 >>> record.annotations
@@ -193,7 +193,7 @@ FASTA file:
 {}
 >>> record.features
 []
-\end{verbatim}
+\end{minted}
 
 In this case our example FASTA file was from the NCBI, and they have a fairly well defined set of conventions for formatting their FASTA lines. This means it would be possible to parse this information and extract the GI number and accession for example. However, FASTA files from other sources vary, so this isn't possible in general.
 
@@ -203,6 +203,7 @@ As in the previous example, we're going to look at the whole sequence for \texti
 Again, this file is included with the Biopython unit tests under the GenBank folder, or online \href{https://raw.githubusercontent.com/biopython/biopython/master/Tests/GenBank/NC_005816.gb}{\texttt{NC\_005816.gb}} from our website.
 
 This file contains a single record (i.e. only one LOCUS line) and starts:
+
 \begin{verbatim}
 LOCUS       NC_005816               9609 bp    DNA     circular BCT 21-JUL-2008
 DEFINITION  Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete
@@ -215,7 +216,7 @@ PROJECT     GenomeProject:10638
 
 Again, we'll use \verb|Bio.SeqIO| to read this file in, and the code is almost identical to that for used above for the FASTA file (see Chapter~\ref{chapter:Bio.SeqIO} for details):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.gb", "genbank")
 >>> record
@@ -223,57 +224,57 @@ SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG'
 IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
 description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence.',
 dbxrefs=['Project:10638'])
-\end{verbatim}
+\end{minted}
 
 You should be able to spot some differences already! But taking the attributes individually,
 the sequence string is the same as before, but this time \verb|Bio.SeqIO| has been able to automatically assign a more specific alphabet (see Chapter~\ref{chapter:Bio.SeqIO} for details):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.seq
 Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG', IUPACAmbiguousDNA())
-\end{verbatim}
+\end{minted}
 
 The \verb|name| comes from the LOCUS line, while the \verb|id| includes the version suffix.
 The description comes from the DEFINITION line:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.id
 'NC_005816.1'
 >>> record.name
 'NC_005816'
 >>> record.description
 'Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence.'
-\end{verbatim}
+\end{minted}
 
 GenBank files don't have any per-letter annotations:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.letter_annotations
 {}
-\end{verbatim}
+\end{minted}
 
 Most of the annotations information gets recorded in the \verb|annotations| dictionary, for example:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(record.annotations)
 11
 >>> record.annotations["source"]
 'Yersinia pestis biovar Microtus str. 91001'
-\end{verbatim}
+\end{minted}
 
 The \verb|dbxrefs| list gets populated from any PROJECT or DBLINK lines:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.dbxrefs
 ['Project:10638']
-\end{verbatim}
+\end{minted}
 
 Finally, and perhaps most interestingly, all the entries in the features table (e.g. the genes or CDS features) get recorded as \verb|SeqFeature| objects in the \verb|features| list.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(record.features)
 29
-\end{verbatim}
+\end{minted}
 
 \noindent We'll talk about \verb|SeqFeature| objects next, in
 Section~\ref{sec:seq_features}.
@@ -414,12 +415,12 @@ of fuzzy positions, so we have five classes do deal with them:
 Here's an example where we create a location with fuzzy end points:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqFeature
 >>> start_pos = SeqFeature.AfterPosition(5)
 >>> end_pos = SeqFeature.BetweenPosition(9, left=8, right=9)
 >>> my_location = SeqFeature.FeatureLocation(start_pos, end_pos)
-\end{verbatim}
+\end{minted}
 
 Note that the details of some of the fuzzy-locations changed in Biopython 1.59,
 in particular for BetweenPosition and WithinPosition you must now make it explicit
@@ -430,15 +431,15 @@ be the higher (right) value.
 If you print out a \verb|FeatureLocation| object, you can get a nice representation of the information:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(my_location)
 [>5:(8^9)]
-\end{verbatim}
+\end{minted}
 
 We can access the fuzzy start and end positions using the start and end attributes of the location:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> my_location.start
 AfterPosition(5)
 >>> print(my_location.start)
@@ -447,37 +448,37 @@ AfterPosition(5)
 BetweenPosition(9, left=8, right=9)
 >>> print(my_location.end)
 (8^9)
-\end{verbatim}
+\end{minted}
 
 If you don't want to deal with fuzzy positions and just want numbers,
 they are actually subclasses of integers so should work like integers:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> int(my_location.start)
 5
 >>> int(my_location.end)
 9
-\end{verbatim}
+\end{minted}
 
 For compatibility with older versions of Biopython you can ask for the
 \verb|nofuzzy_start| and \verb|nofuzzy_end| attributes of the location
 which are plain integers:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> my_location.nofuzzy_start
 5
 >>> my_location.nofuzzy_end
 9
-\end{verbatim}
+\end{minted}
 
 Notice that this just gives you back the position attributes of the fuzzy locations.
 
 Similarly, to make it easy to create a position without worrying about fuzzy positions, you can just pass in numbers to the \verb|FeaturePosition| constructors, and you'll get back out \verb|ExactPosition| objects:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> exact_location = SeqFeature.FeatureLocation(5, 9)
 >>> print(exact_location)
 [5:9]
@@ -487,7 +488,7 @@ ExactPosition(5)
 5
 >>> exact_location.nofuzzy_start
 5
-\end{verbatim}
+\end{minted}
 
 That is most of the nitty gritty about dealing with fuzzy positions in Biopython.
 It has been designed so that dealing with fuzziness is not that much more
@@ -505,7 +506,7 @@ features this SNP is within, and lets suppose this SNP is at index 4350
 check all the features one by one in a loop:
 
 %doctest ../Tests/GenBank
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> my_snp = 4350
 >>> record = SeqIO.read("NC_005816.gb", "genbank")
@@ -516,7 +517,7 @@ check all the features one by one in a loop:
 source ['taxon:229193']
 gene ['GeneID:2767712']
 CDS ['GI:45478716', 'GeneID:2767712']
-\end{verbatim}
+\end{minted}
 
 Note that gene and CDS features from GenBank or EMBL files defined with joins
 are the union of the exons -- they do not cover any introns.
@@ -528,37 +529,37 @@ are the union of the exons -- they do not cover any introns.
 A \verb|SeqFeature| or location object doesn't directly contain a sequence, instead the location (see Section~\ref{sec:locations}) describes how to get this from the parent sequence. For example consider a (short) gene sequence with location 5:18 on the reverse strand, which in GenBank/EMBL notation using 1-based counting would be \texttt{complement(6..18)}, like this:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
 >>> example_parent = Seq("ACCGAGACGGCAAAGGCTAGCATAGGTATGAGACTTCCTTCCTGCCAGTGCTGAGGAACTGGGAGCCTAC")
 >>> example_feature = SeqFeature(FeatureLocation(5, 18), type="gene", strand=-1)
-\end{verbatim}
+\end{minted}
 
 You could take the parent sequence, slice it to extract 5:18, and then take the reverse complement.
 If you are using Biopython 1.59 or later, the feature location's start and end are integer like so this works:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> feature_seq = example_parent[example_feature.location.start:example_feature.location.end].reverse_complement()
 >>> print(feature_seq)
 AGCCTTTGCCGTC
-\end{verbatim}
+\end{minted}
 
 This is a simple example so this isn't too bad -- however once you have to deal with compound features (joins) this is rather messy. Instead, the \verb|SeqFeature| object has an \verb|extract| method to take care of all this:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> feature_seq = example_feature.extract(example_parent)
 >>> print(feature_seq)
 AGCCTTTGCCGTC
-\end{verbatim}
+\end{minted}
 
 The length of a \verb|SeqFeature| or location matches
 that of the region of sequence it describes.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(example_feature.extract(example_parent))
 AGCCTTTGCCGTC
 >>> print(len(example_feature.extract(example_parent)))
@@ -567,7 +568,7 @@ AGCCTTTGCCGTC
 13
 >>> print(len(example_feature.location))
 13
-\end{verbatim}
+\end{minted}
 
 For simple \verb|FeatureLocation| objects the length is just
 the difference between the start and end positions. However,
@@ -579,20 +580,20 @@ constituent regions.
 The \verb|SeqRecord| objects can be very complex, but here's a simple example:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.SeqRecord import SeqRecord
 >>> record1 = SeqRecord(Seq("ACGT"), id="test")
 >>> record2 = SeqRecord(Seq("ACGT"), id="test")
-\end{verbatim}
+\end{minted}
 
 What happens when you try to compare these ``identical'' records?
 
 %this is not a doctest:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record1 == record2
 ...
-\end{verbatim}
+\end{minted}
 
 Perhaps surprisingly older versions of Biopython would use Python's default object
 comparison for the \verb|SeqRecord|, meaning \verb|record1 == record2| would
@@ -601,32 +602,32 @@ In this example, \verb|record1 == record2| would have returned \verb|False|
 here!
 
 %this is not a doctest:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record1 == record2  # on old versions of Biopython!
 False
-\end{verbatim}
+\end{minted}
 
 As of Biopython 1.67, \verb|SeqRecord| comparison like \verb|record1 == record2|
 will instead raise an explicit error to avoid people being caught out by this:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record1 == record2
 Traceback (most recent call last):
 ...
 NotImplementedError: SeqRecord comparison is deliberately not implemented. Explicitly compare the attributes of interest.
-\end{verbatim}
+\end{minted}
 
 Instead you should check the attributes you are interested in, for example the
 identifier and the sequence:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record1.id == record2.id
 True
 >>> record1.seq == record2.seq
 True
-\end{verbatim}
+\end{minted}
 
 Beware that comparing complex objects quickly gets complicated (see also
 Section~\ref{sec:seq-comparison}).
@@ -649,7 +650,7 @@ The \verb|format()| method of the \verb|SeqRecord| class gives a string
 containing your record formatted using one of the output file formats
 supported by \verb|Bio.SeqIO|, such as FASTA:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Alphabet import generic_protein
@@ -662,7 +663,7 @@ record = SeqRecord(Seq("MMYQQGCFAGGTVLRLAKDLAENNRGARVLVVCSEITAVTFRGPSETHLDSMVGQA
                    description="chalcone synthase [Cucumis sativus]")
 
 print(record.format("fasta"))
-\end{verbatim}
+\end{minted}
 \noindent which should give:
 \begin{verbatim}
 >gi|14150838|gb|AAK54648.1|AF376133_1 chalcone synthase [Cucumis sativus]
@@ -689,25 +690,25 @@ completely within the new sequence are preserved (with their locations adjusted)
 For example, taking the same GenBank file used earlier:
 
 %doctest ../Tests/GenBank
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.gb", "genbank")
-\end{verbatim}
+\end{minted}
 %TODO - support line wrapping in doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record
 SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG',
 IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
 description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence',
 dbxrefs=['Project:58037'])
-\end{verbatim}
+\end{minted}
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(record)
 9609
 >>> len(record.features)
 41
-\end{verbatim}
+\end{minted}
 
 
 For this example we're going to focus in on the \verb|pim| gene, \verb|YP_pPCP05|.
@@ -718,7 +719,7 @@ thirteenth entries in the file, so in Python zero-based counting they are
 entries $11$ and $12$ in the \texttt{features} list:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(record.features[20])
 type: gene
 location: [4342:4780](+)
@@ -727,9 +728,9 @@ qualifiers:
     Key: gene, Value: ['pim']
     Key: locus_tag, Value: ['YP_pPCP05']
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 %This one is truncated so can't use for doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(record.features[21])
 type: CDS
 location: [4342:4780](+)
@@ -743,35 +744,35 @@ qualifiers:
     Key: protein_id, Value: ['NP_995571.1']
     Key: transl_table, Value: ['11']
     Key: translation, Value: ['MGGGMISKLFCLALIFLSSSGLAEKNTYTAKDILQNLELNTFGNSLSH...']
-\end{verbatim}
+\end{minted}
 
 Let's slice this parent record from 4300 to 4800 (enough to include the \verb|pim|
 gene/CDS), and see how many features we get:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> sub_record = record[4300:4800]
-\end{verbatim}
+\end{minted}
 %TODO - Line wrapping for doctest?
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> sub_record
 SeqRecord(seq=Seq('ATAAATAGATTATTCCAAATAATTTATTTATGTAAGAACAGGATGGGAGGGGGA...TTA',
 IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
 description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence.',
 dbxrefs=[])
-\end{verbatim}
+\end{minted}
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(sub_record)
 500
 >>> len(sub_record.features)
 2
-\end{verbatim}
+\end{minted}
 
 Our sub-record just has two features, the gene and CDS entries for \verb|YP_pPCP05|:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(sub_record.features[0])
 type: gene
 location: [42:480](+)
@@ -780,9 +781,9 @@ qualifiers:
     Key: gene, Value: ['pim']
     Key: locus_tag, Value: ['YP_pPCP05']
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 %As above, output is truncated so cannot test this as a doctest:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(sub_record.features[1])
 type: CDS
 location: [42:480](+)
@@ -796,7 +797,7 @@ qualifiers:
     Key: protein_id, Value: ['NP_995571.1']
     Key: transl_table, Value: ['11']
     Key: translation, Value: ['MGGGMISKLFCLALIFLSSSGLAEKNTYTAKDILQNLELNTFGNSLSH...']
-\end{verbatim}
+\end{minted}
 
 \noindent Notice that their locations have been adjusted to reflect the new parent sequence!
 
@@ -807,36 +808,36 @@ and \texttt{dbxrefs} are omitted from the sub-record, and it is up to you to tra
 any relevant information as appropriate.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> sub_record.annotations
 {}
 >>> sub_record.dbxrefs
 []
-\end{verbatim}
+\end{minted}
 
 The same point could be made about the record \texttt{id}, \texttt{name}
 and \texttt{description}, but for practicality these are preserved:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> sub_record.id
 'NC_005816.1'
 >>> sub_record.name
 'NC_005816'
 >>> sub_record.description
 'Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence'
-\end{verbatim}
+\end{minted}
 
 \noindent This illustrates the problem nicely though, our new sub-record is
 \emph{not} the complete sequence of the plasmid, so the description is wrong!
 Let's fix this and then view the sub-record as a reduced GenBank file using
 the \texttt{format} method described above in Section~\ref{sec:SeqRecord-format}:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> sub_record.description = "Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, partial."
 >>> print(sub_record.format("genbank"))
 ...
-\end{verbatim}
+\end{minted}
 
 See Sections~\ref{sec:FASTQ-slicing-off-primer}
 and~\ref{sec:FASTQ-slicing-off-adaptor} for some FASTQ examples where the
@@ -855,20 +856,20 @@ For an example with per-letter annotation, we'll use the first record in a
 FASTQ file. Chapter~\ref{chapter:Bio.SeqIO} will explain the \verb|SeqIO| functions:
 
 %doctest ../Tests/Quality
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> record = next(SeqIO.parse("example.fastq", "fastq"))
 >>> len(record)
 25
 >>> print(record.seq)
 CCCTTCTTGTCTTCAGCGTTTCTCC
-\end{verbatim}
+\end{minted}
 %TODO - doctest wrapping
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(record.letter_annotations["phred_quality"])
 [26, 26, 18, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 22, 26, 26, 26, 26,
 26, 26, 26, 23, 23]
-\end{verbatim}
+\end{minted}
 
 \noindent Let's suppose this was Roche 454 data, and that from other information
 you think the \texttt{TTT} should be only \texttt{TT}. We can make a new edited
@@ -876,7 +877,7 @@ record by first slicing the \verb|SeqRecord| before and after the ``extra''
 third \texttt{T}:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> left = record[:20]
 >>> print(left.seq)
 CCCTTCTTGTCTTCAGCGTT
@@ -887,102 +888,102 @@ CCCTTCTTGTCTTCAGCGTT
 CTCC
 >>> print(right.letter_annotations["phred_quality"])
 [26, 26, 23, 23]
-\end{verbatim}
+\end{minted}
 
 \noindent Now add the two parts together:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> edited = left + right
 >>> len(edited)
 24
 >>> print(edited.seq)
 CCCTTCTTGTCTTCAGCGTTCTCC
-\end{verbatim}
-\begin{verbatim}
+\end{minted}
+\begin{minted}{pycon}
 >>> print(edited.letter_annotations["phred_quality"])
 [26, 26, 18, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 22, 26, 26, 26, 26,
 26, 26, 23, 23]
-\end{verbatim}
+\end{minted}
 
 \noindent Easy and intuitive? We hope so! You can make this shorter with just:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> edited = record[:20] + record[21:]
-\end{verbatim}
+\end{minted}
 
 Now, for an example with features, we'll use a GenBank file.
 Suppose you have a circular genome:
 
 %doctest ../Tests/GenBank
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.gb", "genbank")
-\end{verbatim}
+\end{minted}
 %TODO - doctest wrapping
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record
 SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG',
 IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
 description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence.',
 dbxrefs=['Project:10638'])
-\end{verbatim}
+\end{minted}
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(record)
 9609
 >>> len(record.features)
 41
 >>> record.dbxrefs
 ['Project:58037']
-\end{verbatim}
+\end{minted}
 %TODO - doctest wrapping
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record.annotations.keys()
 ['comment', 'sequence_version', 'source', 'taxonomy', 'keywords', 'references',
 'accessions', 'data_file_division', 'date', 'organism', 'gi']
-\end{verbatim}
+\end{minted}
 
 You can shift the origin like this:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> shifted = record[2000:] + record[:2000]
-\end{verbatim}
+\end{minted}
 %TODO - doctest wrapping
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> shifted
 SeqRecord(seq=Seq('GATACGCAGTCATATTTTTTACACAATTCTCTAATCCCGACAAGGTCGTAGGTC...GGA',
 IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
 description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence.',
 dbxrefs=[])
-\end{verbatim}
+\end{minted}
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(shifted)
 9609
-\end{verbatim}
+\end{minted}
 
 Note that this isn't perfect in that some annotation like the database cross references
 and one of the features (the source feature) have been lost:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(shifted.features)
 40
 >>> shifted.dbxrefs
 []
 >>> shifted.annotations.keys()
 []
-\end{verbatim}
+\end{minted}
 
 This is because the \verb|SeqRecord| slicing step is cautious in what annotation
 it preserves (erroneously propagating annotation can cause major problems). If
 you want to keep the database cross references or the annotations dictionary,
 this must be done explicitly:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> shifted.dbxrefs = record.dbxrefs[:]
 >>> shifted.annotations = record.annotations.copy()
 >>> shifted.dbxrefs
@@ -990,7 +991,7 @@ this must be done explicitly:
 >>> shifted.annotations.keys()
 ['comment', 'sequence_version', 'source', 'taxonomy', 'keywords', 'references',
 'accessions', 'data_file_division', 'date', 'organism', 'gi']
-\end{verbatim}
+\end{minted}
 
 Also note that in an example like this, you should probably change the record
 identifiers since the NCBI references refer to the \emph{original} unmodified
@@ -1024,20 +1025,20 @@ the new desired value instead.
 Consider this example record:
 
 %doctest ../Tests/GenBank
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.gb", "genbank")
 >>> print("%s %i %i %i %i" % (record.id, len(record), len(record.features), len(record.dbxrefs), len(record.annotations)))
 NC_005816.1 9609 41 1 13
-\end{verbatim}
+\end{minted}
 
 Here we take the reverse complement and specify a new identifier -- but notice
 how most of the annotation is dropped (but not the features):
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> rc = record.reverse_complement(id="TESTING")
 >>> print("%s %i %i %i %i" % (rc.id, len(rc), len(rc.features), len(rc.dbxrefs), len(rc.annotations)))
 TESTING 9609 41 0 0
-\end{verbatim}
+\end{minted}
 

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -23,19 +23,19 @@ Now that we know what we are dealing with, let's look at how to utilize this cla
 You can create an ambiguous sequence with the default generic alphabet like this:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> my_seq = Seq("AGTACACTGGT")
 >>> my_seq
 Seq('AGTACACTGGT')
 >>> my_seq.alphabet
 Alphabet()
-\end{verbatim}
+\end{minted}
 
 However, where possible you should specify the alphabet explicitly when creating your sequence objects - in this case an unambiguous DNA alphabet object:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> my_seq = Seq("AGTACACTGGT", IUPAC.unambiguous_dna)
@@ -43,12 +43,12 @@ However, where possible you should specify the alphabet explicitly when creating
 Seq('AGTACACTGGT', IUPACUnambiguousDNA())
 >>> my_seq.alphabet
 IUPACUnambiguousDNA()
-\end{verbatim}
+\end{minted}
 
 Unless of course, this really is an amino acid sequence:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> my_prot = Seq("AGTACACTGGT", IUPAC.protein)
@@ -56,14 +56,14 @@ Unless of course, this really is an amino acid sequence:
 Seq('AGTACACTGGT', IUPACProtein())
 >>> my_prot.alphabet
 IUPACProtein()
-\end{verbatim}
+\end{minted}
 
 \section{Sequences act like strings}
 
 In many ways, we can deal with Seq objects as if they were normal Python strings, for example getting the length, or iterating over the elements:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> my_seq = Seq("GATCG", IUPAC.unambiguous_dna)
@@ -76,39 +76,39 @@ In many ways, we can deal with Seq objects as if they were normal Python strings
 4 G
 >>> print(len(my_seq))
 5
-\end{verbatim}
+\end{minted}
 
 You can access elements of the sequence in the same way as for strings (but remember, Python counts from zero!):
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(my_seq[0]) #first letter
 G
 >>> print(my_seq[2]) #third letter
 T
 >>> print(my_seq[-1]) #last letter
 G
-\end{verbatim}
+\end{minted}
 
 The \verb|Seq| object has a \verb|.count()| method, just like a string.
 Note that this means that like a Python string, this gives a
 \emph{non-overlapping} count:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> "AAAA".count("AA")
 2
 >>> Seq("AAAA").count("AA")
 2
-\end{verbatim}
+\end{minted}
 
 \noindent For some biological uses, you may actually want an overlapping count
 (i.e. $3$ in this trivial example). When searching for single letters, this
 makes no difference:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> my_seq = Seq("GATCGATGGGCCTATATAGGATCGAAAATCGC", IUPAC.unambiguous_dna)
@@ -118,19 +118,19 @@ makes no difference:
 9
 >>> 100 * float(my_seq.count("G") + my_seq.count("C")) / len(my_seq)
 46.875
-\end{verbatim}
+\end{minted}
 
 While you could use the above snippet of code to calculate a GC\%, note that  the \verb|Bio.SeqUtils| module has several GC functions already built.  For example:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> from Bio.SeqUtils import GC
 >>> my_seq = Seq("GATCGATGGGCCTATATAGGATCGAAAATCGC", IUPAC.unambiguous_dna)
 >>> GC(my_seq)
 46.875
-\end{verbatim}
+\end{minted}
 
 \noindent Note that using the \verb|Bio.SeqUtils.GC()| function should automatically cope with mixed case sequences and the ambiguous nucleotide S which means G or C.
 
@@ -141,13 +141,13 @@ Also note that just like a normal Python string, the \verb|Seq| object is in som
 A more complicated example, let's get a slice of the sequence:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> my_seq = Seq("GATCGATGGGCCTATATAGGATCGAAAATCGC", IUPAC.unambiguous_dna)
 >>> my_seq[4:12]
 Seq('GATGGGCC', IUPACUnambiguousDNA())
-\end{verbatim}
+\end{minted}
 
 Two things are interesting to note. First, this follows the normal conventions for Python strings.  So the first element of the sequence is 0 (which is normal for computer science, but not so normal for biology). When you do a slice the first item is included (i.e.~4 in this case) and the last is excluded (12 in this case), which is the way things work in Python, but of course not necessarily the way everyone in the world would expect. The main goal is to stay consistent with what Python does.
 
@@ -156,52 +156,52 @@ The second thing to notice is that the slice is performed on the sequence data s
 Also like a Python string, you can do slices with a start, stop and \emph{stride} (the step size, which defaults to one).  For example, we can get the first, second and third codon positions of this DNA sequence:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> my_seq[0::3]
 Seq('GCTGTAGTAAG', IUPACUnambiguousDNA())
 >>> my_seq[1::3]
 Seq('AGGCATGCATC', IUPACUnambiguousDNA())
 >>> my_seq[2::3]
 Seq('TAGCTAAGAC', IUPACUnambiguousDNA())
-\end{verbatim}
+\end{minted}
 
 Another stride trick you might have seen with a Python string is the use of a -1 stride to reverse the string.  You can do this with a \verb|Seq| object too:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> my_seq[::-1]
 Seq('CGCTAAAAGCTAGGATATATCCGGGTAGCTAG', IUPACUnambiguousDNA())
-\end{verbatim}
+\end{minted}
 
 \section{Turning Seq objects into strings}
 \label{sec:seq-to-string}
 
 If you really do just need a plain string, for example to write to a file, or insert into a database, then this is very easy to get:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> str(my_seq)
 'GATCGATGGGCCTATATAGGATCGAAAATCGC'
-\end{verbatim}
+\end{minted}
 
 Since calling \verb|str()| on a \verb|Seq| object returns the full sequence as a string,
 you often don't actually have to do this conversion explicitly.
 Python does this automatically in the print function
 (and the print statement under Python 2):
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(my_seq)
 GATCGATGGGCCTATATAGGATCGAAAATCGC
-\end{verbatim}
+\end{minted}
 
 You can also use the \verb|Seq| object directly with a \verb|%s| placeholder when using the Python string formatting or interpolation operator (\verb|%|):
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> fasta_format_string = ">Name\n%s\n" % my_seq
 >>> print(fasta_format_string)
 >Name
 GATCGATGGGCCTATATAGGATCGAAAATCGC
 <BLANKLINE>
-\end{verbatim}
+\end{minted}
 
 \noindent This line of code constructs a simple FASTA format record (without worrying about line wrapping).
 Section~\ref{sec:SeqRecord-format} describes a neat way to get a FASTA formatted
@@ -209,17 +209,17 @@ string from a \verb|SeqRecord| object, while the more general topic of reading a
 writing FASTA format sequence files is covered in Chapter~\ref{chapter:Bio.SeqIO}.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> str(my_seq)
 'GATCGATGGGCCTATATAGGATCGAAAATCGC'
-\end{verbatim}
+\end{minted}
 
 \section{Concatenating or adding sequences}
 
 Naturally, you can in principle add any two Seq objects together - just like you can with Python strings to concatenate them.  However, you can't add sequences with incompatible alphabets, such as a protein sequence and a DNA sequence:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Alphabet import IUPAC
 >>> from Bio.Seq import Seq
 >>> protein_seq = Seq("EVRNAK", IUPAC.protein)
@@ -228,23 +228,23 @@ Naturally, you can in principle add any two Seq objects together - just like you
 Traceback (most recent call last):
 ...
 TypeError: Incompatible alphabets IUPACProtein() and IUPACUnambiguousDNA()
-\end{verbatim}
+\end{minted}
 
 If you \emph{really} wanted to do this, you'd have to first give both sequences generic alphabets:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Alphabet import generic_alphabet
 >>> protein_seq.alphabet = generic_alphabet
 >>> dna_seq.alphabet = generic_alphabet
 >>> protein_seq + dna_seq
 Seq('EVRNAKACGT')
-\end{verbatim}
+\end{minted}
 
 Here is an example of adding a generic nucleotide sequence to an unambiguous IUPAC DNA sequence, resulting in an ambiguous nucleotide sequence:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import generic_nucleotide
 >>> from Bio.Alphabet import IUPAC
@@ -256,12 +256,12 @@ Seq('GATCGATGC', NucleotideAlphabet())
 Seq('ACGT', IUPACUnambiguousDNA())
 >>> nuc_seq + dna_seq
 Seq('GATCGATGCACGT', NucleotideAlphabet())
-\end{verbatim}
+\end{minted}
 
 You may often have many sequences to add together, which can be done with a for loop like this:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import generic_dna
 >>> list_of_seqs = [Seq("ACGT", generic_dna), Seq("AACC", generic_dna), Seq("GGTT", generic_dna)]
@@ -271,18 +271,18 @@ You may often have many sequences to add together, which can be done with a for 
 ...
 >>> concatenated
 Seq('ACGTAACCGGTT', DNAAlphabet())
-\end{verbatim}
+\end{minted}
 
 Or, a more elegant approach is to the use built in \verb|sum| function with its optional start value argument (which otherwise defaults to zero):
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import generic_dna
 >>> list_of_seqs = [Seq("ACGT", generic_dna), Seq("AACC", generic_dna), Seq("GGTT", generic_dna)]
 >>> sum(list_of_seqs, Seq("", generic_dna))
 Seq('ACGTAACCGGTT', DNAAlphabet())
-\end{verbatim}
+\end{minted}
 
 Unlike the Python string, the Biopython \verb|Seq| does not (currently) have a \verb|.join| method.
 
@@ -293,7 +293,7 @@ As of Biopython 1.53, the \verb|Seq| object gained similar methods which are alp
 For example,
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import generic_dna
 >>> dna_seq = Seq("acgtACGT", generic_dna)
@@ -303,23 +303,23 @@ Seq('acgtACGT', DNAAlphabet())
 Seq('ACGTACGT', DNAAlphabet())
 >>> dna_seq.lower()
 Seq('acgtacgt', DNAAlphabet())
-\end{verbatim}
+\end{minted}
 
 These are useful for doing case insensitive matching:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> "GTAC" in dna_seq
 False
 >>> "GTAC" in dna_seq.upper()
 True
-\end{verbatim}
+\end{minted}
 
 Note that strictly speaking the IUPAC alphabets are for upper case
 sequences only, thus:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> dna_seq = Seq("ACGT", IUPAC.unambiguous_dna)
@@ -327,7 +327,7 @@ sequences only, thus:
 Seq('ACGT', IUPACUnambiguousDNA())
 >>> dna_seq.lower()
 Seq('acgt', DNAAlphabet())
-\end{verbatim}
+\end{minted}
 
 
 \section{Nucleotide sequences and (reverse) complements}
@@ -337,7 +337,7 @@ For nucleotide sequences, you can easily obtain the complement or reverse
 complement of a \verb|Seq| object using its built-in methods:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> my_seq = Seq("GATCGATGGGCCTATATAGGATCGAAAATCGC", IUPAC.unambiguous_dna)
@@ -347,23 +347,23 @@ Seq('GATCGATGGGCCTATATAGGATCGAAAATCGC', IUPACUnambiguousDNA())
 Seq('CTAGCTACCCGGATATATCCTAGCTTTTAGCG', IUPACUnambiguousDNA())
 >>> my_seq.reverse_complement()
 Seq('GCGATTTTCGATCCTATATAGGCCCATCGATC', IUPACUnambiguousDNA())
-\end{verbatim}
+\end{minted}
 
 As mentioned earlier, an easy way to just reverse a \verb|Seq| object (or a
 Python string) is slice it with -1 step:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> my_seq[::-1]
 Seq('CGCTAAAAGCTAGGATATATCCGGGTAGCTAG', IUPACUnambiguousDNA())
-\end{verbatim}
+\end{minted}
 
 In all of these operations, the alphabet property is maintained. This is very
 useful in case you accidentally end up trying to do something weird like take
 the (reverse)complement of a protein sequence:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> protein_seq = Seq("EVRNAK", IUPAC.protein)
@@ -371,7 +371,7 @@ the (reverse)complement of a protein sequence:
 Traceback (most recent call last):
 ...
 ValueError: Proteins do not have complements!
-\end{verbatim}
+\end{minted}
 
 The example in Section~\ref{sec:SeqIO-reverse-complement} combines the \verb|Seq|
 object's reverse complement method with \verb|Bio.SeqIO| for sequence input/output.
@@ -402,7 +402,7 @@ The actual biological transcription process works from the template strand, doin
 
 Now let's actually get down to doing a transcription in Biopython.  First, let's create \verb|Seq| objects for the coding and template DNA strands:
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG", IUPAC.unambiguous_dna)
@@ -411,30 +411,30 @@ Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', IUPACUnambiguousDNA())
 >>> template_dna = coding_dna.reverse_complement()
 >>> template_dna
 Seq('CTATCGGGCACCCTTTCAGCGGCCCATTACAATGGCCAT', IUPACUnambiguousDNA())
-\end{verbatim}
+\end{minted}
 \noindent These should match the figure above - remember by convention nucleotide sequences are normally read from the 5' to 3' direction, while in the figure the template strand is shown reversed.
 
 Now let's transcribe the coding strand into the corresponding mRNA, using the \verb|Seq| object's built in \verb|transcribe| method:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> coding_dna
 Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', IUPACUnambiguousDNA())
 >>> messenger_rna = coding_dna.transcribe()
 >>> messenger_rna
 Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
-\end{verbatim}
+\end{minted}
 \noindent As you can see, all this does is switch T $\rightarrow$ U, and adjust the alphabet.
 
 If you do want to do a true biological transcription starting with the template strand, then this becomes a two-step process:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> template_dna.reverse_complement().transcribe()
 Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
-\end{verbatim}
+\end{minted}
 
 The \verb|Seq| object also includes a back-transcription method for going from the mRNA to the coding strand of the DNA.  Again, this is a simple U $\rightarrow$ T substitution and associated change of alphabet:
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> messenger_rna = Seq("AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG", IUPAC.unambiguous_rna)
@@ -442,7 +442,7 @@ The \verb|Seq| object also includes a back-transcription method for going from t
 Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
 >>> messenger_rna.back_transcribe()
 Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', IUPACUnambiguousDNA())
-\end{verbatim}
+\end{minted}
 
 \emph{Note:} The \verb|Seq| object's \verb|transcribe| and \verb|back_transcribe| methods
 were added in Biopython 1.49.  For older releases you would have to use the \verb|Bio.Seq|
@@ -455,7 +455,7 @@ now let's translate this mRNA into the corresponding protein sequence - again ta
 advantage of one of the \verb|Seq| object's biological methods:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> messenger_rna = Seq("AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG", IUPAC.unambiguous_rna)
@@ -463,11 +463,11 @@ advantage of one of the \verb|Seq| object's biological methods:
 Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
 >>> messenger_rna.translate()
 Seq('MAIVMGR*KGAR*', HasStopCodon(IUPACProtein(), '*'))
-\end{verbatim}
+\end{minted}
 
 You can also translate directly from the coding strand DNA sequence:
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG", IUPAC.unambiguous_dna)
@@ -475,29 +475,29 @@ You can also translate directly from the coding strand DNA sequence:
 Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', IUPACUnambiguousDNA())
 >>> coding_dna.translate()
 Seq('MAIVMGR*KGAR*', HasStopCodon(IUPACProtein(), '*'))
-\end{verbatim}
+\end{minted}
 
 You should notice in the above protein sequences that in addition to the end stop character, there is an internal stop as well.  This was a deliberate choice of example, as it gives an excuse to talk about some optional arguments, including different translation tables (Genetic Codes).
 
 The translation tables available in Biopython are based on those \href{https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi}{from the NCBI} (see the next section of this tutorial).  By default, translation will use the \emph{standard} genetic code (NCBI table id 1).
 Suppose we are dealing with a mitochondrial sequence.  We need to tell the translation function to use the relevant genetic code instead:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> coding_dna.translate(table="Vertebrate Mitochondrial")
 Seq('MAIVMGRWKGAR*', HasStopCodon(IUPACProtein(), '*'))
-\end{verbatim}
+\end{minted}
 
 You can also specify the table using the NCBI table number which is shorter, and often included in the feature annotation of GenBank files:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> coding_dna.translate(table=2)
 Seq('MAIVMGRWKGAR*', HasStopCodon(IUPACProtein(), '*'))
-\end{verbatim}
+\end{minted}
 
 Now, you may want to translate the nucleotides up to the first in frame stop codon,
 and then stop (as happens in nature):
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> coding_dna.translate()
 Seq('MAIVMGR*KGAR*', HasStopCodon(IUPACProtein(), '*'))
 >>> coding_dna.translate(to_stop=True)
@@ -506,17 +506,17 @@ Seq('MAIVMGR', IUPACProtein())
 Seq('MAIVMGRWKGAR*', HasStopCodon(IUPACProtein(), '*'))
 >>> coding_dna.translate(table=2, to_stop=True)
 Seq('MAIVMGRWKGAR', IUPACProtein())
-\end{verbatim}
+\end{minted}
 \noindent Notice that when you use the \verb|to_stop| argument, the stop codon itself
 is not translated - and the stop symbol is not included at the end of your protein
 sequence.
 
 You can even specify the stop symbol if you don't like the default asterisk:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> coding_dna.translate(table=2, stop_symbol="@")
 Seq('MAIVMGRWKGAR@', HasStopCodon(IUPACProtein(), '@'))
-\end{verbatim}
+\end{minted}
 
 Now, suppose you have a complete coding sequence CDS, which is to say a
 nucleotide sequence (e.g. mRNA -- after any splicing) which is a whole number
@@ -528,7 +528,7 @@ sequence uses a non-standard start codon? This happens a lot in bacteria --
 for example the gene yaaX in \texttt{E. coli} K12:
 
 %TODO - handle line wrapping in doctest?
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import generic_dna
 >>> gene = Seq("GTGAAAAAGATGCAATCTATCGTACTCGCACTTTCCCTGGTTCTGGTCGCTCCCATGGCA" + \
@@ -543,7 +543,7 @@ HasStopCodon(ExtendedIUPACProtein(), '*')
 >>> gene.translate(table="Bacterial", to_stop=True)
 Seq('VKKMQSIVLALSLVLVAPMAAQAAEITLVPSVKLQIGDRDNRGYYWDGGHWRDH...HHR',
 ExtendedIUPACProtein())
-\end{verbatim}
+\end{minted}
 
 \noindent In the bacterial genetic code \texttt{GTG} is a valid start codon,
 and while it does \emph{normally} encode Valine, if used as a start codon it
@@ -551,11 +551,11 @@ should be translated as methionine. This happens if you tell Biopython your
 sequence is a complete CDS:
 
 %TODO - handle line wrapping in doctest?
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> gene.translate(table="Bacterial", cds=True)
 Seq('MKKMQSIVLALSLVLVAPMAAQAAEITLVPSVKLQIGDRDNRGYYWDGGHWRDH...HHR',
 ExtendedIUPACProtein())
-\end{verbatim}
+\end{minted}
 
 In addition to telling Biopython to translate an alternative start codon as
 methionine, using this option also makes sure your sequence really is a valid
@@ -576,23 +576,23 @@ As before, let's just focus on two choices: the Standard translation table, and 
 translation table for Vertebrate Mitochondrial DNA.
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Data import CodonTable
 >>> standard_table = CodonTable.unambiguous_dna_by_name["Standard"]
 >>> mito_table = CodonTable.unambiguous_dna_by_name["Vertebrate Mitochondrial"]
-\end{verbatim}
+\end{minted}
 
 Alternatively, these tables are labeled with ID numbers 1 and 2, respectively:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Data import CodonTable
 >>> standard_table = CodonTable.unambiguous_dna_by_id[1]
 >>> mito_table = CodonTable.unambiguous_dna_by_id[2]
-\end{verbatim}
+\end{minted}
 
 You can compare the actual tables visually by printing them:
 %TODO - handle <BLANKLINE> automatically in doctest?
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(standard_table)
 Table 1 Standard, SGC0
 
@@ -618,9 +618,9 @@ G | GTC V   | GCC A   | GAC D   | GGC G   | C
 G | GTA V   | GCA A   | GAA E   | GGA G   | A
 G | GTG V   | GCG A   | GAG E   | GGG G   | G
 --+---------+---------+---------+---------+--
-\end{verbatim}
+\end{minted}
 \noindent and:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(mito_table)
 Table 2 Vertebrate Mitochondrial, SGC1
 
@@ -646,19 +646,19 @@ G | GTC V   | GCC A   | GAC D   | GGC G   | C
 G | GTA V   | GCA A   | GAA E   | GGA G   | A
 G | GTG V(s)| GCG A   | GAG E   | GGG G   | G
 --+---------+---------+---------+---------+--
-\end{verbatim}
+\end{minted}
 
 You may find these following properties useful -- for example if you are trying
 to do your own gene finding:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> mito_table.stop_codons
 ['TAA', 'TAG', 'AGA', 'AGG']
 >>> mito_table.start_codons
 ['ATT', 'ATC', 'ATA', 'ATG', 'GTG']
 >>> mito_table.forward_table["ACG"]
 'T'
-\end{verbatim}
+\end{minted}
 
 \section{Comparing Seq objects}
 \label{sec:seq-comparison}
@@ -692,7 +692,7 @@ alphabet, or at least all be the same type of sequence (all DNA, all RNA, or
 all protein). What you probably want is to just compare the sequences as
 strings -- which you can do explicitly:
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> seq1 = Seq("ACGT", IUPAC.unambiguous_dna)
@@ -701,18 +701,18 @@ strings -- which you can do explicitly:
 True
 >>> str(seq1) == str(seq1)
 True
-\end{verbatim}
+\end{minted}
 
 So, what does Biopython do? Well, as of Biopython 1.65, sequence comparison
 only looks at the sequence, essentially ignoring the alphabet:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> seq1 == seq2
 True
 >>> seq1 == "ACGT"
 True
-\end{verbatim}
+\end{minted}
 
 As an extension to this, using sequence objects as keys in a Python dictionary
 is now equivalent to using the sequence as a plain string for the key.
@@ -722,7 +722,7 @@ Note if you compare sequences with incompatible alphabets (e.g. DNA vs RNA,
 or nucleotide versus protein), then you will get a warning but for the
 comparison itself only the string of letters in the sequence is used:
 %Can we do a doctest with a warning?
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import generic_dna, generic_protein
 >>> dna_seq = Seq("ACGT", generic_dna)
@@ -730,7 +730,7 @@ comparison itself only the string of letters in the sequence is used:
 >>> dna_seq == prot_seq
 BiopythonWarning: Incompatible alphabets DNAAlphabet() and ProteinAlphabet()
 True
-\end{verbatim}
+\end{minted}
 
 \noindent
 \emph{WARNING:} Older versions of Biopython instead used to check if the
@@ -746,41 +746,41 @@ comparison or \verb|id(...)| for object instance based comparison.
 Just like the normal Python string, the \verb|Seq| object is ``read only'', or in Python terminology, immutable.  Apart from wanting the \verb|Seq| object to act like a string, this is also a useful default since in many biological applications you want to ensure you are not changing your sequence data:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
 >>> my_seq = Seq("GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA", IUPAC.unambiguous_dna)
-\end{verbatim}
+\end{minted}
 
 Observe what happens if you try to edit the sequence:
 %TODO - This is not a doctest as Python 2.4 output omits the object name.
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> my_seq[5] = "G"
 Traceback (most recent call last):
 ...
 TypeError: 'Seq' object does not support item assignment
-\end{verbatim}
+\end{minted}
 
 However, you can convert it into a mutable sequence (a \verb|MutableSeq| object) and do pretty much anything you want with it:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> mutable_seq = my_seq.tomutable()
 >>> mutable_seq
 MutableSeq('GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA', IUPACUnambiguousDNA())
-\end{verbatim}
+\end{minted}
 
 Alternatively, you can create a \verb|MutableSeq| object directly from a string:
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import MutableSeq
 >>> from Bio.Alphabet import IUPAC
 >>> mutable_seq = MutableSeq("GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA", IUPAC.unambiguous_dna)
-\end{verbatim}
+\end{minted}
 
 Either way will give you a sequence object which can be changed:
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> mutable_seq
 MutableSeq('GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA', IUPACUnambiguousDNA())
 >>> mutable_seq[5] = "C"
@@ -792,7 +792,7 @@ MutableSeq('GCCACGTAATGGGCCGCTGAAAGGGTGCCCGA', IUPACUnambiguousDNA())
 >>> mutable_seq.reverse()
 >>> mutable_seq
 MutableSeq('AGCCCGTGGGAAAGTCGCCGGGTAATGCACCG', IUPACUnambiguousDNA())
-\end{verbatim}
+\end{minted}
 
 Do note that unlike the \verb|Seq| object, the \verb|MutableSeq| object's methods like \verb|reverse_complement()| and \verb|reverse()| act in-situ!
 
@@ -801,11 +801,11 @@ An important technical difference between mutable and immutable objects in Pytho
 Once you have finished editing your a \verb|MutableSeq| object, it's easy to get back to a read-only \verb|Seq| object should you need to:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> new_seq = mutable_seq.toseq()
 >>> new_seq
 Seq('AGCCCGTGGGAAAGTCGCCGGGTAATGCACCG', IUPACUnambiguousDNA())
-\end{verbatim}
+\end{minted}
 
 You can also get a string from a \verb|MutableSeq| object just like from a \verb|Seq| object (Section~\ref{sec:seq-to-string}).
 
@@ -818,7 +818,7 @@ rather a lot of memory to hold a string of a million ``N'' characters when you c
 just store a single letter ``N'' and the desired length as an integer.
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import UnknownSeq
 >>> unk = UnknownSeq(20)
 >>> unk
@@ -827,13 +827,13 @@ UnknownSeq(20, character='?')
 ????????????????????
 >>> len(unk)
 20
-\end{verbatim}
+\end{minted}
 
 You can of course specify an alphabet, meaning for nucleotide sequences
 the letter defaults to ``N'' and for proteins ``X'', rather than just ``?''.
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import UnknownSeq
 >>> from Bio.Alphabet import IUPAC
 >>> unk_dna = UnknownSeq(20, alphabet=IUPAC.ambiguous_dna)
@@ -841,13 +841,13 @@ the letter defaults to ``N'' and for proteins ``X'', rather than just ``?''.
 UnknownSeq(20, alphabet=IUPACAmbiguousDNA(), character='N')
 >>> print(unk_dna)
 NNNNNNNNNNNNNNNNNNNN
-\end{verbatim}
+\end{minted}
 
 You can use all the usual \verb|Seq| object methods too, note these give back
 memory saving \verb|UnknownSeq| objects where appropriate as you might expect:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> unk_dna
 UnknownSeq(20, alphabet=IUPACAmbiguousDNA(), character='N')
 >>> unk_dna.complement()
@@ -863,7 +863,7 @@ UnknownSeq(6, alphabet=ProteinAlphabet(), character='X')
 XXXXXX
 >>> len(unk_protein)
 6
-\end{verbatim}
+\end{minted}
 
 You may be able to find a use for the \verb|UnknownSeq| object in your own
 code, but it is more likely that you will first come across them in a
@@ -884,7 +884,7 @@ there are module level functions in \verb|Bio.Seq| will accept plain Python stri
 \verb|Seq| objects (including \verb|UnknownSeq| objects) or \verb|MutableSeq| objects:
 
 %doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.Seq import reverse_complement, transcribe, back_transcribe, translate
 >>> my_string = "GCTGTTATGGGTCGTTGGAAGGGTGGTCGTGCTGCTGGTTAG"
 >>> reverse_complement(my_string)
@@ -895,7 +895,7 @@ there are module level functions in \verb|Bio.Seq| will accept plain Python stri
 'GCTGTTATGGGTCGTTGGAAGGGTGGTCGTGCTGCTGGTTAG'
 >>> translate(my_string)
 'AVMGRWKGGRAAG*'
-\end{verbatim}
+\end{minted}
 
 \noindent You are, however, encouraged to work with \verb|Seq| objects by default.
 

--- a/Doc/Tutorial/chapter_seqio.tex
+++ b/Doc/Tutorial/chapter_seqio.tex
@@ -4,11 +4,11 @@
 In this chapter we'll discuss in more detail the \verb|Bio.SeqIO| module, which was briefly introduced in Chapter~\ref{chapter:quick-start} and also used in Chapter~\ref{chapter:SeqRecord}. This aims to provide a simple interface for working with assorted sequence file formats in a uniform way.
 See also the \verb|Bio.SeqIO| wiki page (\url{http://biopython.org/wiki/SeqIO}), and the built in documentation (also \href{http://biopython.org/DIST/docs/api/Bio.SeqIO-module.html}{online}):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> help(SeqIO)
 ...
-\end{verbatim}
+\end{minted}
 
 The ``catch'' is that you have to work with \verb|SeqRecord| objects (see Chapter~\ref{chapter:SeqRecord}), which contain a \verb|Seq| object (see Chapter~\ref{chapter:Bio.Seq}) plus annotation like an identifier and description.
 Note that when dealing with very large FASTA or FASTQ files, the overhead of working with all these objects can make scripts too slow.
@@ -34,23 +34,23 @@ Sometimes you'll find yourself dealing with files which contain only a single re
 
 In general \verb|Bio.SeqIO.parse()| is used to read in sequence files as \verb|SeqRecord| objects, and is typically used with a for loop like this:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 for seq_record in SeqIO.parse("ls_orchid.fasta", "fasta"):
     print(seq_record.id)
     print(repr(seq_record.seq))
     print(len(seq_record))
-\end{verbatim}
+\end{minted}
 
 The above example is repeated from the introduction in Section~\ref{sec:sequence-parsing}, and will load the orchid DNA sequences in the FASTA format file \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/ls_orchid.fasta}{ls\_orchid.fasta}.  If instead you wanted to load a GenBank format file like \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/ls_orchid.gbk}{ls\_orchid.gbk} then all you need to do is change the filename and the format string:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 for seq_record in SeqIO.parse("ls_orchid.gbk", "genbank"):
     print(seq_record.id)
     print(repr(seq_record.seq))
     print(len(seq_record))
-\end{verbatim}
+\end{minted}
 
 Similarly, if you wanted to read in a file in another file format, then assuming \verb|Bio.SeqIO.parse()| supports it you would just need to change the format string as appropriate, for example ``swiss'' for SwissProt files or ``embl'' for EMBL text files. There is a full listing on the wiki page (\url{http://biopython.org/wiki/SeqIO}) and in the built in documentation (also \href{http://biopython.org/DIST/docs/api/Bio.SeqIO-module.html}{online}).
 
@@ -58,12 +58,12 @@ Another very common way to use a Python iterator is within a list comprehension 
 a generator expression).  For example, if all you wanted to extract from the file was
 a list of the record identifiers we can easily do this with the following list comprehension:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> identifiers = [seq_record.id for seq_record in SeqIO.parse("ls_orchid.gbk", "genbank")]
 >>> identifiers
 ['Z78533.1', 'Z78532.1', 'Z78531.1', 'Z78530.1', 'Z78529.1', 'Z78527.1', ..., 'Z78439.1']
-\end{verbatim}
+\end{minted}
 
 \noindent There are more examples using \verb|SeqIO.parse()| in a list
 comprehension like this in Section~\ref{seq:sequence-parsing-plus-pylab}
@@ -77,7 +77,7 @@ The object returned by \verb|Bio.SeqIO| is actually an iterator which returns \v
 
 Instead of using a for loop, can also use the \verb|next()| function on an iterator to step through the entries, like this:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 record_iterator = SeqIO.parse("ls_orchid.fasta", "fasta")
 
@@ -88,16 +88,16 @@ print(first_record.description)
 second_record = next(record_iterator)
 print(second_record.id)
 print(second_record.description)
-\end{verbatim}
+\end{minted}
 
 Note that if you try to use \verb|next()| and there are no more results, you'll get the special \verb|StopIteration| exception.
 
 One special case to consider is when your sequence files have multiple records, but you only want the first one.  In this situation the following code is very concise:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 first_record = next(SeqIO.parse("ls_orchid.gbk", "genbank"))
-\end{verbatim}
+\end{minted}
 
 A word of warning here -- using the \verb|next()| function like this will silently ignore any additional records in the file.
 If your files have {\it one and only one} record, like some of the online examples later in this chapter, or a GenBank file for a single chromosome, then use the new \verb|Bio.SeqIO.read()| function instead.
@@ -107,7 +107,7 @@ This will check there are no extra unexpected records present.
 
 In the previous section we talked about the fact that \verb|Bio.SeqIO.parse()| gives you a \verb|SeqRecord| iterator, and that you get the records one by one.  Very often you need to be able to access the records in any order. The Python \verb|list| data type is perfect for this, and we can turn the record iterator into a list of \verb|SeqRecord| objects using the built-in Python function \verb|list()| like so:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 records = list(SeqIO.parse("ls_orchid.gbk", "genbank"))
 
@@ -124,7 +124,7 @@ first_record = records[0] #remember, Python counts from zero
 print(first_record.id)
 print(repr(first_record.seq))
 print(len(first_record))
-\end{verbatim}
+\end{minted}
 
 \noindent Giving:
 
@@ -147,12 +147,12 @@ You can of course still use a for loop with a list of \verb|SeqRecord| objects. 
 The \verb|SeqRecord| object and its annotation structures are described more fully in
 Chapter~\ref{chapter:SeqRecord}.  As an example of how annotations are stored, we'll look at the output from parsing the first record in the GenBank file \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/ls_orchid.gbk}{ls\_orchid.gbk}.
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 record_iterator = SeqIO.parse("ls_orchid.gbk", "genbank")
 first_record = next(record_iterator)
 print(first_record)
-\end{verbatim}
+\end{minted}
 
 \noindent That should give something like this:
 
@@ -178,33 +178,33 @@ This gives a human readable summary of most of the annotation data for the \verb
 For this example we're going to use the \verb|.annotations| attribute which is just a Python dictionary.
 The contents of this annotations dictionary were shown when we printed the record above.
 You can also print them out directly:
-\begin{verbatim}
+\begin{minted}{python}
 print(first_record.annotations)
-\end{verbatim}
+\end{minted}
 \noindent Like any Python dictionary, you can easily get a list of the keys:
-\begin{verbatim}
+\begin{minted}{python}
 print(first_record.annotations.keys())
-\end{verbatim}
+\end{minted}
 \noindent or values:
-\begin{verbatim}
+\begin{minted}{python}
 print(first_record.annotations.values())
-\end{verbatim}
+\end{minted}
 
 In general, the annotation values are strings, or lists of strings.  One special case is any references in the file get stored as reference objects.
 
 Suppose you wanted to extract a list of the species from the \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/ls_orchid.gbk}{ls\_orchid.gbk} GenBank file.  The information we want, \emph{Cypripedium irapeanum}, is held in the annotations dictionary under `source' and `organism', which we can access like this:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(first_record.annotations["source"])
 Cypripedium irapeanum
-\end{verbatim}
+\end{minted}
 
 \noindent or:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(first_record.annotations["organism"])
 Cypripedium irapeanum
-\end{verbatim}
+\end{minted}
 
 In general, `organism' is used for the scientific name (in Latin, e.g. \textit{Arabidopsis thaliana}),
 while `source' will often be the common name (e.g. thale cress).  In this example, as is often the case,
@@ -212,22 +212,22 @@ the two fields are identical.
 
 Now let's go through all the records, building up a list of the species each orchid sequence is from:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 all_species = []
 for seq_record in SeqIO.parse("ls_orchid.gbk", "genbank"):
     all_species.append(seq_record.annotations["organism"])
 print(all_species)
-\end{verbatim}
+\end{minted}
 
 Another way of writing this code is to use a list comprehension:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 all_species = [seq_record.annotations["organism"] for seq_record in \
                SeqIO.parse("ls_orchid.gbk", "genbank")]
 print(all_species)
-\end{verbatim}
+\end{minted}
 
 \noindent In either case, the result is:
 
@@ -249,13 +249,13 @@ AATCCGGAGGACCGGTGTACTCAGCTCACCGGGGGCATTGCTCCCGTGGTGACCCTGATTTGTTGTTGGG
 
 You can check by hand, but for every record the species name is in the description line as the second word.  This means if we break up each record's \verb|.description| at the spaces, then the species is there as field number one (field zero is the record identifier).  That means we can do this:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 all_species = []
 for seq_record in SeqIO.parse("ls_orchid.fasta", "fasta"):
     all_species.append(seq_record.description.split()[1])
 print(all_species)
-\end{verbatim}
+\end{minted}
 
 \noindent This gives:
 
@@ -265,12 +265,12 @@ print(all_species)
 
 The concise alternative using list comprehensions would be:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 all_species == [seq_record.description.split()[1] for seq_record in \
                 SeqIO.parse("ls_orchid.fasta", "fasta")]
 print(all_species)
-\end{verbatim}
+\end{minted}
 
 In general, extracting information from the FASTA description line is not very nice.
 If you can get your sequences in a well annotated file format like GenBank or EMBL,
@@ -289,35 +289,35 @@ example calculates the total length of the sequences in a multiple
 record GenBank file using a generator expression:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> print(sum(len(r) for r in SeqIO.parse("ls_orchid.gbk", "gb")))
 67518
-\end{verbatim}
+\end{minted}
 
 \noindent
 Here we use a file handle instead, using the \verb|with| statement
 to close the handle automatically:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> with open("ls_orchid.gbk") as handle:
 ...     print(sum(len(r) for r in SeqIO.parse(handle, "gb")))
 67518
-\end{verbatim}
+\end{minted}
 
 \noindent
 Or, the old fashioned way where you manually close the handle:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> handle = open("ls_orchid.gbk")
 >>> print(sum(len(r) for r in SeqIO.parse(handle, "gb")))
 67518
 >>> handle.close()
-\end{verbatim}
+\end{minted}
 
 Now, suppose we have a gzip compressed file instead? These are very
 commonly used on Linux. We can use Python's \verb|gzip| module to open
@@ -325,21 +325,21 @@ the compressed file for reading - which gives us a handle object:
 
 %TODO: Can we make the doctest code Python version specific?
 %This doctest fails on Python 2.7 due to https://bugs.python.org/issue30012
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> import gzip
 >>> from Bio import SeqIO
 >>> with gzip.open("ls_orchid.gbk.gz", "rt") as handle:
 ...     print(sum(len(r) for r in SeqIO.parse(handle, "gb")))
 ...
 67518
-\end{verbatim}
+\end{minted}
 
 Similarly if we had a bzip2 compressed file (sadly the function name isn't
 quite as consistent under Python 2):
 
 %TODO: Can we make the doctest code Python version specific?
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> import bz2
 >>> from Bio import SeqIO
 >>> if hasattr(bz2, "open"):
@@ -351,7 +351,7 @@ quite as consistent under Python 2):
 ...     print(sum(len(r) for r in SeqIO.parse(handle, "gb")))
 ...
 67518
-\end{verbatim}
+\end{minted}
 
 There is a gzip (GNU Zip) variant called BGZF (Blocked GNU Zip Format),
 which can be treated like an ordinary gzip file for reading, but has
@@ -381,14 +381,14 @@ annotations and features downloading a FASTA file is a good choice as these
 are compact.  Now remember, when you expect the handle to contain one and
 only one record, use the \verb|Bio.SeqIO.read()| function:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import Entrez
 from Bio import SeqIO
 Entrez.email = "A.N.Other@example.com"
 with Entrez.efetch(db="nucleotide", rettype="fasta", retmode="text", id="6273291") as handle:
     seq_record = SeqIO.read(handle, "fasta")
 print("%s with %i features" % (seq_record.id, len(seq_record.features)))
-\end{verbatim}
+\end{minted}
 
 \noindent Expected output:
 
@@ -405,14 +405,14 @@ return types of ``gb'' (or ``gp'' for proteins) as described on
 As a result, in Biopython 1.50 onwards, we support ``gb'' as an
 alias for ``genbank'' in \verb|Bio.SeqIO|.
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import Entrez
 from Bio import SeqIO
 Entrez.email = "A.N.Other@example.com"
 with Entrez.efetch(db="nucleotide", rettype="gb", retmode="text", id="6273291") as handle
     seq_record = SeqIO.read(handle, "gb") #using "gb" as an alias for "genbank"
 print("%s with %i features" % (seq_record.id, len(seq_record.features)))
-\end{verbatim}
+\end{minted}
 
 \noindent The expected output of this example is:
 
@@ -425,7 +425,7 @@ AF191665.1 with 3 features
 Now let's fetch several records.  This time the handle contains multiple records,
 so we must use the \verb|Bio.SeqIO.parse()| function:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import Entrez
 from Bio import SeqIO
 Entrez.email = "A.N.Other@example.com"
@@ -435,7 +435,7 @@ with Entrez.efetch(db="nucleotide", rettype="gb", retmode="text",
         print("%s %s..." % (seq_record.id, seq_record.description[:50]))
         print("Sequence length %i, %i features, from: %s"
               % (len(seq_record), len(seq_record.features), seq_record.annotations["source"]))
-\end{verbatim}
+\end{minted}
 
 \noindent That should give the following output:
 
@@ -457,7 +457,7 @@ something covered in more depth in Chapter~\ref{chapter:swiss_prot}.
 As mentioned above, when you expect the handle to contain one and only one record,
 use the \verb|Bio.SeqIO.read()| function:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import ExPASy
 from Bio import SeqIO
 with ExPASy.get_sprot_raw("O23729") as handle:
@@ -468,7 +468,7 @@ print(seq_record.description)
 print(repr(seq_record.seq))
 print("Length %i" % len(seq_record))
 print(seq_record.annotations["keywords"])
-\end{verbatim}
+\end{minted}
 
 \noindent Assuming your network connection is OK, you should get back:
 
@@ -518,10 +518,10 @@ You can use the function \verb|Bio.SeqIO.to_dict()| to make a SeqRecord dictiona
 attribute) as the key.  Let's try this using our GenBank file:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> orchid_dict = SeqIO.to_dict(SeqIO.parse("ls_orchid.gbk", "genbank"))
-\end{verbatim}
+\end{minted}
 
 There is just one required argument for \verb|Bio.SeqIO.to_dict()|, a list or
 generator giving \verb|SeqRecord| objects. Here we have just used the output
@@ -532,36 +532,36 @@ Since this variable \verb|orchid_dict| is an ordinary Python dictionary,
 we can look at all of the keys we have available:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> len(orchid_dict)
 94
-\end{verbatim}
+\end{minted}
 %Can't use following for doctest due to abbreviation
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> list(orchid_dict.keys())
 ['Z78484.1', 'Z78464.1', 'Z78455.1', 'Z78442.1', 'Z78532.1', 'Z78453.1', ..., 'Z78471.1']
-\end{verbatim}
+\end{minted}
 
 You can leave out the ``list(...)`` bit if you are still using Python 2.
 Under Python 3 the dictionary methods like ``.keys()`` and ``.values()``
 are iterators rather than lists.
 
 If you really want to, you can even look at all the records at once:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> list(orchid_dict.values()) #lots of output!
 ...
-\end{verbatim}
+\end{minted}
 
 We can access a single \verb|SeqRecord| object via the keys and manipulate the object as normal:
 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> seq_record = orchid_dict["Z78475.1"]
 >>> print(seq_record.description)
 P.supardii 5.8S rRNA gene and ITS1 and ITS2 DNA
 >>> print(repr(seq_record.seq))
 Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGTTGAGATCACAT...GGT', IUPACAmbiguousDNA())
-\end{verbatim}
+\end{minted}
 
 So, it is very easy to create an in memory ``database'' of our GenBank records.  Next we'll try this for the FASTA file instead.
 
@@ -572,11 +572,11 @@ Note that those of you with prior Python experience should all be able to constr
 
 Using the same code as above, but for the FASTA file instead:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 orchid_dict = SeqIO.to_dict(SeqIO.parse("ls_orchid.fasta", "fasta"))
 print(orchid_dict.keys())
-\end{verbatim}
+\end{minted}
 
 \noindent This time the keys are:
 
@@ -589,7 +589,7 @@ You should recognise these strings from when we parsed the FASTA file earlier in
 
 First you must write your own function to return the key you want (as a string) when given a \verb|SeqRecord| object.  In general, the details of function will depend on the sort of input records you are dealing with.  But for our orchids, we can just split up the record's identifier using the ``pipe'' character (the vertical line) and return the fourth entry (field three):
 
-\begin{verbatim}
+\begin{minted}{python}
 def get_accession(record):
     """"Given a SeqRecord, return the accession number as a string.
 
@@ -598,22 +598,22 @@ def get_accession(record):
     parts = record.id.split("|")
     assert len(parts) == 5 and parts[0] == "gi" and parts[2] == "emb"
     return parts[3]
-\end{verbatim}
+\end{minted}
 
 \noindent Then we can give this function to the \verb|SeqIO.to_dict()| function to use in building the dictionary:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 orchid_dict = SeqIO.to_dict(SeqIO.parse("ls_orchid.fasta", "fasta"), key_function=get_accession)
 print(orchid_dict.keys())
-\end{verbatim}
+\end{minted}
 
 \noindent Finally, as desired, the new dictionary keys:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(orchid_dict.keys())
 ['Z78484.1', 'Z78464.1', 'Z78455.1', 'Z78442.1', 'Z78532.1', 'Z78453.1', ..., 'Z78471.1']
-\end{verbatim}
+\end{minted}
 
 \noindent Not too complicated, I hope!
 
@@ -623,12 +623,12 @@ To give another example of working with dictionaries of \verb|SeqRecord| objects
 
 Once again, working with the orchids GenBank file:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 from Bio.SeqUtils.CheckSum import seguid
 for record in SeqIO.parse("ls_orchid.gbk", "genbank"):
     print(record.id, seguid(record.seq))
-\end{verbatim}
+\end{minted}
 
 \noindent This should give:
 
@@ -642,7 +642,7 @@ Z78439.1 H+JfaShya/4yyAj7IbMqgNkxdxQ
 Now, recall the \verb|Bio.SeqIO.to_dict()| function's \verb|key_function| argument expects a function which turns a \verb|SeqRecord| into a string.  We can't use the \verb|seguid()| function directly because it expects to be given a \verb|Seq| object (or a string).  However, we can use Python's \verb|lambda| feature to create a ``one off'' function to give to \verb|Bio.SeqIO.to_dict()| instead:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> from Bio.SeqUtils.CheckSum import seguid
 >>> seguid_dict = SeqIO.to_dict(SeqIO.parse("ls_orchid.gbk", "genbank"),
@@ -652,7 +652,7 @@ Now, recall the \verb|Bio.SeqIO.to_dict()| function's \verb|key_function| argume
 Z78532.1
 >>> print(record.description)
 C.californicum 5.8S rRNA gene and ITS1 and ITS2 DNA
-\end{verbatim}
+\end{minted}
 
 \noindent That should have retrieved the record {\tt Z78532.1}, the second entry in the file.
 
@@ -675,26 +675,26 @@ it on demand.
 As an example, let's use the same GenBank file as before:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> orchid_dict = SeqIO.index("ls_orchid.gbk", "genbank")
 >>> len(orchid_dict)
 94
-\end{verbatim}
+\end{minted}
 %Following is abbr.
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> orchid_dict.keys()
 ['Z78484.1', 'Z78464.1', 'Z78455.1', 'Z78442.1', 'Z78532.1', 'Z78453.1', ..., 'Z78471.1']
-\end{verbatim}
+\end{minted}
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> seq_record = orchid_dict["Z78475.1"]
 >>> print(seq_record.description)
 P.supardii 5.8S rRNA gene and ITS1 and ITS2 DNA
 >>> seq_record.seq
 Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGTTGAGATCACAT...GGT', IUPACAmbiguousDNA())
 >>> orchid_dict.close()
-\end{verbatim}
+\end{minted}
 
 \noindent Note that \verb|Bio.SeqIO.index()| won't take a handle,
 but only a filename. There are good reasons for this, but it is a little
@@ -708,7 +708,7 @@ argument you can supply an alphabet, or a key function.
 Here is the same example using the FASTA file - all we change is the
 filename and the format name:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> orchid_dict = SeqIO.index("ls_orchid.fasta", "fasta")
 >>> len(orchid_dict)
@@ -716,7 +716,7 @@ filename and the format name:
 >>> orchid_dict.keys()
 ['gi|2765596|emb|Z78471.1|PDZ78471', 'gi|2765646|emb|Z78521.1|CCZ78521', ...
  ..., 'gi|2765613|emb|Z78488.1|PTZ78488', 'gi|2765583|emb|Z78458.1|PHZ78458']
-\end{verbatim}
+\end{minted}
 
 \subsubsection{Specifying the dictionary keys}
 \label{seq:seqio-index-functionkey}
@@ -726,7 +726,7 @@ Suppose you want to use the same keys as before? Much like with the
 you'll need to write a tiny function to map from the FASTA identifier
 (as a string) to the key you want:
 
-\begin{verbatim}
+\begin{minted}{python}
 def get_acc(identifier):
     """"Given a SeqRecord identifier string, return the accession number as a string.
 
@@ -735,17 +735,17 @@ def get_acc(identifier):
     parts = identifier.split("|")
     assert len(parts) == 5 and parts[0] == "gi" and parts[2] == "emb"
     return parts[3]
-\end{verbatim}
+\end{minted}
 
 \noindent Then we can give this function to the \verb|Bio.SeqIO.index()|
 function to use in building the dictionary:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> orchid_dict = SeqIO.index("ls_orchid.fasta", "fasta", key_function=get_acc)
 >>> print(orchid_dict.keys())
 ['Z78484.1', 'Z78464.1', 'Z78455.1', 'Z78442.1', 'Z78532.1', 'Z78453.1', ..., 'Z78471.1']
-\end{verbatim}
+\end{minted}
 
 \noindent Easy when you know how?
 
@@ -772,14 +772,14 @@ text SwissPort file format from their FTP site
 and uncompressed it as the file \verb|uniprot_sprot.dat|, and you
 want to extract just a few records from it:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> uniprot = SeqIO.index("uniprot_sprot.dat", "swiss")
 >>> with open("selected.dat", "wb") as out_handle:
 ...     for acc in ["P33487", "P19801", "P13689", "Q8JZQ5", "Q9TRC7"]:
 ...         out_handle.write(uniprot.get_raw(acc))
 ...
-\end{verbatim}
+\end{minted}
 
 Note with Python 3 onwards, we have to open the file for writing in
 binary mode because the \verb|get_raw()| method returns bytes strings.
@@ -817,28 +817,28 @@ If you were interested in the viruses, you could download all the virus files
 from the command line very easily with the \texttt{rsync} command, and then
 decompress them with \texttt{gunzip}:
 
-\begin{verbatim}
+\begin{minted}{bash}
 # For illustration only, see reduced example below
 $ rsync -avP "ftp.ncbi.nih.gov::genbank/gbvrl*.seq.gz" .
 $ gunzip gbvrl*.seq.gz
-\end{verbatim}
+\end{minted}
 
 Unless you care about viruses, that's a lot of data to download just for this
 example - so let's download \emph{just} the first four chunks (about 25MB each
 compressed), and decompress them (taking in all about 1GB of space):
 
-\begin{verbatim}
+\begin{minted}{bash}
 # Reduced example, download only the first four chunks
 $ curl -O ftp://ftp.ncbi.nih.gov/genbank/gbvrl1.seq.gz
 $ curl -O ftp://ftp.ncbi.nih.gov/genbank/gbvrl2.seq.gz
 $ curl -O ftp://ftp.ncbi.nih.gov/genbank/gbvrl3.seq.gz
 $ curl -O ftp://ftp.ncbi.nih.gov/genbank/gbvrl4.seq.gz
 $ gunzip gbvrl*.seq.gz
-\end{verbatim}
+\end{minted}
 
 Now, in Python, index these GenBank files as follows:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> import glob
 >>> from Bio import SeqIO
 >>> files = glob.glob("gbvrl*.seq")
@@ -847,7 +847,7 @@ Now, in Python, index these GenBank files as follows:
 >>> gb_vrl = SeqIO.index_db("gbvrl.idx", files, "genbank")
 >>> print("%i sequences indexed" % len(gb_vrl))
 272960 sequences indexed
-\end{verbatim}
+\end{minted}
 
 Indexing the full set of virus GenBank files took about ten minutes on my machine,
 just the first four files took about a minute or so.
@@ -858,10 +858,10 @@ in a fraction of a second.
 You can use the index as a read only Python dictionary - without having to worry
 about which file the sequence comes from, e.g.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(gb_vrl["AB811634.1"].description)
 Equine encephalosis virus NS3 gene, complete cds, isolate: Kimron1.
-\end{verbatim}
+\end{minted}
 
 \subsubsection{Getting the raw data for a record}
 
@@ -874,14 +874,14 @@ get at the raw bytes of each record:
 %
 % >>> print(gb_vrl.get_raw("GQ333173.1"))
 % b'LOCUS       GQ333173                 459 bp    DNA     linear   VRL 21-OCT-2009\nDEFINITION...'
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(gb_vrl.get_raw("AB811634.1"))
 LOCUS       AB811634                 723 bp    RNA     linear   VRL 17-JUN-2015
 DEFINITION  Equine encephalosis virus NS3 gene, complete cds, isolate: Kimron1.
 ACCESSION   AB811634
 ...
 //
-\end{verbatim}
+\end{minted}
 
 \subsection{Indexing compressed files}
 \label{sec:SeqIO-index-bgzf}
@@ -905,44 +905,44 @@ used with BGZF compressed files. For example, if you started with an
 uncompressed GenBank file:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> orchid_dict = SeqIO.index("ls_orchid.gbk", "genbank")
 >>> len(orchid_dict)
 94
 >>> orchid_dict.close()
-\end{verbatim}
+\end{minted}
 
 You could compress this (while keeping the original file) at the command
 line using the following command -- but don't worry, the compressed file
 is already included with the other example files:
 
-\begin{verbatim}
+\begin{minted}{bash}
 $ bgzip -c ls_orchid.gbk > ls_orchid.gbk.bgz
-\end{verbatim}
+\end{minted}
 
 You can use the compressed file in exactly the same way:
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> orchid_dict = SeqIO.index("ls_orchid.gbk.bgz", "genbank")
 >>> len(orchid_dict)
 94
 >>> orchid_dict.close()
-\end{verbatim}
+\end{minted}
 
 \noindent
 or:
 
 %Don't use doctest as would have to clean up the *.idx file
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> orchid_dict = SeqIO.index_db("ls_orchid.gbk.bgz.idx", "ls_orchid.gbk.bgz", "genbank")
 >>> len(orchid_dict)
 94
 >>> orchid_dict.close()
-\end{verbatim}
+\end{minted}
 
 The \verb|SeqIO| indexing automatically detects the BGZF compression. Note
 that you can't use the same index file for the uncompressed and compressed files.
@@ -1001,7 +1001,7 @@ We've talked about using \verb|Bio.SeqIO.parse()| for sequence input (reading fi
 
 Here is an example, where we start by creating a few \verb|SeqRecord| objects the hard way (by hand, rather than by loading them from a file):
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Alphabet import generic_protein
@@ -1029,14 +1029,14 @@ rec3 = SeqRecord(Seq("MVTVEEFRRAQCAEGPATVMAIGTATPSNCVDQSTYPDYYFRITNSEHKVELKEKFKR
                  description="chalcone synthase [Nicotiana tabacum]")
 
 my_records = [rec1, rec2, rec3]
-\end{verbatim}
+\end{minted}
 
 \noindent Now we have a list of \verb|SeqRecord| objects, we'll write them to a FASTA format file:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 SeqIO.write(my_records, "my_example.faa", "fasta")
-\end{verbatim}
+\end{minted}
 
 \noindent And if you open this file in your favourite text editor it should look like this:
 
@@ -1105,31 +1105,31 @@ In previous example we used a list of \verb|SeqRecord| objects as input to the \
 
 For this example we'll read in the GenBank format file \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/ls_orchid.gbk}{ls\_orchid.gbk} and write it out in FASTA format:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 records = SeqIO.parse("ls_orchid.gbk", "genbank")
 count = SeqIO.write(records, "my_example.fasta", "fasta")
 print("Converted %i records" % count)
-\end{verbatim}
+\end{minted}
 
 Still, that is a little bit complicated. So, because file conversion is such a
 common task, there is a helper function letting you replace that with just:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 count = SeqIO.convert("ls_orchid.gbk", "genbank", "my_example.fasta", "fasta")
 print("Converted %i records" % count)
-\end{verbatim}
+\end{minted}
 
 The \verb|Bio.SeqIO.convert()| function will take handles \emph{or} filenames.
 Watch out though -- if the output file already exists, it will overwrite it!
 To find out more, see the built in help:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> help(SeqIO.convert)
 ...
-\end{verbatim}
+\end{minted}
 
 In principle, just by changing the filenames and the format names, this code
 could be used to convert between any file formats available in Biopython.
@@ -1153,54 +1153,54 @@ To start with, we'll use \verb|Bio.SeqIO.parse()| to load some nucleotide
 sequences from a file, then print out their reverse complements using
 the \verb|Seq| object's built in \verb|.reverse_complement()| method (see Section~\ref{sec:seq-reverse-complement}):
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> for record in SeqIO.parse("ls_orchid.gbk", "genbank"):
 ...     print(record.id)
 ...     print(record.seq.reverse_complement())
-\end{verbatim}
+\end{minted}
 
 Now, if we want to save these reverse complements to a file, we'll need to make \verb|SeqRecord| objects.
 We can use  the \verb|SeqRecord| object's built in \verb|.reverse_complement()| method (see Section~\ref{sec:SeqRecord-reverse-complement}) but we must decide how to name our new records.
 
 This is an excellent place to demonstrate the power of list comprehensions which make a list in memory:
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> records = [rec.reverse_complement(id="rc_"+rec.id, description = "reverse complement") \
 ...            for rec in SeqIO.parse("ls_orchid.fasta", "fasta")]
 >>> len(records)
 94
-\end{verbatim}
+\end{minted}
 
 \noindent Now list comprehensions have a nice trick up their sleeves, you can add a conditional statement:
 
 %cont-doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> records = [rec.reverse_complement(id="rc_"+rec.id, description = "reverse complement") \
 ...            for rec in SeqIO.parse("ls_orchid.fasta", "fasta") if len(rec)<700]
 >>> len(records)
 18
-\end{verbatim}
+\end{minted}
 
 That would create an in memory list of reverse complement records where the sequence length was under 700 base pairs. However, we can do exactly the same with a generator expression - but with the advantage that this does not create a list of all the records in memory at once:
 
 %cont-doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> records = (rec.reverse_complement(id="rc_"+rec.id, description = "reverse complement") \
 ...           for rec in SeqIO.parse("ls_orchid.fasta", "fasta") if len(rec)<700)
-\end{verbatim}
+\end{minted}
 
 As a complete example:
 
 %not a doctest as would have to remove the output file
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> records = (rec.reverse_complement(id="rc_"+rec.id, description = "reverse complement") \
 ...            for rec in SeqIO.parse("ls_orchid.fasta", "fasta") if len(rec)<700)
 >>> SeqIO.write(records, "rev_comp.fasta", "fasta")
 18
-\end{verbatim}
+\end{minted}
 
 There is a related example in Section~\ref{sec:SeqIO-translate}, translating each
 record in a FASTA file from nucleotides to amino acids.
@@ -1211,7 +1211,7 @@ Suppose that you don't really want to write your records to a file or handle -- 
 
 For an example of how you might use this, let's load in a bunch of \verb|SeqRecord| objects from our orchids GenBank file, and create a string containing the records in FASTA format:
 
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 from StringIO import StringIO
 records = SeqIO.parse("ls_orchid.gbk", "genbank")
@@ -1219,24 +1219,24 @@ out_handle = StringIO()
 SeqIO.write(records, out_handle, "fasta")
 fasta_data = out_handle.getvalue()
 print(fasta_data)
-\end{verbatim}
+\end{minted}
 
 This isn't entirely straightforward the first time you see it!  On the bright side, for the special case where you would like a string containing a \emph{single} record in a particular file format, use the the \verb|SeqRecord| class' \verb|format()| method (see Section~\ref{sec:SeqRecord-format}).
 
 Note that although we don't encourage it, you \emph{can} use the \verb|format()| method to write to a file, for example something like this:
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 with open("ls_orchid_long.tab", "w") as out_handle:
     for record in SeqIO.parse("ls_orchid.gbk", "genbank"):
         if len(record) > 100:
             out_handle.write(record.format("tab"))
-\end{verbatim}
+\end{minted}
 \noindent While this style of code will work for a simple sequential file format like FASTA or the simple tab separated format used here, it will \emph{not} work for more complex or interlaced file formats.  This is why we still recommend using \verb|Bio.SeqIO.write()|, as in the following example:
-\begin{verbatim}
+\begin{minted}{python}
 from Bio import SeqIO
 records = (rec for rec in SeqIO.parse("ls_orchid.gbk", "genbank") if len(rec) > 100)
 SeqIO.write(records, "ls_orchid.tab", "tab")
-\end{verbatim}
+\end{minted}
 \noindent Making a single call to \verb|SeqIO.write(...)| is also much quicker than
 multiple calls to the \verb|SeqRecord.format(...)| method.
 
@@ -1258,7 +1258,7 @@ each record as a tuple of two strings, the title line (everything after
 the \verb|>| character) and the sequence (as a plain string):
 
 %doctest examples
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.SeqIO.FastaIO import SimpleFastaParser
 >>> count = 0
 >>> total_len = 0
@@ -1269,17 +1269,17 @@ the \verb|>| character) and the sequence (as a plain string):
 ...
 >>> print("%i records with total sequence length %i" % (count, total_len))
 94 records with total sequence length 67518
-\end{verbatim}
+\end{minted}
 
 As long as you don't care about line wrapping (and you probably don't
 for short read high-througput data), then outputing FASTA format from
 these strings is also very fast:
 
-\begin{verbatim}
+\begin{minted}{python}
 ...
 out_handle.write(">%s\n%s\n" % (title, seq))
 ...
-\end{verbatim}
+\end{minted}
 
 Likewise, when parsing FASTQ files, internally \verb|Bio.SeqIO.parse()|
 calls the low-level \verb|FastqGeneralIterator| with the file handle.
@@ -1287,7 +1287,7 @@ If you don't need the quality scores turned into integers,
 or can work with them as ASCII strings this is ideal:
 
 %doctest ../Tests/Quality
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.SeqIO.QualityIO import FastqGeneralIterator
 >>> count = 0
 >>> total_len = 0
@@ -1298,13 +1298,13 @@ or can work with them as ASCII strings this is ideal:
 ...
 >>> print("%i records with total sequence length %i" % (count, total_len))
 3 records with total sequence length 75
-\end{verbatim}
+\end{minted}
 
 There are more examples of this in the Cookbook (Chapter~\ref{chapter:cookbook}),
 including how to output FASTQ efficiently from strings using this code snippet:
 
-\begin{verbatim}
+\begin{minted}{python}
 ...
 out_handle.write("@%s\n%s\n+\n%s\n" % (title, seq, qual))
 ...
-\end{verbatim}
+\end{minted}

--- a/Doc/Tutorial/chapter_testing.tex
+++ b/Doc/Tutorial/chapter_testing.tex
@@ -27,34 +27,45 @@ contain input files for the test suite.
 As part of building and installing Biopython you will typically
 run the full test suite at the command line from the Biopython
 source top level directory using the following:
-\begin{verbatim}
-python setup.py test
-\end{verbatim}
+
+\begin{minted}{bash}
+$ python setup.py test
+\end{minted}
+
 This is actually equivalent to going to the \verb|Tests|
 subdirectory and running:
-\begin{verbatim}
-python run_tests.py
-\end{verbatim}
+
+\begin{minted}{bash}
+$ python run_tests.py
+\end{minted}
 
 You'll often want to run just some of the tests, and this is done
 like this:
-\begin{verbatim}
-python run_tests.py test_SeqIO.py test_AlignIO.py
-\end{verbatim}
+
+\begin{minted}{bash}
+$python run_tests.py test_SeqIO.py test_AlignIO.py
+\end{minted}
+
 When giving the list of tests, the \verb|.py| extension is optional,
 so you can also just type:
-\begin{verbatim}
-python run_tests.py test_SeqIO test_AlignIO
-\end{verbatim}
+
+\begin{minted}{bash}
+$ python run_tests.py test_SeqIO test_AlignIO
+\end{minted}
+
 To run the docstring tests (see section \ref{section:doctest}), you can use
-\begin{verbatim}
-python run_tests.py doctest
-\end{verbatim}
+
+\begin{minted}{bash}
+$python run_tests.py doctest
+\end{minted}
+
 You can also skip any tests which have been setup with an explicit
 online component by adding \verb|--offline|, e.g.
-\begin{verbatim}
-python run_tests.py --offline
-\end{verbatim}
+
+\begin{minted}{bash}
+$python run_tests.py --offline
+\end{minted}
+
 By default, \verb|run_tests.py| runs all tests, including the docstring tests.
 
 If an individual test is failing, you can also try running it
@@ -82,15 +93,17 @@ of output on screen, but does not check the output matches the expected
 output.  If the test is failing with an exception error, it should be
 very easy to locate where exactly the script is failing.
 For an example of a print-and-compare test, try:
-\begin{verbatim}
-python test_SeqIO.py
-\end{verbatim}
+
+\begin{minted}{bash}
+$ python test_SeqIO.py
+\end{minted}
 
 The \verb|unittest|-based tests instead show you exactly which sub-section(s) of
 the test are failing. For example,
-\begin{verbatim}
-python test_Cluster.py
-\end{verbatim}
+
+\begin{minted}{bash}
+$python test_Cluster.py
+\end{minted}
 
 \subsection{Running the tests using Tox}
 
@@ -146,7 +159,8 @@ Each Biopython test can have three important files and directories involved with
 It's up to you to decide whether you want to write a print-and-compare test script or a \verb|unittest|-style test script. The important thing is that you cannot mix these two styles in a single test script. Particularly, don't use \verb|unittest| features in a print-and-compare test.
 
 Any script with a \verb|test_| prefix in the \verb|Tests| directory will be found and run by \verb|run_tests.py|. Below, we show an example test script \verb|test_Biospam.py| both for a print-and-compare test and for a \verb|unittest|-based test. If you put this script in the Biopython \verb|Tests| directory, then \verb|run_tests.py| will find it and execute the tests contained in it:
-\begin{verbatim}
+
+\begin{minted}{bash}
 $ python run_tests.py
 test_Ace ... ok
 test_AlignIO ... ok
@@ -155,12 +169,10 @@ test_BioSQL_SeqIO ... ok
 test_Biospam ... ok
 test_CAPS ... ok
 test_Clustalw ... ok
-\end{verbatim}
-\ldots
-\begin{verbatim}
+...
 ----------------------------------------------------------------------
 Ran 107 tests in 86.127 seconds
-\end{verbatim}
+\end{minted}
 
 \subsection{Writing a print-and-compare test}
 
@@ -238,7 +250,7 @@ As an example, the \verb|test_Biospam.py| test script to test the
 \verb|addition| and \verb|multiplication| functions in the \verb|Biospam|
 module  could look as follows:
 
-\begin{verbatim}
+\begin{minted}{python}
 from __future__ import print_function
 from Bio import Biospam
 
@@ -246,7 +258,7 @@ print("2 + 3 =", Biospam.addition(2, 3))
 print("9 - 1 =", Biospam.addition(9, -1))
 print("2 * 3 =", Biospam.multiplication(2, 3))
 print("9 * (- 1) =", Biospam.multiplication(9, -1))
-\end{verbatim}
+\end{minted}
 
 We generate the corresponding output with \verb|python run_tests.py -g test_Biospam.py|, and check the output file \verb|output/test_Biospam|:
 
@@ -281,7 +293,7 @@ find looking at the existing example within Biopython helpful too.
 Here's a minimal \verb|unittest|-style test script for \verb|Biospam|,
 which you can copy and paste to get started:
 
-\begin{verbatim}
+\begin{minted}{python}
 import unittest
 from Bio import Biospam
 
@@ -309,7 +321,7 @@ class BiospamTestDivision(unittest.TestCase):
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity = 2)
     unittest.main(testRunner=runner)
-\end{verbatim}
+\end{minted}
 
 In the division tests, we use \verb|assertAlmostEqual| instead of \verb|assertEqual| to avoid tests failing due to roundoff errors; see the \verb|unittest| chapter in the Python documentation for details and for other functionality available in \verb|unittest| (\href{https://docs.python.org/3/library/unittest.html}{online reference}).
 
@@ -330,16 +342,16 @@ These are the key points of \verb|unittest|-based tests:
     many tests as you want in a class.
 
   \item At the end of the test script, you can use
-\begin{verbatim}
+\begin{minted}{python}
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity = 2)
     unittest.main(testRunner=runner)
-\end{verbatim}
+\end{minted}
         to execute the tests when the script is run by itself (rather than
         imported from \verb|run_tests.py|).
         If you run this script, then you'll see something like the following:
 
-\begin{verbatim}
+\begin{minted}{bash}
 $ python test_BiospamMyModule.py
 test_addition1 (__main__.TestAddition) ... ok
 test_addition2 (__main__.TestAddition) ... ok
@@ -350,13 +362,13 @@ test_division2 (__main__.TestDivision) ... ok
 Ran 4 tests in 0.059s
 
 OK
-\end{verbatim}
+\end{minted}
 
   \item To indicate more clearly what each test is doing, you can add
         docstrings to each test.  These are shown when running the tests,
         which can be useful information if a test is failing.
 
-\begin{verbatim}
+\begin{minted}{python}
 import unittest
 from Bio import Biospam
 
@@ -388,11 +400,11 @@ class BiospamTestDivision(unittest.TestCase):
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity = 2)
     unittest.main(testRunner=runner)
-\end{verbatim}
+\end{minted}
 
         Running the script will now show you:
 
-\begin{verbatim}
+\begin{minted}{bash}
 $ python test_BiospamMyModule.py
 An addition test ... ok
 A second addition test ... ok
@@ -403,7 +415,7 @@ A second division test ... ok
 Ran 4 tests in 0.001s
 
 OK
-\end{verbatim}
+\end{minted}
 \end{itemize}
 
 If your module contains docstring tests (see section \ref{section:doctest}),
@@ -411,14 +423,14 @@ you \emph{may} want to include those in the tests to be run. You can do so as
 follows by modifying the code under \verb|if __name__ == "__main__":|
 to look like this:
 
-\begin{verbatim}
+\begin{minted}{python}
 if __name__ == "__main__":
     unittest_suite = unittest.TestLoader().loadTestsFromName("test_Biospam")
     doctest_suite = doctest.DocTestSuite(Biospam)
     suite = unittest.TestSuite((unittest_suite, doctest_suite))
     runner = unittest.TextTestRunner(sys.stdout, verbosity = 2)
     runner.run(suite)
-\end{verbatim}
+\end{minted}
 
 This is only relevant if you want to run the docstring tests when you
 execute \verb|python test_Biospam.py| if it has some complex run-time
@@ -445,7 +457,7 @@ have them excluded in the Biopython test suite, you must update
 \verb|run_tests.py| to include your module. Currently, the relevant part
 of \verb|run_tests.py| looks as follows:
 
-\begin{verbatim}
+\begin{minted}{python}
 EXCLUDE_DOCTEST_MODULES = [
 DOCTEST_MODULES = [
     'Bio.AlignIO.MauveIO',
@@ -466,7 +478,7 @@ if numpy is None:
         "Bio.KDTree",
         ...
     ])
-\end{verbatim}
+\end{minted}
 
 Note that we regard doctests primarily as documentation, so you should
 stick to typical usage. Generally complicated examples dealing with error
@@ -478,9 +490,9 @@ the code will be run from the \verb|Tests| directory, see the
 \verb|Bio.SeqIO| doctests for an example of this.
 
 To run the docstring tests only, use
-\begin{verbatim}
+\begin{minted}{bash}
 $ python run_tests.py doctest
-\end{verbatim}
+\end{minted}
 
 Note that the doctest system is fragile and care is needed to ensure
 your output will match on all the different versions of Python that
@@ -493,30 +505,30 @@ This Tutorial you are reading has a lot of code snippets, which are
 often formatted like a doctest. We have our own system in file
 \verb|test_Tutorial.py| to allow tagging code snippets in the
 Tutorial source to be run as Python doctests. This works by adding
-special \verb|%doctest| comment lines before each verbatim block,
+special \verb|%doctest| comment lines before each Python block,
 e.g.
 
-\begin{lstlisting}
-%doctest
 \begin{verbatim}
+%doctest
+\begin{minted}{pycon}
 >>> from Bio.Alphabet import generic_dna
 >>> from Bio.Seq import Seq
 >>> len("ACGT")
 4
+\end{minted}
 \end{verbatim}
-\end{lstlisting}
 
 \noindent Often code examples are not self-contained, but
-continue from the previous verbatim block. Here we use the
+continue from the previous Python block. Here we use the
 magic comment \verb|%cont-doctest| as shown here:
 
-\begin{lstlisting}
+\begin{verbatim} 
 %cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> Seq("ACGT") == Seq("ACGT", generic_dna)
 True
+\end{minted}
 \end{verbatim}
-\end{lstlisting}
 
 The special \verb|%doctest| comment line can take a working directory
 (relative to the \verb|Doc/| folder) to use if you have any example
@@ -531,12 +543,12 @@ to indicate \verb|import XXX| must work, e.g.
 
 You can run the Tutorial doctests via:
 
-\begin{verbatim}
+\begin{minted}{bash}
 $ python test_Tutorial.py
-\end{verbatim}
+\end{minted}
 
 or:
 
-\begin{verbatim}
+\begin{minted}{bash}
 $ python run_tests.py test_Tutorial.py
-\end{verbatim}
+\end{minted}

--- a/Doc/Tutorial/chapter_uniprot.tex
+++ b/Doc/Tutorial/chapter_uniprot.tex
@@ -12,37 +12,37 @@ In Section~\ref{sec:SeqIO_ExPASy_and_SwissProt}, we described how to extract the
 To parse a Swiss-Prot record, we first get a handle to a Swiss-Prot record. There are several ways to do so, depending on where and how the Swiss-Prot record is stored:
 \begin{itemize}
 \item Open a Swiss-Prot file locally:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> handle = open("myswissprotfile.dat")
-\end{verbatim} 
+\end{minted} 
 \item Open a gzipped Swiss-Prot file:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> import gzip
 >>> handle = gzip.open("myswissprotfile.dat.gz", "rt")
-\end{verbatim}
+\end{minted}
 \item Open a Swiss-Prot file over the internet:
 %--doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from urllib.request import urlopen # Python 3 only
 >>> from io import TextIOWrapper
 >>> 
 >>> handle = TextIOWrapper(urlopen("https://raw.githubusercontent.com/biopython/biopython/master/Tests/SwissProt/F2CXE6.txt"))
-\end{verbatim}
+\end{minted}
 to open the file stored on the Internet before calling \verb|read|.
 
 Note for Python 2 this can be done by using:
 %--doctest . internet
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from urllib import urlopen #Python 2 only
 >>>
 >>> handle = urlopen("https://raw.githubusercontent.com/biopython/biopython/master/Tests/SwissProt/F2CXE6.txt")
-\end{verbatim}
+\end{minted}
 \item Open a Swiss-Prot file over the internet from the ExPASy database
 (see section \ref{subsec:expasy_swissprot}):
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import ExPASy
 >>> handle = ExPASy.get_sprot_raw(myaccessionnumber)
-\end{verbatim}
+\end{minted}
 \end{itemize}
 The key point is that for the parser, it doesn't matter how the handle was created, as long as it points to data in the Swiss-Prot format.
 
@@ -50,16 +50,16 @@ We can use \verb+Bio.SeqIO+ as described in Section~\ref{sec:SeqIO_ExPASy_and_Sw
 
 To read one Swiss-Prot record from the handle, we use the function \verb|read()|:
 %--cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SwissProt
 >>> record = SwissProt.read(handle)
-\end{verbatim}
+\end{minted}
 This function should be used if the handle points to exactly one Swiss-Prot record. It raises a \verb|ValueError| if no Swiss-Prot record was found, and also if more than one record was found.
 
 We can now print out some information about this record:
 %TODO - Check the single quotes when printing record.description here:
 %--cont-doctest
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> print(record.description)
 SubName: Full=Plasma membrane intrinsic protein {ECO:0000313|EMBL:BAN04711.1}; SubName: Full=Predicted protein {ECO:0000313|EMBL:BAJ87517.1};
 >>> for ref in record.references:
@@ -76,7 +76,7 @@ title: Functional characterization of a novel plasma membrane intrinsic protein2
 authors: Shibasaka M., Katsuhara M., Sasano S.
 title: 
 ['Eukaryota', 'Viridiplantae', 'Streptophyta', 'Embryophyta', 'Tracheophyta', 'Spermatophyta', 'Magnoliophyta', 'Liliopsida', 'Poales', 'Poaceae', 'BEP clade', 'Pooideae', 'Triticeae', 'Hordeum']
-\end{verbatim}
+\end{minted}
 
 To parse a file that contains more than one Swiss-Prot record, we use the \verb|parse| function instead. This function allows us to iterate over the records in the file.
 
@@ -85,19 +85,19 @@ You can download this from the \href{ftp://ftp.expasy.org/databases/uniprot/curr
 
 As described at the start of this section, you can use the Python library \verb|gzip| to open and uncompress a \texttt{.gz} file, like this:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> import gzip
 >>> handle = gzip.open("uniprot_sprot.dat.gz", "rt")
-\end{verbatim}
+\end{minted}
 
 However, uncompressing a large file takes time, and each time you open the file for reading in this way, it has to be decompressed on the fly.  So, if you can spare the disk space you'll save time in the long run if you first decompress the file to disk, to get the \verb|uniprot_sprot.dat| file inside.  Then you can open the file for reading as usual:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> handle = open("uniprot_sprot.dat")
-\end{verbatim}
+\end{minted}
 
 As of June 2009, the full Swiss-Prot database downloaded from ExPASy contained 468851 Swiss-Prot records.  One concise way to build up a list of the record descriptions is with a list comprehension:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SwissProt
 >>> handle = open("uniprot_sprot.dat")
 >>> descriptions = [record.description for record in SwissProt.parse(handle)]
@@ -110,10 +110,10 @@ As of June 2009, the full Swiss-Prot database downloaded from ExPASy contained 4
  'RecName: Full=Protein MGF 100-1R;',
  'RecName: Full=Protein MGF 100-2L;']
 
-\end{verbatim}
+\end{minted}
 
 Or, using a for loop over the record iterator:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import SwissProt
 >>> descriptions = []
 >>> handle = open("uniprot_sprot.dat")
@@ -122,12 +122,12 @@ Or, using a for loop over the record iterator:
 ...
 >>> len(descriptions)
 468851
-\end{verbatim}
+\end{minted}
 
 Because this is such a large input file, either way takes about eleven minutes on my new desktop computer (using the uncompressed \verb|uniprot_sprot.dat| file as input).
 
 It is equally easy to extract any kind of information you'd like from Swiss-Prot records. To see the members of a Swiss-Prot record, use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> dir(record)
 ['__doc__', '__init__', '__module__', 'accessions', 'annotation_update',
 'comments', 'created', 'cross_references', 'data_class', 'description',
@@ -135,7 +135,7 @@ It is equally easy to extract any kind of information you'd like from Swiss-Prot
 'molecule_type', 'organelle', 'organism', 'organism_classification',
 'references', 'seqinfo', 'sequence', 'sequence_length',
 'sequence_update', 'taxonomy_id']
-\end{verbatim}
+\end{minted}
 
 \subsection{Parsing the Swiss-Prot keyword and category list}
 
@@ -169,14 +169,14 @@ ID   3Fe-4S.
 
 The entries in this file can be parsed by the \verb+parse+ function in the \verb+Bio.SwissProt.KeyWList+ module. Each entry is then stored as a \verb+Bio.SwissProt.KeyWList.Record+, which is a Python dictionary.
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.SwissProt import KeyWList
 >>> handle = open("keywlist.txt")
 >>> records = KeyWList.parse(handle)
 >>> for record in records:
 ...     print(record["ID"])
 ...     print(record["DE"])
-\end{verbatim}
+\end{minted}
 
 This prints
 \begin{verbatim}
@@ -193,14 +193,14 @@ Prosite is a database containing protein domains, protein families, functional s
 
 In general, a Prosite file can contain more than one Prosite records. For example, the full set of Prosite records, which can be downloaded as a single file (\verb|prosite.dat|) from the \href{ftp://ftp.expasy.org/databases/prosite/prosite.dat}{ExPASy FTP site}, contains 2073 records (version 20.24 released on 4 December 2007). To parse such a file, we again make use of an iterator:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.ExPASy import Prosite
 >>> handle = open("myprositefile.dat")
 >>> records = Prosite.parse(handle)
-\end{verbatim}
+\end{minted}
 
 We can now take the records one at a time and print out some information. For example, using the file containing the complete Prosite database, we'd find
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.ExPASy import Prosite
 >>> handle = open("prosite.dat")
 >>> records = Prosite.parse(handle)
@@ -225,9 +225,9 @@ We can now take the records one at a time and print out some information. For ex
 'PKC_PHOSPHO_SITE'
 >>> record.pdoc
 'PDOC00005'
-\end{verbatim}
+\end{minted}
 and so on. If you're interested in how many Prosite records there are, you could use
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.ExPASy import Prosite
 >>> handle = open("prosite.dat")
 >>> records = Prosite.parse(handle)
@@ -236,14 +236,14 @@ and so on. If you're interested in how many Prosite records there are, you could
 ...
 >>> n
 2073
-\end{verbatim}
+\end{minted}
 
 To read exactly one Prosite from the handle, you can use the \verb|read| function:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.ExPASy import Prosite
 >>> handle = open("mysingleprositerecord.dat")
 >>> record = Prosite.read(handle)
-\end{verbatim}
+\end{minted}
 This function raises a ValueError if no Prosite record is found, and also if more than one Prosite record is found.
 
 \section{Parsing Prosite documentation records}
@@ -252,12 +252,12 @@ In the Prosite example above, the \verb|record.pdoc| accession numbers \verb|'PD
 
 We use the parser in \verb|Bio.ExPASy.Prodoc| to parse Prosite documentation records. For example, to create a list of all accession numbers of Prosite documentation record, you can use
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.ExPASy import Prodoc
 >>> handle = open("prosite.doc")
 >>> records = Prodoc.parse(handle)
 >>> accessions = [record.accession for record in records]
-\end{verbatim}
+\end{minted}
 
 Again a \verb|read()| function is provided to read exactly one Prosite documentation record from the handle.
 
@@ -288,7 +288,7 @@ In this example, the first line shows the EC (Enzyme Commission) number of lipop
 In Biopython, an Enzyme record is represented by the \verb|Bio.ExPASy.Enzyme.Record| class. This record derives from a Python dictionary and has keys corresponding to the two-letter codes used in Enzyme files. To read an Enzyme file containing one Enzyme record, use the \verb+read+ function in \verb|Bio.ExPASy.Enzyme|:
 
 %doctest ../Tests/Enzymes
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.ExPASy import Enzyme
 >>> with open("lipoprotein.txt") as handle:
 ...     record = Enzyme.read(handle)
@@ -303,9 +303,9 @@ In Biopython, an Enzyme record is represented by the \verb|Bio.ExPASy.Enzyme.Rec
 'Triacylglycerol + H(2)O = diacylglycerol + a carboxylate.'
 >>> record["PR"]
 ['PDOC00110']
-\end{verbatim}
+\end{minted}
 %TODO - line wrapping?
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> record["CC"]
 ['Hydrolyzes triacylglycerols in chylomicrons and very low-density lipoproteins
 (VLDL).', 'Also hydrolyzes diacylglycerol.']
@@ -314,21 +314,21 @@ In Biopython, an Enzyme record is represented by the \verb|Bio.ExPASy.Enzyme.Rec
 ['P55031', 'LIPL_FELCA'], ['P06858', 'LIPL_HUMAN'], ['P11152', 'LIPL_MOUSE'],
 ['O46647', 'LIPL_MUSVI'], ['P49060', 'LIPL_PAPAN'], ['P49923', 'LIPL_PIG'],
 ['Q06000', 'LIPL_RAT'], ['Q29524', 'LIPL_SHEEP']]
-\end{verbatim}
+\end{minted}
 The \verb+read+ function raises a ValueError if no Enzyme record is found, and also if more than one Enzyme record is found.
 
 The full set of Enzyme records can be downloaded as a single file (\verb|enzyme.dat|) from the \href{ftp://ftp.expasy.org/databases/enzyme/enzyme.dat}{ExPASy FTP site}, containing 4877 records (release of 3 March 2009). To parse such a file containing multiple Enzyme records, use the \verb+parse+ function in \verb+Bio.ExPASy.Enzyme+ to obtain an iterator:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio.ExPASy import Enzyme
 >>> handle = open("enzyme.dat")
 >>> records = Enzyme.parse(handle)
-\end{verbatim}
+\end{minted}
 
 We can now iterate over the records one at a time. For example, we can make a list of all EC numbers for which an Enzyme record is available:
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> ecnumbers = [record["ID"] for record in records]
-\end{verbatim}
+\end{minted}
 
 \section{Accessing the ExPASy server}
 
@@ -350,7 +350,7 @@ If you do a search on Swiss-Prot, you can find three orchid proteins for Chalcon
 
 First, we grab the records, using the \verb|get_sprot_raw()| function of \verb|Bio.ExPASy|. This function is very nice since you can feed it an id and get back a handle to a raw text record (no HTML to mess with!). We can the use \verb|Bio.SwissProt.read| to pull out the Swiss-Prot record, or \verb|Bio.SeqIO.read| to get a SeqRecord. The following code accomplishes what I just wrote:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import ExPASy
 >>> from Bio import SwissProt
 
@@ -361,11 +361,11 @@ First, we grab the records, using the \verb|get_sprot_raw()| function of \verb|B
 ...     handle = ExPASy.get_sprot_raw(accession)
 ...     record = SwissProt.read(handle)
 ...     records.append(record)
-\end{verbatim}
+\end{minted}
 
 If the accession number you provided to \verb|ExPASy.get_sprot_raw| does not exist, then \verb|SwissProt.read(handle)| will raise a \verb|ValueError|. You can catch \verb|ValueException| exceptions to detect invalid accession numbers:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> for accession in accessions:
 ...     handle = ExPASy.get_sprot_raw(accession)
 ...     try:
@@ -373,7 +373,7 @@ If the accession number you provided to \verb|ExPASy.get_sprot_raw| does not exi
 ...     except ValueException:
 ...         print("WARNING: Accession %s not found" % accession)
 ...     records.append(record)
-\end{verbatim}
+\end{minted}
 
 \subsection{Searching Swiss-Prot}
 
@@ -390,54 +390,54 @@ Prosite and Prosite documentation records can be retrieved either in HTML format
 
 To retrieve a Prosite or Prosite documentation record in raw format, use \verb|get_prosite_raw()|. For example, to download a Prosite record and print it out in raw text format, use
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import ExPASy
 >>> handle = ExPASy.get_prosite_raw("PS00001")
 >>> text = handle.read()
 >>> print(text)
-\end{verbatim}
+\end{minted}
 
 To retrieve a Prosite record and parse it into a \verb|Bio.Prosite.Record| object, use
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import ExPASy
 >>> from Bio import Prosite
 >>> handle = ExPASy.get_prosite_raw("PS00001")
 >>> record = Prosite.read(handle)
-\end{verbatim}
+\end{minted}
 
 The same function can be used to retrieve a Prosite documentation record and parse it into a \verb|Bio.ExPASy.Prodoc.Record| object:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import ExPASy
 >>> from Bio.ExPASy import Prodoc
 >>> handle = ExPASy.get_prosite_raw("PDOC00001")
 >>> record = Prodoc.read(handle)
-\end{verbatim}
+\end{minted}
 
 For non-existing accession numbers, \verb|ExPASy.get_prosite_raw| returns a handle to an empty string. When faced with an empty string, \verb|Prosite.read| and \verb|Prodoc.read| will raise a ValueError. You can catch these exceptions to detect invalid accession numbers.
 
 The functions \verb|get_prosite_entry()| and \verb|get_prodoc_entry()| are used to download Prosite and Prosite documentation records in HTML format. To create a web page showing one Prosite record, you can use
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import ExPASy
 >>> handle = ExPASy.get_prosite_entry("PS00001")
 >>> html = handle.read()
 >>> with open("myprositerecord.html", "w") as out_handle:
 ...     out_handle.write(html)
 ...
-\end{verbatim}
+\end{minted}
 
 and similarly for a Prosite documentation record:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> from Bio import ExPASy
 >>> handle = ExPASy.get_prodoc_entry("PDOC00001")
 >>> html = handle.read()
 >>> with open("myprodocrecord.html", "w") as out_handle:
 ...     out_handle.write(html)
 ...
-\end{verbatim}
+\end{minted}
 
 For these functions, an invalid accession number returns an error message in HTML format.
 
@@ -454,24 +454,24 @@ CRAFQYHSKEQQCVIMAENRKSSIIIRMRDVVLFEKKVYLSECKTGNGKNYRGTMSKTKN
 
 you can use the following code:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> sequence = "MEHKEVVLLLLLFLKSGQGEPLDDYVNTQGASLFSVTKKQLGAGSIEECAAKCEEDEEFT
 CRAFQYHSKEQQCVIMAENRKSSIIIRMRDVVLFEKKVYLSECKTGNGKNYRGTMSKTKN"
 >>> from Bio.ExPASy import ScanProsite
 >>> handle = ScanProsite.scan(seq=sequence)
-\end{verbatim}
+\end{minted}
 
 By executing \verb+handle.read()+, you can obtain the search results in raw XML format. Instead, let's use \verb+Bio.ExPASy.ScanProsite.read+ to parse the raw XML into a Python object:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> result = ScanProsite.read(handle)
 >>> type(result)
 <class 'Bio.ExPASy.ScanProsite.Record'>
-\end{verbatim}
+\end{minted}
 
 A \verb+Bio.ExPASy.ScanProsite.Record+ object is derived from a list, with each element in the list storing one ScanProsite hit. This object also stores the number of hits, as well as the number of search sequences, as returned by ScanProsite. This ScanProsite search resulted in six hits:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> result.n_seq
 1
 >>> result.n_match
@@ -490,14 +490,14 @@ A \verb+Bio.ExPASy.ScanProsite.Record+ object is derived from a list, with each 
 {'start': 80, 'stop': 83, 'sequence_ac': u'USERSEQ1', 'signature_ac': u'PS00004'}
 >>> result[5]
 {'start': 106, 'stop': 111, 'sequence_ac': u'USERSEQ1', 'signature_ac': u'PS00008'}
-\end{verbatim}
+\end{minted}
 
 Other ScanProsite parameters can be passed as keyword arguments; see the \href{https://prosite.expasy.org/scanprosite/scanprosite_doc.html#rest}{documentation for programmatic access of ScanProsite} for more information. As an example, passing \verb+lowscore=1+ to include matches with low level scores lets use find one additional hit:
 
-\begin{verbatim}
+\begin{minted}{pycon}
 >>> handle = ScanProsite.scan(seq=sequence, lowscore=1)
 >>> result = ScanProsite.read(handle)
 >>> result.n_match
 7
-\end{verbatim}
+\end{minted}
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -61,6 +61,11 @@ structured data source with minimal loss of functionality upon future MAST
 releases. Class structure remains the same plus an additional attribute
 ``Record.strand_handling`` required for diagram parsing.
 
+On the documentation side, all the public modules, classes, methods and
+functions now have docstrings (built in help strings). Furthermore, the PDF
+version of the *Biopython Tutorial and Cookbook* now uses syntax coloring
+for code snippets.
+
 Additionally, a number of small bugs and typos have been fixed with further
 additions to the test suite, and there has been further work to follow the
 Python PEP8, PEP257 and best practice standard coding style.

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -8,21 +8,21 @@
 # e.g.
 #
 # %doctest
-# \begin{verbatim}
+# \begin{minted}{pycon}
 # >>> from Bio.Alphabet import generic_dna
 # >>> from Bio.Seq import Seq
 # >>> len("ACGT")
 # 4
-# \end{verbatim}
+# \end{minted}
 #
 # Code snippets can be extended using a similar syntax, which
 # will create a single combined doctest:
 #
 # %cont-doctest
-# \begin{verbatim}
+# \begin{minted}{pycon}
 # >>> Seq("ACGT") == Seq("ACGT", generic_dna)
 # True
-# \end{verbatim}
+# \end{minted}
 #
 # The %doctest line also supports a relative working directory,
 # and listing multiple Python dependencies as lib:XXX which will
@@ -116,8 +116,8 @@ for latex in os.listdir(os.path.join(tutorial_base, "Tutorial/")):
 
 def _extract(handle):
     line = handle.readline()
-    if line != "\\begin{verbatim}\n":
-        raise ValueError("Any '%doctest' or '%cont-doctest' line should be followed by '\\begin{verbatim}'")
+    if line != "\\begin{minted}{pycon}\n":
+        raise ValueError("Any '%doctest' or '%cont-doctest' line should be followed by '\\begin{minted}{pycon}'")
     lines = []
     while True:
         line = handle.readline()
@@ -127,7 +127,7 @@ def _extract(handle):
                 raise ValueError("Didn't find end of test starting: %r", lines[0])
             else:
                 raise ValueError("Didn't find end of test!")
-        elif line.startswith("\\end{verbatim}"):
+        elif line.startswith("\\end{minted}"):
             break
         else:
             lines.append(line)


### PR DESCRIPTION
The short term benefit of this change is syntax colouring in the PDF output from ``pdflatex``, i.e. our file ``Tutorial.pdf``, currently using  ``python``, ``pycon``, ``bash`` only - may be scope for more, e.g. XML fragments.

Sadly this does not work in the ``Tutorial.html`` generated from the LaTeX source with ``hevea`` (output should be unchanged).

This pull request is linked to #907, replacing LaTeX, in that with this change we get much better reStructuredText or (GitHub Flavour) Markdown output from conversion using pandoc which also understands the syntax markup being used.

I have tried to check that we preserve nice copy-and-paste behaviour with the PDF (at least on macOS), which can be a problem (e.g. curly left/right quote marks, missing indentation). That failed with using ``\usepackage{listings}`` for syntax colouring (although could be made to look quite nice, and pandoc understood this).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
