### PR TITLE
Cosmetic changes to Bio.Cluster doctest

### DIFF
--- a/Bio/Cluster/__init__.py
+++ b/Bio/Cluster/__init__.py
@@ -175,19 +175,17 @@ def kmedoids(distance, nclusters=2, npass=1, initialid=None):
        Examples are:
 
            >>> from numpy import array
-           >>> # option 1.:
+           >>> # option 1:
            >>> distance = array([[0.0, 1.1, 2.3],
            ...                   [1.1, 0.0, 4.5],
            ...                   [2.3, 4.5, 0.0]])
-           ...
-           >>> # option 2.:
+           >>> # option 2:
            >>> distance = array([1.1, 2.3, 4.5])
-           >>> # option 3.:
+           >>> # option 3:
            >>> distance = [array([]),
            ...             array([1.1]),
            ...             array([2.3, 4.5])]
-           ...
-           >>>
+
 
        These three correspond to the same distance matrix.
      - nclusters: number of clusters (the 'k' in k-medoids)
@@ -260,19 +258,16 @@ def treecluster(data, mask=None, weight=None, transpose=False, method='m',
        Examples are:
 
            >>> from numpy import array
-           >>> # option 1.:
+           >>> # option 1:
            >>> distance = array([[0.0, 1.1, 2.3],
            ...                   [1.1, 0.0, 4.5],
            ...                   [2.3, 4.5, 0.0]])
-           ...
-           >>> # option 2.:
+           >>> # option 2:
            >>> distance = array([1.1, 2.3, 4.5])
-           >>> # option 3.:
+           >>> # option 3:
            >>> distance = [array([]),
            ...             array([1.1]),
            ...             array([2.3, 4.5])]
-           ...
-           >>>
 
        These three correspond to the same distance matrix.
 


### PR DESCRIPTION
A quick fix while looking at a separate issue - that the C code's doctests are failing locally (but seem not to get run under TravisCI), missing imports which were fixed in the Python version for the most part. Any ideas @mdehoon - and can you reproduce that? I think it is down to the details of the build/install/test process.

Changes here are partly style, but also removing ``...`` lines which you do not see at the Python terminal if following the example.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
