### PR TITLE
Gitignore fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ build
 
 #Ignore the distribution directory
 dist
- 
+
 #Ignore backup files from some Unix editors,
 \#*.py\#
 *~
@@ -21,11 +21,10 @@ dist
 
 #Ignore hidden files from Dolphin window manager
 .directory
- 
+
 #Ignore all compiled python files (e.g. from running the unit tests):
 *.pyc
 *.pyo
-*.py{}
 *.py-e
 
 #Ignore all Jython class files (present if using Jython)
@@ -42,7 +41,7 @@ MANIFEST
 
 #Ignore potential directory created during install:
 biopython.egg-info
- 
+
 #The graphics unit tests produce output files for human inspection
 #(at the time of writing, only PDF and PNG files are created)
 Tests/Graphics/*.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ Tests/biosql.ini
 Tests/BioSQL/temp_sqlite.db
 Tests/BioSQL/temp_sqlite.db-journal
 Tests/Cluster/cyano_result*
+# Created by Tests/test_BWA_tool.py:
+Tests/out.bam
 
 #TODO - The Tutorial doctests should leave example files after
 #running Tests/test_Tutorial.py


### PR DESCRIPTION
This pull request addresses issue #2335 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ ] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Removes unused and confusing `*.py{}` from `.gitignore` as discussed in linked issue. 

I also discovered that upon running the tests a file `Tests/out.bam` is created that is not in the `.gitignore` file. So I added that as well. 