### PR TITLE
Simplify setup.py for Python 3 only

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -34,8 +34,8 @@ envlist =
     sdist
     bdist_wheel
     api
-    {py36,py37,py38,pypy,pypy3}-cover
-    {py36,py37,py38,pypy,pypy3}-nocov
+    {py36,py37,py38,pypy3}-cover
+    {py36,py37,py38,pypy3}-nocov
 
 [testenv]
 # TODO: Try tox default sdist based install instead:
@@ -67,8 +67,8 @@ deps =
     py37: psycopg2-binary
     py37: mysql-connector-python-rf
     py37: mysqlclient
-    py38,pypy: rdflib
-    pypy,pypy3: mysqlclient
+    py38: rdflib
+    pypy3: mysqlclient
     py37: scipy
     py38: networkx
     py37: matplotlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,14 +92,6 @@ matrix:
       env: TOXENV=py38-cover
       arch: s390x
     - stage: test
-      python: pypy
-      env: TOXENV=pypy-nocov
-      addons:
-        apt:
-          packages:
-            - *amd64_only_packages
-            - *default_packages
-    - stage: test
       python: pypy3
       env: TOXENV=pypy3-nocov
       addons:

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -28,8 +28,9 @@ release 1.66 onwards.
 
 Python 2.7
 ----------
-We will drop support for Python 2.7 no later than 2020, in line with the
-end-of-life or sunset date for Python 2.7 itself.
+No longer supported as of Release 1.77 (2020, in line with end-of-life or
+sunset date for Python 2.7 itself), having triggered a warning in prior
+releases.
 
 Python 3.0, 3.1, 3.2
 --------------------
@@ -49,7 +50,7 @@ warning in release 1.74. First supported in release 1.64.
 
 Python 3.5
 ----------
-First supported in release 1.66.
+No longer supported as of Release 1.77. First supported in release 1.66.
 
 Python 3.6
 ----------
@@ -65,6 +66,7 @@ First supported in release 1.75.
 
 Jython
 ------
+No longer supported as of Release 1.77 with the end of Python 2 support.
 Biopython was mostly working under Jython 2.7.0, but support for Jython
 was deprecated as of Release 1.70.
 

--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,6 @@ class build_py_biopython(build_py):
         """Run the build."""
         if not check_dependencies_once():
             return
-        self.packages.extend(NUMPY_PACKAGES)
         build_py.run(self)
 
 
@@ -245,13 +244,16 @@ REQUIRES = ["numpy"]
 # standard biopython packages
 PACKAGES = [
     "Bio",
+    "Bio.Affy",
     "Bio.Align",
     "Bio.Align.Applications",
+    "Bio.Align.substitution_matrices",
     "Bio.AlignIO",
     "Bio.Alphabet",
     "Bio.Application",
     "Bio.Blast",
     "Bio.CAPS",
+    "Bio.Cluster",
     "Bio.codonalign",
     "Bio.Compass",
     "Bio.Crystal",
@@ -265,6 +267,7 @@ PACKAGES = [
     "Bio.Graphics",
     "Bio.Graphics.GenomeDiagram",
     "Bio.HMM",
+    "Bio.KDTree",
     "Bio.KEGG",
     "Bio.KEGG.Compound",
     "Bio.KEGG.Enzyme",
@@ -281,6 +284,7 @@ PACKAGES = [
     "Bio.Pathway",
     "Bio.Pathway.Rep",
     "Bio.PDB",
+    "Bio.phenotype",
     "Bio.PopGen",
     "Bio.PopGen.GenePop",
     "Bio.Restriction",
@@ -312,15 +316,6 @@ PACKAGES = [
     "Bio._py3k",
     # Other top level packages,
     "BioSQL",
-]
-
-# packages that require Numeric Python
-NUMPY_PACKAGES = [
-    "Bio.Affy",
-    "Bio.Align.substitution_matrices",
-    "Bio.Cluster",
-    "Bio.KDTree",
-    "Bio.phenotype",
 ]
 
 EXTENSIONS = [


### PR DESCRIPTION
This removes special cases for Jython and IronPython (Python 2 only implementations) and NumPy (now assuming present, see #2418 etc).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
