### PR TITLE
Dual license Bio.phenotype under 3-clause BSD

### DIFF
--- a/Bio/phenotype/__init__.py
+++ b/Bio/phenotype/__init__.py
@@ -1,9 +1,9 @@
 # Copyright 2014-2016 by Marco Galardini.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
 #
-
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 r"""phenotype data input/output.
 
 Input

--- a/Bio/phenotype/phen_micro.py
+++ b/Bio/phenotype/phen_micro.py
@@ -1,7 +1,9 @@
 # Copyright 2014-2016 by Marco Galardini.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 """Classes to work with Phenotype Microarray data.
 
 More information on the single plates can be found here: http://www.biolog.com/

--- a/Bio/phenotype/pm_fitting.py
+++ b/Bio/phenotype/pm_fitting.py
@@ -1,7 +1,9 @@
 # Copyright 2014-2016 by Marco Galardini.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 """Growth curves fitting and parameters extraction for phenotype data.
 
 This module provides functions to perform sigmoid functions fitting to

--- a/Tests/test_phenotype.py
+++ b/Tests/test_phenotype.py
@@ -1,8 +1,10 @@
 # Copyright 2014-2016 Marco Galardini.  All rights reserved.
 # Adapted from test_Mymodule.py by Jeff Chang
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 """Tests for the Bio.phenotype module."""
 
 try:

--- a/Tests/test_phenotype_fit.py
+++ b/Tests/test_phenotype_fit.py
@@ -1,8 +1,10 @@
 # Copyright 2014-2016 Marco Galardini.  All rights reserved.
 # Adapted from test_Mymodule.py by Jeff Chang
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 """Tests for the Bio.phenotype module's fitting functionality."""
 
 try:


### PR DESCRIPTION
This pull request addresses issue #898.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

CC @mgalardini