### PR TITLE
Fix #2207 - make feature position instances pickable

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1695,22 +1695,6 @@ class WithinPosition(int, AbstractPosition):
     >>> p2 == 13
     True
 
-
-    To allow pickling and unpickling of class instances, the arguments
-    to __new__ must be defined by __getnewargs__:
-
-    >>> p.__getnewargs__() == (10, 10, 13)
-    True
-
-    >>> import pickle
-    >>> p3 = pickle.loads(pickle.dumps(p))
-    >>> p3 == p
-    True
-    >>> p3._left == p._left
-    True
-    >>> p3._right == p._right
-    True
-
     """
 
     def __new__(cls, position, left, right):
@@ -1723,8 +1707,11 @@ class WithinPosition(int, AbstractPosition):
         obj._right = right
         return obj
 
-    # Must define this to allow instances to be unpickled
     def __getnewargs__(self):
+        """Return the arguments accepted by __new__.
+        
+        Necessary to allow pickling and unpickling of class instances.
+        """
         return (int(self), self._left, self._right)
 
     def __repr__(self):
@@ -1825,21 +1812,6 @@ class BetweenPosition(int, AbstractPosition):
     i.e. For equality (and sorting) the position objects behave like
     integers.
 
-    To allow pickling and unpickling of class instances, the arguments
-    to __new__ must be defined by __getnewargs__:
-
-    >>> p.__getnewargs__() == (456, 123, 456)
-    True
-
-    >>> import pickle
-    >>> p3 = pickle.loads(pickle.dumps(p))
-    >>> p3 == p
-    True
-    >>> p3._left == p._left
-    True
-    >>> p3._right == p._right
-    True
-
     """
 
     def __new__(cls, position, left, right):
@@ -1850,8 +1822,11 @@ class BetweenPosition(int, AbstractPosition):
         obj._right = right
         return obj
 
-    # Must define this to allow instances to be unpickled
     def __getnewargs__(self):
+        """Return the arguments accepted by __new__.
+        
+        Necessary to allow pickling and unpickling of class instances.
+        """
         return (int(self), self._left, self._right)
 
     def __repr__(self):
@@ -2079,20 +2054,6 @@ class OneOfPosition(int, AbstractPosition):
     >>> p2 == 1901
     True
 
-    To allow pickling and unpickling of class instances, the arguments
-    to __new__ must be defined by __getnewargs__:
-
-    >>> p.__getnewargs__() == (1888, [ExactPosition(1888), ExactPosition(1901)])
-    True
-
-    >>> import pickle
-    >>> p3 = pickle.loads(pickle.dumps(p))
-    >>> p3 == p
-    True
-    >>> p3.position_choices == p.position_choices
-    True
-
-
     """
 
     def __new__(cls, position, choices):
@@ -2110,8 +2071,11 @@ class OneOfPosition(int, AbstractPosition):
         obj.position_choices = choices
         return obj
 
-    # Must define this to allow instances to be unpickled
     def __getnewargs__(self):
+        """Return the arguments accepted by __new__.
+        
+        Necessary to allow pickling and unpickling of class instances.
+        """
         return (int(self), self.position_choices)
 
     @property

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1695,6 +1695,22 @@ class WithinPosition(int, AbstractPosition):
     >>> p2 == 13
     True
 
+
+    To allow pickling and unpickling of class instances, the arguments
+    to __new__ must be defined by __getnewargs__:
+
+    >>> p.__getnewargs__() == (10, 10, 13)
+    True
+
+    >>> import pickle
+    >>> p3 = pickle.loads(pickle.dumps(p))
+    >>> p3 == p
+    True
+    >>> p3._left == p._left
+    True
+    >>> p3._right == p._right
+    True
+
     """
 
     def __new__(cls, position, left, right):
@@ -1706,6 +1722,10 @@ class WithinPosition(int, AbstractPosition):
         obj._left = left
         obj._right = right
         return obj
+
+    # Must define this to allow instances to be unpickled
+    def __getnewargs__(self):
+        return (int(self), self._left, self._right)
 
     def __repr__(self):
         """Represent the WithinPosition object as a string for debugging."""
@@ -1804,6 +1824,22 @@ class BetweenPosition(int, AbstractPosition):
 
     i.e. For equality (and sorting) the position objects behave like
     integers.
+
+    To allow pickling and unpickling of class instances, the arguments
+    to __new__ must be defined by __getnewargs__:
+
+    >>> p.__getnewargs__() == (456, 123, 456)
+    True
+
+    >>> import pickle
+    >>> p3 = pickle.loads(pickle.dumps(p))
+    >>> p3 == p
+    True
+    >>> p3._left == p._left
+    True
+    >>> p3._right == p._right
+    True
+
     """
 
     def __new__(cls, position, left, right):
@@ -1813,6 +1849,10 @@ class BetweenPosition(int, AbstractPosition):
         obj._left = left
         obj._right = right
         return obj
+
+    # Must define this to allow instances to be unpickled
+    def __getnewargs__(self):
+        return (int(self), self._left, self._right)
 
     def __repr__(self):
         """Represent the BetweenPosition object as a string for debugging."""
@@ -2039,6 +2079,20 @@ class OneOfPosition(int, AbstractPosition):
     >>> p2 == 1901
     True
 
+    To allow pickling and unpickling of class instances, the arguments
+    to __new__ must be defined by __getnewargs__:
+
+    >>> p.__getnewargs__() == (1888, [ExactPosition(1888), ExactPosition(1901)])
+    True
+
+    >>> import pickle
+    >>> p3 = pickle.loads(pickle.dumps(p))
+    >>> p3 == p
+    True
+    >>> p3.position_choices == p.position_choices
+    True
+
+
     """
 
     def __new__(cls, position, choices):
