### PR TITLE
Add missing writing-sequence-files label to docs

### DIFF
--- a/Doc/Tutorial/chapter_seqio.tex
+++ b/Doc/Tutorial/chapter_seqio.tex
@@ -1036,6 +1036,7 @@ formats the length of each record is stored as well as its offset.
 \end{itemize}
 
 \section{Writing Sequence Files}
+\label{sec:writing-sequence-files}
 
 We've talked about using \verb|Bio.SeqIO.parse()| for sequence input (reading files), and now we'll look at \verb|Bio.SeqIO.write()| which is for sequence output (writing files).  This is a function taking three arguments: some \verb|SeqRecord| objects, a handle or filename to write to, and a sequence format.
 


### PR DESCRIPTION
I just looked at the tutorial and found a missing reference '(see Section ??)' [here](http://biopython.org/DIST/docs/tutorial/Tutorial.html#htoc53). This is my fault from #2296. I have tested the fix by rebuilding the docs with `pdflatex` (I should have done this originally of course). Unfortunately I guess this will not be updated until the next release, at least it is a minor thing

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
