### PR TITLE
`__format__()` method for Seq

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -161,7 +161,7 @@ class Seq(object):
         return self._data
     
     def __format__(self, formatstr):
-        """ Using .format method 
+        """ Using .format() method 
 
         >>> from Bio.Seq import Seq
         >>> seq1 = Seq("ACGT")

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -159,6 +159,16 @@ class Seq(object):
 
         """
         return self._data
+    
+    def __format__(self, formatstr):
+        """ Using .format method 
+
+        >>> from Bio.Seq import Seq
+        >>> seq1 = Seq("ACGT")
+        >>> print('The sequence is {}'.format(seq1))
+        The sequence is ACGT
+        """
+        return self._data.__format__(formatstr)
 
     def __hash__(self):
         """Hash for comparison.


### PR DESCRIPTION
This pull request makes `__format__()` method available for Seq

On the Biopython 'getting started' page ( https://biopython.org/wiki/Getting_Started ) I saw this example:

```python
from Bio.Seq import Seq

#create a sequence object
my_seq = Seq('CATGTAGACTAG')

#print out some details about it
print 'seq %s is %i bases long' % (my_seq, len(my_seq))
print 'reverse complement is %s' % my_seq.reverse_complement()
print 'protein translation is %s' % my_seq.translate()
```

which is python2-styled. A python3 version would be:

```python
print('seq {0:s} is {1:i} bases long'.format(my_seq, len(my_seq)))
print('reverse complement is {0:s}'.format(my_seq.reverse_complement()))
print('protein translation is {0:s}'.format(my_seq.translate()))
```

which require that Seq has a `__format__` method. This pull request addresses the issue.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
