### PR TITLE
Avoid UndoHandles by catching errors in the parser

### DIFF
--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -105,7 +105,9 @@ class MMCIF2Dict(dict):
             raise ValueError("Line ended with quote open: " + line)
 
     def _tokenize(self, handle):
+        empty = True
         for line in handle:
+            empty = False
             if line.startswith("#"):
                 continue
             elif line.startswith(";"):
@@ -122,3 +124,5 @@ class MMCIF2Dict(dict):
             else:
                 for token in self._splitline(line.strip()):
                     yield token
+        if empty:
+            raise ValueError("Empty file.")

--- a/Bio/PDB/PDBParser.py
+++ b/Bio/PDB/PDBParser.py
@@ -86,7 +86,10 @@ class PDBParser(object):
             self.structure_builder.init_structure(id)
 
             with as_handle(file, mode="rU") as handle:
-                self._parse(handle.readlines())
+                lines = handle.readlines()
+                if not lines:
+                    raise ValueError("Empty file.")
+                self._parse(lines)
 
             self.structure_builder.set_header(self.header)
             # Return the Structure instance

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -285,7 +285,7 @@ def PdbAtomIterator(handle):
 
     with as_handle(handle, "rU") as handle:
         struct = PDBParser().get_structure(None, handle)
-        pdb_id = struct.header['idcode']
+        pdb_id = struct.header["idcode"]
         if not pdb_id:
             warnings.warn(
                 "'HEADER' line not found; can't determine PDB ID.",

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -283,28 +283,16 @@ def PdbAtomIterator(handle):
     # Only import PDB when needed, to avoid/delay NumPy dependency in SeqIO
     from Bio.PDB import PDBParser
 
-    from Bio.File import UndoHandle
-
     with as_handle(handle, "rU") as handle:
-        undo_handle = UndoHandle(handle)
-        firstline = undo_handle.peekline()
-        # check if file is empty
-        if not firstline:
-            raise ValueError("Empty file.")
-
-        # Deduce the PDB ID from the PDB header
-        # ENH: or filename?
-        if firstline.startswith("HEADER"):
-            pdb_id = firstline[62:66]
-        else:
+        struct = PDBParser().get_structure(None, handle)
+        pdb_id = struct.header['idcode']
+        if not pdb_id:
             warnings.warn(
-                "First line is not a 'HEADER'; can't determine PDB ID. "
-                "Line: %r" % firstline,
+                "'HEADER' line not found; can't determine PDB ID.",
                 BiopythonParserWarning,
             )
             pdb_id = "????"
 
-        struct = PDBParser().get_structure(pdb_id, undo_handle)
         for record in AtomIterator(pdb_id, struct):
             # The PDB header was loaded as a dictionary, so let's reuse it all
             record.annotations.update(struct.header)
@@ -380,19 +368,11 @@ def CifSeqresIterator(handle):
     # Only import PDB when needed, to avoid/delay NumPy dependency in SeqIO
     from Bio.PDB.MMCIF2Dict import MMCIF2Dict
 
-    from Bio.File import UndoHandle
-
     with as_handle(handle, "rU") as handle:
-
-        undo_handle = UndoHandle(handle)
-
-        # check if file is empty
-        if not undo_handle.peekline():
-            raise ValueError("Empty file.")
 
         chains = collections.defaultdict(list)
         metadata = collections.defaultdict(list)
-        records = MMCIF2Dict(undo_handle)
+        records = MMCIF2Dict(handle)
 
         # Explicitly convert records to list (See #1533).
         # If an item is not present, use an empty list
@@ -513,12 +493,10 @@ def CifAtomIterator(handle):
     from Bio.PDB.MMCIFParser import MMCIFParser
     from Bio.PDB.MMCIF2Dict import MMCIF2Dict
 
-    # The PdbAtomIterator uses UndoHandle to peek at the first line and get the
-    # PDB ID. The equivalent for mmCIF is the _entry.id field. AFAIK, the mmCIF
-    # format does not constrain the order of fields, so we need to parse the
-    # entire file using MMCIF2Dict. We copy the contents of the handle into a
-    # StringIO buffer first, so that both MMCIF2Dict and MMCIFParser can
-    # consume the handle.
+    # We use MMCIF2Dict to find the _entry.id field. AFAIK, the mmCIF format
+    # does not constrain the order of fields, so we need to parse the entire
+    # file. We copy the contents of the handle into a StringIO buffer first,
+    # so that both MMCIF2Dict and MMCIFParser can consume the handle.
     buffer = StringIO()
     with as_handle(handle, "rU") as handle:
         shutil.copyfileobj(handle, buffer)

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -650,13 +650,10 @@ class ParseReal(unittest.TestCase):
     def test_empty(self):
         """Parse an empty file."""
         parser = PDBParser()
-        handle = tempfile.NamedTemporaryFile()
-        try:
-            with self.assertRaises(ValueError) as context_manager:
-                struct = parser.get_structure("MT", handle.name)
-            self.assertEqual(str(context_manager.exception), "Empty file.")
-        finally:
-            handle.close()
+        handle = StringIO()
+        with self.assertRaises(ValueError) as context_manager:
+            struct = parser.get_structure("MT", handle)
+        self.assertEqual(str(context_manager.exception), "Empty file.")
 
     def test_residue_sort(self):
         """Sorting atoms in residues."""

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -650,14 +650,13 @@ class ParseReal(unittest.TestCase):
     def test_empty(self):
         """Parse an empty file."""
         parser = PDBParser()
-        filenumber, filename = tempfile.mkstemp()
-        os.close(filenumber)
+        handle = tempfile.NamedTemporaryFile()
         try:
-            struct = parser.get_structure("MT", filename)
-            # Structure has no children (models)
-            self.assertFalse(len(struct))
+            with self.assertRaises(ValueError) as context_manager:
+                struct = parser.get_structure("MT", handle.name)
+            self.assertEqual(str(context_manager.exception), "Empty file.")
         finally:
-            os.remove(filename)
+            handle.close()
 
     def test_residue_sort(self):
         """Sorting atoms in residues."""


### PR DESCRIPTION
This pull request removes unnecessary UndoHandles in Bio.SeqIO.PdbIO by moving parsing errors to the Bio.PDB parser.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
