### PR TITLE
Apply black to genbank code

### DIFF
--- a/Bio/GenBank/Record.py
+++ b/Bio/GenBank/Record.py
@@ -46,7 +46,7 @@ def _wrapped_genbank(information, indent, wrap_space=1, split_char=" "):
         cur_pos = 0
         info_parts = []
         while cur_pos < len(information):
-            info_parts.append(information[cur_pos: cur_pos + info_length])
+            info_parts.append(information[cur_pos : cur_pos + info_length])
             cur_pos += info_length
 
     # first get the information string split up by line
@@ -149,16 +149,23 @@ class Record(object):
     GB_SEQUENCE_INDENT = 9
 
     BASE_FORMAT = "%-" + str(GB_BASE_INDENT) + "s"
-    INTERNAL_FORMAT = " " * GB_INTERNAL_INDENT + "%-" + \
-                      str(GB_BASE_INDENT - GB_INTERNAL_INDENT) + "s"
-    OTHER_INTERNAL_FORMAT = " " * GB_OTHER_INTERNAL_INDENT + "%-" + \
-                            str(GB_BASE_INDENT - GB_OTHER_INTERNAL_INDENT) + \
-                            "s"
+    INTERNAL_FORMAT = (
+        " " * GB_INTERNAL_INDENT + "%-" + str(GB_BASE_INDENT - GB_INTERNAL_INDENT) + "s"
+    )
+    OTHER_INTERNAL_FORMAT = (
+        " " * GB_OTHER_INTERNAL_INDENT
+        + "%-"
+        + str(GB_BASE_INDENT - GB_OTHER_INTERNAL_INDENT)
+        + "s"
+    )
 
     BASE_FEATURE_FORMAT = "%-" + str(GB_FEATURE_INDENT) + "s"
-    INTERNAL_FEATURE_FORMAT = " " * GB_FEATURE_INTERNAL_INDENT + "%-" + \
-                              str(GB_FEATURE_INDENT -
-                                  GB_FEATURE_INTERNAL_INDENT) + "s"
+    INTERNAL_FEATURE_FORMAT = (
+        " " * GB_FEATURE_INTERNAL_INDENT
+        + "%-"
+        + str(GB_FEATURE_INDENT - GB_FEATURE_INTERNAL_INDENT)
+        + "s"
+    )
     SEQUENCE_FORMAT = "%" + str(GB_SEQUENCE_INDENT) + "s"
 
     def __init__(self):
@@ -344,8 +351,7 @@ class Record(object):
             keyword_info = keyword_info[:-2]
             keyword_info += "."
 
-            output += _wrapped_genbank(keyword_info,
-                                       Record.GB_BASE_INDENT)
+            output += _wrapped_genbank(keyword_info, Record.GB_BASE_INDENT)
 
         return output
 
@@ -393,8 +399,7 @@ class Record(object):
         output = ""
         if self.comment:
             output += Record.BASE_FORMAT % "COMMENT"
-            output += _indent_genbank(self.comment,
-                                      Record.GB_BASE_INDENT)
+            output += _indent_genbank(self.comment, Record.GB_BASE_INDENT)
         return output
 
     def _features_line(self):
@@ -437,8 +442,7 @@ class Record(object):
         if self.sequence:
             output += Record.BASE_FORMAT % "ORIGIN"
             if self.origin:
-                output += _wrapped_genbank(self.origin,
-                                           Record.GB_BASE_INDENT)
+                output += _wrapped_genbank(self.origin, Record.GB_BASE_INDENT)
             else:
                 output += "\n"
         return output
@@ -484,8 +488,9 @@ class Record(object):
         output = ""
         if self.contig:
             output += Record.BASE_FORMAT % "CONTIG"
-            output += _wrapped_genbank(self.contig,
-                                       Record.GB_BASE_INDENT, split_char=",")
+            output += _wrapped_genbank(
+                self.contig, Record.GB_BASE_INDENT, split_char=","
+            )
         return output
 
 
@@ -623,8 +628,9 @@ class Feature(object):
     def __str__(self):
         """Return feature as a GenBank format string."""
         output = Record.INTERNAL_FEATURE_FORMAT % self.key
-        output += _wrapped_genbank(self.location, Record.GB_FEATURE_INDENT,
-                                   split_char=",")
+        output += _wrapped_genbank(
+            self.location, Record.GB_FEATURE_INDENT, split_char=","
+        )
         for qualifier in self.qualifiers:
             output += str(qualifier)
         return output
@@ -657,5 +663,6 @@ class Qualifier(object):
             if no_space_key in self.key:
                 space_wrap = 0
         # return double quotes as-is, leave it to the user to escape them
-        return output + _wrapped_genbank(self.key + self.value,
-                                         Record.GB_FEATURE_INDENT, space_wrap)
+        return output + _wrapped_genbank(
+            self.key + self.value, Record.GB_FEATURE_INDENT, space_wrap
+        )

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -51,7 +51,7 @@ class InsdcScanner(object):
 
     # These constants get redefined with sensible values in the sub classes:
     RECORD_START = "XXX"  # "LOCUS       " or "ID   "
-    HEADER_WIDTH = 3   # 12 or 5
+    HEADER_WIDTH = 3  # 12 or 5
     FEATURE_START_MARKERS = ["XXX***FEATURES***XXX"]
     FEATURE_END_MARKERS = ["XXX***END FEATURES***XXX"]
     FEATURE_QUALIFIER_INDENT = 0
@@ -92,7 +92,7 @@ class InsdcScanner(object):
             if isinstance(line[0], int):
                 # Same exception as for FASTQ files
                 raise ValueError("Is this handle in binary mode not text mode?")
-            if line[:self.HEADER_WIDTH] == self.RECORD_START:
+            if line[: self.HEADER_WIDTH] == self.RECORD_START:
                 if self.debug > 1:
                     print("Found the start of a record:\n" + line)
                 break
@@ -117,7 +117,7 @@ class InsdcScanner(object):
 
         Assumes you have just read in the ID/LOCUS line.
         """
-        if self.line[:self.HEADER_WIDTH] != self.RECORD_START:
+        if self.line[: self.HEADER_WIDTH] != self.RECORD_START:
             raise ValueError("Not at start of record")
 
         header_lines = []
@@ -133,7 +133,7 @@ class InsdcScanner(object):
             # if line[:self.HEADER_WIDTH]==self.FEATURE_START_MARKER[:self.HEADER_WIDTH]:
             #    if self.debug : print("Found header table (?)")
             #    break
-            if line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
+            if line[: self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
                 if self.debug:
                     print("Found start of sequence")
                 break
@@ -166,7 +166,7 @@ class InsdcScanner(object):
         while True:
             if not line:
                 raise ValueError("Premature end of line during features table")
-            if line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
+            if line[: self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
                 if self.debug:
                     print("Found start of sequence")
                 break
@@ -178,41 +178,53 @@ class InsdcScanner(object):
                     print("Found end of features")
                 line = self.handle.readline()
                 break
-            if line[2:self.FEATURE_QUALIFIER_INDENT].strip() == "":
+            if line[2 : self.FEATURE_QUALIFIER_INDENT].strip() == "":
                 # This is an empty feature line between qualifiers. Empty
                 # feature lines within qualifiers are handled below (ignored).
                 line = self.handle.readline()
                 continue
             if len(line) < self.FEATURE_QUALIFIER_INDENT:
-                warnings.warn("line too short to contain a feature: %r" % line,
-                              BiopythonParserWarning)
+                warnings.warn(
+                    "line too short to contain a feature: %r" % line,
+                    BiopythonParserWarning,
+                )
                 line = self.handle.readline()
                 continue
 
             if skip:
                 line = self.handle.readline()
-                while line[:self.FEATURE_QUALIFIER_INDENT] == self.FEATURE_QUALIFIER_SPACER:
+                while (
+                    line[: self.FEATURE_QUALIFIER_INDENT]
+                    == self.FEATURE_QUALIFIER_SPACER
+                ):
                     line = self.handle.readline()
             else:
                 # Build up a list of the lines making up this feature:
-                if line[self.FEATURE_QUALIFIER_INDENT] != " " \
-                        and " " in line[self.FEATURE_QUALIFIER_INDENT:]:
+                if (
+                    line[self.FEATURE_QUALIFIER_INDENT] != " "
+                    and " " in line[self.FEATURE_QUALIFIER_INDENT :]
+                ):
                     # The feature table design enforces a length limit on the feature keys.
                     # Some third party files (e.g. IGMT's EMBL like files) solve this by
                     # over indenting the location and qualifiers.
                     feature_key, line = line[2:].strip().split(None, 1)
                     feature_lines = [line]
-                    warnings.warn("Over indented %s feature?" % feature_key,
-                                  BiopythonParserWarning)
+                    warnings.warn(
+                        "Over indented %s feature?" % feature_key,
+                        BiopythonParserWarning,
+                    )
                 else:
-                    feature_key = line[2:self.FEATURE_QUALIFIER_INDENT].strip()
-                    feature_lines = [line[self.FEATURE_QUALIFIER_INDENT:]]
+                    feature_key = line[2 : self.FEATURE_QUALIFIER_INDENT].strip()
+                    feature_lines = [line[self.FEATURE_QUALIFIER_INDENT :]]
                 line = self.handle.readline()
-                while line[:self.FEATURE_QUALIFIER_INDENT] == self.FEATURE_QUALIFIER_SPACER \
-                        or (line != "" and line.rstrip() == ""):  # cope with blank lines in the midst of a feature
+                while line[
+                    : self.FEATURE_QUALIFIER_INDENT
+                ] == self.FEATURE_QUALIFIER_SPACER or (
+                    line != "" and line.rstrip() == ""
+                ):  # cope with blank lines in the midst of a feature
                     # Use strip to remove any harmless trailing white space AND and leading
                     # white space (e.g. out of spec files with too much indentation)
-                    feature_lines.append(line[self.FEATURE_QUALIFIER_INDENT:].strip())
+                    feature_lines.append(line[self.FEATURE_QUALIFIER_INDENT :].strip())
                     line = self.handle.readline()
                 features.append(self.parse_feature(feature_key, feature_lines))
         self.line = line
@@ -287,9 +299,13 @@ class InsdcScanner(object):
             if feature_location.count("(") > feature_location.count(")"):
                 # Including the prev line in warning would be more explicit,
                 # but this way get one-and-only-one warning shown by default:
-                warnings.warn("Non-standard feature line wrapping (didn't break on comma)?",
-                              BiopythonParserWarning)
-                while feature_location[-1:] == "," or feature_location.count("(") > feature_location.count(")"):
+                warnings.warn(
+                    "Non-standard feature line wrapping (didn't break on comma)?",
+                    BiopythonParserWarning,
+                )
+                while feature_location[-1:] == "," or feature_location.count(
+                    "("
+                ) > feature_location.count(")"):
                     line = next(iterator)
                     feature_location += line.strip()
 
@@ -303,9 +319,12 @@ class InsdcScanner(object):
                     # New qualifier
                     i = line.find("=")
                     key = line[1:i]  # does not work if i==-1
-                    value = line[i + 1:]  # we ignore 'value' if i==-1
+                    value = line[i + 1 :]  # we ignore 'value' if i==-1
                     if i and value.startswith(" ") and value.lstrip().startswith('"'):
-                        warnings.warn("White space after equals in qualifier", BiopythonParserWarning)
+                        warnings.warn(
+                            "White space after equals in qualifier",
+                            BiopythonParserWarning,
+                        )
                         value = value.lstrip()
                     if i == -1:
                         # Qualifier with no key, e.g. /pseudo
@@ -343,21 +362,22 @@ class InsdcScanner(object):
             return feature_key, feature_location, qualifiers
         except StopIteration:
             # Bummer
-            raise ValueError("Problem with '%s' feature:\n%s"
-                             % (feature_key, "\n".join(lines)))
+            raise ValueError(
+                "Problem with '%s' feature:\n%s" % (feature_key, "\n".join(lines))
+            )
 
     def parse_footer(self):
         """Return a tuple containing a list of any misc strings, and the sequence."""
         # This is a basic bit of code to scan and discard the sequence,
         # which was useful when developing the sub classes.
         if self.line in self.FEATURE_END_MARKERS:
-            while self.line[:self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
+            while self.line[: self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
                 self.line = self.handle.readline()
                 if not self.line:
                     raise ValueError("Premature end of file")
                 self.line = self.line.rstrip()
 
-        if self.line[:self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
+        if self.line[: self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
             raise ValueError("Not at start of sequence")
         while True:
             line = self.handle.readline()
@@ -471,8 +491,9 @@ class InsdcScanner(object):
         from Bio.GenBank import _FeatureConsumer
         from Bio.GenBank.utils import FeatureValueCleaner
 
-        consumer = _FeatureConsumer(use_fuzziness=1,
-                                    feature_cleaner=FeatureValueCleaner())
+        consumer = _FeatureConsumer(
+            use_fuzziness=1, feature_cleaner=FeatureValueCleaner()
+        )
 
         if self.feed(handle, consumer, do_features):
             return consumer.data
@@ -501,9 +522,12 @@ class InsdcScanner(object):
                 raise ValueError("Failed to parse the record's description")
             yield record
 
-    def parse_cds_features(self, handle,
-                           alphabet=generic_protein,
-                           tags2id=("protein_id", "locus_tag", "product")):
+    def parse_cds_features(
+        self,
+        handle,
+        alphabet=generic_protein,
+        tags2id=("protein_id", "locus_tag", "product"),
+    ):
         """Parse CDS features, return SeqRecord object iterator.
 
         Each CDS feature becomes a SeqRecord.
@@ -546,8 +570,11 @@ class InsdcScanner(object):
                     annotations["raw_location"] = location_string.replace(" ", "")
 
                     for (qualifier_name, qualifier_data) in qualifiers:
-                        if qualifier_data is not None \
-                                and qualifier_data[0] == '"' and qualifier_data[-1] == '"':
+                        if (
+                            qualifier_data is not None
+                            and qualifier_data[0] == '"'
+                            and qualifier_data[-1] == '"'
+                        ):
                             # Remove quotes
                             qualifier_data = qualifier_data[1:-1]
                         # Append the data to the annotation qualifier...
@@ -559,7 +586,9 @@ class InsdcScanner(object):
                             record.dbxrefs.append(qualifier_data)
                         else:
                             if qualifier_data is not None:
-                                qualifier_data = qualifier_data.replace("\n", " ").replace("  ", " ")
+                                qualifier_data = qualifier_data.replace(
+                                    "\n", " "
+                                ).replace("  ", " ")
                             try:
                                 annotations[qualifier_name] += " " + qualifier_data
                             except KeyError:
@@ -600,22 +629,25 @@ class EmblScanner(InsdcScanner):
 
     def parse_footer(self):
         """Return a tuple containing a list of any misc strings, and the sequence."""
-        if self.line[:self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
+        if self.line[: self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
             raise ValueError("Footer format unexpected: '%s'" % self.line)
 
         # Note that the SQ line can be split into several lines...
         misc_lines = []
-        while self.line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
+        while self.line[: self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
             misc_lines.append(self.line)
             self.line = self.handle.readline()
             if not self.line:
                 raise ValueError("Premature end of file")
             self.line = self.line.rstrip()
 
-        if not (self.line[:self.HEADER_WIDTH] == " " * self.HEADER_WIDTH
-                or self.line.strip() == "//"):
-            raise ValueError("Unexpected content after SQ or CO "
-                             "line: %r" % self.line)
+        if not (
+            self.line[: self.HEADER_WIDTH] == " " * self.HEADER_WIDTH
+            or self.line.strip() == "//"
+        ):
+            raise ValueError(
+                "Unexpected content after SQ or CO " "line: %r" % self.line
+            )
 
         seq_lines = []
         line = self.line
@@ -627,9 +659,11 @@ class EmblScanner(InsdcScanner):
                 raise ValueError("Blank line in sequence data")
             if line == "//":
                 break
-            if self.line[:self.HEADER_WIDTH] != (" " * self.HEADER_WIDTH):
-                raise ValueError("Problem with characters in header line, "
-                                 " or incorrect header width: " + self.line)
+            if self.line[: self.HEADER_WIDTH] != (" " * self.HEADER_WIDTH):
+                raise ValueError(
+                    "Problem with characters in header line, "
+                    " or incorrect header width: " + self.line
+                )
             # Remove tailing number now, remove spaces later
             linersplit = line.rsplit(None, 1)
             if len(linersplit) == 2 and linersplit[1].isdigit():
@@ -639,26 +673,27 @@ class EmblScanner(InsdcScanner):
                 # just the sequence coordinate
                 pass
             else:
-                warnings.warn("EMBL sequence line missing coordinates",
-                              BiopythonParserWarning)
+                warnings.warn(
+                    "EMBL sequence line missing coordinates", BiopythonParserWarning
+                )
                 seq_lines.append(line)
             line = self.handle.readline()
         self.line = line
         return misc_lines, "".join(seq_lines).replace(" ", "")
 
     def _feed_first_line(self, consumer, line):
-        assert line[:self.HEADER_WIDTH].rstrip() == "ID"
-        if line[self.HEADER_WIDTH:].count(";") == 6:
+        assert line[: self.HEADER_WIDTH].rstrip() == "ID"
+        if line[self.HEADER_WIDTH :].count(";") == 6:
             # Looks like the semi colon separated style introduced in 2006
             self._feed_first_line_new(consumer, line)
-        elif line[self.HEADER_WIDTH:].count(";") == 3:
+        elif line[self.HEADER_WIDTH :].count(";") == 3:
             if line.rstrip().endswith(" SQ"):
                 # EMBL-bank patent data
                 self._feed_first_line_patents(consumer, line)
             else:
                 # Looks like the pre 2006 style
                 self._feed_first_line_old(consumer, line)
-        elif line[self.HEADER_WIDTH:].count(";") == 2:
+        elif line[self.HEADER_WIDTH :].count(";") == 2:
             # Looks like KIKO patent data
             self._feed_first_line_patents_kipo(consumer, line)
         else:
@@ -677,7 +712,9 @@ class EmblScanner(InsdcScanner):
         # ID <L2-accession>; <molecule type>; <non-redundant level 2>; <cluster size L2>
         # e.g. ID   NRP0000016E; PRT; NR2; 5 SQ
         # e.g. ID   NRP_AX000635; PRT; NR1; 15 SQ
-        fields = [data.strip() for data in line[self.HEADER_WIDTH:].strip()[:-3].split(";")]
+        fields = [
+            data.strip() for data in line[self.HEADER_WIDTH :].strip()[:-3].split(";")
+        ]
         assert len(fields) == 4
         consumer.locus(fields[0])
         consumer.residue_type(fields[1])  # semi-redundant
@@ -691,9 +728,9 @@ class EmblScanner(InsdcScanner):
         # e.g. ID   DI500001       STANDARD;      PRT;   111 AA.
         #
         # This follows the style of _feed_first_line_old
-        assert line[:self.HEADER_WIDTH].rstrip() == "ID"
-        fields = [line[self.HEADER_WIDTH:].split(None, 1)[0]]
-        fields.extend(line[self.HEADER_WIDTH:].split(None, 1)[1].split(";"))
+        assert line[: self.HEADER_WIDTH].rstrip() == "ID"
+        fields = [line[self.HEADER_WIDTH :].split(None, 1)[0]]
+        fields.extend(line[self.HEADER_WIDTH :].split(None, 1)[1].split(";"))
         fields = [entry.strip() for entry in fields]
         """
         The tokens represent:
@@ -713,9 +750,9 @@ class EmblScanner(InsdcScanner):
         # Expects an ID line in the style before 2006, e.g.
         # ID   SC10H5 standard; DNA; PRO; 4870 BP.
         # ID   BSUB9999   standard; circular DNA; PRO; 4214630 BP.
-        assert line[:self.HEADER_WIDTH].rstrip() == "ID"
-        fields = [line[self.HEADER_WIDTH:].split(None, 1)[0]]
-        fields.extend(line[self.HEADER_WIDTH:].split(None, 1)[1].split(";"))
+        assert line[: self.HEADER_WIDTH].rstrip() == "ID"
+        fields = [line[self.HEADER_WIDTH :].split(None, 1)[0]]
+        fields.extend(line[self.HEADER_WIDTH :].split(None, 1)[1].split(";"))
         fields = [entry.strip() for entry in fields]
         """
         The tokens represent:
@@ -746,8 +783,8 @@ class EmblScanner(InsdcScanner):
         # Expects an ID line in the style introduced in 2006, e.g.
         # ID   X56734; SV 1; linear; mRNA; STD; PLN; 1859 BP.
         # ID   CD789012; SV 4; linear; genomic DNA; HTG; MAM; 500 BP.
-        assert line[:self.HEADER_WIDTH].rstrip() == "ID"
-        fields = [data.strip() for data in line[self.HEADER_WIDTH:].strip().split(";")]
+        assert line[: self.HEADER_WIDTH].rstrip() == "ID"
+        fields = [data.strip() for data in line[self.HEADER_WIDTH :].strip().split(";")]
         assert len(fields) == 7
         """
         The tokens represent:
@@ -771,9 +808,11 @@ class EmblScanner(InsdcScanner):
         # TODO - How to deal with the version field?  At the moment the consumer
         # will try and use this for the ID which isn't ideal for EMBL files.
         version_parts = fields[1].split()
-        if len(version_parts) == 2 \
-            and version_parts[0] == "SV" \
-                and version_parts[1].isdigit():
+        if (
+            len(version_parts) == 2
+            and version_parts[0] == "SV"
+            and version_parts[1].isdigit()
+        ):
             consumer.version_suffix(version_parts[1])
 
         # Based on how the old GenBank parser worked, merge these two:
@@ -817,8 +856,8 @@ class EmblScanner(InsdcScanner):
         # We have to handle the following specially:
         # RX (depending on reference type...)
         for line in lines:
-            line_type = line[:self.EMBL_INDENT].strip()
-            data = line[self.EMBL_INDENT:].strip()
+            line_type = line[: self.EMBL_INDENT].strip()
+            data = line[self.EMBL_INDENT :].strip()
             if line_type == "XX":
                 pass
             elif line_type == "RN":
@@ -836,7 +875,11 @@ class EmblScanner(InsdcScanner):
                     # e.g. '1-4639675' becomes '(bases 1 to 4639675)'
                     # and '160-550, 904-1055' becomes '(bases 160 to 550; 904 to 1055)'
                     # Note could be multi-line, and end with a comma
-                    parts = [bases.replace("-", " to ").strip() for bases in data.split(",") if bases.strip()]
+                    parts = [
+                        bases.replace("-", " to ").strip()
+                        for bases in data.split(",")
+                        if bases.strip()
+                    ]
                     consumer.reference_bases("(bases %s)" % "; ".join(parts))
             elif line_type == "RT":
                 # Remove the enclosing quotes and trailing semi colon.
@@ -884,10 +927,11 @@ class EmblScanner(InsdcScanner):
                 # Turn it into "database_identifier:primary_identifier" to
                 # mimic the GenBank parser. e.g. "MGI:98599"
                 if len(parts) == 1:
-                    warnings.warn("Malformed DR line in EMBL file.", BiopythonParserWarning)
+                    warnings.warn(
+                        "Malformed DR line in EMBL file.", BiopythonParserWarning
+                    )
                 else:
-                    consumer.dblink("%s:%s" % (parts[0].strip(),
-                                               parts[1].strip()))
+                    consumer.dblink("%s:%s" % (parts[0].strip(), parts[1].strip()))
             elif line_type == "RA":
                 # Remove trailing ; at end of authors list
                 consumer.authors(data.rstrip(";"))
@@ -936,7 +980,9 @@ class EmblScanner(InsdcScanner):
                             # Don't need to preseve the whitespace here.
                             contig_location += line[5:].strip()
                         else:
-                            raise ValueError("Expected CO (contig) continuation line, got:\n" + line)
+                            raise ValueError(
+                                "Expected CO (contig) continuation line, got:\n" + line
+                            )
                     consumer.contig_location(contig_location)
                 if line.startswith("SQ   Sequence "):
                     # e.g.
@@ -944,7 +990,9 @@ class EmblScanner(InsdcScanner):
                     #
                     # Or, EMBL-bank patent, e.g.
                     # SQ   Sequence 465 AA; 3963407aa91d3a0d622fec679a4524e0; MD5;
-                    self._feed_seq_length(consumer, line[14:].rstrip().rstrip(";").split(";", 1)[0])
+                    self._feed_seq_length(
+                        consumer, line[14:].rstrip().rstrip(";").split(";", 1)[0]
+                    )
                     # TODO - Record the checksum etc?
             return
         except StopIteration:
@@ -962,14 +1010,16 @@ class _ImgtScanner(EmblScanner):
     This is private to encourage use of Bio.SeqIO rather than Bio.GenBank.
     """
 
-    FEATURE_START_MARKERS = ["FH   Key             Location/Qualifiers",
-                             "FH   Key             Location/Qualifiers (from EMBL)",
-                             "FH   Key                 Location/Qualifiers",
-                             "FH"]
+    FEATURE_START_MARKERS = [
+        "FH   Key             Location/Qualifiers",
+        "FH   Key             Location/Qualifiers (from EMBL)",
+        "FH   Key                 Location/Qualifiers",
+        "FH",
+    ]
 
     def _feed_first_line(self, consumer, line):
-        assert line[:self.HEADER_WIDTH].rstrip() == "ID"
-        if line[self.HEADER_WIDTH:].count(";") != 5:
+        assert line[: self.HEADER_WIDTH].rstrip() == "ID"
+        if line[self.HEADER_WIDTH :].count(";") != 5:
             # Assume its an older EMBL-like line,
             return EmblScanner._feed_first_line(self, consumer, line)
         # Otherwise assume its the new (circa 2016) IMGT style
@@ -986,7 +1036,7 @@ class _ImgtScanner(EmblScanner):
         # becomes
         #
         # ID   HLA00001; SV 1; standard; DNA; HUM; 3503 BP.
-        fields = [data.strip() for data in line[self.HEADER_WIDTH:].strip().split(";")]
+        fields = [data.strip() for data in line[self.HEADER_WIDTH :].strip().split(";")]
         assert len(fields) == 6
         """
         The tokens represent:
@@ -1002,9 +1052,11 @@ class _ImgtScanner(EmblScanner):
 
         # See TODO on the EMBL _feed_first_line_new about version field
         version_parts = fields[1].split()
-        if len(version_parts) == 2 \
-            and version_parts[0] == "SV" \
-                and version_parts[1].isdigit():
+        if (
+            len(version_parts) == 2
+            and version_parts[0] == "SV"
+            and version_parts[1].isdigit()
+        ):
             consumer.version_suffix(version_parts[1])
 
         consumer.residue_type(fields[3])
@@ -1044,7 +1096,7 @@ class _ImgtScanner(EmblScanner):
         while True:
             if not line:
                 raise ValueError("Premature end of line during features table")
-            if line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
+            if line[: self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
                 if self.debug:
                     print("Found start of sequence")
                 break
@@ -1056,7 +1108,7 @@ class _ImgtScanner(EmblScanner):
                     print("Found end of features")
                 line = self.handle.readline()
                 break
-            if line[2:self.FEATURE_QUALIFIER_INDENT].strip() == "":
+            if line[2 : self.FEATURE_QUALIFIER_INDENT].strip() == "":
                 # This is an empty feature line between qualifiers. Empty
                 # feature lines within qualifiers are handled below (ignored).
                 line = self.handle.readline()
@@ -1064,7 +1116,10 @@ class _ImgtScanner(EmblScanner):
 
             if skip:
                 line = self.handle.readline()
-                while line[:self.FEATURE_QUALIFIER_INDENT] == self.FEATURE_QUALIFIER_SPACER:
+                while (
+                    line[: self.FEATURE_QUALIFIER_INDENT]
+                    == self.FEATURE_QUALIFIER_SPACER
+                ):
                     line = self.handle.readline()
             else:
                 assert line[:2] == "FT"
@@ -1078,15 +1133,19 @@ class _ImgtScanner(EmblScanner):
                     location_start = line[25:].strip()
                 feature_lines = [location_start]
                 line = self.handle.readline()
-                while line[:self.FEATURE_QUALIFIER_INDENT] == self.FEATURE_QUALIFIER_SPACER \
-                        or line.rstrip() == "":  # cope with blank lines in the midst of a feature
+                while (
+                    line[: self.FEATURE_QUALIFIER_INDENT]
+                    == self.FEATURE_QUALIFIER_SPACER
+                    or line.rstrip() == ""
+                ):  # cope with blank lines in the midst of a feature
                     # Use strip to remove any harmless trailing white space AND and leading
                     # white space (copes with 21 or 26 indents and orther variants)
                     assert line[:2] == "FT"
-                    feature_lines.append(line[self.FEATURE_QUALIFIER_INDENT:].strip())
+                    feature_lines.append(line[self.FEATURE_QUALIFIER_INDENT :].strip())
                     line = self.handle.readline()
-                feature_key, location, qualifiers = \
-                    self.parse_feature(feature_key, feature_lines)
+                feature_key, location, qualifiers = self.parse_feature(
+                    feature_key, feature_lines
+                )
                 # Try to handle known problems with IMGT locations here:
                 if ">" in location:
                     # Nasty hack for common IMGT bug, should be >123 not 123>
@@ -1110,7 +1169,13 @@ class GenBankScanner(InsdcScanner):
     FEATURE_END_MARKERS = []
     FEATURE_QUALIFIER_INDENT = 21
     FEATURE_QUALIFIER_SPACER = " " * FEATURE_QUALIFIER_INDENT
-    SEQUENCE_HEADERS = ["CONTIG", "ORIGIN", "BASE COUNT", "WGS", "TSA"]  # trailing spaces removed
+    SEQUENCE_HEADERS = [
+        "CONTIG",
+        "ORIGIN",
+        "BASE COUNT",
+        "WGS",
+        "TSA",
+    ]  # trailing spaces removed
 
     GENBANK_INDENT = HEADER_WIDTH
     GENBANK_SPACER = " " * GENBANK_INDENT
@@ -1121,20 +1186,22 @@ class GenBankScanner(InsdcScanner):
 
     def parse_footer(self):
         """Return a tuple containing a list of any misc strings, and the sequence."""
-        if self.line[:self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
+        if self.line[: self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
             raise ValueError("Footer format unexpected:  '%s'" % self.line)
 
         misc_lines = []
-        while self.line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS \
-            or self.line[:self.HEADER_WIDTH] == " " * self.HEADER_WIDTH \
-                or "WGS" == self.line[:3]:
+        while (
+            self.line[: self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS
+            or self.line[: self.HEADER_WIDTH] == " " * self.HEADER_WIDTH
+            or "WGS" == self.line[:3]
+        ):
             misc_lines.append(self.line.rstrip())
             self.line = self.handle.readline()
             if not self.line:
                 raise ValueError("Premature end of file")
             self.line = self.line
 
-        if self.line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
+        if self.line[: self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
             raise ValueError("Eh? '%s'" % self.line)
 
         # Now just consume the sequence lines until reach the // marker
@@ -1143,14 +1210,14 @@ class GenBankScanner(InsdcScanner):
         line = self.line
         while True:
             if not line:
-                warnings.warn("Premature end of file in sequence data",
-                              BiopythonParserWarning)
+                warnings.warn(
+                    "Premature end of file in sequence data", BiopythonParserWarning
+                )
                 line = "//"
                 break
             line = line.rstrip()
             if not line:
-                warnings.warn("Blank line in sequence data",
-                              BiopythonParserWarning)
+                warnings.warn("Blank line in sequence data", BiopythonParserWarning)
                 line = self.handle.readline()
                 continue
             if line == "//":
@@ -1160,8 +1227,9 @@ class GenBankScanner(InsdcScanner):
             if len(line) > 9 and line[9:10] != " ":
                 # Some broken programs indent the sequence by one space too many
                 # so try to get rid of that and test again.
-                warnings.warn("Invalid indentation for sequence line",
-                              BiopythonParserWarning)
+                warnings.warn(
+                    "Invalid indentation for sequence line", BiopythonParserWarning
+                )
                 line = line[1:]
                 if len(line) > 9 and line[9:10] != " ":
                     raise ValueError("Sequence line mal-formed, '%s'" % line)
@@ -1196,7 +1264,7 @@ class GenBankScanner(InsdcScanner):
         #####################################
         # LOCUS line                        #
         #####################################
-        if line[0:self.GENBANK_INDENT] != "LOCUS       ":
+        if line[0 : self.GENBANK_INDENT] != "LOCUS       ":
             raise ValueError("LOCUS line does not start correctly:\n" + line)
 
         # Have to break up the locus line, and handle the different bits of it.
@@ -1224,34 +1292,44 @@ class GenBankScanner(InsdcScanner):
             # assert line[29:33] in [' bp ', ' aa ',' rc '] , \
             #       'LOCUS line does not contain size units at expected position:\n' + line
             if line[41:42] != " ":
-                raise ValueError("LOCUS line does not contain space at "
-                                 "position 42:\n" + line)
+                raise ValueError(
+                    "LOCUS line does not contain space at " "position 42:\n" + line
+                )
             if line[42:51].strip() not in ["", "linear", "circular"]:
-                raise ValueError("LOCUS line does not contain valid entry "
-                                 "(linear, circular, ...):\n" + line)
+                raise ValueError(
+                    "LOCUS line does not contain valid entry "
+                    "(linear, circular, ...):\n" + line
+                )
             if line[51:52] != " ":
-                raise ValueError("LOCUS line does not contain space at "
-                                 "position 52:\n" + line)
+                raise ValueError(
+                    "LOCUS line does not contain space at " "position 52:\n" + line
+                )
             # if line[55:62] != '       ':
             #      raise ValueError('LOCUS line does not contain spaces from position 56 to 62:\n' + line)
             if line[62:73].strip():
                 if line[64:65] != "-":
-                    raise ValueError("LOCUS line does not contain - at "
-                                     "position 65 in date:\n" + line)
+                    raise ValueError(
+                        "LOCUS line does not contain - at "
+                        "position 65 in date:\n" + line
+                    )
                 if line[68:69] != "-":
-                    raise ValueError("LOCUS line does not contain - at "
-                                     "position 69 in date:\n" + line)
+                    raise ValueError(
+                        "LOCUS line does not contain - at "
+                        "position 69 in date:\n" + line
+                    )
 
-            name_and_length_str = line[self.GENBANK_INDENT:29]
+            name_and_length_str = line[self.GENBANK_INDENT : 29]
             while "  " in name_and_length_str:
                 name_and_length_str = name_and_length_str.replace("  ", " ")
             name_and_length = name_and_length_str.split(" ")
             if len(name_and_length) > 2:
-                raise ValueError("Cannot parse the name and length in "
-                                 "the LOCUS line:\n" + line)
+                raise ValueError(
+                    "Cannot parse the name and length in " "the LOCUS line:\n" + line
+                )
             if len(name_and_length) == 1:
-                raise ValueError("Name and length collide in the LOCUS "
-                                 "line:\n" + line)
+                raise ValueError(
+                    "Name and length collide in the LOCUS " "line:\n" + line
+                )
             # Should be possible to split them based on position, if
             # a clear definition of the standard exists THAT AGREES with
             # existing files.
@@ -1260,8 +1338,10 @@ class GenBankScanner(InsdcScanner):
                 # As long as the sequence is short, can steal its leading spaces
                 # to extend the name over the current 16 character limit.
                 # However, that deserves a warning as it is out of spec.
-                warnings.warn("GenBank LOCUS line identifier over 16 characters",
-                              BiopythonParserWarning)
+                warnings.warn(
+                    "GenBank LOCUS line identifier over 16 characters",
+                    BiopythonParserWarning,
+                )
             consumer.locus(name)
             consumer.size(length)
             # consumer.residue_type(line[33:41].strip())
@@ -1280,8 +1360,11 @@ class GenBankScanner(InsdcScanner):
             consumer.data_file_division(line[52:55])
             if line[62:73].strip():
                 consumer.date(line[62:73])
-        elif line[40:44] in [" bp ", " aa ", " rc "] \
-                and line[54:64].strip() in ["", "linear", "circular"]:
+        elif line[40:44] in [" bp ", " aa ", " rc "] and line[54:64].strip() in [
+            "",
+            "linear",
+            "circular",
+        ]:
             # New... linear/circular/big blank test should avoid EnsEMBL style
             # LOCUS line being treated like a proper column based LOCUS line.
             #
@@ -1306,54 +1389,75 @@ class GenBankScanner(InsdcScanner):
                 # JBEI genbank files seem to miss a divison code and date
                 # See issue #1656 e.g.
                 # LOCUS       pEH010                  5743 bp    DNA     circular
-                warnings.warn("Truncated LOCUS line found - is this "
-                              "correct?\n:%r" % line, BiopythonParserWarning)
+                warnings.warn(
+                    "Truncated LOCUS line found - is this " "correct?\n:%r" % line,
+                    BiopythonParserWarning,
+                )
                 padding_len = 79 - len(line)
                 padding = " " * padding_len
                 line += padding
 
             if line[40:44] not in [" bp ", " aa ", " rc "]:
-                raise ValueError("LOCUS line does not contain size units at "
-                                 "expected position:\n" + line)
+                raise ValueError(
+                    "LOCUS line does not contain size units at "
+                    "expected position:\n" + line
+                )
             if line[44:47] not in ["   ", "ss-", "ds-", "ms-"]:
-                raise ValueError("LOCUS line does not have valid strand "
-                                 "type (Single stranded, ...):\n" + line)
+                raise ValueError(
+                    "LOCUS line does not have valid strand "
+                    "type (Single stranded, ...):\n" + line
+                )
 
-            if not (line[47:54].strip() == ""
-                    or "DNA" in line[47:54].strip().upper()
-                    or "RNA" in line[47:54].strip().upper()):
-                raise ValueError("LOCUS line does not contain valid "
-                                 "sequence type (DNA, RNA, ...):\n" + line)
+            if not (
+                line[47:54].strip() == ""
+                or "DNA" in line[47:54].strip().upper()
+                or "RNA" in line[47:54].strip().upper()
+            ):
+                raise ValueError(
+                    "LOCUS line does not contain valid "
+                    "sequence type (DNA, RNA, ...):\n" + line
+                )
             if line[54:55] != " ":
-                raise ValueError("LOCUS line does not contain space at "
-                                 "position 55:\n" + line)
+                raise ValueError(
+                    "LOCUS line does not contain space at " "position 55:\n" + line
+                )
             if line[55:63].strip() not in ["", "linear", "circular"]:
-                raise ValueError("LOCUS line does not contain valid "
-                                 "entry (linear, circular, ...):\n" + line)
+                raise ValueError(
+                    "LOCUS line does not contain valid "
+                    "entry (linear, circular, ...):\n" + line
+                )
             if line[63:64] != " ":
-                raise ValueError("LOCUS line does not contain space at "
-                                 "position 64:\n" + line)
+                raise ValueError(
+                    "LOCUS line does not contain space at " "position 64:\n" + line
+                )
             if line[67:68] != " ":
-                raise ValueError("LOCUS line does not contain space at "
-                                 "position 68:\n" + line)
+                raise ValueError(
+                    "LOCUS line does not contain space at " "position 68:\n" + line
+                )
             if line[68:79].strip():
                 if line[70:71] != "-":
-                    raise ValueError("LOCUS line does not contain - at "
-                                     "position 71 in date:\n" + line)
+                    raise ValueError(
+                        "LOCUS line does not contain - at "
+                        "position 71 in date:\n" + line
+                    )
                 if line[74:75] != "-":
-                    raise ValueError("LOCUS line does not contain - at "
-                                     "position 75 in date:\n" + line)
+                    raise ValueError(
+                        "LOCUS line does not contain - at "
+                        "position 75 in date:\n" + line
+                    )
 
-            name_and_length_str = line[self.GENBANK_INDENT:40]
+            name_and_length_str = line[self.GENBANK_INDENT : 40]
             while "  " in name_and_length_str:
                 name_and_length_str = name_and_length_str.replace("  ", " ")
             name_and_length = name_and_length_str.split(" ")
             if len(name_and_length) > 2:
-                raise ValueError("Cannot parse the name and length in "
-                                 "the LOCUS line:\n" + line)
+                raise ValueError(
+                    "Cannot parse the name and length in " "the LOCUS line:\n" + line
+                )
             if len(name_and_length) == 1:
-                raise ValueError("Name and length collide in the LOCUS "
-                                 "line:\n" + line)
+                raise ValueError(
+                    "Name and length collide in the LOCUS " "line:\n" + line
+                )
             # Should be possible to split them based on position, if
             # a clear definition of the stand exists THAT AGREES with
             # existing files.
@@ -1375,7 +1479,7 @@ class GenBankScanner(InsdcScanner):
                 consumer.data_file_division(line[64:67])
             if line[68:79].strip():
                 consumer.date(line[68:79])
-        elif line[self.GENBANK_INDENT:].strip().count(" ") == 0:
+        elif line[self.GENBANK_INDENT :].strip().count(" ") == 0:
             # Truncated LOCUS line, as produced by some EMBOSS tools - see bug 1762
             #
             # e.g.
@@ -1391,15 +1495,20 @@ class GenBankScanner(InsdcScanner):
             #    00:06      LOCUS
             #    06:12      spaces
             #    12:??      Locus name
-            if line[self.GENBANK_INDENT:].strip() != "":
-                consumer.locus(line[self.GENBANK_INDENT:].strip())
+            if line[self.GENBANK_INDENT :].strip() != "":
+                consumer.locus(line[self.GENBANK_INDENT :].strip())
             else:
                 # Must just have just "LOCUS       ", is this even legitimate?
                 # We should be able to continue parsing... we need real world testcases!
-                warnings.warn("Minimal LOCUS line found - is this "
-                              "correct?\n:%r" % line, BiopythonParserWarning)
-        elif len(line.split()) == 8 and line.split()[3] in ("aa", "bp") \
-                and line.split()[5] in ("linear", "circular"):
+                warnings.warn(
+                    "Minimal LOCUS line found - is this " "correct?\n:%r" % line,
+                    BiopythonParserWarning,
+                )
+        elif (
+            len(line.split()) == 8
+            and line.split()[3] in ("aa", "bp")
+            and line.split()[5] in ("linear", "circular")
+        ):
             # Cope with invalidly spaced GenBank LOCUS lines like
             # LOCUS       AB070938          6497 bp    DNA     linear   BCT 11-OCT-2001
             # This will also cope with extra long accession numbers and
@@ -1409,11 +1518,13 @@ class GenBankScanner(InsdcScanner):
             # Provide descriptive error message if the sequence is too long
             # for python to handle
             import sys
+
             if int(splitline[2]) > sys.maxsize:
-                raise ValueError("Tried to load a sequence with a length %s, "
-                                 "your installation of python can only load "
-                                 "sesquences of length %s" % (splitline[2],
-                                                              sys.maxsize))
+                raise ValueError(
+                    "Tried to load a sequence with a length %s, "
+                    "your installation of python can only load "
+                    "sesquences of length %s" % (splitline[2], sys.maxsize)
+                )
             else:
                 consumer.size(splitline[2])
 
@@ -1422,11 +1533,13 @@ class GenBankScanner(InsdcScanner):
             consumer.data_file_division(splitline[6])
             consumer.date(splitline[7])
             if len(line) < 80:
-                warnings.warn("Attempting to parse malformed locus line:\n%r\n"
-                              "Found locus %r size %r residue_type %r\n"
-                              "Some fields may be wrong."
-                              % (line, splitline[1], splitline[2], splitline[4]),
-                              BiopythonParserWarning)
+                warnings.warn(
+                    "Attempting to parse malformed locus line:\n%r\n"
+                    "Found locus %r size %r residue_type %r\n"
+                    "Some fields may be wrong."
+                    % (line, splitline[1], splitline[2], splitline[4]),
+                    BiopythonParserWarning,
+                )
         elif len(line.split()) == 7 and line.split()[3] in ["aa", "bp"]:
             # Cope with EnsEMBL genbank files which use space separation rather
             # than the expected column based layout. e.g.
@@ -1445,16 +1558,20 @@ class GenBankScanner(InsdcScanner):
         elif len(line.split()) >= 4 and line.split()[3] in ["aa", "bp"]:
             # Cope with EMBOSS seqret output where it seems the locus id can cause
             # the other fields to overflow.  We just IGNORE the other fields!
-            warnings.warn("Malformed LOCUS line found - is this "
-                          "correct?\n:%r" % line, BiopythonParserWarning)
+            warnings.warn(
+                "Malformed LOCUS line found - is this " "correct?\n:%r" % line,
+                BiopythonParserWarning,
+            )
             consumer.locus(line.split()[1])
             consumer.size(line.split()[2])
         elif len(line.split()) >= 4 and line.split()[-1] in ["aa", "bp"]:
             # Cope with pseudo-GenBank files like this:
             #   "LOCUS       RNA5 complete       1718 bp"
             # Treat everything between LOCUS and the size as the identifier.
-            warnings.warn("Malformed LOCUS line found - is this "
-                          "correct?\n:%r" % line, BiopythonParserWarning)
+            warnings.warn(
+                "Malformed LOCUS line found - is this " "correct?\n:%r" % line,
+                BiopythonParserWarning,
+            )
             consumer.locus(line[5:].rsplit(None, 2)[0].strip())
             consumer.size(line.split()[-2])
         else:
@@ -1481,7 +1598,8 @@ class GenBankScanner(InsdcScanner):
             "JOURNAL": "journal",
             "MEDLINE": "medline_id",
             "PUBMED": "pubmed_id",
-            "REMARK": "remark"}
+            "REMARK": "remark",
+        }
         # We have to handle the following specially:
         # ORIGIN (locus, size, residue_type, data_file_division and date)
         # COMMENT (comment)
@@ -1497,8 +1615,8 @@ class GenBankScanner(InsdcScanner):
             while True:
                 if not line:
                     break
-                line_type = line[:self.GENBANK_INDENT].strip()
-                data = line[self.GENBANK_INDENT:].strip()
+                line_type = line[: self.GENBANK_INDENT].strip()
+                data = line[self.GENBANK_INDENT :].strip()
 
                 if line_type == "VERSION":
                     # Need to call consumer.version(), and maybe also consumer.gi() as well.
@@ -1510,7 +1628,13 @@ class GenBankScanner(InsdcScanner):
                         consumer.version(data)
                     else:
                         if self.debug:
-                            print("Version [" + data.split(" GI:")[0] + "], gi [" + data.split(" GI:")[1] + "]")
+                            print(
+                                "Version ["
+                                + data.split(" GI:")[0]
+                                + "], gi ["
+                                + data.split(" GI:")[1]
+                                + "]"
+                            )
                         consumer.version(data.split(" GI:")[0])
                         consumer.gi(data.split(" GI:")[1])
                     # Read in the next line!
@@ -1523,9 +1647,9 @@ class GenBankScanner(InsdcScanner):
                     # Read in the next line, and see if its more of the DBLINK section:
                     while True:
                         line = next(line_iter)
-                        if line[:self.GENBANK_INDENT] == self.GENBANK_SPACER:
+                        if line[: self.GENBANK_INDENT] == self.GENBANK_SPACER:
                             # Add this continuation to the data string
-                            consumer.dblink(line[self.GENBANK_INDENT:].strip())
+                            consumer.dblink(line[self.GENBANK_INDENT :].strip())
                         else:
                             # End of the DBLINK, leave this text in the variable "line"
                             break
@@ -1547,9 +1671,9 @@ class GenBankScanner(InsdcScanner):
                     # Read in the next line, and see if its more of the reference:
                     while True:
                         line = next(line_iter)
-                        if line[:self.GENBANK_INDENT] == self.GENBANK_SPACER:
+                        if line[: self.GENBANK_INDENT] == self.GENBANK_SPACER:
                             # Add this continuation to the data string
-                            data += " " + line[self.GENBANK_INDENT:]
+                            data += " " + line[self.GENBANK_INDENT :]
                             if self.debug > 1:
                                 print("Extended reference text [" + data + "]")
                         else:
@@ -1562,13 +1686,19 @@ class GenBankScanner(InsdcScanner):
                         data = data.replace("  ", " ")
                     if " " not in data:
                         if self.debug > 2:
-                            print('Reference number \"' + data + '\"')
+                            print('Reference number "' + data + '"')
                         consumer.reference_num(data)
                     else:
                         if self.debug > 2:
-                            print('Reference number \"' + data[:data.find(" ")] + '\", \"' + data[data.find(" ") + 1:] + '\"')
-                        consumer.reference_num(data[:data.find(" ")])
-                        consumer.reference_bases(data[data.find(" ") + 1:])
+                            print(
+                                'Reference number "'
+                                + data[: data.find(" ")]
+                                + '", "'
+                                + data[data.find(" ") + 1 :]
+                                + '"'
+                            )
+                        consumer.reference_num(data[: data.find(" ")])
+                        consumer.reference_bases(data[data.find(" ") + 1 :])
                 elif line_type == "ORGANISM":
                     # Typically the first line is the organism, and subsequent lines
                     # are the taxonomy lineage.  However, given longer and longer
@@ -1582,14 +1712,16 @@ class GenBankScanner(InsdcScanner):
                     lineage_data = ""
                     while True:
                         line = next(line_iter)
-                        if line[0:self.GENBANK_INDENT] == self.GENBANK_SPACER:
+                        if line[0 : self.GENBANK_INDENT] == self.GENBANK_SPACER:
                             if lineage_data or ";" in line:
-                                lineage_data += " " + line[self.GENBANK_INDENT:]
-                            elif line[self.GENBANK_INDENT:].strip() == ".":
+                                lineage_data += " " + line[self.GENBANK_INDENT :]
+                            elif line[self.GENBANK_INDENT :].strip() == ".":
                                 # No lineage data, just . place holder
                                 pass
                             else:
-                                organism_data += " " + line[self.GENBANK_INDENT:].strip()
+                                organism_data += (
+                                    " " + line[self.GENBANK_INDENT :].strip()
+                                )
                         else:
                             # End of organism and taxonomy
                             break
@@ -1608,7 +1740,7 @@ class GenBankScanner(InsdcScanner):
                     # the title or header of the table (e.g. Assembly-Data, FluData). See
                     # http://www.ncbi.nlm.nih.gov/genbank/structuredcomment
                     # for more information on Structured Comments.
-                    data = line[self.GENBANK_INDENT:]
+                    data = line[self.GENBANK_INDENT :]
                     if self.debug > 1:
                         print("Found comment")
                     comment_list = []
@@ -1624,21 +1756,39 @@ class GenBankScanner(InsdcScanner):
 
                     while True:
                         line = next(line_iter)
-                        data = line[self.GENBANK_INDENT:]
-                        if line[0:self.GENBANK_INDENT] == self.GENBANK_SPACER:
+                        data = line[self.GENBANK_INDENT :]
+                        if line[0 : self.GENBANK_INDENT] == self.GENBANK_SPACER:
                             if self.STRUCTURED_COMMENT_START in data:
-                                regex = r"([^#]+){0}$".format(self.STRUCTURED_COMMENT_START)
+                                regex = r"([^#]+){0}$".format(
+                                    self.STRUCTURED_COMMENT_START
+                                )
                                 structured_comment_key = re.search(regex, data)
                                 if structured_comment_key is not None:
-                                    structured_comment_key = structured_comment_key.group(1)
+                                    structured_comment_key = structured_comment_key.group(
+                                        1
+                                    )
                                 else:
                                     comment_list.append(data)
-                            elif structured_comment_key is not None and self.STRUCTURED_COMMENT_DELIM in data:
-                                match = re.search(r"(.+?)\s*{0}\s*(.+)".format(self.STRUCTURED_COMMENT_DELIM), data)
-                                structured_comment_dict.setdefault(structured_comment_key, OrderedDict())
-                                structured_comment_dict[structured_comment_key][match.group(1)] = match.group(2)
+                            elif (
+                                structured_comment_key is not None
+                                and self.STRUCTURED_COMMENT_DELIM in data
+                            ):
+                                match = re.search(
+                                    r"(.+?)\s*{0}\s*(.+)".format(
+                                        self.STRUCTURED_COMMENT_DELIM
+                                    ),
+                                    data,
+                                )
+                                structured_comment_dict.setdefault(
+                                    structured_comment_key, OrderedDict()
+                                )
+                                structured_comment_dict[structured_comment_key][
+                                    match.group(1)
+                                ] = match.group(2)
                                 if self.debug > 2:
-                                    print("Structured Comment continuation [" + data + "]")
+                                    print(
+                                        "Structured Comment continuation [" + data + "]"
+                                    )
                             elif self.STRUCTURED_COMMENT_END not in data:
                                 comment_list.append(data)
                                 if self.debug > 2:
@@ -1656,8 +1806,8 @@ class GenBankScanner(InsdcScanner):
                     # Now, this may be a multi line entry...
                     while True:
                         line = next(line_iter)
-                        if line[0:self.GENBANK_INDENT] == self.GENBANK_SPACER:
-                            data += " " + line[self.GENBANK_INDENT:]
+                        if line[0 : self.GENBANK_INDENT] == self.GENBANK_SPACER:
+                            data += " " + line[self.GENBANK_INDENT :]
                         else:
                             # We now have all the data for this entry:
 
@@ -1713,9 +1863,9 @@ class GenBankScanner(InsdcScanner):
                         line = next(line_iter)
                         if not line:
                             break
-                        elif line[:self.GENBANK_INDENT] == self.GENBANK_SPACER:
+                        elif line[: self.GENBANK_INDENT] == self.GENBANK_SPACER:
                             # Don't need to preseve the whitespace here.
-                            contig_location += line[self.GENBANK_INDENT:].rstrip()
+                            contig_location += line[self.GENBANK_INDENT :].rstrip()
                         elif line.startswith("ORIGIN"):
                             # Strange, seen this in GenPept files via Entrez gbwithparts
                             line = line[6:].strip()
@@ -1723,7 +1873,9 @@ class GenBankScanner(InsdcScanner):
                                 consumer.origin_name(line)
                             break
                         else:
-                            raise ValueError("Expected CONTIG continuation line, got:\n" + line)
+                            raise ValueError(
+                                "Expected CONTIG continuation line, got:\n" + line
+                            )
                     consumer.contig_location(contig_location)
             return
         except StopIteration:

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -71,8 +71,10 @@ _between_location = r"\d+\^\d+"
 
 _within_position = r"\(\d+\.\d+\)"
 _re_within_position = re.compile(_within_position)
-_within_location = r"([<>]?\d+|%s)\.\.([<>]?\d+|%s)" \
-                   % (_within_position, _within_position)
+_within_location = r"([<>]?\d+|%s)\.\.([<>]?\d+|%s)" % (
+    _within_position,
+    _within_position,
+)
 assert _re_within_position.match("(3.9)")
 assert re.compile(_within_location).match("(3.9)..10")
 assert re.compile(_within_location).match("26..(30.33)")
@@ -80,8 +82,7 @@ assert re.compile(_within_location).match("(13.19)..(20.28)")
 
 _oneof_position = r"one\-of\(\d+(,\d+)+\)"
 _re_oneof_position = re.compile(_oneof_position)
-_oneof_location = r"([<>]?\d+|%s)\.\.([<>]?\d+|%s)" \
-                   % (_oneof_position, _oneof_position)
+_oneof_location = r"([<>]?\d+|%s)\.\.([<>]?\d+|%s)" % (_oneof_position, _oneof_position)
 assert _re_oneof_position.match("one-of(6,9)")
 assert re.compile(_oneof_location).match("one-of(6,9)..101")
 assert re.compile(_oneof_location).match("one-of(6,9)..one-of(101,104)")
@@ -94,17 +95,25 @@ assert _re_oneof_position.match("one-of(3,6,9)")
 
 _simple_location = r"\d+\.\.\d+"
 _re_simple_location = re.compile(r"^%s$" % _simple_location)
-_re_simple_compound = re.compile(r"^(join|order|bond)\(%s(,%s)*\)$"
-                                 % (_simple_location, _simple_location))
-_complex_location = r"([a-zA-Z][a-zA-Z0-9_\.\|]*[a-zA-Z0-9]?\:)?(%s|%s|%s|%s|%s)" \
-                    % (_pair_location, _solo_location, _between_location,
-                       _within_location, _oneof_location)
+_re_simple_compound = re.compile(
+    r"^(join|order|bond)\(%s(,%s)*\)$" % (_simple_location, _simple_location)
+)
+_complex_location = r"([a-zA-Z][a-zA-Z0-9_\.\|]*[a-zA-Z0-9]?\:)?(%s|%s|%s|%s|%s)" % (
+    _pair_location,
+    _solo_location,
+    _between_location,
+    _within_location,
+    _oneof_location,
+)
 _re_complex_location = re.compile(r"^%s$" % _complex_location)
-_possibly_complemented_complex_location = r"(%s|complement\(%s\))" \
-                                          % (_complex_location, _complex_location)
-_re_complex_compound = re.compile(r"^(join|order|bond)\(%s(,%s)*\)$"
-                                  % (_possibly_complemented_complex_location,
-                                     _possibly_complemented_complex_location))
+_possibly_complemented_complex_location = r"(%s|complement\(%s\))" % (
+    _complex_location,
+    _complex_location,
+)
+_re_complex_compound = re.compile(
+    r"^(join|order|bond)\(%s(,%s)*\)$"
+    % (_possibly_complemented_complex_location, _possibly_complemented_complex_location)
+)
 
 
 assert _re_simple_location.match("104..160")
@@ -120,7 +129,9 @@ assert _re_simple_compound.match("order(1..69,1308..1465)")
 assert not _re_simple_compound.match("order(1..69,1308..1465,1524)")
 assert not _re_simple_compound.match("join(<1..442,992..1228,1524..>1983)")
 assert not _re_simple_compound.match("join(<1..181,254..336,422..497,574..>590)")
-assert not _re_simple_compound.match("join(1475..1577,2841..2986,3074..3193,3314..3481,4126..>4215)")
+assert not _re_simple_compound.match(
+    "join(1475..1577,2841..2986,3074..3193,3314..3481,4126..>4215)"
+)
 assert not _re_simple_compound.match("test(1..69,1308..1465)")
 assert not _re_simple_compound.match("complement(1..69)")
 assert not _re_simple_compound.match("(1..69)")
@@ -131,21 +142,39 @@ assert _re_complex_location.match("41^42")  # between
 assert _re_complex_location.match("AL121804:41^42")
 assert _re_complex_location.match("AL121804:41..610")
 assert _re_complex_location.match("AL121804.2:41..610")
-assert _re_complex_location.match("AL358792.24.1.166931:3274..3461")  # lots of dots in external reference
+assert _re_complex_location.match(
+    "AL358792.24.1.166931:3274..3461"
+)  # lots of dots in external reference
 assert _re_complex_location.match("one-of(3,6)..101")
-assert _re_complex_compound.match("join(153490..154269,AL121804.2:41..610,AL121804.2:672..1487)")
-assert not _re_simple_compound.match("join(153490..154269,AL121804.2:41..610,AL121804.2:672..1487)")
+assert _re_complex_compound.match(
+    "join(153490..154269,AL121804.2:41..610,AL121804.2:672..1487)"
+)
+assert not _re_simple_compound.match(
+    "join(153490..154269,AL121804.2:41..610,AL121804.2:672..1487)"
+)
 assert _re_complex_compound.match("join(complement(69611..69724),139856..140650)")
-assert _re_complex_compound.match("join(complement(AL354868.10.1.164018:80837..81016),complement(AL354868.10.1.164018:80539..80835))")
+assert _re_complex_compound.match(
+    "join(complement(AL354868.10.1.164018:80837..81016),complement(AL354868.10.1.164018:80539..80835))"
+)
 
 # Trans-spliced example from NC_016406, note underscore in reference name:
 assert _re_complex_location.match("NC_016402.1:6618..6676")
 assert _re_complex_location.match("181647..181905")
-assert _re_complex_compound.match("join(complement(149815..150200),complement(293787..295573),NC_016402.1:6618..6676,181647..181905)")
-assert not _re_complex_location.match("join(complement(149815..150200),complement(293787..295573),NC_016402.1:6618..6676,181647..181905)")
-assert not _re_simple_compound.match("join(complement(149815..150200),complement(293787..295573),NC_016402.1:6618..6676,181647..181905)")
-assert not _re_complex_location.match("join(complement(149815..150200),complement(293787..295573),NC_016402.1:6618..6676,181647..181905)")
-assert not _re_simple_location.match("join(complement(149815..150200),complement(293787..295573),NC_016402.1:6618..6676,181647..181905)")
+assert _re_complex_compound.match(
+    "join(complement(149815..150200),complement(293787..295573),NC_016402.1:6618..6676,181647..181905)"
+)
+assert not _re_complex_location.match(
+    "join(complement(149815..150200),complement(293787..295573),NC_016402.1:6618..6676,181647..181905)"
+)
+assert not _re_simple_compound.match(
+    "join(complement(149815..150200),complement(293787..295573),NC_016402.1:6618..6676,181647..181905)"
+)
+assert not _re_complex_location.match(
+    "join(complement(149815..150200),complement(293787..295573),NC_016402.1:6618..6676,181647..181905)"
+)
+assert not _re_simple_location.match(
+    "join(complement(149815..150200),complement(293787..295573),NC_016402.1:6618..6676,181647..181905)"
+)
 
 _solo_bond = re.compile(r"bond\(%s\)" % _solo_location)
 assert _solo_bond.match("bond(196)")
@@ -229,8 +258,10 @@ def _pos(pos_str, offset=0):
     elif _re_oneof_position.match(pos_str):
         assert pos_str.startswith("one-of(")
         assert pos_str[-1] == ")"
-        parts = [SeqFeature.ExactPosition(int(pos) + offset)
-                 for pos in pos_str[7:-1].split(",")]
+        parts = [
+            SeqFeature.ExactPosition(int(pos) + offset)
+            for pos in pos_str[7:-1].split(",")
+        ]
         if offset == -1:
             default = min(int(pos) for pos in parts)
         else:
@@ -320,20 +351,22 @@ def _loc(loc_str, expected_seq_length, strand, seq_type=None):
     e_pos = _pos(e)
     if int(s_pos) > int(e_pos):
         if seq_type is None or "circular" not in seq_type.lower():
-            warnings.warn("It appears that %r is a feature that spans "
-                          "the origin, but the sequence topology is "
-                          "undefined. Skipping feature." % loc_str,
-                          BiopythonParserWarning)
+            warnings.warn(
+                "It appears that %r is a feature that spans "
+                "the origin, but the sequence topology is "
+                "undefined. Skipping feature." % loc_str,
+                BiopythonParserWarning,
+            )
             return None
-        warnings.warn("Attempting to fix invalid location %r as "
-                      "it looks like incorrect origin wrapping. "
-                      "Please fix input file, this could have "
-                      "unintended behavior." % loc_str,
-                      BiopythonParserWarning)
+        warnings.warn(
+            "Attempting to fix invalid location %r as "
+            "it looks like incorrect origin wrapping. "
+            "Please fix input file, this could have "
+            "unintended behavior." % loc_str,
+            BiopythonParserWarning,
+        )
 
-        f1 = SeqFeature.FeatureLocation(s_pos,
-                                        expected_seq_length,
-                                        strand)
+        f1 = SeqFeature.FeatureLocation(s_pos, expected_seq_length, strand)
         f2 = SeqFeature.FeatureLocation(0, int(e_pos), strand)
 
         if strand == -1:
@@ -380,8 +413,8 @@ def _split_compound_loc(compound_loc):
             while part.count("(") > part.count(")"):
                 assert "one-of(" in part, (part, compound_loc)
                 i = compound_loc.find(")")
-                part += compound_loc[:i + 1]
-                compound_loc = compound_loc[i + 1:]
+                part += compound_loc[: i + 1]
+                compound_loc = compound_loc[i + 1 :]
             if compound_loc.startswith(".."):
                 i = compound_loc.find(",")
                 if i == -1:
@@ -393,8 +426,8 @@ def _split_compound_loc(compound_loc):
             while part.count("(") > part.count(")"):
                 assert part.count("one-of(") == 2
                 i = compound_loc.find(")")
-                part += compound_loc[:i + 1]
-                compound_loc = compound_loc[i + 1:]
+                part += compound_loc[: i + 1]
+                compound_loc = compound_loc[i + 1 :]
             if compound_loc.startswith(","):
                 compound_loc = compound_loc[1:]
             assert part
@@ -448,6 +481,7 @@ class Iterator(object):
             return None
 
     if sys.version_info[0] < 3:
+
         def next(self):
             """Python 2 style alias for Python 3 style __next__ method."""
             return self.__next__()
@@ -481,8 +515,7 @@ class FeatureParser(object):
     Please use Bio.SeqIO.parse(...) or Bio.SeqIO.read(...) instead.
     """
 
-    def __init__(self, debug_level=0, use_fuzziness=1,
-                 feature_cleaner=_cleaner):
+    def __init__(self, debug_level=0, use_fuzziness=1, feature_cleaner=_cleaner):
         """Initialize a GenBank parser and Feature consumer.
 
         Arguments:
@@ -504,8 +537,7 @@ class FeatureParser(object):
 
     def parse(self, handle):
         """Parse the specified handle."""
-        _consumer = _FeatureConsumer(self.use_fuzziness,
-                                     self._cleaner)
+        _consumer = _FeatureConsumer(self.use_fuzziness, self._cleaner)
         self._scanner.feed(handle, _consumer)
         return _consumer.data
 
@@ -670,6 +702,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
 
     def __init__(self, use_fuzziness, feature_cleaner=None):
         from Bio.SeqRecord import SeqRecord
+
         _BaseGenBankConsumer.__init__(self)
         self.data = SeqRecord(None, id=None)
         self.data.id = None
@@ -705,14 +738,18 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         """Validate and record sequence topology (linear or circular as strings)."""
         if topology:
             if topology not in ["linear", "circular"]:
-                raise ParserFailureError("Unexpected topology %r should be linear or circular" % topology)
+                raise ParserFailureError(
+                    "Unexpected topology %r should be linear or circular" % topology
+                )
             self.data.annotations["topology"] = topology
 
     def molecule_type(self, mol_type):
         """Validate and record the molecule type (for round-trip etc)."""
         if mol_type:
             if "circular" in mol_type or "linear" in mol_type:
-                raise ParserFailureError("Molecule type %r should not include topology" % mol_type)
+                raise ParserFailureError(
+                    "Molecule type %r should not include topology" % mol_type
+                )
 
             # Writing out records will fail if we have a lower case DNA
             # or RNA string in here, so upper case it.
@@ -720,8 +757,10 @@ class _FeatureConsumer(_BaseGenBankConsumer):
             # the m in mRNA, but thanks to the strip we lost the spaces
             # so we need to index from the back
             if mol_type[-3:].upper() in ("DNA", "RNA") and not mol_type[-3:].isupper():
-                warnings.warn("Non-upper case molecule type in LOCUS line: %s"
-                              % mol_type, BiopythonParserWarning)
+                warnings.warn(
+                    "Non-upper case molecule type in LOCUS line: %s" % mol_type,
+                    BiopythonParserWarning,
+                )
 
             self.data.annotations["molecule_type"] = mol_type
 
@@ -939,19 +978,20 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         elif "residues" in ref_base_info and "to" in ref_base_info:
             residues_start = ref_base_info.find("residues")
             # get only the information after "residues"
-            ref_base_info = ref_base_info[(residues_start + len("residues ")):]
+            ref_base_info = ref_base_info[(residues_start + len("residues ")) :]
             locations = self._split_reference_locations(ref_base_info)
             all_locations.extend(locations)
 
         # make sure if we are not finding information then we have
         # the string 'sites' or the string 'bases'
-        elif (ref_base_info == "sites" or
-              ref_base_info.strip() == "bases"):
+        elif ref_base_info == "sites" or ref_base_info.strip() == "bases":
             pass
         # otherwise raise an error
         else:
-            raise ValueError("Could not parse base info %s in record %s" %
-                             (ref_base_info, self.data.id))
+            raise ValueError(
+                "Could not parse base info %s in record %s"
+                % (ref_base_info, self.data.id)
+            )
 
         self._cur_reference.location = all_locations
 
@@ -971,9 +1011,9 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         new_locations = []
         for base_info in all_base_info:
             start, end = base_info.split("to")
-            new_start, new_end = \
-                self._convert_to_python_numbers(int(start.strip()),
-                                                int(end.strip()))
+            new_start, new_end = self._convert_to_python_numbers(
+                int(start.strip()), int(end.strip())
+            )
             this_location = SeqFeature.FeatureLocation(new_start, new_end)
             new_locations.append(this_location)
         return new_locations
@@ -992,8 +1032,9 @@ class _FeatureConsumer(_BaseGenBankConsumer):
 
     def title(self, content):
         if self._cur_reference is None:
-            warnings.warn("GenBank TITLE line without REFERENCE line.",
-                          BiopythonParserWarning)
+            warnings.warn(
+                "GenBank TITLE line without REFERENCE line.", BiopythonParserWarning
+            )
         elif self._cur_reference.title:
             self._cur_reference.title += " " + content
         else:
@@ -1082,26 +1123,32 @@ class _FeatureConsumer(_BaseGenBankConsumer):
             # e.g. "123..456"
             s, e = location_line.split("..")
             try:
-                cur_feature.location = SeqFeature.FeatureLocation(int(s) - 1,
-                                                                  int(e),
-                                                                  strand)
+                cur_feature.location = SeqFeature.FeatureLocation(
+                    int(s) - 1, int(e), strand
+                )
             except ValueError:
                 # Could be non-integers, more likely bad origin wrapping
-                cur_feature.location = _loc(location_line,
-                                            self._expected_size,
-                                            strand,
-                                            seq_type=self._seq_type.lower())
+                cur_feature.location = _loc(
+                    location_line,
+                    self._expected_size,
+                    strand,
+                    seq_type=self._seq_type.lower(),
+                )
             return
 
         if ",)" in location_line:
-            warnings.warn("Dropping trailing comma in malformed feature location",
-                          BiopythonParserWarning)
+            warnings.warn(
+                "Dropping trailing comma in malformed feature location",
+                BiopythonParserWarning,
+            )
             location_line = location_line.replace(",)", ")")
 
         if _solo_bond.search(location_line):
             # e.g. bond(196)
             # e.g. join(bond(284),bond(305),bond(309),bond(305))
-            warnings.warn("Dropping bond qualifier in feature location", BiopythonParserWarning)
+            warnings.warn(
+                "Dropping bond qualifier in feature location", BiopythonParserWarning
+            )
             # There ought to be a better way to do this...
             for x in _solo_bond.finditer(location_line):
                 x = x.group()
@@ -1113,13 +1160,11 @@ class _FeatureConsumer(_BaseGenBankConsumer):
             # cur_feature.location_operator = location_line[:i]
             # we can split on the comma because these are simple locations
             locs = []
-            for part in location_line[i + 1:-1].split(","):
+            for part in location_line[i + 1 : -1].split(","):
                 s, e = part.split("..")
 
                 try:
-                    locs.append(SeqFeature.FeatureLocation(int(s) - 1,
-                                                           int(e),
-                                                           strand))
+                    locs.append(SeqFeature.FeatureLocation(int(s) - 1, int(e), strand))
                 except ValueError:
                     # Could be non-integers, more likely bad origin wrapping
 
@@ -1127,32 +1172,39 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                     # a CompoundLocation. CompoundLocation.parts returns a
                     # list of the FeatureLocation objects inside the
                     # CompoundLocation.
-                    locs.extend(_loc(part,
-                                     self._expected_size,
-                                     strand,
-                                     self._seq_type.lower()).parts)
+                    locs.extend(
+                        _loc(
+                            part, self._expected_size, strand, self._seq_type.lower()
+                        ).parts
+                    )
 
             if len(locs) < 2:
                 # The CompoundLocation will raise a ValueError here!
-                warnings.warn("Should have at least 2 parts for compound location",
-                              BiopythonParserWarning)
+                warnings.warn(
+                    "Should have at least 2 parts for compound location",
+                    BiopythonParserWarning,
+                )
                 cur_feature.location = None
                 return
             if strand == -1:
-                cur_feature.location = SeqFeature.CompoundLocation(locs[::-1],
-                                                                   operator=location_line[:i])
+                cur_feature.location = SeqFeature.CompoundLocation(
+                    locs[::-1], operator=location_line[:i]
+                )
             else:
-                cur_feature.location = SeqFeature.CompoundLocation(locs,
-                                                                   operator=location_line[:i])
+                cur_feature.location = SeqFeature.CompoundLocation(
+                    locs, operator=location_line[:i]
+                )
             return
 
         # Handle the general case with more complex regular expressions
         if _re_complex_location.match(location_line):
             # e.g. "AL121804.2:41..610"
-            cur_feature.location = _loc(location_line,
-                                        self._expected_size,
-                                        strand,
-                                        seq_type=self._seq_type.lower())
+            cur_feature.location = _loc(
+                location_line,
+                self._expected_size,
+                strand,
+                seq_type=self._seq_type.lower(),
+            )
             return
 
         if _re_complex_compound.match(location_line):
@@ -1160,7 +1212,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
             # cur_feature.location_operator = location_line[:i]
             # Can't split on the comma because of positions like one-of(1,2,3)
             locs = []
-            for part in _split_compound_loc(location_line[i + 1:-1]):
+            for part in _split_compound_loc(location_line[i + 1 : -1]):
                 if part.startswith("complement("):
                     assert part[-1] == ")"
                     part = part[11:-1]
@@ -1173,8 +1225,12 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                     # Using _loc to return a CompoundLocation of the
                     # wrapped feature and returning the two FeatureLocation
                     # objects to extend to the list of feature locations.
-                    loc = _loc(part, self._expected_size, part_strand,
-                               seq_type=self._seq_type.lower()).parts
+                    loc = _loc(
+                        part,
+                        self._expected_size,
+                        part_strand,
+                        seq_type=self._seq_type.lower(),
+                    ).parts
 
                 except ValueError as err:
                     print(location_line)
@@ -1194,22 +1250,30 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                     assert l.strand == -1
                 # Reverse the backwards order used in GenBank files
                 # with complement(join(...))
-                cur_feature.location = SeqFeature.CompoundLocation(locs[::-1],
-                                                                   operator=location_line[:i])
+                cur_feature.location = SeqFeature.CompoundLocation(
+                    locs[::-1], operator=location_line[:i]
+                )
             else:
-                cur_feature.location = SeqFeature.CompoundLocation(locs,
-                                                                   operator=location_line[:i])
+                cur_feature.location = SeqFeature.CompoundLocation(
+                    locs, operator=location_line[:i]
+                )
             return
         # Not recognised
         if "order" in location_line and "join" in location_line:
             # See Bug 3197
-            msg = 'Combinations of "join" and "order" within the same ' + \
-                  "location (nested operators) are illegal:\n" + location_line
+            msg = (
+                'Combinations of "join" and "order" within the same '
+                + "location (nested operators) are illegal:\n"
+                + location_line
+            )
             raise LocationParserError(msg)
         # This used to be an error....
         cur_feature.location = None
-        warnings.warn(BiopythonParserWarning("Couldn't parse feature location: %r"
-                                             % location_line))
+        warnings.warn(
+            BiopythonParserWarning(
+                "Couldn't parse feature location: %r" % location_line
+            )
+        )
 
     def feature_qualifier(self, key, value):
         """When we get a qualifier key and its value.
@@ -1231,8 +1295,11 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         # Handle NCBI escaping
         # Warn if escaping is not according to standard
         if re.search(r'[^"]"[^"]|^"[^"]|[^"]"$', value):
-            warnings.warn('The NCBI states double-quote characters like " should be escaped as "" '
-                          "(two double - quotes), but here it was not: %r" % value, BiopythonParserWarning)
+            warnings.warn(
+                'The NCBI states double-quote characters like " should be escaped as "" '
+                "(two double - quotes), but here it was not: %r" % value,
+                BiopythonParserWarning,
+            )
         # Undo escaping, repeated double quotes -> one double quote
         value = value.replace('""', '"')
 
@@ -1301,8 +1368,10 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         # Try and append the version number to the accession for the full id
         if not self.data.id:
             if "accessions" in self.data.annotations:
-                raise ValueError("Problem adding version number to accession: "
-                                 + str(self.data.annotations["accessions"]))
+                raise ValueError(
+                    "Problem adding version number to accession: "
+                    + str(self.data.annotations["accessions"])
+                )
             self.data.id = self.data.name  # Good fall back?
         elif self.data.id.count(".") == 0:
             try:
@@ -1319,12 +1388,16 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         # now set the sequence
         sequence = "".join(self._seq_data)
 
-        if self._expected_size is not None \
-                and len(sequence) != 0 \
-                and self._expected_size != len(sequence):
-            warnings.warn("Expected sequence length %i, found %i (%s)."
-                          % (self._expected_size, len(sequence), self.data.id),
-                          BiopythonParserWarning)
+        if (
+            self._expected_size is not None
+            and len(sequence) != 0
+            and self._expected_size != len(sequence)
+        ):
+            warnings.warn(
+                "Expected sequence length %i, found %i (%s)."
+                % (self._expected_size, len(sequence), self.data.id),
+                BiopythonParserWarning,
+            )
 
         if self._seq_type:
             # mRNA is really also DNA, since it is actually cDNA
@@ -1338,8 +1411,9 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                     seq_alphabet = IUPAC.ambiguous_dna
                 else:
                     seq_alphabet = IUPAC.ambiguous_rna
-            elif "PROTEIN" in self._seq_type.upper() \
-                    or self._seq_type == "PRT":  # PRT is used in EMBL-bank for patents
+            elif (
+                "PROTEIN" in self._seq_type.upper() or self._seq_type == "PRT"
+            ):  # PRT is used in EMBL-bank for patents
                 seq_alphabet = IUPAC.protein  # or extended protein?
             # work around ugly GenBank records which have circular or
             # linear but no indication of sequence type
@@ -1347,8 +1421,9 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                 pass
             # we have a bug if we get here
             else:
-                raise ValueError("Could not determine alphabet for seq_type %s"
-                                 % self._seq_type)
+                raise ValueError(
+                    "Could not determine alphabet for seq_type %s" % self._seq_type
+                )
 
         if not sequence and self.__expected_size:
             self.data.seq = UnknownSeq(self._expected_size, seq_alphabet)
@@ -1362,6 +1437,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
     def __init__(self):
         _BaseGenBankConsumer.__init__(self)
         from . import Record
+
         self.data = Record.Record()
 
         self._seq_data = []
@@ -1387,8 +1463,10 @@ class _RecordConsumer(_BaseGenBankConsumer):
     def residue_type(self, content):
         # Be lenient about parsing, but technically lowercase residue types are malformed.
         if "dna" in content or "rna" in content:
-            warnings.warn("Invalid seq_type (%s): DNA/RNA should be uppercase." % content,
-                          BiopythonParserWarning)
+            warnings.warn(
+                "Invalid seq_type (%s): DNA/RNA should be uppercase." % content,
+                BiopythonParserWarning,
+            )
         self.data.residue_type = content
 
     def data_file_division(self, content):
@@ -1448,6 +1526,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
             self.data.references.append(self._cur_reference)
 
         from . import Record
+
         self._cur_reference = Record.Reference()
         self._cur_reference.number = content
 
@@ -1462,8 +1541,9 @@ class _RecordConsumer(_BaseGenBankConsumer):
 
     def title(self, content):
         if self._cur_reference is None:
-            warnings.warn("GenBank TITLE line without REFERENCE line.",
-                          BiopythonParserWarning)
+            warnings.warn(
+                "GenBank TITLE line without REFERENCE line.", BiopythonParserWarning
+            )
             return
         self._cur_reference.title = content
 
@@ -1508,6 +1588,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
         self._add_feature()
 
         from . import Record
+
         self._cur_feature = Record.Feature()
         self._cur_feature.key = content
 
@@ -1543,6 +1624,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
         tags separate them in the file)
         """
         from . import Record
+
         for content in content_list:
             # the record parser keeps the /s -- add them if we don't have 'em
             if not content.startswith("/"):
@@ -1641,4 +1723,5 @@ def read(handle):
 
 if __name__ == "__main__":
     from Bio._utils import run_doctest
+
     run_doctest()

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -573,8 +573,7 @@ class _BaseGenBankConsumer(object):
         else:
             keywords = keyword_string
         keyword_list = keywords.split(";")
-        clean_keyword_list = [x.strip() for x in keyword_list]
-        return clean_keyword_list
+        return [x.strip() for x in keyword_list]
 
     @staticmethod
     def _split_accessions(accession_string):
@@ -603,9 +602,7 @@ class _BaseGenBankConsumer(object):
             new_tax_list.extend(new_items)
         while "" in new_tax_list:
             new_tax_list.remove("")
-        clean_tax_list = [x.strip() for x in new_tax_list]
-
-        return clean_tax_list
+        return [x.strip() for x in new_tax_list]
 
     @staticmethod
     def _clean_location(location_string):

--- a/Bio/GenBank/utils.py
+++ b/Bio/GenBank/utils.py
@@ -45,8 +45,7 @@ class FeatureValueCleaner(object):
                 cleaner = getattr(self, "_clean_%s" % key_name)
                 value = cleaner(value)
             except AttributeError:
-                raise AssertionError("No function to clean key: %s"
-                                     % key_name)
+                raise AssertionError("No function to clean key: %s" % key_name)
         return value
 
     def _clean_translation(self, value):

--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -32,7 +32,6 @@ from Bio import GenBank
 
 
 class TestBasics(unittest.TestCase):
-
     def do_comparison(self, good_record, test_record):
         """Compare two records to see if they are the same.
 
@@ -54,8 +53,16 @@ class TestBasics(unittest.TestCase):
     def test_write_format(self):
         """Test writing to the difference formats."""
         # We only test writing on a subset of the examples:
-        filenames = ["noref.gb", "cor6_6.gb", "iro.gb", "pri1.gb", "arab1.gb",
-                     "extra_keywords.gb", "one_of.gb", "origin_line.gb"]
+        filenames = [
+            "noref.gb",
+            "cor6_6.gb",
+            "iro.gb",
+            "pri1.gb",
+            "arab1.gb",
+            "extra_keywords.gb",
+            "one_of.gb",
+            "origin_line.gb",
+        ]
         # don't test writing on protein_refseq, since it is horribly nasty
         # don't test writing on the CONTIG refseq, because the wrapping of
         # locations won't work exactly
@@ -80,7 +87,9 @@ class TestBasics(unittest.TestCase):
 
     def test_cleaning_features(self):
         """Test the ability to clean up feature values."""
-        gb_parser = GenBank.FeatureParser(feature_cleaner=GenBank.utils.FeatureValueCleaner())
+        gb_parser = GenBank.FeatureParser(
+            feature_cleaner=GenBank.utils.FeatureValueCleaner()
+        )
         path = "GenBank/arab1.gb"
         handle = open(path)
         iterator = GenBank.Iterator(handle, gb_parser)
@@ -88,10 +97,10 @@ class TestBasics(unittest.TestCase):
         # test for cleaning of translation
         translation_feature = first_record.features[1]
         test_trans = translation_feature.qualifiers["translation"][0]
-        self.assertNotIn(" ", test_trans,
-                         "Did not clean spaces out of the translation")
-        self.assertNotIn("\012", test_trans,
-                         "Did not clean newlines out of the translation")
+        self.assertNotIn(" ", test_trans, "Did not clean spaces out of the translation")
+        self.assertNotIn(
+            "\012", test_trans, "Did not clean newlines out of the translation"
+        )
         handle.close()
 
     def test_ensembl_locus(self):
@@ -123,17 +132,20 @@ class TestBasics(unittest.TestCase):
 
 
 class TestRecordParser(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.rec_parser = GenBank.RecordParser(debug_level=0)
 
-    def perform_record_parser_test(self, record, length, locus, definition, accession, titles, features):
+    def perform_record_parser_test(
+        self, record, length, locus, definition, accession, titles, features
+    ):
         self.assertEqual(len(record.sequence), length)
         self.assertEqual(record.locus, locus)
         self.assertEqual(record.definition, definition)
         self.assertEqual(record.accession, accession)
-        self.assertEqual(tuple(reference.title for reference in record.references), titles)
+        self.assertEqual(
+            tuple(reference.title for reference in record.references), titles
+        )
         self.assertEqual(len(record.features), len(features))
         for feature1, feature2 in zip(record.features, features):
             self.assertEqual(feature1.key, feature2[0])
@@ -153,11 +165,52 @@ class TestRecordParser(unittest.TestCase):
         definition = "Homo sapiens dynein, cytoplasmic, light intermediate polypeptide 2 (DNCLI2), mRNA"
         accession = ["NM_006141"]
         titles = ()
-        features = [("source", "1..1622", (("/organism=", '"Homo sapiens"'), ("/db_xref=", '"taxon:9606"'), ("/map=", '"16"'))),
-                    ("gene", "1..1622", (("/gene=", '"DNCLI2"'), ("/note=", '"LIC2"'), ("/db_xref=", '"LocusID:1783"'))),
-                    ("CDS", "7..1485", (("/gene=", '"DNCLI2"'), ("/note=", '"similar to R. norvegicus and G. gallus dynein light intermediate chain 2, Swiss-Prot Accession Numbers Q62698 and Q90828, respectively"'), ("/codon_start=", "1"), ("/db_xref=", '"LocusID:1783"'), ("/product=", '"dynein, cytoplasmic, light intermediate polypeptide 2"'), ("/protein_id=", '"NP_006132.1"'), ("/db_xref=", '"GI:5453634"'), ("/translation=", '"MAPVGVEKKLLLGPNGPAVAAAGDLTSEEEEGQSLWSSILSEVSTRARSKLPSGKNILVFGEDGSGKTTLMTKLQGAEHGKKGRGLEYLYLSVHDEDRDDHTRCNVWILDGDLYHKGLLKFAVSAESLPETLVIFVADMSRPWTVMESLQKWASVLREHIDKMKIPPEKMRELERKFVKDFQDYMEPEEGCQGSPQRRGPLTSGSDEENVALPLGDNVLTHNLGIPVLVVCTKCDAVSVLEKEHDYRDEHLDFIQSHLRRFCLQYGAALIYTSVKEEKNLDLLYKYIVHKTYGFHFTTPALVVEKDAVFIPAGWDNEKKIAILHENFTTVKPEDAYEDFIVKPPVRKLVHDKELAAEDEQVFLMKQQSLLAKQPATPTRASESPARGPSGSPRTQGRGGPASVPSSSPGTSVKKPDPNIKNNAASEGVLASFFNSLLSKKTGSPGSPGAGGVQSTAKKSGQKTVLSNVQEELDRMTRKPDSMVTNSSTENEA"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        features = [
+            (
+                "source",
+                "1..1622",
+                (
+                    ("/organism=", '"Homo sapiens"'),
+                    ("/db_xref=", '"taxon:9606"'),
+                    ("/map=", '"16"'),
+                ),
+            ),
+            (
+                "gene",
+                "1..1622",
+                (
+                    ("/gene=", '"DNCLI2"'),
+                    ("/note=", '"LIC2"'),
+                    ("/db_xref=", '"LocusID:1783"'),
+                ),
+            ),
+            (
+                "CDS",
+                "7..1485",
+                (
+                    ("/gene=", '"DNCLI2"'),
+                    (
+                        "/note=",
+                        '"similar to R. norvegicus and G. gallus dynein light intermediate chain 2, Swiss-Prot Accession Numbers Q62698 and Q90828, respectively"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/db_xref=", '"LocusID:1783"'),
+                    (
+                        "/product=",
+                        '"dynein, cytoplasmic, light intermediate polypeptide 2"',
+                    ),
+                    ("/protein_id=", '"NP_006132.1"'),
+                    ("/db_xref=", '"GI:5453634"'),
+                    (
+                        "/translation=",
+                        '"MAPVGVEKKLLLGPNGPAVAAAGDLTSEEEEGQSLWSSILSEVSTRARSKLPSGKNILVFGEDGSGKTTLMTKLQGAEHGKKGRGLEYLYLSVHDEDRDDHTRCNVWILDGDLYHKGLLKFAVSAESLPETLVIFVADMSRPWTVMESLQKWASVLREHIDKMKIPPEKMRELERKFVKDFQDYMEPEEGCQGSPQRRGPLTSGSDEENVALPLGDNVLTHNLGIPVLVVCTKCDAVSVLEKEHDYRDEHLDFIQSHLRRFCLQYGAALIYTSVKEEKNLDLLYKYIVHKTYGFHFTTPALVVEKDAVFIPAGWDNEKKIAILHENFTTVKPEDAYEDFIVKPPVRKLVHDKELAAEDEQVFLMKQQSLLAKQPATPTRASESPARGPSGSPRTQGRGGPASVPSSSPGTSVKKPDPNIKNNAASEGVLASFFNSLLSKKTGSPGSPGAGGVQSTAKKSGQKTVLSNVQEELDRMTRKPDSMVTNSSTENEA"',
+                    ),
+                ),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_02(self):
         path = "GenBank/cor6_6.gb"
@@ -168,87 +221,261 @@ class TestRecordParser(unittest.TestCase):
         locus = "ATCOR66M"
         definition = "A.thaliana cor6.6 mRNA"
         accession = ["X55053"]
-        titles = ("Direct Submission", "cDNA sequence analysis and expression of two cold-regulated genes of Arabidopsis thaliana")
-        features = [("source", "1..513", (("/organism=", '"Arabidopsis thaliana"'), ("/strain=", '"Columbia"'), ("/db_xref=", '"taxon:3702"'))),
-                    ("gene", "50..250", (("/gene=", '"cor6.6"'), )),
-                    ("CDS", "50..250", (("/gene=", '"cor6.6"'), ("/note=", '"cold regulated"'), ("/codon_start=", "1"), ("/protein_id=", '"CAA38894.1"'), ("/db_xref=", '"GI:16230"'), ("/db_xref=", '"SWISS-PROT:P31169"'), ("/translation=", '"MSETNKNAFQAGQAAGKAEEKSNVLLDKAKDAAAAAGASAQQAGKSISDAAVGGVNFVKDKTGLNK"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "Direct Submission",
+            "cDNA sequence analysis and expression of two cold-regulated genes of Arabidopsis thaliana",
+        )
+        features = [
+            (
+                "source",
+                "1..513",
+                (
+                    ("/organism=", '"Arabidopsis thaliana"'),
+                    ("/strain=", '"Columbia"'),
+                    ("/db_xref=", '"taxon:3702"'),
+                ),
+            ),
+            ("gene", "50..250", (("/gene=", '"cor6.6"'),)),
+            (
+                "CDS",
+                "50..250",
+                (
+                    ("/gene=", '"cor6.6"'),
+                    ("/note=", '"cold regulated"'),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAA38894.1"'),
+                    ("/db_xref=", '"GI:16230"'),
+                    ("/db_xref=", '"SWISS-PROT:P31169"'),
+                    (
+                        "/translation=",
+                        '"MSETNKNAFQAGQAAGKAEEKSNVLLDKAKDAAAAAGASAQQAGKSISDAAVGGVNFVKDKTGLNK"',
+                    ),
+                ),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
         record = next(records)
         length = 880
         locus = "ATKIN2"
         definition = "A.thaliana kin2 gene"
         accession = ["X62281"]
-        titles = ("Direct Submission", "Structure and expression of kin2, one of two cold- and ABA-induced genes of Arabidopsis thaliana")
-        features = [("source", "1..880", (("/organism=", '"Arabidopsis thaliana"'), ("/strain=", '"ssp. L. Heynh, Colombia"'), ("/db_xref=", '"taxon:3702"'))),
-                    ("TATA_signal", "9..20", ()),
-                    ("exon", "44..160", (("/gene=", '"kin2"'), ("/number=", "1"))),
-                    ("prim_transcript", "44..>579", (("/gene=", '"kin2"'), )),
-                    ("mRNA", "join(44..160,320..390,504..>579)", (("/gene=", '"kin2"'), )),
-                    ("gene", "44..579", (("/gene=", '"kin2"'), )),
-                    ("CDS", "join(104..160,320..390,504..579)", (("/gene=", '"kin2"'), ("/codon_start=", "1"), ("/protein_id=", '"CAA44171.1"'), ("/db_xref=", '"GI:16354"'), ("/db_xref=", '"SWISS-PROT:P31169"'), ("/translation=", '"MSETNKNAFQAGQAAGKAERRRAMFCWTRPRMLLLQLELPRNRAGKSISDAAVGGVNFVKDKTGLNK"'))),
-                    ("intron", "161..319", (("/gene=", '"kin2"'), ("/number=", "1"))),
-                    ("exon", "320..390", (("/gene=", '"kin2"'), ("/number=", "2"))),
-                    ("intron", "391..503", (("/gene=", '"kin2"'), ("/number=", "2"))),
-                    ("exon", "504..>579", (("/gene=", '"kin2"'), ("/number=", "3"))),
-                    ("polyA_signal", "620..625", ()),
-                    ("polyA_signal", "641..646", ()),
-                    ("polyA_site", "785", ()),
-                    ("polyA_site", "800", ()),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "Direct Submission",
+            "Structure and expression of kin2, one of two cold- and ABA-induced genes of Arabidopsis thaliana",
+        )
+        features = [
+            (
+                "source",
+                "1..880",
+                (
+                    ("/organism=", '"Arabidopsis thaliana"'),
+                    ("/strain=", '"ssp. L. Heynh, Colombia"'),
+                    ("/db_xref=", '"taxon:3702"'),
+                ),
+            ),
+            ("TATA_signal", "9..20", ()),
+            ("exon", "44..160", (("/gene=", '"kin2"'), ("/number=", "1"))),
+            ("prim_transcript", "44..>579", (("/gene=", '"kin2"'),)),
+            ("mRNA", "join(44..160,320..390,504..>579)", (("/gene=", '"kin2"'),)),
+            ("gene", "44..579", (("/gene=", '"kin2"'),)),
+            (
+                "CDS",
+                "join(104..160,320..390,504..579)",
+                (
+                    ("/gene=", '"kin2"'),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAA44171.1"'),
+                    ("/db_xref=", '"GI:16354"'),
+                    ("/db_xref=", '"SWISS-PROT:P31169"'),
+                    (
+                        "/translation=",
+                        '"MSETNKNAFQAGQAAGKAERRRAMFCWTRPRMLLLQLELPRNRAGKSISDAAVGGVNFVKDKTGLNK"',
+                    ),
+                ),
+            ),
+            ("intron", "161..319", (("/gene=", '"kin2"'), ("/number=", "1"))),
+            ("exon", "320..390", (("/gene=", '"kin2"'), ("/number=", "2"))),
+            ("intron", "391..503", (("/gene=", '"kin2"'), ("/number=", "2"))),
+            ("exon", "504..>579", (("/gene=", '"kin2"'), ("/number=", "3"))),
+            ("polyA_signal", "620..625", ()),
+            ("polyA_signal", "641..646", ()),
+            ("polyA_site", "785", ()),
+            ("polyA_site", "800", ()),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
         record = next(records)
         length = 441
         locus = "BNAKINI"
         definition = "Rapeseed Kin1 protein (kin1) mRNA, complete cds"
         accession = ["M81224"]
-        titles = ("Nucleotide sequence of a winter B. napus Kin 1 cDNA", )
-        features = [("source", "1..441", (("/organism=", '"Brassica napus"'), ("/cultivar=", '"Jet neuf"'), ("/db_xref=", '"taxon:3708"'), ("/dev_stage=", '"cold induced"'), ("/tissue_type=", '"leaf"'))),
-                    ("gene", "34..300", (("/gene=", '"kin1"'), )),
-                    ("CDS", "34..231", (("/gene=", '"kin1"'), ("/codon_start=", "1"), ("/evidence=", "experimental"), ("/protein_id=", '"AAA32993.1"'), ("/db_xref=", '"GI:167146"'), ("/translation=", '"MADNKQSFQAGQASGRAEEKGNVLMDKVKDAATAAGASAQTAGQKITEAAGGAVNLVKEKTGMNK"'))),
-                    ("polyA_signal", "241..247", (("/gene=", '"kin1"'), ("/note=", '"putative"'))),
-                    ("polyA_signal", "294..300", (("/gene=", '"kin1"'), ("/note=", '"putative"'))),
-                    ("polyA_site", "441", (("/gene=", '"kin1"'), )),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = ("Nucleotide sequence of a winter B. napus Kin 1 cDNA",)
+        features = [
+            (
+                "source",
+                "1..441",
+                (
+                    ("/organism=", '"Brassica napus"'),
+                    ("/cultivar=", '"Jet neuf"'),
+                    ("/db_xref=", '"taxon:3708"'),
+                    ("/dev_stage=", '"cold induced"'),
+                    ("/tissue_type=", '"leaf"'),
+                ),
+            ),
+            ("gene", "34..300", (("/gene=", '"kin1"'),)),
+            (
+                "CDS",
+                "34..231",
+                (
+                    ("/gene=", '"kin1"'),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "experimental"),
+                    ("/protein_id=", '"AAA32993.1"'),
+                    ("/db_xref=", '"GI:167146"'),
+                    (
+                        "/translation=",
+                        '"MADNKQSFQAGQASGRAEEKGNVLMDKVKDAATAAGASAQTAGQKITEAAGGAVNLVKEKTGMNK"',
+                    ),
+                ),
+            ),
+            (
+                "polyA_signal",
+                "241..247",
+                (("/gene=", '"kin1"'), ("/note=", '"putative"')),
+            ),
+            (
+                "polyA_signal",
+                "294..300",
+                (("/gene=", '"kin1"'), ("/note=", '"putative"')),
+            ),
+            ("polyA_site", "441", (("/gene=", '"kin1"'),)),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
         record = next(records)
         length = 206
         locus = "ARU237582"
         definition = "Armoracia rusticana csp14 gene (partial), exons 2-3"
         accession = ["AJ237582"]
         titles = ("", "Direct Submission")
-        features = [("source", "1..206", (("/organism=", '"Armoracia rusticana"'), ("/db_xref=", '"taxon:3704"'), ("/country=", '"Russia:Bashkortostan"'))),
-                    ("mRNA", "join(<1..48,143..>206)", (("/gene=", '"csp14"'), )),
-                    ("exon", "1..48", (("/gene=", '"csp14"'), ("/number=", "2"))),
-                    ("gene", "1..206", (("/gene=", '"csp14"'), )),
-                    ("CDS", "join(<1..48,143..>206)", (("/gene=", '"csp14"'), ("/codon_start=", "2"), ("/product=", '"cold shock protein"'), ("/protein_id=", '"CAB39890.1"'), ("/db_xref=", '"GI:4538893"'), ("/translation=", '"DKAKDAAAAAGASAQQAGKNISDAAAGGVNFVKEKTG"'))),
-                    ("intron", "49..142", (("/gene=", '"csp14"'), ("/number=", "2"))),
-                    ("exon", "143..206", (("/gene=", '"csp14"'), ("/number=", "3"))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        features = [
+            (
+                "source",
+                "1..206",
+                (
+                    ("/organism=", '"Armoracia rusticana"'),
+                    ("/db_xref=", '"taxon:3704"'),
+                    ("/country=", '"Russia:Bashkortostan"'),
+                ),
+            ),
+            ("mRNA", "join(<1..48,143..>206)", (("/gene=", '"csp14"'),)),
+            ("exon", "1..48", (("/gene=", '"csp14"'), ("/number=", "2"))),
+            ("gene", "1..206", (("/gene=", '"csp14"'),)),
+            (
+                "CDS",
+                "join(<1..48,143..>206)",
+                (
+                    ("/gene=", '"csp14"'),
+                    ("/codon_start=", "2"),
+                    ("/product=", '"cold shock protein"'),
+                    ("/protein_id=", '"CAB39890.1"'),
+                    ("/db_xref=", '"GI:4538893"'),
+                    ("/translation=", '"DKAKDAAAAAGASAQQAGKNISDAAAGGVNFVKEKTG"'),
+                ),
+            ),
+            ("intron", "49..142", (("/gene=", '"csp14"'), ("/number=", "2"))),
+            ("exon", "143..206", (("/gene=", '"csp14"'), ("/number=", "3"))),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
         record = next(records)
         length = 282
         locus = "BRRBIF72"
         definition = "Brassica rapa (clone bif72) kin mRNA, complete cds"
         accession = ["L31939"]
-        titles = ("Nucleotide sequences of kin gene in chinese cabbage", )
-        features = [("source", "1..282", (("/organism=", '"Brassica rapa"'), ("/db_xref=", '"taxon:3711"'), ("/dev_stage=", '"flower"'))),
-                    ("gene", "24..221", (("/gene=", '"kin"'), )),
-                    ("CDS", "24..221", (("/gene=", '"kin"'), ("/codon_start=", "1"), ("/protein_id=", '"AAA91051.1"'), ("/db_xref=", '"GI:1209262"'), ("/translation=", '"MADNKQSFQAGQAAGRAEEKGNVLLMDKVKDAATAAGALQTAGQKITEAAGGAVNLVKEKTGMNK"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = ("Nucleotide sequences of kin gene in chinese cabbage",)
+        features = [
+            (
+                "source",
+                "1..282",
+                (
+                    ("/organism=", '"Brassica rapa"'),
+                    ("/db_xref=", '"taxon:3711"'),
+                    ("/dev_stage=", '"flower"'),
+                ),
+            ),
+            ("gene", "24..221", (("/gene=", '"kin"'),)),
+            (
+                "CDS",
+                "24..221",
+                (
+                    ("/gene=", '"kin"'),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"AAA91051.1"'),
+                    ("/db_xref=", '"GI:1209262"'),
+                    (
+                        "/translation=",
+                        '"MADNKQSFQAGQAAGRAEEKGNVLLMDKVKDAATAAGALQTAGQKITEAAGGAVNLVKEKTGMNK"',
+                    ),
+                ),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
         record = next(records)
         length = 497
         locus = "AF297471"
         definition = "Brassica napus BN28a (BN28a) gene, complete cds"
         accession = ["AF297471"]
-        titles = ("BN28a, a low temperature-induced gene of Brassica napus", "Direct Submission")
-        features = [("source", "1..497", (("/organism=", '"Brassica napus"'), ("/cultivar=", '"Cascade"'), ("/db_xref=", '"taxon:3708"'))),
-                    ("mRNA", "join(<1..54,241..309,423..>497)", (("/gene=", '"BN28a"'), ("/product=", '"BN28a"'))),
-                    ("gene", "<1..>497", (("/gene=", '"BN28a"'), )),
-                    ("CDS", "join(1..54,241..309,423..497)", (("/gene=", '"BN28a"'), ("/note=", '"low temperature-induced; similar to Brassica napus Kin1 in Accession Number M81224"'), ("/codon_start=", "1"), ("/product=", '"BN28a"'), ("/protein_id=", '"AAG13407.1"'), ("/db_xref=", '"GI:10121869"'), ("/translation=", '"MADNKQSFQAGQAAGRAEEKGNVLMDKVKDAATAAGASAQTAGQKITEAAGGAVNLVKEKTGMNK"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "BN28a, a low temperature-induced gene of Brassica napus",
+            "Direct Submission",
+        )
+        features = [
+            (
+                "source",
+                "1..497",
+                (
+                    ("/organism=", '"Brassica napus"'),
+                    ("/cultivar=", '"Cascade"'),
+                    ("/db_xref=", '"taxon:3708"'),
+                ),
+            ),
+            (
+                "mRNA",
+                "join(<1..54,241..309,423..>497)",
+                (("/gene=", '"BN28a"'), ("/product=", '"BN28a"')),
+            ),
+            ("gene", "<1..>497", (("/gene=", '"BN28a"'),)),
+            (
+                "CDS",
+                "join(1..54,241..309,423..497)",
+                (
+                    ("/gene=", '"BN28a"'),
+                    (
+                        "/note=",
+                        '"low temperature-induced; similar to Brassica napus Kin1 in Accession Number M81224"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/product=", '"BN28a"'),
+                    ("/protein_id=", '"AAG13407.1"'),
+                    ("/db_xref=", '"GI:10121869"'),
+                    (
+                        "/translation=",
+                        '"MADNKQSFQAGQAAGRAEEKGNVLMDKVKDAATAAGASAQTAGQKITEAAGGAVNLVKEKTGMNK"',
+                    ),
+                ),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_03(self):
         path = "GenBank/iro.gb"
@@ -259,14 +486,34 @@ class TestRecordParser(unittest.TestCase):
         locus = "IRO125195"
         definition = "Homo sapiens mRNA full length insert cDNA clone EUROIMAGE 125195"
         accession = ["AL109817"]
-        titles = ("The European IMAGE consortium for integrated Molecular analysis of human gene transcripts", "Direct Submission")
-        features = [("source", "1..1326", (("/organism=", '"Homo sapiens"'), ("/db_xref=", '"taxon:9606"'), ("/chromosome=", '"21"'), ("/clone=", '"IMAGE cDNA clone 125195"'), ("/clone_lib=", '"Soares fetal liver spleen 1NFLS"'), ("/note=", '"contains Alu repeat; likely to be be derived from unprocessed nuclear RNA or genomic DNA; encodes putative exons identical to FTCD; formimino transferase cyclodeaminase; formimino transferase (EC 2.1.2.5) /formimino tetrahydro folate cyclodeaminase (EC 4.3.1.4)"'))),
-                    ("gene", "341..756", (("/gene=", '"FTCD"'), )),
-                    ("exon", "341..384", (("/gene=", '"FTCD"'), ("/number=", "1"))),
-                    ("intron", "385..617", (("/gene=", '"FTCD"'), ("/number=", "1"))),
-                    ("exon", "618..756", (("/gene=", '"FTCD"'), ("/number=", "2"))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "The European IMAGE consortium for integrated Molecular analysis of human gene transcripts",
+            "Direct Submission",
+        )
+        features = [
+            (
+                "source",
+                "1..1326",
+                (
+                    ("/organism=", '"Homo sapiens"'),
+                    ("/db_xref=", '"taxon:9606"'),
+                    ("/chromosome=", '"21"'),
+                    ("/clone=", '"IMAGE cDNA clone 125195"'),
+                    ("/clone_lib=", '"Soares fetal liver spleen 1NFLS"'),
+                    (
+                        "/note=",
+                        '"contains Alu repeat; likely to be be derived from unprocessed nuclear RNA or genomic DNA; encodes putative exons identical to FTCD; formimino transferase cyclodeaminase; formimino transferase (EC 2.1.2.5) /formimino tetrahydro folate cyclodeaminase (EC 4.3.1.4)"',
+                    ),
+                ),
+            ),
+            ("gene", "341..756", (("/gene=", '"FTCD"'),)),
+            ("exon", "341..384", (("/gene=", '"FTCD"'), ("/number=", "1"))),
+            ("intron", "385..617", (("/gene=", '"FTCD"'), ("/number=", "1"))),
+            ("exon", "618..756", (("/gene=", '"FTCD"'), ("/number=", "2"))),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_04(self):
         path = "GenBank/pri1.gb"
@@ -277,14 +524,44 @@ class TestRecordParser(unittest.TestCase):
         locus = "HUGLUT1"
         definition = "Human fructose transporter (GLUT5) gene, promoter and exon 1"
         accession = ["U05344"]
-        titles = ("Regulation of expression of the human fructose transporter (GLUT5) by cyclic AMP", "Direct Submission")
-        features = [("source", "1..741", (("/organism=", '"Homo sapiens"'), ("/db_xref=", '"taxon:9606"'), ("/chromosome=", '"1"'), ("/map=", '"1p31"'), ("/clone=", '"lambda hGT5-157"'), ("/tissue_type=", '"liver"'), ("/clone_lib=", '"partial Hae III/Alu I fetal human liver library in lambda Ch4A of Maniatis"'), ("/dev_stage=", '"fetal"'))),
-                    ("repeat_region", "1..73", (("/rpt_family=", '"Alu"'), )),
-                    ("promoter", "1..513", ()),
-                    ("5'UTR", "514..609", (("/gene=", '"GLUT5"'), )),
-                    ("exon", "514..642", (("/gene=", '"GLUT5"'), ("/number=", "1"), ("/product=", '"fructose transporter"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "Regulation of expression of the human fructose transporter (GLUT5) by cyclic AMP",
+            "Direct Submission",
+        )
+        features = [
+            (
+                "source",
+                "1..741",
+                (
+                    ("/organism=", '"Homo sapiens"'),
+                    ("/db_xref=", '"taxon:9606"'),
+                    ("/chromosome=", '"1"'),
+                    ("/map=", '"1p31"'),
+                    ("/clone=", '"lambda hGT5-157"'),
+                    ("/tissue_type=", '"liver"'),
+                    (
+                        "/clone_lib=",
+                        '"partial Hae III/Alu I fetal human liver library in lambda Ch4A of Maniatis"',
+                    ),
+                    ("/dev_stage=", '"fetal"'),
+                ),
+            ),
+            ("repeat_region", "1..73", (("/rpt_family=", '"Alu"'),)),
+            ("promoter", "1..513", ()),
+            ("5'UTR", "514..609", (("/gene=", '"GLUT5"'),)),
+            (
+                "exon",
+                "514..642",
+                (
+                    ("/gene=", '"GLUT5"'),
+                    ("/number=", "1"),
+                    ("/product=", '"fructose transporter"'),
+                ),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_05(self):
         path = "GenBank/arab1.gb"
@@ -295,28 +572,352 @@ class TestRecordParser(unittest.TestCase):
         locus = "AC007323"
         definition = "Genomic sequence for Arabidopsis thaliana BAC T25K16 from chromosome I, complete sequence"
         accession = ["AC007323"]
-        titles = ("Genomic sequence for Arabidopsis thaliana BAC T25K16 from chromosome I", "Direct Submission", "Direct Submission", "Direct Submission", "Direct Submission")
-        features = [("source", "1..86436", (("/organism=", '"Arabidopsis thaliana"'), ("/db_xref=", '"taxon:3702"'), ("/chromosome=", '"1"'), ("/clone=", '"T25K16"'))),
-                    ("CDS", "join(3462..3615,3698..3978,4077..4307,4408..4797,4876..5028,5141..5332)", (("/note=", '"containing similarity to NAM-like proteins gi|3695378"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.1"'), ("/protein_id=", '"AAF26460.1"'), ("/db_xref=", '"GI:6715633"'), ("/translation=", '"MEDQVGFGFRPNDEELVGHYLRNKIEGNTSRDVEVAISEVNICSYDPWNLRFQSKYKSRDAMWYFFSRRENNKGNRQSRTTVSGKWKLTGESVEVKDQWGFCSEGFRGKIGHKRVLVFLDGRYPDKTKSDWVIHEFHYDLLPEHQKLCNVTLFRFSSYFRLSLLSPMFYTDELMCLPPEILQRTYVICRLEYKGDDADILSAYAIDPTPAFVPNMTSSAGSVVNQSRQRNSGSYNTYSEYDSANHGQQFNENSNIMQQQPLQGSFNPLLEYDFANHGGQWLSDYIDLQQQVPYLAPYENESEMIWKHVIEENFEFLVDERTSMQQHYSDHRPKKPVSGVLPDDSSDTETGSMIFEDTSSSTDSVGSSDEPGHTRIDDIPSLNIIEPLHNYKAQEQPKQQSKEKVISSQKSECEWKMAEDSIKIPPSTNTVKQSWIVLENAQWNYLKNMIIGVLLFISVISWIILVG"'))),
-                    ("CDS", "complement(join(6617..6953,7266..7351,7464..7603,7916..7998,8087..8166,8273..8368))", (("/note=", '"hypothetical protein"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.2"'), ("/protein_id=", '"AAF26477.1"'), ("/db_xref=", '"GI:6715650"'), ("/translation=", '"MAASEHRCVGCGFRVKSLFIQYSPGNIRLMKCGNCKEVADEYIECERMVCFNHFLSLFGPKVYRHVLYNAINPATVNIQVKNYFNSTSRCVVGEIHRQTYLKSPELIIDRSLLLRKSDEESSFSDSPVLLSIKVLIGVLSANAAFIISFAIATKGLLNEVSRESLLLQVWEFPMSVIFFVDILLLTSNSMALKGQTFKMFSMQIVFCCCYFGISQCKFVFKPVMTESTMTRCIAVCLIAHLIRFLVGQIFEPTIFLIQIGSLLQYMSYFFRIV"'))),
-                    ("CDS", "complement(11566..12642)", (("/note=", '"putative RAP2.8 protein gi|3695373"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.3"'), ("/protein_id=", '"AAF26476.1"'), ("/db_xref=", '"GI:6715649"'), ("/translation=", '"MDLSLAPTTTTSSDQEQDRDQELTSNIGASSSSGPSGNNNNLPMMMIPPPEKEHMFDKVVTPSDVGKLNRLVIPKQHAERYFPLDSSNNQNGTLLNFQDRNGKMWRFRYSYWNSSQSYVMTKGWSRFVKEKKLDAGDIVSFQRGIGDESERSKLYIDWRHRPDMSLVQAHQFGNFGFNFNFPTTSQYSNRFHPLPEYNSVPIHRGLNIGNHQRSYYNTQRQEFVGYGYGNLAGRCYYTGSPLDHRNIVGSEPLVIDSVPVVPGRLTPVMLPPLPPPPSTAGKRLRLFGVNMECGNDYNQQEESWLVPRGEIGASSSSSSALRLNLSTDHDDDNDDGDDGDDDQFAKKGKSSLSLNFNP"'))),
-                    ("CDS", "join(23221..24174,24244..24357,24412..24664,24743..25137,25226..25445,25527..25711,25783..25905,25994..26478,26564..26730,26814..26983,27074..27235,27320..27415,27505..28133,28314..28507,28592..28782,28862..30013,30112..30518,30604..30781)", (("/note=", '"similar to UFD1 protein emb|CAB10321.1; similar to ESTs gb|H36434, gb|AI996152.1"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.4"'), ("/protein_id=", '"AAF26461.1"'), ("/db_xref=", '"GI:6715634"'), ("/translation=", '"MVMEDEPREATIKPSYWLDACEDISCDLIDDLVSEFDPSSVAVNESTDENGVINDFFGGIDHILDSIKNGGGLPNNGVSDTNSQINEVTVTPQVIAKETVKENGLQKNGGKRDEFSKEEGDKDRKRARVCSYQSERSNLSGRGHVNNSREGDRFMNRKRTRNWDEAGNNKKKRECNNYRRDGRDREVRGYWERDKVGSNELVYRSGTWEADHERDVKKVSGGNRECDVKAEENKSKPEERKEKVVEEQARRYQLDVLEQAKAKNTIAFLETGAGKTLIAILLIKSVHKDLMSQNRKMLSVFLVPKVPLVYQVPPNKKHQAEVIRNQTCFQVGHYCGEMGQDFWDSRRWQREFESKQFLKLTSFFLFSSTQVLVMTAQILLNILRHSIIRMETIDLLILDECHHAVKKHPYSLVMSEFYHTTPKDKRPAIFGMTASPVNLKGVSSQVDCAIKIRNLETKLDSTVCTIKDRKELEKHVPMPSEIVVEYDKAATMWSLHETIKQMIAAVEEAAQASSRKSKWQFMGARDAGAKDELRQVYGVSERTESDGAANLIHKLRAINYTLAELGQWCAYKVGQSFLSALQSDERVNFQVDVKFQESYLSEVVSLLQCELLEGAAAEKVAAEVGKPENGNAHDEMEEGELPDDPVVSGGEHVDEVIGAAVADGKVTPKVQSLIKLLLKYQHTADFRAIVFVERVVAALVLPKVRIKVFAELPSLSFIRCASMIGHNNSQEMKSSQMQDTISKFRDGHVTLLVATSVAEEGLDIRQCNVVMRFDLAKTVLAYIQSRGRARKPGSDYILMVERYIKSFKNYILIFVTTGHQISTDMSTCVTCRGNVSHAAFLRNARNSEETLRKEAIERTDLSHLKDTSRLISIDAVPGTVYKVEATGAMVSLNSAVGLVHFYCSQLPGDRYAILRPEFSMEKHEKPGGHTEYSCRLQLPCNAPFEILEGPVCSSMRLAQQVDIIVSACKKLHEMGAFTDMLLPDKGSGQDAEKADQDDEGEPVPGTARHREFYPEGVADVLKGEWVSSGKEVCESSKLFHLYMYNVRCVDFGSSKDPFLSEVSEFAILFGNELDAEVLSMSMDLYVARAMITKASLAFKGSLDITENQLSSLKKFHVRLMSIVLDVDVEPSTTPWDPAKAYLFVPVTDNTSMEPIKGINWELVEKITKTTAWDNPLQRARPDVYLGTNERTLGGDRREYGFGKLRHNIVFGQKSHPTYGIRGAVASFDVVRASGLLPVRDAFEKEVEEDLSKGKLMMADGCMVAEDLIGKIVTAAHSGKRFYVDSICYDMSAETSFPRKEGYLGPLEYNTYADYYKQKIYVVQDRLFFYFLHNLRLLRLYKSSSIMLFIRYGVDLNCKQQPLIKGRGVSYCKNLLSPRFEQSGESETVLDKTYYVFLPPELCVVHPLSGSLIRGAQRLPSIMRRVESMLLAVQLKNLISYPIPTSKILEALTAASCQETFCYERAELLGDAYLKWVVSRFLFLKYPQKHEGQLTRMRQQMVSNMVLYQFALVKGLQSYIQADRFAPSRWSAPGVPPVFDEDTKDGGSSFFDEEQKPVSEENSDVFEDGEMEDGELEGDLSSYRVLSSKTLADVVEALIGVYYVEGGKIAANHLMKWIGIHVEDDPDEVDGTLKNVNVPESVLKSIDFVGLERALKYEFKEKGLLVEAITHASRPSSGVSCYQRLEFVGDAVLDHLITRHLFFTYTSLPPGRLTDLRAAAVNNENFARVAVKHKLHLYLRHGSSALEKQVNKIKKQSILFSKSFKCLTVWLLFVFQIREFVKEVQTESSKPGFNSFGLGDCKAPKVLGDIVESIAGAIFLDSGKDTTAAWKVFQPLLQPMVTPETLPMHPVRELQERCQQQAEGLEYKASRSGNTATVEVFIDGVQVGVAQNPQKKMAQKLAARNALAALKEKEIAESKEKHINNGNAGEDQGENENGNKKNGHQPFTRQTLNDICLRKNWPMPSYRCVKEGGPAHAKRFTFGVRVNTSDRGWTDECIGEPMPSVKKAKDSAAVLLLELLNKTFS"'))),
-                    ("CDS", "complement(join(31084..31126,31223..31304,31341..31515,31635..31700,31790..31897,31984..32049,32133..32161,32249..32372))", (("/note=", '"putative inorganic pyrophosphatase gi|3510259; similar to ESTs gb|T42316, gb|AI994042.1, gb|AI994013.1, emb|Z29202"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.5"'), ("/protein_id=", '"AAF26475.1"'), ("/db_xref=", '"GI:6715648"'), ("/translation=", '"MSEETKDNQRLQRPAPRLNERILSSLSRRSVAAHPWHDLEIGPGAPQIFNVVVEITKGSKVKYELDKKTGLIKVDRILYSSVVYPHNYGFVPRTLCEDNDPIDVLVIMQEPVLPGCFLRARAIGLMPMIDQGEKDDKIIAVCVDDPEYKHYTDIKELPPHRLSEIRRFFEDCILFLQCSSLFISIDLSTNKKNENKEVAVNDFLPSESAVEAIQYSMDLYAEYILHTLRR"'))),
-                    ("CDS", "complement(join(33694..34029,34103..35173,35269..35349,35432..35701,36326..36387,36512..36623,36725..36763))", (("/note=", '"putative late elongated hypocotyl emb|CAA07004; similar to ESTS gb|AI993521.1, gb|AA650979"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.6"'), ("/protein_id=", '"AAF26474.1"'), ("/db_xref=", '"GI:6715647"'), ("/translation=", '"MDTNTSGEELLAKARKPYTITKQRERWTEDEHERFLEALRLYGRAWQRIEEHIGTKTAVQIRSHAQKFFTKFGKAHSFWFTFQLEKEAEVKGIPVCQALDIEIPPPRPKRKPNTPYPRKPGNNGTSSSQVSSAKDAKLVSSASSSQLNQAFLDLEKMPFSEKTSTGKENQDENCSGVSTVNKYPLPTKVSGDIETSKTSTVDNAVQDVPKKNKDKDGNDGTTVHSMQNYPWHFHADIVNGNIAKCPQNHPSGMVSQDFMFHPMREETHGHANLQATTASATTTASHQAFPACHSQDDYRSFLQISSTFSNLIMSTLLQNPAAHAAATFAASVWPYASVGNSGDSSTPMSSSPPSITAIAAATVAAATAWWASHGLLPVCAPAPITCVPFSTVAVPTPAMTEMDTVENTQPFEKQNTALQDQNLASKSPASSSDDSDETGVTKLNADSKTNDDKIEEVVVTAAVHDSNTAQKKNLVDRSSCGSNTPSGSDAETDALDKMEKDKEDVKETDENQPDVIELNNRKIKMRDNNSNNNATTDSWKEVSEEGRIAFQALFARERLPQSFSPPQVAENVNRKQSDTSMPLAPNFKSQDSCAADQEGVVMIGVGTCKSLKTRQTGFKPYKRCSMEVKESQVGNINNQSDEKVCKRLRLEGEAST"'))),
-                    ("CDS", "complement(join(38600..38756,38838..38989,39111..39516,39915..40031,40377..40579))", (("/note=", '"similar to Medicago truncatula MtN2 gi|3193308; similar to EST gb|H77065"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.7"'), ("/protein_id=", '"AAF26473.1"'), ("/db_xref=", '"GI:6715646"'), ("/translation=", '"MAGDMQGVRVVEKYSPVIVMVMSNVAMGSVNALVKKALDVGVNHMVIGAYRMAISALILVPFAYVLERASLMQFFFLLGLSYTSATVSCALVSMLPAITFALALIFRTENVKILKTKAGMLKVIGTLICISGALFLTFYKGPQISNSHSHSHGGASHNNNDQDKANNWLLGCLYLTIGTVLLSLWMLFQGTLSIKYPCKYSSTCLMSIFAAFQCALLSLYKSRDVNDWIIDDRFVITVIIYAGVVGQAMTTVATTWGIKKLGAVFASAFFPLTLISATLFDFLILHTPLYLGSVIGSLVTITGLYMFLWGKNKETESSTALSSGMDNEAQYTTPNKDNDSKSPV"'))),
-                    ("CDS", "complement(join(45150..45261,45343..45656,45719..45847,46075..46313,47448..47684,47777..48554,48638..48868))", (("/note=", '"putative pyruvate dehydrogenase E1 alpha subunit gi|2454182; similar to ESTs emb|Z48417, gb|AW039459.1, gb|T15146, emb|Z48416, gb|AF066871, gb|T76832, gb|AI996061.1"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.8"'), ("/protein_id=", '"AAF26472.1"'), ("/db_xref=", '"GI:6715645"'), ("/translation=", '"MATAFAPTKLTATVPLHGSHENRLLLPIRLAPPSSFLGSTRSLSLRRLNHSNATRRSPVVSVQEVVKEKQSTNNTSLLITKEEGLELYEDMILGRSFEDMCAQMYYRGKMFGFVHLYNGQEAVSTGFIKLLTKSDSVVSTYRDHVHALSKGVSARAVMSELFGKVTGCCRGQGGSMHMFSKEHNMLGGFAFIGEGIPVATGAAFSSKYRREVLKQDCDDVTVAFFGDGTCNNGQFFECLNMAALYKLPIIFVVENNLWAIGMSHLRATSDPEIWKKGPAFGMPGVHVDGMDVLKVREVAKEAVTRARRGEGPTLVECETYRFRGHSLADPDELRDAAEKAKYAARDPIAALKKYLIENKLAKEAELKSIEKKIDELVEEAVEFADASPQPGRSQLLENVFADPKGFGIGPDGRYRSQPLQIKVSSSELSVLDEEKEEEVVKGEAEPNKDSVVSKAEPVKKPRPCELYVCNIPRSYDIAQLLDMFQPFGTVISVEVVSRNPQTGESRGSGYVTMGSINSAKIAIASLDGTVRARETKKQEVGGREMRVRYSVDMNPGTRRNPEVLNSTPKKILMYESQHKVYVGNLPWFTQPDGLRNHFSKFGTIVSTRVLHDRKTGRNRVFAFLSFTSGEERDAALSFNGTVNNMKVAESSSEKVSRRVSRKPTVLLLLQRHLLDTNNV"'))),
-                    ("CDS", "complement(join(49986..50039,50121..50333,50585..50656))", (("/note=", '"similar to acidic ribosomal protein p1 gi|2252857; similar to ESTs gb|T42111, gb|AI099979, gb|AA728491"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.9"'), ("/protein_id=", '"AAF26471.1"'), ("/db_xref=", '"GI:6715644"'), ("/translation=", '"MSTVGELACSYAVMILEDEGIAITADKIATLVKAAGVSIESYWPMLFAKMAEKRNVTDLIMNVGAGGGGGAPVAAAAPAAGGGAAAAPAAEEKKKDEPAEESDGDLGFGLFD"'))),
-                    ("CDS", "join(51941..52048,52136..52432,52640..52885,53186..53326,53405..54196)", (("/note=", '"hypothetical protein"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.10"'), ("/protein_id=", '"AAF26462.1"'), ("/db_xref=", '"GI:6715635"'), ("/translation=", '"MGKKNGSSSWLTAVKRAFRSPTKKDHSNDVEEDEEKKREKRRWFRKPATQESPVKSSGISPPAPQEDSLNVNSKPSPETAPSYATTTPPSNAGKPPSAVVPIATSASKTLAPRRIYYARENYAAVVIQTSFRGYLARRALRALKGLVKLQALVRGHNVRKQAKMTLRCMQALVRVQSRVLDQRKRLSHDGSRKSAFSDSHAVFESRYLQDLSDRQSMSREGSSAAEDWDDRPHTIDAVKVMLQRRRDTALRHDKTNLSQAFSQKMWRTVGNQSTEGHHEVELEEERPKWLDRWMATRPWDKRASSRASVDQRVSVKTVEIDTSQPYSRTGAGSPSRGQRPSSPSRTSHHYQSRNNFSATPSPAKSRPILIRSASPRCQRDPREDRDRAAYSYTSNTPSLRSNYSFTARSGCSISTTMVNNASLLPNYMASTESAKARIRSHSAPRQRPSTPERDRAGLVKKRLSYPVPPPAEYEDNNSLRSPSFKSVAGSHFGGMLEQQSNYSSCCTESNGVEISPASTSDFRNWLR"'))),
-                    ("CDS", "complement(57094..58680)", (("/note=", '"putative fatty acid elongase 3-ketoacyl-coA synthase 1 gi|4091810; similar to ESTs gb|T42377, gb|N96054, gb|T44368, gb|AI999379.1, emb|Z26005"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.11"'), ("/protein_id=", '"AAF26470.1"'), ("/db_xref=", '"GI:6715643"'), ("/translation=", '"MERTNSIEMDRERLTAEMAFRDSSSAVIRIRRRLPDLLTSVKLKYVKLGLHNSCNVTTILFFLIILPLTGTVLVQLTGLTFDTFSELWSNQAVQLDTATRLTCLVFLSFVLTLYVANRSKPVYLVDFSCYKPEDERKISVDSFLTMTEENGSFTDDTVQFQQRISNRAGLGDETYLPRGITSTPPKLNMSEARAEAEAVMFGALDSLFEKTGIKPAEVGILIVNCSLFNPTPSLSAMIVNHYKMREDIKSYNLGGMGCSAGLISIDLANNLLKANPNSYAVVVSTENITLNWYFGNDRSMLLCNCIFRMGGAAILLSNRRQDRKKSKYSLVNVVRTHKGSDDKNYNCVYQKEDERGTIGVSLARELMSVAGDALKTNITTLGPMVLPLSEQLMFLISLVKRKMFKLKVKPYIPDFKLAFEHFCIHAGGRAVLDEVQKNLDLKDWHMEPSRMTLHRFGNTSSSSLWYEMAYTEAKGRVKAGDRLWQIAFGSGFKCNSAVWKALRPVSTEEMTGNAWAGSIDQYPVKVVQ"'))),
-                    ("CDS", "complement(join(59508..59665,61670..61826,63133..63513))", (("/note=", '"hypothetical protein"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.12"'), ("/protein_id=", '"AAF26469.1"'), ("/db_xref=", '"GI:6715642"'), ("/translation=", '"MEKRSDSESVEILGDWDSPPPEERIVMVSVPTSPESDYARSNQPKEIESRVSDKETASASGEVAARRVLPPWMDPSYEWGGGKWKVDGRKNKNKKEKEKEKEEIIPFKEIIEALLGNSGDKVQQDNKVFEVAPSLHVVELRKTGDDTLEFHKVYFRFNLYQPVQLPLILFVVIRFSMLKIIHYHQFTMAHIKEFVCMWDTHLYKEITNLNIWDTLSSTLVLAIWTVNASHE"'))),
-                    ("CDS", "complement(join(64100..64177,64272..64358,64453..64509,64603..64719,64812..64919,65033..65158,65265..65354,65435..65566,65809..65862,65964..66044,66152..66259,66380..66451,66537..66599,67026..67214))", (("/note=", '"similar to wpk4 protein kinase dbj|BAA34675; similar to ESTs dbj|AB015122, gb|AI997157.1"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.13"'), ("/protein_id=", '"AAF26468.1"'), ("/db_xref=", '"GI:6715641"'), ("/translation=", '"MSGSRRKATPASRTRVGNYEMGRTLGEGSFAKVKYAKNTVTGDQAAIKILDREKVFRHKMVEQLKREISTMKLIKHPNVVEIIEVMASKTKIYIVLELVNGGELFDKIAQQGRLKEDEARRYFQQLINAVDYCHSRGVYHRDLKPENLILDANGVLKVSDFGLSAFSRQVREDGLLHTACGTPNYVAPEVLSDKGYDGAAADVWSCGVILFVLMAGYLPFDEPNLMTLYKRVRICKAEFSCPPWFSQGAKRVIKRILEPNPITRISIAELLEDEWFKKGYKPPSFDQDDEDITIDDVDAAFSNSKECLVTEKKEKPVSMNAFELISSSSEFSLENLFEKQAQLVKKETRFTSQRSASEIMSKMEETAKPLGFNVRKDNYKIKMKGDKSGRKGQLSVATEVFEVAPSLHVVELRKTGGDTLEFHKVCDSFYKNFSSGLKDVVWNTDAAAEEQKQ"'))),
-                    ("CDS", "complement(join(69831..69987,70534..70670,70743..71357,71644..71700))", (("/note=", '"similar to ataxia-telangiectasia group D protein pir|A49618"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.14"'), ("/protein_id=", '"AAF26467.1"'), ("/db_xref=", '"GI:6715640"'), ("/translation=", '"MVSDLPLDEDDIALLKSPYCDDGGDEDVNSAPNIFTYDNVPLKKRHYLGTSDTFRSFEPLNEHACIVCDIADDGVVPCSGNECPLAVHRKCVELDCEDPATFYCPYCWFKEQATRSTALRTRGVAAAKTLVQYGCSELRSGDIVMTRENSQLENGSDNSLPMQLHENLHQLQELVKHLKARNSQLDESTDQFIDMEKSCGEAYAVVNDQPKRVLWTVNEEKMLREGVEKFSDTINKNMPWKKILEMGKGIFHTTRNSSDLKDKWRNMVRIIILIWLRSRLTSSSSSQRSEIKMERERNAGVMKKMSPTGTIQRLEFVGWYL"'))),
-                    ("CDS", "join(72285..72371,72789..72865,72989..73097,73190..73442,73524..73585)", (("/note=", '"similar to SYT gi|2252866; similar to ESTs emb|F14390, gb|H36066, emb|F14391"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.15"'), ("/protein_id=", '"AAF26463.1"'), ("/db_xref=", '"GI:6715636"'), ("/translation=", '"MQQQQSPQMFPMVPSIPPANNITTEQIQKYLDENKKLIMAIMENQNLGKLAECAQYQALLQKNLMYLAAIADAQPPPPTPGPSPSTAVAAQMATPHSGMQPPSYFMQHPQASPAGIFAPRGPLQFGSPLQFQDPQQQQQIHQQAMQGHMGIRPMGMTNNGMQHAMQQPETGLGGNVGLRGGKQDGADGQGKDDGK"'))),
-                    ("CDS", "complement(join(73807..73990,74036..74145))", (("/note=", '"similar to stress-induced protein OZI1 precursor pir|S59544; similar to EST gb|AI995719.1"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.16"'), ("/protein_id=", '"AAF26466.1"'), ("/db_xref=", '"GI:6715639"'), ("/translation=", '"MASGGKAKYIIGALIGSFGISYIFDKVISDNKIFGGKDDLNGYLLVKISGTTPGTVSNKEWWAATDEKFQAWPRTAGPPVVMNPISRQNFIVKTRPE"'))),
-                    ("CDS", "join(75335..76249,76516..76653,76733..76982,77015..77148)", (("/note=", '"putative reverse transcriptase gb|AAD17395"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.17"'), ("/protein_id=", '"AAF26464.1"'), ("/db_xref=", '"GI:6715637"'), ("/translation=", '"MKEDRRLPHKRDAFQFLKTKAAYVIVIVLTYAFGYFSAYHYHQPLQQQLPPSTTAVETTKPQVCSIDNFRVTTPCGNLVPPELIRQTVIDRIFNGTSPYIDFPPPHAKKFLRPKRIKGWGSYGAVFENLIRRVKPKTIVEVGSFLGASAIHMANLTRRLGLEETQILCVDDFRGWPGFRDRFKDMALVNGDVLLMYQFMQNVVISDFSGSILPVPFSTGSALEKLCEWGVTADLVEIDAGHDFNSAWADINRAVRILRPGGVIFGHDYFTAADNRGVRRAVNLFAEINRLKVKTDGQHWVIDSVKVINKGTRFAISKTVAKIKEDANQWFFAQVLENQDLVNEQAVHISVKVLRGFLRDEHGKVLIHARRSFASVHSKLDATFLCWQWAMESMKSLRVDKIIFASEDNDLIGAVTRLPSWPSYKFQIHFLLGELIRSSNLGAHLIAKSVTMEDRRQSYVATGFPFWLKHLFEKERSIA"'))),
-                    ("CDS", "complement(join(82723..82738,82751..83373,83586..84581))", (("/note=", '"putative cytochrome P450 gi|3831440"'), ("/codon_start=", "1"), ("/evidence=", "not_experimental"), ("/product=", '"T25K16.18"'), ("/protein_id=", '"AAF26465.1"'), ("/db_xref=", '"GI:6715638"'), ("/translation=", '"MFSLNMRTEIESLWVFALASKFNIYMQQHFASLLVAIAITWFTITIVFWSTPGGPAWGKYFFTRRFISLDYNRKYKNLIPGPRGFPLVGSMSLRSSHVAHQRIASVAEMSNAKRLMAFSLGDTKVVVTCHPAVAKEILNSSVFADRPVDETAYGLMFNRAMGFAPNGTYWRTLRRLGSNHLFNPKQIKQSEDQRRVIATQMVNAFARNPKSACAVRDLLKTASLCNMMGLVFGREYELESNNNLESECLKGLVEEGYDLLGTLNWTDHLPWLAGLDFQQIRFRCSQLVPKVNLLLSRIIHEQRAATGNFLDMLLSLQGSEKLSESDMVAVLWEMIFRGTDTVAVLVEWVLARIVMHPKVQLTVHDELDRVVGRSRTVDESDLPSLTYLTAMIKEVLRLHPPGPLLSWARLSITDTSVDGYHVPAGTTAMVNMWAIARDPHVWEDPLEFKPERFVAKEGEAEFSVFGSDLRLAPFGSGKRVCPGKNLGLTTVSFWVATLLHEFEWLPSVEANPPDLSEVLRLSCEMACPLIVNVSSRRKIIAWMF"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "Genomic sequence for Arabidopsis thaliana BAC T25K16 from chromosome I",
+            "Direct Submission",
+            "Direct Submission",
+            "Direct Submission",
+            "Direct Submission",
+        )
+        features = [
+            (
+                "source",
+                "1..86436",
+                (
+                    ("/organism=", '"Arabidopsis thaliana"'),
+                    ("/db_xref=", '"taxon:3702"'),
+                    ("/chromosome=", '"1"'),
+                    ("/clone=", '"T25K16"'),
+                ),
+            ),
+            (
+                "CDS",
+                "join(3462..3615,3698..3978,4077..4307,4408..4797,4876..5028,5141..5332)",
+                (
+                    (
+                        "/note=",
+                        '"containing similarity to NAM-like proteins gi|3695378"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.1"'),
+                    ("/protein_id=", '"AAF26460.1"'),
+                    ("/db_xref=", '"GI:6715633"'),
+                    (
+                        "/translation=",
+                        '"MEDQVGFGFRPNDEELVGHYLRNKIEGNTSRDVEVAISEVNICSYDPWNLRFQSKYKSRDAMWYFFSRRENNKGNRQSRTTVSGKWKLTGESVEVKDQWGFCSEGFRGKIGHKRVLVFLDGRYPDKTKSDWVIHEFHYDLLPEHQKLCNVTLFRFSSYFRLSLLSPMFYTDELMCLPPEILQRTYVICRLEYKGDDADILSAYAIDPTPAFVPNMTSSAGSVVNQSRQRNSGSYNTYSEYDSANHGQQFNENSNIMQQQPLQGSFNPLLEYDFANHGGQWLSDYIDLQQQVPYLAPYENESEMIWKHVIEENFEFLVDERTSMQQHYSDHRPKKPVSGVLPDDSSDTETGSMIFEDTSSSTDSVGSSDEPGHTRIDDIPSLNIIEPLHNYKAQEQPKQQSKEKVISSQKSECEWKMAEDSIKIPPSTNTVKQSWIVLENAQWNYLKNMIIGVLLFISVISWIILVG"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(join(6617..6953,7266..7351,7464..7603,7916..7998,8087..8166,8273..8368))",
+                (
+                    ("/note=", '"hypothetical protein"'),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.2"'),
+                    ("/protein_id=", '"AAF26477.1"'),
+                    ("/db_xref=", '"GI:6715650"'),
+                    (
+                        "/translation=",
+                        '"MAASEHRCVGCGFRVKSLFIQYSPGNIRLMKCGNCKEVADEYIECERMVCFNHFLSLFGPKVYRHVLYNAINPATVNIQVKNYFNSTSRCVVGEIHRQTYLKSPELIIDRSLLLRKSDEESSFSDSPVLLSIKVLIGVLSANAAFIISFAIATKGLLNEVSRESLLLQVWEFPMSVIFFVDILLLTSNSMALKGQTFKMFSMQIVFCCCYFGISQCKFVFKPVMTESTMTRCIAVCLIAHLIRFLVGQIFEPTIFLIQIGSLLQYMSYFFRIV"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(11566..12642)",
+                (
+                    ("/note=", '"putative RAP2.8 protein gi|3695373"'),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.3"'),
+                    ("/protein_id=", '"AAF26476.1"'),
+                    ("/db_xref=", '"GI:6715649"'),
+                    (
+                        "/translation=",
+                        '"MDLSLAPTTTTSSDQEQDRDQELTSNIGASSSSGPSGNNNNLPMMMIPPPEKEHMFDKVVTPSDVGKLNRLVIPKQHAERYFPLDSSNNQNGTLLNFQDRNGKMWRFRYSYWNSSQSYVMTKGWSRFVKEKKLDAGDIVSFQRGIGDESERSKLYIDWRHRPDMSLVQAHQFGNFGFNFNFPTTSQYSNRFHPLPEYNSVPIHRGLNIGNHQRSYYNTQRQEFVGYGYGNLAGRCYYTGSPLDHRNIVGSEPLVIDSVPVVPGRLTPVMLPPLPPPPSTAGKRLRLFGVNMECGNDYNQQEESWLVPRGEIGASSSSSSALRLNLSTDHDDDNDDGDDGDDDQFAKKGKSSLSLNFNP"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "join(23221..24174,24244..24357,24412..24664,24743..25137,25226..25445,25527..25711,25783..25905,25994..26478,26564..26730,26814..26983,27074..27235,27320..27415,27505..28133,28314..28507,28592..28782,28862..30013,30112..30518,30604..30781)",
+                (
+                    (
+                        "/note=",
+                        '"similar to UFD1 protein emb|CAB10321.1; similar to ESTs gb|H36434, gb|AI996152.1"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.4"'),
+                    ("/protein_id=", '"AAF26461.1"'),
+                    ("/db_xref=", '"GI:6715634"'),
+                    (
+                        "/translation=",
+                        '"MVMEDEPREATIKPSYWLDACEDISCDLIDDLVSEFDPSSVAVNESTDENGVINDFFGGIDHILDSIKNGGGLPNNGVSDTNSQINEVTVTPQVIAKETVKENGLQKNGGKRDEFSKEEGDKDRKRARVCSYQSERSNLSGRGHVNNSREGDRFMNRKRTRNWDEAGNNKKKRECNNYRRDGRDREVRGYWERDKVGSNELVYRSGTWEADHERDVKKVSGGNRECDVKAEENKSKPEERKEKVVEEQARRYQLDVLEQAKAKNTIAFLETGAGKTLIAILLIKSVHKDLMSQNRKMLSVFLVPKVPLVYQVPPNKKHQAEVIRNQTCFQVGHYCGEMGQDFWDSRRWQREFESKQFLKLTSFFLFSSTQVLVMTAQILLNILRHSIIRMETIDLLILDECHHAVKKHPYSLVMSEFYHTTPKDKRPAIFGMTASPVNLKGVSSQVDCAIKIRNLETKLDSTVCTIKDRKELEKHVPMPSEIVVEYDKAATMWSLHETIKQMIAAVEEAAQASSRKSKWQFMGARDAGAKDELRQVYGVSERTESDGAANLIHKLRAINYTLAELGQWCAYKVGQSFLSALQSDERVNFQVDVKFQESYLSEVVSLLQCELLEGAAAEKVAAEVGKPENGNAHDEMEEGELPDDPVVSGGEHVDEVIGAAVADGKVTPKVQSLIKLLLKYQHTADFRAIVFVERVVAALVLPKVRIKVFAELPSLSFIRCASMIGHNNSQEMKSSQMQDTISKFRDGHVTLLVATSVAEEGLDIRQCNVVMRFDLAKTVLAYIQSRGRARKPGSDYILMVERYIKSFKNYILIFVTTGHQISTDMSTCVTCRGNVSHAAFLRNARNSEETLRKEAIERTDLSHLKDTSRLISIDAVPGTVYKVEATGAMVSLNSAVGLVHFYCSQLPGDRYAILRPEFSMEKHEKPGGHTEYSCRLQLPCNAPFEILEGPVCSSMRLAQQVDIIVSACKKLHEMGAFTDMLLPDKGSGQDAEKADQDDEGEPVPGTARHREFYPEGVADVLKGEWVSSGKEVCESSKLFHLYMYNVRCVDFGSSKDPFLSEVSEFAILFGNELDAEVLSMSMDLYVARAMITKASLAFKGSLDITENQLSSLKKFHVRLMSIVLDVDVEPSTTPWDPAKAYLFVPVTDNTSMEPIKGINWELVEKITKTTAWDNPLQRARPDVYLGTNERTLGGDRREYGFGKLRHNIVFGQKSHPTYGIRGAVASFDVVRASGLLPVRDAFEKEVEEDLSKGKLMMADGCMVAEDLIGKIVTAAHSGKRFYVDSICYDMSAETSFPRKEGYLGPLEYNTYADYYKQKIYVVQDRLFFYFLHNLRLLRLYKSSSIMLFIRYGVDLNCKQQPLIKGRGVSYCKNLLSPRFEQSGESETVLDKTYYVFLPPELCVVHPLSGSLIRGAQRLPSIMRRVESMLLAVQLKNLISYPIPTSKILEALTAASCQETFCYERAELLGDAYLKWVVSRFLFLKYPQKHEGQLTRMRQQMVSNMVLYQFALVKGLQSYIQADRFAPSRWSAPGVPPVFDEDTKDGGSSFFDEEQKPVSEENSDVFEDGEMEDGELEGDLSSYRVLSSKTLADVVEALIGVYYVEGGKIAANHLMKWIGIHVEDDPDEVDGTLKNVNVPESVLKSIDFVGLERALKYEFKEKGLLVEAITHASRPSSGVSCYQRLEFVGDAVLDHLITRHLFFTYTSLPPGRLTDLRAAAVNNENFARVAVKHKLHLYLRHGSSALEKQVNKIKKQSILFSKSFKCLTVWLLFVFQIREFVKEVQTESSKPGFNSFGLGDCKAPKVLGDIVESIAGAIFLDSGKDTTAAWKVFQPLLQPMVTPETLPMHPVRELQERCQQQAEGLEYKASRSGNTATVEVFIDGVQVGVAQNPQKKMAQKLAARNALAALKEKEIAESKEKHINNGNAGEDQGENENGNKKNGHQPFTRQTLNDICLRKNWPMPSYRCVKEGGPAHAKRFTFGVRVNTSDRGWTDECIGEPMPSVKKAKDSAAVLLLELLNKTFS"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(join(31084..31126,31223..31304,31341..31515,31635..31700,31790..31897,31984..32049,32133..32161,32249..32372))",
+                (
+                    (
+                        "/note=",
+                        '"putative inorganic pyrophosphatase gi|3510259; similar to ESTs gb|T42316, gb|AI994042.1, gb|AI994013.1, emb|Z29202"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.5"'),
+                    ("/protein_id=", '"AAF26475.1"'),
+                    ("/db_xref=", '"GI:6715648"'),
+                    (
+                        "/translation=",
+                        '"MSEETKDNQRLQRPAPRLNERILSSLSRRSVAAHPWHDLEIGPGAPQIFNVVVEITKGSKVKYELDKKTGLIKVDRILYSSVVYPHNYGFVPRTLCEDNDPIDVLVIMQEPVLPGCFLRARAIGLMPMIDQGEKDDKIIAVCVDDPEYKHYTDIKELPPHRLSEIRRFFEDCILFLQCSSLFISIDLSTNKKNENKEVAVNDFLPSESAVEAIQYSMDLYAEYILHTLRR"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(join(33694..34029,34103..35173,35269..35349,35432..35701,36326..36387,36512..36623,36725..36763))",
+                (
+                    (
+                        "/note=",
+                        '"putative late elongated hypocotyl emb|CAA07004; similar to ESTS gb|AI993521.1, gb|AA650979"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.6"'),
+                    ("/protein_id=", '"AAF26474.1"'),
+                    ("/db_xref=", '"GI:6715647"'),
+                    (
+                        "/translation=",
+                        '"MDTNTSGEELLAKARKPYTITKQRERWTEDEHERFLEALRLYGRAWQRIEEHIGTKTAVQIRSHAQKFFTKFGKAHSFWFTFQLEKEAEVKGIPVCQALDIEIPPPRPKRKPNTPYPRKPGNNGTSSSQVSSAKDAKLVSSASSSQLNQAFLDLEKMPFSEKTSTGKENQDENCSGVSTVNKYPLPTKVSGDIETSKTSTVDNAVQDVPKKNKDKDGNDGTTVHSMQNYPWHFHADIVNGNIAKCPQNHPSGMVSQDFMFHPMREETHGHANLQATTASATTTASHQAFPACHSQDDYRSFLQISSTFSNLIMSTLLQNPAAHAAATFAASVWPYASVGNSGDSSTPMSSSPPSITAIAAATVAAATAWWASHGLLPVCAPAPITCVPFSTVAVPTPAMTEMDTVENTQPFEKQNTALQDQNLASKSPASSSDDSDETGVTKLNADSKTNDDKIEEVVVTAAVHDSNTAQKKNLVDRSSCGSNTPSGSDAETDALDKMEKDKEDVKETDENQPDVIELNNRKIKMRDNNSNNNATTDSWKEVSEEGRIAFQALFARERLPQSFSPPQVAENVNRKQSDTSMPLAPNFKSQDSCAADQEGVVMIGVGTCKSLKTRQTGFKPYKRCSMEVKESQVGNINNQSDEKVCKRLRLEGEAST"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(join(38600..38756,38838..38989,39111..39516,39915..40031,40377..40579))",
+                (
+                    (
+                        "/note=",
+                        '"similar to Medicago truncatula MtN2 gi|3193308; similar to EST gb|H77065"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.7"'),
+                    ("/protein_id=", '"AAF26473.1"'),
+                    ("/db_xref=", '"GI:6715646"'),
+                    (
+                        "/translation=",
+                        '"MAGDMQGVRVVEKYSPVIVMVMSNVAMGSVNALVKKALDVGVNHMVIGAYRMAISALILVPFAYVLERASLMQFFFLLGLSYTSATVSCALVSMLPAITFALALIFRTENVKILKTKAGMLKVIGTLICISGALFLTFYKGPQISNSHSHSHGGASHNNNDQDKANNWLLGCLYLTIGTVLLSLWMLFQGTLSIKYPCKYSSTCLMSIFAAFQCALLSLYKSRDVNDWIIDDRFVITVIIYAGVVGQAMTTVATTWGIKKLGAVFASAFFPLTLISATLFDFLILHTPLYLGSVIGSLVTITGLYMFLWGKNKETESSTALSSGMDNEAQYTTPNKDNDSKSPV"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(join(45150..45261,45343..45656,45719..45847,46075..46313,47448..47684,47777..48554,48638..48868))",
+                (
+                    (
+                        "/note=",
+                        '"putative pyruvate dehydrogenase E1 alpha subunit gi|2454182; similar to ESTs emb|Z48417, gb|AW039459.1, gb|T15146, emb|Z48416, gb|AF066871, gb|T76832, gb|AI996061.1"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.8"'),
+                    ("/protein_id=", '"AAF26472.1"'),
+                    ("/db_xref=", '"GI:6715645"'),
+                    (
+                        "/translation=",
+                        '"MATAFAPTKLTATVPLHGSHENRLLLPIRLAPPSSFLGSTRSLSLRRLNHSNATRRSPVVSVQEVVKEKQSTNNTSLLITKEEGLELYEDMILGRSFEDMCAQMYYRGKMFGFVHLYNGQEAVSTGFIKLLTKSDSVVSTYRDHVHALSKGVSARAVMSELFGKVTGCCRGQGGSMHMFSKEHNMLGGFAFIGEGIPVATGAAFSSKYRREVLKQDCDDVTVAFFGDGTCNNGQFFECLNMAALYKLPIIFVVENNLWAIGMSHLRATSDPEIWKKGPAFGMPGVHVDGMDVLKVREVAKEAVTRARRGEGPTLVECETYRFRGHSLADPDELRDAAEKAKYAARDPIAALKKYLIENKLAKEAELKSIEKKIDELVEEAVEFADASPQPGRSQLLENVFADPKGFGIGPDGRYRSQPLQIKVSSSELSVLDEEKEEEVVKGEAEPNKDSVVSKAEPVKKPRPCELYVCNIPRSYDIAQLLDMFQPFGTVISVEVVSRNPQTGESRGSGYVTMGSINSAKIAIASLDGTVRARETKKQEVGGREMRVRYSVDMNPGTRRNPEVLNSTPKKILMYESQHKVYVGNLPWFTQPDGLRNHFSKFGTIVSTRVLHDRKTGRNRVFAFLSFTSGEERDAALSFNGTVNNMKVAESSSEKVSRRVSRKPTVLLLLQRHLLDTNNV"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(join(49986..50039,50121..50333,50585..50656))",
+                (
+                    (
+                        "/note=",
+                        '"similar to acidic ribosomal protein p1 gi|2252857; similar to ESTs gb|T42111, gb|AI099979, gb|AA728491"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.9"'),
+                    ("/protein_id=", '"AAF26471.1"'),
+                    ("/db_xref=", '"GI:6715644"'),
+                    (
+                        "/translation=",
+                        '"MSTVGELACSYAVMILEDEGIAITADKIATLVKAAGVSIESYWPMLFAKMAEKRNVTDLIMNVGAGGGGGAPVAAAAPAAGGGAAAAPAAEEKKKDEPAEESDGDLGFGLFD"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "join(51941..52048,52136..52432,52640..52885,53186..53326,53405..54196)",
+                (
+                    ("/note=", '"hypothetical protein"'),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.10"'),
+                    ("/protein_id=", '"AAF26462.1"'),
+                    ("/db_xref=", '"GI:6715635"'),
+                    (
+                        "/translation=",
+                        '"MGKKNGSSSWLTAVKRAFRSPTKKDHSNDVEEDEEKKREKRRWFRKPATQESPVKSSGISPPAPQEDSLNVNSKPSPETAPSYATTTPPSNAGKPPSAVVPIATSASKTLAPRRIYYARENYAAVVIQTSFRGYLARRALRALKGLVKLQALVRGHNVRKQAKMTLRCMQALVRVQSRVLDQRKRLSHDGSRKSAFSDSHAVFESRYLQDLSDRQSMSREGSSAAEDWDDRPHTIDAVKVMLQRRRDTALRHDKTNLSQAFSQKMWRTVGNQSTEGHHEVELEEERPKWLDRWMATRPWDKRASSRASVDQRVSVKTVEIDTSQPYSRTGAGSPSRGQRPSSPSRTSHHYQSRNNFSATPSPAKSRPILIRSASPRCQRDPREDRDRAAYSYTSNTPSLRSNYSFTARSGCSISTTMVNNASLLPNYMASTESAKARIRSHSAPRQRPSTPERDRAGLVKKRLSYPVPPPAEYEDNNSLRSPSFKSVAGSHFGGMLEQQSNYSSCCTESNGVEISPASTSDFRNWLR"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(57094..58680)",
+                (
+                    (
+                        "/note=",
+                        '"putative fatty acid elongase 3-ketoacyl-coA synthase 1 gi|4091810; similar to ESTs gb|T42377, gb|N96054, gb|T44368, gb|AI999379.1, emb|Z26005"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.11"'),
+                    ("/protein_id=", '"AAF26470.1"'),
+                    ("/db_xref=", '"GI:6715643"'),
+                    (
+                        "/translation=",
+                        '"MERTNSIEMDRERLTAEMAFRDSSSAVIRIRRRLPDLLTSVKLKYVKLGLHNSCNVTTILFFLIILPLTGTVLVQLTGLTFDTFSELWSNQAVQLDTATRLTCLVFLSFVLTLYVANRSKPVYLVDFSCYKPEDERKISVDSFLTMTEENGSFTDDTVQFQQRISNRAGLGDETYLPRGITSTPPKLNMSEARAEAEAVMFGALDSLFEKTGIKPAEVGILIVNCSLFNPTPSLSAMIVNHYKMREDIKSYNLGGMGCSAGLISIDLANNLLKANPNSYAVVVSTENITLNWYFGNDRSMLLCNCIFRMGGAAILLSNRRQDRKKSKYSLVNVVRTHKGSDDKNYNCVYQKEDERGTIGVSLARELMSVAGDALKTNITTLGPMVLPLSEQLMFLISLVKRKMFKLKVKPYIPDFKLAFEHFCIHAGGRAVLDEVQKNLDLKDWHMEPSRMTLHRFGNTSSSSLWYEMAYTEAKGRVKAGDRLWQIAFGSGFKCNSAVWKALRPVSTEEMTGNAWAGSIDQYPVKVVQ"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(join(59508..59665,61670..61826,63133..63513))",
+                (
+                    ("/note=", '"hypothetical protein"'),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.12"'),
+                    ("/protein_id=", '"AAF26469.1"'),
+                    ("/db_xref=", '"GI:6715642"'),
+                    (
+                        "/translation=",
+                        '"MEKRSDSESVEILGDWDSPPPEERIVMVSVPTSPESDYARSNQPKEIESRVSDKETASASGEVAARRVLPPWMDPSYEWGGGKWKVDGRKNKNKKEKEKEKEEIIPFKEIIEALLGNSGDKVQQDNKVFEVAPSLHVVELRKTGDDTLEFHKVYFRFNLYQPVQLPLILFVVIRFSMLKIIHYHQFTMAHIKEFVCMWDTHLYKEITNLNIWDTLSSTLVLAIWTVNASHE"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(join(64100..64177,64272..64358,64453..64509,64603..64719,64812..64919,65033..65158,65265..65354,65435..65566,65809..65862,65964..66044,66152..66259,66380..66451,66537..66599,67026..67214))",
+                (
+                    (
+                        "/note=",
+                        '"similar to wpk4 protein kinase dbj|BAA34675; similar to ESTs dbj|AB015122, gb|AI997157.1"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.13"'),
+                    ("/protein_id=", '"AAF26468.1"'),
+                    ("/db_xref=", '"GI:6715641"'),
+                    (
+                        "/translation=",
+                        '"MSGSRRKATPASRTRVGNYEMGRTLGEGSFAKVKYAKNTVTGDQAAIKILDREKVFRHKMVEQLKREISTMKLIKHPNVVEIIEVMASKTKIYIVLELVNGGELFDKIAQQGRLKEDEARRYFQQLINAVDYCHSRGVYHRDLKPENLILDANGVLKVSDFGLSAFSRQVREDGLLHTACGTPNYVAPEVLSDKGYDGAAADVWSCGVILFVLMAGYLPFDEPNLMTLYKRVRICKAEFSCPPWFSQGAKRVIKRILEPNPITRISIAELLEDEWFKKGYKPPSFDQDDEDITIDDVDAAFSNSKECLVTEKKEKPVSMNAFELISSSSEFSLENLFEKQAQLVKKETRFTSQRSASEIMSKMEETAKPLGFNVRKDNYKIKMKGDKSGRKGQLSVATEVFEVAPSLHVVELRKTGGDTLEFHKVCDSFYKNFSSGLKDVVWNTDAAAEEQKQ"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(join(69831..69987,70534..70670,70743..71357,71644..71700))",
+                (
+                    (
+                        "/note=",
+                        '"similar to ataxia-telangiectasia group D protein pir|A49618"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.14"'),
+                    ("/protein_id=", '"AAF26467.1"'),
+                    ("/db_xref=", '"GI:6715640"'),
+                    (
+                        "/translation=",
+                        '"MVSDLPLDEDDIALLKSPYCDDGGDEDVNSAPNIFTYDNVPLKKRHYLGTSDTFRSFEPLNEHACIVCDIADDGVVPCSGNECPLAVHRKCVELDCEDPATFYCPYCWFKEQATRSTALRTRGVAAAKTLVQYGCSELRSGDIVMTRENSQLENGSDNSLPMQLHENLHQLQELVKHLKARNSQLDESTDQFIDMEKSCGEAYAVVNDQPKRVLWTVNEEKMLREGVEKFSDTINKNMPWKKILEMGKGIFHTTRNSSDLKDKWRNMVRIIILIWLRSRLTSSSSSQRSEIKMERERNAGVMKKMSPTGTIQRLEFVGWYL"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "join(72285..72371,72789..72865,72989..73097,73190..73442,73524..73585)",
+                (
+                    (
+                        "/note=",
+                        '"similar to SYT gi|2252866; similar to ESTs emb|F14390, gb|H36066, emb|F14391"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.15"'),
+                    ("/protein_id=", '"AAF26463.1"'),
+                    ("/db_xref=", '"GI:6715636"'),
+                    (
+                        "/translation=",
+                        '"MQQQQSPQMFPMVPSIPPANNITTEQIQKYLDENKKLIMAIMENQNLGKLAECAQYQALLQKNLMYLAAIADAQPPPPTPGPSPSTAVAAQMATPHSGMQPPSYFMQHPQASPAGIFAPRGPLQFGSPLQFQDPQQQQQIHQQAMQGHMGIRPMGMTNNGMQHAMQQPETGLGGNVGLRGGKQDGADGQGKDDGK"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(join(73807..73990,74036..74145))",
+                (
+                    (
+                        "/note=",
+                        '"similar to stress-induced protein OZI1 precursor pir|S59544; similar to EST gb|AI995719.1"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.16"'),
+                    ("/protein_id=", '"AAF26466.1"'),
+                    ("/db_xref=", '"GI:6715639"'),
+                    (
+                        "/translation=",
+                        '"MASGGKAKYIIGALIGSFGISYIFDKVISDNKIFGGKDDLNGYLLVKISGTTPGTVSNKEWWAATDEKFQAWPRTAGPPVVMNPISRQNFIVKTRPE"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "join(75335..76249,76516..76653,76733..76982,77015..77148)",
+                (
+                    ("/note=", '"putative reverse transcriptase gb|AAD17395"'),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.17"'),
+                    ("/protein_id=", '"AAF26464.1"'),
+                    ("/db_xref=", '"GI:6715637"'),
+                    (
+                        "/translation=",
+                        '"MKEDRRLPHKRDAFQFLKTKAAYVIVIVLTYAFGYFSAYHYHQPLQQQLPPSTTAVETTKPQVCSIDNFRVTTPCGNLVPPELIRQTVIDRIFNGTSPYIDFPPPHAKKFLRPKRIKGWGSYGAVFENLIRRVKPKTIVEVGSFLGASAIHMANLTRRLGLEETQILCVDDFRGWPGFRDRFKDMALVNGDVLLMYQFMQNVVISDFSGSILPVPFSTGSALEKLCEWGVTADLVEIDAGHDFNSAWADINRAVRILRPGGVIFGHDYFTAADNRGVRRAVNLFAEINRLKVKTDGQHWVIDSVKVINKGTRFAISKTVAKIKEDANQWFFAQVLENQDLVNEQAVHISVKVLRGFLRDEHGKVLIHARRSFASVHSKLDATFLCWQWAMESMKSLRVDKIIFASEDNDLIGAVTRLPSWPSYKFQIHFLLGELIRSSNLGAHLIAKSVTMEDRRQSYVATGFPFWLKHLFEKERSIA"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(join(82723..82738,82751..83373,83586..84581))",
+                (
+                    ("/note=", '"putative cytochrome P450 gi|3831440"'),
+                    ("/codon_start=", "1"),
+                    ("/evidence=", "not_experimental"),
+                    ("/product=", '"T25K16.18"'),
+                    ("/protein_id=", '"AAF26465.1"'),
+                    ("/db_xref=", '"GI:6715638"'),
+                    (
+                        "/translation=",
+                        '"MFSLNMRTEIESLWVFALASKFNIYMQQHFASLLVAIAITWFTITIVFWSTPGGPAWGKYFFTRRFISLDYNRKYKNLIPGPRGFPLVGSMSLRSSHVAHQRIASVAEMSNAKRLMAFSLGDTKVVVTCHPAVAKEILNSSVFADRPVDETAYGLMFNRAMGFAPNGTYWRTLRRLGSNHLFNPKQIKQSEDQRRVIATQMVNAFARNPKSACAVRDLLKTASLCNMMGLVFGREYELESNNNLESECLKGLVEEGYDLLGTLNWTDHLPWLAGLDFQQIRFRCSQLVPKVNLLLSRIIHEQRAATGNFLDMLLSLQGSEKLSESDMVAVLWEMIFRGTDTVAVLVEWVLARIVMHPKVQLTVHDELDRVVGRSRTVDESDLPSLTYLTAMIKEVLRLHPPGPLLSWARLSITDTSVDGYHVPAGTTAMVNMWAIARDPHVWEDPLEFKPERFVAKEGEAEFSVFGSDLRLAPFGSGKRVCPGKNLGLTTVSFWVATLLHEFEWLPSVEANPPDLSEVLRLSCEMACPLIVNVSSRRKIIAWMF"',
+                    ),
+                ),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_06(self):
         path = "GenBank/protein_refseq.gb"
@@ -327,16 +928,55 @@ class TestRecordParser(unittest.TestCase):
         locus = "NP_034640"
         definition = "interferon beta, fibroblast [Mus musculus]"
         accession = ["NP_034640"]
-        titles = ("structure and expression of a cloned cdna for mouse interferon-beta", )
-        features = [("source", "1..182", (("/organism=", '"Mus musculus"'), ("/db_xref=", '"taxon:10090"'), ("/chromosome=", '"4"'), ("/map=", '"4 42.6 cM"'))),
-                    ("Protein", "1..182", (("/product=", '"interferon beta, fibroblast"'), )),
-                    ("sig_peptide", "1..21", ()),
-                    ("Region", "1..182", (("/region_name=", '"Interferon alpha/beta domain"'), ("/db_xref=", '"CDD:pfam00143"'), ("/note=", '"interferon"'))),
-                    ("mat_peptide", "22..182", (("/product=", '"ifn-beta"'), )),
-                    ("Region", "56..170", (("/region_name=", '"Interferon alpha, beta and delta."'), ("/db_xref=", '"CDD:IFabd"'), ("/note=", '"IFabd"'))),
-                    ("CDS", "1..182", (("/gene=", '"Ifnb"'), ("/db_xref=", '"LocusID:15977"'), ("/db_xref=", '"MGD:MGI:107657"'), ("/coded_by=", '"NM_010510.1:21..569"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "structure and expression of a cloned cdna for mouse interferon-beta",
+        )
+        features = [
+            (
+                "source",
+                "1..182",
+                (
+                    ("/organism=", '"Mus musculus"'),
+                    ("/db_xref=", '"taxon:10090"'),
+                    ("/chromosome=", '"4"'),
+                    ("/map=", '"4 42.6 cM"'),
+                ),
+            ),
+            ("Protein", "1..182", (("/product=", '"interferon beta, fibroblast"'),)),
+            ("sig_peptide", "1..21", ()),
+            (
+                "Region",
+                "1..182",
+                (
+                    ("/region_name=", '"Interferon alpha/beta domain"'),
+                    ("/db_xref=", '"CDD:pfam00143"'),
+                    ("/note=", '"interferon"'),
+                ),
+            ),
+            ("mat_peptide", "22..182", (("/product=", '"ifn-beta"'),)),
+            (
+                "Region",
+                "56..170",
+                (
+                    ("/region_name=", '"Interferon alpha, beta and delta."'),
+                    ("/db_xref=", '"CDD:IFabd"'),
+                    ("/note=", '"IFabd"'),
+                ),
+            ),
+            (
+                "CDS",
+                "1..182",
+                (
+                    ("/gene=", '"Ifnb"'),
+                    ("/db_xref=", '"LocusID:15977"'),
+                    ("/db_xref=", '"MGD:MGI:107657"'),
+                    ("/coded_by=", '"NM_010510.1:21..569"'),
+                ),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_07(self):
         path = "GenBank/extra_keywords.gb"
@@ -347,34 +987,252 @@ class TestRecordParser(unittest.TestCase):
         locus = "DMBR25B3"
         definition = "Drosophila melanogaster BAC clone BACR25B3"
         accession = ["AL138972"]
-        titles = ("Sequencing the distal X chromosome of Drosophila melanogaster", "Direct Submission")
-        features = [("source", "1..154329", (("/organism=", '"Drosophila melanogaster"'), ("/db_xref=", '"taxon:7227"'), ("/clone=", '"BAC BACR25B3"'))),
-                    ("gene", "complement(22148..27773)", (("/gene=", '"EG:BACR25B3.11"'), ("/note=", ""))),
-                    ("CDS", "complement(join(22148..22299,22375..22791,22860..23560,23630..24555,24616..24888,25024..25178,26677..27009,27623..27773))", (("/gene=", '"EG:BACR25B3.11"'), ("/note=", "\"/prediction=(method:''genefinder'', version:''084'', score:''105.71''); /prediction=(method:''genscan'', version:''1.0''); /match=(desc:''BASEMENT MEMBRANE-SPECIFIC HEPARAN SULFATE PROTEOGLYCAN CORE PROTEIN PRECURSOR (HSPG) (PERLECAN) (PLC)'', species:''Homo sapiens (Human)'', ranges:(query:24292..24549, target:SWISS-PROT::P98160:3713..3628, score:''201.00''), (query:24016..24291, target:SWISS-PROT::P98160:3815..3724, score:''139.00''), (query:23857..24006, target:SWISS-PROT::P98160:3866..3817, score:''99.00''), (query:24052..24327, target:SWISS-PROT::P98160:4059..3968, score:''143.00''), (query:24046..24312, target:SWISS-PROT::P98160:4341..4253, score:''116.00''), (query:23806..23901, target:SWISS-PROT::P98160:4177..4146, score:''76.00''), (query:23203..23382, target:SWISS-PROT::P98160:4062..4003, score:''116.00''), (query:22523..22777, target:SWISS-PROT::P98160:4288..4204, score:''112.00''), (query:22235..22300, target:SWISS-PROT::P98160:4358..4337, score:''64.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''GM03359.5prime GM Drosophila melanogaster ovary BlueScript Drosophila melanogaster cDNA clone GM03359 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:25024..25235, target:EMBL::AA801707:438..227, score:''1024.00''), (query:24851..24898, target:EMBL::AA801707:476..429, score:''204.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''LD08615.5prime LD Drosophila melanogaster embryo BlueScript Drosophila melanogaster cDNA clone LD08615 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:24629..24727, target:EMBL::AA264808:99..1, score:''495.00''), (query:24417..24566, target:EMBL::AA264808:250..101, score:''687.00''), (query:24048..24420, target:EMBL::AA264808:618..246, score:''1847.00''), (query:23986..24036, target:EMBL::AA264808:678..628, score:''237.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''HL02745.5prime HL Drosophila melanogaster head BlueScript Drosophila melanogaster cDNA clone HL02745 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:23944..24045, target:EMBL::AA697546:103..2, score:''510.00''), (query:23630..23943, target:EMBL::AA697546:416..103, score:''1570.00''), (query:23419..23561, target:EMBL::AA697546:558..416, score:''715.00''), (query:23306..23417, target:EMBL::AA697546:670..559, score:''524.00''), (query:23280..23316, target:EMBL::AA697546:695..659, score:''167.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''GM08137.5prime GM Drosophila melanogaster ovary BlueScript Drosophila melanogaster cDNA clone GM08137 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:23235..23278, target:EMBL::AA696682:44..1, score:''139.00''), (query:22986..23251, target:EMBL::AA696682:294..29, score:''1321.00'')), method:''blastn'', version:''1.4.9'')\""), ("/codon_start=", "1"), ("/protein_id=", '"CAB72284.1"'), ("/db_xref=", '"GI:6946669"'), ("/translation=", '"MACNCNQSMIYQSNERRDYNCPGAPQYPYNRFKGGVSLKDTPCMVLYICADFKSSKLSSAKPIISGPATTRAPAISYVCQPNDFKCVSHPHTCVRANMVCDGIYDCTDHSDEFNCIAGKGSGKSESNSGSGSFKRWKKSPEQGRRSLAKAVKNRKLRKRSFAKSRDYSLKLDDQSSNLRAGESTDVECYSSDDTYTDVVWERSDGAPLSNNVRQVGNRLVISNVSPSDAGNYVCKCKTDEGDLYTTSYKLEVEDQPHELKSSKIVYAKVGANADLQCGADESRQPTYRWSRQYGQLQAGRSLMNEKLSLDSVQANDAGTYICTAQYADGETADFPNILVVTGAIPQFRQEPRSYMSFPTLPNSSFKFNFELTFRPENGDGLLLFNGQTRGSGDYIALSLKDRYAEFRFDFGGKPMLVRAEEPLALNEWHTVRVSRFKRDGYIQVDEQHPVAFPTLQQIPQLDLIEDLYIGGVPNWELLPADAVSQQVGFVGCISRLTLQGRTVELIREAKYKEGITDCRPCAQGPCQNKGVCLESQTEQAYTCICQPGWTGRDCAIEGTQCTPGVCGAGRCENTENDMECLCPLNRSGDRCQYNEILNEHSLNFKGNSFAAYGTPKVTKVNITLSVRPASLEDSVILYTAESTLPSGDYLALVLRGGHAELLINTAARLDPVVVRSAEPLPLNRWTRIEIRRRLGEGILRVGDGPERKAKAPGSDRILSLKTHLYVGGYDRSTVKVNRDVNITKGFDGCISRLYNFQKPVNLLADIKDAANIQSCGETNMIGGDEDSDNEPPVPPPTPDVHENELQPYAMAPCASDPCENGGSCSEQEDVAVCSCPFGFSGKHCQEHLQLGFNASFRGDGYVELNRSHFQPALEQSYTSMGIVFTTNKPNGLLFWWGQEAGEEYTGQDFIAAAVVDGYVEYSMRLDGEEAVIRNSDIRVDNGERHIVIAKRDENTAILEVDRMLHSGETRPTSKKSMKLPGNVFVGGAPDLEVFTGFRYKHNLNGCIVVVEGETVGQINLSSAAVNGVNANVCPA"'))),
-                    ("gene", "complement(29926..33978)", (("/gene=", '"EG:BACR25B3.10"'), )),
-                    ("CDS", "complement(join(29926..30108,30270..30519,30617..31076,31197..31591,31659..31836,32324..32634,32686..33289,33533..33713,33817..33978))", (("/gene=", '"EG:BACR25B3.10"'), ("/note=", "\"/prediction=(method:''genefinder'', version:''084'', score:''98.50''); /prediction=(method:''genscan'', version:''1.0''); /match=(desc:''BASEMENT MEMBRANE-SPECIFIC HEPARAN SULFATE PROTEOGLYCAN CORE PROTEIN PRECURSOR (HSPG) (PERLECAN) (PLC)'', species:''Homo sapiens (Human)'', ranges:(query:33540..33716, target:SWISS-PROT::P98160:2716..2658, score:''113.00''), (query:32859..32963, target:SWISS-PROT::P98160:3341..3307, score:''63.00''), (query:33150..33215, target:SWISS-PROT::P98160:3530..3509, score:''73.00''), (query:32973..33089, target:SWISS-PROT::P98160:3588..3550, score:''71.00''), (query:32358..32567, target:SWISS-PROT::P98160:3650..3581, score:''107.00''), (query:31222..31323, target:SWISS-PROT::P98160:2620..2587, score:''80.00''), (query:31489..31572, target:SWISS-PROT::P98160:3387..3360, score:''72.00''), (query:31495..31593, target:SWISS-PROT::P98160:3575..3543, score:''60.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''GM02481.5prime GM Drosophila melanogaster ovary BlueScript Drosophila melanogaster cDNA clone GM02481 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:30008..30036, target:EMBL::AA695253:29..1, score:''145.00''), (query:29549..30004, target:EMBL::AA695253:487..32, score:''2262.00'')), method:''blastn'', version:''1.4.9'')\""), ("/codon_start=", "1"), ("/protein_id=", '"CAB72285.1"'), ("/db_xref=", '"GI:6946670"'), ("/translation=", '"MFLATLDTNDPTDIGTEDPVLTQIIVSIQKPEITIVPVGGSMTLSCSGRMRWSNSPVIVNWYKENSRLPENVEVQGGNLYLYDLQVSDSGVYICQAVNNETASVFKDTVSITITKKDQLSPAEIVNLPSHVTFEEYVNNEIICEVLGNPAPRVTWARVDGHADAQSTRTYDNRLIFDSPRKSDEGRYRCQAENDQNRDEKYVIVYVQSNPPQPPPQQDRLYITPEEINGLAGESFQLNCQFTSVASLRYDWSHNGRSLSSSPARNVEIRGNTLEVRDASESDSGVYTCVAYDVRTRRNFTESARVNIDRREEQPFGVLMRMMILTDSLINHSNKPIIESLEQNILIIQGEDYSITCEASGSPYPSIKWAKVHDFMPENVHISGNVLTIYGARFENRGVYSCVAENDHGSDLSSTSIDIEPRERPSVKIVSAPLQTFSVGAPASLYCTVEGIPDPTVEWVRVDGQPLSPRHKIQSPGYMVIDDIQLEDSGDYECRAKNIVGEATGVATITVQEPTLVQIIPDNRDLRLTEGDELSLTCVGSGVPNPEVEWVNEMALKRDLYSPPSNTAILKIYRVTKADAGIYTCHGKNEAGSDEAHVRVEVQERRGDIGGVDDDSDRDPINYNPPQQQNPGIHQPGSNQLLATDIGDNVTLTCDMFQPLNTRWERVDGAPLPRNAYTIKNRLEIVRVEQQNLGQYRCNGIGRDGNVKTYFVKELVLMPLPRIRFYPNIPLTVEAGQNLDVHCQVENVRPEDVHWSTDNNRPLPSSVRIVGSVLRFVSITQAAAGEYRCSAFNQYGNRSQIARVAVKKPADFHQVPQSQLQRHREGENIQLQCTVTDQYGVRAQDNVEFNWFRDDRRPLPNNARTDSQILVLTNLRPEDAGRYICNSYDVDRGQQLPEVSIDLQVLSE"'))),
-                    ("gene", "complement(36119..56153)", (("/gene=", '"EG:BACR25B3.1"'), )),
-                    ("CDS", "complement(join(36119..37213,37281..39517,39656..40042,40345..40434,40519..40612,40681..40814,41546..41620,41855..42085,42188..42415,42751..42876,43604..43837,44241..44438,44812..44928,45148..45233,45661..45793,45976..46125,46518..46688,47222..47315,47683..47831,48411..48878,49437..49562,49763..49876,49971..50102,50319..50441,50827..50937,52849..52966,56031..56153))", (("/gene=", '"EG:BACR25B3.1"'), ("/note=", "\"/prediction=(method:''genscan'', version:''1.0''); /prediction=(method:''genefinder'', version:''084''); /match=(desc:''LOW-DENSITY LIPOPROTEIN RECEPTOR-RELATED PROTEIN PRECURSOR (LRP)'', species:''Caenorhabditis elegans'', ranges:(query:50831..50941, target:SWISS-PROT::Q04833:1221..1185, score:''95.00''), (query:50840..51025, target:SWISS-PROT::Q04833:2865..2804, score:''102.00''), (query:50828..50935, target:SWISS-PROT::Q04833:3788..3753, score:''119.00''), (query:50323..50394, target:SWISS-PROT::Q04833:3706..3683, score:''77.00''), (query:50326..50433, target:SWISS-PROT::Q04833:1263..1228, score:''120.00''), (query:49948..50079, target:SWISS-PROT::Q04833:2917..2874, score:''88.00''), (query:49432..49587, target:SWISS-PROT::Q04833:4085..4034, score:''102.00''), (query:49429..49560, target:SWISS-PROT::Q04833:3915..3872, score:''97.00''), (query:48622..48720, target:SWISS-PROT::Q04833:1302..1270, score:''99.00''), (query:47698..47799, target:SWISS-PROT::Q04833:3996..3963, score:''88.00''), (query:47686..47775, target:SWISS-PROT::Q04833:3835..3806, score:''59.00''), (query:47692..47787, target:SWISS-PROT::Q04833:4041..4010, score:''83.00''), (query:47229..47315, target:SWISS-PROT::Q04833:3742..3714, score:''88.00''), (query:47220..47312, target:SWISS-PROT::Q04833:3829..3799, score:''67.00''), (query:47232..47318, target:SWISS-PROT::Q04833:3866..3838, score:''78.00''), (query:46552..46656, target:SWISS-PROT::Q04833:1344..1310, score:''95.00''), (query:46543..46650, target:SWISS-PROT::Q04833:3951..3916, score:''98.00''), (query:45983..46129, target:SWISS-PROT::Q04833:2870..2822, score:''82.00''), (query:45971..46096, target:SWISS-PROT::Q04833:4089..4048, score:''82.00''), (query:45678..45764, target:SWISS-PROT::Q04833:3666..3638, score:''80.00''), (query:45128..45238, target:SWISS-PROT::Q04833:94..58, score:''100.00''), (query:45158..45268, target:SWISS-PROT::Q04833:3990..3954, score:''80.00''), (query:44263..44379, target:SWISS-PROT::Q04833:85..47, score:''77.00''), (query:44251..44367, target:SWISS-PROT::Q04833:3995..3957, score:''100.00''), (query:43605..43688, target:SWISS-PROT::Q04833:2994..2967, score:''84.00''), (query:42764..42877, target:SWISS-PROT::Q04833:2951..2914, score:''77.00''), (query:42180..42377, target:SWISS-PROT::Q04833:260..195, score:''148.00''), (query:42234..42419, target:SWISS-PROT::Q04833:3199..3138, score:''106.00''), (query:39807..40013, target:SWISS-PROT::Q04833:2901..2833, score:''167.00''), (query:39645..39857, target:SWISS-PROT::Q04833:3138..3068, score:''151.00''), (query:39846..40046, target:SWISS-PROT::Q04833:3241..3175, score:''132.00''), (query:39654..39866, target:SWISS-PROT::Q04833:3913..3843, score:''201.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''LOW-DENSITY LIPOPROTEIN RECEPTOR-RELATED PROTEIN 2 PRECURSOR (MEGALIN) (GLYCOPROTEIN 330)'', species:''Homo sapiens (Human)'', ranges:(query:50834..50935, target:SWISS-PROT::P98164:2733..2700, score:''99.00''), (query:50840..50947, target:SWISS-PROT::P98164:3063..3028, score:''94.00''), (query:50831..50926, target:SWISS-PROT::P98164:3918..3887, score:''102.00''), (query:50326..50433, target:SWISS-PROT::P98164:1222..1187, score:''107.00''), (query:50302..50394, target:SWISS-PROT::P98164:3762..3732, score:''91.00''), (query:49773..49904, target:SWISS-PROT::P98164:2939..2896, score:''90.00''), (query:49438..49578, target:SWISS-PROT::P98164:217..171, score:''116.00''), (query:49429..49545, target:SWISS-PROT::P98164:3796..3758, score:''108.00''), (query:48622..48720, target:SWISS-PROT::P98164:3544..3512, score:''94.00''), (query:48595..48708, target:SWISS-PROT::P98164:3720..3683, score:''86.00''), (query:47701..47814, target:SWISS-PROT::P98164:2817..2780, score:''90.00''), (query:47692..47799, target:SWISS-PROT::P98164:3674..3639, score:''60.00''), (query:47217..47366, target:SWISS-PROT::P98164:3716..3667, score:''96.00''), (query:46543..46647, target:SWISS-PROT::P98164:1101..1067, score:''107.00''), (query:46552..46656, target:SWISS-PROT::P98164:3873..3839, score:''84.00''), (query:45989..46126, target:SWISS-PROT::P98164:3832..3787, score:''98.00''), (query:45149..45274, target:SWISS-PROT::P98164:2775..2734, score:''99.00''), (query:44780..44893, target:SWISS-PROT::P98164:268..231, score:''76.00''), (query:44813..44905, target:SWISS-PROT::P98164:1223..1193, score:''73.00''), (query:44251..44361, target:SWISS-PROT::P98164:3630..3594, score:''119.00''), (query:43602..43700, target:SWISS-PROT::P98164:179..147, score:''97.00''), (query:43674..43781, target:SWISS-PROT::P98164:191..156, score:''90.00''), (query:43584..43685, target:SWISS-PROT::P98164:1107..1074, score:''89.00''), (query:42758..42865, target:SWISS-PROT::P98164:1264..1229, score:''79.00''), (query:42204..42413, target:SWISS-PROT::P98164:2810..2741, score:''136.00''), (query:42189..42377, target:SWISS-PROT::P98164:3027..2965, score:''125.00''), (query:42186..42293, target:SWISS-PROT::P98164:3110..3075, score:''109.00''), (query:42198..42389, target:SWISS-PROT::P98164:3584..3521, score:''137.00''), (query:42309..42422, target:SWISS-PROT::P98164:3793..3756, score:''95.00''), (query:39654..39791, target:SWISS-PROT::P98164:63..18, score:''132.00''), (query:39786..40049, target:SWISS-PROT::P98164:1183..1096, score:''230.00''), (query:39657..39890, target:SWISS-PROT::P98164:3109..3032, score:''200.00''), (query:39780..39983, target:SWISS-PROT::P98164:3756..3689, score:''194.00''), (query:39618..39761, target:SWISS-PROT::P98164:3845..3798, score:''105.00''), (query:39651..39779, target:SWISS-PROT::P98164:3964..3922, score:''128.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''GM06086.5prime GM Drosophila melanogaster ovary BlueScript Drosophila melanogaster cDNA clone GM06086 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:50852..51290, target:EMBL::AA802674:672..234, score:''2195.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''SD04592.5prime SD Drosophila melanogaster Schneider L2 cell culture pOT2 Drosophila melanogaster cDNA clone SD04592 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:37280..37708, target:EMBL::AI532939:429..1, score:''2136.00''), (query:37097..37217, target:EMBL::AI532939:545..425, score:''569.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''GH03622.5prime GH Drosophila melanogaster head pOT2 Drosophila melanogaster cDNA clone GH03622 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:36446..37075, target:EMBL::AI063674:1..630, score:''3150.00'')), method:''blastn'', version:''1.4.9''); EST embl|AA802674|AA802674 comes from the 5\' UTR\""), ("/codon_start=", "1"), ("/protein_id=", '"CAB72286.1"'), ("/db_xref=", '"GI:6946671"'), ("/translation=", '"MLLLQLLLQLLLLGKLLLGKTPPTVFGFRLLFAAFRFPLSLHFPHRMHDHFFVRGDTHSCGWKNSTTFTIRISAIYRYLNQCQANEFRCNNGDCIDARKRCNNVSDCSEGEDENEECPAACSGMEYQCRDGTRCISVSQQCDGHSDCSDGDDEEHCDGIVPKLRYTCPKGKFTCRDLSCISIVHRCDGRADCPNDRSDEEGCPCLYDKWQCDDGTCIAKELLCNGNIDCPEDISDERYCEGGYDSEECRFDEFHCGTGECIPMRQVCDNIYDCNDYSDEVNCVEGEEEDRVGIPIGHQPWRPASKHDDWLHEMDTSEYQVYQPSNVYEKANSQNPCASNQFRCTTSNVCIPLHLRCDGFYHCNDMSDEKSCEQYQRHTTTRRPLTLATPTSRITTQGPGLLERRNTTTATEASRWPWATKTTTIATTTSNPITTVGVANSPPQTCLENIEFACHNRDCISIESVCDGIPDCGRNEDEDDALCKCSGDKYKCQRGGGCIPKSQVCDGKPQCHDRSDESACHLHGRLNKTRLGVKCLESQYQCGDGSCISGYKRCNGIHDCADASDEYNCIYDYEDTYDTDPNNNPLNECDILEFECDYSQCLPLEKKCDGYADCEDMSDELECQSYTDHCLESEFECDSYCLPRDQLCNGIPNCQDGSDERNCTFCREDAYLCNTGECVADNQRCNGIADCADGSDERHCARIYCPPNKLACNGTCVSRRIKCDGIRDCLDGYDEMYCPETNNHYPTQNVNVIRPKLGPNPIPKSCRPHEWQCANLECIDSSLQCNEIKDCSDGSDEELSVCFGTATTRLKPSDCSPEQFYCDESCYNRSVRCNGHVDCSDGSDEVGCSLPCPQHQCPSGRCYTESERCDRHRHCEDGSDEANCTAILCKDNEFLCFDRQFCINATQQCDGYYDCRDFSDEQNCIGCYANQFRCNNGDCVSGSAPCNGYSECSDHSDELNCGGTQECLPNQFRCNSGQCVSSSVRCNGRTDCQDSSDEQNCGHRHTEVSQGLETTGVFTTSTTSTTAMTPLRIICPPTSFKCENGPCISLGLKCNGRVDCPYDGSDEADCGQISNDIDPADSNDRRPNQLNLKTYPDSQIIKESREVIFRCRDEGPARAKVKWSRPGGRPLPPGFTDRNGRLEIPNIRVEDAGTYVCEAVGYASYIPGQQVTVNLNVERSWGENKYEEIRSNRIRYGTVPHIDLEFFGLDNDVGSRPESACTEYQATCMNGECIDKSSICDGNPDCSDASDEQSCSLGLKCQPNQFMCSNSKCVDRTWRCDGENDCGDNSDETSCDPEPSGAPCRYNEFQCRSGHCIPKSFQCDNVPDCTDGTDEVGCMAPLPIRPPPQSVSLLEYEVLELTCVATGTPTPTIVWRLNWGHVPDKCESKSYGGTGTLRCPDMRPQDSGAYSCEIINTRGTHFVNPDTIVTVRPVRTDVCEAGFFNMLARKAEECVQCFCFGVAKACDSANLFTYAIHPPILSHRVVSVELSPLRQIVINEAAPGQDLLTLLHGVQFRATNVHFSGRETPYLALPADYMGNQLKSYGGNLRYEVNYRGSGRPVNGPDVIITGNRFTLTYRVRTQPGQNNRVSIPFVPGGWQKPDGRKASREEIMMILANVDNILIRLGYLDSTAREVDLINIALDSAGTADKGLGSASLVEKCQCPPGYVGDSCESCASGYVRQPGGPWLGHCVPFIPDSCPSGTYGDPRRGVPCKECPCPLTGSNNFASGCQQSPDGDVVCRCNEGYTGRRCEQCAAGYQGNPLAAGGICRRIPDTSCNVDGTYSVHSNGTCQCKDSVIGEQCDTCKSKSFHLNSFTYTGCIECFCSGVGLDCDSSTWYRDQVTSTFGRSRVDHGFVLVTNYMQPTPDTVPVSMAAEPNALSFIGSADQSGNTLYWSLPAAFLGNKLSSYGGKLTYTLSYSPLPNGIMSRNSAPDVVIKSGEDLRLIHYRKSQVVPSVANTYSVEIKESAWQRGDEVVANREHVLMALSDITAIYIKATYTTSTKEASLRQVTLDVATPTNLGTPRAVEVEQCRCPEGYLGLSCEQCAPGYARDPEGGIYLGLCRPCECNGHSKYCNSDTGDCEECSDNTEGPSCERCAAGYVGDATRGTIYDCQPDEGYPIPSPPAPGNQTLECTAYCQIEGIYDCRGNECLCKRNVIGDQCDQCRPGTYGLSAQNQDGCKECYCSGLASQCRSAALYRQLIPVDFILNAPLITDESGAVQDTENLIPDISRNMYTYTHTSYLPKYWSLRGSVLGNQLFSYGGRLSYSLIVESYGNYERGHDIVLIGNGLKLIWSRPDGNENQEEYNVRLHEDEQWTRQDRESARPASRSDFMTVLSDLQHILIRATPRVPTQSTSIGNVILESAVTTRTPGATHASDIELCQCPSGYVGTSCESCAPLHYRDASGSCSLCPCDVSNTESCDLVSGGYVECRCKARWKGDRCREIGE"'))),
-                    ("gene", "complement(70720..75241)", (("/gene=", '"EG:BACR25B3.2"'), )),
-                    ("CDS", "complement(join(70720..70988,71424..71621,72605..72768,72839..73016,73086..73559,75217..75241))", (("/gene=", '"EG:BACR25B3.2"'), ("/note=", "\"/prediction=(method:''genefinder'', version:''084'', score:''41.82''); /prediction=(method:''genscan'', version:''1.0'')\""), ("/codon_start=", "1"), ("/protein_id=", '"CAB72287.1"'), ("/db_xref=", '"GI:6946672"'), ("/translation=", '"MANSKVVAHDESLQGINDSEWQLMGDDIDDGLLDDVDETLKPMETKSEEEDLPTGNWFSQSVHRVRRSINRLFGSDDNQERGRRQQRERSQRNRDAINRQKELRRRQKEDHNRWKQMRMERQLEKQRLVKRTNHVVFNRATDPRKRASDLYDENEASGYHEEDTTLYRTYFVVNEPYDNEYRDRESVQFQNLQKLLDDDLRNFFHSNYEGNDDEEQEIRSTLERVEPTNDNFKIRVQLRIELPTSVNDFGSKLQQQLNVYNRIENLSAATDGVFSFTESSDIEEEAIDVTLPQEEVEGSGSDDSSCRGDATFTCPRSGKTICDEMRCDREIQCPDGEDEEYCNYPNVCTEDQFKCDDKCLELKKRCDGSIDCLDQTDEAGCINAPEPEPEPEPEPEPEPESEPEAEPEPEPEPEPESEPEQEPEPQVPEANGKFY"'))),
-                    ("gene", "121867..127124", (("/gene=", '"EG:BACR25B3.3"'), )),
-                    ("CDS", "join(121867..122046,122174..122630,123672..123823,124063..124320,124392..124688,124755..125018,125094..125254,125317..125576,126793..127124)", (("/gene=", '"EG:BACR25B3.3"'), ("/note=", "\"/prediction=(method:''genscan'', version:''1.0'', score:''174.91''); /prediction=(method:''genefinder'', version:''084''); /match=(desc:''PROBABLE G PROTEIN-COUPLED RECEPTOR C13B9.4 IN CHROMOSOME III'', species:''Caenorhabditis elegans'', ranges:(query:123671..123775, target:SWISS-PROT::Q09460:107..141, score:''80.00''), (query:123743..123829, target:SWISS-PROT::Q09460:235..263, score:''72.00''), (query:124072..124332, target:SWISS-PROT::Q09460:265..351, score:''161.00''), (query:124392..124691, target:SWISS-PROT::Q09460:349..448, score:''206.00''), (query:124755..124958, target:SWISS-PROT::Q09460:448..515, score:''123.00''), (query:124764..125027, target:SWISS-PROT::Q09460:454..541, score:''108.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''CALCITONIN RECEPTOR PRECURSOR (CT-R)'', species:''Sus scrofa (Pig)'', ranges:(query:124165..124236, target:SWISS-PROT::P25117:191..214, score:''54.00''), (query:124392..124580, target:SWISS-PROT::P25117:233..295, score:''118.00''), (query:124725..124886, target:SWISS-PROT::P25117:318..371, score:''127.00'')), method:''blastx'', version:''1.4.9'')\""), ("/codon_start=", "1"), ("/protein_id=", '"CAB72288.1"'), ("/db_xref=", '"GI:6946673"'), ("/translation=", '"MGAGNRKSETKTKTEAEIEIEMERDQFSIAANACMSMGPMLISKDKAPCSGGRVRHADSLHIYYAVDGKMTLLSNILDCGGCISAQRFTRLLRQSGSSGPSPSAPTAGTFESKSMLEPTSSHSLATGRVPLLHDFDASTTESPGTYVLDGVARVAQLALEPTVMDALPDSDTEQVLGNLNSSAPWNLTLASAAATNFENCSALFVNYTLPQTEFAIRKCELDGRWGSRPNATEVNPPGWTDYGPCYKPEIIRLMQQMGSKDFDAYIDIARRTRTLEIVGLCLSLFALIVSLLIFCTFRSLRNNRTKIHKNLFVAMVLQVIIRLTLYLDQFRRGNKEAATNTSLSVIENTPYLCEASYVLLEYARTAMFMWMFIEGLYLHNMVTVAVFQGSFPLKFFSRLGWCVPILMTTVWARCTVMYMDTSLGECLWNYNLTPYYWILEGPRLAVILLNFCFLVNIIRVLVMKLRQSQASDIEQTRKAVRAAIVLLPLLGITNLLHQLAPLKTATNFAVWSYGTHFLTSFQGFFIALIYCFLNGEVRAVLLKSLATQLSVRGHPEWAPKRASMYSGAYNTAPDTDAVQPAGDPSATGKRISPPNKRLNGRKPSSASIVMIHEPQQRQRLMPRLQNKAREKGKDRVEKTDAEAEPDPTISHIHSKEAGSARSRTRGSKWIMGICFRGQMCDAGLAKDAANIHDVANAADVDACSGSNNNYHNINNNNGSQNNNSIHCNHRDDDKVKGESQSDFKEPSNTNAESLVHLALFTAHTSNTQNNTHRNTIFTPIRRRNCS"'))),
-                    ("gene", "complement(128489..129414)", (("/gene=", '"EG:BACR25B3.4"'), )),
-                    ("CDS", "complement(join(128489..128715,128777..129140,129196..129313,129374..129414))", (("/gene=", '"EG:BACR25B3.4"'), ("/note=", "\"/prediction=(method:''genefinder'', version:''084'', score:''61.35''); /prediction=(method:''genscan'', version:''1.0''); /match=(desc:''VACUOLAR PROTON-ATPASE SUBUNIT D'', species:''Oryctolagus cuniculus (Rabbit)'', ranges:(query:129190..129324, target:SPTREMBL::O97755:55..11, score:''130.00''), (query:128778..129176, target:SPTREMBL::O97755:174..42, score:''472.00''), (query:128546..128716, target:SPTREMBL::O97755:231..175, score:''169.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''VACUOLAR ATP SYNTHASE SUBUNIT D (EC 3.6.1.34) (V-ATPASE D SUBUNIT) (V- ATPASE 28 KD ACCESSORY PROTEIN)'', species:''Bos taurus (Bovine)'', ranges:(query:129190..129324, target:SWISS-PROT::P39942:55..11, score:''130.00''), (query:128778..129176, target:SWISS-PROT::P39942:174..42, score:''471.00''), (query:128546..128716, target:SWISS-PROT::P39942:231..175, score:''173.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''GH28048.5prime GH Drosophila melanogaster head pOT2 Drosophila melanogaster cDNA clone GH28048 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:129196..129317, target:EMBL::AI517334:233..112, score:''412.00''), (query:128777..129145, target:EMBL::AI517334:597..229, score:''1251.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''GH07112.5prime GH Drosophila melanogaster head pOT2 Drosophila melanogaster cDNA clone GH07112 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:129196..129317, target:EMBL::AI108302:223..102, score:''412.00''), (query:128777..129145, target:EMBL::AI108302:587..219, score:''1251.00''), (query:128636..128716, target:EMBL::AI108302:667..587, score:''243.00'')), method:''blastn'', version:''1.4.9'')\""), ("/codon_start=", "1"), ("/protein_id=", '"CAB72289.1"'), ("/db_xref=", '"GI:6946674"'), ("/translation=", '"MAAKDRLPIFPSRGAQTLMKSRLAGATKGHGLLKKKADALQMRFRLILGKIIETKTLMGQVMKEAAFSLAEVKFTTGDINQIVLQNVTKAQIKIRTKKDNVAGVTLPIFEPYTDGVDTYELAGLARGGQQLAKLKKNYQSAVRLLVQLASLQTSFVTLDDVIKVTNRRVNAIEHVIIPRINRTIEYIISELDELEREEFYRLKKIQDKKREARKASDKLRAEQRLLGQMAEAQEVQNILDEDGDEDLLF"'))),
-                    ("gene", "132240..132926", (("/gene=", '"EG:BACR25B3.5"'), )),
-                    ("CDS", "132240..132926", (("/gene=", '"EG:BACR25B3.5"'), ("/note=", "\"/prediction=(method:''genefinder'', version:''084'', score:''48.06''); /prediction=(method:''genscan'', version:''1.0'', score:''132.90''); /match=(desc:''N-ACETYLTRANSFERASE'', species:''Drosophila melanogaster (Fruit fly)'', ranges:(query:132249..132326, target:SPTREMBL::Q94521:60..85, score:''64.00''), (query:132600..132842, target:SPTREMBL::Q94521:171..251, score:''105.00'')), method:''blastx'', version:''1.4.9''); EST embl|AI063093|AI063093 comes from the 3\' UTR\""), ("/codon_start=", "1"), ("/protein_id=", '"CAB72290.1"'), ("/db_xref=", '"GI:6946675"'), ("/translation=", '"MEYKMIAPEHSEQVMEHLRRNFFADEPLNKAAGLCQNGSSCPALEAHCAEAIQHRMSVMAVDAKEKDTLKIVGVVLNGILKPGDTAKALSKLDCNDDADFRKIFDLLHRHNLKHNLFEHFDVDCMFDVRILSVDSCYRGQGIANELVKRSVAVAKKNGFRLLKADATGIFSQKIFRSHGFEVFSEQPYSKYTDENGKVILPVEAPHIKLQQLYKAICADDQDEKKQSL"'))),
-                    ("gene", "complement(133492..134407)", (("/gene=", '"EG:BACR25B3.6"'), )),
-                    ("CDS", "complement(join(133492..133595,133663..133748,133867..134135,134198..134407))", (("/gene=", '"EG:BACR25B3.6"'), ("/note=", "\"/prediction=(method:''genscan'', version:''1.0'', score:''119.22''); /prediction=(method:''genefinder'', version:''084''); /match=(desc:''LD41675.5prime LD Drosophila melanogaster embryo pOT2 Drosophila melanogaster cDNA clone LD41675 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:134192..134531, target:EMBL::AI515958:340..1, score:''1691.00''), (query:133879..134139, target:EMBL::AI515958:591..331, score:''1305.00'')), method:''blastn'', version:''1.4.9'')\""), ("/codon_start=", "1"), ("/protein_id=", '"CAB72291.1"'), ("/db_xref=", '"GI:6946676"'), ("/translation=", '"MNGLPPSKHYNLTHYQQRYNWDCGLSCIIMILSAQQREQLLGNFDAVCGEEGFGSSTWTIDLCYLLMRYQVRHEYFTQTLGIDPNYAQHTYYSKIIDKDERRVTRKFKDARAHGLRVEQRTVDMEVILRHLARHGPVILLTNASLLTCEVCKRNVLEKFGYAGHYVVLCGYDMAAQKLFYHNPEVHDGHICRCLIESMDTARRAYGTDEDIIFIYEKKETRE"'))),
-                    ("gene", "135479..136829", (("/gene=", '"EG:BACR25B3.7"'), )),
-                    ("CDS", "join(135479..135749,135961..136586,136641..136829)", (("/gene=", '"EG:BACR25B3.7"'), ("/note=", "\"/prediction=(method:''genefinder'', version:''084'', score:''66.07''); /prediction=(method:''genscan'', version:''1.0'', score:''145.64''); /match=(desc:''HYPOTHETICAL 40.4 KD TRP-ASP REPEATS CONTAINING PROTEIN C14B1.4 IN CHROMOSOME III'', species:''Caenorhabditis elegans'', ranges:(query:135548..135748, target:SWISS-PROT::Q17963:39..105, score:''120.00''), (query:135957..136586, target:SWISS-PROT::Q17963:105..314, score:''899.00''), (query:136641..136823, target:SWISS-PROT::Q17963:315..375, score:''219.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''LD30385.5prime LD Drosophila melanogaster embryo pOT2 Drosophila melanogaster cDNA clone LD30385 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:135288..135749, target:EMBL::AA950546:102..563, score:''2301.00''), (query:135956..136047, target:EMBL::AA950546:559..650, score:''442.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''LD10938.5prime LD Drosophila melanogaster embryo BlueScript Drosophila melanogaster cDNA clone LD10938 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:136108..136288, target:EMBL::AA392005:776..596, score:''212.00'')), method:''blastn'', version:''1.4.9'')\""), ("/codon_start=", "1"), ("/protein_id=", '"CAB72292.1"'), ("/db_xref=", '"GI:6946677"'), ("/translation=", '"MVPIGAVHGGHPGVVHPPQQPLPTAPSGPNSLQPNSVGQPGATTSSNSSASNKSSLSVKPNYTLKFTLAGHTKAVSAVKFSPNGEWLASSSADKLIKIWGAYDGKFEKTISGHKLGISDVAWSSDSRLLVSGSDDKTLKVWELSTGKSLKTLKGHSNYVFCCNFNPQSNLIVSGSFDESVRIWDVRTGKCLKTLPAHSDPVSAVHFNRDGSLIVSSSYDGLCRIWDTASGQCLKTLIDDDNPPVSFVKFSPNGKYILAATLDNTLKLWDYSKGKCLKTYTGHKNEKYCIFANFSVTGGKWIVSGSEDNMVYIWNLQSKEVVQKLQGHTDTVLCTACHPTENIIASAALENDKTIKLWKSDT"'))),
-                    ("gene", "145403..147087", (("/gene=", '"EG:BACR25B3.8"'), )),
-                    ("CDS", "join(145403..146203,146515..147087)", (("/gene=", '"EG:BACR25B3.8"'), ("/codon_start=", "1"), ("/protein_id=", '"CAB72293.1"'), ("/db_xref=", '"GI:6946678"'), ("/translation=", '"MNSTTKHLLHCTLLITVIVTFEVFSGGIKIDENSFTLVDPWTEYGQLATVLLYLLRFLTLLTLPQVLFNFCGLVFYNAFPEKVVLKGSPLLAPFICIRVVTRGDFPDLVKTNVLRNMNTCLDTGLENFLIEVVTDKAVNLSQHRRIREIVVPKEYKTRTGALFKSRALQYCLEDNVNVLNDSDWIVHLDEETLLTENSVRGIINFVLDGKHPFGQGLITYANENVVNWLTTLADSFRVSDDMGKLRLQFKLFHKPLFSWKGSYVVTQVSAERSVSFDNGIDGSVAEDCFFAMRAFSQGYTFNFIEGEMYEKSPFTLLDFLQQRKRWLQGILLVVHSKMIPFKHKLLLGISVYSWVTMPLSTSNIIFAALYPIPCPNLVDFVCAFIAAINIYMYVFGVIKSFSLYRFGLFRFLACVLGAVCTIPVNVVIENVAVIWGLVGKKHKFYVVQKDVRVLETV"'))),
-                    ("gene", "complement(148860..152785)", (("/gene=", '"EG:BACR25B3.9"'), )),
-                    ("CDS", "complement(join(148860..148905,148966..149462,149546..151809,151881..152032,152106..152785))", (("/gene=", '"EG:BACR25B3.9"'), ("/note=", "\"/prediction=(method:''genscan'', version:''1.0''); /prediction=(method:''genefinder'', version:''084''); /match=(desc:''HYPOTHETICAL 135.8 KD PROTEIN'', species:''Drosophila melanogaster (Fruit fly)'', ranges:(query:152096..152785, target:SPTREMBL::Q9XZ29:230..1, score:''1147.00''), (query:151882..152043, target:SPTREMBL::Q9XZ29:277..224, score:''250.00''), (query:149546..151816, target:SPTREMBL::Q9XZ29:1032..276, score:''3735.00''), (query:148953..149465, target:SPTREMBL::Q9XZ29:1202..1032, score:''890.00''), (query:148863..148907, target:SPTREMBL::Q9XZ29:1212..1198, score:''76.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''LD21815.5prime LD Drosophila melanogaster embryo pOT2 Drosophila melanogaster cDNA clone LD21815 5prime similar to L19117: Drosophila melanogaster (chromosome X 3A6-8) kinesin-like protein of 3A (klp3A) mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:152482..152787, target:EMBL::AA816942:460..155, score:''1485.00''), (query:152401..152483, target:EMBL::AA816942:540..458, score:''397.00'')), method:''blastn'', version:''1.4.9'')\""), ("/codon_start=", "1"), ("/protein_id=", '"CAB72294.1"'), ("/db_xref=", '"GI:6946679"'), ("/translation=", '"MSSEDPSCVAVALRVRPLVQSELDRGCRIAVERSADGAPQVTVNRNESYTYNYVFDIDDSQKDLFETCVQAKVKKLLNGYNVTILAYGQTGSGKTYTMGTAFNGVLDDHVGVIPRAVHDIFTAIAEMQSEFRFAVTCSFVELYQEQFYDLFSSKTRDKATVDIREVKNRIIMPGLTELVVTSAQQVTDHLIRGSAGRAVAATAMNETSSRSHAIFTLTLVATKLDGKQSVTTSRFNLVDLAGSERCSKTLASGDRFKEGVNINKGLLALGNVINALGSGQAAGYIPYRQSKLTRLLQDSLGGNSITLMIACVSPADYNVAETLSTLRYADRALQIKNKPVVNLDPHAAEVNMLKDVIQKLRVELLSGGKMSSSLISAVGAAGLGAIPCEESLAGSMANAAEIQRLKEQVRTLQDRNRKLQQELHQSLLDLTEKEMRAHIAEQAHDKLRSHVSELKNKLDQREQAQFGNENTNGDNEMRDFSLLVNRVHVELQRTQEELESQGHESRQRLSSRSHTEGGESGGDEVHEMLHSHSEEYTNKQMNFAGELRNINRQLDLKQELHERIMRNFSRLDSDDEDVKLRLCNQKIDDLEAERRDLMDQLRNIKSKDISAKLAEERRKRLQLLEQEISDLRRKLITQANLLKIRDKEREKIQNLSTEIRTMKESKVKLIRAMRGESEKFRQWKMVREKELTQLKSKDRKMQSEIVRQQTLHSKQRQVLKRKCEEALAANKRLKDALERQASAQAQRHKYKDNGGSAAGSSNANAKTDSWVDRELEIILSLIDAEHSLEQLMEDRAVINNHYHLLQQEKTSDPAEAAEQARILASLEEELEMRNAQISDLQQKVCPTDLDSRIRSLAEGVQSLGESRTVSKQLLKTLVQQRRLQASSLNEQRTTLDELRAQLLDAQQQEDAASKRLRLLQSQHEEQMLAQQRAYEEKVSVLIRTANQRWAEARSPAEDQQRNQILEELLSSREALQQELDKLRAKNKSKSKAVKSEPQDLDDSFQIVDGNETVVLSDVSDDPDWVPSTSKSKRIQSDSRNVISPPEKQDANVTSLGNSSIQSLNSTSATEDGKRCKGCKCRTKCTTKRCGCLSGNNACSETCVCKSNCRNPLNLKDHASQCGDGDGQKDETEDADKSDDDGDDEPQTSKENAVKFVTPEAPGKVVASPKQTLQEPKAAATPLMNSNVVEDINGPKLAKMSGLAFDTPKRKFF"'))),
-                    ("gene", "join(153490..154269,AL121804.2:41..610,AL121804.2:672..1487)", (("/gene=", '"EG:BACR7C10.3"'), )),
-                    ("CDS", "join(153490..154269,AL121804.2:41..610,AL121804.2:672..1487)", (("/gene=", '"EG:BACR7C10.3"'), ("/codon_start=", "1"), ("/protein_id=", '"CAB72295.1"'), ("/db_xref=", '"GI:6946680"'), ("/translation=", '"MEEEAPRFNVLEEAFNGNGNGCANVEATQSAILKVLTRVNRFQMRVRKHIEDNYTEFLPNNTSPDIFLEESGSLNREIHDMLENLGSEGLDALDEANVKMAGNGRQLREILLGLGVSEHVLRIDELFQCVEEAKATKDYLVLLDLVGRLRAFIYGDDSVDGDAQVATPEVRRIFKALECYETIKVKYHVQAYMLQQSLQERFDRLVQLQCKSFPTSRCVTLQVSRDQTQLQDIVQALFQEPYNPARLAEFLLDNCIEPVIMRPVMADYSEEADGGTYVRLSLSYATKEPSSAHVRPNYKQVLENLRLLLHTLAGINCSVSRDQHVFGIIGDHVKDKMLKLLVDECLIPAVPESTEEYQTSTLCEDVAQLEQLLVDSFIINPEQDRALGQFVEKYETYYRNRMYRRVLETAREIIQRDLQDMVLVAPNNHSAEVANDPFLFPRCMISKSAQDFVKLMDRILRQPTDKLGDQEADPIAGVISIMLHTYINEVPKVHRKLLESIPQQAVLFHNNCMFFTHWVAQHANKGIESLAALAKTLQATGQQHFRVQVDYQSSILMGIMQEFEFESTHTLGSGPLKLVRQCLRQLELLKNVWANVLPETVYNATFCELINTFVAELIRRVFTLRHISAQMACELSDLIDVVLQRAPTLFREPNEVVQVLSWLKLQQLKAMLNASLMEITELWGDGVGPLTASYKSDEIKHLIRALFQDTDWRAKAITQIV"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "Sequencing the distal X chromosome of Drosophila melanogaster",
+            "Direct Submission",
+        )
+        features = [
+            (
+                "source",
+                "1..154329",
+                (
+                    ("/organism=", '"Drosophila melanogaster"'),
+                    ("/db_xref=", '"taxon:7227"'),
+                    ("/clone=", '"BAC BACR25B3"'),
+                ),
+            ),
+            (
+                "gene",
+                "complement(22148..27773)",
+                (("/gene=", '"EG:BACR25B3.11"'), ("/note=", "")),
+            ),
+            (
+                "CDS",
+                "complement(join(22148..22299,22375..22791,22860..23560,23630..24555,24616..24888,25024..25178,26677..27009,27623..27773))",
+                (
+                    ("/gene=", '"EG:BACR25B3.11"'),
+                    (
+                        "/note=",
+                        "\"/prediction=(method:''genefinder'', version:''084'', score:''105.71''); /prediction=(method:''genscan'', version:''1.0''); /match=(desc:''BASEMENT MEMBRANE-SPECIFIC HEPARAN SULFATE PROTEOGLYCAN CORE PROTEIN PRECURSOR (HSPG) (PERLECAN) (PLC)'', species:''Homo sapiens (Human)'', ranges:(query:24292..24549, target:SWISS-PROT::P98160:3713..3628, score:''201.00''), (query:24016..24291, target:SWISS-PROT::P98160:3815..3724, score:''139.00''), (query:23857..24006, target:SWISS-PROT::P98160:3866..3817, score:''99.00''), (query:24052..24327, target:SWISS-PROT::P98160:4059..3968, score:''143.00''), (query:24046..24312, target:SWISS-PROT::P98160:4341..4253, score:''116.00''), (query:23806..23901, target:SWISS-PROT::P98160:4177..4146, score:''76.00''), (query:23203..23382, target:SWISS-PROT::P98160:4062..4003, score:''116.00''), (query:22523..22777, target:SWISS-PROT::P98160:4288..4204, score:''112.00''), (query:22235..22300, target:SWISS-PROT::P98160:4358..4337, score:''64.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''GM03359.5prime GM Drosophila melanogaster ovary BlueScript Drosophila melanogaster cDNA clone GM03359 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:25024..25235, target:EMBL::AA801707:438..227, score:''1024.00''), (query:24851..24898, target:EMBL::AA801707:476..429, score:''204.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''LD08615.5prime LD Drosophila melanogaster embryo BlueScript Drosophila melanogaster cDNA clone LD08615 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:24629..24727, target:EMBL::AA264808:99..1, score:''495.00''), (query:24417..24566, target:EMBL::AA264808:250..101, score:''687.00''), (query:24048..24420, target:EMBL::AA264808:618..246, score:''1847.00''), (query:23986..24036, target:EMBL::AA264808:678..628, score:''237.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''HL02745.5prime HL Drosophila melanogaster head BlueScript Drosophila melanogaster cDNA clone HL02745 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:23944..24045, target:EMBL::AA697546:103..2, score:''510.00''), (query:23630..23943, target:EMBL::AA697546:416..103, score:''1570.00''), (query:23419..23561, target:EMBL::AA697546:558..416, score:''715.00''), (query:23306..23417, target:EMBL::AA697546:670..559, score:''524.00''), (query:23280..23316, target:EMBL::AA697546:695..659, score:''167.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''GM08137.5prime GM Drosophila melanogaster ovary BlueScript Drosophila melanogaster cDNA clone GM08137 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:23235..23278, target:EMBL::AA696682:44..1, score:''139.00''), (query:22986..23251, target:EMBL::AA696682:294..29, score:''1321.00'')), method:''blastn'', version:''1.4.9'')\"",
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAB72284.1"'),
+                    ("/db_xref=", '"GI:6946669"'),
+                    (
+                        "/translation=",
+                        '"MACNCNQSMIYQSNERRDYNCPGAPQYPYNRFKGGVSLKDTPCMVLYICADFKSSKLSSAKPIISGPATTRAPAISYVCQPNDFKCVSHPHTCVRANMVCDGIYDCTDHSDEFNCIAGKGSGKSESNSGSGSFKRWKKSPEQGRRSLAKAVKNRKLRKRSFAKSRDYSLKLDDQSSNLRAGESTDVECYSSDDTYTDVVWERSDGAPLSNNVRQVGNRLVISNVSPSDAGNYVCKCKTDEGDLYTTSYKLEVEDQPHELKSSKIVYAKVGANADLQCGADESRQPTYRWSRQYGQLQAGRSLMNEKLSLDSVQANDAGTYICTAQYADGETADFPNILVVTGAIPQFRQEPRSYMSFPTLPNSSFKFNFELTFRPENGDGLLLFNGQTRGSGDYIALSLKDRYAEFRFDFGGKPMLVRAEEPLALNEWHTVRVSRFKRDGYIQVDEQHPVAFPTLQQIPQLDLIEDLYIGGVPNWELLPADAVSQQVGFVGCISRLTLQGRTVELIREAKYKEGITDCRPCAQGPCQNKGVCLESQTEQAYTCICQPGWTGRDCAIEGTQCTPGVCGAGRCENTENDMECLCPLNRSGDRCQYNEILNEHSLNFKGNSFAAYGTPKVTKVNITLSVRPASLEDSVILYTAESTLPSGDYLALVLRGGHAELLINTAARLDPVVVRSAEPLPLNRWTRIEIRRRLGEGILRVGDGPERKAKAPGSDRILSLKTHLYVGGYDRSTVKVNRDVNITKGFDGCISRLYNFQKPVNLLADIKDAANIQSCGETNMIGGDEDSDNEPPVPPPTPDVHENELQPYAMAPCASDPCENGGSCSEQEDVAVCSCPFGFSGKHCQEHLQLGFNASFRGDGYVELNRSHFQPALEQSYTSMGIVFTTNKPNGLLFWWGQEAGEEYTGQDFIAAAVVDGYVEYSMRLDGEEAVIRNSDIRVDNGERHIVIAKRDENTAILEVDRMLHSGETRPTSKKSMKLPGNVFVGGAPDLEVFTGFRYKHNLNGCIVVVEGETVGQINLSSAAVNGVNANVCPA"',
+                    ),
+                ),
+            ),
+            ("gene", "complement(29926..33978)", (("/gene=", '"EG:BACR25B3.10"'),)),
+            (
+                "CDS",
+                "complement(join(29926..30108,30270..30519,30617..31076,31197..31591,31659..31836,32324..32634,32686..33289,33533..33713,33817..33978))",
+                (
+                    ("/gene=", '"EG:BACR25B3.10"'),
+                    (
+                        "/note=",
+                        "\"/prediction=(method:''genefinder'', version:''084'', score:''98.50''); /prediction=(method:''genscan'', version:''1.0''); /match=(desc:''BASEMENT MEMBRANE-SPECIFIC HEPARAN SULFATE PROTEOGLYCAN CORE PROTEIN PRECURSOR (HSPG) (PERLECAN) (PLC)'', species:''Homo sapiens (Human)'', ranges:(query:33540..33716, target:SWISS-PROT::P98160:2716..2658, score:''113.00''), (query:32859..32963, target:SWISS-PROT::P98160:3341..3307, score:''63.00''), (query:33150..33215, target:SWISS-PROT::P98160:3530..3509, score:''73.00''), (query:32973..33089, target:SWISS-PROT::P98160:3588..3550, score:''71.00''), (query:32358..32567, target:SWISS-PROT::P98160:3650..3581, score:''107.00''), (query:31222..31323, target:SWISS-PROT::P98160:2620..2587, score:''80.00''), (query:31489..31572, target:SWISS-PROT::P98160:3387..3360, score:''72.00''), (query:31495..31593, target:SWISS-PROT::P98160:3575..3543, score:''60.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''GM02481.5prime GM Drosophila melanogaster ovary BlueScript Drosophila melanogaster cDNA clone GM02481 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:30008..30036, target:EMBL::AA695253:29..1, score:''145.00''), (query:29549..30004, target:EMBL::AA695253:487..32, score:''2262.00'')), method:''blastn'', version:''1.4.9'')\"",
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAB72285.1"'),
+                    ("/db_xref=", '"GI:6946670"'),
+                    (
+                        "/translation=",
+                        '"MFLATLDTNDPTDIGTEDPVLTQIIVSIQKPEITIVPVGGSMTLSCSGRMRWSNSPVIVNWYKENSRLPENVEVQGGNLYLYDLQVSDSGVYICQAVNNETASVFKDTVSITITKKDQLSPAEIVNLPSHVTFEEYVNNEIICEVLGNPAPRVTWARVDGHADAQSTRTYDNRLIFDSPRKSDEGRYRCQAENDQNRDEKYVIVYVQSNPPQPPPQQDRLYITPEEINGLAGESFQLNCQFTSVASLRYDWSHNGRSLSSSPARNVEIRGNTLEVRDASESDSGVYTCVAYDVRTRRNFTESARVNIDRREEQPFGVLMRMMILTDSLINHSNKPIIESLEQNILIIQGEDYSITCEASGSPYPSIKWAKVHDFMPENVHISGNVLTIYGARFENRGVYSCVAENDHGSDLSSTSIDIEPRERPSVKIVSAPLQTFSVGAPASLYCTVEGIPDPTVEWVRVDGQPLSPRHKIQSPGYMVIDDIQLEDSGDYECRAKNIVGEATGVATITVQEPTLVQIIPDNRDLRLTEGDELSLTCVGSGVPNPEVEWVNEMALKRDLYSPPSNTAILKIYRVTKADAGIYTCHGKNEAGSDEAHVRVEVQERRGDIGGVDDDSDRDPINYNPPQQQNPGIHQPGSNQLLATDIGDNVTLTCDMFQPLNTRWERVDGAPLPRNAYTIKNRLEIVRVEQQNLGQYRCNGIGRDGNVKTYFVKELVLMPLPRIRFYPNIPLTVEAGQNLDVHCQVENVRPEDVHWSTDNNRPLPSSVRIVGSVLRFVSITQAAAGEYRCSAFNQYGNRSQIARVAVKKPADFHQVPQSQLQRHREGENIQLQCTVTDQYGVRAQDNVEFNWFRDDRRPLPNNARTDSQILVLTNLRPEDAGRYICNSYDVDRGQQLPEVSIDLQVLSE"',
+                    ),
+                ),
+            ),
+            ("gene", "complement(36119..56153)", (("/gene=", '"EG:BACR25B3.1"'),)),
+            (
+                "CDS",
+                "complement(join(36119..37213,37281..39517,39656..40042,40345..40434,40519..40612,40681..40814,41546..41620,41855..42085,42188..42415,42751..42876,43604..43837,44241..44438,44812..44928,45148..45233,45661..45793,45976..46125,46518..46688,47222..47315,47683..47831,48411..48878,49437..49562,49763..49876,49971..50102,50319..50441,50827..50937,52849..52966,56031..56153))",
+                (
+                    ("/gene=", '"EG:BACR25B3.1"'),
+                    (
+                        "/note=",
+                        "\"/prediction=(method:''genscan'', version:''1.0''); /prediction=(method:''genefinder'', version:''084''); /match=(desc:''LOW-DENSITY LIPOPROTEIN RECEPTOR-RELATED PROTEIN PRECURSOR (LRP)'', species:''Caenorhabditis elegans'', ranges:(query:50831..50941, target:SWISS-PROT::Q04833:1221..1185, score:''95.00''), (query:50840..51025, target:SWISS-PROT::Q04833:2865..2804, score:''102.00''), (query:50828..50935, target:SWISS-PROT::Q04833:3788..3753, score:''119.00''), (query:50323..50394, target:SWISS-PROT::Q04833:3706..3683, score:''77.00''), (query:50326..50433, target:SWISS-PROT::Q04833:1263..1228, score:''120.00''), (query:49948..50079, target:SWISS-PROT::Q04833:2917..2874, score:''88.00''), (query:49432..49587, target:SWISS-PROT::Q04833:4085..4034, score:''102.00''), (query:49429..49560, target:SWISS-PROT::Q04833:3915..3872, score:''97.00''), (query:48622..48720, target:SWISS-PROT::Q04833:1302..1270, score:''99.00''), (query:47698..47799, target:SWISS-PROT::Q04833:3996..3963, score:''88.00''), (query:47686..47775, target:SWISS-PROT::Q04833:3835..3806, score:''59.00''), (query:47692..47787, target:SWISS-PROT::Q04833:4041..4010, score:''83.00''), (query:47229..47315, target:SWISS-PROT::Q04833:3742..3714, score:''88.00''), (query:47220..47312, target:SWISS-PROT::Q04833:3829..3799, score:''67.00''), (query:47232..47318, target:SWISS-PROT::Q04833:3866..3838, score:''78.00''), (query:46552..46656, target:SWISS-PROT::Q04833:1344..1310, score:''95.00''), (query:46543..46650, target:SWISS-PROT::Q04833:3951..3916, score:''98.00''), (query:45983..46129, target:SWISS-PROT::Q04833:2870..2822, score:''82.00''), (query:45971..46096, target:SWISS-PROT::Q04833:4089..4048, score:''82.00''), (query:45678..45764, target:SWISS-PROT::Q04833:3666..3638, score:''80.00''), (query:45128..45238, target:SWISS-PROT::Q04833:94..58, score:''100.00''), (query:45158..45268, target:SWISS-PROT::Q04833:3990..3954, score:''80.00''), (query:44263..44379, target:SWISS-PROT::Q04833:85..47, score:''77.00''), (query:44251..44367, target:SWISS-PROT::Q04833:3995..3957, score:''100.00''), (query:43605..43688, target:SWISS-PROT::Q04833:2994..2967, score:''84.00''), (query:42764..42877, target:SWISS-PROT::Q04833:2951..2914, score:''77.00''), (query:42180..42377, target:SWISS-PROT::Q04833:260..195, score:''148.00''), (query:42234..42419, target:SWISS-PROT::Q04833:3199..3138, score:''106.00''), (query:39807..40013, target:SWISS-PROT::Q04833:2901..2833, score:''167.00''), (query:39645..39857, target:SWISS-PROT::Q04833:3138..3068, score:''151.00''), (query:39846..40046, target:SWISS-PROT::Q04833:3241..3175, score:''132.00''), (query:39654..39866, target:SWISS-PROT::Q04833:3913..3843, score:''201.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''LOW-DENSITY LIPOPROTEIN RECEPTOR-RELATED PROTEIN 2 PRECURSOR (MEGALIN) (GLYCOPROTEIN 330)'', species:''Homo sapiens (Human)'', ranges:(query:50834..50935, target:SWISS-PROT::P98164:2733..2700, score:''99.00''), (query:50840..50947, target:SWISS-PROT::P98164:3063..3028, score:''94.00''), (query:50831..50926, target:SWISS-PROT::P98164:3918..3887, score:''102.00''), (query:50326..50433, target:SWISS-PROT::P98164:1222..1187, score:''107.00''), (query:50302..50394, target:SWISS-PROT::P98164:3762..3732, score:''91.00''), (query:49773..49904, target:SWISS-PROT::P98164:2939..2896, score:''90.00''), (query:49438..49578, target:SWISS-PROT::P98164:217..171, score:''116.00''), (query:49429..49545, target:SWISS-PROT::P98164:3796..3758, score:''108.00''), (query:48622..48720, target:SWISS-PROT::P98164:3544..3512, score:''94.00''), (query:48595..48708, target:SWISS-PROT::P98164:3720..3683, score:''86.00''), (query:47701..47814, target:SWISS-PROT::P98164:2817..2780, score:''90.00''), (query:47692..47799, target:SWISS-PROT::P98164:3674..3639, score:''60.00''), (query:47217..47366, target:SWISS-PROT::P98164:3716..3667, score:''96.00''), (query:46543..46647, target:SWISS-PROT::P98164:1101..1067, score:''107.00''), (query:46552..46656, target:SWISS-PROT::P98164:3873..3839, score:''84.00''), (query:45989..46126, target:SWISS-PROT::P98164:3832..3787, score:''98.00''), (query:45149..45274, target:SWISS-PROT::P98164:2775..2734, score:''99.00''), (query:44780..44893, target:SWISS-PROT::P98164:268..231, score:''76.00''), (query:44813..44905, target:SWISS-PROT::P98164:1223..1193, score:''73.00''), (query:44251..44361, target:SWISS-PROT::P98164:3630..3594, score:''119.00''), (query:43602..43700, target:SWISS-PROT::P98164:179..147, score:''97.00''), (query:43674..43781, target:SWISS-PROT::P98164:191..156, score:''90.00''), (query:43584..43685, target:SWISS-PROT::P98164:1107..1074, score:''89.00''), (query:42758..42865, target:SWISS-PROT::P98164:1264..1229, score:''79.00''), (query:42204..42413, target:SWISS-PROT::P98164:2810..2741, score:''136.00''), (query:42189..42377, target:SWISS-PROT::P98164:3027..2965, score:''125.00''), (query:42186..42293, target:SWISS-PROT::P98164:3110..3075, score:''109.00''), (query:42198..42389, target:SWISS-PROT::P98164:3584..3521, score:''137.00''), (query:42309..42422, target:SWISS-PROT::P98164:3793..3756, score:''95.00''), (query:39654..39791, target:SWISS-PROT::P98164:63..18, score:''132.00''), (query:39786..40049, target:SWISS-PROT::P98164:1183..1096, score:''230.00''), (query:39657..39890, target:SWISS-PROT::P98164:3109..3032, score:''200.00''), (query:39780..39983, target:SWISS-PROT::P98164:3756..3689, score:''194.00''), (query:39618..39761, target:SWISS-PROT::P98164:3845..3798, score:''105.00''), (query:39651..39779, target:SWISS-PROT::P98164:3964..3922, score:''128.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''GM06086.5prime GM Drosophila melanogaster ovary BlueScript Drosophila melanogaster cDNA clone GM06086 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:50852..51290, target:EMBL::AA802674:672..234, score:''2195.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''SD04592.5prime SD Drosophila melanogaster Schneider L2 cell culture pOT2 Drosophila melanogaster cDNA clone SD04592 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:37280..37708, target:EMBL::AI532939:429..1, score:''2136.00''), (query:37097..37217, target:EMBL::AI532939:545..425, score:''569.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''GH03622.5prime GH Drosophila melanogaster head pOT2 Drosophila melanogaster cDNA clone GH03622 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:36446..37075, target:EMBL::AI063674:1..630, score:''3150.00'')), method:''blastn'', version:''1.4.9''); EST embl|AA802674|AA802674 comes from the 5' UTR\"",
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAB72286.1"'),
+                    ("/db_xref=", '"GI:6946671"'),
+                    (
+                        "/translation=",
+                        '"MLLLQLLLQLLLLGKLLLGKTPPTVFGFRLLFAAFRFPLSLHFPHRMHDHFFVRGDTHSCGWKNSTTFTIRISAIYRYLNQCQANEFRCNNGDCIDARKRCNNVSDCSEGEDENEECPAACSGMEYQCRDGTRCISVSQQCDGHSDCSDGDDEEHCDGIVPKLRYTCPKGKFTCRDLSCISIVHRCDGRADCPNDRSDEEGCPCLYDKWQCDDGTCIAKELLCNGNIDCPEDISDERYCEGGYDSEECRFDEFHCGTGECIPMRQVCDNIYDCNDYSDEVNCVEGEEEDRVGIPIGHQPWRPASKHDDWLHEMDTSEYQVYQPSNVYEKANSQNPCASNQFRCTTSNVCIPLHLRCDGFYHCNDMSDEKSCEQYQRHTTTRRPLTLATPTSRITTQGPGLLERRNTTTATEASRWPWATKTTTIATTTSNPITTVGVANSPPQTCLENIEFACHNRDCISIESVCDGIPDCGRNEDEDDALCKCSGDKYKCQRGGGCIPKSQVCDGKPQCHDRSDESACHLHGRLNKTRLGVKCLESQYQCGDGSCISGYKRCNGIHDCADASDEYNCIYDYEDTYDTDPNNNPLNECDILEFECDYSQCLPLEKKCDGYADCEDMSDELECQSYTDHCLESEFECDSYCLPRDQLCNGIPNCQDGSDERNCTFCREDAYLCNTGECVADNQRCNGIADCADGSDERHCARIYCPPNKLACNGTCVSRRIKCDGIRDCLDGYDEMYCPETNNHYPTQNVNVIRPKLGPNPIPKSCRPHEWQCANLECIDSSLQCNEIKDCSDGSDEELSVCFGTATTRLKPSDCSPEQFYCDESCYNRSVRCNGHVDCSDGSDEVGCSLPCPQHQCPSGRCYTESERCDRHRHCEDGSDEANCTAILCKDNEFLCFDRQFCINATQQCDGYYDCRDFSDEQNCIGCYANQFRCNNGDCVSGSAPCNGYSECSDHSDELNCGGTQECLPNQFRCNSGQCVSSSVRCNGRTDCQDSSDEQNCGHRHTEVSQGLETTGVFTTSTTSTTAMTPLRIICPPTSFKCENGPCISLGLKCNGRVDCPYDGSDEADCGQISNDIDPADSNDRRPNQLNLKTYPDSQIIKESREVIFRCRDEGPARAKVKWSRPGGRPLPPGFTDRNGRLEIPNIRVEDAGTYVCEAVGYASYIPGQQVTVNLNVERSWGENKYEEIRSNRIRYGTVPHIDLEFFGLDNDVGSRPESACTEYQATCMNGECIDKSSICDGNPDCSDASDEQSCSLGLKCQPNQFMCSNSKCVDRTWRCDGENDCGDNSDETSCDPEPSGAPCRYNEFQCRSGHCIPKSFQCDNVPDCTDGTDEVGCMAPLPIRPPPQSVSLLEYEVLELTCVATGTPTPTIVWRLNWGHVPDKCESKSYGGTGTLRCPDMRPQDSGAYSCEIINTRGTHFVNPDTIVTVRPVRTDVCEAGFFNMLARKAEECVQCFCFGVAKACDSANLFTYAIHPPILSHRVVSVELSPLRQIVINEAAPGQDLLTLLHGVQFRATNVHFSGRETPYLALPADYMGNQLKSYGGNLRYEVNYRGSGRPVNGPDVIITGNRFTLTYRVRTQPGQNNRVSIPFVPGGWQKPDGRKASREEIMMILANVDNILIRLGYLDSTAREVDLINIALDSAGTADKGLGSASLVEKCQCPPGYVGDSCESCASGYVRQPGGPWLGHCVPFIPDSCPSGTYGDPRRGVPCKECPCPLTGSNNFASGCQQSPDGDVVCRCNEGYTGRRCEQCAAGYQGNPLAAGGICRRIPDTSCNVDGTYSVHSNGTCQCKDSVIGEQCDTCKSKSFHLNSFTYTGCIECFCSGVGLDCDSSTWYRDQVTSTFGRSRVDHGFVLVTNYMQPTPDTVPVSMAAEPNALSFIGSADQSGNTLYWSLPAAFLGNKLSSYGGKLTYTLSYSPLPNGIMSRNSAPDVVIKSGEDLRLIHYRKSQVVPSVANTYSVEIKESAWQRGDEVVANREHVLMALSDITAIYIKATYTTSTKEASLRQVTLDVATPTNLGTPRAVEVEQCRCPEGYLGLSCEQCAPGYARDPEGGIYLGLCRPCECNGHSKYCNSDTGDCEECSDNTEGPSCERCAAGYVGDATRGTIYDCQPDEGYPIPSPPAPGNQTLECTAYCQIEGIYDCRGNECLCKRNVIGDQCDQCRPGTYGLSAQNQDGCKECYCSGLASQCRSAALYRQLIPVDFILNAPLITDESGAVQDTENLIPDISRNMYTYTHTSYLPKYWSLRGSVLGNQLFSYGGRLSYSLIVESYGNYERGHDIVLIGNGLKLIWSRPDGNENQEEYNVRLHEDEQWTRQDRESARPASRSDFMTVLSDLQHILIRATPRVPTQSTSIGNVILESAVTTRTPGATHASDIELCQCPSGYVGTSCESCAPLHYRDASGSCSLCPCDVSNTESCDLVSGGYVECRCKARWKGDRCREIGE"',
+                    ),
+                ),
+            ),
+            ("gene", "complement(70720..75241)", (("/gene=", '"EG:BACR25B3.2"'),)),
+            (
+                "CDS",
+                "complement(join(70720..70988,71424..71621,72605..72768,72839..73016,73086..73559,75217..75241))",
+                (
+                    ("/gene=", '"EG:BACR25B3.2"'),
+                    (
+                        "/note=",
+                        "\"/prediction=(method:''genefinder'', version:''084'', score:''41.82''); /prediction=(method:''genscan'', version:''1.0'')\"",
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAB72287.1"'),
+                    ("/db_xref=", '"GI:6946672"'),
+                    (
+                        "/translation=",
+                        '"MANSKVVAHDESLQGINDSEWQLMGDDIDDGLLDDVDETLKPMETKSEEEDLPTGNWFSQSVHRVRRSINRLFGSDDNQERGRRQQRERSQRNRDAINRQKELRRRQKEDHNRWKQMRMERQLEKQRLVKRTNHVVFNRATDPRKRASDLYDENEASGYHEEDTTLYRTYFVVNEPYDNEYRDRESVQFQNLQKLLDDDLRNFFHSNYEGNDDEEQEIRSTLERVEPTNDNFKIRVQLRIELPTSVNDFGSKLQQQLNVYNRIENLSAATDGVFSFTESSDIEEEAIDVTLPQEEVEGSGSDDSSCRGDATFTCPRSGKTICDEMRCDREIQCPDGEDEEYCNYPNVCTEDQFKCDDKCLELKKRCDGSIDCLDQTDEAGCINAPEPEPEPEPEPEPEPESEPEAEPEPEPEPEPESEPEQEPEPQVPEANGKFY"',
+                    ),
+                ),
+            ),
+            ("gene", "121867..127124", (("/gene=", '"EG:BACR25B3.3"'),)),
+            (
+                "CDS",
+                "join(121867..122046,122174..122630,123672..123823,124063..124320,124392..124688,124755..125018,125094..125254,125317..125576,126793..127124)",
+                (
+                    ("/gene=", '"EG:BACR25B3.3"'),
+                    (
+                        "/note=",
+                        "\"/prediction=(method:''genscan'', version:''1.0'', score:''174.91''); /prediction=(method:''genefinder'', version:''084''); /match=(desc:''PROBABLE G PROTEIN-COUPLED RECEPTOR C13B9.4 IN CHROMOSOME III'', species:''Caenorhabditis elegans'', ranges:(query:123671..123775, target:SWISS-PROT::Q09460:107..141, score:''80.00''), (query:123743..123829, target:SWISS-PROT::Q09460:235..263, score:''72.00''), (query:124072..124332, target:SWISS-PROT::Q09460:265..351, score:''161.00''), (query:124392..124691, target:SWISS-PROT::Q09460:349..448, score:''206.00''), (query:124755..124958, target:SWISS-PROT::Q09460:448..515, score:''123.00''), (query:124764..125027, target:SWISS-PROT::Q09460:454..541, score:''108.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''CALCITONIN RECEPTOR PRECURSOR (CT-R)'', species:''Sus scrofa (Pig)'', ranges:(query:124165..124236, target:SWISS-PROT::P25117:191..214, score:''54.00''), (query:124392..124580, target:SWISS-PROT::P25117:233..295, score:''118.00''), (query:124725..124886, target:SWISS-PROT::P25117:318..371, score:''127.00'')), method:''blastx'', version:''1.4.9'')\"",
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAB72288.1"'),
+                    ("/db_xref=", '"GI:6946673"'),
+                    (
+                        "/translation=",
+                        '"MGAGNRKSETKTKTEAEIEIEMERDQFSIAANACMSMGPMLISKDKAPCSGGRVRHADSLHIYYAVDGKMTLLSNILDCGGCISAQRFTRLLRQSGSSGPSPSAPTAGTFESKSMLEPTSSHSLATGRVPLLHDFDASTTESPGTYVLDGVARVAQLALEPTVMDALPDSDTEQVLGNLNSSAPWNLTLASAAATNFENCSALFVNYTLPQTEFAIRKCELDGRWGSRPNATEVNPPGWTDYGPCYKPEIIRLMQQMGSKDFDAYIDIARRTRTLEIVGLCLSLFALIVSLLIFCTFRSLRNNRTKIHKNLFVAMVLQVIIRLTLYLDQFRRGNKEAATNTSLSVIENTPYLCEASYVLLEYARTAMFMWMFIEGLYLHNMVTVAVFQGSFPLKFFSRLGWCVPILMTTVWARCTVMYMDTSLGECLWNYNLTPYYWILEGPRLAVILLNFCFLVNIIRVLVMKLRQSQASDIEQTRKAVRAAIVLLPLLGITNLLHQLAPLKTATNFAVWSYGTHFLTSFQGFFIALIYCFLNGEVRAVLLKSLATQLSVRGHPEWAPKRASMYSGAYNTAPDTDAVQPAGDPSATGKRISPPNKRLNGRKPSSASIVMIHEPQQRQRLMPRLQNKAREKGKDRVEKTDAEAEPDPTISHIHSKEAGSARSRTRGSKWIMGICFRGQMCDAGLAKDAANIHDVANAADVDACSGSNNNYHNINNNNGSQNNNSIHCNHRDDDKVKGESQSDFKEPSNTNAESLVHLALFTAHTSNTQNNTHRNTIFTPIRRRNCS"',
+                    ),
+                ),
+            ),
+            ("gene", "complement(128489..129414)", (("/gene=", '"EG:BACR25B3.4"'),)),
+            (
+                "CDS",
+                "complement(join(128489..128715,128777..129140,129196..129313,129374..129414))",
+                (
+                    ("/gene=", '"EG:BACR25B3.4"'),
+                    (
+                        "/note=",
+                        "\"/prediction=(method:''genefinder'', version:''084'', score:''61.35''); /prediction=(method:''genscan'', version:''1.0''); /match=(desc:''VACUOLAR PROTON-ATPASE SUBUNIT D'', species:''Oryctolagus cuniculus (Rabbit)'', ranges:(query:129190..129324, target:SPTREMBL::O97755:55..11, score:''130.00''), (query:128778..129176, target:SPTREMBL::O97755:174..42, score:''472.00''), (query:128546..128716, target:SPTREMBL::O97755:231..175, score:''169.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''VACUOLAR ATP SYNTHASE SUBUNIT D (EC 3.6.1.34) (V-ATPASE D SUBUNIT) (V- ATPASE 28 KD ACCESSORY PROTEIN)'', species:''Bos taurus (Bovine)'', ranges:(query:129190..129324, target:SWISS-PROT::P39942:55..11, score:''130.00''), (query:128778..129176, target:SWISS-PROT::P39942:174..42, score:''471.00''), (query:128546..128716, target:SWISS-PROT::P39942:231..175, score:''173.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''GH28048.5prime GH Drosophila melanogaster head pOT2 Drosophila melanogaster cDNA clone GH28048 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:129196..129317, target:EMBL::AI517334:233..112, score:''412.00''), (query:128777..129145, target:EMBL::AI517334:597..229, score:''1251.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''GH07112.5prime GH Drosophila melanogaster head pOT2 Drosophila melanogaster cDNA clone GH07112 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:129196..129317, target:EMBL::AI108302:223..102, score:''412.00''), (query:128777..129145, target:EMBL::AI108302:587..219, score:''1251.00''), (query:128636..128716, target:EMBL::AI108302:667..587, score:''243.00'')), method:''blastn'', version:''1.4.9'')\"",
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAB72289.1"'),
+                    ("/db_xref=", '"GI:6946674"'),
+                    (
+                        "/translation=",
+                        '"MAAKDRLPIFPSRGAQTLMKSRLAGATKGHGLLKKKADALQMRFRLILGKIIETKTLMGQVMKEAAFSLAEVKFTTGDINQIVLQNVTKAQIKIRTKKDNVAGVTLPIFEPYTDGVDTYELAGLARGGQQLAKLKKNYQSAVRLLVQLASLQTSFVTLDDVIKVTNRRVNAIEHVIIPRINRTIEYIISELDELEREEFYRLKKIQDKKREARKASDKLRAEQRLLGQMAEAQEVQNILDEDGDEDLLF"',
+                    ),
+                ),
+            ),
+            ("gene", "132240..132926", (("/gene=", '"EG:BACR25B3.5"'),)),
+            (
+                "CDS",
+                "132240..132926",
+                (
+                    ("/gene=", '"EG:BACR25B3.5"'),
+                    (
+                        "/note=",
+                        "\"/prediction=(method:''genefinder'', version:''084'', score:''48.06''); /prediction=(method:''genscan'', version:''1.0'', score:''132.90''); /match=(desc:''N-ACETYLTRANSFERASE'', species:''Drosophila melanogaster (Fruit fly)'', ranges:(query:132249..132326, target:SPTREMBL::Q94521:60..85, score:''64.00''), (query:132600..132842, target:SPTREMBL::Q94521:171..251, score:''105.00'')), method:''blastx'', version:''1.4.9''); EST embl|AI063093|AI063093 comes from the 3' UTR\"",
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAB72290.1"'),
+                    ("/db_xref=", '"GI:6946675"'),
+                    (
+                        "/translation=",
+                        '"MEYKMIAPEHSEQVMEHLRRNFFADEPLNKAAGLCQNGSSCPALEAHCAEAIQHRMSVMAVDAKEKDTLKIVGVVLNGILKPGDTAKALSKLDCNDDADFRKIFDLLHRHNLKHNLFEHFDVDCMFDVRILSVDSCYRGQGIANELVKRSVAVAKKNGFRLLKADATGIFSQKIFRSHGFEVFSEQPYSKYTDENGKVILPVEAPHIKLQQLYKAICADDQDEKKQSL"',
+                    ),
+                ),
+            ),
+            ("gene", "complement(133492..134407)", (("/gene=", '"EG:BACR25B3.6"'),)),
+            (
+                "CDS",
+                "complement(join(133492..133595,133663..133748,133867..134135,134198..134407))",
+                (
+                    ("/gene=", '"EG:BACR25B3.6"'),
+                    (
+                        "/note=",
+                        "\"/prediction=(method:''genscan'', version:''1.0'', score:''119.22''); /prediction=(method:''genefinder'', version:''084''); /match=(desc:''LD41675.5prime LD Drosophila melanogaster embryo pOT2 Drosophila melanogaster cDNA clone LD41675 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:134192..134531, target:EMBL::AI515958:340..1, score:''1691.00''), (query:133879..134139, target:EMBL::AI515958:591..331, score:''1305.00'')), method:''blastn'', version:''1.4.9'')\"",
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAB72291.1"'),
+                    ("/db_xref=", '"GI:6946676"'),
+                    (
+                        "/translation=",
+                        '"MNGLPPSKHYNLTHYQQRYNWDCGLSCIIMILSAQQREQLLGNFDAVCGEEGFGSSTWTIDLCYLLMRYQVRHEYFTQTLGIDPNYAQHTYYSKIIDKDERRVTRKFKDARAHGLRVEQRTVDMEVILRHLARHGPVILLTNASLLTCEVCKRNVLEKFGYAGHYVVLCGYDMAAQKLFYHNPEVHDGHICRCLIESMDTARRAYGTDEDIIFIYEKKETRE"',
+                    ),
+                ),
+            ),
+            ("gene", "135479..136829", (("/gene=", '"EG:BACR25B3.7"'),)),
+            (
+                "CDS",
+                "join(135479..135749,135961..136586,136641..136829)",
+                (
+                    ("/gene=", '"EG:BACR25B3.7"'),
+                    (
+                        "/note=",
+                        "\"/prediction=(method:''genefinder'', version:''084'', score:''66.07''); /prediction=(method:''genscan'', version:''1.0'', score:''145.64''); /match=(desc:''HYPOTHETICAL 40.4 KD TRP-ASP REPEATS CONTAINING PROTEIN C14B1.4 IN CHROMOSOME III'', species:''Caenorhabditis elegans'', ranges:(query:135548..135748, target:SWISS-PROT::Q17963:39..105, score:''120.00''), (query:135957..136586, target:SWISS-PROT::Q17963:105..314, score:''899.00''), (query:136641..136823, target:SWISS-PROT::Q17963:315..375, score:''219.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''LD30385.5prime LD Drosophila melanogaster embryo pOT2 Drosophila melanogaster cDNA clone LD30385 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:135288..135749, target:EMBL::AA950546:102..563, score:''2301.00''), (query:135956..136047, target:EMBL::AA950546:559..650, score:''442.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''LD10938.5prime LD Drosophila melanogaster embryo BlueScript Drosophila melanogaster cDNA clone LD10938 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:136108..136288, target:EMBL::AA392005:776..596, score:''212.00'')), method:''blastn'', version:''1.4.9'')\"",
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAB72292.1"'),
+                    ("/db_xref=", '"GI:6946677"'),
+                    (
+                        "/translation=",
+                        '"MVPIGAVHGGHPGVVHPPQQPLPTAPSGPNSLQPNSVGQPGATTSSNSSASNKSSLSVKPNYTLKFTLAGHTKAVSAVKFSPNGEWLASSSADKLIKIWGAYDGKFEKTISGHKLGISDVAWSSDSRLLVSGSDDKTLKVWELSTGKSLKTLKGHSNYVFCCNFNPQSNLIVSGSFDESVRIWDVRTGKCLKTLPAHSDPVSAVHFNRDGSLIVSSSYDGLCRIWDTASGQCLKTLIDDDNPPVSFVKFSPNGKYILAATLDNTLKLWDYSKGKCLKTYTGHKNEKYCIFANFSVTGGKWIVSGSEDNMVYIWNLQSKEVVQKLQGHTDTVLCTACHPTENIIASAALENDKTIKLWKSDT"',
+                    ),
+                ),
+            ),
+            ("gene", "145403..147087", (("/gene=", '"EG:BACR25B3.8"'),)),
+            (
+                "CDS",
+                "join(145403..146203,146515..147087)",
+                (
+                    ("/gene=", '"EG:BACR25B3.8"'),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAB72293.1"'),
+                    ("/db_xref=", '"GI:6946678"'),
+                    (
+                        "/translation=",
+                        '"MNSTTKHLLHCTLLITVIVTFEVFSGGIKIDENSFTLVDPWTEYGQLATVLLYLLRFLTLLTLPQVLFNFCGLVFYNAFPEKVVLKGSPLLAPFICIRVVTRGDFPDLVKTNVLRNMNTCLDTGLENFLIEVVTDKAVNLSQHRRIREIVVPKEYKTRTGALFKSRALQYCLEDNVNVLNDSDWIVHLDEETLLTENSVRGIINFVLDGKHPFGQGLITYANENVVNWLTTLADSFRVSDDMGKLRLQFKLFHKPLFSWKGSYVVTQVSAERSVSFDNGIDGSVAEDCFFAMRAFSQGYTFNFIEGEMYEKSPFTLLDFLQQRKRWLQGILLVVHSKMIPFKHKLLLGISVYSWVTMPLSTSNIIFAALYPIPCPNLVDFVCAFIAAINIYMYVFGVIKSFSLYRFGLFRFLACVLGAVCTIPVNVVIENVAVIWGLVGKKHKFYVVQKDVRVLETV"',
+                    ),
+                ),
+            ),
+            ("gene", "complement(148860..152785)", (("/gene=", '"EG:BACR25B3.9"'),)),
+            (
+                "CDS",
+                "complement(join(148860..148905,148966..149462,149546..151809,151881..152032,152106..152785))",
+                (
+                    ("/gene=", '"EG:BACR25B3.9"'),
+                    (
+                        "/note=",
+                        "\"/prediction=(method:''genscan'', version:''1.0''); /prediction=(method:''genefinder'', version:''084''); /match=(desc:''HYPOTHETICAL 135.8 KD PROTEIN'', species:''Drosophila melanogaster (Fruit fly)'', ranges:(query:152096..152785, target:SPTREMBL::Q9XZ29:230..1, score:''1147.00''), (query:151882..152043, target:SPTREMBL::Q9XZ29:277..224, score:''250.00''), (query:149546..151816, target:SPTREMBL::Q9XZ29:1032..276, score:''3735.00''), (query:148953..149465, target:SPTREMBL::Q9XZ29:1202..1032, score:''890.00''), (query:148863..148907, target:SPTREMBL::Q9XZ29:1212..1198, score:''76.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''LD21815.5prime LD Drosophila melanogaster embryo pOT2 Drosophila melanogaster cDNA clone LD21815 5prime similar to L19117: Drosophila melanogaster (chromosome X 3A6-8) kinesin-like protein of 3A (klp3A) mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:152482..152787, target:EMBL::AA816942:460..155, score:''1485.00''), (query:152401..152483, target:EMBL::AA816942:540..458, score:''397.00'')), method:''blastn'', version:''1.4.9'')\"",
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAB72294.1"'),
+                    ("/db_xref=", '"GI:6946679"'),
+                    (
+                        "/translation=",
+                        '"MSSEDPSCVAVALRVRPLVQSELDRGCRIAVERSADGAPQVTVNRNESYTYNYVFDIDDSQKDLFETCVQAKVKKLLNGYNVTILAYGQTGSGKTYTMGTAFNGVLDDHVGVIPRAVHDIFTAIAEMQSEFRFAVTCSFVELYQEQFYDLFSSKTRDKATVDIREVKNRIIMPGLTELVVTSAQQVTDHLIRGSAGRAVAATAMNETSSRSHAIFTLTLVATKLDGKQSVTTSRFNLVDLAGSERCSKTLASGDRFKEGVNINKGLLALGNVINALGSGQAAGYIPYRQSKLTRLLQDSLGGNSITLMIACVSPADYNVAETLSTLRYADRALQIKNKPVVNLDPHAAEVNMLKDVIQKLRVELLSGGKMSSSLISAVGAAGLGAIPCEESLAGSMANAAEIQRLKEQVRTLQDRNRKLQQELHQSLLDLTEKEMRAHIAEQAHDKLRSHVSELKNKLDQREQAQFGNENTNGDNEMRDFSLLVNRVHVELQRTQEELESQGHESRQRLSSRSHTEGGESGGDEVHEMLHSHSEEYTNKQMNFAGELRNINRQLDLKQELHERIMRNFSRLDSDDEDVKLRLCNQKIDDLEAERRDLMDQLRNIKSKDISAKLAEERRKRLQLLEQEISDLRRKLITQANLLKIRDKEREKIQNLSTEIRTMKESKVKLIRAMRGESEKFRQWKMVREKELTQLKSKDRKMQSEIVRQQTLHSKQRQVLKRKCEEALAANKRLKDALERQASAQAQRHKYKDNGGSAAGSSNANAKTDSWVDRELEIILSLIDAEHSLEQLMEDRAVINNHYHLLQQEKTSDPAEAAEQARILASLEEELEMRNAQISDLQQKVCPTDLDSRIRSLAEGVQSLGESRTVSKQLLKTLVQQRRLQASSLNEQRTTLDELRAQLLDAQQQEDAASKRLRLLQSQHEEQMLAQQRAYEEKVSVLIRTANQRWAEARSPAEDQQRNQILEELLSSREALQQELDKLRAKNKSKSKAVKSEPQDLDDSFQIVDGNETVVLSDVSDDPDWVPSTSKSKRIQSDSRNVISPPEKQDANVTSLGNSSIQSLNSTSATEDGKRCKGCKCRTKCTTKRCGCLSGNNACSETCVCKSNCRNPLNLKDHASQCGDGDGQKDETEDADKSDDDGDDEPQTSKENAVKFVTPEAPGKVVASPKQTLQEPKAAATPLMNSNVVEDINGPKLAKMSGLAFDTPKRKFF"',
+                    ),
+                ),
+            ),
+            (
+                "gene",
+                "join(153490..154269,AL121804.2:41..610,AL121804.2:672..1487)",
+                (("/gene=", '"EG:BACR7C10.3"'),),
+            ),
+            (
+                "CDS",
+                "join(153490..154269,AL121804.2:41..610,AL121804.2:672..1487)",
+                (
+                    ("/gene=", '"EG:BACR7C10.3"'),
+                    ("/codon_start=", "1"),
+                    ("/protein_id=", '"CAB72295.1"'),
+                    ("/db_xref=", '"GI:6946680"'),
+                    (
+                        "/translation=",
+                        '"MEEEAPRFNVLEEAFNGNGNGCANVEATQSAILKVLTRVNRFQMRVRKHIEDNYTEFLPNNTSPDIFLEESGSLNREIHDMLENLGSEGLDALDEANVKMAGNGRQLREILLGLGVSEHVLRIDELFQCVEEAKATKDYLVLLDLVGRLRAFIYGDDSVDGDAQVATPEVRRIFKALECYETIKVKYHVQAYMLQQSLQERFDRLVQLQCKSFPTSRCVTLQVSRDQTQLQDIVQALFQEPYNPARLAEFLLDNCIEPVIMRPVMADYSEEADGGTYVRLSLSYATKEPSSAHVRPNYKQVLENLRLLLHTLAGINCSVSRDQHVFGIIGDHVKDKMLKLLVDECLIPAVPESTEEYQTSTLCEDVAQLEQLLVDSFIINPEQDRALGQFVEKYETYYRNRMYRRVLETAREIIQRDLQDMVLVAPNNHSAEVANDPFLFPRCMISKSAQDFVKLMDRILRQPTDKLGDQEADPIAGVISIMLHTYINEVPKVHRKLLESIPQQAVLFHNNCMFFTHWVAQHANKGIESLAALAKTLQATGQQHFRVQVDYQSSILMGIMQEFEFESTHTLGSGPLKLVRQCLRQLELLKNVWANVLPETVYNATFCELINTFVAELIRRVFTLRHISAQMACELSDLIDVVLQRAPTLFREPNEVVQVLSWLKLQQLKAMLNASLMEITELWGDGVGPLTASYKSDEIKHLIRALFQDTDWRAKAITQIV"',
+                    ),
+                ),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_08(self):
         path = "GenBank/one_of.gb"
@@ -385,15 +1243,71 @@ class TestRecordParser(unittest.TestCase):
         locus = "HSTMPO1"
         definition = "Human thymopoietin (TMPO) gene, exon 1"
         accession = ["U18266"]
-        titles = ("Structure and mapping of the human thymopoietin (TMPO) gene and relationship of TMPO beta to rat lamin-associated polypeptide 2", "Direct Submission")
-        features = [("source", "1..2509", (("/organism=", '"Homo sapiens"'), ("/db_xref=", '"taxon:9606"'), ("/chromosome=", '"12"'), ("/map=", '"12q22; 64% (% distance from centromere to telomere)"'), ("/clone=", '"P1.516 (DMPC-HFFno.1B-0943F)"'), ("/clone_lib=", '"DuPont Merck Hum Fibroblast P1 Library no.1 Series B (compressed) (Genome Systems Inc)"'))),
-                    ("5'UTR", "one-of(1888,1901)..2200", (("/gene=", '"TMPO"'), )),
-                    ("gene", "join(1888..2509,U18267.1:1..270,U18268.1:1..309,U18270.1:1..6905,U18269.1:1..128,U18271.1:1..3234)", (("/gene=", '"TMPO"'), )),
-                    ("exon", "one-of(1888,1901)..2479", (("/gene=", '"TMPO"'), ("/number=", "1"))),
-                    ("CDS", "join(2201..2479,U18267.1:120..246,U18268.1:130..288,U18270.1:4691..4788,U18269.1:82..>128)", (("/gene=", '"TMPO"'), ("/codon_start=", "1"), ("/product=", '"thymopoietin beta"'), ("/protein_id=", '"AAB60434.1"'), ("/db_xref=", '"GI:885684"'), ("/translation=", '"MPEFLEDPSVLTKDKLKSELVANNVTLPAGEQRKDVYVQLYLQHLTARNRPPLPAGTNSKGPPDFSSDEEREPTPVLGSGAAAAGRSRAAVGRKATKKTDKPRQEDKDDLDVTELTNEDLLDQLVKYGVNPGPIVGTTRKLYEKKLLKLREQGTESRSSTPLPTISSSAENTRQNGSNDSDRYSDNEEDSKIELKLEKREPLKGRAKTPVTLKQRRVEHNQSYSQAGITETEWTSGS"'))),
-                    ("CDS", "join(2201..2479,U18267.1:120..246,U18268.1:130..288,U18270.1:39..1558)", (("/gene=", '"TMPO"'), ("/codon_start=", "1"), ("/product=", '"thymopoietin alpha"'), ("/protein_id=", '"AAB60433.1"'), ("/db_xref=", '"GI:885683"'), ("/translation=", '"MPEFLEDPSVLTKDKLKSELVANNVTLPAGEQRKDVYVQLYLQHLTARNRPPLPAGTNSKGPPDFSSDEEREPTPVLGSGAAAAGRSRAAVGRKATKKTDKPRQEDKDDLDVTELTNEDLLDQLVKYGVNPGPIVGTTRKLYEKKLLKLREQGTESRSSTPLPTISSSAENTRQNGSNDSDRYSDNEEGKKKEHKKVKSTRDIVPFSELGTTPSGGGFFQGISFPEISTRPPLGSTELQAAKKVHTSKGDLPREPLVATNLPGRGQLQKLASERNLFISCKSSHDRCLEKSSSSSSQPEHSAMLVSTAASPSLIKETTTGYYKDIVENICGREKSGIQPLCPERSHISDQSPLSSKRKALEESESSQLISPPLAQAIRDYVNSLLVQGGVGSLPGTSNSMPPLDVENIQKRIDQSKFQETEFLSPPRKVPRLSEKSVEERDSGSFVAFQNIPGSELMSSFAKTVVSHSLTTLGLEVAKQSQHDKIDASELSFPFHESILKVIEEEWQQVDRQLPSLACKYPVSSREATQILSVPKVDDEILGFISEATPLGGIQAASTESCNQQLDLALCRAYEAAASALQIATHTAFVAKAMQADISEAAQILSSDPSRTHQALGILSKTYDAASYICEAAFDEVKMAAHTMGNATVGRRYLWLKDCKINLASKNKLASTPFKGGTLFGGEVCKVIKKRGNKH"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "Structure and mapping of the human thymopoietin (TMPO) gene and relationship of TMPO beta to rat lamin-associated polypeptide 2",
+            "Direct Submission",
+        )
+        features = [
+            (
+                "source",
+                "1..2509",
+                (
+                    ("/organism=", '"Homo sapiens"'),
+                    ("/db_xref=", '"taxon:9606"'),
+                    ("/chromosome=", '"12"'),
+                    ("/map=", '"12q22; 64% (% distance from centromere to telomere)"'),
+                    ("/clone=", '"P1.516 (DMPC-HFFno.1B-0943F)"'),
+                    (
+                        "/clone_lib=",
+                        '"DuPont Merck Hum Fibroblast P1 Library no.1 Series B (compressed) (Genome Systems Inc)"',
+                    ),
+                ),
+            ),
+            ("5'UTR", "one-of(1888,1901)..2200", (("/gene=", '"TMPO"'),)),
+            (
+                "gene",
+                "join(1888..2509,U18267.1:1..270,U18268.1:1..309,U18270.1:1..6905,U18269.1:1..128,U18271.1:1..3234)",
+                (("/gene=", '"TMPO"'),),
+            ),
+            (
+                "exon",
+                "one-of(1888,1901)..2479",
+                (("/gene=", '"TMPO"'), ("/number=", "1")),
+            ),
+            (
+                "CDS",
+                "join(2201..2479,U18267.1:120..246,U18268.1:130..288,U18270.1:4691..4788,U18269.1:82..>128)",
+                (
+                    ("/gene=", '"TMPO"'),
+                    ("/codon_start=", "1"),
+                    ("/product=", '"thymopoietin beta"'),
+                    ("/protein_id=", '"AAB60434.1"'),
+                    ("/db_xref=", '"GI:885684"'),
+                    (
+                        "/translation=",
+                        '"MPEFLEDPSVLTKDKLKSELVANNVTLPAGEQRKDVYVQLYLQHLTARNRPPLPAGTNSKGPPDFSSDEEREPTPVLGSGAAAAGRSRAAVGRKATKKTDKPRQEDKDDLDVTELTNEDLLDQLVKYGVNPGPIVGTTRKLYEKKLLKLREQGTESRSSTPLPTISSSAENTRQNGSNDSDRYSDNEEDSKIELKLEKREPLKGRAKTPVTLKQRRVEHNQSYSQAGITETEWTSGS"',
+                    ),
+                ),
+            ),
+            (
+                "CDS",
+                "join(2201..2479,U18267.1:120..246,U18268.1:130..288,U18270.1:39..1558)",
+                (
+                    ("/gene=", '"TMPO"'),
+                    ("/codon_start=", "1"),
+                    ("/product=", '"thymopoietin alpha"'),
+                    ("/protein_id=", '"AAB60433.1"'),
+                    ("/db_xref=", '"GI:885683"'),
+                    (
+                        "/translation=",
+                        '"MPEFLEDPSVLTKDKLKSELVANNVTLPAGEQRKDVYVQLYLQHLTARNRPPLPAGTNSKGPPDFSSDEEREPTPVLGSGAAAAGRSRAAVGRKATKKTDKPRQEDKDDLDVTELTNEDLLDQLVKYGVNPGPIVGTTRKLYEKKLLKLREQGTESRSSTPLPTISSSAENTRQNGSNDSDRYSDNEEGKKKEHKKVKSTRDIVPFSELGTTPSGGGFFQGISFPEISTRPPLGSTELQAAKKVHTSKGDLPREPLVATNLPGRGQLQKLASERNLFISCKSSHDRCLEKSSSSSSQPEHSAMLVSTAASPSLIKETTTGYYKDIVENICGREKSGIQPLCPERSHISDQSPLSSKRKALEESESSQLISPPLAQAIRDYVNSLLVQGGVGSLPGTSNSMPPLDVENIQKRIDQSKFQETEFLSPPRKVPRLSEKSVEERDSGSFVAFQNIPGSELMSSFAKTVVSHSLTTLGLEVAKQSQHDKIDASELSFPFHESILKVIEEEWQQVDRQLPSLACKYPVSSREATQILSVPKVDDEILGFISEATPLGGIQAASTESCNQQLDLALCRAYEAAASALQIATHTAFVAKAMQADISEAAQILSSDPSRTHQALGILSKTYDAASYICEAAFDEVKMAAHTMGNATVGRRYLWLKDCKINLASKNKLASTPFKGGTLFGGEVCKVIKKRGNKH"',
+                    ),
+                ),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_09(self):
         path = "GenBank/NT_019265.gb"
@@ -404,14 +1318,58 @@ class TestRecordParser(unittest.TestCase):
         locus = "NT_019265"
         definition = "Homo sapiens chromosome 1 working draft sequence segment"
         accession = ["NT_019265"]
-        titles = ("Direct Submission", )
-        features = [("source", "1..1250660", (("/organism=", '"Homo sapiens"'), ("/db_xref=", '"taxon:9606"'), ("/chromosome=", '"1"'))),
-                    ("source", "1..3290", (("/note=", '"Accession AL391218 sequenced by The Sanger Centre"'), ("/organism=", '"Homo sapiens"'), ("/db_xref=", '"taxon:9606"'), ("/clone=", '"RP11-13G5"'))),
-                    ("misc_feature", "215902..365470", (("/standard_name=", '"RP11-242F24"'), ("/note=", '"FISH-mapped clone"'))),
-                    ("variation", "217508", (("/allele=", '"T"'), ("/allele=", '"C"'), ("/db_xref=", '"dbSNP:811400"'))),
-                    ("mRNA", "join(342430..342515,363171..363300,365741..365814,376398..376499,390169..390297,391257..391379,392606..392679,398230..398419,399082..399167,399534..399650,405844..405913,406704..406761,406868..407010,407962..408091,408508..409092)", (("/gene=", '"FLJ10737"'), ("/product=", '"hypothetical protein FLJ10737"'), ("/transcript_id=", '"XM_057697.1"'), ("/db_xref=", '"LocusID:55735"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = ("Direct Submission",)
+        features = [
+            (
+                "source",
+                "1..1250660",
+                (
+                    ("/organism=", '"Homo sapiens"'),
+                    ("/db_xref=", '"taxon:9606"'),
+                    ("/chromosome=", '"1"'),
+                ),
+            ),
+            (
+                "source",
+                "1..3290",
+                (
+                    ("/note=", '"Accession AL391218 sequenced by The Sanger Centre"'),
+                    ("/organism=", '"Homo sapiens"'),
+                    ("/db_xref=", '"taxon:9606"'),
+                    ("/clone=", '"RP11-13G5"'),
+                ),
+            ),
+            (
+                "misc_feature",
+                "215902..365470",
+                (
+                    ("/standard_name=", '"RP11-242F24"'),
+                    ("/note=", '"FISH-mapped clone"'),
+                ),
+            ),
+            (
+                "variation",
+                "217508",
+                (
+                    ("/allele=", '"T"'),
+                    ("/allele=", '"C"'),
+                    ("/db_xref=", '"dbSNP:811400"'),
+                ),
+            ),
+            (
+                "mRNA",
+                "join(342430..342515,363171..363300,365741..365814,376398..376499,390169..390297,391257..391379,392606..392679,398230..398419,399082..399167,399534..399650,405844..405913,406704..406761,406868..407010,407962..408091,408508..409092)",
+                (
+                    ("/gene=", '"FLJ10737"'),
+                    ("/product=", '"hypothetical protein FLJ10737"'),
+                    ("/transcript_id=", '"XM_057697.1"'),
+                    ("/db_xref=", '"LocusID:55735"'),
+                ),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_10(self):
         path = "GenBank/origin_line.gb"
@@ -422,11 +1380,25 @@ class TestRecordParser(unittest.TestCase):
         locus = "NC_002678"
         definition = "Mesorhizobium loti, complete genome (edited)"
         accession = ["NC_002678"]
-        titles = ("Complete genome structure of the nitrogen-fixing symbiotic bacterium Mesorhizobium loti", "Direct Submission")
-        features = [("source", "1..180", (("/organism=", '"Mesorhizobium loti"'), ("/strain=", '"MAFF303099"'), ("/db_xref=", '"taxon:381"'))),
-                    ("gene", "20..120", (("/gene=", '"fake"'), )),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "Complete genome structure of the nitrogen-fixing symbiotic bacterium Mesorhizobium loti",
+            "Direct Submission",
+        )
+        features = [
+            (
+                "source",
+                "1..180",
+                (
+                    ("/organism=", '"Mesorhizobium loti"'),
+                    ("/strain=", '"MAFF303099"'),
+                    ("/db_xref=", '"taxon:381"'),
+                ),
+            ),
+            ("gene", "20..120", (("/gene=", '"fake"'),)),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_11(self):
         path = "GenBank/blank_seq.gb"
@@ -437,13 +1409,51 @@ class TestRecordParser(unittest.TestCase):
         locus = "NP_001832"
         definition = "cannabinoid receptor 2 (macrophage) [Homo sapiens]"
         accession = ["NP_001832"]
-        titles = ("Molecular characterization of a peripheral receptor for cannabinoids", "Expression of central and peripheral cannabinoid receptors in human immune tissues and leukocyte subpopulations", "Molecular cloning, expression and function of the murine CB2 peripheral cannabinoid receptor")
-        features = [("source", "1..360", (("/organism=", '"Homo sapiens"'), ("/db_xref=", '"taxon:9606"'), ("/chromosome=", '"1"'), ("/map=", '"1p36.11"'))),
-                    ("Protein", "1..360", (("/product=", '"cannabinoid receptor 2 (macrophage)"'), )),
-                    ("Region", "50..299", (("/region_name=", '"7 transmembrane receptor (rhodopsin family)"'), ("/db_xref=", '"CDD:pfam00001"'), ("/note=", '"7tm_1"'))),
-                    ("CDS", "1..360", (("/pseudo", ""), ("/gene=", '"CNR2"'), ("/db_xref=", '"LocusID:1269"'), ("/db_xref=", '"MIM:605051"'), ("/coded_by=", '"NM_001841.1:127..1209"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "Molecular characterization of a peripheral receptor for cannabinoids",
+            "Expression of central and peripheral cannabinoid receptors in human immune tissues and leukocyte subpopulations",
+            "Molecular cloning, expression and function of the murine CB2 peripheral cannabinoid receptor",
+        )
+        features = [
+            (
+                "source",
+                "1..360",
+                (
+                    ("/organism=", '"Homo sapiens"'),
+                    ("/db_xref=", '"taxon:9606"'),
+                    ("/chromosome=", '"1"'),
+                    ("/map=", '"1p36.11"'),
+                ),
+            ),
+            (
+                "Protein",
+                "1..360",
+                (("/product=", '"cannabinoid receptor 2 (macrophage)"'),),
+            ),
+            (
+                "Region",
+                "50..299",
+                (
+                    ("/region_name=", '"7 transmembrane receptor (rhodopsin family)"'),
+                    ("/db_xref=", '"CDD:pfam00001"'),
+                    ("/note=", '"7tm_1"'),
+                ),
+            ),
+            (
+                "CDS",
+                "1..360",
+                (
+                    ("/pseudo", ""),
+                    ("/gene=", '"CNR2"'),
+                    ("/db_xref=", '"LocusID:1269"'),
+                    ("/db_xref=", '"MIM:605051"'),
+                    ("/coded_by=", '"NM_001841.1:127..1209"'),
+                ),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_12(self):
         path = "GenBank/dbsource_wrap.gb"
@@ -454,16 +1464,44 @@ class TestRecordParser(unittest.TestCase):
         locus = "SCX3_BUTOC"
         definition = "Neurotoxin III"
         accession = ["P01485"]
-        titles = ("Neurotoxins from the venoms of two scorpions: Buthus occitanus tunetanus and Buthus occitanus mardochei", )
-        features = [("source", "1..64", (("/organism=", '"Buthus occitanus tunetanus"'), ("/db_xref=", '"taxon:6871"'))),
-                    ("Protein", "1..64", (("/product=", '"Neurotoxin III"'), )),
-                    ("Bond", "bond(12,63)", (("/bond_type=", '"disulfide"'), ("/note=", '"BY SIMILARITY."'))),
-                    ("Bond", "bond(16,36)", (("/bond_type=", '"disulfide"'), ("/note=", '"BY SIMILARITY."'))),
-                    ("Bond", "bond(22,46)", (("/bond_type=", '"disulfide"'), ("/note=", '"BY SIMILARITY."'))),
-                    ("Bond", "bond(26,48)", (("/bond_type=", '"disulfide"'), ("/note=", '"BY SIMILARITY."'))),
-                    ("Site", "64", (("/site_type=", '"amidation"'), )),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "Neurotoxins from the venoms of two scorpions: Buthus occitanus tunetanus and Buthus occitanus mardochei",
+        )
+        features = [
+            (
+                "source",
+                "1..64",
+                (
+                    ("/organism=", '"Buthus occitanus tunetanus"'),
+                    ("/db_xref=", '"taxon:6871"'),
+                ),
+            ),
+            ("Protein", "1..64", (("/product=", '"Neurotoxin III"'),)),
+            (
+                "Bond",
+                "bond(12,63)",
+                (("/bond_type=", '"disulfide"'), ("/note=", '"BY SIMILARITY."')),
+            ),
+            (
+                "Bond",
+                "bond(16,36)",
+                (("/bond_type=", '"disulfide"'), ("/note=", '"BY SIMILARITY."')),
+            ),
+            (
+                "Bond",
+                "bond(22,46)",
+                (("/bond_type=", '"disulfide"'), ("/note=", '"BY SIMILARITY."')),
+            ),
+            (
+                "Bond",
+                "bond(26,48)",
+                (("/bond_type=", '"disulfide"'), ("/note=", '"BY SIMILARITY."')),
+            ),
+            ("Site", "64", (("/site_type=", '"amidation"'),)),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_13(self):
         path = "GenBank/gbvrl1_start.seq"
@@ -472,33 +1510,120 @@ class TestRecordParser(unittest.TestCase):
         record = next(records)
         length = 2007
         locus = "AB000048"
-        definition = "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
+        definition = (
+            "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
+        )
         accession = ["AB000048"]
-        titles = ("Evolutionary pattern of feline panleukopenia virus differs from that of canine parvovirus", "Direct Submission")
-        features = [("source", "1..2007", (("/organism=", '"Feline panleukopenia virus"'), ("/mol_type=", '"genomic DNA"'), ("/isolate=", '"483"'), ("/db_xref=", '"taxon:10786"'), ("/lab_host=", '"Felis domesticus"'))),
-                    ("CDS", "1..2007", (("/codon_start=", "1"), ("/product=", '"nonstructural protein 1"'), ("/protein_id=", '"BAA19009.1"'), ("/db_xref=", '"GI:1769754"'), ("/translation=", '"MSGNQYTEEVMEGVNWLKKHAEDEAFSFVFKCDNVQLNGKDVRWNNYTKPIQNEELTSLIRGAQTAMDQTEEEEMDWESEVDSLAKKQVQTFDALIKKCLFEVFVSKNIEPNECVWFIQHEWGKDQGWHCHVLLHSKNLQQATGKWLRRQMNMYWSRWLVTLCSINLTPTEKIKLREIAEDSEWVTILTYRHKQTKKDYVKMVHFGNMIAYYFLTKKKIVHMTKESGYFLSTDSGWKFNFMKYQDRHTVSTLYTEQMKPETVETTVTTAQETKRGRIQTKKEVSIKCTLRDLVSKRVTSPEDWMMLQPDSYIEMMAQPGGENLLKNTLEICTLTLARTKTAFELILEKADNTKLTNFDLANSRTCQIFRMHGWNWIKVCHAIACVLNRQGGKRNTVLFHGPASTGKSIIAQAIAQAVGNVGCYNAANVNFPFNDCTNKNLIWVEEAGNFGQQVNQFKAICSGQTIRIDQKGKGSKQIEPTPVIMTTNENITIVRIGCEERPEHTQPIRDRMLNIKLVCKLPGDFGLVDKEEWPLICAWLVKHGYQSTMANYTHHWGKVPEWDENWAEPKIQEGINSPGCKDLETQAASNPQSQDHVLTPLTPDVVDLALEPWSTPDTPIAETANQQSNQLGVTHKDVQASPTWSEIEADLRAIFTSEQLEEDFRDDLD"'))),
-                    ]
+        titles = (
+            "Evolutionary pattern of feline panleukopenia virus differs from that of canine parvovirus",
+            "Direct Submission",
+        )
+        features = [
+            (
+                "source",
+                "1..2007",
+                (
+                    ("/organism=", '"Feline panleukopenia virus"'),
+                    ("/mol_type=", '"genomic DNA"'),
+                    ("/isolate=", '"483"'),
+                    ("/db_xref=", '"taxon:10786"'),
+                    ("/lab_host=", '"Felis domesticus"'),
+                ),
+            ),
+            (
+                "CDS",
+                "1..2007",
+                (
+                    ("/codon_start=", "1"),
+                    ("/product=", '"nonstructural protein 1"'),
+                    ("/protein_id=", '"BAA19009.1"'),
+                    ("/db_xref=", '"GI:1769754"'),
+                    (
+                        "/translation=",
+                        '"MSGNQYTEEVMEGVNWLKKHAEDEAFSFVFKCDNVQLNGKDVRWNNYTKPIQNEELTSLIRGAQTAMDQTEEEEMDWESEVDSLAKKQVQTFDALIKKCLFEVFVSKNIEPNECVWFIQHEWGKDQGWHCHVLLHSKNLQQATGKWLRRQMNMYWSRWLVTLCSINLTPTEKIKLREIAEDSEWVTILTYRHKQTKKDYVKMVHFGNMIAYYFLTKKKIVHMTKESGYFLSTDSGWKFNFMKYQDRHTVSTLYTEQMKPETVETTVTTAQETKRGRIQTKKEVSIKCTLRDLVSKRVTSPEDWMMLQPDSYIEMMAQPGGENLLKNTLEICTLTLARTKTAFELILEKADNTKLTNFDLANSRTCQIFRMHGWNWIKVCHAIACVLNRQGGKRNTVLFHGPASTGKSIIAQAIAQAVGNVGCYNAANVNFPFNDCTNKNLIWVEEAGNFGQQVNQFKAICSGQTIRIDQKGKGSKQIEPTPVIMTTNENITIVRIGCEERPEHTQPIRDRMLNIKLVCKLPGDFGLVDKEEWPLICAWLVKHGYQSTMANYTHHWGKVPEWDENWAEPKIQEGINSPGCKDLETQAASNPQSQDHVLTPLTPDVVDLALEPWSTPDTPIAETANQQSNQLGVTHKDVQASPTWSEIEADLRAIFTSEQLEEDFRDDLD"',
+                    ),
+                ),
+            ),
+        ]
         records = GenBank.Iterator(handle, self.rec_parser)
         record = next(records)
         length = 2007
         locus = "AB000049"
-        definition = "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
+        definition = (
+            "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
+        )
         accession = ["AB000049"]
-        titles = ("Evolutionary pattern of feline panleukopenia virus differs that of canine parvovirus", "Direct Submission")
-        features = [("source", "1..2007", (("/organism=", '"Feline panleukopenia virus"'), ("/mol_type=", '"genomic DNA"'), ("/isolate=", '"94-1"'), ("/db_xref=", '"taxon:10786"'), ("/lab_host=", '"Felis domesticus"'))),
-                    ("CDS", "1..2007", (("/codon_start=", "1"), ("/product=", '"nonstructural protein 1"'), ("/protein_id=", '"BAA19010.1"'), ("/db_xref=", '"GI:1769756"'), ("/translation=", '"MSGNQYTEEVMEGVNWLKKHAEDEAFSFVFKCDNVQLNGKDVRWNNYTKPIQNEELTSLIRGAQTAMDQTEEEEMDWESEVDSLAKKQVQTFDALIKKCLFEVFVSKNIEPNECVWFIQHEWGKDQGWHCHVLLHSKNLQQATGKWLRRQMNMYWSRWLVTLCSINLTPTEKIKLREIAEDSEWVTILTYRHKQTKKDYVKMVHFGNMIAYYFLTKKKIVHMTKESGYFLSTDSGWKFNFMKYQDRHTVSTLYTEQMKPETVETTVTTAQETKRGRIQTKKEVSIKCTLRDLVSKRVTSPEDWMMLQPDSYIEMMAQPGGENLLKNTLEICTLTLARTKTAFELILEKADNTKLTNFDLANSRTCQIFRMHGWNWIKVCHAIACVLNRQGGKRNTVLFHGPASTGKSIIAQAIAQAVGNVGCYNAANVNFPFNDCTNKNLIWVEEAGNFGQQVNQFKAICSGQTIRIDQKGKGSKQIEPTPVIMTTNENITIVRIGCEERPEHTQPIRDRMLNIKLVCKLPGDFGLVDKEEWPLICAWLVKHGYQSTMANYTHHWGKVPEWDENWAEPKIQEGINSPGCKDLETQAASNPQSQDHVLTPLTPDVVDLALEPWSTPDTPIAETANQQSNQLGVTHKDVQASPTWSEIEADLRAIFTSEQLEEDFRDDLD"'))),
-                    ]
+        titles = (
+            "Evolutionary pattern of feline panleukopenia virus differs that of canine parvovirus",
+            "Direct Submission",
+        )
+        features = [
+            (
+                "source",
+                "1..2007",
+                (
+                    ("/organism=", '"Feline panleukopenia virus"'),
+                    ("/mol_type=", '"genomic DNA"'),
+                    ("/isolate=", '"94-1"'),
+                    ("/db_xref=", '"taxon:10786"'),
+                    ("/lab_host=", '"Felis domesticus"'),
+                ),
+            ),
+            (
+                "CDS",
+                "1..2007",
+                (
+                    ("/codon_start=", "1"),
+                    ("/product=", '"nonstructural protein 1"'),
+                    ("/protein_id=", '"BAA19010.1"'),
+                    ("/db_xref=", '"GI:1769756"'),
+                    (
+                        "/translation=",
+                        '"MSGNQYTEEVMEGVNWLKKHAEDEAFSFVFKCDNVQLNGKDVRWNNYTKPIQNEELTSLIRGAQTAMDQTEEEEMDWESEVDSLAKKQVQTFDALIKKCLFEVFVSKNIEPNECVWFIQHEWGKDQGWHCHVLLHSKNLQQATGKWLRRQMNMYWSRWLVTLCSINLTPTEKIKLREIAEDSEWVTILTYRHKQTKKDYVKMVHFGNMIAYYFLTKKKIVHMTKESGYFLSTDSGWKFNFMKYQDRHTVSTLYTEQMKPETVETTVTTAQETKRGRIQTKKEVSIKCTLRDLVSKRVTSPEDWMMLQPDSYIEMMAQPGGENLLKNTLEICTLTLARTKTAFELILEKADNTKLTNFDLANSRTCQIFRMHGWNWIKVCHAIACVLNRQGGKRNTVLFHGPASTGKSIIAQAIAQAVGNVGCYNAANVNFPFNDCTNKNLIWVEEAGNFGQQVNQFKAICSGQTIRIDQKGKGSKQIEPTPVIMTTNENITIVRIGCEERPEHTQPIRDRMLNIKLVCKLPGDFGLVDKEEWPLICAWLVKHGYQSTMANYTHHWGKVPEWDENWAEPKIQEGINSPGCKDLETQAASNPQSQDHVLTPLTPDVVDLALEPWSTPDTPIAETANQQSNQLGVTHKDVQASPTWSEIEADLRAIFTSEQLEEDFRDDLD"',
+                    ),
+                ),
+            ),
+        ]
         records = GenBank.Iterator(handle, self.rec_parser)
         record = next(records)
         length = 1755
         locus = "AB000050"
         definition = "Feline panleukopenia virus DNA for capsid protein 2, complete cds"
         accession = ["AB000050"]
-        titles = ("Evolutionary pattern of feline panleukopenia virus differs from that of canine parvovirus", "Direct Submission")
-        features = [("source", "1..1755", (("/organism=", '"Feline panleukopenia virus"'), ("/mol_type=", '"genomic DNA"'), ("/isolate=", '"94-1"'), ("/db_xref=", '"taxon:10786"'), ("/lab_host=", '"Felis domesticus"'))),
-                    ("CDS", "1..1755", (("/codon_start=", "1"), ("/product=", '"capsid protein 2"'), ("/protein_id=", '"BAA19011.1"'), ("/db_xref=", '"GI:1769758"'), ("/translation=", '"MSDGAVQPDGGQPAVRNERATGSGNGSGGGGGGGSGGVGISTGTFNNQTEFKFLENGWVEITANSSRLVHLNMPESENYKRVVVNNMDKTAVKGNMALDDTHVQIVTPWSLVDANAWGVWFNPGDWQLIVNTMSELHLVSFEQEIFNVVLKTVSESATQPPTKVYNNDLTASLMVALDSNNTMPFTPAAMRSETLGFYPWKPTIPTPWRYYFQWDRTLIPSHTGTSGTPTNVYHGTDPDDVQFYTIENSVPVHLLRTGDEFATGTFFFDCKPCRLTHTWQTNRALGLPPFLNSLPQSEGATNFGDIGVQQDKRRGVTQMGNTDYITEATIMRPAEVGYSAPYYSFEASTQGPFKTPIAAGRGGAQTDENQAADGDPRYAFGRQHGQKTTTTGETPERFTYIAHQDTGRYPEGDWIQNINFNLPVTNDNVLLPTDPIGGKTGINYTNIFNTYGPLTALNNVPPVYPNGQIWDKEFDTDLKPRLHVNAPFVCQNNCPGQLFVKVAPNLTNEYDPDASANMSRIVTYSDFWWKGKLVFKAKLRASHTWNPIQQMSINVDNQFNYVPNNIGAMKIVYEKSQLAPRKLY"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "Evolutionary pattern of feline panleukopenia virus differs from that of canine parvovirus",
+            "Direct Submission",
+        )
+        features = [
+            (
+                "source",
+                "1..1755",
+                (
+                    ("/organism=", '"Feline panleukopenia virus"'),
+                    ("/mol_type=", '"genomic DNA"'),
+                    ("/isolate=", '"94-1"'),
+                    ("/db_xref=", '"taxon:10786"'),
+                    ("/lab_host=", '"Felis domesticus"'),
+                ),
+            ),
+            (
+                "CDS",
+                "1..1755",
+                (
+                    ("/codon_start=", "1"),
+                    ("/product=", '"capsid protein 2"'),
+                    ("/protein_id=", '"BAA19011.1"'),
+                    ("/db_xref=", '"GI:1769758"'),
+                    (
+                        "/translation=",
+                        '"MSDGAVQPDGGQPAVRNERATGSGNGSGGGGGGGSGGVGISTGTFNNQTEFKFLENGWVEITANSSRLVHLNMPESENYKRVVVNNMDKTAVKGNMALDDTHVQIVTPWSLVDANAWGVWFNPGDWQLIVNTMSELHLVSFEQEIFNVVLKTVSESATQPPTKVYNNDLTASLMVALDSNNTMPFTPAAMRSETLGFYPWKPTIPTPWRYYFQWDRTLIPSHTGTSGTPTNVYHGTDPDDVQFYTIENSVPVHLLRTGDEFATGTFFFDCKPCRLTHTWQTNRALGLPPFLNSLPQSEGATNFGDIGVQQDKRRGVTQMGNTDYITEATIMRPAEVGYSAPYYSFEASTQGPFKTPIAAGRGGAQTDENQAADGDPRYAFGRQHGQKTTTTGETPERFTYIAHQDTGRYPEGDWIQNINFNLPVTNDNVLLPTDPIGGKTGINYTNIFNTYGPLTALNNVPPVYPNGQIWDKEFDTDLKPRLHVNAPFVCQNNCPGQLFVKVAPNLTNEYDPDASANMSRIVTYSDFWWKGKLVFKAKLRASHTWNPIQQMSINVDNQFNYVPNNIGAMKIVYEKSQLAPRKLY"',
+                    ),
+                ),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_14(self):
         path = "GenBank/NC_005816.gb"
@@ -512,50 +1637,486 @@ class TestRecordParser(unittest.TestCase):
         locus = "NC_005816"
         definition = "Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence"
         accession = ["NC_005816"]
-        titles = ("Genetics of metabolic variations between Yersinia pestis biovars and the proposal of a new biovar, microtus", "Complete genome sequence of Yersinia pestis strain 91001, an isolate avirulent to humans", "Direct Submission", "Direct Submission")
-        features = [("source", "1..9609", (("/organism=", '"Yersinia pestis biovar Microtus str. 91001"'), ("/mol_type=", '"genomic DNA"'), ("/strain=", '"91001"'), ("/db_xref=", '"taxon:229193"'), ("/plasmid=", '"pPCP1"'), ("/biovar=", '"Microtus"'))),
-                    ("repeat_region", "1..1954", ()),
-                    ("gene", "87..1109", (("/locus_tag=", '"YP_pPCP01"'), ("/db_xref=", '"GeneID:2767718"'))),
-                    ("CDS", "87..1109", (("/locus_tag=", '"YP_pPCP01"'), ("/note=", '"similar to corresponding CDS from previously sequenced pPCP plasmid of Yersinia pestis KIM (AF053945) and CO92 (AL109969), also many transposase entries for insertion sequence IS100 of Yersinia pestis. Contains IS21-like element transposase, HTH domain (Interpro|IPR007101)"'), ("/codon_start=", "1"), ("/transl_table=", "11"), ("/product=", '"putative transposase"'), ("/protein_id=", '"NP_995567.1"'), ("/db_xref=", '"GI:45478712"'), ("/db_xref=", '"GeneID:2767718"'), ("/translation=", '"MVTFETVMEIKILHKQGMSSRAIARELGISRNTVKRYLQAKSEPPKYTPRPAVASLLDEYRDYIRQRIADAHPYKIPATVIAREIRDQGYRGGMTILRAFIRSLSVPQEQEPAVRFETEPGRQMQVDWGTMRNGRSPLHVFVAVLGYSRMLYIEFTDNMRYDTLETCHRNAFRFFGGVPREVLYDNMKTVVLQRDAYQTGQHRFHPSLWQFGKEMGFSPRLCRPFRAQTKGKVERMVQYTRNSFYIPLMTRLRPMGITVDVETANRHGLRWLHDVANQRKHETIQARPCDRWLEEQQSMLALPPEKKEYDVHLDENLVNFDKHPLHHPLSIYDSFCRGVA"'))),
-                    ("misc_feature", "87..959", (("/locus_tag=", '"YP_pPCP01"'), ("/note=", '"Transposase and inactivated derivatives [DNA replication, recombination, and repair]; Region: COG4584"'), ("/db_xref=", '"CDD:34222"'))),
-                    ("misc_feature", "<111..209", (("/locus_tag=", '"YP_pPCP01"'), ("/note=", '"Helix-turn-helix domain of Hin and related proteins, a family of DNA-binding domains unique to bacteria and represented by the Hin protein of Salmonella. The basic HTH domain is a simple fold comprised of three core helices that form a right-handed...; Region: HTH_Hin_like; cl01116"'), ("/db_xref=", '"CDD:186341"'))),
-                    ("misc_feature", "438..812", (("/locus_tag=", '"YP_pPCP01"'), ("/note=", '"Integrase core domain; Region: rve; cl01316"'), ("/db_xref=", '"CDD:194099"'))),
-                    ("gene", "1106..1888", (("/locus_tag=", '"YP_pPCP02"'), ("/db_xref=", '"GeneID:2767716"'))),
-                    ("CDS", "1106..1888", (("/locus_tag=", '"YP_pPCP02"'), ("/note=", '"similar to corresponding CDS form previously sequenced pPCP plasmid of Yersinia pestis KIM (AF053945) and CO92 (AL109969), also many ATP-binding protein entries for insertion sequence IS100 of Yersinia pestis. Contains Chaperonin clpA/B (Interpro|IPR001270). Contains ATP/GTP-binding site motif A (P-loop) (Interpro|IPR001687, Molecular Function: ATP binding (GO:0005524)). Contains Bacterial chromosomal replication initiator protein, DnaA (Interpro|IPR001957, Molecular Function: DNA binding (GO:0003677), Molecular Function: DNA replication origin binding (GO:0003688), Molecular Function: ATP binding (GO:0005524), Biological Process: DNA replication initiation (GO:0006270), Biological Process: regulation of DNA replication (GO:0006275)). Contains AAA ATPase (Interpro|IPR003593, Molecular Function: nucleotide binding (GO:0000166))"'), ("/codon_start=", "1"), ("/transl_table=", "11"), ("/product=", '"transposase/IS protein"'), ("/protein_id=", '"NP_995568.1"'), ("/db_xref=", '"GI:45478713"'), ("/db_xref=", '"GeneID:2767716"'), ("/translation=", '"MMMELQHQRLMALAGQLQLESLISAAPALSQQAVDQEWSYMDFLEHLLHEEKLARHQRKQAMYTRMAAFPAVKTFEEYDFTFATGAPQKQLQSLRSLSFIERNENIVLLGPSGVGKTHLAIAMGYEAVRAGIKVRFTTAADLLLQLSTAQRQGRYKTTLQRGVMAPRLLIIDEIGYLPFSQEEAKLFFQVIAKRYEKSAMILTSNLPFGQWDQTFAGDAALTSAMLDRILHHSHVVQIKGESYRLRQKRKAGVIAEANPE"'))),
-                    ("misc_feature", "1109..1885", (("/locus_tag=", '"YP_pPCP02"'), ("/note=", '"transposase/IS protein; Provisional; Region: PRK09183"'), ("/db_xref=", '"CDD:181681"'))),
-                    ("misc_feature", "1367..>1669", (("/locus_tag=", '"YP_pPCP02"'), ("/note=", '"The AAA+ (ATPases Associated with a wide variety of cellular Activities) superfamily represents an ancient group of ATPases belonging to the ASCE (for additional strand, catalytic E) division of the P-loop NTPase fold. The ASCE division also includes...; Region: AAA; cd00009"'), ("/db_xref=", '"CDD:99707"'))),
-                    ("misc_feature", "1433..1456", (("/locus_tag=", '"YP_pPCP02"'), ("/note=", '"Walker A motif; other site"'), ("/db_xref=", '"CDD:99707"'))),
-                    ("misc_feature", "order(1436..1459,1619..1621)", (("/locus_tag=", '"YP_pPCP02"'), ("/note=", '"ATP binding site [chemical binding]; other site"'), ("/db_xref=", '"CDD:99707"'))),
-                    ("misc_feature", "1607..1624", (("/locus_tag=", '"YP_pPCP02"'), ("/note=", '"Walker B motif; other site"'), ("/db_xref=", '"CDD:99707"'))),
-                    ("gene", "2925..3119", (("/gene=", '"rop"'), ("/locus_tag=", '"YP_pPCP03"'), ("/gene_synonym=", '"rom"'), ("/db_xref=", '"GeneID:2767717"'))),
-                    ("CDS", "2925..3119", (("/gene=", '"rop"'), ("/locus_tag=", '"YP_pPCP03"'), ("/gene_synonym=", '"rom"'), ("/note=", '"Best Blastp hit =gi|16082682|ref|NP_395229.1| (NC_003132) putative replication regulatory protein [Yersinia pestis], gi|5763813|emb|CAB531 66.1| (AL109969) putative replication regulatory protein [Yersinia pestis]; similar to gb|AAK91579.1| (AY048853), RNAI modulator protein Rom [Salmonella choleraesuis], Contains Regulatory protein Rop (Interpro|IPR000769)"'), ("/codon_start=", "1"), ("/transl_table=", "11"), ("/product=", '"putative replication regulatory protein"'), ("/protein_id=", '"NP_995569.1"'), ("/db_xref=", '"GI:45478714"'), ("/db_xref=", '"GeneID:2767717"'), ("/translation=", '"MNKQQQTALNMARFIRSQSLILLEKLDALDADEQAAMCERLHELAEELQNSIQARFEAESETGT"'))),
-                    ("misc_feature", "2925..3107", (("/gene=", '"rop"'), ("/locus_tag=", '"YP_pPCP03"'), ("/gene_synonym=", '"rom"'), ("/note=", '"Rop protein; Region: Rop; pfam01815"'), ("/db_xref=", '"CDD:145136"'))),
-                    ("gene", "3486..3857", (("/locus_tag=", '"YP_pPCP04"'), ("/db_xref=", '"GeneID:2767720"'))),
-                    ("CDS", "3486..3857", (("/locus_tag=", '"YP_pPCP04"'), ("/note=", '"Best Blastp hit = gi|321919|pir||JQ1541 hypothetical 16.9K protein - Salmonella typhi murium plasmid NTP16."'), ("/codon_start=", "1"), ("/transl_table=", "11"), ("/product=", '"hypothetical protein"'), ("/protein_id=", '"NP_995570.1"'), ("/db_xref=", '"GI:45478715"'), ("/db_xref=", '"GeneID:2767720"'), ("/translation=", '"MSKKRRPQKRPRRRRFFHRLRPPDEHHKNRRSSQRWRNPTGLKDTRRFPPEAPSCALLFRPCRLPDTSPPFSLREAWRFLIAHAVGISVRCRSFAPSWAVCTNPPFSPTTAPYPVTIVLSPTR"'))),
-                    ("misc_feature", "3498..3626", (("/locus_tag=", '"YP_pPCP04"'), ("/note=", '"ProfileScan match to entry PS50323 ARG_RICH, E-value 8.981"'))),
-                    ("gene", "4343..4780", (("/gene=", '"pim"'), ("/locus_tag=", '"YP_pPCP05"'), ("/db_xref=", '"GeneID:2767712"'))),
-                    ("CDS", "4343..4780", (("/gene=", '"pim"'), ("/locus_tag=", '"YP_pPCP05"'), ("/note=", '"similar to many previously sequenced pesticin immunity protein entries of Yersinia pestis plasmid pPCP, e.g. gi| 16082683|,ref|NP_395230.1| (NC_003132) , gi|1200166|emb|CAA90861.1| (Z54145 ) , gi|1488655| emb|CAA63439.1| (X92856) , gi|2996219|gb|AAC62543.1| (AF053945) , and gi|5763814|emb|CAB531 67.1| (AL109969)"'), ("/codon_start=", "1"), ("/transl_table=", "11"), ("/product=", '"pesticin immunity protein"'), ("/protein_id=", '"NP_995571.1"'), ("/db_xref=", '"GI:45478716"'), ("/db_xref=", '"GeneID:2767712"'), ("/translation=", '"MGGGMISKLFCLALIFLSSSGLAEKNTYTAKDILQNLELNTFGNSLSHGIYGKQTTFKQTEFTNIKSNTKKHIALINKDNSWMISLKILGIKRDEYTVCFEDFSLIRPPTYVAIHPLLIKKVKSGNFIVVKEIKKSIPGCTVYYH"'))),
-                    ("gene", "complement(4815..5888)", (("/gene=", '"pst"'), ("/locus_tag=", '"YP_pPCP06"'), ("/db_xref=", '"GeneID:2767721"'))),
-                    ("CDS", "complement(4815..5888)", (("/gene=", '"pst"'), ("/locus_tag=", '"YP_pPCP06"'), ("/note=", '"Best Blastp hit =|16082684|ref|NP_395231.1| (NC_003132) pesticin [Yersinia pestis], gi|984824|gb|AAA75369.1| (U31974) pesticin [Yersinia pestis], gi|1488654|emb|CAA63438.1| (X92856) pesticin [Yersinia pestis], gi|2996220|gb|AAC62544.1| (AF053945) pesticin [Yersinia pestis], gi|5763815|emb|CAB53168.1| (AL1099 69) pesticin [Yersinia pestis]"'), ("/codon_start=", "1"), ("/transl_table=", "11"), ("/product=", '"pesticin"'), ("/protein_id=", '"NP_995572.1"'), ("/db_xref=", '"GI:45478717"'), ("/db_xref=", '"GeneID:2767721"'), ("/translation=", '"MSDTMVVNGSGGVPAFLFSGSTLSSYRPNFEANSITIALPHYVDLPGRSNFKLMYIMGFPIDTEMEKDSEYSNKIRQESKISKTEGTVSYEQKITVETGQEKDGVKVYRVMVLEGTIAESIEHLDKKENEDILNNNRNRIVLADNTVINFDNISQLKEFLRRSVNIVDHDIFSSNGFEGFNPTSHFPSNPSSDYFNSTGVTFGSGVDLGQRSKQDLLNDGVPQYIADRLDGYYMLRGKEAYDKVRTAPLTLSDNEAHLLSNIYIDKFSHKIEGLFNDANIGLRFSDLPLRTRTALVSIGYQKGFKLSRTAPTVWNKVIAKDWNGLVNAFNNIVDGMSDRRKREGALVQKDIDSGLLK"'))),
-                    ("variation", "5910..5911", (("/note=", '"compared to AF053945"'), ("/replace=", '""'))),
-                    ("variation", "5933^5934", (("/note=", '"compared to AL109969"'), ("/replace=", '"a"'))),
-                    ("variation", "5933^5934", (("/note=", '"compared to AF053945"'), ("/replace=", '"aa"'))),
-                    ("variation", "5948", (("/note=", '"compared to AL109969"'), ("/replace=", '"c"'))),
-                    ("gene", "6005..6421", (("/locus_tag=", '"YP_pPCP07"'), ("/db_xref=", '"GeneID:2767719"'))),
-                    ("CDS", "6005..6421", (("/locus_tag=", '"YP_pPCP07"'), ("/note=", '"Best Blastp hit = gi|16082685|ref|NP_395232.1| (NC_003132) hypothetical protein [Yersinia pestis], gi|5763816|emb|CAB53169.1| (AL109969) hypothetical protein [Yersinia pestis]"'), ("/codon_start=", "1"), ("/transl_table=", "11"), ("/product=", '"hypothetical protein"'), ("/protein_id=", '"NP_995573.1"'), ("/db_xref=", '"GI:45478718"'), ("/db_xref=", '"GeneID:2767719"'), ("/translation=", '"MKFHFCDLNHSYKNQEGKIRSRKTAPGNIRKKQKGDNVSKTKSGRHRLSKTDKRLLAALVVAGYEERTARDLIQKHVYTLTQADLRHLVSEISNGVGQSQAYDAIYQARRIRLARKYLSGKKPEGVEPREGQEREDLP"'))),
-                    ("variation", "6525", (("/note=", '"compared to AF053945 and AL109969"'), ("/replace=", '"c"'))),
-                    ("gene", "6664..7602", (("/gene=", '"pla"'), ("/locus_tag=", '"YP_pPCP08"'), ("/db_xref=", '"GeneID:2767715"'))),
-                    ("CDS", "6664..7602", (("/gene=", '"pla"'), ("/locus_tag=", '"YP_pPCP08"'), ("/EC_number=", '"3.4.23.48"'), ("/note=", '"outer membrane protease; involved in virulence in many organisms; OmpT; IcsP; SopA; Pla; PgtE; omptin; in Escherichia coli OmpT can degrade antimicrobial peptides; in Yersinia Pla activates plasminogen during infection; in Shigella flexneria SopA cleaves the autotransporter IcsA"'), ("/codon_start=", "1"), ("/transl_table=", "11"), ("/product=", '"outer membrane protease"'), ("/protein_id=", '"NP_995574.1"'), ("/db_xref=", '"GI:45478719"'), ("/db_xref=", '"GeneID:2767715"'), ("/translation=", '"MKKSSIVATIITILSGSANAASSQLIPNISPDSFTVAASTGMLSGKSHEMLYDAETGRKISQLDWKIKNVAILKGDISWDPYSFLTLNARGWTSLASGSGNMDDYDWMNENQSEWTDHSSHPATNVNHANEYDLNVKGWLLQDENYKAGITAGYQETRFSWTATGGSYSYNNGAYTGNFPKGVRVIGYNQRFSMPYIGLAGQYRINDFELNALFKFSDWVRAHDNDEHYMRDLTFREKTSGSRYYGTVINAGYYVTPNAKVFAEFTYSKYDEGKGGTQIIDKNSGDSVSIGGDAAGISNKNYTVTAGLQYRF"'))),
-                    ("misc_feature", "6664..7599", (("/gene=", '"pla"'), ("/locus_tag=", '"YP_pPCP08"'), ("/note=", '"Omptin family; Region: Omptin; cl01886"'), ("/db_xref=", '"CDD:186487"'))),
-                    ("gene", "complement(7789..8088)", (("/locus_tag=", '"YP_pPCP09"'), ("/db_xref=", '"GeneID:2767713"'))),
-                    ("CDS", "complement(7789..8088)", (("/locus_tag=", '"YP_pPCP09"'), ("/note=", '"Best Blastp hit = gi|16082687|ref|NP_395234.1| (NC_003132) putative transcriptional regulator [Yersinia pestis], gi|5763818|emb|CAB53171.1| (AL109969) putative transcriptional regulator [Yersinia pestis]."'), ("/codon_start=", "1"), ("/transl_table=", "11"), ("/product=", '"putative transcriptional regulator"'), ("/protein_id=", '"NP_995575.1"'), ("/db_xref=", '"GI:45478720"'), ("/db_xref=", '"GeneID:2767713"'), ("/translation=", '"MRTLDEVIASRSPESQTRIKEMADEMILEVGLQMMREELQLSQKQVAEAMGISQPAVTKLEQRGNDLKLATLKRYVEAMGGKLSLDVELPTGRRVAFHV"'))),
-                    ("misc_feature", "complement(7837..7995)", (("/locus_tag=", '"YP_pPCP09"'), ("/note=", '"Helix-turn-helix XRE-family like proteins. Prokaryotic DNA binding proteins belonging to the xenobiotic response element family of transcriptional regulators; Region: HTH_XRE; cl09100"'), ("/db_xref=", '"CDD:195788"'))),
-                    ("gene", "complement(8088..8360)", (("/locus_tag=", '"YP_pPCP10"'), ("/db_xref=", '"GeneID:2767714"'))),
-                    ("CDS", "complement(8088..8360)", (("/locus_tag=", '"YP_pPCP10"'), ("/note=", '"Best Blastp hit = gi|16082688|ref|NP_395235.1| (NC_003132) hypothetical protein [ Yersinia pestis], gi|5763819|emb|CAB53172.1| (AL109969) hypothetical protein [Yersinia pestis]"'), ("/codon_start=", "1"), ("/transl_table=", "11"), ("/product=", '"hypothetical protein"'), ("/protein_id=", '"NP_995576.1"'), ("/db_xref=", '"GI:45478721"'), ("/db_xref=", '"GeneID:2767714"'), ("/translation=", '"MADLKKLQVYGPELPRPYADTVKGSRYKNMKELRVQFSGRPIRAFYAFDPIRRAIVLCAGDKSNDKRFYEKLVRIAEDEFTAHLNTLESK"'))),
-                    ("misc_feature", "complement(8091..>8357)", (("/locus_tag=", '"YP_pPCP10"'), ("/note=", '"Phage derived protein Gp49-like (DUF891); Region: Gp49; cl01470"'), ("/db_xref=", '"CDD:194142"'))),
-                    ("variation", "8529^8530", (("/note=", '"compared to AL109969"'), ("/replace=", '"tt"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "Genetics of metabolic variations between Yersinia pestis biovars and the proposal of a new biovar, microtus",
+            "Complete genome sequence of Yersinia pestis strain 91001, an isolate avirulent to humans",
+            "Direct Submission",
+            "Direct Submission",
+        )
+        features = [
+            (
+                "source",
+                "1..9609",
+                (
+                    ("/organism=", '"Yersinia pestis biovar Microtus str. 91001"'),
+                    ("/mol_type=", '"genomic DNA"'),
+                    ("/strain=", '"91001"'),
+                    ("/db_xref=", '"taxon:229193"'),
+                    ("/plasmid=", '"pPCP1"'),
+                    ("/biovar=", '"Microtus"'),
+                ),
+            ),
+            ("repeat_region", "1..1954", ()),
+            (
+                "gene",
+                "87..1109",
+                (("/locus_tag=", '"YP_pPCP01"'), ("/db_xref=", '"GeneID:2767718"')),
+            ),
+            (
+                "CDS",
+                "87..1109",
+                (
+                    ("/locus_tag=", '"YP_pPCP01"'),
+                    (
+                        "/note=",
+                        '"similar to corresponding CDS from previously sequenced pPCP plasmid of Yersinia pestis KIM (AF053945) and CO92 (AL109969), also many transposase entries for insertion sequence IS100 of Yersinia pestis. Contains IS21-like element transposase, HTH domain (Interpro|IPR007101)"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/transl_table=", "11"),
+                    ("/product=", '"putative transposase"'),
+                    ("/protein_id=", '"NP_995567.1"'),
+                    ("/db_xref=", '"GI:45478712"'),
+                    ("/db_xref=", '"GeneID:2767718"'),
+                    (
+                        "/translation=",
+                        '"MVTFETVMEIKILHKQGMSSRAIARELGISRNTVKRYLQAKSEPPKYTPRPAVASLLDEYRDYIRQRIADAHPYKIPATVIAREIRDQGYRGGMTILRAFIRSLSVPQEQEPAVRFETEPGRQMQVDWGTMRNGRSPLHVFVAVLGYSRMLYIEFTDNMRYDTLETCHRNAFRFFGGVPREVLYDNMKTVVLQRDAYQTGQHRFHPSLWQFGKEMGFSPRLCRPFRAQTKGKVERMVQYTRNSFYIPLMTRLRPMGITVDVETANRHGLRWLHDVANQRKHETIQARPCDRWLEEQQSMLALPPEKKEYDVHLDENLVNFDKHPLHHPLSIYDSFCRGVA"',
+                    ),
+                ),
+            ),
+            (
+                "misc_feature",
+                "87..959",
+                (
+                    ("/locus_tag=", '"YP_pPCP01"'),
+                    (
+                        "/note=",
+                        '"Transposase and inactivated derivatives [DNA replication, recombination, and repair]; Region: COG4584"',
+                    ),
+                    ("/db_xref=", '"CDD:34222"'),
+                ),
+            ),
+            (
+                "misc_feature",
+                "<111..209",
+                (
+                    ("/locus_tag=", '"YP_pPCP01"'),
+                    (
+                        "/note=",
+                        '"Helix-turn-helix domain of Hin and related proteins, a family of DNA-binding domains unique to bacteria and represented by the Hin protein of Salmonella. The basic HTH domain is a simple fold comprised of three core helices that form a right-handed...; Region: HTH_Hin_like; cl01116"',
+                    ),
+                    ("/db_xref=", '"CDD:186341"'),
+                ),
+            ),
+            (
+                "misc_feature",
+                "438..812",
+                (
+                    ("/locus_tag=", '"YP_pPCP01"'),
+                    ("/note=", '"Integrase core domain; Region: rve; cl01316"'),
+                    ("/db_xref=", '"CDD:194099"'),
+                ),
+            ),
+            (
+                "gene",
+                "1106..1888",
+                (("/locus_tag=", '"YP_pPCP02"'), ("/db_xref=", '"GeneID:2767716"')),
+            ),
+            (
+                "CDS",
+                "1106..1888",
+                (
+                    ("/locus_tag=", '"YP_pPCP02"'),
+                    (
+                        "/note=",
+                        '"similar to corresponding CDS form previously sequenced pPCP plasmid of Yersinia pestis KIM (AF053945) and CO92 (AL109969), also many ATP-binding protein entries for insertion sequence IS100 of Yersinia pestis. Contains Chaperonin clpA/B (Interpro|IPR001270). Contains ATP/GTP-binding site motif A (P-loop) (Interpro|IPR001687, Molecular Function: ATP binding (GO:0005524)). Contains Bacterial chromosomal replication initiator protein, DnaA (Interpro|IPR001957, Molecular Function: DNA binding (GO:0003677), Molecular Function: DNA replication origin binding (GO:0003688), Molecular Function: ATP binding (GO:0005524), Biological Process: DNA replication initiation (GO:0006270), Biological Process: regulation of DNA replication (GO:0006275)). Contains AAA ATPase (Interpro|IPR003593, Molecular Function: nucleotide binding (GO:0000166))"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/transl_table=", "11"),
+                    ("/product=", '"transposase/IS protein"'),
+                    ("/protein_id=", '"NP_995568.1"'),
+                    ("/db_xref=", '"GI:45478713"'),
+                    ("/db_xref=", '"GeneID:2767716"'),
+                    (
+                        "/translation=",
+                        '"MMMELQHQRLMALAGQLQLESLISAAPALSQQAVDQEWSYMDFLEHLLHEEKLARHQRKQAMYTRMAAFPAVKTFEEYDFTFATGAPQKQLQSLRSLSFIERNENIVLLGPSGVGKTHLAIAMGYEAVRAGIKVRFTTAADLLLQLSTAQRQGRYKTTLQRGVMAPRLLIIDEIGYLPFSQEEAKLFFQVIAKRYEKSAMILTSNLPFGQWDQTFAGDAALTSAMLDRILHHSHVVQIKGESYRLRQKRKAGVIAEANPE"',
+                    ),
+                ),
+            ),
+            (
+                "misc_feature",
+                "1109..1885",
+                (
+                    ("/locus_tag=", '"YP_pPCP02"'),
+                    (
+                        "/note=",
+                        '"transposase/IS protein; Provisional; Region: PRK09183"',
+                    ),
+                    ("/db_xref=", '"CDD:181681"'),
+                ),
+            ),
+            (
+                "misc_feature",
+                "1367..>1669",
+                (
+                    ("/locus_tag=", '"YP_pPCP02"'),
+                    (
+                        "/note=",
+                        '"The AAA+ (ATPases Associated with a wide variety of cellular Activities) superfamily represents an ancient group of ATPases belonging to the ASCE (for additional strand, catalytic E) division of the P-loop NTPase fold. The ASCE division also includes...; Region: AAA; cd00009"',
+                    ),
+                    ("/db_xref=", '"CDD:99707"'),
+                ),
+            ),
+            (
+                "misc_feature",
+                "1433..1456",
+                (
+                    ("/locus_tag=", '"YP_pPCP02"'),
+                    ("/note=", '"Walker A motif; other site"'),
+                    ("/db_xref=", '"CDD:99707"'),
+                ),
+            ),
+            (
+                "misc_feature",
+                "order(1436..1459,1619..1621)",
+                (
+                    ("/locus_tag=", '"YP_pPCP02"'),
+                    ("/note=", '"ATP binding site [chemical binding]; other site"'),
+                    ("/db_xref=", '"CDD:99707"'),
+                ),
+            ),
+            (
+                "misc_feature",
+                "1607..1624",
+                (
+                    ("/locus_tag=", '"YP_pPCP02"'),
+                    ("/note=", '"Walker B motif; other site"'),
+                    ("/db_xref=", '"CDD:99707"'),
+                ),
+            ),
+            (
+                "gene",
+                "2925..3119",
+                (
+                    ("/gene=", '"rop"'),
+                    ("/locus_tag=", '"YP_pPCP03"'),
+                    ("/gene_synonym=", '"rom"'),
+                    ("/db_xref=", '"GeneID:2767717"'),
+                ),
+            ),
+            (
+                "CDS",
+                "2925..3119",
+                (
+                    ("/gene=", '"rop"'),
+                    ("/locus_tag=", '"YP_pPCP03"'),
+                    ("/gene_synonym=", '"rom"'),
+                    (
+                        "/note=",
+                        '"Best Blastp hit =gi|16082682|ref|NP_395229.1| (NC_003132) putative replication regulatory protein [Yersinia pestis], gi|5763813|emb|CAB531 66.1| (AL109969) putative replication regulatory protein [Yersinia pestis]; similar to gb|AAK91579.1| (AY048853), RNAI modulator protein Rom [Salmonella choleraesuis], Contains Regulatory protein Rop (Interpro|IPR000769)"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/transl_table=", "11"),
+                    ("/product=", '"putative replication regulatory protein"'),
+                    ("/protein_id=", '"NP_995569.1"'),
+                    ("/db_xref=", '"GI:45478714"'),
+                    ("/db_xref=", '"GeneID:2767717"'),
+                    (
+                        "/translation=",
+                        '"MNKQQQTALNMARFIRSQSLILLEKLDALDADEQAAMCERLHELAEELQNSIQARFEAESETGT"',
+                    ),
+                ),
+            ),
+            (
+                "misc_feature",
+                "2925..3107",
+                (
+                    ("/gene=", '"rop"'),
+                    ("/locus_tag=", '"YP_pPCP03"'),
+                    ("/gene_synonym=", '"rom"'),
+                    ("/note=", '"Rop protein; Region: Rop; pfam01815"'),
+                    ("/db_xref=", '"CDD:145136"'),
+                ),
+            ),
+            (
+                "gene",
+                "3486..3857",
+                (("/locus_tag=", '"YP_pPCP04"'), ("/db_xref=", '"GeneID:2767720"')),
+            ),
+            (
+                "CDS",
+                "3486..3857",
+                (
+                    ("/locus_tag=", '"YP_pPCP04"'),
+                    (
+                        "/note=",
+                        '"Best Blastp hit = gi|321919|pir||JQ1541 hypothetical 16.9K protein - Salmonella typhi murium plasmid NTP16."',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/transl_table=", "11"),
+                    ("/product=", '"hypothetical protein"'),
+                    ("/protein_id=", '"NP_995570.1"'),
+                    ("/db_xref=", '"GI:45478715"'),
+                    ("/db_xref=", '"GeneID:2767720"'),
+                    (
+                        "/translation=",
+                        '"MSKKRRPQKRPRRRRFFHRLRPPDEHHKNRRSSQRWRNPTGLKDTRRFPPEAPSCALLFRPCRLPDTSPPFSLREAWRFLIAHAVGISVRCRSFAPSWAVCTNPPFSPTTAPYPVTIVLSPTR"',
+                    ),
+                ),
+            ),
+            (
+                "misc_feature",
+                "3498..3626",
+                (
+                    ("/locus_tag=", '"YP_pPCP04"'),
+                    (
+                        "/note=",
+                        '"ProfileScan match to entry PS50323 ARG_RICH, E-value 8.981"',
+                    ),
+                ),
+            ),
+            (
+                "gene",
+                "4343..4780",
+                (
+                    ("/gene=", '"pim"'),
+                    ("/locus_tag=", '"YP_pPCP05"'),
+                    ("/db_xref=", '"GeneID:2767712"'),
+                ),
+            ),
+            (
+                "CDS",
+                "4343..4780",
+                (
+                    ("/gene=", '"pim"'),
+                    ("/locus_tag=", '"YP_pPCP05"'),
+                    (
+                        "/note=",
+                        '"similar to many previously sequenced pesticin immunity protein entries of Yersinia pestis plasmid pPCP, e.g. gi| 16082683|,ref|NP_395230.1| (NC_003132) , gi|1200166|emb|CAA90861.1| (Z54145 ) , gi|1488655| emb|CAA63439.1| (X92856) , gi|2996219|gb|AAC62543.1| (AF053945) , and gi|5763814|emb|CAB531 67.1| (AL109969)"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/transl_table=", "11"),
+                    ("/product=", '"pesticin immunity protein"'),
+                    ("/protein_id=", '"NP_995571.1"'),
+                    ("/db_xref=", '"GI:45478716"'),
+                    ("/db_xref=", '"GeneID:2767712"'),
+                    (
+                        "/translation=",
+                        '"MGGGMISKLFCLALIFLSSSGLAEKNTYTAKDILQNLELNTFGNSLSHGIYGKQTTFKQTEFTNIKSNTKKHIALINKDNSWMISLKILGIKRDEYTVCFEDFSLIRPPTYVAIHPLLIKKVKSGNFIVVKEIKKSIPGCTVYYH"',
+                    ),
+                ),
+            ),
+            (
+                "gene",
+                "complement(4815..5888)",
+                (
+                    ("/gene=", '"pst"'),
+                    ("/locus_tag=", '"YP_pPCP06"'),
+                    ("/db_xref=", '"GeneID:2767721"'),
+                ),
+            ),
+            (
+                "CDS",
+                "complement(4815..5888)",
+                (
+                    ("/gene=", '"pst"'),
+                    ("/locus_tag=", '"YP_pPCP06"'),
+                    (
+                        "/note=",
+                        '"Best Blastp hit =|16082684|ref|NP_395231.1| (NC_003132) pesticin [Yersinia pestis], gi|984824|gb|AAA75369.1| (U31974) pesticin [Yersinia pestis], gi|1488654|emb|CAA63438.1| (X92856) pesticin [Yersinia pestis], gi|2996220|gb|AAC62544.1| (AF053945) pesticin [Yersinia pestis], gi|5763815|emb|CAB53168.1| (AL1099 69) pesticin [Yersinia pestis]"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/transl_table=", "11"),
+                    ("/product=", '"pesticin"'),
+                    ("/protein_id=", '"NP_995572.1"'),
+                    ("/db_xref=", '"GI:45478717"'),
+                    ("/db_xref=", '"GeneID:2767721"'),
+                    (
+                        "/translation=",
+                        '"MSDTMVVNGSGGVPAFLFSGSTLSSYRPNFEANSITIALPHYVDLPGRSNFKLMYIMGFPIDTEMEKDSEYSNKIRQESKISKTEGTVSYEQKITVETGQEKDGVKVYRVMVLEGTIAESIEHLDKKENEDILNNNRNRIVLADNTVINFDNISQLKEFLRRSVNIVDHDIFSSNGFEGFNPTSHFPSNPSSDYFNSTGVTFGSGVDLGQRSKQDLLNDGVPQYIADRLDGYYMLRGKEAYDKVRTAPLTLSDNEAHLLSNIYIDKFSHKIEGLFNDANIGLRFSDLPLRTRTALVSIGYQKGFKLSRTAPTVWNKVIAKDWNGLVNAFNNIVDGMSDRRKREGALVQKDIDSGLLK"',
+                    ),
+                ),
+            ),
+            (
+                "variation",
+                "5910..5911",
+                (("/note=", '"compared to AF053945"'), ("/replace=", '""')),
+            ),
+            (
+                "variation",
+                "5933^5934",
+                (("/note=", '"compared to AL109969"'), ("/replace=", '"a"')),
+            ),
+            (
+                "variation",
+                "5933^5934",
+                (("/note=", '"compared to AF053945"'), ("/replace=", '"aa"')),
+            ),
+            (
+                "variation",
+                "5948",
+                (("/note=", '"compared to AL109969"'), ("/replace=", '"c"')),
+            ),
+            (
+                "gene",
+                "6005..6421",
+                (("/locus_tag=", '"YP_pPCP07"'), ("/db_xref=", '"GeneID:2767719"')),
+            ),
+            (
+                "CDS",
+                "6005..6421",
+                (
+                    ("/locus_tag=", '"YP_pPCP07"'),
+                    (
+                        "/note=",
+                        '"Best Blastp hit = gi|16082685|ref|NP_395232.1| (NC_003132) hypothetical protein [Yersinia pestis], gi|5763816|emb|CAB53169.1| (AL109969) hypothetical protein [Yersinia pestis]"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/transl_table=", "11"),
+                    ("/product=", '"hypothetical protein"'),
+                    ("/protein_id=", '"NP_995573.1"'),
+                    ("/db_xref=", '"GI:45478718"'),
+                    ("/db_xref=", '"GeneID:2767719"'),
+                    (
+                        "/translation=",
+                        '"MKFHFCDLNHSYKNQEGKIRSRKTAPGNIRKKQKGDNVSKTKSGRHRLSKTDKRLLAALVVAGYEERTARDLIQKHVYTLTQADLRHLVSEISNGVGQSQAYDAIYQARRIRLARKYLSGKKPEGVEPREGQEREDLP"',
+                    ),
+                ),
+            ),
+            (
+                "variation",
+                "6525",
+                (
+                    ("/note=", '"compared to AF053945 and AL109969"'),
+                    ("/replace=", '"c"'),
+                ),
+            ),
+            (
+                "gene",
+                "6664..7602",
+                (
+                    ("/gene=", '"pla"'),
+                    ("/locus_tag=", '"YP_pPCP08"'),
+                    ("/db_xref=", '"GeneID:2767715"'),
+                ),
+            ),
+            (
+                "CDS",
+                "6664..7602",
+                (
+                    ("/gene=", '"pla"'),
+                    ("/locus_tag=", '"YP_pPCP08"'),
+                    ("/EC_number=", '"3.4.23.48"'),
+                    (
+                        "/note=",
+                        '"outer membrane protease; involved in virulence in many organisms; OmpT; IcsP; SopA; Pla; PgtE; omptin; in Escherichia coli OmpT can degrade antimicrobial peptides; in Yersinia Pla activates plasminogen during infection; in Shigella flexneria SopA cleaves the autotransporter IcsA"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/transl_table=", "11"),
+                    ("/product=", '"outer membrane protease"'),
+                    ("/protein_id=", '"NP_995574.1"'),
+                    ("/db_xref=", '"GI:45478719"'),
+                    ("/db_xref=", '"GeneID:2767715"'),
+                    (
+                        "/translation=",
+                        '"MKKSSIVATIITILSGSANAASSQLIPNISPDSFTVAASTGMLSGKSHEMLYDAETGRKISQLDWKIKNVAILKGDISWDPYSFLTLNARGWTSLASGSGNMDDYDWMNENQSEWTDHSSHPATNVNHANEYDLNVKGWLLQDENYKAGITAGYQETRFSWTATGGSYSYNNGAYTGNFPKGVRVIGYNQRFSMPYIGLAGQYRINDFELNALFKFSDWVRAHDNDEHYMRDLTFREKTSGSRYYGTVINAGYYVTPNAKVFAEFTYSKYDEGKGGTQIIDKNSGDSVSIGGDAAGISNKNYTVTAGLQYRF"',
+                    ),
+                ),
+            ),
+            (
+                "misc_feature",
+                "6664..7599",
+                (
+                    ("/gene=", '"pla"'),
+                    ("/locus_tag=", '"YP_pPCP08"'),
+                    ("/note=", '"Omptin family; Region: Omptin; cl01886"'),
+                    ("/db_xref=", '"CDD:186487"'),
+                ),
+            ),
+            (
+                "gene",
+                "complement(7789..8088)",
+                (("/locus_tag=", '"YP_pPCP09"'), ("/db_xref=", '"GeneID:2767713"')),
+            ),
+            (
+                "CDS",
+                "complement(7789..8088)",
+                (
+                    ("/locus_tag=", '"YP_pPCP09"'),
+                    (
+                        "/note=",
+                        '"Best Blastp hit = gi|16082687|ref|NP_395234.1| (NC_003132) putative transcriptional regulator [Yersinia pestis], gi|5763818|emb|CAB53171.1| (AL109969) putative transcriptional regulator [Yersinia pestis]."',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/transl_table=", "11"),
+                    ("/product=", '"putative transcriptional regulator"'),
+                    ("/protein_id=", '"NP_995575.1"'),
+                    ("/db_xref=", '"GI:45478720"'),
+                    ("/db_xref=", '"GeneID:2767713"'),
+                    (
+                        "/translation=",
+                        '"MRTLDEVIASRSPESQTRIKEMADEMILEVGLQMMREELQLSQKQVAEAMGISQPAVTKLEQRGNDLKLATLKRYVEAMGGKLSLDVELPTGRRVAFHV"',
+                    ),
+                ),
+            ),
+            (
+                "misc_feature",
+                "complement(7837..7995)",
+                (
+                    ("/locus_tag=", '"YP_pPCP09"'),
+                    (
+                        "/note=",
+                        '"Helix-turn-helix XRE-family like proteins. Prokaryotic DNA binding proteins belonging to the xenobiotic response element family of transcriptional regulators; Region: HTH_XRE; cl09100"',
+                    ),
+                    ("/db_xref=", '"CDD:195788"'),
+                ),
+            ),
+            (
+                "gene",
+                "complement(8088..8360)",
+                (("/locus_tag=", '"YP_pPCP10"'), ("/db_xref=", '"GeneID:2767714"')),
+            ),
+            (
+                "CDS",
+                "complement(8088..8360)",
+                (
+                    ("/locus_tag=", '"YP_pPCP10"'),
+                    (
+                        "/note=",
+                        '"Best Blastp hit = gi|16082688|ref|NP_395235.1| (NC_003132) hypothetical protein [ Yersinia pestis], gi|5763819|emb|CAB53172.1| (AL109969) hypothetical protein [Yersinia pestis]"',
+                    ),
+                    ("/codon_start=", "1"),
+                    ("/transl_table=", "11"),
+                    ("/product=", '"hypothetical protein"'),
+                    ("/protein_id=", '"NP_995576.1"'),
+                    ("/db_xref=", '"GI:45478721"'),
+                    ("/db_xref=", '"GeneID:2767714"'),
+                    (
+                        "/translation=",
+                        '"MADLKKLQVYGPELPRPYADTVKGSRYKNMKELRVQFSGRPIRAFYAFDPIRRAIVLCAGDKSNDKRFYEKLVRIAEDEFTAHLNTLESK"',
+                    ),
+                ),
+            ),
+            (
+                "misc_feature",
+                "complement(8091..>8357)",
+                (
+                    ("/locus_tag=", '"YP_pPCP10"'),
+                    (
+                        "/note=",
+                        '"Phage derived protein Gp49-like (DUF891); Region: Gp49; cl01470"',
+                    ),
+                    ("/db_xref=", '"CDD:194142"'),
+                ),
+            ),
+            (
+                "variation",
+                "8529^8530",
+                (("/note=", '"compared to AL109969"'), ("/replace=", '"tt"')),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_15(self):
         path = "GenBank/no_end_marker.gb"
@@ -570,9 +2131,20 @@ class TestRecordParser(unittest.TestCase):
         definition = "Streptomyces avermitilis melanin biosynthetic gene cluster"
         accession = ["AB070938"]
         titles = ()
-        features = [("source", "1..6497", (("/organism=", '"Streptomyces avermitilis"'), ("/mol_type=", '"genomic DNA"'), ("/db_xref=", '"taxon:33903"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        features = [
+            (
+                "source",
+                "1..6497",
+                (
+                    ("/organism=", '"Streptomyces avermitilis"'),
+                    ("/mol_type=", '"genomic DNA"'),
+                    ("/db_xref=", '"taxon:33903"'),
+                ),
+            )
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_16(self):
         path = "GenBank/wrong_sequence_indent.gb"
@@ -587,9 +2159,20 @@ class TestRecordParser(unittest.TestCase):
         definition = "Streptomyces avermitilis melanin biosynthetic gene cluster"
         accession = ["AB070938"]
         titles = ()
-        features = [("source", "1..6497", (("/organism=", '"Streptomyces avermitilis"'), ("/mol_type=", '"genomic DNA"'), ("/db_xref=", '"taxon:33903"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        features = [
+            (
+                "source",
+                "1..6497",
+                (
+                    ("/organism=", '"Streptomyces avermitilis"'),
+                    ("/mol_type=", '"genomic DNA"'),
+                    ("/db_xref=", '"taxon:33903"'),
+                ),
+            )
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_17(self):
         path = "GenBank/invalid_locus_line_spacing.gb"
@@ -604,9 +2187,20 @@ class TestRecordParser(unittest.TestCase):
         definition = "Streptomyces avermitilis melanin biosynthetic gene cluster"
         accession = ["AB070938"]
         titles = ()
-        features = [("source", "1..6497", (("/organism=", '"Streptomyces avermitilis"'), ("/mol_type=", '"genomic DNA"'), ("/db_xref=", '"taxon:33903"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        features = [
+            (
+                "source",
+                "1..6497",
+                (
+                    ("/organism=", '"Streptomyces avermitilis"'),
+                    ("/mol_type=", '"genomic DNA"'),
+                    ("/db_xref=", '"taxon:33903"'),
+                ),
+            )
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_18(self):
         path = "GenBank/empty_feature_qualifier.gb"
@@ -618,9 +2212,22 @@ class TestRecordParser(unittest.TestCase):
         definition = "Streptomyces avermitilis melanin biosynthetic gene cluster"
         accession = ["AB070938"]
         titles = ()
-        features = [("source", "1..6497", (("/organism=", '"Streptomyces avermitilis"'), ("/mol_type=", '"genomic DNA"'), ("/db_xref=", '"taxon:33903"'), ("/note=", '"This is a correct note, the following one isn\'t"'), ("/note", ""))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        features = [
+            (
+                "source",
+                "1..6497",
+                (
+                    ("/organism=", '"Streptomyces avermitilis"'),
+                    ("/mol_type=", '"genomic DNA"'),
+                    ("/db_xref=", '"taxon:33903"'),
+                    ("/note=", '"This is a correct note, the following one isn\'t"'),
+                    ("/note", ""),
+                ),
+            )
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_19(self):
         path = "GenBank/invalid_misc_feature.gb"
@@ -635,9 +2242,20 @@ class TestRecordParser(unittest.TestCase):
         definition = "Streptomyces avermitilis melanin biosynthetic gene cluster"
         accession = ["AB070938"]
         titles = ()
-        features = [("source", "1..6497", (("/organism=", '"Streptomyces avermitilis"'), ("/mol_type=", '"genomic DNA"'), ("/db_xref=", '"taxon:33903"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        features = [
+            (
+                "source",
+                "1..6497",
+                (
+                    ("/organism=", '"Streptomyces avermitilis"'),
+                    ("/mol_type=", '"genomic DNA"'),
+                    ("/db_xref=", '"taxon:33903"'),
+                ),
+            )
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_20(self):
         path = "GenBank/1MRR_A.gp"
@@ -648,37 +2266,163 @@ class TestRecordParser(unittest.TestCase):
         locus = "1MRR_A"
         definition = "Chain A, Substitution Of Manganese For Iron In Ribonucleotide Reductase From Escherichia Coli. Spectroscopic And Crystallographic Characterization"
         accession = ["1MRR_A"]
-        titles = ("Three-dimensional structure of the free radical protein of ribonucleotide reductase", "Substitution of manganese for iron in ribonucleotide reductase from Escherichia coli. Spectroscopic and crystallographic characterization", "Direct Submission")
-        features = [("source", "1..375", (("/organism=", '"Escherichia coli"'), ("/db_xref=", '"taxon:562"'))),
-                    ("Region", "28..340", (("/region_name=", '"RNRR2"'), ("/note=", '"Ribonucleotide Reductase, R2/beta subunit, ferritin-like diiron-binding domain; cd01049"'), ("/db_xref=", '"CDD:153108"'))),
-                    ("SecStr", "35..46", (("/sec_str_type=", '"helix"'), ("/note=", '"helix 1"'))),
-                    ("Site", "order(37,44,109..110,113,116..117,120,123,137..138,141)", (("/site_type=", '"other"'), ("/note=", '"dimer interface [polypeptide binding]"'), ("/db_xref=", '"CDD:153108"'))),
-                    ("Site", "order(48,84,115,118,122,236..237,241)", (("/site_type=", '"other"'), ("/note=", '"putative radical transfer pathway"'), ("/db_xref=", '"CDD:153108"'))),
-                    ("SecStr", "57..65", (("/sec_str_type=", '"helix"'), ("/note=", '"helix 2"'))),
-                    ("SecStr", "67..87", (("/sec_str_type=", '"helix"'), ("/note=", '"helix 3"'))),
-                    ("Site", "order(84,115,118,204,238,241)", (("/site_type=", '"other"'), ("/note=", '"diiron center [ion binding]"'), ("/db_xref=", '"CDD:153108"'))),
-                    ("Het", "join(bond(84),bond(115),bond(118),bond(238))", (("/heterogen=", '"( MN,1000 )"'), )),
-                    ("SecStr", "102..129", (("/sec_str_type=", '"helix"'), ("/note=", '"helix 4"'))),
-                    ("Het", "join(bond(115),bond(204),bond(238),bond(241))", (("/heterogen=", '"( MN,1001 )"'), )),
-                    ("Site", "122", (("/site_type=", '"other"'), ("/note=", '"tyrosyl radical"'), ("/db_xref=", '"CDD:153108"'))),
-                    ("SecStr", "133..140", (("/sec_str_type=", '"helix"'), ("/note=", '"helix 5"'))),
-                    ("SecStr", "143..151", (("/sec_str_type=", '"helix"'), ("/note=", '"helix 6"'))),
-                    ("SecStr", "153..169", (("/sec_str_type=", '"helix"'), ("/note=", '"helix 7"'))),
-                    ("SecStr", "172..177", (("/sec_str_type=", '"sheet"'), ("/note=", '"strand 1"'))),
-                    ("SecStr", "180..185", (("/sec_str_type=", '"sheet"'), ("/note=", '"strand 2"'))),
-                    ("SecStr", "186..216", (("/sec_str_type=", '"helix"'), ("/note=", '"helix 8"'))),
-                    ("Het", "join(bond(194),bond(272))", (("/heterogen=", '"( HG,1003 )"'), )),
-                    ("Het", "bond(196)", (("/heterogen=", '"( HG,1005 )"'), )),
-                    ("Het", "join(bond(196),bond(196))", (("/heterogen=", '"( HG,1002 )"'), )),
-                    ("Het", "join(bond(210),bond(214),bond(214))", (("/heterogen=", '"( HG,1004 )"'), )),
-                    ("SecStr", "225..253", (("/sec_str_type=", '"helix"'), ("/note=", '"helix 9"'), )),
-                    ("SecStr", "260..269", (("/sec_str_type=", '"helix"'), ("/note=", '"helix 10"'), )),
-                    ("Bond", "bond(268,272)", (("/bond_type=", '"disulfide"'), )),
-                    ("SecStr", "270..285", (("/sec_str_type=", '"helix"'), ("/note=", '"helix 11"'))),
-                    ("Het", "join(bond(284),bond(305),bond(309),bond(305))", (("/heterogen=", '"( HG,1006 )"'), )),
-                    ("SecStr", "301..319", (("/sec_str_type=", '"helix"'), ("/note=", '"helix 12"'))),
-                    ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        titles = (
+            "Three-dimensional structure of the free radical protein of ribonucleotide reductase",
+            "Substitution of manganese for iron in ribonucleotide reductase from Escherichia coli. Spectroscopic and crystallographic characterization",
+            "Direct Submission",
+        )
+        features = [
+            (
+                "source",
+                "1..375",
+                (("/organism=", '"Escherichia coli"'), ("/db_xref=", '"taxon:562"')),
+            ),
+            (
+                "Region",
+                "28..340",
+                (
+                    ("/region_name=", '"RNRR2"'),
+                    (
+                        "/note=",
+                        '"Ribonucleotide Reductase, R2/beta subunit, ferritin-like diiron-binding domain; cd01049"',
+                    ),
+                    ("/db_xref=", '"CDD:153108"'),
+                ),
+            ),
+            (
+                "SecStr",
+                "35..46",
+                (("/sec_str_type=", '"helix"'), ("/note=", '"helix 1"')),
+            ),
+            (
+                "Site",
+                "order(37,44,109..110,113,116..117,120,123,137..138,141)",
+                (
+                    ("/site_type=", '"other"'),
+                    ("/note=", '"dimer interface [polypeptide binding]"'),
+                    ("/db_xref=", '"CDD:153108"'),
+                ),
+            ),
+            (
+                "Site",
+                "order(48,84,115,118,122,236..237,241)",
+                (
+                    ("/site_type=", '"other"'),
+                    ("/note=", '"putative radical transfer pathway"'),
+                    ("/db_xref=", '"CDD:153108"'),
+                ),
+            ),
+            (
+                "SecStr",
+                "57..65",
+                (("/sec_str_type=", '"helix"'), ("/note=", '"helix 2"')),
+            ),
+            (
+                "SecStr",
+                "67..87",
+                (("/sec_str_type=", '"helix"'), ("/note=", '"helix 3"')),
+            ),
+            (
+                "Site",
+                "order(84,115,118,204,238,241)",
+                (
+                    ("/site_type=", '"other"'),
+                    ("/note=", '"diiron center [ion binding]"'),
+                    ("/db_xref=", '"CDD:153108"'),
+                ),
+            ),
+            (
+                "Het",
+                "join(bond(84),bond(115),bond(118),bond(238))",
+                (("/heterogen=", '"( MN,1000 )"'),),
+            ),
+            (
+                "SecStr",
+                "102..129",
+                (("/sec_str_type=", '"helix"'), ("/note=", '"helix 4"')),
+            ),
+            (
+                "Het",
+                "join(bond(115),bond(204),bond(238),bond(241))",
+                (("/heterogen=", '"( MN,1001 )"'),),
+            ),
+            (
+                "Site",
+                "122",
+                (
+                    ("/site_type=", '"other"'),
+                    ("/note=", '"tyrosyl radical"'),
+                    ("/db_xref=", '"CDD:153108"'),
+                ),
+            ),
+            (
+                "SecStr",
+                "133..140",
+                (("/sec_str_type=", '"helix"'), ("/note=", '"helix 5"')),
+            ),
+            (
+                "SecStr",
+                "143..151",
+                (("/sec_str_type=", '"helix"'), ("/note=", '"helix 6"')),
+            ),
+            (
+                "SecStr",
+                "153..169",
+                (("/sec_str_type=", '"helix"'), ("/note=", '"helix 7"')),
+            ),
+            (
+                "SecStr",
+                "172..177",
+                (("/sec_str_type=", '"sheet"'), ("/note=", '"strand 1"')),
+            ),
+            (
+                "SecStr",
+                "180..185",
+                (("/sec_str_type=", '"sheet"'), ("/note=", '"strand 2"')),
+            ),
+            (
+                "SecStr",
+                "186..216",
+                (("/sec_str_type=", '"helix"'), ("/note=", '"helix 8"')),
+            ),
+            ("Het", "join(bond(194),bond(272))", (("/heterogen=", '"( HG,1003 )"'),)),
+            ("Het", "bond(196)", (("/heterogen=", '"( HG,1005 )"'),)),
+            ("Het", "join(bond(196),bond(196))", (("/heterogen=", '"( HG,1002 )"'),)),
+            (
+                "Het",
+                "join(bond(210),bond(214),bond(214))",
+                (("/heterogen=", '"( HG,1004 )"'),),
+            ),
+            (
+                "SecStr",
+                "225..253",
+                (("/sec_str_type=", '"helix"'), ("/note=", '"helix 9"')),
+            ),
+            (
+                "SecStr",
+                "260..269",
+                (("/sec_str_type=", '"helix"'), ("/note=", '"helix 10"')),
+            ),
+            ("Bond", "bond(268,272)", (("/bond_type=", '"disulfide"'),)),
+            (
+                "SecStr",
+                "270..285",
+                (("/sec_str_type=", '"helix"'), ("/note=", '"helix 11"')),
+            ),
+            (
+                "Het",
+                "join(bond(284),bond(305),bond(309),bond(305))",
+                (("/heterogen=", '"( HG,1006 )"'),),
+            ),
+            (
+                "SecStr",
+                "301..319",
+                (("/sec_str_type=", '"helix"'), ("/note=", '"helix 12"')),
+            ),
+        ]
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
     def test_record_parser_tsa(self):
         path = "GenBank/tsa_acropora.gb"
@@ -689,22 +2433,30 @@ class TestRecordParser(unittest.TestCase):
         locus = "GHGH01000000"
         definition = "TSA: Acropora millepora, transcriptome shotgun assembly"
         accession = ["GHGH00000000"]
-        titles = ("Acropora millepora genome sequencing and assembly", "Direct Submission")
+        titles = (
+            "Acropora millepora genome sequencing and assembly",
+            "Direct Submission",
+        )
         features = [
-            ("source", "1..126539", (
-                ("/organism=", '"Acropora millepora"'),
-                ("/mol_type=", '"transcribed RNA"'),
-                ("/db_xref=", '"taxon:45264"'),
-                ("/tissue_type=", '"late planula"'),
-                ("/country=", '"Australia: Queensland"'),
-                ("/collection_date=", '"2011"'),
-            ))
+            (
+                "source",
+                "1..126539",
+                (
+                    ("/organism=", '"Acropora millepora"'),
+                    ("/mol_type=", '"transcribed RNA"'),
+                    ("/db_xref=", '"taxon:45264"'),
+                    ("/tissue_type=", '"late planula"'),
+                    ("/country=", '"Australia: Queensland"'),
+                    ("/collection_date=", '"2011"'),
+                ),
+            )
         ]
-        self.perform_record_parser_test(record, length, locus, definition, accession, titles, features)
+        self.perform_record_parser_test(
+            record, length, locus, definition, accession, titles, features
+        )
 
 
 class TestFeatureParser(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.feat_parser = GenBank.FeatureParser(debug_level=0)
@@ -715,7 +2467,18 @@ class TestFeatureParser(unittest.TestCase):
         else:
             return seq[:54] + "..." + seq[-3:]
 
-    def perform_feature_parser_test(self, record, seq, id, name, description, annotations, references, features, dbxrefs):
+    def perform_feature_parser_test(
+        self,
+        record,
+        seq,
+        id,
+        name,
+        description,
+        annotations,
+        references,
+        features,
+        dbxrefs,
+    ):
         self.assertEqual(self.shorten(record.seq), seq)
         self.assertEqual(record.id, id)
         self.assertEqual(record.name, name)
@@ -744,38 +2507,60 @@ class TestFeatureParser(unittest.TestCase):
         id = "NM_006141.1"
         name = "NM_006141"
         description = "Homo sapiens dynein, cytoplasmic, light intermediate polypeptide 2 (DNCLI2), mRNA"
-        annotations = {"accessions": ["NM_006141"],
-                       "comment": """\
+        annotations = {
+            "accessions": ["NM_006141"],
+            "comment": """\
 PROVISIONAL REFSEQ: This record has not yet been subject to final
 NCBI review. The reference sequence was derived from AF035812.1.""",
-                       "data_file_division": "PRI",
-                       "date": "01-NOV-2000",
-                       "gi": "5453633",
-                       "keywords": [""],
-                       "molecule_type": "mRNA",
-                       "organism": "Homo sapiens",
-                       "sequence_version": 1,
-                       "source": "human",
-                       "taxonomy": ["Eukaryota", "Metazoa", "Chordata", "Craniata", "Vertebrata", "Euteleostomi", "Mammalia", "Eutheria", "Primates", "Catarrhini", "Hominidae", "Homo"],
-                       }
+            "data_file_division": "PRI",
+            "date": "01-NOV-2000",
+            "gi": "5453633",
+            "keywords": [""],
+            "molecule_type": "mRNA",
+            "organism": "Homo sapiens",
+            "sequence_version": 1,
+            "source": "human",
+            "taxonomy": [
+                "Eukaryota",
+                "Metazoa",
+                "Chordata",
+                "Craniata",
+                "Vertebrata",
+                "Euteleostomi",
+                "Mammalia",
+                "Eutheria",
+                "Primates",
+                "Catarrhini",
+                "Hominidae",
+                "Homo",
+            ],
+        }
         references = []
-        features = (("""\
+        features = (
+            (
+                """\
 type: source
 location: [0:1622](+)
 qualifiers:
     Key: db_xref, Value: ['taxon:9606']
     Key: map, Value: ['16']
     Key: organism, Value: ['Homo sapiens']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [0:1622](+)
 qualifiers:
     Key: db_xref, Value: ['LocusID:1783']
     Key: gene, Value: ['DNCLI2']
     Key: note, Value: ['LIC2']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [6:1485](+)
 qualifiers:
@@ -786,10 +2571,22 @@ qualifiers:
     Key: product, Value: ['dynein, cytoplasmic, light intermediate polypeptide 2']
     Key: protein_id, Value: ['NP_006132.1']
     Key: translation, Value: ['MAPVGVEKKLLLGPNGPAVAAAGDLTSEEEEGQSLWSSILSEVSTRARSKLPSGKNILVFGEDGSGKTTLMTKLQGAEHGKKGRGLEYLYLSVHDEDRDDHTRCNVWILDGDLYHKGLLKFAVSAESLPETLVIFVADMSRPWTVMESLQKWASVLREHIDKMKIPPEKMRELERKFVKDFQDYMEPEEGCQGSPQRRGPLTSGSDEENVALPLGDNVLTHNLGIPVLVVCTKCDAVSVLEKEHDYRDEHLDFIQSHLRRFCLQYGAALIYTSVKEEKNLDLLYKYIVHKTYGFHFTTPALVVEKDAVFIPAGWDNEKKIAILHENFTTVKPEDAYEDFIVKPPVRKLVHDKELAAEDEQVFLMKQQSLLAKQPATPTRASESPARGPSGSPRTQGRGGPASVPSSSPGTSVKKPDPNIKNNAASEGVLASFFNSLLSKKTGSPGSPGAGGVQSTAKKSGQKTVLSNVQEELDRMTRKPDSMVTNSSTENEA']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_02(self):
         path = "GenBank/cor6_6.gb"
@@ -800,36 +2597,67 @@ qualifiers:
         id = "X55053.1"
         name = "ATCOR66M"
         description = "A.thaliana cor6.6 mRNA"
-        annotations = {"accessions": ["X55053"],
-                       "comment": """\
+        annotations = {
+            "accessions": ["X55053"],
+            "comment": """\
 Cor6.6 homologous to KIN1. KIN1 is a cold-regulated Arabidopsis
 gene with suggested similarity to type I fish antifreeze proteins.""",
-                       "data_file_division": "PLN",
-                       "date": "02-MAR-1992",
-                       "gi": "16229",
-                       "keywords": ["antifreeze protein homology", "cold-regulated gene", "cor6.6 gene", "KIN1 homology"],
-                       "molecule_type": "mRNA",
-                       "organism": "Arabidopsis thaliana",
-                       "sequence_version": 1,
-                       "source": "thale cress",
-                       "taxonomy": ["Eukaryota", "Viridiplantae", "Streptophyta", "Embryophyta", "Tracheophyta", "euphyllophytes", "Spermatophyta", "Magnoliophyta", "eudicotyledons", "Rosidae", "Capparales", "Brassicaceae", "Arabidopsis"],
-                       }
-        references = ["location: [0:513]\nauthors: Thomashow,M.F.\ntitle: Direct Submission\njournal: Submitted (01-FEB-1991) M.F. Thomashow, Dept. Crop and Soil Sciences, Dept. Microbiology, Michigan State University, East Lansing, Michigan 48824, USA\nmedline id: \npubmed id: \ncomment: \n", "location: [0:513]\nauthors: Gilmour,S.J., Artus,N.N. and Thomashow,M.F.\ntitle: cDNA sequence analysis and expression of two cold-regulated genes of Arabidopsis thaliana\njournal: Plant Mol. Biol. 18 (1), 13-21 (1992)\nmedline id: 92119220\npubmed id: \ncomment: \n"]
-        features = (("""\
+            "data_file_division": "PLN",
+            "date": "02-MAR-1992",
+            "gi": "16229",
+            "keywords": [
+                "antifreeze protein homology",
+                "cold-regulated gene",
+                "cor6.6 gene",
+                "KIN1 homology",
+            ],
+            "molecule_type": "mRNA",
+            "organism": "Arabidopsis thaliana",
+            "sequence_version": 1,
+            "source": "thale cress",
+            "taxonomy": [
+                "Eukaryota",
+                "Viridiplantae",
+                "Streptophyta",
+                "Embryophyta",
+                "Tracheophyta",
+                "euphyllophytes",
+                "Spermatophyta",
+                "Magnoliophyta",
+                "eudicotyledons",
+                "Rosidae",
+                "Capparales",
+                "Brassicaceae",
+                "Arabidopsis",
+            ],
+        }
+        references = [
+            "location: [0:513]\nauthors: Thomashow,M.F.\ntitle: Direct Submission\njournal: Submitted (01-FEB-1991) M.F. Thomashow, Dept. Crop and Soil Sciences, Dept. Microbiology, Michigan State University, East Lansing, Michigan 48824, USA\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:513]\nauthors: Gilmour,S.J., Artus,N.N. and Thomashow,M.F.\ntitle: cDNA sequence analysis and expression of two cold-regulated genes of Arabidopsis thaliana\njournal: Plant Mol. Biol. 18 (1), 13-21 (1992)\nmedline id: 92119220\npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:513](+)
 qualifiers:
     Key: db_xref, Value: ['taxon:3702']
     Key: organism, Value: ['Arabidopsis thaliana']
     Key: strain, Value: ['Columbia']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [49:250](+)
 qualifiers:
     Key: gene, Value: ['cor6.6']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [49:250](+)
 qualifiers:
@@ -839,66 +2667,116 @@ qualifiers:
     Key: note, Value: ['cold regulated']
     Key: protein_id, Value: ['CAA38894.1']
     Key: translation, Value: ['MSETNKNAFQAGQAAGKAEEKSNVLLDKAKDAAAAAGASAQQAGKSISDAAVGGVNFVKDKTGLNK']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
         record = next(records)
         seq = "ATTTGGCCTATAAATATAAACCCTTAAGCCCACATATCTTCTCAATCCATCACA...ATA"
         id = "X62281.1"
         name = "ATKIN2"
         description = "A.thaliana kin2 gene"
-        annotations = {"accessions": ["X62281"],
-                       "data_file_division": "PLN",
-                       "date": "23-JUL-1992",
-                       "gi": "16353",
-                       "keywords": ["kin2 gene"],
-                       "molecule_type": "DNA",
-                       "organism": "Arabidopsis thaliana",
-                       "sequence_version": 1,
-                       "source": "thale cress",
-                       "taxonomy": ["Eukaryota", "Viridiplantae", "Streptophyta", "Embryophyta", "Tracheophyta", "euphyllophytes", "Spermatophyta", "Magnoliophyta", "eudicotyledons", "Rosidae", "Capparales", "Brassicaceae", "Arabidopsis"],
-                       }
-        references = ["location: [0:880]\nauthors: Borg-Franck,M.E.\ntitle: Direct Submission\njournal: Submitted (27-SEP-1991) M.E. Borg-Franck, Inst of Biotechnology, University of Helsinki, Karvaamokuja 3, SF-00380 Helsinki, FINLAND\nmedline id: \npubmed id: \ncomment: \n", "location: [0:880]\nauthors: Kurkela,S. and Borg-Franck,M.\ntitle: Structure and expression of kin2, one of two cold- and ABA-induced genes of Arabidopsis thaliana\njournal: Plant Mol. Biol. 19 (4), 689-692 (1992)\nmedline id: 92329728\npubmed id: \ncomment: \n"]
-        features = (("""\
+        annotations = {
+            "accessions": ["X62281"],
+            "data_file_division": "PLN",
+            "date": "23-JUL-1992",
+            "gi": "16353",
+            "keywords": ["kin2 gene"],
+            "molecule_type": "DNA",
+            "organism": "Arabidopsis thaliana",
+            "sequence_version": 1,
+            "source": "thale cress",
+            "taxonomy": [
+                "Eukaryota",
+                "Viridiplantae",
+                "Streptophyta",
+                "Embryophyta",
+                "Tracheophyta",
+                "euphyllophytes",
+                "Spermatophyta",
+                "Magnoliophyta",
+                "eudicotyledons",
+                "Rosidae",
+                "Capparales",
+                "Brassicaceae",
+                "Arabidopsis",
+            ],
+        }
+        references = [
+            "location: [0:880]\nauthors: Borg-Franck,M.E.\ntitle: Direct Submission\njournal: Submitted (27-SEP-1991) M.E. Borg-Franck, Inst of Biotechnology, University of Helsinki, Karvaamokuja 3, SF-00380 Helsinki, FINLAND\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:880]\nauthors: Kurkela,S. and Borg-Franck,M.\ntitle: Structure and expression of kin2, one of two cold- and ABA-induced genes of Arabidopsis thaliana\njournal: Plant Mol. Biol. 19 (4), 689-692 (1992)\nmedline id: 92329728\npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:880](+)
 qualifiers:
     Key: db_xref, Value: ['taxon:3702']
     Key: organism, Value: ['Arabidopsis thaliana']
     Key: strain, Value: ['ssp. L. Heynh, Colombia']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: TATA_signal
 location: [8:20](+)
 qualifiers:
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: exon
 location: [43:160](+)
 qualifiers:
     Key: gene, Value: ['kin2']
     Key: number, Value: ['1']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: prim_transcript
 location: [43:>579](+)
 qualifiers:
     Key: gene, Value: ['kin2']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: mRNA
 location: join{[43:160](+), [319:390](+), [503:>579](+)}
 qualifiers:
     Key: gene, Value: ['kin2']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [43:579](+)
 qualifiers:
     Key: gene, Value: ['kin2']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[103:160](+), [319:390](+), [503:579](+)}
 qualifiers:
@@ -907,76 +2785,131 @@ qualifiers:
     Key: gene, Value: ['kin2']
     Key: protein_id, Value: ['CAA44171.1']
     Key: translation, Value: ['MSETNKNAFQAGQAAGKAERRRAMFCWTRPRMLLLQLELPRNRAGKSISDAAVGGVNFVKDKTGLNK']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: intron
 location: [160:319](+)
 qualifiers:
     Key: gene, Value: ['kin2']
     Key: number, Value: ['1']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: exon
 location: [319:390](+)
 qualifiers:
     Key: gene, Value: ['kin2']
     Key: number, Value: ['2']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: intron
 location: [390:503](+)
 qualifiers:
     Key: gene, Value: ['kin2']
     Key: number, Value: ['2']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: exon
 location: [503:>579](+)
 qualifiers:
     Key: gene, Value: ['kin2']
     Key: number, Value: ['3']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: polyA_signal
 location: [619:625](+)
 qualifiers:
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: polyA_signal
 location: [640:646](+)
 qualifiers:
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: polyA_site
 location: [784:785](+)
 qualifiers:
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: polyA_site
 location: [799:800](+)
 qualifiers:
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
         record = next(records)
         seq = "AAAAAAACACAACAAAACTCAATAAATAAACAAATGGCAGACAACAAGCAGAGC...TTC"
         id = "M81224.1"
         name = "BNAKINI"
         description = "Rapeseed Kin1 protein (kin1) mRNA, complete cds"
-        annotations = {"accessions": ["M81224"],
-                       "data_file_division": "PLN",
-                       "date": "27-APR-1993",
-                       "gi": "167145",
-                       "keywords": [""],
-                       "molecule_type": "mRNA",
-                       "organism": "Brassica napus",
-                       "sequence_version": 1,
-                       "source": "Brassica napus (cultivar Jet neuf) cold induced leaf cDNA to mRNA",
-                       "taxonomy": ["Eukaryota", "Viridiplantae", "Embryophyta", "Tracheophyta", "Spermatophyta", "Magnoliophyta", "eudicotyledons", "core eudicots", "Rosidae", "eurosids II", "Brassicales", "Brassicaceae", "Brassica"],
-                       }
-        references = ["location: [0:441]\nauthors: Orr,W., Iu,B., White,T., Robert,L.S. and Singh,J.\ntitle: Nucleotide sequence of a winter B. napus Kin 1 cDNA\njournal: Plant Physiol. 98, 1532-1534 (1992)\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+        annotations = {
+            "accessions": ["M81224"],
+            "data_file_division": "PLN",
+            "date": "27-APR-1993",
+            "gi": "167145",
+            "keywords": [""],
+            "molecule_type": "mRNA",
+            "organism": "Brassica napus",
+            "sequence_version": 1,
+            "source": "Brassica napus (cultivar Jet neuf) cold induced leaf cDNA to mRNA",
+            "taxonomy": [
+                "Eukaryota",
+                "Viridiplantae",
+                "Embryophyta",
+                "Tracheophyta",
+                "Spermatophyta",
+                "Magnoliophyta",
+                "eudicotyledons",
+                "core eudicots",
+                "Rosidae",
+                "eurosids II",
+                "Brassicales",
+                "Brassicaceae",
+                "Brassica",
+            ],
+        }
+        references = [
+            "location: [0:441]\nauthors: Orr,W., Iu,B., White,T., Robert,L.S. and Singh,J.\ntitle: Nucleotide sequence of a winter B. napus Kin 1 cDNA\njournal: Plant Physiol. 98, 1532-1534 (1992)\nmedline id: \npubmed id: \ncomment: \n"
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:441](+)
 qualifiers:
@@ -985,14 +2918,20 @@ qualifiers:
     Key: dev_stage, Value: ['cold induced']
     Key: organism, Value: ['Brassica napus']
     Key: tissue_type, Value: ['leaf']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [33:300](+)
 qualifiers:
     Key: gene, Value: ['kin1']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [33:231](+)
 qualifiers:
@@ -1002,75 +2941,128 @@ qualifiers:
     Key: gene, Value: ['kin1']
     Key: protein_id, Value: ['AAA32993.1']
     Key: translation, Value: ['MADNKQSFQAGQASGRAEEKGNVLMDKVKDAATAAGASAQTAGQKITEAAGGAVNLVKEKTGMNK']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: polyA_signal
 location: [240:247](+)
 qualifiers:
     Key: gene, Value: ['kin1']
     Key: note, Value: ['putative']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: polyA_signal
 location: [293:300](+)
 qualifiers:
     Key: gene, Value: ['kin1']
     Key: note, Value: ['putative']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: polyA_site
 location: [440:441](+)
 qualifiers:
     Key: gene, Value: ['kin1']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
         record = next(records)
         seq = "GGACAAGGCCAAGGATGCTGCTGCTGCAGCTGGAGCTTCCGCGCAACAAGTAAA...GGC"
         id = "AJ237582.1"
         name = "ARU237582"
         description = "Armoracia rusticana csp14 gene (partial), exons 2-3"
-        annotations = {"accessions": ["AJ237582"],
-                       "data_file_division": "PLN",
-                       "date": "24-MAR-1999",
-                       "gi": "4538892",
-                       "keywords": ["cold shock protein", "csp14 gene"],
-                       "molecule_type": "DNA",
-                       "organism": "Armoracia rusticana",
-                       "sequence_version": 1,
-                       "source": "horseradish",
-                       "taxonomy": ["Eukaryota", "Viridiplantae", "Streptophyta", "Embryophyta", "Tracheophyta", "euphyllophytes", "Spermatophyta", "Magnoliophyta", "eudicotyledons", "Rosidae", "Capparales", "Brassicaceae", "Armoracia"],
-                       }
-        references = ["location: [0:206]\nauthors: Baymiev,A.K., Gimalov,F.R. and Vakhitov,V.A.\ntitle: \njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n", "location: [0:206]\nauthors: Baymiev,A.K.\ntitle: Direct Submission\njournal: Submitted (20-MAR-1999) Baymiev A.K., Departament of Biochemistry and Cytochemistry, Ufa Scientific Centre, pr. Oktyabrya 69, Ufa, Bashkortostan, Russia, 450054, RUSSIA\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+        annotations = {
+            "accessions": ["AJ237582"],
+            "data_file_division": "PLN",
+            "date": "24-MAR-1999",
+            "gi": "4538892",
+            "keywords": ["cold shock protein", "csp14 gene"],
+            "molecule_type": "DNA",
+            "organism": "Armoracia rusticana",
+            "sequence_version": 1,
+            "source": "horseradish",
+            "taxonomy": [
+                "Eukaryota",
+                "Viridiplantae",
+                "Streptophyta",
+                "Embryophyta",
+                "Tracheophyta",
+                "euphyllophytes",
+                "Spermatophyta",
+                "Magnoliophyta",
+                "eudicotyledons",
+                "Rosidae",
+                "Capparales",
+                "Brassicaceae",
+                "Armoracia",
+            ],
+        }
+        references = [
+            "location: [0:206]\nauthors: Baymiev,A.K., Gimalov,F.R. and Vakhitov,V.A.\ntitle: \njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:206]\nauthors: Baymiev,A.K.\ntitle: Direct Submission\njournal: Submitted (20-MAR-1999) Baymiev A.K., Departament of Biochemistry and Cytochemistry, Ufa Scientific Centre, pr. Oktyabrya 69, Ufa, Bashkortostan, Russia, 450054, RUSSIA\nmedline id: \npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:206](+)
 qualifiers:
     Key: country, Value: ['Russia:Bashkortostan']
     Key: db_xref, Value: ['taxon:3704']
     Key: organism, Value: ['Armoracia rusticana']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: mRNA
 location: join{[<0:48](+), [142:>206](+)}
 qualifiers:
     Key: gene, Value: ['csp14']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: exon
 location: [0:48](+)
 qualifiers:
     Key: gene, Value: ['csp14']
     Key: number, Value: ['2']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [0:206](+)
 qualifiers:
     Key: gene, Value: ['csp14']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[<0:48](+), [142:>206](+)}
 qualifiers:
@@ -1080,56 +3072,99 @@ qualifiers:
     Key: product, Value: ['cold shock protein']
     Key: protein_id, Value: ['CAB39890.1']
     Key: translation, Value: ['DKAKDAAAAAGASAQQAGKNISDAAAGGVNFVKEKTG']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: intron
 location: [48:142](+)
 qualifiers:
     Key: gene, Value: ['csp14']
     Key: number, Value: ['2']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: exon
 location: [142:206](+)
 qualifiers:
     Key: gene, Value: ['csp14']
     Key: number, Value: ['3']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
         record = next(records)
         seq = "AACAAAACTCAATAAATAAACAAATGGCAGACAACAAGCAGAGCTTCCAAGCCG...TTT"
         id = "L31939.1"
         name = "BRRBIF72"
         description = "Brassica rapa (clone bif72) kin mRNA, complete cds"
-        annotations = {"accessions": ["L31939"],
-                       "data_file_division": "PLN",
-                       "date": "01-MAR-1996",
-                       "gi": "1209261",
-                       "keywords": [""],
-                       "molecule_type": "mRNA",
-                       "organism": "Brassica rapa",
-                       "sequence_version": 1,
-                       "source": "Brassica rapa flower cDNA to mRNA",
-                       "taxonomy": ["Eukaryota", "Viridiplantae", "Embryophyta", "Tracheophyta", "Spermatophyta", "Magnoliophyta", "eudicotyledons", "core eudicots", "Rosidae", "eurosids II", "Brassicales", "Brassicaceae", "Brassica"],
-                       }
-        references = ["location: [0:282]\nauthors: Kim,J.-B., Kim,H.-U., Park,B.-S., Yun,C.-H., Cho,W.-S., Ryu,J.-C. and Chung,T.-Y.\ntitle: Nucleotide sequences of kin gene in chinese cabbage\njournal: Unpublished (1994)\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+        annotations = {
+            "accessions": ["L31939"],
+            "data_file_division": "PLN",
+            "date": "01-MAR-1996",
+            "gi": "1209261",
+            "keywords": [""],
+            "molecule_type": "mRNA",
+            "organism": "Brassica rapa",
+            "sequence_version": 1,
+            "source": "Brassica rapa flower cDNA to mRNA",
+            "taxonomy": [
+                "Eukaryota",
+                "Viridiplantae",
+                "Embryophyta",
+                "Tracheophyta",
+                "Spermatophyta",
+                "Magnoliophyta",
+                "eudicotyledons",
+                "core eudicots",
+                "Rosidae",
+                "eurosids II",
+                "Brassicales",
+                "Brassicaceae",
+                "Brassica",
+            ],
+        }
+        references = [
+            "location: [0:282]\nauthors: Kim,J.-B., Kim,H.-U., Park,B.-S., Yun,C.-H., Cho,W.-S., Ryu,J.-C. and Chung,T.-Y.\ntitle: Nucleotide sequences of kin gene in chinese cabbage\njournal: Unpublished (1994)\nmedline id: \npubmed id: \ncomment: \n"
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:282](+)
 qualifiers:
     Key: db_xref, Value: ['taxon:3711']
     Key: dev_stage, Value: ['flower']
     Key: organism, Value: ['Brassica rapa']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [23:221](+)
 qualifiers:
     Key: gene, Value: ['kin']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [23:221](+)
 qualifiers:
@@ -1138,49 +3173,90 @@ qualifiers:
     Key: gene, Value: ['kin']
     Key: protein_id, Value: ['AAA91051.1']
     Key: translation, Value: ['MADNKQSFQAGQAAGRAEEKGNVLLMDKVKDAATAAGALQTAGQKITEAAGGAVNLVKEKTGMNK']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
         record = next(records)
         seq = "ATGGCAGACAACAAGCAGAGCTTCCAAGCCGGTCAAGCCGCTGGTCGTGCTGAG...TAG"
         id = "AF297471.1"
         name = "AF297471"
         description = "Brassica napus BN28a (BN28a) gene, complete cds"
-        annotations = {"accessions": ["AF297471"],
-                       "data_file_division": "PLN",
-                       "date": "14-SEP-2000",
-                       "gi": "10121868",
-                       "keywords": [""],
-                       "molecule_type": "DNA",
-                       "organism": "Brassica napus",
-                       "sequence_version": 1,
-                       "source": "rape",
-                       "taxonomy": ["Eukaryota", "Viridiplantae", "Embryophyta", "Tracheophyta", "Spermatophyta", "Magnoliophyta", "eudicotyledons", "core eudicots", "Rosidae", "eurosids II", "Brassicales", "Brassicaceae", "Brassica"],
-                       }
-        references = ["location: [0:497]\nauthors: Byass,L.J. and Flanagan,A.M.\ntitle: BN28a, a low temperature-induced gene of Brassica napus\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n", "location: [0:497]\nauthors: Byass,L.J. and Flanagan,A.M.\ntitle: Direct Submission\njournal: Submitted (18-AUG-2000) AFNS, University of Alberta, 4-10 Agriculture/Forestry Centre, Edmonton, Alberta T6G 2P5, Canada\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+        annotations = {
+            "accessions": ["AF297471"],
+            "data_file_division": "PLN",
+            "date": "14-SEP-2000",
+            "gi": "10121868",
+            "keywords": [""],
+            "molecule_type": "DNA",
+            "organism": "Brassica napus",
+            "sequence_version": 1,
+            "source": "rape",
+            "taxonomy": [
+                "Eukaryota",
+                "Viridiplantae",
+                "Embryophyta",
+                "Tracheophyta",
+                "Spermatophyta",
+                "Magnoliophyta",
+                "eudicotyledons",
+                "core eudicots",
+                "Rosidae",
+                "eurosids II",
+                "Brassicales",
+                "Brassicaceae",
+                "Brassica",
+            ],
+        }
+        references = [
+            "location: [0:497]\nauthors: Byass,L.J. and Flanagan,A.M.\ntitle: BN28a, a low temperature-induced gene of Brassica napus\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:497]\nauthors: Byass,L.J. and Flanagan,A.M.\ntitle: Direct Submission\njournal: Submitted (18-AUG-2000) AFNS, University of Alberta, 4-10 Agriculture/Forestry Centre, Edmonton, Alberta T6G 2P5, Canada\nmedline id: \npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:497](+)
 qualifiers:
     Key: cultivar, Value: ['Cascade']
     Key: db_xref, Value: ['taxon:3708']
     Key: organism, Value: ['Brassica napus']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: mRNA
 location: join{[<0:54](+), [240:309](+), [422:>497](+)}
 qualifiers:
     Key: gene, Value: ['BN28a']
     Key: product, Value: ['BN28a']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [<0:>497](+)
 qualifiers:
     Key: gene, Value: ['BN28a']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[0:54](+), [240:309](+), [422:497](+)}
 qualifiers:
@@ -1191,10 +3267,22 @@ qualifiers:
     Key: product, Value: ['BN28a']
     Key: protein_id, Value: ['AAG13407.1']
     Key: translation, Value: ['MADNKQSFQAGQAAGRAEEKGNVLMDKVKDAATAAGASAQTAGQKITEAAGGAVNLVKEKTGMNK']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_03(self):
         path = "GenBank/iro.gb"
@@ -1205,8 +3293,9 @@ qualifiers:
         id = "AL109817.1"
         name = "IRO125195"
         description = "Homo sapiens mRNA full length insert cDNA clone EUROIMAGE 125195"
-        annotations = {"accessions": ["AL109817"],
-                       "comment": """\
+        annotations = {
+            "accessions": ["AL109817"],
+            "comment": """\
 EURO-IMAGE Consortium Contact: Auffray C
 CNRS UPR 420 - Genetique Moleculaire et Biologie du Developement
 IFR 1221 - Rue Guy Moquet 19, Batiment G - BP 8
@@ -1220,18 +3309,35 @@ IMPORTANT: This sequence represents the full insert of this IMAGE
 cDNA clone. No attempt has been made to verify whether this
 corresponds to the full-length of the original mRNA from which it
 was derived.""",
-                       "data_file_division": "PRI",
-                       "date": "11-AUG-1999",
-                       "gi": "5731880",
-                       "keywords": ["FLI_CDNA"],
-                       "molecule_type": "mRNA",
-                       "organism": "Homo sapiens",
-                       "sequence_version": 1,
-                       "source": "human",
-                       "taxonomy": ["Eukaryota", "Metazoa", "Chordata", "Craniata", "Vertebrata", "Mammalia", "Eutheria", "Primates", "Catarrhini", "Hominidae", "Homo"],
-                       }
-        references = ["location: [0:1326]\nauthors: Auffray,C., Ansorge,W., Ballabio,A., Estivill,X., Gibson,K., Lehrach,H., Poustka,A. and Lundeberg,J.\ntitle: The European IMAGE consortium for integrated Molecular analysis of human gene transcripts\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n", "location: [0:1326]\nauthors: Carim,L., Estivill,X., Sumoy,L. and Escarceller,M.\ntitle: Direct Submission\njournal: Submitted (11-AUG-1999) Dept. Genetica Molecular, Institut de Recerca Oncologica (IRO), Hospital Duran i Reynals, Autovia de Castelldefels Km 2,7 L'Hospitalet de Llobregat, 08907 Barcelona, Catalunya, SPAIN. Tel: ++34-93-260-7775 Fax: ++34-93-260-7776 WWW site: http://www.iro.es e-mail enquiries: lsumoy@iro.es, mescarceller@iro.es\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+            "data_file_division": "PRI",
+            "date": "11-AUG-1999",
+            "gi": "5731880",
+            "keywords": ["FLI_CDNA"],
+            "molecule_type": "mRNA",
+            "organism": "Homo sapiens",
+            "sequence_version": 1,
+            "source": "human",
+            "taxonomy": [
+                "Eukaryota",
+                "Metazoa",
+                "Chordata",
+                "Craniata",
+                "Vertebrata",
+                "Mammalia",
+                "Eutheria",
+                "Primates",
+                "Catarrhini",
+                "Hominidae",
+                "Homo",
+            ],
+        }
+        references = [
+            "location: [0:1326]\nauthors: Auffray,C., Ansorge,W., Ballabio,A., Estivill,X., Gibson,K., Lehrach,H., Poustka,A. and Lundeberg,J.\ntitle: The European IMAGE consortium for integrated Molecular analysis of human gene transcripts\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:1326]\nauthors: Carim,L., Estivill,X., Sumoy,L. and Escarceller,M.\ntitle: Direct Submission\njournal: Submitted (11-AUG-1999) Dept. Genetica Molecular, Institut de Recerca Oncologica (IRO), Hospital Duran i Reynals, Autovia de Castelldefels Km 2,7 L'Hospitalet de Llobregat, 08907 Barcelona, Catalunya, SPAIN. Tel: ++34-93-260-7775 Fax: ++34-93-260-7776 WWW site: http://www.iro.es e-mail enquiries: lsumoy@iro.es, mescarceller@iro.es\nmedline id: \npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:1326](+)
 qualifiers:
@@ -1241,37 +3347,61 @@ qualifiers:
     Key: db_xref, Value: ['taxon:9606']
     Key: note, Value: ['contains Alu repeat; likely to be be derived from unprocessed nuclear RNA or genomic DNA; encodes putative exons identical to FTCD; formimino transferase cyclodeaminase; formimino transferase (EC 2.1.2.5) /formimino tetrahydro folate cyclodeaminase (EC 4.3.1.4)']
     Key: organism, Value: ['Homo sapiens']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [340:756](+)
 qualifiers:
     Key: gene, Value: ['FTCD']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: exon
 location: [340:384](+)
 qualifiers:
     Key: gene, Value: ['FTCD']
     Key: number, Value: ['1']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: intron
 location: [384:617](+)
 qualifiers:
     Key: gene, Value: ['FTCD']
     Key: number, Value: ['1']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: exon
 location: [617:756](+)
 qualifiers:
     Key: gene, Value: ['FTCD']
     Key: number, Value: ['2']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_04(self):
         path = "GenBank/pri1.gb"
@@ -1282,19 +3412,38 @@ qualifiers:
         id = "U05344.1"
         name = "HUGLUT1"
         description = "Human fructose transporter (GLUT5) gene, promoter and exon 1"
-        annotations = {"accessions": ["U05344"],
-                       "data_file_division": "PRI",
-                       "date": "16-NOV-1994",
-                       "gi": "452475",
-                       "keywords": [""],
-                       "molecule_type": "DNA",
-                       "organism": "Homo sapiens",
-                       "sequence_version": 1,
-                       "source": "human",
-                       "taxonomy": ["Eukaryota", "Metazoa", "Chordata", "Craniata", "Vertebrata", "Euteleostomi", "Mammalia", "Eutheria", "Primates", "Catarrhini", "Hominidae", "Homo"],
-                       }
-        references = ["location: [0:741]\nauthors: Mahraoui,L., Takeda,J., Mesonero,J., Chantret,I., Dussaulx,E., Bell,G.I. and Brot-Laroche,E.\ntitle: Regulation of expression of the human fructose transporter (GLUT5) by cyclic AMP\njournal: Biochem. J. 301 (Pt 1), 169-175 (1994)\nmedline id: 94311827\npubmed id: \ncomment: \n", "location: [0:741]\nauthors: Takeda,J.\ntitle: Direct Submission\njournal: Submitted (24-JAN-1994) Jun Takeda, Howard Hughes Medical Institute, The University of Chicago, 5841 S. Maryland Ave., Chicago, IL 60637, USA\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+        annotations = {
+            "accessions": ["U05344"],
+            "data_file_division": "PRI",
+            "date": "16-NOV-1994",
+            "gi": "452475",
+            "keywords": [""],
+            "molecule_type": "DNA",
+            "organism": "Homo sapiens",
+            "sequence_version": 1,
+            "source": "human",
+            "taxonomy": [
+                "Eukaryota",
+                "Metazoa",
+                "Chordata",
+                "Craniata",
+                "Vertebrata",
+                "Euteleostomi",
+                "Mammalia",
+                "Eutheria",
+                "Primates",
+                "Catarrhini",
+                "Hominidae",
+                "Homo",
+            ],
+        }
+        references = [
+            "location: [0:741]\nauthors: Mahraoui,L., Takeda,J., Mesonero,J., Chantret,I., Dussaulx,E., Bell,G.I. and Brot-Laroche,E.\ntitle: Regulation of expression of the human fructose transporter (GLUT5) by cyclic AMP\njournal: Biochem. J. 301 (Pt 1), 169-175 (1994)\nmedline id: 94311827\npubmed id: \ncomment: \n",
+            "location: [0:741]\nauthors: Takeda,J.\ntitle: Direct Submission\njournal: Submitted (24-JAN-1994) Jun Takeda, Howard Hughes Medical Institute, The University of Chicago, 5841 S. Maryland Ave., Chicago, IL 60637, USA\nmedline id: \npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:741](+)
 qualifiers:
@@ -1306,35 +3455,59 @@ qualifiers:
     Key: map, Value: ['1p31']
     Key: organism, Value: ['Homo sapiens']
     Key: tissue_type, Value: ['liver']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: repeat_region
 location: [0:73](+)
 qualifiers:
     Key: rpt_family, Value: ['Alu']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: promoter
 location: [0:513](+)
 qualifiers:
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: 5'UTR
 location: [513:609](+)
 qualifiers:
     Key: gene, Value: ['GLUT5']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: exon
 location: [513:642](+)
 qualifiers:
     Key: gene, Value: ['GLUT5']
     Key: number, Value: ['1']
     Key: product, Value: ['fructose transporter']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_05(self):
         path = "GenBank/arab1.gb"
@@ -1345,21 +3518,44 @@ qualifiers:
         id = "AC007323.5"
         name = "AC007323"
         description = "Genomic sequence for Arabidopsis thaliana BAC T25K16 from chromosome I, complete sequence"
-        annotations = {"accessions": ["AC007323"],
-                       "comment": """\
+        annotations = {
+            "accessions": ["AC007323"],
+            "comment": """\
 On Dec 16, 1999 this sequence version replaced gi:5729683.""",
-                       "data_file_division": "PLN",
-                       "date": "19-JAN-2000",
-                       "gi": "6587720",
-                       "keywords": ["HTG"],
-                       "molecule_type": "DNA",
-                       "organism": "Arabidopsis thaliana",
-                       "sequence_version": 5,
-                       "source": "thale cress",
-                       "taxonomy": ["Eukaryota", "Viridiplantae", "Embryophyta", "Tracheophyta", "Spermatophyta", "Magnoliophyta", "eudicotyledons", "core eudicots", "Rosidae", "eurosids II", "Brassicales", "Brassicaceae", "Arabidopsis"],
-                       }
-        references = ["location: [0:86436]\nauthors: Dunn,P., Shinn,P., Brooks,S., Buehler,E., Chao,Q., Johnson-Hopson,C., Khan,S., Kim,C., Altafi,H., Bei,Q., Chin,C., Chiou,J., Choi,E., Conn,L., Conway,A., Gonzales,A., Hansen,N., Howing,B., Koo,T., Lam,B., Lee,J., Lenz,C., Li,J., Liu,A., Liu,K., Liu,S., Mukharsky,N., Nguyen,M., Palm,C., Pham,P., Sakano,H., Schwartz,J., Southwick,A., Thaveri,A., Toriumi,M., Vaysberg,M., Yu,G., Federspiel,N.A., Theologis,A. and Ecker,J.R.\ntitle: Genomic sequence for Arabidopsis thaliana BAC T25K16 from chromosome I\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n", "location: [0:86436]\nauthors: Ecker,J.R.\ntitle: Direct Submission\njournal: Submitted (17-APR-1999) Arabidopsis thaliana Genome Center, Department of Biology, University of Pennsylvania, 38th Street and Hamilton Walk, Philadelphia, Pennsylvania 19104-6018, USA\nmedline id: \npubmed id: \ncomment: \n", "location: [0:86436]\nauthors: Ecker,J.R.\ntitle: Direct Submission\njournal: Submitted (11-AUG-1999) Arabidopsis thaliana Genome Center, Department of Biology, University of Pennsylvania, 38th Street and Hamilton Walk, Philadelphia, Pennsylvania 19104-6018, USA\nmedline id: \npubmed id: \ncomment: \n", "location: [0:86436]\nauthors: Ecker,J.R.\ntitle: Direct Submission\njournal: Submitted (16-DEC-1999) Arabidopsis thaliana Genome Center, Department of Biology, University of Pennsylvania, 38th Street and Hamilton Walk, Philadelphia, Pennsylvania 19104-6018, USA\nmedline id: \npubmed id: \ncomment: \n", "location: [0:86436]\nauthors: Chao,Q., Brooks,S., Buehler,E., Johnson-Hopson,C., Khan,S., Kim,C., Shinn,P., Altafi,H., Bei,B., Chin,C., Chiou,J., Choi,E., Conn,L., Conway,A., Gonzalez,A., Hansen,N., Howing,B., Koo,T., Lam,B., Lee,J., Lenz,C., Li,J., Liu,A., Liu,J., Liu,S., Mukharsky,N., Nguyen,M., Palm,C., Pham,P., Sakano,H., Schwartz,J., Southwick,A., Thaveri,A., Toriumi,M., Vaysberg,M., Yu,G., Davis,R., Federspiel,N., Theologis,A. and Ecker,J.\ntitle: Direct Submission\njournal: Submitted (19-JAN-2000) Arabidopsis thaliana Genome Center, Department of Biology, University of Pennsylvania, 38th and Hamilton Walk, Philadelphia, PA 19104-6018, USA\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+            "data_file_division": "PLN",
+            "date": "19-JAN-2000",
+            "gi": "6587720",
+            "keywords": ["HTG"],
+            "molecule_type": "DNA",
+            "organism": "Arabidopsis thaliana",
+            "sequence_version": 5,
+            "source": "thale cress",
+            "taxonomy": [
+                "Eukaryota",
+                "Viridiplantae",
+                "Embryophyta",
+                "Tracheophyta",
+                "Spermatophyta",
+                "Magnoliophyta",
+                "eudicotyledons",
+                "core eudicots",
+                "Rosidae",
+                "eurosids II",
+                "Brassicales",
+                "Brassicaceae",
+                "Arabidopsis",
+            ],
+        }
+        references = [
+            "location: [0:86436]\nauthors: Dunn,P., Shinn,P., Brooks,S., Buehler,E., Chao,Q., Johnson-Hopson,C., Khan,S., Kim,C., Altafi,H., Bei,Q., Chin,C., Chiou,J., Choi,E., Conn,L., Conway,A., Gonzales,A., Hansen,N., Howing,B., Koo,T., Lam,B., Lee,J., Lenz,C., Li,J., Liu,A., Liu,K., Liu,S., Mukharsky,N., Nguyen,M., Palm,C., Pham,P., Sakano,H., Schwartz,J., Southwick,A., Thaveri,A., Toriumi,M., Vaysberg,M., Yu,G., Federspiel,N.A., Theologis,A. and Ecker,J.R.\ntitle: Genomic sequence for Arabidopsis thaliana BAC T25K16 from chromosome I\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:86436]\nauthors: Ecker,J.R.\ntitle: Direct Submission\njournal: Submitted (17-APR-1999) Arabidopsis thaliana Genome Center, Department of Biology, University of Pennsylvania, 38th Street and Hamilton Walk, Philadelphia, Pennsylvania 19104-6018, USA\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:86436]\nauthors: Ecker,J.R.\ntitle: Direct Submission\njournal: Submitted (11-AUG-1999) Arabidopsis thaliana Genome Center, Department of Biology, University of Pennsylvania, 38th Street and Hamilton Walk, Philadelphia, Pennsylvania 19104-6018, USA\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:86436]\nauthors: Ecker,J.R.\ntitle: Direct Submission\njournal: Submitted (16-DEC-1999) Arabidopsis thaliana Genome Center, Department of Biology, University of Pennsylvania, 38th Street and Hamilton Walk, Philadelphia, Pennsylvania 19104-6018, USA\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:86436]\nauthors: Chao,Q., Brooks,S., Buehler,E., Johnson-Hopson,C., Khan,S., Kim,C., Shinn,P., Altafi,H., Bei,B., Chin,C., Chiou,J., Choi,E., Conn,L., Conway,A., Gonzalez,A., Hansen,N., Howing,B., Koo,T., Lam,B., Lee,J., Lenz,C., Li,J., Liu,A., Liu,J., Liu,S., Mukharsky,N., Nguyen,M., Palm,C., Pham,P., Sakano,H., Schwartz,J., Southwick,A., Thaveri,A., Toriumi,M., Vaysberg,M., Yu,G., Davis,R., Federspiel,N., Theologis,A. and Ecker,J.\ntitle: Direct Submission\njournal: Submitted (19-JAN-2000) Arabidopsis thaliana Genome Center, Department of Biology, University of Pennsylvania, 38th and Hamilton Walk, Philadelphia, PA 19104-6018, USA\nmedline id: \npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:86436](+)
 qualifiers:
@@ -1367,8 +3563,11 @@ qualifiers:
     Key: clone, Value: ['T25K16']
     Key: db_xref, Value: ['taxon:3702']
     Key: organism, Value: ['Arabidopsis thaliana']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[3461:3615](+), [3697:3978](+), [4076:4307](+), [4407:4797](+), [4875:5028](+), [5140:5332](+)}
 qualifiers:
@@ -1379,8 +3578,11 @@ qualifiers:
     Key: product, Value: ['T25K16.1']
     Key: protein_id, Value: ['AAF26460.1']
     Key: translation, Value: ['MEDQVGFGFRPNDEELVGHYLRNKIEGNTSRDVEVAISEVNICSYDPWNLRFQSKYKSRDAMWYFFSRRENNKGNRQSRTTVSGKWKLTGESVEVKDQWGFCSEGFRGKIGHKRVLVFLDGRYPDKTKSDWVIHEFHYDLLPEHQKLCNVTLFRFSSYFRLSLLSPMFYTDELMCLPPEILQRTYVICRLEYKGDDADILSAYAIDPTPAFVPNMTSSAGSVVNQSRQRNSGSYNTYSEYDSANHGQQFNENSNIMQQQPLQGSFNPLLEYDFANHGGQWLSDYIDLQQQVPYLAPYENESEMIWKHVIEENFEFLVDERTSMQQHYSDHRPKKPVSGVLPDDSSDTETGSMIFEDTSSSTDSVGSSDEPGHTRIDDIPSLNIIEPLHNYKAQEQPKQQSKEKVISSQKSECEWKMAEDSIKIPPSTNTVKQSWIVLENAQWNYLKNMIIGVLLFISVISWIILVG']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[8272:8368](-), [8086:8166](-), [7915:7998](-), [7463:7603](-), [7265:7351](-), [6616:6953](-)}
 qualifiers:
@@ -1391,8 +3593,11 @@ qualifiers:
     Key: product, Value: ['T25K16.2']
     Key: protein_id, Value: ['AAF26477.1']
     Key: translation, Value: ['MAASEHRCVGCGFRVKSLFIQYSPGNIRLMKCGNCKEVADEYIECERMVCFNHFLSLFGPKVYRHVLYNAINPATVNIQVKNYFNSTSRCVVGEIHRQTYLKSPELIIDRSLLLRKSDEESSFSDSPVLLSIKVLIGVLSANAAFIISFAIATKGLLNEVSRESLLLQVWEFPMSVIFFVDILLLTSNSMALKGQTFKMFSMQIVFCCCYFGISQCKFVFKPVMTESTMTRCIAVCLIAHLIRFLVGQIFEPTIFLIQIGSLLQYMSYFFRIV']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: [11565:12642](-)
 qualifiers:
@@ -1403,8 +3608,11 @@ qualifiers:
     Key: product, Value: ['T25K16.3']
     Key: protein_id, Value: ['AAF26476.1']
     Key: translation, Value: ['MDLSLAPTTTTSSDQEQDRDQELTSNIGASSSSGPSGNNNNLPMMMIPPPEKEHMFDKVVTPSDVGKLNRLVIPKQHAERYFPLDSSNNQNGTLLNFQDRNGKMWRFRYSYWNSSQSYVMTKGWSRFVKEKKLDAGDIVSFQRGIGDESERSKLYIDWRHRPDMSLVQAHQFGNFGFNFNFPTTSQYSNRFHPLPEYNSVPIHRGLNIGNHQRSYYNTQRQEFVGYGYGNLAGRCYYTGSPLDHRNIVGSEPLVIDSVPVVPGRLTPVMLPPLPPPPSTAGKRLRLFGVNMECGNDYNQQEESWLVPRGEIGASSSSSSALRLNLSTDHDDDNDDGDDGDDDQFAKKGKSSLSLNFNP']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[23220:24174](+), [24243:24357](+), [24411:24664](+), [24742:25137](+), [25225:25445](+), [25526:25711](+), [25782:25905](+), [25993:26478](+), [26563:26730](+), [26813:26983](+), [27073:27235](+), [27319:27415](+), [27504:28133](+), [28313:28507](+), [28591:28782](+), [28861:30013](+), [30111:30518](+), [30603:30781](+)}
 qualifiers:
@@ -1415,8 +3623,11 @@ qualifiers:
     Key: product, Value: ['T25K16.4']
     Key: protein_id, Value: ['AAF26461.1']
     Key: translation, Value: ['MVMEDEPREATIKPSYWLDACEDISCDLIDDLVSEFDPSSVAVNESTDENGVINDFFGGIDHILDSIKNGGGLPNNGVSDTNSQINEVTVTPQVIAKETVKENGLQKNGGKRDEFSKEEGDKDRKRARVCSYQSERSNLSGRGHVNNSREGDRFMNRKRTRNWDEAGNNKKKRECNNYRRDGRDREVRGYWERDKVGSNELVYRSGTWEADHERDVKKVSGGNRECDVKAEENKSKPEERKEKVVEEQARRYQLDVLEQAKAKNTIAFLETGAGKTLIAILLIKSVHKDLMSQNRKMLSVFLVPKVPLVYQVPPNKKHQAEVIRNQTCFQVGHYCGEMGQDFWDSRRWQREFESKQFLKLTSFFLFSSTQVLVMTAQILLNILRHSIIRMETIDLLILDECHHAVKKHPYSLVMSEFYHTTPKDKRPAIFGMTASPVNLKGVSSQVDCAIKIRNLETKLDSTVCTIKDRKELEKHVPMPSEIVVEYDKAATMWSLHETIKQMIAAVEEAAQASSRKSKWQFMGARDAGAKDELRQVYGVSERTESDGAANLIHKLRAINYTLAELGQWCAYKVGQSFLSALQSDERVNFQVDVKFQESYLSEVVSLLQCELLEGAAAEKVAAEVGKPENGNAHDEMEEGELPDDPVVSGGEHVDEVIGAAVADGKVTPKVQSLIKLLLKYQHTADFRAIVFVERVVAALVLPKVRIKVFAELPSLSFIRCASMIGHNNSQEMKSSQMQDTISKFRDGHVTLLVATSVAEEGLDIRQCNVVMRFDLAKTVLAYIQSRGRARKPGSDYILMVERYIKSFKNYILIFVTTGHQISTDMSTCVTCRGNVSHAAFLRNARNSEETLRKEAIERTDLSHLKDTSRLISIDAVPGTVYKVEATGAMVSLNSAVGLVHFYCSQLPGDRYAILRPEFSMEKHEKPGGHTEYSCRLQLPCNAPFEILEGPVCSSMRLAQQVDIIVSACKKLHEMGAFTDMLLPDKGSGQDAEKADQDDEGEPVPGTARHREFYPEGVADVLKGEWVSSGKEVCESSKLFHLYMYNVRCVDFGSSKDPFLSEVSEFAILFGNELDAEVLSMSMDLYVARAMITKASLAFKGSLDITENQLSSLKKFHVRLMSIVLDVDVEPSTTPWDPAKAYLFVPVTDNTSMEPIKGINWELVEKITKTTAWDNPLQRARPDVYLGTNERTLGGDRREYGFGKLRHNIVFGQKSHPTYGIRGAVASFDVVRASGLLPVRDAFEKEVEEDLSKGKLMMADGCMVAEDLIGKIVTAAHSGKRFYVDSICYDMSAETSFPRKEGYLGPLEYNTYADYYKQKIYVVQDRLFFYFLHNLRLLRLYKSSSIMLFIRYGVDLNCKQQPLIKGRGVSYCKNLLSPRFEQSGESETVLDKTYYVFLPPELCVVHPLSGSLIRGAQRLPSIMRRVESMLLAVQLKNLISYPIPTSKILEALTAASCQETFCYERAELLGDAYLKWVVSRFLFLKYPQKHEGQLTRMRQQMVSNMVLYQFALVKGLQSYIQADRFAPSRWSAPGVPPVFDEDTKDGGSSFFDEEQKPVSEENSDVFEDGEMEDGELEGDLSSYRVLSSKTLADVVEALIGVYYVEGGKIAANHLMKWIGIHVEDDPDEVDGTLKNVNVPESVLKSIDFVGLERALKYEFKEKGLLVEAITHASRPSSGVSCYQRLEFVGDAVLDHLITRHLFFTYTSLPPGRLTDLRAAAVNNENFARVAVKHKLHLYLRHGSSALEKQVNKIKKQSILFSKSFKCLTVWLLFVFQIREFVKEVQTESSKPGFNSFGLGDCKAPKVLGDIVESIAGAIFLDSGKDTTAAWKVFQPLLQPMVTPETLPMHPVRELQERCQQQAEGLEYKASRSGNTATVEVFIDGVQVGVAQNPQKKMAQKLAARNALAALKEKEIAESKEKHINNGNAGEDQGENENGNKKNGHQPFTRQTLNDICLRKNWPMPSYRCVKEGGPAHAKRFTFGVRVNTSDRGWTDECIGEPMPSVKKAKDSAAVLLLELLNKTFS']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[32248:32372](-), [32132:32161](-), [31983:32049](-), [31789:31897](-), [31634:31700](-), [31340:31515](-), [31222:31304](-), [31083:31126](-)}
 qualifiers:
@@ -1427,8 +3638,11 @@ qualifiers:
     Key: product, Value: ['T25K16.5']
     Key: protein_id, Value: ['AAF26475.1']
     Key: translation, Value: ['MSEETKDNQRLQRPAPRLNERILSSLSRRSVAAHPWHDLEIGPGAPQIFNVVVEITKGSKVKYELDKKTGLIKVDRILYSSVVYPHNYGFVPRTLCEDNDPIDVLVIMQEPVLPGCFLRARAIGLMPMIDQGEKDDKIIAVCVDDPEYKHYTDIKELPPHRLSEIRRFFEDCILFLQCSSLFISIDLSTNKKNENKEVAVNDFLPSESAVEAIQYSMDLYAEYILHTLRR']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[36724:36763](-), [36511:36623](-), [36325:36387](-), [35431:35701](-), [35268:35349](-), [34102:35173](-), [33693:34029](-)}
 qualifiers:
@@ -1439,8 +3653,11 @@ qualifiers:
     Key: product, Value: ['T25K16.6']
     Key: protein_id, Value: ['AAF26474.1']
     Key: translation, Value: ['MDTNTSGEELLAKARKPYTITKQRERWTEDEHERFLEALRLYGRAWQRIEEHIGTKTAVQIRSHAQKFFTKFGKAHSFWFTFQLEKEAEVKGIPVCQALDIEIPPPRPKRKPNTPYPRKPGNNGTSSSQVSSAKDAKLVSSASSSQLNQAFLDLEKMPFSEKTSTGKENQDENCSGVSTVNKYPLPTKVSGDIETSKTSTVDNAVQDVPKKNKDKDGNDGTTVHSMQNYPWHFHADIVNGNIAKCPQNHPSGMVSQDFMFHPMREETHGHANLQATTASATTTASHQAFPACHSQDDYRSFLQISSTFSNLIMSTLLQNPAAHAAATFAASVWPYASVGNSGDSSTPMSSSPPSITAIAAATVAAATAWWASHGLLPVCAPAPITCVPFSTVAVPTPAMTEMDTVENTQPFEKQNTALQDQNLASKSPASSSDDSDETGVTKLNADSKTNDDKIEEVVVTAAVHDSNTAQKKNLVDRSSCGSNTPSGSDAETDALDKMEKDKEDVKETDENQPDVIELNNRKIKMRDNNSNNNATTDSWKEVSEEGRIAFQALFARERLPQSFSPPQVAENVNRKQSDTSMPLAPNFKSQDSCAADQEGVVMIGVGTCKSLKTRQTGFKPYKRCSMEVKESQVGNINNQSDEKVCKRLRLEGEAST']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[40376:40579](-), [39914:40031](-), [39110:39516](-), [38837:38989](-), [38599:38756](-)}
 qualifiers:
@@ -1451,8 +3668,11 @@ qualifiers:
     Key: product, Value: ['T25K16.7']
     Key: protein_id, Value: ['AAF26473.1']
     Key: translation, Value: ['MAGDMQGVRVVEKYSPVIVMVMSNVAMGSVNALVKKALDVGVNHMVIGAYRMAISALILVPFAYVLERASLMQFFFLLGLSYTSATVSCALVSMLPAITFALALIFRTENVKILKTKAGMLKVIGTLICISGALFLTFYKGPQISNSHSHSHGGASHNNNDQDKANNWLLGCLYLTIGTVLLSLWMLFQGTLSIKYPCKYSSTCLMSIFAAFQCALLSLYKSRDVNDWIIDDRFVITVIIYAGVVGQAMTTVATTWGIKKLGAVFASAFFPLTLISATLFDFLILHTPLYLGSVIGSLVTITGLYMFLWGKNKETESSTALSSGMDNEAQYTTPNKDNDSKSPV']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[48637:48868](-), [47776:48554](-), [47447:47684](-), [46074:46313](-), [45718:45847](-), [45342:45656](-), [45149:45261](-)}
 qualifiers:
@@ -1463,8 +3683,11 @@ qualifiers:
     Key: product, Value: ['T25K16.8']
     Key: protein_id, Value: ['AAF26472.1']
     Key: translation, Value: ['MATAFAPTKLTATVPLHGSHENRLLLPIRLAPPSSFLGSTRSLSLRRLNHSNATRRSPVVSVQEVVKEKQSTNNTSLLITKEEGLELYEDMILGRSFEDMCAQMYYRGKMFGFVHLYNGQEAVSTGFIKLLTKSDSVVSTYRDHVHALSKGVSARAVMSELFGKVTGCCRGQGGSMHMFSKEHNMLGGFAFIGEGIPVATGAAFSSKYRREVLKQDCDDVTVAFFGDGTCNNGQFFECLNMAALYKLPIIFVVENNLWAIGMSHLRATSDPEIWKKGPAFGMPGVHVDGMDVLKVREVAKEAVTRARRGEGPTLVECETYRFRGHSLADPDELRDAAEKAKYAARDPIAALKKYLIENKLAKEAELKSIEKKIDELVEEAVEFADASPQPGRSQLLENVFADPKGFGIGPDGRYRSQPLQIKVSSSELSVLDEEKEEEVVKGEAEPNKDSVVSKAEPVKKPRPCELYVCNIPRSYDIAQLLDMFQPFGTVISVEVVSRNPQTGESRGSGYVTMGSINSAKIAIASLDGTVRARETKKQEVGGREMRVRYSVDMNPGTRRNPEVLNSTPKKILMYESQHKVYVGNLPWFTQPDGLRNHFSKFGTIVSTRVLHDRKTGRNRVFAFLSFTSGEERDAALSFNGTVNNMKVAESSSEKVSRRVSRKPTVLLLLQRHLLDTNNV']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[50584:50656](-), [50120:50333](-), [49985:50039](-)}
 qualifiers:
@@ -1475,8 +3698,11 @@ qualifiers:
     Key: product, Value: ['T25K16.9']
     Key: protein_id, Value: ['AAF26471.1']
     Key: translation, Value: ['MSTVGELACSYAVMILEDEGIAITADKIATLVKAAGVSIESYWPMLFAKMAEKRNVTDLIMNVGAGGGGGAPVAAAAPAAGGGAAAAPAAEEKKKDEPAEESDGDLGFGLFD']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[51940:52048](+), [52135:52432](+), [52639:52885](+), [53185:53326](+), [53404:54196](+)}
 qualifiers:
@@ -1487,8 +3713,11 @@ qualifiers:
     Key: product, Value: ['T25K16.10']
     Key: protein_id, Value: ['AAF26462.1']
     Key: translation, Value: ['MGKKNGSSSWLTAVKRAFRSPTKKDHSNDVEEDEEKKREKRRWFRKPATQESPVKSSGISPPAPQEDSLNVNSKPSPETAPSYATTTPPSNAGKPPSAVVPIATSASKTLAPRRIYYARENYAAVVIQTSFRGYLARRALRALKGLVKLQALVRGHNVRKQAKMTLRCMQALVRVQSRVLDQRKRLSHDGSRKSAFSDSHAVFESRYLQDLSDRQSMSREGSSAAEDWDDRPHTIDAVKVMLQRRRDTALRHDKTNLSQAFSQKMWRTVGNQSTEGHHEVELEEERPKWLDRWMATRPWDKRASSRASVDQRVSVKTVEIDTSQPYSRTGAGSPSRGQRPSSPSRTSHHYQSRNNFSATPSPAKSRPILIRSASPRCQRDPREDRDRAAYSYTSNTPSLRSNYSFTARSGCSISTTMVNNASLLPNYMASTESAKARIRSHSAPRQRPSTPERDRAGLVKKRLSYPVPPPAEYEDNNSLRSPSFKSVAGSHFGGMLEQQSNYSSCCTESNGVEISPASTSDFRNWLR']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [57093:58680](-)
 qualifiers:
@@ -1499,8 +3728,11 @@ qualifiers:
     Key: product, Value: ['T25K16.11']
     Key: protein_id, Value: ['AAF26470.1']
     Key: translation, Value: ['MERTNSIEMDRERLTAEMAFRDSSSAVIRIRRRLPDLLTSVKLKYVKLGLHNSCNVTTILFFLIILPLTGTVLVQLTGLTFDTFSELWSNQAVQLDTATRLTCLVFLSFVLTLYVANRSKPVYLVDFSCYKPEDERKISVDSFLTMTEENGSFTDDTVQFQQRISNRAGLGDETYLPRGITSTPPKLNMSEARAEAEAVMFGALDSLFEKTGIKPAEVGILIVNCSLFNPTPSLSAMIVNHYKMREDIKSYNLGGMGCSAGLISIDLANNLLKANPNSYAVVVSTENITLNWYFGNDRSMLLCNCIFRMGGAAILLSNRRQDRKKSKYSLVNVVRTHKGSDDKNYNCVYQKEDERGTIGVSLARELMSVAGDALKTNITTLGPMVLPLSEQLMFLISLVKRKMFKLKVKPYIPDFKLAFEHFCIHAGGRAVLDEVQKNLDLKDWHMEPSRMTLHRFGNTSSSSLWYEMAYTEAKGRVKAGDRLWQIAFGSGFKCNSAVWKALRPVSTEEMTGNAWAGSIDQYPVKVVQ']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[63132:63513](-), [61669:61826](-), [59507:59665](-)}
 qualifiers:
@@ -1511,8 +3743,11 @@ qualifiers:
     Key: product, Value: ['T25K16.12']
     Key: protein_id, Value: ['AAF26469.1']
     Key: translation, Value: ['MEKRSDSESVEILGDWDSPPPEERIVMVSVPTSPESDYARSNQPKEIESRVSDKETASASGEVAARRVLPPWMDPSYEWGGGKWKVDGRKNKNKKEKEKEKEEIIPFKEIIEALLGNSGDKVQQDNKVFEVAPSLHVVELRKTGDDTLEFHKVYFRFNLYQPVQLPLILFVVIRFSMLKIIHYHQFTMAHIKEFVCMWDTHLYKEITNLNIWDTLSSTLVLAIWTVNASHE']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[67025:67214](-), [66536:66599](-), [66379:66451](-), [66151:66259](-), [65963:66044](-), [65808:65862](-), [65434:65566](-), [65264:65354](-), [65032:65158](-), [64811:64919](-), [64602:64719](-), [64452:64509](-), [64271:64358](-), [64099:64177](-)}
 qualifiers:
@@ -1523,8 +3758,11 @@ qualifiers:
     Key: product, Value: ['T25K16.13']
     Key: protein_id, Value: ['AAF26468.1']
     Key: translation, Value: ['MSGSRRKATPASRTRVGNYEMGRTLGEGSFAKVKYAKNTVTGDQAAIKILDREKVFRHKMVEQLKREISTMKLIKHPNVVEIIEVMASKTKIYIVLELVNGGELFDKIAQQGRLKEDEARRYFQQLINAVDYCHSRGVYHRDLKPENLILDANGVLKVSDFGLSAFSRQVREDGLLHTACGTPNYVAPEVLSDKGYDGAAADVWSCGVILFVLMAGYLPFDEPNLMTLYKRVRICKAEFSCPPWFSQGAKRVIKRILEPNPITRISIAELLEDEWFKKGYKPPSFDQDDEDITIDDVDAAFSNSKECLVTEKKEKPVSMNAFELISSSSEFSLENLFEKQAQLVKKETRFTSQRSASEIMSKMEETAKPLGFNVRKDNYKIKMKGDKSGRKGQLSVATEVFEVAPSLHVVELRKTGGDTLEFHKVCDSFYKNFSSGLKDVVWNTDAAAEEQKQ']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[71643:71700](-), [70742:71357](-), [70533:70670](-), [69830:69987](-)}
 qualifiers:
@@ -1535,8 +3773,11 @@ qualifiers:
     Key: product, Value: ['T25K16.14']
     Key: protein_id, Value: ['AAF26467.1']
     Key: translation, Value: ['MVSDLPLDEDDIALLKSPYCDDGGDEDVNSAPNIFTYDNVPLKKRHYLGTSDTFRSFEPLNEHACIVCDIADDGVVPCSGNECPLAVHRKCVELDCEDPATFYCPYCWFKEQATRSTALRTRGVAAAKTLVQYGCSELRSGDIVMTRENSQLENGSDNSLPMQLHENLHQLQELVKHLKARNSQLDESTDQFIDMEKSCGEAYAVVNDQPKRVLWTVNEEKMLREGVEKFSDTINKNMPWKKILEMGKGIFHTTRNSSDLKDKWRNMVRIIILIWLRSRLTSSSSSQRSEIKMERERNAGVMKKMSPTGTIQRLEFVGWYL']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[72284:72371](+), [72788:72865](+), [72988:73097](+), [73189:73442](+), [73523:73585](+)}
 qualifiers:
@@ -1547,8 +3788,11 @@ qualifiers:
     Key: product, Value: ['T25K16.15']
     Key: protein_id, Value: ['AAF26463.1']
     Key: translation, Value: ['MQQQQSPQMFPMVPSIPPANNITTEQIQKYLDENKKLIMAIMENQNLGKLAECAQYQALLQKNLMYLAAIADAQPPPPTPGPSPSTAVAAQMATPHSGMQPPSYFMQHPQASPAGIFAPRGPLQFGSPLQFQDPQQQQQIHQQAMQGHMGIRPMGMTNNGMQHAMQQPETGLGGNVGLRGGKQDGADGQGKDDGK']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[74035:74145](-), [73806:73990](-)}
 qualifiers:
@@ -1559,8 +3803,11 @@ qualifiers:
     Key: product, Value: ['T25K16.16']
     Key: protein_id, Value: ['AAF26466.1']
     Key: translation, Value: ['MASGGKAKYIIGALIGSFGISYIFDKVISDNKIFGGKDDLNGYLLVKISGTTPGTVSNKEWWAATDEKFQAWPRTAGPPVVMNPISRQNFIVKTRPE']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[75334:76249](+), [76515:76653](+), [76732:76982](+), [77014:77148](+)}
 qualifiers:
@@ -1571,8 +3818,11 @@ qualifiers:
     Key: product, Value: ['T25K16.17']
     Key: protein_id, Value: ['AAF26464.1']
     Key: translation, Value: ['MKEDRRLPHKRDAFQFLKTKAAYVIVIVLTYAFGYFSAYHYHQPLQQQLPPSTTAVETTKPQVCSIDNFRVTTPCGNLVPPELIRQTVIDRIFNGTSPYIDFPPPHAKKFLRPKRIKGWGSYGAVFENLIRRVKPKTIVEVGSFLGASAIHMANLTRRLGLEETQILCVDDFRGWPGFRDRFKDMALVNGDVLLMYQFMQNVVISDFSGSILPVPFSTGSALEKLCEWGVTADLVEIDAGHDFNSAWADINRAVRILRPGGVIFGHDYFTAADNRGVRRAVNLFAEINRLKVKTDGQHWVIDSVKVINKGTRFAISKTVAKIKEDANQWFFAQVLENQDLVNEQAVHISVKVLRGFLRDEHGKVLIHARRSFASVHSKLDATFLCWQWAMESMKSLRVDKIIFASEDNDLIGAVTRLPSWPSYKFQIHFLLGELIRSSNLGAHLIAKSVTMEDRRQSYVATGFPFWLKHLFEKERSIA']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[83585:84581](-), [82750:83373](-), [82722:82738](-)}
 qualifiers:
@@ -1583,10 +3833,22 @@ qualifiers:
     Key: product, Value: ['T25K16.18']
     Key: protein_id, Value: ['AAF26465.1']
     Key: translation, Value: ['MFSLNMRTEIESLWVFALASKFNIYMQQHFASLLVAIAITWFTITIVFWSTPGGPAWGKYFFTRRFISLDYNRKYKNLIPGPRGFPLVGSMSLRSSHVAHQRIASVAEMSNAKRLMAFSLGDTKVVVTCHPAVAKEILNSSVFADRPVDETAYGLMFNRAMGFAPNGTYWRTLRRLGSNHLFNPKQIKQSEDQRRVIATQMVNAFARNPKSACAVRDLLKTASLCNMMGLVFGREYELESNNNLESECLKGLVEEGYDLLGTLNWTDHLPWLAGLDFQQIRFRCSQLVPKVNLLLSRIIHEQRAATGNFLDMLLSLQGSEKLSESDMVAVLWEMIFRGTDTVAVLVEWVLARIVMHPKVQLTVHDELDRVVGRSRTVDESDLPSLTYLTAMIKEVLRLHPPGPLLSWARLSITDTSVDGYHVPAGTTAMVNMWAIARDPHVWEDPLEFKPERFVAKEGEAEFSVFGSDLRLAPFGSGKRVCPGKNLGLTTVSFWVATLLHEFEWLPSVEANPPDLSEVLRLSCEMACPLIVNVSSRRKIIAWMF']
-""", -1),
-                    )
+""",
+                -1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_06(self):
         path = "GenBank/protein_refseq.gb"
@@ -1597,23 +3859,42 @@ qualifiers:
         id = "NP_034640.1"
         name = "NP_034640"
         description = "interferon beta, fibroblast [Mus musculus]"
-        annotations = {"accessions": ["NP_034640"],
-                       "comment": """\
+        annotations = {
+            "accessions": ["NP_034640"],
+            "comment": """\
 PROVISIONAL REFSEQ: This record has not yet been subject to final
 NCBI review. The reference sequence was derived from K00020.1.""",
-                       "data_file_division": "ROD",
-                       "date": "01-NOV-2000",
-                       "db_source": "REFSEQ: accession NM_010510.1",
-                       "gi": "6754304",
-                       "keywords": [""],
-                       "organism": "Mus musculus",
-                       "pid": "g6754304",
-                       "sequence_version": 1,
-                       "source": "house mouse",
-                       "taxonomy": ["Eukaryota", "Metazoa", "Chordata", "Craniata", "Vertebrata", "Euteleostomi", "Mammalia", "Eutheria", "Rodentia", "Sciurognathi", "Muridae", "Murinae", "Mus"],
-                       }
-        references = ["location: [0:182]\nauthors: Higashi,Y., Sokawa,Y., Watanabe,Y., Kawade,Y., Ohno,S., Takaoka,C. and Taniguchi,T.\ntitle: structure and expression of a cloned cdna for mouse interferon-beta\njournal: J. Biol. Chem. 258, 9522-9529 (1983)\nmedline id: 83265757\npubmed id: \ncomment: \n"]
-        features = (("""\
+            "data_file_division": "ROD",
+            "date": "01-NOV-2000",
+            "db_source": "REFSEQ: accession NM_010510.1",
+            "gi": "6754304",
+            "keywords": [""],
+            "organism": "Mus musculus",
+            "pid": "g6754304",
+            "sequence_version": 1,
+            "source": "house mouse",
+            "taxonomy": [
+                "Eukaryota",
+                "Metazoa",
+                "Chordata",
+                "Craniata",
+                "Vertebrata",
+                "Euteleostomi",
+                "Mammalia",
+                "Eutheria",
+                "Rodentia",
+                "Sciurognathi",
+                "Muridae",
+                "Murinae",
+                "Mus",
+            ],
+        }
+        references = [
+            "location: [0:182]\nauthors: Higashi,Y., Sokawa,Y., Watanabe,Y., Kawade,Y., Ohno,S., Takaoka,C. and Taniguchi,T.\ntitle: structure and expression of a cloned cdna for mouse interferon-beta\njournal: J. Biol. Chem. 258, 9522-9529 (1983)\nmedline id: 83265757\npubmed id: \ncomment: \n"
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:182]
 qualifiers:
@@ -1621,51 +3902,81 @@ qualifiers:
     Key: db_xref, Value: ['taxon:10090']
     Key: map, Value: ['4 42.6 cM']
     Key: organism, Value: ['Mus musculus']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Protein
 location: [0:182]
 qualifiers:
     Key: product, Value: ['interferon beta, fibroblast']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: sig_peptide
 location: [0:21]
 qualifiers:
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Region
 location: [0:182]
 qualifiers:
     Key: db_xref, Value: ['CDD:pfam00143']
     Key: note, Value: ['interferon']
     Key: region_name, Value: ['Interferon alpha/beta domain']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: mat_peptide
 location: [21:182]
 qualifiers:
     Key: product, Value: ['ifn-beta']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Region
 location: [55:170]
 qualifiers:
     Key: db_xref, Value: ['CDD:IFabd']
     Key: note, Value: ['IFabd']
     Key: region_name, Value: ['Interferon alpha, beta and delta.']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: CDS
 location: [0:182]
 qualifiers:
     Key: coded_by, Value: ['NM_010510.1:21..569']
     Key: db_xref, Value: ['LocusID:15977', 'MGD:MGI:107657']
     Key: gene, Value: ['Ifnb']
-""", None),
-                    )
+""",
+                None,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_07(self):
         path = "GenBank/extra_keywords.gb"
@@ -1676,8 +3987,9 @@ qualifiers:
         id = "AL138972.1"
         name = "DMBR25B3"
         description = "Drosophila melanogaster BAC clone BACR25B3"
-        annotations = {"accessions": ["AL138972"],
-                       "comment": """\
+        annotations = {
+            "accessions": ["AL138972"],
+            "comment": """\
 Sequence submitted by Takis Benos, EMBL Outstation - The EBI,
 Hinxton, Cambridge, CB10 1SD, U.K.
 E-mail: benos@ebi.ac.uk on behalf of the European Drosophila Genome
@@ -1701,33 +4013,60 @@ clone BACR25B3.  It may be shorter, since we are minimising the
 overlap between clones to 100 bases, by trimming them. Sequence in
 absolute orientation with respect to chromosome Clone=BACR25B3;
 Contig ID=1; Length=154329; Status=Finished.""",
-                       "data_file_division": "INV",
-                       "date": "07-FEB-2000",
-                       "gi": "6946668",
-                       "keywords": [""],
-                       "molecule_type": "DNA",
-                       "organism": "Drosophila melanogaster",
-                       "sequence_version": 1,
-                       "source": "fruit fly",
-                       "taxonomy": ["Eukaryota", "Metazoa", "Arthropoda", "Tracheata", "Hexapoda", "Insecta", "Pterygota", "Neoptera", "Endopterygota", "Diptera", "Brachycera", "Muscomorpha", "Ephydroidea", "Drosophilidae", "Drosophila"],
-                       }
-        references = ["location: [0:154329]\nauthors: Murphy,L., Harris,D. and Barrell,B.\ntitle: Sequencing the distal X chromosome of Drosophila melanogaster\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: Sanger Centre, Wellcome Trust Genome Campus, Hinxton Hall, Hinxton, Cambridge CB10 1SA, U.K.\n", "location: [0:154329]\nauthors: Benos,P.\ntitle: Direct Submission\njournal: Submitted (06-FEB-2000) European Drosophila Genome Sequencing Consortium\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+            "data_file_division": "INV",
+            "date": "07-FEB-2000",
+            "gi": "6946668",
+            "keywords": [""],
+            "molecule_type": "DNA",
+            "organism": "Drosophila melanogaster",
+            "sequence_version": 1,
+            "source": "fruit fly",
+            "taxonomy": [
+                "Eukaryota",
+                "Metazoa",
+                "Arthropoda",
+                "Tracheata",
+                "Hexapoda",
+                "Insecta",
+                "Pterygota",
+                "Neoptera",
+                "Endopterygota",
+                "Diptera",
+                "Brachycera",
+                "Muscomorpha",
+                "Ephydroidea",
+                "Drosophilidae",
+                "Drosophila",
+            ],
+        }
+        references = [
+            "location: [0:154329]\nauthors: Murphy,L., Harris,D. and Barrell,B.\ntitle: Sequencing the distal X chromosome of Drosophila melanogaster\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: Sanger Centre, Wellcome Trust Genome Campus, Hinxton Hall, Hinxton, Cambridge CB10 1SA, U.K.\n",
+            "location: [0:154329]\nauthors: Benos,P.\ntitle: Direct Submission\njournal: Submitted (06-FEB-2000) European Drosophila Genome Sequencing Consortium\nmedline id: \npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:154329](+)
 qualifiers:
     Key: clone, Value: ['BAC BACR25B3']
     Key: db_xref, Value: ['taxon:7227']
     Key: organism, Value: ['Drosophila melanogaster']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [22147:27773](-)
 qualifiers:
     Key: gene, Value: ['EG:BACR25B3.11']
     Key: note, Value: ['']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[27622:27773](-), [26676:27009](-), [25023:25178](-), [24615:24888](-), [23629:24555](-), [22859:23560](-), [22374:22791](-), [22147:22299](-)}
 qualifiers:
@@ -1737,14 +4076,20 @@ qualifiers:
     Key: note, Value: ["/prediction=(method:''genefinder'', version:''084'', score:''105.71''); /prediction=(method:''genscan'', version:''1.0''); /match=(desc:''BASEMENT MEMBRANE-SPECIFIC HEPARAN SULFATE PROTEOGLYCAN CORE PROTEIN PRECURSOR (HSPG) (PERLECAN) (PLC)'', species:''Homo sapiens (Human)'', ranges:(query:24292..24549, target:SWISS-PROT::P98160:3713..3628, score:''201.00''), (query:24016..24291, target:SWISS-PROT::P98160:3815..3724, score:''139.00''), (query:23857..24006, target:SWISS-PROT::P98160:3866..3817, score:''99.00''), (query:24052..24327, target:SWISS-PROT::P98160:4059..3968, score:''143.00''), (query:24046..24312, target:SWISS-PROT::P98160:4341..4253, score:''116.00''), (query:23806..23901, target:SWISS-PROT::P98160:4177..4146, score:''76.00''), (query:23203..23382, target:SWISS-PROT::P98160:4062..4003, score:''116.00''), (query:22523..22777, target:SWISS-PROT::P98160:4288..4204, score:''112.00''), (query:22235..22300, target:SWISS-PROT::P98160:4358..4337, score:''64.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''GM03359.5prime GM Drosophila melanogaster ovary BlueScript Drosophila melanogaster cDNA clone GM03359 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:25024..25235, target:EMBL::AA801707:438..227, score:''1024.00''), (query:24851..24898, target:EMBL::AA801707:476..429, score:''204.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''LD08615.5prime LD Drosophila melanogaster embryo BlueScript Drosophila melanogaster cDNA clone LD08615 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:24629..24727, target:EMBL::AA264808:99..1, score:''495.00''), (query:24417..24566, target:EMBL::AA264808:250..101, score:''687.00''), (query:24048..24420, target:EMBL::AA264808:618..246, score:''1847.00''), (query:23986..24036, target:EMBL::AA264808:678..628, score:''237.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''HL02745.5prime HL Drosophila melanogaster head BlueScript Drosophila melanogaster cDNA clone HL02745 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:23944..24045, target:EMBL::AA697546:103..2, score:''510.00''), (query:23630..23943, target:EMBL::AA697546:416..103, score:''1570.00''), (query:23419..23561, target:EMBL::AA697546:558..416, score:''715.00''), (query:23306..23417, target:EMBL::AA697546:670..559, score:''524.00''), (query:23280..23316, target:EMBL::AA697546:695..659, score:''167.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''GM08137.5prime GM Drosophila melanogaster ovary BlueScript Drosophila melanogaster cDNA clone GM08137 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:23235..23278, target:EMBL::AA696682:44..1, score:''139.00''), (query:22986..23251, target:EMBL::AA696682:294..29, score:''1321.00'')), method:''blastn'', version:''1.4.9'')"]
     Key: protein_id, Value: ['CAB72284.1']
     Key: translation, Value: ['MACNCNQSMIYQSNERRDYNCPGAPQYPYNRFKGGVSLKDTPCMVLYICADFKSSKLSSAKPIISGPATTRAPAISYVCQPNDFKCVSHPHTCVRANMVCDGIYDCTDHSDEFNCIAGKGSGKSESNSGSGSFKRWKKSPEQGRRSLAKAVKNRKLRKRSFAKSRDYSLKLDDQSSNLRAGESTDVECYSSDDTYTDVVWERSDGAPLSNNVRQVGNRLVISNVSPSDAGNYVCKCKTDEGDLYTTSYKLEVEDQPHELKSSKIVYAKVGANADLQCGADESRQPTYRWSRQYGQLQAGRSLMNEKLSLDSVQANDAGTYICTAQYADGETADFPNILVVTGAIPQFRQEPRSYMSFPTLPNSSFKFNFELTFRPENGDGLLLFNGQTRGSGDYIALSLKDRYAEFRFDFGGKPMLVRAEEPLALNEWHTVRVSRFKRDGYIQVDEQHPVAFPTLQQIPQLDLIEDLYIGGVPNWELLPADAVSQQVGFVGCISRLTLQGRTVELIREAKYKEGITDCRPCAQGPCQNKGVCLESQTEQAYTCICQPGWTGRDCAIEGTQCTPGVCGAGRCENTENDMECLCPLNRSGDRCQYNEILNEHSLNFKGNSFAAYGTPKVTKVNITLSVRPASLEDSVILYTAESTLPSGDYLALVLRGGHAELLINTAARLDPVVVRSAEPLPLNRWTRIEIRRRLGEGILRVGDGPERKAKAPGSDRILSLKTHLYVGGYDRSTVKVNRDVNITKGFDGCISRLYNFQKPVNLLADIKDAANIQSCGETNMIGGDEDSDNEPPVPPPTPDVHENELQPYAMAPCASDPCENGGSCSEQEDVAVCSCPFGFSGKHCQEHLQLGFNASFRGDGYVELNRSHFQPALEQSYTSMGIVFTTNKPNGLLFWWGQEAGEEYTGQDFIAAAVVDGYVEYSMRLDGEEAVIRNSDIRVDNGERHIVIAKRDENTAILEVDRMLHSGETRPTSKKSMKLPGNVFVGGAPDLEVFTGFRYKHNLNGCIVVVEGETVGQINLSSAAVNGVNANVCPA']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: gene
 location: [29925:33978](-)
 qualifiers:
     Key: gene, Value: ['EG:BACR25B3.10']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[33816:33978](-), [33532:33713](-), [32685:33289](-), [32323:32634](-), [31658:31836](-), [31196:31591](-), [30616:31076](-), [30269:30519](-), [29925:30108](-)}
 qualifiers:
@@ -1754,14 +4099,20 @@ qualifiers:
     Key: note, Value: ["/prediction=(method:''genefinder'', version:''084'', score:''98.50''); /prediction=(method:''genscan'', version:''1.0''); /match=(desc:''BASEMENT MEMBRANE-SPECIFIC HEPARAN SULFATE PROTEOGLYCAN CORE PROTEIN PRECURSOR (HSPG) (PERLECAN) (PLC)'', species:''Homo sapiens (Human)'', ranges:(query:33540..33716, target:SWISS-PROT::P98160:2716..2658, score:''113.00''), (query:32859..32963, target:SWISS-PROT::P98160:3341..3307, score:''63.00''), (query:33150..33215, target:SWISS-PROT::P98160:3530..3509, score:''73.00''), (query:32973..33089, target:SWISS-PROT::P98160:3588..3550, score:''71.00''), (query:32358..32567, target:SWISS-PROT::P98160:3650..3581, score:''107.00''), (query:31222..31323, target:SWISS-PROT::P98160:2620..2587, score:''80.00''), (query:31489..31572, target:SWISS-PROT::P98160:3387..3360, score:''72.00''), (query:31495..31593, target:SWISS-PROT::P98160:3575..3543, score:''60.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''GM02481.5prime GM Drosophila melanogaster ovary BlueScript Drosophila melanogaster cDNA clone GM02481 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:30008..30036, target:EMBL::AA695253:29..1, score:''145.00''), (query:29549..30004, target:EMBL::AA695253:487..32, score:''2262.00'')), method:''blastn'', version:''1.4.9'')"]
     Key: protein_id, Value: ['CAB72285.1']
     Key: translation, Value: ['MFLATLDTNDPTDIGTEDPVLTQIIVSIQKPEITIVPVGGSMTLSCSGRMRWSNSPVIVNWYKENSRLPENVEVQGGNLYLYDLQVSDSGVYICQAVNNETASVFKDTVSITITKKDQLSPAEIVNLPSHVTFEEYVNNEIICEVLGNPAPRVTWARVDGHADAQSTRTYDNRLIFDSPRKSDEGRYRCQAENDQNRDEKYVIVYVQSNPPQPPPQQDRLYITPEEINGLAGESFQLNCQFTSVASLRYDWSHNGRSLSSSPARNVEIRGNTLEVRDASESDSGVYTCVAYDVRTRRNFTESARVNIDRREEQPFGVLMRMMILTDSLINHSNKPIIESLEQNILIIQGEDYSITCEASGSPYPSIKWAKVHDFMPENVHISGNVLTIYGARFENRGVYSCVAENDHGSDLSSTSIDIEPRERPSVKIVSAPLQTFSVGAPASLYCTVEGIPDPTVEWVRVDGQPLSPRHKIQSPGYMVIDDIQLEDSGDYECRAKNIVGEATGVATITVQEPTLVQIIPDNRDLRLTEGDELSLTCVGSGVPNPEVEWVNEMALKRDLYSPPSNTAILKIYRVTKADAGIYTCHGKNEAGSDEAHVRVEVQERRGDIGGVDDDSDRDPINYNPPQQQNPGIHQPGSNQLLATDIGDNVTLTCDMFQPLNTRWERVDGAPLPRNAYTIKNRLEIVRVEQQNLGQYRCNGIGRDGNVKTYFVKELVLMPLPRIRFYPNIPLTVEAGQNLDVHCQVENVRPEDVHWSTDNNRPLPSSVRIVGSVLRFVSITQAAAGEYRCSAFNQYGNRSQIARVAVKKPADFHQVPQSQLQRHREGENIQLQCTVTDQYGVRAQDNVEFNWFRDDRRPLPNNARTDSQILVLTNLRPEDAGRYICNSYDVDRGQQLPEVSIDLQVLSE']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: gene
 location: [36118:56153](-)
 qualifiers:
     Key: gene, Value: ['EG:BACR25B3.1']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[56030:56153](-), [52848:52966](-), [50826:50937](-), [50318:50441](-), [49970:50102](-), [49762:49876](-), [49436:49562](-), [48410:48878](-), [47682:47831](-), [47221:47315](-), [46517:46688](-), [45975:46125](-), [45660:45793](-), [45147:45233](-), [44811:44928](-), [44240:44438](-), [43603:43837](-), [42750:42876](-), [42187:42415](-), [41854:42085](-), [41545:41620](-), [40680:40814](-), [40518:40612](-), [40344:40434](-), [39655:40042](-), [37280:39517](-), [36118:37213](-)}
 qualifiers:
@@ -1771,14 +4122,20 @@ qualifiers:
     Key: note, Value: ["/prediction=(method:''genscan'', version:''1.0''); /prediction=(method:''genefinder'', version:''084''); /match=(desc:''LOW-DENSITY LIPOPROTEIN RECEPTOR-RELATED PROTEIN PRECURSOR (LRP)'', species:''Caenorhabditis elegans'', ranges:(query:50831..50941, target:SWISS-PROT::Q04833:1221..1185, score:''95.00''), (query:50840..51025, target:SWISS-PROT::Q04833:2865..2804, score:''102.00''), (query:50828..50935, target:SWISS-PROT::Q04833:3788..3753, score:''119.00''), (query:50323..50394, target:SWISS-PROT::Q04833:3706..3683, score:''77.00''), (query:50326..50433, target:SWISS-PROT::Q04833:1263..1228, score:''120.00''), (query:49948..50079, target:SWISS-PROT::Q04833:2917..2874, score:''88.00''), (query:49432..49587, target:SWISS-PROT::Q04833:4085..4034, score:''102.00''), (query:49429..49560, target:SWISS-PROT::Q04833:3915..3872, score:''97.00''), (query:48622..48720, target:SWISS-PROT::Q04833:1302..1270, score:''99.00''), (query:47698..47799, target:SWISS-PROT::Q04833:3996..3963, score:''88.00''), (query:47686..47775, target:SWISS-PROT::Q04833:3835..3806, score:''59.00''), (query:47692..47787, target:SWISS-PROT::Q04833:4041..4010, score:''83.00''), (query:47229..47315, target:SWISS-PROT::Q04833:3742..3714, score:''88.00''), (query:47220..47312, target:SWISS-PROT::Q04833:3829..3799, score:''67.00''), (query:47232..47318, target:SWISS-PROT::Q04833:3866..3838, score:''78.00''), (query:46552..46656, target:SWISS-PROT::Q04833:1344..1310, score:''95.00''), (query:46543..46650, target:SWISS-PROT::Q04833:3951..3916, score:''98.00''), (query:45983..46129, target:SWISS-PROT::Q04833:2870..2822, score:''82.00''), (query:45971..46096, target:SWISS-PROT::Q04833:4089..4048, score:''82.00''), (query:45678..45764, target:SWISS-PROT::Q04833:3666..3638, score:''80.00''), (query:45128..45238, target:SWISS-PROT::Q04833:94..58, score:''100.00''), (query:45158..45268, target:SWISS-PROT::Q04833:3990..3954, score:''80.00''), (query:44263..44379, target:SWISS-PROT::Q04833:85..47, score:''77.00''), (query:44251..44367, target:SWISS-PROT::Q04833:3995..3957, score:''100.00''), (query:43605..43688, target:SWISS-PROT::Q04833:2994..2967, score:''84.00''), (query:42764..42877, target:SWISS-PROT::Q04833:2951..2914, score:''77.00''), (query:42180..42377, target:SWISS-PROT::Q04833:260..195, score:''148.00''), (query:42234..42419, target:SWISS-PROT::Q04833:3199..3138, score:''106.00''), (query:39807..40013, target:SWISS-PROT::Q04833:2901..2833, score:''167.00''), (query:39645..39857, target:SWISS-PROT::Q04833:3138..3068, score:''151.00''), (query:39846..40046, target:SWISS-PROT::Q04833:3241..3175, score:''132.00''), (query:39654..39866, target:SWISS-PROT::Q04833:3913..3843, score:''201.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''LOW-DENSITY LIPOPROTEIN RECEPTOR-RELATED PROTEIN 2 PRECURSOR (MEGALIN) (GLYCOPROTEIN 330)'', species:''Homo sapiens (Human)'', ranges:(query:50834..50935, target:SWISS-PROT::P98164:2733..2700, score:''99.00''), (query:50840..50947, target:SWISS-PROT::P98164:3063..3028, score:''94.00''), (query:50831..50926, target:SWISS-PROT::P98164:3918..3887, score:''102.00''), (query:50326..50433, target:SWISS-PROT::P98164:1222..1187, score:''107.00''), (query:50302..50394, target:SWISS-PROT::P98164:3762..3732, score:''91.00''), (query:49773..49904, target:SWISS-PROT::P98164:2939..2896, score:''90.00''), (query:49438..49578, target:SWISS-PROT::P98164:217..171, score:''116.00''), (query:49429..49545, target:SWISS-PROT::P98164:3796..3758, score:''108.00''), (query:48622..48720, target:SWISS-PROT::P98164:3544..3512, score:''94.00''), (query:48595..48708, target:SWISS-PROT::P98164:3720..3683, score:''86.00''), (query:47701..47814, target:SWISS-PROT::P98164:2817..2780, score:''90.00''), (query:47692..47799, target:SWISS-PROT::P98164:3674..3639, score:''60.00''), (query:47217..47366, target:SWISS-PROT::P98164:3716..3667, score:''96.00''), (query:46543..46647, target:SWISS-PROT::P98164:1101..1067, score:''107.00''), (query:46552..46656, target:SWISS-PROT::P98164:3873..3839, score:''84.00''), (query:45989..46126, target:SWISS-PROT::P98164:3832..3787, score:''98.00''), (query:45149..45274, target:SWISS-PROT::P98164:2775..2734, score:''99.00''), (query:44780..44893, target:SWISS-PROT::P98164:268..231, score:''76.00''), (query:44813..44905, target:SWISS-PROT::P98164:1223..1193, score:''73.00''), (query:44251..44361, target:SWISS-PROT::P98164:3630..3594, score:''119.00''), (query:43602..43700, target:SWISS-PROT::P98164:179..147, score:''97.00''), (query:43674..43781, target:SWISS-PROT::P98164:191..156, score:''90.00''), (query:43584..43685, target:SWISS-PROT::P98164:1107..1074, score:''89.00''), (query:42758..42865, target:SWISS-PROT::P98164:1264..1229, score:''79.00''), (query:42204..42413, target:SWISS-PROT::P98164:2810..2741, score:''136.00''), (query:42189..42377, target:SWISS-PROT::P98164:3027..2965, score:''125.00''), (query:42186..42293, target:SWISS-PROT::P98164:3110..3075, score:''109.00''), (query:42198..42389, target:SWISS-PROT::P98164:3584..3521, score:''137.00''), (query:42309..42422, target:SWISS-PROT::P98164:3793..3756, score:''95.00''), (query:39654..39791, target:SWISS-PROT::P98164:63..18, score:''132.00''), (query:39786..40049, target:SWISS-PROT::P98164:1183..1096, score:''230.00''), (query:39657..39890, target:SWISS-PROT::P98164:3109..3032, score:''200.00''), (query:39780..39983, target:SWISS-PROT::P98164:3756..3689, score:''194.00''), (query:39618..39761, target:SWISS-PROT::P98164:3845..3798, score:''105.00''), (query:39651..39779, target:SWISS-PROT::P98164:3964..3922, score:''128.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''GM06086.5prime GM Drosophila melanogaster ovary BlueScript Drosophila melanogaster cDNA clone GM06086 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:50852..51290, target:EMBL::AA802674:672..234, score:''2195.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''SD04592.5prime SD Drosophila melanogaster Schneider L2 cell culture pOT2 Drosophila melanogaster cDNA clone SD04592 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:37280..37708, target:EMBL::AI532939:429..1, score:''2136.00''), (query:37097..37217, target:EMBL::AI532939:545..425, score:''569.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''GH03622.5prime GH Drosophila melanogaster head pOT2 Drosophila melanogaster cDNA clone GH03622 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:36446..37075, target:EMBL::AI063674:1..630, score:''3150.00'')), method:''blastn'', version:''1.4.9''); EST embl|AA802674|AA802674 comes from the 5' UTR"]
     Key: protein_id, Value: ['CAB72286.1']
     Key: translation, Value: ['MLLLQLLLQLLLLGKLLLGKTPPTVFGFRLLFAAFRFPLSLHFPHRMHDHFFVRGDTHSCGWKNSTTFTIRISAIYRYLNQCQANEFRCNNGDCIDARKRCNNVSDCSEGEDENEECPAACSGMEYQCRDGTRCISVSQQCDGHSDCSDGDDEEHCDGIVPKLRYTCPKGKFTCRDLSCISIVHRCDGRADCPNDRSDEEGCPCLYDKWQCDDGTCIAKELLCNGNIDCPEDISDERYCEGGYDSEECRFDEFHCGTGECIPMRQVCDNIYDCNDYSDEVNCVEGEEEDRVGIPIGHQPWRPASKHDDWLHEMDTSEYQVYQPSNVYEKANSQNPCASNQFRCTTSNVCIPLHLRCDGFYHCNDMSDEKSCEQYQRHTTTRRPLTLATPTSRITTQGPGLLERRNTTTATEASRWPWATKTTTIATTTSNPITTVGVANSPPQTCLENIEFACHNRDCISIESVCDGIPDCGRNEDEDDALCKCSGDKYKCQRGGGCIPKSQVCDGKPQCHDRSDESACHLHGRLNKTRLGVKCLESQYQCGDGSCISGYKRCNGIHDCADASDEYNCIYDYEDTYDTDPNNNPLNECDILEFECDYSQCLPLEKKCDGYADCEDMSDELECQSYTDHCLESEFECDSYCLPRDQLCNGIPNCQDGSDERNCTFCREDAYLCNTGECVADNQRCNGIADCADGSDERHCARIYCPPNKLACNGTCVSRRIKCDGIRDCLDGYDEMYCPETNNHYPTQNVNVIRPKLGPNPIPKSCRPHEWQCANLECIDSSLQCNEIKDCSDGSDEELSVCFGTATTRLKPSDCSPEQFYCDESCYNRSVRCNGHVDCSDGSDEVGCSLPCPQHQCPSGRCYTESERCDRHRHCEDGSDEANCTAILCKDNEFLCFDRQFCINATQQCDGYYDCRDFSDEQNCIGCYANQFRCNNGDCVSGSAPCNGYSECSDHSDELNCGGTQECLPNQFRCNSGQCVSSSVRCNGRTDCQDSSDEQNCGHRHTEVSQGLETTGVFTTSTTSTTAMTPLRIICPPTSFKCENGPCISLGLKCNGRVDCPYDGSDEADCGQISNDIDPADSNDRRPNQLNLKTYPDSQIIKESREVIFRCRDEGPARAKVKWSRPGGRPLPPGFTDRNGRLEIPNIRVEDAGTYVCEAVGYASYIPGQQVTVNLNVERSWGENKYEEIRSNRIRYGTVPHIDLEFFGLDNDVGSRPESACTEYQATCMNGECIDKSSICDGNPDCSDASDEQSCSLGLKCQPNQFMCSNSKCVDRTWRCDGENDCGDNSDETSCDPEPSGAPCRYNEFQCRSGHCIPKSFQCDNVPDCTDGTDEVGCMAPLPIRPPPQSVSLLEYEVLELTCVATGTPTPTIVWRLNWGHVPDKCESKSYGGTGTLRCPDMRPQDSGAYSCEIINTRGTHFVNPDTIVTVRPVRTDVCEAGFFNMLARKAEECVQCFCFGVAKACDSANLFTYAIHPPILSHRVVSVELSPLRQIVINEAAPGQDLLTLLHGVQFRATNVHFSGRETPYLALPADYMGNQLKSYGGNLRYEVNYRGSGRPVNGPDVIITGNRFTLTYRVRTQPGQNNRVSIPFVPGGWQKPDGRKASREEIMMILANVDNILIRLGYLDSTAREVDLINIALDSAGTADKGLGSASLVEKCQCPPGYVGDSCESCASGYVRQPGGPWLGHCVPFIPDSCPSGTYGDPRRGVPCKECPCPLTGSNNFASGCQQSPDGDVVCRCNEGYTGRRCEQCAAGYQGNPLAAGGICRRIPDTSCNVDGTYSVHSNGTCQCKDSVIGEQCDTCKSKSFHLNSFTYTGCIECFCSGVGLDCDSSTWYRDQVTSTFGRSRVDHGFVLVTNYMQPTPDTVPVSMAAEPNALSFIGSADQSGNTLYWSLPAAFLGNKLSSYGGKLTYTLSYSPLPNGIMSRNSAPDVVIKSGEDLRLIHYRKSQVVPSVANTYSVEIKESAWQRGDEVVANREHVLMALSDITAIYIKATYTTSTKEASLRQVTLDVATPTNLGTPRAVEVEQCRCPEGYLGLSCEQCAPGYARDPEGGIYLGLCRPCECNGHSKYCNSDTGDCEECSDNTEGPSCERCAAGYVGDATRGTIYDCQPDEGYPIPSPPAPGNQTLECTAYCQIEGIYDCRGNECLCKRNVIGDQCDQCRPGTYGLSAQNQDGCKECYCSGLASQCRSAALYRQLIPVDFILNAPLITDESGAVQDTENLIPDISRNMYTYTHTSYLPKYWSLRGSVLGNQLFSYGGRLSYSLIVESYGNYERGHDIVLIGNGLKLIWSRPDGNENQEEYNVRLHEDEQWTRQDRESARPASRSDFMTVLSDLQHILIRATPRVPTQSTSIGNVILESAVTTRTPGATHASDIELCQCPSGYVGTSCESCAPLHYRDASGSCSLCPCDVSNTESCDLVSGGYVECRCKARWKGDRCREIGE']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: gene
 location: [70719:75241](-)
 qualifiers:
     Key: gene, Value: ['EG:BACR25B3.2']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[75216:75241](-), [73085:73559](-), [72838:73016](-), [72604:72768](-), [71423:71621](-), [70719:70988](-)}
 qualifiers:
@@ -1788,14 +4145,20 @@ qualifiers:
     Key: note, Value: ["/prediction=(method:''genefinder'', version:''084'', score:''41.82''); /prediction=(method:''genscan'', version:''1.0'')"]
     Key: protein_id, Value: ['CAB72287.1']
     Key: translation, Value: ['MANSKVVAHDESLQGINDSEWQLMGDDIDDGLLDDVDETLKPMETKSEEEDLPTGNWFSQSVHRVRRSINRLFGSDDNQERGRRQQRERSQRNRDAINRQKELRRRQKEDHNRWKQMRMERQLEKQRLVKRTNHVVFNRATDPRKRASDLYDENEASGYHEEDTTLYRTYFVVNEPYDNEYRDRESVQFQNLQKLLDDDLRNFFHSNYEGNDDEEQEIRSTLERVEPTNDNFKIRVQLRIELPTSVNDFGSKLQQQLNVYNRIENLSAATDGVFSFTESSDIEEEAIDVTLPQEEVEGSGSDDSSCRGDATFTCPRSGKTICDEMRCDREIQCPDGEDEEYCNYPNVCTEDQFKCDDKCLELKKRCDGSIDCLDQTDEAGCINAPEPEPEPEPEPEPEPESEPEAEPEPEPEPEPESEPEQEPEPQVPEANGKFY']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: gene
 location: [121866:127124](+)
 qualifiers:
     Key: gene, Value: ['EG:BACR25B3.3']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[121866:122046](+), [122173:122630](+), [123671:123823](+), [124062:124320](+), [124391:124688](+), [124754:125018](+), [125093:125254](+), [125316:125576](+), [126792:127124](+)}
 qualifiers:
@@ -1805,14 +4168,20 @@ qualifiers:
     Key: note, Value: ["/prediction=(method:''genscan'', version:''1.0'', score:''174.91''); /prediction=(method:''genefinder'', version:''084''); /match=(desc:''PROBABLE G PROTEIN-COUPLED RECEPTOR C13B9.4 IN CHROMOSOME III'', species:''Caenorhabditis elegans'', ranges:(query:123671..123775, target:SWISS-PROT::Q09460:107..141, score:''80.00''), (query:123743..123829, target:SWISS-PROT::Q09460:235..263, score:''72.00''), (query:124072..124332, target:SWISS-PROT::Q09460:265..351, score:''161.00''), (query:124392..124691, target:SWISS-PROT::Q09460:349..448, score:''206.00''), (query:124755..124958, target:SWISS-PROT::Q09460:448..515, score:''123.00''), (query:124764..125027, target:SWISS-PROT::Q09460:454..541, score:''108.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''CALCITONIN RECEPTOR PRECURSOR (CT-R)'', species:''Sus scrofa (Pig)'', ranges:(query:124165..124236, target:SWISS-PROT::P25117:191..214, score:''54.00''), (query:124392..124580, target:SWISS-PROT::P25117:233..295, score:''118.00''), (query:124725..124886, target:SWISS-PROT::P25117:318..371, score:''127.00'')), method:''blastx'', version:''1.4.9'')"]
     Key: protein_id, Value: ['CAB72288.1']
     Key: translation, Value: ['MGAGNRKSETKTKTEAEIEIEMERDQFSIAANACMSMGPMLISKDKAPCSGGRVRHADSLHIYYAVDGKMTLLSNILDCGGCISAQRFTRLLRQSGSSGPSPSAPTAGTFESKSMLEPTSSHSLATGRVPLLHDFDASTTESPGTYVLDGVARVAQLALEPTVMDALPDSDTEQVLGNLNSSAPWNLTLASAAATNFENCSALFVNYTLPQTEFAIRKCELDGRWGSRPNATEVNPPGWTDYGPCYKPEIIRLMQQMGSKDFDAYIDIARRTRTLEIVGLCLSLFALIVSLLIFCTFRSLRNNRTKIHKNLFVAMVLQVIIRLTLYLDQFRRGNKEAATNTSLSVIENTPYLCEASYVLLEYARTAMFMWMFIEGLYLHNMVTVAVFQGSFPLKFFSRLGWCVPILMTTVWARCTVMYMDTSLGECLWNYNLTPYYWILEGPRLAVILLNFCFLVNIIRVLVMKLRQSQASDIEQTRKAVRAAIVLLPLLGITNLLHQLAPLKTATNFAVWSYGTHFLTSFQGFFIALIYCFLNGEVRAVLLKSLATQLSVRGHPEWAPKRASMYSGAYNTAPDTDAVQPAGDPSATGKRISPPNKRLNGRKPSSASIVMIHEPQQRQRLMPRLQNKAREKGKDRVEKTDAEAEPDPTISHIHSKEAGSARSRTRGSKWIMGICFRGQMCDAGLAKDAANIHDVANAADVDACSGSNNNYHNINNNNGSQNNNSIHCNHRDDDKVKGESQSDFKEPSNTNAESLVHLALFTAHTSNTQNNTHRNTIFTPIRRRNCS']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [128488:129414](-)
 qualifiers:
     Key: gene, Value: ['EG:BACR25B3.4']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[129373:129414](-), [129195:129313](-), [128776:129140](-), [128488:128715](-)}
 qualifiers:
@@ -1822,14 +4191,20 @@ qualifiers:
     Key: note, Value: ["/prediction=(method:''genefinder'', version:''084'', score:''61.35''); /prediction=(method:''genscan'', version:''1.0''); /match=(desc:''VACUOLAR PROTON-ATPASE SUBUNIT D'', species:''Oryctolagus cuniculus (Rabbit)'', ranges:(query:129190..129324, target:SPTREMBL::O97755:55..11, score:''130.00''), (query:128778..129176, target:SPTREMBL::O97755:174..42, score:''472.00''), (query:128546..128716, target:SPTREMBL::O97755:231..175, score:''169.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''VACUOLAR ATP SYNTHASE SUBUNIT D (EC 3.6.1.34) (V-ATPASE D SUBUNIT) (V- ATPASE 28 KD ACCESSORY PROTEIN)'', species:''Bos taurus (Bovine)'', ranges:(query:129190..129324, target:SWISS-PROT::P39942:55..11, score:''130.00''), (query:128778..129176, target:SWISS-PROT::P39942:174..42, score:''471.00''), (query:128546..128716, target:SWISS-PROT::P39942:231..175, score:''173.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''GH28048.5prime GH Drosophila melanogaster head pOT2 Drosophila melanogaster cDNA clone GH28048 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:129196..129317, target:EMBL::AI517334:233..112, score:''412.00''), (query:128777..129145, target:EMBL::AI517334:597..229, score:''1251.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''GH07112.5prime GH Drosophila melanogaster head pOT2 Drosophila melanogaster cDNA clone GH07112 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:129196..129317, target:EMBL::AI108302:223..102, score:''412.00''), (query:128777..129145, target:EMBL::AI108302:587..219, score:''1251.00''), (query:128636..128716, target:EMBL::AI108302:667..587, score:''243.00'')), method:''blastn'', version:''1.4.9'')"]
     Key: protein_id, Value: ['CAB72289.1']
     Key: translation, Value: ['MAAKDRLPIFPSRGAQTLMKSRLAGATKGHGLLKKKADALQMRFRLILGKIIETKTLMGQVMKEAAFSLAEVKFTTGDINQIVLQNVTKAQIKIRTKKDNVAGVTLPIFEPYTDGVDTYELAGLARGGQQLAKLKKNYQSAVRLLVQLASLQTSFVTLDDVIKVTNRRVNAIEHVIIPRINRTIEYIISELDELEREEFYRLKKIQDKKREARKASDKLRAEQRLLGQMAEAQEVQNILDEDGDEDLLF']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: gene
 location: [132239:132926](+)
 qualifiers:
     Key: gene, Value: ['EG:BACR25B3.5']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [132239:132926](+)
 qualifiers:
@@ -1839,14 +4214,20 @@ qualifiers:
     Key: note, Value: ["/prediction=(method:''genefinder'', version:''084'', score:''48.06''); /prediction=(method:''genscan'', version:''1.0'', score:''132.90''); /match=(desc:''N-ACETYLTRANSFERASE'', species:''Drosophila melanogaster (Fruit fly)'', ranges:(query:132249..132326, target:SPTREMBL::Q94521:60..85, score:''64.00''), (query:132600..132842, target:SPTREMBL::Q94521:171..251, score:''105.00'')), method:''blastx'', version:''1.4.9''); EST embl|AI063093|AI063093 comes from the 3' UTR"]
     Key: protein_id, Value: ['CAB72290.1']
     Key: translation, Value: ['MEYKMIAPEHSEQVMEHLRRNFFADEPLNKAAGLCQNGSSCPALEAHCAEAIQHRMSVMAVDAKEKDTLKIVGVVLNGILKPGDTAKALSKLDCNDDADFRKIFDLLHRHNLKHNLFEHFDVDCMFDVRILSVDSCYRGQGIANELVKRSVAVAKKNGFRLLKADATGIFSQKIFRSHGFEVFSEQPYSKYTDENGKVILPVEAPHIKLQQLYKAICADDQDEKKQSL']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [133491:134407](-)
 qualifiers:
     Key: gene, Value: ['EG:BACR25B3.6']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[134197:134407](-), [133866:134135](-), [133662:133748](-), [133491:133595](-)}
 qualifiers:
@@ -1856,14 +4237,20 @@ qualifiers:
     Key: note, Value: ["/prediction=(method:''genscan'', version:''1.0'', score:''119.22''); /prediction=(method:''genefinder'', version:''084''); /match=(desc:''LD41675.5prime LD Drosophila melanogaster embryo pOT2 Drosophila melanogaster cDNA clone LD41675 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:134192..134531, target:EMBL::AI515958:340..1, score:''1691.00''), (query:133879..134139, target:EMBL::AI515958:591..331, score:''1305.00'')), method:''blastn'', version:''1.4.9'')"]
     Key: protein_id, Value: ['CAB72291.1']
     Key: translation, Value: ['MNGLPPSKHYNLTHYQQRYNWDCGLSCIIMILSAQQREQLLGNFDAVCGEEGFGSSTWTIDLCYLLMRYQVRHEYFTQTLGIDPNYAQHTYYSKIIDKDERRVTRKFKDARAHGLRVEQRTVDMEVILRHLARHGPVILLTNASLLTCEVCKRNVLEKFGYAGHYVVLCGYDMAAQKLFYHNPEVHDGHICRCLIESMDTARRAYGTDEDIIFIYEKKETRE']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: gene
 location: [135478:136829](+)
 qualifiers:
     Key: gene, Value: ['EG:BACR25B3.7']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[135478:135749](+), [135960:136586](+), [136640:136829](+)}
 qualifiers:
@@ -1873,14 +4260,20 @@ qualifiers:
     Key: note, Value: ["/prediction=(method:''genefinder'', version:''084'', score:''66.07''); /prediction=(method:''genscan'', version:''1.0'', score:''145.64''); /match=(desc:''HYPOTHETICAL 40.4 KD TRP-ASP REPEATS CONTAINING PROTEIN C14B1.4 IN CHROMOSOME III'', species:''Caenorhabditis elegans'', ranges:(query:135548..135748, target:SWISS-PROT::Q17963:39..105, score:''120.00''), (query:135957..136586, target:SWISS-PROT::Q17963:105..314, score:''899.00''), (query:136641..136823, target:SWISS-PROT::Q17963:315..375, score:''219.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''LD30385.5prime LD Drosophila melanogaster embryo pOT2 Drosophila melanogaster cDNA clone LD30385 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:135288..135749, target:EMBL::AA950546:102..563, score:''2301.00''), (query:135956..136047, target:EMBL::AA950546:559..650, score:''442.00'')), method:''blastn'', version:''1.4.9''); /match=(desc:''LD10938.5prime LD Drosophila melanogaster embryo BlueScript Drosophila melanogaster cDNA clone LD10938 5prime, mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:136108..136288, target:EMBL::AA392005:776..596, score:''212.00'')), method:''blastn'', version:''1.4.9'')"]
     Key: protein_id, Value: ['CAB72292.1']
     Key: translation, Value: ['MVPIGAVHGGHPGVVHPPQQPLPTAPSGPNSLQPNSVGQPGATTSSNSSASNKSSLSVKPNYTLKFTLAGHTKAVSAVKFSPNGEWLASSSADKLIKIWGAYDGKFEKTISGHKLGISDVAWSSDSRLLVSGSDDKTLKVWELSTGKSLKTLKGHSNYVFCCNFNPQSNLIVSGSFDESVRIWDVRTGKCLKTLPAHSDPVSAVHFNRDGSLIVSSSYDGLCRIWDTASGQCLKTLIDDDNPPVSFVKFSPNGKYILAATLDNTLKLWDYSKGKCLKTYTGHKNEKYCIFANFSVTGGKWIVSGSEDNMVYIWNLQSKEVVQKLQGHTDTVLCTACHPTENIIASAALENDKTIKLWKSDT']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [145402:147087](+)
 qualifiers:
     Key: gene, Value: ['EG:BACR25B3.8']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[145402:146203](+), [146514:147087](+)}
 qualifiers:
@@ -1889,14 +4282,20 @@ qualifiers:
     Key: gene, Value: ['EG:BACR25B3.8']
     Key: protein_id, Value: ['CAB72293.1']
     Key: translation, Value: ['MNSTTKHLLHCTLLITVIVTFEVFSGGIKIDENSFTLVDPWTEYGQLATVLLYLLRFLTLLTLPQVLFNFCGLVFYNAFPEKVVLKGSPLLAPFICIRVVTRGDFPDLVKTNVLRNMNTCLDTGLENFLIEVVTDKAVNLSQHRRIREIVVPKEYKTRTGALFKSRALQYCLEDNVNVLNDSDWIVHLDEETLLTENSVRGIINFVLDGKHPFGQGLITYANENVVNWLTTLADSFRVSDDMGKLRLQFKLFHKPLFSWKGSYVVTQVSAERSVSFDNGIDGSVAEDCFFAMRAFSQGYTFNFIEGEMYEKSPFTLLDFLQQRKRWLQGILLVVHSKMIPFKHKLLLGISVYSWVTMPLSTSNIIFAALYPIPCPNLVDFVCAFIAAINIYMYVFGVIKSFSLYRFGLFRFLACVLGAVCTIPVNVVIENVAVIWGLVGKKHKFYVVQKDVRVLETV']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [148859:152785](-)
 qualifiers:
     Key: gene, Value: ['EG:BACR25B3.9']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[152105:152785](-), [151880:152032](-), [149545:151809](-), [148965:149462](-), [148859:148905](-)}
 qualifiers:
@@ -1906,14 +4305,20 @@ qualifiers:
     Key: note, Value: ["/prediction=(method:''genscan'', version:''1.0''); /prediction=(method:''genefinder'', version:''084''); /match=(desc:''HYPOTHETICAL 135.8 KD PROTEIN'', species:''Drosophila melanogaster (Fruit fly)'', ranges:(query:152096..152785, target:SPTREMBL::Q9XZ29:230..1, score:''1147.00''), (query:151882..152043, target:SPTREMBL::Q9XZ29:277..224, score:''250.00''), (query:149546..151816, target:SPTREMBL::Q9XZ29:1032..276, score:''3735.00''), (query:148953..149465, target:SPTREMBL::Q9XZ29:1202..1032, score:''890.00''), (query:148863..148907, target:SPTREMBL::Q9XZ29:1212..1198, score:''76.00'')), method:''blastx'', version:''1.4.9''); /match=(desc:''LD21815.5prime LD Drosophila melanogaster embryo pOT2 Drosophila melanogaster cDNA clone LD21815 5prime similar to L19117: Drosophila melanogaster (chromosome X 3A6-8) kinesin-like protein of 3A (klp3A) mRNA sequence'', species:''Drosophila melanogaster (fruit fly)'', ranges:(query:152482..152787, target:EMBL::AA816942:460..155, score:''1485.00''), (query:152401..152483, target:EMBL::AA816942:540..458, score:''397.00'')), method:''blastn'', version:''1.4.9'')"]
     Key: protein_id, Value: ['CAB72294.1']
     Key: translation, Value: ['MSSEDPSCVAVALRVRPLVQSELDRGCRIAVERSADGAPQVTVNRNESYTYNYVFDIDDSQKDLFETCVQAKVKKLLNGYNVTILAYGQTGSGKTYTMGTAFNGVLDDHVGVIPRAVHDIFTAIAEMQSEFRFAVTCSFVELYQEQFYDLFSSKTRDKATVDIREVKNRIIMPGLTELVVTSAQQVTDHLIRGSAGRAVAATAMNETSSRSHAIFTLTLVATKLDGKQSVTTSRFNLVDLAGSERCSKTLASGDRFKEGVNINKGLLALGNVINALGSGQAAGYIPYRQSKLTRLLQDSLGGNSITLMIACVSPADYNVAETLSTLRYADRALQIKNKPVVNLDPHAAEVNMLKDVIQKLRVELLSGGKMSSSLISAVGAAGLGAIPCEESLAGSMANAAEIQRLKEQVRTLQDRNRKLQQELHQSLLDLTEKEMRAHIAEQAHDKLRSHVSELKNKLDQREQAQFGNENTNGDNEMRDFSLLVNRVHVELQRTQEELESQGHESRQRLSSRSHTEGGESGGDEVHEMLHSHSEEYTNKQMNFAGELRNINRQLDLKQELHERIMRNFSRLDSDDEDVKLRLCNQKIDDLEAERRDLMDQLRNIKSKDISAKLAEERRKRLQLLEQEISDLRRKLITQANLLKIRDKEREKIQNLSTEIRTMKESKVKLIRAMRGESEKFRQWKMVREKELTQLKSKDRKMQSEIVRQQTLHSKQRQVLKRKCEEALAANKRLKDALERQASAQAQRHKYKDNGGSAAGSSNANAKTDSWVDRELEIILSLIDAEHSLEQLMEDRAVINNHYHLLQQEKTSDPAEAAEQARILASLEEELEMRNAQISDLQQKVCPTDLDSRIRSLAEGVQSLGESRTVSKQLLKTLVQQRRLQASSLNEQRTTLDELRAQLLDAQQQEDAASKRLRLLQSQHEEQMLAQQRAYEEKVSVLIRTANQRWAEARSPAEDQQRNQILEELLSSREALQQELDKLRAKNKSKSKAVKSEPQDLDDSFQIVDGNETVVLSDVSDDPDWVPSTSKSKRIQSDSRNVISPPEKQDANVTSLGNSSIQSLNSTSATEDGKRCKGCKCRTKCTTKRCGCLSGNNACSETCVCKSNCRNPLNLKDHASQCGDGDGQKDETEDADKSDDDGDDEPQTSKENAVKFVTPEAPGKVVASPKQTLQEPKAAATPLMNSNVVEDINGPKLAKMSGLAFDTPKRKFF']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: gene
 location: join{[153489:154269](+), AL121804.2[40:610](+), AL121804.2[671:1487](+)}
 qualifiers:
     Key: gene, Value: ['EG:BACR7C10.3']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[153489:154269](+), AL121804.2[40:610](+), AL121804.2[671:1487](+)}
 qualifiers:
@@ -1922,10 +4327,22 @@ qualifiers:
     Key: gene, Value: ['EG:BACR7C10.3']
     Key: protein_id, Value: ['CAB72295.1']
     Key: translation, Value: ['MEEEAPRFNVLEEAFNGNGNGCANVEATQSAILKVLTRVNRFQMRVRKHIEDNYTEFLPNNTSPDIFLEESGSLNREIHDMLENLGSEGLDALDEANVKMAGNGRQLREILLGLGVSEHVLRIDELFQCVEEAKATKDYLVLLDLVGRLRAFIYGDDSVDGDAQVATPEVRRIFKALECYETIKVKYHVQAYMLQQSLQERFDRLVQLQCKSFPTSRCVTLQVSRDQTQLQDIVQALFQEPYNPARLAEFLLDNCIEPVIMRPVMADYSEEADGGTYVRLSLSYATKEPSSAHVRPNYKQVLENLRLLLHTLAGINCSVSRDQHVFGIIGDHVKDKMLKLLVDECLIPAVPESTEEYQTSTLCEDVAQLEQLLVDSFIINPEQDRALGQFVEKYETYYRNRMYRRVLETAREIIQRDLQDMVLVAPNNHSAEVANDPFLFPRCMISKSAQDFVKLMDRILRQPTDKLGDQEADPIAGVISIMLHTYINEVPKVHRKLLESIPQQAVLFHNNCMFFTHWVAQHANKGIESLAALAKTLQATGQQHFRVQVDYQSSILMGIMQEFEFESTHTLGSGPLKLVRQCLRQLELLKNVWANVLPETVYNATFCELINTFVAELIRRVFTLRHISAQMACELSDLIDVVLQRAPTLFREPNEVVQVLSWLKLQQLKAMLNASLMEITELWGDGVGPLTASYKSDEIKHLIRALFQDTDWRAKAITQIV']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_08(self):
         path = "GenBank/one_of.gb"
@@ -1936,20 +4353,39 @@ qualifiers:
         id = "U18266.1"
         name = "HSTMPO1"
         description = "Human thymopoietin (TMPO) gene, exon 1"
-        annotations = {"accessions": ["U18266"],
-                       "data_file_division": "PRI",
-                       "date": "01-JUL-1995",
-                       "gi": "885676",
-                       "keywords": [""],
-                       "molecule_type": "DNA",
-                       "organism": "Homo sapiens",
-                       "segment": "1 of 6",
-                       "sequence_version": 1,
-                       "source": "human",
-                       "taxonomy": ["Eukaryota", "Metazoa", "Chordata", "Craniata", "Vertebrata", "Euteleostomi", "Mammalia", "Eutheria", "Primates", "Catarrhini", "Hominidae", "Homo"],
-                       }
-        references = ["location: [0:2509]\nauthors: Harris,C.A., Andryuk,P.J., Cline,S.W., Siekierka,J.J. and Goldstein,G.\ntitle: Structure and mapping of the human thymopoietin (TMPO) gene and relationship of TMPO beta to rat lamin-associated polypeptide 2\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n", "location: [0:2509]\nauthors: Harris,C.A.\ntitle: Direct Submission\njournal: Submitted (07-DEC-1994) Crafford A. Harris, Immunobiology Research Institute, Route 22 East, Annandale, NJ 08801-0999, USA\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+        annotations = {
+            "accessions": ["U18266"],
+            "data_file_division": "PRI",
+            "date": "01-JUL-1995",
+            "gi": "885676",
+            "keywords": [""],
+            "molecule_type": "DNA",
+            "organism": "Homo sapiens",
+            "segment": "1 of 6",
+            "sequence_version": 1,
+            "source": "human",
+            "taxonomy": [
+                "Eukaryota",
+                "Metazoa",
+                "Chordata",
+                "Craniata",
+                "Vertebrata",
+                "Euteleostomi",
+                "Mammalia",
+                "Eutheria",
+                "Primates",
+                "Catarrhini",
+                "Hominidae",
+                "Homo",
+            ],
+        }
+        references = [
+            "location: [0:2509]\nauthors: Harris,C.A., Andryuk,P.J., Cline,S.W., Siekierka,J.J. and Goldstein,G.\ntitle: Structure and mapping of the human thymopoietin (TMPO) gene and relationship of TMPO beta to rat lamin-associated polypeptide 2\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:2509]\nauthors: Harris,C.A.\ntitle: Direct Submission\njournal: Submitted (07-DEC-1994) Crafford A. Harris, Immunobiology Research Institute, Route 22 East, Annandale, NJ 08801-0999, USA\nmedline id: \npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:2509](+)
 qualifiers:
@@ -1959,27 +4395,39 @@ qualifiers:
     Key: db_xref, Value: ['taxon:9606']
     Key: map, Value: ['12q22; 64% (% distance from centromere to telomere)']
     Key: organism, Value: ['Homo sapiens']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: 5'UTR
 location: [one-of(1887,1900):2200](+)
 qualifiers:
     Key: gene, Value: ['TMPO']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: join{[1887:2509](+), U18267.1[0:270](+), U18268.1[0:309](+), U18270.1[0:6905](+), U18269.1[0:128](+), U18271.1[0:3234](+)}
 qualifiers:
     Key: gene, Value: ['TMPO']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: exon
 location: [one-of(1887,1900):2479](+)
 qualifiers:
     Key: gene, Value: ['TMPO']
     Key: number, Value: ['1']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[2200:2479](+), U18267.1[119:246](+), U18268.1[129:288](+), U18270.1[4690:4788](+), U18269.1[81:>128](+)}
 qualifiers:
@@ -1989,8 +4437,11 @@ qualifiers:
     Key: product, Value: ['thymopoietin beta']
     Key: protein_id, Value: ['AAB60434.1']
     Key: translation, Value: ['MPEFLEDPSVLTKDKLKSELVANNVTLPAGEQRKDVYVQLYLQHLTARNRPPLPAGTNSKGPPDFSSDEEREPTPVLGSGAAAAGRSRAAVGRKATKKTDKPRQEDKDDLDVTELTNEDLLDQLVKYGVNPGPIVGTTRKLYEKKLLKLREQGTESRSSTPLPTISSSAENTRQNGSNDSDRYSDNEEDSKIELKLEKREPLKGRAKTPVTLKQRRVEHNQSYSQAGITETEWTSGS']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: join{[2200:2479](+), U18267.1[119:246](+), U18268.1[129:288](+), U18270.1[38:1558](+)}
 qualifiers:
@@ -2000,10 +4451,22 @@ qualifiers:
     Key: product, Value: ['thymopoietin alpha']
     Key: protein_id, Value: ['AAB60433.1']
     Key: translation, Value: ['MPEFLEDPSVLTKDKLKSELVANNVTLPAGEQRKDVYVQLYLQHLTARNRPPLPAGTNSKGPPDFSSDEEREPTPVLGSGAAAAGRSRAAVGRKATKKTDKPRQEDKDDLDVTELTNEDLLDQLVKYGVNPGPIVGTTRKLYEKKLLKLREQGTESRSSTPLPTISSSAENTRQNGSNDSDRYSDNEEGKKKEHKKVKSTRDIVPFSELGTTPSGGGFFQGISFPEISTRPPLGSTELQAAKKVHTSKGDLPREPLVATNLPGRGQLQKLASERNLFISCKSSHDRCLEKSSSSSSQPEHSAMLVSTAASPSLIKETTTGYYKDIVENICGREKSGIQPLCPERSHISDQSPLSSKRKALEESESSQLISPPLAQAIRDYVNSLLVQGGVGSLPGTSNSMPPLDVENIQKRIDQSKFQETEFLSPPRKVPRLSEKSVEERDSGSFVAFQNIPGSELMSSFAKTVVSHSLTTLGLEVAKQSQHDKIDASELSFPFHESILKVIEEEWQQVDRQLPSLACKYPVSSREATQILSVPKVDDEILGFISEATPLGGIQAASTESCNQQLDLALCRAYEAAASALQIATHTAFVAKAMQADISEAAQILSSDPSRTHQALGILSKTYDAASYICEAAFDEVKMAAHTMGNATVGRRYLWLKDCKINLASKNKLASTPFKGGTLFGGEVCKVIKKRGNKH']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_09(self):
         path = "GenBank/NT_019265.gb"
@@ -2014,34 +4477,55 @@ qualifiers:
         id = "NT_019265.6"
         name = "NT_019265"
         description = "Homo sapiens chromosome 1 working draft sequence segment"
-        annotations = {"accessions": ["NT_019265"],
-                       "comment": """\
+        annotations = {
+            "accessions": ["NT_019265"],
+            "comment": """\
 GENOME ANNOTATION REFSEQ:  NCBI contigs are derived from assembled
 genomic sequence data. They may include both draft and finished
 sequence.
 On Oct 16, 2001 this sequence version replaced gi:15294341.
 COMPLETENESS: not full length.""",
-                       "contig": "join(AL391218.9:105173..108462,gap(100),complement(AL512330.12:1..182490),complement(AL590128.4:9034..81287),gap(100),AL591163.7:85799..94832,gap(100),AL591163.7:94933..113245,gap(100),AL591163.7:42173..44897,complement(AL590128.4:1..6208),AL591163.7:51307..52779,gap(100),AL591163.7:52880..85698,gap(100),AL591163.7:113346..126143,complement(AL159177.12:184729..186047),AL031447.4:1..112158,complement(AL159177.12:1..72671),complement(AL591866.12:23507..86371),AL031848.11:1..142965,AL031847.17:1..166418,AL035406.25:1..161651,complement(AL356261.20:94599..98345),complement(AC026968.3:54432..54579),gap(100),complement(AC062024.2:98529..107911),gap(100),AC062024.2:7713..11594,gap(100),complement(AL356261.20:1..94498),complement(AL356693.18:19988..70853),gap(100),AL356693.18:17351..19887,gap(100),complement(AL356693.18:3037..17250),gap(100),complement(AL356693.18:1..2936),gap(100),AC026968.3:675..2393,gap(100),AC026968.3:1..574,gap(100),AL356261.20:179029..182233)",
-                       "data_file_division": "CON",
-                       "date": "16-OCT-2001",
-                       "gi": "16156830",
-                       "keywords": [""],
-                       "molecule_type": "DNA",
-                       "organism": "Homo sapiens",
-                       "sequence_version": 6,
-                       "source": "human",
-                       "taxonomy": ["Eukaryota", "Metazoa", "Chordata", "Craniata", "Vertebrata", "Euteleostomi", "Mammalia", "Eutheria", "Primates", "Catarrhini", "Hominidae", "Homo"],
-                       }
-        references = ["location: [0:1250660]\nauthors: NCBI Annotation Project.\ntitle: Direct Submission\njournal: Submitted (11-OCT-2001) National Center for Biotechnology Information, NIH, Bethesda, MD 20894, USA\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+            "contig": "join(AL391218.9:105173..108462,gap(100),complement(AL512330.12:1..182490),complement(AL590128.4:9034..81287),gap(100),AL591163.7:85799..94832,gap(100),AL591163.7:94933..113245,gap(100),AL591163.7:42173..44897,complement(AL590128.4:1..6208),AL591163.7:51307..52779,gap(100),AL591163.7:52880..85698,gap(100),AL591163.7:113346..126143,complement(AL159177.12:184729..186047),AL031447.4:1..112158,complement(AL159177.12:1..72671),complement(AL591866.12:23507..86371),AL031848.11:1..142965,AL031847.17:1..166418,AL035406.25:1..161651,complement(AL356261.20:94599..98345),complement(AC026968.3:54432..54579),gap(100),complement(AC062024.2:98529..107911),gap(100),AC062024.2:7713..11594,gap(100),complement(AL356261.20:1..94498),complement(AL356693.18:19988..70853),gap(100),AL356693.18:17351..19887,gap(100),complement(AL356693.18:3037..17250),gap(100),complement(AL356693.18:1..2936),gap(100),AC026968.3:675..2393,gap(100),AC026968.3:1..574,gap(100),AL356261.20:179029..182233)",
+            "data_file_division": "CON",
+            "date": "16-OCT-2001",
+            "gi": "16156830",
+            "keywords": [""],
+            "molecule_type": "DNA",
+            "organism": "Homo sapiens",
+            "sequence_version": 6,
+            "source": "human",
+            "taxonomy": [
+                "Eukaryota",
+                "Metazoa",
+                "Chordata",
+                "Craniata",
+                "Vertebrata",
+                "Euteleostomi",
+                "Mammalia",
+                "Eutheria",
+                "Primates",
+                "Catarrhini",
+                "Hominidae",
+                "Homo",
+            ],
+        }
+        references = [
+            "location: [0:1250660]\nauthors: NCBI Annotation Project.\ntitle: Direct Submission\njournal: Submitted (11-OCT-2001) National Center for Biotechnology Information, NIH, Bethesda, MD 20894, USA\nmedline id: \npubmed id: \ncomment: \n"
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:1250660](+)
 qualifiers:
     Key: chromosome, Value: ['1']
     Key: db_xref, Value: ['taxon:9606']
     Key: organism, Value: ['Homo sapiens']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: source
 location: [0:3290](+)
 qualifiers:
@@ -2049,22 +4533,31 @@ qualifiers:
     Key: db_xref, Value: ['taxon:9606']
     Key: note, Value: ['Accession AL391218 sequenced by The Sanger Centre']
     Key: organism, Value: ['Homo sapiens']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: misc_feature
 location: [215901:365470](+)
 qualifiers:
     Key: note, Value: ['FISH-mapped clone']
     Key: standard_name, Value: ['RP11-242F24']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: variation
 location: [217507:217508](+)
 qualifiers:
     Key: allele, Value: ['T', 'C']
     Key: db_xref, Value: ['dbSNP:811400']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: mRNA
 location: join{[342429:342515](+), [363170:363300](+), [365740:365814](+), [376397:376499](+), [390168:390297](+), [391256:391379](+), [392605:392679](+), [398229:398419](+), [399081:399167](+), [399533:399650](+), [405843:405913](+), [406703:406761](+), [406867:407010](+), [407961:408091](+), [408507:409092](+)}
 qualifiers:
@@ -2072,10 +4565,22 @@ qualifiers:
     Key: gene, Value: ['FLJ10737']
     Key: product, Value: ['hypothetical protein FLJ10737']
     Key: transcript_id, Value: ['XM_057697.1']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_10(self):
         path = "GenBank/origin_line.gb"
@@ -2086,36 +4591,64 @@ qualifiers:
         id = "NC_002678.1"
         name = "NC_002678"
         description = "Mesorhizobium loti, complete genome (edited)"
-        annotations = {"accessions": ["NC_002678"],
-                       "data_file_division": "BCT",
-                       "date": "28-MAR-2001",
-                       "gi": "13470324",
-                       "keywords": [""],
-                       "molecule_type": "DNA",
-                       "organism": "Mesorhizobium loti",
-                       "sequence_version": 1,
-                       "source": "Mesorhizobium loti",
-                       "taxonomy": ["Bacteria", "Proteobacteria", "alpha subdivision", "Rhizobiaceae group", "Phyllobacteriaceae", "Mesorhizobium"],
-                       "topology": "circular",
-                       }
-        references = ["authors: Kaneko,T., Nakamura,Y., Sato,S., Asamizu,E., Kato,T., Sasamoto,S., Watanabe,A., Idesawa,K., Ishikawa,A., Kawashima,K., Kimura,T., Kishida,Y., Kiyokawa,C., Kohara,M., Matsumoto,M., Matsuno,A., Mochizuki,Y., Nakayama,S., Nakazaki,N., Shimpo,S., Sugimoto,M., Takeuchi,C., Yamada,M. and Tabata,S.\ntitle: Complete genome structure of the nitrogen-fixing symbiotic bacterium Mesorhizobium loti\njournal: DNA Res. 7, 331-338 (2000)\nmedline id: \npubmed id: \ncomment: \n", "location: [0:180]\nauthors: Kaneko,T.\ntitle: Direct Submission\njournal: Submitted (05-DEC-2000) Takakazu Kaneko, Kazusa DNA Research Institute, The First Laboratory for Plant Gene Research; Yana 1532-3, Kisarazu, Chiba 292-0812, Japan (E-mail:kaneko@kazusa.or.jp, URL:http://www.kazusa.or.jp/rhizobase/, Tel:81-438-52-3935, Fax:81-438-52-3934)\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+        annotations = {
+            "accessions": ["NC_002678"],
+            "data_file_division": "BCT",
+            "date": "28-MAR-2001",
+            "gi": "13470324",
+            "keywords": [""],
+            "molecule_type": "DNA",
+            "organism": "Mesorhizobium loti",
+            "sequence_version": 1,
+            "source": "Mesorhizobium loti",
+            "taxonomy": [
+                "Bacteria",
+                "Proteobacteria",
+                "alpha subdivision",
+                "Rhizobiaceae group",
+                "Phyllobacteriaceae",
+                "Mesorhizobium",
+            ],
+            "topology": "circular",
+        }
+        references = [
+            "authors: Kaneko,T., Nakamura,Y., Sato,S., Asamizu,E., Kato,T., Sasamoto,S., Watanabe,A., Idesawa,K., Ishikawa,A., Kawashima,K., Kimura,T., Kishida,Y., Kiyokawa,C., Kohara,M., Matsumoto,M., Matsuno,A., Mochizuki,Y., Nakayama,S., Nakazaki,N., Shimpo,S., Sugimoto,M., Takeuchi,C., Yamada,M. and Tabata,S.\ntitle: Complete genome structure of the nitrogen-fixing symbiotic bacterium Mesorhizobium loti\njournal: DNA Res. 7, 331-338 (2000)\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:180]\nauthors: Kaneko,T.\ntitle: Direct Submission\njournal: Submitted (05-DEC-2000) Takakazu Kaneko, Kazusa DNA Research Institute, The First Laboratory for Plant Gene Research; Yana 1532-3, Kisarazu, Chiba 292-0812, Japan (E-mail:kaneko@kazusa.or.jp, URL:http://www.kazusa.or.jp/rhizobase/, Tel:81-438-52-3935, Fax:81-438-52-3934)\nmedline id: \npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:180](+)
 qualifiers:
     Key: db_xref, Value: ['taxon:381']
     Key: organism, Value: ['Mesorhizobium loti']
     Key: strain, Value: ['MAFF303099']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [19:120](+)
 qualifiers:
     Key: gene, Value: ['fake']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_11(self):
         path = "GenBank/blank_seq.gb"
@@ -2126,8 +4659,9 @@ qualifiers:
         id = "NP_001832.1"
         name = "NP_001832"
         description = "cannabinoid receptor 2 (macrophage) [Homo sapiens]"
-        annotations = {"accessions": ["NP_001832"],
-                       "comment": """\
+        annotations = {
+            "accessions": ["NP_001832"],
+            "comment": """\
 REVIEWED REFSEQ: This record has been curated by NCBI staff. The
 reference sequence was derived from X74328.1.
 Summary: The cannabinoid delta-9-tetrahydrocannabinol is the
@@ -2141,20 +4675,39 @@ found to be involved in the cannabinoid-induced CNS effects
 (including alterations in mood and cognition) experienced by users
 of marijuana. The cannabinoid receptors are members of family 1 of
 the G-protein-coupled receptors.""",
-                       "data_file_division": "PRI",
-                       "date": "18-DEC-2001",
-                       "db_source": "REFSEQ: accession NM_001841.1",
-                       "gi": "4502929",
-                       "keywords": [""],
-                       "organism": "Homo sapiens",
-                       "pid": "g4502929",
-                       "sequence_version": 1,
-                       "source": "human",
-                       "taxonomy": ["Eukaryota", "Metazoa", "Chordata", "Craniata", "Vertebrata", "Euteleostomi", "Mammalia", "Eutheria", "Primates", "Catarrhini", "Hominidae", "Homo"],
-                       "topology": "linear",
-                       }
-        references = ["location: [0:360]\nauthors: Munro,S., Thomas,K.L. and Abu-Shaar,M.\ntitle: Molecular characterization of a peripheral receptor for cannabinoids\njournal: Nature 365 (6441), 61-65 (1993)\nmedline id: 93368659\npubmed id: 7689702\ncomment: \n", "location: [0:360]\nauthors: Galiegue,S., Mary,S., Marchand,J., Dussossoy,D., Carriere,D., Carayon,P., Bouaboula,M., Shire,D., Le Fur,G. and Casellas,P.\ntitle: Expression of central and peripheral cannabinoid receptors in human immune tissues and leukocyte subpopulations\njournal: Eur. J. Biochem. 232 (1), 54-61 (1995)\nmedline id: 96048028\npubmed id: 7556170\ncomment: \n", "location: [0:360]\nauthors: Shire,D., Calandra,B., Rinaldi-Carmona,M., Oustric,D., Pessegue,B., Bonnin-Cabanne,O., Le Fur,G., Caput,D. and Ferrara,P.\ntitle: Molecular cloning, expression and function of the murine CB2 peripheral cannabinoid receptor\njournal: Biochim. Biophys. Acta 1307 (2), 132-136 (1996)\nmedline id: 96283804\npubmed id: 8679694\ncomment: \n"]
-        features = (("""\
+            "data_file_division": "PRI",
+            "date": "18-DEC-2001",
+            "db_source": "REFSEQ: accession NM_001841.1",
+            "gi": "4502929",
+            "keywords": [""],
+            "organism": "Homo sapiens",
+            "pid": "g4502929",
+            "sequence_version": 1,
+            "source": "human",
+            "taxonomy": [
+                "Eukaryota",
+                "Metazoa",
+                "Chordata",
+                "Craniata",
+                "Vertebrata",
+                "Euteleostomi",
+                "Mammalia",
+                "Eutheria",
+                "Primates",
+                "Catarrhini",
+                "Hominidae",
+                "Homo",
+            ],
+            "topology": "linear",
+        }
+        references = [
+            "location: [0:360]\nauthors: Munro,S., Thomas,K.L. and Abu-Shaar,M.\ntitle: Molecular characterization of a peripheral receptor for cannabinoids\njournal: Nature 365 (6441), 61-65 (1993)\nmedline id: 93368659\npubmed id: 7689702\ncomment: \n",
+            "location: [0:360]\nauthors: Galiegue,S., Mary,S., Marchand,J., Dussossoy,D., Carriere,D., Carayon,P., Bouaboula,M., Shire,D., Le Fur,G. and Casellas,P.\ntitle: Expression of central and peripheral cannabinoid receptors in human immune tissues and leukocyte subpopulations\njournal: Eur. J. Biochem. 232 (1), 54-61 (1995)\nmedline id: 96048028\npubmed id: 7556170\ncomment: \n",
+            "location: [0:360]\nauthors: Shire,D., Calandra,B., Rinaldi-Carmona,M., Oustric,D., Pessegue,B., Bonnin-Cabanne,O., Le Fur,G., Caput,D. and Ferrara,P.\ntitle: Molecular cloning, expression and function of the murine CB2 peripheral cannabinoid receptor\njournal: Biochim. Biophys. Acta 1307 (2), 132-136 (1996)\nmedline id: 96283804\npubmed id: 8679694\ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:360]
 qualifiers:
@@ -2162,22 +4715,31 @@ qualifiers:
     Key: db_xref, Value: ['taxon:9606']
     Key: map, Value: ['1p36.11']
     Key: organism, Value: ['Homo sapiens']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Protein
 location: [0:360]
 qualifiers:
     Key: product, Value: ['cannabinoid receptor 2 (macrophage)']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Region
 location: [49:299]
 qualifiers:
     Key: db_xref, Value: ['CDD:pfam00001']
     Key: note, Value: ['7tm_1']
     Key: region_name, Value: ['7 transmembrane receptor (rhodopsin family)']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: CDS
 location: [0:360]
 qualifiers:
@@ -2185,10 +4747,22 @@ qualifiers:
     Key: db_xref, Value: ['LocusID:1269', 'MIM:605051']
     Key: gene, Value: ['CNR2']
     Key: pseudo, Value: ['']
-""", None),
-                    )
+""",
+                None,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_12(self):
         path = "GenBank/dbsource_wrap.gb"
@@ -2199,75 +4773,120 @@ qualifiers:
         id = "P01485"
         name = "SCX3_BUTOC"
         description = "Neurotoxin III"
-        annotations = {"accessions": ["P01485"],
-                       "comment": """\
+        annotations = {
+            "accessions": ["P01485"],
+            "comment": """\
 [FUNCTION] BINDS TO SODIUM CHANNELS AND INHIBITS THE INACTIVATION
 OF THE ACTIVATED CHANNELS, THEREBY BLOCKING NEURONAL TRANSMISSION.
 [SUBCELLULAR LOCATION] SECRETED.
 [SIMILARITY] BELONGS TO THE ALPHA/BETA-SCORPION TOXIN FAMILY.
 ALPHA-TOXIN SUBFAMILY.""",
-                       "data_file_division": "INV",
-                       "date": "16-OCT-2001",
-                       "db_source": "swissprot: locus SCX3_BUTOC, accession P01485; class: standard. created: Jul 21, 1986. sequence updated: Jul 21, 1986. annotation updated: Oct 16, 2001. xrefs: gi: gi: 69530 xrefs (non-sequence databases): HSSP P01484, InterPro IPR003614, InterPro IPR002061, InterPro IPR001219, Pfam PF00537, PRINTS PR00284, ProDom PD000908, SMART SM00505",
-                       "gi": "134354",
-                       "keywords": ["Neurotoxin", "Sodium channel inhibitor", "Amidation"],
-                       "organism": "Buthus occitanus tunetanus",
-                       "pid": "g134354",
-                       "source": "Tunisian scorpion",
-                       "taxonomy": ["Eukaryota", "Metazoa", "Arthropoda", "Chelicerata", "Arachnida", "Scorpiones", "Buthoidea", "Buthidae", "Buthus"],
-                       "topology": "linear",
-                       }
-        references = ["location: [0:64]\nauthors: Vargas,O., Gregoire,J., Martin,M.-F., Bechis,G. and Rochat,H.\ntitle: Neurotoxins from the venoms of two scorpions: Buthus occitanus tunetanus and Buthus occitanus mardochei\njournal: Toxicon 20, 79-79 (1982)\nmedline id: \npubmed id: \ncomment: SEQUENCE.\n"]
-        features = (("""\
+            "data_file_division": "INV",
+            "date": "16-OCT-2001",
+            "db_source": "swissprot: locus SCX3_BUTOC, accession P01485; class: standard. created: Jul 21, 1986. sequence updated: Jul 21, 1986. annotation updated: Oct 16, 2001. xrefs: gi: gi: 69530 xrefs (non-sequence databases): HSSP P01484, InterPro IPR003614, InterPro IPR002061, InterPro IPR001219, Pfam PF00537, PRINTS PR00284, ProDom PD000908, SMART SM00505",
+            "gi": "134354",
+            "keywords": ["Neurotoxin", "Sodium channel inhibitor", "Amidation"],
+            "organism": "Buthus occitanus tunetanus",
+            "pid": "g134354",
+            "source": "Tunisian scorpion",
+            "taxonomy": [
+                "Eukaryota",
+                "Metazoa",
+                "Arthropoda",
+                "Chelicerata",
+                "Arachnida",
+                "Scorpiones",
+                "Buthoidea",
+                "Buthidae",
+                "Buthus",
+            ],
+            "topology": "linear",
+        }
+        references = [
+            "location: [0:64]\nauthors: Vargas,O., Gregoire,J., Martin,M.-F., Bechis,G. and Rochat,H.\ntitle: Neurotoxins from the venoms of two scorpions: Buthus occitanus tunetanus and Buthus occitanus mardochei\njournal: Toxicon 20, 79-79 (1982)\nmedline id: \npubmed id: \ncomment: SEQUENCE.\n"
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:64]
 qualifiers:
     Key: db_xref, Value: ['taxon:6871']
     Key: organism, Value: ['Buthus occitanus tunetanus']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Protein
 location: [0:64]
 qualifiers:
     Key: product, Value: ['Neurotoxin III']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Bond
 location: bond{[11:12], [62:63]}
 qualifiers:
     Key: bond_type, Value: ['disulfide']
     Key: note, Value: ['BY SIMILARITY.']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Bond
 location: bond{[15:16], [35:36]}
 qualifiers:
     Key: bond_type, Value: ['disulfide']
     Key: note, Value: ['BY SIMILARITY.']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Bond
 location: bond{[21:22], [45:46]}
 qualifiers:
     Key: bond_type, Value: ['disulfide']
     Key: note, Value: ['BY SIMILARITY.']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Bond
 location: bond{[25:26], [47:48]}
 qualifiers:
     Key: bond_type, Value: ['disulfide']
     Key: note, Value: ['BY SIMILARITY.']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Site
 location: [63:64]
 qualifiers:
     Key: site_type, Value: ['amidation']
-""", None),
-                    )
+""",
+                None,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_13(self):
         path = "GenBank/gbvrl1_start.seq"
@@ -2277,21 +4896,35 @@ qualifiers:
         seq = "ATGTCTGGCAACCAGTATACTGAGGAAGTTATGGAGGGAGTAAATTGGTTAAAG...TAA"
         id = "AB000048.1"
         name = "AB000048"
-        description = "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
-        annotations = {"accessions": ["AB000048"],
-                       "data_file_division": "VRL",
-                       "date": "05-FEB-1999",
-                       "gi": "1769753",
-                       "keywords": ["nonstructural protein 1"],
-                       "molecule_type": "DNA",
-                       "organism": "Feline panleukopenia virus",
-                       "sequence_version": 1,
-                       "source": "Feline panleukopenia virus",
-                       "taxonomy": ["Viruses", "ssDNA viruses", "Parvoviridae", "Parvovirinae", "Parvovirus"],
-                       "topology": "linear",
-                       }
-        references = ["location: [0:2007]\nauthors: Horiuchi,M.\ntitle: Evolutionary pattern of feline panleukopenia virus differs from that of canine parvovirus\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n", "location: [0:2007]\nauthors: Horiuchi,M.\ntitle: Direct Submission\njournal: Submitted (22-DEC-1996) Motohiro Horiuchi, Obihiro University of Agriculture and Veterinary Medicine, Veterinary Public Health; Inada cho, Obihiro, Hokkaido 080, Japan (E-mail:horiuchi@obihiro.ac.jp, Tel:0155-49-5392, Fax:0155-49-5402)\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+        description = (
+            "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
+        )
+        annotations = {
+            "accessions": ["AB000048"],
+            "data_file_division": "VRL",
+            "date": "05-FEB-1999",
+            "gi": "1769753",
+            "keywords": ["nonstructural protein 1"],
+            "molecule_type": "DNA",
+            "organism": "Feline panleukopenia virus",
+            "sequence_version": 1,
+            "source": "Feline panleukopenia virus",
+            "taxonomy": [
+                "Viruses",
+                "ssDNA viruses",
+                "Parvoviridae",
+                "Parvovirinae",
+                "Parvovirus",
+            ],
+            "topology": "linear",
+        }
+        references = [
+            "location: [0:2007]\nauthors: Horiuchi,M.\ntitle: Evolutionary pattern of feline panleukopenia virus differs from that of canine parvovirus\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:2007]\nauthors: Horiuchi,M.\ntitle: Direct Submission\njournal: Submitted (22-DEC-1996) Motohiro Horiuchi, Obihiro University of Agriculture and Veterinary Medicine, Veterinary Public Health; Inada cho, Obihiro, Hokkaido 080, Japan (E-mail:horiuchi@obihiro.ac.jp, Tel:0155-49-5392, Fax:0155-49-5402)\nmedline id: \npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:2007](+)
 qualifiers:
@@ -2300,8 +4933,11 @@ qualifiers:
     Key: lab_host, Value: ['Felis domesticus']
     Key: mol_type, Value: ['genomic DNA']
     Key: organism, Value: ['Feline panleukopenia virus']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [0:2007](+)
 qualifiers:
@@ -2310,29 +4946,55 @@ qualifiers:
     Key: product, Value: ['nonstructural protein 1']
     Key: protein_id, Value: ['BAA19009.1']
     Key: translation, Value: ['MSGNQYTEEVMEGVNWLKKHAEDEAFSFVFKCDNVQLNGKDVRWNNYTKPIQNEELTSLIRGAQTAMDQTEEEEMDWESEVDSLAKKQVQTFDALIKKCLFEVFVSKNIEPNECVWFIQHEWGKDQGWHCHVLLHSKNLQQATGKWLRRQMNMYWSRWLVTLCSINLTPTEKIKLREIAEDSEWVTILTYRHKQTKKDYVKMVHFGNMIAYYFLTKKKIVHMTKESGYFLSTDSGWKFNFMKYQDRHTVSTLYTEQMKPETVETTVTTAQETKRGRIQTKKEVSIKCTLRDLVSKRVTSPEDWMMLQPDSYIEMMAQPGGENLLKNTLEICTLTLARTKTAFELILEKADNTKLTNFDLANSRTCQIFRMHGWNWIKVCHAIACVLNRQGGKRNTVLFHGPASTGKSIIAQAIAQAVGNVGCYNAANVNFPFNDCTNKNLIWVEEAGNFGQQVNQFKAICSGQTIRIDQKGKGSKQIEPTPVIMTTNENITIVRIGCEERPEHTQPIRDRMLNIKLVCKLPGDFGLVDKEEWPLICAWLVKHGYQSTMANYTHHWGKVPEWDENWAEPKIQEGINSPGCKDLETQAASNPQSQDHVLTPLTPDVVDLALEPWSTPDTPIAETANQQSNQLGVTHKDVQASPTWSEIEADLRAIFTSEQLEEDFRDDLD']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
         record = next(records)
         seq = "ATGTCTGGCAACCAGTATACTGAGGAAGTTATGGAGGGAGTAAATTGGTTAAAG...TAA"
         id = "AB000049.1"
         name = "AB000049"
-        description = "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
-        annotations = {"accessions": ["AB000049"],
-                       "data_file_division": "VRL",
-                       "date": "05-FEB-1999",
-                       "gi": "1769755",
-                       "keywords": ["nonstructural protein 1"],
-                       "molecule_type": "DNA",
-                       "organism": "Feline panleukopenia virus",
-                       "sequence_version": 1,
-                       "source": "Feline panleukopenia virus",
-                       "taxonomy": ["Viruses", "ssDNA viruses", "Parvoviridae", "Parvovirinae", "Parvovirus"],
-                       "topology": "linear",
-                       }
-        references = ["location: [0:2007]\nauthors: Horiuchi,M.\ntitle: Evolutionary pattern of feline panleukopenia virus differs that of canine parvovirus\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n", "location: [0:2007]\nauthors: Horiuchi,M.\ntitle: Direct Submission\njournal: Submitted (22-DEC-1996) Motohiro Horiuchi, Obihiro University of Agriculture and Veterinary Medicine, Veterinary Public Health; Inada cho, Obihiro, Hokkaido 080, Japan (E-mail:horiuchi@obihiro.ac.jp, Tel:0155-49-5392, Fax:0155-49-5402)\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+        description = (
+            "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
+        )
+        annotations = {
+            "accessions": ["AB000049"],
+            "data_file_division": "VRL",
+            "date": "05-FEB-1999",
+            "gi": "1769755",
+            "keywords": ["nonstructural protein 1"],
+            "molecule_type": "DNA",
+            "organism": "Feline panleukopenia virus",
+            "sequence_version": 1,
+            "source": "Feline panleukopenia virus",
+            "taxonomy": [
+                "Viruses",
+                "ssDNA viruses",
+                "Parvoviridae",
+                "Parvovirinae",
+                "Parvovirus",
+            ],
+            "topology": "linear",
+        }
+        references = [
+            "location: [0:2007]\nauthors: Horiuchi,M.\ntitle: Evolutionary pattern of feline panleukopenia virus differs that of canine parvovirus\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:2007]\nauthors: Horiuchi,M.\ntitle: Direct Submission\njournal: Submitted (22-DEC-1996) Motohiro Horiuchi, Obihiro University of Agriculture and Veterinary Medicine, Veterinary Public Health; Inada cho, Obihiro, Hokkaido 080, Japan (E-mail:horiuchi@obihiro.ac.jp, Tel:0155-49-5392, Fax:0155-49-5402)\nmedline id: \npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:2007](+)
 qualifiers:
@@ -2341,8 +5003,11 @@ qualifiers:
     Key: lab_host, Value: ['Felis domesticus']
     Key: mol_type, Value: ['genomic DNA']
     Key: organism, Value: ['Feline panleukopenia virus']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [0:2007](+)
 qualifiers:
@@ -2351,29 +5016,55 @@ qualifiers:
     Key: product, Value: ['nonstructural protein 1']
     Key: protein_id, Value: ['BAA19010.1']
     Key: translation, Value: ['MSGNQYTEEVMEGVNWLKKHAEDEAFSFVFKCDNVQLNGKDVRWNNYTKPIQNEELTSLIRGAQTAMDQTEEEEMDWESEVDSLAKKQVQTFDALIKKCLFEVFVSKNIEPNECVWFIQHEWGKDQGWHCHVLLHSKNLQQATGKWLRRQMNMYWSRWLVTLCSINLTPTEKIKLREIAEDSEWVTILTYRHKQTKKDYVKMVHFGNMIAYYFLTKKKIVHMTKESGYFLSTDSGWKFNFMKYQDRHTVSTLYTEQMKPETVETTVTTAQETKRGRIQTKKEVSIKCTLRDLVSKRVTSPEDWMMLQPDSYIEMMAQPGGENLLKNTLEICTLTLARTKTAFELILEKADNTKLTNFDLANSRTCQIFRMHGWNWIKVCHAIACVLNRQGGKRNTVLFHGPASTGKSIIAQAIAQAVGNVGCYNAANVNFPFNDCTNKNLIWVEEAGNFGQQVNQFKAICSGQTIRIDQKGKGSKQIEPTPVIMTTNENITIVRIGCEERPEHTQPIRDRMLNIKLVCKLPGDFGLVDKEEWPLICAWLVKHGYQSTMANYTHHWGKVPEWDENWAEPKIQEGINSPGCKDLETQAASNPQSQDHVLTPLTPDVVDLALEPWSTPDTPIAETANQQSNQLGVTHKDVQASPTWSEIEADLRAIFTSEQLEEDFRDDLD']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
         record = next(records)
         seq = "ATGAGTGATGGAGCAGTTCAACCAGACGGTGGTCAACCTGCTGTCAGAAATGAA...TAA"
         id = "AB000050.1"
         name = "AB000050"
-        description = "Feline panleukopenia virus DNA for capsid protein 2, complete cds"
-        annotations = {"accessions": ["AB000050"],
-                       "data_file_division": "VRL",
-                       "date": "05-FEB-1999",
-                       "gi": "1769757",
-                       "keywords": ["capsid protein 2"],
-                       "molecule_type": "DNA",
-                       "organism": "Feline panleukopenia virus",
-                       "sequence_version": 1,
-                       "source": "Feline panleukopenia virus",
-                       "taxonomy": ["Viruses", "ssDNA viruses", "Parvoviridae", "Parvovirinae", "Parvovirus"],
-                       "topology": "linear",
-                       }
-        references = ["location: [0:1755]\nauthors: Horiuchi,M.\ntitle: Evolutionary pattern of feline panleukopenia virus differs from that of canine parvovirus\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n", "location: [0:1755]\nauthors: Horiuchi,M.\ntitle: Direct Submission\njournal: Submitted (22-DEC-1996) Motohiro Horiuchi, Obihiro University of Agriculture and Veterinary Medicine, Veterinary Public Health; Inada cho, Obihiro, Hokkaido 080, Japan (E-mail:horiuchi@obihiro.ac.jp, Tel:0155-49-5392, Fax:0155-49-5402)\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+        description = (
+            "Feline panleukopenia virus DNA for capsid protein 2, complete cds"
+        )
+        annotations = {
+            "accessions": ["AB000050"],
+            "data_file_division": "VRL",
+            "date": "05-FEB-1999",
+            "gi": "1769757",
+            "keywords": ["capsid protein 2"],
+            "molecule_type": "DNA",
+            "organism": "Feline panleukopenia virus",
+            "sequence_version": 1,
+            "source": "Feline panleukopenia virus",
+            "taxonomy": [
+                "Viruses",
+                "ssDNA viruses",
+                "Parvoviridae",
+                "Parvovirinae",
+                "Parvovirus",
+            ],
+            "topology": "linear",
+        }
+        references = [
+            "location: [0:1755]\nauthors: Horiuchi,M.\ntitle: Evolutionary pattern of feline panleukopenia virus differs from that of canine parvovirus\njournal: Unpublished\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:1755]\nauthors: Horiuchi,M.\ntitle: Direct Submission\njournal: Submitted (22-DEC-1996) Motohiro Horiuchi, Obihiro University of Agriculture and Veterinary Medicine, Veterinary Public Health; Inada cho, Obihiro, Hokkaido 080, Japan (E-mail:horiuchi@obihiro.ac.jp, Tel:0155-49-5392, Fax:0155-49-5402)\nmedline id: \npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:1755](+)
 qualifiers:
@@ -2382,8 +5073,11 @@ qualifiers:
     Key: lab_host, Value: ['Felis domesticus']
     Key: mol_type, Value: ['genomic DNA']
     Key: organism, Value: ['Feline panleukopenia virus']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [0:1755](+)
 qualifiers:
@@ -2392,10 +5086,22 @@ qualifiers:
     Key: product, Value: ['capsid protein 2']
     Key: protein_id, Value: ['BAA19011.1']
     Key: translation, Value: ['MSDGAVQPDGGQPAVRNERATGSGNGSGGGGGGGSGGVGISTGTFNNQTEFKFLENGWVEITANSSRLVHLNMPESENYKRVVVNNMDKTAVKGNMALDDTHVQIVTPWSLVDANAWGVWFNPGDWQLIVNTMSELHLVSFEQEIFNVVLKTVSESATQPPTKVYNNDLTASLMVALDSNNTMPFTPAAMRSETLGFYPWKPTIPTPWRYYFQWDRTLIPSHTGTSGTPTNVYHGTDPDDVQFYTIENSVPVHLLRTGDEFATGTFFFDCKPCRLTHTWQTNRALGLPPFLNSLPQSEGATNFGDIGVQQDKRRGVTQMGNTDYITEATIMRPAEVGYSAPYYSFEASTQGPFKTPIAAGRGGAQTDENQAADGDPRYAFGRQHGQKTTTTGETPERFTYIAHQDTGRYPEGDWIQNINFNLPVTNDNVLLPTDPIGGKTGINYTNIFNTYGPLTALNNVPPVYPNGQIWDKEFDTDLKPRLHVNAPFVCQNNCPGQLFVKVAPNLTNEYDPDASANMSRIVTYSDFWWKGKLVFKAKLRASHTWNPIQQMSINVDNQFNYVPNNIGAMKIVYEKSQLAPRKLY']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_14(self):
         path = "GenBank/NC_005816.gb"
@@ -2409,24 +5115,39 @@ qualifiers:
         id = "NC_005816.1"
         name = "NC_005816"
         description = "Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence"
-        annotations = {"accessions": ["NC_005816"],
-                       "comment": """\
+        annotations = {
+            "accessions": ["NC_005816"],
+            "comment": """\
 PROVISIONAL REFSEQ: This record has not yet been subject to final
 NCBI review. The reference sequence was derived from AE017046.
 COMPLETENESS: full length.""",
-                       "data_file_division": "BCT",
-                       "date": "21-JUL-2008",
-                       "gi": "45478711",
-                       "keywords": [""],
-                       "molecule_type": "DNA",
-                       "organism": "Yersinia pestis biovar Microtus str. 91001",
-                       "sequence_version": 1,
-                       "source": "Yersinia pestis biovar Microtus str. 91001",
-                       "taxonomy": ["Bacteria", "Proteobacteria", "Gammaproteobacteria", "Enterobacteriales", "Enterobacteriaceae", "Yersinia"],
-                       "topology": "circular",
-                       }
-        references = ["location: [0:9609]\nauthors: Zhou,D., Tong,Z., Song,Y., Han,Y., Pei,D., Pang,X., Zhai,J., Li,M., Cui,B., Qi,Z., Jin,L., Dai,R., Du,Z., Wang,J., Guo,Z., Wang,J., Huang,P. and Yang,R.\ntitle: Genetics of metabolic variations between Yersinia pestis biovars and the proposal of a new biovar, microtus\njournal: J. Bacteriol. 186 (15), 5147-5152 (2004)\nmedline id: \npubmed id: 15262951\ncomment: \n", "location: [0:9609]\nauthors: Song,Y., Tong,Z., Wang,J., Wang,L., Guo,Z., Han,Y., Zhang,J., Pei,D., Zhou,D., Qin,H., Pang,X., Han,Y., Zhai,J., Li,M., Cui,B., Qi,Z., Jin,L., Dai,R., Chen,F., Li,S., Ye,C., Du,Z., Lin,W., Wang,J., Yu,J., Yang,H., Wang,J., Huang,P. and Yang,R.\ntitle: Complete genome sequence of Yersinia pestis strain 91001, an isolate avirulent to humans\njournal: DNA Res. 11 (3), 179-197 (2004)\nmedline id: \npubmed id: 15368893\ncomment: \n", "location: [0:9609]\nauthors: \nconsrtm: NCBI Genome Project\ntitle: Direct Submission\njournal: Submitted (16-MAR-2004) National Center for Biotechnology Information, NIH, Bethesda, MD 20894, USA\nmedline id: \npubmed id: \ncomment: \n", "location: [0:9609]\nauthors: Song,Y., Tong,Z., Wang,L., Han,Y., Zhang,J., Pei,D., Wang,J., Zhou,D., Han,Y., Pang,X., Zhai,J., Chen,F., Qin,H., Wang,J., Li,S., Guo,Z., Ye,C., Du,Z., Lin,W., Wang,J., Yu,J., Yang,H., Wang,J., Huang,P. and Yang,R.\ntitle: Direct Submission\njournal: Submitted (24-APR-2003) The Institute of Microbiology and Epidemiology, Academy of Military Medical Sciences, No. 20, Dongdajie Street, Fengtai District, Beijing 100071, People's Republic of China\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+            "data_file_division": "BCT",
+            "date": "21-JUL-2008",
+            "gi": "45478711",
+            "keywords": [""],
+            "molecule_type": "DNA",
+            "organism": "Yersinia pestis biovar Microtus str. 91001",
+            "sequence_version": 1,
+            "source": "Yersinia pestis biovar Microtus str. 91001",
+            "taxonomy": [
+                "Bacteria",
+                "Proteobacteria",
+                "Gammaproteobacteria",
+                "Enterobacteriales",
+                "Enterobacteriaceae",
+                "Yersinia",
+            ],
+            "topology": "circular",
+        }
+        references = [
+            "location: [0:9609]\nauthors: Zhou,D., Tong,Z., Song,Y., Han,Y., Pei,D., Pang,X., Zhai,J., Li,M., Cui,B., Qi,Z., Jin,L., Dai,R., Du,Z., Wang,J., Guo,Z., Wang,J., Huang,P. and Yang,R.\ntitle: Genetics of metabolic variations between Yersinia pestis biovars and the proposal of a new biovar, microtus\njournal: J. Bacteriol. 186 (15), 5147-5152 (2004)\nmedline id: \npubmed id: 15262951\ncomment: \n",
+            "location: [0:9609]\nauthors: Song,Y., Tong,Z., Wang,J., Wang,L., Guo,Z., Han,Y., Zhang,J., Pei,D., Zhou,D., Qin,H., Pang,X., Han,Y., Zhai,J., Li,M., Cui,B., Qi,Z., Jin,L., Dai,R., Chen,F., Li,S., Ye,C., Du,Z., Lin,W., Wang,J., Yu,J., Yang,H., Wang,J., Huang,P. and Yang,R.\ntitle: Complete genome sequence of Yersinia pestis strain 91001, an isolate avirulent to humans\njournal: DNA Res. 11 (3), 179-197 (2004)\nmedline id: \npubmed id: 15368893\ncomment: \n",
+            "location: [0:9609]\nauthors: \nconsrtm: NCBI Genome Project\ntitle: Direct Submission\njournal: Submitted (16-MAR-2004) National Center for Biotechnology Information, NIH, Bethesda, MD 20894, USA\nmedline id: \npubmed id: \ncomment: \n",
+            "location: [0:9609]\nauthors: Song,Y., Tong,Z., Wang,L., Han,Y., Zhang,J., Pei,D., Wang,J., Zhou,D., Han,Y., Pang,X., Zhai,J., Chen,F., Qin,H., Wang,J., Li,S., Guo,Z., Ye,C., Du,Z., Lin,W., Wang,J., Yu,J., Yang,H., Wang,J., Huang,P. and Yang,R.\ntitle: Direct Submission\njournal: Submitted (24-APR-2003) The Institute of Microbiology and Epidemiology, Academy of Military Medical Sciences, No. 20, Dongdajie Street, Fengtai District, Beijing 100071, People's Republic of China\nmedline id: \npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:9609](+)
 qualifiers:
@@ -2436,20 +5157,29 @@ qualifiers:
     Key: organism, Value: ['Yersinia pestis biovar Microtus str. 91001']
     Key: plasmid, Value: ['pPCP1']
     Key: strain, Value: ['91001']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: repeat_region
 location: [0:1954](+)
 qualifiers:
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [86:1109](+)
 qualifiers:
     Key: db_xref, Value: ['GeneID:2767718']
     Key: locus_tag, Value: ['YP_pPCP01']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [86:1109](+)
 qualifiers:
@@ -2461,39 +5191,54 @@ qualifiers:
     Key: protein_id, Value: ['NP_995567.1']
     Key: transl_table, Value: ['11']
     Key: translation, Value: ['MVTFETVMEIKILHKQGMSSRAIARELGISRNTVKRYLQAKSEPPKYTPRPAVASLLDEYRDYIRQRIADAHPYKIPATVIAREIRDQGYRGGMTILRAFIRSLSVPQEQEPAVRFETEPGRQMQVDWGTMRNGRSPLHVFVAVLGYSRMLYIEFTDNMRYDTLETCHRNAFRFFGGVPREVLYDNMKTVVLQRDAYQTGQHRFHPSLWQFGKEMGFSPRLCRPFRAQTKGKVERMVQYTRNSFYIPLMTRLRPMGITVDVETANRHGLRWLHDVANQRKHETIQARPCDRWLEEQQSMLALPPEKKEYDVHLDENLVNFDKHPLHHPLSIYDSFCRGVA']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: misc_feature
 location: [86:959](+)
 qualifiers:
     Key: db_xref, Value: ['CDD:34222']
     Key: locus_tag, Value: ['YP_pPCP01']
     Key: note, Value: ['Transposase and inactivated derivatives [DNA replication, recombination, and repair]; Region: COG4584']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: misc_feature
 location: [<110:209](+)
 qualifiers:
     Key: db_xref, Value: ['CDD:186341']
     Key: locus_tag, Value: ['YP_pPCP01']
     Key: note, Value: ['Helix-turn-helix domain of Hin and related proteins, a family of DNA-binding domains unique to bacteria and represented by the Hin protein of Salmonella. The basic HTH domain is a simple fold comprised of three core helices that form a right-handed...; Region: HTH_Hin_like; cl01116']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: misc_feature
 location: [437:812](+)
 qualifiers:
     Key: db_xref, Value: ['CDD:194099']
     Key: locus_tag, Value: ['YP_pPCP01']
     Key: note, Value: ['Integrase core domain; Region: rve; cl01316']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [1105:1888](+)
 qualifiers:
     Key: db_xref, Value: ['GeneID:2767716']
     Key: locus_tag, Value: ['YP_pPCP02']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [1105:1888](+)
 qualifiers:
@@ -2505,48 +5250,66 @@ qualifiers:
     Key: protein_id, Value: ['NP_995568.1']
     Key: transl_table, Value: ['11']
     Key: translation, Value: ['MMMELQHQRLMALAGQLQLESLISAAPALSQQAVDQEWSYMDFLEHLLHEEKLARHQRKQAMYTRMAAFPAVKTFEEYDFTFATGAPQKQLQSLRSLSFIERNENIVLLGPSGVGKTHLAIAMGYEAVRAGIKVRFTTAADLLLQLSTAQRQGRYKTTLQRGVMAPRLLIIDEIGYLPFSQEEAKLFFQVIAKRYEKSAMILTSNLPFGQWDQTFAGDAALTSAMLDRILHHSHVVQIKGESYRLRQKRKAGVIAEANPE']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: misc_feature
 location: [1108:1885](+)
 qualifiers:
     Key: db_xref, Value: ['CDD:181681']
     Key: locus_tag, Value: ['YP_pPCP02']
     Key: note, Value: ['transposase/IS protein; Provisional; Region: PRK09183']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: misc_feature
 location: [1366:>1669](+)
 qualifiers:
     Key: db_xref, Value: ['CDD:99707']
     Key: locus_tag, Value: ['YP_pPCP02']
     Key: note, Value: ['The AAA+ (ATPases Associated with a wide variety of cellular Activities) superfamily represents an ancient group of ATPases belonging to the ASCE (for additional strand, catalytic E) division of the P-loop NTPase fold. The ASCE division also includes...; Region: AAA; cd00009']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: misc_feature
 location: [1432:1456](+)
 qualifiers:
     Key: db_xref, Value: ['CDD:99707']
     Key: locus_tag, Value: ['YP_pPCP02']
     Key: note, Value: ['Walker A motif; other site']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: misc_feature
 location: order{[1435:1459](+), [1618:1621](+)}
 qualifiers:
     Key: db_xref, Value: ['CDD:99707']
     Key: locus_tag, Value: ['YP_pPCP02']
     Key: note, Value: ['ATP binding site [chemical binding]; other site']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: misc_feature
 location: [1606:1624](+)
 qualifiers:
     Key: db_xref, Value: ['CDD:99707']
     Key: locus_tag, Value: ['YP_pPCP02']
     Key: note, Value: ['Walker B motif; other site']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [2924:3119](+)
 qualifiers:
@@ -2554,8 +5317,11 @@ qualifiers:
     Key: gene, Value: ['rop']
     Key: gene_synonym, Value: ['rom']
     Key: locus_tag, Value: ['YP_pPCP03']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [2924:3119](+)
 qualifiers:
@@ -2569,8 +5335,11 @@ qualifiers:
     Key: protein_id, Value: ['NP_995569.1']
     Key: transl_table, Value: ['11']
     Key: translation, Value: ['MNKQQQTALNMARFIRSQSLILLEKLDALDADEQAAMCERLHELAEELQNSIQARFEAESETGT']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: misc_feature
 location: [2924:3107](+)
 qualifiers:
@@ -2579,15 +5348,21 @@ qualifiers:
     Key: gene_synonym, Value: ['rom']
     Key: locus_tag, Value: ['YP_pPCP03']
     Key: note, Value: ['Rop protein; Region: Rop; pfam01815']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [3485:3857](+)
 qualifiers:
     Key: db_xref, Value: ['GeneID:2767720']
     Key: locus_tag, Value: ['YP_pPCP04']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [3485:3857](+)
 qualifiers:
@@ -2599,23 +5374,32 @@ qualifiers:
     Key: protein_id, Value: ['NP_995570.1']
     Key: transl_table, Value: ['11']
     Key: translation, Value: ['MSKKRRPQKRPRRRRFFHRLRPPDEHHKNRRSSQRWRNPTGLKDTRRFPPEAPSCALLFRPCRLPDTSPPFSLREAWRFLIAHAVGISVRCRSFAPSWAVCTNPPFSPTTAPYPVTIVLSPTR']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: misc_feature
 location: [3497:3626](+)
 qualifiers:
     Key: locus_tag, Value: ['YP_pPCP04']
     Key: note, Value: ['ProfileScan match to entry PS50323 ARG_RICH, E-value 8.981']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [4342:4780](+)
 qualifiers:
     Key: db_xref, Value: ['GeneID:2767712']
     Key: gene, Value: ['pim']
     Key: locus_tag, Value: ['YP_pPCP05']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [4342:4780](+)
 qualifiers:
@@ -2628,16 +5412,22 @@ qualifiers:
     Key: protein_id, Value: ['NP_995571.1']
     Key: transl_table, Value: ['11']
     Key: translation, Value: ['MGGGMISKLFCLALIFLSSSGLAEKNTYTAKDILQNLELNTFGNSLSHGIYGKQTTFKQTEFTNIKSNTKKHIALINKDNSWMISLKILGIKRDEYTVCFEDFSLIRPPTYVAIHPLLIKKVKSGNFIVVKEIKKSIPGCTVYYH']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [4814:5888](-)
 qualifiers:
     Key: db_xref, Value: ['GeneID:2767721']
     Key: gene, Value: ['pst']
     Key: locus_tag, Value: ['YP_pPCP06']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: [4814:5888](-)
 qualifiers:
@@ -2650,43 +5440,61 @@ qualifiers:
     Key: protein_id, Value: ['NP_995572.1']
     Key: transl_table, Value: ['11']
     Key: translation, Value: ['MSDTMVVNGSGGVPAFLFSGSTLSSYRPNFEANSITIALPHYVDLPGRSNFKLMYIMGFPIDTEMEKDSEYSNKIRQESKISKTEGTVSYEQKITVETGQEKDGVKVYRVMVLEGTIAESIEHLDKKENEDILNNNRNRIVLADNTVINFDNISQLKEFLRRSVNIVDHDIFSSNGFEGFNPTSHFPSNPSSDYFNSTGVTFGSGVDLGQRSKQDLLNDGVPQYIADRLDGYYMLRGKEAYDKVRTAPLTLSDNEAHLLSNIYIDKFSHKIEGLFNDANIGLRFSDLPLRTRTALVSIGYQKGFKLSRTAPTVWNKVIAKDWNGLVNAFNNIVDGMSDRRKREGALVQKDIDSGLLK']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: variation
 location: [5909:5911](+)
 qualifiers:
     Key: note, Value: ['compared to AF053945']
     Key: replace, Value: ['']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: variation
 location: [5933:5933](+)
 qualifiers:
     Key: note, Value: ['compared to AL109969']
     Key: replace, Value: ['a']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: variation
 location: [5933:5933](+)
 qualifiers:
     Key: note, Value: ['compared to AF053945']
     Key: replace, Value: ['aa']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: variation
 location: [5947:5948](+)
 qualifiers:
     Key: note, Value: ['compared to AL109969']
     Key: replace, Value: ['c']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [6004:6421](+)
 qualifiers:
     Key: db_xref, Value: ['GeneID:2767719']
     Key: locus_tag, Value: ['YP_pPCP07']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [6004:6421](+)
 qualifiers:
@@ -2698,23 +5506,32 @@ qualifiers:
     Key: protein_id, Value: ['NP_995573.1']
     Key: transl_table, Value: ['11']
     Key: translation, Value: ['MKFHFCDLNHSYKNQEGKIRSRKTAPGNIRKKQKGDNVSKTKSGRHRLSKTDKRLLAALVVAGYEERTARDLIQKHVYTLTQADLRHLVSEISNGVGQSQAYDAIYQARRIRLARKYLSGKKPEGVEPREGQEREDLP']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: variation
 location: [6524:6525](+)
 qualifiers:
     Key: note, Value: ['compared to AF053945 and AL109969']
     Key: replace, Value: ['c']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [6663:7602](+)
 qualifiers:
     Key: db_xref, Value: ['GeneID:2767715']
     Key: gene, Value: ['pla']
     Key: locus_tag, Value: ['YP_pPCP08']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: CDS
 location: [6663:7602](+)
 qualifiers:
@@ -2728,8 +5545,11 @@ qualifiers:
     Key: protein_id, Value: ['NP_995574.1']
     Key: transl_table, Value: ['11']
     Key: translation, Value: ['MKKSSIVATIITILSGSANAASSQLIPNISPDSFTVAASTGMLSGKSHEMLYDAETGRKISQLDWKIKNVAILKGDISWDPYSFLTLNARGWTSLASGSGNMDDYDWMNENQSEWTDHSSHPATNVNHANEYDLNVKGWLLQDENYKAGITAGYQETRFSWTATGGSYSYNNGAYTGNFPKGVRVIGYNQRFSMPYIGLAGQYRINDFELNALFKFSDWVRAHDNDEHYMRDLTFREKTSGSRYYGTVINAGYYVTPNAKVFAEFTYSKYDEGKGGTQIIDKNSGDSVSIGGDAAGISNKNYTVTAGLQYRF']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: misc_feature
 location: [6663:7599](+)
 qualifiers:
@@ -2737,15 +5557,21 @@ qualifiers:
     Key: gene, Value: ['pla']
     Key: locus_tag, Value: ['YP_pPCP08']
     Key: note, Value: ['Omptin family; Region: Omptin; cl01886']
-""", 1),
-                    ("""\
+""",
+                1,
+            ),
+            (
+                """\
 type: gene
 location: [7788:8088](-)
 qualifiers:
     Key: db_xref, Value: ['GeneID:2767713']
     Key: locus_tag, Value: ['YP_pPCP09']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: [7788:8088](-)
 qualifiers:
@@ -2757,23 +5583,32 @@ qualifiers:
     Key: protein_id, Value: ['NP_995575.1']
     Key: transl_table, Value: ['11']
     Key: translation, Value: ['MRTLDEVIASRSPESQTRIKEMADEMILEVGLQMMREELQLSQKQVAEAMGISQPAVTKLEQRGNDLKLATLKRYVEAMGGKLSLDVELPTGRRVAFHV']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: misc_feature
 location: [7836:7995](-)
 qualifiers:
     Key: db_xref, Value: ['CDD:195788']
     Key: locus_tag, Value: ['YP_pPCP09']
     Key: note, Value: ['Helix-turn-helix XRE-family like proteins. Prokaryotic DNA binding proteins belonging to the xenobiotic response element family of transcriptional regulators; Region: HTH_XRE; cl09100']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: gene
 location: [8087:8360](-)
 qualifiers:
     Key: db_xref, Value: ['GeneID:2767714']
     Key: locus_tag, Value: ['YP_pPCP10']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: CDS
 location: [8087:8360](-)
 qualifiers:
@@ -2785,25 +5620,43 @@ qualifiers:
     Key: protein_id, Value: ['NP_995576.1']
     Key: transl_table, Value: ['11']
     Key: translation, Value: ['MADLKKLQVYGPELPRPYADTVKGSRYKNMKELRVQFSGRPIRAFYAFDPIRRAIVLCAGDKSNDKRFYEKLVRIAEDEFTAHLNTLESK']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: misc_feature
 location: [8090:>8357](-)
 qualifiers:
     Key: db_xref, Value: ['CDD:194142']
     Key: locus_tag, Value: ['YP_pPCP10']
     Key: note, Value: ['Phage derived protein Gp49-like (DUF891); Region: Gp49; cl01470']
-""", -1),
-                    ("""\
+""",
+                -1,
+            ),
+            (
+                """\
 type: variation
 location: [8529:8529](+)
 qualifiers:
     Key: note, Value: ['compared to AL109969']
     Key: replace, Value: ['tt']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = ["Project:58037"]
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_15(self):
         path = "GenBank/no_end_marker.gb"
@@ -2817,30 +5670,53 @@ qualifiers:
         id = "AB070938.1"
         name = "AB070938"
         description = "Streptomyces avermitilis melanin biosynthetic gene cluster"
-        annotations = {"accessions": ["AB070938"],
-                       "data_file_division": "BCT",
-                       "date": "11-OCT-2001",
-                       "gi": "15823953",
-                       "keywords": [""],
-                       "molecule_type": "DNA",
-                       "organism": "Streptomyces avermitilis",
-                       "sequence_version": 1,
-                       "source": "Streptomyces avermitilis",
-                       "taxonomy": ["Bacteria", "Actinobacteria", "Actinobacteridae", "Actinomycetales", "Streptomycineae", "Streptomycetaceae", "Streptomyces"],
-                       "topology": "linear",
-                       }
+        annotations = {
+            "accessions": ["AB070938"],
+            "data_file_division": "BCT",
+            "date": "11-OCT-2001",
+            "gi": "15823953",
+            "keywords": [""],
+            "molecule_type": "DNA",
+            "organism": "Streptomyces avermitilis",
+            "sequence_version": 1,
+            "source": "Streptomyces avermitilis",
+            "taxonomy": [
+                "Bacteria",
+                "Actinobacteria",
+                "Actinobacteridae",
+                "Actinomycetales",
+                "Streptomycineae",
+                "Streptomycetaceae",
+                "Streptomyces",
+            ],
+            "topology": "linear",
+        }
         references = []
-        features = (("""\
+        features = (
+            (
+                """\
 type: source
 location: [0:6497](+)
 qualifiers:
     Key: db_xref, Value: ['taxon:33903']
     Key: mol_type, Value: ['genomic DNA']
     Key: organism, Value: ['Streptomyces avermitilis']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_16(self):
         path = "GenBank/wrong_sequence_indent.gb"
@@ -2854,30 +5730,53 @@ qualifiers:
         id = "AB070938.1"
         name = "AB070938"
         description = "Streptomyces avermitilis melanin biosynthetic gene cluster"
-        annotations = {"accessions": ["AB070938"],
-                       "data_file_division": "BCT",
-                       "date": "11-OCT-2001",
-                       "gi": "15823953",
-                       "keywords": [""],
-                       "molecule_type": "DNA",
-                       "organism": "Streptomyces avermitilis",
-                       "sequence_version": 1,
-                       "source": "Streptomyces avermitilis",
-                       "taxonomy": ["Bacteria", "Actinobacteria", "Actinobacteridae", "Actinomycetales", "Streptomycineae", "Streptomycetaceae", "Streptomyces"],
-                       "topology": "linear",
-                       }
+        annotations = {
+            "accessions": ["AB070938"],
+            "data_file_division": "BCT",
+            "date": "11-OCT-2001",
+            "gi": "15823953",
+            "keywords": [""],
+            "molecule_type": "DNA",
+            "organism": "Streptomyces avermitilis",
+            "sequence_version": 1,
+            "source": "Streptomyces avermitilis",
+            "taxonomy": [
+                "Bacteria",
+                "Actinobacteria",
+                "Actinobacteridae",
+                "Actinomycetales",
+                "Streptomycineae",
+                "Streptomycetaceae",
+                "Streptomyces",
+            ],
+            "topology": "linear",
+        }
         references = []
-        features = (("""\
+        features = (
+            (
+                """\
 type: source
 location: [0:6497](+)
 qualifiers:
     Key: db_xref, Value: ['taxon:33903']
     Key: mol_type, Value: ['genomic DNA']
     Key: organism, Value: ['Streptomyces avermitilis']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_17(self):
         path = "GenBank/invalid_locus_line_spacing.gb"
@@ -2891,29 +5790,52 @@ qualifiers:
         id = "AB070938.1"
         name = "AB070938"
         description = "Streptomyces avermitilis melanin biosynthetic gene cluster"
-        annotations = {"accessions": ["AB070938"],
-                       "data_file_division": "BCT",
-                       "date": "11-OCT-2001",
-                       "gi": "15823953",
-                       "keywords": [""],
-                       "organism": "Streptomyces avermitilis",
-                       "sequence_version": 1,
-                       "source": "Streptomyces avermitilis",
-                       "taxonomy": ["Bacteria", "Actinobacteria", "Actinobacteridae", "Actinomycetales", "Streptomycineae", "Streptomycetaceae", "Streptomyces"],
-                       "topology": "linear",
-                       }
+        annotations = {
+            "accessions": ["AB070938"],
+            "data_file_division": "BCT",
+            "date": "11-OCT-2001",
+            "gi": "15823953",
+            "keywords": [""],
+            "organism": "Streptomyces avermitilis",
+            "sequence_version": 1,
+            "source": "Streptomyces avermitilis",
+            "taxonomy": [
+                "Bacteria",
+                "Actinobacteria",
+                "Actinobacteridae",
+                "Actinomycetales",
+                "Streptomycineae",
+                "Streptomycetaceae",
+                "Streptomyces",
+            ],
+            "topology": "linear",
+        }
         references = []
-        features = (("""\
+        features = (
+            (
+                """\
 type: source
 location: [0:6497](+)
 qualifiers:
     Key: db_xref, Value: ['taxon:33903']
     Key: mol_type, Value: ['genomic DNA']
     Key: organism, Value: ['Streptomyces avermitilis']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_18(self):
         path = "GenBank/empty_feature_qualifier.gb"
@@ -2924,20 +5846,31 @@ qualifiers:
         id = "AB070938.1"
         name = "AB070938"
         description = "Streptomyces avermitilis melanin biosynthetic gene cluster"
-        annotations = {"accessions": ["AB070938"],
-                       "data_file_division": "BCT",
-                       "date": "11-OCT-2001",
-                       "gi": "15823953",
-                       "keywords": [""],
-                       "molecule_type": "DNA",
-                       "organism": "Streptomyces avermitilis",
-                       "sequence_version": 1,
-                       "source": "Streptomyces avermitilis",
-                       "taxonomy": ["Bacteria", "Actinobacteria", "Actinobacteridae", "Actinomycetales", "Streptomycineae", "Streptomycetaceae", "Streptomyces"],
-                       "topology": "linear",
-                       }
+        annotations = {
+            "accessions": ["AB070938"],
+            "data_file_division": "BCT",
+            "date": "11-OCT-2001",
+            "gi": "15823953",
+            "keywords": [""],
+            "molecule_type": "DNA",
+            "organism": "Streptomyces avermitilis",
+            "sequence_version": 1,
+            "source": "Streptomyces avermitilis",
+            "taxonomy": [
+                "Bacteria",
+                "Actinobacteria",
+                "Actinobacteridae",
+                "Actinomycetales",
+                "Streptomycineae",
+                "Streptomycetaceae",
+                "Streptomyces",
+            ],
+            "topology": "linear",
+        }
         references = []
-        features = (("""\
+        features = (
+            (
+                """\
 type: source
 location: [0:6497](+)
 qualifiers:
@@ -2945,10 +5878,22 @@ qualifiers:
     Key: mol_type, Value: ['genomic DNA']
     Key: note, Value: ["This is a correct note, the following one isn't"]
     Key: organism, Value: ['Streptomyces avermitilis']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_19(self):
         path = "GenBank/invalid_misc_feature.gb"
@@ -2962,30 +5907,53 @@ qualifiers:
         id = "AB070938.1"
         name = "AB070938"
         description = "Streptomyces avermitilis melanin biosynthetic gene cluster"
-        annotations = {"accessions": ["AB070938"],
-                       "data_file_division": "BCT",
-                       "date": "11-OCT-2001",
-                       "gi": "15823953",
-                       "keywords": [""],
-                       "molecule_type": "DNA",
-                       "organism": "Streptomyces avermitilis",
-                       "sequence_version": 1,
-                       "source": "Streptomyces avermitilis",
-                       "taxonomy": ["Bacteria", "Actinobacteria", "Actinobacteridae", "Actinomycetales", "Streptomycineae", "Streptomycetaceae", "Streptomyces"],
-                       "topology": "linear",
-                       }
+        annotations = {
+            "accessions": ["AB070938"],
+            "data_file_division": "BCT",
+            "date": "11-OCT-2001",
+            "gi": "15823953",
+            "keywords": [""],
+            "molecule_type": "DNA",
+            "organism": "Streptomyces avermitilis",
+            "sequence_version": 1,
+            "source": "Streptomyces avermitilis",
+            "taxonomy": [
+                "Bacteria",
+                "Actinobacteria",
+                "Actinobacteridae",
+                "Actinomycetales",
+                "Streptomycineae",
+                "Streptomycetaceae",
+                "Streptomyces",
+            ],
+            "topology": "linear",
+        }
         references = []
-        features = (("""\
+        features = (
+            (
+                """\
 type: source
 location: [0:6497](+)
 qualifiers:
     Key: db_xref, Value: ['taxon:33903']
     Key: mol_type, Value: ['genomic DNA']
     Key: organism, Value: ['Streptomyces avermitilis']
-""", 1),
-                    )
+""",
+                1,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
     def test_feature_parser_20(self):
         path = "GenBank/1MRR_A.gp"
@@ -2999,216 +5967,323 @@ qualifiers:
         id = "1MRR_A"
         name = "1MRR_A"
         description = "Chain A, Substitution Of Manganese For Iron In Ribonucleotide Reductase From Escherichia Coli. Spectroscopic And Crystallographic Characterization"
-        annotations = {"accessions": ["1MRR_A"],
-                       "comment": """\
+        annotations = {
+            "accessions": ["1MRR_A"],
+            "comment": """\
 1 Ribonucleotide Reductase R1 Protein.""",
-                       "data_file_division": "BCT",
-                       "date": "10-OCT-2012",
-                       "db_source": "pdb: molecule 1MRR, chain 65, release Aug 28, 2012; deposition: Jul 28, 1992; class: Reductase(Acting On Ch2); source: Mmdb_id: 50351, Pdb_id 1: 1MRR; Exp. method: X-Ray Diffraction.",
-                       "gi": "494379",
-                       "keywords": [""],
-                       "organism": "Escherichia coli",
-                       "source": "Escherichia coli",
-                       "taxonomy": ["Bacteria", "Proteobacteria", "Gammaproteobacteria", "Enterobacteriales", "Enterobacteriaceae", "Escherichia"],
-                       "topology": "linear",
-                       }
-        references = ["location: [0:375]\nauthors: Nordlund,P., Sjoberg,B.M. and Eklund,H.\ntitle: Three-dimensional structure of the free radical protein of ribonucleotide reductase\njournal: Nature 345 (6276), 593-598 (1990)\nmedline id: \npubmed id: 2190093\ncomment: \n", "location: [0:375]\nauthors: Atta,M., Nordlund,P., Aberg,A., Eklund,H. and Fontecave,M.\ntitle: Substitution of manganese for iron in ribonucleotide reductase from Escherichia coli. Spectroscopic and crystallographic characterization\njournal: J. Biol. Chem. 267 (29), 20682-20688 (1992)\nmedline id: \npubmed id: 1328209\ncomment: \n", "location: [0:375]\nauthors: Eklund,H. and Nordlund,P.\ntitle: Direct Submission\njournal: Submitted (28-JUL-1992)\nmedline id: \npubmed id: \ncomment: \n"]
-        features = (("""\
+            "data_file_division": "BCT",
+            "date": "10-OCT-2012",
+            "db_source": "pdb: molecule 1MRR, chain 65, release Aug 28, 2012; deposition: Jul 28, 1992; class: Reductase(Acting On Ch2); source: Mmdb_id: 50351, Pdb_id 1: 1MRR; Exp. method: X-Ray Diffraction.",
+            "gi": "494379",
+            "keywords": [""],
+            "organism": "Escherichia coli",
+            "source": "Escherichia coli",
+            "taxonomy": [
+                "Bacteria",
+                "Proteobacteria",
+                "Gammaproteobacteria",
+                "Enterobacteriales",
+                "Enterobacteriaceae",
+                "Escherichia",
+            ],
+            "topology": "linear",
+        }
+        references = [
+            "location: [0:375]\nauthors: Nordlund,P., Sjoberg,B.M. and Eklund,H.\ntitle: Three-dimensional structure of the free radical protein of ribonucleotide reductase\njournal: Nature 345 (6276), 593-598 (1990)\nmedline id: \npubmed id: 2190093\ncomment: \n",
+            "location: [0:375]\nauthors: Atta,M., Nordlund,P., Aberg,A., Eklund,H. and Fontecave,M.\ntitle: Substitution of manganese for iron in ribonucleotide reductase from Escherichia coli. Spectroscopic and crystallographic characterization\njournal: J. Biol. Chem. 267 (29), 20682-20688 (1992)\nmedline id: \npubmed id: 1328209\ncomment: \n",
+            "location: [0:375]\nauthors: Eklund,H. and Nordlund,P.\ntitle: Direct Submission\njournal: Submitted (28-JUL-1992)\nmedline id: \npubmed id: \ncomment: \n",
+        ]
+        features = (
+            (
+                """\
 type: source
 location: [0:375]
 qualifiers:
     Key: db_xref, Value: ['taxon:562']
     Key: organism, Value: ['Escherichia coli']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Region
 location: [27:340]
 qualifiers:
     Key: db_xref, Value: ['CDD:153108']
     Key: note, Value: ['Ribonucleotide Reductase, R2/beta subunit, ferritin-like diiron-binding domain; cd01049']
     Key: region_name, Value: ['RNRR2']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [34:46]
 qualifiers:
     Key: note, Value: ['helix 1']
     Key: sec_str_type, Value: ['helix']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Site
 location: order{[36:37], [43:44], [108:110], [112:113], [115:117], [119:120], [122:123], [136:138], [140:141]}
 qualifiers:
     Key: db_xref, Value: ['CDD:153108']
     Key: note, Value: ['dimer interface [polypeptide binding]']
     Key: site_type, Value: ['other']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Site
 location: order{[47:48], [83:84], [114:115], [117:118], [121:122], [235:237], [240:241]}
 qualifiers:
     Key: db_xref, Value: ['CDD:153108']
     Key: note, Value: ['putative radical transfer pathway']
     Key: site_type, Value: ['other']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [56:65]
 qualifiers:
     Key: note, Value: ['helix 2']
     Key: sec_str_type, Value: ['helix']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [66:87]
 qualifiers:
     Key: note, Value: ['helix 3']
     Key: sec_str_type, Value: ['helix']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Site
 location: order{[83:84], [114:115], [117:118], [203:204], [237:238], [240:241]}
 qualifiers:
     Key: db_xref, Value: ['CDD:153108']
     Key: note, Value: ['diiron center [ion binding]']
     Key: site_type, Value: ['other']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Het
 location: join{[83:84], [114:115], [117:118], [237:238]}
 qualifiers:
     Key: heterogen, Value: ['( MN,1000 )']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [101:129]
 qualifiers:
     Key: note, Value: ['helix 4']
     Key: sec_str_type, Value: ['helix']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Het
 location: join{[114:115], [203:204], [237:238], [240:241]}
 qualifiers:
     Key: heterogen, Value: ['( MN,1001 )']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Site
 location: [121:122]
 qualifiers:
     Key: db_xref, Value: ['CDD:153108']
     Key: note, Value: ['tyrosyl radical']
     Key: site_type, Value: ['other']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [132:140]
 qualifiers:
     Key: note, Value: ['helix 5']
     Key: sec_str_type, Value: ['helix']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [142:151]
 qualifiers:
     Key: note, Value: ['helix 6']
     Key: sec_str_type, Value: ['helix']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [152:169]
 qualifiers:
     Key: note, Value: ['helix 7']
     Key: sec_str_type, Value: ['helix']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [171:177]
 qualifiers:
     Key: note, Value: ['strand 1']
     Key: sec_str_type, Value: ['sheet']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [179:185]
 qualifiers:
     Key: note, Value: ['strand 2']
     Key: sec_str_type, Value: ['sheet']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [185:216]
 qualifiers:
     Key: note, Value: ['helix 8']
     Key: sec_str_type, Value: ['helix']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Het
 location: join{[193:194], [271:272]}
 qualifiers:
     Key: heterogen, Value: ['( HG,1003 )']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Het
 location: [195:196]
 qualifiers:
     Key: heterogen, Value: ['( HG,1005 )']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Het
 location: join{[195:196], [195:196]}
 qualifiers:
     Key: heterogen, Value: ['( HG,1002 )']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Het
 location: join{[209:210], [213:214], [213:214]}
 qualifiers:
     Key: heterogen, Value: ['( HG,1004 )']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [224:253]
 qualifiers:
     Key: note, Value: ['helix 9']
     Key: sec_str_type, Value: ['helix']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [259:269]
 qualifiers:
     Key: note, Value: ['helix 10']
     Key: sec_str_type, Value: ['helix']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Bond
 location: bond{[267:268], [271:272]}
 qualifiers:
     Key: bond_type, Value: ['disulfide']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [269:285]
 qualifiers:
     Key: note, Value: ['helix 11']
     Key: sec_str_type, Value: ['helix']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: Het
 location: join{[283:284], [304:305], [308:309], [304:305]}
 qualifiers:
     Key: heterogen, Value: ['( HG,1006 )']
-""", None),
-                    ("""\
+""",
+                None,
+            ),
+            (
+                """\
 type: SecStr
 location: [300:319]
 qualifiers:
     Key: note, Value: ['helix 12']
     Key: sec_str_type, Value: ['helix']
-""", None),
-                    )
+""",
+                None,
+            ),
+        )
         dbxrefs = []
-        self.perform_feature_parser_test(record, seq, id, name, description, annotations, references, features, dbxrefs)
+        self.perform_feature_parser_test(
+            record,
+            seq,
+            id,
+            name,
+            description,
+            annotations,
+            references,
+            features,
+            dbxrefs,
+        )
 
 
 class GenBankTests(unittest.TestCase):
@@ -3254,7 +6329,10 @@ class GenBankTests(unittest.TestCase):
             with open(path) as handle:
                 with self.assertRaises(BiopythonParserWarning) as cm:
                     GenBank.read(handle)
-                self.assertEqual("Non-standard feature line wrapping (didn't break on comma)?", str(cm.exception))
+                self.assertEqual(
+                    "Non-standard feature line wrapping (didn't break on comma)?",
+                    str(cm.exception),
+                )
 
     # Similar hack as we also want to catch that warning here
     def test_001_negative_location_warning(self):
@@ -3264,7 +6342,9 @@ class GenBankTests(unittest.TestCase):
             warnings.simplefilter("error", BiopythonParserWarning)
             with self.assertRaises(BiopythonParserWarning) as cm:
                 record = SeqIO.read(path, "genbank")
-            self.assertEqual("Couldn't parse feature location: '-2..492'", str(cm.exception))
+            self.assertEqual(
+                "Couldn't parse feature location: '-2..492'", str(cm.exception)
+            )
 
     def test_001_genbank_bad_origin_wrapping_location(self):
         """Bad origin wrapping."""
@@ -3273,8 +6353,10 @@ class GenBankTests(unittest.TestCase):
             warnings.simplefilter("error", BiopythonParserWarning)
             with self.assertRaises(BiopythonParserWarning) as cm:
                 record = SeqIO.read(path, "genbank")
-            self.assertIn("It appears that '6801..100' is a feature "
-                          "that spans the origin", str(cm.exception))
+            self.assertIn(
+                "It appears that '6801..100' is a feature " "that spans the origin",
+                str(cm.exception),
+            )
 
     def test_001_implicit_orign_wrap_fix(self):
         """Attempt to fix implied origin wrapping."""
@@ -3283,37 +6365,40 @@ class GenBankTests(unittest.TestCase):
             warnings.simplefilter("error", BiopythonParserWarning)
             with self.assertRaises(BiopythonParserWarning) as cm:
                 record = SeqIO.read(path, "genbank")
-            self.assertEqual(str(cm.exception),
-                             "Attempting to fix invalid location '6801..100' "
-                             "as it looks like incorrect origin wrapping. "
-                             "Please fix input file, this could have "
-                             "unintended behavior.")
+            self.assertEqual(
+                str(cm.exception),
+                "Attempting to fix invalid location '6801..100' "
+                "as it looks like incorrect origin wrapping. "
+                "Please fix input file, this could have "
+                "unintended behavior.",
+            )
 
     def test_compound_complex_origin_wrap(self):
         """Test the attempts to fix compound complex origin wrapping."""
         from Bio.SeqFeature import CompoundLocation
+
         path = "GenBank/bad_origin_wrap.gb"
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", BiopythonParserWarning)
             record = SeqIO.read(path, "genbank")
 
-            self.assertIsInstance(record.features[3].location,
-                                  CompoundLocation)
-            self.assertEqual(str(record.features[3].location),
-                             "join{[<5399:5600](+), [5699:6100](+), "
-                             "[6800:7000](+), [0:100](+)}")
+            self.assertIsInstance(record.features[3].location, CompoundLocation)
+            self.assertEqual(
+                str(record.features[3].location),
+                "join{[<5399:5600](+), [5699:6100](+), " "[6800:7000](+), [0:100](+)}",
+            )
 
-            self.assertIsInstance(record.features[4].location,
-                                  CompoundLocation)
-            self.assertEqual(str(record.features[4].location),
-                             "join{[5399:5600](+), [5699:6100](+), "
-                             "[<6800:7000](+), [0:100](+)}")
+            self.assertIsInstance(record.features[4].location, CompoundLocation)
+            self.assertEqual(
+                str(record.features[4].location),
+                "join{[5399:5600](+), [5699:6100](+), " "[<6800:7000](+), [0:100](+)}",
+            )
 
-            self.assertIsInstance(record.features[5].location,
-                                  CompoundLocation)
-            self.assertEqual(str(record.features[5].location),
-                             "join{[5399:5600](+), [5699:6100](+), "
-                             "[0:100](-), [<6800:7000](-)}")
+            self.assertIsInstance(record.features[5].location, CompoundLocation)
+            self.assertEqual(
+                str(record.features[5].location),
+                "join{[5399:5600](+), [5699:6100](+), " "[0:100](-), [<6800:7000](-)}",
+            )
 
     def test_implicit_orign_wrap_extract_and_translate(self):
         """Test that features wrapped around origin give expected data."""
@@ -3323,16 +6408,22 @@ class GenBankTests(unittest.TestCase):
             with open(path) as handle:
                 seq_record = SeqIO.read(handle, "genbank")
         seq_features = seq_record.features
-        self.assertEqual(str(seq_features[1].extract(seq_record).seq.lower()),
-                         "atgccctataaaacccagggctgccttggaaaaggcgcaacccc"
-                         "aaccccctcgagccgcggcatataa")
-        self.assertEqual(str(seq_features[2].extract(seq_record).seq.lower()),
-                         "atgccgcggctcgagggggttggggttgcgccttttccaaggca"
-                         "gccctgggttttatag")
-        self.assertEqual(str(seq_features[1].extract(seq_record).seq.translate()),
-                         "MPYKTQGCLGKGATPTPSSRGI*")
-        self.assertEqual(str(seq_features[2].extract(seq_record).seq.translate()),
-                         "MPRLEGVGVAPFPRQPWVL*")
+        self.assertEqual(
+            str(seq_features[1].extract(seq_record).seq.lower()),
+            "atgccctataaaacccagggctgccttggaaaaggcgcaacccc" "aaccccctcgagccgcggcatataa",
+        )
+        self.assertEqual(
+            str(seq_features[2].extract(seq_record).seq.lower()),
+            "atgccgcggctcgagggggttggggttgcgccttttccaaggca" "gccctgggttttatag",
+        )
+        self.assertEqual(
+            str(seq_features[1].extract(seq_record).seq.translate()),
+            "MPYKTQGCLGKGATPTPSSRGI*",
+        )
+        self.assertEqual(
+            str(seq_features[2].extract(seq_record).seq.translate()),
+            "MPRLEGVGVAPFPRQPWVL*",
+        )
 
     def test_fuzzy_origin_wrap(self):
         """Test features that wrap an origin, and have fuzzy location."""
@@ -3341,18 +6432,22 @@ class GenBankTests(unittest.TestCase):
             warnings.simplefilter("error", BiopythonParserWarning)
             with self.assertRaises(BiopythonParserWarning) as cm:
                 record = SeqIO.read(path, "genbank")
-            self.assertEqual(str(cm.exception),
-                             "Attempting to fix invalid location '<2644..159' "
-                             "as it looks like incorrect origin wrapping. "
-                             "Please fix input file, this could have "
-                             "unintended behavior.")
+            self.assertEqual(
+                str(cm.exception),
+                "Attempting to fix invalid location '<2644..159' "
+                "as it looks like incorrect origin wrapping. "
+                "Please fix input file, this could have "
+                "unintended behavior.",
+            )
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", BiopythonParserWarning)
                 with open(path) as handle:
                     seq_record = SeqIO.read(handle, "genbank")
-                    self.assertEqual(str(seq_record.features[3].location),
-                                     "join{[<2643:2686](+), [0:159](+)}")
+                    self.assertEqual(
+                        str(seq_record.features[3].location),
+                        "join{[<2643:2686](+), [0:159](+)}",
+                    )
 
     def test_genbank_bad_loc_wrap_parsing(self):
         """Bad location wrapping."""
@@ -3363,7 +6458,10 @@ class GenBankTests(unittest.TestCase):
                 record = GenBank.read(handle)
         self.assertEqual(1, len(record.features))
         loc = record.features[0].location
-        self.assertEqual(loc, "join(3462..3615,3698..3978,4077..4307,4408..4797,4876..5028,5141..5332)")
+        self.assertEqual(
+            loc,
+            "join(3462..3615,3698..3978,4077..4307,4408..4797,4876..5028,5141..5332)",
+        )
 
     def test_negative_location(self):
         """Negative feature locations."""
@@ -3396,13 +6494,16 @@ class GenBankTests(unittest.TestCase):
         """Parse GenBank record with old and new DBLINK project entries."""
         path = "GenBank/NP_416719.gbwithparts"
         record = SeqIO.read(path, "gb")
-        self.assertEqual(record.dbxrefs,
-                         ["Project:57779", "BioProject:PRJNA57779"])
+        self.assertEqual(record.dbxrefs, ["Project:57779", "BioProject:PRJNA57779"])
         gb = record.format("gb")
-        self.assertTrue("""
+        self.assertTrue(
+            """
 DBLINK      Project: 57779
             BioProject: PRJNA57779
-KEYWORDS    """ in gb, gb)
+KEYWORDS    """
+            in gb,
+            gb,
+        )
         embl = record.format("embl")
         self.assertIn("XX\nPR   Project:PRJNA57779;\nXX\n", embl)
 
@@ -3411,10 +6512,14 @@ KEYWORDS    """ in gb, gb)
         record = SeqIO.read("GenBank/DS830848.gb", "gb")
         self.assertIn("BioProject:PRJNA16232", record.dbxrefs)
         gb = record.format("gb")
-        self.assertTrue("""
+        self.assertTrue(
+            """
 DBLINK      BioProject: PRJNA16232
             BioSample: SAMN03004382
-KEYWORDS    """ in gb, gb)
+KEYWORDS    """
+            in gb,
+            gb,
+        )
         # Also check EMBL output
         embl = record.format("embl")
         self.assertIn("XX\nPR   Project:PRJNA16232;\nXX\n", embl)
@@ -3425,13 +6530,17 @@ KEYWORDS    """ in gb, gb)
         # TODO: Should we map this to BioProject:PRJNA16232
         self.assertIn("Project:PRJNA16232", record.dbxrefs)
         gb = record.format("gb")
-        self.assertTrue("""
+        self.assertTrue(
+            """
 DBLINK      Project: PRJNA16232
             MD5: 387e72e4f7ae804780d06f875ab3bc41
             ENA: ABJB010000000
             ENA: ABJB000000000
             BioSample: SAMN03004382
-KEYWORDS    """ in gb, gb)
+KEYWORDS    """
+            in gb,
+            gb,
+        )
         embl = record.format("embl")
         self.assertIn("XX\nPR   Project:PRJNA16232;\nXX\n", embl)
 
@@ -3440,17 +6549,28 @@ KEYWORDS    """ in gb, gb)
         # GISAID_EpiFlu(TM)Data, HM138502.gbk has both 'comment' and 'structured_comment'
         path = "GenBank/HM138502.gbk"
         record = SeqIO.read(path, "genbank")
-        self.assertEqual(record.annotations["comment"],
-                         "Swine influenza A (H1N1) virus isolated during human swine flu\noutbreak of 2009.")
-        self.assertEqual(record.annotations["structured_comment"]["GISAID_EpiFlu(TM)Data"]["Lineage"], "swl")
-        self.assertEqual(len(record.annotations["structured_comment"]["GISAID_EpiFlu(TM)Data"]), 3)
+        self.assertEqual(
+            record.annotations["comment"],
+            "Swine influenza A (H1N1) virus isolated during human swine flu\noutbreak of 2009.",
+        )
+        self.assertEqual(
+            record.annotations["structured_comment"]["GISAID_EpiFlu(TM)Data"][
+                "Lineage"
+            ],
+            "swl",
+        )
+        self.assertEqual(
+            len(record.annotations["structured_comment"]["GISAID_EpiFlu(TM)Data"]), 3
+        )
         path = "GenBank/HM138502_output.gbk"
         with open(path, "r") as ifile:
             self.assertEqual(record.format("gb"), ifile.read())
         # FluData structured comment
         path = "GenBank/EU851978.gbk"
         record = SeqIO.read(path, "genbank")
-        self.assertEqual(record.annotations["structured_comment"]["FluData"]["LabID"], "2008704957")
+        self.assertEqual(
+            record.annotations["structured_comment"]["FluData"]["LabID"], "2008704957"
+        )
         self.assertEqual(len(record.annotations["structured_comment"]["FluData"]), 5)
         path = "GenBank/EU851978_output.gbk"
         with open(path, "r") as ifile:
@@ -3458,8 +6578,15 @@ KEYWORDS    """ in gb, gb)
         # Assembly-Data structured comment
         path = "GenBank/KF527485.gbk"
         record = SeqIO.read(path, "genbank")
-        self.assertEqual(record.annotations["structured_comment"]["Assembly-Data"]["Assembly Method"], "Lasergene v. 10")
-        self.assertEqual(len(record.annotations["structured_comment"]["Assembly-Data"]), 2)
+        self.assertEqual(
+            record.annotations["structured_comment"]["Assembly-Data"][
+                "Assembly Method"
+            ],
+            "Lasergene v. 10",
+        )
+        self.assertEqual(
+            len(record.annotations["structured_comment"]["Assembly-Data"]), 2
+        )
         path = "GenBank/KF527485_output.gbk"
         with open(path, "r") as ifile:
             self.assertEqual(record.format("gb"), ifile.read())
@@ -3467,10 +6594,12 @@ KEYWORDS    """ in gb, gb)
         path = "GenBank/NC_000932.gb"
         record = SeqIO.read(path, "genbank")
         self.assertFalse("structured_comment" in record.annotations)
-        self.assertEqual(record.annotations["comment"],
-                         "REVIEWED REFSEQ: This record has been curated by NCBI staff. The\n"
-                         "reference sequence was derived from AP000423.\n"
-                         "COMPLETENESS: full length.")
+        self.assertEqual(
+            record.annotations["comment"],
+            "REVIEWED REFSEQ: This record has been curated by NCBI staff. The\n"
+            "reference sequence was derived from AP000423.\n"
+            "COMPLETENESS: full length.",
+        )
 
     def test_locus_line_topogoly(self):
         """Test if chromosome topology is conserved."""
@@ -3488,8 +6617,10 @@ KEYWORDS    """ in gb, gb)
         """Check the qualifier order is preserved."""
         record = SeqIO.read("GenBank/DS830848.gb", "gb")
         f = record.features[0]
-        self.assertEqual(list(f.qualifiers),
-                         ["organism", "mol_type", "strain", "db_xref", "dev_stage"])
+        self.assertEqual(
+            list(f.qualifiers),
+            ["organism", "mol_type", "strain", "db_xref", "dev_stage"],
+        )
 
     def test_qualifier_escaping_read(self):
         """Check qualifier escaping is preserved when parsing."""
@@ -3499,9 +6630,12 @@ KEYWORDS    """ in gb, gb)
             record = SeqIO.read("GenBank/qualifier_escaping_read.gb", "gb")
             self.assertEqual(len(caught), 4)
             self.assertEqual(caught[0].category, BiopythonParserWarning)
-            self.assertEqual(str(caught[0].message), 'The NCBI states double-quote characters like " should be escaped'
-                                                     ' as "" (two double - quotes), but here it was not: '
-                                                     "%r" % 'One missing ""quotation mark" here')
+            self.assertEqual(
+                str(caught[0].message),
+                'The NCBI states double-quote characters like " should be escaped'
+                ' as "" (two double - quotes), but here it was not: '
+                "%r" % 'One missing ""quotation mark" here',
+            )
         # Check records parsed as expected
         f1 = record.features[0]
         f2 = record.features[1]
@@ -3528,7 +6662,9 @@ KEYWORDS    """ in gb, gb)
         record = SeqIO.read(genbank_out, "gb")
         f1 = record.features[0]
         f2 = record.features[1]
-        self.assertEqual(f1.qualifiers["note"][0], '"Should" now "be" escaped in "file"')
+        self.assertEqual(
+            f1.qualifiers["note"][0], '"Should" now "be" escaped in "file"'
+        )
         self.assertEqual(f2.qualifiers["note"][0], '"Should also be escaped in file"')
 
     def test_long_names(self):
@@ -3537,15 +6673,16 @@ KEYWORDS    """ in gb, gb)
         self.assertEqual(len(original), 1326)
         # Acceptability of LOCUS line with length > 80 invalidates some of these tests
         for name, seq_len, ok in [
-                ("short", 1, True),
-                ("max_length_of_16", 1000, True),
-                ("overly_long_at_17", 1000, True),
-                ("excessively_long_at_22", 99999, True),
-                ("excessively_long_at_22", 100000, True),
-                ("pushing_the_limits_at_24", 999, True),
-                ("pushing_the_limits_at_24", 1000, True),
-                ("old_max_name_length_was_26", 10, True),  # 2 digits
-                ("old_max_name_length_was_26", 9, True)]:  # 1 digit
+            ("short", 1, True),
+            ("max_length_of_16", 1000, True),
+            ("overly_long_at_17", 1000, True),
+            ("excessively_long_at_22", 99999, True),
+            ("excessively_long_at_22", 100000, True),
+            ("pushing_the_limits_at_24", 999, True),
+            ("pushing_the_limits_at_24", 1000, True),
+            ("old_max_name_length_was_26", 10, True),  # 2 digits
+            ("old_max_name_length_was_26", 9, True),
+        ]:  # 1 digit
             # Make the length match the desired target
             record = original[:]
             # TODO - Implement Seq * int
@@ -3585,10 +6722,12 @@ KEYWORDS    """ in gb, gb)
         """Check if default date is handled correctly."""
         sequence_object = Seq("ATGC", generic_dna)
         # check if default value is inserted correctly
-        record = SeqRecord(sequence_object,
-                           id="123456789",
-                           name="UnitTest",
-                           description="Test case for date parsing")
+        record = SeqRecord(
+            sequence_object,
+            id="123456789",
+            name="UnitTest",
+            description="Test case for date parsing",
+        )
         handle = StringIO()
         SeqIO.write(record, handle, "genbank")
         handle.seek(0)
@@ -3598,10 +6737,12 @@ KEYWORDS    """ in gb, gb)
     def test_genbank_date_correct(self):
         """Check if user provided date is inserted correctly."""
         sequence_object = Seq("ATGC", generic_dna)
-        record = SeqRecord(sequence_object,
-                           id="123456789",
-                           name="UnitTest",
-                           description="Test case for date parsing")
+        record = SeqRecord(
+            sequence_object,
+            id="123456789",
+            name="UnitTest",
+            description="Test case for date parsing",
+        )
         record.annotations["date"] = "24-DEC-2015"
         handle = StringIO()
         SeqIO.write(record, handle, "genbank")
@@ -3612,10 +6753,12 @@ KEYWORDS    """ in gb, gb)
     def test_genbank_date_list(self):
         """Check if date lists are handled correctly."""
         sequence_object = Seq("ATGC", generic_dna)
-        record = SeqRecord(sequence_object,
-                           id="123456789",
-                           name="UnitTest",
-                           description="Test case for date parsing")
+        record = SeqRecord(
+            sequence_object,
+            id="123456789",
+            name="UnitTest",
+            description="Test case for date parsing",
+        )
         record.annotations["date"] = ["24-DEC-2015"]
         handle = StringIO()
         SeqIO.write(record, handle, "genbank")
@@ -3623,10 +6766,12 @@ KEYWORDS    """ in gb, gb)
         gb = SeqIO.read(handle, "gb")
         self.assertEqual(gb.annotations["date"], "24-DEC-2015")
 
-        record = SeqRecord(sequence_object,
-                           id="123456789",
-                           name="UnitTest",
-                           description="Test case for date parsing")
+        record = SeqRecord(
+            sequence_object,
+            id="123456789",
+            name="UnitTest",
+            description="Test case for date parsing",
+        )
         record.annotations["date"] = ["24-DEC-2015", "25-JAN-2016"]
         handle = StringIO()
         SeqIO.write(record, handle, "genbank")
@@ -3637,10 +6782,12 @@ KEYWORDS    """ in gb, gb)
     def test_genbank_date_datetime(self):
         """Check if datetime objects are handled correctly."""
         sequence_object = Seq("ATGC", generic_dna)
-        record = SeqRecord(sequence_object,
-                           id="123456789",
-                           name="UnitTest",
-                           description="Test case for date parsing")
+        record = SeqRecord(
+            sequence_object,
+            id="123456789",
+            name="UnitTest",
+            description="Test case for date parsing",
+        )
         record.annotations["date"] = datetime(2000, 2, 2)
         handle = StringIO()
         SeqIO.write(record, handle, "genbank")
@@ -3650,18 +6797,16 @@ KEYWORDS    """ in gb, gb)
 
     def test_genbank_date_invalid(self):
         """Check if invalid dates are treated as default."""
-        invalid_dates = ("invalid date",
-                         "29-2-1981",
-                         "35-1-2018",
-                         "1-1-80",
-                         "1-9-99")
+        invalid_dates = ("invalid date", "29-2-1981", "35-1-2018", "1-1-80", "1-9-99")
 
         sequence_object = Seq("ATGC", generic_dna)
         for invalid_date in invalid_dates:
-            record = SeqRecord(sequence_object,
-                               id="123456789",
-                               name="UnitTest",
-                               description="Test case for date parsing")
+            record = SeqRecord(
+                sequence_object,
+                id="123456789",
+                name="UnitTest",
+                description="Test case for date parsing",
+            )
 
             record.annotations["date"] = invalid_date
             handle = StringIO()
@@ -3676,7 +6821,9 @@ KEYWORDS    """ in gb, gb)
         path = "GenBank/DS830848.gb"
         with open(path, "r") as inhandle:
             data = inhandle.readlines()
-        data[0] = "LOCUS       AZZZAA021234567891234 2147483647 bp    DNA     linear   PRI 15-OCT-2018\n"
+        data[
+            0
+        ] = "LOCUS       AZZZAA021234567891234 2147483647 bp    DNA     linear   PRI 15-OCT-2018\n"
 
         # Create memory file from modified genbank file
         in_tmp = StringIO()
@@ -3700,6 +6847,7 @@ KEYWORDS    """ in gb, gb)
             self.assertEqual(len(record_in.seq), 2147483647)
 
     if sys.maxsize > 2147483647:
+
         def test_extremely_long_sequence(self):
             """Tests if extremely long sequences can be read.
 
@@ -3709,7 +6857,9 @@ KEYWORDS    """ in gb, gb)
             path = "GenBank/DS830848.gb"
             with open(path, "r") as inhandle:
                 data = inhandle.readlines()
-            data[0] = "LOCUS       AZZZAA02123456789 10000000000 bp    DNA     linear   PRI 15-OCT-2018\n"
+            data[
+                0
+            ] = "LOCUS       AZZZAA02123456789 10000000000 bp    DNA     linear   PRI 15-OCT-2018\n"
 
             # Create memory file from modified genbank file
             in_tmp = StringIO()
@@ -3736,7 +6886,11 @@ KEYWORDS    """ in gb, gb)
                 path = "GenBank/DS830848.gb"
                 with open(path, "r") as inhandle:
                     data2 = inhandle.readlines()
-                data2[0] = "LOCUS       AZZZAA02123456789 " + str(sys.maxsize + 1) + " bp    DNA     linear   PRI 15-OCT-2018\n"
+                data2[0] = (
+                    "LOCUS       AZZZAA02123456789 "
+                    + str(sys.maxsize + 1)
+                    + " bp    DNA     linear   PRI 15-OCT-2018\n"
+                )
 
                 long_in_tmp = StringIO()
                 long_in_tmp.writelines(data2)
@@ -3753,22 +6907,51 @@ class LineOneTests(unittest.TestCase):
         """Check GenBank LOCUS line parsing."""
         # This is a bit low level, but can test pasing the LOCUS line only
         tests = [
-            ("LOCUS       U00096",
-             None, None, None, None),
+            ("LOCUS       U00096", None, None, None, None),
             # This example is actually fungal, accession U49845 from Saccharomyces cerevisiae:
-            ("LOCUS       SCU49845     5028 bp    DNA             PLN       21-JUN-1999",
-             None, "DNA", "PLN", None),
-            ("LOCUS       AB070938                6497 bp    DNA     linear   BCT 11-OCT-2001",
-             "linear", "DNA", "BCT", None),
-            ("LOCUS       NC_005816               9609 bp    DNA     circular BCT 21-JUL-2008",
-             "circular", "DNA", "BCT", None),
-            ("LOCUS       SCX3_BUTOC                64 aa            linear   INV 16-OCT-2001",
-             "linear", None, "INV", None),
-            ("LOCUS       pEH010                  5743 bp    DNA     circular",
-             "circular", "DNA", None, [BiopythonParserWarning]),
+            (
+                "LOCUS       SCU49845     5028 bp    DNA             PLN       21-JUN-1999",
+                None,
+                "DNA",
+                "PLN",
+                None,
+            ),
+            (
+                "LOCUS       AB070938                6497 bp    DNA     linear   BCT 11-OCT-2001",
+                "linear",
+                "DNA",
+                "BCT",
+                None,
+            ),
+            (
+                "LOCUS       NC_005816               9609 bp    DNA     circular BCT 21-JUL-2008",
+                "circular",
+                "DNA",
+                "BCT",
+                None,
+            ),
+            (
+                "LOCUS       SCX3_BUTOC                64 aa            linear   INV 16-OCT-2001",
+                "linear",
+                None,
+                "INV",
+                None,
+            ),
+            (
+                "LOCUS       pEH010                  5743 bp    DNA     circular",
+                "circular",
+                "DNA",
+                None,
+                [BiopythonParserWarning],
+            ),
             # This is a test of the format > 80 chars long
-            ("LOCUS       AZZZAA02123456789 1000000000 bp    DNA     linear   PRI 15-OCT-2018",
-             "linear", "DNA", "PRI", None)
+            (
+                "LOCUS       AZZZAA02123456789 1000000000 bp    DNA     linear   PRI 15-OCT-2018",
+                "linear",
+                "DNA",
+                "PRI",
+                None,
+            ),
         ]
         for (line, topo, mol_type, div, warning_list) in tests:
             with warnings.catch_warnings(record=True) as caught:
@@ -3777,15 +6960,19 @@ class LineOneTests(unittest.TestCase):
                 consumer = GenBank._FeatureConsumer(1, GenBank.FeatureValueCleaner)
                 scanner._feed_first_line(consumer, line)
                 t = consumer.data.annotations.get("topology", None)
-                self.assertEqual(t, topo,
-                                 "Wrong topology %r not %r from %r" % (t, topo, line))
+                self.assertEqual(
+                    t, topo, "Wrong topology %r not %r from %r" % (t, topo, line)
+                )
                 mt = consumer.data.annotations.get("molecule_type", None)
-                self.assertEqual(mt, mol_type,
-                                 "Wrong molecule_type %r not %r from %r" %
-                                 (mt, mol_type, line))
+                self.assertEqual(
+                    mt,
+                    mol_type,
+                    "Wrong molecule_type %r not %r from %r" % (mt, mol_type, line),
+                )
                 d = consumer.data.annotations.get("data_file_division", None)
-                self.assertEqual(d, div,
-                                 "Wrong division %r not %r from %r" % (d, div, line))
+                self.assertEqual(
+                    d, div, "Wrong division %r not %r from %r" % (d, div, line)
+                )
                 if warning_list is None:
                     self.assertEqual(len(caught), 0)
                 else:
@@ -3798,22 +6985,41 @@ class LineOneTests(unittest.TestCase):
         # This is a bit low level, but can test pasing the ID line only
         tests = [
             # Modern examples with sequence version
-            ("ID   X56734; SV 1; linear; mRNA; STD; PLN; 1859 BP.",
-             "linear", "mRNA", "PLN"),
-            ("ID   CD789012; SV 4; linear; genomic DNA; HTG; MAM; 500 BP.",
-             "linear", "genomic DNA", "MAM"),
+            (
+                "ID   X56734; SV 1; linear; mRNA; STD; PLN; 1859 BP.",
+                "linear",
+                "mRNA",
+                "PLN",
+            ),
+            (
+                "ID   CD789012; SV 4; linear; genomic DNA; HTG; MAM; 500 BP.",
+                "linear",
+                "genomic DNA",
+                "MAM",
+            ),
             # Example to match GenBank example used above:
-            ("ID   U49845; SV 1; linear; genomic DNA; STD; FUN; 5028 BP.",
-             "linear", "genomic DNA", "FUN"),
+            (
+                "ID   U49845; SV 1; linear; genomic DNA; STD; FUN; 5028 BP.",
+                "linear",
+                "genomic DNA",
+                "FUN",
+            ),
             # Old examples:
-            ("ID   BSUB9999   standard; circular DNA; PRO; 4214630 BP.",
-             "circular", "DNA", "PRO"),
-            ("ID   SC10H5 standard; DNA; PRO; 4870 BP.",
-             None, "DNA", "PRO"),
+            (
+                "ID   BSUB9999   standard; circular DNA; PRO; 4214630 BP.",
+                "circular",
+                "DNA",
+                "PRO",
+            ),
+            ("ID   SC10H5 standard; DNA; PRO; 4870 BP.", None, "DNA", "PRO"),
             # Patent example from 2016-06-10
             # ftp://ftp.ebi.ac.uk/pub/databases/embl/patent/
-            ("ID   A01679; SV 1; linear; unassigned DNA; PAT; MUS; 12 BP.",
-             "linear", "unassigned DNA", "MUS"),
+            (
+                "ID   A01679; SV 1; linear; unassigned DNA; PAT; MUS; 12 BP.",
+                "linear",
+                "unassigned DNA",
+                "MUS",
+            ),
             # Old patent examples
             ("ID   NRP_AX000635; PRT; NR1; 15 SQ", None, None, "NR1"),
             ("ID   NRP0000016E; PRT; NR2; 5 SQ", None, None, "NR2"),
@@ -3826,39 +7032,45 @@ class LineOneTests(unittest.TestCase):
             consumer = GenBank._FeatureConsumer(1, GenBank.FeatureValueCleaner)
             scanner._feed_first_line(consumer, line)
             t = consumer.data.annotations.get("topology", None)
-            self.assertEqual(t, topo,
-                             "Wrong topology %r not %r from %r" % (t, topo, line))
+            self.assertEqual(
+                t, topo, "Wrong topology %r not %r from %r" % (t, topo, line)
+            )
             mt = consumer.data.annotations.get("molecule_type", None)
-            self.assertEqual(mt, mol_type,
-                             "Wrong molecule_type %r not %r from %r" %
-                             (mt, mol_type, line))
+            self.assertEqual(
+                mt,
+                mol_type,
+                "Wrong molecule_type %r not %r from %r" % (mt, mol_type, line),
+            )
             d = consumer.data.annotations.get("data_file_division", None)
-            self.assertEqual(d, div,
-                             "Wrong division %r not %r from %r" % (d, div, line))
+            self.assertEqual(
+                d, div, "Wrong division %r not %r from %r" % (d, div, line)
+            )
 
     def test_first_line_imgt(self):
         """Check IMGT ID line parsing."""
         # This is a bit low level, but can test pasing the ID line only
         tests = [
-            ("ID   HLA00001   standard; DNA; HUM; 3503 BP.",
-             None, "DNA", "HUM"),
-            ("ID   HLA00001; SV 1; standard; DNA; HUM; 3503 BP.",
-             None, "DNA", "HUM"),
+            ("ID   HLA00001   standard; DNA; HUM; 3503 BP.", None, "DNA", "HUM"),
+            ("ID   HLA00001; SV 1; standard; DNA; HUM; 3503 BP.", None, "DNA", "HUM"),
         ]
         for (line, topo, mol_type, div) in tests:
             scanner = GenBank.Scanner._ImgtScanner()
             consumer = GenBank._FeatureConsumer(1, GenBank.FeatureValueCleaner)
             scanner._feed_first_line(consumer, line)
             t = consumer.data.annotations.get("topology", None)
-            self.assertEqual(t, topo,
-                             "Wrong topology %r not %r from %r" % (t, topo, line))
+            self.assertEqual(
+                t, topo, "Wrong topology %r not %r from %r" % (t, topo, line)
+            )
             mt = consumer.data.annotations.get("molecule_type", None)
-            self.assertEqual(mt, mol_type,
-                             "Wrong molecule_type %r not %r from %r" %
-                             (mt, mol_type, line))
+            self.assertEqual(
+                mt,
+                mol_type,
+                "Wrong molecule_type %r not %r from %r" % (mt, mol_type, line),
+            )
             d = consumer.data.annotations.get("data_file_division", None)
-            self.assertEqual(d, div,
-                             "Wrong division %r not %r from %r" % (d, div, line))
+            self.assertEqual(
+                d, div, "Wrong division %r not %r from %r" % (d, div, line)
+            )
 
 
 class OutputTests(unittest.TestCase):
@@ -3866,15 +7078,13 @@ class OutputTests(unittest.TestCase):
 
     def test_mad_dots(self):
         """Writing and reading back accesssion.version variants."""
-        for identifier in ["example",
-                           "example.1a",
-                           "example.1.2",
-                           "example.1-2",
-                           ]:
-            old = SeqRecord(Seq("ACGT", generic_dna),
-                            id=identifier,
-                            name=identifier,
-                            description="mad dots")
+        for identifier in ["example", "example.1a", "example.1.2", "example.1-2"]:
+            old = SeqRecord(
+                Seq("ACGT", generic_dna),
+                id=identifier,
+                name=identifier,
+                description="mad dots",
+            )
             new = SeqIO.read(StringIO(old.format("gb")), "gb")
             self.assertEqual(old.id, new.id)
             self.assertEqual(old.name, new.name)
@@ -3883,9 +7093,7 @@ class OutputTests(unittest.TestCase):
 
     def test_seqrecord_default_description(self):
         """Read in file using SeqRecord default description."""
-        old = SeqRecord(Seq("ACGT", generic_dna),
-                        id="example",
-                        name="short")
+        old = SeqRecord(Seq("ACGT", generic_dna), id="example", name="short")
         self.assertEqual(old.description, "<unknown description>")
         txt = old.format("gb")
         self.assertIn("DEFINITION  .\n", txt)
@@ -3915,7 +7123,10 @@ class OutputTests(unittest.TestCase):
             rec = SeqIO.read(fake_handle, "genbank")
             self.assertEqual(len(caught), 1)
             self.assertEqual(caught[0].category, BiopythonParserWarning)
-            self.assertEqual(str(caught[0].message), "Non-upper case molecule type in LOCUS line: dna")
+            self.assertEqual(
+                str(caught[0].message),
+                "Non-upper case molecule type in LOCUS line: dna",
+            )
 
         out_handle = StringIO()
 
@@ -3958,8 +7169,9 @@ class GenBankScannerTests(unittest.TestCase):
         self.assertEqual(l_cds_f[84].id, "NP_051123.1")
 
         # Test parse CDS features on NC_005816.gb, Tag to ID
-        l_cds_f = self.gb_to_l_cds_f("GenBank/NC_005816.gb",
-                                     tags2id=("gene", "locus_tag", "product"))
+        l_cds_f = self.gb_to_l_cds_f(
+            "GenBank/NC_005816.gb", tags2id=("gene", "locus_tag", "product")
+        )
         # number of records, should be 10
         self.assertEqual(len(l_cds_f), 10)
         # Seq ID
@@ -3967,10 +7179,12 @@ class GenBankScannerTests(unittest.TestCase):
         self.assertEqual(l_cds_f[0].name, "YP_pPCP01")
 
         # Test parse CDS features on NC_000932.gb and NC_005816.gb combined
-        l_cds_f1 = self.gb_to_l_cds_f("GenBank/NC_000932.gb",
-                                      tags2id=("gene", "locus_tag", "product"))
-        l_cds_f2 = self.gb_to_l_cds_f("GenBank/NC_005816.gb",
-                                      tags2id=("gene", "locus_tag", "product"))
+        l_cds_f1 = self.gb_to_l_cds_f(
+            "GenBank/NC_000932.gb", tags2id=("gene", "locus_tag", "product")
+        )
+        l_cds_f2 = self.gb_to_l_cds_f(
+            "GenBank/NC_005816.gb", tags2id=("gene", "locus_tag", "product")
+        )
         l_cds_combined = l_cds_f1 + l_cds_f2
         # number of records combined, should be 95
         self.assertEqual(len(l_cds_combined), 95)
@@ -3988,9 +7202,12 @@ class GenBankScannerTests(unittest.TestCase):
         self.assertEqual(len(l_r), 1)
         self.assertEqual(l_r[0].id, "NC_005816.1")
         self.assertEqual(l_r[0].name, "NC_005816")
-        self.assertEqual(l_r[0].description, "Yersinia pestis biovar "
-                                             "Microtus str. 91001 plasmid "
-                                             "pPCP1, complete sequence")
+        self.assertEqual(
+            l_r[0].description,
+            "Yersinia pestis biovar "
+            "Microtus str. 91001 plasmid "
+            "pPCP1, complete sequence",
+        )
         self.assertEqual(len(l_r[0].features), 0)
 
         # Test parse records on NC_005816, do_features True
@@ -3999,9 +7216,12 @@ class GenBankScannerTests(unittest.TestCase):
         self.assertEqual(len(l_r), 1)
         self.assertEqual(l_r[0].id, "NC_005816.1")
         self.assertEqual(l_r[0].name, "NC_005816")
-        self.assertEqual(l_r[0].description, "Yersinia pestis biovar "
-                                             "Microtus str. 91001 plasmid "
-                                             "pPCP1, complete sequence")
+        self.assertEqual(
+            l_r[0].description,
+            "Yersinia pestis biovar "
+            "Microtus str. 91001 plasmid "
+            "pPCP1, complete sequence",
+        )
         self.assertEqual(len(l_r[0].features), 41)
 
         # Test parse records on "GenBank/NC_000932.gb", do_features False
@@ -4010,8 +7230,9 @@ class GenBankScannerTests(unittest.TestCase):
         self.assertEqual(len(l_r), 1)
         self.assertEqual(l_r[0].id, "NC_000932.1")
         self.assertEqual(l_r[0].name, "NC_000932")
-        self.assertEqual(l_r[0].description, "Arabidopsis thaliana chloroplast, "
-                                             "complete genome")
+        self.assertEqual(
+            l_r[0].description, "Arabidopsis thaliana chloroplast, " "complete genome"
+        )
         self.assertEqual(len(l_r[0].features), 0)
 
         # Test parse records on NC_000932, do_features True
@@ -4020,8 +7241,9 @@ class GenBankScannerTests(unittest.TestCase):
         self.assertEqual(len(l_r), 1)
         self.assertEqual(l_r[0].id, "NC_000932.1")
         self.assertEqual(l_r[0].name, "NC_000932")
-        self.assertEqual(l_r[0].description, "Arabidopsis thaliana chloroplast, "
-                                             "complete genome")
+        self.assertEqual(
+            l_r[0].description, "Arabidopsis thaliana chloroplast, " "complete genome"
+        )
         self.assertEqual(len(l_r[0].features), 259)
 
     def test_embl_cds_interaction(self):
@@ -4047,9 +7269,12 @@ class GenBankScannerTests(unittest.TestCase):
         # number of records, should be 1
         self.assertEqual(len(l_embl_r), 1)
         self.assertEqual(l_embl_r[0].id, "AE017046.1")
-        self.assertEqual(l_embl_r[0].description, "Yersinia pestis biovar Microtus "
-                                                  "str. 91001 plasmid pPCP1, complete "
-                                                  "sequence.")
+        self.assertEqual(
+            l_embl_r[0].description,
+            "Yersinia pestis biovar Microtus "
+            "str. 91001 plasmid pPCP1, complete "
+            "sequence.",
+        )
         self.assertEqual(len(l_embl_r[0].features), 29)
 
 


### PR DESCRIPTION
This pull request addresses in part issue #2008, see also discussion on #2029. This needs a second opinion although I didn't spot anything I considered a problem while looking at the diff at the command line.

Note: The black commit was done using something like this, to avoid inflating my commit count:

```
$ black Bio/GenBank/*.py Tests/test_GenBank*.py
$ git commit --author "black <black@example.org>" Bio/GenBank/*.py Tests/test_GenBank*.py
```

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
