### PR TITLE
Define encode method on Seq objects, giving bytes object

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -921,6 +921,21 @@ class Seq(object):
         """
         return Seq(str(self).lower(), self.alphabet._lower())
 
+    def encode(self, encoding="utf-8", errors="strict"):
+        """Return an encoded version of the sequence as a bytes object.
+
+        The Seq object aims to match the interfact of a Python string.
+        (This means on Python 3 it acts like a unicode string.)
+
+        This is essentially to save you doing str(my_seq).encode() when
+        you need a bytes string, for example for computing a hash:
+
+        >>> from Bio.Seq import Seq
+        >>> Seq("ACGT").encode("ascii")
+        b'ACGT'
+        """
+        return str(self).encode(encoding, errors)
+
     def complement(self):
         """Return the complement sequence by creating a new Seq object.
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -480,6 +480,15 @@ class StringMethodTests(unittest.TestCase):
             str1 = str(example1)
             self.assertEqual(str(example1.lower()), str1.lower())
 
+    def test_str_encode(self):
+        """Check matches the python string encode method."""
+        for example1 in self._examples:
+            if isinstance(example1, MutableSeq):
+                continue
+            str1 = str(example1)
+            self.assertEqual(example1.encode("ascii"), str1.encode("ascii"))
+            self.assertEqual(example1.encode(), str1.encode())
+
     def test_str_hash(self):
         for example1 in self._examples:
             if isinstance(example1, MutableSeq):


### PR DESCRIPTION
This pull request addresses the general intend to make the ``Seq`` object more like the Python string.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
