### PR TITLE
Address future D412 cases.

### DIFF
--- a/Bio/Graphics/GenomeDiagram/_Colors.py
+++ b/Bio/Graphics/GenomeDiagram/_Colors.py
@@ -93,13 +93,12 @@ class ColorTranslator(object):
         """Translate a color into a ReportLab Color object.
 
         Arguments:
-
-        - color - Color defined as an int, a tuple of three ints 0->255
-          or a tuple of three floats 0 -> 1, or a string giving
-          one of the named colors defined by ReportLab, or a
-          ReportLab color object (returned as is).
-        - colour - Backards compatible alias using UK spelling (which
-          will over-ride any color argument).
+         - color - Color defined as an int, a tuple of three ints 0->255
+           or a tuple of three floats 0 -> 1, or a string giving
+           one of the named colors defined by ReportLab, or a
+           ReportLab color object (returned as is).
+         - colour - Backwards compatible alias using UK spelling (which
+           will over-ride any color argument).
 
         Returns a colors.Color object, determined semi-intelligently
         depending on the input values
@@ -166,12 +165,11 @@ class ColorTranslator(object):
         """Artemis color (integer) to ReportLab Color object.
 
         Arguments:
-
-        - value: An int representing a functional class in the Artemis
-          color scheme (see www.sanger.ac.uk for a description),
-          or a string from a GenBank feature annotation for the
-          color which may be dot delimited (in which case the
-          first value is used).
+         - value: An int representing a functional class in the Artemis
+           color scheme (see www.sanger.ac.uk for a description),
+           or a string from a GenBank feature annotation for the
+           color which may be dot delimited (in which case the
+           first value is used).
 
         Takes an int representing a functional class in the Artemis color
         scheme, and returns the appropriate colors.Color object

--- a/Bio/Graphics/GenomeDiagram/_Diagram.py
+++ b/Bio/Graphics/GenomeDiagram/_Diagram.py
@@ -47,40 +47,39 @@ class Diagram(object):
     """Diagram container.
 
     Arguments:
-
-    - name           - a string, identifier for the diagram.
-    - tracks         - a list of Track objects comprising the diagram.
-    - format         - a string, format of the diagram 'circular' or
-      'linear', depending on the sort of diagram required.
-    - pagesize       - a string, the pagesize of output describing the ISO
-      size of the image, or a tuple of pixels.
-    - orientation    - a string describing the required orientation of the
-      final drawing ('landscape' or 'portrait').
-    - x              - a float (0->1), the proportion of the page to take
-      up with even X margins t the page.
-    - y              - a float (0->1), the proportion of the page to take
-      up with even Y margins to the page.
-    - xl             - a float (0->1), the proportion of the page to take
-      up with the left X margin to the page (overrides x).
-    - xr             - a float (0->1), the proportion of the page to take
-      up with the right X margin to the page (overrides x).
-    - yt             - a float (0->1), the proportion of the page to take
-      up with the top Y margin to the page (overrides y).
-    - yb             - a float (0->1), the proportion of the page to take
-      up with the bottom Y margin to the page (overrides y).
-    - circle_core    - a float, the proportion of the available radius to
-      leave empty at the center of a circular diagram (0 to 1).
-    - start          - an integer, the base/aa position to start the diagram at.
-    - end            - an integer, the base/aa position to end the diagram at.
-    - tracklines     - a boolean, True if track guidelines are to be drawn.
-    - fragments      - and integer, for a linear diagram, the number of equal
-      divisions into which the sequence is divided.
-    - fragment_size  - a float (0->1), the proportion of the space
-      available to each fragment that should be used in drawing.
-    - track_size     - a float (0->1), the proportion of the space
-      available to each track that should be used in drawing with sigils.
-    - circular       - a boolean, True if the genome/sequence to be drawn
-      is, in reality, circular.
+     - name           - a string, identifier for the diagram.
+     - tracks         - a list of Track objects comprising the diagram.
+     - format         - a string, format of the diagram 'circular' or
+       'linear', depending on the sort of diagram required.
+     - pagesize       - a string, the pagesize of output describing the ISO
+       size of the image, or a tuple of pixels.
+     - orientation    - a string describing the required orientation of the
+       final drawing ('landscape' or 'portrait').
+     - x              - a float (0->1), the proportion of the page to take
+       up with even X margins t the page.
+     - y              - a float (0->1), the proportion of the page to take
+       up with even Y margins to the page.
+     - xl             - a float (0->1), the proportion of the page to take
+       up with the left X margin to the page (overrides x).
+     - xr             - a float (0->1), the proportion of the page to take
+       up with the right X margin to the page (overrides x).
+     - yt             - a float (0->1), the proportion of the page to take
+       up with the top Y margin to the page (overrides y).
+     - yb             - a float (0->1), the proportion of the page to take
+       up with the bottom Y margin to the page (overrides y).
+     - circle_core    - a float, the proportion of the available radius to
+       leave empty at the center of a circular diagram (0 to 1).
+     - start          - an integer, the base/aa position to start the diagram at.
+     - end            - an integer, the base/aa position to end the diagram at.
+     - tracklines     - a boolean, True if track guidelines are to be drawn.
+     - fragments      - and integer, for a linear diagram, the number of equal
+       divisions into which the sequence is divided.
+     - fragment_size  - a float (0->1), the proportion of the space
+       available to each fragment that should be used in drawing.
+     - track_size     - a float (0->1), the proportion of the space
+       available to each track that should be used in drawing with sigils.
+     - circular       - a boolean, True if the genome/sequence to be drawn
+       is, in reality, circular.
 
     """
 
