### PR TITLE
Comply with flake8-comprehensions upgrade

### DIFF
--- a/Bio/AlignIO/MafIO.py
+++ b/Bio/AlignIO/MafIO.py
@@ -582,7 +582,7 @@ class MafIndex(object):
             raise ValueError("Strand must be 1 or -1, got %s" % str(strand))
 
         # pull all alignments that span the desired intervals
-        fetched = [multiseq for multiseq in self.search(starts, ends)]
+        fetched = list(self.search(starts, ends))
 
         # keep track of the expected letter count
         # (sum of lengths of [start, end) segments,

--- a/Bio/Nexus/Trees.py
+++ b/Bio/Nexus/Trees.py
@@ -334,7 +334,7 @@ class Tree(Nodes.Chain):
                 if len(genera) == 1:
                     self.node(n).data.taxon = genera[0] + " <collapsed>"
                     # now we kill all nodes downstream
-                    nodes2kill = [kn for kn in self._walk(node=n)]
+                    nodes2kill = list(self._walk(node=n))
                     for kn in nodes2kill:
                         self.kill(kn)
                     self.node(n).succ = []

--- a/Bio/Phylo/_utils.py
+++ b/Bio/Phylo/_utils.py
@@ -537,7 +537,7 @@ def draw(tree, label_func=str, do_show=True, show_confidence=True,
     for key, value in kwargs.items():
         try:
             # Check that the pyplot option input is iterable, as required
-            [i for i in value]
+            list(value)
         except TypeError:
             raise ValueError('Keyword argument "%s=%s" is not in the format '
                              "pyplot_option_name=(tuple), pyplot_option_name=(tuple, dict),"

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -1006,9 +1006,9 @@ class NonPalindromic(AbstractCut):
 
         for start, group in iterator:
             if group(s):
-                cls.results += [r for r in modif(start)]
+                cls.results += list(modif(start))
             else:
-                cls.on_minus += [r for r in revmodif(start)]
+                cls.on_minus += list(revmodif(start))
         cls.results += cls.on_minus
 
         if cls.results:
@@ -1547,8 +1547,8 @@ class Defined(AbstractCut):
         drop = itertools.dropwhile
         take = itertools.takewhile
         if cls.dna.is_linear():
-            cls.results = [x for x in drop(lambda x:x <= 1, cls.results)]
-            cls.results = [x for x in take(lambda x:x <= length, cls.results)]
+            cls.results = list(drop(lambda x:x <= 1, cls.results))
+            cls.results = list(take(lambda x:x <= length, cls.results))
         else:
             for index, location in enumerate(cls.results):
                 if location < 1:
@@ -1696,8 +1696,8 @@ class Ambiguous(AbstractCut):
         drop = itertools.dropwhile
         take = itertools.takewhile
         if cls.dna.is_linear():
-            cls.results = [x for x in drop(lambda x: x <= 1, cls.results)]
-            cls.results = [x for x in take(lambda x: x <= length, cls.results)]
+            cls.results = list(drop(lambda x: x <= 1, cls.results))
+            cls.results = list(take(lambda x: x <= length, cls.results))
         else:
             for index, location in enumerate(cls.results):
                 if location < 1:
@@ -2138,7 +2138,7 @@ class RestrictionBatch(set):
         The new batch will contain only the enzymes for which
         func return True.
         """
-        d = [x for x in filter(func, self)]
+        d = list(filter(func, self))
         new = RestrictionBatch()
         new._data = dict(zip(d, [True] * len(d)))
         return new
@@ -2251,7 +2251,7 @@ class RestrictionBatch(set):
                 else:
                     continue
             return True
-        d = [k for k in filter(splittest, self)]
+        d = list(filter(splittest, self))
         new = RestrictionBatch()
         new._data = dict(zip(d, [True] * len(d)))
         return new

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -1547,8 +1547,8 @@ class Defined(AbstractCut):
         drop = itertools.dropwhile
         take = itertools.takewhile
         if cls.dna.is_linear():
-            cls.results = list(drop(lambda x:x <= 1, cls.results))
-            cls.results = list(take(lambda x:x <= length, cls.results))
+            cls.results = list(drop(lambda x: x <= 1, cls.results))
+            cls.results = list(take(lambda x: x <= length, cls.results))
         else:
             for index, location in enumerate(cls.results):
                 if location < 1:

--- a/Bio/SearchIO/BlastIO/blast_xml.py
+++ b/Bio/SearchIO/BlastIO/blast_xml.py
@@ -426,9 +426,8 @@ class BlastXmlParser(object):
             hit_id, alt_hit_ids = ids[0], ids[1:]
             hit_desc, alt_hit_descs = descs[0], descs[1:]
 
-            hsps = [hsp for hsp in
-                    self._parse_hsp(hit_elem.find("Hit_hsps"),
-                                    query_id, hit_id)]
+            hsps = list(self._parse_hsp(hit_elem.find("Hit_hsps"),
+                                        query_id, hit_id))
 
             hit = Hit(hsps)
             hit.description = hit_desc

--- a/Bio/SearchIO/InterproscanIO/interproscan_xml.py
+++ b/Bio/SearchIO/InterproscanIO/interproscan_xml.py
@@ -126,9 +126,8 @@ class InterproscanXmlParser(object):
                 signature.find(self.NS + "entry"))
 
             # parse each hsp
-            hsps = [hsp for hsp in self._parse_hsp(
-                hit_elem.find(self.NS + "locations"),
-                query_id, hit_id, query_seq)]
+            hsps = list(self._parse_hsp(hit_elem.find(self.NS + "locations"),
+                                        query_id, hit_id, query_seq))
 
             # create hit and assign attributes
             hit = Hit(hsps, hit_id)

--- a/Bio/SearchIO/_model/hit.py
+++ b/Bio/SearchIO/_model/hit.py
@@ -328,7 +328,7 @@ class Hit(_BaseSearchObject):
     @property
     def fragments(self):
         """Access the HSPFragment objects contained in the Hit."""
-        return [frag for frag in chain(*self._items)]
+        return list(chain(*self._items))
 
     # public methods #
     def append(self, hsp):

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -462,7 +462,7 @@ class QueryResult(_BaseSearchObject):
     @property
     def fragments(self):
         """Access the HSPFragment objects contained in the QueryResult."""
-        return [frag for frag in chain(*self.hsps)]
+        return list(chain(*self.hsps))
 
     # public methods #
     def absorb(self, hit):

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -598,7 +598,7 @@ class Parser(object):
                 pass
 
         # remove duplicate dbxrefs
-        self.ParsedSeqRecord.dbxrefs = sorted(list(set(self.ParsedSeqRecord.dbxrefs)))
+        self.ParsedSeqRecord.dbxrefs = sorted(set(self.ParsedSeqRecord.dbxrefs))
 
         # use first accession as id
         if not self.ParsedSeqRecord.id:

--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -188,7 +188,7 @@ def _read(handle):
             _read_id(record, line)
             _sequence_lines = []
         elif key == "AC":
-            accessions = [word for word in value.rstrip(";").split("; ")]
+            accessions = value.rstrip(";").split("; ")
             record.accessions.extend(accessions)
         elif key == "DT":
             _read_dt(record, line)
@@ -203,7 +203,7 @@ def _read(handle):
         elif key == "OG":
             record.organelle += line[5:]
         elif key == "OC":
-            cols = [col for col in value.rstrip(";.").split("; ")]
+            cols = value.rstrip(";.").split("; ")
             record.organism_classification.extend(cols)
         elif key == "OX":
             _read_ox(record, line)

--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -420,17 +420,17 @@ def _count_site_NG86(codon_lst, k=1, codon_table=default_codon_table):
                 if i == j:
                     pass
                 elif i in purine and j in purine:
-                    codon_chars = [c for c in codon]
+                    codon_chars = list(codon)
                     codon_chars[n] = j
                     this_codon = "".join(codon_chars)
                     neighbor_codon["transition"].append(this_codon)
                 elif i in pyrimidine and j in pyrimidine:
-                    codon_chars = [c for c in codon]
+                    codon_chars = list(codon)
                     codon_chars[n] = j
                     this_codon = "".join(codon_chars)
                     neighbor_codon["transition"].append(this_codon)
                 else:
-                    codon_chars = [c for c in codon]
+                    codon_chars = list(codon)
                     codon_chars[n] = j
                     this_codon = "".join(codon_chars)
                     neighbor_codon["transversion"].append(this_codon)
@@ -592,7 +592,7 @@ def _get_codon_fold(codon_table):
     def find_fold_class(codon, forward_table):
         base = {"A", "T", "C", "G"}
         fold = ""
-        codon_base_lst = [i for i in codon]
+        codon_base_lst = list(codon)
         for i, b in enumerate(codon_base_lst):
             other_base = base - set(b)
             aa = []

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -24,6 +24,7 @@ style has been reformatted with the ``black`` tool.
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
+- Chris Rands
 - Christian Brueffer
 - Peter Cock
 - Sergio Valqui

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -889,8 +889,7 @@ class DictionaryBuilder(object):
 
     def removestart(self, file):
         """Remove the header of the file."""
-        return [l for l in itertools.dropwhile(lambda l:l.startswith("#"),
-                                               file)]
+        return list(itertools.dropwhile(lambda l:l.startswith("#"), file))
 
     def getblock(self, file, index):
         """Get a data block from the emboss_r file."""
@@ -898,8 +897,7 @@ class DictionaryBuilder(object):
         #   emboss_r.txt, separation between blocks is //
         #
         take = itertools.takewhile
-        block = [l for l in take(lambda l: not l.startswith("//"),
-                                 file[index:])]
+        block = list(take(lambda l: not l.startswith("//"), file[index:]))
         index += len(block) + 1
         return block, index
 

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -889,7 +889,7 @@ class DictionaryBuilder(object):
 
     def removestart(self, file):
         """Remove the header of the file."""
-        return list(itertools.dropwhile(lambda l:l.startswith("#"), file))
+        return list(itertools.dropwhile(lambda l: l.startswith("#"), file))
 
     def getblock(self, file, index):
         """Get a data block from the emboss_r file."""

--- a/Scripts/xbbtools/xbb_translations.py
+++ b/Scripts/xbbtools/xbb_translations.py
@@ -73,7 +73,7 @@ class xbb_translations(object):
         length = len(seq)
         protein = self.frame(seq, frame, translation_table)
         protein_length = len(protein)
-        protein = "  ".join([aa for aa in protein])
+        protein = "  ".join(list(protein))
         protein += (((length - (abs(frame) - 1)) % 3) + 2) * " "
         if frame < 0:
             protein = protein[::-1]

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -307,7 +307,7 @@ class TestRunner(unittest.TextTestRunner):
             self.tests.remove("doctest")
             modules = find_modules(self.testdir + "/..")
             modules.difference_update(set(EXCLUDE_DOCTEST_MODULES))
-            self.tests.extend(sorted(list(modules)))
+            self.tests.extend(sorted(modules))
         stream = StringIO()
         unittest.TextTestRunner.__init__(self, stream,
                                          verbosity=verbosity)

--- a/Tests/test_CodonTable.py
+++ b/Tests/test_CodonTable.py
@@ -23,7 +23,7 @@ from Bio.Data.CodonTable import list_ambiguous_codons, list_possible_proteins
 from Bio.Data.CodonTable import TranslationError
 
 exception_list = []
-ids = [key for key in unambiguous_dna_by_id]
+ids = list(unambiguous_dna_by_id)
 
 # Find codon tables with 'ambiguous' stop codons (coding both for stop and
 # an amino acid) and put them into exception_list

--- a/Tests/test_GraphicsChromosome.py
+++ b/Tests/test_GraphicsChromosome.py
@@ -309,7 +309,7 @@ class OrganismSubAnnotationsTest(unittest.TestCase):
                             for (start, end, strand, label) in features]
             else:
                 # Features as 5-tuples
-                features = [(start, end, strand, label, color)
+                features = [(start, end, strand, label, color)  # noqa: C416
                             for (start, end, strand, label) in features]
 
             # I haven't found a nice source of data for real Arabidopsis

--- a/Tests/test_KGML_graphics.py
+++ b/Tests/test_KGML_graphics.py
@@ -134,7 +134,7 @@ class KGMLPathwayTest(unittest.TestCase):
         # modifying the reaction colours for each ortholog entry
         with open(p[1].infilename) as f:
             pathway = read(f)
-            orthologs = [e for e in pathway.orthologs]
+            orthologs = list(pathway.orthologs)
             # Use Biopython's ColorSpiral to generate colours
             cs = ColorSpiral(a=2, b=0.2, v_init=0.85, v_final=0.5,
                              jitter=0.03)
@@ -168,7 +168,7 @@ class KGMLPathwayTest(unittest.TestCase):
         # modifying the alpha channel for each ortholog entry
         with open(p[1].infilename) as f:
             pathway = read(f)
-            orthologs = [e for e in pathway.orthologs]
+            orthologs = list(pathway.orthologs)
             # Use Biopython's ColorSpiral to generate colours
             cs = ColorSpiral(a=2, b=0.2, v_init=0.85, v_final=0.5,
                              jitter=0.03)

--- a/Tests/test_MafIO_index.py
+++ b/Tests/test_MafIO_index.py
@@ -288,7 +288,7 @@ if sqlite3:
         def test_correct_retrieval_1(self):
             """Correct retrieval of Cnksr3 in mouse."""
             search = self.idx.search((3014742, 3018161), (3015028, 3018644))
-            results = [x for x in search]
+            results = list(search)
 
             self.assertEqual(len(results), 4 + 4)
 
@@ -310,7 +310,7 @@ if sqlite3:
 
         def test_correct_retrieval_2(self):
             search = self.idx.search((3009319, 3021421), (3012566, 3021536))
-            results = [x for x in search]
+            results = list(search)
 
             self.assertEqual(len(results), 6)
 
@@ -335,7 +335,7 @@ if sqlite3:
             https://github.com/biopython/biopython/issues/1083
             """
             search = self.idx.search((3012076, 3012076 + 300), (3012076 + 100, 3012076 + 400))
-            results = [x for x in search]
+            results = list(search)
 
             self.assertEqual(len(results), 2)
 

--- a/Tests/test_Nexus.py
+++ b/Tests/test_Nexus.py
@@ -543,7 +543,7 @@ Root:  16
                                                                          0.1894244])
 
         subtree = tree.set_subtree(10)
