### PR TITLE
Cif header

### DIFF
--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -41,7 +41,7 @@ class MMCIFParser(object):
             self._structure_builder = structure_builder
         else:
             self._structure_builder = StructureBuilder()
-        # self.header = None
+        self.header = None
         # self.trailer = None
         self.line_counter = 0
         self.build_structure = None
@@ -62,6 +62,7 @@ class MMCIFParser(object):
                 warnings.filterwarnings("ignore", category=PDBConstructionWarning)
             self._mmcif_dict = MMCIF2Dict(filename)
             self._build_structure(structure_id)
+            self._structure_builder.set_header(self._get_header())
 
         return self._structure_builder.get_structure()
 
@@ -74,8 +75,20 @@ class MMCIFParser(object):
                 return rslt
         return deflt
 
-    def _get_mmcif_header_dict(self, md):
-        dict = {
+    def _update_header_entry(self, target_key, keys, is_float=False):
+        md = self._mmcif_dict
+        for key in keys:
+            val = md.get(key)
+            try:
+                item = val[0]
+            except (TypeError, IndexError):
+                continue
+            if item != "?":
+                self.header[target_key] = item if not is_float else float(item)
+                return
+
+    def _get_header(self):
+        self.header = {
             "name": "",
             "head": "",
             "idcode": "",
@@ -84,31 +97,22 @@ class MMCIFParser(object):
             "resolution": 0.0,
         }
 
-        dict["idcode"] = self._mmcif_get("_entry.id", md, None)
-        if not dict["idcode"]:
-            dict["idcode"] = self._mmcif_get("_exptl.entry_id", md, None)
-        if not dict["idcode"]:
-            dict["idcode"] = self._mmcif_get("_struct.entry_id", md, None)
-
-        dict["name"] = self._mmcif_get("_struct.title", md, None)
-
-        dict["head"] = self._mmcif_get("_struct_keywords.pdbx_keywords", md, None)
-        if not dict["head"]:
-            dict["head"] = self._mmcif_get("_struct_keywords.text", md, None)
-
-        dict["deposition_date"] = self._mmcif_get(
-            "_pdbx_database_status.recvd_initial_deposition_date", md, None
+        self._update_header_entry(
+            "idcode", ["_entry_id", "_exptl.entry_id", "_struct.entry_id"]
+        )
+        self._update_header_entry("name", ["_struct.title"])
+        self._update_header_entry(
+            "head", ["_struct_keywords.pdbx_keywords", "_struct_keywords.text"]
+        )
+        self._update_header_entry(
+            "deposition_date", ["_pdbx_database_status.recvd_initial_deposition_date"]
+        )
+        self._update_header_entry("structure_method", ["_exptl.method"])
+        self._update_header_entry(
+            "resolution", ["_refine.ls_d_res_high", "_refine_hist.d_res_high"], True
         )
 
-        dict["structure_method"] = self._mmcif_get("_exptl.method", md, None)
-
-        dict["resolution"] = float(self._mmcif_get("_refine.ls_d_res_high", md, 0.0))
-        if 0.0 == dict["resolution"]:
-            dict["resolution"] = float(
-                self._mmcif_get("_refine_hist.d_res_high", md, 0.0)
-            )
-
-        return dict
+        return self.header
 
     def _build_structure(self, structure_id):
 
@@ -165,7 +169,6 @@ class MMCIFParser(object):
         structure_builder = self._structure_builder
         structure_builder.init_structure(structure_id)
         structure_builder.init_seg(" ")
-        structure_builder.set_header(self._get_mmcif_header_dict(mmcif_dict))
         # Historically, Biopython PDB parser uses model_id to mean array index
         # so serial_id means the Model ID specified in the file
         current_model_id = -1

--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -85,7 +85,7 @@ class MMCIFParser(object):
                 continue
             if item != "?":
                 self.header[target_key] = item
-                return
+                break
 
     def _get_header(self):
         self.header = {

--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -75,7 +75,7 @@ class MMCIFParser(object):
                 return rslt
         return deflt
 
-    def _update_header_entry(self, target_key, keys, is_float=False):
+    def _update_header_entry(self, target_key, keys):
         md = self._mmcif_dict
         for key in keys:
             val = md.get(key)
@@ -84,7 +84,7 @@ class MMCIFParser(object):
             except (TypeError, IndexError):
                 continue
             if item != "?":
-                self.header[target_key] = item if not is_float else float(item)
+                self.header[target_key] = item
                 return
 
     def _get_header(self):
@@ -109,8 +109,9 @@ class MMCIFParser(object):
         )
         self._update_header_entry("structure_method", ["_exptl.method"])
         self._update_header_entry(
-            "resolution", ["_refine.ls_d_res_high", "_refine_hist.d_res_high"], True
+            "resolution", ["_refine.ls_d_res_high", "_refine_hist.d_res_high"]
         )
+        self.header["resolution"] = float(self.header["resolution"])
 
         return self.header
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -41,6 +41,7 @@ possible, especially the following contributors:
 - Michael R. Crusoe (first contribution)
 - Michiel de Hoon
 - Peter Cock
+- Rob Miller
 - Sergio Valqui
 
 6 November 2019: Biopython 1.75
@@ -230,7 +231,7 @@ possible, especially the following contributors:
 - Peter Cock
 - Peter Kerpedjiev
 - Ralf Stephan
-- Rob Miller
+- Rob Miller (first contribution)
 - Sergio Valqui
 - Victor Lin
 - Wibowo 'Bow' Arindrarto

--- a/Tests/test_PDB_MMCIFParser.py
+++ b/Tests/test_PDB_MMCIFParser.py
@@ -323,10 +323,18 @@ class ParseReal(unittest.TestCase):
     def test_header(self):
         """Test if the parser populates header data."""
         parser = MMCIFParser()
+
+        structure = parser.get_structure("example", "PDB/a_structure.cif")
+        self.assertEqual("", structure.header["idcode"])
+        self.assertEqual("", structure.header["head"])
+        self.assertEqual("", structure.header["deposition_date"])
+        self.assertEqual("", structure.header["structure_method"])
+        self.assertEqual(0.0, structure.header["resolution"])
+
         structure = parser.get_structure("example", "PDB/1A8O.cif")
         self.assertEqual("1A8O", structure.header["idcode"])
         self.assertEqual("Viral protein", structure.header["head"])
-        self.assertIsNone(structure.header["deposition_date"])
+        self.assertEqual("", structure.header["deposition_date"])
         self.assertEqual("X-RAY DIFFRACTION", structure.header["structure_method"])
         self.assertEqual(1.7, structure.header["resolution"])
 

--- a/Tests/test_PDB_MMCIFParser.py
+++ b/Tests/test_PDB_MMCIFParser.py
@@ -17,12 +17,13 @@ import warnings
 try:
     import numpy
     from numpy import dot  # Missing on old PyPy's micronumpy
+
     del dot
     from numpy.linalg import svd, det  # Missing in PyPy 2.0 numpypy
 except ImportError:
     from Bio import MissingPythonDependencyError
-    raise MissingPythonDependencyError(
-        "Install NumPy if you want to use Bio.PDB.")
+
+    raise MissingPythonDependencyError("Install NumPy if you want to use Bio.PDB.")
 
 
 from Bio.Seq import Seq
@@ -81,8 +82,11 @@ class ParseReal(unittest.TestCase):
             self.assertEqual(s.alphabet, generic_protein)
 
             # Here non-standard MSE are shown as M
-            self.assertEqual("MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQ"
-                             "NANPDCKTILKALGPGATLEEMMTACQG", str(s))
+            self.assertEqual(
+                "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQ"
+                "NANPDCKTILKALGPGATLEEMMTACQG",
+                str(s),
+            )
 
             # ==========================================================
             # Now try strict version with only standard amino acids
@@ -127,7 +131,9 @@ class ParseReal(unittest.TestCase):
             self.assertSequenceEqual([a.get_name() for a in atoms[:5]], atom_names)
             self.assertSequenceEqual([a.get_id() for a in atoms[:5]], atom_names)
             self.assertSequenceEqual([a.get_fullname() for a in atoms[:5]], atom_names)
-            self.assertSequenceEqual([a.get_occupancy() for a in atoms[:5]], [1., 1., 1., 1., 1.])
+            self.assertSequenceEqual(
+                [a.get_occupancy() for a in atoms[:5]], [1.0, 1.0, 1.0, 1.0, 1.0]
+            )
             self.assertIsInstance(atoms[0].get_coord(), numpy.ndarray)
             coord = numpy.array([19.594, 32.367, 28.012], dtype=numpy.float32)
             numpy.testing.assert_array_equal(atoms[0].get_coord(), coord)
@@ -156,15 +162,21 @@ class ParseReal(unittest.TestCase):
             self.assertSequenceEqual([a.get_name() for a in atoms[:5]], atom_names)
             self.assertSequenceEqual([a.get_id() for a in atoms[:5]], atom_names)
             self.assertSequenceEqual([a.get_fullname() for a in atoms[:5]], atom_names)
-            self.assertSequenceEqual([a.get_occupancy() for a in atoms[:5]], [1., 1., 1., 1., 1.])
+            self.assertSequenceEqual(
+                [a.get_occupancy() for a in atoms[:5]], [1.0, 1.0, 1.0, 1.0, 1.0]
+            )
             self.assertIsInstance(atoms[0].get_coord(), numpy.ndarray)
             coord = numpy.array([50.346, 19.287, 17.288], dtype=numpy.float32)
             numpy.testing.assert_array_equal(atoms[0].get_coord(), coord)
             self.assertEqual(atoms[0].get_bfactor(), 32.02)
 
-            ansiou = numpy.array([0.4738, -0.0309, -0.0231, 0.4524, 0.0036, 0.2904], dtype=numpy.float32)
+            ansiou = numpy.array(
+                [0.4738, -0.0309, -0.0231, 0.4524, 0.0036, 0.2904], dtype=numpy.float32
+            )
             numpy.testing.assert_array_equal(atoms[0].get_anisou(), ansiou)
-            ansiou = numpy.array([1.1242, 0.2942, -0.0995, 1.1240, -0.1088, 0.8221], dtype=numpy.float32)
+            ansiou = numpy.array(
+                [1.1242, 0.2942, -0.0995, 1.1240, -0.1088, 0.8221], dtype=numpy.float32
+            )
             atom_937 = list(f_structure[0]["A"])[114]["CB"]
             numpy.testing.assert_array_equal(atom_937.get_anisou(), ansiou)
 
@@ -198,8 +210,9 @@ class ParseReal(unittest.TestCase):
             self.assertTrue(isinstance(s, Seq))
             self.assertEqual(s.alphabet, generic_protein)
             # Here non-standard MSE are shown as M
-            self.assertEqual("MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR",
-                             str(s))
+            self.assertEqual(
+                "MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR", str(s)
+            )
             # ==========================================================
             # Now try strict version with only standard amino acids
             polypeptides = ppbuild.build_peptides(structure[0], True)
@@ -212,8 +225,9 @@ class ParseReal(unittest.TestCase):
             s = pp.get_sequence()
             self.assertTrue(isinstance(s, Seq))
             self.assertEqual(s.alphabet, generic_protein)
-            self.assertEqual("MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR",
-                             str(s))
+            self.assertEqual(
+                "MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR", str(s)
+            )
 
         # This structure contains several models with multiple lengths.
         # The tests were failing.
@@ -279,30 +293,42 @@ class ParseReal(unittest.TestCase):
         # Check a non-mutated residue just to be sure we didn't break the
         # parser and cause everyhing to be disordered.
         self.assertFalse(
-            structure[0]["A"][13].is_disordered(),
-            "Residue 13 is not disordered")
+            structure[0]["A"][13].is_disordered(), "Residue 13 is not disordered"
+        )
 
         # Check that the residue types were parsed correctly.
         self.assertSetEqual(
             set(res_1.disordered_get_id_list()),
             {"PRO", "SER"},
-            "Residue 1 is proline/serine")
+            "Residue 1 is proline/serine",
+        )
         self.assertSetEqual(
             set(res_15.disordered_get_id_list()),
             {"ARG", "GLN", "GLU"},
-            "Residue 15 is arginine/glutamine/glutamic acid")
+            "Residue 15 is arginine/glutamine/glutamic acid",
+        )
 
         # Quickly check that we can switch between residues and that the
         # correct set of residues was parsed.
         res_1.disordered_select("PRO")
         self.assertAlmostEqual(
-            res_1["CA"].get_occupancy(),
-            0.83, 2, "Residue 1 proline occupancy correcy")
+            res_1["CA"].get_occupancy(), 0.83, 2, "Residue 1 proline occupancy correcy"
+        )
 
         res_1.disordered_select("SER")
         self.assertAlmostEqual(
-            res_1["CA"].get_occupancy(),
-            0.17, 2, "Residue 1 serine occupancy correcy")
+            res_1["CA"].get_occupancy(), 0.17, 2, "Residue 1 serine occupancy correcy"
+        )
+
+    def test_header(self):
+        """Test if the parser populates header data."""
+        parser = MMCIFParser()
+        structure = parser.get_structure("example", "PDB/1A8O.cif")
+        self.assertEqual("1A8O", structure.header["idcode"])
+        self.assertEqual("Viral protein", structure.header["head"])
+        self.assertIsNone(structure.header["deposition_date"])
+        self.assertEqual("X-RAY DIFFRACTION", structure.header["structure_method"])
+        self.assertEqual(1.7, structure.header["resolution"])
 
 
 class CIFtoPDB(unittest.TestCase):


### PR DESCRIPTION
This pull request adds code to PDB/MMCIFParser.py to populate the `<structure>.header` dict with fields `idcode`, `head`, `deposition_date`, `structure_method` and `resolution` if they can be easily found in the CIF dictionary as loaded. A `test_header()` routine is added to test_PDB_MMCIFParser.py to confirm the functionality, and the test_ file is black formatted.

The use case is to provide similar metadata regardless of loading from a mmCIF or a PDB file.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