@@ -2055,6 +2109,10 @@ class OneOfPosition(int, AbstractPosition):
         obj = int.__new__(cls, position)
         obj.position_choices = choices
         return obj
+
+    # Must define this to allow instances to be unpickled
+    def __getnewargs__(self):
+        return (int(self), self.position_choices)
 
     @property
     def position(self):

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1709,7 +1709,7 @@ class WithinPosition(int, AbstractPosition):
 
     def __getnewargs__(self):
         """Return the arguments accepted by __new__.
-        
+
         Necessary to allow pickling and unpickling of class instances.
         """
         return (int(self), self._left, self._right)
@@ -1824,7 +1824,7 @@ class BetweenPosition(int, AbstractPosition):
 
     def __getnewargs__(self):
         """Return the arguments accepted by __new__.
-        
+
         Necessary to allow pickling and unpickling of class instances.
         """
         return (int(self), self._left, self._right)
@@ -2073,7 +2073,7 @@ class OneOfPosition(int, AbstractPosition):
 
     def __getnewargs__(self):
         """Return the arguments accepted by __new__.
-        
+
         Necessary to allow pickling and unpickling of class instances.
         """
         return (int(self), self.position_choices)

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -66,6 +66,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Chaitanya Gupta <https://github.com/iCHAIT>
 - Cheng Soon Ong <chengsoon.ong at tuebingen.mpg.de>
 - Chris Lasher <chris.lasher at gmail.com>
+- Chris MacRaild <https://github.com/macraild>
 - Chris Mitchell <https://github.com/chrismit>
 - Chris Rands <https://github.com/chris-rands>
 - Chris Warth <https://github.com/cswarth>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -26,7 +26,7 @@ PDB-style Astral files.
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
-- Chris MacRaild 
+- Chris MacRaild
 - Chris Rands
 - Joe Greener
 - Konstantin Vdovkin

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -26,6 +26,7 @@ PDB-style Astral files.
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
+- Chris MacRaild 
 - Chris Rands
 - Joe Greener
 - Konstantin Vdovkin

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -16,6 +16,7 @@ from Bio.Data.CodonTable import TranslationError
 from Bio.SeqFeature import FeatureLocation, AfterPosition, BeforePosition
 from Bio.SeqFeature import CompoundLocation, UnknownPosition, SeqFeature
 from Bio.SeqFeature import ExactPosition, WithinPosition, BetweenPosition
+from Bio.SeqFeature import OneOfPosition
 
 
 class TestReference(unittest.TestCase):
@@ -192,6 +193,34 @@ class TestLocations(unittest.TestCase):
         self.assertEqual(location2.nofuzzy_end, 24)
         self.assertEqual(location3.nofuzzy_start, 10)
         self.assertEqual(location3.nofuzzy_end, 40)
+
+
+class TestPositions(unittest.TestCase):
+
+    def test_pickle(self):
+        """Test pickle behaviour of position instances."""
+        # setup
+        import pickle
+        within_pos = WithinPosition(10, left=10, right=13)
+        between_pos = BetweenPosition(24, left=20, right=24)
+        oneof_pos = OneOfPosition(1888, [ExactPosition(1888), ExactPosition(1901)])
+        # test __getnewargs__
+        self.assertEqual(within_pos.__getnewargs__(), (10, 10, 13))
+        self.assertEqual(between_pos.__getnewargs__(), (24, 20, 24))
+        self.assertEqual(oneof_pos.__getnewargs__(), 
+                         (1888, [ExactPosition(1888), ExactPosition(1901)]))
+        # test pickle behaviour
+        within_pos2 = pickle.loads(pickle.dumps(within_pos))
+        between_pos2 = pickle.loads(pickle.dumps(between_pos))
+        oneof_pos2 = pickle.loads(pickle.dumps(oneof_pos))
+        self.assertEqual(within_pos, within_pos2)
+        self.assertEqual(between_pos, between_pos2)
+        self.assertEqual(oneof_pos, oneof_pos2)
+        self.assertEqual(within_pos._left, within_pos2._left)
+        self.assertEqual(within_pos._right, within_pos2._right)
+        self.assertEqual(between_pos._left, between_pos2._left)
+        self.assertEqual(between_pos._right, between_pos2._right)
+        self.assertEqual(oneof_pos.position_choices, oneof_pos2.position_choices)
 
 
 if __name__ == "__main__":

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -207,7 +207,7 @@ class TestPositions(unittest.TestCase):
         # test __getnewargs__
         self.assertEqual(within_pos.__getnewargs__(), (10, 10, 13))
         self.assertEqual(between_pos.__getnewargs__(), (24, 20, 24))
-        self.assertEqual(oneof_pos.__getnewargs__(), 
+        self.assertEqual(oneof_pos.__getnewargs__(),
                          (1888, [ExactPosition(1888), ExactPosition(1901)]))
         # test pickle behaviour
         within_pos2 = pickle.loads(pickle.dumps(within_pos))


### PR DESCRIPTION
This adds \_\_getnewargs\_\_ to SeqFeatures.*Positions classes where required, so that instances are (un)picklable

This pull request addresses issue #2207 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X ] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
