### PR TITLE
Workaround Python 2.7 gzip.open rejecting rt mode

### DIFF
--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -133,7 +133,12 @@ class TestZipped(unittest.TestCase):
 
     def test_gzip_fastq(self):
         """Testing FASTQ with gzip."""
-        with gzip.open("Quality/example.fastq.gz", "rt") as handle:
+        if sys.version_info >= (3,):
+            mode = "rt"
+        else:
+            # Workaround for bug https://bugs.python.org/issue30012
+            mode = "r"  # implicitly text mode, rejects making explicit
+        with gzip.open("Quality/example.fastq.gz", mode) as handle:
             self.assertEqual(3, len(list(SeqIO.parse(handle, "fastq"))))
         if 3 <= sys.version_info[0]:
             with gzip.open("Quality/example.fastq.gz") as handle:
@@ -143,7 +148,12 @@ class TestZipped(unittest.TestCase):
 
     def test_gzip_fasta(self):
         """Testing FASTA with gzip."""
-        with gzip.open("Fasta/flowers.pro.gz", "rt") as handle:
+        if sys.version_info >= (3,):
+            mode = "rt"
+        else:
+            # Workaround for bug https://bugs.python.org/issue30012
+            mode = "r"  # implicitly text mode, rejects making explicit
+        with gzip.open("Fasta/flowers.pro.gz", mode) as handle:
             self.assertEqual(3, len(list(SeqIO.parse(handle, "fasta"))))
         if 3 <= sys.version_info[0]:
             with gzip.open("Fasta/flowers.pro.gz") as handle:
@@ -154,7 +164,12 @@ class TestZipped(unittest.TestCase):
     def test_gzip_genbank(self):
         """Testing GenBank with gzip."""
         # BGZG files are still GZIP files
-        with gzip.open("GenBank/cor6_6.gb.bgz", "rt") as handle:
+        if sys.version_info >= (3,):
+            mode = "rt"
+        else:
+            # Workaround for bug https://bugs.python.org/issue30012
+            mode = "r"  # implicitly text mode, rejects making explicit
+        with gzip.open("GenBank/cor6_6.gb.bgz", mode) as handle:
             self.assertEqual(6, len(list(SeqIO.parse(handle, "gb"))))
         if 3 <= sys.version_info[0]:
             with gzip.open("GenBank/cor6_6.gb.bgz") as handle:


### PR DESCRIPTION
Once again, bitten by https://bugs.python.org/issue30012

This pull request addresses issue #2159

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
