### PR TITLE
Fix RST markup; doctest ELLIPSIS is redundant

### DIFF
--- a/Bio/TogoWS/__init__.py
+++ b/Bio/TogoWS/__init__.py
@@ -189,6 +189,7 @@ def search_iter(db, query, limit=None, batch=100):
        TogoWS (currently limited to 100).
 
     You would use this function within a for loop, e.g.
+
     >>> from Bio import TogoWS
     >>> for id in TogoWS.search_iter("pubmed", "diabetes+human", limit=10):
     ...     print("PubMed ID: %s" %id) # maybe fetch data with entry?

--- a/Bio/TogoWS/__init__.py
+++ b/Bio/TogoWS/__init__.py
@@ -349,3 +349,8 @@ def _open(url, post=None):
 
 
 _open.previous = 0
+
+
+if __name__ == "__main__":
+    from Bio._utils import run_doctest
+    run_doctest(verbose=0)

--- a/Bio/phenotype/phen_micro.py
+++ b/Bio/phenotype/phen_micro.py
@@ -1168,3 +1168,8 @@ class JsonWriter(object):
         handle.write(json.dumps(out) + '\n')
 
         return len(out)
+
+
+if __name__ == "__main__":
+    from Bio._utils import run_doctest
+    run_doctest(verbose=0)

--- a/Bio/phenotype/phen_micro.py
+++ b/Bio/phenotype/phen_micro.py
@@ -65,7 +65,7 @@ class PlateRecord(object):
     >>> plate = phenotype.read("phenotype/Plate.json", "pm-json")
     >>> well = plate['A05']
     >>> for well in plate:
-    ...    print("%s" % well.id) # doctest:+ELLIPSIS
+    ...    print(well.id)
     ...
     A01
     ...
@@ -105,7 +105,7 @@ class PlateRecord(object):
     the well id) in the plate can be obtained:
 
     >>> for well in plate.get_row('H'):
-    ...     print("%s" % well.id) # doctest:+ELLIPSIS
+    ...     print(well.id)
     ...
     H01
     H02
@@ -116,7 +116,7 @@ class PlateRecord(object):
     in the plate can be obtained:
 
     >>> for well in plate.get_column(12):
-    ...     print("%s" % well.id) # doctest:+ELLIPSIS
+    ...     print(well.id)
     ...
     A12
     B12


### PR DESCRIPTION
Cross reference discussion on #2126 with @MarkusPiotrowski and @svalqui 

This was missing a blank line which on http://rst.ninjs.org at least was needed before the ``>>>`` to render the code snippet.

Unfortunately, with that changed, the doctest fails due to the incomplete output. We could try using ``# doctest:+ELLIPSIS`` but the nature of this example is going to be highly unstable over time.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
