### PR TITLE
TravisCI: Skip coverage tracking on alternative CPUs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ matrix:
             - *default_packages
     - stage: test
       python: 3.8
-      env: TOXENV=py38-cover
+      env: TOXENV=py38-nocov
       arch: arm64
     - stage: test
       python: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ matrix:
       arch: arm64
     - stage: test
       python: 3.8
-      env: TOXENV=py38-cover
+      env: TOXENV=py38-nocov
       arch: ppc64le
     - stage: test
       python: 3.8


### PR DESCRIPTION
With #2401 from @mr-c merged yesterday we are unfortunately often seeing failures from AMD64 and ppc64le.

These appear to be time out related, and therefore as with pypy3, this change skips the overhead of Python coverage tracking.

(We don't currently track the C code coverage, so the downsides of this are minimal)