### PR TITLE
Add Sequence class to Bio.motifs.mast

### DIFF
--- a/Bio/motifs/mast.py
+++ b/Bio/motifs/mast.py
@@ -51,6 +51,17 @@ class Record(list):
             return list.__getitem__(self, key)
 
 
+class Sequence(object):
+    def __init__(self):
+        self.name = ""
+        self.description = ""
+        self.length = None
+        self.strand = ""
+        self.evalue = None
+        self.combined_pvalue = None
+        self.diagram = ""
+
+
 def read(handle):
     """Parse a MAST XML format handle as a Record object."""
     record = Record()
@@ -86,11 +97,17 @@ def __read_metadata(record, xml_tree):
 def __read_sequences(record, xml_tree):
     """Read sequences from XML ElementTree object."""
     for sequence_tree in xml_tree.find('sequences').findall('sequence'):
-        sequence_name = sequence_tree.get('name')
-        record.sequences.append(sequence_name)
-        diagram_str = __make_diagram(record, sequence_tree)
-        record.diagrams[sequence_name] = diagram_str
-        # TODO - add description, evalue, length, combined_pvalue
+        sequence = Sequence()
+        sequence.name = sequence_tree.get('name')
+        sequence.description = sequence_tree.get('comment')
+        sequence.length = int(sequence_tree.get('length'))
+        score_tree = sequence_tree.find('score')
+        sequence.strand = score_tree.get('strand')
+        sequence.combined_pvalue = float(score_tree.get('combined_pvalue'))
+        sequence.evalue = float(score_tree.get('evalue'))
+        sequence.diagram = __make_diagram(record, sequence_tree)
+        record.sequences.append(sequence)
+        record.diagrams[sequence.name] = sequence.diagram
 
 
 def __make_diagram(record, sequence_tree):

--- a/Bio/motifs/mast.py
+++ b/Bio/motifs/mast.py
@@ -53,6 +53,7 @@ class Record(list):
 
 class Sequence(object):
     def __init__(self):
+        """Initialize the class."""
         self.name = ""
         self.description = ""
         self.length = None
@@ -60,6 +61,10 @@ class Sequence(object):
         self.evalue = None
         self.combined_pvalue = None
         self.diagram = ""
+
+    def __str__(self):
+        """Return the name of the sequence."""
+        return self.name
 
 
 def read(handle):


### PR DESCRIPTION
This pull request introduces a class `Sequence` to `Bio.motifs.mast`. This allows for an organized way of parsing additional sequence information from the XML.

Previous functionality:

```python
>>> from Bio.motifs import mast
>>> record = mast.read('Tests/motifs/mast.adh.de.oops.html.xml')
>>> type(record.sequences[0])
<type 'str'>
>>> print(record.sequences[0])
ENTA_ECOLI
```

New functionality:

```python
>>> record = mast.read('Tests/motifs/mast.adh.de.oops.html.xml')
>>> type(record.sequences[0])
<class 'Bio.motifs.mast.Sequence'>
>>> print(record.sequences[0])
ENTA_ECOLI
>>> vars(record.sequences[0])
{'combined_pvalue': 9.46e-16,
 'description': '2,3-DIHYDRO-2,3-DIHYDROXYBENZOATE DEHYDROGENASE (EC 1.3.1.28)',
 'diagram': '[1]-[2]-224',
 'evalue': 3.1e-14,
 'length': 248,
 'name': 'ENTA_ECOLI',
 'strand': 'both'}
```

Tests will need to be modified accordingly.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
