### PR TITLE
Dual license more of Bio.PDB

### DIFF
--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 r"""Use the DSSP program to calculate secondary structure and accessibility.
 

--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -1,8 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@binf.ku.dk)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
-
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 """Base class for Residue, Chain, Model and Structure classes.
 
 It is a simple container class, with list and dictionary like properties.

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
-
 # Copyright 2003, by Kristian Rother. All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
-
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 #
 # PDBList.py
 #
@@ -29,9 +29,6 @@
 #   homepage : http://jaceksmietanski.net
 #   email    : jacek.smietanski@ii.uj.edu.pl
 #
-# This code is released under the conditions of the Biopython license.
-# Please see the LICENSE file that should have been included as part of this
-# package.
 # It may be distributed freely with respect to the original authors.
 # Any maintainer of the Biopython code may change this notice
 # when appropriate.

--- a/Bio/SVDSuperimposer/__init__.py
+++ b/Bio/SVDSuperimposer/__init__.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2002, Thomas Hamelryck (thamelry@vub.ac.be)
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 """Align on protein structure onto another using SVD alignment.
 
 SVDSuperimposer finds the best rotation and translation to put

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -157,6 +157,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Kevin Wu <https://github.com/kevinwuhoo>
 - Kian Ho <https://github.com/kianho>
 - Kiran Mukhyala <https://github.com/mukhyala>
+- Klaus Kopec <https://github.com/klauskopec>
 - Konrad Förstner <https://github.com/konrad>
 - Konstantin Okonechnikov <k.okonechnikov at domain gmail.com>
 - Konstantin Vdovkin <https://github.com/rtf_const>

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -5,9 +5,10 @@
 # Converted by Eric Talevich from an older unit test copyright 2002
 # by Thomas Hamelryck.
 #
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Unit tests for the Bio.PDB module."""
 from __future__ import print_function


### PR DESCRIPTION
This pull request addresses in part issue #898, continuing work on #2212 

See also #2240 (``MMCIFParser.py``) and #2241 (``Entity.py``), and also waiting to hear from @kokonech for the remaining files under ``Bio/PDB/``.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
