### PR TITLE
TravisCI Python 2.7 doc8 style check workaround

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -103,6 +103,10 @@ deps =
     flake8-bugbear;python_version>="3.5"
     restructuredtext_lint
     doc8
+    # doc8 needs docutils, but docutils==0.15 has an import order bug
+    # https://bugs.launchpad.net/doc8/+bug/1837515
+    # https://sourceforge.net/p/docutils/bugs/366/
+    docutils==0.14
     # flake8-docstrings uses a function removed in pydocstyle 4.0.0; once a fix
     # is released in flake8-docstrings we can remove the following constraint:
     pydocstyle<4.0.0


### PR DESCRIPTION
The Python 2.7 style checks on TravisCI call ``doc8`` which started failing with the release of ``docutils=0.15``, see https://bugs.launchpad.net/doc8/+bug/1837515 and https://sourceforge.net/p/docutils/bugs/366/

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
