### PR TITLE
Tweak API table of contents in Sphinx output

### DIFF
--- a/Doc/api/index.rst
+++ b/Doc/api/index.rst
@@ -6,8 +6,8 @@ Welcome to Biopython's API documentation!
 =========================================
 
 .. toctree::
-   :maxdepth: 4
-   :caption: Contents:
+   :maxdepth: 1
+   :caption: API Contents:
 
    Bio
    BioSQL


### PR DESCRIPTION
Cross reference issue #906, currently looks like this:

<img width="799" alt="Screenshot 2019-06-28 17 24 31" src="https://user-images.githubusercontent.com/63959/60356730-a22f5d00-99c9-11e9-913d-56346741a5ce.png">

(and it keeps going for pages below - not great visually)

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
