### PR TITLE
no more print-and-compare tests

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -612,7 +612,7 @@ class GenBankWriter(_InsdcWriter):
 
         if len(locus.split()) > 1:
             # locus could be unicode, and u'with space' versus 'with space'
-            # causes trouble with doctest or print-and-compare tests, so
+            # causes trouble with doctests, so
             tmp = repr(locus)
             if tmp.startswith("u'") and tmp.endswith("'"):
                 tmp = tmp[1:]

--- a/Doc/Tutorial/chapter_testing.tex
+++ b/Doc/Tutorial/chapter_testing.tex
@@ -20,9 +20,8 @@ are strongly encouraged to run the unit tests.
 When you download the Biopython source code, or check it out from
 our source code repository, you should find a subdirectory call
 \verb|Tests|.  This contains the key script \verb|run_tests.py|,
-lots of individual scripts named \verb|test_XXX.py|, a subdirectory
-called \verb|output| and lots of other subdirectories which
-contain input files for the test suite.
+lots of individual scripts named \verb|test_XXX.py|, and lots of
+other subdirectories which contain input files for the test suite.
 
 As part of building and installing Biopython you will typically
 run the full test suite at the command line from the Biopython
@@ -71,39 +70,10 @@ By default, \verb|run_tests.py| runs all tests, including the docstring tests.
 If an individual test is failing, you can also try running it
 directly, which may give you more information.
 
-Importantly, note that the individual unit test files come in two types:
-\begin{itemize}
-\item Older simple print-and-compare scripts.  These unit tests are
-      essentially short example Python programs, which print out
-      various output text.  For a test file named \verb|test_XXX.py|
-      there will be a matching text file called \verb|test_XXX| under
-      the \verb|output| subdirectory which contains the expected
-      output.  All that the test framework does to is run the script,
-      and check the output agrees.
-\item Standard \verb|unittest|- based tests.  These will \verb|import unittest|
-      and then define \verb|unittest.TestCase| classes, each with one
-      or more sub-tests as methods starting with \verb|test_| which
-      check some specific aspect of the code.
-      These tests should not print any output directly.
-\end{itemize}
-Currently, about half of the Biopython tests are \verb|unittest|-style tests, and half are print-and-compare tests.
-
-Running a simple print-and-compare test directly will usually give lots
-of output on screen, but does not check the output matches the expected
-output.  If the test is failing with an exception error, it should be
-very easy to locate where exactly the script is failing.
-For an example of a print-and-compare test, try:
-
-\begin{minted}{bash}
-$ python test_SeqIO.py
-\end{minted}
-
-The \verb|unittest|-based tests instead show you exactly which sub-section(s) of
-the test are failing. For example,
-
-\begin{minted}{bash}
-$python test_Cluster.py
-\end{minted}
+Tests based on Python's standard  \verb|unittest| framework will
+\verb|import unittest| and then define \verb|unittest.TestCase| classes,
+each with one or more sub-tests as methods starting with \verb|test_| which
+check some specific aspect of the code.
 
 \subsection{Running the tests using Tox}
 
@@ -142,23 +112,18 @@ This can be a module you wrote, or an existing module that doesn't have
 any tests yet.  In the examples below, we assume that
 \verb|Biospam| is a module that does simple math.
 
-Each Biopython test can have three important files and directories involved with it:
+Each Biopython test consists of a script containing the test itself, and
+optionally a directory with input files used by the test:
 
 \begin{enumerate}
   \item \verb|test_Biospam.py| -- The actual test code for your module.
   \item \verb|Biospam| [optional]-- A directory where any necessary input files
     will be located. If you have any output files that should be manually
     reviewed, output them here (but this is discouraged) to prevent clogging
-    up the main Tests directory. In general use a temporary file/folder.
-  \item \verb|output/Biospam| -- [for print-and-compare tests only] This
-    file contains the expected output from running \verb|test_Biospam.py|.
-    This file is not needed for \verb|unittest|-style tests, since there
-    the validation is done in the test script \verb|test_Biospam.py| itself.
+    up the main Tests directory. In general, use a temporary file/folder.
 \end{enumerate}
 
