### PR TITLE
make string consistent with attribute names

### DIFF
--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -1804,10 +1804,10 @@ Aligner_str(Aligner* self)
         p += n;
     }
     else {
-        n = sprintf(p, "  target_open_gap_score: %f\n",
+        n = sprintf(p, "  target_internal_open_gap_score: %f\n",
                        self->target_open_gap_score);
         p += n;
-        n = sprintf(p, "  target_extend_gap_score: %f\n",
+        n = sprintf(p, "  target_internal_extend_gap_score: %f\n",
                        self->target_extend_gap_score);
         p += n;
         n = sprintf(p, "  target_left_open_gap_score: %f\n",
@@ -1828,10 +1828,10 @@ Aligner_str(Aligner* self)
         p += n;
     }
     else {
-        n = sprintf(p, "  query_open_gap_score: %f\n",
+        n = sprintf(p, "  query_internal_open_gap_score: %f\n",
                        self->query_open_gap_score);
         p += n;
-        n = sprintf(p, "  query_extend_gap_score: %f\n",
+        n = sprintf(p, "  query_internal_extend_gap_score: %f\n",
                        self->query_extend_gap_score);
         p += n;
         n = sprintf(p, "  query_left_open_gap_score: %f\n",

--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -1682,14 +1682,14 @@ typedef struct {
     double match;
     double mismatch;
     double epsilon;
-    double target_open_gap_score;
-    double target_extend_gap_score;
+    double target_internal_open_gap_score;
+    double target_internal_extend_gap_score;
     double target_left_open_gap_score;
     double target_left_extend_gap_score;
     double target_right_open_gap_score;
     double target_right_extend_gap_score;
-    double query_open_gap_score;
-    double query_extend_gap_score;
+    double query_internal_open_gap_score;
+    double query_internal_extend_gap_score;
     double query_left_open_gap_score;
     double query_left_extend_gap_score;
     double query_right_open_gap_score;
@@ -1734,10 +1734,10 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->match = 1.0;
     self->mismatch = 0.0;
     self->epsilon = 1.e-6;
-    self->target_open_gap_score = 0;
-    self->target_extend_gap_score = 0;
-    self->query_open_gap_score = 0;
-    self->query_extend_gap_score = 0;
+    self->target_internal_open_gap_score = 0;
+    self->target_internal_extend_gap_score = 0;
+    self->query_internal_open_gap_score = 0;
+    self->query_internal_extend_gap_score = 0;
     self->target_left_open_gap_score = 0;
     self->target_left_extend_gap_score = 0;
     self->target_right_open_gap_score = 0;
@@ -1805,10 +1805,10 @@ Aligner_str(Aligner* self)
     }
     else {
         n = sprintf(p, "  target_internal_open_gap_score: %f\n",
-                       self->target_open_gap_score);
+                       self->target_internal_open_gap_score);
         p += n;
         n = sprintf(p, "  target_internal_extend_gap_score: %f\n",
-                       self->target_extend_gap_score);
+                       self->target_internal_extend_gap_score);
         p += n;
         n = sprintf(p, "  target_left_open_gap_score: %f\n",
                        self->target_left_open_gap_score);
@@ -1829,10 +1829,10 @@ Aligner_str(Aligner* self)
     }
     else {
         n = sprintf(p, "  query_internal_open_gap_score: %f\n",
-                       self->query_open_gap_score);
+                       self->query_internal_open_gap_score);
         p += n;
         n = sprintf(p, "  query_internal_extend_gap_score: %f\n",
-                       self->query_extend_gap_score);
+                       self->query_internal_extend_gap_score);
         p += n;
         n = sprintf(p, "  query_left_open_gap_score: %f\n",
                        self->query_left_open_gap_score);
@@ -2167,14 +2167,14 @@ Aligner_get_gap_score(Aligner* self, void* closure)
         return self->target_gap_function;
     }
     else {
-        const double score = self->target_open_gap_score;
-        if (score != self->target_extend_gap_score
+        const double score = self->target_internal_open_gap_score;
+        if (score != self->target_internal_extend_gap_score
          || score != self->target_left_open_gap_score
          || score != self->target_left_extend_gap_score
          || score != self->target_right_open_gap_score
          || score != self->target_right_extend_gap_score
-         || score != self->query_open_gap_score
-         || score != self->query_extend_gap_score
+         || score != self->query_internal_open_gap_score
+         || score != self->query_internal_extend_gap_score
          || score != self->query_left_open_gap_score
          || score != self->query_left_extend_gap_score
          || score != self->query_right_open_gap_score
@@ -2207,14 +2207,14 @@ Aligner_set_gap_score(Aligner* self, PyObject* value, void* closure)
             Py_DECREF(self->query_gap_function);
             self->query_gap_function = NULL;
         }
-        self->target_open_gap_score = score;
-        self->target_extend_gap_score = score;
+        self->target_internal_open_gap_score = score;
+        self->target_internal_extend_gap_score = score;
         self->target_left_open_gap_score = score;
         self->target_left_extend_gap_score = score;
         self->target_right_open_gap_score = score;
         self->target_right_extend_gap_score = score;
-        self->query_open_gap_score = score;
-        self->query_extend_gap_score = score;
+        self->query_internal_open_gap_score = score;
+        self->query_internal_extend_gap_score = score;
         self->query_left_open_gap_score = score;
         self->query_left_extend_gap_score = score;
         self->query_right_open_gap_score = score;
@@ -2234,10 +2234,10 @@ Aligner_get_open_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_open_gap_score;
+        const double score = self->target_internal_open_gap_score;
         if (score != self->target_left_open_gap_score
          || score != self->target_right_open_gap_score
-         || score != self->query_open_gap_score
+         || score != self->query_internal_open_gap_score
          || score != self->query_left_open_gap_score
          || score != self->query_right_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2259,10 +2259,10 @@ Aligner_set_open_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_open_gap_score = score;
+    self->target_internal_open_gap_score = score;
     self->target_left_open_gap_score = score;
     self->target_right_open_gap_score = score;
-    self->query_open_gap_score = score;
+    self->query_internal_open_gap_score = score;
     self->query_left_open_gap_score = score;
     self->query_right_open_gap_score = score;
     self->algorithm = Unknown;
@@ -2279,10 +2279,10 @@ Aligner_get_extend_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_extend_gap_score;
+        const double score = self->target_internal_extend_gap_score;
         if (score != self->target_left_extend_gap_score
          || score != self->target_right_extend_gap_score
-         || score != self->query_extend_gap_score
+         || score != self->query_internal_extend_gap_score
          || score != self->query_left_extend_gap_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2304,10 +2304,10 @@ Aligner_set_extend_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_extend_gap_score = score;
+    self->target_internal_extend_gap_score = score;
     self->target_left_extend_gap_score = score;
     self->target_right_extend_gap_score = score;
-    self->query_extend_gap_score = score;
+    self->query_internal_extend_gap_score = score;
     self->query_left_extend_gap_score = score;
     self->query_right_extend_gap_score = score;
     self->algorithm = Unknown;
@@ -2323,10 +2323,10 @@ Aligner_get_internal_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_open_gap_score;
-        if (score != self->target_extend_gap_score
-         || score != self->query_open_gap_score
-         || score != self->query_extend_gap_score) {
+        const double score = self->target_internal_open_gap_score;
+        if (score != self->target_internal_extend_gap_score
+         || score != self->query_internal_open_gap_score
+         || score != self->query_internal_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2346,10 +2346,10 @@ Aligner_set_internal_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_open_gap_score = score;
-    self->target_extend_gap_score = score;
-    self->query_open_gap_score = score;
-    self->query_extend_gap_score = score;
+    self->target_internal_open_gap_score = score;
+    self->target_internal_extend_gap_score = score;
+    self->query_internal_open_gap_score = score;
+    self->query_internal_extend_gap_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2363,8 +2363,8 @@ Aligner_get_internal_open_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_open_gap_score;
-        if (score != self->query_open_gap_score) {
+        const double score = self->target_internal_open_gap_score;
+        if (score != self->query_internal_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2384,8 +2384,8 @@ Aligner_set_internal_open_gap_score(Aligner* self, PyObject* value, void* closur
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_open_gap_score = score;
-    self->query_open_gap_score = score;
+    self->target_internal_open_gap_score = score;
+    self->query_internal_open_gap_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2399,8 +2399,8 @@ Aligner_get_internal_extend_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_extend_gap_score;
-        if (score != self->query_extend_gap_score) {
+        const double score = self->target_internal_extend_gap_score;
+        if (score != self->query_internal_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2421,8 +2421,8 @@ Aligner_set_internal_extend_gap_score(Aligner* self, PyObject* value,
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_extend_gap_score = score;
-    self->query_extend_gap_score = score;
+    self->target_internal_extend_gap_score = score;
+    self->query_internal_extend_gap_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2788,7 +2788,7 @@ Aligner_get_target_open_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_open_gap_score;
+        const double score = self->target_internal_open_gap_score;
         if (score != self->target_left_open_gap_score
          || score != self->target_right_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2802,7 +2802,7 @@ static int
 Aligner_set_target_open_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_open_gap_score = score;
+    self->target_internal_open_gap_score = score;
     self->target_left_open_gap_score = score;
     self->target_right_open_gap_score = score;
     if (self->target_gap_function) {
@@ -2822,7 +2822,7 @@ Aligner_get_target_extend_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_extend_gap_score;
+        const double score = self->target_internal_extend_gap_score;
         if (score != self->target_left_extend_gap_score
          || score != self->target_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2836,7 +2836,7 @@ static int
 Aligner_set_target_extend_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_extend_gap_score = score;
+    self->target_internal_extend_gap_score = score;
     self->target_left_extend_gap_score = score;
     self->target_right_extend_gap_score = score;
     if (self->target_gap_function) {
@@ -2856,8 +2856,8 @@ Aligner_get_target_gap_score(Aligner* self, void* closure)
         return self->target_gap_function;
     }
     else {
-        const double score = self->target_open_gap_score;
-        if (score != self->target_extend_gap_score
+        const double score = self->target_internal_open_gap_score;
+        if (score != self->target_internal_extend_gap_score
          || score != self->target_left_open_gap_score
          || score != self->target_left_extend_gap_score
          || score != self->target_right_open_gap_score
@@ -2884,8 +2884,8 @@ Aligner_set_target_gap_score(Aligner* self, PyObject* value, void* closure)
                             "gap score should be numerical or callable");
             return -1;
         }
-        self->target_open_gap_score = score;
-        self->target_extend_gap_score = score;
+        self->target_internal_open_gap_score = score;
+        self->target_internal_extend_gap_score = score;
         self->target_left_open_gap_score = score;
         self->target_left_extend_gap_score = score;
         self->target_right_open_gap_score = score;
@@ -2908,7 +2908,7 @@ Aligner_get_query_open_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->query_open_gap_score;
+        const double score = self->query_internal_open_gap_score;
         if (score != self->query_left_open_gap_score
          || score != self->query_right_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2922,7 +2922,7 @@ static int
 Aligner_set_query_open_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_open_gap_score = score;
+    self->query_internal_open_gap_score = score;
     self->query_left_open_gap_score = score;
     self->query_right_open_gap_score = score;
     if (self->query_gap_function) {
@@ -2942,7 +2942,7 @@ Aligner_get_query_extend_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->query_extend_gap_score;
+        const double score = self->query_internal_extend_gap_score;
         if (score != self->query_left_extend_gap_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2956,7 +2956,7 @@ static int
 Aligner_set_query_extend_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_extend_gap_score = score;
+    self->query_internal_extend_gap_score = score;
     self->query_left_extend_gap_score = score;
     self->query_right_extend_gap_score = score;
     if (self->query_gap_function) {
@@ -2976,10 +2976,10 @@ Aligner_get_query_gap_score(Aligner* self, void* closure)
         return self->query_gap_function;
     }
     else {
-        const double score = self->query_open_gap_score;
+        const double score = self->query_internal_open_gap_score;
         if (score != self->query_left_open_gap_score
          || score != self->query_right_open_gap_score
-         || score != self->query_extend_gap_score
+         || score != self->query_internal_extend_gap_score
          || score != self->query_left_extend_gap_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -3003,8 +3003,8 @@ Aligner_set_query_gap_score(Aligner* self, PyObject* value, void* closure)
                             "gap score should be numerical or callable");
             return -1;
         }
-        self->query_open_gap_score = score;
-        self->query_extend_gap_score = score;
+        self->query_internal_open_gap_score = score;
+        self->query_internal_extend_gap_score = score;
         self->query_left_open_gap_score = score;
         self->query_left_extend_gap_score = score;
         self->query_right_open_gap_score = score;
@@ -3026,7 +3026,7 @@ Aligner_get_target_internal_open_gap_score(Aligner* self, void* closure)
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->target_open_gap_score);
+    return PyFloat_FromDouble(self->target_internal_open_gap_score);
 }
 
 static int
@@ -3034,7 +3034,7 @@ Aligner_set_target_internal_open_gap_score(Aligner* self,
                                            PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_open_gap_score = score;
+    self->target_internal_open_gap_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -3051,7 +3051,7 @@ Aligner_get_target_internal_extend_gap_score(Aligner* self, void* closure)
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->target_extend_gap_score);
+    return PyFloat_FromDouble(self->target_internal_extend_gap_score);
 }
 
 static int
@@ -3059,7 +3059,7 @@ Aligner_set_target_internal_extend_gap_score(Aligner* self,
                                              PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_extend_gap_score = score;
+    self->target_internal_extend_gap_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -3077,8 +3077,8 @@ Aligner_get_target_internal_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_open_gap_score;
-        if (score != self->target_extend_gap_score) {
+        const double score = self->target_internal_open_gap_score;
+        if (score != self->target_internal_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3091,8 +3091,8 @@ Aligner_set_target_internal_gap_score(Aligner* self, PyObject* value,
                                       void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_open_gap_score = score;
-    self->target_extend_gap_score = score;
+    self->target_internal_open_gap_score = score;
+    self->target_internal_extend_gap_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -3470,7 +3470,7 @@ Aligner_get_query_internal_open_gap_score(Aligner* self, void* closure)
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->query_open_gap_score);
+    return PyFloat_FromDouble(self->query_internal_open_gap_score);
 }
 
 static int
@@ -3478,7 +3478,7 @@ Aligner_set_query_internal_open_gap_score(Aligner* self, PyObject* value,
                                           void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_open_gap_score = score;
+    self->query_internal_open_gap_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -3495,7 +3495,7 @@ Aligner_get_query_internal_extend_gap_score(Aligner* self, void* closure)
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->query_extend_gap_score);
+    return PyFloat_FromDouble(self->query_internal_extend_gap_score);
 }
 
 static int
@@ -3503,7 +3503,7 @@ Aligner_set_query_internal_extend_gap_score(Aligner* self, PyObject* value,
                                             void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_extend_gap_score = score;
+    self->query_internal_extend_gap_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -3521,8 +3521,8 @@ Aligner_get_query_internal_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->query_open_gap_score;
-        if (score != self->query_extend_gap_score) {
+        const double score = self->query_internal_open_gap_score;
+        if (score != self->query_internal_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3535,8 +3535,8 @@ Aligner_set_query_internal_gap_score(Aligner* self, PyObject* value,
                                      void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_open_gap_score = score;
-    self->query_extend_gap_score = score;
+    self->query_internal_open_gap_score = score;
+    self->query_internal_extend_gap_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -3725,10 +3725,10 @@ static Algorithm _get_algorithm(Aligner* self)
 {
     Algorithm algorithm = self->algorithm;
     if (algorithm == Unknown) {
-        const double target_gap_open = self->target_open_gap_score;
-        const double query_gap_open = self->query_open_gap_score;
-        const double target_gap_extend = self->target_extend_gap_score;
-        const double query_gap_extend = self->query_extend_gap_score;
+        const double target_gap_open = self->target_internal_open_gap_score;
+        const double query_gap_open = self->query_internal_open_gap_score;
+        const double target_gap_extend = self->target_internal_extend_gap_score;
+        const double query_gap_extend = self->query_internal_extend_gap_score;
         const double target_left_open = self->target_left_open_gap_score;
         const double target_left_extend = self->target_left_extend_gap_score;
         const double query_left_open = self->query_left_open_gap_score;
@@ -4300,8 +4300,8 @@ static PyGetSetDef Aligner_getset[] = {
     int j; \
     int kA; \
     int kB; \
-    const double gap_extend_A = self->target_extend_gap_score; \
-    const double gap_extend_B = self->query_extend_gap_score; \
+    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_B = self->query_internal_extend_gap_score; \
     const double left_gap_extend_A = self->target_left_extend_gap_score; \
     const double right_gap_extend_A = self->target_right_extend_gap_score; \
     const double left_gap_extend_B = self->query_left_extend_gap_score; \
@@ -4362,8 +4362,8 @@ static PyGetSetDef Aligner_getset[] = {
     int j; \
     int kA; \
     int kB; \
-    const double gap_extend_A = self->target_extend_gap_score; \
-    const double gap_extend_B = self->query_extend_gap_score; \
+    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_B = self->query_internal_extend_gap_score; \
     double score; \
     double* row; \
     double temp; \
@@ -4413,8 +4413,8 @@ static PyGetSetDef Aligner_getset[] = {
     int j; \
     int kA; \
     int kB; \
-    const double gap_extend_A = self->target_extend_gap_score; \
-    const double gap_extend_B = self->query_extend_gap_score; \
+    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_B = self->query_internal_extend_gap_score; \
     const double left_gap_extend_A = self->target_left_extend_gap_score; \
     const double left_gap_extend_B = self->query_left_extend_gap_score; \
     const double right_gap_extend_A = self->target_right_extend_gap_score; \
@@ -4470,8 +4470,8 @@ static PyGetSetDef Aligner_getset[] = {
     int jm = nB; \
     int kA; \
     int kB; \
-    const double gap_extend_A = self->target_extend_gap_score; \
-    const double gap_extend_B = self->query_extend_gap_score; \
+    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_B = self->query_internal_extend_gap_score; \
     const double epsilon = self->epsilon; \
     Trace** M = NULL; \
     double maximum = 0; \
@@ -4552,10 +4552,10 @@ static PyGetSetDef Aligner_getset[] = {
     int j; \
     int kA; \
     int kB; \
-    const double gap_open_A = self->target_open_gap_score; \
-    const double gap_open_B = self->query_open_gap_score; \
-    const double gap_extend_A = self->target_extend_gap_score; \
-    const double gap_extend_B = self->query_extend_gap_score; \
+    const double gap_open_A = self->target_internal_open_gap_score; \
+    const double gap_open_B = self->query_internal_open_gap_score; \
+    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_B = self->query_internal_extend_gap_score; \
     const double left_gap_open_A = self->target_left_open_gap_score; \
     const double left_gap_open_B = self->query_left_open_gap_score; \
     const double left_gap_extend_A = self->target_left_extend_gap_score; \
@@ -4696,10 +4696,10 @@ exit: \
     int j; \
     int kA; \
     int kB; \
-    const double gap_open_A = self->target_open_gap_score; \
-    const double gap_open_B = self->query_open_gap_score; \
-    const double gap_extend_A = self->target_extend_gap_score; \
-    const double gap_extend_B = self->query_extend_gap_score; \
+    const double gap_open_A = self->target_internal_open_gap_score; \
+    const double gap_open_B = self->query_internal_open_gap_score; \
+    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_B = self->query_internal_extend_gap_score; \
     double* M_row = NULL; \
     double* Ix_row = NULL; \
     double* Iy_row = NULL; \
@@ -4807,10 +4807,10 @@ exit: \
     int j; \
     int kA; \
     int kB; \
-    const double gap_open_A = self->target_open_gap_score; \
-    const double gap_open_B = self->query_open_gap_score; \
-    const double gap_extend_A = self->target_extend_gap_score; \
-    const double gap_extend_B = self->query_extend_gap_score; \
+    const double gap_open_A = self->target_internal_open_gap_score; \
+    const double gap_open_B = self->query_internal_open_gap_score; \
+    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_B = self->query_internal_extend_gap_score; \
     const double left_gap_open_A = self->target_left_open_gap_score; \
     const double left_gap_open_B = self->query_left_open_gap_score; \
     const double left_gap_extend_A = self->target_left_extend_gap_score; \
@@ -4959,10 +4959,10 @@ exit: \
     int jm = nB; \
     int kA; \
     int kB; \
-    const double gap_open_A = self->target_open_gap_score; \
-    const double gap_open_B = self->query_open_gap_score; \
-    const double gap_extend_A = self->target_extend_gap_score; \
-    const double gap_extend_B = self->query_extend_gap_score; \
+    const double gap_open_A = self->target_internal_open_gap_score; \
+    const double gap_open_B = self->query_internal_open_gap_score; \
+    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_B = self->query_internal_extend_gap_score; \
     const double epsilon = self->epsilon; \
     Trace** M = NULL; \
     TraceGapsGotoh** gaps = NULL; \
@@ -6169,8 +6169,8 @@ _call_query_gap_function(Aligner* aligner, int i, int j, double* score)
     PyObject* result;
     PyObject* function = aligner->query_gap_function;
     if (!function)
-        value = aligner->query_open_gap_score
-              + (j-1) * aligner->query_extend_gap_score;
+        value = aligner->query_internal_open_gap_score
+              + (j-1) * aligner->query_internal_extend_gap_score;
     else {
         result = PyObject_CallFunction(function, "ii", i, j);
         if (result == NULL) return 0;
@@ -6189,8 +6189,8 @@ _call_target_gap_function(Aligner* aligner, int i, int j, double* score)
     PyObject* result;
     PyObject* function = aligner->target_gap_function;
     if (!function)
-        value = aligner->target_open_gap_score
-              + (j-1) * aligner->target_extend_gap_score;
+        value = aligner->target_internal_open_gap_score
+              + (j-1) * aligner->target_internal_extend_gap_score;
     else {
         result = PyObject_CallFunction(function, "ii", i, j);
         if (result == NULL) return 0;

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1693,14 +1693,14 @@ for the pairwise alignments. To see an overview of the values for all parameters
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: 0.000000
-  target_extend_gap_score: 0.000000
+  target_internal_open_gap_score: 0.000000
+  target_internal_extend_gap_score: 0.000000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
-  query_open_gap_score: 0.000000
-  query_extend_gap_score: 0.000000
+  query_internal_open_gap_score: 0.000000
+  query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: 0.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: 0.000000

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -52,14 +52,14 @@ class TestAlignerProperties(unittest.TestCase):
 Pairwise sequence aligner with parameters
   match_score: 3.000000
   mismatch_score: -2.000000
-  target_open_gap_score: 0.000000
-  target_extend_gap_score: 0.000000
+  target_internal_open_gap_score: 0.000000
+  target_internal_extend_gap_score: 0.000000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
-  query_open_gap_score: 0.000000
-  query_extend_gap_score: 0.000000
+  query_internal_open_gap_score: 0.000000
+  query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: 0.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: 0.000000
@@ -91,14 +91,14 @@ Pairwise sequence aligner with parameters
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -5.000000
-  target_extend_gap_score: -1.000000
+  target_internal_open_gap_score: -5.000000
+  target_internal_extend_gap_score: -1.000000
   target_left_open_gap_score: -3.000000
   target_left_extend_gap_score: -9.000000
   target_right_open_gap_score: -3.000000
   target_right_extend_gap_score: -9.000000
-  query_open_gap_score: -6.000000
-  query_extend_gap_score: -7.000000
+  query_internal_open_gap_score: -6.000000
+  query_internal_extend_gap_score: -7.000000
   query_left_open_gap_score: -1.000000
   query_left_extend_gap_score: -2.000000
   query_right_open_gap_score: -1.000000
@@ -143,14 +143,14 @@ Pairwise sequence aligner with parameters
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -3.000000
-  target_extend_gap_score: -3.000000
+  target_internal_open_gap_score: -3.000000
+  target_internal_extend_gap_score: -3.000000
   target_left_open_gap_score: -4.000000
   target_left_extend_gap_score: -4.000000
   target_right_open_gap_score: -4.000000
   target_right_extend_gap_score: -4.000000
-  query_open_gap_score: -2.000000
-  query_extend_gap_score: -2.000000
+  query_internal_open_gap_score: -2.000000
+  query_internal_extend_gap_score: -2.000000
   query_left_open_gap_score: -5.000000
   query_left_extend_gap_score: -5.000000
   query_right_open_gap_score: -5.000000
@@ -185,14 +185,14 @@ class TestPairwiseGlobal(unittest.TestCase):
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: 0.000000
-  target_extend_gap_score: 0.000000
+  target_internal_open_gap_score: 0.000000
+  target_internal_extend_gap_score: 0.000000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
-  query_open_gap_score: 0.000000
-  query_extend_gap_score: 0.000000
+  query_internal_open_gap_score: 0.000000
+  query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: 0.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: 0.000000
@@ -233,14 +233,14 @@ G-A-T
 Pairwise sequence aligner with parameters
   match_score: 0.000000
   mismatch_score: -1.000000
-  target_open_gap_score: -5.000000
-  target_extend_gap_score: -1.000000
+  target_internal_open_gap_score: -5.000000
+  target_internal_extend_gap_score: -1.000000
   target_left_open_gap_score: -5.000000
   target_left_extend_gap_score: -1.000000
   target_right_open_gap_score: -5.000000
   target_right_extend_gap_score: -1.000000
-  query_open_gap_score: -5.000000
-  query_extend_gap_score: -1.000000
+  query_internal_open_gap_score: -5.000000
+  query_internal_extend_gap_score: -1.000000
   query_left_open_gap_score: -5.000000
   query_left_extend_gap_score: -1.000000
   query_right_open_gap_score: -5.000000
@@ -262,14 +262,14 @@ class TestPairwiseLocal(unittest.TestCase):
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -0.100000
-  target_extend_gap_score: -0.100000
+  target_internal_open_gap_score: -0.100000
+  target_internal_extend_gap_score: -0.100000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: -0.100000
-  query_open_gap_score: -0.100000
-  query_extend_gap_score: -0.100000
+  query_internal_open_gap_score: -0.100000
+  query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.100000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.100000
@@ -299,14 +299,14 @@ zA-Bz
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -0.100000
-  target_extend_gap_score: 0.000000
+  target_internal_open_gap_score: -0.100000
+  target_internal_extend_gap_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
-  query_open_gap_score: -0.100000
-  query_extend_gap_score: 0.000000
+  query_internal_open_gap_score: -0.100000
+  query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.100000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.100000
@@ -341,14 +341,14 @@ class TestPairwiseOpenPenalty(unittest.TestCase):
 Pairwise sequence aligner with parameters
   match_score: 2.000000
   mismatch_score: -1.000000
-  target_open_gap_score: -0.100000
-  target_extend_gap_score: 0.000000
+  target_internal_open_gap_score: -0.100000
+  target_internal_extend_gap_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
-  query_open_gap_score: -0.100000
-  query_extend_gap_score: 0.000000
+  query_internal_open_gap_score: -0.100000
+  query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.100000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.100000
@@ -390,14 +390,14 @@ A-
 Pairwise sequence aligner with parameters
   match_score: 1.500000
   mismatch_score: 0.000000
-  target_open_gap_score: -0.100000
-  target_extend_gap_score: 0.000000
+  target_internal_open_gap_score: -0.100000
+  target_internal_extend_gap_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
-  query_open_gap_score: -0.100000
-  query_extend_gap_score: 0.000000
+  query_internal_open_gap_score: -0.100000
+  query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.100000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.100000
@@ -437,14 +437,14 @@ GA-
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: 0.000000
-  target_extend_gap_score: 0.000000
+  target_internal_open_gap_score: 0.000000
+  target_internal_extend_gap_score: 0.000000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
-  query_open_gap_score: -0.100000
-  query_extend_gap_score: 0.000000
+  query_internal_open_gap_score: -0.100000
+  query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.100000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.100000
@@ -477,14 +477,14 @@ GA--T
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: -2.000000
-  target_open_gap_score: -0.100000
-  target_extend_gap_score: 0.000000
+  target_internal_open_gap_score: -0.100000
+  target_internal_extend_gap_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
-  query_open_gap_score: -0.100000
-  query_extend_gap_score: 0.000000
+  query_internal_open_gap_score: -0.100000
+  query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.100000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.100000
@@ -527,14 +527,14 @@ class TestPairwiseExtendPenalty(unittest.TestCase):
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -0.200000
-  target_extend_gap_score: -0.500000
+  target_internal_open_gap_score: -0.200000
+  target_internal_extend_gap_score: -0.500000
   target_left_open_gap_score: -0.200000
   target_left_extend_gap_score: -0.500000
   target_right_open_gap_score: -0.200000
   target_right_extend_gap_score: -0.500000
-  query_open_gap_score: -0.200000
-  query_extend_gap_score: -0.500000
+  query_internal_open_gap_score: -0.200000
+  query_internal_extend_gap_score: -0.500000
   query_left_open_gap_score: -0.200000
   query_left_extend_gap_score: -0.500000
   query_right_open_gap_score: -0.200000
@@ -566,14 +566,14 @@ G--T
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -0.200000
-  target_extend_gap_score: -1.500000
+  target_internal_open_gap_score: -0.200000
+  target_internal_extend_gap_score: -1.500000
   target_left_open_gap_score: -0.200000
   target_left_extend_gap_score: -1.500000
   target_right_open_gap_score: -0.200000
   target_right_extend_gap_score: -1.500000
-  query_open_gap_score: -0.200000
-  query_extend_gap_score: -1.500000
+  query_internal_open_gap_score: -0.200000
+  query_internal_extend_gap_score: -1.500000
   query_left_open_gap_score: -0.200000
   query_left_extend_gap_score: -1.500000
   query_right_open_gap_score: -0.200000
@@ -616,14 +616,14 @@ class TestPairwisePenalizeExtendWhenOpening(unittest.TestCase):
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -1.700000
-  target_extend_gap_score: -1.500000
+  target_internal_open_gap_score: -1.700000
+  target_internal_extend_gap_score: -1.500000
   target_left_open_gap_score: -1.700000
   target_left_extend_gap_score: -1.500000
   target_right_open_gap_score: -1.700000
   target_right_extend_gap_score: -1.500000
-  query_open_gap_score: -1.700000
-  query_extend_gap_score: -1.500000
+  query_internal_open_gap_score: -1.700000
+  query_internal_extend_gap_score: -1.500000
   query_left_open_gap_score: -1.700000
   query_left_extend_gap_score: -1.500000
   query_right_open_gap_score: -1.700000
@@ -660,14 +660,14 @@ class TestPairwisePenalizeEndgaps(unittest.TestCase):
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -0.200000
-  target_extend_gap_score: -0.800000
+  target_internal_open_gap_score: -0.200000
+  target_internal_extend_gap_score: -0.800000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
-  query_open_gap_score: -0.200000
-  query_extend_gap_score: -0.800000
+  query_internal_open_gap_score: -0.200000
+  query_internal_extend_gap_score: -0.800000
   query_left_open_gap_score: 0.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: 0.000000
@@ -729,14 +729,14 @@ class TestPairwiseSeparateGapPenalties(unittest.TestCase):
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -0.300000
-  target_extend_gap_score: 0.000000
+  target_internal_open_gap_score: -0.300000
+  target_internal_extend_gap_score: 0.000000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: 0.000000
-  query_open_gap_score: -0.800000
-  query_extend_gap_score: 0.000000
+  query_internal_open_gap_score: -0.800000
+  query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.800000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.800000
@@ -776,14 +776,14 @@ GTCT
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -0.300000
-  target_extend_gap_score: 0.000000
+  target_internal_open_gap_score: -0.300000
+  target_internal_extend_gap_score: 0.000000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: 0.000000
-  query_open_gap_score: -0.200000
-  query_extend_gap_score: 0.000000
+  query_internal_open_gap_score: -0.200000
+  query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.200000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.200000
@@ -826,14 +826,14 @@ class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -0.100000
-  target_extend_gap_score: 0.000000
+  target_internal_open_gap_score: -0.100000
+  target_internal_extend_gap_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
-  query_open_gap_score: -0.100000
-  query_extend_gap_score: -0.100000
+  query_internal_open_gap_score: -0.100000
+  query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.100000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.100000
@@ -928,14 +928,14 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
         self.assertTrue(line.startswith(prefix))
         self.assertTrue(line.endswith(suffix))
         address = int(line[len(prefix):-len(suffix)], 16)
-        self.assertEqual(lines[2], "  target_open_gap_score: -0.500000")
-        self.assertEqual(lines[3], "  target_extend_gap_score: 0.000000")
+        self.assertEqual(lines[2], "  target_internal_open_gap_score: -0.500000")
+        self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -0.500000")
         self.assertEqual(lines[5], "  target_left_extend_gap_score: 0.000000")
         self.assertEqual(lines[6], "  target_right_open_gap_score: -0.500000")
         self.assertEqual(lines[7], "  target_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[8], "  query_open_gap_score: -0.500000")
-        self.assertEqual(lines[9], "  query_extend_gap_score: 0.000000")
+        self.assertEqual(lines[8], "  query_internal_open_gap_score: -0.500000")
+        self.assertEqual(lines[9], "  query_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[10], "  query_left_open_gap_score: -0.500000")
         self.assertEqual(lines[11], "  query_left_extend_gap_score: 0.000000")
         self.assertEqual(lines[12], "  query_right_open_gap_score: -0.500000")
@@ -984,14 +984,14 @@ AT-T
         self.assertTrue(line.startswith(prefix))
         self.assertTrue(line.endswith(suffix))
         address = int(line[len(prefix):-len(suffix)], 16)
-        self.assertEqual(lines[2], "  target_open_gap_score: -1.000000")
-        self.assertEqual(lines[3], "  target_extend_gap_score: 0.000000")
+        self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
+        self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
         self.assertEqual(lines[5], "  target_left_extend_gap_score: 0.000000")
         self.assertEqual(lines[6], "  target_right_open_gap_score: -1.000000")
         self.assertEqual(lines[7], "  target_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[8], "  query_open_gap_score: -1.000000")
-        self.assertEqual(lines[9], "  query_extend_gap_score: 0.000000")
+        self.assertEqual(lines[8], "  query_internal_open_gap_score: -1.000000")
+        self.assertEqual(lines[9], "  query_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[10], "  query_left_open_gap_score: -1.000000")
         self.assertEqual(lines[11], "  query_left_extend_gap_score: 0.000000")
         self.assertEqual(lines[12], "  query_right_open_gap_score: -1.000000")
@@ -1032,14 +1032,14 @@ ATT
         self.assertTrue(line.startswith(prefix))
         self.assertTrue(line.endswith(suffix))
         address = int(line[len(prefix):-len(suffix)], 16)
-        self.assertEqual(lines[2], "  target_open_gap_score: -1.000000")
-        self.assertEqual(lines[3], "  target_extend_gap_score: 0.000000")
+        self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
+        self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
         self.assertEqual(lines[5], "  target_left_extend_gap_score: 0.000000")
         self.assertEqual(lines[6], "  target_right_open_gap_score: -1.000000")
         self.assertEqual(lines[7], "  target_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[8], "  query_open_gap_score: -1.000000")
-        self.assertEqual(lines[9], "  query_extend_gap_score: 0.000000")
+        self.assertEqual(lines[8], "  query_internal_open_gap_score: -1.000000")
+        self.assertEqual(lines[9], "  query_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[10], "  query_left_open_gap_score: -1.000000")
         self.assertEqual(lines[11], "  query_left_extend_gap_score: 0.000000")
         self.assertEqual(lines[12], "  query_right_open_gap_score: -1.000000")
@@ -1083,14 +1083,14 @@ ATAT
         self.assertTrue(line.startswith(prefix))
         self.assertTrue(line.endswith(suffix))
         address = int(line[len(prefix):-len(suffix)], 16)
-        self.assertEqual(lines[2], "  target_open_gap_score: -0.500000")
-        self.assertEqual(lines[3], "  target_extend_gap_score: 0.000000")
+        self.assertEqual(lines[2], "  target_internal_open_gap_score: -0.500000")
+        self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -0.500000")
         self.assertEqual(lines[5], "  target_left_extend_gap_score: 0.000000")
         self.assertEqual(lines[6], "  target_right_open_gap_score: -0.500000")
         self.assertEqual(lines[7], "  target_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[8], "  query_open_gap_score: -0.500000")
-        self.assertEqual(lines[9], "  query_extend_gap_score: 0.000000")
+        self.assertEqual(lines[8], "  query_internal_open_gap_score: -0.500000")
+        self.assertEqual(lines[9], "  query_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[10], "  query_left_open_gap_score: -0.500000")
         self.assertEqual(lines[11], "  query_left_extend_gap_score: 0.000000")
         self.assertEqual(lines[12], "  query_right_open_gap_score: -0.500000")
@@ -1141,14 +1141,14 @@ AT-T
         self.assertTrue(line.startswith(prefix))
         self.assertTrue(line.endswith(suffix))
         address = int(line[len(prefix):-len(suffix)], 16)
-        self.assertEqual(lines[2], "  target_open_gap_score: -1.000000")
-        self.assertEqual(lines[3], "  target_extend_gap_score: 0.000000")
+        self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
+        self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
         self.assertEqual(lines[5], "  target_left_extend_gap_score: 0.000000")
         self.assertEqual(lines[6], "  target_right_open_gap_score: -1.000000")
         self.assertEqual(lines[7], "  target_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[8], "  query_open_gap_score: -1.000000")
-        self.assertEqual(lines[9], "  query_extend_gap_score: 0.000000")
+        self.assertEqual(lines[8], "  query_internal_open_gap_score: -1.000000")
+        self.assertEqual(lines[9], "  query_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[10], "  query_left_open_gap_score: -1.000000")
         self.assertEqual(lines[11], "  query_left_extend_gap_score: 0.000000")
         self.assertEqual(lines[12], "  query_right_open_gap_score: -1.000000")
@@ -1191,14 +1191,14 @@ ATT
         self.assertTrue(line.startswith(prefix))
         self.assertTrue(line.endswith(suffix))
         address = int(line[len(prefix):-len(suffix)], 16)
-        self.assertEqual(lines[2], "  target_open_gap_score: -1.000000")
-        self.assertEqual(lines[3], "  target_extend_gap_score: 0.000000")
+        self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
+        self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
         self.assertEqual(lines[5], "  target_left_extend_gap_score: 0.000000")
         self.assertEqual(lines[6], "  target_right_open_gap_score: -1.000000")
         self.assertEqual(lines[7], "  target_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[8], "  query_open_gap_score: -1.000000")
-        self.assertEqual(lines[9], "  query_extend_gap_score: 0.000000")
+        self.assertEqual(lines[8], "  query_internal_open_gap_score: -1.000000")
+        self.assertEqual(lines[9], "  query_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[10], "  query_left_open_gap_score: -1.000000")
         self.assertEqual(lines[11], "  query_left_extend_gap_score: 0.000000")
         self.assertEqual(lines[12], "  query_right_open_gap_score: -1.000000")
@@ -1230,14 +1230,14 @@ class TestPairwiseOneCharacter(unittest.TestCase):
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -0.300000
-  target_extend_gap_score: -0.100000
+  target_internal_open_gap_score: -0.300000
+  target_internal_extend_gap_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
-  query_open_gap_score: -0.300000
-  query_extend_gap_score: -0.100000
+  query_internal_open_gap_score: -0.300000
+  query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.300000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.300000
@@ -1267,14 +1267,14 @@ abcde
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -0.300000
-  target_extend_gap_score: -0.100000
+  target_internal_open_gap_score: -0.300000
+  target_internal_extend_gap_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
-  query_open_gap_score: -0.300000
-  query_extend_gap_score: -0.100000
+  query_internal_open_gap_score: -0.300000
+  query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.300000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.300000
@@ -1312,14 +1312,14 @@ abcce
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -0.300000
-  target_extend_gap_score: -0.100000
+  target_internal_open_gap_score: -0.300000
+  target_internal_extend_gap_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
-  query_open_gap_score: -0.300000
-  query_extend_gap_score: -0.100000
+  query_internal_open_gap_score: -0.300000
+  query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.300000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.300000
@@ -1351,14 +1351,14 @@ abcde
 Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_open_gap_score: -0.300000
-  target_extend_gap_score: -0.100000
+  target_internal_open_gap_score: -0.300000
+  target_internal_extend_gap_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
-  query_open_gap_score: -0.300000
-  query_extend_gap_score: -0.100000
+  query_internal_open_gap_score: -0.300000
+  query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.300000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.300000
@@ -1486,8 +1486,8 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: -10.000000
   target_gap_function: %s
-  query_open_gap_score: 0.000000
-  query_extend_gap_score: 0.000000
+  query_internal_open_gap_score: 0.000000
+  query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: 0.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: 0.000000
@@ -1670,8 +1670,8 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: -10.000000
   target_gap_function: %s
-  query_open_gap_score: 0.000000
-  query_extend_gap_score: 0.000000
+  query_internal_open_gap_score: 0.000000
+  query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: 0.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: 0.000000


### PR DESCRIPTION
This pull request changes the text returned by str(aligner) to be consistent with its attribute names.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
