### PR TITLE
Fix bug in _prim() to deal with codons [3 letters]

### DIFF
--- a/Bio/codonalign/codonalignment.py
+++ b/Bio/codonalign/codonalignment.py
@@ -424,7 +424,7 @@ def _prim(G):
         conn[n1].append((c, n1, n2))
         conn[n2].append((c, n2, n1))
     mst = []  # minimum spanning tree
-    used = set(nodes[0])
+    used = set([nodes[0]])
     usable_edges = conn[nodes[0]][:]
     heapify(usable_edges)
     while usable_edges:


### PR DESCRIPTION
Nodes in the graph have names longer than 1.

This pull request addresses issue #...

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [ ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ ] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