-It's up to you to decide whether you want to write a print-and-compare test script or a \verb|unittest|-style test script. The important thing is that you cannot mix these two styles in a single test script. Particularly, don't use \verb|unittest| features in a print-and-compare test.
-
-Any script with a \verb|test_| prefix in the \verb|Tests| directory will be found and run by \verb|run_tests.py|. Below, we show an example test script \verb|test_Biospam.py| both for a print-and-compare test and for a \verb|unittest|-based test. If you put this script in the Biopython \verb|Tests| directory, then \verb|run_tests.py| will find it and execute the tests contained in it:
+Any script with a \verb|test_| prefix in the \verb|Tests| directory will be found and run by \verb|run_tests.py|. Below, we show an example test script \verb|test_Biospam.py|. If you put this script in the Biopython \verb|Tests| directory, then \verb|run_tests.py| will find it and execute the tests contained in it:
 
 \begin{minted}{bash}
 $ python run_tests.py
@@ -174,112 +139,7 @@ test_Clustalw ... ok
 Ran 107 tests in 86.127 seconds
 \end{minted}
 
-\subsection{Writing a print-and-compare test}
-
-A print-and-compare style test should be much simpler for beginners
-or novices to write - essentially it is just an example script using
-your new module.
-
-Here is what you should do to make a print-and-compare test for the
-\verb|Biospam| module.
-
-\begin{enumerate}
-  \item Write a script called \verb|test_Biospam.py|
-
-  \begin{itemize}
-
-    \item This script should live in the Tests directory
-
-     \item The script should test all of the important functionality
-     of the module (the more you test the better your test is, of course!).
-
-     \item Try to avoid anything which might be platform specific,
-     such as printing floating point numbers without using an explicit
-     formatting string to avoid having too many decimal places
-     (different platforms can give very slightly different values).
-
-  \end{itemize}
-
-  \item If the script requires files to do the testing, these should go in
-       the directory Tests/Biospam (if you just need something generic, like
-       a FASTA sequence file, or a GenBank record, try and use an existing
-       sample input file instead).
-
-  \item Write out the test output and verify the output to be correct.
-
-       There are two ways to do this:
-
-  \begin{enumerate}
-    \item The long way:
-
-    \begin{itemize}
-
-     \item Run the script and write its output to a file. On UNIX (including
-       Linux and Mac OS X) machines, you would do something like:
-       \verb|python test_Biospam.py > test_Biospam| which would write the
-       output to the file \verb|test_Biospam|.
-
-     \item Manually look at the file \verb|test_Biospam| to make sure the output is correct. When you are sure it is all right and there are no bugs, you need to quickly edit the \verb|test_Biospam| file so that the first line is: `\verb|test_Biospam|' (no quotes).
-
-     \item copy the \verb|test_Biospam| file to the directory Tests/output
-
-   \end{itemize}
-
-   \item The quick way:
-
-   \begin{itemize}
-      \item Run \verb|python run_tests.py -g test_Biospam.py|. The
-            regression testing framework is nifty enough that it'll put
-            the output in the right place in just the way it likes it.
-
-       \item Go to the output (which should be in \verb|Tests/output/test_Biospam|) and double check the output to make sure it is all correct.
-
-   \end{itemize}
-
- \end{enumerate}
-
- \item Now change to the Tests directory and run the regression tests
-       with \verb|python run_tests.py|. This will run all of the tests, and
-       you should see your test run (and pass!).
-
-  \item That's it! Now you've got a nice test for your module ready to check in,
-  or submit to Biopython.  Congratulations!
-\end{enumerate}
-
-As an example, the \verb|test_Biospam.py| test script to test the
-\verb|addition| and \verb|multiplication| functions in the \verb|Biospam|
-module  could look as follows:
-
-\begin{minted}{python}
-from __future__ import print_function
-from Bio import Biospam
-
-print("2 + 3 =", Biospam.addition(2, 3))
-print("9 - 1 =", Biospam.addition(9, -1))
-print("2 * 3 =", Biospam.multiplication(2, 3))
-print("9 * (- 1) =", Biospam.multiplication(9, -1))
-\end{minted}
-
-We generate the corresponding output with \verb|python run_tests.py -g test_Biospam.py|, and check the output file \verb|output/test_Biospam|:
-
-\begin{verbatim}
-test_Biospam
-2 + 3 = 5
-9 - 1 = 8
-2 * 3 = 6
-9 * (- 1) = -9
-\end{verbatim}
-
-Often, the difficulty with larger print-and-compare tests is to keep track which line in the output corresponds to which command in the test script. For this purpose, it is important to print out some markers to help you match lines in the input script with the generated output.
-
-\subsection{Writing a unittest-based test}
-
-We want all the modules in Biopython to have unit tests, and a simple
-print-and-compare test is better than no test at all.  However, although
-there is a steeper learning curve, using the \verb|unittest| framework
-gives a more structured result, and if there is a test failure this can
-clearly pinpoint which part of the test is going wrong.  The sub-tests can
-also be run individually which is helpful for testing or debugging.
+\subsection{Writing a test using \verb|unittest|}
 
 The \verb|unittest|-framework has been included with Python since version
 2.1, and is documented in the Python Library Reference (which I know you

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -61,6 +61,9 @@ structured data source with minimal loss of functionality upon future MAST
 releases. Class structure remains the same plus an additional attribute
 ``Record.strand_handling`` required for diagram parsing.
 
+All tests using the older print-and-compare approach have been replaced by
+unittests following Python's standard testing framework.
+
 On the documentation side, all the public modules, classes, methods and
 functions now have docstrings (built in help strings). Furthermore, the PDF
 version of the *Biopython Tutorial and Cookbook* now uses syntax coloring

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -26,7 +26,6 @@ from __future__ import print_function
 # standard modules
 import sys
 import os
-import re
 import getopt
 import time
 import traceback

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -12,11 +12,7 @@ Command line options::
 
     --help        -- show usage info
     --offline     -- skip tests which require internet access
-    -g;--generate -- write the output file for a test instead of comparing it.
-                     The name of the test to write the output for must be
-                     specified.
-    -v;--verbose  -- run tests with higher verbosity (does not affect our
-                     print-and-compare style unit tests).
+    -v;--verbose  -- run tests with higher verbosity
     <test_name>   -- supply the name of one (or more) tests to be run.
                      The .py file extension is optional.
     doctest       -- run the docstring tests.
@@ -276,22 +272,6 @@ def main(argv):
                 raise RuntimeError("Internal test suite error, attempting to use internet despite --offline setting")
 
             Bio._py3k.urlopen = dummy_urlopen
-        if opt == "-g" or opt == "--generate":
-            if len(args) > 1:
-                print("Only one argument (the test name) needed for generate")
-                print(__doc__)
-                return 2
-            elif len(args) == 0:
-                print("No test name specified to generate output for.")
-                print(__doc__)
-                return 2
-            # strip off .py if it was included
-            if args[0][-3:] == ".py":
-                args[0] = args[0][:-3]
-
-            test = ComparisonTestCase(args[0])
-            test.generate_output()
-            return 0
 
         if opt == "-v" or opt == "--verbose":
             verbosity = 2
@@ -308,109 +288,6 @@ def main(argv):
     # run the tests
     runner = TestRunner(args, verbosity)
     return runner.run()
-
-
-class ComparisonTestCase(unittest.TestCase):
-    """Run a print-and-compare test and check it against expected output."""
-
-    def __init__(self, name, output=None):
-        """Initialize with the test to run.
-
-        Arguments:
-            - name - The name of the test. The expected output should be
-              stored in the file output/name.
-            - output - The output that was generated when this test was run.
-
-        """
-        unittest.TestCase.__init__(self)
-        self.name = name
-        self.output = output
-
-    def shortDescription(self):
-        return self.name
-
-    def runTest(self):
-        # check the expected output to be consistent with what
-        # we generated
-        outputdir = os.path.join(TestRunner.testdir, "output")
-        outputfile = os.path.join(outputdir, self.name)
-        try:
-            if sys.version_info[0] >= 3:
-                # Python 3 problem: Can't use utf8 on output/test_geo
-                # due to micro (\xb5) and degrees (\xb0) symbols
-                # Also universal new lines mode deprecated on Python 3
-                expected = open(outputfile, encoding="latin")
-            else:
-                expected = open(outputfile, "rU")
-        except IOError:
-            self.fail("Warning: Can't open %s for test %s" %
-                      (outputfile, self.name))
-
-        self.output.seek(0)
-        # first check that we are dealing with the right output
-        # the first line of the output file is the test name
-        expected_test = expected.readline().strip()
-
-        if expected_test != self.name:
-            expected.close()
-            raise ValueError("\nOutput:   %s\nExpected: %s"
-                             % (self.name, expected_test))
-
-        # Track the line number. Starts at 1 to account for the output file
-        # header line.
-        line_number = 1
-
-        # now loop through the output and compare it to the expected file
-        while True:
-            expected_line = expected.readline()
-            output_line = self.output.readline()
-            line_number += 1
-
-            # stop looping if either of the info handles reach the end
-            if (not expected_line) or (not output_line):
-                # make sure both have no information left
-                assert expected_line == '', "Unread: %s" % expected_line
-                assert output_line == '', "Extra output: %s" % output_line
-                break
-
-            # normalize the newlines in the two lines
-            expected_line = expected_line.strip("\r\n")
-            output_line = output_line.strip("\r\n")
-
-            # if the line is a doctest or PyUnit time output like:
-            # Ran 2 tests in 0.285s
-            # ignore it, so we don't have problems with different running times
-            if re.compile("^Ran [0-9]+ tests? in ").match(expected_line):
-                pass
-            # otherwise make sure the two lines are the same
-            elif expected_line != output_line:
-                expected.close()
-                raise ValueError("\nOutput  : %s\nExpected: %s\n%s line %s"
-                                 % (repr(output_line), repr(expected_line),
-                                    outputfile, line_number))
-
-        expected.close()
-
-    def generate_output(self):
-        """Generate the golden output for the specified test."""
-        outputdir = os.path.join(TestRunner.testdir, "output")
-        outputfile = os.path.join(outputdir, self.name)
-
-        output_handle = open(outputfile, 'w')
-
-        # write the test name as the first line of the output
-        output_handle.write(self.name + "\n")
-
-        # remember standard out so we can reset it after we are done
-        save_stdout = sys.stdout
-        try:
-            # write the output from the test into a string
-            sys.stdout = output_handle
-            __import__(self.name)
-        finally:
-            output_handle.close()
-            # return standard out to its normal setting
-            sys.stdout = save_stdout
 
 
 class TestRunner(unittest.TextTestRunner):
@@ -466,8 +343,8 @@ class TestRunner(unittest.TextTestRunner):
             stdout = sys.stdout
             sys.stdout = output
             if name.startswith("test_"):
+                # It's a unittest
                 sys.stderr.write("%s ... " % name)
-                # It's either a unittest or a print-and-compare test
                 loader = unittest.TestLoader()
                 suite = loader.loadTestsFromName(name)
                 if hasattr(loader, "errors") and loader.errors:
@@ -487,10 +364,7 @@ class TestRunner(unittest.TextTestRunner):
                         sys.stderr.write("%s\n" % msg)
                     return False
                 if suite.countTestCases() == 0:
-                    # This is a print-and-compare test instead of a
-                    # unittest-type test.
-                    test = ComparisonTestCase(name, output)
-                    suite = unittest.TestSuite([test])
+                    raise RuntimeError("No tests found in %s" % name)
             else:
                 # It's a doc test
                 sys.stderr.write("%s docstring test ... " % name)


### PR DESCRIPTION
This pull request updates the documentation to remove the parts on print-and-compare tests.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
