### PR TITLE
Fix bug motif reverse complement

### DIFF
--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -396,12 +396,22 @@ class Motif(object):
             res = Motif(alphabet=alphabet, instances=instances)
         else:  # has counts
             counts = {"A": self.counts["T"][::-1],
-                      "T": self.counts["A"][::-1],
-                      "G": self.counts["C"][::-1],
                       "C": self.counts["G"][::-1],
+                      "G": self.counts["C"][::-1],
+                      "T": self.counts["A"][::-1],
                      }
             res = Motif(alphabet=alphabet, counts=counts)
         res.__mask = self.__mask[::-1]
+        res.background = {"A": self.background["T"],
+                          "C": self.background["G"],
+                          "G": self.background["C"],
+                          "T": self.background["A"],
+                         }
+        res.pseudocounts = {"A": self.pseudocounts["T"],
+                            "C": self.pseudocounts["G"],
+                            "G": self.pseudocounts["C"],
+                            "T": self.pseudocounts["A"],
+                           }
         return res
 
     @property

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -399,19 +399,19 @@ class Motif(object):
                       "C": self.counts["G"][::-1],
                       "G": self.counts["C"][::-1],
                       "T": self.counts["A"][::-1],
-                     }
+                      }
             res = Motif(alphabet=alphabet, counts=counts)
         res.__mask = self.__mask[::-1]
         res.background = {"A": self.background["T"],
                           "C": self.background["G"],
                           "G": self.background["C"],
                           "T": self.background["A"],
-                         }
+                          }
         res.pseudocounts = {"A": self.pseudocounts["T"],
                             "C": self.pseudocounts["G"],
                             "G": self.pseudocounts["C"],
                             "T": self.pseudocounts["A"],
-                           }
+                            }
         return res
 
     @property

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -393,15 +393,14 @@ class Motif(object):
         alphabet = self.alphabet
         if self.instances is not None:
             instances = self.instances.reverse_complement()
-            res = Motif(instances=instances, alphabet=alphabet)
+            res = Motif(alphabet=alphabet, instances=instances)
         else:  # has counts
-            res = Motif(alphabet)
-            res.counts = {}
-            res.counts["A"] = self.counts["T"][::-1]
-            res.counts["T"] = self.counts["A"][::-1]
-            res.counts["G"] = self.counts["C"][::-1]
-            res.counts["C"] = self.counts["G"][::-1]
-            res.length = self.length
+            counts = {"A": self.counts["T"][::-1],
+                      "T": self.counts["A"][::-1],
+                      "G": self.counts["C"][::-1],
+                      "C": self.counts["G"][::-1],
+                     }
+            res = Motif(alphabet=alphabet, counts=counts)
         res.__mask = self.__mask[::-1]
         return res
 

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -470,7 +470,7 @@ XX
 
     def test_reverse_complement(self):
         """Test if motifs can be reverse-complemented."""
-        background = {'A': 0.3, 'C': 0.2, 'G': 0.2, 'T': 0.3}
+        background = {"A": 0.3, "C": 0.2, "G": 0.2, "T": 0.3}
         pseudocounts = 0.5
         m = self.m
         m.background = background

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -468,6 +468,61 @@ XX
         self.assertEqual(s3, expected_transfac)
         self.assertRaises(ValueError, self.m.format, "foo_bar")
 
