### PR TITLE
Use assertEqual over deprecated assertEquals

### DIFF
--- a/Tests/test_AlignIO.py
+++ b/Tests/test_AlignIO.py
@@ -760,11 +760,11 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_iterator_next_and_list(path, "emboss", 5)
         self.check_iterator_next_for_loop(path, "emboss", 5)
         self.check_read_fails(path, "emboss")
-        self.assertEquals(alignments[0].get_alignment_length(), 145)
-        self.assertEquals(alignments[1].get_alignment_length(), 13)
-        self.assertEquals(alignments[2].get_alignment_length(), 18)
-        self.assertEquals(alignments[3].get_alignment_length(), 10)
-        self.assertEquals(alignments[4].get_alignment_length(), 10)
+        self.assertEqual(alignments[0].get_alignment_length(), 145)
+        self.assertEqual(alignments[1].get_alignment_length(), 13)
+        self.assertEqual(alignments[2].get_alignment_length(), 18)
+        self.assertEqual(alignments[3].get_alignment_length(), 10)
+        self.assertEqual(alignments[4].get_alignment_length(), 10)
         self.check_alignment_rows(
             alignments[0],
             [("HBA_HUMAN", "LSPADKTNVKAAWGKVGAHAGEYGAEALERMFLS...SKY"),

--- a/Tests/test_Entrez_online.py
+++ b/Tests/test_Entrez_online.py
@@ -240,7 +240,7 @@ class EntrezOnlineCase(unittest.TestCase):
         self.assertIn("retmode=xml", url)
         result = handle.read()
         expected_result = "proc natl acad sci u s a|1991|88|3248|mann bj|citation_1|2014248\n"
-        self.assertEquals(result, expected_result)
+        self.assertEqual(result, expected_result)
         handle.close()
 
     def test_efetch_gds_utf8(self):

--- a/Tests/test_MafIO_index.py
+++ b/Tests/test_MafIO_index.py
@@ -135,11 +135,11 @@ if sqlite3:
 
         def test_good_small(self):
             idx = MafIndex(self.tmpfile, "MAF/ucsc_mm9_chr10.maf", "mm9.chr10")
-            self.assertEquals(len(idx), 48)
+            self.assertEqual(len(idx), 48)
 
         def test_good_big(self):
             idx = MafIndex(self.tmpfile, "MAF/ucsc_mm9_chr10_big.maf", "mm9.chr10")
-            self.assertEquals(len(idx), 983)
+            self.assertEqual(len(idx), 983)
 
         def test_bundle_without_target(self):
             self.assertRaises(ValueError,

--- a/Tests/test_cellosaurus.py
+++ b/Tests/test_cellosaurus.py
@@ -16,7 +16,7 @@ class TestCellosaurus(unittest.TestCase):
         """Test read function."""
         handle = open("Cellosaurus/cell_lines_1.txt")
         record = cellosaurus.read(handle)
-        self.assertEquals(record["ID"], "#15310-LN")
+        self.assertEqual(record["ID"], "#15310-LN")
         self.assertEqual(record["AC"], "CVCL_E548")
         self.assertEqual(record["SY"], "15310-LN; TER461")
         self.assertEqual(record["DR"][0], ("dbMHC", "48439"))
@@ -131,7 +131,7 @@ class TestCellosaurus(unittest.TestCase):
             "OX: ['NCBI_TaxID=9925; ! Capra hircus'] HI: [] OI: [] SX:  CA: "
             "Spontaneously immortalized cell line"
         )
-        self.assertEquals(record.__str__(), input)
+        self.assertEqual(record.__str__(), input)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request addresses issue a deprecation warning on Python 3

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
