### PR TITLE
Verify don't need NumPy to compile anymore

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -142,10 +142,9 @@ commands =
     python setup.py sdist --formats=gztar,zip
 
 [testenv:bdist_wheel]
-# This should use NumPy while compiling our C code...
+# This should not require NumPy while compiling our C code...
 skip_install = True
 deps =
-    numpy
 commands =
     python setup.py bdist_wheel
 


### PR DESCRIPTION
This pull request reflects changes in Biopython 1.72 (see e.g. #1672) meaning we do not need NumPy at compile time anymore.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