+    def test_reverse_complement(self):
+        """Test if motifs can be reverse-complemented."""
+        m = self.m
+        received_forward = self.m.format("transfac")
+        expected_forward = """\
+P0      A      C      G      T
+01      1      0      0      0      A
+02      0      0      0      1      T
+03      1      0      0      0      A
+04      0      0      0      1      T
+05      1      0      0      0      A
+XX
+//
+"""
+        self.assertEqual(received_forward, expected_forward)
+        expected_forward_pwm = """\
+        0      1      2      3      4
+A:   1.00   0.00   1.00   0.00   1.00
+C:   0.00   0.00   0.00   0.00   0.00
+G:   0.00   0.00   0.00   0.00   0.00
+T:   0.00   1.00   0.00   1.00   0.00
+"""
+        self.assertEqual(str(m.pwm), expected_forward_pwm)
+        m = m.reverse_complement()
+        received_reverse = m.format("transfac")
+        expected_reverse = """\
+P0      A      C      G      T
+01      0      0      0      1      T
+02      1      0      0      0      A
+03      0      0      0      1      T
+04      1      0      0      0      A
+05      0      0      0      1      T
+XX
+//
+"""
+        self.assertEqual(received_reverse, expected_reverse)
+        expected_reverse_pwm = """\
+        0      1      2      3      4
+A:   0.00   1.00   0.00   1.00   0.00
+C:   0.00   0.00   0.00   0.00   0.00
+G:   0.00   0.00   0.00   0.00   0.00
+T:   1.00   0.00   1.00   0.00   1.00
+"""
+        self.assertEqual(str(m.pwm), expected_reverse_pwm)
+        # Same thing, but now start with a motif calculated from a count matrix
+        counts = self.m.counts
+        m = motifs.Motif(counts=counts)
+        received_forward = m.format("transfac")
+        self.assertEqual(received_forward, expected_forward)
+        self.assertEqual(str(m.pwm), expected_forward_pwm)
+        m = m.reverse_complement()
+        received_reverse = m.format("transfac")
+        self.assertEqual(received_reverse, expected_reverse)
+        self.assertEqual(str(m.pwm), expected_reverse_pwm)
+
 
 class TestMEME(unittest.TestCase):
 

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -470,7 +470,11 @@ XX
 
     def test_reverse_complement(self):
         """Test if motifs can be reverse-complemented."""
+        background = {'A': 0.3, 'C': 0.2, 'G': 0.2, 'T': 0.3}
+        pseudocounts = 0.5
         m = self.m
+        m.background = background
+        m.pseudocounts = pseudocounts
         received_forward = self.m.format("transfac")
         expected_forward = """\
 P0      A      C      G      T
@@ -485,10 +489,10 @@ XX
         self.assertEqual(received_forward, expected_forward)
         expected_forward_pwm = """\
         0      1      2      3      4
-A:   1.00   0.00   1.00   0.00   1.00
-C:   0.00   0.00   0.00   0.00   0.00
-G:   0.00   0.00   0.00   0.00   0.00
-T:   0.00   1.00   0.00   1.00   0.00
+A:   0.50   0.17   0.50   0.17   0.50
+C:   0.17   0.17   0.17   0.17   0.17
+G:   0.17   0.17   0.17   0.17   0.17
+T:   0.17   0.50   0.17   0.50   0.17
 """
         self.assertEqual(str(m.pwm), expected_forward_pwm)
         m = m.reverse_complement()
@@ -506,15 +510,17 @@ XX
         self.assertEqual(received_reverse, expected_reverse)
         expected_reverse_pwm = """\
         0      1      2      3      4
-A:   0.00   1.00   0.00   1.00   0.00
-C:   0.00   0.00   0.00   0.00   0.00
-G:   0.00   0.00   0.00   0.00   0.00
-T:   1.00   0.00   1.00   0.00   1.00
+A:   0.17   0.50   0.17   0.50   0.17
+C:   0.17   0.17   0.17   0.17   0.17
+G:   0.17   0.17   0.17   0.17   0.17
+T:   0.50   0.17   0.50   0.17   0.50
 """
         self.assertEqual(str(m.pwm), expected_reverse_pwm)
         # Same thing, but now start with a motif calculated from a count matrix
         counts = self.m.counts
         m = motifs.Motif(counts=counts)
+        m.background = background
+        m.pseudocounts = pseudocounts
         received_forward = m.format("transfac")
         self.assertEqual(received_forward, expected_forward)
         self.assertEqual(str(m.pwm), expected_forward_pwm)


### PR DESCRIPTION
This pull request fixes the reverse complement calculation of motifs by going through `Motif.__init__`` to initialize the new `Motif` object correctly.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
