### PR TITLE
Latex added empty lines before %doctest and %cont-doctest

### DIFF
--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -189,6 +189,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Mike Poidinger <Michael.Poidinger at domain eBioinformatics.com>
 - Milind Luthra <https://github.com/milindl>
 - morrme <https://github.com/morrme>
+- Mustafa Anil Tuncel <https://github.com/anilbey>
 - Nader Morshed <https://github.com/naderm>
 - Nate Sutton <https://github.com/nmsutton>
 - Nathan J. Edwards <nje5 at edu domain georgetown>

--- a/Doc/Tutorial/chapter_advanced.tex
+++ b/Doc/Tutorial/chapter_advanced.tex
@@ -296,3 +296,4 @@ Any one of the following may be done to geerate the frequency table (ftab):
 
 \end{enumerate}
 
+

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2224,3 +2224,4 @@ LSPADKTNVKAA
 >>> print(alignment.score)
 16.0
 \end{minted}
+

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -815,6 +815,7 @@ Depending on what you are doing, it can be more useful to turn the alignment
 object into an array of letters -- and you can do this with NumPy:
 
 %This example fails under PyPy 2.0, https://bugs.pypy.org/issue1546
+
 %doctest examples lib:numpy
 \begin{minted}{pycon}
 >>> import numpy as np
@@ -1595,6 +1596,7 @@ We refer to Durbin \textit{et al.} \cite{durbin1998} for in-depth information on
 \label{sec:pairwise-basic}
 
 To generate pairwise alignments, first create a \verb+PairwiseAligner+ object:
+
 %doctest examples
 \begin{minted}{pycon}
 >>> from Bio import Align
@@ -1606,6 +1608,7 @@ stores the alignment parameters to be used for the pairwise alignments.
 
 Use the \verb+aligner.score+ method to calculate the alignment score between
 two sequences:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> seq1 = "GAACT"
@@ -1616,6 +1619,7 @@ two sequences:
 \end{minted}
 
 To see the actual alignments, use the \verb+aligner.align+ method and iterate over the \verb+PairwiseAlignment+ objects returned:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> alignments = aligner.align(seq1, seq2)
@@ -1664,6 +1668,7 @@ Note that there is some ambiguity in the definition of the best local alignments
 
 The \verb+PairwiseAligner+ object stores all alignment parameters to be used
 for the pairwise alignments. To see an overview of the values for all parameters, use
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(aligner)
@@ -1692,6 +1697,7 @@ Depending on the gap scoring parameters
 (see Sections~\ref{sec:pairwise-affine-gapscores} and
 \ref{sec:pairwise-general-gapscores}) and mode, a \verb+PairwiseAligner+ object
 automatically chooses the appropriate algorithm to use for pairwise sequence alignment. To verify the selected algorithm, use
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> aligner.algorithm
@@ -1700,6 +1706,8 @@ automatically chooses the appropriate algorithm to use for pairwise sequence ali
 This attribute is read-only.
 
 A \verb+PairwiseAligner+ object also stores the precision $\epsilon$ to be used during alignment. The value of $\epsilon$ is stored in the attribute \verb+aligner.epsilon+, and by default is equal to $10^{-6}$:
+
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> aligner.epsilon
@@ -1712,6 +1720,7 @@ Two scores will be considered equal to each other for the purpose of the alignme
 
 The match and mismatch scores are stored as attributes of an \verb+PairwiseAligner+
 object:
+
 %doctest examples
 \begin{minted}{pycon}
 >>> from Bio import Align
@@ -1730,6 +1739,7 @@ object:
 \end{minted}
 
 Alternatively, you can specify a substitution matrix as follows:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> matrix = {('A','A'): 1.0, ('A','B'): -1.0, ('B','B'): 2.0}
@@ -1744,6 +1754,7 @@ specifying \verb+aligner.match_score+ or \verb+aligner.mismatch_score+,
 Note that \verb+aligner.substitution_matrix+ will return a copy of the
 substitution matrix stored in the \verb+PairwiseAligner+ object. Therefore,
 modifying the substitution matrix directly has no effect:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> aligner.substitution_matrix[('A','A')] = 5.0 # does nothing
@@ -1910,6 +1921,7 @@ The \verb+alignments+ returned by \verb+aligner.align+ are a kind of immutable i
 You can perform the following operations on \verb+alignments+:
 \begin{itemize}
 \item \verb+len(alignments)+ returns the number of alignments stored. This function returns quickly, even if the number of alignments is huge. If the number of alignments is extremely large (typically, larger than 9,223,372,036,854,775,807, which is the largest integer that can be stored as a \verb+long int+ on 64 bit machines), \verb+len(alignments)+ will raise an \verb+OverflowError+. A large number of alignments suggests that the alignment quality is low.
+
 %doctest examples
 \begin{minted}{pycon}
 >>> from Bio import Align
@@ -1919,6 +1931,7 @@ You can perform the following operations on \verb+alignments+:
 3
 \end{minted}
 \item You can extract a specific alignment by index:
+
 %doctest examples
 \begin{minted}{pycon}
 >>> from Bio import Align
@@ -1942,6 +1955,7 @@ AA-
 ...
 \end{minted}
 Note that \verb+alignments+ can be reused, i.e. you can iterate over alignments multiple times:
+
 %doctest examples
 \begin{minted}{pycon}
 >>> from Bio import Align
@@ -1984,6 +1998,7 @@ You can also convert the \verb+alignments+ iterator into a \verb+list+ or \verb+
 \end{minted}
 It is wise to check the number of alignments by calling \verb+len(alignments)+ before attempting to call \verb+list(alignments)+ to save all alignments as a list.
 \item The alignment score (which has the same value for each alignment in \verb+alignments+), is stored as an attribute. This allows you to check the alignment score before proceeding to extract individual alignments:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignments.score)
@@ -1993,6 +2008,7 @@ It is wise to check the number of alignments by calling \verb+len(alignments)+ b
 
 \subsubsection{Alignment objects}
 The \verb+aligner.align+ method returns \verb+PairwiseAlignment+ objects, each representing one alignment between the two sequences.
