### PR TITLE
TravisCI now provides PyPy2/3 version 7.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,33 +129,6 @@ before_install:
   # Setup environment for t-coffee
   - mkdir -p $HOME/tcoffee_temp
   - export HOME_4_TCOFFEE=$HOME/tcoffee_temp
-  # There are TravisCI provided versions of PyPy and PyPy3, but currently too old.
-  # We therefore deactivate that, and download and unzip portable PyPy binaries.
-  - |
-    if [[ $TRAVIS_PYTHON_VERSION == 'pypy' ]]; then
-        deactivate
-        wget https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-6.0.0-linux_x86_64-portable.tar.bz2
-        tar -jxvf pypy-6.0.0-linux_x86_64-portable.tar.bz2
-        echo 'Setting up aliases...'
-        cd pypy-6.0.0-linux_x86_64-portable/bin/
-        export PATH=$PWD:$PATH
-        ln -s pypy python
-        echo 'Setting up pip...'
-        ./pypy -m ensurepip
-    fi
-  - |
-    if [[ $TRAVIS_PYTHON_VERSION == 'pypy3' ]]; then
-        deactivate
-        wget https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.5-6.0.0-linux_x86_64-portable.tar.bz2
-        tar -jxvf pypy3.5-6.0.0-linux_x86_64-portable.tar.bz2
-        echo 'Setting up aliases...'
-        cd pypy3.5-6.0.0-linux_x86_64-portable/bin/
-        export PATH=$PWD:$PATH
-        ln -s pypy3 python
-        echo 'Setting up pip...'
-        ./pypy3 -m ensurepip
-        ln -s pip3 pip
-    fi
   - popd
   - cp Tests/biosql.ini.sample Tests/biosql.ini
   - psql -c "create database biosql_test;" -U postgres
@@ -170,6 +143,7 @@ install:
   - tox -c .travis-tox.ini -e $TOXENV --notest
 
 script:
+  - python --version
   - travis_wait 30 tox -c .travis-tox.ini -e $TOXENV
 
 notifications:

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ implementations:
   support for Python 2.7 in early 2020, in line with the end-of-life or
   sunset date for Python 2.7 itself.
 
-- PyPy2.7 v6.0.0, or PyPy3.5 v6.0.0 -- see http://www.pypy.org
+- PyPy2.7 or PyPy3.5 v7.1.1 -- see http://www.pypy.org
 
   Aside from ``Bio.trie`` (which does not compile as ``marshal.h`` is
   currently missing under PyPy), everything should work. Older versions


### PR DESCRIPTION
This pull request addresses an issue noted on #2297, we're now downgrading the version of PyPy used on TravisCI.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
