### PR TITLE
appveyor: Add installation of unittest2 for Python 2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,6 +48,7 @@ build_script:
 # https://github.com/biopython/biopython/issues/2120
 # We don't install mysql-connector-python for Python 2
   - if "%PY_MAJOR_VER%"=="3" conda install mysql-connector-python==8.0.13
+  - if "%PY_MAJOR_VER%"=="2" conda install unittest2
   - python setup.py build
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,7 +48,7 @@ build_script:
 # https://github.com/biopython/biopython/issues/2120
 # We don't install mysql-connector-python for Python 2
   - if "%PY_MAJOR_VER%"=="3" conda install mysql-connector-python==8.0.13
-  - if "%PY_MAJOR_VER%"=="2" conda install unittest2==1.1.0
+  - if "%PY_MAJOR_VER%"=="2" conda install unittest2-1.1.0-py27_0.tar.bz2
   - python setup.py build
 
 test_script:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -48,7 +48,7 @@ build_script:
 # https://github.com/biopython/biopython/issues/2120
 # We don't install mysql-connector-python for Python 2
   - if "%PY_MAJOR_VER%"=="3" conda install mysql-connector-python==8.0.13
-  - if "%PY_MAJOR_VER%"=="2" conda install unittest2
+  - if "%PY_MAJOR_VER%"=="2" conda install unittest2==1.1.0
   - python setup.py build
 
 test_script:


### PR DESCRIPTION
Trying to add unittest2 installation for Python 2 for appveyor.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
