### PR TITLE
Use Python 3.7 for sdist,bdist_wheel,api tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ matrix:
           packages:
       before_install: echo "Going to run basic checks"
     - stage: basics
+      python: 3.7
       env: TOXENV=sdist,bdist_wheel
       services:
       addons:
@@ -45,7 +46,7 @@ matrix:
           packages:
       before_install: echo "Going to run basic checks"
     - stage: test
-      python: 2.7
+      python: 3.7
       env: TOXENV=api
       services:
       addons:


### PR DESCRIPTION
This seems a sensible update to our testing framework given we will be dropping Python 2.7 next year (in 2020), and I will need to run the Sphinx based API stuff under a recent Python 3 version for some work in progress.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
