### PR TITLE
Pairwise2: Add keyword argument "show_full_sequences" to "format_alignment"

### DIFF
--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -1100,7 +1100,7 @@ def print_matrix(matrix):
 
 
 def format_alignment(align1, align2, score, begin, end,
-                     show_full_sequences=False):
+                     full_sequences=False):
     """Format the alignment prettily into a string.
 
     IMPORTANT: Gap symbol must be "-" (or ['-'] for lists)!
@@ -1122,7 +1122,7 @@ def format_alignment(align1, align2, score, begin, end,
     in the *aligned* sequences.
 
     If you want to see the whole sequences (including the non-
-    aligned parts), use ``show_full_sequences=True``. In this
+    aligned parts), use ``full_sequences=True``. In this
     case, the non-aligned leading and trailing parts are also
     indicated by spaces in the match-line.
     """
@@ -1131,13 +1131,13 @@ def format_alignment(align1, align2, score, begin, end,
     start1 = start2 = ''
     start_m = begin  # Begin of match line (how many spaces to include)
     # For local alignments:
-    if not show_full_sequences and (begin != 0 or end != len(align1)):
+    if not full_sequences and (begin != 0 or end != len(align1)):
         # Calculate the actual start positions in the un-aligned sequences
         # This will only work if the gap symbol is '-' or ['-']!
         start1 = str(len(align1[:begin]) - align1[:begin].count("-") + 1) + " "
         start2 = str(len(align2[:begin]) - align2[:begin].count("-") + 1) + " "
         start_m = max(len(start1), len(start2))
-    elif show_full_sequences:
+    elif full_sequences:
         start_m = 0
         begin = 0
         end = len(align1)
@@ -1159,7 +1159,7 @@ def format_alignment(align1, align2, score, begin, end,
         m_len = max(len(a), len(b))
         s1_line.append("{:^{width}}".format(a, width=m_len))
         s2_line.append("{:^{width}}".format(b, width=m_len))
-        if show_full_sequences and (n < align_begin or n >= align_end):
+        if full_sequences and (n < align_begin or n >= align_end):
             m_line.append("{:^{width}}".format(' ', width=m_len))  # space
             continue
         if a == b:

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -1099,7 +1099,8 @@ def print_matrix(matrix):
                        for j in range(len(matrix[i]))))
 
 
-def format_alignment(align1, align2, score, begin, end):
+def format_alignment(align1, align2, score, begin, end,
+                     show_full_sequences=False):
     """Format the alignment prettily into a string.
 
     IMPORTANT: Gap symbol must be "-" (or ['-'] for lists)!
@@ -1119,16 +1120,27 @@ def format_alignment(align1, align2, score, begin, end):
     NOTE: This is different to the alignment's begin/end values,
     which give the Python indices (0-based) of the bases/amino acids
     in the *aligned* sequences.
+
+    If you want to see the whole sequences (including the non-
+    aligned parts), use ``show_full_sequences=True``. In this
+    case, the non-aligned leading and trailing parts are also
+    indicated by spaces in the match-line.
     """
-    start1 = start2 = ""
+    align_begin = begin
+    align_end = end
+    start1 = start2 = ''
     start_m = begin  # Begin of match line (how many spaces to include)
-    # Is this a local alignment?
-    if begin != 0 or end != len(align1):
+    # For local alignments:
+    if not show_full_sequences and (begin != 0 or end != len(align1)):
         # Calculate the actual start positions in the un-aligned sequences
         # This will only work if the gap symbol is '-' or ['-']!
         start1 = str(len(align1[:begin]) - align1[:begin].count("-") + 1) + " "
         start2 = str(len(align2[:begin]) - align2[:begin].count("-") + 1) + " "
         start_m = max(len(start1), len(start2))
+    elif show_full_sequences:
+        start_m = 0
+        begin = 0
+        end = len(align1)
 
     if isinstance(align1, list):
         # List elements will be separated by spaces, since they can be
@@ -1140,12 +1152,16 @@ def format_alignment(align1, align2, score, begin, end):
     m_line = [" " * start_m]  # match line
     s2_line = ["{:>{width}}".format(start2, width=start_m)]  # seq2 line
 
-    for a, b in zip(align1[begin:end], align2[begin:end]):
+    for n, (a, b) in enumerate(zip(align1[begin:end],
+                                   align2[begin:end])):
         # Since list elements can be of different length, we center them,
         # using the maximum length of the two compared elements as width
         m_len = max(len(a), len(b))
         s1_line.append("{:^{width}}".format(a, width=m_len))
         s2_line.append("{:^{width}}".format(b, width=m_len))
+        if show_full_sequences and (n < align_begin or n >= align_end):
+            m_line.append("{:^{width}}".format(' ', width=m_len))  # space
+            continue
         if a == b:
             m_line.append("{:^{width}}".format("|", width=m_len))  # match
         elif a.strip() == "-" or b.strip() == "-":

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -134,6 +134,24 @@ Some examples:
       Score=3
     <BLANKLINE>
 
