### PR TITLE
Apply black style formatting to GenomeDiagram

### DIFF
--- a/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
@@ -57,8 +57,8 @@ def page_sizes(size):
      - size - A string representing a standard page size, eg 'A4' or 'LETTER'
 
     """
-    sizes = {
-        "A0": pagesizes.A0,  # ReportLab pagesizes, keyed by ISO string
+    sizes = {  # ReportLab pagesizes, keyed by ISO string
+        "A0": pagesizes.A0,
         "A1": pagesizes.A1,
         "A2": pagesizes.A2,
         "A3": pagesizes.A3,
@@ -87,9 +87,10 @@ def _stroke_and_fill_colors(color, border):
     if not isinstance(color, colors.Color):
         raise ValueError("Invalid color %r" % color)
 
-    if color == colors.white and border is None:  # Force black border on
-        strokecolor = colors.black  # white boxes with
-    elif border is None:  # undefined border, else
+    if color == colors.white and border is None:
+        # Force black border on white boxes with undefined border
+        strokecolor = colors.black
+    elif border is None:
         strokecolor = color  # use fill color
     elif border:
         if not isinstance(border, colors.Color):

--- a/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
@@ -436,8 +436,6 @@ class AbstractDrawer(object):
            margins to the page
          - xl        Float (0->1) describing the relative size of the left X
            margin to the page (overrides x)
-         - xl        Float (0->1) describing the relative size of the left X
-           margin to the page (overrides x)
          - xr        Float (0->1) describing the relative size of the right X
            margin to the page (overrides x)
          - yt        Float (0->1) describing the relative size of the top Y

--- a/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
@@ -57,24 +57,25 @@ def page_sizes(size):
      - size - A string representing a standard page size, eg 'A4' or 'LETTER'
 
     """
-    sizes = {'A0': pagesizes.A0,    # ReportLab pagesizes, keyed by ISO string
-             'A1': pagesizes.A1,
-             'A2': pagesizes.A2,
-             'A3': pagesizes.A3,
-             'A4': pagesizes.A4,
-             'A5': pagesizes.A5,
-             'A6': pagesizes.A6,
-             'B0': pagesizes.B0,
-             'B1': pagesizes.B1,
-             'B2': pagesizes.B2,
-             'B3': pagesizes.B3,
-             'B4': pagesizes.B4,
-             'B5': pagesizes.B5,
-             'B6': pagesizes.B6,
-             'ELEVENSEVENTEEN': pagesizes.ELEVENSEVENTEEN,
-             'LEGAL': pagesizes.LEGAL,
-             'LETTER': pagesizes.LETTER
-             }
+    sizes = {
+        "A0": pagesizes.A0,  # ReportLab pagesizes, keyed by ISO string
+        "A1": pagesizes.A1,
+        "A2": pagesizes.A2,
+        "A3": pagesizes.A3,
+        "A4": pagesizes.A4,
+        "A5": pagesizes.A5,
+        "A6": pagesizes.A6,
+        "B0": pagesizes.B0,
+        "B1": pagesizes.B1,
+        "B2": pagesizes.B2,
+        "B3": pagesizes.B3,
+        "B4": pagesizes.B4,
+        "B5": pagesizes.B5,
+        "B6": pagesizes.B6,
+        "ELEVENSEVENTEEN": pagesizes.ELEVENSEVENTEEN,
+        "LEGAL": pagesizes.LEGAL,
+        "LETTER": pagesizes.LETTER,
+    }
     try:
         return sizes[size]
     except KeyError:
@@ -86,10 +87,10 @@ def _stroke_and_fill_colors(color, border):
     if not isinstance(color, colors.Color):
         raise ValueError("Invalid color %r" % color)
 
-    if color == colors.white and border is None:   # Force black border on
-        strokecolor = colors.black                 # white boxes with
-    elif border is None:                           # undefined border, else
-        strokecolor = color                        # use fill color
+    if color == colors.white and border is None:  # Force black border on
+        strokecolor = colors.black  # white boxes with
+    elif border is None:  # undefined border, else
+        strokecolor = color  # use fill color
     elif border:
         if not isinstance(border, colors.Color):
             raise ValueError("Invalid border color %r" % border)
@@ -101,9 +102,9 @@ def _stroke_and_fill_colors(color, border):
     return strokecolor, color
 
 
-def draw_box(point1, point2,
-             color=colors.lightgreen, border=None, colour=None,
-             **kwargs):
+def draw_box(
+    point1, point2, color=colors.lightgreen, border=None, colour=None, **kwargs
+):
     """Draw a box.
 
     Arguments:
@@ -127,15 +128,18 @@ def draw_box(point1, point2,
     strokecolor, color = _stroke_and_fill_colors(color, border)
 
     x1, y1, x2, y2 = min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2)
-    return Polygon([x1, y1, x2, y1, x2, y2, x1, y2],
-                   strokeColor=strokecolor,
-                   fillColor=color,
-                   strokewidth=0,
-                   **kwargs)
+    return Polygon(
+        [x1, y1, x2, y1, x2, y2, x1, y2],
+        strokeColor=strokecolor,
+        fillColor=color,
+        strokewidth=0,
+        **kwargs
+    )
 
 
-def draw_cut_corner_box(point1, point2, corner=0.5,
-                        color=colors.lightgreen, border=None, **kwargs):
+def draw_cut_corner_box(
+    point1, point2, corner=0.5, color=colors.lightgreen, border=None, **kwargs
+):
     """Draw a box with the corners cut off."""
     x1, y1 = point1
     x2, y2 = point2
@@ -152,25 +156,37 @@ def draw_cut_corner_box(point1, point2, corner=0.5,
     x_corner = min(boxheight * 0.5 * corner, boxwidth * 0.5)
     y_corner = min(boxheight * 0.5 * corner, boxheight * 0.5)
 
-    points = [x1, y1 + y_corner,
-              x1, y2 - y_corner,
-              x1 + x_corner, y2,
-              x2 - x_corner, y2,
-              x2, y2 - y_corner,
-              x2, y1 + y_corner,
-              x2 - x_corner, y1,
-              x1 + x_corner, y1]
-    return Polygon(deduplicate(points),
-                   strokeColor=strokecolor,
-                   strokeWidth=1,
-                   strokeLineJoin=1,  # 1=round
-                   fillColor=color,
-                   **kwargs)
+    points = [
+        x1,
+        y1 + y_corner,
+        x1,
+        y2 - y_corner,
+        x1 + x_corner,
+        y2,
+        x2 - x_corner,
+        y2,
+        x2,
+        y2 - y_corner,
+        x2,
+        y1 + y_corner,
+        x2 - x_corner,
+        y1,
+        x1 + x_corner,
+        y1,
+    ]
+    return Polygon(
+        deduplicate(points),
+        strokeColor=strokecolor,
+        strokeWidth=1,
+        strokeLineJoin=1,  # 1=round
+        fillColor=color,
+        **kwargs
+    )
 
 
-def draw_polygon(list_of_points,
-                 color=colors.lightgreen, border=None, colour=None,
-                 **kwargs):
+def draw_polygon(
+    list_of_points, color=colors.lightgreen, border=None, colour=None, **kwargs
+):
     """Draw polygon.
 
     Arguments:
