### PR TITLE
Test translate unittest

### DIFF
--- a/Tests/output/test_translate
+++ b/Tests/output/test_translate
@@ -1,1 +1,0 @@
-test_translate

--- a/Tests/output/test_translate
+++ b/Tests/output/test_translate
@@ -1,17 +1,1 @@
 test_translate
-Starting with TCAAAAAGGTGCATCTAGATG
-5 ungapped residues translated
-SKRCI
-7 residues translated, including gaps
-SKRCI*M
-2 SGC1 has a stop codon
-SK
-Actually, there are 2 stops.
-SK*CI*M
-Yep, 2 stops.
-SK+CI+M
-RNA translation ... works.
-RNA translation to stop ... works.
-Forward ambiguous
-BD*NL
-BD

--- a/Tests/test_translate.py
+++ b/Tests/test_translate.py
@@ -2,122 +2,92 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
-# Make sure the translation functions work.
-# Start simple - unambiguous DNA to unambiguous protein
 
-"""Tests for translate module."""
+"""Tests of the transcription and translation methods of Seq objects."""
 
-from __future__ import print_function
+
+import unittest
 
 from Bio import Seq
 from Bio import Alphabet
 from Bio.Alphabet import IUPAC
 
-# First, test the transcription functions
 
-s = "ATA"
-dna = Seq.Seq(s, IUPAC.unambiguous_dna)
-rna = dna.transcribe()
-assert str(rna) == "AUA"
+class TestTranscriptionTranslation(unittest.TestCase):
 
-s = "GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCATATT"
-dna = Seq.Seq(s, IUPAC.unambiguous_dna)
-rna = dna.transcribe()
-assert str(rna) == 'GAAAAUUCAUUUUCUUUGGACUUUCUCUGAAAUCCGAGUCCUAGGAAAGAUGCGUGAGAUUCUUCAUAUU'
+    def test_transcription(self):
+        s = "ATA"
+        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        rna = dna.transcribe()
+        self.assertEqual(str(rna), "AUA")
+        s = "GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCATATT"
+        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        rna = dna.transcribe()
+        self.assertEqual(str(rna), 'GAAAAUUCAUUUUCUUUGGACUUUCUCUGAAAUCCGAGUCCUAGGAAAGAUGCGUGAGAUUCUUCAUAUU')
+        s = "GAAAAUUCAUUUUCUUUGGACUUUCUCUGAAAUCCGAGUCCUAGGAAAGAUGCGUGAGAUUCUUCAUAUU"
+        rna = Seq.Seq(s, IUPAC.unambiguous_rna)
+        dna = rna.back_transcribe()
+        self.assertEqual(str(dna), 'GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCATATT')
 
-s = "GAAAAUUCAUUUUCUUUGGACUUUCUCUGAAAUCCGAGUCCUAGGAAAGAUGCGUGAGAUUCUUCAUAUU"
-rna = Seq.Seq(s, IUPAC.unambiguous_rna)
-dna = rna.back_transcribe()
-assert str(dna) == 'GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCATATT'
+    def test_translation(self):
+        s = ""
+        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        protein = dna.translate(to_stop=True)
+        self.assertEqual(str(protein), "")
+        s = "TAA"
+        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        protein = dna.translate(to_stop=True)
+        self.assertEqual(str(protein), "")
+        s = "GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCA"
+        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        protein = dna.translate(to_stop=True)
+        self.assertEqual(str(protein), 'ENSFSLDFL')
+        s = "GAA"
+        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        protein = dna.translate(15, to_stop=True)
+        self.assertEqual(str(protein), "E")
+        s = "ATA"
+        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        protein = dna.translate('Vertebrate Mitochondrial', to_stop=True)
+        self.assertEqual(str(protein), 'M')
+        s = "GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCATAT"
+        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        protein = dna.translate('SGC8', to_stop=True)
+        self.assertEqual(str(protein), 'ENSFSLDFLWNPSPSNDAWDSSY')
 
+    def test_dna_rna_translation(self):
+        s = "TCAAAAAGGTGCATCTAGATG"
+        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        protein = dna.translate(to_stop=True)
+        self.assertIsInstance(protein.alphabet, IUPAC.IUPACProtein)
+        self.assertEqual(str(protein), "SKRCI")
+        gapped_protein = dna.translate()
+        self.assertIsInstance(gapped_protein.alphabet, Alphabet.HasStopCodon)
+        self.assertEqual(str(gapped_protein), "SKRCI*M")
+        # The table used here has "AGG" as a stop codon:
+        p2 = dna.translate(table=2, to_stop=True)
+        self.assertEqual(str(p2), "SK")
+        p2 = dna.translate(table=2)
+        self.assertEqual(str(p2), "SK*CI*M")
+        p2 = dna.translate(table=2, stop_symbol="+")
+        self.assertEqual(str(p2), "SK+CI+M")
+        r = s.replace("T", "U")
+        rna = Seq.Seq(r, IUPAC.unambiguous_rna)
+        protein = rna.translate(to_stop=True)
+        self.assertIsInstance(protein.alphabet, IUPAC.IUPACProtein)
+        self.assertEqual(str(protein), "SKRCI")
+        gapped_protein = rna.translate()
+        self.assertEqual(str(gapped_protein), "SKRCI*M")
 
