### PR TITLE
Deploy API docs from Sphinx autodoc HTML using GitHub pages

### DIFF
--- a/.github/deploy_docs.sh
+++ b/.github/deploy_docs.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+# Assumes being called from the Biopython repository's root folder,
+# (i.e. a clone of https://github.com/biopython/biopython) as part
+# of our continuous integration testing to save the compiled docs
+# to https://github.com/biopython/docs
+#
+# In order to have write permissions, we put a private key into the
+# TravisCI settings as a secure environment variable, and put the
+# matching public key into the GitHub documentation repository's
+# settings as a deploy key with write permissions.
+#
+# Key creation,
+#
+# $ ssh-keygen -t rsa -b 4096 -C "biopython documentation deploy key" -f biopython_doc_key -N ""
+# Generating public/private rsa key pair.
+# Your identification has been saved in biopython_doc_key.
+# Your public key has been saved in biopython_doc_key.pub.
+# The key fingerprint is:
+# SHA256:nFfhbwryDLDz8eDEHa4sjdH0gOgwyXGGDUBGfDi5luQ biopython documentation deploy key
+# The key's randomart image is:
+# +---[RSA 4096]----+
+# |===+o       .    |
+# |.B.*.. .   . .   |
+# |o X . o o . o    |
+# | E +   B * o .   |
+# |.   . + S *   o  |
+# |       X @ . o   |
+# |      o * + .    |
+# |       .         |
+# |                 |
+# +----[SHA256]-----+
+#
+# Next, we add the public key to https://github.com/biopython/docs as
+# a deployment key with write permission,
+#
+# $ cat biopython_doc_key.pub
+# ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDpQ3I6ZpL9cqUpqkHMPALTQg9ya3sL1MVXYjbTnuWnDoRml5UYXVgD8hgOJxwaxDo1BV+fKn68LXPEwlZ5FC6eRSCJz20SvWPkMDhAwChJJ+nE7f/vvK18R3Ge9ksWra8LFSR3EL7joQTN+c1VyaJH22qj1OED3G68Ix+bgvnUpZgeurV8vDV06FVx7H1Q5a5MoTWFdMa9wzJn5o6m7khditOTDKqznFULoOONpw7CsTiJD6drQPk1pwftDxEBMEAG7cKwux/dRWJtzsRQ7IO0d/AhzsqnLJJIgkHzQwmvpGpffWfoomNwF4bWJuWzu6tRcGcX16fLMyGK8kFJaL1zY6gQFkAbfsIdA2G28S79mIC4jT1JtiNYBOV9wIjxyZUyvzSeQGVC7yBafHE5eEb267dgGnDl654XzyIImLSKv/nx8No16UK/e5F+ds3hp0DPTknzeVOGBUEt1k8pEp47J9JVKoeceph0cJbfzFNv9pgOgyaHb1mhs9pI4kIQ3R+ibeAZbPWT709n26Y99Q2MSSZyPuZvX8VBA1NfoENmuTrEn/qqGlvZez3Blh4MIvYg24DFv/rHN92Edk5S7xY0eB7E6D6X/N80ThuBSqxlJpxSQlA+LICcq/EPd37/WT7exiheXysN5oIOvwNgUNNFftDWv2gPBu2bf/foHfAQKQ== biopython documentation deploy key
+#
+# Finally, we add the private key to TravisCI by going to
+# https://travis-ci.org/biopython/biopython/settings or any authorised
+# fork like https://travis-ci.org/peterjc/biopython/settings and
+# setting DOC_KEY to the following (secret) value:
+#
+# $ python -c "print(open('biopython_doc_key').read().strip().replace(' ', r'\ ').replace('\n', r'\\\n'))"
+# ...
+#
+# TravisCI requires we escape spaces as '\ ' and newlines as '\\n', and
+# we explicitly strip the trailing new line so that we don't get an extra
+# one when rebuilding the key later.
+#
+# Make sure "DISPLAY VALUE IN BUILD LOG" is off (the default).
+#
+# For testing locally, set local environment $DOC_KEY to this value.
+# Thereafter, when ever this script gets run on TravisCI it should
+# be able to deplop the HTML documentation to our documentation
+# repository (which will dispaly on biopython.org via GitHub pages).
+
+set -e
+
+if [ -z "$DOC_KEY" ]; then
+    echo "Missing (secret) environment variable DOC_KEY,"
+    echo "which should hold the private SSH deployment key."
+    false
+fi
+
+set -euo pipefail
+
+DEST_SLUG=biopython/docs
+# Could look at $TRAVIS_TAG, e.g. DEST_DIR=${TRAVIS_TAG:-dev}
+# However, tags lack the dots in the version number. Since
+# Biopython was installed to run Sphinx and build the docs,
+# can use this:
+DEST_DIR=`python -c "import Bio; v=Bio.__version__; print('dev' if 'dev' in v else v)"`
+SOURCE_DIR=${TRAVIS_BUILD_DIR:-$PWD}/Doc/api/_build/html
+WORKING_DIR=/tmp/deploy_biopython_docs
+
+if [ -z "$DEST_DIR" ]; then
+   echo "ERROR: Failed to get Biopython version, is it not installed?"
+   python -c "import Bio; print(Bio.__version__)"
+   false
+fi
+DEST_DIR=$DEST_DIR/api
+echo "Aiming to deploy $SOURCE_DIR to $DEST_SLUG branch gh-pages as $DEST_DIR"
+
+# On TravisCI, must create the variable using '\ ' and '\n', so
+# here we must unescape the whitespace to recover the SSH deploy key:
+python -c "import os; print(os.environ['DOC_KEY'].strip().replace(r'\ ', ' ').replace(r'\n', '\n'))" > $HOME/.biopython_doc_deploy.key
+# Check we have a sane looking line structure:
+if [ `grep -c "^\-\-\-\-\-" $HOME/.biopython_doc_deploy.key` -ne 2 ]; then
+    echo "ERROR: Failed to rebuild the SSH key,"
+    wc -l $HOME/.biopython_doc_deploy.key
+    md5sum $HOME/.biopython_doc_deploy.key
+    false
+fi
+chmod 600 $HOME/.biopython_doc_deploy.key
+export GIT_SSH=${TRAVIS_BUILD_DIR:-$PWD}/.github/ssh_via_deploy_key.sh
+
+if ! [[ -f "$GIT_SSH" ]]; then
+    echo "Error, set GIT_SSH="$GIT_SSH" but does not exist"
+    false
+elif ! [[ -x "$GIT_SSH" ]]; then
+    echo "Error, set GIT_SSH="$GIT_SSH" but not executable"
+    false
+fi;
+
+echo "Setting up clone of $DEST_SLUG locally at $WORKING_DIR"
+
+# Clone the destination under /tmp (public URL, no key needed)
+rm -rf $WORKING_DIR
+git clone https://github.com/$DEST_SLUG.git $WORKING_DIR
+pushd $WORKING_DIR
+git checkout gh-pages
+# Switch the git protocol to SSH based so we can use our key
+git remote set-url origin --push git@github.com:$DEST_SLUG.git
+popd
+
+echo "Copying $SOURCE_DIR/* to $WORKING_DIR/$DEST_DIR/ next"
+if [ ! -d $SOURCE_DIR ]; then
+    echo "ERROR: Directory $SOURCE_DIR/ does not exist."
+    false
+fi
+
+# Remove any old files
+pushd $WORKING_DIR
+if [ -d $DEST_DIR ]; then
+    echo "Removing old files"
+    git rm -r $DEST_DIR/
+fi
+mkdir -p $DEST_DIR
+echo "Copying files"
+cp -R $SOURCE_DIR/* $DEST_DIR/
+echo "Staging files in git"
+git add $DEST_DIR/
+
+if [[ -z $(git status --porcelain) ]]; then
+    echo "Nothing has changed, nothing needs pushing."
+else
+    echo "Making commit of new files"
+    git commit -m "Automated update ${TRAVIS_COMMIT:-}" --author "TravisCI <travisci@example.org>"
+    echo "Finally, pushing to $DEST_SLUG gh-pages branch"
+    git push origin gh-pages
+    echo "Documentation deployed!"
+fi
+
+popd

--- a/.github/ssh_via_deploy_key.sh
+++ b/.github/ssh_via_deploy_key.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Call ssh using our GitHub repository deploy key (set via -i)
+# using -F to make sure this ignores ~/.ssh/config
+ssh -i "$HOME/.biopython_doc_deploy.key" -F /dev/null -p 22 $*

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -157,6 +157,7 @@ deps =
     scipy
     sphinx>=1.8.0
     numpydoc
+    sphinx_rtd_theme
 commands =
     bash -c \'python setup.py install > /dev/null\'
     bash -c \'mkdir -p Doc/api/_templates Doc/api/_static Doc/api/_build\'

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ matrix:
         apt:
           packages:
       before_install: echo "Going to build API docs"
+      after_success:  .github/deploy_docs.sh
     - stage: test
       python: 2.7
       env: TOXENV=py27-cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,12 @@ matrix:
         apt:
           packages:
       before_install: echo "Going to build API docs"
-      after_success:  .github/deploy_docs.sh
+      deploy:
+        provider: script
+        script: .github/deploy_docs.sh
+        skip_cleanup: true
+        on:
+          branch: master
     - stage: test
       python: 2.7
       env: TOXENV=py27-cover

--- a/Bio/AlignIO/FastaIO.py
+++ b/Bio/AlignIO/FastaIO.py
@@ -77,10 +77,10 @@ def FastaM10Iterator(handle, alphabet=single_letter_alphabet):
         from Bio import AlignIO
         handle = ...
         for a in AlignIO.parse(handle, "fasta-m10"):
-          assert len(a) == 2, "Should be pairwise!"
-          print("Alignment length %i" % a.get_alignment_length())
-          for record in a:
-            print("%s %s %s" % (record.seq, record.name, record.id))
+            assert len(a) == 2, "Should be pairwise!"
+            print("Alignment length %i" % a.get_alignment_length())
+            for record in a:
+                print("%s %s %s" % (record.seq, record.name, record.id))
 
     Note that this is not a full blown parser for all the information
     in the FASTA output - for example, most of the header and all of the

--- a/Bio/Data/CodonTable.py
+++ b/Bio/Data/CodonTable.py
@@ -178,6 +178,11 @@ class NCBICodonTable(CodonTable):
         self.start_codons = start_codons
         self.stop_codons = stop_codons
 
+    def __repr__(self):
+        """Represent the NCBI codon table class as a string for debugging."""
+        return "%s(id=%r, names=%r, ...)" % (self.__class__.__name__,
+                                             self.id, self.names)
+
 
 class NCBICodonTableDNA(NCBICodonTable):
     """Codon table for unambiguous DNA sequences."""

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -13,9 +13,10 @@ It is used by Bio.GenBank to parse GenBank files
 It is also used by Bio.SeqIO to parse GenBank and EMBL files
 
 Feature Table Documentation:
-http://www.insdc.org/files/feature_table.html
-http://www.ncbi.nlm.nih.gov/projects/collab/FT/index.html
-ftp://ftp.ncbi.nih.gov/genbank/docs/
+
+- http://www.insdc.org/files/feature_table.html
+- http://www.ncbi.nlm.nih.gov/projects/collab/FT/index.html
+- ftp://ftp.ncbi.nih.gov/genbank/docs/
 """
 # 17-MAR-2009: added wgs, wgs_scafld for GenBank whole genome shotgun master records.
 # These are GenBank files that summarize the content of a project, and provide lists of

--- a/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
+++ b/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
@@ -13,7 +13,7 @@ from Bio._utils import read_forward
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 from Bio.Alphabet import generic_protein
 
-__all__ = ('Hhsuite2TextParser')
+__all__ = ('Hhsuite2TextParser', )
 
 # precompile regex patterns for faster processing
 # regex for query name capture

--- a/Bio/SearchIO/__init__.py
+++ b/Bio/SearchIO/__init__.py
@@ -375,13 +375,13 @@ def read(handle, format=None, **kwargs):
     return first
 
 
-def to_dict(qresults, key_function=lambda rec: rec.id):
+def to_dict(qresults, key_function=None):
     """Turn a QueryResult iterator or list into a dictionary.
 
      - qresults     - Iterable returning QueryResult objects.
      - key_function - Optional callback function which when given a
                       QueryResult object should return a unique key for the
-                      dictionary.
+                      dictionary. Defaults to using .id of the result.
 
     This function enables access of QueryResult objects from a single search
     output file using its identifier.
@@ -423,6 +423,12 @@ def to_dict(qresults, key_function=lambda rec: rec.id):
     than 3.6 (and for other Python older than 3.7) so that you can always
     assume the record order is preserved.
     """
+    def _default_key_function(rec):
+        return rec.id
+
+    if key_function is None:
+        key_function = _default_key_function
+
     qdict = _dict()
     for qresult in qresults:
         key = key_function(qresult)

--- a/Bio/kNN.py
+++ b/Bio/kNN.py
@@ -71,7 +71,7 @@ def train(xs, ys, k, typecode=None):
     return knn
 
 
-def calculate(knn, x, weight_fn=equal_weight, distance_fn=None):
+def calculate(knn, x, weight_fn=None, distance_fn=None):
     """Calculate the probability for each class.
 
     Arguments:
@@ -84,6 +84,9 @@ def calculate(knn, x, weight_fn=equal_weight, distance_fn=None):
 
     Returns a dictionary of the class to the weight given to the class.
     """
+    if weight_fn is None:
+        weight_fn = equal_weight
+
     x = numpy.asarray(x)
 
     order = []  # list of (distance, index)
@@ -113,7 +116,7 @@ def calculate(knn, x, weight_fn=equal_weight, distance_fn=None):
     return weights
 
 
-def classify(knn, x, weight_fn=equal_weight, distance_fn=None):
+def classify(knn, x, weight_fn=None, distance_fn=None):
     """Classify an observation into a class.
 
     If not specified, weight_fn will give all neighbors equal weight.
@@ -121,6 +124,9 @@ def classify(knn, x, weight_fn=equal_weight, distance_fn=None):
     the distance between them.  If distance_fn is None (the default),
     the Euclidean distance is used.
     """
+    if weight_fn is None:
+        weight_fn = equal_weight
+
     weights = calculate(
         knn, x, weight_fn=weight_fn, distance_fn=distance_fn)
 

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -253,8 +253,8 @@ class DBServer(object):
     def remove_database(self, db_name):
         """Remove a namespace and all its entries (OBSOLETE).
 
-        Examples:
-        ---------
+        Examples
+        --------
         Try to remove all references to items in a database::
 
             server.remove_database(name)

--- a/Doc/api/conf.py
+++ b/Doc/api/conf.py
@@ -89,7 +89,7 @@ autodoc_default_values = {
 }
 
 # To avoid import errors.
-autodoc_mock_imports = ['MySQLdb']
+autodoc_mock_imports = ['MySQLdb', 'Bio.Restriction.Restriction']
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/Doc/api/conf.py
+++ b/Doc/api/conf.py
@@ -93,16 +93,16 @@ autodoc_mock_imports = ['MySQLdb', 'Bio.Restriction.Restriction']
 
 # -- Options for HTML output ----------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-html_theme = 'alabaster'
+# Sphinx default was html_theme = "alabaster"
+html_theme = "sphinx_rtd_theme"
 
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
-#
-# html_theme_options = {}
+# Sphinx Read The Docs theme settings, see
+# https://sphinx-rtd-theme.readthedocs.io/en/latest/configuring.html
+html_theme_options = {
+    "prev_next_buttons_location": "both",
+    # Same a Hyde theme sidebar on biopython.org:
+    "style_nav_header_background": "#10100F",
+}
 
 html_logo = "../images/biopython_logo.svg"
 

--- a/Doc/api/conf.py
+++ b/Doc/api/conf.py
@@ -104,6 +104,12 @@ html_theme = 'alabaster'
 #
 # html_theme_options = {}
 
+html_logo = "../images/biopython_logo.svg"
+
+# The RST source is transient, don't need/want to include it
+html_show_sourcelink = False
+html_copy_source = False
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/Doc/api/conf.py
+++ b/Doc/api/conf.py
@@ -26,7 +26,8 @@ needs_sphinx = '1.8'
 # ones.
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.todo',
-              'sphinx.ext.viewcode',
+              # Don't want to include source code in the API docs
+              # 'sphinx.ext.viewcode',
               'sphinx.ext.autosummary',
               'numpydoc']
 

--- a/Doc/api/index.rst
+++ b/Doc/api/index.rst
@@ -5,6 +5,18 @@
 Welcome to Biopython's API documentation!
 =========================================
 
+This content is automatically extracted from the "docstrings" within the
+Biopython source code, which can be viewed within an interactive Python
+session using the ``help()`` command.
+
+Historically Biopython used `epydoc <http://epydoc.sourceforge.net/>`_ for
+making API documentation webpages, hosted here:
+
+https://biopython.org/DIST/docs/api/
+
+This copy was generated using the more modern `Sphinx with autodoc
+<https://www.sphinx-doc.org/>`_ instead.
+
 .. toctree::
    :maxdepth: 1
    :caption: API Contents:


### PR DESCRIPTION
This pull request addresses issue #906, replacing epydoc with Sphinx and autodoc.

Since #1803 we already build the API documentation with Sphinx and autodoc on TravisCI via the tox ``api`` target.

This adds automated deployment of the HTML output (via a bash script using a deployment key) to the new repository https://github.com/biopython/docs using github pages, to appear online under https://biopython.org/docs/dev/api/ etc (with ``.../dev/`` for the master branch development code, or a version like ``.../1.74/...`` instead for releases).

This URL patterns should leave open the possibility of hosting all the Tutorial here as well, probably easiest to do if if we convert that from LaTeX to RST and stay within Sphinx, see #907.

This requires an SSH deployment key. We add the public key to https://github.com/biopython/docs (multiple keys can be added, see below), and the private key is added to https://travis-ci.org/biopython/biopython/settings (suitably escaped).

The proposed setup uses the TravisCI ``deploy:`` stage https://docs.travis-ci.com/user/job-lifecycle/ (although ``after_success:`` works nicely too), currently restricted to the ``master`` branch only.

Testing on a fork is possible, for example from https://github.com/peterjc/biopython/ to https://github.com/biopython/docs as long as you have the private key (have permission to add a new key to the docs repository). Alternatively we could make it try to push to the owner's fork of the docs repository?

e.g. https://travis-ci.org/peterjc/biopython/jobs/557346277 didn't deploy as ``deploy`` was not the ``master`` branch (nor should the testing of this pull request trigger a deploy), while identical code in https://travis-ci.org/peterjc/biopython/jobs/557346457 on my fork's ``master`` branch did run the deploy script.

The implementation right now is in a bash script ``.github/deploy_docs.sh`` and tiny helper ``.github/ssh_via_deploy_key.sh`` but in principle this private key approach could be added to the tool ``doctr`` instead (see https://github.com/drdoctr/doctr/issues/348 and https://github.com/drdoctr/doctr/pull/349 where I am working on this).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
