### PR TITLE
Define Seq object .index() and .rindex()

### DIFF
--- a/Bio/Phylo/_utils.py
+++ b/Bio/Phylo/_utils.py
@@ -108,7 +108,7 @@ def draw_graphviz(tree, label_func=str, prog="twopi", args="",
                 from Bio import Phylo, AlignIO
                 from Bio.Phylo.TreeConstruction import DistanceCalculator, DistanceTreeConstructor
                 constructor = DistanceTreeConstructor()
-                aln = AlignIO.read(open('/TreeConstruction/msa.phy'), 'phylip')
+                aln = AlignIO.read(open('TreeConstruction/msa.phy'), 'phylip')
                 calculator = DistanceCalculator('identity')
                 dm = calculator.get_distance(aln)
                 tree = constructor.upgma(dm)

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -675,7 +675,7 @@ class Seq(object):
         >>> my_rna.index("T")
         Traceback (most recent call last):
                    ...
-        ValueError: substring not found
+        ValueError: substring not found...
         """
         # If it has one, check the alphabet:
         sub_str = self._get_seq_str_and_check_alphabet(sub)

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -665,6 +665,28 @@ class Seq(object):
         sub_str = self._get_seq_str_and_check_alphabet(sub)
         return str(self).rfind(sub_str, start, end)
 
+    def index(self, sub, start=0, end=sys.maxsize):
+        """Like find() but raise ValueError when the substring is not found.
+
+        >>> from Bio.Seq import Seq
+        >>> my_rna = Seq("GUCAUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAGUUG")
+        >>> my_rna.find("T")
+        -1
+        >>> my_rna.index("T")
+        Traceback (most recent call last):
+                   ...
+        ValueError: substring not found
+        """
+        # If it has one, check the alphabet:
+        sub_str = self._get_seq_str_and_check_alphabet(sub)
+        return str(self).index(sub_str, start, end)
+
+    def rindex(self, sub, start=0, end=sys.maxsize):
+        """Like rfind() but raise ValueError when the substring is not found."""
+        # If it has one, check the alphabet:
+        sub_str = self._get_seq_str_and_check_alphabet(sub)
+        return str(self).rindex(sub_str, start, end)
+
     def startswith(self, prefix, start=0, end=sys.maxsize):
         """Return True if the Seq starts with the given prefix, False otherwise.
 
@@ -2447,15 +2469,19 @@ class MutableSeq(object):
     def index(self, item):
         """Return first occurrence position of a single entry (i.e. letter).
 
-        >>> my_seq = MutableSeq('ACTCGACGTCG')
-        >>> my_seq.index('A')
+        >>> my_seq = MutableSeq("ACTCGACGTCG")
+        >>> my_seq.index("A")
         0
-        >>> my_seq.index('T')
+        >>> my_seq.index("T")
+        2
+        >>> my_seq.index(Seq("T"))
         2
 
         Note unlike a Biopython Seq object, or Python string, multi-letter
-        subsequences are not supported.
+        subsequences are not supported.  Instead this acts like an array or
+        a list of the entries. There is therefore no ``.rindex()`` method.
         """
+        # TODO?: return self.data.index(i)
         for i in range(len(self.data)):
             if self.data[i] == item:
                 return i

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -25,6 +25,10 @@ Christian Marck's DNA Strider program ("xdna" format, also used by Serial
 Cloner), as well as reading files in the native formats of GSL Biotech's
 SnapGene ("snapgene") and Textco Biosoftware's Gene Construction Kit ("gck").
 
+The main ``Seq`` object now has string-like ``.index()`` and ``.rindex()``
+methods, matching the existing ``.find()`` and ``.rfind()`` implementations.
+The ``MutableSeq`` object retains its more list-like ``.index()`` behaviour.
+
 The ``MMTFIO`` class is added that allows writing of MMTF file format files
 from a Biopython structure object. ``MMTFIO`` has a similar interface to
 ``PDBIO`` and ``MMCIFIO``, including the use of a ``Select`` class to write

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1,3 +1,4 @@
+
 # Copyright 2009 by Peter Cock.  All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
@@ -103,6 +104,12 @@ class StringMethodTests(unittest.TestCase):
     def _test_method(self, method_name, pre_comp_function=None,
                      start_end=False):
         """Check this method matches the plain string's method."""
+        if pre_comp_function is None:
+            # Define a no-op function:
+
+            def pre_comp_function(x):
+                return x
+
         self.assertTrue(isinstance(method_name, str))
         for example1 in self._examples:
             if not hasattr(example1, method_name):
@@ -114,15 +121,21 @@ class StringMethodTests(unittest.TestCase):
                 if not hasattr(example2, method_name):
                     # e.g. MutableSeq does not support find
                     continue
