### PR TITLE
fix SAFE_ADD

### DIFF
--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -29,9 +29,11 @@
 #define CHARINDEX(s) (c = s, c >= 'a' ? c - 'a' : c - 'A')
 
 #define SAFE_ADD(t, s) \
-{   term = t; \
-    if (term > PY_SSIZE_T_MAX - s) { count = OVERFLOW_ERROR; goto exit; } \
-    s += term; \
+{   if (s != OVERFLOW_ERROR) { \
+        term = t; \
+        if (term > PY_SSIZE_T_MAX - s) s = OVERFLOW_ERROR; \
+        else s += term; \
+    } \
 }
 
 
@@ -232,7 +234,6 @@ PathGenerator_needlemanwunsch_length(PathGenerator* self)
             counts[j] = count;
         }
     }
-exit:
     PyMem_Free(counts);
     return count;
 }
@@ -271,7 +272,6 @@ PathGenerator_smithwaterman_length(PathGenerator* self)
         }
     }
     count = total;
-exit:
     PyMem_Free(counts);
     return count;
 }


### PR DESCRIPTION
SAFE_ADD in Bio/Align/_aligners.c returns OVERFLOW_ERROR and goes to exit if the count overflows. However, overflows at some point in the trace matrix does not necessarily imply that the count at the final position in the matrix overflows, and therefore we should not go to exit.


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
