### PR TITLE
Make Entrez module retry requests on failure automatically

### DIFF
--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -29,6 +29,13 @@ which has a ``.name`` attribute giving the filename, the handles from
 ``Bio.Entrez`` all have a ``.url`` attribute instead giving the URL
 used to connect to the NCBI Entrez API.
 
+All the functions that send requests to the NCBI Entrez API will
+automatically respect the NCBI rate limit (of 3 requests per second
+without an API key, or 10 requests per second with an API key) and
+will automatically retry when encountering transient failures
+(i.e. connection failures or HTTP 5XX codes) until three failures
+have been reached.
+
 The Entrez module also provides an XML parser which takes a handle
 as input.
 

--- a/Bio/_py3k/__init__.py
+++ b/Bio/_py3k/__init__.py
@@ -133,7 +133,7 @@ if sys.version_info[0] >= 3:
     # On Python 3 urllib, urllib2, and urlparse were merged:
     from urllib.request import urlopen, Request, urlretrieve, urlparse, urlcleanup
     from urllib.parse import urlencode, quote
-    from urllib.error import HTTPError
+    from urllib.error import URLError, HTTPError
 
 else:
     # Python 2 code
@@ -194,7 +194,7 @@ else:
     from urllib import urlencode, quote
 
     # Under urllib.error on Python 3:
-    from urllib2 import HTTPError
+    from urllib2 import URLError, HTTPError
 
 
 if sys.platform == "win32":

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -171,6 +171,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Marc Colosimo <mcolosimo at domain mitre.org>
 - Marcin Magnus <https://github.com/mmagnus>
 - Marco Galardini <https://github.com/mgalardini>
+- Mark Amery <https://github.com/ExplodingCabbage>
 - Markus Piotrowski <https://github.com/MarkusPiotrowski>
 - Mateusz Korycinski <https://github.com/mkorycinski>
 - Matt Ruffalo <https://github.com/mruffalo>

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -3,7 +3,7 @@ CONTRIBUTORS
 
 This is a list of people who have made contributions to Biopython.
 
-People are listed alphabetically, as verfied with Unix sort::
+People are listed alphabetically, as verified with Unix sort::
 
     $ grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f
 

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -1394,39 +1394,23 @@ True
 
 Having stored these values in variables {\tt session\_cookie} and {\tt query\_key} we can use them as parameters to \verb|Bio.Entrez.efetch()| instead of giving the GI numbers as identifiers.
 
-While for small searches you might be OK downloading everything at once, it is better to download in batches.  You use the {\tt retstart} and {\tt retmax} parameters to specify which range of search results you want returned (starting entry using zero-based counting, and maximum number of results to return).  Sometimes you will get intermittent errors from Entrez, HTTPError 5XX, we use a try except pause retry block to address this.
+While for small searches you might be OK downloading everything at once, it is better to download in batches.  You use the {\tt retstart} and {\tt retmax} parameters to specify which range of search results you want returned (starting entry using zero-based counting, and maximum number of results to return). Note that if Biopython encounters a transient failure like a HTTP 500 response when communicating with NCBI, it will automatically try again a couple of times.
 For example,
 
 \begin{minted}{python}
 # This assumes you have already run a search as shown above,
 # and set the variables count, webenv, query_key
 
-try:
-    from urllib.error import HTTPError  # for Python 3
-except ImportError:
-    from urllib2 import HTTPError  # for Python 2
-
 batch_size = 3
 out_handle = open("orchid_rpl16.fasta", "w")
 for start in range(0, count, batch_size):
     end = min(count, start+batch_size)
     print("Going to download record %i to %i" % (start+1, end))
-    attempt = 0
-    while attempt < 3:
-        attempt += 1
-        try:
-            fetch_handle = Entrez.efetch(db="nucleotide",
-                                         rettype="fasta", retmode="text",
-                                         retstart=start, retmax=batch_size,
-                                         webenv=webenv, query_key=query_key,
-                                         idtype="acc")
-        except HTTPError as err:
-            if 500 <= err.code <= 599:
-                print("Received error from server %s" % err)
-                print("Attempt %i of 3" % attempt)
-                time.sleep(15)
-            else:
-                raise
+    fetch_handle = Entrez.efetch(db="nucleotide",
+                                 rettype="fasta", retmode="text",
+                                 retstart=start, retmax=batch_size,
+                                 webenv=webenv, query_key=query_key,
+                                 idtype="acc")
     data = fetch_handle.read()
     fetch_handle.close()
     out_handle.write(data)
