### PR TITLE
Reduce presision in part of Tests/test_phenotype_fit.py

### DIFF
--- a/Tests/test_phenotype_fit.py
+++ b/Tests/test_phenotype_fit.py
@@ -56,7 +56,7 @@ class TestPhenoMicro(unittest.TestCase):
         self.assertAlmostEqual(w.area, 20879.5)
         self.assertEqual(w.model, "gompertz")
         self.assertAlmostEqual(w.lag, 6.0425868725090357, places=5)
-        self.assertAlmostEqual(w.plateau, 188.51404344898586, places=5)
+        self.assertAlmostEqual(w.plateau, 188.51404344898586, places=4)
         self.assertAlmostEqual(w.slope, 48.190618284831132, places=4)
         self.assertAlmostEqual(w.v, 0.10000000000000001, places=5)
         self.assertAlmostEqual(w.y0, 45.879770069807989, places=5)


### PR DESCRIPTION
This pull request fixes #1945 

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)