### PR TITLE
Include Python 3.8 (pre-release) on TravisCI; fix for int change

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -34,8 +34,8 @@ envlist =
     sdist
     bdist_wheel
     api
-    {py27,py35,py36,py37,pypy,pypy3}-cover
-    {py27,py35,py36,py37,pypy,pypy3}-nocov
+    {py27,py35,py36,py37,py38,pypy,pypy3}-cover
+    {py27,py35,py36,py37,py38,pypy,pypy3}-nocov
 
 [testenv]
 # TODO: Try tox default sdist based install instead:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,10 @@ matrix:
       python: 3.7
       env: TOXENV=py37-cover
     - stage: test
+      # TODO: Change this once a stable Python 3.8 is on TravisCI:
+      python: 3.8-dev
+      env: TOXENV=py38-cover
+    - stage: test
       python: pypy
       env: TOXENV=pypy-nocov
     - stage: test

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -2073,8 +2073,7 @@ class OneOfPosition(int, AbstractPosition):
         for position in self.position_choices:
             out += "%s," % position
         # replace the last comma with the closing parenthesis
-        out = out[:-1] + ")"
-        return out
+        return out[:-1] + ")"
 
     def _shift(self, offset):
         """Return a copy of the position object with its location shifted (PRIVATE)."""
@@ -2100,8 +2099,7 @@ class PositionGap(object):
 
     def __str__(self):
         """Return a representation of the PositionGap object (with python counting)."""
-        out = "gap(%s)" % self.gap_size
-        return out
+        return "gap(%s)" % self.gap_size
 
 
 if __name__ == "__main__":

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1539,6 +1539,11 @@ class ExactPosition(int, AbstractPosition):
                                  % extension)
         return int.__new__(cls, position)
 
+    # Must define this on Python 3.8 onwards because we redefine __repr__
+    def __str__(self):
+        """Return a representation of the ExactPosition object (with python counting)."""
+        return str(int(self))
+
     def __repr__(self):
         """Represent the ExactPosition object as a string for debugging."""
         return "%s(%i)" % (self.__class__.__name__, int(self))


### PR DESCRIPTION
This pull request addresses issue #2145.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