+
 %doctest
 \begin{minted}{pycon}
 >>> from Bio import Align
@@ -2008,12 +2024,14 @@ The \verb+aligner.align+ method returns \verb+PairwiseAlignment+ objects, each r
 \end{minted}
 
 Each alignment stores the alignment score:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> alignment.score
 3.0
 \end{minted}
 as well as pointers to the sequences that were aligned:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> alignment.target
@@ -2023,6 +2041,7 @@ as well as pointers to the sequences that were aligned:
 \end{minted}
 
 Print the \verb+PairwiseAlignment+ object to show the alignment explicitly:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment)
@@ -2033,6 +2052,7 @@ GA--T
 \end{minted}
 
 You can also represent the alignment as a string in PSL (Pattern Space Layout, as generated by BLAT \cite{kent2002}) format:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> format(alignment, 'psl')
@@ -2049,12 +2069,14 @@ chunks, you get two tuples of length N:
 \end{minted}
 
 In the current example, `alignment.aligned` returns two tuples of length 2:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> alignment.aligned
 (((0, 2), (4, 5)), ((0, 2), (2, 3)))
 \end{minted}
 while for the alternative alignment, two tuples of length 3 are returned:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> alignment = alignments[1]
@@ -2067,6 +2089,7 @@ G-A-T
 (((0, 1), (2, 3), (4, 5)), ((0, 1), (1, 2), (2, 3)))
 \end{minted}
 Note that different alignments may have the same subsequences aligned to each other. In particular, this may occur if alignments differ from each other in terms of their gap placement only:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> aligner.mismatch_score = -10
@@ -2110,6 +2133,7 @@ stored in \texttt{alpha.faa} and \texttt{beta.faa}:
 \end{minted}
 
 showing an alignment score of 72.0. To see the individual alignments, do
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> alignments = aligner.align(seq1.seq, seq2.seq)
@@ -2121,6 +2145,7 @@ In this example, the total number of optimal alignments is huge (more than $4 \t
 OverflowError: number of optimal alignments is larger than 9223372036854775807
 \end{minted}
 Let's have a look at the first alignment:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> alignment = alignments[0]
@@ -2128,6 +2153,7 @@ Let's have a look at the first alignment:
 
 The alignment object stores the alignment score, as well as the alignment
 itself:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment.score)
@@ -2180,6 +2206,7 @@ This alignment has the same score that we obtained earlier with EMBOSS needle
 using the same sequences and the same parameters.
 
 To perform a local alignment, set \verb+aligner.mode+ to \verb+'local'+:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> aligner.mode = 'local'

--- a/Doc/Tutorial/chapter_appendix.tex
+++ b/Doc/Tutorial/chapter_appendix.tex
@@ -110,3 +110,4 @@ A string
 >>> print(second_line)
  with multiple lines.
 \end{minted}
+

--- a/Doc/Tutorial/chapter_blast.tex
+++ b/Doc/Tutorial/chapter_blast.tex
@@ -501,3 +501,4 @@ You can use the \verb|Bio.Blast.NCBIXML| parser to read the XML output from
 current versions of RPS-BLAST.
 
 
+

--- a/Doc/Tutorial/chapter_cluster.tex
+++ b/Doc/Tutorial/chapter_cluster.tex
@@ -1001,3 +1001,4 @@ Similarly, we can save a $k$-means clustering solution:
 \end{minted}
 
 This will create the files \verb|cyano_result_K_G2_A2.cdt|, \verb|cyano_result_K_G2.kgg|, and \verb|cyano_result_K_A2.kag|.
+

--- a/Doc/Tutorial/chapter_cluster.tex
+++ b/Doc/Tutorial/chapter_cluster.tex
@@ -972,6 +972,7 @@ The example data \verb|cyano.txt| can be found in Biopython's \verb|Tests/Cluste
 
 %all cyano_result* files created here during the run of test_Tutorial.py are 
 %after automatically deleted at the end of the test run.
+
 %doctest ../Tests/Cluster lib:numpy
 \begin{minted}{pycon}
 >>> from Bio import Cluster

--- a/Doc/Tutorial/chapter_contributing.tex
+++ b/Doc/Tutorial/chapter_contributing.tex
@@ -113,3 +113,4 @@ Hopefully this documentation has got you excited enough about
 Biopython to try it out (and most importantly, contribute!). Thanks
 for reading all the way through!
 
