### PR TITLE
Dual license most of Bio.PDB

### DIFF
--- a/Bio/PDB/AbstractPropertyMap.py
+++ b/Bio/PDB/AbstractPropertyMap.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Class that maps (chain_id, residue_id) to a residue property."""
 

--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Atom class, used in Structure objects."""
 

--- a/Bio/PDB/Chain.py
+++ b/Bio/PDB/Chain.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Chain class, used in Structure objects."""
 

--- a/Bio/PDB/Dice.py
+++ b/Bio/PDB/Dice.py
@@ -1,7 +1,10 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
+
 """Code for chopping up (dicing) a structure.
 
 This module is used internally by the Bio.PDB.extract() function.

--- a/Bio/PDB/FragmentMapper.py
+++ b/Bio/PDB/FragmentMapper.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classify protein backbone structure with Kolodny et al's fragment libraries.
 

--- a/Bio/PDB/HSExposure.py
+++ b/Bio/PDB/HSExposure.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Half-sphere exposure and coordination number calculation."""
 

--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Turn an mmCIF file into a dictionary."""
 

--- a/Bio/PDB/NACCESS.py
+++ b/Bio/PDB/NACCESS.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 # NACCESS interface adapted from Bio/PDB/DSSP.py
 

--- a/Bio/PDB/NeighborSearch.py
+++ b/Bio/PDB/NeighborSearch.py
@@ -1,9 +1,10 @@
 # Copyright (C) 2002, 2004 Thomas Hamelryck (thamelry@binf.ku.dk)
 # All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
-
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Fast atom neighbor lookup using a KD tree (implemented in C)."""
 

--- a/Bio/PDB/PDBExceptions.py
+++ b/Bio/PDB/PDBExceptions.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Some Bio.PDB-specific exceptions."""
 

--- a/Bio/PDB/PSEA.py
+++ b/Bio/PDB/PSEA.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2006, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Wrappers for PSEA, a program for secondary structure assignment.
 

--- a/Bio/PDB/Polypeptide.py
+++ b/Bio/PDB/Polypeptide.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Polypeptide-related classes (construction and representation).
 

--- a/Bio/PDB/QCPSuperimposer/__init__.py
+++ b/Bio/PDB/QCPSuperimposer/__init__.py
@@ -1,7 +1,10 @@
 # Copyright (C) 2015, Anuj Sharma (anuj.sharma80@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
+
 """Structural alignment using Quaternion Characteristic Polynomial (QCP).
 
 QCPSuperimposer finds the best rotation and translation to put

--- a/Bio/PDB/Residue.py
+++ b/Bio/PDB/Residue.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Residue class, used by Structure objects."""
 

--- a/Bio/PDB/ResidueDepth.py
+++ b/Bio/PDB/ResidueDepth.py
@@ -1,8 +1,10 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
 # Copyright (C) 2017, Joao Rodrigues (j.p.g.l.m.rodrigues@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Calculation of residue depth using command line tool MSMS.
 

--- a/Bio/PDB/Selection.py
+++ b/Bio/PDB/Selection.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Selection of atoms, residues, etc."""
 

--- a/Bio/PDB/Structure.py
+++ b/Bio/PDB/Structure.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """The structure class, representing a macromolecular structure."""
 

--- a/Bio/PDB/StructureAlignment.py
+++ b/Bio/PDB/StructureAlignment.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Map residues of two structures to each other based on a FASTA alignment."""
 

--- a/Bio/PDB/Superimposer.py
+++ b/Bio/PDB/Superimposer.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Superimpose two structures."""
 

--- a/Bio/PDB/__init__.py
+++ b/Bio/PDB/__init__.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classes that deal with macromolecular crystal structures.
 

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -1,31 +1,17 @@
 #!/usr/bin/env python
-# Copyright 2004 Kristian Rother
+# Copyright 2004 Kristian Rother.
+# Revisions copyright 2004 Thomas Hamelryck.
 #
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
-#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
+
 """Parse header of PDB files into a python dictionary.
 
-Emerged from the Columba database project www.columba-db.de.
-
-Original author: Kristian Rother.
+Emerged from the Columba database project www.columba-db.de, original author
+Kristian Rother.
 """
-
-# license: same as Biopython, read LICENSE.TXT from current Biopython release.
-#
-# last modified: 9.2.2004
-#
-# Added some small changes: the whole PDB file is not read in anymore, but just
-# until the first ATOM record (faster). I also split parse_pdb_header into
-# parse_pdb_header and parse_pdb_header_list, because parse_pdb_header_list
-# can be more easily reused in PDBParser.
-#
-# Thomas, 19/03/04
-#
-# Renamed some clearly private functions to _something (ie. parse_pdb_header_list
-# is now _parse_pdb_header_list)
-# Thomas 9/05/04
 
 from __future__ import print_function
 

--- a/Bio/PDB/vectors.py
+++ b/Bio/PDB/vectors.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2004, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Vector class, including rotation-related functions."""
 

--- a/Tests/test_PDB_KDTree.py
+++ b/Tests/test_PDB_KDTree.py
@@ -4,9 +4,10 @@
 # Converted by Eric Talevich from an older unit test copyright 2002
 # by Thomas Hamelryck.
 #
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Unit tests for those parts of the Bio.PDB module using Bio.KDTree."""
 

--- a/Tests/test_PDB_MMCIFParser.py
+++ b/Tests/test_PDB_MMCIFParser.py
@@ -1,11 +1,12 @@
 # Copyright 2012 Lenna X. Peterson (arklenna@gmail.com).
 # All rights reserved.
 #
-# Tests adapted from test_PDB.py
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 #
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+# Tests adapted from test_PDB.py
 
 """Unit tests for the MMCIF portion of the Bio.PDB module."""
 


### PR DESCRIPTION
This pull request addresses in part issue #989

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

For dual licensing the remaining Python code under ``Bio/PDB/``, I believe we still need consent from the following (apologies if you have agreed and I've missed it) - agreement to the mailing list, here, or on #989 would be appreciated - thank you:

 - [ ] @andrewguy (sorry, was initially missing the y)
 - [ ] @asford
 - [x] @biojerm (below)
 - [x] @fcaramia https://github.com/biopython/biopython/pull/576#issuecomment-521465740
 - [x] @hectormartinezdev (below)
 - [ ] @kokonech

