### PR TITLE
Remove pinning of pydocstyle

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -108,10 +108,6 @@ deps =
     # https://bugs.launchpad.net/doc8/+bug/1837515
     # https://sourceforge.net/p/docutils/bugs/366/
     docutils==0.14
-    # flake8-docstrings uses a function removed in pydocstyle 4.0.0; once a fix
-    # is released in flake8-docstrings we can remove the following constraint:
-    pydocstyle<4.0.0
-    # See https://gitlab.com/pycqa/flake8-docstrings/issues/36
 commands =
     # PEP-8 and PEP-257 style checks:
     flake8


### PR DESCRIPTION
With the recent update of `flake8-docstring`, pinning of `pydocstyle` to versions < 4.0.0 should no longer be necessary (https://gitlab.com/pycqa/flake8-docstrings/issues/36).

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
