### PR TITLE
setattr was missing for "mismatch_num"

### DIFF
--- a/Bio/SearchIO/BlastIO/blast_tab.py
+++ b/Bio/SearchIO/BlastIO/blast_tab.py
@@ -178,7 +178,7 @@ def _augment_blast_hsp(hsp, attr):
             setattr(hsp, attr, hsp.aln_span - hsp.ident_num - hsp.mismatch_num)
 
         elif attr == "mismatch_num":
-            hsp.mistmatch_num = hsp.aln_span - hsp.ident_num - hsp.gap_num
+            setattr(hsp, attr, hsp.aln_span - hsp.ident_num - hsp.gap_num)
 
         elif attr == "gapopen_num":
             if not hasattr(hsp, "query") or not hasattr(hsp, "hit"):


### PR DESCRIPTION
This pull request addresses issue #2218

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