+  To restore the 'historic' behaviour of ``format_alignemt``, i.e., showing
+  also the un-aligned parts of both sequences, use the new keyword parameter
+  ``full_sequences``:
+
+    >>> for a in pairwise2.align.localxx("ACCGT", "ACG"):
+    ...     print(format_alignment(*a, full_sequences=True))
+    ACCGT
+    | || 
+    A-CG-
+      Score=3
+    <BLANKLINE>
+    ACCGT
+    || | 
+    AC-G-
+      Score=3
+    <BLANKLINE>
+
+
 - Do a global alignment. Identical characters are given 2 points, 1 point is
   deducted for each non-identical character. Don't penalize gaps.
 
@@ -1121,10 +1139,10 @@ def format_alignment(align1, align2, score, begin, end,
     which give the Python indices (0-based) of the bases/amino acids
     in the *aligned* sequences.
 
-    If you want to see the whole sequences (including the non-
-    aligned parts), use ``full_sequences=True``. In this
-    case, the non-aligned leading and trailing parts are also
-    indicated by spaces in the match-line.
+    If you want to restore the 'historic' behaviour, that means
+    displaying the whole sequences (including the non-aligned parts),
+    use ``full_sequences=True``. In this case, the non-aligned leading
+    and trailing parts are also indicated by spaces in the match-line.
     """
     align_begin = begin
     align_end = end

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1534,14 +1534,14 @@ where again XX stands for a two letter code for the match and gap functions:
 In recent Biopython versions, \verb|format_alignment| will only print the 
 aligned part of a local alignment (together with the start positions in 1-based
 notation, as shown in the above example). If you are also interested in the non-
-aligned parts of the sequences, use the keyword-parameter \verb|show_full_sequences=True|:
+aligned parts of the sequences, use the keyword-parameter \verb|full_sequences=True|:
 
 %doctest
 \begin{minted}{pycon}
 >>> from Bio import pairwise2
 >>> from Bio.SubsMat.MatrixInfo import blosum62
 >>> alignments = pairwise2.align.localds("LSPADKTNVKAA", "PEEKSAV", blosum62, -10, -1)
->>> print(pairwise2.format_alignment(*alignments[0], show_full_sequences=True))
+>>> print(pairwise2.format_alignment(*alignments[0], full_sequences=True))
 LSPADKTNVKAA
   |..|..|   
 --PEEKSAV---

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1531,6 +1531,24 @@ where again XX stands for a two letter code for the match and gap functions:
 <BLANKLINE>
 \end{minted}
 
+In recent Biopython versions, \verb|format_alignment| will only print the 
+aligned part of a local alignment (together with the start positions in 1-based
+notation, as shown in the above example). If you are also interested in the non-
+aligned parts of the sequences, use the keyword-parameter \verb|show_full_sequences=True|:
+
+%doctest
+\begin{minted}{pycon}
+>>> from Bio import pairwise2
+>>> from Bio.SubsMat.MatrixInfo import blosum62
+>>> alignments = pairwise2.align.localds("LSPADKTNVKAA", "PEEKSAV", blosum62, -10, -1)
+>>> print(pairwise2.format_alignment(*alignments[0], show_full_sequences=True))
+LSPADKTNVKAA
+  |..|..|   
+--PEEKSAV---
+  Score=16
+<BLANKLINE>
+\end{minted}
+
 Note that local alignments must, as defined by Smith \& Waterman, have a 
 positive score (\textgreater 0). Thus, \verb|pairwise2| may return no
 alignments if no score \textgreater 0 has been obtained. Also, \verb|pairwise2|

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -38,6 +38,11 @@ making an error, but will require user code to be updated accordingly.
 ``Bio.PDB`` has been updated to support parsing REMARK 99 header entries from
 PDB-style Astral files.
 
+A new keyword parameter ``full_sequences`` was added to ``Bio.pairwise2``'s
+pretty print method ``format_alignment`` to restore the output of local
+alignments to the 'old' format (showing the whole sequences including the
+un-aligned parts instead of only showing the aligned parts).
+
 As in recent releases, more of our code is now explicitly available under
 either our original "Biopython License Agreement", or the very similar but
 more commonly used "3-Clause BSD License".  See the ``LICENSE.rst`` file for
@@ -53,6 +58,7 @@ possible, especially the following contributors:
 - Joe Greener
 - Kiran Mukhyala (first contribution)
 - Konstantin Vdovkin
+- Markus Piotrowski
 - Mike Moritz (first contribution)
 - Mustafa Anil Tuncel
 - Nick Negretti
@@ -88,10 +94,8 @@ We now capture the IDcode field from PDB Header records.
 ``Bio.pairwise2``'s pretty-print output from ``format_alignment`` has been
 optimized for local alignments: If they do not consist of the whole sequences,
 only the aligned section of the sequences are shown, together with the start
-positions of the sequences (in 1-based notation). For seeing the whole
-sequences including the un-aligned parts, the keyword-parameter
-``full_sequences`` was added. Alignments of lists will now also be prettily
-printed.
+positions of the sequences (in 1-based notation). Alignments of lists will now
+also be prettily printed.
 
 ``Bio.SearchIO`` now supports parsing the text output of the HHsuite protein
 sequence search tool. The format name is ``hhsuite2-text`` and

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -88,8 +88,10 @@ We now capture the IDcode field from PDB Header records.
 ``Bio.pairwise2``'s pretty-print output from ``format_alignment`` has been
 optimized for local alignments: If they do not consist of the whole sequences,
 only the aligned section of the sequences are shown, together with the start
-positions of the sequences (in 1-based notation). Alignments of lists will now
-also be prettily printed.
+positions of the sequences (in 1-based notation). For seeing the whole
+sequences including the un-aligned parts, the keyword-parameter
+``show_full_sequences`` was added. Alignments of lists will now also be
+prettily printed.
 
 ``Bio.SearchIO`` now supports parsing the text output of the HHsuite protein
 sequence search tool. The format name is ``hhsuite2-text`` and

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -90,8 +90,8 @@ optimized for local alignments: If they do not consist of the whole sequences,
 only the aligned section of the sequences are shown, together with the start
 positions of the sequences (in 1-based notation). For seeing the whole
 sequences including the un-aligned parts, the keyword-parameter
-``show_full_sequences`` was added. Alignments of lists will now also be
-prettily printed.
+``full_sequences`` was added. Alignments of lists will now also be prettily
+printed.
 
 ``Bio.SearchIO`` now supports parsing the text output of the HHsuite protein
 sequence search tool. The format name is ``hhsuite2-text`` and

--- a/Tests/pairwise2_testCases.py
+++ b/Tests/pairwise2_testCases.py
@@ -168,7 +168,7 @@ class TestPairwiseLocal(unittest.TestCase):
 """)
 
     def test_localxs_2(self):
