### PR TITLE
Parse multiline structured comments in GenBank files

### DIFF
--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1792,7 +1792,21 @@ class GenBankScanner(InsdcScanner):
                                     print(
                                         "Structured Comment continuation [" + data + "]"
                                     )
-                            elif self.STRUCTURED_COMMENT_END not in data:
+                            elif (
+                                structured_comment_key is not None
+                                and self.STRUCTURED_COMMENT_END not in data
+                            ):
+                                # The current structured comment has a multiline value
+                                previous_value_line = structured_comment_dict[
+                                    structured_comment_key][
+                                    match.group(1)]
+                                structured_comment_dict[
+                                    structured_comment_key][
+                                    match.group(1)] = previous_value_line + " " + line.strip()
+                            elif self.STRUCTURED_COMMENT_END in data:
+                                # End of structured comment
+                                structured_comment_key = None
+                            else:
                                 comment_list.append(data)
                                 if self.debug > 2:
                                     print("Comment continuation [" + data + "]")

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -184,6 +184,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Matt Ruffalo <https://github.com/mruffalo>
 - Matt Shirley <https://github.com/mdshw5>
 - Matteo Sticco <https://github.com/sticken88>
+- Matteo Ugolotti <https://github.com/matteougolotti>
 - Maximilian Greil <https://github.com/MaxGreil>
 - Maximilian Peters <maximili.peters at mail.huji.ac.il>
 - Melissa Gymrek <https://github.com/mgymrek>

--- a/Tests/GenBank/GU949562.1.gb
+++ b/Tests/GenBank/GU949562.1.gb
@@ -1,0 +1,74 @@
+LOCUS       GU949562                 717 bp    DNA     linear   BCT 30-JUL-2010
+DEFINITION  Shewanella sp. MAR_280_P06_2010-01-20 16S ribosomal RNA gene,
+            partial sequence.
+ACCESSION   GU949562
+VERSION     GU949562.1
+KEYWORDS    GSC:MIENS:2.1.
+SOURCE      Shewanella sp. MAR_280_P06_2010-01-20
+  ORGANISM  Shewanella sp. MAR_280_P06_2010-01-20
+            Bacteria; Proteobacteria; Gammaproteobacteria; Alteromonadales;
+            Shewanellaceae; Shewanella.
+REFERENCE   1  (bases 1 to 717)
+  AUTHORS   Hankeln,W., Buttigieg,P.L., Fink,D., Kottmann,R., Yilmaz,P. and
+            Glockner,F.O.
+  TITLE     MetaBar - a tool for consistent contextual data acquisition and
+            standards compliant submission
+  JOURNAL   BMC Bioinformatics 11, 358 (2010)
+   PUBMED   20591175
+  REMARK    Publication Status: Online-Only
+REFERENCE   2  (bases 1 to 717)
+  AUTHORS   Hankeln,W., Buttigieg,P.L., Fink,D., Kottman,R., Yilmaz,P. and
+            Gloeckner,F.O.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (02-MAR-2010) Microbial Genomics Group, Max Planck
+            Institute for Marine Microbiology, Celsiusstr. 1, Bremen 28359,
+            Germany
+COMMENT     ##MIENS-Data-START##
+            collection_date    :: 2009-10-14
+            collection_time    :: 09:38:00
+            lat_lon            :: 55.02814 8.45248
+            geodetic_datum     :: WGS84
+            lat_long_details   :: 11 m recorded accuracy
+            site               :: German Wadden Sea, Sylt
+            depth              :: -1.0 m
+            samp_size          :: 1000.0 ml
+            temperature        :: 10.155 degrees Celsius
+            container          :: 10 ml glass exetainers
+            environment        :: Temperate shelf and sea biome
+                                  [ENVO:00000895], coastal water body
+                                  [ENVO:02000049], coastal water
+                                  [ENVO:00002150]
+            alt_elev           :: 0 m
+            country            :: Germany
+            investigation_type :: miens-survey
+            project_name       :: Marine Microbiology (MarMic) class 2013 field
+                                  excursion to Sylt, 2009
+            sequencing_meth    :: Sanger
+            target_gene        :: 16S rRNA
+            MetaBar_barcode    :: 1000009000039
+            ##MIENS-Data-END##
+FEATURES             Location/Qualifiers
+     source          1..717
+                     /organism="Shewanella sp. MAR_280_P06_2010-01-20"
+                     /mol_type="genomic DNA"
+                     /strain="MAR_280_P06_2010-01-20"
+                     /db_xref="taxon:748143"
+                     /lat_lon="55.03 N 8.45 E"
+                     /collection_date="14-Oct-2009"
+                     /collected_by="Olga Matantseva"
+     rRNA            <1..>717
+                     /product="16S ribosomal RNA"
+ORIGIN      
+        1 tcagattgaa cgcggcggca ggcctaacac atgcaagtcg agcggtaaca ggaattagct
+       61 tgctaatttg ctgacgagcg gcggacgggt gagtaatgcc tagggaactg cccagtcgag
+      121 ggggataaca gttggaaacg actgctaata ccgcatacgc cctacggggg aaaagagggg
+      181 accttcgggc cttctgcgat tggatgtacc taggtgggat tagctagttg gtgaggtaat
+      241 ggctcaccaa ggcgacgatc cctagctgtt tgagaggatg atcagccaca ctgggactga
+      301 gacacggccc agactcctac gggaggcagc agtggggaat attgcacaat gggcgcaagc
+      361 ctgatgcagc catgccgcgt gtgtgaagaa gcttcgggtt gtaaagcact ttcagcgagg
+      421 aggaaagaat agcgtttagg tgtgacgtta ctcgcagaag aaggaccggc taacttcgtg
+      481 ccagcagccg cggtaatacg aggggtcaac gttaatcgga attactgggc gtaaagcgta
+      541 cgcaggcggt ttgttaagcg agatgtgaaa gccccgggct caacctggga actgcatttc
+      601 gaactggcaa actagagtct gtagaggggg gtagaatttc aggtgtagcg gtgaaatgaa
+      661 gatctgaagg aataccggtg gcgaaggcgg ccccctggac aaagactgac gctcatg
+//

