### PR TITLE
Update references to Motif -> motifs

### DIFF
--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -1960,8 +1960,8 @@ class MotifTestPWM(unittest.TestCase):
         pssm = pwm.log_odds()
         result = pssm.calculate(self.s)
         self.assertEqual(6, len(result))
-        # The fast C-code in Bio/Motif/_pwm.c stores all results as 32-bit
-        # floats; the slower Python code in Bio/Motif/__init__.py uses 64-bit
+        # The fast C-code in Bio/motifs/_pwm.c stores all results as 32-bit
+        # floats; the slower Python code in Bio/motifs/__init__.py uses 64-bit
         # doubles. The C-code and Python code results will therefore not be
         # exactly equal. Test the first 5 decimal places only to avoid either
         # the C-code or the Python code to inadvertently fail this test.

--- a/Tests/test_motifs_online.py
+++ b/Tests/test_motifs_online.py
@@ -36,17 +36,17 @@ class TestotifWeblogo(unittest.TestCase):
         m.weblogo(os.devnull)
 
     def test_dna(self):
-        """Test Bio.Motif.weblogo with a DNA sequence."""
+        """Test Bio.motifs.weblogo with a DNA sequence."""
         self.check(["TACAA", "TACGC", "TACAC", "TACCC",
                     "AACCC", "AATGC", "AATGC"], extended_dna)
 
     def test_rna(self):
-        """Test Bio.Motif.weblogo with an RNA sequence."""
+        """Test Bio.motifs.weblogo with an RNA sequence."""
         self.check(["UACAA", "UACGC", "UACAC", "UACCC",
                     "AACCC", "AAUGC", "AAUGC"], unambiguous_rna)
 
     def test_protein(self):
-        """Test Bio.Motif.weblogo with a protein sequence."""
+        """Test Bio.motifs.weblogo with a protein sequence."""
         self.check(["ACDEG", "AYCRN", "HYLID", "AYHEL",
                     "ACDEH", "AYYRN", "HYIID"], extended_protein)
 


### PR DESCRIPTION
This pull request updates a few remaining references to the old `Motif` naming.

related: #2057

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)