### PR TITLE
Consistent error messages for empty files in SeqIO (PdbSeqres, CifSeqres, Abi, AbiTrim)

### DIFF
--- a/Bio/SeqIO/AbiIO.py
+++ b/Bio/SeqIO/AbiIO.py
@@ -372,7 +372,8 @@ def AbiIterator(handle, alphabet=None, trim=False):
     marker = handle.read(4)
     if not marker:
         # handle empty file gracefully
-        return
+        raise ValueError("Empty file.")
+
     if marker != b"ABIF":
         raise IOError("File should start ABIF, not %r" % marker)
 

--- a/Bio/SeqIO/GckIO.py
+++ b/Bio/SeqIO/GckIO.py
@@ -14,6 +14,7 @@ from Textco BioSoftware, Inc.
 from struct import unpack
 
 from Bio import Alphabet
+from Bio._utils import _read_header
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation
 from Bio.SeqRecord import SeqRecord
@@ -75,7 +76,8 @@ def GckIterator(handle):
     # GCK files start with a 24-bytes header. Bytes 4 and 8 seem to
     # always be 12, maybe this could act as a magic cookie. Bytes
     # 17-20 and 21-24 contain variable values of unknown meaning.
-    _read(handle, 24)
+    # check if file is empty
+    _read_header(handle, 24)
 
     # Read the actual sequence data
     packet, length = _read_packet(handle)

--- a/Bio/SeqIO/NibIO.py
+++ b/Bio/SeqIO/NibIO.py
@@ -117,6 +117,11 @@ def NibIterator(handle, alphabet=None):
     if alphabet is not None:
         raise ValueError("Alphabets are ignored.")
     word = handle.read(4)
+
+    # check if file is empty
+    if not word:
+        raise ValueError("Empty file.")
+
     signature = bytes2hex(word)
     if signature == "3a3de96b":
         byteorder = "little"  # little-endian

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -57,7 +57,12 @@ class XMLRecordIterator(object):
         """Iterate over the records in the XML file."""
         record = None
         try:
+            empty = True
             for event, node in self._events:
+
+                # the for loop is entered only if there is some content in self._events
+                # if the empty flag is still True, the file is empty
+                empty = False
 
                 if event == "START_ELEMENT" and node.namespaceURI == self._namespace:
 
@@ -85,6 +90,9 @@ class XMLRecordIterator(object):
                     and node.localName == self._recordTag
                 ):
                     yield record
+
+            if empty:
+                raise ValueError("Empty file.")
 
         except SAXParseException as e:
 

--- a/Bio/SeqIO/SnapGeneIO.py
+++ b/Bio/SeqIO/SnapGeneIO.py
@@ -258,12 +258,19 @@ def SnapGeneIterator(handle):
     record = SeqRecord(None)
     n = 0
 
+    # check if file is empty
+    empty = True
+
     for n, (type, length, data) in enumerate(_PacketIterator(handle)):
+        empty = False
         if n == 0 and type != 0x09:
             raise ValueError("The file does not start with a SnapGene cookie packet")
 
         if type in _packet_handlers:
             _packet_handlers[type](length, data, record)
+
+    if empty:
+        raise ValueError("Empty file.")
 
     if not record.seq:
         raise ValueError("No DNA packet in file")

--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -16,6 +16,7 @@ from struct import pack, unpack
 import warnings
 
 from Bio import Alphabet, BiopythonWarning
+from Bio._utils import _read_header
 from Bio.Seq import Seq
 from Bio.SeqIO.Interfaces import SequenceWriter
 from Bio.SeqFeature import SeqFeature, FeatureLocation, ExactPosition
@@ -153,7 +154,7 @@ def XdnaIterator(handle):
     # Biopython's SeqRecord has no such concept of a sequence origin as far
     # as I know, so we ignore that value. SerialCloner has no such concept
     # either and always generates files with a neg_length of zero.
-    header = _read(handle, 112)
+    header = _read_header(handle, 112)
     (version, type, topology, length, neg_length, com_length) = unpack(
         ">BBB25xII60xI12x", header
     )

--- a/Bio/_utils.py
+++ b/Bio/_utils.py
@@ -46,6 +46,22 @@ def read_forward(handle):
             return line
 
 
+def _read_header(handle, length):
+    """Read the specified number of characters from the given handle.
+
+    Raise a ValueError("Empty file.") if the length of data read is zero. The
+    reason for having a separate function for the header is it enables raising
+    an empty file error if the length of the data read is zero. This might
+    not always be the case later in the file.
+    """
+    data = handle.read(length)
+    if not data:
+        raise ValueError("Empty file.")
+    if len(data) < length:
+        raise ValueError("Improper header, cannot read %d bytes from handle" % length)
+    return data
+
+
 def trim_str(string, max_len, concat_char):
     """Truncate the given string for display."""
     if len(string) > max_len:

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -59,6 +59,7 @@ possible, especially the following contributors:
 - Chris MacRaild
 - Chris Rands
 - Damien Goutte-Gattat (first contribution)
+- Devang Thakkar
 - Harry Jubb
 - Joe Greener
 - Kiran Mukhyala (first contribution)

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -4421,13 +4421,18 @@ class TestSeqIO(unittest.TestCase):
     def test_empty_file(self):
         """Check parsers can cope with an empty file."""
         for t_format in SeqIO._FormatToIterator:
-            if t_format in SeqIO._BinaryFormats or \
-               t_format in ("uniprot-xml", "pdb-seqres", "pdb-atom", "cif-atom"):
-                # Not allowed empty SFF files.
-                continue
-            handle = StringIO()
-            records = list(SeqIO.parse(handle, t_format))
-            self.assertEqual(len(records), 0)
+            if t_format in SeqIO._BinaryFormats:
+                handle = BytesIO()
+                with self.assertRaisesRegexp(ValueError, "Empty file."):
+                    list(SeqIO.parse(handle, t_format))
+            elif t_format in ("uniprot-xml", "pdb-seqres", "pdb-atom", "cif-atom", "cif-seqres"):
+                handle = StringIO()
+                with self.assertRaisesRegexp(ValueError, "Empty file."):
+                    list(SeqIO.parse(handle, t_format))
+            else:
+                handle = StringIO()
+                records = list(SeqIO.parse(handle, t_format))
+                self.assertEqual(len(records), 0)
 
 
 if __name__ == "__main__":

--- a/Tests/test_SeqIO_Gck.py
+++ b/Tests/test_SeqIO_Gck.py
@@ -380,6 +380,16 @@ class TestGckWithArtificialData(unittest.TestCase):
         h.close()
 
 
+class TestGckWithImproperHeader(unittest.TestCase):
+
+    def test_read(self):
+        """Read a file with an incomplete header."""
+        handle = BytesIO(b"tiny")
+        with self.assertRaisesRegexp(ValueError, "Improper header, cannot read 24 bytes from handle"):
+            SeqIO.read(handle, "gck")
+        handle.close()
+
+
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)
     unittest.main(testRunner=runner)


### PR DESCRIPTION
This pull request addresses issue #1838 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