@@ -193,16 +209,26 @@ def draw_polygon(list_of_points,
         xy_list.append(x)
         xy_list.append(y)
 
-    return Polygon(deduplicate(xy_list),
-                   strokeColor=strokecolor,
-                   fillColor=color,
-                   strokewidth=0,
-                   **kwargs)
+    return Polygon(
+        deduplicate(xy_list),
+        strokeColor=strokecolor,
+        fillColor=color,
+        strokewidth=0,
+        **kwargs
+    )
 
 
-def draw_arrow(point1, point2, color=colors.lightgreen, border=None,
-               shaft_height_ratio=0.4, head_length_ratio=0.5, orientation='right',
-               colour=None, **kwargs):
+def draw_arrow(
+    point1,
+    point2,
+    color=colors.lightgreen,
+    border=None,
+    shaft_height_ratio=0.4,
+    head_length_ratio=0.5,
+    orientation="right",
+    colour=None,
+    **kwargs
+):
     """Draw an arrow.
 
     Returns a closed path object representing an arrow enclosed by the
@@ -231,13 +257,14 @@ def draw_arrow(point1, point2, color=colors.lightgreen, border=None,
     # using the same relative co-ordinates:
     xmin, ymin = min(x1, x2), min(y1, y2)
     xmax, ymax = max(x1, x2), max(y1, y2)
-    if orientation == 'right':
+    if orientation == "right":
         x1, x2, y1, y2 = xmin, xmax, ymin, ymax
-    elif orientation == 'left':
+    elif orientation == "left":
         x1, x2, y1, y2 = xmax, xmin, ymin, ymax
     else:
-        raise ValueError("Invalid orientation %s, should be 'left' or 'right'"
-                         % repr(orientation))
+        raise ValueError(
+            "Invalid orientation %s, should be 'left' or 'right'" % repr(orientation)
+        )
 
     # We define boxheight and boxwidth accordingly, and calculate the shaft
     # height from these.  We also ensure that the maximum head length is
@@ -254,22 +281,33 @@ def draw_arrow(point1, point2, color=colors.lightgreen, border=None,
     headbase = boxwidth - headlength
     midheight = 0.5 * boxheight
 
-    points = [x1, y1 + shafttop,
-              x1 + headbase, y1 + shafttop,
-              x1 + headbase, y2,
-              x2, y1 + midheight,
-              x1 + headbase, y1,
-              x1 + headbase, y1 + shaftbase,
-              x1, y1 + shaftbase]
+    points = [
+        x1,
+        y1 + shafttop,
+        x1 + headbase,
+        y1 + shafttop,
+        x1 + headbase,
+        y2,
+        x2,
+        y1 + midheight,
+        x1 + headbase,
+        y1,
+        x1 + headbase,
+        y1 + shaftbase,
+        x1,
+        y1 + shaftbase,
+    ]
 
-    return Polygon(deduplicate(points),
-                   strokeColor=strokecolor,
-                   # strokeWidth=max(1, int(boxheight/40.)),
-                   strokeWidth=1,
-                   # default is mitre/miter which can stick out too much:
-                   strokeLineJoin=1,  # 1=round
-                   fillColor=color,
-                   **kwargs)
+    return Polygon(
+        deduplicate(points),
+        strokeColor=strokecolor,
+        # strokeWidth=max(1, int(boxheight/40.)),
+        strokeWidth=1,
+        # default is mitre/miter which can stick out too much:
+        strokeLineJoin=1,  # 1=round
+        fillColor=color,
+        **kwargs
+    )
 
 
 def deduplicate(points):
@@ -306,7 +344,7 @@ def angle2trig(theta):
     """
     c = cos(theta * pi / 180)
     s = sin(theta * pi / 180)
-    return(c, s, -s, c)         # Vector for rotating point around an origin
+    return (c, s, -s, c)  # Vector for rotating point around an origin
 
 
 def intermediate_points(start, end, graph_data):
@@ -316,24 +354,29 @@ def intermediate_points(start, end, graph_data):
     graph data as 'bins' between position midpoints.
     """
     # print start, end, len(graph_data)
-    newdata = []    # data in form (X0, X1, val)
+    newdata = []  # data in form (X0, X1, val)
     # add first block
-    newdata.append((start,
-                    graph_data[0][0] + (graph_data[1][0] - graph_data[0][0]) / 2.,
-                    graph_data[0][1]))
+    newdata.append(
+        (
+            start,
+            graph_data[0][0] + (graph_data[1][0] - graph_data[0][0]) / 2.0,
+            graph_data[0][1],
+        )
+    )
     # add middle set
     for index in range(1, len(graph_data) - 1):
         lastxval, lastyval = graph_data[index - 1]
         xval, yval = graph_data[index]
         nextxval, nextyval = graph_data[index + 1]
-        newdata.append((lastxval + (xval - lastxval) / 2.,
-                        xval + (nextxval - xval) / 2., yval))
+        newdata.append(
+            (lastxval + (xval - lastxval) / 2.0, xval + (nextxval - xval) / 2.0, yval)
+        )
     # add last block
-    newdata.append((xval + (nextxval - xval) / 2.,
-                    end, graph_data[-1][1]))
+    newdata.append((xval + (nextxval - xval) / 2.0, end, graph_data[-1][1]))
     # print newdata[-1]
     # print newdata
     return newdata
+
 
 ################################################################################
 # CLASSES
@@ -362,9 +405,22 @@ class AbstractDrawer(object):
 
     """
 
-    def __init__(self, parent, pagesize='A3', orientation='landscape',
-                 x=0.05, y=0.05, xl=None, xr=None, yt=None, yb=None,
-                 start=None, end=None, tracklines=0, cross_track_links=None):
+    def __init__(
+        self,
+        parent,
+        pagesize="A3",
+        orientation="landscape",
+        x=0.05,
+        y=0.05,
+        xl=None,
+        xr=None,
+        yt=None,
+        yb=None,
+        start=None,
+        end=None,
+        tracklines=0,
+        cross_track_links=None,
+    ):
         """Create the object.
 
         Arguments:
@@ -395,13 +451,13 @@ class AbstractDrawer(object):
            feature A, track B, feature B) to be linked.
 
         """
-        self._parent = parent   # The calling Diagram object
+        self._parent = parent  # The calling Diagram object
 
         # Perform 'administrative' tasks of setting up the page
-        self.set_page_size(pagesize, orientation)   # Set drawing size
-        self.set_margins(x, y, xl, xr, yt, yb)      # Set page margins
+        self.set_page_size(pagesize, orientation)  # Set drawing size
+        self.set_margins(x, y, xl, xr, yt, yb)  # Set page margins
         self.set_bounds(start, end)  # Set limits on what will be drawn
-        self.tracklines = tracklines    # Set flags
+        self.tracklines = tracklines  # Set flags
         if cross_track_links is None:
             cross_track_links = []
         else:
@@ -417,7 +473,7 @@ class AbstractDrawer(object):
          - orientation   String: 'landscape' or 'portrait'
 
         """
-        if isinstance(pagesize, str):     # A string, so translate
+        if isinstance(pagesize, str):  # A string, so translate
             pagesize = page_sizes(pagesize)
         elif isinstance(pagesize, tuple):  # A tuple, so don't translate
             pagesize = pagesize
@@ -426,9 +482,9 @@ class AbstractDrawer(object):
         shortside, longside = min(pagesize), max(pagesize)
 
         orientation = orientation.lower()
-        if orientation not in ('landscape', 'portrait'):
+        if orientation not in ("landscape", "portrait"):
             raise ValueError("Orientation %s not recognised" % orientation)
-        if orientation == 'landscape':
+        if orientation == "landscape":
             self.pagesize = (longside, shortside)
         else:
             self.pagesize = (shortside, longside)
@@ -456,10 +512,16 @@ class AbstractDrawer(object):
 
         # Set page limits, center and height/width
         self.x0, self.y0 = self.pagesize[0] * xmargin_l, self.pagesize[1] * ymargin_btm
-        self.xlim, self.ylim = self.pagesize[0] * (1 - xmargin_r), self.pagesize[1] * (1 - ymargin_top)
+        self.xlim, self.ylim = (
+            self.pagesize[0] * (1 - xmargin_r),
+            self.pagesize[1] * (1 - ymargin_top),
+        )
         self.pagewidth = self.xlim - self.x0
         self.pageheight = self.ylim - self.y0
-        self.xcenter, self.ycenter = self.x0 + self.pagewidth / 2., self.y0 + self.pageheight / 2.
+        self.xcenter, self.ycenter = (
+            self.x0 + self.pagewidth / 2.0,
+            self.y0 + self.pageheight / 2.0,
+        )
 
     def set_bounds(self, start, end):
         """Set start and end points for the drawing as a whole.
@@ -475,7 +537,7 @@ class AbstractDrawer(object):
             start, end = end, start
 
         if start is None or start < 0:  # Check validity of passed args and
-            start = 0   # default to 0
+            start = 0  # default to 0
         if end is None or end < 0:
             end = high + 1  # default to track range top limit
 

--- a/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
@@ -620,7 +620,7 @@ class CircularDrawer(AbstractDrawer):
         datarange = maxval - minval
         if datarange == 0:
             datarange = trackheight
-        data = graph[self.start : self.end]
+        data = graph[self.start:self.end]
         # midval is the value at which the x-axis is plotted, and is the
         # central ring in the track
         if graph.center is None:

--- a/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
@@ -61,10 +61,25 @@ class CircularDrawer(AbstractDrawer):
 
     """
 
-    def __init__(self, parent=None, pagesize='A3', orientation='landscape',
-                 x=0.05, y=0.05, xl=None, xr=None, yt=None, yb=None,
-                 start=None, end=None, tracklines=0, track_size=0.75,
-                 circular=1, circle_core=0.0, cross_track_links=None):
+    def __init__(
+        self,
+        parent=None,
+        pagesize="A3",
+        orientation="landscape",
+        x=0.05,
+        y=0.05,
+        xl=None,
+        xr=None,
+        yt=None,
+        yb=None,
+        start=None,
+        end=None,
+        tracklines=0,
+        track_size=0.75,
+        circular=1,
+        circle_core=0.0,
+        cross_track_links=None,
+    ):
         """Create CircularDrawer object.
 
         Arguments:
@@ -103,15 +118,28 @@ class CircularDrawer(AbstractDrawer):
 
         """
         # Use the superclass' instantiation method
-        AbstractDrawer.__init__(self, parent, pagesize, orientation,
-                                x, y, xl, xr, yt, yb, start, end,
-                                tracklines, cross_track_links)
+        AbstractDrawer.__init__(
+            self,
+            parent,
+            pagesize,
+            orientation,
+            x,
+            y,
+            xl,
+            xr,
+            yt,
+            yb,
+            start,
+            end,
+            tracklines,
+            cross_track_links,
+        )
 
         # Useful measurements on the page
         self.track_size = track_size
         self.circle_core = circle_core
-        if not circular:   # Determine the proportion of the circumference
-            self.sweep = 0.9    # around which information will be drawn
+        if not circular:  # Determine the proportion of the circumference
+            self.sweep = 0.9  # around which information will be drawn
         else:
             self.sweep = 1
 
@@ -143,11 +171,13 @@ class CircularDrawer(AbstractDrawer):
 
         # Calculate top and bottom radii for each track
         self.track_radii = {}  # The inner, outer and center radii for each track
-        track_crop = trackunit_height * (1 - self.track_size) / 2.  # 'step back' in pixels
+        track_crop = (
+            trackunit_height * (1 - self.track_size) / 2.0
+        )  # 'step back' in pixels
         for track in trackunits:
             top = trackunits[track][1] * trackunit_height - track_crop + track_core
             btm = trackunits[track][0] * trackunit_height + track_crop + track_core
-            ctr = btm + (top - btm) / 2.
+            ctr = btm + (top - btm) / 2.0
             self.track_radii[track] = (btm, ctr, top)
 
     def draw(self):
@@ -155,12 +185,12 @@ class CircularDrawer(AbstractDrawer):
         # Instantiate the drawing canvas
         self.drawing = Drawing(self.pagesize[0], self.pagesize[1])
 
-        feature_elements = []           # holds feature elements
-        feature_labels = []             # holds feature labels
-        greytrack_bgs = []              # holds track background
-        greytrack_labels = []           # holds track foreground labels
-        scale_axes = []                 # holds scale axes
-        scale_labels = []               # holds scale axis labels
+        feature_elements = []  # holds feature elements
+        feature_labels = []  # holds feature labels
+        greytrack_bgs = []  # holds track background
+        greytrack_labels = []  # holds track foreground labels
+        scale_axes = []  # holds scale axes
+        scale_labels = []  # holds scale axis labels
 
         # Get tracks to be drawn and set track sizes
         self.drawn_tracks = self._parent.get_drawn_levels()
@@ -171,14 +201,14 @@ class CircularDrawer(AbstractDrawer):
         for track_level in self._parent.get_drawn_levels():
             self.current_track_level = track_level
             track = self._parent[track_level]
-            gbgs, glabels = self.draw_greytrack(track)    # Greytracks
+            gbgs, glabels = self.draw_greytrack(track)  # Greytracks
             greytrack_bgs.append(gbgs)
             greytrack_labels.append(glabels)
-            features, flabels = self.draw_track(track)   # Features and graphs
+            features, flabels = self.draw_track(track)  # Features and graphs
             feature_elements.append(features)
             feature_labels.append(flabels)
             if track.scale:
-                axes, slabels = self.draw_scale(track)       # Scale axes
+                axes, slabels = self.draw_scale(track)  # Scale axes
                 scale_axes.append(axes)
                 scale_labels.append(slabels)
 
@@ -196,11 +226,15 @@ class CircularDrawer(AbstractDrawer):
         # Draw scale labels
         # Draw feature labels
         # Draw track labels
-        element_groups = [greytrack_bgs, feature_cross_links,
-                          feature_elements,
-                          scale_axes, scale_labels,
-                          feature_labels, greytrack_labels
-                          ]
+        element_groups = [
+            greytrack_bgs,
+            feature_cross_links,
+            feature_elements,
+            scale_axes,
+            scale_labels,
+            feature_labels,
+            greytrack_labels,
+        ]
         for element_group in element_groups:
             for element_list in element_group:
                 [self.drawing.add(element) for element in element_list]
@@ -212,12 +246,10 @@ class CircularDrawer(AbstractDrawer):
     def draw_track(self, track):
         """Return list of track elements and list of track labels."""
         track_elements = []  # Holds elements for features and graphs
-        track_labels = []   # Holds labels for features and graphs
+        track_labels = []  # Holds labels for features and graphs
 
         # Distribution dictionary for dealing with different set types
-        set_methods = {FeatureSet: self.draw_feature_set,
-                       GraphSet: self.draw_graph_set
-                       }
+        set_methods = {FeatureSet: self.draw_feature_set, GraphSet: self.draw_graph_set}
 
         for set in track.get_sets():  # Draw the feature or graph sets
             elements, labels = set_methods[set.__class__](set)
@@ -229,7 +261,7 @@ class CircularDrawer(AbstractDrawer):
         """Return list of feature elements and list of labels for them."""
         # print 'draw feature set'
         feature_elements = []  # Holds diagram elements belonging to the features
-        label_elements = []   # Holds diagram elements belonging to feature labels
+        label_elements = []  # Holds diagram elements belonging to feature labels
 
         # Collect all the elements for the feature set
         for feature in set.get_features():
@@ -243,9 +275,9 @@ class CircularDrawer(AbstractDrawer):
     def draw_feature(self, feature):
         """Return list of feature elements and list of labels for them."""
         feature_elements = []  # Holds drawable elements for a single feature
-        label_elements = []   # Holds labels for a single feature
+        label_elements = []  # Holds labels for a single feature
 
-        if feature.hide:    # Don't show feature: return early
+        if feature.hide:  # Don't show feature: return early
             return feature_elements, label_elements
 
         start, end = self._current_track_start_end()
@@ -260,7 +292,7 @@ class CircularDrawer(AbstractDrawer):
             # Get sigil for the feature/ each subfeature
             feature_sigil, label = self.get_feature_sigil(feature, locstart, locend)
             feature_elements.append(feature_sigil)
-            if label is not None:   # If there's a label
+            if label is not None:  # If there's a label
                 label_elements.append(label)
 
         return feature_elements, label_elements
@@ -284,17 +316,18 @@ class CircularDrawer(AbstractDrawer):
         # Distribution dictionary for various ways of drawing the feature
         # Each method takes the inner and outer radii, the start and end angle
         # subtended at the diagram center, and the color as arguments
-        draw_methods = {'BOX': self._draw_sigil_box,
-                        'OCTO': self._draw_sigil_cut_corner_box,
-                        'JAGGY': self._draw_sigil_jaggy,
-                        'ARROW': self._draw_sigil_arrow,
-                        'BIGARROW': self._draw_sigil_big_arrow,
-                        }
+        draw_methods = {
+            "BOX": self._draw_sigil_box,
+            "OCTO": self._draw_sigil_cut_corner_box,
+            "JAGGY": self._draw_sigil_jaggy,
+            "ARROW": self._draw_sigil_arrow,
+            "BIGARROW": self._draw_sigil_big_arrow,
+        }
 
         # Get sigil for the feature, location dependent on the feature strand
         method = draw_methods[feature.sigil]
-        kwargs['head_length_ratio'] = feature.arrowhead_length
-        kwargs['shaft_height_ratio'] = feature.arrowshaft_height
+        kwargs["head_length_ratio"] = feature.arrowhead_length
+        kwargs["shaft_height_ratio"] = feature.arrowshaft_height
 
         # Support for clickable links... needs ReportLab 2.4 or later
         # which added support for links in SVG output.
@@ -302,22 +335,35 @@ class CircularDrawer(AbstractDrawer):
             kwargs["hrefURL"] = feature.url
             kwargs["hrefTitle"] = feature.name
 
-        sigil = method(btm, ctr, top, startangle, endangle, feature.strand,
-                       color=feature.color, border=feature.border, **kwargs)
+        sigil = method(
+            btm,
+            ctr,
+            top,
+            startangle,
+            endangle,
+            feature.strand,
+            color=feature.color,
+            border=feature.border,
+            **kwargs
+        )
 
-        if feature.label:   # Feature needs a label
+        if feature.label:  # Feature needs a label
             # The spaces are a hack to force a little space between the label
             # and the edge of the feature
-            label = String(0, 0, " %s " % feature.name.strip(),
-                           fontName=feature.label_font,
-                           fontSize=feature.label_size,
-                           fillColor=feature.label_color)
+            label = String(
+                0,
+                0,
+                " %s " % feature.name.strip(),
+                fontName=feature.label_font,
+                fontSize=feature.label_size,
+                fillColor=feature.label_color,
+            )
             labelgroup = Group(label)
             if feature.label_strand:
                 strand = feature.label_strand
             else:
                 strand = feature.strand
-            if feature.label_position in ('start', "5'", 'left'):
+            if feature.label_position in ("start", "5'", "left"):
                 # Position the label at the feature's start
                 if strand != -1:
                     label_angle = startangle + 0.5 * pi  # Make text radial
@@ -325,11 +371,11 @@ class CircularDrawer(AbstractDrawer):
                 else:
                     label_angle = endangle + 0.5 * pi  # Make text radial
                     sinval, cosval = endsin, endcos
-            elif feature.label_position in ('middle', 'center', 'centre'):
+            elif feature.label_position in ("middle", "center", "centre"):
                 # Position the label at the feature's midpoint
                 label_angle = midangle + 0.5 * pi  # Make text radial
                 sinval, cosval = midsin, midcos
-            elif feature.label_position in ('end', "3'", 'right'):
+            elif feature.label_position in ("end", "3'", "right"):
                 # Position the label at the feature's end
                 if strand != -1:
                     label_angle = endangle + 0.5 * pi  # Make text radial
@@ -353,19 +399,25 @@ class CircularDrawer(AbstractDrawer):
                 if startangle < pi:  # Turn text round
                     label_angle -= pi
                 else:
-                    labelgroup.contents[0].textAnchor = 'end'
+                    labelgroup.contents[0].textAnchor = "end"
             else:
                 # Feature label on bottom
                 radius = btm
                 if startangle < pi:  # Turn text round and anchor end
                     label_angle -= pi
-                    labelgroup.contents[0].textAnchor = 'end'
+                    labelgroup.contents[0].textAnchor = "end"
             x_pos = self.xcenter + radius * sinval
             y_pos = self.ycenter + radius * cosval
             coslabel = cos(label_angle)
             sinlabel = sin(label_angle)
-            labelgroup.transform = (coslabel, -sinlabel, sinlabel, coslabel,
-                                    x_pos, y_pos)
+            labelgroup.transform = (
+                coslabel,
+                -sinlabel,
+                sinlabel,
+                coslabel,
+                x_pos,
+                y_pos,
+            )
         else:
             # No label required
             labelgroup = None
@@ -437,17 +489,33 @@ class CircularDrawer(AbstractDrawer):
         btmB, ctrB, topB = self.track_radii[trackB]
 
         if ctrA < ctrB:
-            return [self._draw_arc_poly(topA, btmB,
-                                        startangleA, endangleA,
-                                        startangleB, endangleB,
-                                        cross_link.color, cross_link.border,
-                                        cross_link.flip)]
+            return [
+                self._draw_arc_poly(
+                    topA,
+                    btmB,
+                    startangleA,
+                    endangleA,
+                    startangleB,
+                    endangleB,
+                    cross_link.color,
+                    cross_link.border,
+                    cross_link.flip,
+                )
+            ]
         else:
-            return [self._draw_arc_poly(btmA, topB,
-                                        startangleA, endangleA,
-                                        startangleB, endangleB,
-                                        cross_link.color, cross_link.border,
-                                        cross_link.flip)]
+            return [
+                self._draw_arc_poly(
+                    btmA,
+                    topB,
+                    startangleA,
+                    endangleA,
+                    startangleB,
+                    endangleB,
+                    cross_link.color,
+                    cross_link.border,
+                    cross_link.flip,
+                )
+            ]
 
     def draw_graph_set(self, set):
         """Return list of graph elements and list of their labels.
@@ -460,10 +528,11 @@ class CircularDrawer(AbstractDrawer):
         elements = []  # Holds graph elements
 
         # Distribution dictionary for how to draw the graph
-        style_methods = {'line': self.draw_line_graph,
-                         'heat': self.draw_heat_graph,
-                         'bar': self.draw_bar_graph
-                         }
+        style_methods = {
+            "line": self.draw_line_graph,
+            "heat": self.draw_heat_graph,
+            "bar": self.draw_bar_graph,
+        }
 
         for graph in set.get_graphs():
             elements += style_methods[graph.style](graph)
@@ -497,7 +566,7 @@ class CircularDrawer(AbstractDrawer):
         # midval is the value at which the x-axis is plotted, and is the
         # central ring in the track
         if graph.center is None:
-            midval = (maxval + minval) / 2.
+            midval = (maxval + minval) / 2.0
         else:
             midval = graph.center
         # Whichever is the greatest difference: max-midval or min-midval, is
@@ -515,11 +584,18 @@ class CircularDrawer(AbstractDrawer):
         for pos, val in data:
             posangle, poscos, possin = self.canvas_angle(pos)
             posheight = trackheight * (val - midval) / resolution + ctr
-            x = self.xcenter + posheight * possin   # next xy coords
+            x = self.xcenter + posheight * possin  # next xy coords
             y = self.ycenter + posheight * poscos
-            line_elements.append(Line(lastx, lasty, x, y,
-                                      strokeColor=graph.poscolor,
-                                      strokeWidth=graph.linewidth))
+            line_elements.append(
+                Line(
+                    lastx,
+                    lasty,
+                    x,
+                    y,
+                    strokeColor=graph.poscolor,
+                    strokeWidth=graph.linewidth,
+                )
+            )
             lastx, lasty, = x, y
         return line_elements
 
@@ -544,11 +620,11 @@ class CircularDrawer(AbstractDrawer):
         datarange = maxval - minval
         if datarange == 0:
             datarange = trackheight
-        data = graph[self.start:self.end]
+        data = graph[self.start : self.end]
         # midval is the value at which the x-axis is plotted, and is the
         # central ring in the track
         if graph.center is None:
-            midval = (maxval + minval) / 2.
+            midval = (maxval + minval) / 2.0
         else:
             midval = graph.center
 
@@ -580,8 +656,9 @@ class CircularDrawer(AbstractDrawer):
                 barcolor = graph.negcolor
 
             # Draw bar
-            bar_elements.append(self._draw_arc(ctr, ctr + barval, pos0angle,
-                                               pos1angle, barcolor))
+            bar_elements.append(
+                self._draw_arc(ctr, ctr + barval, pos0angle, pos1angle, barcolor)
+            )
         return bar_elements
 
     def draw_heat_graph(self, graph):
@@ -600,9 +677,9 @@ class CircularDrawer(AbstractDrawer):
         # Get graph data
         data_quartiles = graph.quartiles()
         minval, maxval = data_quartiles[0], data_quartiles[4]
-        midval = (maxval + minval) / 2.  # mid is the value at the X-axis
+        midval = (maxval + minval) / 2.0  # mid is the value at the X-axis
         btm, ctr, top = self.track_radii[self.current_track_level]
-        trackheight = (top - btm)
+        trackheight = top - btm
 
         start, end = self._current_track_start_end()
         data = intermediate_points(start, end, graph[start:end])
@@ -616,13 +693,14 @@ class CircularDrawer(AbstractDrawer):
 
             # Calculate the heat color, based on the differential between
             # the value and the median value
-            heat = colors.linearlyInterpolatedColor(graph.poscolor,
-                                                    graph.negcolor,
-                                                    maxval, minval, val)
+            heat = colors.linearlyInterpolatedColor(
+                graph.poscolor, graph.negcolor, maxval, minval, val
+            )
 
             # Draw heat box
-            heat_elements.append(self._draw_arc(btm, top, pos0angle, pos1angle,
-                                                heat, border=heat))
+            heat_elements.append(
+                self._draw_arc(btm, top, pos0angle, pos1angle, heat, border=heat)
+            )
         return heat_elements
 
     def draw_scale(self, track):
@@ -641,7 +719,7 @@ class CircularDrawer(AbstractDrawer):
 
         # Get track locations
         btm, ctr, top = self.track_radii[self.current_track_level]
-        trackheight = (top - ctr)
+        trackheight = top - ctr
 
         # X-axis
         start, end = self._current_track_start_end()
@@ -650,9 +728,13 @@ class CircularDrawer(AbstractDrawer):
             p = ArcPath(strokeColor=track.scale_color, fillColor=None)
             startangle, startcos, startsin = self.canvas_angle(start)
             endangle, endcos, endsin = self.canvas_angle(end)
-            p.addArc(self.xcenter, self.ycenter, ctr,
-                     90 - (endangle * 180 / pi),
-                     90 - (startangle * 180 / pi))
+            p.addArc(
+                self.xcenter,
+                self.ycenter,
+                ctr,
+                90 - (endangle * 180 / pi),
+                90 - (startangle * 180 / pi),
+            )
             scale_elements.append(p)
             del p
             # Y-axis start marker
@@ -669,9 +751,13 @@ class CircularDrawer(AbstractDrawer):
             # Note reportlab counts angles anti-clockwise from the horizontal
             # (as in mathematics, e.g. complex numbers and polar coordinates)
             # in degrees.
-            p.addArc(self.xcenter, self.ycenter, ctr,
-                     startangledegrees=90 - 360 * self.sweep,
-                     endangledegrees=90)
+            p.addArc(
+                self.xcenter,
+                self.ycenter,
+                ctr,
+                startangledegrees=90 - 360 * self.sweep,
+                endangledegrees=90,
+            )
             scale_elements.append(p)
             del p
             # Y-axis start marker
@@ -685,9 +771,15 @@ class CircularDrawer(AbstractDrawer):
             scale_elements.append(Line(x0, y0, x1, y1, strokeColor=track.scale_color))
         else:
             # Draw a full circle
-            scale_elements.append(Circle(self.xcenter, self.ycenter, ctr,
-                                         strokeColor=track.scale_color,
-                                         fillColor=None))
+            scale_elements.append(
+                Circle(
+                    self.xcenter,
+                    self.ycenter,
+                    ctr,
+                    strokeColor=track.scale_color,
+                    fillColor=None,
+                )
+            )
 
         start, end = self._current_track_start_end()
         if track.scale_ticks:  # Ticks are required on the scale
@@ -702,26 +794,28 @@ class CircularDrawer(AbstractDrawer):
             # range(0,self.end,tickinterval) and the filter out the
             # ones before self.start - but this seems wasteful.
             # Using tickiterval * (self.start/tickiterval) is a shortcut.
-            for tickpos in range(tickiterval * (self.start // tickiterval),
-                                 int(self.end), tickiterval):
+            for tickpos in range(
+                tickiterval * (self.start // tickiterval), int(self.end), tickiterval
+            ):
                 if tickpos <= start or end <= tickpos:
                     continue
-                tick, label = self.draw_tick(tickpos, ctr, ticklen,
-                                             track,
-                                             track.scale_largetick_labels)
+                tick, label = self.draw_tick(
+                    tickpos, ctr, ticklen, track, track.scale_largetick_labels
+                )
                 scale_elements.append(tick)
                 if label is not None:  # If there's a label, add it
                     scale_labels.append(label)
             # Draw small ticks
             ticklen = track.scale_smallticks * trackheight
             tickiterval = int(track.scale_smalltick_interval)
-            for tickpos in range(tickiterval * (self.start // tickiterval),
-                                 int(self.end), tickiterval):
+            for tickpos in range(
+                tickiterval * (self.start // tickiterval), int(self.end), tickiterval
+            ):
                 if tickpos <= start or end <= tickpos:
                     continue
-                tick, label = self.draw_tick(tickpos, ctr, ticklen,
-                                             track,
-                                             track.scale_smalltick_labels)
+                tick, label = self.draw_tick(
+                    tickpos, ctr, ticklen, track, track.scale_smalltick_labels
+                )
                 scale_elements.append(tick)
                 if label is not None:  # If there's a label, add it
                     scale_labels.append(label)
@@ -740,10 +834,17 @@ class CircularDrawer(AbstractDrawer):
                         if angle < startangle or endangle < angle:
                             continue
                         ticksin, tickcos = sin(angle), cos(angle)
-                        x0, y0 = self.xcenter + btm * ticksin, self.ycenter + btm * tickcos
-                        x1, y1 = self.xcenter + top * ticksin, self.ycenter + top * tickcos
-                        scale_elements.append(Line(x0, y0, x1, y1,
-                                                   strokeColor=track.scale_color))
+                        x0, y0 = (
+                            self.xcenter + btm * ticksin,
+                            self.ycenter + btm * tickcos,
+                        )
+                        x1, y1 = (
+                            self.xcenter + top * ticksin,
+                            self.ycenter + top * tickcos,
+                        )
+                        scale_elements.append(
+                            Line(x0, y0, x1, y1, strokeColor=track.scale_color)
+                        )
 
                         graph_label_min = []
                         graph_label_max = []
@@ -752,32 +853,44 @@ class CircularDrawer(AbstractDrawer):
                             quartiles = graph.quartiles()
                             minval, maxval = quartiles[0], quartiles[4]
                             if graph.center is None:
-                                midval = (maxval + minval) / 2.
+                                midval = (maxval + minval) / 2.0
                                 graph_label_min.append("%.3f" % minval)
                                 graph_label_max.append("%.3f" % maxval)
                                 graph_label_mid.append("%.3f" % midval)
                             else:
-                                diff = max((graph.center - minval),
-                                           (maxval - graph.center))
+                                diff = max(
+                                    (graph.center - minval), (maxval - graph.center)
+                                )
                                 minval = graph.center - diff
                                 maxval = graph.center + diff
                                 midval = graph.center
                                 graph_label_mid.append("%.3f" % midval)
                                 graph_label_min.append("%.3f" % minval)
                                 graph_label_max.append("%.3f" % maxval)
-                        xmid, ymid = (x0 + x1) / 2., (y0 + y1) / 2.
-                        for limit, x, y, in [(graph_label_min, x0, y0),
-                                             (graph_label_max, x1, y1),
-                                             (graph_label_mid, xmid, ymid)]:
-                            label = String(0, 0, ";".join(limit),
-                                           fontName=track.scale_font,
-                                           fontSize=track.scale_fontsize,
-                                           fillColor=track.scale_color)
-                            label.textAnchor = 'middle'
+                        xmid, ymid = (x0 + x1) / 2.0, (y0 + y1) / 2.0
+                        for limit, x, y in [
+                            (graph_label_min, x0, y0),
+                            (graph_label_max, x1, y1),
+                            (graph_label_mid, xmid, ymid),
+                        ]:
+                            label = String(
+                                0,
+                                0,
+                                ";".join(limit),
+                                fontName=track.scale_font,
+                                fontSize=track.scale_fontsize,
+                                fillColor=track.scale_color,
+                            )
+                            label.textAnchor = "middle"
                             labelgroup = Group(label)
-                            labelgroup.transform = (tickcos, -ticksin,
-                                                    ticksin, tickcos,
-                                                    x, y)
+                            labelgroup.transform = (
+                                tickcos,
+                                -ticksin,
+                                ticksin,
+                                tickcos,
+                                x,
+                                y,
+                            )
                             scale_labels.append(labelgroup)
 
         return scale_elements, scale_labels
@@ -796,7 +909,10 @@ class CircularDrawer(AbstractDrawer):
         # Calculate tick co-ordinates
         tickangle, tickcos, ticksin = self.canvas_angle(tickpos)
         x0, y0 = self.xcenter + ctr * ticksin, self.ycenter + ctr * tickcos
-        x1, y1 = self.xcenter + (ctr + ticklen) * ticksin, self.ycenter + (ctr + ticklen) * tickcos
+        x1, y1 = (
+            self.xcenter + (ctr + ticklen) * ticksin,
+            self.ycenter + (ctr + ticklen) * tickcos,
+        )
         # Calculate height of text label so it can be offset on lower half
         # of diagram
         # LP: not used, as not all fonts have ascent_descent data in reportlab.pdfbase._fontdata
@@ -805,7 +921,7 @@ class CircularDrawer(AbstractDrawer):
         tick = Line(x0, y0, x1, y1, strokeColor=track.scale_color)
         if draw_label:
             # Put tick position on as label
-            if track.scale_format == 'SInt':
+            if track.scale_format == "SInt":
                 if tickpos >= 1000000:
                     tickstring = str(tickpos // 1000000) + " Mbp"
                 elif tickpos >= 1000:
@@ -814,12 +930,16 @@ class CircularDrawer(AbstractDrawer):
                     tickstring = str(tickpos)
             else:
                 tickstring = str(tickpos)
-            label = String(0, 0, tickstring,  # Make label string
-                           fontName=track.scale_font,
-                           fontSize=track.scale_fontsize,
-                           fillColor=track.scale_color)
+            label = String(
+                0,
+                0,
+                tickstring,  # Make label string
+                fontName=track.scale_font,
+                fontSize=track.scale_fontsize,
+                fillColor=track.scale_color,
+            )
             if tickangle > pi:
-                label.textAnchor = 'end'
+                label.textAnchor = "end"
             # LP: This label_offset depends on ascent_descent data, which is not available for all
             # fonts, so has been deprecated.
             # if 0.5*pi < tickangle < 1.5*pi:
@@ -835,15 +955,33 @@ class CircularDrawer(AbstractDrawer):
         # Add lines only for drawn tracks
         for track in self.drawn_tracks:
             btm, ctr, top = self.track_radii[track]
-            self.drawing.add(Circle(self.xcenter, self.ycenter, top,
-                                    strokeColor=colors.blue,
-                                    fillColor=None))  # top line
-            self.drawing.add(Circle(self.xcenter, self.ycenter, ctr,
-                                    strokeColor=colors.green,
-                                    fillColor=None))  # middle line
-            self.drawing.add(Circle(self.xcenter, self.ycenter, btm,
-                                    strokeColor=colors.blue,
-                                    fillColor=None))  # bottom line
+            self.drawing.add(
+                Circle(
+                    self.xcenter,
+                    self.ycenter,
+                    top,
+                    strokeColor=colors.blue,
+                    fillColor=None,
+                )
+            )  # top line
+            self.drawing.add(
+                Circle(
+                    self.xcenter,
+                    self.ycenter,
+                    ctr,
+                    strokeColor=colors.green,
+                    fillColor=None,
+                )
+            )  # middle line
+            self.drawing.add(
+                Circle(
+                    self.xcenter,
+                    self.ycenter,
+                    btm,
+                    strokeColor=colors.blue,
+                    fillColor=None,
+                )
+            )  # bottom line
 
     def draw_greytrack(self, track):
         """Drawing element for grey background to passed Track object."""
@@ -864,39 +1002,60 @@ class CircularDrawer(AbstractDrawer):
         if track.start is not None or track.end is not None:
             # Draw an arc, leaving out the wedge
             p = ArcPath(strokeColor=track.scale_color, fillColor=None)
-            greytrack_bgs.append(self._draw_arc(btm, top, startangle, endangle,
-                                                colors.Color(0.96, 0.96, 0.96)))
+            greytrack_bgs.append(
+                self._draw_arc(
+                    btm, top, startangle, endangle, colors.Color(0.96, 0.96, 0.96)
+                )
+            )
         elif self.sweep < 1:
             # Make a partial circle, a large arc box
             # This method assumes the correct center for us.
-            greytrack_bgs.append(self._draw_arc(btm, top, 0, 2 * pi * self.sweep,
-                                                colors.Color(0.96, 0.96, 0.96)))
+            greytrack_bgs.append(
+                self._draw_arc(
+                    btm, top, 0, 2 * pi * self.sweep, colors.Color(0.96, 0.96, 0.96)
+                )
+            )
         else:
             # Make a full circle (using a VERY thick linewidth)
-            greytrack_bgs.append(Circle(self.xcenter, self.ycenter, ctr,
-                                        strokeColor=colors.Color(0.96, 0.96, 0.96),
-                                        fillColor=None, strokeWidth=top - btm))
+            greytrack_bgs.append(
+                Circle(
+                    self.xcenter,
+                    self.ycenter,
+                    ctr,
+                    strokeColor=colors.Color(0.96, 0.96, 0.96),
+                    fillColor=None,
+                    strokeWidth=top - btm,
+                )
+            )
 
         if track.greytrack_labels:
             # Labels are required for this track
             labelstep = self.length // track.greytrack_labels  # label interval
             for pos in range(self.start, self.end, labelstep):
-                label = String(0, 0, track.name,            # Add a new label at
-                               fontName=track.greytrack_font,   # each interval
-                               fontSize=track.greytrack_fontsize,
-                               fillColor=track.greytrack_fontcolor)
+                label = String(
+                    0,
+                    0,
+                    track.name,  # Add a new label at
+                    fontName=track.greytrack_font,  # each interval
+                    fontSize=track.greytrack_fontsize,
+                    fillColor=track.greytrack_fontcolor,
+                )
                 theta, costheta, sintheta = self.canvas_angle(pos)
                 if theta < startangle or endangle < theta:
                     continue
-                x, y = self.xcenter + btm * sintheta, self.ycenter + btm * costheta  # start text halfway up marker
+                x, y = (
+                    self.xcenter + btm * sintheta,
+                    self.ycenter + btm * costheta,
+                )  # start text halfway up marker
                 labelgroup = Group(label)
-                labelangle = self.sweep * 2 * pi * (pos - self.start) / self.length - pi / 2
+                labelangle = (
+                    self.sweep * 2 * pi * (pos - self.start) / self.length - pi / 2
+                )
                 if theta > pi:
-                    label.textAnchor = 'end'    # Anchor end of text to inner radius
-                    labelangle += pi            # and reorient it
+                    label.textAnchor = "end"  # Anchor end of text to inner radius
+                    labelangle += pi  # and reorient it
                 cosA, sinA = cos(labelangle), sin(labelangle)
-                labelgroup.transform = (cosA, -sinA, sinA,
-                                        cosA, x, y)
+                labelgroup.transform = (cosA, -sinA, sinA, cosA, x, y)
                 if not self.length - x <= labelstep:  # Don't overrun the circle
                     greytrack_labels.append(labelgroup)
 
@@ -907,9 +1066,9 @@ class CircularDrawer(AbstractDrawer):
         angle = self.sweep * 2 * pi * (base - self.start) / self.length
         return (angle, cos(angle), sin(angle))
 
-    def _draw_sigil_box(self, bottom, center, top,
-                        startangle, endangle, strand,
-                        **kwargs):
+    def _draw_sigil_box(
+        self, bottom, center, top, startangle, endangle, strand, **kwargs
+    ):
         """Draw BOX sigil (PRIVATE)."""
         if strand == 1:
             inner_radius = center
@@ -920,10 +1079,21 @@ class CircularDrawer(AbstractDrawer):
         else:
             inner_radius = bottom
             outer_radius = top
-        return self._draw_arc(inner_radius, outer_radius, startangle, endangle, **kwargs)
+        return self._draw_arc(
+            inner_radius, outer_radius, startangle, endangle, **kwargs
+        )
 
-    def _draw_arc(self, inner_radius, outer_radius, startangle, endangle,
-                  color, border=None, colour=None, **kwargs):
+    def _draw_arc(
+        self,
+        inner_radius,
+        outer_radius,
+        startangle,
+        endangle,
+        color,
+        border=None,
+        colour=None,
+        **kwargs
+    ):
         """Return closed path describing an arc box (PRIVATE).
 
         Arguments:
@@ -946,21 +1116,29 @@ class CircularDrawer(AbstractDrawer):
 
         strokecolor, color = _stroke_and_fill_colors(color, border)
 
-        if abs(float(endangle - startangle)) > .01:
+        if abs(float(endangle - startangle)) > 0.01:
             # Wide arc, must use full curves
-            p = ArcPath(strokeColor=strokecolor,
-                        fillColor=color,
-                        strokewidth=0)
+            p = ArcPath(strokeColor=strokecolor, fillColor=color, strokewidth=0)
             # Note reportlab counts angles anti-clockwise from the horizontal
             # (as in mathematics, e.g. complex numbers and polar coordinates)
             # but we use clockwise from the vertical.  Also reportlab uses
             # degrees, but we use radians.
-            p.addArc(self.xcenter, self.ycenter, inner_radius,
-                     90 - (endangle * 180 / pi), 90 - (startangle * 180 / pi),
-                     moveTo=True)
-            p.addArc(self.xcenter, self.ycenter, outer_radius,
-                     90 - (endangle * 180 / pi), 90 - (startangle * 180 / pi),
-                     reverse=True)
+            p.addArc(
+                self.xcenter,
+                self.ycenter,
+                inner_radius,
+                90 - (endangle * 180 / pi),
+                90 - (startangle * 180 / pi),
+                moveTo=True,
+            )
+            p.addArc(
+                self.xcenter,
+                self.ycenter,
+                outer_radius,
+                90 - (endangle * 180 / pi),
+                90 - (startangle * 180 / pi),
+                reverse=True,
+            )
             p.closePath()
             return p
         else:
@@ -975,8 +1153,9 @@ class CircularDrawer(AbstractDrawer):
             x4, y4 = (x0 + outer_radius * startsin, y0 + outer_radius * startcos)
             return draw_polygon([(x1, y1), (x2, y2), (x3, y3), (x4, y4)], color, border)
 
-    def _draw_arc_line(self, path, start_radius, end_radius, start_angle, end_angle,
-                       move=False):
+    def _draw_arc_line(
+        self, path, start_radius, end_radius, start_angle, end_angle, move=False
+    ):
         """Add a list of points to a path object (PRIVATE).
 
         Assumes angles given are in degrees!
@@ -996,32 +1175,46 @@ class CircularDrawer(AbstractDrawer):
         if 0.01 <= abs(dx):
             while x < 1:
                 r = start_radius + x * radius_diff
-                a = (start_angle + x * (angle_diff)) * pi / 180  # to radians for sin/cos
+                a = (
+                    (start_angle + x * (angle_diff)) * pi / 180
+                )  # to radians for sin/cos
                 # print x0+r*cos(a), y0+r*sin(a)
                 path.lineTo(x0 + r * cos(a), y0 + r * sin(a))
                 x += dx
         a = end_angle * pi / 180
         path.lineTo(x0 + end_radius * cos(a), y0 + end_radius * sin(a))
 
-    def _draw_arc_poly(self, inner_radius, outer_radius,
-                       inner_startangle, inner_endangle,
-                       outer_startangle, outer_endangle,
-                       color, border=None, flip=False,
-                       **kwargs):
+    def _draw_arc_poly(
+        self,
+        inner_radius,
+        outer_radius,
+        inner_startangle,
+        inner_endangle,
+        outer_startangle,
+        outer_endangle,
+        color,
+        border=None,
+        flip=False,
+        **kwargs
+    ):
         """Return polygon path describing an arc."""
         strokecolor, color = _stroke_and_fill_colors(color, border)
 
-        x0, y0 = self.xcenter, self.ycenter      # origin of the circle
-        if abs(inner_endangle - outer_startangle) > 0.01 \
-        or abs(outer_endangle - inner_startangle) > 0.01 \
-        or abs(inner_startangle - outer_startangle) > 0.01 \
-        or abs(outer_startangle - outer_startangle) > 0.01:
+        x0, y0 = self.xcenter, self.ycenter  # origin of the circle
+        if (
+            abs(inner_endangle - outer_startangle) > 0.01
+            or abs(outer_endangle - inner_startangle) > 0.01
+            or abs(inner_startangle - outer_startangle) > 0.01
+            or abs(outer_startangle - outer_startangle) > 0.01
+        ):
             # Wide arc, must use full curves
-            p = ArcPath(strokeColor=strokecolor,
-                        fillColor=color,
-                        # default is mitre/miter which can stick out too much:
-                        strokeLineJoin=1,  # 1=round
-                        strokewidth=0)
+            p = ArcPath(
+                strokeColor=strokecolor,
+                fillColor=color,
+                # default is mitre/miter which can stick out too much:
+                strokeLineJoin=1,  # 1=round
+                strokewidth=0,
+            )
             # Note reportlab counts angles anti-clockwise from the horizontal
             # (as in mathematics, e.g. complex numbers and polar coordinates)
             # but we use clockwise from the vertical.  Also reportlab uses
@@ -1030,8 +1223,7 @@ class CircularDrawer(AbstractDrawer):
             i_end = 90 - (inner_endangle * 180 / pi)
             o_start = 90 - (outer_startangle * 180 / pi)
             o_end = 90 - (outer_endangle * 180 / pi)
-            p.addArc(x0, y0, inner_radius, i_end, i_start,
-                     moveTo=True, reverse=True)
+            p.addArc(x0, y0, inner_radius, i_end, i_start, moveTo=True, reverse=True)
             if flip:
                 # Flipped, join end to start,
                 self._draw_arc_line(p, inner_radius, outer_radius, i_end, o_start)
@@ -1040,31 +1232,60 @@ class CircularDrawer(AbstractDrawer):
             else:
                 # Not flipped, join start to start, end to end
                 self._draw_arc_line(p, inner_radius, outer_radius, i_end, o_end)
-                p.addArc(x0, y0, outer_radius, o_end, o_start,
-                         reverse=False)
+                p.addArc(x0, y0, outer_radius, o_end, o_start, reverse=False)
                 self._draw_arc_line(p, outer_radius, inner_radius, o_start, i_start)
             p.closePath()
             return p
         else:
             # Cheat and just use a four sided polygon.
             # Calculate trig values for angle and coordinates
-            inner_startcos, inner_startsin = cos(inner_startangle), sin(inner_startangle)
+            inner_startcos, inner_startsin = (
+                cos(inner_startangle),
+                sin(inner_startangle),
+            )
             inner_endcos, inner_endsin = cos(inner_endangle), sin(inner_endangle)
-            outer_startcos, outer_startsin = cos(outer_startangle), sin(outer_startangle)
+            outer_startcos, outer_startsin = (
+                cos(outer_startangle),
+                sin(outer_startangle),
+            )
             outer_endcos, outer_endsin = cos(outer_endangle), sin(outer_endangle)
-            x1, y1 = (x0 + inner_radius * inner_startsin, y0 + inner_radius * inner_startcos)
-            x2, y2 = (x0 + inner_radius * inner_endsin, y0 + inner_radius * inner_endcos)
-            x3, y3 = (x0 + outer_radius * outer_endsin, y0 + outer_radius * outer_endcos)
-            x4, y4 = (x0 + outer_radius * outer_startsin, y0 + outer_radius * outer_startcos)
-            return draw_polygon([(x1, y1), (x2, y2), (x3, y3), (x4, y4)], color, border,
-                                # default is mitre/miter which can stick out too much:
-                                strokeLineJoin=1,  # 1=round
-                                )
+            x1, y1 = (
+                x0 + inner_radius * inner_startsin,
+                y0 + inner_radius * inner_startcos,
+            )
+            x2, y2 = (
+                x0 + inner_radius * inner_endsin,
+                y0 + inner_radius * inner_endcos,
+            )
+            x3, y3 = (
+                x0 + outer_radius * outer_endsin,
+                y0 + outer_radius * outer_endcos,
+            )
+            x4, y4 = (
+                x0 + outer_radius * outer_startsin,
+                y0 + outer_radius * outer_startcos,
+            )
+            return draw_polygon(
+                [(x1, y1), (x2, y2), (x3, y3), (x4, y4)],
+                color,
+                border,
+                # default is mitre/miter which can stick out too much:
+                strokeLineJoin=1,  # 1=round
+            )
 
-    def _draw_sigil_cut_corner_box(self, bottom, center, top,
-                                   startangle, endangle, strand,
-                                   color, border=None, corner=0.5,
-                                   **kwargs):
+    def _draw_sigil_cut_corner_box(
+        self,
+        bottom,
+        center,
+        top,
+        startangle,
+        endangle,
+        strand,
+        color,
+        border=None,
+        corner=0.5,
+        **kwargs
+    ):
         """Draw OCTO sigil, box with corners cut off (PRIVATE)."""
         if strand == 1:
             inner_radius = center
@@ -1088,42 +1309,54 @@ class CircularDrawer(AbstractDrawer):
         shaft_inner_radius = inner_radius + corner_len
         shaft_outer_radius = outer_radius - corner_len
 
-        cornerangle_delta = max(0.0, min(abs(boxheight) * 0.5 * corner / middle_radius, abs(angle * 0.5)))
+        cornerangle_delta = max(
+            0.0, min(abs(boxheight) * 0.5 * corner / middle_radius, abs(angle * 0.5))
+        )
         if angle < 0:
             cornerangle_delta *= -1  # reverse it
 
         # Calculate trig values for angle and coordinates
         startcos, startsin = cos(startangle), sin(startangle)
         endcos, endsin = cos(endangle), sin(endangle)
-        x0, y0 = self.xcenter, self.ycenter      # origin of the circle
-        p = ArcPath(strokeColor=strokecolor,
-                    fillColor=color,
-                    strokeLineJoin=1,  # 1=round
-                    strokewidth=0,
-                    **kwargs)
+        x0, y0 = self.xcenter, self.ycenter  # origin of the circle
+        p = ArcPath(
+            strokeColor=strokecolor,
+            fillColor=color,
+            strokeLineJoin=1,  # 1=round
+            strokewidth=0,
+            **kwargs
+        )
         # Inner curved edge
-        p.addArc(self.xcenter, self.ycenter, inner_radius,
-                 90 - ((endangle - cornerangle_delta) * 180 / pi),
-                 90 - ((startangle + cornerangle_delta) * 180 / pi),
-                 moveTo=True)
+        p.addArc(
+            self.xcenter,
+            self.ycenter,
+            inner_radius,
+            90 - ((endangle - cornerangle_delta) * 180 / pi),
+            90 - ((startangle + cornerangle_delta) * 180 / pi),
+            moveTo=True,
+        )
         # Corner edge - straight lines assumes small angle!
         # TODO - Use self._draw_arc_line(p, ...) here if we expose corner setting
         p.lineTo(x0 + shaft_inner_radius * startsin, y0 + shaft_inner_radius * startcos)
         p.lineTo(x0 + shaft_outer_radius * startsin, y0 + shaft_outer_radius * startcos)
         # Outer curved edge
-        p.addArc(self.xcenter, self.ycenter, outer_radius,
-                 90 - ((endangle - cornerangle_delta) * 180 / pi),
-                 90 - ((startangle + cornerangle_delta) * 180 / pi),
-                 reverse=True)
+        p.addArc(
+            self.xcenter,
+            self.ycenter,
+            outer_radius,
+            90 - ((endangle - cornerangle_delta) * 180 / pi),
+            90 - ((startangle + cornerangle_delta) * 180 / pi),
+            reverse=True,
+        )
         # Corner edges
         p.lineTo(x0 + shaft_outer_radius * endsin, y0 + shaft_outer_radius * endcos)
         p.lineTo(x0 + shaft_inner_radius * endsin, y0 + shaft_inner_radius * endcos)
         p.closePath()
         return p
 
-    def _draw_sigil_arrow(self, bottom, center, top,
-                          startangle, endangle, strand,
-                          **kwargs):
+    def _draw_sigil_arrow(
+        self, bottom, center, top, startangle, endangle, strand, **kwargs
+    ):
         """Draw ARROW sigil (PRIVATE)."""
         if strand == 1:
             inner_radius = center
@@ -1137,24 +1370,41 @@ class CircularDrawer(AbstractDrawer):
             inner_radius = bottom
             outer_radius = top
             orientation = "right"  # backwards compatibility
-        return self._draw_arc_arrow(inner_radius, outer_radius, startangle, endangle,
-                                    orientation=orientation, **kwargs)
+        return self._draw_arc_arrow(
+            inner_radius,
+            outer_radius,
+            startangle,
+            endangle,
+            orientation=orientation,
+            **kwargs
+        )
 
-    def _draw_sigil_big_arrow(self, bottom, center, top,
-                              startangle, endangle, strand,
-                              **kwargs):
+    def _draw_sigil_big_arrow(
+        self, bottom, center, top, startangle, endangle, strand, **kwargs
+    ):
         """Draw BIGARROW sigil, like ARROW but straddles the axis (PRIVATE)."""
         if strand == -1:
             orientation = "left"
         else:
             orientation = "right"
-        return self._draw_arc_arrow(bottom, top, startangle, endangle,
-                                    orientation=orientation, **kwargs)
+        return self._draw_arc_arrow(
+            bottom, top, startangle, endangle, orientation=orientation, **kwargs
+        )
 
-    def _draw_arc_arrow(self, inner_radius, outer_radius, startangle, endangle,
-                        color, border=None,
-                        shaft_height_ratio=0.4, head_length_ratio=0.5,
-                        orientation='right', colour=None, **kwargs):
+    def _draw_arc_arrow(
+        self,
+        inner_radius,
+        outer_radius,
+        startangle,
+        endangle,
+        color,
+        border=None,
+        shaft_height_ratio=0.4,
+        head_length_ratio=0.5,
+        orientation="right",
+        colour=None,
+        **kwargs
+    ):
         """Draw an arrow along an arc (PRIVATE)."""
         # Let the UK spelling (colour) override the USA spelling (color)
         if colour is not None:
@@ -1169,16 +1419,20 @@ class CircularDrawer(AbstractDrawer):
         # else:
         startangle, endangle = min(startangle, endangle), max(startangle, endangle)
         if orientation != "left" and orientation != "right":
-            raise ValueError("Invalid orientation %s, should be 'left' or 'right'"
-                             % repr(orientation))
+            raise ValueError(
+                "Invalid orientation %s, should be 'left' or 'right'"
+                % repr(orientation)
+            )
 
-        angle = float(endangle - startangle)    # angle subtended by arc
+        angle = float(endangle - startangle)  # angle subtended by arc
         middle_radius = 0.5 * (inner_radius + outer_radius)
         boxheight = outer_radius - inner_radius
         shaft_height = boxheight * shaft_height_ratio
         shaft_inner_radius = middle_radius - 0.5 * shaft_height
         shaft_outer_radius = middle_radius + 0.5 * shaft_height
-        headangle_delta = max(0.0, min(abs(boxheight) * head_length_ratio / middle_radius, abs(angle)))
+        headangle_delta = max(
+            0.0, min(abs(boxheight) * head_length_ratio / middle_radius, abs(angle))
+        )
         if angle < 0:
             headangle_delta *= -1  # reverse it
         if orientation == "right":
@@ -1189,18 +1443,20 @@ class CircularDrawer(AbstractDrawer):
             headangle = max(min(headangle, endangle), startangle)
         else:
             headangle = max(min(headangle, startangle), endangle)
-        if not (startangle <= headangle <= endangle
-                or endangle <= headangle <= startangle):
-            raise RuntimeError("Problem drawing arrow, invalid positions. "
-                               "Start angle: %s, Head angle: %s, "
-                               "End angle: %s, Angle: %s"
-                               % (startangle, headangle, endangle, angle))
+        if not (
+            startangle <= headangle <= endangle or endangle <= headangle <= startangle
+        ):
+            raise RuntimeError(
+                "Problem drawing arrow, invalid positions. "
+                "Start angle: %s, Head angle: %s, "
+                "End angle: %s, Angle: %s" % (startangle, headangle, endangle, angle)
+            )
 
         # Calculate trig values for angle and coordinates
         startcos, startsin = cos(startangle), sin(startangle)
         headcos, headsin = cos(headangle), sin(headangle)
         endcos, endsin = cos(endangle), sin(endangle)
-        x0, y0 = self.xcenter, self.ycenter      # origin of the circle
+        x0, y0 = self.xcenter, self.ycenter  # origin of the circle
         if 0.5 >= abs(angle) and abs(headangle_delta) >= abs(angle):
             # If the angle is small, and the arrow is all head,
             # cheat and just use a triangle.
@@ -1214,58 +1470,93 @@ class CircularDrawer(AbstractDrawer):
                 x3, y3 = (x0 + middle_radius * startsin, y0 + middle_radius * startcos)
             # return draw_polygon([(x1,y1),(x2,y2),(x3,y3)], color, border,
             #                    stroke_line_join=1)
-            return Polygon([x1, y1, x2, y2, x3, y3],
-                           strokeColor=border or color,
-                           fillColor=color,
-                           strokeLineJoin=1,  # 1=round, not mitre!
-                           strokewidth=0)
+            return Polygon(
+                [x1, y1, x2, y2, x3, y3],
+                strokeColor=border or color,
+                fillColor=color,
+                strokeLineJoin=1,  # 1=round, not mitre!
+                strokewidth=0,
+            )
         elif orientation == "right":
-            p = ArcPath(strokeColor=strokecolor,
-                        fillColor=color,
-                        # default is mitre/miter which can stick out too much:
-                        strokeLineJoin=1,  # 1=round
-                        strokewidth=0,
-                        **kwargs)
+            p = ArcPath(
+                strokeColor=strokecolor,
+                fillColor=color,
+                # default is mitre/miter which can stick out too much:
+                strokeLineJoin=1,  # 1=round
+                strokewidth=0,
+                **kwargs
+            )
             # Note reportlab counts angles anti-clockwise from the horizontal
             # (as in mathematics, e.g. complex numbers and polar coordinates)
             # but we use clockwise from the vertical.  Also reportlab uses
             # degrees, but we use radians.
-            p.addArc(self.xcenter, self.ycenter, shaft_inner_radius,
-                     90 - (headangle * 180 / pi), 90 - (startangle * 180 / pi),
-                     moveTo=True)
-            p.addArc(self.xcenter, self.ycenter, shaft_outer_radius,
-                     90 - (headangle * 180 / pi), 90 - (startangle * 180 / pi),
-                     reverse=True)
+            p.addArc(
+                self.xcenter,
+                self.ycenter,
+                shaft_inner_radius,
+                90 - (headangle * 180 / pi),
+                90 - (startangle * 180 / pi),
+                moveTo=True,
+            )
+            p.addArc(
+                self.xcenter,
+                self.ycenter,
+                shaft_outer_radius,
+                90 - (headangle * 180 / pi),
+                90 - (startangle * 180 / pi),
+                reverse=True,
+            )
             if abs(angle) < 0.5:
                 p.lineTo(x0 + outer_radius * headsin, y0 + outer_radius * headcos)
                 p.lineTo(x0 + middle_radius * endsin, y0 + middle_radius * endcos)
                 p.lineTo(x0 + inner_radius * headsin, y0 + inner_radius * headcos)
             else:
-                self._draw_arc_line(p, outer_radius, middle_radius,
-                                    90 - (headangle * 180 / pi),
-                                    90 - (endangle * 180 / pi))
-                self._draw_arc_line(p, middle_radius, inner_radius,
-                                    90 - (endangle * 180 / pi),
-                                    90 - (headangle * 180 / pi))
+                self._draw_arc_line(
+                    p,
+                    outer_radius,
+                    middle_radius,
+                    90 - (headangle * 180 / pi),
+                    90 - (endangle * 180 / pi),
+                )
+                self._draw_arc_line(
+                    p,
+                    middle_radius,
+                    inner_radius,
+                    90 - (endangle * 180 / pi),
+                    90 - (headangle * 180 / pi),
+                )
             p.closePath()
             return p
         else:
-            p = ArcPath(strokeColor=strokecolor,
-                        fillColor=color,
-                        # default is mitre/miter which can stick out too much:
-                        strokeLineJoin=1,  # 1=round
-                        strokewidth=0,
-                        **kwargs)
+            p = ArcPath(
+                strokeColor=strokecolor,
+                fillColor=color,
+                # default is mitre/miter which can stick out too much:
+                strokeLineJoin=1,  # 1=round
+                strokewidth=0,
+                **kwargs
+            )
             # Note reportlab counts angles anti-clockwise from the horizontal
             # (as in mathematics, e.g. complex numbers and polar coordinates)
             # but we use clockwise from the vertical.  Also reportlab uses
             # degrees, but we use radians.
-            p.addArc(self.xcenter, self.ycenter, shaft_inner_radius,
-                     90 - (endangle * 180 / pi), 90 - (headangle * 180 / pi),
-                     moveTo=True, reverse=True)
-            p.addArc(self.xcenter, self.ycenter, shaft_outer_radius,
-                     90 - (endangle * 180 / pi), 90 - (headangle * 180 / pi),
-                     reverse=False)
+            p.addArc(
+                self.xcenter,
+                self.ycenter,
+                shaft_inner_radius,
+                90 - (endangle * 180 / pi),
+                90 - (headangle * 180 / pi),
+                moveTo=True,
+                reverse=True,
+            )
+            p.addArc(
+                self.xcenter,
+                self.ycenter,
+                shaft_outer_radius,
+                90 - (endangle * 180 / pi),
+                90 - (headangle * 180 / pi),
+                reverse=False,
+            )
             # Note - two staight lines is only a good approximation for small
             # head angle, in general will need to curved lines here:
             if abs(angle) < 0.5:
@@ -1273,19 +1564,35 @@ class CircularDrawer(AbstractDrawer):
                 p.lineTo(x0 + middle_radius * startsin, y0 + middle_radius * startcos)
                 p.lineTo(x0 + inner_radius * headsin, y0 + inner_radius * headcos)
             else:
-                self._draw_arc_line(p, outer_radius, middle_radius,
-                                    90 - (headangle * 180 / pi),
-                                    90 - (startangle * 180 / pi))
-                self._draw_arc_line(p, middle_radius, inner_radius,
-                                    90 - (startangle * 180 / pi),
-                                    90 - (headangle * 180 / pi))
+                self._draw_arc_line(
+                    p,
+                    outer_radius,
+                    middle_radius,
+                    90 - (headangle * 180 / pi),
+                    90 - (startangle * 180 / pi),
+                )
+                self._draw_arc_line(
+                    p,
+                    middle_radius,
+                    inner_radius,
+                    90 - (startangle * 180 / pi),
+                    90 - (headangle * 180 / pi),
+                )
             p.closePath()
             return p
 
-    def _draw_sigil_jaggy(self, bottom, center, top,
-                          startangle, endangle, strand,
-                          color, border=None,
-                          **kwargs):
+    def _draw_sigil_jaggy(
+        self,
+        bottom,
+        center,
+        top,
+        startangle,
+        endangle,
+        strand,
+        color,
+        border=None,
+        **kwargs
+    ):
         """Draw JAGGY sigil (PRIVATE).
 
         Although we may in future expose the head/tail jaggy lengths, for now
@@ -1311,71 +1618,111 @@ class CircularDrawer(AbstractDrawer):
         strokecolor, color = _stroke_and_fill_colors(color, border)
 
         startangle, endangle = min(startangle, endangle), max(startangle, endangle)
-        angle = float(endangle - startangle)    # angle subtended by arc
+        angle = float(endangle - startangle)  # angle subtended by arc
         height = outer_radius - inner_radius
 
         assert startangle <= endangle and angle >= 0
         if head_length_ratio and tail_length_ratio:
-            headangle = max(endangle - min(height * head_length_ratio / (center * teeth), angle * 0.5), startangle)
-            tailangle = min(startangle + min(height * tail_length_ratio / (center * teeth), angle * 0.5), endangle)
+            headangle = max(
+                endangle
+                - min(height * head_length_ratio / (center * teeth), angle * 0.5),
+                startangle,
+            )
+            tailangle = min(
+                startangle
+                + min(height * tail_length_ratio / (center * teeth), angle * 0.5),
+                endangle,
+            )
             # With very small features, can due to floating point calculations
             # violate the assertion below that start <= tail <= head <= end
             tailangle = min(tailangle, headangle)
         elif head_length_ratio:
-            headangle = max(endangle - min(height * head_length_ratio / (center * teeth), angle), startangle)
+            headangle = max(
+                endangle - min(height * head_length_ratio / (center * teeth), angle),
+                startangle,
+            )
             tailangle = startangle
         else:
             headangle = endangle
-            tailangle = min(startangle + min(height * tail_length_ratio / (center * teeth), angle), endangle)
+            tailangle = min(
+                startangle + min(height * tail_length_ratio / (center * teeth), angle),
+                endangle,
+            )
 
         if not startangle <= tailangle <= headangle <= endangle:
-            raise RuntimeError("Problem drawing jaggy sigil, invalid "
-                               "positions. Start angle: %s, "
-                               "Tail angle: %s, Head angle: %s, End angle %s, "
-                               "Angle: %s" % (startangle, tailangle, headangle,
-                                              endangle, angle))
+            raise RuntimeError(
+                "Problem drawing jaggy sigil, invalid "
+                "positions. Start angle: %s, "
+                "Tail angle: %s, Head angle: %s, End angle %s, "
+                "Angle: %s" % (startangle, tailangle, headangle, endangle, angle)
+            )
 
         # Calculate trig values for angle and coordinates
         startcos, startsin = cos(startangle), sin(startangle)
         headcos, headsin = cos(headangle), sin(headangle)
         endcos, endsin = cos(endangle), sin(endangle)
-        x0, y0 = self.xcenter, self.ycenter      # origin of the circle
+        x0, y0 = self.xcenter, self.ycenter  # origin of the circle
 
-        p = ArcPath(strokeColor=strokecolor,
-                    fillColor=color,
-                    # default is mitre/miter which can stick out too much:
-                    strokeLineJoin=1,  # 1=round
-                    strokewidth=0,
-                    **kwargs)
+        p = ArcPath(
+            strokeColor=strokecolor,
+            fillColor=color,
+            # default is mitre/miter which can stick out too much:
+            strokeLineJoin=1,  # 1=round
+            strokewidth=0,
+            **kwargs
+        )
         # Note reportlab counts angles anti-clockwise from the horizontal
         # (as in mathematics, e.g. complex numbers and polar coordinates)
         # but we use clockwise from the vertical.  Also reportlab uses
         # degrees, but we use radians.
-        p.addArc(self.xcenter, self.ycenter, inner_radius,
-                 90 - (headangle * 180 / pi), 90 - (tailangle * 180 / pi),
-                 moveTo=True)
+        p.addArc(
+            self.xcenter,
+            self.ycenter,
+            inner_radius,
+            90 - (headangle * 180 / pi),
+            90 - (tailangle * 180 / pi),
+            moveTo=True,
+        )
         for i in range(0, teeth):
-            p.addArc(self.xcenter, self.ycenter, inner_radius + i * height / teeth,
-                     90 - (tailangle * 180 / pi), 90 - (startangle * 180 / pi))
+            p.addArc(
+                self.xcenter,
+                self.ycenter,
+                inner_radius + i * height / teeth,
+                90 - (tailangle * 180 / pi),
+                90 - (startangle * 180 / pi),
+            )
             # Curved line needed when drawing long jaggies
-            self._draw_arc_line(p,
-                                inner_radius + i * height / teeth,
-                                inner_radius + (i + 1) * height / teeth,
-                                90 - (startangle * 180 / pi),
-                                90 - (tailangle * 180 / pi))
-        p.addArc(self.xcenter, self.ycenter, outer_radius,
-                 90 - (headangle * 180 / pi), 90 - (tailangle * 180 / pi),
-                 reverse=True)
+            self._draw_arc_line(
+                p,
+                inner_radius + i * height / teeth,
+                inner_radius + (i + 1) * height / teeth,
+                90 - (startangle * 180 / pi),
+                90 - (tailangle * 180 / pi),
+            )
+        p.addArc(
+            self.xcenter,
+            self.ycenter,
+            outer_radius,
+            90 - (headangle * 180 / pi),
+            90 - (tailangle * 180 / pi),
+            reverse=True,
+        )
         for i in range(0, teeth):
-            p.addArc(self.xcenter, self.ycenter,
-                     outer_radius - i * height / teeth,
-                     90 - (endangle * 180 / pi), 90 - (headangle * 180 / pi),
-                     reverse=True)
+            p.addArc(
+                self.xcenter,
+                self.ycenter,
+                outer_radius - i * height / teeth,
+                90 - (endangle * 180 / pi),
+                90 - (headangle * 180 / pi),
+                reverse=True,
+            )
             # Curved line needed when drawing long jaggies
-            self._draw_arc_line(p,
-                                outer_radius - i * height / teeth,
-                                outer_radius - (i + 1) * height / teeth,
-                                90 - (endangle * 180 / pi),
-                                90 - (headangle * 180 / pi))
+            self._draw_arc_line(
+                p,
+                outer_radius - i * height / teeth,
+                outer_radius - (i + 1) * height / teeth,
+                90 - (endangle * 180 / pi),
+                90 - (headangle * 180 / pi),
+            )
         p.closePath()
         return p

--- a/Bio/Graphics/GenomeDiagram/_Colors.py
+++ b/Bio/Graphics/GenomeDiagram/_Colors.py
@@ -64,7 +64,7 @@ class ColorTranslator(object):
         colorscheme information.
         """
         self._artemis_colorscheme = {
-            0: (colors.Color(1, 1, 1,), "pathogenicity, adaptation, chaperones"),
+            0: (colors.Color(1, 1, 1), "pathogenicity, adaptation, chaperones"),
             1: (colors.Color(0.39, 0.39, 0.39), "energy metabolism"),
             2: (colors.Color(1, 0, 0), "information transfer"),
             3: (colors.Color(0, 1, 0), "surface"),
@@ -82,7 +82,7 @@ class ColorTranslator(object):
             15: (colors.Color(1, 0.25, 0.25), "secondary metabolism"),
             16: (colors.Color(1, 0.5, 0.5), ""),
             17: (colors.Color(1, 0.75, 0.75), ""),
-        }      # Hardwired Artemis color scheme
+        }  # Hardwired Artemis color scheme
         self._colorscheme = {}
         if filename is not None:
             self.read_colorscheme(filename)  # Imported color scheme
@@ -139,9 +139,9 @@ class ColorTranslator(object):
             2 \t 255 \t 0 \t 0 \t Red: Information transfer
 
         """
-        with open(filename, 'r').readlines() as lines:
+        with open(filename, "r").readlines() as lines:
             for line in lines:
-                data = line.strip().split('\t')
+                data = line.strip().split("\t")
                 try:
                     label = int(data[0])
                     red, green, blue = int(data[1]), int(data[2]), int(data[3])
@@ -149,10 +149,14 @@ class ColorTranslator(object):
                         comment = data[4]
                     else:
                         comment = ""
-                    self._colorscheme[label] = (self.int255_color((red, green, blue)),
-                                                comment)
+                    self._colorscheme[label] = (
+                        self.int255_color((red, green, blue)),
+                        comment,
+                    )
                 except ValueError:
-                    raise ValueError("Expected INT \t INT \t INT \t INT \t string input")
+                    raise ValueError(
+                        "Expected INT \t INT \t INT \t INT \t string input"
+                    )
 
     def get_artemis_colorscheme(self):
         """Return the Artemis color scheme as a dictionary."""
@@ -175,8 +179,8 @@ class ColorTranslator(object):
         try:
             value = int(value)
         except ValueError:
-            if value.count('.'):  # dot-delimited
-                value = int(value.split('.', 1)[0])  # Use only first integer
+            if value.count("."):  # dot-delimited
+                value = int(value.split(".", 1)[0])  # Use only first integer
             else:
                 raise
         if value in self._artemis_colorscheme:
@@ -212,7 +216,7 @@ class ColorTranslator(object):
         0 -> 255 and returns an appropriate colors.Color object.
         """
         red, green, blue = values
-        factor = 1 / 255.
+        factor = 1 / 255.0
         red, green, blue = red * factor, green * factor, blue * factor
         return colors.Color(red, green, blue)
 
@@ -229,6 +233,7 @@ class ColorTranslator(object):
         return colors.Color(red, green, blue)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from Bio._utils import run_doctest
+
     run_doctest(verbose=2)

--- a/Bio/Graphics/GenomeDiagram/_CrossLink.py
+++ b/Bio/Graphics/GenomeDiagram/_CrossLink.py
@@ -12,8 +12,9 @@ from reportlab.lib import colors
 class CrossLink(object):
     """Hold information for drawing a cross link between features."""
 
-    def __init__(self, featureA, featureB,
-                 color=colors.lightgreen, border=None, flip=False):
+    def __init__(
+        self, featureA, featureB, color=colors.lightgreen, border=None, flip=False
+    ):
         """Create a new cross link.
 
         Arguments featureA and featureB should GenomeDiagram feature objects,
@@ -32,7 +33,7 @@ class CrossLink(object):
         # Initialize attributes
         self.featureA = featureA
         self.featureB = featureB
-        self.color = color            # default color to draw the feature
+        self.color = color  # default color to draw the feature
         self.border = border
         self.flip = flip
 

--- a/Bio/Graphics/GenomeDiagram/_Diagram.py
+++ b/Bio/Graphics/GenomeDiagram/_Diagram.py
@@ -84,17 +84,33 @@ class Diagram(object):
 
     """
 
-    def __init__(self, name=None, format='circular', pagesize='A3',
-                 orientation='landscape', x=0.05, y=0.05, xl=None,
-                 xr=None, yt=None, yb=None, start=None, end=None,
-                 tracklines=False, fragments=10, fragment_size=None,
-                 track_size=0.75, circular=True, circle_core=0.0):
+    def __init__(
+        self,
+        name=None,
+        format="circular",
+        pagesize="A3",
+        orientation="landscape",
+        x=0.05,
+        y=0.05,
+        xl=None,
+        xr=None,
+        yt=None,
+        yb=None,
+        start=None,
+        end=None,
+        tracklines=False,
+        fragments=10,
+        fragment_size=None,
+        track_size=0.75,
+        circular=True,
+        circle_core=0.0,
+    ):
         """Initialize.
 
         gdd = Diagram(name=None)
         """
-        self.tracks = {}   # Holds all Track objects, keyed by level
-        self.name = name    # Description of the diagram
+        self.tracks = {}  # Holds all Track objects, keyed by level
+        self.name = name  # Description of the diagram
         # Diagram page setup attributes
         self.format = format
         self.pagesize = pagesize
@@ -117,7 +133,7 @@ class Diagram(object):
                 self.fragment_size = 1
             else:
                 # Otherwise keep a 10% gap between fragments
-                self.fragment_size = .9
+                self.fragment_size = 0.9
         self.track_size = track_size
         self.circular = circular
         self.circle_core = circle_core
@@ -134,15 +150,31 @@ class Diagram(object):
         set_all_tracks(self, attr, value)
         """
         for track in self.tracks.values():
-            if hasattr(track, attr):          # If the feature has the attribute
+            if hasattr(track, attr):  # If the feature has the attribute
                 if getattr(track, attr) != value:
-                    setattr(track, attr, value)   # set it to the passed value
+                    setattr(track, attr, value)  # set it to the passed value
 
-    def draw(self, format=None, pagesize=None, orientation=None,
-             x=None, y=None, xl=None, xr=None, yt=None, yb=None,
-             start=None, end=None, tracklines=None, fragments=None,
-             fragment_size=None, track_size=None, circular=None,
-             circle_core=None, cross_track_links=None):
+    def draw(
+        self,
+        format=None,
+        pagesize=None,
+        orientation=None,
+        x=None,
+        y=None,
+        xl=None,
+        xr=None,
+        yt=None,
+        yb=None,
+        start=None,
+        end=None,
+        tracklines=None,
+        fragments=None,
+        fragment_size=None,
+        track_size=None,
+        circular=None,
+        circle_core=None,
+        cross_track_links=None,
+    ):
         """Draw the diagram, with passed parameters overriding existing attributes.
 
         gdd.draw(format='circular')
@@ -151,42 +183,48 @@ class Diagram(object):
         # diagrams.  At the moment, we detect overrides with an or in the
         # Instantiation arguments, but I suspect there's a neater way to do
         # this.
-        if format == 'linear':
-            drawer = LinearDrawer(self, _first_defined(pagesize, self.pagesize),
-                                  _first_defined(orientation, self.orientation),
-                                  _first_defined(x, self.x),
-                                  _first_defined(y, self.y),
-                                  _first_defined(xl, self.xl),
-                                  _first_defined(xr, self.xr),
-                                  _first_defined(yt, self.yt),
-                                  _first_defined(yb, self.yb),
-                                  _first_defined(start, self.start),
-                                  _first_defined(end, self.end),
-                                  _first_defined(tracklines, self.tracklines),
-                                  _first_defined(fragments, self.fragments),
-                                  _first_defined(fragment_size, self.fragment_size),
-                                  _first_defined(track_size, self.track_size),
-                                  _first_defined(cross_track_links, self.cross_track_links))
+        if format == "linear":
+            drawer = LinearDrawer(
+                self,
+                _first_defined(pagesize, self.pagesize),
+                _first_defined(orientation, self.orientation),
+                _first_defined(x, self.x),
+                _first_defined(y, self.y),
+                _first_defined(xl, self.xl),
+                _first_defined(xr, self.xr),
+                _first_defined(yt, self.yt),
+                _first_defined(yb, self.yb),
+                _first_defined(start, self.start),
+                _first_defined(end, self.end),
+                _first_defined(tracklines, self.tracklines),
+                _first_defined(fragments, self.fragments),
+                _first_defined(fragment_size, self.fragment_size),
+                _first_defined(track_size, self.track_size),
+                _first_defined(cross_track_links, self.cross_track_links),
+            )
         else:
-            drawer = CircularDrawer(self, _first_defined(pagesize, self.pagesize),
-                                    _first_defined(orientation, self.orientation),
-                                    _first_defined(x, self.x),
-                                    _first_defined(y, self.y),
-                                    _first_defined(xl, self.xl),
-                                    _first_defined(xr, self.xr),
-                                    _first_defined(yt, self.yt),
-                                    _first_defined(yb, self.yb),
-                                    _first_defined(start, self.start),
-                                    _first_defined(end, self.end),
-                                    _first_defined(tracklines, self.tracklines),
-                                    _first_defined(track_size, self.track_size),
-                                    _first_defined(circular, self.circular),
-                                    _first_defined(circle_core, self.circle_core),
-                                    _first_defined(cross_track_links, self.cross_track_links))
-        drawer.draw()   # Tell the drawer to complete the drawing
+            drawer = CircularDrawer(
+                self,
+                _first_defined(pagesize, self.pagesize),
+                _first_defined(orientation, self.orientation),
+                _first_defined(x, self.x),
+                _first_defined(y, self.y),
+                _first_defined(xl, self.xl),
+                _first_defined(xr, self.xr),
+                _first_defined(yt, self.yt),
+                _first_defined(yb, self.yb),
+                _first_defined(start, self.start),
+                _first_defined(end, self.end),
+                _first_defined(tracklines, self.tracklines),
+                _first_defined(track_size, self.track_size),
+                _first_defined(circular, self.circular),
+                _first_defined(circle_core, self.circle_core),
+                _first_defined(cross_track_links, self.cross_track_links),
+            )
+        drawer.draw()  # Tell the drawer to complete the drawing
         self.drawing = drawer.drawing  # Get the completed drawing
 
-    def write(self, filename='test1.ps', output='PS', dpi=72):
+    def write(self, filename="test1.ps", output="PS", dpi=72):
         """Write the drawn diagram to a specified file, in a specified format.
 
         Arguments:
@@ -206,7 +244,7 @@ class Diagram(object):
         """
         return _write(self.drawing, filename, output, dpi=dpi)
 
-    def write_to_string(self, output='PS', dpi=72):
+    def write_to_string(self, output="PS", dpi=72):
         """Return a byte string containing the diagram in the requested format.
 
         Arguments:
@@ -228,6 +266,7 @@ class Diagram(object):
         #
         # TODO - Rename this method to include keyword bytes?
         from io import BytesIO
+
         handle = BytesIO()
         self.write(handle, output, dpi)
         return handle.getvalue()
@@ -247,16 +286,18 @@ class Diagram(object):
         """
         if track is None:
             raise ValueError("Must specify track")
-        if track_level not in self.tracks:     # No track at that level
-            self.tracks[track_level] = track   # so just add it
-        else:       # Already a track there, so shunt all higher tracks up one
-            occupied_levels = sorted(self.get_levels())  # Get list of occupied levels...
-            occupied_levels.reverse()           # ...reverse it (highest first)
+        if track_level not in self.tracks:  # No track at that level
+            self.tracks[track_level] = track  # so just add it
+        else:  # Already a track there, so shunt all higher tracks up one
+            occupied_levels = sorted(
+                self.get_levels()
+            )  # Get list of occupied levels...
+            occupied_levels.reverse()  # ...reverse it (highest first)
             for val in occupied_levels:
                 # If track value >= that to be added
                 if val >= track.track_level:
                     self.tracks[val + 1] = self.tracks[val]  # ...increment by 1
-            self.tracks[track_level] = track   # And put the new track in
+            self.tracks[track_level] = track  # And put the new track in
         self.tracks[track_level].track_level = track_level
 
     def new_track(self, track_level, **args):
@@ -273,15 +314,17 @@ class Diagram(object):
         newtrack = Track()
         for key in args:
             setattr(newtrack, key, args[key])
-        if track_level not in self.tracks:        # No track at that level
-            self.tracks[track_level] = newtrack   # so just add it
-        else:       # Already a track there, so shunt all higher tracks up one
-            occupied_levels = sorted(self.get_levels())  # Get list of occupied levels...
-            occupied_levels.reverse()           # ...reverse (highest first)...
+        if track_level not in self.tracks:  # No track at that level
+            self.tracks[track_level] = newtrack  # so just add it
+        else:  # Already a track there, so shunt all higher tracks up one
+            occupied_levels = sorted(
+                self.get_levels()
+            )  # Get list of occupied levels...
+            occupied_levels.reverse()  # ...reverse (highest first)...
             for val in occupied_levels:
-                if val >= track_level:        # Track value >= that to be added
+                if val >= track_level:  # Track value >= that to be added
                     self.tracks[val + 1] = self.tracks[val]  # ..increment by 1
-            self.tracks[track_level] = newtrack   # And put the new track in
+            self.tracks[track_level] = newtrack  # And put the new track in
         self.tracks[track_level].track_level = track_level
         return newtrack
 
@@ -326,15 +369,15 @@ class Diagram(object):
           tracks.
 
         """
-        track = low                 # Start numbering from here
+        track = low  # Start numbering from here
         levels = self.get_levels()
 
-        conversion = {}             # Holds new set of levels
-        for level in levels:        # Starting at low...
+        conversion = {}  # Holds new set of levels
+        for level in levels:  # Starting at low...
             conversion[track] = self.tracks[level]  # Add old tracks to new set
             conversion[track].track_level = track
-            track += step                           # step interval
-        self.tracks = conversion   # Replace old set of levels with new set
+            track += step  # step interval
+        self.tracks = conversion  # Replace old set of levels with new set
 
     def get_levels(self):
         """Return a sorted list of levels occupied by tracks in the diagram."""
@@ -357,7 +400,7 @@ class Diagram(object):
             low, high = track.range()
             lows.append(low)
             highs.append(high)
-        return min(lows), max(highs)      # Return extremes from all tracks
+        return min(lows), max(highs)  # Return extremes from all tracks
 
     def __getitem__(self, key):
         """Return the track contained at the level of the passed key."""
@@ -369,5 +412,5 @@ class Diagram(object):
         outstr.append("%d tracks" % len(self.tracks))
         for level in self.get_levels():
             outstr.append("Track %d: %s\n" % (level, self.tracks[level]))
-        outstr = '\n'.join(outstr)
+        outstr = "\n".join(outstr)
         return outstr

--- a/Bio/Graphics/GenomeDiagram/_Diagram.py
+++ b/Bio/Graphics/GenomeDiagram/_Diagram.py
@@ -150,9 +150,10 @@ class Diagram(object):
         set_all_tracks(self, attr, value)
         """
         for track in self.tracks.values():
-            if hasattr(track, attr):  # If the feature has the attribute
+            if hasattr(track, attr):
+                # If the feature has the attribute set it to the passed value
                 if getattr(track, attr) != value:
-                    setattr(track, attr, value)  # set it to the passed value
+                    setattr(track, attr, value)
 
     def draw(
         self,
@@ -322,8 +323,9 @@ class Diagram(object):
             )  # Get list of occupied levels...
             occupied_levels.reverse()  # ...reverse (highest first)...
             for val in occupied_levels:
-                if val >= track_level:  # Track value >= that to be added
-                    self.tracks[val + 1] = self.tracks[val]  # ..increment by 1
+                if val >= track_level:
+                    # Track value >= that to be added, increment by 1
+                    self.tracks[val + 1] = self.tracks[val]
             self.tracks[track_level] = newtrack  # And put the new track in
         self.tracks[track_level].track_level = track_level
         return newtrack

--- a/Bio/Graphics/GenomeDiagram/_Feature.py
+++ b/Bio/Graphics/GenomeDiagram/_Feature.py
@@ -67,8 +67,16 @@ class Feature(object):
 
     """
 
-    def __init__(self, parent=None, feature_id=None, feature=None,
-                 color=colors.lightgreen, label=0, border=None, colour=None):
+    def __init__(
+        self,
+        parent=None,
+        feature_id=None,
+        feature=None,
+        color=colors.lightgreen,
+        label=0,
+        border=None,
+        colour=None,
+    ):
         """Initialize.
 
         Arguments:
@@ -93,16 +101,16 @@ class Feature(object):
         # Initialize attributes
         self.parent = parent
         self.id = feature_id
-        self.color = color            # default color to draw the feature
+        self.color = color  # default color to draw the feature
         self.border = border
-        self._feature = None            # Bio.SeqFeature object to wrap
-        self.hide = 0                   # show by default
-        self.sigil = 'BOX'
+        self._feature = None  # Bio.SeqFeature object to wrap
+        self.hide = 0  # show by default
+        self.sigil = "BOX"
         self.arrowhead_length = 0.5  # 50% of the box height
         self.arrowshaft_height = 0.4  # 40% of the box height
-        self.name_qualifiers = ['gene', 'label', 'name', 'locus_tag', 'product']
+        self.name_qualifiers = ["gene", "label", "name", "locus_tag", "product"]
         self.label = label
-        self.label_font = 'Helvetica'
+        self.label_font = "Helvetica"
         self.label_size = 6
         self.label_color = colors.black
         self.label_angle = 45
@@ -129,17 +137,18 @@ class Feature(object):
             #    start, end = end, start
             self.locations.append((start, end))
             bounds += [start, end]
-        self.type = str(self._feature.type)                     # Feature type
+        self.type = str(self._feature.type)  # Feature type
         # TODO - Strand can vary with subfeatures (e.g. mixed strand tRNA)
         if self._feature.strand is None:
             # This is the SeqFeature default (None), but the drawing code
             # only expects 0, +1 or -1.
             self.strand = 0
         else:
-            self.strand = int(self._feature.strand)                 # Feature strand
-        if 'color' in self._feature.qualifiers:                # Artemis color (if present)
+            self.strand = int(self._feature.strand)  # Feature strand
+        if "color" in self._feature.qualifiers:  # Artemis color (if present)
             self.color = self._colortranslator.artemis_color(
-                                         self._feature.qualifiers['color'][0])
+                self._feature.qualifiers["color"][0]
+            )
         self.name = self.type
         for qualifier in self.name_qualifiers:
             if qualifier in self._feature.qualifiers:
@@ -183,7 +192,7 @@ class Feature(object):
 # RUN AS SCRIPT
 ################################################################################
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     # Test code
     gdf = Feature()

--- a/Bio/Graphics/GenomeDiagram/_FeatureSet.py
+++ b/Bio/Graphics/GenomeDiagram/_FeatureSet.py
@@ -45,10 +45,10 @@ class FeatureSet(object):
 
         """
         self.parent = parent
-        self.id = id            # Unique id for the set
-        self.next_id = 0       # counter for unique feature ids
-        self.features = {}     # Holds features, keyed by ID
-        self.name = name        # String describing the set
+        self.id = id  # Unique id for the set
+        self.next_id = 0  # counter for unique feature ids
+        self.features = {}  # Holds features, keyed by ID
+        self.name = name  # String describing the set
 
     def add_feature(self, feature, **kwargs):
         """Add a new feature.
@@ -74,7 +74,7 @@ class FeatureSet(object):
                 self.features[id].set_color(kwargs[key])
                 continue
             setattr(self.features[id], key, kwargs[key])
-        self.next_id += 1                                  # increment next id
+        self.next_id += 1  # increment next id
         return f
 
     def del_feature(self, feature_id):
@@ -133,23 +133,35 @@ class FeatureSet(object):
         # If no comparator is specified, return all features where the attribute
         # value matches that passed
         if comparator is None:
-            return [feature for feature in self.features.values() if
-                    getattr(feature, attribute) == value]
+            return [
+                feature
+                for feature in self.features.values()
+                if getattr(feature, attribute) == value
+            ]
         # If the comparator is 'not', return all features where the attribute
         # value does not match that passed
-        elif comparator == 'not':
-            return [feature for feature in self.features.values() if
-                    getattr(feature, attribute) != value]
+        elif comparator == "not":
+            return [
+                feature
+                for feature in self.features.values()
+                if getattr(feature, attribute) != value
+            ]
         # If the comparator is 'startswith', return all features where the attribute
         # value does not match that passed
-        elif comparator == 'startswith':
-            return [feature for feature in self.features.values() if
-                    getattr(feature, attribute).startswith(value)]
+        elif comparator == "startswith":
+            return [
+                feature
+                for feature in self.features.values()
+                if getattr(feature, attribute).startswith(value)
+            ]
         # If the comparator is 'like', use a regular expression search to identify
         # features
-        elif comparator == 'like':
-            return [feature for feature in self.features.values() if
-                    re.search(value, getattr(feature, attribute))]
+        elif comparator == "like":
+            return [
+                feature
+                for feature in self.features.values()
+                if re.search(value, getattr(feature, attribute))
+            ]
         # As a final option, just return an empty list
         return []
 
@@ -164,8 +176,8 @@ class FeatureSet(object):
             for start, end in feature.locations:
                 lows.append(start)
                 highs.append(end)
-        if len(lows) != 0 and len(highs) != 0:      # Default in case there is
-            return (min(lows), max(highs))          # nothing in the set
+        if len(lows) != 0 and len(highs) != 0:  # Default in case there is
+            return (min(lows), max(highs))  # nothing in the set
         return 0, 0
 
     def to_string(self, verbose=0):
@@ -177,9 +189,9 @@ class FeatureSet(object):
           complete account of the set is required
 
         """
-        if not verbose:         # Short account only required
+        if not verbose:  # Short account only required
             return "%s" % self
-        else:                   # Long account desired
+        else:  # Long account desired
             outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
             outstr.append("%d features" % len(self.features))
             for key in self.features:
@@ -196,6 +208,7 @@ class FeatureSet(object):
 
     def __str__(self):
         """Return a formatted string with information about the feature set."""
-        outstr = ["\n<%s: %s %d features>" % (self.__class__, self.name,
-                                              len(self.features))]
+        outstr = [
+            "\n<%s: %s %d features>" % (self.__class__, self.name, len(self.features))
+        ]
         return "\n".join(outstr)

--- a/Bio/Graphics/GenomeDiagram/_Graph.py
+++ b/Bio/Graphics/GenomeDiagram/_Graph.py
@@ -44,9 +44,18 @@ class GraphData(object):
 
     """
 
-    def __init__(self, id=None, data=None, name=None, style='bar',
-                 color=colors.lightgreen, altcolor=colors.darkseagreen,
-                 center=None, colour=None, altcolour=None):
+    def __init__(
+        self,
+        id=None,
+        data=None,
+        name=None,
+        style="bar",
+        color=colors.lightgreen,
+        altcolor=colors.darkseagreen,
+        center=None,
+        colour=None,
+        altcolour=None,
+    ):
         """Initialize.
 
         Arguments:
@@ -70,22 +79,22 @@ class GraphData(object):
         if altcolour is not None:
             altcolor = altcolour
 
-        self.id = id            # Unique identifier for the graph
-        self.data = {}          # holds values, keyed by sequence position
+        self.id = id  # Unique identifier for the graph
+        self.data = {}  # holds values, keyed by sequence position
         if data is not None:
             self.set_data(data)
-        self.name = name        # Descriptive string
+        self.name = name  # Descriptive string
 
         # Attributes describing how the graph will be drawn
-        self.style = style          # One of 'bar', 'heat' or 'line'
-        self.poscolor = color     # Color to draw all, or 'high' values
+        self.style = style  # One of 'bar', 'heat' or 'line'
+        self.poscolor = color  # Color to draw all, or 'high' values
         self.negcolor = altcolor  # Color to draw 'low' values
-        self.linewidth = 2          # linewidth to use in line graphs
-        self.center = center        # value at which x-axis crosses y-axis
+        self.linewidth = 2  # linewidth to use in line graphs
+        self.center = center  # value at which x-axis crosses y-axis
 
     def set_data(self, data):
         """Add data as a list of (position, value) tuples."""
-        for (pos, val) in data:     # Fill data dictionary
+        for (pos, val) in data:  # Fill data dictionary
             self.data[pos] = val
 
     def get_data(self):
@@ -106,8 +115,13 @@ class GraphData(object):
         """Return (minimum, lowerQ, medianQ, upperQ, maximum) values as tuple."""
         data = sorted(self.data.values())
         datalen = len(data)
-        return(data[0], data[datalen // 4], data[datalen // 2],
-               data[3 * datalen // 4], data[-1])
+        return (
+            data[0],
+            data[datalen // 4],
+            data[datalen // 2],
+            data[3 * datalen // 4],
+            data[-1],
+        )
 
     def range(self):
         """Return range of data as (start, end) tuple.
@@ -123,7 +137,7 @@ class GraphData(object):
     def mean(self):
         """Return the mean value for the data points (float)."""
         data = list(self.data.values())
-        sum = 0.
+        sum = 0.0
         for item in data:
             sum += float(item)
         return sum / len(data)
@@ -132,7 +146,7 @@ class GraphData(object):
         """Return the sample standard deviation for the data (float)."""
         data = list(self.data.values())
         m = self.mean()
-        runtotal = 0.
+        runtotal = 0.0
         for entry in data:
             runtotal += float((entry - m) ** 2)
         # This is sample standard deviation; population stdev would involve
@@ -175,6 +189,8 @@ class GraphData(object):
         outstr.append("Number of points: %d" % len(self.data))
         outstr.append("Mean data value: %s" % self.mean())
         outstr.append("Sample SD: %.3f" % self.stdev())
-        outstr.append("Minimum: %s\n1Q: %s\n2Q: %s\n3Q: %s\nMaximum: %s" % self.quartiles())
+        outstr.append(
+            "Minimum: %s\n1Q: %s\n2Q: %s\n3Q: %s\nMaximum: %s" % self.quartiles()
+        )
         outstr.append("Sequence Range: %s..%s" % self.range())
         return "\n".join(outstr)

--- a/Bio/Graphics/GenomeDiagram/_GraphSet.py
+++ b/Bio/Graphics/GenomeDiagram/_GraphSet.py
@@ -47,14 +47,24 @@ class GraphSet(object):
          - name      String identifying the graph set sensibly
 
         """
-        self.id = id            # Unique identifier for the set
-        self._next_id = 0       # Holds unique ids for graphs
-        self._graphs = {}       # Holds graphs, keyed by unique id
-        self.name = name        # Holds description of graph
+        self.id = id  # Unique identifier for the set
+        self._next_id = 0  # Holds unique ids for graphs
+        self._graphs = {}  # Holds graphs, keyed by unique id
+        self.name = name  # Holds description of graph
 
-    def new_graph(self, data, name=None, style='bar', color=colors.lightgreen,
-                  altcolor=colors.darkseagreen, linewidth=1, center=None,
-                  colour=None, altcolour=None, centre=None):
+    def new_graph(
+        self,
+        data,
+        name=None,
+        style="bar",
+        color=colors.lightgreen,
+        altcolor=colors.darkseagreen,
+        linewidth=1,
+        center=None,
+        colour=None,
+        altcolour=None,
+        centre=None,
+    ):
         """Add a GraphData object to the diagram.
 
         Arguments:
@@ -83,11 +93,11 @@ class GraphSet(object):
         if centre is not None:
             center = centre
 
-        id = self._next_id                              # get id number
+        id = self._next_id  # get id number
         graph = GraphData(id, data, name, style, color, altcolor, center)
         graph.linewidth = linewidth
-        self._graphs[id] = graph                        # add graph data
-        self._next_id += 1                              # increment next id
+        self._graphs[id] = graph  # add graph data
+        self._next_id += 1  # increment next id
         return graph
 
     def del_graph(self, graph_id):
@@ -121,8 +131,13 @@ class GraphSet(object):
             data += list(graph.data.values())
         data.sort()
         datalen = len(data)
-        return(data[0], data[datalen / 4], data[datalen / 2],
-               data[3 * datalen / 4], data[-1])
+        return (
+            data[0],
+            data[datalen / 4],
+            data[datalen / 2],
+            data[3 * datalen / 4],
+            data[-1],
+        )
 
     def to_string(self, verbose=0):
         """Return a formatted string with information about the set.

--- a/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
@@ -79,10 +79,25 @@ class LinearDrawer(AbstractDrawer):
 
     """
 
-    def __init__(self, parent=None, pagesize='A3', orientation='landscape',
-                 x=0.05, y=0.05, xl=None, xr=None, yt=None, yb=None,
-                 start=None, end=None, tracklines=0, fragments=10,
-                 fragment_size=None, track_size=0.75, cross_track_links=None):
+    def __init__(
+        self,
+        parent=None,
+        pagesize="A3",
+        orientation="landscape",
+        x=0.05,
+        y=0.05,
+        xl=None,
+        xr=None,
+        yt=None,
+        yb=None,
+        start=None,
+        end=None,
+        tracklines=0,
+        fragments=10,
+        fragment_size=None,
+        track_size=0.75,
+        cross_track_links=None,
+    ):
         """Initialize.
 
         Arguments:
@@ -119,9 +134,22 @@ class LinearDrawer(AbstractDrawer):
            feature A, track B, feature B) to be linked.
         """
         # Use the superclass' instantiation method
-        AbstractDrawer.__init__(self, parent, pagesize, orientation,
-                                x, y, xl, xr, yt, yb, start, end,
-                                tracklines, cross_track_links)
+        AbstractDrawer.__init__(
+            self,
+            parent,
+            pagesize,
+            orientation,
+            x,
+            y,
+            xl,
+            xr,
+            yt,
+            yb,
+            start,
+            end,
+            tracklines,
+            cross_track_links,
+        )
 
         # Useful measurements on the page
         self.fragments = fragments
@@ -133,7 +161,7 @@ class LinearDrawer(AbstractDrawer):
                 self.fragment_size = 1
             else:
                 # Otherwise keep a 10% gap between fragments
-                self.fragment_size = .9
+                self.fragment_size = 0.9
         self.track_size = track_size
 
     def draw(self):
@@ -141,12 +169,12 @@ class LinearDrawer(AbstractDrawer):
         # Instantiate the drawing canvas
         self.drawing = Drawing(self.pagesize[0], self.pagesize[1])
 
-        feature_elements = []           # holds feature elements
-        feature_labels = []             # holds feature labels
-        greytrack_bgs = []              # holds track background
-        greytrack_labels = []           # holds track foreground labels
-        scale_axes = []                 # holds scale axes
-        scale_labels = []               # holds scale axis labels
+        feature_elements = []  # holds feature elements
+        feature_labels = []  # holds feature labels
+        greytrack_bgs = []  # holds track background
+        greytrack_labels = []  # holds track foreground labels
+        scale_axes = []  # holds scale axes
+        scale_labels = []  # holds scale axis labels
 
         # Get the tracks to be drawn
         self.drawn_tracks = self._parent.get_drawn_levels()
@@ -158,8 +186,8 @@ class LinearDrawer(AbstractDrawer):
         # Go through each track in the parent (if it is to be drawn) one by
         # one and collate the data as drawing elements
         for track_level in self.drawn_tracks:  # only use tracks to be drawn
-            self.current_track_level = track_level      # establish track level
-            track = self._parent[track_level]           # get the track at that level
+            self.current_track_level = track_level  # establish track level
+            track = self._parent[track_level]  # get the track at that level
             gbgs, glabels = self.draw_greytrack(track)  # get greytrack elements
             greytrack_bgs.append(gbgs)
             greytrack_labels.append(glabels)
@@ -167,7 +195,7 @@ class LinearDrawer(AbstractDrawer):
             feature_elements.append(features)
             feature_labels.append(flabels)
             if track.scale:
-                axes, slabels = self.draw_scale(track)      # get scale elements
+                axes, slabels = self.draw_scale(track)  # get scale elements
                 scale_axes.append(axes)
                 scale_labels.append(slabels)
 
@@ -185,34 +213,50 @@ class LinearDrawer(AbstractDrawer):
         # Draw scale labels
         # Draw feature labels
         # Draw track labels
-        element_groups = [greytrack_bgs, feature_cross_links,
-                          feature_elements, scale_axes,
-                          scale_labels, feature_labels, greytrack_labels]
+        element_groups = [
+            greytrack_bgs,
+            feature_cross_links,
+            feature_elements,
+            scale_axes,
+            scale_labels,
+            feature_labels,
+            greytrack_labels,
+        ]
         for element_group in element_groups:
             for element_list in element_group:
                 [self.drawing.add(element) for element in element_list]
 
-        if self.tracklines:             # Draw test tracks over top of diagram
+        if self.tracklines:  # Draw test tracks over top of diagram
             self.draw_test_tracks()
 
     def init_fragments(self):
         """Initialize useful values for positioning diagram elements."""
         # Set basic heights, lengths etc
-        self.fragment_height = 1. * self.pageheight / self.fragments     # total fragment height in pixels
-        self.fragment_bases = ceil(1. * self.length / self.fragments)    # fragment length in bases
+        self.fragment_height = (
+            1.0 * self.pageheight / self.fragments
+        )  # total fragment height in pixels
+        self.fragment_bases = ceil(
+            1.0 * self.length / self.fragments
+        )  # fragment length in bases
 
         # Key fragment base and top lines by fragment number
-        self.fragment_lines = {}    # Holds bottom and top line locations of fragments, keyed by fragment number
-        fragment_crop = (1 - self.fragment_size) / 2    # No of pixels to crop the fragment
-        fragy = self.ylim           # Holder for current absolute fragment base
+        self.fragment_lines = (
+            {}
+        )  # Holds bottom and top line locations of fragments, keyed by fragment number
+        fragment_crop = (
+            1 - self.fragment_size
+        ) / 2  # No of pixels to crop the fragment
+        fragy = self.ylim  # Holder for current absolute fragment base
         for fragment in range(self.fragments):
-            fragtop = fragy - fragment_crop * self.fragment_height     # top - crop
-            fragbtm = fragy - (1 - fragment_crop) * self.fragment_height  # bottom + crop
+            fragtop = fragy - fragment_crop * self.fragment_height  # top - crop
+            fragbtm = (
+                fragy - (1 - fragment_crop) * self.fragment_height
+            )  # bottom + crop
             self.fragment_lines[fragment] = (fragbtm, fragtop)
-            fragy -= self.fragment_height                   # next fragment base
+            fragy -= self.fragment_height  # next fragment base
 
         # Key base starts and ends for each fragment by fragment number
-        self.fragment_limits = {}   # Holds first and last base positions in a fragment
+        self.fragment_limits = {}  # Holds first and last base positions in a fragment
         fragment_step = self.fragment_bases  # bases per fragment
         fragment_count = 0
         # Add start and end positions for each fragment to dictionary
@@ -228,30 +272,34 @@ class LinearDrawer(AbstractDrawer):
         stored in a dictionary - self.track_offsets, keyed by track number.
         """
         bot_track = min(min(self.drawn_tracks), 1)
-        top_track = max(self.drawn_tracks)     # The 'highest' track number to draw
+        top_track = max(self.drawn_tracks)  # The 'highest' track number to draw
 
-        trackunit_sum = 0           # Total number of 'units' for the tracks
-        trackunits = {}             # The start and end units for each track, keyed by track number
-        heightholder = 0            # placeholder variable
+        trackunit_sum = 0  # Total number of 'units' for the tracks
+        trackunits = {}  # The start and end units for each track, keyed by track number
+        heightholder = 0  # placeholder variable
         for track in range(bot_track, top_track + 1):  # for all track numbers to 'draw'
             try:
-                trackheight = self._parent[track].height    # Get track height
+                trackheight = self._parent[track].height  # Get track height
             except Exception:  # TODO: IndexError?
-                trackheight = 1                             # ...or default to 1
-            trackunit_sum += trackheight    # increment total track unit height
+                trackheight = 1  # ...or default to 1
+            trackunit_sum += trackheight  # increment total track unit height
             trackunits[track] = (heightholder, heightholder + trackheight)
-            heightholder += trackheight     # move to next height
-        trackunit_height = 1. * self.fragment_height * self.fragment_size / trackunit_sum
+            heightholder += trackheight  # move to next height
+        trackunit_height = (
+            1.0 * self.fragment_height * self.fragment_size / trackunit_sum
+        )
 
         # Calculate top and bottom offsets for each track, relative to fragment
         # base
-        track_offsets = {}      # The offsets from fragment base for each track
-        track_crop = trackunit_height * (1 - self.track_size) / 2.    # 'step back' in pixels
+        track_offsets = {}  # The offsets from fragment base for each track
+        track_crop = (
+            trackunit_height * (1 - self.track_size) / 2.0
+        )  # 'step back' in pixels
         assert track_crop >= 0
         for track in trackunits:
             top = trackunits[track][1] * trackunit_height - track_crop  # top offset
             btm = trackunits[track][0] * trackunit_height + track_crop  # bottom offset
-            ctr = btm + (top - btm) / 2.                          # center offset
+            ctr = btm + (top - btm) / 2.0  # center offset
             track_offsets[track] = (btm, ctr, top)
         self.track_offsets = track_offsets
 
@@ -263,22 +311,33 @@ class LinearDrawer(AbstractDrawer):
         """
         # Add lines for each fragment
         for fbtm, ftop in self.fragment_lines.values():
-            self.drawing.add(Line(self.x0, ftop, self.xlim, ftop,
-                                  strokeColor=colors.red))  # top line
-            self.drawing.add(Line(self.x0, fbtm, self.xlim, fbtm,
-                                  strokeColor=colors.red))  # bottom line
+            self.drawing.add(
+                Line(self.x0, ftop, self.xlim, ftop, strokeColor=colors.red)
+            )  # top line
+            self.drawing.add(
+                Line(self.x0, fbtm, self.xlim, fbtm, strokeColor=colors.red)
+            )  # bottom line
 
             # Add track lines for this fragment - but only for drawn tracks
             for track in self.drawn_tracks:
                 trackbtm = fbtm + self.track_offsets[track][0]
                 trackctr = fbtm + self.track_offsets[track][1]
                 tracktop = fbtm + self.track_offsets[track][2]
-                self.drawing.add(Line(self.x0, tracktop, self.xlim, tracktop,
-                                      strokeColor=colors.blue))  # top line
-                self.drawing.add(Line(self.x0, trackctr, self.xlim, trackctr,
-                                      strokeColor=colors.green))  # center line
-                self.drawing.add(Line(self.x0, trackbtm, self.xlim, trackbtm,
-                                      strokeColor=colors.blue))  # bottom line
+                self.drawing.add(
+                    Line(
+                        self.x0, tracktop, self.xlim, tracktop, strokeColor=colors.blue
+                    )
+                )  # top line
+                self.drawing.add(
+                    Line(
+                        self.x0, trackctr, self.xlim, trackctr, strokeColor=colors.green
+                    )
+                )  # center line
+                self.drawing.add(
+                    Line(
+                        self.x0, trackbtm, self.xlim, trackbtm, strokeColor=colors.blue
+                    )
+                )  # bottom line
 
     def draw_track(self, track):
         """Draw track.
@@ -289,15 +348,13 @@ class LinearDrawer(AbstractDrawer):
         Returns a tuple (list of elements in the track, list of labels in
         the track).
         """
-        track_elements = []     # Holds elements from features and graphs
-        track_labels = []       # Holds labels from features and graphs
+        track_elements = []  # Holds elements from features and graphs
+        track_labels = []  # Holds labels from features and graphs
 
         # Distribution dictionary for dealing with different set types
-        set_methods = {FeatureSet: self.draw_feature_set,
-                       GraphSet: self.draw_graph_set
-                       }
+        set_methods = {FeatureSet: self.draw_feature_set, GraphSet: self.draw_graph_set}
 
-        for set in track.get_sets():        # Draw the feature or graph sets
+        for set in track.get_sets():  # Draw the feature or graph sets
             elements, labels = set_methods[set.__class__](set)
             track_elements += elements
             track_labels += labels
@@ -316,20 +373,25 @@ class LinearDrawer(AbstractDrawer):
         Returns a drawing element that is the tick on the scale
         """
         if self.start >= tickpos and tickpos >= self.end:
-            raise RuntimeError("Tick at %i, but showing %i to %i"
-                               % (tickpos, self.start, self.end))
-        if not ((track.start is None or track.start <= tickpos)
-                and (track.end is None or tickpos <= track.end)):
-            raise RuntimeError("Tick at %i, but showing %r to %r for track"
-                               % (tickpos, track.start, track.end))
+            raise RuntimeError(
+                "Tick at %i, but showing %i to %i" % (tickpos, self.start, self.end)
+            )
+        if not (
+            (track.start is None or track.start <= tickpos)
+            and (track.end is None or tickpos <= track.end)
+        ):
+            raise RuntimeError(
+                "Tick at %i, but showing %r to %r for track"
+                % (tickpos, track.start, track.end)
+            )
         fragment, tickx = self.canvas_location(tickpos)  # Tick co-ordinates
         assert fragment >= 0, "Fragment %i, tickpos %i" % (fragment, tickpos)
-        tctr = ctr + self.fragment_lines[fragment][0]   # Center line of the track
-        tickx += self.x0                # Tick X co-ord
-        ticktop = tctr + ticklen        # Y co-ord of tick top
+        tctr = ctr + self.fragment_lines[fragment][0]  # Center line of the track
+        tickx += self.x0  # Tick X co-ord
+        ticktop = tctr + ticklen  # Y co-ord of tick top
         tick = Line(tickx, tctr, tickx, ticktop, strokeColor=track.scale_color)
         if draw_label:  # Put tick position on as label
-            if track.scale_format == 'SInt':
+            if track.scale_format == "SInt":
                 if tickpos >= 1000000:
                     tickstring = str(tickpos // 1000000) + " Mbp"
                 elif tickpos >= 1000:
@@ -338,14 +400,24 @@ class LinearDrawer(AbstractDrawer):
                     tickstring = str(tickpos)
             else:
                 tickstring = str(tickpos)
-            label = String(0, 0, tickstring,  # Make label string
-                           fontName=track.scale_font,
-                           fontSize=track.scale_fontsize,
-                           fillColor=track.scale_color)
+            label = String(
+                0,
+                0,
+                tickstring,  # Make label string
+                fontName=track.scale_font,
+                fontSize=track.scale_fontsize,
+                fillColor=track.scale_color,
+            )
             labelgroup = Group(label)
             rotation = angle2trig(track.scale_fontangle)
-            labelgroup.transform = (rotation[0], rotation[1], rotation[2],
-                                    rotation[3], tickx, ticktop)
+            labelgroup.transform = (
+                rotation[0],
+                rotation[1],
+                rotation[2],
+                rotation[3],
+                tickx,
+                ticktop,
+            )
         else:
             labelgroup = None
         return tick, labelgroup
@@ -359,15 +431,15 @@ class LinearDrawer(AbstractDrawer):
         Returns a tuple of (list of elements in the scale, list of labels
         in the scale).
         """
-        scale_elements = []     # Holds axes and ticks
-        scale_labels = []       # Holds labels
+        scale_elements = []  # Holds axes and ticks
+        scale_labels = []  # Holds labels
 
-        if not track.scale:     # No scale required, exit early
+        if not track.scale:  # No scale required, exit early
             return [], []
 
         # Get track location
         btm, ctr, top = self.track_offsets[self.current_track_level]
-        trackheight = (top - ctr)
+        trackheight = top - ctr
 
         # For each fragment, draw the scale for this track
         start, end = self._current_track_start_end()
@@ -386,18 +458,39 @@ class LinearDrawer(AbstractDrawer):
             if fragment == end_f:
                 x_right = end_x
                 # Y-axis end marker
-                scale_elements.append(Line(self.x0 + x_right, tbtm, self.x0 + x_right, ttop,
-                                           strokeColor=track.scale_color))
+                scale_elements.append(
+                    Line(
+                        self.x0 + x_right,
+                        tbtm,
+                        self.x0 + x_right,
+                        ttop,
+                        strokeColor=track.scale_color,
+                    )
+                )
             else:
                 x_right = self.xlim - self.x0
-            scale_elements.append(Line(self.x0 + x_left, tctr, self.x0 + x_right, tctr,
-                                       strokeColor=track.scale_color))
+            scale_elements.append(
+                Line(
+                    self.x0 + x_left,
+                    tctr,
+                    self.x0 + x_right,
+                    tctr,
+                    strokeColor=track.scale_color,
+                )
+            )
             # Y-axis start marker
-            scale_elements.append(Line(self.x0 + x_left, tbtm, self.x0 + x_left, ttop,
-                                       strokeColor=track.scale_color))
+            scale_elements.append(
+                Line(
+                    self.x0 + x_left,
+                    tbtm,
+                    self.x0 + x_left,
+                    ttop,
+                    strokeColor=track.scale_color,
+                )
+            )
 
         start, end = self._current_track_start_end()
-        if track.scale_ticks:   # Ticks are required on the scale
+        if track.scale_ticks:  # Ticks are required on the scale
             # Draw large ticks
             # I want the ticks to be consistently positioned relative to
             # the start of the sequence (position 0), not relative to the
@@ -409,35 +502,37 @@ class LinearDrawer(AbstractDrawer):
             # range(0,self.end,tickinterval) and the filter out the
             # ones before self.start - but this seems wasteful.
             # Using tickiterval * (self.start//tickiterval) is a shortcut.
-            for tickpos in range(tickiterval * (self.start // tickiterval),
-                                 int(self.end), tickiterval):
+            for tickpos in range(
+                tickiterval * (self.start // tickiterval), int(self.end), tickiterval
+            ):
                 if tickpos <= start or end <= tickpos:
                     continue
-                tick, label = self.draw_tick(tickpos, ctr, ticklen,
-                                             track,
-                                             track.scale_largetick_labels)
+                tick, label = self.draw_tick(
+                    tickpos, ctr, ticklen, track, track.scale_largetick_labels
+                )
                 scale_elements.append(tick)
-                if label is not None:   # If there's a label, add it
+                if label is not None:  # If there's a label, add it
                     scale_labels.append(label)
             # Draw small ticks
             ticklen = track.scale_smallticks * trackheight
             tickiterval = int(track.scale_smalltick_interval)
-            for tickpos in range(tickiterval * (self.start // tickiterval),
-                                 int(self.end), tickiterval):
+            for tickpos in range(
+                tickiterval * (self.start // tickiterval), int(self.end), tickiterval
+            ):
                 if tickpos <= start or end <= tickpos:
                     continue
-                tick, label = self.draw_tick(tickpos, ctr, ticklen,
-                                             track,
-                                             track.scale_smalltick_labels)
+                tick, label = self.draw_tick(
+                    tickpos, ctr, ticklen, track, track.scale_smalltick_labels
+                )
                 scale_elements.append(tick)
-                if label is not None:   # If there's a label, add it
+                if label is not None:  # If there's a label, add it
                     scale_labels.append(label)
 
         # Check to see if the track contains a graph - if it does, get the
         # minimum and maximum values, and put them on the scale Y-axis
         if track.axis_labels:
-            for set in track.get_sets():            # Check all sets...
-                if set.__class__ is GraphSet:     # ...for a graph set
+            for set in track.get_sets():  # Check all sets...
+                if set.__class__ is GraphSet:  # ...for a graph set
                     graph_label_min = []
                     graph_label_mid = []
                     graph_label_max = []
@@ -445,19 +540,20 @@ class LinearDrawer(AbstractDrawer):
                         quartiles = graph.quartiles()
                         minval, maxval = quartiles[0], quartiles[4]
                         if graph.center is None:
-                            midval = (maxval + minval) / 2.
+                            midval = (maxval + minval) / 2.0
                             graph_label_min.append("%.3f" % minval)
                             graph_label_max.append("%.3f" % maxval)
                         else:
-                            diff = max((graph.center - minval),
-                                       (maxval - graph.center))
+                            diff = max((graph.center - minval), (maxval - graph.center))
                             minval = graph.center - diff
                             maxval = graph.center + diff
                             midval = graph.center
                             graph_label_mid.append("%.3f" % midval)
                             graph_label_min.append("%.3f" % minval)
                             graph_label_max.append("%.3f" % maxval)
-                    for fragment in range(start_f, end_f + 1):  # Add to all used fragment axes
+                    for fragment in range(
+                        start_f, end_f + 1
+                    ):  # Add to all used fragment axes
                         tbtm = btm + self.fragment_lines[fragment][0]
                         tctr = ctr + self.fragment_lines[fragment][0]
                         ttop = top + self.fragment_lines[fragment][0]
@@ -465,17 +561,29 @@ class LinearDrawer(AbstractDrawer):
                             x_left = start_x
                         else:
                             x_left = 0
-                        for val, pos in [(";".join(graph_label_min), tbtm),
-                                         (";".join(graph_label_max), ttop),
-                                         (";".join(graph_label_mid), tctr)]:
-                            label = String(0, 0, val,
-                                           fontName=track.scale_font,
-                                           fontSize=track.scale_fontsize,
-                                           fillColor=track.scale_color)
+                        for val, pos in [
+                            (";".join(graph_label_min), tbtm),
+                            (";".join(graph_label_max), ttop),
+                            (";".join(graph_label_mid), tctr),
+                        ]:
+                            label = String(
+                                0,
+                                0,
+                                val,
+                                fontName=track.scale_font,
+                                fontSize=track.scale_fontsize,
+                                fillColor=track.scale_color,
+                            )
                             labelgroup = Group(label)
                             rotation = angle2trig(track.scale_fontangle)
-                            labelgroup.transform = (rotation[0], rotation[1], rotation[2],
-                                                    rotation[3], self.x0 + x_left, pos)
+                            labelgroup.transform = (
+                                rotation[0],
+                                rotation[1],
+                                rotation[2],
+                                rotation[3],
+                                self.x0 + x_left,
+                                pos,
+                            )
                             scale_labels.append(labelgroup)
 
         return scale_elements, scale_labels
@@ -489,8 +597,8 @@ class LinearDrawer(AbstractDrawer):
         Put in a grey background to the current track in all fragments,
         if track specifies that we should.
         """
-        greytrack_bgs = []      # Holds grey track backgrounds
-        greytrack_labels = []   # Holds grey foreground labels
+        greytrack_bgs = []  # Holds grey track backgrounds
+        greytrack_labels = []  # Holds grey foreground labels
 
         if not track.greytrack:  # No greytrack required, return early
             return [], []
@@ -515,27 +623,45 @@ class LinearDrawer(AbstractDrawer):
                 x2 = self.x0 + end_offset
             else:
                 x2 = self.xlim
-            box = draw_box((x1, tbtm), (x2, ttop),  # Grey track bg
-                           colors.Color(0.96, 0.96, 0.96))       # is just a box
+            box = draw_box(
+                (x1, tbtm), (x2, ttop), colors.Color(0.96, 0.96, 0.96)  # Grey track bg
+            )  # is just a box
             greytrack_bgs.append(box)
 
             if track.greytrack_labels:  # If labels are required
-                labelstep = (self.pagewidth) / track.greytrack_labels  # how far apart should they be?
-                label = String(0, 0, track.name,    # label contents
-                               fontName=track.greytrack_font,
-                               fontSize=track.greytrack_fontsize,
-                               fillColor=track.greytrack_fontcolor)
+                labelstep = (
+                    self.pagewidth
+                ) / track.greytrack_labels  # how far apart should they be?
+                label = String(
+                    0,
+                    0,
+                    track.name,  # label contents
+                    fontName=track.greytrack_font,
+                    fontSize=track.greytrack_fontsize,
+                    fillColor=track.greytrack_fontcolor,
+                )
                 # Create a new labelgroup at each position the label is required
                 for x in range(int(self.x0), int(self.xlim), int(labelstep)):
                     if fragment == start_fragment and x < start_offset:
                         continue
-                    if fragment == end_fragment and end_offset < x + label.getBounds()[2]:
+                    if (
+                        fragment == end_fragment
+                        and end_offset < x + label.getBounds()[2]
+                    ):
                         continue
                     labelgroup = Group(label)
                     rotation = angle2trig(track.greytrack_font_rotation)
-                    labelgroup.transform = (rotation[0], rotation[1], rotation[2],
-                                            rotation[3], x, tbtm)
-                    if not self.xlim - x <= labelstep:    # Don't overlap the end of the track
+                    labelgroup.transform = (
+                        rotation[0],
+                        rotation[1],
+                        rotation[2],
+                        rotation[3],
+                        x,
+                        tbtm,
+                    )
+                    if (
+                        not self.xlim - x <= labelstep
+                    ):  # Don't overlap the end of the track
                         greytrack_labels.append(labelgroup)
 
         return greytrack_bgs, greytrack_labels
@@ -550,13 +676,13 @@ class LinearDrawer(AbstractDrawer):
         labels for elements).
         """
         # print 'draw feature set'
-        feature_elements = []   # Holds diagram elements belonging to the features
-        label_elements = []     # Holds diagram elements belonging to feature labels
+        feature_elements = []  # Holds diagram elements belonging to the features
+        label_elements = []  # Holds diagram elements belonging to feature labels
 
         # Collect all the elements for the feature set
         for feature in set.get_features():
             if self.is_in_bounds(feature.start) or self.is_in_bounds(feature.end):
-                features, labels = self.draw_feature(feature)   # get elements and labels
+                features, labels = self.draw_feature(feature)  # get elements and labels
                 feature_elements += features
                 label_elements += labels
 
@@ -571,11 +697,11 @@ class LinearDrawer(AbstractDrawer):
         Returns tuple of (list of elements describing single feature, list
         of labels for those elements).
         """
-        if feature.hide:        # Feature hidden, don't draw it...
+        if feature.hide:  # Feature hidden, don't draw it...
             return [], []
 
-        feature_elements = []   # Holds diagram elements belonging to the feature
-        label_elements = []     # Holds labels belonging to the feature
+        feature_elements = []  # Holds diagram elements belonging to the feature
+        label_elements = []  # Holds labels belonging to the feature
 
         start, end = self._current_track_start_end()
         # A single feature may be split into subfeatures, so loop over them
@@ -612,8 +738,9 @@ class LinearDrawer(AbstractDrawer):
         if start_fragment in allowed_fragments and end_fragment in allowed_fragments:
             # print feature.name, feature.start, feature.end, start_offset, end_offset
             if start_fragment == end_fragment:  # Feature is found on one fragment
-                feature_box, label = self.get_feature_sigil(feature, start_offset,
-                                                            end_offset, start_fragment)
+                feature_box, label = self.get_feature_sigil(
+                    feature, start_offset, end_offset, start_fragment
+                )
                 feature_boxes.append((feature_box, label))
                 # feature_elements.append(feature_box)
                 # if label is not None:   # There is a label for the feature
@@ -625,12 +752,12 @@ class LinearDrawer(AbstractDrawer):
                 # and any bits that subsequently span whole fragments
                 while self.fragment_limits[fragment][1] < locend:
                     # print fragment, self.fragment_limits[fragment][1], locend
-                    feature_box, label = self.get_feature_sigil(feature, start,
-                                                                self.pagewidth,
-                                                                fragment)
+                    feature_box, label = self.get_feature_sigil(
+                        feature, start, self.pagewidth, fragment
+                    )
 
-                    fragment += 1   # move to next fragment
-                    start = 0       # start next sigil from start of fragment
+                    fragment += 1  # move to next fragment
+                    start = 0  # start next sigil from start of fragment
                     feature_boxes.append((feature_box, label))
                     # feature_elements.append(feature_box)
                     # if label is not None:   # There's a label for the feature
@@ -638,8 +765,9 @@ class LinearDrawer(AbstractDrawer):
                 # The last bit of the feature
                 # print locend, self.end, fragment
                 # print self.fragment_bases, self.length
-                feature_box, label = self.get_feature_sigil(feature, 0,
-                                                            end_offset, fragment)
+                feature_box, label = self.get_feature_sigil(
+                    feature, 0, end_offset, fragment
+                )
                 feature_boxes.append((feature_box, label))
         # if locstart > locend:
         #    print locstart, locend, feature.strand, feature_boxes, feature.name
@@ -699,27 +827,34 @@ class LinearDrawer(AbstractDrawer):
         if trackA == trackB:
             raise NotImplementedError()
 
-        strokecolor, fillcolor = _stroke_and_fill_colors(cross_link.color, cross_link.border)
+        strokecolor, fillcolor = _stroke_and_fill_colors(
+            cross_link.color, cross_link.border
+        )
 
         allowed_fragments = list(self.fragment_limits.keys())
 
         start_fragmentA, start_offsetA = self.canvas_location(startA)
         end_fragmentA, end_offsetA = self.canvas_location(endA)
-        if start_fragmentA not in allowed_fragments \
-        or end_fragmentA not in allowed_fragments:
+        if (
+            start_fragmentA not in allowed_fragments
+            or end_fragmentA not in allowed_fragments
+        ):
             return
 
         start_fragmentB, start_offsetB = self.canvas_location(startB)
         end_fragmentB, end_offsetB = self.canvas_location(endB)
-        if start_fragmentB not in allowed_fragments \
-        or end_fragmentB not in allowed_fragments:
+        if (
+            start_fragmentB not in allowed_fragments
+            or end_fragmentB not in allowed_fragments
+        ):
             return
 
         # TODO - Better drawing of flips when split between fragments
 
         answer = []
-        for fragment in range(min(start_fragmentA, start_fragmentB),
-                              max(end_fragmentA, end_fragmentB) + 1):
+        for fragment in range(
+            min(start_fragmentA, start_fragmentB), max(end_fragmentA, end_fragmentB) + 1
+        ):
             btmA, ctrA, topA = self.track_offsets[trackA]
             btmA += self.fragment_lines[fragment][0]
             ctrA += self.fragment_lines[fragment][0]
@@ -781,17 +916,29 @@ class LinearDrawer(AbstractDrawer):
                         extra = [self.x0, 0.5 * (yA + yB)]
                 else:
                     if fragment < start_fragmentB:
-                        extra = [self.x0 + self.pagewidth, 0.7 * yA + 0.3 * yB,
-                                 self.x0 + self.pagewidth, 0.3 * yA + 0.7 * yB]
+                        extra = [
+                            self.x0 + self.pagewidth,
+                            0.7 * yA + 0.3 * yB,
+                            self.x0 + self.pagewidth,
+                            0.3 * yA + 0.7 * yB,
+                        ]
                     else:
-                        extra = [self.x0, 0.3 * yA + 0.7 * yB,
-                                 self.x0, 0.7 * yA + 0.3 * yB]
-                answer.append(Polygon(deduplicate([xAs, yA, xAe, yA] + extra),
-                                      strokeColor=strokecolor,
-                                      fillColor=fillcolor,
-                                      # default is mitre/miter which can stick out too much:
-                                      strokeLineJoin=1,  # 1=round
-                                      strokewidth=0))
+                        extra = [
+                            self.x0,
+                            0.3 * yA + 0.7 * yB,
+                            self.x0,
+                            0.7 * yA + 0.3 * yB,
+                        ]
+                answer.append(
+                    Polygon(
+                        deduplicate([xAs, yA, xAe, yA] + extra),
+                        strokeColor=strokecolor,
+                        fillColor=fillcolor,
+                        # default is mitre/miter which can stick out too much:
+                        strokeLineJoin=1,  # 1=round
+                        strokewidth=0,
+                    )
+                )
             elif fragment < start_fragmentA or end_fragmentA < fragment:
                 if cross_link.flip:
                     # Just draw B as a triangle to left
@@ -801,53 +948,105 @@ class LinearDrawer(AbstractDrawer):
                         extra = [self.x0, 0.5 * (yA + yB)]
                 else:
                     if fragment < start_fragmentA:
-                        extra = [self.x0 + self.pagewidth, 0.3 * yA + 0.7 * yB,
-                                 self.x0 + self.pagewidth, 0.7 * yA + 0.3 * yB]
+                        extra = [
+                            self.x0 + self.pagewidth,
+                            0.3 * yA + 0.7 * yB,
+                            self.x0 + self.pagewidth,
+                            0.7 * yA + 0.3 * yB,
+                        ]
                     else:
-                        extra = [self.x0, 0.7 * yA + 0.3 * yB,
-                                 self.x0, 0.3 * yA + 0.7 * yB]
-                answer.append(Polygon(deduplicate([xBs, yB, xBe, yB] + extra),
-                                      strokeColor=strokecolor,
-                                      fillColor=fillcolor,
-                                      # default is mitre/miter which can stick out too much:
-                                      strokeLineJoin=1,  # 1=round
-                                      strokewidth=0))
-            elif cross_link.flip and ((crop_leftA and not crop_rightA) or
-                                      (crop_leftB and not crop_rightB)):
+                        extra = [
+                            self.x0,
+                            0.7 * yA + 0.3 * yB,
+                            self.x0,
+                            0.3 * yA + 0.7 * yB,
+                        ]
+                answer.append(
+                    Polygon(
+                        deduplicate([xBs, yB, xBe, yB] + extra),
+                        strokeColor=strokecolor,
+                        fillColor=fillcolor,
+                        # default is mitre/miter which can stick out too much:
+                        strokeLineJoin=1,  # 1=round
+                        strokewidth=0,
+                    )
+                )
+            elif cross_link.flip and (
+                (crop_leftA and not crop_rightA) or (crop_leftB and not crop_rightB)
+            ):
                 # On left end of fragment... force "crossing" to margin
-                answer.append(Polygon(deduplicate([xAs, yA, xAe, yA,
-                                                   self.x0, 0.5 * (yA + yB),
-                                                   xBe, yB, xBs, yB]),
-                                      strokeColor=strokecolor,
-                                      fillColor=fillcolor,
-                                      # default is mitre/miter which can stick out too much:
-                                      strokeLineJoin=1,  # 1=round
-                                      strokewidth=0))
-            elif cross_link.flip and ((crop_rightA and not crop_leftA) or
-                                      (crop_rightB and not crop_leftB)):
+                answer.append(
+                    Polygon(
+                        deduplicate(
+                            [
+                                xAs,
+                                yA,
+                                xAe,
+                                yA,
+                                self.x0,
+                                0.5 * (yA + yB),
+                                xBe,
+                                yB,
+                                xBs,
+                                yB,
+                            ]
+                        ),
+                        strokeColor=strokecolor,
+                        fillColor=fillcolor,
+                        # default is mitre/miter which can stick out too much:
+                        strokeLineJoin=1,  # 1=round
+                        strokewidth=0,
+                    )
+                )
+            elif cross_link.flip and (
+                (crop_rightA and not crop_leftA) or (crop_rightB and not crop_leftB)
+            ):
                 # On right end... force "crossing" to margin
-                answer.append(Polygon(deduplicate([xAs, yA, xAe, yA,
-                                                   xBe, yB, xBs, yB,
-                                                   self.x0 + self.pagewidth, 0.5 * (yA + yB)]),
-                                      strokeColor=strokecolor,
-                                      fillColor=fillcolor,
-                                      # default is mitre/miter which can stick out too much:
-                                      strokeLineJoin=1,  # 1=round
-                                      strokewidth=0))
+                answer.append(
+                    Polygon(
+                        deduplicate(
+                            [
+                                xAs,
+                                yA,
+                                xAe,
+                                yA,
+                                xBe,
+                                yB,
+                                xBs,
+                                yB,
+                                self.x0 + self.pagewidth,
+                                0.5 * (yA + yB),
+                            ]
+                        ),
+                        strokeColor=strokecolor,
+                        fillColor=fillcolor,
+                        # default is mitre/miter which can stick out too much:
+                        strokeLineJoin=1,  # 1=round
+                        strokewidth=0,
+                    )
+                )
             elif cross_link.flip:
-                answer.append(Polygon(deduplicate([xAs, yA, xAe, yA, xBs, yB, xBe, yB]),
-                                      strokeColor=strokecolor,
-                                      fillColor=fillcolor,
-                                      # default is mitre/miter which can stick out too much:
-                                      strokeLineJoin=1,  # 1=round
-                                      strokewidth=0))
+                answer.append(
+                    Polygon(
+                        deduplicate([xAs, yA, xAe, yA, xBs, yB, xBe, yB]),
+                        strokeColor=strokecolor,
+                        fillColor=fillcolor,
+                        # default is mitre/miter which can stick out too much:
+                        strokeLineJoin=1,  # 1=round
+                        strokewidth=0,
+                    )
+                )
             else:
-                answer.append(Polygon(deduplicate([xAs, yA, xAe, yA, xBe, yB, xBs, yB]),
-                                      strokeColor=strokecolor,
-                                      fillColor=fillcolor,
-                                      # default is mitre/miter which can stick out too much:
-                                      strokeLineJoin=1,  # 1=round
-                                      strokewidth=0))
+                answer.append(
+                    Polygon(
+                        deduplicate([xAs, yA, xAe, yA, xBe, yB, xBs, yB]),
+                        strokeColor=strokecolor,
+                        fillColor=fillcolor,
+                        # default is mitre/miter which can stick out too much:
+                        strokeLineJoin=1,  # 1=round
+                        strokewidth=0,
+                    )
+                )
         return answer
 
     def get_feature_sigil(self, feature, x0, x1, fragment, **kwargs):
@@ -869,7 +1068,7 @@ class LinearDrawer(AbstractDrawer):
             btm += self.fragment_lines[fragment][0]
             ctr += self.fragment_lines[fragment][0]
             top += self.fragment_lines[fragment][0]
-        except Exception:     # Only called if the method screws up big time
+        except Exception:  # Only called if the method screws up big time
             print("We've got a screw-up")
             print("%s %s" % (self.start, self.end))
             print(self.fragment_bases)
@@ -877,20 +1076,21 @@ class LinearDrawer(AbstractDrawer):
             for locstart, locend in feature.locations:
                 print(self.canvas_location(locstart))
                 print(self.canvas_location(locend))
-            print('FEATURE\n%s' % feature)
+            print("FEATURE\n%s" % feature)
             raise
 
         # Distribution dictionary for various ways of drawing the feature
-        draw_methods = {'BOX': self._draw_sigil_box,
-                        'ARROW': self._draw_sigil_arrow,
-                        'BIGARROW': self._draw_sigil_big_arrow,
-                        'OCTO': self._draw_sigil_octo,
-                        'JAGGY': self._draw_sigil_jaggy,
-                        }
+        draw_methods = {
+            "BOX": self._draw_sigil_box,
+            "ARROW": self._draw_sigil_arrow,
+            "BIGARROW": self._draw_sigil_big_arrow,
+            "OCTO": self._draw_sigil_octo,
+            "JAGGY": self._draw_sigil_jaggy,
+        }
 
         method = draw_methods[feature.sigil]
-        kwargs['head_length_ratio'] = feature.arrowhead_length
-        kwargs['shaft_height_ratio'] = feature.arrowshaft_height
+        kwargs["head_length_ratio"] = feature.arrowhead_length
+        kwargs["shaft_height_ratio"] = feature.arrowshaft_height
 
         # Support for clickable links... needs ReportLab 2.4 or later
         # which added support for links in SVG output.
@@ -900,44 +1100,68 @@ class LinearDrawer(AbstractDrawer):
 
         # Get sigil for the feature, give it the bounding box straddling
         # the axis (it decides strand specific placement)
-        sigil = method(btm, ctr, top, x0, x1, strand=feature.strand,
-                       color=feature.color, border=feature.border,
-                       **kwargs)
+        sigil = method(
+            btm,
+            ctr,
+            top,
+            x0,
+            x1,
+            strand=feature.strand,
+            color=feature.color,
+            border=feature.border,
+            **kwargs
+        )
 
         if feature.label_strand:
             strand = feature.label_strand
         else:
             strand = feature.strand
-        if feature.label:   # Feature requires a label
-            label = String(0, 0, feature.name,
-                           fontName=feature.label_font,
-                           fontSize=feature.label_size,
-                           fillColor=feature.label_color)
+        if feature.label:  # Feature requires a label
+            label = String(
+                0,
+                0,
+                feature.name,
+                fontName=feature.label_font,
+                fontSize=feature.label_size,
+                fillColor=feature.label_color,
+            )
             labelgroup = Group(label)
             # Feature is on top, or covers both strands (location affects
             # the height and rotation of the label)
             if strand != -1:
                 rotation = angle2trig(feature.label_angle)
-                if feature.label_position in ('end', "3'", 'right'):
+                if feature.label_position in ("end", "3'", "right"):
                     pos = x1
-                elif feature.label_position in ('middle', 'center', 'centre'):
-                    pos = (x1 + x0) / 2.
+                elif feature.label_position in ("middle", "center", "centre"):
+                    pos = (x1 + x0) / 2.0
                 else:
                     # Default to start, i.e. 'start', "5'", 'left'
                     pos = x0
-                labelgroup.transform = (rotation[0], rotation[1], rotation[2],
-                                        rotation[3], pos, top)
-            else:   # Feature on bottom strand
+                labelgroup.transform = (
+                    rotation[0],
+                    rotation[1],
+                    rotation[2],
+                    rotation[3],
+                    pos,
+                    top,
+                )
+            else:  # Feature on bottom strand
                 rotation = angle2trig(feature.label_angle + 180)
-                if feature.label_position in ('end', "3'", 'right'):
+                if feature.label_position in ("end", "3'", "right"):
                     pos = x0
-                elif feature.label_position in ('middle', 'center', 'centre'):
-                    pos = (x1 + x0) / 2.
+                elif feature.label_position in ("middle", "center", "centre"):
+                    pos = (x1 + x0) / 2.0
                 else:
                     # Default to start, i.e. 'start', "5'", 'left'
                     pos = x1
-                labelgroup.transform = (rotation[0], rotation[1], rotation[2],
-                                        rotation[3], pos, btm)
+                labelgroup.transform = (
+                    rotation[0],
+                    rotation[1],
+                    rotation[2],
+                    rotation[3],
+                    pos,
+                    btm,
+                )
         else:
             labelgroup = None
         return sigil, labelgroup
@@ -951,13 +1175,14 @@ class LinearDrawer(AbstractDrawer):
         Returns tuple (list of graph elements, list of graph labels).
         """
         # print 'draw graph set'
-        elements = []   # Holds graph elements
+        elements = []  # Holds graph elements
 
         # Distribution dictionary for how to draw the graph
-        style_methods = {'line': self.draw_line_graph,
-                         'heat': self.draw_heat_graph,
-                         'bar': self.draw_bar_graph
-                         }
+        style_methods = {
+            "line": self.draw_line_graph,
+            "heat": self.draw_heat_graph,
+            "bar": self.draw_bar_graph,
+        }
 
         for graph in set.get_graphs():
             elements += style_methods[graph.style](graph)
@@ -972,7 +1197,7 @@ class LinearDrawer(AbstractDrawer):
 
         """
         # print '\tdraw_line_graph'
-        line_elements = []                  # Holds drawable elements
+        line_elements = []  # Holds drawable elements
 
         # Get graph data
         data_quartiles = graph.quartiles()
@@ -989,7 +1214,7 @@ class LinearDrawer(AbstractDrawer):
         # midval is the value at which the x-axis is plotted, and is the
         # central ring in the track
         if graph.center is None:
-            midval = (maxval + minval) / 2.
+            midval = (maxval + minval) / 2.0
         else:
             midval = graph.center
         # Whichever is the greatest difference: max-midval or min-midval, is
@@ -1000,31 +1225,64 @@ class LinearDrawer(AbstractDrawer):
         # Start from first data point
         pos, val = data[0]
         lastfrag, lastx = self.canvas_location(pos)
-        lastx += self.x0        # Start xy co-ords
-        lasty = (trackheight * (val - midval) / resolution
-                 + self.fragment_lines[lastfrag][0] + ctr)
+        lastx += self.x0  # Start xy co-ords
+        lasty = (
+            trackheight * (val - midval) / resolution
+            + self.fragment_lines[lastfrag][0]
+            + ctr
+        )
         lastval = val
         # Add a series of lines linking consecutive data points
         for pos, val in data:
             frag, x = self.canvas_location(pos)
-            x += self.x0        # next xy co-ords
-            y = (trackheight * (val - midval) / resolution
-                 + self.fragment_lines[frag][0] + ctr)
-            if frag == lastfrag:    # Points on the same fragment: draw the line
-                line_elements.append(Line(lastx, lasty, x, y,
-                                          strokeColor=graph.poscolor,
-                                          strokeWidth=graph.linewidth))
-            else:   # Points not on the same fragment, so interpolate
-                tempy = (trackheight * (val - midval) / resolution
-                         + self.fragment_lines[lastfrag][0] + ctr)
-                line_elements.append(Line(lastx, lasty, self.xlim, tempy,
-                                          strokeColor=graph.poscolor,
-                                          strokeWidth=graph.linewidth))
-                tempy = (trackheight * (val - midval) / resolution
-                         + self.fragment_lines[frag][0] + ctr)
-                line_elements.append(Line(self.x0, tempy, x, y,
-                                          strokeColor=graph.poscolor,
-                                          strokeWidth=graph.linewidth))
+            x += self.x0  # next xy co-ords
+            y = (
+                trackheight * (val - midval) / resolution
+                + self.fragment_lines[frag][0]
+                + ctr
+            )
+            if frag == lastfrag:  # Points on the same fragment: draw the line
+                line_elements.append(
+                    Line(
+                        lastx,
+                        lasty,
+                        x,
+                        y,
+                        strokeColor=graph.poscolor,
+                        strokeWidth=graph.linewidth,
+                    )
+                )
+            else:  # Points not on the same fragment, so interpolate
+                tempy = (
+                    trackheight * (val - midval) / resolution
+                    + self.fragment_lines[lastfrag][0]
+                    + ctr
+                )
+                line_elements.append(
+                    Line(
+                        lastx,
+                        lasty,
+                        self.xlim,
+                        tempy,
+                        strokeColor=graph.poscolor,
+                        strokeWidth=graph.linewidth,
+                    )
+                )
+                tempy = (
+                    trackheight * (val - midval) / resolution
+                    + self.fragment_lines[frag][0]
+                    + ctr
+                )
+                line_elements.append(
+                    Line(
+                        self.x0,
+                        tempy,
+                        x,
+                        y,
+                        strokeColor=graph.poscolor,
+                        strokeWidth=graph.linewidth,
+                    )
+                )
             lastfrag, lastx, lasty, lastval = frag, x, y, val
 
         return line_elements
@@ -1041,9 +1299,9 @@ class LinearDrawer(AbstractDrawer):
         # Get graph data and information
         data_quartiles = graph.quartiles()
         minval, maxval = data_quartiles[0], data_quartiles[4]
-        midval = (maxval + minval) / 2.    # mid is the value at the X-axis
+        midval = (maxval + minval) / 2.0  # mid is the value at the X-axis
         btm, ctr, top = self.track_offsets[self.current_track_level]
-        trackheight = (top - btm)
+        trackheight = top - btm
 
         start, end = self._current_track_start_end()
         data = intermediate_points(start, end, graph[start:end])
@@ -1058,14 +1316,14 @@ class LinearDrawer(AbstractDrawer):
             # assert start <= pos0 <= pos1 <= end
             fragment0, x0 = self.canvas_location(pos0)
             fragment1, x1 = self.canvas_location(pos1)
-            x0, x1 = self.x0 + x0, self.x0 + x1     # account for margin
+            x0, x1 = self.x0 + x0, self.x0 + x1  # account for margin
             # print 'x1 before:', x1
 
             # Calculate the heat color, based on the differential between
             # the value and the median value
-            heat = colors.linearlyInterpolatedColor(graph.poscolor,
-                                                    graph.negcolor,
-                                                    maxval, minval, val)
+            heat = colors.linearlyInterpolatedColor(
+                graph.poscolor, graph.negcolor, maxval, minval, val
+            )
 
             # Draw heat box
             if fragment0 == fragment1:  # Box is contiguous on one fragment
@@ -1075,9 +1333,10 @@ class LinearDrawer(AbstractDrawer):
                 tbtm = btm + self.fragment_lines[fragment0][0]
                 # print 'equal', pos0, pos1, val
                 # print pos0, pos1, fragment0, fragment1
-                heat_elements.append(draw_box((x0, tbtm), (x1, ttop),
-                                              color=heat, border=None))
-            else:   # box is split over two or more fragments
+                heat_elements.append(
+                    draw_box((x0, tbtm), (x1, ttop), color=heat, border=None)
+                )
+            else:  # box is split over two or more fragments
                 # if pos0 >= self.fragment_limits[fragment0][0]:
                 #    fragment0 += 1
                 fragment = fragment0
@@ -1086,18 +1345,20 @@ class LinearDrawer(AbstractDrawer):
                     # print pos0, self.fragment_limits[fragment][1], pos1
                     ttop = top + self.fragment_lines[fragment][0]
                     tbtm = btm + self.fragment_lines[fragment][0]
-                    heat_elements.append(draw_box((start_x, tbtm),
-                                                  (self.xlim, ttop),
-                                                  color=heat,
-                                                  border=None))
+                    heat_elements.append(
+                        draw_box(
+                            (start_x, tbtm), (self.xlim, ttop), color=heat, border=None
+                        )
+                    )
                     fragment += 1
                     start_x = self.x0
                 ttop = top + self.fragment_lines[fragment][0]
                 tbtm = btm + self.fragment_lines[fragment][0]
                 # Add the last part of the bar
                 # print 'x1 after:', x1, '\n'
-                heat_elements.append(draw_box((self.x0, tbtm), (x1, ttop),
-                                              color=heat, border=None))
+                heat_elements.append(
+                    draw_box((self.x0, tbtm), (x1, ttop), color=heat, border=None)
+                )
 
         return heat_elements
 
@@ -1108,7 +1369,7 @@ class LinearDrawer(AbstractDrawer):
         # from the track center to the height of the datapoint value (positive
         # values go up in one color, negative go down in the alternative
         # color).
-        bar_elements = []   # Holds drawable elements for the graph
+        bar_elements = []  # Holds drawable elements for the graph
 
         # Set the number of pixels per unit for the data
         data_quartiles = graph.quartiles()
@@ -1118,11 +1379,11 @@ class LinearDrawer(AbstractDrawer):
         datarange = maxval - minval
         if datarange == 0:
             datarange = trackheight
-        data = graph[self.start:self.end]
+        data = graph[self.start : self.end]
         # midval is the value at which the x-axis is plotted, and is the
         # central ring in the track
         if graph.center is None:
-            midval = (maxval + minval) / 2.
+            midval = (maxval + minval) / 2.0
         else:
             midval = graph.center
 
@@ -1146,11 +1407,11 @@ class LinearDrawer(AbstractDrawer):
         for pos0, pos1, val in data:
             fragment0, x0 = self.canvas_location(pos0)
             fragment1, x1 = self.canvas_location(pos1)
-            x0, x1 = self.x0 + x0, self.x0 + x1     # account for margin
+            x0, x1 = self.x0 + x0, self.x0 + x1  # account for margin
             barval = trackheight * (val - midval) / resolution
             if barval >= 0:  # Different colors for bars that extend above...
                 barcolor = graph.poscolor
-            else:           # ...or below the axis
+            else:  # ...or below the axis
                 barcolor = graph.negcolor
 
             # Draw bar
@@ -1159,9 +1420,8 @@ class LinearDrawer(AbstractDrawer):
                     x1 = self.xlim
                 tctr = ctr + self.fragment_lines[fragment0][0]
                 barval += tctr
-                bar_elements.append(draw_box((x0, tctr), (x1, barval),
-                                             color=barcolor))
-            else:   # Box is split over two or more fragments
+                bar_elements.append(draw_box((x0, tctr), (x1, barval), color=barcolor))
+            else:  # Box is split over two or more fragments
                 fragment = fragment0
                 # if pos0 >= self.fragment_limits[fragment0][0]:
                 #    fragment += 1
@@ -1169,16 +1429,17 @@ class LinearDrawer(AbstractDrawer):
                 while self.fragment_limits[fragment][1] < pos1:
                     tctr = ctr + self.fragment_lines[fragment][0]
                     thisbarval = barval + tctr
-                    bar_elements.append(draw_box((start, tctr),
-                                                 (self.xlim, thisbarval),
-                                                 color=barcolor))
+                    bar_elements.append(
+                        draw_box((start, tctr), (self.xlim, thisbarval), color=barcolor)
+                    )
                     fragment += 1
                     start = self.x0
                 tctr = ctr + self.fragment_lines[fragment1][0]
                 barval += tctr
                 # Add the last part of the bar
-                bar_elements.append(draw_box((self.x0, tctr), (x1, barval),
-                                             color=barcolor))
+                bar_elements.append(
+                    draw_box((self.x0, tctr), (x1, barval), color=barcolor)
+                )
 
         return bar_elements
 
@@ -1191,19 +1452,25 @@ class LinearDrawer(AbstractDrawer):
         Returns the x-coordinate and fragment number of a base on the
         genome sequence, in the context of the current drawing setup
         """
-        base = int(base - self.start)   # number of bases we are from the start
+        base = int(base - self.start)  # number of bases we are from the start
         fragment = int(base / self.fragment_bases)
-        if fragment < 1:    # First fragment
+        if fragment < 1:  # First fragment
             base_offset = base
             fragment = 0
         elif fragment >= self.fragments:
             fragment = self.fragments - 1
             base_offset = self.fragment_bases
-        else:               # Calculate number of bases from start of fragment
+        else:  # Calculate number of bases from start of fragment
             base_offset = base % self.fragment_bases
-        assert fragment < self.fragments, (base, self.start, self.end, self.length, self.fragment_bases)
+        assert fragment < self.fragments, (
+            base,
+            self.start,
+            self.end,
+            self.length,
+            self.fragment_bases,
+        )
         # Calculate number of pixels from start of fragment
-        x_offset = 1. * self.pagewidth * base_offset / self.fragment_bases
+        x_offset = 1.0 * self.pagewidth * base_offset / self.fragment_bases
         return fragment, x_offset
 
     def _draw_sigil_box(self, bottom, center, top, x1, x2, strand, **kwargs):
@@ -1232,8 +1499,9 @@ class LinearDrawer(AbstractDrawer):
             y2 = top
         return draw_cut_corner_box((x1, y1), (x2, y2), **kwargs)
 
-    def _draw_sigil_jaggy(self, bottom, center, top, x1, x2, strand,
-                          color, border=None, **kwargs):
+    def _draw_sigil_jaggy(
+        self, bottom, center, top, x1, x2, strand, color, border=None, **kwargs
+    ):
         """Draw JAGGY sigil (PRIVATE).
 
         Although we may in future expose the head/tail jaggy lengths, for now
@@ -1265,18 +1533,32 @@ class LinearDrawer(AbstractDrawer):
 
         points = []
         for i in range(teeth):
-            points.extend((xmin, y1 + i * height / teeth,
-                           xmin + taillength, y1 + (i + 1) * height / teeth))
+            points.extend(
+                (
+                    xmin,
+                    y1 + i * height / teeth,
+                    xmin + taillength,
+                    y1 + (i + 1) * height / teeth,
+                )
+            )
         for i in range(teeth):
-            points.extend((xmax, y1 + (teeth - i) * height / teeth,
-                           xmax - headlength, y1 + (teeth - i - 1) * height / teeth))
+            points.extend(
+                (
+                    xmax,
+                    y1 + (teeth - i) * height / teeth,
+                    xmax - headlength,
+                    y1 + (teeth - i - 1) * height / teeth,
+                )
+            )
 
-        return Polygon(deduplicate(points),
-                       strokeColor=strokecolor,
-                       strokeWidth=1,
-                       strokeLineJoin=1,  # 1=round
-                       fillColor=color,
-                       **kwargs)
+        return Polygon(
+            deduplicate(points),
+            strokeColor=strokecolor,
+            strokeWidth=1,
+            strokeLineJoin=1,  # 1=round
+            fillColor=color,
+            **kwargs
+        )
 
     def _draw_sigil_arrow(self, bottom, center, top, x1, x2, strand, **kwargs):
         """Draw ARROW sigil (PRIVATE)."""

--- a/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
@@ -1379,7 +1379,7 @@ class LinearDrawer(AbstractDrawer):
         datarange = maxval - minval
         if datarange == 0:
             datarange = trackheight
-        data = graph[self.start : self.end]
+        data = graph[self.start:self.end]
         # midval is the value at which the x-axis is plotted, and is the
         # central ring in the track
         if graph.center is None:

--- a/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
@@ -240,12 +240,10 @@ class LinearDrawer(AbstractDrawer):
         )  # fragment length in bases
 
         # Key fragment base and top lines by fragment number
-        self.fragment_lines = (
-            {}
-        )  # Holds bottom and top line locations of fragments, keyed by fragment number
-        fragment_crop = (
-            1 - self.fragment_size
-        ) / 2  # No of pixels to crop the fragment
+        # Holds bottom and top line locations of fragments, keyed by fragment number
+        self.fragment_lines = {}
+        # Number of pixels to crop the fragment:
+        fragment_crop = (1 - self.fragment_size) / 2
         fragy = self.ylim  # Holder for current absolute fragment base
         for fragment in range(self.fragments):
             fragtop = fragy - fragment_crop * self.fragment_height  # top - crop

--- a/Bio/Graphics/GenomeDiagram/_Track.py
+++ b/Bio/Graphics/GenomeDiagram/_Track.py
@@ -81,18 +81,36 @@ class Track(object):
 
     """
 
-    def __init__(self, name=None, height=1, hide=0, greytrack=0,
-                 greytrack_labels=5, greytrack_fontsize=8,
-                 greytrack_font='Helvetica', greytrack_font_rotation=0,
-                 greytrack_font_color=_grey,
-                 scale=1, scale_format=None, scale_color=colors.black,
-                 scale_font='Helvetica', scale_fontsize=6,
-                 scale_fontangle=45, scale_largeticks=0.5, scale_ticks=1,
-                 scale_smallticks=0.3, scale_largetick_interval=1e6,
-                 scale_smalltick_interval=1e4, scale_largetick_labels=1,
-                 scale_smalltick_labels=0, axis_labels=1,
-                 start=None, end=None,
-                 greytrack_font_colour=None, scale_colour=None):
+    def __init__(
+        self,
+        name=None,
+        height=1,
+        hide=0,
+        greytrack=0,
+        greytrack_labels=5,
+        greytrack_fontsize=8,
+        greytrack_font="Helvetica",
+        greytrack_font_rotation=0,
+        greytrack_font_color=_grey,
+        scale=1,
+        scale_format=None,
+        scale_color=colors.black,
+        scale_font="Helvetica",
+        scale_fontsize=6,
+        scale_fontangle=45,
+        scale_largeticks=0.5,
+        scale_ticks=1,
+        scale_smallticks=0.3,
+        scale_largetick_interval=1e6,
+        scale_smalltick_interval=1e4,
+        scale_largetick_labels=1,
+        scale_smalltick_labels=0,
+        axis_labels=1,
+        start=None,
+        end=None,
+        greytrack_font_colour=None,
+        scale_colour=None,
+    ):
         """Initialize.
 
         Arguments:
@@ -147,8 +165,8 @@ class Track(object):
         if scale_colour is not None:
             scale_color = scale_colour
 
-        self._next_id = 0       # This will count sets as they are added to the track
-        self._sets = {}         # Holds sets, keyed by unique ID
+        self._next_id = 0  # This will count sets as they are added to the track
+        self._sets = {}  # Holds sets, keyed by unique ID
 
         # Assign attribute values from instantiation
         self.height = height
@@ -186,27 +204,25 @@ class Track(object):
 
     def add_set(self, set):
         """Add a preexisting FeatureSet or GraphSet object to the track."""
-        set.id = self._next_id          # Assign unique id to set
-        set.parent = self               # Make set's parent this track
+        set.id = self._next_id  # Assign unique id to set
+        set.parent = self  # Make set's parent this track
         self._sets[self._next_id] = set  # Add set, keyed by unique id
-        self._next_id += 1              # Increment unique set ids
+        self._next_id += 1  # Increment unique set ids
 
-    def new_set(self, type='feature', **args):
+    def new_set(self, type="feature", **args):
         """Create a new FeatureSet or GraphSet object.
 
         Create a new FeatureSet or GraphSet object, add it to the
         track, and return for user manipulation
         """
-        type_dict = {'feature': FeatureSet,
-                     'graph': GraphSet
-                     }
+        type_dict = {"feature": FeatureSet, "graph": GraphSet}
         set = type_dict[type]()
         for key in args:
             setattr(set, key, args[key])
-        set.id = self._next_id          # Assign unique id to set
-        set.parent = self               # Make set's parent this track
+        set.id = self._next_id  # Assign unique id to set
+        set.parent = self  # Make set's parent this track
         self._sets[self._next_id] = set  # Add set, keyed by unique id
-        self._next_id += 1              # Increment unique set ids
+        self._next_id += 1  # Increment unique set ids
         return set
 
     def del_set(self, set_id):
@@ -223,13 +239,13 @@ class Track(object):
 
     def range(self):
         """Return the lowest and highest base (or mark) numbers as a tuple."""
-        lows, highs = [], []            # Holds set of low and high values from sets
+        lows, highs = [], []  # Holds set of low and high values from sets
         if self.start is not None:
             lows.append(self.start)
         if self.end is not None:
             highs.append(self.end)
         for set in self._sets.values():
-            low, high = set.range()     # Get each set range
+            low, high = set.range()  # Get each set range
             lows.append(low)
             highs.append(high)
         if lows:
@@ -250,9 +266,9 @@ class Track(object):
            account of the track is required
 
         """
-        if not verbose:             # Return the short description
-            return "%s" % self      # Use __str__ method instead
-        else:                       # Return the long description
+        if not verbose:  # Return the short description
+            return "%s" % self  # Use __str__ method instead
+        else:  # Return the long description
             outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
             outstr.append("%d sets" % len(self._sets))
             for key in self._sets:

--- a/Bio/Graphics/GenomeDiagram/__init__.py
+++ b/Bio/Graphics/GenomeDiagram/__init__.py
@@ -25,5 +25,13 @@ from ._Colors import ColorTranslator
 from ._Feature import Feature
 from ._Graph import GraphData
 
-__all__ = ('Diagram', 'Track', 'FeatureSet', 'Feature', 'GraphSet',
-           'GraphData', 'CrossLink', 'ColorTranslator')
+__all__ = (
+    "Diagram",
+    "Track",
+    "FeatureSet",
+    "Feature",
+    "GraphSet",
+    "GraphData",
+    "CrossLink",
+    "ColorTranslator",
+)

--- a/Tests/test_GenomeDiagram.py
+++ b/Tests/test_GenomeDiagram.py
@@ -16,6 +16,7 @@ from Bio._py3k import range
 
 # Do we have ReportLab?  Raise error if not present.
 from Bio import MissingPythonDependencyError
+
 try:
     from reportlab.lib import colors
     from reportlab.pdfbase import pdfmetrics
@@ -23,7 +24,8 @@ try:
     from reportlab.lib.units import cm
 except ImportError:
     raise MissingPythonDependencyError(
-        "Install reportlab if you want to use Bio.Graphics.")
+        "Install reportlab if you want to use Bio.Graphics."
+    )
 
 try:
     # The preferred PIL import has changed over time...
@@ -47,6 +49,7 @@ from Bio.Graphics.GenomeDiagram._Graph import GraphData
 from Bio.Graphics.GenomeDiagram._Colors import ColorTranslator
 
 from reportlab import rl_config
+
 rl_config.invariant = True
 
 
@@ -59,6 +62,7 @@ def fill_and_border(base_color, alpha=0.5):
     except AttributeError:
         # Old ReportLab, no transparency and/or no clone
         return base_color, base_color
+
 
 ###############################################################################
 # Utility functions for graph plotting, originally in GenomeDiagram.Utilities #
@@ -84,13 +88,13 @@ def apply_to_window(sequence, window_size, function, step=None):
 
     apply_to_window(sequence, window_size, function) -> [(int, float),(int, float),...]
     """
-    seqlen = len(sequence)      # Total length of sequence to be used
-    if step is None:    # No step specified, so use half window-width or 1 if larger
+    seqlen = len(sequence)  # Total length of sequence to be used
+    if step is None:  # No step specified, so use half window-width or 1 if larger
         step = max(window_size // 2, 1)
-    else:               # Use specified step, or 1 if greater
+    else:  # Use specified step, or 1 if greater
         step = max(step, 1)
 
-    results = []    # Holds (position, value) results
+    results = []  # Holds (position, value) results
 
     # Perform the passed function on as many windows as possible, short of
     # overrunning the sequence
@@ -116,7 +120,7 @@ def apply_to_window(sequence, window_size, function, step=None):
         value = function(fragment)
         results.append((middle, value))  # Add results to list
 
-    return results      # Return the list of (position, value) results
+    return results  # Return the list of (position, value) results
 
 
 def calc_gc_content(sequence):
@@ -128,14 +132,14 @@ def calc_gc_content(sequence):
     calc_gc_content(sequence)
     """
     d = {}
-    for nt in ['A', 'T', 'G', 'C']:
+    for nt in ["A", "T", "G", "C"]:
         d[nt] = sequence.count(nt) + sequence.count(nt.lower())
-    gc = d.get('G', 0) + d.get('C', 0)
+    gc = d.get("G", 0) + d.get("C", 0)
 
     if gc == 0:
         return 0
     # print(gc*100.0/(d['A'] +d['T'] + gc))
-    return gc * 1. / (d['A'] + d['T'] + gc)
+    return gc * 1.0 / (d["A"] + d["T"] + gc)
 
 
 def calc_at_content(sequence):
@@ -147,13 +151,13 @@ def calc_at_content(sequence):
     calc_at_content(sequence)
     """
     d = {}
-    for nt in ['A', 'T', 'G', 'C']:
+    for nt in ["A", "T", "G", "C"]:
         d[nt] = sequence.count(nt) + sequence.count(nt.lower())
-    at = d.get('A', 0) + d.get('T', 0)
+    at = d.get("A", 0) + d.get("T", 0)
 
     if at == 0:
         return 0
-    return at * 1. / (d['G'] + d['G'] + at)
+    return at * 1.0 / (d["G"] + d["G"] + at)
 
 
 def calc_gc_skew(sequence):
@@ -164,8 +168,8 @@ def calc_gc_skew(sequence):
 
     calc_gc_skew(sequence)
     """
-    g = sequence.count('G') + sequence.count('g')
-    c = sequence.count('C') + sequence.count('c')
+    g = sequence.count("G") + sequence.count("g")
+    c = sequence.count("C") + sequence.count("c")
     if g + c == 0:
         return 0.0  # TODO - return NaN or None here?
     else:
@@ -180,8 +184,8 @@ def calc_at_skew(sequence):
 
     calc_at_skew(sequence)
     """
-    a = sequence.count('A') + sequence.count('a')
-    t = sequence.count('T') + sequence.count('t')
+    a = sequence.count("A") + sequence.count("a")
+    t = sequence.count("T") + sequence.count("t")
     if a + t == 0:
         return 0.0  # TODO - return NaN or None here?
     else:
@@ -202,6 +206,7 @@ def calc_dinucleotide_counts(sequence):
         total += sequence.count(letter + letter)
     return total
 
+
 ###############################################################################
 # End of utility functions for graph plotting                                 #
 ###############################################################################
@@ -221,14 +226,18 @@ class ColorsTest(unittest.TestCase):
         translator = ColorTranslator()
 
         # Does the translate method correctly convert the passed argument?
-        assert translator.float1_color((0.5, 0.5, 0.5)) == translator.translate((0.5, 0.5, 0.5)), \
-            "Did not correctly translate colour from floating point RGB tuple"
-        assert translator.int255_color((1, 75, 240)) == translator.translate((1, 75, 240)), \
-            "Did not correctly translate colour from integer RGB tuple"
-        assert translator.artemis_color(7) == translator.translate(7), \
-            "Did not correctly translate colour from Artemis colour scheme"
-        assert translator.scheme_color(2) == translator.translate(2), \
-            "Did not correctly translate colour from user-defined colour scheme"
+        assert translator.float1_color((0.5, 0.5, 0.5)) == translator.translate(
+            (0.5, 0.5, 0.5)
+        ), "Did not correctly translate colour from floating point RGB tuple"
+        assert translator.int255_color((1, 75, 240)) == translator.translate(
+            (1, 75, 240)
+        ), "Did not correctly translate colour from integer RGB tuple"
+        assert translator.artemis_color(7) == translator.translate(
+            7
+        ), "Did not correctly translate colour from Artemis colour scheme"
+        assert translator.scheme_color(2) == translator.translate(
+            2
+        ), "Did not correctly translate colour from user-defined colour scheme"
 
 
 class GraphTest(unittest.TestCase):
@@ -243,31 +252,45 @@ class GraphTest(unittest.TestCase):
         data2 = [math.cos(x * scale) for x in range(points)]
         data3 = [2 * math.sin(2 * x * scale) for x in range(points)]
 
-        gdd = Diagram('Test Diagram', circular=False,
-                      y=0.01, yt=0.01, yb=0.01,
-                      x=0.01, xl=0.01, xr=0.01)
+        gdd = Diagram(
+            "Test Diagram",
+            circular=False,
+            y=0.01,
+            yt=0.01,
+            yb=0.01,
+            x=0.01,
+            xl=0.01,
+            xr=0.01,
+        )
         gdt_data = gdd.new_track(1, greytrack=False)
         gds_data = gdt_data.new_set("graph")
-        for data_values, _name, color in zip([data1, data2, data3],
-                                             ["sin", "cos", "2sin2"],
-                                             ["red", "green", "blue"]):
+        for data_values, _name, color in zip(
+            [data1, data2, data3], ["sin", "cos", "2sin2"], ["red", "green", "blue"]
+        ):
             data = list(zip(range(points), data_values))
-            gds_data.new_graph(data, "", style="line",
-                               color=color, altcolor=color,
-                               center=0)
+            gds_data.new_graph(
+                data, "", style="line", color=color, altcolor=color, center=0
+            )
 
-        gdd.draw(format='linear',
-                 tracklines=False,
-                 pagesize=(15 * cm, 15 * cm),
-                 fragments=1,
-                 start=0, end=points)
-        gdd.write(os.path.join('Graphics', "line_graph.pdf"), "pdf")
+        gdd.draw(
+            format="linear",
+            tracklines=False,
+            pagesize=(15 * cm, 15 * cm),
+            fragments=1,
+            start=0,
+            end=points,
+        )
+        gdd.write(os.path.join("Graphics", "line_graph.pdf"), "pdf")
         # Circular diagram
-        gdd.draw(tracklines=False,
-                 pagesize=(15 * cm, 15 * cm),
-                 circular=True,  # Data designed to be periodic
-                 start=0, end=points, circle_core=0.5)
-        gdd.write(os.path.join('Graphics', "line_graph_c.pdf"), "pdf")
+        gdd.draw(
+            tracklines=False,
+            pagesize=(15 * cm, 15 * cm),
+            circular=True,  # Data designed to be periodic
+            start=0,
+            end=points,
+            circle_core=0.5,
+        )
+        gdd.write(os.path.join("Graphics", "line_graph_c.pdf"), "pdf")
 
     def test_slicing(self):
         """Check GraphData slicing."""
@@ -275,8 +298,10 @@ class GraphTest(unittest.TestCase):
         gd.set_data([(1, 10), (5, 15), (20, 40)])
         gd.add_point((10, 20))
 
-        assert gd[4:16] == [(5, 15), (10, 20)], \
-            "Unable to insert and retrieve points correctly"
+        assert gd[4:16] == [
+            (5, 15),
+            (10, 20),
+        ], "Unable to insert and retrieve points correctly"
 
 
 class LabelTest(unittest.TestCase):
@@ -284,9 +309,16 @@ class LabelTest(unittest.TestCase):
 
     def setUp(self):
         """Start a diagram."""
-        self.gdd = Diagram('Test Diagram', circular=False,
-                           y=0.01, yt=0.01, yb=0.01,
-                           x=0.01, xl=0.01, xr=0.01)
+        self.gdd = Diagram(
+            "Test Diagram",
+            circular=False,
+            y=0.01,
+            yt=0.01,
+            yb=0.01,
+            x=0.01,
+            xl=0.01,
+            xr=0.01,
+        )
 
     def finish(self, name, circular=True):
         """Draw it..."""
@@ -297,17 +329,21 @@ class LabelTest(unittest.TestCase):
             orient = "landscape"
         else:
             orient = "portrait"
-        self.gdd.draw(format='linear', orientation=orient,
-                      tracklines=False,
-                      pagesize=(15 * cm, 5 * cm * tracks),
-                      fragments=1,
-                      start=0, end=400)
-        self.gdd.write(os.path.join('Graphics', name + ".pdf"), "pdf")
+        self.gdd.draw(
+            format="linear",
+            orientation=orient,
+            tracklines=False,
+            pagesize=(15 * cm, 5 * cm * tracks),
+            fragments=1,
+            start=0,
+            end=400,
+        )
+        self.gdd.write(os.path.join("Graphics", name + ".pdf"), "pdf")
         global renderPM
         if renderPM:
             try:
                 # For the tutorial this is useful:
-                self.gdd.write(os.path.join('Graphics', name + ".png"), "png")
+                self.gdd.write(os.path.join("Graphics", name + ".png"), "png")
             except renderPM.RenderPMError:
                 # Probably a font problem, e.g.
                 # RenderPMError: Can't setFont(Times-Roman) missing the T1 files?
@@ -320,12 +356,15 @@ class LabelTest(unittest.TestCase):
                 renderPM = None
         if circular:
             # Circular diagram
-            self.gdd.draw(tracklines=False,
-                          pagesize=(15 * cm, 15 * cm),
-                          fragments=1,
-                          circle_core=0.5,
-                          start=0, end=400)
-            self.gdd.write(os.path.join('Graphics', name + "_c.pdf"), "pdf")
+            self.gdd.draw(
+                tracklines=False,
+                pagesize=(15 * cm, 15 * cm),
+                fragments=1,
+                circle_core=0.5,
+                start=0,
+                end=400,
+            )
+            self.gdd.write(os.path.join("Graphics", name + "_c.pdf"), "pdf")
 
     def add_track_with_sigils(self, **kwargs):
         """Add track with sigils."""
@@ -347,8 +386,9 @@ class LabelTest(unittest.TestCase):
                 name = "Reverse"
                 color = colors.blue
             feature = SeqFeature(FeatureLocation(start, end), strand=strand)
-            self.gds_features.add_feature(feature, name=name,
-                                          color=color, label=True, **kwargs)
+            self.gds_features.add_feature(
+                feature, name=name, color=color, label=True, **kwargs
+            )
 
     def test_label_default(self):
         """Feature labels - default."""
@@ -364,16 +404,22 @@ class SigilsTest(unittest.TestCase):
 
     def setUp(self):
         """Initialise diagram."""
-        self.gdd = Diagram('Test Diagram', circular=False,
-                           y=0.01, yt=0.01, yb=0.01,
-                           x=0.01, xl=0.01, xr=0.01)
+        self.gdd = Diagram(
+            "Test Diagram",
+            circular=False,
+            y=0.01,
+            yt=0.01,
+            yb=0.01,
+            x=0.01,
+            xl=0.01,
+            xr=0.01,
+        )
 
     def add_track_with_sigils(self, track_caption="", **kwargs):
         """Add a track of features."""
-        self.gdt_features = self.gdd.new_track(1,
-                                               greytrack=(track_caption != ""),
-                                               name=track_caption,
-                                               greytrack_labels=1)
+        self.gdt_features = self.gdd.new_track(
+            1, greytrack=(track_caption != ""), name=track_caption, greytrack_labels=1
+        )
         # We'll just use one feature set for these features,
         self.gds_features = self.gdt_features.new_set()
         # Add three features to show the strand options,
@@ -393,87 +439,112 @@ class SigilsTest(unittest.TestCase):
             orient = "landscape"
         else:
             orient = "portrait"
-        self.gdd.draw(format='linear', orientation=orient,
-                      tracklines=False,
-                      pagesize=(15 * cm, 5 * cm * tracks),
-                      fragments=1,
-                      start=0, end=400)
-        self.gdd.write(os.path.join('Graphics', name + ".pdf"), "pdf")
+        self.gdd.draw(
+            format="linear",
+            orientation=orient,
+            tracklines=False,
+            pagesize=(15 * cm, 5 * cm * tracks),
+            fragments=1,
+            start=0,
+            end=400,
+        )
+        self.gdd.write(os.path.join("Graphics", name + ".pdf"), "pdf")
         global renderPM
         if renderPM:
             # For the tutorial this might be useful:
             try:
-                self.gdd.write(os.path.join('Graphics', name + ".png"), "png")
+                self.gdd.write(os.path.join("Graphics", name + ".png"), "png")
             except renderPM.RenderPMError:
                 # Probably a font problem
                 renderPM = None
         if circular:
             # Circular diagram
-            self.gdd.draw(tracklines=False,
-                          pagesize=(15 * cm, 15 * cm),
-                          fragments=1,
-                          circle_core=0.5,
-                          start=0, end=400)
-            self.gdd.write(os.path.join('Graphics', name + "_c.pdf"), "pdf")
+            self.gdd.draw(
+                tracklines=False,
+                pagesize=(15 * cm, 15 * cm),
+                fragments=1,
+                circle_core=0.5,
+                start=0,
+                end=400,
+            )
+            self.gdd.write(os.path.join("Graphics", name + "_c.pdf"), "pdf")
 
     def test_all_sigils(self):
         """All sigils."""
         for glyph in ["BOX", "OCTO", "JAGGY", "ARROW", "BIGARROW"]:
-            self.add_track_with_sigils(track_caption='  sigil="%s"' % glyph,
-                                       sigil=glyph)
+            self.add_track_with_sigils(
+                track_caption='  sigil="%s"' % glyph, sigil=glyph
+            )
         self.finish("GD_sigils")
 
     def test_labels(self):
         """Feature labels."""
         self.add_track_with_sigils(label=True)
-        self.add_track_with_sigils(label=True, color="green",
-                                   # label_position left as default!
-                                   label_size=25, label_angle=0)
-        self.add_track_with_sigils(label=True, color="purple",
-                                   label_position="end",
-                                   label_size=4, label_angle=90)
-        self.add_track_with_sigils(label=True, color="blue",
-                                   label_position="middle",
-                                   label_size=6, label_angle=-90)
-        self.add_track_with_sigils(label=True, color="cyan",
-                                   label_position="start",
-                                   label_size=6, label_angle=-90)
+        self.add_track_with_sigils(
+            label=True,
+            color="green",
+            # label_position left as default!
+            label_size=25,
+            label_angle=0,
+        )
+        self.add_track_with_sigils(
+            label=True,
+            color="purple",
+            label_position="end",
+            label_size=4,
+            label_angle=90,
+        )
+        self.add_track_with_sigils(
+            label=True,
+            color="blue",
+            label_position="middle",
+            label_size=6,
+            label_angle=-90,
+        )
+        self.add_track_with_sigils(
+            label=True,
+            color="cyan",
+            label_position="start",
+            label_size=6,
+            label_angle=-90,
+        )
         self.assertEqual(len(self.gdd.tracks), 5)
         self.finish("GD_sigil_labels", circular=True)
 
     def test_arrow_shafts(self):
         """Feature arrow sigils, varying shafts."""
         self.add_track_with_sigils(sigil="ARROW")
-        self.add_track_with_sigils(sigil="ARROW", color="brown",
-                                   arrowshaft_height=1.0)
-        self.add_track_with_sigils(sigil="ARROW", color="teal",
-                                   arrowshaft_height=0.2)
-        self.add_track_with_sigils(sigil="ARROW", color="darkgreen",
-                                   arrowshaft_height=0.1)
+        self.add_track_with_sigils(sigil="ARROW", color="brown", arrowshaft_height=1.0)
+        self.add_track_with_sigils(sigil="ARROW", color="teal", arrowshaft_height=0.2)
+        self.add_track_with_sigils(
+            sigil="ARROW", color="darkgreen", arrowshaft_height=0.1
+        )
         self.assertEqual(len(self.gdd.tracks), 4)
         self.finish("GD_sigil_arrow_shafts")
 
     def test_big_arrow_shafts(self):
         """Feature big-arrow sigils, varying shafts."""
         self.add_track_with_sigils(sigil="BIGARROW")
-        self.add_track_with_sigils(sigil="BIGARROW", color="orange",
-                                   arrowshaft_height=1.0)
-        self.add_track_with_sigils(sigil="BIGARROW", color="teal",
-                                   arrowshaft_height=0.2)
-        self.add_track_with_sigils(sigil="BIGARROW", color="green",
-                                   arrowshaft_height=0.1)
+        self.add_track_with_sigils(
+            sigil="BIGARROW", color="orange", arrowshaft_height=1.0
+        )
+        self.add_track_with_sigils(
+            sigil="BIGARROW", color="teal", arrowshaft_height=0.2
+        )
+        self.add_track_with_sigils(
+            sigil="BIGARROW", color="green", arrowshaft_height=0.1
+        )
         self.assertEqual(len(self.gdd.tracks), 4)
         self.finish("GD_sigil_bigarrow_shafts")
 
     def test_arrow_heads(self):
         """Feature arrow sigils, varying heads."""
         self.add_track_with_sigils(sigil="ARROW")
-        self.add_track_with_sigils(sigil="ARROW", color="blue",
-                                   arrowhead_length=0.25)
-        self.add_track_with_sigils(sigil="ARROW", color="orange",
-                                   arrowhead_length=1)
-        self.add_track_with_sigils(sigil="ARROW", color="red",
-                                   arrowhead_length=10000)  # Triangles
+        self.add_track_with_sigils(sigil="ARROW", color="blue", arrowhead_length=0.25)
+        self.add_track_with_sigils(sigil="ARROW", color="orange", arrowhead_length=1)
+        self.add_track_with_sigils(
+            sigil="ARROW", color="red", arrowhead_length=10000
+        )  # Triangles
         self.assertEqual(len(self.gdd.tracks), 4)
         self.finish("GD_sigil_arrows")
 
@@ -494,60 +565,69 @@ class SigilsTest(unittest.TestCase):
         self.gds_features.add_feature(feature, color="blue")
         feature = SeqFeature(FeatureLocation(15, 30), strand=+1)
         self.gds_features.add_feature(feature, color="grey")
-        self.gds_features.add_feature(feature, name="Forward", sigil=glyph,
-                                      arrowhead_length=0.05)
+        self.gds_features.add_feature(
+            feature, name="Forward", sigil=glyph, arrowhead_length=0.05
+        )
 
         feature = SeqFeature(FeatureLocation(55, 60), strand=-1)
         self.gds_features.add_feature(feature, color="blue")
         feature = SeqFeature(FeatureLocation(55, 60), strand=+1)
         self.gds_features.add_feature(feature, color="grey")
-        self.gds_features.add_feature(feature, name="Forward", sigil=glyph,
-                                      arrowhead_length=1000, color="red")
+        self.gds_features.add_feature(
+            feature, name="Forward", sigil=glyph, arrowhead_length=1000, color="red"
+        )
 
         feature = SeqFeature(FeatureLocation(75, 125), strand=-1)
         self.gds_features.add_feature(feature, color="blue")
         feature = SeqFeature(FeatureLocation(75, 125), strand=+1)
         self.gds_features.add_feature(feature, color="grey")
-        self.gds_features.add_feature(feature, name="Forward", sigil=glyph,
-                                      arrowhead_length=0.05)
+        self.gds_features.add_feature(
+            feature, name="Forward", sigil=glyph, arrowhead_length=0.05
+        )
 
         # Strandless:
         feature = SeqFeature(FeatureLocation(140, 155), strand=None)
         self.gds_features.add_feature(feature, color="grey")
-        self.gds_features.add_feature(feature, name="Strandless", sigil=glyph,
-                                      arrowhead_length=0.05)
+        self.gds_features.add_feature(
+            feature, name="Strandless", sigil=glyph, arrowhead_length=0.05
+        )
 
         feature = SeqFeature(FeatureLocation(180, 185), strand=None)
         self.gds_features.add_feature(feature, color="grey")
-        self.gds_features.add_feature(feature, name="Strandless", sigil=glyph,
-                                      arrowhead_length=1000, color="red")
+        self.gds_features.add_feature(
+            feature, name="Strandless", sigil=glyph, arrowhead_length=1000, color="red"
+        )
 
         feature = SeqFeature(FeatureLocation(200, 250), strand=None)
         self.gds_features.add_feature(feature, color="grey")
-        self.gds_features.add_feature(feature, name="Strandless", sigil=glyph,
-                                      arrowhead_length=0.05)
+        self.gds_features.add_feature(
+            feature, name="Strandless", sigil=glyph, arrowhead_length=0.05
+        )
 
         # Reverse strand:
         feature = SeqFeature(FeatureLocation(265, 280), strand=+1)
         self.gds_features.add_feature(feature, color="blue")
         feature = SeqFeature(FeatureLocation(265, 280), strand=-1)
         self.gds_features.add_feature(feature, color="grey")
-        self.gds_features.add_feature(feature, name="Reverse", sigil=glyph,
-                                      arrowhead_length=0.05)
+        self.gds_features.add_feature(
+            feature, name="Reverse", sigil=glyph, arrowhead_length=0.05
+        )
 
         feature = SeqFeature(FeatureLocation(305, 310), strand=+1)
         self.gds_features.add_feature(feature, color="blue")
         feature = SeqFeature(FeatureLocation(305, 310), strand=-1)
         self.gds_features.add_feature(feature, color="grey")
-        self.gds_features.add_feature(feature, name="Reverse", sigil=glyph,
-                                      arrowhead_length=1000, color="red")
+        self.gds_features.add_feature(
+            feature, name="Reverse", sigil=glyph, arrowhead_length=1000, color="red"
+        )
 
         feature = SeqFeature(FeatureLocation(325, 375), strand=+1)
         self.gds_features.add_feature(feature, color="blue")
         feature = SeqFeature(FeatureLocation(325, 375), strand=-1)
         self.gds_features.add_feature(feature, color="grey")
-        self.gds_features.add_feature(feature, name="Reverse", sigil=glyph,
-                                      arrowhead_length=0.05)
+        self.gds_features.add_feature(
+            feature, name="Reverse", sigil=glyph, arrowhead_length=0.05
+        )
 
         self.finish("GD_sigil_short_%s" % glyph)
 
@@ -581,8 +661,9 @@ class SigilsTest(unittest.TestCase):
         else:
             feature = SeqFeature(FeatureLocation(25, 375), strand=+1)
             self.gds_features.add_feature(feature, color="lightblue")
-        self.gds_features.add_feature(feature, name="Forward", sigil=glyph,
-                                      color="blue", arrowhead_length=2.0)
+        self.gds_features.add_feature(
+            feature, name="Forward", sigil=glyph, color="blue", arrowhead_length=2.0
+        )
 
         if glyph in ["BIGARROW"]:
             # These straddle the axis, so don't want to draw them on top of each other
@@ -594,16 +675,18 @@ class SigilsTest(unittest.TestCase):
         else:
             feature = SeqFeature(FeatureLocation(25, 375), strand=-1)
             self.gds_features.add_feature(feature, color="pink")
-        self.gds_features.add_feature(feature, name="Reverse", sigil=glyph,
-                                      color="red", arrowhead_length=2.0)
+        self.gds_features.add_feature(
+            feature, name="Reverse", sigil=glyph, color="red", arrowhead_length=2.0
+        )
         # Add another track of features, bigger height to emphasise any sigil errors
         self.gdt_features = self.gdd.new_track(1, greytrack=True, height=3)
         # We'll just use one feature set for these features,
         self.gds_features = self.gdt_features.new_set()
         feature = SeqFeature(FeatureLocation(25, 375), strand=None)
         self.gds_features.add_feature(feature, color="lightgreen")
-        self.gds_features.add_feature(feature, name="Standless", sigil=glyph,
-                                      color="green", arrowhead_length=2.0)
+        self.gds_features.add_feature(
+            feature, name="Standless", sigil=glyph, color="green", arrowhead_length=2.0
+        )
         self.finish("GD_sigil_long_%s" % glyph)
 
     def test_long_arrow_heads(self):
@@ -628,14 +711,15 @@ class DiagramTest(unittest.TestCase):
 
     def setUp(self):
         """Test setup, just loads a GenBank file as a SeqRecord."""
-        handle = open(os.path.join("GenBank", "NC_005816.gb"), 'r')
+        handle = open(os.path.join("GenBank", "NC_005816.gb"), "r")
         self.record = SeqIO.read(handle, "genbank")
         handle.close()
 
-        self.gdd = Diagram('Test Diagram')
+        self.gdd = Diagram("Test Diagram")
         # Add a track of features,
-        self.gdd.new_track(1, greytrack=True, name="CDS Features",
-                           greytrack_labels=0, height=0.5)
+        self.gdd.new_track(
+            1, greytrack=True, name="CDS Features", greytrack_labels=0, height=0.5
+        )
 
     def tearDown(self):
         """Release the drawing objects."""
@@ -643,12 +727,14 @@ class DiagramTest(unittest.TestCase):
 
     def test_str(self):
         """Test diagram's info as string."""
-        expected = "\n<<class 'Bio.Graphics.GenomeDiagram._Diagram.Diagram'>: Test Diagram>" \
-                   "\n1 tracks" \
-                   "\nTrack 1: " \
-                   "\n<<class 'Bio.Graphics.GenomeDiagram._Track.Track'>: CDS Features>" \
-                   "\n0 sets" \
-                   "\n"
+        expected = (
+            "\n<<class 'Bio.Graphics.GenomeDiagram._Diagram.Diagram'>: Test Diagram>"
+            "\n1 tracks"
+            "\nTrack 1: "
+            "\n<<class 'Bio.Graphics.GenomeDiagram._Track.Track'>: CDS Features>"
+            "\n0 sets"
+            "\n"
+        )
         self.assertEqual(expected, str(self.gdd))
 
     def test_add_track(self):
@@ -679,28 +765,32 @@ class DiagramTest(unittest.TestCase):
     def test_move_track(self):
         """Move a track."""
         self.gdd.move_track(1, 2)
-        expected = "\n<<class 'Bio.Graphics.GenomeDiagram._Diagram.Diagram'>: Test Diagram>" \
-                   "\n1 tracks" \
-                   "\nTrack 2: " \
-                   "\n<<class 'Bio.Graphics.GenomeDiagram._Track.Track'>: CDS Features>" \
-                   "\n0 sets" \
-                   "\n"
+        expected = (
+            "\n<<class 'Bio.Graphics.GenomeDiagram._Diagram.Diagram'>: Test Diagram>"
+            "\n1 tracks"
+            "\nTrack 2: "
+            "\n<<class 'Bio.Graphics.GenomeDiagram._Track.Track'>: CDS Features>"
+            "\n0 sets"
+            "\n"
+        )
         self.assertEqual(expected, str(self.gdd))
 
     def test_renumber(self):
         """Test renumbering tracks."""
         self.gdd.renumber_tracks(0)
-        expected = "\n<<class 'Bio.Graphics.GenomeDiagram._Diagram.Diagram'>: Test Diagram>" \
-                   "\n1 tracks" \
-                   "\nTrack 0: " \
-                   "\n<<class 'Bio.Graphics.GenomeDiagram._Track.Track'>: CDS Features>" \
-                   "\n0 sets" \
-                   "\n"
+        expected = (
+            "\n<<class 'Bio.Graphics.GenomeDiagram._Diagram.Diagram'>: Test Diagram>"
+            "\n1 tracks"
+            "\nTrack 0: "
+            "\n<<class 'Bio.Graphics.GenomeDiagram._Track.Track'>: CDS Features>"
+            "\n0 sets"
+            "\n"
+        )
         self.assertEqual(expected, str(self.gdd))
 
     def test_write_arguments(self):
         """Check how the write methods respond to output format arguments."""
-        gdd = Diagram('Test Diagram')
+        gdd = Diagram("Test Diagram")
         gdd.drawing = None  # Hack - need the ReportLab drawing object to be created.
         filename = os.path.join("Graphics", "error.txt")
         # We (now) allow valid formats in any case.
@@ -716,18 +806,22 @@ class DiagramTest(unittest.TestCase):
         start = 6500
         end = 8750
 
-        gdd = Diagram('Test Diagram',
-                      # For the circular diagram we don't want a closed cirle:
-                      circular=False,
-                      )
+        gdd = Diagram(
+            "Test Diagram",
+            # For the circular diagram we don't want a closed cirle:
+            circular=False,
+        )
         # Add a track of features,
-        gdt_features = gdd.new_track(1, greytrack=True,
-                                     name="CDS Features",
-                                     scale_largetick_interval=1000,
-                                     scale_smalltick_interval=100,
-                                     scale_format="SInt",
-                                     greytrack_labels=False,
-                                     height=0.5)
+        gdt_features = gdd.new_track(
+            1,
+            greytrack=True,
+            name="CDS Features",
+            scale_largetick_interval=1000,
+            scale_smalltick_interval=100,
+            scale_format="SInt",
+            greytrack_labels=False,
+            height=0.5,
+        )
         # We'll just use one feature set for these features,
         gds_features = gdt_features.new_set()
         for feature in genbank_entry.features:
@@ -744,8 +838,10 @@ class DiagramTest(unittest.TestCase):
             # This URL should work in SVG output from recent versions
             # of ReportLab.  You need ReportLab 2.4 or later
             try:
-                url = "http://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi" +\
-                      "?db=protein&id=%s" % feature.qualifiers["protein_id"][0]
+                url = (
+                    "http://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi"
+                    + "?db=protein&id=%s" % feature.qualifiers["protein_id"][0]
+                )
             except KeyError:
                 url = None
 
@@ -757,46 +853,59 @@ class DiagramTest(unittest.TestCase):
                 color = "red"
             # Checking it can cope with the old UK spelling colour.
             # Also show the labels perpendicular to the track.
-            gds_features.add_feature(feature, colour=color,
-                                     url=url,
-                                     sigil="ARROW",
-                                     label_position=None,
-                                     label_size=8,
-                                     label_angle=90,
-                                     label=True)
+            gds_features.add_feature(
+                feature,
+                colour=color,
+                url=url,
+                sigil="ARROW",
+                label_position=None,
+                label_size=8,
+                label_angle=90,
+                label=True,
+            )
 
         # And draw it...
-        gdd.draw(format='linear', orientation='landscape',
-                 tracklines=False, pagesize=(10 * cm, 6 * cm), fragments=1,
-                 start=start, end=end)
-        output_filename = os.path.join('Graphics', 'GD_region_linear.pdf')
-        gdd.write(output_filename, 'PDF')
+        gdd.draw(
+            format="linear",
+            orientation="landscape",
+            tracklines=False,
+            pagesize=(10 * cm, 6 * cm),
+            fragments=1,
+            start=start,
+            end=end,
+        )
+        output_filename = os.path.join("Graphics", "GD_region_linear.pdf")
+        gdd.write(output_filename, "PDF")
 
         # Also check the write_to_string (bytes string) method matches,
-        assert open(output_filename, "rb").read() == gdd.write_to_string('PDF')
+        assert open(output_filename, "rb").read() == gdd.write_to_string("PDF")
 
-        output_filename = os.path.join('Graphics', 'GD_region_linear.svg')
-        gdd.write(output_filename, 'SVG')
+        output_filename = os.path.join("Graphics", "GD_region_linear.svg")
+        gdd.write(output_filename, "SVG")
 
         # Circular with a particular start/end is a bit odd, but by setting
         # circular=False (above) a sweep of 90% is used (a wedge is left out)
-        gdd.draw(format='circular',
-                 tracklines=False, pagesize=(10 * cm, 10 * cm),
-                 start=start, end=end)
-        output_filename = os.path.join('Graphics', 'GD_region_circular.pdf')
-        gdd.write(output_filename, 'PDF')
-        output_filename = os.path.join('Graphics', 'GD_region_circular.svg')
-        gdd.write(output_filename, 'SVG')
+        gdd.draw(
+            format="circular",
+            tracklines=False,
+            pagesize=(10 * cm, 10 * cm),
+            start=start,
+            end=end,
+        )
+        output_filename = os.path.join("Graphics", "GD_region_circular.pdf")
+        gdd.write(output_filename, "PDF")
+        output_filename = os.path.join("Graphics", "GD_region_circular.svg")
+        gdd.write(output_filename, "SVG")
 
     def test_diagram_via_methods_pdf(self):
         """Construct and draw PDF using method approach."""
         genbank_entry = self.record
-        gdd = Diagram('Test Diagram')
+        gdd = Diagram("Test Diagram")
 
         # Add a track of features,
-        gdt_features = gdd.new_track(1, greytrack=True,
-                                     name="CDS Features", greytrack_labels=0,
-                                     height=0.5)
+        gdt_features = gdd.new_track(
+            1, greytrack=True, name="CDS Features", greytrack_labels=0, height=0.5
+        )
         # We'll just use one feature set for the genes and misc_features,
         gds_features = gdt_features.new_set()
         for feature in genbank_entry.features:
@@ -805,21 +914,26 @@ class DiagramTest(unittest.TestCase):
                     color = "blue"
                 else:
                     color = "lightblue"
-                gds_features.add_feature(feature, color=color,
-                                         # label_position="middle",
-                                         # label_position="end",
-                                         label_position="start",
-                                         label_size=11,
-                                         # label_angle=90,
-                                         sigil="ARROW",
-                                         label=True)
+                gds_features.add_feature(
+                    feature,
+                    color=color,
+                    # label_position="middle",
+                    # label_position="end",
+                    label_position="start",
+                    label_size=11,
+                    # label_angle=90,
+                    sigil="ARROW",
+                    label=True,
+                )
 
         # I want to include some strandless features, so for an example
         # will use EcoRI recognition sites etc.
-        for site, name, color in [("GAATTC", "EcoRI", "green"),
-                                  ("CCCGGG", "SmaI", "orange"),
-                                  ("AAGCTT", "HindIII", "red"),
-                                  ("GGATCC", "BamHI", "purple")]:
+        for site, name, color in [
+            ("GAATTC", "EcoRI", "green"),
+            ("CCCGGG", "SmaI", "orange"),
+            ("AAGCTT", "HindIII", "red"),
+            ("GGATCC", "BamHI", "purple"),
+        ]:
             index = 0
             while True:
                 index = genbank_entry.seq.find(site, start=index)
@@ -830,75 +944,99 @@ class DiagramTest(unittest.TestCase):
                 # This URL should work in SVG output from recent versions
                 # of ReportLab.  You need ReportLab 2.4 or later
                 try:
-                    url = "http://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi" +\
-                          "?db=protein&id=%s" % feature.qualifiers["protein_id"][0]
+                    url = (
+                        "http://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi"
+                        + "?db=protein&id=%s" % feature.qualifiers["protein_id"][0]
+                    )
                 except KeyError:
                     url = None
 
-                gds_features.add_feature(feature, color=color,
-                                         url=url,
-                                         # label_position="middle",
-                                         label_size=10,
-                                         label_color=color,
-                                         # label_angle=90,
-                                         name=name,
-                                         label=True)
+                gds_features.add_feature(
+                    feature,
+                    color=color,
+                    url=url,
+                    # label_position="middle",
+                    label_size=10,
+                    label_color=color,
+                    # label_angle=90,
+                    name=name,
+                    label=True,
+                )
                 index += len(site)
             del index
 
         # Now add a graph track...
-        gdt_at_gc = gdd.new_track(2, greytrack=True,
-                                  name="AT and GC content",
-                                  greytrack_labels=True)
+        gdt_at_gc = gdd.new_track(
+            2, greytrack=True, name="AT and GC content", greytrack_labels=True
+        )
         gds_at_gc = gdt_at_gc.new_set(type="graph")
 
         step = len(genbank_entry) // 200
-        gds_at_gc.new_graph(apply_to_window(genbank_entry.seq, step, calc_gc_content, step),
-                            'GC content', style='line',
-                            color=colors.lightgreen,
-                            altcolor=colors.darkseagreen)
-        gds_at_gc.new_graph(apply_to_window(genbank_entry.seq, step, calc_at_content, step),
-                            'AT content', style='line',
-                            color=colors.orange,
-                            altcolor=colors.red)
+        gds_at_gc.new_graph(
+            apply_to_window(genbank_entry.seq, step, calc_gc_content, step),
+            "GC content",
+            style="line",
+            color=colors.lightgreen,
+            altcolor=colors.darkseagreen,
+        )
+        gds_at_gc.new_graph(
+            apply_to_window(genbank_entry.seq, step, calc_at_content, step),
+            "AT content",
+            style="line",
+            color=colors.orange,
+            altcolor=colors.red,
+        )
 
         # Finally draw it in both formats,
-        gdd.draw(format='linear', orientation='landscape', tracklines=0,
-                 pagesize='A4', fragments=3)
-        output_filename = os.path.join('Graphics', 'GD_by_meth_linear.pdf')
-        gdd.write(output_filename, 'PDF')
+        gdd.draw(
+            format="linear",
+            orientation="landscape",
+            tracklines=0,
+            pagesize="A4",
+            fragments=3,
+        )
+        output_filename = os.path.join("Graphics", "GD_by_meth_linear.pdf")
+        gdd.write(output_filename, "PDF")
 
-        gdd.draw(format='circular', tracklines=False, circle_core=0.8,
-                 pagesize=(20 * cm, 20 * cm), circular=True)
-        output_filename = os.path.join('Graphics', 'GD_by_meth_circular.pdf')
-        gdd.write(output_filename, 'PDF')
+        gdd.draw(
+            format="circular",
+            tracklines=False,
+            circle_core=0.8,
+            pagesize=(20 * cm, 20 * cm),
+            circular=True,
+        )
+        output_filename = os.path.join("Graphics", "GD_by_meth_circular.pdf")
+        gdd.write(output_filename, "PDF")
 
     def test_diagram_via_object_pdf(self):
         """Construct and draw PDF using object approach."""
         genbank_entry = self.record
-        gdd = Diagram('Test Diagram')
+        gdd = Diagram("Test Diagram")
 
-        gdt1 = Track('CDS features', greytrack=True,
-                     scale_largetick_interval=1e4,
-                     scale_smalltick_interval=1e3,
-                     greytrack_labels=10,
-                     greytrack_font_color="red",
-                     scale_format="SInt")
-        gdt2 = Track('gene features', greytrack=1, scale_largetick_interval=1e4)
+        gdt1 = Track(
+            "CDS features",
+            greytrack=True,
+            scale_largetick_interval=1e4,
+            scale_smalltick_interval=1e3,
+            greytrack_labels=10,
+            greytrack_font_color="red",
+            scale_format="SInt",
+        )
+        gdt2 = Track("gene features", greytrack=1, scale_largetick_interval=1e4)
 
         # First add some feature sets:
-        gdfsA = FeatureSet(name='CDS backgrounds')
-        gdfsB = FeatureSet(name='gene background')
+        gdfsA = FeatureSet(name="CDS backgrounds")
+        gdfsB = FeatureSet(name="gene background")
 
-        gdfs1 = FeatureSet(name='CDS features')
-        gdfs2 = FeatureSet(name='gene features')
-        gdfs3 = FeatureSet(name='misc_features')
-        gdfs4 = FeatureSet(name='repeat regions')
+        gdfs1 = FeatureSet(name="CDS features")
+        gdfs2 = FeatureSet(name="gene features")
+        gdfs3 = FeatureSet(name="misc_features")
+        gdfs4 = FeatureSet(name="repeat regions")
 
         prev_gene = None
         cds_count = 0
         for feature in genbank_entry.features:
-            if feature.type == 'CDS':
+            if feature.type == "CDS":
                 cds_count += 1
                 if prev_gene:
                     # Assuming it goes with this CDS!
@@ -907,93 +1045,143 @@ class DiagramTest(unittest.TestCase):
                     else:
                         dark, light = colors.burlywood, colors.bisque
                     # Background for CDS,
-                    a = gdfsA.add_feature(SeqFeature(FeatureLocation(feature.location.start, feature.location.end, strand=0)),
-                                          color=dark)
+                    a = gdfsA.add_feature(
+                        SeqFeature(
+                            FeatureLocation(
+                                feature.location.start, feature.location.end, strand=0
+                            )
+                        ),
+                        color=dark,
+                    )
                     # Background for gene,
-                    b = gdfsB.add_feature(SeqFeature(FeatureLocation(prev_gene.location.start, prev_gene.location.end, strand=0)),
-                                          color=dark)
+                    b = gdfsB.add_feature(
+                        SeqFeature(
+                            FeatureLocation(
+                                prev_gene.location.start,
+                                prev_gene.location.end,
+                                strand=0,
+                            )
+                        ),
+                        color=dark,
+                    )
                     # Cross link,
                     gdd.cross_track_links.append(CrossLink(a, b, light, dark))
                     prev_gene = None
-            if feature.type == 'gene':
+            if feature.type == "gene":
                 prev_gene = feature
 
         # Some cross links on the same linear diagram fragment,
         f, c = fill_and_border(colors.red)
-        a = gdfsA.add_feature(SeqFeature(FeatureLocation(2220, 2230)), color=f, border=c)
-        b = gdfsB.add_feature(SeqFeature(FeatureLocation(2200, 2210)), color=f, border=c)
+        a = gdfsA.add_feature(
+            SeqFeature(FeatureLocation(2220, 2230)), color=f, border=c
+        )
+        b = gdfsB.add_feature(
+            SeqFeature(FeatureLocation(2200, 2210)), color=f, border=c
+        )
         gdd.cross_track_links.append(CrossLink(a, b, f, c))
 
         f, c = fill_and_border(colors.blue)
-        a = gdfsA.add_feature(SeqFeature(FeatureLocation(2150, 2200)), color=f, border=c)
-        b = gdfsB.add_feature(SeqFeature(FeatureLocation(2220, 2290)), color=f, border=c)
+        a = gdfsA.add_feature(
+            SeqFeature(FeatureLocation(2150, 2200)), color=f, border=c
+        )
+        b = gdfsB.add_feature(
+            SeqFeature(FeatureLocation(2220, 2290)), color=f, border=c
+        )
         gdd.cross_track_links.append(CrossLink(a, b, f, c, flip=True))
 
         f, c = fill_and_border(colors.green)
-        a = gdfsA.add_feature(SeqFeature(FeatureLocation(2250, 2560)), color=f, border=c)
-        b = gdfsB.add_feature(SeqFeature(FeatureLocation(2300, 2860)), color=f, border=c)
+        a = gdfsA.add_feature(
+            SeqFeature(FeatureLocation(2250, 2560)), color=f, border=c
+        )
+        b = gdfsB.add_feature(
+            SeqFeature(FeatureLocation(2300, 2860)), color=f, border=c
+        )
         gdd.cross_track_links.append(CrossLink(a, b, f, c))
 
         # Some cross links where both parts are saddling the linear diagram fragment boundary,
         f, c = fill_and_border(colors.red)
-        a = gdfsA.add_feature(SeqFeature(FeatureLocation(3155, 3250)), color=f, border=c)
-        b = gdfsB.add_feature(SeqFeature(FeatureLocation(3130, 3300)), color=f, border=c)
+        a = gdfsA.add_feature(
+            SeqFeature(FeatureLocation(3155, 3250)), color=f, border=c
+        )
+        b = gdfsB.add_feature(
+            SeqFeature(FeatureLocation(3130, 3300)), color=f, border=c
+        )
         gdd.cross_track_links.append(CrossLink(a, b, f, c))
         # Nestled within that (drawn on top),
         f, c = fill_and_border(colors.blue)
-        a = gdfsA.add_feature(SeqFeature(FeatureLocation(3160, 3275)), color=f, border=c)
-        b = gdfsB.add_feature(SeqFeature(FeatureLocation(3180, 3225)), color=f, border=c)
+        a = gdfsA.add_feature(
+            SeqFeature(FeatureLocation(3160, 3275)), color=f, border=c
+        )
+        b = gdfsB.add_feature(
+            SeqFeature(FeatureLocation(3180, 3225)), color=f, border=c
+        )
         gdd.cross_track_links.append(CrossLink(a, b, f, c, flip=True))
 
         # Some cross links where two features are on either side of the linear diagram fragment boundary,
         f, c = fill_and_border(colors.green)
-        a = gdfsA.add_feature(SeqFeature(FeatureLocation(6450, 6550)), color=f, border=c)
-        b = gdfsB.add_feature(SeqFeature(FeatureLocation(6265, 6365)), color=f, border=c)
+        a = gdfsA.add_feature(
+            SeqFeature(FeatureLocation(6450, 6550)), color=f, border=c
+        )
+        b = gdfsB.add_feature(
+            SeqFeature(FeatureLocation(6265, 6365)), color=f, border=c
+        )
         gdd.cross_track_links.append(CrossLink(a, b, color=f, border=c))
         f, c = fill_and_border(colors.gold)
-        a = gdfsA.add_feature(SeqFeature(FeatureLocation(6265, 6365)), color=f, border=c)
-        b = gdfsB.add_feature(SeqFeature(FeatureLocation(6450, 6550)), color=f, border=c)
+        a = gdfsA.add_feature(
+            SeqFeature(FeatureLocation(6265, 6365)), color=f, border=c
+        )
+        b = gdfsB.add_feature(
+            SeqFeature(FeatureLocation(6450, 6550)), color=f, border=c
+        )
         gdd.cross_track_links.append(CrossLink(a, b, color=f, border=c))
         f, c = fill_and_border(colors.red)
-        a = gdfsA.add_feature(SeqFeature(FeatureLocation(6275, 6375)), color=f, border=c)
-        b = gdfsB.add_feature(SeqFeature(FeatureLocation(6430, 6530)), color=f, border=c)
+        a = gdfsA.add_feature(
+            SeqFeature(FeatureLocation(6275, 6375)), color=f, border=c
+        )
+        b = gdfsB.add_feature(
+            SeqFeature(FeatureLocation(6430, 6530)), color=f, border=c
+        )
         gdd.cross_track_links.append(CrossLink(a, b, color=f, border=c, flip=True))
         f, c = fill_and_border(colors.blue)
-        a = gdfsA.add_feature(SeqFeature(FeatureLocation(6430, 6530)), color=f, border=c)
-        b = gdfsB.add_feature(SeqFeature(FeatureLocation(6275, 6375)), color=f, border=c)
+        a = gdfsA.add_feature(
+            SeqFeature(FeatureLocation(6430, 6530)), color=f, border=c
+        )
+        b = gdfsB.add_feature(
+            SeqFeature(FeatureLocation(6275, 6375)), color=f, border=c
+        )
         gdd.cross_track_links.append(CrossLink(a, b, color=f, border=c, flip=True))
 
         cds_count = 0
         for feature in genbank_entry.features:
-            if feature.type == 'CDS':
+            if feature.type == "CDS":
                 cds_count += 1
                 if cds_count % 2 == 0:
                     gdfs1.add_feature(feature, color=colors.pink, sigil="ARROW")
                 else:
                     gdfs1.add_feature(feature, color=colors.red, sigil="ARROW")
 
-            if feature.type == 'gene':
+            if feature.type == "gene":
                 # Note we set the colour of ALL the genes later on as a test,
                 gdfs2.add_feature(feature, sigil="ARROW")
 
-            if feature.type == 'misc_feature':
+            if feature.type == "misc_feature":
                 gdfs3.add_feature(feature, color=colors.orange)
 
-            if feature.type == 'repeat_region':
+            if feature.type == "repeat_region":
                 gdfs4.add_feature(feature, color=colors.purple)
 
         # gdd.cross_track_links = gdd.cross_track_links[:1]
 
-        gdfs1.set_all_features('label', 1)
-        gdfs2.set_all_features('label', 1)
-        gdfs3.set_all_features('label', 1)
-        gdfs4.set_all_features('label', 1)
+        gdfs1.set_all_features("label", 1)
+        gdfs2.set_all_features("label", 1)
+        gdfs3.set_all_features("label", 1)
+        gdfs4.set_all_features("label", 1)
 
-        gdfs3.set_all_features('hide', 0)
-        gdfs4.set_all_features('hide', 0)
+        gdfs3.set_all_features("hide", 0)
+        gdfs4.set_all_features("hide", 0)
 
         # gdfs1.set_all_features('color', colors.red)
-        gdfs2.set_all_features('color', colors.blue)
+        gdfs2.set_all_features("color", colors.blue)
 
         gdt1.add_set(gdfsA)  # Before CDS so under them!
         gdt1.add_set(gdfs1)
@@ -1001,8 +1189,9 @@ class DiagramTest(unittest.TestCase):
         gdt2.add_set(gdfsB)  # Before genes so under them!
         gdt2.add_set(gdfs2)
 
-        gdt3 = Track('misc features and repeats', greytrack=1,
-                     scale_largetick_interval=1e4)
+        gdt3 = Track(
+            "misc features and repeats", greytrack=1, scale_largetick_interval=1e4
+        )
         gdt3.add_set(gdfs3)
         gdt3.add_set(gdfs4)
 
@@ -1011,35 +1200,57 @@ class DiagramTest(unittest.TestCase):
         # Use a fairly large step so we can easily tell the difference
         # between the bar and line graphs.
         step = len(genbank_entry) // 200
-        gdgs1 = GraphSet('GC skew')
+        gdgs1 = GraphSet("GC skew")
 
         graphdata1 = apply_to_window(genbank_entry.seq, step, calc_gc_skew, step)
-        gdgs1.new_graph(graphdata1, 'GC Skew', style='bar',
-                        color=colors.violet, altcolor=colors.purple)
+        gdgs1.new_graph(
+            graphdata1,
+            "GC Skew",
+            style="bar",
+            color=colors.violet,
+            altcolor=colors.purple,
+        )
 
-        gdt4 = Track('GC Skew (bar)', height=1.94, greytrack=1,
-                     scale_largetick_interval=1e4)
+        gdt4 = Track(
+            "GC Skew (bar)", height=1.94, greytrack=1, scale_largetick_interval=1e4
+        )
         gdt4.add_set(gdgs1)
 
-        gdgs2 = GraphSet('GC and AT Content')
-        gdgs2.new_graph(apply_to_window(genbank_entry.seq, step, calc_gc_content, step),
-                        'GC content', style='line', color=colors.lightgreen,
-                        altcolor=colors.darkseagreen)
+        gdgs2 = GraphSet("GC and AT Content")
+        gdgs2.new_graph(
+            apply_to_window(genbank_entry.seq, step, calc_gc_content, step),
+            "GC content",
+            style="line",
+            color=colors.lightgreen,
+            altcolor=colors.darkseagreen,
+        )
 
-        gdgs2.new_graph(apply_to_window(genbank_entry.seq, step, calc_at_content, step),
-                        'AT content', style='line', color=colors.orange,
-                        altcolor=colors.red)
+        gdgs2.new_graph(
+            apply_to_window(genbank_entry.seq, step, calc_at_content, step),
+            "AT content",
+            style="line",
+            color=colors.orange,
+            altcolor=colors.red,
+        )
 
-        gdt5 = Track('GC Content(green line), AT Content(red line)',
-                     height=1.94, greytrack=1, scale_largetick_interval=1e4)
+        gdt5 = Track(
+            "GC Content(green line), AT Content(red line)",
+            height=1.94,
+            greytrack=1,
+            scale_largetick_interval=1e4,
+        )
         gdt5.add_set(gdgs2)
 
-        gdgs3 = GraphSet('Di-nucleotide count')
+        gdgs3 = GraphSet("Di-nucleotide count")
         step = len(genbank_entry) // 400  # smaller step
-        gdgs3.new_graph(apply_to_window(genbank_entry.seq, step, calc_dinucleotide_counts, step),
-                        'Di-nucleotide count', style='heat',
-                        color=colors.red, altcolor=colors.orange)
-        gdt6 = Track('Di-nucleotide count', height=0.5, greytrack=False, scale=False)
+        gdgs3.new_graph(
+            apply_to_window(genbank_entry.seq, step, calc_dinucleotide_counts, step),
+            "Di-nucleotide count",
+            style="heat",
+            color=colors.red,
+            altcolor=colors.orange,
+        )
+        gdt6 = Track("Di-nucleotide count", height=0.5, greytrack=False, scale=False)
         gdt6.add_set(gdgs3)
 
         # Add the tracks (from both features and graphs)
@@ -1052,28 +1263,46 @@ class DiagramTest(unittest.TestCase):
         gdd.add_track(gdt6, 8)  # Feature depth
 
         # Finally draw it in both formats, and full view and partial
-        gdd.draw(format='circular', orientation='landscape',
-                 tracklines=0, pagesize='A0')
-        output_filename = os.path.join('Graphics', 'GD_by_obj_circular.pdf')
-        gdd.write(output_filename, 'PDF')
+        gdd.draw(
+            format="circular", orientation="landscape", tracklines=0, pagesize="A0"
+        )
+        output_filename = os.path.join("Graphics", "GD_by_obj_circular.pdf")
+        gdd.write(output_filename, "PDF")
 
         gdd.circular = False
-        gdd.draw(format='circular', orientation='landscape',
-                 tracklines=0, pagesize='A0', start=3000, end=6300)
-        output_filename = os.path.join('Graphics', 'GD_by_obj_frag_circular.pdf')
-        gdd.write(output_filename, 'PDF')
+        gdd.draw(
+            format="circular",
+            orientation="landscape",
+            tracklines=0,
+            pagesize="A0",
+            start=3000,
+            end=6300,
+        )
+        output_filename = os.path.join("Graphics", "GD_by_obj_frag_circular.pdf")
+        gdd.write(output_filename, "PDF")
 
-        gdd.draw(format='linear', orientation='landscape',
-                 tracklines=0, pagesize='A0', fragments=3)
-        output_filename = os.path.join('Graphics', 'GD_by_obj_linear.pdf')
-        gdd.write(output_filename, 'PDF')
+        gdd.draw(
+            format="linear",
+            orientation="landscape",
+            tracklines=0,
+            pagesize="A0",
+            fragments=3,
+        )
+        output_filename = os.path.join("Graphics", "GD_by_obj_linear.pdf")
+        gdd.write(output_filename, "PDF")
 
         gdd.set_all_tracks("greytrack_labels", 2)
-        gdd.draw(format='linear', orientation='landscape',
-                 tracklines=0, pagesize=(30 * cm, 10 * cm), fragments=1,
-                 start=3000, end=6300)
-        output_filename = os.path.join('Graphics', 'GD_by_obj_frag_linear.pdf')
-        gdd.write(output_filename, 'PDF')
+        gdd.draw(
+            format="linear",
+            orientation="landscape",
+            tracklines=0,
+            pagesize=(30 * cm, 10 * cm),
+            fragments=1,
+            start=3000,
+            end=6300,
+        )
+        output_filename = os.path.join("Graphics", "GD_by_obj_frag_linear.pdf")
+        gdd.write(output_filename, "PDF")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request is a test case for issue #2008, chosen since the GenomeDiagram author @widdowquinn is a fan of the black tool and it's output, and we historically have had some variation in style between modules.

Note that I reverted two black edits (white space with slicing) due to a known disagreement between black and flake8 over the PEP8 ruling (looks like a flake8 false positive).

I also manually reviewed and fixed some multi-line comments (previously vertically aligned with spaces), in general making them into one-line comments.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