-        self.assertEqual(sorted(list(subtree)), ["E 0", "E 7"])
+        self.assertEqual(sorted(subtree), ["E 0", "E 7"])
         tree.collapse_genera()
         self.assertEqual(tree.all_ids(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 17])
 

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -579,7 +579,7 @@ class ParseTest(unittest.TestCase):
         residues = [r.id[1] for r in sorted(struct[1]["A"])][79:81]
         self.assertEqual(residues, [80, 81])
         # Insertion code + hetflag + chain
-        residues = [r for r in struct[1]["B"]] + [struct[1]["A"][44]]
+        residues = list(struct[1]["B"]) + [struct[1]["A"][44]]
         self.assertEqual([("{}" * 4).format(r.parent.id, *r.id) for r in sorted(residues)],
                          ["A 44 ", "B 44 ", "B 46 ", "B 47 ", "B 48 ", "B 49 ", "B 50 ",
                           "B 51 ", "B 51A", "B 52 ", "BH_SEP45 ", "BW0 "])

--- a/Tests/test_SearchIO_model.py
+++ b/Tests/test_SearchIO_model.py
@@ -112,19 +112,19 @@ class QueryResultCases(unittest.TestCase):
     def test_hits(self):
         """Test QueryResult.hits."""
         # hits should return hits contained in qresult
