### PR TITLE
BSD dual license Bio.Pathway and most of Bio.KEGG

### DIFF
--- a/Bio/KEGG/Compound/__init__.py
+++ b/Bio/KEGG/Compound/__init__.py
@@ -1,8 +1,10 @@
 # Copyright 2001 by Tarjei Mikkelsen.  All rights reserved.
 # Copyright 2007 by Michiel de Hoon.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Code to work with the KEGG Ligand/Compound database.
 

--- a/Bio/KEGG/Gene/__init__.py
+++ b/Bio/KEGG/Gene/__init__.py
@@ -1,7 +1,9 @@
 # Copyright 2017 by Kozo Nishida.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Code to work with the KEGG Gene database.
 

--- a/Bio/KEGG/KGML/KGML_parser.py
+++ b/Bio/KEGG/KGML/KGML_parser.py
@@ -1,7 +1,9 @@
 # Copyright 2013 by Leighton Pritchard.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classes and functions to parse a KGML pathway map.
 

--- a/Bio/KEGG/KGML/KGML_pathway.py
+++ b/Bio/KEGG/KGML/KGML_pathway.py
@@ -1,7 +1,9 @@
 # Copyright 2013 by Leighton Pritchard.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classes to represent a KGML Pathway Map.
 

--- a/Bio/KEGG/KGML/__init__.py
+++ b/Bio/KEGG/KGML/__init__.py
@@ -1,7 +1,9 @@
 # Copyright 2013 by Leighton Pritchard.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Code to work with data from the KEGG database.
 

--- a/Bio/KEGG/Map/__init__.py
+++ b/Bio/KEGG/Map/__init__.py
@@ -1,8 +1,10 @@
 # Copyright 2001 by Tarjei Mikkelsen. All rights reserved.
 # Copyright 2007 by Michiel de Hoon. All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Load KEGG Pathway maps for use with the Biopython Pathway module.
 

--- a/Bio/KEGG/REST.py
+++ b/Bio/KEGG/REST.py
@@ -1,9 +1,11 @@
 # Copyright 2014 by Kevin Wu.
 # Revisions copyright 2014 by Peter Cock.
 # All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Provides code to access the REST-style KEGG online API.
 

--- a/Bio/KEGG/__init__.py
+++ b/Bio/KEGG/__init__.py
@@ -1,7 +1,9 @@
 # Copyright 2001 by Tarjei Mikkelsen.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Code to work with data from the KEGG database.
 

--- a/Bio/Pathway/Rep/Graph.py
+++ b/Bio/Pathway/Rep/Graph.py
@@ -1,8 +1,10 @@
 # Copyright 2002 by Tarjei Mikkelsen.  All rights reserved.
 # Revisions copyright 2018 by Maximilian Greil. All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """get/set abstraction for graph representation."""
 

--- a/Bio/Pathway/Rep/MultiGraph.py
+++ b/Bio/Pathway/Rep/MultiGraph.py
@@ -1,8 +1,10 @@
 # Copyright 2001 by Tarjei Mikkelsen.  All rights reserved.
 # Revisions copyright 2018 by Maximilian Greil. All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """get/set abstraction for multi-graph representation."""
 

--- a/Bio/Pathway/Rep/__init__.py
+++ b/Bio/Pathway/Rep/__init__.py
@@ -1,7 +1,9 @@
 # Copyright 2001 by Tarjei Mikkelsen. All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """BioPython Pathway support module.
 

--- a/Bio/Pathway/__init__.py
+++ b/Bio/Pathway/__init__.py
@@ -1,7 +1,9 @@
 # Copyright 2001 by Tarjei Mikkelsen.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """BioPython Pathway module.
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -241,7 +241,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Stuart Nelis <https://github.com/biostu24>
 - Sunhwan Jo <https://github.com/sunhwan>
 - Tarcisio Fedrizzi <https://github.com/hcraT>
-- Tarjei Mikkelsen <tarjei at domain genome.wi.mit.edu>
+- Tarjei Mikkelsen <https://github.com/tmikkelsen>
 - Ted Cybulski <https://github.com/tcyb>
 - Terry Jones <https://github.com/terrycojones>
 - Thomas Hamelryck <thamelry at domain binf.ku.dk>

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -166,7 +166,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Kuan-Yi Li <https://github.com/kuanyili>
 - Kurt Graff <https://github.com/graph1994>
 - Kyle Ellrott <https://github.com/kellrott>
-- Leighton Pritchard <lpritc at domain scri.sari.ac.uk>
+- Leighton Pritchard <https://github.com/widdowquinn>
 - Lenna Peterson <ark first-name at gmail dot com>
 - Leonhard Heizinger <https://github.com/he-leon>
 - Leszek Pryszcz <https://github.com/lpryszcz>


### PR DESCRIPTION
This pull request addresses issue #2243, bar ``Bio/KEGG/Enzyme/__init__.py``

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
