### PR TITLE
Origin wrap bad formatting of compound locations

### DIFF
--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -1122,6 +1122,11 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                                                            strand))
                 except ValueError:
                     # Could be non-integers, more likely bad origin wrapping
+
+                    # In the case of bad origin wrapping, _loc will return
+                    # a CompoundLocation. CompoundLocation.parts returns a
+                    # list of the FeatureLocation objects inside the
+                    # CompoundLocation.
                     locs.extend(_loc(part,
                                      self._expected_size,
                                      strand,
@@ -1164,6 +1169,10 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                 else:
                     part_strand = strand
                 try:
+                    # There is likely a problem with origin wrapping.
+                    # Using _loc to return a CompoundLocation of the
+                    # wrapped feature and returning the two FeatureLocation
+                    # objects to extend to the list of feature locations.
                     loc = _loc(part, self._expected_size, part_strand,
                                seq_type=self._seq_type.lower()).parts
 
@@ -1171,6 +1180,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                     print(location_line)
                     print(part)
                     raise err
+                # loc will be a list of one or two FeatureLocation items.
                 locs.extend(loc)
             # Historically a join on the reverse strand has been represented
             # in Biopython with both the parent SeqFeature and its children

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -55,6 +55,7 @@ possible, especially the following contributors:
 - Konstantin Vdovkin
 - Mike Moritz (first contribution)
 - Mustafa Anil Tuncel
+- Nick Negretti
 - Peter Cock
 - Peter Kerpedjiev
 - Sergio Valqui

--- a/Tests/GenBank/bad_origin_wrap.gb
+++ b/Tests/GenBank/bad_origin_wrap.gb
@@ -33,5 +33,20 @@ FEATURES             Location/Qualifiers
      gene            6801..100
                      /gene="fake"
                      /note="Bad location, should be a join wrapping origin"
+     CDS             join(5400..5600,5700..6100,6801..100)
+                     /gene="white"
+                     /note="compound location, spanning origin"
+     CDS             join(<5400..5600,5700..6100,6801..100)
+                     /gene="white"
+                     /note="compound, inexact, location, spanning origin"
+     CDS             join(5400..5600,5700..6100,<6801..100)
+                     /gene="white"
+                     /note="compound location, with inexact
+                     feature spanning origin"
+     CDS             join(5400..5600,5700..6100,complement(<6801..100))
+                     /gene="white"
+                     /note="compound location, with inexact
+                     feature spanning origin"
+
 CONTIG      join(ABCD0123456789.1:1..7000)
 //

--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -3254,7 +3254,7 @@ class GenBankTests(unittest.TestCase):
             self.assertIn("It appears that '6801..100' is a feature "
                           "that spans the origin", str(cm.exception))
 
-    def test_implicit_orign_wrap_fix(self):
+    def test_001_implicit_orign_wrap_fix(self):
         """Attempt to fix implied origin wrapping."""
         path = "GenBank/bad_origin_wrap.gb"
         with warnings.catch_warnings():

--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -3267,6 +3267,32 @@ class GenBankTests(unittest.TestCase):
                              "Please fix input file, this could have "
                              "unintended behavior.")
 
+    def test_compound_complex_origin_wrap(self):
+        """Test the attempts to fix compound complex origin wrapping."""
+        from Bio.SeqFeature import CompoundLocation
+        path = "GenBank/bad_origin_wrap.gb"
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonParserWarning)
+            record = SeqIO.read(path, "genbank")
+
+            self.assertIsInstance(record.features[3].location,
+                                  CompoundLocation)
+            self.assertEqual(str(record.features[3].location),
+                             "join{[<5399:5600](+), [5699:6100](+), "
+                             "[6800:7000](+), [0:100](+)}")
+
+            self.assertIsInstance(record.features[4].location,
+                                  CompoundLocation)
+            self.assertEqual(str(record.features[4].location),
+                             "join{[5399:5600](+), [5699:6100](+), "
+                             "[<6800:7000](+), [0:100](+)}")
+
+            self.assertIsInstance(record.features[5].location,
+                                  CompoundLocation)
+            self.assertEqual(str(record.features[5].location),
+                             "join{[5399:5600](+), [5699:6100](+), "
+                             "[0:100](-), [<6800:7000](-)}")
+
     def test_implicit_orign_wrap_extract_and_translate(self):
         """Test that features wrapped around origin give expected data."""
         path = "GenBank/bad_origin_wrap_CDS.gb"


### PR DESCRIPTION
This pull request addresses issue #2247 

Last time I fixed this, I didn't consider genes with introns (compound locations) spanning the origin. It looks like most current tools don't generate files that are incompatible with the specification, but there are some old files floating around.

Because of the way this was fixed last time, it was simple to add the fix to other location string types. This is beginning to feel a little hack-y, but it is consistent with previous changes. 

I think I said this last time, but I don't think there are other types of location strings that won't be fixed.

I modified one of the test files to capture the problem raised in the issue.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
