### PR TITLE
Follow conda best practise and set strict channel_priority

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,6 +39,8 @@ build_script:
   - cmd: C:\Miniconda.exe /S /D=C:\Py
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes --set channel_priority strict
+  - conda config --add channels defaults
+  - conda config --add channels conda-forge
   - conda update conda
   - conda info -a
 # Pinning pillow==5.4.1 as version 6 breaks on current latest reportlab

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,7 +38,7 @@ build_script:
   - ps: Start-FileDownload "https://repo.continuum.io/miniconda/Miniconda$env:PY_MAJOR_VER-latest-Windows-$env:PYTHON_ARCH.exe" C:\Miniconda.exe; echo "Finished downloading miniconda"
   - cmd: C:\Miniconda.exe /S /D=C:\Py
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
-  - conda config --set always_yes yes
+  - conda config --set always_yes yes --set channel_priority strict
   - conda update conda
 # Pinning pillow==5.4.1 as version 6 breaks on current latest reportlab
 # https://bitbucket.org/rptlab/reportlab/issues/176/incompatibility-with-pillow-600

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,7 +44,8 @@ build_script:
 # https://bitbucket.org/rptlab/reportlab/issues/176/incompatibility-with-pillow-600
 # Pinning mysql-connector-python==8.0.13 as 8.0.16 breaks  our tests
 # https://github.com/biopython/biopython/issues/2120
-  - conda install setuptools numpy mysql-connector-python==8.0.13 psycopg2 matplotlib networkx reportlab scipy coverage pillow==5.4.1
+# Pinning matplotlib as v3 does not support Python 2.7 (and conda got stuck otherwise)
+  - conda install setuptools numpy mysql-connector-python==8.0.13 psycopg2 matplotlib==2.2.4 networkx reportlab scipy coverage pillow==5.4.1
   - if "PY_MAJOR_VER"=="2" conda install unittest2
   - python setup.py build
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,7 +45,7 @@ build_script:
 # Pinning mysql-connector-python==8.0.13 as 8.0.16 breaks  our tests
 # https://github.com/biopython/biopython/issues/2120
 # Pinning matplotlib as v3 does not support Python 2.7 (and conda got stuck otherwise)
-  - conda install setuptools numpy mysql-connector-python==8.0.13 psycopg2 matplotlib==2.2.4 networkx reportlab scipy coverage pillow==5.4.1
+  - conda install setuptools numpy mysql-connector-python==8.0.13 psycopg2 matplotlib==2.2.3 networkx reportlab scipy coverage pillow==5.4.1
   - if "PY_MAJOR_VER"=="2" conda install unittest2
   - python setup.py build
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,8 +39,6 @@ build_script:
   - cmd: C:\Miniconda.exe /S /D=C:\Py
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes --set channel_priority strict
-  - conda config --add channels defaults
-  - conda config --add channels conda-forge
   - conda update conda
   - conda info -a
 # Pinning pillow==5.4.1 as version 6 breaks on current latest reportlab

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,6 +40,7 @@ build_script:
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes --set channel_priority strict
   - conda update conda
+  - conda info -a
 # Pinning pillow==5.4.1 as version 6 breaks on current latest reportlab
 # https://bitbucket.org/rptlab/reportlab/issues/176/incompatibility-with-pillow-600
 # Pinning mysql-connector-python==8.0.13 as 8.0.16 breaks  our tests

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,7 +45,7 @@ build_script:
 # https://bitbucket.org/rptlab/reportlab/issues/176/incompatibility-with-pillow-600
 # Pinning mysql-connector-python==8.0.13 as 8.0.16 breaks  our tests
 # https://github.com/biopython/biopython/issues/2120
-  - conda install python=$PY_MAJOR_VER.7 setuptools numpy mysql-connector-python==8.0.13 psycopg2 matplotlib networkx reportlab scipy coverage pillow==5.4.1
+  - conda install python==$PY_MAJOR_VER.7 setuptools numpy mysql-connector-python==8.0.13 psycopg2 matplotlib networkx reportlab scipy coverage pillow==5.4.1
   - if "PY_MAJOR_VER"=="2" conda install unittest2
   - python setup.py build
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,8 +45,7 @@ build_script:
 # https://bitbucket.org/rptlab/reportlab/issues/176/incompatibility-with-pillow-600
 # Pinning mysql-connector-python==8.0.13 as 8.0.16 breaks  our tests
 # https://github.com/biopython/biopython/issues/2120
-# Pinning matplotlib as v3 does not support Python 2.7 (and conda got stuck otherwise)
-  - conda install setuptools numpy mysql-connector-python==8.0.13 psycopg2 matplotlib==2.2.3 networkx reportlab scipy coverage pillow==5.4.1
+  - conda install python=$PY_MAJOR_VER.7 setuptools numpy mysql-connector-python==8.0.13 psycopg2 matplotlib networkx reportlab scipy coverage pillow==5.4.1
   - if "PY_MAJOR_VER"=="2" conda install unittest2
   - python setup.py build
 


### PR DESCRIPTION
Known to reduce conflict conda dependency clashes which happen occasionally otherwise (saw that last night on a branch).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