-# use the standard table
-
-# Do some simple tests first
-s = ""
-dna = Seq.Seq(s, IUPAC.unambiguous_dna)
-protein = dna.translate(to_stop=True)
-assert str(protein) == ""
-
-s = "TAA"
-dna = Seq.Seq(s, IUPAC.unambiguous_dna)
-protein = dna.translate(to_stop=True)
-assert str(protein) == ""
-
-s = "GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCA"
-dna = Seq.Seq(s, IUPAC.unambiguous_dna)
-protein = dna.translate(to_stop=True)
-assert str(protein) == 'ENSFSLDFL'
-
-s = "GAA"
-dna = Seq.Seq(s, IUPAC.unambiguous_dna)
-protein = dna.translate(15, to_stop=True)
-assert str(protein) == "E"
-
-s = "ATA"
-dna = Seq.Seq(s, IUPAC.unambiguous_dna)
-protein = dna.translate('Vertebrate Mitochondrial', to_stop=True)
-assert str(protein) == "M"
-
-s = "GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCATAT"
-dna = Seq.Seq(s, IUPAC.unambiguous_dna)
-protein = dna.translate('SGC8', to_stop=True)
-assert str(protein) == 'ENSFSLDFLWNPSPSNDAWDSSY'
-
-# use the standard table
-
-s = "TCAAAAAGGTGCATCTAGATG"
-print("Starting with %s" % s)
-dna = Seq.Seq(s, IUPAC.unambiguous_dna)
-protein = dna.translate(to_stop=True)
-assert isinstance(protein.alphabet, IUPAC.IUPACProtein)
-
-print("%i ungapped residues translated" % len(protein))
-
-gapped_protein = dna.translate()
-assert isinstance(gapped_protein.alphabet, Alphabet.HasStopCodon)
-print(str(protein))
-
-print("%i residues translated, including gaps" % len(gapped_protein))
-print(str(gapped_protein))
-
-# This has "AGG" as a stop codon
-p2 = dna.translate(table=2, to_stop=True)
-print("%i SGC1 has a stop codon" % len(p2))
-print(str(p2))
-p2 = dna.translate(table=2)
-print("Actually, there are %i stops." % p2.count("*"))
-print(str(p2))
-
-# Make sure I can change the stop character
-p2 = dna.translate(table=2, stop_symbol="+")
-print("Yep, %i stops." % p2.count("+"))
-print(str(p2))
+    def test_ambiguous(self):
+        s = "RATGATTARAATYTA"
+        dna = Seq.Seq(s, IUPAC.ambiguous_dna)
+        protein = dna.translate('Vertebrate Mitochondrial')
+        self.assertEqual(str(protein), "BD*NL")
+        stop_protein = dna.translate('SGC1', to_stop=True)
+        self.assertEqual(str(stop_protein), "BD")
 
 
-# Some of the same things, with RNA
-# (The code is the same, so I'm not doing all of the tests.)
-rna = Seq.Seq(s.replace("T", "U"), IUPAC.unambiguous_rna)
-
-protein_from_rna = rna.translate(to_stop=True)
-assert protein.alphabet is protein_from_rna.alphabet
-assert str(protein) == str(protein_from_rna)
-print("RNA translation ... works.")
-
-gapped_protein_from_rna = rna.translate()
-assert len(gapped_protein) == len(gapped_protein_from_rna)
-assert str(gapped_protein) == str(gapped_protein_from_rna)
-print("RNA translation to stop ... works.")
-
-# some tests for "by name"
-# How about some forward ambiguity?
-print("Forward ambiguous")
-s = "RATGATTARAATYTA"
-#     B  D  *  N  L
-dna = Seq.Seq(s, IUPAC.ambiguous_dna)
-protein = dna.translate('Vertebrate Mitochondrial')
-print(str(protein))
-stop_protein = dna.translate('SGC1', to_stop=True)
-print(str(stop_protein))
-
-# XXX (Backwards with ambiguity code is unfinished!)
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)


### PR DESCRIPTION
This pull request replaces the print-and-compare test in test_translate.py by a unittest.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
