### PR TITLE
define a SwissProtParserError

### DIFF
--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -16,10 +16,6 @@ Functions:
 
 """
 
-from __future__ import print_function
-
-from Bio._py3k import _as_string
-
 
 class SwissProtParserError(ValueError):
     """An error occurred while parsing a SwissProt file."""
@@ -177,7 +173,6 @@ def _read(handle):
     record = None
     unread = ""
     line = next(handle)
-    line = _as_string(line)
     key, value = line[:2], line[5:].rstrip()
     if key != "ID":
         raise SwissProtParserError("Failed to find ID in first line", line=line)
@@ -185,9 +180,6 @@ def _read(handle):
     _read_id(record, line)
     _sequence_lines = []
     for line in handle:
-        # This is for Python 3 to cope with a binary handle (byte strings),
-        # or a text handle (unicode strings):
-        line = _as_string(line)
         key, value = line[:2], line[5:].rstrip()
         if unread:
             value = unread + " " + value

--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -25,6 +25,7 @@ class SwissProtParserError(ValueError):
     """An error occurred while parsing a SwissProt file."""
 
     def __init__(self, *args, line=None):
+        """Create a SwissProtParserError object with the offending line."""
         super().__init__(*args)
         self.line = line
 

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -97,6 +97,7 @@ class ForwardOnlyHandle(object):
         return iter(self._handle)
 
     def __next__(self):
+        """Get the next line."""
         return next(self._handle)
 
     def read(self, length=None):

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -96,6 +96,9 @@ class ForwardOnlyHandle(object):
         """Iterate."""
         return iter(self._handle)
 
+    def __next__(self):
+        return next(self._handle)
+
     def read(self, length=None):
         if length is None:
             return self._handle.read()

--- a/Tests/test_SeqIO_online.py
+++ b/Tests/test_SeqIO_online.py
@@ -43,8 +43,8 @@ class ExPASyTests(unittest.TestCase):
             record = SeqIO.read(handle, "swiss")
         except SwissProtParserError as e:
             # This is to catch an error page from our proxy
-            if (str(e) == 'Failed to find ID in first line'
-                and e.line.startswith("<!DOCTYPE HTML")):
+            if (str(e) == 'Failed to find ID in first line' and
+                    e.line.startswith("<!DOCTYPE HTML")):
                 raise IOError from None
         handle.close()
         self.assertEqual(record.id, identifier)

--- a/Tests/test_SeqIO_online.py
+++ b/Tests/test_SeqIO_online.py
@@ -24,9 +24,9 @@ from Bio import ExPASy
 from Bio import SeqIO
 from Bio._py3k import StringIO
 from Bio.SeqUtils.CheckSum import seguid
+from Bio.SwissProt import SwissProtParserError
 
-from Bio.File import UndoHandle
-from Bio._py3k import _as_string
+from Bio._py3k import _as_string, raise_from
 
 import requires_internet
 requires_internet.check()
@@ -41,11 +41,13 @@ class ExPASyTests(unittest.TestCase):
     def test_get_sprot_raw(self):
         """Bio.ExPASy.get_sprot_raw("O23729")."""
         identifier = "O23729"
-        # This is to catch an error page from our proxy:
-        handle = UndoHandle(ExPASy.get_sprot_raw(identifier))
-        if _as_string(handle.peekline()).startswith("<!DOCTYPE HTML"):
-            raise IOError
-        record = SeqIO.read(handle, "swiss")
+        handle = ExPASy.get_sprot_raw(identifier)
+        try:
+            record = SeqIO.read(handle, "swiss")
+        except SwissProtParserError as e:
+            # This is to catch an error page from our proxy
+            if e.line.startswith("<!DOCTYPE HTML"):
+                raise_from(IOError, None)
         handle.close()
         self.assertEqual(record.id, identifier)
         self.assertEqual(len(record), 394)

--- a/Tests/test_SeqIO_online.py
+++ b/Tests/test_SeqIO_online.py
@@ -22,11 +22,8 @@ from Bio import ExPASy
 
 # In order to check any sequences returned
 from Bio import SeqIO
-from Bio._py3k import StringIO
 from Bio.SeqUtils.CheckSum import seguid
 from Bio.SwissProt import SwissProtParserError
-
-from Bio._py3k import _as_string, raise_from
 
 import requires_internet
 requires_internet.check()
@@ -46,8 +43,9 @@ class ExPASyTests(unittest.TestCase):
             record = SeqIO.read(handle, "swiss")
         except SwissProtParserError as e:
             # This is to catch an error page from our proxy
-            if e.line.startswith("<!DOCTYPE HTML"):
-                raise_from(IOError, None)
+            if (str(e) == 'Failed to find ID in first line'
+                and e.line.startswith("<!DOCTYPE HTML")):
+                raise IOError from None
         handle.close()
         self.assertEqual(record.id, identifier)
         self.assertEqual(len(record), 394)

--- a/Tests/test_SeqIO_online.py
+++ b/Tests/test_SeqIO_online.py
@@ -43,7 +43,7 @@ class ExPASyTests(unittest.TestCase):
             record = SeqIO.read(handle, "swiss")
         except SwissProtParserError as e:
             # This is to catch an error page from our proxy
-            if (str(e) == 'Failed to find ID in first line' and
+            if (str(e) == "Failed to find ID in first line" and
                     e.line.startswith("<!DOCTYPE HTML")):
                 raise IOError from None
         handle.close()


### PR DESCRIPTION
This pull request introduces a `SwissProtParserError` that inherits from `ValueError` but stores the line in which the error occurred as an attribute. This PR also checks if the ID line occurs in the first line of the SwissProt file, and does not allow ID lines later in the file.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
