### PR TITLE
TravisCI: allow ARM64 failure (often times out)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,6 +131,8 @@ matrix:
           packages:
             - *amd64_only_packages
             - *default_packages
+  allow_failures:
+    - arch: arm64
 
 addons:
   apt:


### PR DESCRIPTION
This pull request follows on from #2401 and #2415 which was not enough to stop time outs (perhaps cache related).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
