### PR TITLE
Ignore C modules with no docstrings

### DIFF
--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -358,6 +358,15 @@ class TestRunner(unittest.TextTestRunner):
                 except MissingPythonDependencyError:
                     sys.stderr.write("skipped, missing Python dependency\n")
                     return True
+                except ValueError as e:
+                    if str(e).startswith("module ") and str(e).endswith("has no docstrings"):
+                        # Seen with some C modules via Debian build testing
+                        sys.stderr.write("skipped, has no docstrings\n")
+                        return True
+                    sys.stderr.write("FAIL, ValueError\n")
+                    result.stream.write("ERROR while importing %s: %s\n" % (name, e))
+                    result.printErrors()
+                    return False
                 except ImportError as e:
                     sys.stderr.write("FAIL, ImportError\n")
                     result.stream.write("ERROR while importing %s: %s\n" % (name, e))


### PR DESCRIPTION
This pull request is intended to addresses this issue https://alioth-lists.debian.net/pipermail/debian-med-packaging/2019-November/074775.html where the Debian build system attempts to run the doctests in our C code, and some fail (at least on Python 2.7) due to no docstrings:

```
$ python2.7 run_tests.py --offline
test_Ace ... ok
test_Affy ... ok
...
test_translate ... ok
test_trie ... ok
Bio docstring test ... ok
Bio.Affy docstring test ... ok
...
Bio.KDTree.KDTree docstring test ... ok
Bio.KDTree._CKDTree docstring test ... ERROR
Bio.KEGG docstring test ... ok
...
Bio.Nexus.Trees docstring test ... ok
Bio.Nexus.cnexus docstring test ... ERROR
Bio.PDB.Atom docstring test ... ok
...
Bio.PDB.QCPSuperimposer docstring test ... ok
Bio.PDB.QCPSuperimposer.qcprot docstring test ... ERROR
Bio.PDB.Residue docstring test ... ok
...
Bio.PDB.Superimposer docstring test ... ok
Bio.PDB.kdtrees docstring test ... ERROR
Bio.PDB.mmcifio docstring test ... ok
...
BioSQL.DBUtils docstring test ... ok
BioSQL.Loader docstring test ... ok
======================================================================
ERROR: Bio.KDTree._CKDTree
----------------------------------------------------------------------
Traceback (most recent call last):
  File "run_tests.py", line 367, in runTest
    optionflags=doctest.ELLIPSIS)
  File "/usr/lib/python2.7/doctest.py", line 2412, in DocTestSuite
    raise ValueError(module, "has no docstrings")
ValueError: (<module 'Bio.KDTree._CKDTree' from '/build/python-biopython-1.75+dfsg/.pybuild/cpython2_2.7/build/Bio/KDTree/_CKDTree.so'>, 'has no docstrings')
======================================================================
ERROR: Bio.Nexus.cnexus
----------------------------------------------------------------------
Traceback (most recent call last):
  File "run_tests.py", line 367, in runTest
    optionflags=doctest.ELLIPSIS)
  File "/usr/lib/python2.7/doctest.py", line 2412, in DocTestSuite
    raise ValueError(module, "has no docstrings")
ValueError: (<module 'Bio.Nexus.cnexus' from '/build/python-biopython-1.75+dfsg/.pybuild/cpython2_2.7/build/Bio/Nexus/cnexus.so'>, 'has no docstrings')
======================================================================
ERROR: Bio.PDB.QCPSuperimposer.qcprot
----------------------------------------------------------------------
Traceback (most recent call last):
  File "run_tests.py", line 367, in runTest
    optionflags=doctest.ELLIPSIS)
  File "/usr/lib/python2.7/doctest.py", line 2412, in DocTestSuite
    raise ValueError(module, "has no docstrings")
ValueError: (<module 'Bio.PDB.QCPSuperimposer.qcprotmodule' from '/build/python-biopython-1.75+dfsg/.pybuild/cpython2_2.7/build/Bio/PDB/QCPSuperimposer/qcprotmodule.so'>, 'has no docstrings')
======================================================================
ERROR: Bio.PDB.kdtrees
----------------------------------------------------------------------
Traceback (most recent call last):
  File "run_tests.py", line 367, in runTest
    optionflags=doctest.ELLIPSIS)
  File "/usr/lib/python2.7/doctest.py", line 2412, in DocTestSuite
    raise ValueError(module, "has no docstrings")
ValueError: (<module 'Bio.PDB.kdtrees' from '/build/python-biopython-1.75+dfsg/.pybuild/cpython2_2.7/build/Bio/PDB/kdtrees.so'>, 'has no docstrings')
----------------------------------------------------------------------
Ran 519 tests in 287.024 seconds

FAILED (failures = 4)
```

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Waiting to hear back from the Debian team if this works...