### PR TITLE
Use pydocstyle v5 in TravisCI style tests

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -108,10 +108,8 @@ deps =
     # https://bugs.launchpad.net/doc8/+bug/1837515
     # https://sourceforge.net/p/docutils/bugs/366/
     docutils==0.14
-    # flake8-docstrings uses a function removed in pydocstyle 4.0.0; once a fix
-    # is released in flake8-docstrings we can remove the following constraint:
-    pydocstyle<4.0.0
-    # See https://gitlab.com/pycqa/flake8-docstrings/issues/36
+    # pydocstyle v4 had false positives with D413, need v5
+    pydocstyle>=5.0.0
 commands =
     # PEP-8 and PEP-257 style checks:
     flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,7 @@ matrix:
             - *default_packages
   allow_failures:
     - arch: arm64
+    - arch: ppc64le
 
 addons:
   apt:


### PR DESCRIPTION
This pull request builds on PR #2230 which would have removed the version pinning but at the time v4 had false positives with D413. The recently released v5 looks OK.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
