### PR TITLE
bgzf: Make append mode work

### DIFF
--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -247,6 +247,7 @@ If your data is in UTF-8 or any other incompatible encoding, you must use
 binary mode, and decode the appropriate fragments yourself.
 """
 
+import os
 import struct
 import sys
 import zlib
@@ -806,8 +807,10 @@ class BgzfWriter:
             if "w" not in mode.lower() and "a" not in mode.lower():
                 raise ValueError(f"Must use write or append mode, not {mode!r}")
             if "a" in mode.lower():
-                raise NotImplementedError("Append mode is not implemented yet")
-                # handle = _open(filename, "ab")
+                handle = _open(filename, "ab")
+                # py27 on Windows will get confused about our current position
+                # immediately after opening; explicitly seek to end to fix it
+                handle.seek(0, os.SEEK_END)
             else:
                 handle = _open(filename, "wb")
         self._text = "b" not in mode.lower()

--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -247,7 +247,6 @@ If your data is in UTF-8 or any other incompatible encoding, you must use
 binary mode, and decode the appropriate fragments yourself.
 """
 
-import os
 import struct
 import sys
 import zlib
@@ -808,9 +807,6 @@ class BgzfWriter:
                 raise ValueError(f"Must use write or append mode, not {mode!r}")
             if "a" in mode.lower():
                 handle = _open(filename, "ab")
-                # py27 on Windows will get confused about our current position
-                # immediately after opening; explicitly seek to end to fix it
-                handle.seek(0, os.SEEK_END)
             else:
                 handle = _open(filename, "wb")
         self._text = "b" not in mode.lower()

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -25,6 +25,9 @@ The Local Composition Complexity functions from ``Bio.SeqUtils`` now uses
 base 4 log instead of 2 as stated in the original reference Konopka (2005),
 Sequence Complexity and Composition. https://doi.org/10.1038/npg.els.0005260
 
+Append mode is now supported in ``Bio.bgzf`` (and a bug parsing blocked GZIP
+files with an internal empty block fixed).
+
 The experimental warning was dropped from ``Bio.phenotype`` (which was new in
 Biopython 1.67).
 
@@ -39,6 +42,7 @@ possible, especially the following contributors:
 - Damien Goutte-Gattat
 - Fabian Egli
 - Sebastian Bassi
+- Tim Burke
 - Michiel de Hoon
 - Peter Cock
 

--- a/Tests/test_bgzf.py
+++ b/Tests/test_bgzf.py
@@ -384,8 +384,36 @@ class BgzfTests(unittest.TestCase):
             self.assertEqual(h.read(5), "Magic")
 
     def test_append_mode(self):
-        with self.assertRaises(NotImplementedError):
-            bgzf.open(self.temp_file, "ab")
+        with bgzf.open(self.temp_file, "wb") as h:
+            h.write(b">hello\n")
+            h.write(b"aaaaaaaaaaaaaaaaaa\n")
+            h.flush()
+            previous_offsets = bgzf.split_virtual_offset(h.tell())
+            # Just flushed, so new block
+            self.assertEqual(previous_offsets[1], 0)
+        with bgzf.open(self.temp_file, "ab") as h:
+            append_position = h.tell()
+            self.assertEqual(
+                (previous_offsets[0] + 28, 0),
+                bgzf.split_virtual_offset(append_position),
+            )
+            h.write(b">there\n")
+            self.assertEqual(
+                (previous_offsets[0] + 28, 7), bgzf.split_virtual_offset(h.tell())
+            )
+            h.write(b"cccccccccccccccccc\n")
+        with bgzf.open(self.temp_file, "rb") as h:
+            self.assertEqual(
+                list(h),
+                [
+                    b">hello\n",
+                    b"aaaaaaaaaaaaaaaaaa\n",
+                    b">there\n",
+                    b"cccccccccccccccccc\n",
+                ],
+            )
+            h.seek(append_position)
+            self.assertEqual(list(h), [b">there\n", b"cccccccccccccccccc\n"])
 
     def test_double_flush(self):
         with bgzf.open(self.temp_file, "wb") as h:


### PR DESCRIPTION
Previously, trying to open a BGZF file in append mode would start writing data after the previous EOF marker. As a result, the appended data would not be available when the file was re-opened for reading.

Now when opening in append mode:

  - read the last 28 bytes of the file,
  - verify that it matches the EOF marker, and
  - truncate the file so it no longer includes the EOF

before re-opening the file in append mode. This ensures that only one EOF marker is written when the `BgzfWriter` is closed. At the same time, it (mostly) preserves callers' append-only expectations.

Note that a series of small appends will create a series of small segments; this is similar to what would happen if the caller did a flush rather than a close and re-open.

This pull request addresses issue #2142

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
