### PR TITLE
fix docstring for _open in Bio.SCOP

### DIFF
--- a/Bio/SCOP/__init__.py
+++ b/Bio/SCOP/__init__.py
@@ -937,12 +937,11 @@ def search(
 
 
 def _open(cgi, params=None, get=1):
-    """Open a handle to SCOP, returns an UndoHandle (PRIVATE).
+    """Open a handle to SCOP and return it (PRIVATE).
 
     Open a handle to SCOP.  cgi is the URL for the cgi script to access.
     params is a dictionary with the options to pass to it.  get is a boolean
-    that describes whether a GET should be used.  Does some
-    simple error checking, and will raise an IOError if it encounters one.
+    that describes whether a GET should be used.
 
     """
     from Bio._py3k import urlopen, urlencode


### PR DESCRIPTION
This pull request addresses fixes the docstring for _open in Bio.SCOP.
 
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