--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -6601,6 +6601,18 @@ KEYWORDS    """
             "COMPLETENESS: full length.",
         )
 
+    def test_multiline_structured_comment_parsing(self):
+        """Multiline structured comment parsing."""
+        # GU949562.1, MIENS-Data, environment has value on multiple lines
+        path = "GenBank/GU949562.1.gb"
+        record = SeqIO.read(path, "genbank")
+        self.assertEqual(
+            record.annotations["structured_comment"]["MIENS-Data"]["environment"],
+            "Temperate shelf and sea biome [ENVO:00000895], "
+            "coastal water body [ENVO:02000049], "
+            "coastal water [ENVO:00002150]"
+        )
+
     def test_locus_line_topogoly(self):
         """Test if chromosome topology is conserved."""
         record = SeqIO.read("GenBank/DS830848.gb", "genbank")


### PR DESCRIPTION
GenBank files can contain multiline comments in the form

COMMENT     ##MIENS-Data-START##
            environment        :: Temperate shelf and sea biome
                                  [ENVO:00000895], coastal water body
                                  [ENVO:02000049], coastal water
                                  [ENVO:00002150]
            ##MIENS-Data-END##

Previously lines after the 'environment' comment key were attached to the
global comment instead of the structured comment, resulting in

["MIENS-Data"]["environment"] == "Temperate shelf and sea biome"

After this commit the extra lines are attached to the value at the previous
structured comment's key, resulting in

["MIENS-Data"]["environment"] == "Temperate shelf and sea biome[ENVO:00000895], coastal water body[ENVO:02000049], coastal water[ENVO:00002150]"

Issue: #2177

This pull request addresses issue #2177 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
