### PR TITLE
Apply black style to Bio.SeqUtils

### DIFF
--- a/Bio/SeqUtils/CheckSum.py
+++ b/Bio/SeqUtils/CheckSum.py
@@ -47,10 +47,10 @@ def _init_table_h():
             rflag = part_l & 1
             part_l >>= 1
             if part_h & 1:
-                part_l |= (1 << 31)
+                part_l |= 1 << 31
             part_h >>= 1
             if rflag:
-                part_h ^= 0xd8000000
+                part_h ^= 0xD8000000
         _table_h.append(part_h)
     return _table_h
 
@@ -136,6 +136,7 @@ def seguid(seq):
     """
     import hashlib
     import base64
+
     m = hashlib.sha1()
     try:
         # Assume it's a Seq object
@@ -156,4 +157,5 @@ def seguid(seq):
 
 if __name__ == "__main__":
     from Bio._utils import run_doctest
+
     run_doctest()

--- a/Bio/SeqUtils/CodonUsage.py
+++ b/Bio/SeqUtils/CodonUsage.py
@@ -51,7 +51,8 @@ SynonymousCodons = {
     "TRP": ["TGG"],
     "VAL": ["GTA", "GTC", "GTG", "GTT"],
     "GLU": ["GAG", "GAA"],
-    "TYR": ["TAT", "TAC"]}
+    "TYR": ["TAT", "TAC"],
+}
 
 
 class CodonAdaptationIndex(object):
@@ -89,8 +90,10 @@ class CodonAdaptationIndex(object):
         """
         # first make sure we're not overwriting an existing index:
         if self.index != {} or self.codon_count != {}:
-            raise ValueError("an index has already been set or a codon count "
-                             "has been done. Cannot overwrite either.")
+            raise ValueError(
+                "an index has already been set or a codon count "
+                "has been done. Cannot overwrite either."
+            )
 
         # count codon occurrences in the file.
         self._count_codons(fasta_file)
@@ -134,7 +137,7 @@ class CodonAdaptationIndex(object):
             dna_sequence = dna_sequence.upper()
 
         for i in range(0, len(dna_sequence), 3):
-            codon = dna_sequence[i:i + 3]
+            codon = dna_sequence[i : i + 3]
             if codon in self.index:
                 # these two codons are always one, exclude them:
                 if codon not in ["ATG", "TGG"]:
@@ -142,8 +145,9 @@ class CodonAdaptationIndex(object):
                     cai_length += 1
             # some indices may not include stop codons:
             elif codon not in ["TGA", "TAA", "TAG"]:
-                raise TypeError("illegal codon in sequence: %s.\n%s"
-                                % (codon, self.index))
+                raise TypeError(
+                    "illegal codon in sequence: %s.\n%s" % (codon, self.index)
+                )
 
         return math.exp(cai_value / (cai_length - 1.0))
 
@@ -161,12 +165,13 @@ class CodonAdaptationIndex(object):
                 else:
                     dna_sequence = str(cur_record.seq)
                 for i in range(0, len(dna_sequence), 3):
-                    codon = dna_sequence[i:i + 3]
+                    codon = dna_sequence[i : i + 3]
                     if codon in self.codon_count:
                         self.codon_count[codon] += 1
                     else:
-                        raise TypeError("illegal codon %s in gene: %s"
-                                        % (codon, cur_record.id))
+                        raise TypeError(
+                            "illegal codon %s in gene: %s" % (codon, cur_record.id)
+                        )
 
     def print_index(self):
         """Print out the index used.

--- a/Bio/SeqUtils/CodonUsage.py
+++ b/Bio/SeqUtils/CodonUsage.py
@@ -12,21 +12,29 @@ import math
 from .CodonUsageIndices import SharpEcoliIndex
 from Bio import SeqIO  # To parse a FASTA file
 
+# Turn black code style off
+# fmt: off
 
 CodonsDict = {
-    "TTT": 0, "TTC": 0, "TTA": 0, "TTG": 0, "CTT": 0,
-    "CTC": 0, "CTA": 0, "CTG": 0, "ATT": 0, "ATC": 0,
-    "ATA": 0, "ATG": 0, "GTT": 0, "GTC": 0, "GTA": 0,
-    "GTG": 0, "TAT": 0, "TAC": 0, "TAA": 0, "TAG": 0,
-    "CAT": 0, "CAC": 0, "CAA": 0, "CAG": 0, "AAT": 0,
-    "AAC": 0, "AAA": 0, "AAG": 0, "GAT": 0, "GAC": 0,
-    "GAA": 0, "GAG": 0, "TCT": 0, "TCC": 0, "TCA": 0,
-    "TCG": 0, "CCT": 0, "CCC": 0, "CCA": 0, "CCG": 0,
-    "ACT": 0, "ACC": 0, "ACA": 0, "ACG": 0, "GCT": 0,
-    "GCC": 0, "GCA": 0, "GCG": 0, "TGT": 0, "TGC": 0,
-    "TGA": 0, "TGG": 0, "CGT": 0, "CGC": 0, "CGA": 0,
-    "CGG": 0, "AGT": 0, "AGC": 0, "AGA": 0, "AGG": 0,
+    "TTT": 0, "TTC": 0, "TTA": 0, "TTG": 0,
+    "CTT": 0, "CTC": 0, "CTA": 0, "CTG": 0,
+    "ATT": 0, "ATC": 0, "ATA": 0, "ATG": 0,
+    "GTT": 0, "GTC": 0, "GTA": 0, "GTG": 0,
+    "TAT": 0, "TAC": 0, "TAA": 0, "TAG": 0,
+    "CAT": 0, "CAC": 0, "CAA": 0, "CAG": 0,
+    "AAT": 0, "AAC": 0, "AAA": 0, "AAG": 0,
+    "GAT": 0, "GAC": 0, "GAA": 0, "GAG": 0,
+    "TCT": 0, "TCC": 0, "TCA": 0, "TCG": 0,
+    "CCT": 0, "CCC": 0, "CCA": 0, "CCG": 0,
+    "ACT": 0, "ACC": 0, "ACA": 0, "ACG": 0,
+    "GCT": 0, "GCC": 0, "GCA": 0, "GCG": 0,
+    "TGT": 0, "TGC": 0, "TGA": 0, "TGG": 0,
+    "CGT": 0, "CGC": 0, "CGA": 0, "CGG": 0,
+    "AGT": 0, "AGC": 0, "AGA": 0, "AGG": 0,
     "GGT": 0, "GGC": 0, "GGA": 0, "GGG": 0}
+
+# Turn black code style on
+# fmt: on
 
 
 # this dictionary shows which codons encode the same AA

--- a/Bio/SeqUtils/CodonUsageIndices.py
+++ b/Bio/SeqUtils/CodonUsageIndices.py
@@ -8,7 +8,8 @@
 Currently this module only defines a single codon adaption index from
 Sharp & Li, Nucleic Acids Res. 1987.
 """
