### PR TITLE
use raise_from to prevent exception chaining in Python3

### DIFF
--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -48,6 +48,7 @@ from xml.sax.saxutils import escape
 from Bio._py3k import urlopen as _urlopen
 from Bio._py3k import urlparse as _urlparse
 from Bio._py3k import unicode
+from Bio._py3k import raise_from as _raise_from
 
 
 # The following four classes are used to add a member .attributes to integers,
@@ -336,11 +337,11 @@ class DataHandler(object):
                 # We saw the initial <!xml declaration, so we can be sure that
                 # we are parsing XML data. Most likely, the XML file is
                 # corrupted.
-                raise CorruptedXMLError(e)
+                _raise_from(CorruptedXMLError(e), None)
             else:
                 # We have not seen the initial <!xml declaration, so probably
                 # the input data is not in XML format.
-                raise NotXMLError(e)
+                _raise_from(NotXMLError(e), None)
         try:
             return self.record
         except AttributeError:
@@ -348,11 +349,11 @@ class DataHandler(object):
                 # We saw the initial <!xml declaration, and expat didn't notice
                 # any errors, so self.record should be defined. If not, this is
                 # a bug.
-                raise RuntimeError("Failed to parse the XML file correctly, possibly due to a bug in Bio.Entrez. Please contact the Biopython developers via the mailing list or GitHub for assistance.")
+                _raise_from(RuntimeError("Failed to parse the XML file correctly, possibly due to a bug in Bio.Entrez. Please contact the Biopython developers via the mailing list or GitHub for assistance."), None)
             else:
                 # We did not see the initial <!xml declaration, so probably
                 # the input data is not in XML format.
-                raise NotXMLError("XML declaration not found")
+                _raise_from(NotXMLError("XML declaration not found"), None)
 
     def parse(self, handle):
         """Parse the XML in the given file handle."""
@@ -367,11 +368,11 @@ class DataHandler(object):
                     # We saw the initial <!xml declaration, so we can be sure
                     # that we are parsing XML data. Most likely, the XML file
                     # is corrupted.
-                    raise CorruptedXMLError(e)
+                    _raise_from(CorruptedXMLError(e), None)
                 else:
                     # We have not seen the initial <!xml declaration, so
                     # probably the input data is not in XML format.
-                    raise NotXMLError(e)
+                    _raise_from(NotXMLError(e), None)
             try:
                 records = self.record
             except AttributeError:
@@ -379,11 +380,11 @@ class DataHandler(object):
                     # We saw the initial <!xml declaration, and expat
                     # didn't notice any errors, so self.record should be
                     # defined. If not, this is a bug.
-                    raise RuntimeError("Failed to parse the XML file correctly, possibly due to a bug in Bio.Entrez. Please contact the Biopython developers via the mailing list or GitHub for assistance.")
+                    _raise_from(RuntimeError("Failed to parse the XML file correctly, possibly due to a bug in Bio.Entrez. Please contact the Biopython developers via the mailing list or GitHub for assistance."), None)
                 else:
                     # We did not see the initial <!xml declaration, so
                     # probably the input data is not in XML format.
-                    raise NotXMLError("XML declaration not found")
+                    _raise_from(NotXMLError("XML declaration not found"), None)
 
             if not isinstance(records, list):
                 raise ValueError("The XML file does not represent a list. Please use Entrez.read instead of Entrez.parse")
@@ -947,7 +948,7 @@ class DataHandler(object):
             try:
                 handle = _urlopen(url)
             except IOError:
-                raise RuntimeError("Failed to access %s at %s" % (filename, url))
+                _raise_from(RuntimeError("Failed to access %s at %s" % (filename, url)), None)
             text = handle.read()
             handle.close()
             self.save_dtd_file(filename, text)
@@ -985,14 +986,14 @@ class DataHandler(object):
             # Trying os.makedirs first and then checking for os.path.isdir avoids
             # a race condition.
             if not os.path.isdir(self.local_dtd_dir):
-                raise exception
+                _raise_from(exception, None)
         # Create XSD local directory
         self.local_xsd_dir = os.path.join(self.directory, "Bio", "Entrez", "XSDs")
         try:
             os.makedirs(self.local_xsd_dir)  # use exist_ok=True on Python >= 3.2
         except OSError as exception:
             if not os.path.isdir(self.local_xsd_dir):
-                raise exception
+                _raise_from(exception, None)
 
     @property
     def directory(self):

--- a/Bio/_py3k/__init__.py
+++ b/Bio/_py3k/__init__.py
@@ -135,6 +135,14 @@ if sys.version_info[0] >= 3:
     from urllib.parse import urlencode, quote
     from urllib.error import URLError, HTTPError
 
+    exec("""\
+def raise_from(value, from_value):
+    try:
+        raise value from from_value
+    finally:
+        value = None
+""")
+
 else:
     # Python 2 code
     from __builtin__ import open, basestring, unicode
@@ -195,6 +203,9 @@ else:
 
     # Under urllib.error on Python 3:
     from urllib2 import URLError, HTTPError
+
+    def raise_from(value, from_value):
+        raise value
 
 
 if sys.platform == "win32":


### PR DESCRIPTION
This pull request prevents exception chaining with Python3.

Using `einfo4.xml` in `Tests/Entrez` as an example.

Old behavior with Python2:
```python
$ python2
Python 2.7.14 (v2.7.14:84471935ed, Sep 16 2017, 12:01:12) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from Bio import Entrez
>>> handle = open("einfo4.xml", "rb")
>>> Entrez.read(handle)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/Bio/Entrez/__init__.py", line 474, in read
    record = handler.read(handle)
  File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/Bio/Entrez/Parser.py", line 339, in read
    raise CorruptedXMLError(e)
Bio.Entrez.Parser.CorruptedXMLError: Failed to parse the XML data (no element found: line 16, column 0). Please make sure that the input data are not corrupted.
>>> 
```

Old behavior with Python3:
```
$ python
Python 3.6.6 (v3.6.6:4cf1f54eb7, Jun 26 2018, 17:02:57) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from Bio.Entrez import Parser
>>> from Bio import Entrez
>>> handle = open("Entrez/einfo4.xml", "rb")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
FileNotFoundError: [Errno 2] No such file or directory: 'Entrez/einfo4.xml'
>>> handle = open("einfo4.xml", "rb")
>>> Entrez.read(handle)
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/Bio/Entrez/Parser.py", line 333, in read
    self.parser.ParseFile(handle)
xml.parsers.expat.ExpatError: no element found: line 16, column 0

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/Bio/Entrez/__init__.py", line 474, in read
    record = handler.read(handle)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/Bio/Entrez/Parser.py", line 339, in read
    raise CorruptedXMLError(e)
Bio.Entrez.Parser.CorruptedXMLError: Failed to parse the XML data (no element found: line 16, column 0). Please make sure that the input data are not corrupted.
>>> 
```

i.e. with python3, the inner exception is no longer masked by the outer exception.

To prevent this with python3, use `raise Exception from None`. This is implemented in `Bio._py3k`.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
