### PR TITLE
fixed the Bio.motifs ones. Note that Bio.motifs.jaspar.db has no doctest

### DIFF
--- a/Bio/motifs/mast.py
+++ b/Bio/motifs/mast.py
@@ -22,7 +22,7 @@ class Record(list):
     by its name:
 
     >>> from Bio import motifs
-    >>> with open("motifs/mast.dna.oops.txt") as f:
+    >>> with open("motifs/mast.crp0.de.oops.txt.xml") as f:
     ...     record = motifs.parse(f, 'MAST')
     >>> motif = record[0]
     >>> print(motif.name)

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -78,10 +78,6 @@ VERBOSITY = 0
 # Following modules have historic failures. If you fix one of these
 # please remove here!
 EXCLUDE_DOCTEST_MODULES = [
-    'Bio.motifs.jaspar.db',
-    'Bio.motifs.mast',
-    'Bio.motifs.meme',
-    'Bio.motifs.minimal',
     'Bio.PDB',
     'Bio.PDB.AbstractPropertyMap',
     'Bio.PDB.Atom',


### PR DESCRIPTION
This pull request fixes the doctests for Bio.motifs; see issue #1902.
Note that Bio.motifs.jaspar.db did not actually have a doctest.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
