### PR TITLE
Speed up index loading from SQLite for SeqIO, SearchIO, etc

### DIFF
--- a/Bio/File.py
+++ b/Bio/File.py
@@ -587,7 +587,7 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
                 con.close()
                 raise ValueError("Unfinished/partial database")
             count, = con.execute(
-                "SELECT COUNT(key) FROM offset_data;").fetchone()
+                "SELECT MAX(_ROWID_) FROM offset_data;").fetchone()
             if self._length != int(count):
                 con.close()
                 raise ValueError("Corrupt database? %i entries not %i"

--- a/Bio/File.py
+++ b/Bio/File.py
@@ -586,6 +586,10 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
             if self._length == -1:
                 con.close()
                 raise ValueError("Unfinished/partial database")
+
+            # use MAX(_ROWID_) to obtain the number of sequences in the database
+            # using COUNT(key) is quite slow in SQLITE
+            # (https://stackoverflow.com/questions/8988915/sqlite-count-slow-on-big-tables)
             count, = con.execute(
                 "SELECT MAX(_ROWID_) FROM offset_data;").fetchone()
             if self._length != int(count):

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -202,6 +202,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Paul T. Bathen
 - Peter Bienstman <Peter.Bienstman at domain rug.ac.be>
 - Peter Cock <https://github.com/peterjc>
+- Peter Kerpedjiev <https://github.com/pkerpedjiev>
 - Peter Slickers <piet at domain clondiag.com>
 - Philip Bergstrom <https://github.com/phber>
 - Phillip Garland <pgarland at gmail>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -92,6 +92,7 @@ possible, especially the following contributors:
 - Micky Yun Chan (first contribution)
 - Nick Negretti
 - Peter Cock
+- Peter Kerpedjiev
 - Ralf Stephan
 - Rob Miller
 - Sergio Valqui


### PR DESCRIPTION
The current `SELECT COUNT(key) FROM offset_data;` call to obtain the number of sequences in the database is slow for substantial fasta files.

Because the index is read-only, this can be replaced with `SELECT MAX(_ROWID_) FROM offset_data;` for orders of magnitude better performance.

For example, on a fasta with 17M sequences, loading the index with the current `COUNT(key)` call takes about 4 seconds. With `MAX(_ROWID_)` it takes 2.64ms.

On a fasta file with 307M sequences, loading the index with `COUNT(key)` takes 1 minute and 20 seconds. With `MAX(_ROWID_)` it takes 10ms. 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