@@ -144,8 +143,8 @@ class Diagram(object):
         """Set the passed attribute of all tracks in the set to the passed value.
 
         Arguments:
-            - attr    - An attribute of the Track class.
-            - value   - The value to set that attribute.
+         - attr    - An attribute of the Track class.
+         - value   - The value to set that attribute.
 
         set_all_tracks(self, attr, value)
         """
@@ -349,10 +348,9 @@ class Diagram(object):
         """Move a track from one level on the diagram to another.
 
         Arguments:
-
-        - from_level   - an integer. The level at which the track to be
-          moved is found.
-        - to_level     - an integer. The level to move the track to.
+         - from_level   - an integer. The level at which the track to be
+           moved is found.
+         - to_level     - an integer. The level to move the track to.
 
         """
         aux = self.tracks[from_level]
@@ -365,10 +363,9 @@ class Diagram(object):
         Optionally from a passed lowest number.
 
         Arguments:
-
-        - low     - an integer. The track number to start from.
-        - step    - an integer. The track interval for separation of
-          tracks.
+         - low     - an integer. The track number to start from.
+         - step    - an integer. The track interval for separation of
+           tracks.
 
         """
         track = low  # Start numbering from here

--- a/Bio/Graphics/GenomeDiagram/_FeatureSet.py
+++ b/Bio/Graphics/GenomeDiagram/_FeatureSet.py
@@ -184,9 +184,8 @@ class FeatureSet(object):
         """Return a formatted string with information about the set.
 
         Arguments:
-
-        - verbose: Boolean indicating whether a short (default) or
-          complete account of the set is required
+         - verbose: Boolean indicating whether a short (default) or
+           complete account of the set is required
 
         """
         if not verbose:  # Short account only required

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -331,7 +331,6 @@ def _compact4nexus(orig_list):
 
     Example
     -------
-
     >>> _compact4nexus([1, 2, 3, 5, 6, 7, 8, 12, 15, 18, 20])
     '2-4 6-9 13-19\\3 21'
 

--- a/Bio/PDB/Chain.py
+++ b/Bio/PDB/Chain.py
@@ -82,8 +82,7 @@ class Chain(Entity):
         " ") tuple.
 
         Arguments:
-
-        - id - int, residue resseq
+         - id - int, residue resseq
 
         """
         if isinstance(id, int):
@@ -98,8 +97,7 @@ class Chain(Entity):
         method.
 
         Arguments:
-
-        - id - (string, int, string) or int
+         - id - (string, int, string) or int
 
         """
         id = self._translate_id(id)
@@ -109,8 +107,7 @@ class Chain(Entity):
         """Check if a residue with given id is present in this chain.
 
         Arguments:
-
-        - id - (string, int, string) or int
+         - id - (string, int, string) or int
 
         """
         id = self._translate_id(id)
@@ -120,8 +117,7 @@ class Chain(Entity):
         """Delete item.
 
         Arguments:
-
-        - id - (string, int, string) or int
+         - id - (string, int, string) or int
 
         """
         id = self._translate_id(id)
@@ -158,8 +154,7 @@ class Chain(Entity):
         method.
 
         Arguments:
-
-        - id - (string, int, string) or int
+         - id - (string, int, string) or int
 
         """
         id = self._translate_id(id)

