### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -103,6 +103,10 @@ deps =
     flake8-bugbear;python_version>="3.5"
     restructuredtext_lint
     doc8
+    # flake8-docstrings uses a function removed in pydocstyle 4.0.0; once a fix
+    # is released in flake8-docstrings we can remove the following constraint:
+    pydocstyle<4.0.0
+    # See https://gitlab.com/pycqa/flake8-docstrings/issues/36
 commands =
     # PEP-8 and PEP-257 style checks:
     flake8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -93,7 +93,7 @@ If you have multiple versions of Python installed, ideally test them all
 
 
 Continuous Integration
----------------------
+----------------------
 
 Once you submit your pull request on GitHub, several automated tests should
 be run, and their results reported on the pull request.


### PR DESCRIPTION
Previously, Travis style builds would fail with

    WARNING CONTRIBUTING.rst:96 Title underline too short.
    WARNING CONTRIBUTING.rst:96 Title underline too short.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
