### PR TITLE
TravisCI: Use latest numpy on all platforms

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -55,6 +55,7 @@ whitelist_externals =
 # (But must compile numpy for PyPy right now)
 install_command = pip install --only-binary=scipy {opts} {packages}
 deps =
+    numpy
     #Lines startings xxx: are filtered by the environment.
     #Leaving py36 without any dependencies (even numpy)
     cover: coverage
@@ -69,9 +70,7 @@ deps =
     py27,py35: mysql-connector-python-rf
     py35,py37: mysqlclient
     py27,py35,pypy: rdflib
-    pypy,pypy3: numpy==1.12.1
     pypy,pypy3: mysqlclient
-    py27,py35,py37,py38: numpy
     py37: scipy
     py27: networkx
     py37: matplotlib


### PR DESCRIPTION
See discussion on #2390, previously deliberately had a target (python 3.6) without numpy.

This pull request addresses issue #...

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
