### PR TITLE
Dual license BSD dual license Bio.KDTreemodule

### DIFF
--- a/Bio/KDTree/KDTreemodule.c
+++ b/Bio/KDTree/KDTreemodule.c
@@ -1,3 +1,11 @@
+/* Copyright 2008-2018 by Michiel de Hoon.  All rights reserved.
+ *
+ * This file is part of the Biopython distribution and governed by your
+ * choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+ * Please see the LICENSE file that should have been included as part of this
+ * package.
+ */
+
 #include <Python.h>
 #include "KDTree.h"
 


### PR DESCRIPTION
Original author Michiel de Hoon and contributors since as
tracked with version control have all agree:

-- Michiel de Hoon (@mdehoon)
   [#2374 (comment)](https://github.com/biopython/biopython/issues/2374#issuecomment-566825939)
-- Christian Brueffer (@cbrueffer)
   [#898 (comment)](https://github.com/biopython/biopython/issues/898#issuecomment-236922857)
-- She Zhang (@SHZ66)
   [#1617 (comment)](https://github.com/biopython/biopython/pull/1617#issue-182351202)

This pull request addresses issue #2374 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
