### PR TITLE
Fix PDB Entity.copy() for disordered atoms

### DIFF
--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -434,6 +434,12 @@ class DisorderedAtom(DisorderedEntityWrapper):
         """Return disordered atom identifier."""
         return "<Disordered Atom %s>" % self.get_id()
 
+    def __copy__(self):
+        shallow = copy.copy(self)
+        for child in self.child_dict.values():
+            shallow.disordered_add(child.copy())
+        return shallow
+
     def disordered_add(self, atom):
         """Add a disordered atom."""
         # Add atom to dict, use altloc as key


### PR DESCRIPTION
This pull request addresses issue #455

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Implemented fix suggested in comments.