+

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1703,3 +1703,4 @@ thing as if you had loaded the GenBank file directly as a SeqRecord using
 Biopython's BioSQL module is currently documented at
 \url{http://biopython.org/wiki/BioSQL} which is part of our wiki pages.
 
+

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -1082,6 +1082,7 @@ This returns a Python list containing all of the PubMed IDs of articles related 
 \end{minted}
 
 Now that we've got them, we obviously want to get the corresponding Medline records and extract the information from them. Here, we'll download the Medline records in the Medline flat-file format, and use the \verb+Bio.Medline+ module to parse them:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> from Bio import Medline
@@ -1093,6 +1094,7 @@ Now that we've got them, we obviously want to get the corresponding Medline reco
 NOTE - We've just done a separate search and fetch here, the NCBI much prefer you to take advantage of their history support in this situation.  See Section~\ref{sec:entrez-webenv}.
 
 Keep in mind that \verb+records+ is an iterator, so you can iterate through the records only once. If you want to save the records, you can convert them to a list:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> records = list(records)
@@ -1327,6 +1329,7 @@ Staying with a plant example, let's now find the lineage of the Cypripedioideae 
 '158330'
 \end{minted}
 Now, we use \verb+efetch+ to download this entry in the Taxonomy database, and then parse it:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> handle = Entrez.efetch(db="Taxonomy", id="158330", retmode="xml")
@@ -1512,3 +1515,4 @@ Now, let's do that all again but with the history \ldots
 \textit{TODO}.
 
 And finally, don't forget to include your \emph{own} email address in the Entrez calls.
+

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -41,6 +41,7 @@ Include \verb|api_key="MyAPIkey"| in the argument list or set it as a module lev
 >>> Entrez.api_key = "MyAPIkey"
 \end{minted}
 \item Use the optional email parameter so the NCBI can contact you if there is a problem.  You can either explicitly set this as a parameter with each call to Entrez (e.g. include \texttt{email="A.N.Other@example.com"} in the argument list), or you can set a global email address:
+
 %doctest
 \begin{minted}{pycon}
 >>> from Bio import Entrez
@@ -48,6 +49,7 @@ Include \verb|api_key="MyAPIkey"| in the argument list or set it as a module lev
 \end{minted}
 \texttt{Bio.Entrez} will then use this email address with each call to Entrez.  The \texttt{example.com} address is a reserved domain name specifically for documentation (RFC 2606).  Please DO NOT use a random email -- it's better not to give an email at all. The email parameter has been mandatory since June 1, 2010. In case of excessive usage, NCBI will attempt to contact a user at the e-mail address provided prior to blocking access to the E-utilities.
 \item If you are using Biopython within some larger software suite, use the tool parameter to specify this.  You can either explicitly set the tool name as a parameter with each call to Entrez (e.g. include \texttt{tool="MyLocalScript"} in the argument list), or you can set a global tool name:
+
 %doctest
 \begin{minted}{pycon}
 >>> from Bio import Entrez
@@ -63,6 +65,7 @@ In conclusion, be sensible with your usage levels.  If you plan to download lots
 \label{sec:entrez-einfo}
 EInfo provides field index term counts, last update, and available links for each of NCBI's databases. In addition, you can use EInfo to obtain a list of all database names accessible through the Entrez utilities:
 %Run this as a doctest in current directory, requires internet access!
+
 %doctest . internet
 \begin{minted}{pycon}
 >>> from Bio import Entrez
@@ -121,6 +124,7 @@ The variable \verb+result+ now contains a list of databases in XML format:
 \end{minted}
 
 Since this is a fairly simple XML file, we could extract the information it contains simply by string searching. Using \verb+Bio.Entrez+'s parser instead, we can directly parse this XML file into a Python object:
+
 %doctest . internet
 \begin{minted}{pycon}
 >>> from Bio import Entrez
@@ -146,6 +150,7 @@ The values stored in this key is the list of database names shown in the XML abo
 \end{minted}
 
 For each of these databases, we can use EInfo again to obtain more information:
+
 %doctest . internet
 \begin{minted}{pycon}
 >>> from Bio import Entrez
@@ -192,6 +197,7 @@ familiar with a particular database.
 \section{ESearch: Searching the Entrez databases}
 \label{sec:entrez-esearch}
 To search any of these databases, we use \verb+Bio.Entrez.esearch()+. For example, let's search in PubMed for publications related to Biopython:
+
 %doctest . internet
 \begin{minted}{pycon}
 >>> from Bio import Entrez
@@ -277,6 +283,7 @@ Let's look at a simple example to see how EPost works -- uploading some PubMed i
 \end{minted}
 \noindent The returned XML includes two important strings, \verb|QueryKey| and \verb|WebEnv| which together define your history session.
 You would extract these values for use with another Entrez call such as EFetch:
+
 %doctest . internet
 \begin{minted}{pycon}
 >>> from Bio import Entrez
@@ -290,6 +297,7 @@ You would extract these values for use with another Entrez call such as EFetch:
 
 \section{ESummary: Retrieving summaries from primary IDs}
 ESummary retrieves document summaries from a list of primary IDs (see the  \href{https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESummary}{ESummary help page} for more information). In Biopython, ESummary is available as \verb+Bio.Entrez.esummary()+. Using the search result above, we can for example find out more about the journal with ID 30367:
+
 %doctest . internet
 \begin{minted}{pycon}
 >>> from Bio import Entrez
@@ -662,6 +670,7 @@ Three things can go wrong when parsing an XML file:
 \end{itemize}
 
 The first case occurs if, for example, you try to parse a Fasta file as if it were an XML file:
+
 %doctest ../Tests/GenBank
 \begin{minted}{pycon}
 >>> from Bio import Entrez
@@ -743,6 +752,7 @@ Traceback (most recent call last):
 Bio.Entrez.Parser.ValidationError: Failed to find tag 'DocsumList' in the DTD. To skip all tags that are not represented in the DTD, please call Bio.Entrez.read or Bio.Entrez.parse with validate=False.
 \end{minted}
 Optionally, you can instruct the parser to skip such tags instead of raising a ValidationError. This is done by calling \verb|Entrez.read| or \verb|Entrez.parse| with the argument \verb|validate| equal to False:
+
 %doctest ../Tests/Entrez/
 \begin{minted}{pycon}
 >>> from Bio import Entrez
@@ -785,6 +795,7 @@ AB  - Bioinformatics research is often difficult to do with commercial software.
 ...
 \end{minted}
 We first open the file and then parse it:
+
 %doctest ../Tests/Medline
 \begin{minted}{pycon}
 >>> from Bio import Medline
@@ -793,6 +804,7 @@ We first open the file and then parse it:
 ...
 \end{minted}
 The \verb+record+ now contains the Medline record as a Python dictionary:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> record["PMID"]
@@ -816,6 +828,7 @@ The key names used in a Medline record can be rather obscure; use
 for a brief summary.
 
 To parse a file containing multiple Medline records, you can use the \verb+parse+ function instead:
+
 %doctest ../Tests/Medline
 \begin{minted}{pycon}
 >>> from Bio import Medline
@@ -1049,6 +1062,7 @@ In this example, we will query PubMed for all articles having to do with orchids
 \end{minted}
 
 Now we use the \verb+Bio.Entrez.efetch+ function to download the PubMed IDs of these 463 articles:
+
 %doctest . internet
 \begin{minted}{pycon}
 >>> from Bio import Entrez
@@ -1300,6 +1314,7 @@ Finally, if plan to repeat your analysis, rather than downloading the files from
 \subsection{Finding the lineage of an organism}
 
 Staying with a plant example, let's now find the lineage of the Cypripedioideae orchid family. First, we search the Taxonomy database for Cypripedioideae, which yields exactly one NCBI taxonomy identifier:
+
 %doctest . internet
 \begin{minted}{pycon}
 >>> from Bio import Entrez

--- a/Doc/Tutorial/chapter_graphics.tex
+++ b/Doc/Tutorial/chapter_graphics.tex
@@ -1093,3 +1093,4 @@ here:
 in Figure~\ref{fig:simplechromosome}.
 \end{latexonly}
 
+

--- a/Doc/Tutorial/chapter_introduction.tex
+++ b/Doc/Tutorial/chapter_introduction.tex
@@ -271,3 +271,4 @@ from __future__ import print_function
 \end{enumerate}
 
 \noindent For more general questions, the Python FAQ pages \url{https://docs.python.org/3/faq/index.html} may be useful.
+

--- a/Doc/Tutorial/chapter_kegg.tex
+++ b/Doc/Tutorial/chapter_kegg.tex
@@ -101,3 +101,4 @@ The KEGG API wrapper is compatible with all endpoints. Usage is essentially repl
 /find/compound/300-310/mol_weight	 -> REST.kegg_find("compound", "300-310", "mol_weight")
 /get/hsa:10458+ece:Z5100/aaseq	    -> REST.kegg_get(["hsa:10458", "ece:Z5100"], "aaseq")
 \end{minted}
+

--- a/Doc/Tutorial/chapter_learning.tex
+++ b/Doc/Tutorial/chapter_learning.tex
@@ -416,3 +416,4 @@ This section will describe the \verb|Bio.MaximumEntropy| module.
 
 This section will describe the \verb|Bio.MarkovModel| and/or \verb|Bio.HMM.MarkovModel| modules.
 
+

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -40,6 +40,7 @@ or motif finding software.
 \subsection{Creating a motif from instances}
 
 Suppose we have these instances of a DNA motif:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
@@ -53,12 +54,14 @@ Suppose we have these instances of a DNA motif:
 ...             ]
 \end{minted}
 then we can create a Motif object as follows:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> m = motifs.create(instances)
 \end{minted}
 The instances are saved in an attribute \verb+m.instances+, which is essentially a Python list with some added functionality, as described below.
 Printing out the Motif object shows the instances from which it was constructed:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(m)
@@ -72,6 +75,7 @@ AATGC
 <BLANKLINE>
 \end{minted}
 The length of the motif is defined as the sequence length, which should be the same for all instances:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> len(m)
@@ -79,6 +83,7 @@ The length of the motif is defined as the sequence length, which should be the s
 \end{minted}
 The Motif object has an attribute \verb+.counts+ containing the counts of each
 nucleotide at each position. Printing this counts matrix shows it in an easily readable format:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(m.counts)
@@ -91,6 +96,7 @@ T:   4.00   0.00   2.00   0.00   0.00
 \end{minted}
 
 You can access these counts as a dictionary:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> m.counts["A"]
@@ -98,6 +104,7 @@ You can access these counts as a dictionary:
 \end{minted}
 but you can also think of it as a 2D array with the nucleotide as the first
 dimension and the position as the second dimension:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> m.counts["T", 0]
@@ -115,6 +122,7 @@ You can also directly access columns of the counts matrix
 \end{minted}
 Instead of the nucleotide itself, you can also use the index of the nucleotide
 in the alphabet of the motif:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> m.alphabet
@@ -127,6 +135,7 @@ in the alphabet of the motif:
 The motif has an associated consensus sequence, defined as the sequence of
 letters along the positions of the motif for which the largest value in the
 corresponding columns of the \verb+.counts+ matrix is obtained:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> m.consensus
@@ -134,6 +143,7 @@ Seq('TACGC')
 \end{minted}
 as well as an anticonsensus sequence, corresponding to the smallest values in
 the columns of the \verb+.counts+ matrix:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> m.anticonsensus
@@ -144,6 +154,7 @@ Note that there is some ambiguity in the definition of the consensus and anticon
 You can also ask for a degenerate consensus sequence, in which ambiguous
 nucleotides are used for positions where there are multiple nucleotides with
 high counts:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> m.degenerate_consensus
@@ -154,6 +165,7 @@ and V is A, C, or G \cite{cornish1985}. The degenerate consensus sequence is
 constructed following the rules specified by Cavener \cite{cavener1987}.
 
 We can also get the reverse complement of a motif:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> r = m.reverse_complement()
@@ -233,6 +245,7 @@ aggaatCGCGTGc
 The parts of the sequence in capital letters are the motif instances that were found to align to each other.
 
 We can create a \verb+Motif+ object from these instances as follows:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> from Bio import motifs
@@ -241,6 +254,7 @@ We can create a \verb+Motif+ object from these instances as follows:
 ...
 \end{minted}
 The instances from which this motif was created is stored in the \verb+.instances+ property:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(arnt.instances[:3])
@@ -270,6 +284,7 @@ AACGTG
 CGCGTG
 \end{minted}
 The counts matrix of this motif is automatically calculated from the instances:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(arnt.counts)
@@ -295,6 +310,7 @@ For example, this is the JASPAR file \verb+SRF.pfm+ containing the counts matrix
  4 2 0 0 13 42 0 45 3 30 0 0
 \end{minted}
 We can create a motif for this count matrix as follows:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> with open("SRF.pfm") as handle:
@@ -309,12 +325,14 @@ T:   4.00   2.00   0.00   0.00  13.00  42.00   0.00  45.00   3.00  30.00   0.00 
 <BLANKLINE>
 \end{minted}
 As this motif was created from the counts matrix directly, it has no instances associated with it:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(srf.instances)
 None
 \end{minted}
 We can now ask for the consensus sequence of these two motifs:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(arnt.counts.consensus)
@@ -574,6 +592,7 @@ probability       G  ::::1::94:4:
 matrix            T  aa:1::9::11:
 \end{minted}
 To parse this file (stored as \verb+meme.dna.oops.txt+), use
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> with open("meme.dna.oops.txt") as handle:
@@ -583,6 +602,7 @@ To parse this file (stored as \verb+meme.dna.oops.txt+), use
 The \verb+motifs.parse+ command reads the complete file directly, so you can
 close the file after calling \verb+motifs.parse+.
 The header information is stored in attributes:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> record.version
@@ -598,6 +618,7 @@ The header information is stored in attributes:
 \end{minted}
 The record is an object of the \verb+Bio.motifs.meme.Record+ class.
 The class inherits from list, and you can think of \verb+record+ as a list of Motif objects:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> len(record)
@@ -610,6 +631,7 @@ TTCACATGSCNC
 \end{minted}
 In addition to these generic motif attributes, each motif also stores its
 specific information as calculated by MEME. For example,
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> motif.num_occurrences
@@ -624,12 +646,14 @@ specific information as calculated by MEME. For example,
 \end{minted}
 In addition to using an index into the record, as we did above,
 you can also find it by its name:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> motif = record["Motif 1"]
 \end{minted}
 Each motif has an attribute \verb+.instances+ with the sequence instances
 in which the motif was found, providing some information on each instance:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> len(motif.instances)
@@ -704,6 +728,7 @@ P0      A      C      G      T
 //
 \end{minted}
 To parse a TRANSFAC file, use
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> with open("transfac.dat") as handle:
@@ -717,6 +742,7 @@ If any discrepancies between the file contents and the TRANSFAC file format are 
 When parsing a non-compliant file, we recommend to check the record returned by \verb+motif.parse+ to ensure that it is consistent with the file contents.
 
 The overall version number, if available, is stored as \verb+record.version+:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> record.version
@@ -727,6 +753,7 @@ Each motif in \verb+record+ is in instance of the \verb+Bio.motifs.transfac.Moti
 class, which inherits both from the \verb+Bio.motifs.Motif+ class and
 from a Python dictionary. The dictionary uses the two-letter keys to
 store any additional information about the motif:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> motif = record[0]
@@ -785,6 +812,7 @@ references associated with the motif, using these two-letter keys:
 \end{table}
 
 Printing the motifs writes them out in their native TRANSFAC format:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(record)
@@ -857,6 +885,7 @@ T [  0.00   0.00   0.00   0.00  20.00   0.00]
 \end{minted}
 
 To write the motif in a TRANSFAC-like matrix format, use
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(m.format("transfac"))
@@ -873,6 +902,7 @@ XX
 
 To write out multiple motifs, you can use \verb+motifs.write+.
 This function can be used regardless of whether the motifs originated from a TRANSFAC file. For example,
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> two_motifs = [arnt, srf]
@@ -937,6 +967,7 @@ number of motif instances in the alignment, and can also prevent
 probabilities from becoming zero. To add a fixed pseudocount to all
 nucleotides at all positions, specify a number for the
 \verb+pseudocounts+ argument:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> pwm = m.counts.normalize(pseudocounts=0.5)
@@ -952,6 +983,7 @@ Alternatively, \verb+pseudocounts+ can be a dictionary specifying the
 pseudocounts for each nucleotide. For example, as the GC content of
 the human genome is about 40\%, you may want to choose the
 pseudocounts accordingly:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> pwm = m.counts.normalize(pseudocounts={"A":0.6, "C": 0.4, "G": 0.4, "T": 0.6})
@@ -965,6 +997,7 @@ T:   0.51   0.07   0.29   0.07   0.07
 \end{minted}
 The position-weight matrix has its own methods to calculate the
 consensus, anticonsensus, and degenerate consensus sequences:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> pwm.consensus
@@ -978,12 +1011,14 @@ Note that due to the pseudocounts, the degenerate consensus sequence
 calculated from the position-weight matrix is slightly different
 from the degenerate consensus sequence calculated from the instances
 in the motif:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> m.degenerate_consensus
 Seq('WACVC')
 \end{minted}
 The reverse complement of the position-weight matrix can be calculated directly from the \verb+pwm+:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> rpwm = pwm.reverse_complement()
@@ -1003,6 +1038,7 @@ it's easy to compute the log-odds ratios, telling us what are the log
 odds of a particular symbol to be coming from a motif against the
 background. We can use the \verb|.log_odds()| method on the position-weight
 matrix:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> pssm = pwm.log_odds()
@@ -1023,6 +1059,7 @@ This assumes that A, C, G, and T are equally likely in the background. To
 calculate the position-specific scoring matrix against a background with
 unequal probabilities for A, C, G, T, use the \verb+background+ argument.
 For example, against a background with a 40\% GC content, use
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> background = {"A":0.3,"C":0.2,"G":0.2,"T":0.3}
@@ -1038,6 +1075,7 @@ T:   0.77  -2.17  -0.05  -2.17  -2.17
 
 The maximum and minimum score obtainable from the PSSM are stored in the
 \verb+.max+ and \verb+.min+ properties:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print("%4.2f" % pssm.max)
@@ -1048,6 +1086,7 @@ The maximum and minimum score obtainable from the PSSM are stored in the
 
 The mean and standard deviation of the PSSM scores with respect to a specific
 background are calculated by the \verb+.mean+ and \verb+.std+ methods.
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> mean = pssm.mean(background)
@@ -1082,6 +1121,7 @@ sequence. For the sake of this section, we will use an artificial sequence like 
 
 The simplest way to find instances, is to look for exact matches of
 the true instances of the motif:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> for pos, seq in m.instances.search(test_seq):
@@ -1092,6 +1132,7 @@ the true instances of the motif:
 13 AACCC
 \end{minted}
 We can do the same with the reverse complement (to find instances on the complementary strand):
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> for pos, seq in r.instances.search(test_seq):
@@ -1104,6 +1145,7 @@ We can do the same with the reverse complement (to find instances on the complem
 \subsection{Searching for matches using the PSSM score}
 
 It's just as easy to look for positions, giving rise to high log-odds scores against our motif:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> for position, score in pssm.search(test_seq, threshold=3.0):
@@ -1159,12 +1201,14 @@ If you want to use a less arbitrary way of selecting thresholds, you
 can explore the distribution of PSSM scores. Since the space for a score
 distribution grows exponentially with motif length, we are using an
 approximation with a given precision to keep computation cost manageable:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> distribution = pssm.distribution(background=background, precision=10**4)
 \end{minted}
 The \verb+distribution+ object can be used to determine a number of different thresholds.
 We can specify the requested false-positive rate (probability of ``finding'' a motif instance in background generated sequence):
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> threshold = distribution.threshold_fpr(0.01)
@@ -1172,6 +1216,7 @@ We can specify the requested false-positive rate (probability of ``finding'' a m
 4.009
 \end{minted}
 or the false-negative rate (probability of ``not finding'' an instance generated from the motif):
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> threshold = distribution.threshold_fnr(0.1)
@@ -1179,6 +1224,7 @@ or the false-negative rate (probability of ``not finding'' an instance generated
 -0.510
 \end{minted}
 or a threshold (approximately) satisfying some relation between the false-positive rate and the false-negative rate ($\frac{\textrm{fnr}}{\textrm{fpr}}\simeq t$):
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> threshold = distribution.threshold_balanced(1000)
@@ -1188,6 +1234,7 @@ or a threshold (approximately) satisfying some relation between the false-positi
 or a threshold satisfying (roughly) the equality between the $-log$ of the
 false-positive rate and the information content (as used in patser software by
 Hertz and Stormo):
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> threshold = distribution.threshold_patser()
@@ -1198,6 +1245,7 @@ Hertz and Stormo):
 For example, in case of our motif, you can get the threshold giving
 you exactly the same results (for this sequence) as searching for
 instances with balanced threshold with rate of $1000$.
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> threshold = distribution.threshold_fpr(0.01)
@@ -1216,6 +1264,7 @@ Position -6: score = 4.601
 
 To facilitate searching for potential TFBSs using PSSMs, both the position-weight matrix and the position-specific scoring matrix are associated with each motif. Using the Arnt motif as an example:
 %TODO - Start a new doctest here?
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> from Bio import motifs
@@ -1248,6 +1297,7 @@ T:   -inf   -inf   -inf   -inf   2.00   -inf
 <BLANKLINE>
 \end{minted}
 The negative infinities appear here because the corresponding entry in the frequency matrix is 0, and we are using zero pseudocounts by default:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> for letter in "ACGT":
@@ -1259,6 +1309,7 @@ G: 0.00
 T: 0.00
 \end{minted}
 If you change the \verb+.pseudocounts+ attribute, the position-frequency matrix and the position-specific scoring matrix are recalculated automatically:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> motif.pseudocounts = 3.0
@@ -1281,6 +1332,7 @@ G:   0.09   0.12   0.09   0.72   0.09   0.72
 T:   0.09   0.09   0.09   0.09   0.72   0.09
 <BLANKLINE>
 \end{minted}
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(motif.pssm)
@@ -1294,6 +1346,7 @@ T:  -1.42  -1.42  -1.42  -1.42   1.52  -1.42
 You can also set the \verb+.pseudocounts+ to a dictionary over the four nucleotides if you want to use different pseudocounts for them. Setting \verb+motif.pseudocounts+ to \verb+None+ resets it to its default value of zero.
 
 The position-specific scoring matrix depends on the background distribution, which is uniform by default:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> for letter in "ACGT":
@@ -1305,6 +1358,7 @@ G: 0.25
 T: 0.25
 \end{minted}
 Again, if you modify the background distribution, the position-specific scoring matrix is recalculated:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> motif.background = {"A": 0.2, "C": 0.3, "G": 0.3, "T": 0.2}
@@ -1317,6 +1371,7 @@ T:  -1.09  -1.09  -1.09  -1.09   1.85  -1.09
 <BLANKLINE>
 \end{minted}
 Setting \verb+motif.background+ to \verb+None+ resets it to a uniform distribution:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> motif.background = None
@@ -1329,6 +1384,7 @@ G: 0.25
 T: 0.25
 \end{minted}
 If you set \verb+motif.background+ equal to a single value, it will be interpreted as the GC content:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> motif.background = 0.8
@@ -1341,18 +1397,21 @@ G: 0.40
 T: 0.10
 \end{minted}
 Note that you can now calculate the mean of the PSSM scores over the background against which it was computed:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print("%f" % motif.pssm.mean(motif.background))
 4.703928
 \end{minted}
 as well as its standard deviation:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print("%f" % motif.pssm.std(motif.background))
 3.290900
 \end{minted}
 and its distribution:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> distribution = motif.pssm.distribution(background=motif.background)
@@ -1388,6 +1447,7 @@ well as the corresponding offset in their alignment.
 To give an example, let us first load another motif,
 which is similar to our test motif \verb|m|:
 %TODO - Start a new doctest here?
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> with open("REB1.pfm") as handle:
@@ -1405,6 +1465,7 @@ T:  10.00 100.00 100.00   0.00   0.00   0.00   0.00  40.00  15.00
 \end{minted}
 
 To make the motifs comparable, we choose the same values for the pseudocounts and the background distribution as our motif \verb|m|:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> m_reb1.pseudocounts = {"A":0.6, "C": 0.4, "G": 0.4, "T": 0.6}
@@ -1421,6 +1482,7 @@ T:  -1.53   1.72   1.72  -5.67  -5.67  -5.67  -5.67   0.41  -0.97
 We'll compare these motifs using the Pearson correlation.
 Since we want it to resemble a distance measure, we actually take
 $1-r$, where $r$ is the Pearson correlation coefficient (PCC):
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> distance, offset = pssm.dist_pearson(pssm_reb1)
@@ -1505,5 +1567,6 @@ Seq('CTCAATCGTA')
 \item \href{https://en.wikipedia.org/wiki/Consensus_sequence}{Consensus sequence} in wikipedia
 \item \href{http://bio.cs.washington.edu/assessment/}{Comparison of different motif finding programs}
 \end{itemize}
+
 
 

--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -1263,3 +1263,4 @@ used by several LPCs (Large Pharmaceutical Companies :-).
 
 % Perhaps this section should be updated for other Biopython modules, and
 % moved to the Biopython FAQ above.
+

--- a/Doc/Tutorial/chapter_phenotype.tex
+++ b/Doc/Tutorial/chapter_phenotype.tex
@@ -269,3 +269,4 @@ or \href{https://combogenomics.github.io/DuctApe/}{DuctApe}.
 >>> phenotype.write(record, "out.json", "pm-json")
 1
 \end{minted}
+

--- a/Doc/Tutorial/chapter_phylo.tex
+++ b/Doc/Tutorial/chapter_phylo.tex
@@ -278,6 +278,7 @@ Write a tree or iterable of trees back to file with the \verb|write| function:
 
 %the files tree1.nwk and other_trees.nwk are created and then deleted during the
 %run of test_Tutorial.py
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> trees = list(Phylo.parse("../../Tests/PhyloXML/phyloxml_examples.xml", "phyloxml"))
@@ -795,5 +796,6 @@ for phylogenetics such as DendroPy (\url{https://dendropy.org/}) or
 PyCogent (\url{http://pycogent.org/}). Since these libraries also support
 standard file formats for phylogenetic trees, you can easily transfer data
 between libraries by writing to a temporary file or StringIO object.
+
 
 

--- a/Doc/Tutorial/chapter_popgen.tex
+++ b/Doc/Tutorial/chapter_popgen.tex
@@ -105,3 +105,4 @@ being planned for Biopython. These extensions won't break compatibility in
 any way with the standard format.  In the medium term, we would also like to
 support the GenePop web service.
 
+

--- a/Doc/Tutorial/chapter_quick_start.tex
+++ b/Doc/Tutorial/chapter_quick_start.tex
@@ -176,3 +176,4 @@ If you know what you want to do, but can't figure out how to do it, please feel 
 
 Enjoy the code!
 
+

--- a/Doc/Tutorial/chapter_searchio.tex
+++ b/Doc/Tutorial/chapter_searchio.tex
@@ -1173,3 +1173,4 @@ default values a BLAST tabular file requires, so it works just fine. However,
 other format conversions are less likely to work since you need to manually
 assign the required attributes first.
 
+

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -702,6 +702,7 @@ IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
 description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence',
 dbxrefs=['Project:58037'])
 \end{minted}
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> len(record)
@@ -761,6 +762,7 @@ IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
 description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence.',
 dbxrefs=[])
 \end{minted}
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> len(sub_record)
@@ -929,6 +931,7 @@ IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
 description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence.',
 dbxrefs=['Project:10638'])
 \end{minted}
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> len(record)
@@ -959,6 +962,7 @@ IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
 description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence.',
 dbxrefs=[])
 \end{minted}
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> len(shifted)
@@ -1041,4 +1045,5 @@ how most of the annotation is dropped (but not the features):
 >>> print("%s %i %i %i %i" % (rc.id, len(rc), len(rc.features), len(rc.dbxrefs), len(rc.annotations)))
 TESTING 9609 41 0 0
 \end{minted}
+
 

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -177,6 +177,7 @@ Seq('CGCTAAAAGCTAGGATATATCCGGGTAGCTAG', IUPACUnambiguousDNA())
 \label{sec:seq-to-string}
 
 If you really do just need a plain string, for example to write to a file, or insert into a database, then this is very easy to get:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> str(my_seq)
@@ -187,6 +188,7 @@ Since calling \verb|str()| on a \verb|Seq| object returns the full sequence as a
 you often don't actually have to do this conversion explicitly.
 Python does this automatically in the print function
 (and the print statement under Python 2):
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(my_seq)
@@ -194,6 +196,7 @@ GATCGATGGGCCTATATAGGATCGAAAATCGC
 \end{minted}
 
 You can also use the \verb|Seq| object directly with a \verb|%s| placeholder when using the Python string formatting or interpolation operator (\verb|%|):
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> fasta_format_string = ">Name\n%s\n" % my_seq
@@ -428,6 +431,7 @@ Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
 \noindent As you can see, all this does is switch T $\rightarrow$ U, and adjust the alphabet.
 
 If you do want to do a true biological transcription starting with the template strand, then this becomes a two-step process:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> template_dna.reverse_complement().transcribe()
@@ -485,6 +489,7 @@ You should notice in the above protein sequences that in addition to the end sto
 
 The translation tables available in Biopython are based on those \href{https://www.ncbi.nlm.nih.gov/Taxonomy/Utils/wprintgc.cgi}{from the NCBI} (see the next section of this tutorial).  By default, translation will use the \emph{standard} genetic code (NCBI table id 1).
 Suppose we are dealing with a mitochondrial sequence.  We need to tell the translation function to use the relevant genetic code instead:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna.translate(table="Vertebrate Mitochondrial")
@@ -492,6 +497,7 @@ Seq('MAIVMGRWKGAR*', HasStopCodon(IUPACProtein(), '*'))
 \end{minted}
 
 You can also specify the table using the NCBI table number which is shorter, and often included in the feature annotation of GenBank files:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna.translate(table=2)
@@ -500,6 +506,7 @@ Seq('MAIVMGRWKGAR*', HasStopCodon(IUPACProtein(), '*'))
 
 Now, you may want to translate the nucleotides up to the first in frame stop codon,
 and then stop (as happens in nature):
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna.translate()
@@ -516,6 +523,7 @@ is not translated - and the stop symbol is not included at the end of your prote
 sequence.
 
 You can even specify the stop symbol if you don't like the default asterisk:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna.translate(table=2, stop_symbol="@")
@@ -655,6 +663,7 @@ G | GTG V(s)| GCG A   | GAG E   | GGG G   | G
 
 You may find these following properties useful -- for example if you are trying
 to do your own gene finding:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> mito_table.stop_codons
@@ -906,4 +915,5 @@ there are module level functions in \verb|Bio.Seq| will accept plain Python stri
 \end{minted}
 
 \noindent You are, however, encouraged to work with \verb|Seq| objects by default.
+
 

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -401,6 +401,7 @@ encodes a short peptide:
 The actual biological transcription process works from the template strand, doing a reverse complement (TCAG $\rightarrow$ CUGA) to give the mRNA.  However, in Biopython and bioinformatics in general, we typically work directly with the coding strand because this means we can get the mRNA sequence just by switching T $\rightarrow$ U.
 
 Now let's actually get down to doing a transcription in Biopython.  First, let's create \verb|Seq| objects for the coding and template DNA strands:
+
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
@@ -415,6 +416,7 @@ Seq('CTATCGGGCACCCTTTCAGCGGCCCATTACAATGGCCAT', IUPACUnambiguousDNA())
 \noindent These should match the figure above - remember by convention nucleotide sequences are normally read from the 5' to 3' direction, while in the figure the template strand is shown reversed.
 
 Now let's transcribe the coding strand into the corresponding mRNA, using the \verb|Seq| object's built in \verb|transcribe| method:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna
@@ -433,6 +435,7 @@ Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
 \end{minted}
 
 The \verb|Seq| object also includes a back-transcription method for going from the mRNA to the coding strand of the DNA.  Again, this is a simple U $\rightarrow$ T substitution and associated change of alphabet:
+
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
@@ -466,6 +469,7 @@ Seq('MAIVMGR*KGAR*', HasStopCodon(IUPACProtein(), '*'))
 \end{minted}
 
 You can also translate directly from the coding strand DNA sequence:
+
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
@@ -583,6 +587,7 @@ translation table for Vertebrate Mitochondrial DNA.
 \end{minted}
 
 Alternatively, these tables are labeled with ID numbers 1 and 2, respectively:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> from Bio.Data import CodonTable
@@ -691,6 +696,7 @@ Now, in everyday use, your sequences will probably all have the same
 alphabet, or at least all be the same type of sequence (all DNA, all RNA, or
 all protein). What you probably want is to just compare the sequences as
 strings -- which you can do explicitly:
+
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
@@ -771,6 +777,7 @@ MutableSeq('GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA', IUPACUnambiguousDNA())
 \end{minted}
 
 Alternatively, you can create a \verb|MutableSeq| object directly from a string:
+
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import MutableSeq
@@ -779,6 +786,7 @@ Alternatively, you can create a \verb|MutableSeq| object directly from a string:
 \end{minted}
 
 Either way will give you a sequence object which can be changed:
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> mutable_seq

--- a/Doc/Tutorial/chapter_seqio.tex
+++ b/Doc/Tutorial/chapter_seqio.tex
@@ -338,6 +338,7 @@ Similarly if we had a bzip2 compressed file (sadly the function name isn't
 quite as consistent under Python 2):
 
 %TODO: Can we make the doctest code Python version specific?
+
 %doctest examples
 \begin{minted}{pycon}
 >>> import bz2
@@ -1164,6 +1165,7 @@ Now, if we want to save these reverse complements to a file, we'll need to make 
 We can use  the \verb|SeqRecord| object's built in \verb|.reverse_complement()| method (see Section~\ref{sec:SeqRecord-reverse-complement}) but we must decide how to name our new records.
 
 This is an excellent place to demonstrate the power of list comprehensions which make a list in memory:
+
 %doctest examples
 \begin{minted}{pycon}
 >>> from Bio import SeqIO

--- a/Doc/Tutorial/chapter_seqio.tex
+++ b/Doc/Tutorial/chapter_seqio.tex
@@ -687,6 +687,7 @@ As an example, let's use the same GenBank file as before:
 >>> orchid_dict.keys()
 ['Z78484.1', 'Z78464.1', 'Z78455.1', 'Z78442.1', 'Z78532.1', 'Z78453.1', ..., 'Z78471.1']
 \end{minted}
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> seq_record = orchid_dict["Z78475.1"]
@@ -1310,3 +1311,4 @@ including how to output FASTQ efficiently from strings using this code snippet:
 out_handle.write("@%s\n%s\n+\n%s\n" % (title, seq, qual))
 ...
 \end{minted}
+

--- a/Doc/Tutorial/chapter_testing.tex
+++ b/Doc/Tutorial/chapter_testing.tex
@@ -376,6 +376,7 @@ special \verb|%doctest| comment lines before each Python block,
 e.g.
 
 \begin{verbatim}
+
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Alphabet import generic_dna
@@ -390,6 +391,7 @@ continue from the previous Python block. Here we use the
 magic comment \verb|%cont-doctest| as shown here:
 
 \begin{verbatim}
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> Seq("ACGT") == Seq("ACGT", generic_dna)

--- a/Doc/Tutorial/chapter_testing.tex
+++ b/Doc/Tutorial/chapter_testing.tex
@@ -421,3 +421,4 @@ or:
 \begin{minted}{console}
 $ python run_tests.py test_Tutorial.py
 \end{minted}
+

--- a/Doc/Tutorial/chapter_uniprot.tex
+++ b/Doc/Tutorial/chapter_uniprot.tex
@@ -501,3 +501,4 @@ Other ScanProsite parameters can be passed as keyword arguments; see the \href{h
 7
 \end{minted}
 
+

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -20,8 +20,8 @@ Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
 - Konstantin Vdovkin
+- Mustafa Anil Tuncel
 - Peter Cock
-
 
 16 July 2019: Biopython 1.74
 ============================


### PR DESCRIPTION
This pull request addresses issue #...

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