-        """Test localxx with ``show_full_sequences=True``."""
+        """Test localxx with ``full_sequences=True``."""
         aligns = sorted(pairwise2.align.localxs("AxBx", "zABz", -0.1, 0))
         # From Biopython 1.74 on this should only give one alignment, since
         # we disallow leading and trailing 'zero-extensions'
@@ -176,7 +176,7 @@ class TestPairwiseLocal(unittest.TestCase):
         seq1, seq2, score, begin, end = aligns[0]
         alignment = pairwise2.format_alignment(seq1, seq2, score,
                                                begin, end,
-                                               show_full_sequences=True)
+                                               full_sequences=True)
         self.assertEqual(alignment, """\
 -AxBx
  | | 

--- a/Tests/pairwise2_testCases.py
+++ b/Tests/pairwise2_testCases.py
@@ -151,7 +151,7 @@ GAACT
 class TestPairwiseLocal(unittest.TestCase):
     """Test some simple local alignments."""
 
-    def test_localxs(self):
+    def test_localxs_1(self):
         """Test localxx."""
         aligns = sorted(pairwise2.align.localxs("AxBx", "zABz", -0.1, 0))
         # From Biopython 1.74 on this should only give one alignment, since
@@ -166,6 +166,23 @@ class TestPairwiseLocal(unittest.TestCase):
 2 A-B
   Score=1.9
 """)
+
+    def test_localxs_2(self):
+        """Test localxx with ``show_full_sequences=True``."""
+        aligns = sorted(pairwise2.align.localxs("AxBx", "zABz", -0.1, 0))
+        # From Biopython 1.74 on this should only give one alignment, since
+        # we disallow leading and trailing 'zero-extensions'
+        self.assertEqual(len(aligns), 1)
+        seq1, seq2, score, begin, end = aligns[0]
+        alignment = pairwise2.format_alignment(seq1, seq2, score,
+                                               begin, end,
+                                               show_full_sequences=True)
+        self.assertEqual(alignment, """\
+-AxBx
+ | | 
+zA-Bz
+  Score=1.9
+""")  # noqa: W291
 
     def test_localds_zero_score_segments_symmetric(self):
         """Test if alignment is independent on direction of sequence."""


### PR DESCRIPTION
This pull request results from the discussion in issue #2136.

With PR #1505 the output of local alignments in `pairwise2` with `format_alignment` was optimized to only show the aligned parts of both sequences. However, there may be situations where it would be beneficial to see also the un-aligned leading and trailing parts of both sequences (https://github.com/biopython/biopython/issues/2136#issuecomment-502736721).

Thus, with this PR, a new keyword argument `show_full_sequences` is added to `format_alignment` to restore the old output (prior Biopython 1.74) of local alignments. The new argument defaults to `False`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
