### PR TITLE
Do not replace double spaces when cleaning

### DIFF
--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -92,7 +92,7 @@ def _get_seq_string(record):
 # Function variant of the SequenceWriter method.
 def _clean(text):
     """Use this to avoid getting newlines in the output (PRIVATE)."""
-    return text.replace("\n", " ").replace("\r", " ").replace("  ", " ")
+    return text.replace("\n", " ").replace("\r", " ")
 
 
 class SequenceWriter(object):
@@ -123,7 +123,7 @@ class SequenceWriter(object):
 
     def clean(self, text):
         """Use this to avoid getting newlines in the output."""
-        return text.replace("\n", " ").replace("\r", " ").replace("  ", " ")
+        return text.replace("\n", " ").replace("\r", " ")
 
     def write_file(self, records):
         """Use this to write an entire file containing the given records.

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -150,6 +150,13 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX', ProteinAlphabet())"""
         expected = ">TestID TestDescr\nABCDEFGHIJKLMNOPQRSTUVWZYX\n"
         self.assertEqual(expected, self.record.format("fasta"))
 
+    def test_format_spaces(self):
+        rec = SeqRecord(Seq("ABCDEFGHIJKLMNOPQRSTUVWZYX", generic_protein),
+                        id="TestID", name="TestName", description="TestDescr")
+        rec.description = "TestDescr     with5spaces"
+        expected = ">TestID TestDescr     with5spaces\nABCDEFGHIJKLMNOPQRSTUVWZYX\n"
+        self.assertEqual(expected, rec.format("fasta"))
+
     def test_upper(self):
         self.assertEqual("ABCDEFGHIJKLMNOPQRSTUVWZYX", str(self.record.lower().upper().seq))
 


### PR DESCRIPTION
This pull request is related to issue #2270

If all the tests pass then I propose to add a unit test to `Tests/test_SeqRecord.py` to enforce the new behaviour

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
