### PR TITLE
Replace alphabet.letters => alphabet in calculate_pseudocount

### DIFF
--- a/Bio/motifs/jaspar/__init__.py
+++ b/Bio/motifs/jaspar/__init__.py
@@ -319,6 +319,8 @@ def calculate_pseudocounts(motif):
     the background nucleotide.
     """
     alphabet = motif.alphabet
+    if hasattr(alphabet, "letters"):
+        alphabet = alphabet.letters
     background = motif.background
 
     # It is possible to have unequal column sums so use the average
@@ -326,7 +328,7 @@ def calculate_pseudocounts(motif):
     total = 0
     for i in range(motif.length):
         total += sum(float(motif.counts[letter][i])
-                     for letter in alphabet.letters)
+                     for letter in alphabet)
 
     avg_nb_instances = total / motif.length
     sq_nb_instances = math.sqrt(avg_nb_instances)
@@ -334,12 +336,12 @@ def calculate_pseudocounts(motif):
     if background:
         background = dict(background)
     else:
-        background = dict.fromkeys(sorted(alphabet.letters), 1.0)
+        background = dict.fromkeys(sorted(alphabet), 1.0)
 
     total = sum(background.values())
     pseudocounts = {}
 
-    for letter in alphabet.letters:
+    for letter in alphabet:
         background[letter] /= total
         pseudocounts[letter] = sq_nb_instances * background[letter]
 


### PR DESCRIPTION
It seems that everywhere else in this module the "alphabet" is not more an Alphabet instance, but rather a string like "ATGC". So calculate_pseudocounts should not use ``alphabet.letters``. This fixes a bug breaking calculate_pseudocounts in Biopython 1.75.

This pull request addresses issue #...

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ ] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
