### PR TITLE
BSD dual license Bio.Phylo

### DIFF
--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2009 by Eric Talevich (eric.talevich@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Base classes for Bio.Phylo objects.
 

--- a/Bio/Phylo/CDAO.py
+++ b/Bio/Phylo/CDAO.py
@@ -1,8 +1,10 @@
 # Copyright (C) 2013 by Ben Morris (ben@bendmorris.com)
 # based on code by Eric Talevich (eric.talevich@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classes corresponding to CDAO trees.
 

--- a/Bio/Phylo/CDAOIO.py
+++ b/Bio/Phylo/CDAOIO.py
@@ -2,9 +2,11 @@
 # Based on Bio.Nexus, copyright 2005-2008 by Frank Kauff & Cymon J. Cox
 # and Bio.Phylo.Newick, copyright 2009 by Eric Talevich.
 # All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """I/O function wrappers for the RDF/CDAO file format.
 

--- a/Bio/Phylo/Consensus.py
+++ b/Bio/Phylo/Consensus.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2013 by Yanbo Ye (yeyanbo289@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classes and methods for finding consensus trees.
 

--- a/Bio/Phylo/NeXML.py
+++ b/Bio/Phylo/NeXML.py
@@ -1,8 +1,9 @@
 # Copyright (C) 2013 Ben Morris (ben@bendmorris.com)
-# based on code by Eric Talevich (eric.talevich@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classes corresponding to NeXML trees.
 

--- a/Bio/Phylo/Newick.py
+++ b/Bio/Phylo/Newick.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2009 by Eric Talevich (eric.talevich@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classes corresponding to Newick trees, also used for Nexus trees.
 

--- a/Bio/Phylo/NewickIO.py
+++ b/Bio/Phylo/NewickIO.py
@@ -1,9 +1,11 @@
 # Copyright (C) 2009 by Eric Talevich (eric.talevich@gmail.com)
 # Based on Bio.Nexus, copyright 2005-2008 by Frank Kauff & Cymon J. Cox.
 # All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """I/O function wrappers for the Newick file format.
 

--- a/Bio/Phylo/NexusIO.py
+++ b/Bio/Phylo/NexusIO.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2009 by Eric Talevich (eric.talevich@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """I/O function wrappers for ``Bio.Nexus`` trees."""
 

--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2009 by Eric Talevich (eric.talevich@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classes corresponding to phyloXML elements.
 

--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2013 by Yanbo Ye (yeyanbo289@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classes and methods for tree construction."""
 

--- a/Bio/Phylo/__init__.py
+++ b/Bio/Phylo/__init__.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2009 by Eric Talevich (eric.talevich@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Package for working with phylogenetic trees.
 
@@ -10,4 +12,4 @@ See Also: http://biopython.org/wiki/Phylo
 """
 
 from Bio.Phylo._io import parse, read, write, convert
-from Bio.Phylo._utils import (draw, draw_ascii, draw_graphviz, to_networkx)
+from Bio.Phylo._utils import draw, draw_ascii, draw_graphviz, to_networkx

--- a/Bio/Phylo/_cdao_owl.py
+++ b/Bio/Phylo/_cdao_owl.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2013 by Ben Morris (ben@bendmorris.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classes to support Comparative Data Analysis Ontology (CDAO)."""
 

--- a/Bio/Phylo/_io.py
+++ b/Bio/Phylo/_io.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2009 by Eric Talevich (eric.talevich@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """I/O function wrappers for phylogenetic tree formats.
 

--- a/Bio/Phylo/_utils.py
+++ b/Bio/Phylo/_utils.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2009 by Eric Talevich (eric.talevich@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Utilities for handling, displaying and exporting Phylo trees.
 


### PR DESCRIPTION
This pull request addresses in part issue #898.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

@etal your eyes on this for would be welcome in case I've missed a contributor, also for the PAML part @brandoninvergo.

The one file this has not yet dual-licensed is ``Bio/Phylo/PAML/chi2.py`` which is based on the PAML source itself (which as far as I can see has not stated license) with permission of the author. Depending exactly what was agreed, this may be fine - could you check your old emails please Brandon:

https://github.com/biopython/biopython/blob/master/Bio/Phylo/PAML/chi2.py

See also #1610 which is about the licensing of another bit of chi2 code in Biopython...