### PR TITLE
Use flake8-comprehensions plugin

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -99,6 +99,7 @@ deps =
     flake8-docstrings
     flake8-blind-except
     flake8-rst-docstrings
+    flake8-comprehensions
     flake8-bugbear;python_version>="3.5"
     restructuredtext_lint
     doc8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -40,7 +40,7 @@ checks, so if you are making a contribution it is best to check this locally.
 We use the tool ``flake8`` for code style checks, together with various
 plugins which can be installed as follows::
 
-    $ pip install flake8 flake8-docstrings flake8-blind-except flake8-rst-docstrings
+    $ pip install flake8 flake8-docstrings flake8-blind-except flake8-rst-docstrings flake8-comprehensions
 
 Unless you are using Python 2.7, please also install the bugbear plugin::
 

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -323,6 +323,8 @@ class TypeCompiler(object):
                     dct.update({'scd5': None, 'scd3': None})
 
             class klass(type):
+                """Dynamically defined restriction enzyme class."""
+
                 def __new__(cls):
                     return type.__new__(cls, 'type%i' % n, ty, dct)
 
@@ -405,7 +407,7 @@ class DictionaryBuilder(object):
             #   Now select the right type for the enzyme.
             #
             bases = cls.bases
-            clsbases = tuple([eval(x) for x in bases])
+            clsbases = tuple(eval(x) for x in bases)
             typestuff = ''
             for t in tdct.values():
                 #
@@ -432,8 +434,7 @@ class DictionaryBuilder(object):
             else:
                 enzlst = []
                 tydct = dict(typestuff.__dict__)
-                tydct = dict([(k, v) for k, v in tydct.items()
-                              if k in commonattr])
+                tydct = {k: v for k, v in tydct.items() if k in commonattr}
                 enzlst.append(name)
                 typedict[typename] = (bases, enzlst)
             for letter in cls.__dict__['suppl']:

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -407,7 +407,7 @@ class DictionaryBuilder(object):
             #   Now select the right type for the enzyme.
             #
             bases = cls.bases
-            clsbases = tuple(eval(x) for x in bases)
+            clsbases = tuple([eval(x) for x in bases])  # noqa: C407
             typestuff = ''
             for t in tdct.values():
                 #
@@ -434,7 +434,8 @@ class DictionaryBuilder(object):
             else:
                 enzlst = []
                 tydct = dict(typestuff.__dict__)
-                tydct = {k: v for k, v in tydct.items() if k in commonattr}
+                tydct = dict([(k, v) for k, v in tydct.items()  # noqa: C404
+                              if k in commonattr])
                 enzlst.append(name)
                 typedict[typename] = (bases, enzlst)
             for letter in cls.__dict__['suppl']:


### PR DESCRIPTION
This will resolve the conversation in #2091 and close #2085.

Note the use of the ``#noqa`` pragma as a workaround for what appears to be a flake8/pydocstyle bug, possibly a duplicate of:

https://gitlab.com/pycqa/flake8-docstrings/issues/24

CC @chris-rands for comment

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
