### PR TITLE
Dual license Bio.Phylo.PAML code

### DIFF
--- a/Bio/Phylo/PAML/__init__.py
+++ b/Bio/Phylo/PAML/__init__.py
@@ -1,6 +1,10 @@
 # Copyright (C) 2011 by Brandon Invergo (b.invergo@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
+
 """Support for PAML."""
+
 # TODO: Remove empty __init__.py once we drop Python 2 support

--- a/Bio/Phylo/PAML/_paml.py
+++ b/Bio/Phylo/PAML/_paml.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2011 by Brandon Invergo (b.invergo@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Base class for the support of PAML, Phylogenetic Analysis by Maximum Likelihood."""
 

--- a/Bio/Phylo/PAML/_parse_baseml.py
+++ b/Bio/Phylo/PAML/_parse_baseml.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2011 by Brandon Invergo (b.invergo@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Methods for parsing baseml results files."""
 

--- a/Bio/Phylo/PAML/_parse_codeml.py
+++ b/Bio/Phylo/PAML/_parse_codeml.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2011, 2016 by Brandon Invergo (b.invergo@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Methods for parsing codeml results files."""
 

--- a/Bio/Phylo/PAML/_parse_yn00.py
+++ b/Bio/Phylo/PAML/_parse_yn00.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2011, 2019 by Brandon Invergo (b.invergo@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Methods for parsing yn00 results files."""
 

--- a/Bio/Phylo/PAML/baseml.py
+++ b/Bio/Phylo/PAML/baseml.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2011, 2018 by Brandon Invergo (b.invergo@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classes for the support of baseml.
 

--- a/Bio/Phylo/PAML/chi2.py
+++ b/Bio/Phylo/PAML/chi2.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2011 by Brandon Invergo (b.invergo@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 #
 # This code is adapted (with permission) from the C source code of chi2.c,
 # written by Ziheng Yang and included in the PAML software package:

--- a/Bio/Phylo/PAML/codeml.py
+++ b/Bio/Phylo/PAML/codeml.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2011, 2018 by Brandon Invergo (b.invergo@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classes for the support of CODEML.
 

--- a/Bio/Phylo/PAML/yn00.py
+++ b/Bio/Phylo/PAML/yn00.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2011, 2018 by Brandon Invergo (b.invergo@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Classes for the support of yn00.
 


### PR DESCRIPTION
Excerpt from #2320, just the PAML code as reviewed by @brandoninvergo - see issue #898.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