+                if method_name in ("index", "rindex") and isinstance(example1, MutableSeq) and len(example2) > 1:
+                    # MutableSeq index only supports single entries
+                    continue
                 str2 = str(example2)
 
-                i = getattr(example1, method_name)(str2)
-                j = getattr(str1, method_name)(str2)
-                if pre_comp_function:
-                    i = pre_comp_function(i)
-                    j = pre_comp_function(j)
+                try:
+                    i = pre_comp_function(getattr(example1, method_name)(str2))
+                except ValueError:
+                    i = ValueError
+                try:
+                    j = pre_comp_function(getattr(str1, method_name)(str2))
+                except ValueError:
+                    j = ValueError
                 if i != j:
-                    raise ValueError("%s.%s(%s) = %i, not %i"
+                    raise ValueError("%s.%s(%s) = %r, not %r"
                                      % (repr(example1),
                                         method_name,
                                         repr(str2),
@@ -130,13 +143,16 @@ class StringMethodTests(unittest.TestCase):
                                         j))
 
                 try:
-                    i = getattr(example1, method_name)(example2)
-                    j = getattr(str1, method_name)(str2)
-                    if pre_comp_function:
-                        i = pre_comp_function(i)
-                        j = pre_comp_function(j)
+                    try:
+                        i = pre_comp_function(getattr(example1, method_name)(example2))
+                    except ValueError:
+                        i = ValueError
+                    try:
+                        j = pre_comp_function(getattr(str1, method_name)(str2))
+                    except ValueError:
+                        j = ValueError
                     if i != j:
-                        raise ValueError("%s.%s(%s) = %i, not %i"
+                        raise ValueError("%s.%s(%s) = %r, not %r"
                                          % (repr(example1),
                                             method_name,
                                             repr(example2),
@@ -147,14 +163,20 @@ class StringMethodTests(unittest.TestCase):
                     pass
 
                 if start_end:
+                    if isinstance(example1, MutableSeq):
+                        # Does not support start/end arguments
+                        continue
                     for start in self._start_end_values:
-                        i = getattr(example1, method_name)(str2, start)
-                        j = getattr(str1, method_name)(str2, start)
-                        if pre_comp_function:
-                            i = pre_comp_function(i)
-                            j = pre_comp_function(j)
+                        try:
+                            i = pre_comp_function(getattr(example1, method_name)(str2, start))
+                        except ValueError:
+                            i = ValueError
+                        try:
+                            j = pre_comp_function(getattr(str1, method_name)(str2, start))
+                        except ValueError:
+                            j = ValueError
                         if i != j:
-                            raise ValueError("%s.%s(%s, %i) = %i, not %i"
+                            raise ValueError("%s.%s(%s, %i) = %r, not %r"
                                              % (repr(example1),
                                                 method_name,
                                                 repr(str2),
@@ -163,13 +185,16 @@ class StringMethodTests(unittest.TestCase):
                                                 j))
 
                         for end in self._start_end_values:
-                            i = getattr(example1, method_name)(str2, start, end)
-                            j = getattr(str1, method_name)(str2, start, end)
-                            if pre_comp_function:
-                                i = pre_comp_function(i)
-                                j = pre_comp_function(j)
+                            try:
+                                i = pre_comp_function(getattr(example1, method_name)(str2, start, end))
+                            except ValueError:
+                                i = ValueError
+                            try:
+                                j = pre_comp_function(getattr(str1, method_name)(str2, start, end))
+                            except ValueError:
+                                j = ValueError
                             if i != j:
-                                raise ValueError("%s.%s(%s, %i, %i) = %i, not %i"
+                                raise ValueError("%s.%s(%s, %i, %i) = %r, not %r"
                                                  % (repr(example1),
                                                     method_name,
                                                     repr(str2),
@@ -349,6 +374,14 @@ class StringMethodTests(unittest.TestCase):
     def test_str_rfind(self):
         """Check matches the python string rfind method."""
         self._test_method("rfind", start_end=True)
+
+    def test_str_index(self):
+        """Check matches the python string index method."""
+        self._test_method("index", start_end=True)
+
+    def test_str_rindex(self):
+        """Check matches the python string rindex method."""
+        self._test_method("rindex", start_end=True)
 
     def test_str_startswith(self):
         """Check matches the python string startswith method."""


### PR DESCRIPTION
This gives Seq (and subclasses) a string-like .index() and .rindex() method.

Note that MutableSeq has just an array or list-like .index(), and like a list, no .rindex() method or .find() and .rfind() - adding these would clash with the partial support for things like three-letter-alphabet sequences using this object.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
