### PR TITLE
Python 2.7 warning in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,10 @@ if sys.version_info[:2] < (2, 7):
     sys.stderr.write("Biopython requires Python 2.7, or Python 3.5 or later. "
                      "Python %d.%d detected.\n" % sys.version_info[:2])
     sys.exit(1)
+elif sys.version_info[0] < 3:
+    sys.stderr.write(
+        "WARNING: Biopython will drop support for Python 2.7 in early 2020.\n"
+    )
 elif sys.version_info[0] == 3 and sys.version_info[:2] < (3, 5):
     sys.stderr.write("Biopython requires Python 3.5 or later (or Python 2.7). "
                      "Python %d.%d detected.\n" % sys.version_info[:2])

--- a/setup.py
+++ b/setup.py
@@ -189,6 +189,12 @@ class install_biopython(install):
         if check_dependencies_once():
             # Run the normal install.
             install.run(self)
+        if sys.version_info[0] < 3:
+            sys.stderr.write(
+                "=" * 66 +
+                "\nWARNING: Biopython will drop support for Python 2.7 in early 2020.\n" +
+                "=" * 66 + "\n"
+            )
 
 
 class build_py_biopython(build_py):

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,9 @@ if sys.version_info[:2] < (2, 7):
     sys.exit(1)
 elif sys.version_info[0] < 3:
     sys.stderr.write(
-        "WARNING: Biopython will drop support for Python 2.7 in early 2020.\n"
+        "=" * 66 +
+        "\nWARNING: Biopython will drop support for Python 2.7 in early 2020.\n" +
+        "=" * 66 + "\n"
     )
 elif sys.version_info[0] == 3 and sys.version_info[:2] < (3, 5):
     sys.stderr.write("Biopython requires Python 3.5 or later (or Python 2.7). "


### PR DESCRIPTION
This adds a warning to setup.py in line with previous statements about ending Python 2.7 support.

According to https://pypistats.org/packages/biopython the Python 2.7 downloads are still surprisingly high (although much of this could be automated dependency testing on continuous integration platforms).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
