### PR TITLE
Fix and enforce double quotes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,10 +6,10 @@
 #             D2## - Whitespace Issues
 #             D4## - Docstring Content issues
 # flake8-bugbear: B###
+# flake8-quotes: Q###
 # flake8-commas: C#### (in case installed locally)
 # flake8-black : BLK### (in case installed locally)
 # flake8-pie : PIE### (in case installed locally)
-# flake8-quote : Q### (in case installed locally)
 # =================================================
 [flake8]
 doctests = True
@@ -84,7 +84,7 @@ per-file-ignores =
 #             instead callers should raise AssertionError()
 #        C812 missing trailing comma
 
-# ======================
-# flake8-quote settings:
-# ======================
+# =======================
+# flake8-quotes settings:
+# =======================
 inline-quotes = double

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -101,6 +101,7 @@ deps =
     flake8-rst-docstrings
     flake8-comprehensions
     flake8-bugbear;python_version>="3.5"
+    flake8-quotes
     restructuredtext_lint
     doc8
     pygments

--- a/Bio/Blast/Record.py
+++ b/Bio/Blast/Record.py
@@ -231,10 +231,10 @@ class HSP(object):
     def __str__(self):
         """Return the BLAST HSP as a formatted string."""
         lines = ["Score %s (%s bits), expectation %s, alignment length %s" % (
-            fmt_(self.score, '%i'),
-            fmt_(self.bits, '%i'),
-            fmt_(self.expect, '%0.1e'),
-            fmt_(self.align_length, '%i'),
+            fmt_(self.score, "%i"),
+            fmt_(self.bits, "%i"),
+            fmt_(self.expect, "%0.1e"),
+            fmt_(self.align_length, "%i"),
         )]
         if self.align_length is None:
             return "\n".join(lines)

--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -58,8 +58,8 @@ class StructureIO(object):
             structure = pdb_object
         else:
             sb = StructureBuilder()
-            sb.init_structure('pdb')
-            sb.init_seg(' ')
+            sb.init_structure("pdb")
+            sb.init_seg(" ")
             # Build parts as necessary
             if pdb_object.level == "M":
                 sb.structure.add(pdb_object.copy())
@@ -69,23 +69,23 @@ class StructureIO(object):
                 if pdb_object.level == "C":
                     sb.structure[0].add(pdb_object.copy())
                 else:
-                    sb.init_chain('A')
+                    sb.init_chain("A")
                     if pdb_object.level == "R":
                         try:
                             parent_id = pdb_object.parent.id
-                            sb.structure[0]['A'].id = parent_id
+                            sb.structure[0]["A"].id = parent_id
                         except Exception:
                             pass
-                        sb.structure[0]['A'].add(pdb_object.copy())
+                        sb.structure[0]["A"].add(pdb_object.copy())
                     else:
                         # Atom
-                        sb.init_residue('DUM', ' ', 1, ' ')
+                        sb.init_residue("DUM", " ", 1, " ")
                         try:
                             parent_id = pdb_object.parent.parent.id
-                            sb.structure[0]['A'].id = parent_id
+                            sb.structure[0]["A"].id = parent_id
                         except Exception:
                             pass
-                        sb.structure[0]['A'].child_list[0].add(pdb_object.copy())
+                        sb.structure[0]["A"].child_list[0].add(pdb_object.copy())
 
             # Return structure
             structure = sb.structure

--- a/Bio/PDB/mmtf/DefaultParser.py
+++ b/Bio/PDB/mmtf/DefaultParser.py
@@ -121,7 +121,7 @@ class StructureDecoder(object):
         if insertion_code == "\x00":
             insertion_code = " "
 
