### PR TITLE
MMTF file writer

### DIFF
--- a/Bio/PDB/mmcifio.py
+++ b/Bio/PDB/mmcifio.py
@@ -15,7 +15,7 @@ from collections import defaultdict
 
 from Bio._py3k import basestring
 from Bio.PDB.StructureBuilder import StructureBuilder
-from Bio.PDB.PDBIO import Select
+from Bio.PDB.PDBIO import Select, StructureIO
 
 # If certain entries should have a certain order of keys, that is specified here
 mmcif_order = {
@@ -48,7 +48,7 @@ mmcif_order = {
 _select = Select()
 
 
-class MMCIFIO(object):
+class MMCIFIO(StructureIO):
     """Write a Structure object or a mmCIF dictionary as a mmCIF file.
 
     Examples
@@ -69,46 +69,6 @@ class MMCIFIO(object):
     def __init__(self):
         """Initialise."""
         pass
-
-    def set_structure(self, pdb_object):
-        """Check what object the user is providing and build a structure."""
-        # This is duplicated from the PDBIO class
-        if pdb_object.level == "S":
-            structure = pdb_object
-        else:
-            sb = StructureBuilder()
-            sb.init_structure("pdb")
-            sb.init_seg(" ")
-            # Build parts as necessary
-            if pdb_object.level == "M":
-                sb.structure.add(pdb_object)
-                self.structure = sb.structure
-            else:
-                sb.init_model(0)
-                if pdb_object.level == "C":
-                    sb.structure[0].add(pdb_object)
-                else:
-                    sb.init_chain("A")
-                    if pdb_object.level == "R":
-                        try:
-                            parent_id = pdb_object.parent.id
-                            sb.structure[0]["A"].id = parent_id
-                        except ValueError:
-                            pass
-                        sb.structure[0]["A"].add(pdb_object)
-                    else:
-                        # Atom
-                        sb.init_residue("DUM", " ", 1, " ")
-                        try:
-                            parent_id = pdb_object.parent.parent.id
-                            sb.structure[0]["A"].id = parent_id
-                        except ValueError:
-                            pass
-                        sb.structure[0]["A"].child_list[0].add(pdb_object)
-
-            # Return structure
-            structure = sb.structure
-        self.structure = structure
 
     def set_dict(self, dic):
         """Set the mmCIF dictionary to be written out."""

--- a/Bio/PDB/mmtf/DefaultParser.py
+++ b/Bio/PDB/mmtf/DefaultParser.py
@@ -30,8 +30,8 @@ class StructureDecoder(object):
         :param structure_id: the id of the structure (e.g. PDB id)
 
         """
-        self.structure_bulder = StructureBuilder()
-        self.structure_bulder.init_structure(structure_id=structure_id)
+        self.structure_builder = StructureBuilder()
+        self.structure_builder.init_structure(structure_id=structure_id)
         self.chain_index_to_type_map = {}
         self.chain_index_to_seq_map = {}
         self.chain_index_to_description_map = {}
@@ -59,7 +59,7 @@ class StructureDecoder(object):
             alternative_location_id = " "
 
         # Atom_name is in twice - the full_name is with spaces
-        self.structure_bulder.init_atom(str(atom_name), numpy.array((x, y, z), "f"),
+        self.structure_builder.init_atom(str(atom_name), numpy.array((x, y, z), "f"),
                                         temperature_factor, occupancy,
                                         alternative_location_id, str(atom_name),
                                         serial_number=serial_number,
@@ -75,7 +75,7 @@ class StructureDecoder(object):
         """
         # A Bradley - chose to use chain_name (auth_id) as it complies
         # with current Biopython. Chain_id might be better.
-        self.structure_bulder.init_chain(chain_id=chain_name)
+        self.structure_builder.init_chain(chain_id=chain_name)
         if self.chain_index_to_type_map[self.chain_counter] == "polymer":
             self.this_type = " "
         elif self.chain_index_to_type_map[self.chain_counter] == "non-polymer":
@@ -121,8 +121,8 @@ class StructureDecoder(object):
         if insertion_code == "\x00":
             insertion_code = " "
 
-        self.structure_bulder.init_seg(" ")
-        self.structure_bulder.init_residue(group_name, self.this_type,
+        self.structure_builder.init_seg(' ')
+        self.structure_builder.init_residue(group_name, self.this_type,
                                            group_number, insertion_code)
 
     def set_model_info(self, model_id, chain_count):
@@ -132,7 +132,7 @@ class StructureDecoder(object):
         :param chain_count: the number of chains in the model
 
         """
-        self.structure_bulder.init_model(model_id)
+        self.structure_builder.init_model(model_id)
 
     def set_xtal_info(self, space_group, unit_cell):
         """Set the crystallographic information for the structure.
@@ -141,7 +141,7 @@ class StructureDecoder(object):
         :param unit_cell: an array of length 6 with the unit cell parameters in order: a, b, c, alpha, beta, gamma
 
         """
-        self.structure_bulder.set_symmetry(space_group, unit_cell)
+        self.structure_builder.set_symmetry(space_group, unit_cell)
 
     def set_header_info(self, r_free, r_work, resolution, title,
                         deposition_date, release_date, experimnetal_methods):

--- a/Bio/PDB/mmtf/DefaultParser.py
+++ b/Bio/PDB/mmtf/DefaultParser.py
@@ -60,10 +60,10 @@ class StructureDecoder(object):
 
         # Atom_name is in twice - the full_name is with spaces
         self.structure_builder.init_atom(str(atom_name), numpy.array((x, y, z), "f"),
-                                        temperature_factor, occupancy,
-                                        alternative_location_id, str(atom_name),
-                                        serial_number=serial_number,
-                                        element=str(element).upper())
+                                         temperature_factor, occupancy,
+                                         alternative_location_id, str(atom_name),
+                                         serial_number=serial_number,
+                                         element=str(element).upper())
 
     def set_chain_info(self, chain_id, chain_name, num_groups):
         """Set the chain information.
@@ -123,7 +123,7 @@ class StructureDecoder(object):
 
         self.structure_builder.init_seg(' ')
         self.structure_builder.init_residue(group_name, self.this_type,
-                                           group_number, insertion_code)
+                                            group_number, insertion_code)
 
     def set_model_info(self, model_id, chain_count):
         """Set the information for a model.

--- a/Bio/PDB/mmtf/__init__.py
+++ b/Bio/PDB/mmtf/__init__.py
@@ -12,6 +12,7 @@ except ImportError:
     raise MissingPythonDependencyError("Install mmtf to use Bio.PDB.mmtf "
                                        "(e.g. pip install mmtf-python)")
 from Bio.PDB.mmtf.DefaultParser import StructureDecoder
+from .mmtfio import MMTFIO
 
 
 def get_from_decoded(decoder):
@@ -45,5 +46,3 @@ class MMTFParser(object):
         """
         decoder = parse(file_path)
         return get_from_decoded(decoder)
-
-from .mmtfio import MMTFIO

--- a/Bio/PDB/mmtf/__init__.py
+++ b/Bio/PDB/mmtf/__init__.py
@@ -18,7 +18,7 @@ def get_from_decoded(decoder):
     """Return structure from decoder."""
     structure_decoder = StructureDecoder()
     decoder.pass_data_on(structure_decoder)
-    return structure_decoder.structure_bulder.get_structure()
+    return structure_decoder.structure_builder.get_structure()
 
 
 class MMTFParser(object):

--- a/Bio/PDB/mmtf/__init__.py
+++ b/Bio/PDB/mmtf/__init__.py
@@ -45,3 +45,5 @@ class MMTFParser(object):
         """
         decoder = parse(file_path)
         return get_from_decoded(decoder)
+
+from .mmtfio import MMTFIO

--- a/Bio/PDB/mmtf/mmtfio.py
+++ b/Bio/PDB/mmtf/mmtfio.py
@@ -7,11 +7,15 @@
 
 """Write a MMTF file."""
 
+import itertools
 from collections import defaultdict
+from string import ascii_uppercase
 from Bio._py3k import basestring
 from Bio.PDB.StructureBuilder import StructureBuilder
 from Bio.PDB.PDBIO import Select, StructureIO
 from mmtf.api.mmtf_writer import MMTFEncoder
+from Bio.SeqUtils import seq1
+from Bio.Data.SCOPData import protein_letters_3to1
 
 _select = Select()
 
@@ -65,6 +69,12 @@ class MMTFIO(StructureIO):
         else:
             raise ValueError("Use set_structure to set a structure to write out")
 
+    def _chain_id_iterator(self):
+        """Label chains sequentially: A, B, ..., Z, AA, AB etc."""
+        for size in itertools.count(1):
+            for s in itertools.product(ascii_uppercase, repeat=size):
+                yield "".join(s)
+
     def _save_structure(self, filepath, select):
         count_models, count_chains, count_groups, count_atoms = 0, 0, 0, 0
 
@@ -104,9 +114,11 @@ class MMTFIO(StructureIO):
             experimental_methods=header_dict["structure_method"]
         )
 
-        # Tracks values to replace arrays at the end
+        # Tracks values to replace them at the end
         chains_per_model = []
         groups_per_chain = []
+
+        chain_id_iterator = self._chain_id_iterator()
 
         for mi, model in enumerate(self.structure.get_models()):
             if not select.accept_model(model):
@@ -121,8 +133,11 @@ class MMTFIO(StructureIO):
                 if not select.accept_chain(chain):
                     continue
 
+                seqs = []
+                seq = ""
                 prev_residue_type = ""
                 prev_resname = ""
+                first_chain = True
 
                 for residue in chain.get_residues():
                     if not select.accept_residue(residue):
@@ -145,23 +160,30 @@ class MMTFIO(StructureIO):
                     # This will always increment for the first residue in a
                     #  chain due to the starting values above
                     # Checking for similar entities is non-trivial from the
-                    #  strucure object so we treat each molecule as a separate
+                    #  structure object so we treat each molecule as a separate
                     #  entity
                     if residue_type != prev_residue_type or (residue_type == "HETATM" and resname != prev_resname):
                         encoder.set_entity_info(
                             chain_indices=[count_chains],
-                            sequence="",
+                            sequence="", # Set to empty here and changed later
                             description="",
                             entity_type=entity_type
                         )
                         encoder.set_chain_info(
-                            chain_id=chain.get_id(), # This should increment
+                            chain_id=next(chain_id_iterator),
                             chain_name=chain.get_id(),
                             num_groups=0  # Set to 0 here and changed later
                         )
                         if count_chains > 0:
                             groups_per_chain.append(count_groups - sum(groups_per_chain) - 1)
+                        if not first_chain:
+                            seqs.append(seq)
+                        first_chain = False
                         count_chains += 1
+                        seq = ""
+
+                    if entity_type == "polymer":
+                        seq += seq1(residue.resname, custom_map=protein_letters_3to1)
 
                     prev_residue_type = residue_type
                     prev_resname = resname
@@ -192,6 +214,12 @@ class MMTFIO(StructureIO):
                                 element=atom.element,
                                 charge=0
                             )
+
+                seqs.append(seq)
+                # Now that we have the sequences, edit the entities
+                start_ind = len(encoder.entity_list) - len(seqs)
+                for i, seq in enumerate(seqs):
+                    encoder.entity_list[start_ind + i]["sequence"] = seq
 
             chains_per_model.append(count_chains - sum(chains_per_model))
 

--- a/Bio/PDB/mmtf/mmtfio.py
+++ b/Bio/PDB/mmtf/mmtfio.py
@@ -19,6 +19,7 @@ from Bio.Data.SCOPData import protein_letters_3to1
 
 _select = Select()
 
+
 class MMTFIO(StructureIO):
     """Write a Structure object as a MMTF file.
 
@@ -129,8 +130,8 @@ class MMTFIO(StructureIO):
 
             count_models += 1
             encoder.set_model_info(
-                model_id=mi, # According to mmtf-python this is meaningless
-                chain_count=0 # Set to 0 here and changed later
+                model_id=mi,  # According to mmtf-python this is meaningless
+                chain_count=0  # Set to 0 here and changed later
             )
             for chain in model.get_chains():
                 if not select.accept_chain(chain):
@@ -168,7 +169,7 @@ class MMTFIO(StructureIO):
                     if residue_type != prev_residue_type or (residue_type == "HETATM" and resname != prev_resname):
                         encoder.set_entity_info(
                             chain_indices=[count_chains],
-                            sequence="", # Set to empty here and changed later
+                            sequence="",  # Set to empty here and changed later
                             description="",
                             entity_type=entity_type
                         )
@@ -195,7 +196,7 @@ class MMTFIO(StructureIO):
                         group_name=resname,
                         group_number=residue.id[1],
                         insertion_code="\x00" if residue.id[2] == " " else residue.id[2],
-                        group_type="", # Value in the chemcomp dictionary, which is unknown here
+                        group_type="",  # Value in the chemcomp dictionary, which is unknown here
                         atom_count=sum(1 for a in residue.get_unpacked_list() if select.accept_atom(a)),
                         bond_count=0,
                         single_letter_code=seq1(resname, custom_map=protein_letters_3to1),

--- a/Bio/PDB/mmtf/mmtfio.py
+++ b/Bio/PDB/mmtf/mmtfio.py
@@ -1,0 +1,209 @@
+# Copyright 2019 Joe Greener. All rights reserved.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
+
+"""Write a MMTF file."""
+
+from Bio._py3k import basestring
+from Bio.PDB.StructureBuilder import StructureBuilder
+from Bio.PDB.PDBIO import Select
+from mmtf.api.mmtf_writer import MMTFEncoder
+
+_select = Select()
+
+class MMTFIO(object):
+    """Write a Structure object as a MMTF file.
+
+    Examples
+    --------
+        >>> from Bio.PDB import MMCIFParser
+        >>> from Bio.PDB.mmtf import MMTFIO
+        >>> parser = MMCIFParser()
+        >>> structure = parser.get_structure("1a8o", "PDB/1A8O.cif")
+        >>> io=MMTFIO()
+        >>> io.set_structure(structure)
+        >>> io.save("bio-pdb-mmtf-out.mmtf")
+        >>> import os
+        >>> os.remove("bio-pdb-mmtf-out.mmtf")  # tidy up
+
+    """
+
+    def __init__(self):
+        """Initialise."""
+        pass
+
+    def set_structure(self, pdb_object):
+        """Check what object the user is providing and build a structure."""
+        # This is duplicated from the PDBIO class
+        if pdb_object.level == "S":
+            structure = pdb_object
+        else:
+            sb = StructureBuilder()
+            sb.init_structure('pdb')
+            sb.init_seg(' ')
+            # Build parts as necessary
+            if pdb_object.level == "M":
+                sb.structure.add(pdb_object)
+                self.structure = sb.structure
+            else:
+                sb.init_model(0)
+                if pdb_object.level == "C":
+                    sb.structure[0].add(pdb_object)
+                else:
+                    sb.init_chain('A')
+                    if pdb_object.level == "R":
+                        try:
+                            parent_id = pdb_object.parent.id
+                            sb.structure[0]['A'].id = parent_id
+                        except ValueError:
+                            pass
+                        sb.structure[0]['A'].add(pdb_object)
+                    else:
+                        # Atom
+                        sb.init_residue('DUM', ' ', 1, ' ')
+                        try:
+                            parent_id = pdb_object.parent.parent.id
+                            sb.structure[0]['A'].id = parent_id
+                        except ValueError:
+                            pass
+                        sb.structure[0]['A'].child_list[0].add(pdb_object)
+
+            # Return structure
+            structure = sb.structure
+        self.structure = structure
+
+    def save(self, filepath, select=_select):
+        """Save the structure to a file.
+
+        :param filepath: output file
+        :type filepath: string
+
+        :param select: selects which entities will be written.
+        :type select: object
+
+        Typically select is a subclass of L{Select}, it should
+        have the following methods:
+
+         - accept_model(model)
+         - accept_chain(chain)
+         - accept_residue(residue)
+         - accept_atom(atom)
+
+        These methods should return 1 if the entity is to be
+        written out, 0 otherwise.
+        """
+        # Similar to the PDBIO save method, we check if the filepath is a
+        # string for a filepath or an open file handle
+        if not isinstance(filepath, basestring):
+            raise ValueError("Writing to a file handle is not supported for MMTF, filepath must be a string")
+        if hasattr(self, "structure"):
+            self._save_structure(filepath, select)
+        else:
+            raise ValueError("Use set_structure to set a structure to write out")
+
+    def _save_structure(self, filepath, select):
+        encoder = MMTFEncoder()
+        encoder.init_structure(
+            total_num_bonds=0,
+            total_num_atoms=len(list(self.structure.get_atoms())),
+            total_num_groups=len(list(self.structure.get_residues())),
+            total_num_chains=len(list(self.structure.get_chains())),
+            total_num_models=len(list(self.structure.get_models())),
+            structure_id=self.structure.id
+        )
+
+        encoder.set_xtal_info(
+            space_group="",
+            unit_cell=[0, 0, 0, 0, 0, 0]
+        )
+
+        encoder.set_header_info(
+            r_free=0.0,
+            r_work=0.0,
+            resolution=self.structure.header["resolution"],
+            title=self.structure.header["name"],
+            deposition_date=self.structure.header["deposition_date"],
+            release_date=self.structure.header["release_date"],
+            experimental_methods=self.structure.header["structure_method"]
+        )
+
+        for mi, model in enumerate(self.structure.get_models()):
+            if not select.accept_model(model):
+                continue
+
+            encoder.set_model_info(
+                model_id=mi,
+                chain_count=len(list(model.get_chains()))
+            )
+            for ci, chain in enumerate(model.get_chains()):
+                if not select.accept_chain(chain):
+                    continue
+
+                encoder.set_chain_info(
+                    chain_id=chain.get_id(),
+                    chain_name=chain.get_id(),
+                    num_groups=len(list(chain.get_residues()))
+                )
+
+                prev_residue_type = ""
+                prev_resname = ""
+
+                for residue in chain.get_residues():
+                    if not select.accept_residue(residue):
+                        continue
+
+                    hetfield, resseq, icode = residue.get_id()
+                    if hetfield == " ":
+                        residue_type = "ATOM"
+                        entity_type = "polymer"
+                    elif hetfield == "W":
+                        residue_type = "HETATM"
+                        entity_type = "water"
+                    else:
+                        residue_type = "HETATM"
+                        entity_type = "non-polymer"
+                    resname = residue.get_resname()
+                    # Check if the molecule changes within the chain
+                    # This will always increment for the first residue in a
+                    # chain due to the starting values above
+                    if residue_type != prev_residue_type or (residue_type == "HETATM" and resname != prev_resname):
+                        encoder.set_entity_info(
+                            chain_indices=[ci],
+                            sequence="",
+                            description="",
+                            entity_type=entity_type
+                        )
+                    prev_residue_type = residue_type
+                    prev_resname = resname
+
+                    encoder.set_group_info(
+                        group_name=resname,
+                        group_number=residue.id[1],
+                        insertion_code=residue.id[2],
+                        group_type="",
+                        atom_count=len(list(residue.get_atoms())),
+                        bond_count=0,
+                        single_letter_code="",
+                        sequence_index=0,
+                        secondary_structure_type=0
+                    )
+                    for atom in residue.get_atoms():
+                        if select.accept_atom(atom):
+                            encoder.set_atom_info(
+                                atom_name=atom.name,
+                                serial_number=atom.serial_number,
+                                alternative_location_id=atom.altloc,
+                                x=atom.coord[0],
+                                y=atom.coord[1],
+                                z=atom.coord[2],
+                                occupancy=atom.occupancy,
+                                temperature_factor=atom.bfactor,
+                                element=atom.element,
+                                charge=0
+                            )
+
+        encoder.finalize_structure()
+        encoder.write_file(filepath)

--- a/Bio/PDB/mmtf/mmtfio.py
+++ b/Bio/PDB/mmtf/mmtfio.py
@@ -10,12 +10,12 @@
 from collections import defaultdict
 from Bio._py3k import basestring
 from Bio.PDB.StructureBuilder import StructureBuilder
-from Bio.PDB.PDBIO import Select
+from Bio.PDB.PDBIO import Select, StructureIO
 from mmtf.api.mmtf_writer import MMTFEncoder
 
 _select = Select()
 
-class MMTFIO(object):
+class MMTFIO(StructureIO):
     """Write a Structure object as a MMTF file.
 
     Examples
@@ -35,46 +35,6 @@ class MMTFIO(object):
     def __init__(self):
         """Initialise."""
         pass
-
-    def set_structure(self, pdb_object):
-        """Check what object the user is providing and build a structure."""
-        # This is duplicated from the PDBIO class
-        if pdb_object.level == "S":
-            structure = pdb_object
-        else:
-            sb = StructureBuilder()
-            sb.init_structure('pdb')
-            sb.init_seg(' ')
-            # Build parts as necessary
-            if pdb_object.level == "M":
-                sb.structure.add(pdb_object)
-                self.structure = sb.structure
-            else:
-                sb.init_model(0)
-                if pdb_object.level == "C":
-                    sb.structure[0].add(pdb_object)
-                else:
-                    sb.init_chain('A')
-                    if pdb_object.level == "R":
-                        try:
-                            parent_id = pdb_object.parent.id
-                            sb.structure[0]['A'].id = parent_id
-                        except ValueError:
-                            pass
-                        sb.structure[0]['A'].add(pdb_object)
-                    else:
-                        # Atom
-                        sb.init_residue('DUM', ' ', 1, ' ')
-                        try:
-                            parent_id = pdb_object.parent.parent.id
-                            sb.structure[0]['A'].id = parent_id
-                        except ValueError:
-                            pass
-                        sb.structure[0]['A'].child_list[0].add(pdb_object)
-
-            # Return structure
-            structure = sb.structure
-        self.structure = structure
 
     def save(self, filepath, select=_select):
         """Save the structure to a file.

--- a/Bio/PDB/mmtf/mmtfio.py
+++ b/Bio/PDB/mmtf/mmtfio.py
@@ -143,7 +143,7 @@ class MMTFIO(StructureIO):
                 prev_resname = ""
                 first_chain = True
 
-                for residue in chain.get_residues():
+                for residue in chain.get_unpacked_list():
                     if not select.accept_residue(residue):
                         continue
 

--- a/Bio/PDB/mmtf/mmtfio.py
+++ b/Bio/PDB/mmtf/mmtfio.py
@@ -120,6 +120,11 @@ class MMTFIO(object):
                                     if select.accept_atom(atom):
                                         count_atoms += 1
 
+        # If atom serials are missing, renumber atoms starting from 1
+        atom_serials = [a.serial_number for a in self.structure.get_atoms()]
+        renumber_atoms = None in atom_serials
+        atom_n = 1
+
         encoder = MMTFEncoder()
         encoder.init_structure(
             total_num_bonds=0,
@@ -136,7 +141,7 @@ class MMTFIO(object):
         )
 
         # The header information is missing for some structure objects
-        # Missing items are treated as empty strings apart from the resolution
+        # Missing items are treated as empty strings, apart from the resolution
         header_dict = defaultdict(str, self.structure.header)
         if header_dict["resolution"] == "":
             header_dict["resolution"] = 0.0
@@ -215,7 +220,7 @@ class MMTFIO(object):
                         if select.accept_atom(atom):
                             encoder.set_atom_info(
                                 atom_name=atom.name,
-                                serial_number=atom.serial_number,
+                                serial_number=atom_n if renumber_atoms else atom.serial_number,
                                 alternative_location_id=atom.altloc,
                                 x=atom.coord[0],
                                 y=atom.coord[1],
@@ -225,6 +230,7 @@ class MMTFIO(object):
                                 element=atom.element,
                                 charge=0
                             )
+                            atom_n += 1
 
         encoder.finalize_structure()
         encoder.write_file(filepath)

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -112,6 +112,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Gert Hulselmans <https://github.com/ghuls>
 - Gleb Kuznetsov <https://github.com/glebkuznetsov>
 - Gokcen Eraslan <https://github.com/gokceneraslan>
+- Harry Jubb <https://github.com/harryjubb>
 - Harry Zuzan <iliketobicycle at domain yahoo.ca>
 - Hector Martinez <https://github.com/hmarlo>
 - Hongbo Zhu <https://github.com/hongbo-zhu-cn>

--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -9,7 +9,7 @@ Bio.PDB is a Biopython module that focuses on working with crystal structures of
 
 \subsection{Reading an mmCIF file}
 
-Similarly to the case of PDB files, first create an \texttt{MMCIFParser} object:
+First create an \texttt{MMCIFParser} object:
 
 \begin{minted}{pycon}
 >>> from Bio.PDB.MMCIFParser import MMCIFParser
@@ -99,7 +99,7 @@ incomplete or erroneous information. Many of the errors have been
 fixed in the equivalent mmCIF files. \emph{Hence, if you are interested
 in the header information, it is a good idea to extract information
 from mmCIF files using the} \texttt{\emph{MMCIF2Dict}} \emph{tool
-described below, instead of parsing the PDB header. }
+described above, instead of parsing the PDB header. }
 
 Now that is clarified, let's return to parsing the PDB header. The
 structure object has an attribute called \texttt{header} which is
@@ -147,14 +147,14 @@ via the mailing list if you need this.
 
 \subsection{Writing mmCIF files}
 
-A similar interface can be used to write structures to the mmCIF file format:
+The \texttt{MMCIFIO} class can be used to write structures to the mmCIF file format:
 
 \begin{minted}{pycon}
 >>> io = MMCIFIO()
 >>> io.set_structure(s)
 >>> io.save("out.cif")
 \end{minted}
-The \texttt{Select} class can be used in a similar way to \texttt{PDBIO} above.
+The \texttt{Select} class can be used in a similar way to \texttt{PDBIO} below.
 mmCIF dictionaries read using \texttt{MMCIF2Dict} can also be written:
 
 \begin{minted}{pycon}
@@ -165,7 +165,7 @@ mmCIF dictionaries read using \texttt{MMCIF2Dict} can also be written:
 
 \subsection{Writing PDB files}
 
-Use the PDBIO class for this. It's easy to write out specific parts
+Use the \texttt{PDBIO} class for this. It's easy to write out specific parts
 of a structure too, of course.
 
 Example: saving a structure

--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -206,6 +206,23 @@ If this is all too complicated for you, the \texttt{Dice} module contains
 a handy \texttt{extract} function that writes out all residues in
 a chain between a start and end residue.
 
+\subsection{Writing MMTF files}
+
+To write structures to the MMTF file format:
+
+\begin{minted}{pycon}
+>>> from Bio.PDB.mmtf import MMTFIO
+>>> io = MMTFIO()
+>>> io.set_structure(s)
+>>> io.save("out.mmtf")
+\end{minted}
+
+The \texttt{Select} class can be used as above. Note that the bonding
+information contained in standard MMTF files is not written out as it is not
+easy to determine from the structure object. In addition, molecules that are
+grouped into the same entity in standard MMTF files are treated as separate
+entities by \texttt{MMTFIO}.
+
 
 \section{Structure representation}
 

--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -218,10 +218,11 @@ To write structures to the MMTF file format:
 \end{minted}
 
 The \texttt{Select} class can be used as above. Note that the bonding
-information contained in standard MMTF files is not written out as it is not
-easy to determine from the structure object. In addition, molecules that are
-grouped into the same entity in standard MMTF files are treated as separate
-entities by \texttt{MMTFIO}.
+information, secondary structure assignment and some other information contained
+in standard MMTF files is not written out as it is not easy to determine from
+the structure object. In addition, molecules that are grouped into the same
+entity in standard MMTF files are treated as separate entities by
+\texttt{MMTFIO}.
 
 
 \section{Structure representation}

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -31,8 +31,9 @@ SnapGene ("snapgene") and Textco Biosoftware's Gene Construction Kit ("gck").
 The ``MMTFIO`` class is added that allows writing of MMTF file format files
 from a Biopython structure object. ``MMTFIO`` has a similar interface to
 ``PDBIO`` and ``MMCIFIO``, including the use of a ``Select`` class to write out
-a specified selection. This final addition to the six combinations of read/write
-for PDB/mmCIF/MMTF in Biopython allows conversion between the file formats.
+a specified selection. This final addition to the six combinations of
+read/write for PDB/mmCIF/MMTF in Biopython allows conversion between the file
+formats.
 
 As in recent releases, more of our code is now explicitly available under
 either our original "Biopython License Agreement", or the very similar but

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -28,6 +28,12 @@ Christian Marck's DNA Strider program ("xdna" format, also used by Serial
 Cloner), as well as reading files in the native formats of GSL Biotech's
 SnapGene ("snapgene") and Textco Biosoftware's Gene Construction Kit ("gck").
 
+The ``MMTFIO`` class is added that allows writing of MMTF file format files
+from a Biopython structure object. ``MMTFIO`` has a similar interface to
+``PDBIO`` and ``MMCIFIO``, including the use of a ``Select`` class to write out
+a specified selection. This final addition to the six combinations of read/write
+for PDB/mmCIF/MMTF in Biopython allows conversion between the file formats.
+
 As in recent releases, more of our code is now explicitly available under
 either our original "Biopython License Agreement", or the very similar but
 more commonly used "3-Clause BSD License".  See the ``LICENSE.rst`` file for
@@ -39,6 +45,7 @@ possible, especially the following contributors:
 - Chris MacRaild
 - Chris Rands
 - Damien Goutte-Gattat (first contribution)
+- Harry Jubb
 - Joe Greener
 - Kiran Mukhyala (first contribution)
 - Konstantin Vdovkin

--- a/Tests/test_mmtf.py
+++ b/Tests/test_mmtf.py
@@ -137,8 +137,8 @@ class WriteMMTF(unittest.TestCase):
             self.assertEqual(len(dict_back.b_factor_list), 644)
             self.assertEqual(len(dict_back.occupancy_list), 644)
             self.assertEqual(dict_back.x_coord_list[5], 20.022)
-            self.assertEqual(set(dict_back.ins_code_list), set(["\x00"]))
-            self.assertEqual(set(dict_back.alt_loc_list), set(["\x00"]))
+            self.assertEqual(set(dict_back.ins_code_list), {"\x00"})
+            self.assertEqual(set(dict_back.alt_loc_list), {"\x00"})
             self.assertEqual(list(dict_back.atom_id_list), list(range(1, 645)))
             self.assertEqual(list(dict_back.sequence_index_list), list(range(70)) + [-1] * 88)
             self.assertEqual(dict_back.chain_id_list, ["A", "B"])
@@ -151,8 +151,7 @@ class WriteMMTF(unittest.TestCase):
             self.assertEqual(len(dict_back.entity_list), 2)
             self.assertEqual(dict_back.entity_list[0]["type"], "polymer")
             self.assertEqual(dict_back.entity_list[0]["chainIndexList"], [0])
-            self.assertEqual(dict_back.entity_list[0]["sequence"],
-                                "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQNANPDCKTILKALGPGATLEEMMTACQG")
+            self.assertEqual(dict_back.entity_list[0]["sequence"], "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQNANPDCKTILKALGPGATLEEMMTACQG")
             self.assertEqual(dict_back.entity_list[1]["type"], "water")
             self.assertEqual(dict_back.entity_list[1]["chainIndexList"], [1])
             self.assertEqual(dict_back.entity_list[1]["sequence"], "")
@@ -208,7 +207,7 @@ class WriteMMTF(unittest.TestCase):
             dict_back = mmtf.parse(filename)
             self.assertEqual(dict_back.num_atoms, 116)
             self.assertEqual(len(dict_back.x_coord_list), 116)
-            self.assertEqual(set(dict_back.alt_loc_list), set(["\x00", "A", "B"]))
+            self.assertEqual(set(dict_back.alt_loc_list), {"\x00", "A", "B"})
         finally:
             os.remove(filename)
 

--- a/Tests/test_mmtf.py
+++ b/Tests/test_mmtf.py
@@ -1,5 +1,6 @@
 # Copyright 2016 by Anthony Bradley.  All rights reserved.
 # Revisions copyright 2017 by Peter Cock.  All rights reserved.
+# Revisions copyright 2019 by Joe Greener.  All rights reserved.
 # This file is part of the Biopython distribution and governed by your
 # choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
 # Please see the LICENSE file that should have been included as part of this
@@ -9,9 +10,13 @@
 
 import unittest
 import warnings
-from Bio.PDB.mmtf import MMTFParser
+import os
+import tempfile
+from Bio.PDB import PDBParser, Select
+from Bio.PDB.mmtf import MMTFParser, MMTFIO
 from Bio.PDB.MMCIFParser import MMCIFParser
 from Bio.PDB.PDBExceptions import PDBConstructionWarning
+import mmtf
 
 
 class ParseMMTF(unittest.TestCase):
@@ -104,6 +109,108 @@ class SimpleParseMMTF(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", PDBConstructionWarning)
             structure = MMTFParser.get_structure("PDB/1A8O.mmtf")
+
+
+class WriteMMTF(unittest.TestCase):
+    """Write some MMTF files, read them back in and check them."""
+
+    def test_write(self):
+        """Test a simple structure object is written out correctly to MMTF."""
+        parser = MMCIFParser()
+        struc = parser.get_structure("1A8O", "PDB/1A8O.cif")
+        io = MMTFIO()
+        io.set_structure(struc)
+        filenumber, filename = tempfile.mkstemp()
+        os.close(filenumber)
+        try:
+            io.save(filename)
+            struc_back = MMTFParser.get_structure(filename)
+            dict_back = mmtf.parse(filename)
+            self.assertEqual(dict_back.structure_id, "1A8O")
+            self.assertEqual(dict_back.num_models, 1)
+            self.assertEqual(dict_back.num_chains, 2)
+            self.assertEqual(dict_back.num_groups, 158)
+            self.assertEqual(dict_back.num_atoms, 644)
+            self.assertEqual(len(dict_back.x_coord_list), 644)
+            self.assertEqual(len(dict_back.y_coord_list), 644)
+            self.assertEqual(len(dict_back.z_coord_list), 644)
+            self.assertEqual(len(dict_back.b_factor_list), 644)
+            self.assertEqual(len(dict_back.occupancy_list), 644)
+            self.assertEqual(dict_back.x_coord_list[5], 20.022)
+            self.assertEqual(set(dict_back.ins_code_list), set(["\x00"]))
+            self.assertEqual(set(dict_back.alt_loc_list), set(["\x00"]))
+            self.assertEqual(list(dict_back.atom_id_list), list(range(1, 645)))
+            self.assertEqual(list(dict_back.sequence_index_list), list(range(70)) + [-1] * 88)
+            self.assertEqual(dict_back.chain_id_list, ["A", "B"])
+            self.assertEqual(dict_back.chain_name_list, ["A", "A"])
+            self.assertEqual(dict_back.chains_per_model, [2])
+            self.assertEqual(len(dict_back.group_list), 21)
+            self.assertEqual(len(dict_back.group_id_list), 158)
+            self.assertEqual(len(dict_back.group_type_list), 158)
+            self.assertEqual(dict_back.groups_per_chain, [70, 88])
+            self.assertEqual(len(dict_back.entity_list), 2)
+            self.assertEqual(dict_back.entity_list[0]["type"], "polymer")
+            self.assertEqual(dict_back.entity_list[0]["chainIndexList"], [0])
+            self.assertEqual(dict_back.entity_list[0]["sequence"],
+                                "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQNANPDCKTILKALGPGATLEEMMTACQG")
+            self.assertEqual(dict_back.entity_list[1]["type"], "water")
+            self.assertEqual(dict_back.entity_list[1]["chainIndexList"], [1])
+            self.assertEqual(dict_back.entity_list[1]["sequence"], "")
+        finally:
+            os.remove(filename)
+
+    def test_multi_model_write(self):
+        """Test multiple models are written out correctly to MMTF."""
+        parser = PDBParser()
+        struc = parser.get_structure("1SSU_mod", "PDB/1SSU_mod.pdb")
+        io = MMTFIO()
+        io.set_structure(struc)
+        filenumber, filename = tempfile.mkstemp()
+        os.close(filenumber)
+        try:
+            io.save(filename)
+            struc_back = MMTFParser.get_structure(filename)
+            dict_back = mmtf.parse(filename)
+            self.assertEqual(dict_back.num_models, 2)
+            self.assertEqual(dict_back.num_chains, 4)
+            self.assertEqual(dict_back.num_groups, 4)
+            self.assertEqual(dict_back.num_atoms, 4)
+            self.assertEqual(list(dict_back.x_coord_list), [-1.058, -0.025, 7.024, 6.259])
+            self.assertEqual(dict_back.chain_id_list, ["A", "B", "A", "B"])
+            self.assertEqual(dict_back.chain_name_list, ["A", "B", "A", "B"])
+            self.assertEqual(dict_back.chains_per_model, [2, 2])
+            self.assertEqual(len(dict_back.group_list), 1)
+            self.assertEqual(len(dict_back.group_id_list), 4)
+            self.assertEqual(len(dict_back.group_type_list), 4)
+            self.assertEqual(dict_back.groups_per_chain, [1, 1, 1, 1])
+            self.assertEqual(len(dict_back.entity_list), 4)
+        finally:
+            os.remove(filename)
+
+    def test_selection_write(self):
+        """Test the use of a Select subclass when writing MMTF files."""
+        struc = MMTFParser.get_structure("PDB/4CUP.mmtf")
+        io = MMTFIO()
+        io.set_structure(struc)
+        filenumber, filename = tempfile.mkstemp()
+        os.close(filenumber)
+
+        class CAonly(Select):
+            """Accepts only CA residues."""
+
+            def accept_atom(self, atom):
+                if atom.name == "CA" and atom.element == "C":
+                    return 1
+
+        try:
+            io.save(filename, CAonly())
+            struc_back = MMTFParser.get_structure(filename)
+            dict_back = mmtf.parse(filename)
+            self.assertEqual(dict_back.num_atoms, 116)
+            self.assertEqual(len(dict_back.x_coord_list), 116)
+            self.assertEqual(set(dict_back.alt_loc_list), set(["\x00", "A", "B"]))
+        finally:
+            os.remove(filename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I think a [MMTF](http://mmtf.rcsb.org) file writer would be great, and would complete the last of the 6 {PDB, mmCIF, MMTF}{read, write} combinations.

I took inspiration from #1956 where this is discussed and expanded @harryjubb's code into a `MMTFIO` class. It seems to work using a simple test like:

```python
from Bio.PDB import PDBParser
from Bio.PDB.mmtf import MMTFIO, MMTFParser

pdb_parser = PDBParser()
structure = pdb_parser.get_structure("1xkk", "1xkk.pdb")

mmtf_writer = MMTFIO()
mmtf_writer.set_structure(structure)
mmtf_writer.save("1xkk.mmtf")

structure_back = MMTFParser.get_structure("1xkk.mmtf")
```

@harryjubb do you mind me using your code as a basis here? Your name being added to contributors too of course.

Still work in progress, needs testing and docs. Doesn't write bonding information but personally I don't use that information much, not sure if others need that feature though.

Work ongoing at CoFest2019!

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