--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -6,41 +6,40 @@
 """Simple protein analysis.
 
 Example:
+>>> from Bio.SeqUtils.ProtParam import ProteinAnalysis
+>>> X = ProteinAnalysis("MAEGEITTFTALTEKFNLPPGNYKKPKLLYCSNGGHFLRILPDGTVDGT"
+...                     "RDRSDQHIQLQLSAESVGEVYIKSTETGQYLAMDTSGLLYGSQTPSEEC"
+...                     "LFLERLEENHYNTYTSKKHAEKNWFVGLKKNGSCKRGPRTHYGQKAILF"
+...                     "LPLPV")
+>>> print(X.count_amino_acids()['A'])
+6
+>>> print(X.count_amino_acids()['E'])
+12
+>>> print("%0.2f" % X.get_amino_acids_percent()['A'])
+0.04
+>>> print("%0.2f" % X.get_amino_acids_percent()['L'])
+0.12
+>>> print("%0.2f" % X.molecular_weight())
+17103.16
+>>> print("%0.2f" % X.aromaticity())
+0.10
+>>> print("%0.2f" % X.instability_index())
+41.98
+>>> print("%0.2f" % X.isoelectric_point())
+7.72
+>>> sec_struc = X.secondary_structure_fraction()  # [helix, turn, sheet]
+>>> print("%0.2f" % sec_struc[0])  # helix
+0.28
+>>> epsilon_prot = X.molar_extinction_coefficient()  # [reduced, oxidized]
+>>> print(epsilon_prot[0])  # with reduced cysteines
+17420
+>>> print(epsilon_prot[1])  # with disulfid bridges
+17545
 
-    >>> from Bio.SeqUtils.ProtParam import ProteinAnalysis
-    >>> X = ProteinAnalysis("MAEGEITTFTALTEKFNLPPGNYKKPKLLYCSNGGHFLRILPDGTVDGT"
-    ...                     "RDRSDQHIQLQLSAESVGEVYIKSTETGQYLAMDTSGLLYGSQTPSEEC"
-    ...                     "LFLERLEENHYNTYTSKKHAEKNWFVGLKKNGSCKRGPRTHYGQKAILF"
-    ...                     "LPLPV")
-    >>> print(X.count_amino_acids()['A'])
-    6
-    >>> print(X.count_amino_acids()['E'])
-    12
-    >>> print("%0.2f" % X.get_amino_acids_percent()['A'])
-    0.04
-    >>> print("%0.2f" % X.get_amino_acids_percent()['L'])
-    0.12
-    >>> print("%0.2f" % X.molecular_weight())
-    17103.16
-    >>> print("%0.2f" % X.aromaticity())
-    0.10
-    >>> print("%0.2f" % X.instability_index())
-    41.98
-    >>> print("%0.2f" % X.isoelectric_point())
-    7.72
-    >>> sec_struc = X.secondary_structure_fraction()  # [helix, turn, sheet]
-    >>> print("%0.2f" % sec_struc[0])  # helix
-    0.28
-    >>> epsilon_prot = X.molar_extinction_coefficient()  # [reduced, oxidized]
-    >>> print(epsilon_prot[0])  # with reduced cysteines
-    17420
-    >>> print(epsilon_prot[1])  # with disulfid bridges
-    17545
-
-    Other public methods are:
-     - gravy
-     - protein_scale
-     - flexibility
+Other public methods are:
+ - gravy
+ - protein_scale
+ - flexibility
 """
 
 from __future__ import print_function

--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -41,6 +41,7 @@ Other public methods are:
  - gravy
  - protein_scale
  - flexibility
+
 """
 
 from __future__ import print_function

--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -5,7 +5,8 @@
 # package.
 """Simple protein analysis.
 