-        self.structure_builder.init_seg(' ')
+        self.structure_builder.init_seg(" ")
         self.structure_builder.init_residue(group_name, self.this_type,
                                             group_number, insertion_code)
 

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -1146,7 +1146,7 @@ def format_alignment(align1, align2, score, begin, end,
     """
     align_begin = begin
     align_end = end
-    start1 = start2 = ''
+    start1 = start2 = ""
     start_m = begin  # Begin of match line (how many spaces to include)
     # For local alignments:
     if not full_sequences and (begin != 0 or end != len(align1)):
@@ -1178,7 +1178,7 @@ def format_alignment(align1, align2, score, begin, end,
         s1_line.append("{:^{width}}".format(a, width=m_len))
         s2_line.append("{:^{width}}".format(b, width=m_len))
         if full_sequences and (n < align_begin or n >= align_end):
-            m_line.append("{:^{width}}".format(' ', width=m_len))  # space
+            m_line.append("{:^{width}}".format(" ", width=m_len))  # space
             continue
         if a == b:
             m_line.append("{:^{width}}".format("|", width=m_len))  # match

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -40,7 +40,7 @@ checks, so if you are making a contribution it is best to check this locally.
 We use the tool ``flake8`` for code style checks, together with various
 plugins which can be installed as follows::
 
-    $ pip install flake8 flake8-docstrings flake8-blind-except flake8-rst-docstrings flake8-comprehensions
+    $ pip install flake8 flake8-docstrings flake8-blind-except flake8-rst-docstrings flake8-comprehensions flake8-quotes
 
 Unless you are using Python 2.7, please also install the bugbear plugin::
 

--- a/Tests/test_Blast_Record.py
+++ b/Tests/test_Blast_Record.py
@@ -15,7 +15,7 @@ class TestHsp(unittest.TestCase):
         # Test empty instance
         self.assertEqual(
             str(HSP()),
-            'Score <unknown> (<unknown> bits), expectation <unknown>, alignment length <unknown>'
+            "Score <unknown> (<unknown> bits), expectation <unknown>, alignment length <unknown>"
         )
 
         # Test instance with non-default attributes
@@ -26,7 +26,7 @@ class TestHsp(unittest.TestCase):
         hsp.align_length = 4
         # Ignore trailing whitespace in output
         self.assertEqual(
-            '\n'.join(l.strip() for l in str(hsp).split('\n')),
+            "\n".join(l.strip() for l in str(hsp).split("\n")),
             """Score 1 (2 bits), expectation 3.0e+00, alignment length 4
 Query:    None  None
 

--- a/Tests/test_SeqIO_Gck.py
+++ b/Tests/test_SeqIO_Gck.py
@@ -20,247 +20,247 @@ import requires_internet
 class TestGckWithDGVC(unittest.TestCase):
 
     sample_data = {
-        'pACW': {
-            'file': 'Drosophila Gateway Vectors GCK/pACW',
-            'name': 'Construct:',
-            'id': 'Construct:',
-            'description': 'Construct:  pACTIN-RW-SV',
-            'length': 7957,
-            'topology': 'circular',
-            'features': [
+        "pACW": {
+            "file": "Drosophila Gateway Vectors GCK/pACW",
+            "name": "Construct:",
+            "id": "Construct:",
+            "description": "Construct:  pACTIN-RW-SV",
+            "length": 7957,
+            "topology": "circular",
+            "features": [
                 {
-                    'type': 'CDS',
-                    'start': 6155,
-                    'end': 7013,
-                    'strand': 1,
-                    'label': 'ampR'
+                    "type": "CDS",
+                    "start": 6155,
+                    "end": 7013,
+                    "strand": 1,
+                    "label": "ampR"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 5216,
-                    'end': 6071,
-                    'strand': 1,
-                    'label': 'SV40 sti/polyA'
+                    "type": "misc_feature",
+                    "start": 5216,
+                    "end": 6071,
+                    "strand": 1,
+                    "label": "SV40 sti/polyA"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 89,
-                    'end': 2662,
-                    'strand': 1,
-                    'label': 'actin5C promoter'
+                    "type": "misc_feature",
+                    "start": 89,
+                    "end": 2662,
+                    "strand": 1,
+                    "label": "actin5C promoter"
                     },
                 {
-                    'type': 'CDS',
-                    'start': 3722,
-                    'end': 4400,
-                    'strand': 1,
-                    'label': 'chlR'
+                    "type": "CDS",
+                    "start": 3722,
+                    "end": 4400,
+                    "strand": 1,
+                    "label": "chlR"
                     },
                 {
-                    'type': 'CDS',
-                    'start': 4722,
-                    'end': 5025,
-                    'strand': 1,
-                    'label': 'ccdB'
+                    "type": "CDS",
+                    "start": 4722,
+                    "end": 5025,
+                    "strand": 1,
+                    "label": "ccdB"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 3489,
-                    'end': 3507,
-                    'strand': 1,
-                    'label': 'attR1'
+                    "type": "misc_feature",
+                    "start": 3489,
+                    "end": 3507,
+                    "strand": 1,
+                    "label": "attR1"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 5175,
-                    'end': 5193,
-                    'strand': -1,
-                    'label': 'attR2'
+                    "type": "misc_feature",
+                    "start": 5175,
+                    "end": 5193,
+                    "strand": -1,
+                    "label": "attR2"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 3489,
-                    'end': 5193,
-                    'strand': 1,
-                    'label': 'Gateway cassette'
+                    "type": "misc_feature",
+                    "start": 3489,
+                    "end": 5193,
+                    "strand": 1,
+                    "label": "Gateway cassette"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 5192,
-                    'end': 5205,
-                    'strand': 1,
-                    'label': 'triple STOP'
+                    "type": "misc_feature",
+                    "start": 5192,
+                    "end": 5205,
+                    "strand": 1,
+                    "label": "triple STOP"
                     },
                 {
-                    'type': 'CDS',
-                    'start': 2763,
-                    'end': 3480,
-                    'strand': 1,
-                    'label': 'ECFP'
+                    "type": "CDS",
+                    "start": 2763,
+                    "end": 3480,
+                    "strand": 1,
+                    "label": "ECFP"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 2755,
-                    'end': 3482,
-                    'strand': 1,
-                    'label': 'pACTIN-SV'
+                    "type": "misc_feature",
+                    "start": 2755,
+                    "end": 3482,
+                    "strand": 1,
+                    "label": "pACTIN-SV"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 2755,
-                    'end': 3482,
-                    'strand': 1,
-                    'label': 'Construct:  pACTIN-RW-SV'
+                    "type": "misc_feature",
+                    "start": 2755,
+                    "end": 3482,
+                    "strand": 1,
+                    "label": "Construct:  pACTIN-RW-SV"
                     },
                 ]
             },
-        'pPWF': {
-            'file': 'Drosophila Gateway Vectors GCK/pPWG',
-            'name': 'Construct:',
-            'id': 'Construct:',
-            'description': 'Construct:  pPWF',
-            'length': 12320,
-            'topology': 'circular',
-            'features': [
+        "pPWF": {
+            "file": "Drosophila Gateway Vectors GCK/pPWG",
+            "name": "Construct:",
+            "id": "Construct:",
+            "description": "Construct:  pPWF",
+            "length": 12320,
+            "topology": "circular",
+            "features": [
                 {
-                    'type': 'misc_feature',
-                    'start': 0,
-                    'end': 587,
-                    'strand': 1,
-                    'label': "P 5' end"
+                    "type": "misc_feature",
+                    "start": 0,
+                    "end": 587,
+                    "strand": 1,
+                    "label": "P 5' end"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 9327,
-                    'end': 9560,
-                    'strand': -1,
-                    'label': "P 3' end"
+                    "type": "misc_feature",
+                    "start": 9327,
+                    "end": 9560,
+                    "strand": -1,
+                    "label": "P 3' end"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 1363,
-                    'end': 4244,
-                    'strand': -1,
-                    'label': 'mini-white'
+                    "type": "misc_feature",
+                    "start": 1363,
+                    "end": 4244,
+                    "strand": -1,
+                    "label": "mini-white"
                     },
                 {
-                    'type': 'CDS',
-                    'start': 10466,
-                    'end': 11324,
-                    'strand': 1,
-                    'label': 'ampR'
+                    "type": "CDS",
+                    "start": 10466,
+                    "end": 11324,
+                    "strand": 1,
+                    "label": "ampR"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 7930,
-                    'end': 9314,
-                    'strand': 1,
-                    'label': 'K10 terminator'
+                    "type": "misc_feature",
+                    "start": 7930,
+                    "end": 9314,
+                    "strand": 1,
+                    "label": "K10 terminator"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 4762,
-                    'end': 4829,
-                    'strand': 1,
-                    'label': 'GAGA repeats'
+                    "type": "misc_feature",
+                    "start": 4762,
+                    "end": 4829,
+                    "strand": 1,
+                    "label": "GAGA repeats"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 4855,
-                    'end': 5177,
-                    'strand': 1,
-                    'label': 'GAL4 sites'
+                    "type": "misc_feature",
+                    "start": 4855,
+                    "end": 5177,
+                    "strand": 1,
+                    "label": "GAL4 sites"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 5279,
-                    'end': 5415,
-                    'strand': 1,
-                    'label': 'P intron'
+                    "type": "misc_feature",
+                    "start": 5279,
+                    "end": 5415,
+                    "strand": 1,
+                    "label": "P intron"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 5184,
-                    'end': 5279,
-                    'strand': 1,
-                    'label': 'P promoter'
+                    "type": "misc_feature",
+                    "start": 5184,
+                    "end": 5279,
+                    "strand": 1,
+                    "label": "P promoter"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 4762,
-                    'end': 5416,
-                    'strand': 1,
-                    'label': 'UASp promoter'
+                    "type": "misc_feature",
+                    "start": 4762,
+                    "end": 5416,
+                    "strand": 1,
+                    "label": "UASp promoter"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 10060,
-                    'end': 12092,
-                    'strand': 1,
-                    'label': 'pUC8'
+                    "type": "misc_feature",
+                    "start": 10060,
+                    "end": 12092,
+                    "strand": 1,
+                    "label": "pUC8"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 7106,
-                    'end': 7124,
-                    'strand': -1,
-                    'label': 'attR2'
+                    "type": "misc_feature",
+                    "start": 7106,
+                    "end": 7124,
+                    "strand": -1,
+                    "label": "attR2"
                     },
                 {
-                    'type': 'CDS',
-                    'start': 6653,
-                    'end': 6956,
-                    'strand': 1,
-                    'label': 'ccdB'
+                    "type": "CDS",
+                    "start": 6653,
+                    "end": 6956,
+                    "strand": 1,
+                    "label": "ccdB"
                     },
                 {
-                    'type': 'CDS',
-                    'start': 5653,
-                    'end': 6331,
-                    'strand': 1,
-                    'label': 'chlR'
+                    "type": "CDS",
+                    "start": 5653,
+                    "end": 6331,
+                    "strand": 1,
+                    "label": "chlR"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 5420,
-                    'end': 7124,
-                    'strand': 1,
-                    'label': 'Gateway Cassette'
+                    "type": "misc_feature",
+                    "start": 5420,
+                    "end": 7124,
+                    "strand": 1,
+                    "label": "Gateway Cassette"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 5420,
-                    'end': 5438,
-                    'strand': 1,
-                    'label': 'attR1'
+                    "type": "misc_feature",
+                    "start": 5420,
+                    "end": 5438,
+                    "strand": 1,
+                    "label": "attR1"
                     },
                 {
-                    'type': 'CDS',
-                    'start': 7137,
-                    'end': 7854,
-                    'strand': 1,
-                    'label': 'EGFP'
+                    "type": "CDS",
+                    "start": 7137,
+                    "end": 7854,
+                    "strand": 1,
+                    "label": "EGFP"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 7129,
-                    'end': 7856,
-                    'strand': 1,
-                    'label': 'pACTIN-SV'
+                    "type": "misc_feature",
+                    "start": 7129,
+                    "end": 7856,
+                    "strand": 1,
+                    "label": "pACTIN-SV"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 7129,
-                    'end': 7856,
-                    'strand': 1,
-                    'label': 'Construct:  pACTIN-WC-SV'
+                    "type": "misc_feature",
+                    "start": 7129,
+                    "end": 7856,
+                    "strand": 1,
+                    "label": "Construct:  pACTIN-WC-SV"
                     },
                 {
-                    'type': 'misc_feature',
-                    'start': 5416,
-                    'end': 7875,
-                    'strand': 1,
-                    'label': 'Construct:  pPWF'
+                    "type": "misc_feature",
+                    "start": 5416,
+                    "end": 7875,
+                    "strand": 1,
+                    "label": "Construct:  pPWF"
                     },
                 ]
             }
@@ -271,7 +271,7 @@ class TestGckWithDGVC(unittest.TestCase):
         # (<https://emb.carnegiescience.edu/drosophila-gateway-vector-collection>)
         # as sample Gck files. We cannot redistribute those files along with
         # Biopython, so we need to download them now for the tests to run.
-        if not os.path.exists('Gck/DGVC_GCK.zip'):
+        if not os.path.exists("Gck/DGVC_GCK.zip"):
             try:
                 requires_internet.check()
             except MissingExternalDependencyError:
@@ -279,15 +279,15 @@ class TestGckWithDGVC(unittest.TestCase):
                 return
 
             try:
-                src = urlopen('https://emb.carnegiescience.edu/sites/default/files/DGVC_GCK.zip')
-                with open('Gck/DGVC_GCK.zip', 'wb') as dst:
+                src = urlopen("https://emb.carnegiescience.edu/sites/default/files/DGVC_GCK.zip")
+                with open("Gck/DGVC_GCK.zip", "wb") as dst:
                     shutil.copyfileobj(src, dst)
                 src.close()
             except HTTPError:
                 self.skipTest("Cannot download the sample files")
                 return
 
-        self.zipdata = ZipFile('Gck/DGVC_GCK.zip')
+        self.zipdata = ZipFile("Gck/DGVC_GCK.zip")
 
     def tearDown(self):
         self.zipdata.close()
@@ -295,23 +295,23 @@ class TestGckWithDGVC(unittest.TestCase):
     def test_read(self):
         """Read sample files."""
         for sample in self.sample_data.values():
-            f = self.zipdata.open(sample['file'])
-            record = SeqIO.read(f, 'gck')
-            self.assertEqual(sample['name'], record.name)
-            self.assertEqual(sample['id'], record.id)
-            self.assertEqual(sample['description'], record.description)
-            self.assertEqual(sample['length'], len(record))
-            self.assertEqual(sample['topology'], record.annotations['topology'])
+            f = self.zipdata.open(sample["file"])
+            record = SeqIO.read(f, "gck")
+            self.assertEqual(sample["name"], record.name)
+            self.assertEqual(sample["id"], record.id)
+            self.assertEqual(sample["description"], record.description)
+            self.assertEqual(sample["length"], len(record))
+            self.assertEqual(sample["topology"], record.annotations["topology"])
 
-            self.assertEqual(len(sample['features']), len(record.features))
-            for i in range(len(sample['features'])):
-                exp_feat = sample['features'][i]
+            self.assertEqual(len(sample["features"]), len(record.features))
+            for i in range(len(sample["features"])):
+                exp_feat = sample["features"][i]
                 read_feat = record.features[i]
-                self.assertEqual(exp_feat['type'], read_feat.type)
-                self.assertEqual(exp_feat['start'], read_feat.location.start)
-                self.assertEqual(exp_feat['end'], read_feat.location.end)
-                self.assertEqual(exp_feat['strand'], read_feat.location.strand)
-                self.assertEqual(exp_feat['label'], read_feat.qualifiers['label'][0])
+                self.assertEqual(exp_feat["type"], read_feat.type)
+                self.assertEqual(exp_feat["start"], read_feat.location.start)
+                self.assertEqual(exp_feat["end"], read_feat.location.end)
+                self.assertEqual(exp_feat["strand"], read_feat.location.strand)
+                self.assertEqual(exp_feat["label"], read_feat.qualifiers["label"][0])
 
             f.close()
 
@@ -319,29 +319,29 @@ class TestGckWithDGVC(unittest.TestCase):
 class TestGckWithArtificialData(unittest.TestCase):
 
     def setUp(self):
-        with open('Gck/artificial.gck', 'rb') as f:
+        with open("Gck/artificial.gck", "rb") as f:
             self.buffer = f.read()
 
     def test_read(self):
         """Read an artificial sample file."""
         h = BytesIO(self.buffer)
-        record = SeqIO.read(h, 'gck')
-        self.assertEqual('ACGTACGTACGT', record.seq)
-        self.assertEqual('Sample construct', record.description)
-        self.assertEqual('linear', record.annotations['topology'])
+        record = SeqIO.read(h, "gck")
+        self.assertEqual("ACGTACGTACGT", record.seq)
+        self.assertEqual("Sample construct", record.description)
+        self.assertEqual("linear", record.annotations["topology"])
         self.assertEqual(2, len(record.features))
 
         self.assertEqual(2, record.features[0].location.start)
         self.assertEqual(6, record.features[0].location.end)
         self.assertEqual(1, record.features[0].location.strand)
-        self.assertEqual('misc_feature', record.features[0].type)
-        self.assertEqual('FeatureA', record.features[0].qualifiers['label'][0])
+        self.assertEqual("misc_feature", record.features[0].type)
+        self.assertEqual("FeatureA", record.features[0].qualifiers["label"][0])
 
         self.assertEqual(7, record.features[1].location.start)
         self.assertEqual(11, record.features[1].location.end)
         self.assertEqual(-1, record.features[1].location.strand)
-        self.assertEqual('CDS', record.features[1].type)
-        self.assertEqual('FeatureB', record.features[1].qualifiers['label'][0])
+        self.assertEqual("CDS", record.features[1].type)
+        self.assertEqual("FeatureB", record.features[1].qualifiers["label"][0])
 
         h.close()
 
@@ -358,25 +358,25 @@ class TestGckWithArtificialData(unittest.TestCase):
         # Change the sequence length as indicated in the sequence packet
         h = self.munge_buffer(0x1C, [0x00, 0x00, 0x20, 0x15])
         with self.assertRaisesRegexp(ValueError, "Conflicting sequence length values"):
-            SeqIO.read(h, 'gck')
+            SeqIO.read(h, "gck")
         h.close()
 
         # Change the sequence length as indicated in the features packet
         h = self.munge_buffer(0x36, [0x00, 0x00, 0x20, 0x15])
         with self.assertRaisesRegexp(ValueError, "Conflicting sequence length values"):
-            SeqIO.read(h, 'gck')
+            SeqIO.read(h, "gck")
         h.close()
 
         # Change the number of features
         h = self.munge_buffer(0x3B, 0x30)
         with self.assertRaisesRegexp(ValueError, "Features packet size inconsistent with number of features"):
-            SeqIO.read(h, 'gck')
+            SeqIO.read(h, "gck")
         h.close()
 
         # Change the number of restriction sites
         h = self.munge_buffer(0x137, 0x30)
         with self.assertRaisesRegexp(ValueError, "Sites packet size inconsistent with number of sites"):
-            SeqIO.read(h, 'gck')
+            SeqIO.read(h, "gck")
         h.close()
 
 

--- a/Tests/test_SeqIO_Gck.py
+++ b/Tests/test_SeqIO_Gck.py
@@ -127,14 +127,14 @@ class TestGckWithDGVC(unittest.TestCase):
                     'start': 0,
                     'end': 587,
                     'strand': 1,
-                    'label': 'P 5\' end'
+                    'label': "P 5' end"
                     },
                 {
                     'type': 'misc_feature',
                     'start': 9327,
                     'end': 9560,
                     'strand': -1,
-                    'label': 'P 3\' end'
+                    'label': "P 3' end"
                     },
                 {
                     'type': 'misc_feature',

--- a/Tests/test_SeqIO_SnapGene.py
+++ b/Tests/test_SeqIO_SnapGene.py
@@ -16,53 +16,53 @@ from Bio import SeqIO
 class TestSnapGene(unittest.TestCase):
 
     sample_data = {
-        'sample-d': {
-            'file': 'SnapGene/sample-d.dna',
-            'name': 'Sample',
-            'id': 'Sample',
-            'description': 'Sample Sequence D',
-            'length': 1000,
-            'topology': 'linear',
-            'date': datetime.datetime(2019, 8, 3, 0, 0),
-            'features': [
+        "sample-d": {
+            "file": "SnapGene/sample-d.dna",
+            "name": "Sample",
+            "id": "Sample",
+            "description": "Sample Sequence D",
+            "length": 1000,
+            "topology": "linear",
+            "date": datetime.datetime(2019, 8, 3, 0, 0),
+            "features": [
                 {
-                    'type': 'misc_binding',
-                    'start': 499,
-                    'end': 700,
-                    'strand': 1,
-                    'label': 'FeatureB'
+                    "type": "misc_binding",
+                    "start": 499,
+                    "end": 700,
+                    "strand": 1,
+                    "label": "FeatureB"
                     },
                 {
-                    'type': 'promoter',
-                    'start': 49,
-                    'end': 150,
-                    'strand': 1,
-                    'label': 'FeatureA'
+                    "type": "promoter",
+                    "start": 49,
+                    "end": 150,
+                    "strand": 1,
+                    "label": "FeatureA"
                     }
                 ]
             },
-        'sample-b': {
-            'file': 'SnapGene/sample-e.dna',
-            'name': 'Sample',
-            'id': 'Sample',
-            'description': 'Sample Sequence E',
-            'length': 1000,
-            'date': datetime.datetime(2019, 8, 3, 0, 0),
-            'topology': 'circular',
-            'features': [
+        "sample-b": {
+            "file": "SnapGene/sample-e.dna",
+            "name": "Sample",
+            "id": "Sample",
+            "description": "Sample Sequence E",
+            "length": 1000,
+            "date": datetime.datetime(2019, 8, 3, 0, 0),
+            "topology": "circular",
+            "features": [
                 {
-                    'type': 'terminator',
-                    'start': 399,
-                    'end': 750,
-                    'strand': -1,
-                    'label': 'FeatureB'
+                    "type": "terminator",
+                    "start": 399,
+                    "end": 750,
+                    "strand": -1,
+                    "label": "FeatureB"
                     },
                 {
-                    'type': 'rep_origin',
-                    'start': 160,
-                    'end': 241,
-                    'strand': 1,
-                    'label': 'FeatureA'
+                    "type": "rep_origin",
+                    "start": 160,
+                    "end": 241,
+                    "strand": 1,
+                    "label": "FeatureA"
                     }
                 ]
             }
@@ -71,29 +71,29 @@ class TestSnapGene(unittest.TestCase):
     def test_read(self):
         """Read sample files."""
         for sample in self.sample_data.values():
-            record = SeqIO.read(sample['file'], 'snapgene')
-            self.assertEqual(sample['name'], record.name)
-            self.assertEqual(sample['id'], record.id)
-            self.assertEqual(sample['description'], record.description)
-            self.assertEqual(sample['length'], len(record))
-            self.assertEqual(sample['date'], record.annotations['date'])
-            self.assertEqual(sample['topology'], record.annotations['topology'])
+            record = SeqIO.read(sample["file"], "snapgene")
+            self.assertEqual(sample["name"], record.name)
+            self.assertEqual(sample["id"], record.id)
+            self.assertEqual(sample["description"], record.description)
+            self.assertEqual(sample["length"], len(record))
+            self.assertEqual(sample["date"], record.annotations["date"])
+            self.assertEqual(sample["topology"], record.annotations["topology"])
 
-            self.assertEqual(len(sample['features']), len(record.features))
-            for i in range(len(sample['features'])):
-                exp_feat = sample['features'][i]
+            self.assertEqual(len(sample["features"]), len(record.features))
+            for i in range(len(sample["features"])):
+                exp_feat = sample["features"][i]
                 read_feat = record.features[i]
-                self.assertEqual(exp_feat['type'], read_feat.type)
-                self.assertEqual(exp_feat['start'], read_feat.location.start)
-                self.assertEqual(exp_feat['end'], read_feat.location.end)
-                self.assertEqual(exp_feat['strand'], read_feat.location.strand)
-                self.assertEqual(exp_feat['label'], read_feat.qualifiers['label'][0])
+                self.assertEqual(exp_feat["type"], read_feat.type)
+                self.assertEqual(exp_feat["start"], read_feat.location.start)
+                self.assertEqual(exp_feat["end"], read_feat.location.end)
+                self.assertEqual(exp_feat["strand"], read_feat.location.strand)
+                self.assertEqual(exp_feat["label"], read_feat.qualifiers["label"][0])
 
 
 class TestCorruptedSnapGene(unittest.TestCase):
 
     def setUp(self):
-        f = open('SnapGene/sample-d.dna', 'rb')
+        f = open("SnapGene/sample-d.dna", "rb")
         self.buffer = f.read()
         f.close()
 
@@ -110,13 +110,13 @@ class TestCorruptedSnapGene(unittest.TestCase):
         # Remove the first packet
         h = BytesIO(self.buffer[19:])
         with self.assertRaisesRegexp(ValueError, "The file does not start with a SnapGene cookie packet"):
-            SeqIO.read(h, 'snapgene')
+            SeqIO.read(h, "snapgene")
         h.close()
 
         # Keep the first packet but destroy the magic cookie
         h = self.munge_buffer(5, [0x4B, 0x41, 0x42, 0x4F, 0x4F, 0x4D])
         with self.assertRaisesRegexp(ValueError, "The file is not a valid SnapGene file"):
-            SeqIO.read(h, 'snapgene')
+            SeqIO.read(h, "snapgene")
         h.close()
 
     def test_missing_dna(self):
@@ -125,7 +125,7 @@ class TestCorruptedSnapGene(unittest.TestCase):
         # unknown packet type, so that the parser will skip the packet.
         h = self.munge_buffer(19, 0x80)
         with self.assertRaisesRegexp(ValueError, "No DNA packet in file"):
-            SeqIO.read(h, 'snapgene')
+            SeqIO.read(h, "snapgene")
         h.close()
 
     def test_extra_dna(self):
@@ -135,7 +135,7 @@ class TestCorruptedSnapGene(unittest.TestCase):
         buf.extend(self.buffer[19:1025])    # Append duplicated DNA packet
         h = BytesIO(buf)
         with self.assertRaisesRegexp(ValueError, "The file contains more than one DNA packet"):
-            SeqIO.read(h, 'snapgene')
+            SeqIO.read(h, "snapgene")
         h.close()
 
     def test_truncated_packet(self):
@@ -143,13 +143,13 @@ class TestCorruptedSnapGene(unittest.TestCase):
         # Truncate before the end of the length bytes
         h = BytesIO(self.buffer[3:])
         with self.assertRaisesRegexp(ValueError, "Unexpected end of packet"):
-            SeqIO.read(h, 'snapgene')
+            SeqIO.read(h, "snapgene")
         h.close()
 
         # Truncate before the end of the data
         h = BytesIO(self.buffer[10:])
         with self.assertRaisesRegexp(ValueError, "Unexpected end of packet"):
-            SeqIO.read(h, 'snapgene')
+            SeqIO.read(h, "snapgene")
         h.close()
 
 

--- a/Tests/test_SeqIO_Xdna.py
+++ b/Tests/test_SeqIO_Xdna.py
@@ -29,78 +29,78 @@ else:
 class TestXdna(unittest.TestCase):
 
     sample_data = {
-        'sample-a': {
-            'file': 'Xdna/sample-a.xdna',
-            'name': 'Sample',
-            'id': 'Sample',
-            'description': 'Sample sequence A',
-            'length': 1000,
-            'alphabet': Alphabet.generic_dna,
-            'topology': 'linear',
-            'features': [
+        "sample-a": {
+            "file": "Xdna/sample-a.xdna",
+            "name": "Sample",
+            "id": "Sample",
+            "description": "Sample sequence A",
+            "length": 1000,
+            "alphabet": Alphabet.generic_dna,
+            "topology": "linear",
+            "features": [
                 {
-                    'type': 'promoter',
-                    'start': 49,
-                    'end': 150,
-                    'strand': 1,
-                    'label': 'FeatureA'
+                    "type": "promoter",
+                    "start": 49,
+                    "end": 150,
+                    "strand": 1,
+                    "label": "FeatureA"
                     },
                 {
-                    'type': 'misc_binding',
-                    'start': 499,
-                    'end': 700,
-                    'strand': -1,
-                    'label': 'FeatureB'
+                    "type": "misc_binding",
+                    "start": 499,
+                    "end": 700,
+                    "strand": -1,
+                    "label": "FeatureB"
                     }
                 ]
             },
-        'sample-b': {
-            'file': 'Xdna/sample-b.xdna',
-            'name': 'Sample',
-            'id': 'Sample',
-            'description': 'Sample sequence B',
-            'length': 1000,
-            'alphabet': Alphabet.generic_dna,
-            'topology': 'circular',
-            'features': [
+        "sample-b": {
+            "file": "Xdna/sample-b.xdna",
+            "name": "Sample",
+            "id": "Sample",
+            "description": "Sample sequence B",
+            "length": 1000,
+            "alphabet": Alphabet.generic_dna,
+            "topology": "circular",
+            "features": [
                 {
-                    'type': 'rep_origin',
-                    'start': 160,
-                    'end': 241,
-                    'strand': 1,
-                    'label': 'FeatureA'
+                    "type": "rep_origin",
+                    "start": 160,
+                    "end": 241,
+                    "strand": 1,
+                    "label": "FeatureA"
                     },
                 {
-                    'type': 'terminator',
-                    'start': 399,
-                    'end': 750,
-                    'strand': -1,
-                    'label': 'FeatureB'
+                    "type": "terminator",
+                    "start": 399,
+                    "end": 750,
+                    "strand": -1,
+                    "label": "FeatureB"
                     }
                 ]
             },
-        'sample-c': {
-            'file': 'Xdna/sample-c.xprt',
-            'name': 'Sample',
-            'id': 'Sample',
-            'description': 'Sample Sequence C',
-            'length': 1000,
-            'alphabet': Alphabet.generic_protein,
-            'topology': 'linear',
-            'features': [
+        "sample-c": {
+            "file": "Xdna/sample-c.xprt",
+            "name": "Sample",
+            "id": "Sample",
+            "description": "Sample Sequence C",
+            "length": 1000,
+            "alphabet": Alphabet.generic_protein,
+            "topology": "linear",
+            "features": [
                 {
-                    'type': 'misc_feature',
-                    'start': 10,
-                    'end': 11,
-                    'strand': 1,
-                    'label': 'S11'
+                    "type": "misc_feature",
+                    "start": 10,
+                    "end": 11,
+                    "strand": 1,
+                    "label": "S11"
                     },
                 {
-                    'type': 'misc_binding',
-                    'start': 164,
-                    'end': 195,
-                    'strand': 1,
-                    'label': 'RIP1'
+                    "type": "misc_binding",
+                    "start": 164,
+                    "end": 195,
+                    "strand": 1,
+                    "label": "RIP1"
                     }
                 ]
             }
@@ -109,29 +109,29 @@ class TestXdna(unittest.TestCase):
     def test_read(self):
         """Read sample files."""
         for sample in self.sample_data.values():
-            record = SeqIO.read(sample['file'], 'xdna')
-            self.assertEqual(sample['name'], record.name)
-            self.assertEqual(sample['id'], record.id)
-            self.assertEqual(sample['description'], record.description)
-            self.assertEqual(sample['length'], len(record))
-            self.assertEqual(sample['alphabet'], record.seq.alphabet)
-            self.assertEqual(sample['topology'], record.annotations['topology'])
+            record = SeqIO.read(sample["file"], "xdna")
+            self.assertEqual(sample["name"], record.name)
+            self.assertEqual(sample["id"], record.id)
+            self.assertEqual(sample["description"], record.description)
+            self.assertEqual(sample["length"], len(record))
+            self.assertEqual(sample["alphabet"], record.seq.alphabet)
+            self.assertEqual(sample["topology"], record.annotations["topology"])
 
-            self.assertEqual(len(sample['features']), len(record.features))
-            for i in range(len(sample['features'])):
-                exp_feat = sample['features'][i]
+            self.assertEqual(len(sample["features"]), len(record.features))
+            for i in range(len(sample["features"])):
+                exp_feat = sample["features"][i]
                 read_feat = record.features[i]
-                self.assertEqual(exp_feat['type'], read_feat.type)
-                self.assertEqual(exp_feat['start'], read_feat.location.start)
-                self.assertEqual(exp_feat['end'], read_feat.location.end)
-                self.assertEqual(exp_feat['strand'], read_feat.location.strand)
-                self.assertEqual(exp_feat['label'], read_feat.qualifiers['label'][0])
+                self.assertEqual(exp_feat["type"], read_feat.type)
+                self.assertEqual(exp_feat["start"], read_feat.location.start)
+                self.assertEqual(exp_feat["end"], read_feat.location.end)
+                self.assertEqual(exp_feat["strand"], read_feat.location.strand)
+                self.assertEqual(exp_feat["label"], read_feat.qualifiers["label"][0])
 
 
 class TestInvalidXdna(unittest.TestCase):
 
     def setUp(self):
-        f = open('Xdna/sample-a.xdna', 'rb')
+        f = open("Xdna/sample-a.xdna", "rb")
         self.buffer = f.read()
         f.close()
 
@@ -147,14 +147,14 @@ class TestInvalidXdna(unittest.TestCase):
         """Read a file with unexpected version number."""
         h = self.munge_buffer(0, 0x01)  # Change version byte
         with self.assertRaisesRegexp(ValueError, "Unsupported XDNA version"):
-            SeqIO.read(h, 'xdna')
+            SeqIO.read(h, "xdna")
         h.close()
 
     def test_invalid_sequence_type(self):
         """Read a file with an unknown sequence type."""
         h = self.munge_buffer(1, 0x0A)  # Change type byte
         with self.assertRaisesRegexp(ValueError, "Unknown sequence type"):
-            SeqIO.read(h, 'xdna')
+            SeqIO.read(h, "xdna")
         h.close()
 
     def test_corrupted_length(self):
@@ -162,13 +162,13 @@ class TestInvalidXdna(unittest.TestCase):
         # Set a length shorter than the actual length of the sequence
         h = self.munge_buffer(29, [0x00, 0x00, 0x00, 0x80])
         with self.assertRaisesRegexp(ValueError, "invalid literal"):
-            SeqIO.read(h, 'xdna')
+            SeqIO.read(h, "xdna")
         h.close()
 
         # Set a length larger than the actual length of the sequence
         h = self.munge_buffer(29, [0x00, 0x08, 0x00, 0x00])
         with self.assertRaisesRegexp(ValueError, "Cannot read 2048 bytes from handle"):
-            SeqIO.read(h, 'xdna')
+            SeqIO.read(h, "xdna")
         h.close()
 
     def test_missing_features(self):
@@ -176,10 +176,10 @@ class TestInvalidXdna(unittest.TestCase):
         # Set a larger number of features than the file actually contains
         # Offset of the features number byte:
         # header + length of sequence + length of comment + overhangs
-        feature_byte = 112 + 1000 + len('Sample sequence A') + 5
+        feature_byte = 112 + 1000 + len("Sample sequence A") + 5
         h = self.munge_buffer(feature_byte, 3)
         with self.assertRaisesRegexp(ValueError, "Cannot read 1 bytes from handle"):
-            SeqIO.read(h, 'xdna')
+            SeqIO.read(h, "xdna")
         h.close()
 
 
@@ -189,7 +189,7 @@ class TestXdnaWriter(unittest.TestCase):
         """Write correct sequence type."""
         h = BytesIO()
 
-        record = SeqRecord(Seq('ACGT'))
+        record = SeqRecord(Seq("ACGT"))
 
         for alphabet, expected_byte in [
                 (Alphabet.generic_alphabet, 0),
@@ -198,40 +198,40 @@ class TestXdnaWriter(unittest.TestCase):
                 (Alphabet.generic_protein, 4)]:
             record.seq.alphabet = alphabet
             h.seek(0, 0)
-            SeqIO.write([record], h, 'xdna')
+            SeqIO.write([record], h, "xdna")
             buf = bytearray(h.getvalue())
             self.assertEqual(expected_byte, buf[1])
 
         h.close()
 
-    @unittest.skipUnless(has_assert_warn, 'No assertWarn support in unittest')
+    @unittest.skipUnless(has_assert_warn, "No assertWarn support in unittest")
     def test_warnings_on_data_loss(self):
         """Emit warnings when dropping data on write."""
         h = BytesIO()
 
         # Fabricate a record with > 255 features
-        record = SeqRecord(Seq('ACGT'))
+        record = SeqRecord(Seq("ACGT"))
         for i in range(260):
-            feature = SeqFeature(FeatureLocation(1, 2), type='misc_feature')
+            feature = SeqFeature(FeatureLocation(1, 2), type="misc_feature")
             record.features.append(feature)
         with self.assertWarnsRegex(BiopythonWarning, "Too many features"):
-            SeqIO.write([record], h, 'xdna')
+            SeqIO.write([record], h, "xdna")
 
         # Now a record with a fuzzy-located feature
         feature = SeqFeature(FeatureLocation(BeforePosition(2), 3),
-                             type='misc_feature')
+                             type="misc_feature")
         record.features = [feature]
         with self.assertWarnsRegex(BiopythonWarning, r"Dropping \d+ features with fuzzy locations"):
-            SeqIO.write([record], h, 'xdna')
+            SeqIO.write([record], h, "xdna")
 
         # Now a record with a feature with a qualifier too long
-        qualifiers = {'note': ["x" * 260]}
+        qualifiers = {"note": ["x" * 260]}
         feature = SeqFeature(FeatureLocation(2, 3),
-                             type='misc_feature',
+                             type="misc_feature",
                              qualifiers=qualifiers)
         record.features = [feature]
         with self.assertWarnsRegex(BiopythonWarning, "Some annotations were truncated to 255 characters"):
-            SeqIO.write([record], h, 'xdna')
+            SeqIO.write([record], h, "xdna")
 
         h.close()
 

--- a/Tests/test_UniProt_GOA.py
+++ b/Tests/test_UniProt_GOA.py
@@ -21,7 +21,7 @@ class GoaTests(unittest.TestCase):
         """Test GOA GAF file iterator."""
         # Test GAF 2.0
         recs = []
-        with open('UniProt/goa_yeast.gaf', 'r') as handle:
+        with open("UniProt/goa_yeast.gaf", "r") as handle:
             for rec in GOA.gafiterator(handle):
                 recs.append(rec)
 
@@ -30,18 +30,18 @@ class GoaTests(unittest.TestCase):
         # Check keys are same as predefined fields
         self.assertEqual(sorted(recs[0].keys()), sorted(GOA.GAF20FIELDS))
         # Check values of first record
-        self.assertEqual(recs[0]['DB'], 'UniProtKB')
-        self.assertEqual(recs[0]['DB_Object_ID'], 'A0A023PXA5')
-        self.assertEqual(recs[0]['DB_Object_Symbol'], 'YAL019W-A')
-        self.assertEqual(recs[0]['Qualifier'], [''])
-        self.assertEqual(recs[0]['GO_ID'], 'GO:0003674')
-        self.assertEqual(recs[0]['DB:Reference'], ['GO_REF:0000015'])
-        self.assertEqual(recs[0]['Evidence'], 'ND')
-        self.assertEqual(recs[0]['With'], [''])
+        self.assertEqual(recs[0]["DB"], "UniProtKB")
+        self.assertEqual(recs[0]["DB_Object_ID"], "A0A023PXA5")
+        self.assertEqual(recs[0]["DB_Object_Symbol"], "YAL019W-A")
+        self.assertEqual(recs[0]["Qualifier"], [""])
+        self.assertEqual(recs[0]["GO_ID"], "GO:0003674")
+        self.assertEqual(recs[0]["DB:Reference"], ["GO_REF:0000015"])
+        self.assertEqual(recs[0]["Evidence"], "ND")
+        self.assertEqual(recs[0]["With"], [""])
 
         # Test GAF 2.1, it has the same fields as GAF 2.0
         recs = []
-        with open('UniProt/gene_association.goa_yeast.1.gaf', 'r') as handle:
+        with open("UniProt/gene_association.goa_yeast.1.gaf", "r") as handle:
             for rec in GOA.gafiterator(handle):
                 recs.append(rec)
 
@@ -50,57 +50,57 @@ class GoaTests(unittest.TestCase):
         # Check keys are same as predefined fields
         self.assertEqual(sorted(recs[0].keys()), sorted(GOA.GAF20FIELDS))
         # Check values of first record
-        self.assertEqual(recs[0]['DB'], 'UniProtKB')
-        self.assertEqual(recs[0]['DB_Object_ID'], 'P17536')
-        self.assertEqual(recs[0]['DB_Object_Symbol'], 'TPM1')
-        self.assertEqual(recs[0]['Qualifier'], [''])
-        self.assertEqual(recs[0]['GO_ID'], 'GO:0000001')
-        self.assertEqual(recs[0]['DB:Reference'], ['PMID:10652251'])
-        self.assertEqual(recs[0]['Evidence'], 'TAS')
-        self.assertEqual(recs[0]['With'], [''])
+        self.assertEqual(recs[0]["DB"], "UniProtKB")
+        self.assertEqual(recs[0]["DB_Object_ID"], "P17536")
+        self.assertEqual(recs[0]["DB_Object_Symbol"], "TPM1")
+        self.assertEqual(recs[0]["Qualifier"], [""])
+        self.assertEqual(recs[0]["GO_ID"], "GO:0000001")
+        self.assertEqual(recs[0]["DB:Reference"], ["PMID:10652251"])
+        self.assertEqual(recs[0]["Evidence"], "TAS")
+        self.assertEqual(recs[0]["With"], [""])
 
     def test_gpa_iterator(self):
         """Test GOA GPA file iterator."""
         recs = []
-        with open('UniProt/goa_yeast.gpa.59.gpa', 'r') as handle:
+        with open("UniProt/goa_yeast.gpa.59.gpa", "r") as handle:
             for rec in GOA.gpa_iterator(handle):
                 recs.append(rec)
         self.assertEqual(len(recs), 300)
         self.assertEqual(sorted(recs[0].keys()), sorted(GOA.GPA11FIELDS))
         # Check values of first record
-        self.assertEqual(recs[0]['DB'], 'UniProtKB')
-        self.assertEqual(recs[0]['DB_Object_ID'], 'A0A023PXA5')
-        self.assertEqual(recs[0]['Qualifier'], ['enables'])
-        self.assertEqual(recs[0]['GO_ID'], 'GO:0003674')
-        self.assertEqual(recs[0]['DB:Reference'], ['GO_REF:0000015'])
-        self.assertEqual(recs[0]['ECO_Evidence_code'], 'ECO:0000307')
-        self.assertEqual(recs[0]['With'], [''])
-        self.assertEqual(recs[0]['Interacting_taxon_ID'], '')
-        self.assertEqual(recs[0]['Date'], '20030730')
-        self.assertEqual(recs[0]['Assigned_by'], 'SGD')
-        self.assertEqual(recs[0]['Annotation Extension'], [''])
-        self.assertEqual(recs[0]['Annotation_Properties'], 'go_evidence=ND')
+        self.assertEqual(recs[0]["DB"], "UniProtKB")
+        self.assertEqual(recs[0]["DB_Object_ID"], "A0A023PXA5")
+        self.assertEqual(recs[0]["Qualifier"], ["enables"])
+        self.assertEqual(recs[0]["GO_ID"], "GO:0003674")
+        self.assertEqual(recs[0]["DB:Reference"], ["GO_REF:0000015"])
+        self.assertEqual(recs[0]["ECO_Evidence_code"], "ECO:0000307")
+        self.assertEqual(recs[0]["With"], [""])
+        self.assertEqual(recs[0]["Interacting_taxon_ID"], "")
+        self.assertEqual(recs[0]["Date"], "20030730")
+        self.assertEqual(recs[0]["Assigned_by"], "SGD")
+        self.assertEqual(recs[0]["Annotation Extension"], [""])
+        self.assertEqual(recs[0]["Annotation_Properties"], "go_evidence=ND")
 
     def test_gpi_iterator(self):
         """Test GOA GPI file iterator."""
         recs = []
-        with open('UniProt/gp_information.goa_yeast.28.gpi', 'r') as handle:
+        with open("UniProt/gp_information.goa_yeast.28.gpi", "r") as handle:
             for rec in GOA.gpi_iterator(handle):
                 recs.append(rec)
         self.assertEqual(len(recs), 300)
         self.assertEqual(sorted(recs[0].keys()), sorted(GOA.GPI11FIELDS))
         # Check values of first record
-        self.assertEqual(recs[0]['DB_Object_ID'], 'A2P2R3')
-        self.assertEqual(recs[0]['DB_Object_Symbol'], 'YMR084W')
-        self.assertEqual(recs[0]['DB_Object_Name'], ['Putative glutamine--fructose'
-                                                     '-6-phosphate aminotransferase'
-                                                     ' [isomerizing]'])
-        self.assertEqual(recs[0]['DB_Object_Synonym'], ['YM084_YEAST', 'YMR084W'])
-        self.assertEqual(recs[0]['DB_Object_Type'], 'protein')
-        self.assertEqual(recs[0]['Taxon'], 'taxon:559292')
-        self.assertEqual(recs[0]['Parent_Object_ID'], '')
-        self.assertEqual(recs[0]['DB_Xref'], [''])
-        self.assertEqual(recs[0]['Gene_Product_Properties'], ['db_subset=Swiss-Prot'])
+        self.assertEqual(recs[0]["DB_Object_ID"], "A2P2R3")
+        self.assertEqual(recs[0]["DB_Object_Symbol"], "YMR084W")
+        self.assertEqual(recs[0]["DB_Object_Name"], ["Putative glutamine--fructose"
+                                                     "-6-phosphate aminotransferase"
+                                                     " [isomerizing]"])
+        self.assertEqual(recs[0]["DB_Object_Synonym"], ["YM084_YEAST", "YMR084W"])
+        self.assertEqual(recs[0]["DB_Object_Type"], "protein")
+        self.assertEqual(recs[0]["Taxon"], "taxon:559292")
+        self.assertEqual(recs[0]["Parent_Object_ID"], "")
+        self.assertEqual(recs[0]["DB_Xref"], [""])
+        self.assertEqual(recs[0]["Gene_Product_Properties"], ["db_subset=Swiss-Prot"])
 
     def test_selection_writing(self):
         """Test record_has, and writerec.
@@ -111,16 +111,16 @@ class GoaTests(unittest.TestCase):
         filtered = []
 
         # Fields to filter
-        evidence = {'Evidence': {'ND'}}
-        synonym = {'Synonym': {'YA19A_YEAST', 'YAL019W-A'}}
-        taxon_id = {'Taxon_ID': {'taxon:559292'}}
+        evidence = {"Evidence": {"ND"}}
+        synonym = {"Synonym": {"YA19A_YEAST", "YAL019W-A"}}
+        taxon_id = {"Taxon_ID": {"taxon:559292"}}
 
         # Temporal file to test writerec
         f_number, f_filtered = tempfile.mkstemp()
         os.close(f_number)
 
         # Open a file and select records as per filter
-        with open('UniProt/goa_yeast.gaf', 'r') as handle:
+        with open("UniProt/goa_yeast.gaf", "r") as handle:
             for rec in GOA.gafiterator(handle):
                 recs.append(rec)
                 # Filtering
@@ -133,15 +133,15 @@ class GoaTests(unittest.TestCase):
         self.assertEqual(len(filtered), 3)
 
         # Write the filtered records to a file using writerec
-        with open(f_filtered, 'w') as handle:
+        with open(f_filtered, "w") as handle:
             # '!gaf-version: 2.1'
-            handle.write('!gaf-version: 2.1 \n')  # Adding file header
+            handle.write("!gaf-version: 2.1 \n")  # Adding file header
             for rec in filtered:
                 GOA.writerec(rec, handle)
 
         # Open and read the file containing the filtered records
         recs_ff = []  # Records from filtered file
-        with open(f_filtered, 'r') as handle:
+        with open(f_filtered, "r") as handle:
             for rec in GOA.gafiterator(handle):
                 recs_ff.append(rec)
 
@@ -152,6 +152,6 @@ class GoaTests(unittest.TestCase):
         self.assertEqual(filtered, recs_ff)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)
     unittest.main(testRunner=runner)


### PR DESCRIPTION
This pull request addresses issue noted on #2260, we have not been enforcing double quotes since #2192 was applied - and doing so will help as we move towards adopting the black style #2008.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
