### PR TITLE
Fix undohandle searchio fastaio

### DIFF
--- a/Bio/SearchIO/FastaIO.py
+++ b/Bio/SearchIO/FastaIO.py
@@ -345,6 +345,7 @@ class FastaM10Parser(object):
                 if qres_state == state_QRES_HITTAB:
                     # parse hit table if flag is set
                     hit_rows = self.__parse_hit_table()
+                    self.line = self.handle.readline()
 
                 elif qres_state == state_QRES_END:
                     yield _set_qresult_hits(qresult, hit_rows)
@@ -368,6 +369,7 @@ class FastaM10Parser(object):
                     # set values from preamble
                     for key, value in self._preamble.items():
                         setattr(qresult, key, value)
+                    self.line = self.handle.readline()
 
                 elif qres_state == state_QRES_CONTENT:
                     assert self.line[3:].startswith(qresult.id), self.line
@@ -386,7 +388,8 @@ class FastaM10Parser(object):
                                 assert strand != hsp.query_strand
                                 qresult[hit.id].append(hsp)
 
-            self.line = self.handle.readline()
+            else:
+                self.line = self.handle.readline()
 
     def _parse_hit(self, query_id):
         """Parse hit on query identifier (PRIVATE)."""
@@ -421,6 +424,7 @@ class FastaM10Parser(object):
                 hit.seq_len = seq_len
                 yield hit, strand
                 hsp_list = []
+                self.line = self.handle.readline()
                 break
             # yield hit and create a new one if we're still in the same query
             elif self.line.startswith(">>"):

--- a/Bio/SearchIO/FastaIO.py
+++ b/Bio/SearchIO/FastaIO.py
@@ -304,13 +304,13 @@ class FastaM10Parser(object):
 
     def __parse_hit_table(self):
         """Parse hit table rows."""
-        # move to the first row
-        line = self.handle.readline()
         # parse hit table until we see an empty line
         hit_rows = []
-        while line and not line.strip():
-            hit_rows.append(line.strip())
+        while True:
             line = self.handle.readline()
+            if (not line) or line.strip():
+                break
+            hit_rows.append('')
         self.line = line
         return hit_rows
 

--- a/Bio/SearchIO/FastaIO.py
+++ b/Bio/SearchIO/FastaIO.py
@@ -309,7 +309,7 @@ class FastaM10Parser(object):
             line = self.handle.readline()
             if (not line) or line.strip():
                 break
-            hit_rows.append('')
+            hit_rows.append("")
         self.line = line
         return hit_rows
 
@@ -396,7 +396,6 @@ class FastaM10Parser(object):
                 line = self.handle.readline()
 
         self.line = line
-
 
     def _parse_hit(self, query_id):
         """Parse hit on query identifier (PRIVATE)."""

--- a/Bio/SearchIO/FastaIO.py
+++ b/Bio/SearchIO/FastaIO.py
@@ -325,9 +325,9 @@ class FastaM10Parser(object):
         state_QRES_CONTENT = 5
         state_QRES_END = 7
 
-        while True:
+        line = self.line
 
-            line = self.line
+        while True:
 
             # one line before the hit table
             if line.startswith("The best scores are:"):
@@ -350,6 +350,7 @@ class FastaM10Parser(object):
                     # parse hit table if flag is set
                     hit_rows = self.__parse_hit_table()
                     self.line = self.handle.readline()
+                    line = self.line
 
                 elif qres_state == state_QRES_END:
                     yield _set_qresult_hits(qresult, hit_rows)
@@ -367,6 +368,7 @@ class FastaM10Parser(object):
                     qresult.seq_len = int(seq_len)
                     # get target from the next line
                     line = self.handle.readline()
+                    self.line = line
                     qresult.target = [x for x in line.split(" ") if x][1].strip()
                     if desc is not None:
                         qresult.description = desc
@@ -374,6 +376,7 @@ class FastaM10Parser(object):
                     for key, value in self._preamble.items():
                         setattr(qresult, key, value)
                     self.line = self.handle.readline()
+                    line = self.line
 
                 elif qres_state == state_QRES_CONTENT:
                     assert self.line[3:].startswith(qresult.id), self.line
@@ -391,9 +394,12 @@ class FastaM10Parser(object):
                             for hsp in hit.hsps:
                                 assert strand != hsp.query_strand
                                 qresult[hit.id].append(hsp)
+                    line = self.line
 
             else:
                 self.line = self.handle.readline()
+                line = self.line
+
 
     def _parse_hit(self, query_id):
         """Parse hit on query identifier (PRIVATE)."""

--- a/Bio/SearchIO/FastaIO.py
+++ b/Bio/SearchIO/FastaIO.py
@@ -349,8 +349,8 @@ class FastaM10Parser(object):
                 if qres_state == state_QRES_HITTAB:
                     # parse hit table if flag is set
                     hit_rows = self.__parse_hit_table()
-                    self.line = self.handle.readline()
-                    line = self.line
+                    line = self.handle.readline()
+                    self.line = line
 
                 elif qres_state == state_QRES_END:
                     yield _set_qresult_hits(qresult, hit_rows)