-        hits = [x for x in self.qresult.hits]
+        hits = list(self.qresult.hits)
         self.assertEqual([hit11, hit21, hit31], hits)
 
     def test_hit_keys(self):
         """Test QueryResult.hit_keys."""
         # hit_keys should return hit keys (which default to hit ids)
-        hit_keys = [x for x in self.qresult.hit_keys]
+        hit_keys = list(self.qresult.hit_keys)
         self.assertEqual(["hit1", "hit2", "hit3"], hit_keys)
 
     def test_items(self):
         """Test QueryResult.items."""
         # items should return tuples of hit key, hit object pair
-        items = [x for x in self.qresult.items]
+        items = list(self.qresult.items)
         self.assertEqual([("hit1", hit11), ("hit2", hit21),
                          ("hit3", hit31)], items)
 

--- a/Tests/test_SffIO.py
+++ b/Tests/test_SffIO.py
@@ -64,7 +64,7 @@ class TestUAN(unittest.TestCase):
     """Test annotations."""
 
     def setUp(self):
-        self.records = [record for record in SeqIO.parse("Roche/E3MFGYR02_random_10_reads.sff", "sff")]
+        self.records = list(SeqIO.parse("Roche/E3MFGYR02_random_10_reads.sff", "sff"))
         self.test_annotations = {}
         for line in test_data.splitlines():
             fields = re.split(r"\s+", line.strip())