-
+# Turn black code style off
+# fmt: off
 
 SharpEcoliIndex = {
     "GCA": 0.586, "GCC": 0.122, "GCG": 0.424, "GCT": 1, "AGA": 0.004,
@@ -22,3 +23,6 @@ SharpEcoliIndex = {
     "AGT": 0.085, "TCA": 0.077, "TCC": 0.744, "TCG": 0.017, "TCT": 1,
     "ACA": 0.076, "ACC": 1, "ACG": 0.099, "ACT": 0.965, "TGG": 1, "TAC": 1,
     "TAT": 0.239, "GTA": 0.495, "GTC": 0.066, "GTG": 0.221, "GTT": 1}
+
+# Turn black code style on
+# fmt: on

--- a/Bio/SeqUtils/IsoelectricPoint.py
+++ b/Bio/SeqUtils/IsoelectricPoint.py
@@ -80,6 +80,7 @@ class IsoelectricPoint(object):
         self.sequence = str(protein_sequence).upper()
         if not aa_content:
             from Bio.SeqUtils.ProtParam import ProteinAnalysis as _PA
+
             aa_content = _PA(self.sequence).count_amino_acids()
         self.charged_aas_content = self._select_charged(aa_content)
 

--- a/Bio/SeqUtils/IsoelectricPoint.py
+++ b/Bio/SeqUtils/IsoelectricPoint.py
@@ -25,8 +25,15 @@ http://fields.scripps.edu/DTASelect/20010710-pI-Algorithm.pdf
 positive_pKs = {"Nterm": 7.5, "K": 10.0, "R": 12.0, "H": 5.98}
 negative_pKs = {"Cterm": 3.55, "D": 4.05, "E": 4.45, "C": 9.0, "Y": 10.0}
 pKcterminal = {"D": 4.55, "E": 4.75}
-pKnterminal = {"A": 7.59, "M": 7.0, "S": 6.93, "P": 8.36, "T": 6.82, "V": 7.44,
-               "E": 7.7}
+pKnterminal = {
+    "A": 7.59,
+    "M": 7.0,
+    "S": 6.93,
+    "P": 8.36,
+    "T": 6.82,
+    "V": 7.44,
+    "E": 7.7,
+}
 charged_aas = ("K", "R", "H", "D", "E", "C", "Y")
 
 

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -565,11 +565,12 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
         corr = 11.7 * math.log10(mon)
     if method == 5:
         corr = 0.368 * (len(seq) - 1) * math.log(mon)
+    if method == 6:
+        corr = (
+            (4.29 * SeqUtils.GC(seq) / 100 - 3.95) * 1e-5 * math.log(mon)
+        ) + 9.40e-6 * math.log(mon) ** 2
     # Turn black code style off
     # fmt: off
-    if method == 6:
-        corr = (4.29 * SeqUtils.GC(seq) / 100 - 3.95) * 1e-5 * math.log(mon) +\
-            9.40e-6 * math.log(mon) ** 2
     if method == 7:
         a, b, c, d = 3.92, -0.911, 6.26, 1.42
         e, f, g = -48.2, 52.5, 8.31

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -570,11 +570,7 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
     if method == 6:
         corr = (4.29 * SeqUtils.GC(seq) / 100 - 3.95) * 1e-5 * math.log(mon) +\
             9.40e-6 * math.log(mon) ** 2
-    # Turn black code style on
-    # fmt: on
     if method == 7:
-        # Turn black code style off
-        # fmt: off
         a, b, c, d = 3.92, -0.911, 6.26, 1.42
         e, f, g = -48.2, 52.5, 8.31
         if dNTPs > 0:
@@ -599,8 +595,8 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
         corr = (a + b * math.log(mg) + (SeqUtils.GC(seq) / 100) *
                 (c + d * math.log(mg)) + (1 / (2.0 * (len(seq) - 1))) *
                 (e + f * math.log(mg) + g * math.log(mg) ** 2)) * 1e-5
-        # Turn black code style on
-        # fmt: on
+    # Turn black code style on
+    # fmt: on
     if method > 7:
         raise ValueError("Allowed values for parameter 'method' are 1-7.")
     return corr

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -180,6 +180,9 @@ from Bio import BiopythonWarning
 # duplex sequence (e.g., GT/CA, to read 5'GT3'-3'CA5'). The values are tuples
 # of dH (kcal/mol), dS (cal/mol K).
 
+# Turn black code style off
+# fmt: off
+
 # DNA/DNA
 # Breslauer et al. (1986), Proc Natl Acad Sci USA 83: 3746-3750
 DNA_NN1 = {
@@ -381,6 +384,9 @@ RNA_DE1 = {
     "AG/.T": (1.6, 6.1), "CG/.T": (2.2, 8.1), "GG/.T": (0.7, 3.5),
     "TG/.T": (3.1, 10.6)}
 
+# Turn black code style on
+# fmt: on
+
 
 def make_table(oldtable=None, values=None):
     """Return a table with thermodynamic parameters (as dictionary).
@@ -404,12 +410,25 @@ def make_table(oldtable=None, values=None):
 
     """
     if oldtable is None:
-        table = {"init": (0, 0), "init_A/T": (0, 0), "init_G/C": (0, 0),
-                 "init_oneG/C": (0, 0), "init_allA/T": (0, 0),
-                 "init_5T/A": (0, 0), "sym": (0, 0), "AA/TT": (0, 0),
-                 "AT/TA": (0, 0), "TA/AT": (0, 0), "CA/GT": (0, 0),
-                 "GT/CA": (0, 0), "CT/GA": (0, 0), "GA/CT": (0, 0),
-                 "CG/GC": (0, 0), "GC/CG": (0, 0), "GG/CC": (0, 0)}
+        table = {
+            "init": (0, 0),
+            "init_A/T": (0, 0),
+            "init_G/C": (0, 0),
+            "init_oneG/C": (0, 0),
+            "init_allA/T": (0, 0),
+            "init_5T/A": (0, 0),
+            "sym": (0, 0),
+            "AA/TT": (0, 0),
+            "AT/TA": (0, 0),
+            "TA/AT": (0, 0),
+            "CA/GT": (0, 0),
+            "GT/CA": (0, 0),
+            "CT/GA": (0, 0),
+            "GA/CT": (0, 0),
+            "CG/GC": (0, 0),
+            "GC/CG": (0, 0),
+            "GG/CC": (0, 0),
+        }
     else:
         table = oldtable.copy()
     if values:
@@ -440,8 +459,25 @@ def _check(seq, method):
     if method == "Tm_Wallace":
         return seq
     if method == "Tm_GC":
-        baseset = ("A", "B", "C", "D", "G", "H", "I", "K", "M", "N", "R", "S",
-                   "T", "V", "W", "X", "Y")
+        baseset = (
+            "A",
+            "B",
+            "C",
+            "D",
+            "G",
+            "H",
+            "I",
+            "K",
+            "M",
+            "N",
+            "R",
+            "S",
+            "T",
+            "V",
+            "W",
+            "X",
+            "Y",
+        )
     if method == "Tm_NN":
         baseset = ("A", "C", "G", "T", "I")
     seq = "".join([base for base in seq if base in baseset])
@@ -672,8 +708,20 @@ def Tm_Wallace(seq, check=True, strict=True):
     return melting_temp
 
 
-def Tm_GC(seq, check=True, strict=True, valueset=7, userset=None, Na=50, K=0,
-          Tris=0, Mg=0, dNTPs=0, saltcorr=0, mismatch=True):
+def Tm_GC(
+    seq,
+    check=True,
+    strict=True,
+    valueset=7,
+    userset=None,
+    Na=50,
+    K=0,
+    Tris=0,
+    Mg=0,
+    dNTPs=0,
+    saltcorr=0,
+    mismatch=True,
+):
     """Return the Tm using empirical formulas based on GC content.
 
     General format: Tm = A + B(%GC) - C/N + salt correction - D(%mismatch)
@@ -799,10 +847,26 @@ def _key_error(neighbors, strict):
         )
 
 
-def Tm_NN(seq, check=True, strict=True, c_seq=None, shift=0,
-          nn_table=None, tmm_table=None, imm_table=None, de_table=None,
-          dnac1=25, dnac2=25, selfcomp=False, Na=50, K=0, Tris=0, Mg=0,
-          dNTPs=0, saltcorr=5):
+def Tm_NN(
+    seq,
+    check=True,
+    strict=True,
+    c_seq=None,
+    shift=0,
+    nn_table=None,
+    tmm_table=None,
+    imm_table=None,
+    de_table=None,
+    dnac1=25,
+    dnac2=25,
+    selfcomp=False,
+    Na=50,
+    K=0,
+    Tris=0,
+    Mg=0,
+    dNTPs=0,
+    saltcorr=5,
+):
     """Return the Tm using nearest neighbor thermodynamics.
 
     Arguments:

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -498,15 +498,17 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
 
     """
     if method in (5, 6, 7) and not seq:
-        raise ValueError("sequence is missing (is needed to calculate " +
-                         "GC content or sequence length).")
+        raise ValueError(
+            "sequence is missing (is needed to calculate "
+            + "GC content or sequence length)."
+        )
     if seq:
         seq = str(seq)
     corr = 0
     if not method:
         return corr
     Mon = Na + K + Tris / 2.0  # Note: all these values are millimolar
-    mg = Mg * 1e-3             # Lowercase ions (mg, mon, dntps) are molar
+    mg = Mg * 1e-3  # Lowercase ions (mg, mon, dntps) are molar
     # Na equivalent according to von Ahsen et al. (2001):
     if sum((K, Mg, Tris, dNTPs)) > 0 and not method == 7 and dNTPs < Mg:
         # dNTPs bind Mg2+ strongly. If [dNTPs] is larger or equal than
@@ -515,8 +517,9 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
     mon = Mon * 1e-3
     # Note: math.log = ln(), math.log10 = log()
     if method in range(1, 7) and not mon:
-        raise ValueError("Total ion concentration of zero is not allowed in " +
-                         "this method.")
+        raise ValueError(
+            "Total ion concentration of zero is not allowed in " + "this method."
+        )
     if method == 1:
         corr = 16.6 * math.log10(mon)
     if method == 2:
@@ -528,8 +531,9 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
     if method == 5:
         corr = 0.368 * (len(seq) - 1) * math.log(mon)
     if method == 6:
-        corr = (4.29 * SeqUtils.GC(seq) / 100 - 3.95) * 1e-5 * math.log(mon) +\
-            9.40e-6 * math.log(mon) ** 2
+        corr = (4.29 * SeqUtils.GC(seq) / 100 - 3.95) * 1e-5 * math.log(
+            mon
+        ) + 9.40e-6 * math.log(mon) ** 2
     if method == 7:
         a, b, c, d = 3.92, -0.911, 6.26, 1.42
         e, f, g = -48.2, 52.5, 8.31
@@ -537,31 +541,40 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
             dntps = dNTPs * 1e-3
             ka = 3e4  # Dissociation constant for Mg:dNTP
             # Free Mg2+ calculation:
-            mg = (-(ka * dntps - ka * mg + 1.0) +
-                  math.sqrt((ka * dntps - ka * mg + 1.0) ** 2 +
-                            4.0 * ka * mg)) / (2.0 * ka)
+            mg = (
+                -(ka * dntps - ka * mg + 1.0)
+                + math.sqrt((ka * dntps - ka * mg + 1.0) ** 2 + 4.0 * ka * mg)
+            ) / (2.0 * ka)
         if Mon > 0:
             R = math.sqrt(mg) / mon
             if R < 0.22:
-                corr = (4.29 * SeqUtils.GC(seq) / 100 - 3.95) * \
-                    1e-5 * math.log(mon) + 9.40e-6 * math.log(mon) ** 2
+                corr = (4.29 * SeqUtils.GC(seq) / 100 - 3.95) * 1e-5 * math.log(
+                    mon
+                ) + 9.40e-6 * math.log(mon) ** 2
                 return corr
             elif R < 6.0:
                 a = 3.92 * (0.843 - 0.352 * math.sqrt(mon) * math.log(mon))
-                d = 1.42 * (1.279 - 4.03e-3 * math.log(mon) -
-                            8.03e-3 * math.log(mon) ** 2)
-                g = 8.31 * (0.486 - 0.258 * math.log(mon) +
-                            5.25e-3 * math.log(mon) ** 3)
-        corr = (a + b * math.log(mg) + (SeqUtils.GC(seq) / 100) *
-                (c + d * math.log(mg)) + (1 / (2.0 * (len(seq) - 1))) *
-                (e + f * math.log(mg) + g * math.log(mg) ** 2)) * 1e-5
+                d = 1.42 * (
+                    1.279 - 4.03e-3 * math.log(mon) - 8.03e-3 * math.log(mon) ** 2
+                )
+                g = 8.31 * (
+                    0.486 - 0.258 * math.log(mon) + 5.25e-3 * math.log(mon) ** 3
+                )
+        corr = (
+            a
+            + b * math.log(mg)
+            + (SeqUtils.GC(seq) / 100) * (c + d * math.log(mg))
+            + (1 / (2.0 * (len(seq) - 1)))
+            * (e + f * math.log(mg) + g * math.log(mg) ** 2)
+        ) * 1e-5
     if method > 7:
         raise ValueError("Allowed values for parameter 'method' are 1-7.")
     return corr
 
 
-def chem_correction(melting_temp, DMSO=0, fmd=0, DMSOfactor=0.75,
-                    fmdfactor=0.65, fmdmethod=1, GC=None):
+def chem_correction(
+    melting_temp, DMSO=0, fmd=0, DMSOfactor=0.75, fmdfactor=0.65, fmdmethod=1, GC=None
+):
     """Correct a given Tm for DMSO and formamide.
 
     Please note that these corrections are +/- rough approximations.
@@ -640,16 +653,20 @@ def Tm_Wallace(seq, check=True, strict=True):
     if check:
         seq = _check(seq, "Tm_Wallace")
 
-    melting_temp = 2 * (sum(map(seq.count, ("A", "T", "W")))) + \
-        4 * (sum(map(seq.count, ("C", "G", "S"))))
+    melting_temp = 2 * (sum(map(seq.count, ("A", "T", "W")))) + 4 * (
+        sum(map(seq.count, ("C", "G", "S")))
+    )
 
     # Intermediate values for ambiguous positions:
-    tmp = 3 * (sum(map(seq.count, ("K", "M", "N", "R", "Y")))) + \
-        10 / 3.0 * (sum(map(seq.count, ("B", "V")))) + \
-        8 / 3.0 * (sum(map(seq.count, ("D", "H"))))
+    tmp = (
+        3 * (sum(map(seq.count, ("K", "M", "N", "R", "Y"))))
+        + 10 / 3.0 * (sum(map(seq.count, ("B", "V"))))
+        + 8 / 3.0 * (sum(map(seq.count, ("D", "H"))))
+    )
     if strict and tmp:
-        raise ValueError("ambiguous bases B, D, H, K, M, N, R, V, Y not " +
-                         "allowed when strict=True")
+        raise ValueError(
+            "ambiguous bases B, D, H, K, M, N, R, V, Y not allowed when strict=True"
+        )
     else:
         melting_temp += tmp
     return melting_temp
@@ -712,19 +729,21 @@ def Tm_GC(seq, check=True, strict=True, valueset=7, userset=None, Na=50, K=0,
 
     """
     if saltcorr == 5:
-        raise ValueError("salt-correction method 5 not applicable "
-                         "to Tm_GC")
+        raise ValueError("salt-correction method 5 not applicable " "to Tm_GC")
     seq = str(seq)
     if check:
         seq = _check(seq, "Tm_GC")
     percent_gc = SeqUtils.GC(seq)
     # Ambiguous bases: add 0.5, 0.67 or 0.33% depending on G+C probability:
-    tmp = sum(map(seq.count, ("K", "M", "N", "R", "Y"))) * 50.0 / len(seq) + \
-        sum(map(seq.count, ("B", "V"))) * 66.67 / len(seq) + \
-        sum(map(seq.count, ("D", "H"))) * 33.33 / len(seq)
+    tmp = (
+        sum(map(seq.count, ("K", "M", "N", "R", "Y"))) * 50.0 / len(seq)
+        + sum(map(seq.count, ("B", "V"))) * 66.67 / len(seq)
+        + sum(map(seq.count, ("D", "H"))) * 33.33 / len(seq)
+    )
     if strict and tmp:
-        raise ValueError("ambiguous bases B, D, H, K, M, N, R, V, Y not "
-                         "allowed when 'strict=True'")
+        raise ValueError(
+            "ambiguous bases B, D, H, K, M, N, R, V, Y not allowed when 'strict=True'"
+        )
     else:
         percent_gc += tmp
     if userset:
@@ -759,8 +778,9 @@ def Tm_GC(seq, check=True, strict=True, valueset=7, userset=None, Na=50, K=0,
 
     melting_temp = A + B * percent_gc - C / (len(seq) * 1.0)
     if saltcorr:
-        melting_temp += salt_correction(Na=Na, K=K, Tris=Tris, Mg=Mg,
-                                        dNTPs=dNTPs, seq=seq, method=saltcorr)
+        melting_temp += salt_correction(
+            Na=Na, K=K, Tris=Tris, Mg=Mg, dNTPs=dNTPs, seq=seq, method=saltcorr
+        )
     if mismatch:
         melting_temp -= D * (seq.count("X") * 100.0 / len(seq))
     return melting_temp
@@ -770,12 +790,13 @@ def _key_error(neighbors, strict):
     """Throw an error or a warning if there is no data for the neighbors (PRIVATE)."""
     # We haven't found the key in the tables
     if strict:
-        raise ValueError("no thermodynamic data for neighbors %r available"
-                         % neighbors)
+        raise ValueError("no thermodynamic data for neighbors %r available" % neighbors)
     else:
-        warnings.warn("no themodynamic data for neighbors %r available. "
-                      "Calculation will be wrong" % neighbors,
-                      BiopythonWarning)
+        warnings.warn(
+            "no themodynamic data for neighbors %r available. "
+            "Calculation will be wrong" % neighbors,
+            BiopythonWarning,
+        )
 
 
 def Tm_NN(seq, check=True, strict=True, c_seq=None, shift=0,
@@ -961,8 +982,11 @@ def Tm_NN(seq, check=True, strict=True, c_seq=None, shift=0,
 
     # Finally, the 'zipping'
     for basenumber in range(len(tmp_seq) - 1):
-        neighbors = tmp_seq[basenumber:basenumber + 2] + "/" + \
-            tmp_cseq[basenumber:basenumber + 2]
+        neighbors = (
+            tmp_seq[basenumber : basenumber + 2]
+            + "/"
+            + tmp_cseq[basenumber : basenumber + 2]
+        )
         if neighbors in imm_table:
             delta_h += imm_table[neighbors][d_h]
             delta_s += imm_table[neighbors][d_s]
@@ -986,8 +1010,9 @@ def Tm_NN(seq, check=True, strict=True, c_seq=None, shift=0,
         delta_s += nn_table["sym"][d_s]
     R = 1.987  # universal gas constant in Cal/degrees C*Mol
     if saltcorr:
-        corr = salt_correction(Na=Na, K=K, Tris=Tris, Mg=Mg, dNTPs=dNTPs,
-                               method=saltcorr, seq=seq)
+        corr = salt_correction(
+            Na=Na, K=K, Tris=Tris, Mg=Mg, dNTPs=dNTPs, method=saltcorr, seq=seq
+        )
     if saltcorr == 5:
         delta_s += corr
     melting_temp = (1000 * delta_h) / (delta_s + (R * (math.log(k)))) - 273.15
@@ -995,7 +1020,7 @@ def Tm_NN(seq, check=True, strict=True, c_seq=None, shift=0,
         melting_temp += corr
     if saltcorr in (6, 7):
         # Tm = 1/(1/Tm + corr)
-        melting_temp = (1 / (1 / (melting_temp + 273.15) + corr) - 273.15)
+        melting_temp = 1 / (1 / (melting_temp + 273.15) + corr) - 273.15
 
     return melting_temp
 
@@ -1035,17 +1060,19 @@ def Tm_staluc(s, dnac=50, saltc=50, rna=0):
     # Original method was by Sebastian Bassi <sbassi@genesdigitales.com>. It is
     # now superseded by Tm_NN.
 
-    warnings.warn("Tm_staluc may be depreciated in the future. Use Tm_NN " +
-                  "instead.", PendingDeprecationWarning)
+    warnings.warn(
+        "Tm_staluc may be depreciated in the future. Use Tm_NN " + "instead.",
+        PendingDeprecationWarning,
+    )
     if not rna:
         return Tm_NN(s, dnac1=dnac / 2.0, dnac2=dnac / 2.0, Na=saltc)
     elif rna == 1:
-        return Tm_NN(s, dnac1=dnac / 2.0, dnac2=dnac / 2.0, Na=saltc,
-                     nn_table=RNA_NN2)
+        return Tm_NN(s, dnac1=dnac / 2.0, dnac2=dnac / 2.0, Na=saltc, nn_table=RNA_NN2)
     else:
         raise ValueError("rna={0} not supported".format(rna))
 
 
 if __name__ == "__main__":
     from Bio._utils import run_doctest
+
     run_doctest()

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -535,8 +535,7 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
     """
     if method in (5, 6, 7) and not seq:
         raise ValueError(
-            "sequence is missing (is needed to calculate "
-            + "GC content or sequence length)."
+            "sequence is missing (is needed to calculate GC content or sequence length)."
         )
     if seq:
         seq = str(seq)
@@ -554,7 +553,7 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
     # Note: math.log = ln(), math.log10 = log()
     if method in range(1, 7) and not mon:
         raise ValueError(
-            "Total ion concentration of zero is not allowed in " + "this method."
+            "Total ion concentration of zero is not allowed in this method."
         )
     if method == 1:
         corr = 16.6 * math.log10(mon)
@@ -566,43 +565,42 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
         corr = 11.7 * math.log10(mon)
     if method == 5:
         corr = 0.368 * (len(seq) - 1) * math.log(mon)
+    # Turn black code style off
+    # fmt: off
     if method == 6:
-        corr = (4.29 * SeqUtils.GC(seq) / 100 - 3.95) * 1e-5 * math.log(
-            mon
-        ) + 9.40e-6 * math.log(mon) ** 2
+        corr = (4.29 * SeqUtils.GC(seq) / 100 - 3.95) * 1e-5 * math.log(mon) +\
+            9.40e-6 * math.log(mon) ** 2
+    # Turn black code style on
+    # fmt: on
     if method == 7:
+        # Turn black code style off
+        # fmt: off
         a, b, c, d = 3.92, -0.911, 6.26, 1.42
         e, f, g = -48.2, 52.5, 8.31
         if dNTPs > 0:
             dntps = dNTPs * 1e-3
             ka = 3e4  # Dissociation constant for Mg:dNTP
             # Free Mg2+ calculation:
-            mg = (
-                -(ka * dntps - ka * mg + 1.0)
-                + math.sqrt((ka * dntps - ka * mg + 1.0) ** 2 + 4.0 * ka * mg)
-            ) / (2.0 * ka)
+            mg = (-(ka * dntps - ka * mg + 1.0) +
+                  math.sqrt((ka * dntps - ka * mg + 1.0) ** 2 +
+                            4.0 * ka * mg)) / (2.0 * ka)
         if Mon > 0:
             R = math.sqrt(mg) / mon
             if R < 0.22:
-                corr = (4.29 * SeqUtils.GC(seq) / 100 - 3.95) * 1e-5 * math.log(
-                    mon
-                ) + 9.40e-6 * math.log(mon) ** 2
+                corr = (4.29 * SeqUtils.GC(seq) / 100 - 3.95) * \
+                    1e-5 * math.log(mon) + 9.40e-6 * math.log(mon) ** 2
                 return corr
             elif R < 6.0:
                 a = 3.92 * (0.843 - 0.352 * math.sqrt(mon) * math.log(mon))
-                d = 1.42 * (
-                    1.279 - 4.03e-3 * math.log(mon) - 8.03e-3 * math.log(mon) ** 2
-                )
-                g = 8.31 * (
-                    0.486 - 0.258 * math.log(mon) + 5.25e-3 * math.log(mon) ** 3
-                )
-        corr = (
-            a
-            + b * math.log(mg)
-            + (SeqUtils.GC(seq) / 100) * (c + d * math.log(mg))
-            + (1 / (2.0 * (len(seq) - 1)))
-            * (e + f * math.log(mg) + g * math.log(mg) ** 2)
-        ) * 1e-5
+                d = 1.42 * (1.279 - 4.03e-3 * math.log(mon) -
+                            8.03e-3 * math.log(mon) ** 2)
+                g = 8.31 * (0.486 - 0.258 * math.log(mon) +
+                            5.25e-3 * math.log(mon) ** 3)
+        corr = (a + b * math.log(mg) + (SeqUtils.GC(seq) / 100) *
+                (c + d * math.log(mg)) + (1 / (2.0 * (len(seq) - 1))) *
+                (e + f * math.log(mg) + g * math.log(mg) ** 2)) * 1e-5
+        # Turn black code style on
+        # fmt: on
     if method > 7:
         raise ValueError("Allowed values for parameter 'method' are 1-7.")
     return corr
@@ -777,7 +775,7 @@ def Tm_GC(
 
     """
     if saltcorr == 5:
-        raise ValueError("salt-correction method 5 not applicable " "to Tm_GC")
+        raise ValueError("salt-correction method 5 not applicable to Tm_GC")
     seq = str(seq)
     if check:
         seq = _check(seq, "Tm_GC")
@@ -1125,7 +1123,7 @@ def Tm_staluc(s, dnac=50, saltc=50, rna=0):
     # now superseded by Tm_NN.
 
     warnings.warn(
-        "Tm_staluc may be depreciated in the future. Use Tm_NN " + "instead.",
+        "Tm_staluc may be depreciated in the future. Use Tm_NN instead.",
         PendingDeprecationWarning,
     )
     if not rna:

--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -155,7 +155,7 @@ class ProteinAnalysis(object):
         score = 0.0
 
         for i in range(self.length - 1):
-            this, next = self.sequence[i:i + 2]
+            this, next = self.sequence[i : i + 2]
             dipeptide_value = index[this][next]
             score += dipeptide_value
 
@@ -174,14 +174,13 @@ class ProteinAnalysis(object):
         scores = []
 
         for i in range(self.length - window_size):
-            subsequence = self.sequence[i:i + window_size]
+            subsequence = self.sequence[i : i + window_size]
             score = 0.0
 
             for j in range(window_size // 2):
                 front = subsequence[j]
                 back = subsequence[window_size - j - 1]
-                score += (flexibilities[front] +
-                          flexibilities[back]) * weights[j]
+                score += (flexibilities[front] + flexibilities[back]) * weights[j]
 
             middle = subsequence[window_size // 2 + 1]
             score += flexibilities[middle]
@@ -258,7 +257,7 @@ class ProteinAnalysis(object):
         sum_of_weights = sum(weights) * 2 + 1
 
         for i in range(self.length - window + 1):
-            subsequence = self.sequence[i:i + window]
+            subsequence = self.sequence[i : i + window]
             score = 0.0
 
             for j in range(window // 2):
@@ -270,18 +269,19 @@ class ProteinAnalysis(object):
                     back = param_dict[subsequence[window - j - 1]]
                     score += weights[j] * front + weights[j] * back
                 except KeyError:
-                    sys.stderr.write("warning: %s or %s is not a standard "
-                                     "amino acid.\n"
-                                     % (subsequence[j],
-                                        subsequence[window - j - 1]))
+                    sys.stderr.write(
+                        "warning: %s or %s is not a standard "
+                        "amino acid.\n" % (subsequence[j], subsequence[window - j - 1])
+                    )
 
             # Now add the middle value, which always has a weight of 1.
             middle = subsequence[window // 2]
             if middle in param_dict:
                 score += param_dict[middle]
             else:
-                sys.stderr.write("warning: %s  is not a standard amino acid.\n"
-                                 % middle)
+                sys.stderr.write(
+                    "warning: %s  is not a standard amino acid.\n" % middle
+                )
 
             scores.append(score / sum_of_weights)
 
@@ -332,9 +332,10 @@ class ProteinAnalysis(object):
         num_aa = self.count_amino_acids()
         mec_reduced = num_aa["W"] * 5500 + num_aa["Y"] * 1490
         mec_cystines = mec_reduced + (num_aa["C"] // 2) * 125
-        return(mec_reduced, mec_cystines)
+        return (mec_reduced, mec_cystines)
 
 
 if __name__ == "__main__":
     from Bio._utils import run_doctest
+
     run_doctest()

--- a/Bio/SeqUtils/ProtParamData.py
+++ b/Bio/SeqUtils/ProtParamData.py
@@ -5,6 +5,8 @@
 # package.
 """Indices to be used with ProtParam."""
 
+# Turn black code style off
+# fmt: off
 
 # Kyte & Doolittle index of hydrophobicity
 # J. Mol. Biol. 157:105-132(1982).
@@ -151,3 +153,6 @@ DIWV = {"A": {"A": 1.0, "C": 44.94, "E": 1.0, "D": -7.49,
               "Q": 1.0, "P": 13.34, "S": 1.0, "R": -15.91,
               "T": -7.49, "W": -9.37, "V": 1.0, "Y": 13.34},
         }
+
+# Turn black code style on
+# fmt: on

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -63,7 +63,7 @@ def GC123(seq):
         d[nt] = [0, 0, 0]
 
     for i in range(0, len(seq), 3):
-        codon = seq[i:i + 3]
+        codon = seq[i : i + 3]
         if len(codon) < 3:
             codon += "  "
         for pos in range(0, 3):
@@ -100,7 +100,7 @@ def GC_skew(seq, window=100):
     # 8/19/03: Iddo: added lowercase
     values = []
     for i in range(0, len(seq), window):
-        s = seq[i: i + window]
+        s = seq[i : i + window]
         g = s.count("G") + s.count("g")
         c = s.count("C") + s.count("c")
         try:
@@ -120,8 +120,9 @@ def xGC_skew(seq, window=1000, zoom=100, r=300, px=100, py=100):
 
     yscroll = tkinter.Scrollbar(orient=tkinter.VERTICAL)
     xscroll = tkinter.Scrollbar(orient=tkinter.HORIZONTAL)
-    canvas = tkinter.Canvas(yscrollcommand=yscroll.set,
-                            xscrollcommand=xscroll.set, background="white")
+    canvas = tkinter.Canvas(
+        yscrollcommand=yscroll.set, xscrollcommand=xscroll.set, background="white"
+    )
     win = canvas.winfo_toplevel()
     win.geometry("700x700")
 
@@ -136,8 +137,7 @@ def xGC_skew(seq, window=1000, zoom=100, r=300, px=100, py=100):
     x1, x2, y1, y2 = X0 - r, X0 + r, Y0 - r, Y0 + r
 
     ty = Y0
-    canvas.create_text(X0, ty, text="%s...%s (%d nt)" % (seq[:7],
-                                                         seq[-7:], len(seq)))
+    canvas.create_text(X0, ty, text="%s...%s (%d nt)" % (seq[:7], seq[-7:], len(seq)))
     ty += 20
     canvas.create_text(X0, ty, text="GC %3.2f%%" % (GC(seq)))
     ty += 20
@@ -250,8 +250,9 @@ def seq3(seq, custom_map=None, undef_code="Xaa"):
         custom_map = {"*": "Ter"}
     # not doing .update() on IUPACData dict with custom_map dict
     # to preserve its initial state (may be imported in other modules)
-    threecode = dict(list(IUPACData.protein_letters_1to3_extended.items()) +
-                     list(custom_map.items()))
+    threecode = dict(
+        list(IUPACData.protein_letters_1to3_extended.items()) + list(custom_map.items())
+    )
     # We use a default of 'Xaa' for undefined letters
     # Note this will map '-' to 'Xaa' which may be undesirable!
     return "".join(threecode.get(aa, undef_code) for aa in seq)
@@ -305,11 +306,10 @@ def seq1(seq, custom_map=None, undef_code="X"):
         custom_map = {"Ter": "*"}
     # reverse map of threecode
     # upper() on all keys to enable caps-insensitive input seq handling
-    onecode = {k.upper(): v for k, v in
-               IUPACData.protein_letters_3to1_extended.items()}
+    onecode = {k.upper(): v for k, v in IUPACData.protein_letters_3to1_extended.items()}
     # add the given termination codon code and custom maps
     onecode.update((k.upper(), v) for k, v in custom_map.items())
-    seqlist = [seq[3 * i:3 * (i + 1)] for i in range(len(seq) // 3)]
+    seqlist = [seq[3 * i : 3 * (i + 1)] for i in range(len(seq) // 3)]
     return "".join(onecode.get(aa.upper(), undef_code) for aa in seqlist)
 
 
@@ -318,8 +318,9 @@ def seq1(seq, custom_map=None, undef_code="X"):
 ######################
 
 
-def molecular_weight(seq, seq_type=None, double_stranded=False, circular=False,
-                     monoisotopic=False):
+def molecular_weight(
+    seq, seq_type=None, double_stranded=False, circular=False, monoisotopic=False
+):
     """Calculate the molecular mass of DNA, RNA or protein sequences as float.
 
     Only unambiguous letters are allowed. Nucleotide sequences are assumed to
@@ -391,13 +392,15 @@ def molecular_weight(seq, seq_type=None, double_stranded=False, circular=False,
             # Convert to one-letter sequence. Have to use a string for seq1
             seq = Seq(seq1(str(seq)), alphabet=Alphabet.ProteinAlphabet())
         elif not isinstance(base_alphabet, Alphabet.Alphabet):
-            raise TypeError("%s is not a valid alphabet for mass calculations"
-                            % base_alphabet)
+            raise TypeError(
+                "%s is not a valid alphabet for mass calculations" % base_alphabet
+            )
         else:
             tmp_type = "DNA"  # backward compatibity
         if seq_type and tmp_type and tmp_type != seq_type:
-            raise ValueError("seq_type=%r contradicts %s from seq alphabet"
-                             % (seq_type, tmp_type))
+            raise ValueError(
+                "seq_type=%r contradicts %s from seq alphabet" % (seq_type, tmp_type)
+            )
         seq_type = tmp_type
     elif isinstance(seq, str):
         if seq_type is None:
@@ -423,8 +426,7 @@ def molecular_weight(seq, seq_type=None, double_stranded=False, circular=False,
         else:
             weight_table = IUPACData.protein_weights
     else:
-        raise ValueError("Allowed seq_types are DNA, RNA or protein, not %r"
-                         % seq_type)
+        raise ValueError("Allowed seq_types are DNA, RNA or protein, not %r" % seq_type)
 
     if monoisotopic:
         water = 18.010565
@@ -436,8 +438,7 @@ def molecular_weight(seq, seq_type=None, double_stranded=False, circular=False,
         if circular:
             weight -= water
     except KeyError as e:
-        raise ValueError("%s is not a valid unambiguous letter for %s"
-                         % (e, seq_type))
+        raise ValueError("%s is not a valid unambiguous letter for %s" % (e, seq_type))
 
     if seq_type in ("DNA", "RNA") and double_stranded:
         seq = str(Seq(seq).complement())
@@ -476,15 +477,15 @@ def six_frame_translations(seq, genetic_code=1):
 
     """  # noqa for pep8 W291 trailing whitespace
     from Bio.Seq import reverse_complement, translate
+
     anti = reverse_complement(seq)
     comp = anti[::-1]
     length = len(seq)
     frames = {}
     for i in range(0, 3):
         fragment_length = 3 * ((length - i) // 3)
-        frames[i + 1] = translate(seq[i:i + fragment_length], genetic_code)
-        frames[-(i + 1)] = translate(anti[i:i + fragment_length],
-                                     genetic_code)[::-1]
+        frames[i + 1] = translate(seq[i : i + fragment_length], genetic_code)
+        frames[-(i + 1)] = translate(anti[i : i + fragment_length], genetic_code)[::-1]
 
     # create header
     if length > 20:
@@ -495,28 +496,32 @@ def six_frame_translations(seq, genetic_code=1):
     for nt in ["a", "t", "g", "c"]:
         header += "%s:%d " % (nt, seq.count(nt.upper()))
 
-    header += "\nSequence: %s, %d nt, %0.2f %%GC\n\n\n" % (short.lower(),
-                                                           length, GC(seq))
+    header += "\nSequence: %s, %d nt, %0.2f %%GC\n\n\n" % (
+        short.lower(),
+        length,
+        GC(seq),
+    )
     res = header
 
     for i in range(0, length, 60):
-        subseq = seq[i:i + 60]
-        csubseq = comp[i:i + 60]
+        subseq = seq[i : i + 60]
+        csubseq = comp[i : i + 60]
         p = i // 3
         res += "%d/%d\n" % (i + 1, i / 3 + 1)
-        res += "  " + "  ".join(frames[3][p:p + 20]) + "\n"
-        res += " " + "  ".join(frames[2][p:p + 20]) + "\n"
-        res += "  ".join(frames[1][p:p + 20]) + "\n"
+        res += "  " + "  ".join(frames[3][p : p + 20]) + "\n"
+        res += " " + "  ".join(frames[2][p : p + 20]) + "\n"
+        res += "  ".join(frames[1][p : p + 20]) + "\n"
         # seq
         res += subseq.lower() + "%5d %%\n" % int(GC(subseq))
         res += csubseq.lower() + "\n"
         # - frames
-        res += "  ".join(frames[-2][p:p + 20]) + " \n"
-        res += " " + "  ".join(frames[-1][p:p + 20]) + "\n"
-        res += "  " + "  ".join(frames[-3][p:p + 20]) + "\n\n"
+        res += "  ".join(frames[-2][p : p + 20]) + " \n"
+        res += " " + "  ".join(frames[-1][p : p + 20]) + "\n"
+        res += "  " + "  ".join(frames[-3][p : p + 20]) + "\n\n"
     return res
 
 
 if __name__ == "__main__":
     from Bio._utils import run_doctest
+
     run_doctest()

--- a/Bio/SeqUtils/lcc.py
+++ b/Bio/SeqUtils/lcc.py
@@ -34,8 +34,9 @@ def lcc_mult(seq, wsize):
     compone = [0]
     lccsal = [0]
     for i in range(wsize):
-        compone.append(((i + 1) / float(wsize)) *
-                       ((math.log((i + 1) / float(wsize))) / l2))
+        compone.append(
+            ((i + 1) / float(wsize)) * ((math.log((i + 1) / float(wsize))) / l2)
+        )
     window = seq[0:wsize]
     cant_a = window.count("A")
     cant_c = window.count("C")
@@ -48,7 +49,7 @@ def lcc_mult(seq, wsize):
     lccsal.append(-(term_a + term_c + term_t + term_g))
     tail = seq[0]
     for x in range(tamseq - wsize):
-        window = upper[x + 1:wsize + x + 1]
+        window = upper[x + 1 : wsize + x + 1]
         if tail == window[-1]:
             lccsal.append(lccsal[-1])
         elif tail == "A":
@@ -147,21 +148,25 @@ def lcc_simp(seq):
         term_a = 0
         # Check to avoid calculating the log of 0.
     else:
-        term_a = ((upper.count("A")) / float(wsize)) * \
-                 ((math.log((upper.count("A")) / float(wsize))) / l2)
+        term_a = ((upper.count("A")) / float(wsize)) * (
+            (math.log((upper.count("A")) / float(wsize))) / l2
+        )
     if "C" not in seq:
         term_c = 0
     else:
-        term_c = ((upper.count("C")) / float(wsize)) * \
-                 ((math.log((upper.count("C")) / float(wsize))) / l2)
+        term_c = ((upper.count("C")) / float(wsize)) * (
+            (math.log((upper.count("C")) / float(wsize))) / l2
+        )
     if "T" not in seq:
         term_t = 0
     else:
-        term_t = ((upper.count("T")) / float(wsize)) * \
-                 ((math.log((upper.count("T")) / float(wsize))) / l2)
+        term_t = ((upper.count("T")) / float(wsize)) * (
+            (math.log((upper.count("T")) / float(wsize))) / l2
+        )
     if "G" not in seq:
         term_g = 0
     else:
-        term_g = ((upper.count("G")) / float(wsize)) * \
-                 ((math.log((upper.count("G")) / float(wsize))) / l2)
+        term_g = ((upper.count("G")) / float(wsize)) * (
+            (math.log((upper.count("G")) / float(wsize))) / l2
+        )
     return -(term_a + term_c + term_t + term_g)


### PR DESCRIPTION
This pull request addresses issue #2008 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Merging this PR should be fine but these changes are a mix, as follow:

Applied black:
Bio/SeqUtils/__init__.py
Bio/SeqUtils/CheckSum.py
Bio/SeqUtils/lcc.py
Bio/SeqUtils/ProtParam.py

Partially changed, when lists have been presented one item per line, and looked long, the section has been kept the same as it was; other black changes to the rest of file have been applied manually.
Bio/SeqUtils/CodonUsage.py
Bio/SeqUtils/IsoelectricPoint.py
Bio/SeqUtils/MeltingTemp.py

No changed, the only changes applying black style relate to list items presented one item per line, so no changes to these files.
Bio/SeqUtils/CodonUsageIndices.py
Bio/SeqUtils/ProtParamData.py

Just to note, partially changed or no changed files will need manual attention.