-Example:
+Examples
+--------
 >>> from Bio.SeqUtils.ProtParam import ProteinAnalysis
 >>> X = ProteinAnalysis("MAEGEITTFTALTEKFNLPPGNYKKPKLLYCSNGGHFLRILPDGTVDGT"
 ...                     "RDRSDQHIQLQLSAESVGEVYIKSTETGQYLAMDTSGLLYGSQTPSEEC"

--- a/Bio/motifs/jaspar/db.py
+++ b/Bio/motifs/jaspar/db.py
@@ -86,11 +86,10 @@ class JASPAR5(object):
         """Construct a JASPAR5 instance and connect to specified DB.
 
         Arguments:
-
-        - host - host name of the the JASPAR DB server
-        - name - name of the JASPAR database
-        - user - user name to connect to the JASPAR DB
-        - password - JASPAR DB password
+         - host - host name of the the JASPAR DB server
+         - name - name of the JASPAR database
+         - user - user name to connect to the JASPAR DB
+         - password - JASPAR DB password
 
         """
         self.name = name
@@ -110,14 +109,13 @@ class JASPAR5(object):
         Example id 'MA0001.1'.
 
         Arguments:
-
-            - id - JASPAR matrix ID. This may be a fully specified ID including
-              the version number (e.g. MA0049.2) or just the base ID (e.g.
-              MA0049). If only a base ID is provided, the latest version is
-              returned.
+         - id - JASPAR matrix ID. This may be a fully specified ID including
+                the version number (e.g. MA0049.2) or just the base ID (e.g.
+                MA0049). If only a base ID is provided, the latest version is
+                returned.
 
         Returns:
-            - A Bio.motifs.jaspar.Motif object
+         - A Bio.motifs.jaspar.Motif object
 
         **NOTE:** The perl TFBS module allows you to specify the type of matrix
         to return (PFM, PWM, ICM) but matrices are always stored in JASPAR as

--- a/Bio/motifs/minimal.py
+++ b/Bio/motifs/minimal.py
@@ -42,6 +42,7 @@ def read(handle):
     IFXA
 
     This function wont retrieve instances, as there are none in minimal meme format.
+
     """
     motif_number = 0
     record = Record()

--- a/Bio/motifs/minimal.py
+++ b/Bio/motifs/minimal.py
@@ -16,7 +16,8 @@ import math
 def read(handle):
     """Parse the text output of the MEME program into a meme.Record object.
 
-    Example:
+    Examples
+    --------
     >>> from Bio.motifs import minimal
     >>> with open("motifs/meme.out") as f:
     ...     record = minimal.read(f)
@@ -29,7 +30,6 @@ def read(handle):
     You can access individual motifs in the record by their index or find a motif
     by its name:
 
-    Example:
     >>> from Bio import motifs
     >>> with open("motifs/minimal_test.meme") as f:
     ...     record = motifs.parse(f, 'minimal')

--- a/Bio/motifs/minimal.py
+++ b/Bio/motifs/minimal.py
@@ -17,7 +17,6 @@ def read(handle):
     """Parse the text output of the MEME program into a meme.Record object.
 
     Example:
-
     >>> from Bio.motifs import minimal
     >>> with open("motifs/meme.out") as f:
     ...     record = minimal.read(f)
@@ -31,7 +30,6 @@ def read(handle):
     by its name:
 
     Example:
-
     >>> from Bio import motifs
     >>> with open("motifs/minimal_test.meme") as f:
     ...     record = motifs.parse(f, 'minimal')

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -384,10 +384,9 @@ class DatabaseLoader(object):
         """Get the taxon id for record from NCBI taxon ID (PRIVATE).
 
         Arguments:
-
-        - ncbi_taxon_id - string containing an NCBI taxon id
-        - scientific_name - string, used if a stub entry is recorded
-        - common_name - string, used if a stub entry is recorded
+         - ncbi_taxon_id - string containing an NCBI taxon id
+         - scientific_name - string, used if a stub entry is recorded
+         - common_name - string, used if a stub entry is recorded
 
         This searches the taxon table using ONLY the NCBI taxon ID
         to find the matching taxon table entry's ID (database key).

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -103,9 +103,8 @@ def regex(site):
     """Construct a regular expression (string) from a DNA sequence.
 
     Example:
-
-        >>> regex('ABCGN')
-        'A[CGT]CG.'
+    >>> regex('ABCGN')
+    'A[CGT]CG.'
 
     """
     reg_ex = str(site)

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -102,7 +102,8 @@ class OverhangError(ValueError):
 def regex(site):
     """Construct a regular expression (string) from a DNA sequence.
 
-    Example:
+    Examples
+    --------
     >>> regex('ABCGN')
     'A[CGT]CG.'
 


### PR DESCRIPTION
This pull request is related to PR #2230. Recent releases of `pydocstyle` do recognize more section headers by using additional keywords. This will bring up some new `D412` issues (no blank lines allowed between a section header and its content) and many new `D413` issues (no blank lines allowed between a section header and its content. However, `D413` was just removed from the `pep257` convention that we are using (https://github.com/PyCQA/pydocstyle/pull/404).

This PR addresses the future `D412` issues which will come up when we remove the pinning of `pydocstyle` to versions < 4.0.0

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