--- a/Tests/test_mmtf.py
+++ b/Tests/test_mmtf.py
@@ -53,8 +53,8 @@ class ParseMMTF(unittest.TestCase):
             self.assertEqual(mmtf_r.disordered, mmcif_r.disordered)
             self.assertEqual(mmtf_r.resname, mmcif_r.resname)
             self.assertEqual(mmtf_r.segid, mmcif_r.segid)
-            self.mmcif_atoms = [x for x in mmcif_r.get_atoms()]
-            self.mmtf_atoms = [x for x in mmtf_r.get_atoms()]
+            self.mmcif_atoms = list(mmcif_r.get_atoms())
+            self.mmtf_atoms = list(mmtf_r.get_atoms())
             self.check_atoms()
 
     def check_mmtf_vs_cif(self, mmtf_filename, cif_filename):
@@ -64,21 +64,21 @@ class ParseMMTF(unittest.TestCase):
             mmtf_struct = MMTFParser.get_structure(mmtf_filename)
         mmcif_parser = MMCIFParser()
         mmcif_struct = mmcif_parser.get_structure("4CUP", cif_filename)
-        self.mmcif_atoms = [x for x in mmcif_struct.get_atoms()]
-        self.mmtf_atoms = [x for x in mmtf_struct.get_atoms()]
+        self.mmcif_atoms = list(mmcif_struct.get_atoms())
+        self.mmtf_atoms = list(mmtf_struct.get_atoms())
         self.check_atoms()
