### PR TITLE
Import ABCs from collections.abc for Python 3.8 support

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -27,6 +27,13 @@ import sys
 import warnings
 import collections
 
+try:
+    # Python 3
+    from collections.abc import Iterable as _Iterable
+except ImportError:
+    # Python 2.7
+    from collections import Iterable as _Iterable
+
 from Bio._py3k import range
 from Bio._py3k import basestring
 
@@ -1302,7 +1309,7 @@ class Seq(object):
         Throws error if other is not an iterable and if objects inside of the iterable
         are not Seq or String objects
         """
-        if not isinstance(other, collections.Iterable):  # doesn't detect single strings
+        if not isinstance(other, _Iterable):  # doesn't detect single strings
             raise ValueError("Input must be an iterable")
         if isinstance(other, basestring):
             raise ValueError("Input must be an iterable")


### PR DESCRIPTION
Noticed by chance,

```
$ python --version
Python 3.7.3

$ python -c "from collections import Iterable"
-c:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