@@ -1440,11 +1424,6 @@ Here is another history example, searching for papers published in the last year
 
 \begin{minted}{python}
 from Bio import Entrez
-import time
-try:
-    from urllib.error import HTTPError  # for Python 3
-except ImportError:
-    from urllib2 import HTTPError  # for Python 2
 Entrez.email = "history.user@example.com"
 search_results = Entrez.read(Entrez.esearch(db="pubmed",
                                             term="Opuntia[ORGN]",
@@ -1458,22 +1437,11 @@ out_handle = open("recent_orchid_papers.txt", "w")
 for start in range(0,count,batch_size):
     end = min(count, start+batch_size)
     print("Going to download record %i to %i" % (start+1, end))
-    attempt = 1
-    while attempt <= 3:
-        try:
-            fetch_handle = Entrez.efetch(db="pubmed",rettype="medline",
-                                         retmode="text",retstart=start,
-                                         retmax=batch_size,
-                                         webenv=search_results["WebEnv"],
-                                         query_key=search_results["QueryKey"])
-        except HTTPError as err:
-            if 500 <= err.code <= 599:
-                print("Received error from server %s" % err)
-                print("Attempt %i of 3" % attempt)
-                attempt += 1
-                time.sleep(15)
-            else:
-                raise
+    fetch_handle = Entrez.efetch(db="pubmed",rettype="medline",
+                                 retmode="text",retstart=start,
+                                 retmax=batch_size,
+                                 webenv=search_results["WebEnv"],
+                                 query_key=search_results["QueryKey"])
     data = fetch_handle.read()
     fetch_handle.close()
     out_handle.write(data)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -61,6 +61,11 @@ structured data source with minimal loss of functionality upon future MAST
 releases. Class structure remains the same plus an additional attribute
 ``Record.strand_handling`` required for diagram parsing.
 
+``Bio.Entrez`` now automatically retries HTTP requests on failure. The
+maximum number of tries and the sleep between them can be configured by
+changing ``Bio.Entrez.max_tries`` and ``Bio.Entrez.sleep_between_tries``.
+(The defaults are 3 tries and 15 seconds, respectively.)
+
 All tests using the older print-and-compare approach have been replaced by
 unittests following Python's standard testing framework.
 
@@ -88,6 +93,7 @@ possible, especially the following contributors:
 - Jens Thomas (first contribution)
 - Konstantin Vdovkin
 - Lenna Peterson
+- Mark Amery
 - Markus Piotrowski
 - Micky Yun Chan (first contribution)
 - Nick Negretti


### PR DESCRIPTION
This pull request addresses issue #...

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

---

I figured it was dumb and user-unfriendly for the end-user to have to write this logic all the time, especially given that we can see [evidence in the wild](https://www.biostars.org/p/121287/) of people hitting these transient errors and not knowing what to do about them, so I thought it'd make sense to chuck it into biopython itself. Here's a proposal that does that.

It turns out the tutorial already proposed using basically the same retry-on-error logic as I've used here, but the tutorial's approach is slightly inferior because it only catches `HTTPError`s. It's possible to get a transient `URLError` that is not a `HTTPError` but rather a connection timeout due to NCBI dropping a connection. It makes sense to catch those too.

At this point I think this is a good change but have a few concerns that you may want to consider before deciding whether to merge:

* I haven't built the docs and checked my doc changes look good; I'm not sure how to do so and don't see instructions on it in CONTRIBUTING.rst

* I don't have any unit tests for this functionality. I figure we probably don't want them since we don't want tests that hit NCBI when run. I'm currently using the version of the code from this PR to run a script that downloads ~20000 sequence ranges from NCBI with `efetch` and reliably failed at some point with a 5XX or connection timeout prior to me making these changes; assuming that still runs to completion fine, I guess that's at least a reasonable level of one-off testing. Update: this ran to completion fine.

* People who've already implemented their own retry-on-failure logic around these functions in their programs will end up with an unwantedly large maximum number of retries (e.g. 3*3 = 9 retries) if they don't see this change in the release notes and delete their own retry boilerplate. Probably not really a problem, but maybe annoying to some people.

* If for some reason somebody wants to use a different retry strategy altogether (e.g. exponential backoff instead of a fixed sleep) this change gets in their way instead of making their life simpler.

Despite all that I think this is a sensible default that's more user-friendly than what was there before, and therefore a desirable change. But, up to you!