### PR TITLE
Update .flake8 to ignore some folders

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,7 +11,8 @@
 # =================================================
 [flake8]
 doctests = True
-exclude = .git,.github,build, # Some folders we don't need to check
+# Exclude some file types and folders that shouldn't be checked:
+exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.github,build,
 ignore =
     # =============================================================
     # Biopython's 'standard' ignores we can agree to always accept:

--- a/.flake8
+++ b/.flake8
@@ -11,6 +11,7 @@
 # =================================================
 [flake8]
 doctests = True
+exclude = .git,.github,build, # Some folders we don't need to check
 ignore =
     # =============================================================
     # Biopython's 'standard' ignores we can agree to always accept:


### PR DESCRIPTION
This pull request addresses issue #2090. It uses `flake8`'s `exclude` option to exclude some folders which don't need to be style-checked.

UPDATE: Also added `flake8`'s standard excludes `.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,` to furthermore exclude them.

This will close #2090.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
