### PR TITLE
removed the dead link, and fixed a typo

### DIFF
--- a/Bio/motifs/jaspar/db.py
+++ b/Bio/motifs/jaspar/db.py
@@ -150,7 +150,7 @@ class JASPAR5(object):
         Arguments:
         name - a single name or list of names
         Returns:
-        A list of Bio.motifs.Motif.japar objects
+        A list of Bio.motifs.jaspar.Motif objects
 
         Notes:
         Names are not guaranteed to be unique. There may be more than one

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -203,7 +203,7 @@ One of the most popular motif databases is \href{http://jaspar.genereg.net}{JASP
     \item \verb+acc+ - the accession number of the TF protein, e.g. 'P53762'
     \item \verb+data_type+ - the type of data used to construct this motif, e.g. 'SELEX'
     \item \verb+medline+ - the Pubmed ID of literature supporting this motif, may be multiple values, e.g. 7592839
-    \item \verb+pazar_id+ - external reference to the TF in the \href{http://pazar.info}{PAZAR} database, e.g. 'TF0000003'
+    \item \verb+pazar_id+ - external reference to the TF in the PAZAR database, e.g. 'TF0000003'
     \item \verb+comment+ - free form text containing notes about the construction of the motif
 \end{itemize}
 


### PR DESCRIPTION
This pull request addresses issue #1826  for the reference to PAZAR. I didn't find a current link to PAZAR, so I removed the hyperlink from the documentation. PAZAR is still being used in the JASPAR database, so we should keep it for now.
Also, one typo was fixed.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
