### PR TITLE
Fix TypeError raised by str(HSP())

### DIFF
--- a/Bio/Blast/Record.py
+++ b/Bio/Blast/Record.py
@@ -26,6 +26,13 @@ from Bio.SeqRecord import SeqRecord
 from Bio.Align import MultipleSeqAlignment
 
 
+def fmt_(value, format_spec="%s", default_str="<unknown>"):
+    """Ensure the given value formats to a string correctly"""
+    if value is None:
+        return default_str
+    return format_spec % value
+
+
 class Header(object):
     """Saves information from a blast header.
 
@@ -223,12 +230,12 @@ class HSP(object):
 
     def __str__(self):
         """Return the BLAST HSP as a formatted string."""
-        if any(i is None for i in (self.score, self.bits, self.expect, self.align_length)):
-            lines = ["Score %s (%s bits), expectation %s, alignment length %s"
-                     % (self.score, self.bits, self.expect, self.align_length)]
-        else:
-            lines = ["Score %i (%i bits), expectation %0.1e, alignment length %i"
-                     % (self.score, self.bits, self.expect, self.align_length)]
+        lines = ["Score %s (%s bits), expectation %s, alignment length %s" % (
+            fmt_(self.score, '%i'), 
+            fmt_(self.bits, '%i'), 
+            fmt_(self.expect, '%0.1e'), 
+            fmt_(self.align_length, '%i'),
+        )]
         if self.align_length is None:
             return "\n".join(lines)
         if self.align_length < 50:

--- a/Bio/Blast/Record.py
+++ b/Bio/Blast/Record.py
@@ -229,6 +229,8 @@ class HSP(object):
         else:
             lines = ["Score %i (%i bits), expectation %0.1e, alignment length %i"
                      % (self.score, self.bits, self.expect, self.align_length)]
+        if self.align_length is None:
+            return "\n".join(lines)
         if self.align_length < 50:
             lines.append("Query:%s %s %s" % (str(self.query_start).rjust(8),
                                              str(self.query),

--- a/Bio/Blast/Record.py
+++ b/Bio/Blast/Record.py
@@ -223,8 +223,12 @@ class HSP(object):
 
     def __str__(self):
         """Return the BLAST HSP as a formatted string."""
-        lines = ["Score %i (%i bits), expectation %0.1e, alignment length %i"
-                 % (self.score, self.bits, self.expect, self.align_length)]
+        if any(i is None for i in (self.score, self.bits, self.expect, self.align_length)):
+            lines = ["Score %s (%s bits), expectation %s, alignment length %s"
+                     % (self.score, self.bits, self.expect, self.align_length)]
+        else:
+            lines = ["Score %i (%i bits), expectation %0.1e, alignment length %i"
+                     % (self.score, self.bits, self.expect, self.align_length)]
         if self.align_length < 50:
             lines.append("Query:%s %s %s" % (str(self.query_start).rjust(8),
                                              str(self.query),

--- a/Bio/Blast/Record.py
+++ b/Bio/Blast/Record.py
@@ -27,7 +27,7 @@ from Bio.Align import MultipleSeqAlignment
 
 
 def fmt_(value, format_spec="%s", default_str="<unknown>"):
-    """Ensure the given value formats to a string correctly"""
+    """Ensure the given value formats to a string correctly."""
     if value is None:
         return default_str
     return format_spec % value
@@ -231,9 +231,9 @@ class HSP(object):
     def __str__(self):
         """Return the BLAST HSP as a formatted string."""
         lines = ["Score %s (%s bits), expectation %s, alignment length %s" % (
-            fmt_(self.score, '%i'), 
-            fmt_(self.bits, '%i'), 
-            fmt_(self.expect, '%0.1e'), 
+            fmt_(self.score, '%i'),
+            fmt_(self.bits, '%i'),
+            fmt_(self.expect, '%0.1e'),
             fmt_(self.align_length, '%i'),
         )]
         if self.align_length is None:

--- a/Tests/test_Blast_Record.py
+++ b/Tests/test_Blast_Record.py
@@ -11,7 +11,10 @@ from Bio.Blast.Record import HSP
 class TestHsp(unittest.TestCase):
     def test_str(self):
         # Test empty instance
-        self.assertEqual(str(HSP()), 'Score None (None bits), expectation None, alignment length None')
+        self.assertEqual(
+            str(HSP()), 
+            'Score <unknown> (<unknown> bits), expectation <unknown>, alignment length <unknown>'
+        )
 
         # Test instance with non-default attributes
         hsp = HSP()

--- a/Tests/test_Blast_Record.py
+++ b/Tests/test_Blast_Record.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+
+import unittest
+
+from Bio.Blast.Record import HSP
+
+
+class TestHsp(unittest.TestCase):
+    def test_str(self):
+        # Test empty instance
+        self.assertEqual(str(HSP()), 'Score None (None bits), expectation None, alignment length None')
+
+        # Test instance with non-default attributes
+        hsp = HSP()
+        hsp.score = 1.0
+        hsp.bits = 2.0
+        hsp.expect = 3.0
+        hsp.align_length = 4
+        self.assertEqual(
+            str(hsp()),
+            """Score 1 (2 bits), expectation 3.0e+00, alignment length 4
+Query:    None  None
+               
+Sbjct:    None  None"""
+        )
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)

--- a/Tests/test_Blast_Record.py
+++ b/Tests/test_Blast_Record.py
@@ -26,7 +26,7 @@ class TestHsp(unittest.TestCase):
         hsp.align_length = 4
         # Ignore trailing whitespace in output
         self.assertEqual(
-            '\n'.join(l.strip() for l in str(hsp()).split('\n')),
+            '\n'.join(l.strip() for l in str(hsp).split('\n')),
             """Score 1 (2 bits), expectation 3.0e+00, alignment length 4
 Query:    None  None
 

--- a/Tests/test_Blast_Record.py
+++ b/Tests/test_Blast_Record.py
@@ -3,6 +3,8 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
+"""Test for Blast records."""
+
 import unittest
 
 from Bio.Blast.Record import HSP
@@ -12,7 +14,7 @@ class TestHsp(unittest.TestCase):
     def test_str(self):
         # Test empty instance
         self.assertEqual(
-            str(HSP()), 
+            str(HSP()),
             'Score <unknown> (<unknown> bits), expectation <unknown>, alignment length <unknown>'
         )
 
@@ -22,11 +24,12 @@ class TestHsp(unittest.TestCase):
         hsp.bits = 2.0
         hsp.expect = 3.0
         hsp.align_length = 4
+        # Ignore trailing whitespace in output
         self.assertEqual(
-            str(hsp()),
+            '\n'.join(l.strip() for l in str(hsp()).split('\n')),
             """Score 1 (2 bits), expectation 3.0e+00, alignment length 4
 Query:    None  None
-               
+
 Sbjct:    None  None"""
         )
 


### PR DESCRIPTION
`TypeError` is raised if you try to print an uninitialized `HSP` instance:

```python
>>> from Bio.Blast.Record import HSP
>>> str(HSP())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../site-packages/Bio/Blast/Record.py", line 227, in __str__
    % (self.score, self.bits, self.expect, self.align_length)]
TypeError: %i format: a number is required, not NoneType
```

This pull request addresses issue #...

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
