### PR TITLE
Change assertAlmostEqual(round(...

### DIFF
--- a/Tests/test_codonalign.py
+++ b/Tests/test_codonalign.py
@@ -172,11 +172,11 @@ class Test_dn_ds(unittest.TestCase):
         codon_seq1 = self.aln[0]
         codon_seq2 = self.aln[1]
         dN, dS = cal_dn_ds(codon_seq1, codon_seq2, method='NG86')
-        self.assertAlmostEqual(round(dN, 4), 0.0209, places=4)
-        self.assertAlmostEqual(round(dS, 4), 0.0178, places=4)
+        self.assertAlmostEqual(dN, 0.0209, places=4)
+        self.assertAlmostEqual(dS, 0.0178, places=4)
         dN, dS = cal_dn_ds(codon_seq1, codon_seq2, method='LWL85')
-        self.assertAlmostEqual(round(dN, 4), 0.0203, places=4)
-        self.assertAlmostEqual(round(dS, 4), 0.0164, places=4)
+        self.assertAlmostEqual(dN, 0.0203, places=4)
+        self.assertAlmostEqual(dS, 0.0164, places=4)
 
         try:
             import scipy
@@ -187,15 +187,15 @@ class Test_dn_ds(unittest.TestCase):
         # This should be present:
         from scipy.linalg import expm
         dN, dS = cal_dn_ds(codon_seq1, codon_seq2, method='YN00')
-        self.assertAlmostEqual(round(dN, 4), 0.0198, places=4)
-        self.assertAlmostEqual(round(dS, 4), 0.0222, places=4)
+        self.assertAlmostEqual(dN, 0.0198, places=4)
+        self.assertAlmostEqual(dS, 0.0222, places=4)
 
         try:
             # New in scipy v0.11
             from scipy.optimize import minimize
             dN, dS = cal_dn_ds(codon_seq1, codon_seq2, method='ML')
-            self.assertAlmostEqual(round(dN, 4), 0.0194, places=4)
-            self.assertAlmostEqual(round(dS, 4), 0.0217, places=4)
+            self.assertAlmostEqual(dN, 0.0194, places=4)
+            self.assertAlmostEqual(dS, 0.0217, places=4)
         except ImportError:
             # TODO - Show a warning?
             pass
@@ -209,12 +209,12 @@ class Test_dn_ds(unittest.TestCase):
         for i in dn.matrix:
             dn_list.extend(i)
         for dn_cal, dn_corr in zip(dn_list, dn_correct):
-            self.assertAlmostEqual(round(dn_cal, 4), round(dn_corr, 4), places=4)
+            self.assertAlmostEqual(dn_cal, dn_corr, places=4)
         ds_list = []
         for i in ds.matrix:
             ds_list.extend(i)
         for ds_cal, ds_corr in zip(ds_list, ds_correct):
-            self.assertAlmostEqual(round(ds_cal, 4), round(ds_corr, 4), places=4)
+            self.assertAlmostEqual(ds_cal, ds_corr, places=4)
         # YN00 method with user specified codon table
         dn_correct = [0, 0.019701773284646867, 0, 0.6109649819852769, 0.6099903856901369, 0, 0.6114499930666559, 0.6028068208599121, 0.045158286242251426, 0, 0.6151835071687592, 0.6053227393422296, 0.07034397741651377, 0.06956967795096626, 0, 0.6103850655769698, 0.5988716898831496, 0.07905930042150053, 0.08203052937107111, 0.05659346894088538, 0]
         ds_correct = [0, 0.01881718550096053, 0, 1.814457265482046, 1.8417575124882066, 0, 1.5627041719628896, 1.563930819079887, 0.4748890153032888, 0, 1.6754828466084355, 1.6531212012501901, 0.5130923627791538, 0.5599667707191436, 0, 2.0796114236540943, 2.1452591651827304, 0.7243066372971764, 0.8536617406770075, 0.6509203399899367, 0]
@@ -223,12 +223,12 @@ class Test_dn_ds(unittest.TestCase):
         for i in dn.matrix:
             dn_list.extend(i)
         for dn_cal, dn_corr in zip(dn_list, dn_correct):
-            self.assertAlmostEqual(round(dn_cal, 4), round(dn_corr, 4), places=4)
+            self.assertAlmostEqual(dn_cal, dn_corr, places=4)
         ds_list = []
         for i in ds.matrix:
             ds_list.extend(i)
         for ds_cal, ds_corr in zip(ds_list, ds_correct):
-            self.assertAlmostEqual(round(ds_cal, 4), round(ds_corr, 4), places=4)
+            self.assertAlmostEqual(ds_cal, ds_corr, places=4)
 
 
 try:
@@ -248,7 +248,7 @@ if numpy and lgamma:
             pro_aln = AlignIO.read(TEST_ALIGN_FILE7[0][1], 'clustal', alphabet=IUPAC.protein)
             codon_aln = codonalign.build(pro_aln, p)
             p.close()  # Close indexed FASTA file
-            self.assertAlmostEqual(round(codonalign.mktest([codon_aln[1:12], codon_aln[12:16], codon_aln[16:]]), 4), 0.0021, places=4)
+            self.assertAlmostEqual(codonalign.mktest([codon_aln[1:12], codon_aln[12:16], codon_aln[16:]]), 0.0021, places=4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`assertAlmostEqual` does perform rounding, thus statements like
```
self.assertAlmostEqual(round(something, 2), 1.57)
```
can be expressed as:
```
self.assertAlmostEqual(something, 1.57, 2)
```

This issue only occurs in `test_codonsalign` and `test_ProtParam` (which has been addressed in a different PR)

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
