### PR TITLE
Fixes motifs.jaspar.calculate_pseudocounts

### DIFF
--- a/Bio/motifs/jaspar/__init__.py
+++ b/Bio/motifs/jaspar/__init__.py
@@ -326,7 +326,7 @@ def calculate_pseudocounts(motif):
     total = 0
     for i in range(motif.length):
         total += sum(float(motif.counts[letter][i])
-                     for letter in alphabet.letters)
+                     for letter in alphabet)
 
     avg_nb_instances = total / motif.length
     sq_nb_instances = math.sqrt(avg_nb_instances)
@@ -334,12 +334,12 @@ def calculate_pseudocounts(motif):
     if background:
         background = dict(background)
     else:
-        background = dict.fromkeys(sorted(alphabet.letters), 1.0)
+        background = dict.fromkeys(sorted(alphabet), 1.0)
 
     total = sum(background.values())
     pseudocounts = {}
 
-    for letter in alphabet.letters:
+    for letter in alphabet:
         background[letter] /= total
         pseudocounts[letter] = sq_nb_instances * background[letter]
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -122,6 +122,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Ivan Antonov <https://github.com/vanya-antonov>
 - Jacek Śmietański <https://github.com/dadoskawina>
 - Jack Twilley <https://github.com/mathuin>
+- Jakub Lipinski <https://github.com/jakublipinski>
 - James Casbon <https://github.com/jamescasbon>
 - James Jeffryes <https://github.com/JamesJeffryes>
 - Jared Andrews <https://github.com/j-andrews7>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -32,10 +32,10 @@ possible, especially the following contributors:
 - Chris Daley (first contribution)
 - Chris Rands
 - Christian Brueffer
+- Jakub Lipinski (first contribution)
 - Michiel de Hoon
 - Peter Cock
 - Sergio Valqui
-- Jakub Lipinski (first contribution)
 
 6 November 2019: Biopython 1.75
 ===============================

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -35,6 +35,7 @@ possible, especially the following contributors:
 - Michiel de Hoon
 - Peter Cock
 - Sergio Valqui
+- Jakub Lipinski (first contribution)
 
 6 November 2019: Biopython 1.75
 ===============================

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -2260,10 +2260,10 @@ class MotifTestPWM(unittest.TestCase):
 
     def test_calculate_pseudocounts(self):
         pseudocounts = motifs.jaspar.calculate_pseudocounts(self.m)
-        self.assertAlmostEqual(pseudocounts['A'], 1.695582495781317, places=5)
-        self.assertAlmostEqual(pseudocounts['C'], 1.695582495781317, places=5)
-        self.assertAlmostEqual(pseudocounts['G'], 1.695582495781317, places=5)
-        self.assertAlmostEqual(pseudocounts['T'], 1.695582495781317, places=5)
+        self.assertAlmostEqual(pseudocounts["A"], 1.695582495781317, places=5)
+        self.assertAlmostEqual(pseudocounts["C"], 1.695582495781317, places=5)
+        self.assertAlmostEqual(pseudocounts["G"], 1.695582495781317, places=5)
+        self.assertAlmostEqual(pseudocounts["T"], 1.695582495781317, places=5)
 
 
 if __name__ == "__main__":

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -2258,6 +2258,13 @@ class MotifTestPWM(unittest.TestCase):
         # ValueError: Alphabets are inconsistent
         self.assertRaises(ValueError, motifs.create, seqs)
 
+    def test_calculate_pseudocounts(self):
+        pseudocounts = motifs.jaspar.calculate_pseudocounts(self.m)
+        self.assertAlmostEqual(pseudocounts['A'], 1.695582495781317, places=5)
+        self.assertAlmostEqual(pseudocounts['C'], 1.695582495781317, places=5)
+        self.assertAlmostEqual(pseudocounts['G'], 1.695582495781317, places=5)
+        self.assertAlmostEqual(pseudocounts['T'], 1.695582495781317, places=5)
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
This pull request addresses the issue in `motifs.jaspar.calculate_pseudocounts`. The `motif.alphabet` is a `str` object therefore it does not contain `letters` field and should be enumerated directly. I added a `test_calculate_pseudocounts` test which fails without the changes introduced by this PR.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
