### PR TITLE
Fix same line implicit string concatenation from black

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -823,7 +823,7 @@ class GenBankWriter(_InsdcWriter):
                 )
             if line[54:55] != " ":
                 raise ValueError(
-                    "LOCUS line does not contain space at " "position 55:\n" + line
+                    "LOCUS line does not contain space at position 55:\n" + line
                 )
             if line[55:63].strip() not in ["", "linear", "circular"]:
                 raise ValueError(
@@ -832,19 +832,19 @@ class GenBankWriter(_InsdcWriter):
                 )
             if line[63:64] != " ":
                 raise ValueError(
-                    "LOCUS line does not contain space at " "position 64:\n" + line
+                    "LOCUS line does not contain space at position 64:\n" + line
                 )
             if line[67:68] != " ":
                 raise ValueError(
-                    "LOCUS line does not contain space at " "position 68:\n" + line
+                    "LOCUS line does not contain space at position 68:\n" + line
                 )
             if line[70:71] != "-":
                 raise ValueError(
-                    "LOCUS line does not contain - at " "position 71 in date:\n" + line
+                    "LOCUS line does not contain - at position 71 in date:\n" + line
                 )
             if line[74:75] != "-":
                 raise ValueError(
-                    "LOCUS line does not contain - at " "position 75 in date:\n" + line
+                    "LOCUS line does not contain - at position 75 in date:\n" + line
                 )
 
             self.handle.write(line)

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -565,7 +565,7 @@ def _sff_find_roche_index(handle):
         )
     elif magic_number == _hsh:
         raise ValueError(
-            "Hash table style indexes (.hsh) in SFF files are " "not (yet) supported"
+            "Hash table style indexes (.hsh) in SFF files are not (yet) supported"
         )
     else:
         raise ValueError(
@@ -1144,7 +1144,7 @@ def _check_eof(handle, index_offset, index_length):
         )
     elif extra:
         raise ValueError(
-            "Additional data at end of SFF file, " "see offset %i" % offset
+            "Additional data at end of SFF file, see offset %i" % offset
         )
 
 

--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -445,7 +445,7 @@ def _load_bgzf_block(handle, text_mode=False):
     expected_crc = handle.read(4)
     expected_size = struct.unpack("<I", handle.read(4))[0]
     if expected_size != len(data):
-        raise RuntimeError("Decompressed to %i, " "not %i" % (len(data), expected_size))
+        raise RuntimeError("Decompressed to %i, not %i" % (len(data), expected_size))
     # Should cope with a mix of Python platforms...
     crc = zlib.crc32(data)
     if crc < 0:


### PR DESCRIPTION
There is an open issue on black for fixing this:
https://github.com/psf/black/issues/26#issuecomment-558983613

These specific cases were spotted while testing a new flake8 plugin:
https://github.com/keisheiled/flake8-implicit-str-concat/

Once that plugin as matured a little, we should start using it on our continuous integration testing (at least until the black issue is addressed).


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