@@ -360,7 +360,7 @@ class FastaM10Parser(object):
                     # if qresult is filled, yield it first
                     if qresult is not None:
                         yield _set_qresult_hits(qresult, hit_rows)
-                    regx = re.search(_RE_ID_DESC_SEQLEN, self.line)
+                    regx = re.search(_RE_ID_DESC_SEQLEN, line)
                     query_id = regx.group(1)
                     seq_len = regx.group(3)
                     desc = regx.group(2)
@@ -375,11 +375,11 @@ class FastaM10Parser(object):
                     # set values from preamble
                     for key, value in self._preamble.items():
                         setattr(qresult, key, value)
-                    self.line = self.handle.readline()
-                    line = self.line
+                    line = self.handle.readline()
+                    self.line = line
 
                 elif qres_state == state_QRES_CONTENT:
-                    assert self.line[3:].startswith(qresult.id), self.line
+                    assert line[3:].startswith(qresult.id), line
                     for hit, strand in self._parse_hit(query_id):
                         # HACK: re-set desc, for hsp hit and query description
                         hit.description = hit.description
@@ -397,8 +397,8 @@ class FastaM10Parser(object):
                     line = self.line
 
             else:
-                self.line = self.handle.readline()
-                line = self.line
+                line = self.handle.readline()
+                self.line = line
 
 
     def _parse_hit(self, query_id):

--- a/Bio/SearchIO/FastaIO.py
+++ b/Bio/SearchIO/FastaIO.py
@@ -350,7 +350,6 @@ class FastaM10Parser(object):
                     # parse hit table if flag is set
                     hit_rows = self.__parse_hit_table()
                     line = self.handle.readline()
-                    self.line = line
 
                 elif qres_state == state_QRES_END:
                     yield _set_qresult_hits(qresult, hit_rows)
@@ -368,7 +367,6 @@ class FastaM10Parser(object):
                     qresult.seq_len = int(seq_len)
                     # get target from the next line
                     line = self.handle.readline()
-                    self.line = line
                     qresult.target = [x for x in line.split(" ") if x][1].strip()
                     if desc is not None:
                         qresult.description = desc
@@ -376,7 +374,6 @@ class FastaM10Parser(object):
                     for key, value in self._preamble.items():
                         setattr(qresult, key, value)
                     line = self.handle.readline()
-                    self.line = line
 
                 elif qres_state == state_QRES_CONTENT:
                     assert line[3:].startswith(qresult.id), line
@@ -398,14 +395,15 @@ class FastaM10Parser(object):
 
             else:
                 line = self.handle.readline()
-                self.line = line
+
+        self.line = line
 
 
     def _parse_hit(self, query_id):
         """Parse hit on query identifier (PRIVATE)."""
         while True:
-            self.line = self.handle.readline()
-            if self.line.startswith(">>"):
+            line = self.handle.readline()
+            if line.startswith(">>"):
                 break
 
         state = _STATE_NONE
@@ -416,7 +414,6 @@ class FastaM10Parser(object):
         hit_desc = None
         seq_len = None
         while True:
-            line = self.line
             # yield hit if we've reached the start of a new query or
             # the end of the search
             self.line = self.handle.readline()
@@ -528,7 +525,7 @@ class FastaM10Parser(object):
                 # we should not get here!
                 else:
                     raise ValueError("Unexpected line: %r" % line)
-
+            line = self.line
 
 
 class FastaM10Indexer(SearchIndexer):

--- a/Bio/SearchIO/FastaIO.py
+++ b/Bio/SearchIO/FastaIO.py
@@ -327,17 +327,19 @@ class FastaM10Parser(object):
 
         while True:
 
+            line = self.line
+
             # one line before the hit table
-            if self.line.startswith("The best scores are:"):
+            if line.startswith("The best scores are:"):
                 qres_state = state_QRES_HITTAB
             # the end of a query or the file altogether
-            elif self.line.strip() == ">>>///" or not self.line:
+            elif line.strip() == ">>>///" or not line:
                 qres_state = state_QRES_END
             # the beginning of a new query
-            elif not self.line.startswith(">>>") and ">>>" in self.line:
+            elif not line.startswith(">>>") and ">>>" in line:
                 qres_state = state_QRES_NEW
             # the beginning of the query info and its hits + hsps
-            elif self.line.startswith(">>>") and not self.line.strip() == ">>><<<":
+            elif line.startswith(">>>") and not line.strip() == ">>><<<":
                 qres_state = state_QRES_CONTENT
             # default qres mark
             else:


### PR DESCRIPTION
This pull request removes the `UndoHandle` from `Bio.SearchIO.FastaIO`.

The current parser uses an `UndoHandle` to peek at the next line in the file. But the parser also has an attribute `self.line`, which can be used for the same purpose. By rearranging the code a bit, parsing can be done using the `self.line` attribute only, and the `UndoHandle` becomes unnecessary.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