-        mmcif_chains = [x for x in mmcif_struct.get_chains()]
-        mmtf_chains = [x for x in mmtf_struct.get_chains()]
+        mmcif_chains = list(mmcif_struct.get_chains())
+        mmtf_chains = list(mmtf_struct.get_chains())
         self.assertEqual(len(mmcif_chains), len(mmtf_chains))
         for i, e in enumerate(mmcif_chains):
-            self.mmcif_res = [x for x in mmcif_chains[i].get_residues()]
-            self.mmtf_res = [x for x in mmtf_chains[i].get_residues()]
+            self.mmcif_res = list(mmcif_chains[i].get_residues())
+            self.mmtf_res = list(mmtf_chains[i].get_residues())
             self.check_residues()
 
-        self.mmcif_res = [x for x in mmcif_struct.get_residues()]
-        self.mmtf_res = [x for x in mmtf_struct.get_residues()]
+        self.mmcif_res = list(mmcif_struct.get_residues())
+        self.mmtf_res = list(mmtf_struct.get_residues())
         self.check_residues()
-        self.assertEqual(len([x for x in mmcif_struct.get_models()]), len([x for x in mmtf_struct.get_models()]))
+        self.assertEqual(sum(1 for _ in mmcif_struct.get_models()), sum(1 for _ in mmtf_struct.get_models()))
 
     def test_4CUP(self):
         """Compare parsing 4CUP.mmtf and 4CUP.cif."""

--- a/Tests/test_mmtf_online.py
+++ b/Tests/test_mmtf_online.py
@@ -25,7 +25,7 @@ class OnlineMMTF(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", PDBConstructionWarning)
             struct = parser.get_structure_from_url("4ZHL")
-        atoms = [x for x in struct.get_atoms()]
+        atoms = list(struct.get_atoms())
         self.assertEqual(len(atoms), 2080)
 
 


### PR DESCRIPTION
The upgrade of flake8-comprehensions (in particular see the changes for version 3.1.0) includes some new checks:
https://github.com/adamchainz/flake8-comprehensions/blob/master/HISTORY.rst

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
