### PR TITLE
move the OverflowError from the doctest to the unittest

### DIFF
--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2184,9 +2184,9 @@ showing an alignment score of 72.0. To see the individual alignments, do
 \end{minted}
 In this example, the total number of optimal alignments is huge (more than $4 \times 10^{37}$), and calling \verb+len(alignments)+ will raise an \verb+OverflowError+:
 
-%cont-doctest
+% don't include in the doctest, as 32-bit system show a different number
 \begin{minted}{pycon}
->>> len(alignments)  #doctest: +ELLIPSIS
+>>> len(alignments)
 Traceback (most recent call last):
 ...
 OverflowError: number of optimal alignments is larger than 9223372036854775807

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -1964,8 +1964,8 @@ class TestOverflowError(unittest.TestCase):
         self.assertIn(str(context_manager.exception),
                       [message % 2147483647,  # on 32-bit systems
                        message % 9223372036854775807,  # on 64-bit systems
-                      ]
-                     )
+                       ]
+                      )
         # confirm that we can still pull out individual alignments
         alignment = alignments[0]
         self.assertEqual(str(alignment), """\


### PR DESCRIPTION
This pull request addresses the issue mentioned in pull request #2297 , i.e. the fact that the OverflowError message is different for 32-bits and 64-bits systems. Remove the doctest from this section, and add a test to the unittest.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
