### PR TITLE
Allow "$ python setup.py test" to run offline

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,7 +214,7 @@ If you want to skip the online tests (which is recommended when doing repeated
 testing), use::
 
     python setup.py test --offline
-    
+
 Do not panic if you see messages warning of skipped tests::
 
     test_DocSQL ... skipping. Install MySQLdb if you want to use Bio.DocSQL.

--- a/README.rst
+++ b/README.rst
@@ -187,9 +187,14 @@ Now change directory to the Biopython source code folder and run::
 Substitute ``python`` with your specific version, for example ``python3``,
 ``pypy`` or ``jython``.
 
-If you need to do additional configuration, e.g. changing the install
-directory prefix, please type ``python setup.py``, or see the documentation
-here:
+To exlude tests that require an internet connection (and which may take a long
+time), use the ``--offline`` option::
+
+    python setup.py test --offline
+
+If you need to do additional configuration, e.g. changing
+the install directory prefix, please type ``python setup.py``, or see the
+documentation here:
 
 * HTML - http://biopython.org/DIST/docs/install/Installation.html
 * PDF - http://biopython.org/DIST/docs/install/Installation.pdf
@@ -205,6 +210,11 @@ directory and type::
     python setup.py build
     python setup.py test
 
+If you want to skip the online tests (which is recommended when doing repeated
+testing), use::
+
+    python setup.py test --offline
+    
 Do not panic if you see messages warning of skipped tests::
 
     test_DocSQL ... skipping. Install MySQLdb if you want to use Bio.DocSQL.
@@ -216,7 +226,7 @@ the required dependency and re-run the tests.
 
 Some of the tests may fail due to network issues, this is often down to
 chance or a service outage. If the problem does not go away on
-re-running the tests, it is possible to run only the offline tests.
+re-running the tests, you can use the ``--offline`` option.
 
 There is more testing information in the Biopython Tutorial & Cookbook.
 

--- a/setup.py
+++ b/setup.py
@@ -228,11 +228,11 @@ class test_biopython(Command):
     """
 
     description = "Automatically run the test suite for Biopython."
-    user_options = []
+    user_options = [("offline", None, "Don't run online tests")]
 
     def initialize_options(self):
         """No-op, initialise options."""
-        pass
+        self.offline = None
 
     def finalize_options(self):
         """No-op, finalise options."""
@@ -246,7 +246,10 @@ class test_biopython(Command):
         os.chdir("Tests")
         sys.path.insert(0, '')
         import run_tests
-        run_tests.main([])
+        if self.offline:
+            run_tests.main(['--offline'])
+        else:
+            run_tests.main([])
 
         # change back to the current directory
         os.chdir(this_dir)


### PR DESCRIPTION
Doing much testing of different Windows installations lately, I realized that it would be nice to have the opportunity to easily turn off the online tests:

```bash
$ python setup.py test --offline
```

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
