### PR TITLE
Replace assert in HMMER3 table parser

### DIFF
--- a/Bio/SearchIO/HmmerIO/hmmer3_tab.py
+++ b/Bio/SearchIO/HmmerIO/hmmer3_tab.py
@@ -38,15 +38,11 @@ class Hmmer3TabParser(object):
     def _parse_row(self):
         """Return a dictionary of parsed row values (PRIVATE)."""
         cols = [x for x in self.line.strip().split(' ') if x]
+        if len(cols) < 18:
+            raise ValueError("Less columns than expected, only %i" % len(cols))
         # if len(cols) > 19, we have extra description columns
         # combine them all into one string in the 19th column
-        if len(cols) > 19:
-            cols[18] = ' '.join(cols[18:])
-        # if it's < 19, we have no description columns, so use an empty string
-        # instead
-        elif len(cols) < 19:
-            cols.append('')
-            assert len(cols) == 19
+        cols[18] = ' '.join(cols[18:])
 
         # assign parsed column data into qresult, hit, and hsp dicts
         qresult = {}


### PR DESCRIPTION
This pull request fixes a corner case found while looking at #2139 (trying to parse ``nhmmscan`` output which has different columns). It replaces an assert statement with an explicit ``ValueError`` instead.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
