### PR TITLE
moving UndoHandle to Bio.SearchIO._legacy.ParserSupport

### DIFF
--- a/Bio/File.py
+++ b/Bio/File.py
@@ -11,7 +11,6 @@ Bio.File defines private classes used in Bio.SeqIO and Bio.SearchIO for
 indexing files. These are not intended for direct use.
 """
 
-
 import codecs
 import os
 import sys
@@ -46,6 +45,10 @@ except ImportError:
     # Still want to offer in-memory indexing.
     _sqlite = None
     pass
+
+
+import warnings
+from Bio import BiopythonDeprecationWarning
 
 
 @contextlib.contextmanager
@@ -146,6 +149,25 @@ def _open_for_random_access(filename):
             )
 
     return handle
+
+
+class UndoHandle(object):
+    """A Python handle that adds functionality for saving lines (DEPRECATED).
+
+    Saves lines in a LIFO fashion.
+
+    Added methods:
+     - saveline    Save a line to be returned next time.
+     - peekline    Peek at the next line without consuming it.
+
+    """
+
+    def __init__(self, handle):
+        """Initialize the class."""
+        warnings.warn("The UndoHandle class has been deprecated, and was "
+                      "moved to Bio/SearchIO/_legacy/ParserSupport.py "
+                      "(which is the only module in Biopython still using "
+                      "UndoHandle.")
 
 
 # The rest of this file defines code used in Bio.SeqIO and Bio.SearchIO

--- a/Bio/File.py
+++ b/Bio/File.py
@@ -164,10 +164,10 @@ class UndoHandle(object):
 
     def __init__(self, handle):
         """Initialize the class."""
-        warnings.warn("The UndoHandle class has been deprecated, and was "
-                      "moved to Bio/SearchIO/_legacy/ParserSupport.py "
-                      "(which is the only module in Biopython still using "
-                      "UndoHandle.")
+        raise Exception("The UndoHandle class has been deprecated, and was "
+                        "moved to Bio/SearchIO/_legacy/ParserSupport.py "
+                        "(which is the only module in Biopython still using "
+                        "UndoHandle.")
 
 
 # The rest of this file defines code used in Bio.SeqIO and Bio.SearchIO

--- a/Bio/SearchIO/_legacy/NCBIStandalone.py
+++ b/Bio/SearchIO/_legacy/NCBIStandalone.py
@@ -25,9 +25,10 @@ wrappers for these under Bio.Blast.Applications (see the tutorial).
 
 import sys
 import re
-
 from io import StringIO
+
 from Bio.SearchIO._legacy.ParserSupport import (
+    UndoHandle,
     AbstractParser,
     AbstractConsumer,
     read_and_call,
@@ -38,7 +39,6 @@ from Bio.SearchIO._legacy.ParserSupport import (
     safe_peekline,
     safe_readline,
 )
-from Bio import File
 from Bio.Blast import Record
 
 from Bio import BiopythonWarning
@@ -103,10 +103,10 @@ class _Scanner:
          - consumer is a Consumer object that will receive events as the
            report is scanned.
         """
-        if isinstance(handle, File.UndoHandle):
+        if isinstance(handle, UndoHandle):
             uhandle = handle
         else:
-            uhandle = File.UndoHandle(handle)
+            uhandle = UndoHandle(handle)
 
         # Try to fast-forward to the beginning of the blast report.
         read_and_call_until(uhandle, consumer.noevent, contains="BLAST")
@@ -1741,7 +1741,7 @@ class Iterator:
             raise ValueError(
                 "I expected a file handle or file-like object, got %s" % type(handle)
             )
-        self._uhandle = File.UndoHandle(handle)
+        self._uhandle = UndoHandle(handle)
         self._parser = parser
         self._header = []
 

--- a/Bio/SearchIO/_legacy/ParserSupport.py
+++ b/Bio/SearchIO/_legacy/ParserSupport.py
@@ -8,6 +8,7 @@
 """Code to support writing parsers (DEPRECATED).
 
 Classes:
+ - UndoHandle     File object decorator with support for undo-like operations.
  - AbstractParser         Base class for parsers.
  - AbstractConsumer       Base class of all Consumers.
  - TaggingConsumer        Consumer that tags output with its event.  For debugging
@@ -25,6 +26,108 @@ Functions:
 
 import sys
 from io import StringIO
+
+
+class UndoHandle(object):
+    """A Python handle that adds functionality for saving lines.
+
+    Saves lines in a LIFO fashion.
+
+    Added methods:
+     - saveline    Save a line to be returned next time.
+     - peekline    Peek at the next line without consuming it.
+
+    """
+
+    def __init__(self, handle):
+        """Initialize the class."""
+        self._handle = handle
+        self._saved = []
+        try:
+            # If wrapping an online handle, this this is nice to have:
+            self.url = handle.url
+        except AttributeError:
+            pass
+
+    def __iter__(self):
+        """Iterate over the lines in the File."""
+        return self
+
+    def __next__(self):
+        """Return the next line."""
+        next = self.readline()
+        if not next:
+            raise StopIteration
+        return next
+
+    def readlines(self, *args, **keywds):
+        """Read all the lines from the file as a list of strings."""
+        lines = self._saved + self._handle.readlines(*args, **keywds)
+        self._saved = []
+        return lines
+
+    def readline(self, *args, **keywds):
+        """Read the next line from the file as string."""
+        if self._saved:
+            line = self._saved.pop(0)
+        else:
+            line = self._handle.readline(*args, **keywds)
+        return line
+
+    def read(self, size=-1):
+        """Read the File."""
+        if size == -1:
+            saved = "".join(self._saved)
+            self._saved[:] = []
+        else:
+            saved = ""
+            while size > 0 and self._saved:
+                if len(self._saved[0]) <= size:
+                    size = size - len(self._saved[0])
+                    saved = saved + self._saved.pop(0)
+                else:
+                    saved = saved + self._saved[0][:size]
+                    self._saved[0] = self._saved[0][size:]
+                    size = 0
+        return saved + self._handle.read(size)
+
+    def saveline(self, line):
+        """Store a line in the cache memory for later use.
+
+        This acts to undo a readline, reflecting the name of the class: UndoHandle.
+        """
+        if line:
+            self._saved = [line] + self._saved
+
+    def peekline(self):
+        """Return the next line in the file, but do not move forward though the file."""
+        if self._saved:
+            line = self._saved[0]
+        else:
+            line = self._handle.readline()
+            self.saveline(line)
+        return line
+
+    def tell(self):
+        """Return the current position of the file read/write pointer within the File."""
+        return self._handle.tell() - sum(len(line) for line in self._saved)
+
+    def seek(self, *args):
+        """Set the current position at the offset specified."""
+        self._saved = []
+        self._handle.seek(*args)
+
+    def __getattr__(self, attr):
+        """Return File attribute."""
+        return getattr(self._handle, attr)
+
+    def __enter__(self):
+        """Call special method when opening the file using a with-statement."""
+        return self
+
+    def __exit__(self, type, value, traceback):
+        """Call special method when closing the file using a with-statement."""
+        self._handle.close()
 
 
 class AbstractParser:

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -835,3 +835,9 @@ Bio.Statistics
 --------------
 This module was declared obsolete in Release 1.74, and deprecated in Release
 1.76.
+
+Bio.File
+--------
+The UndoHandle class was deprecated in Release 1.77, and moved to
+Bio/SearchIO/_legacy/ParserSupport.py, which was the only module in
+Biopython still using this class.

--- a/Tests/test_File.py
+++ b/Tests/test_File.py
@@ -9,65 +9,10 @@ import os.path
 import shutil
 import tempfile
 import unittest
+from io import StringIO
 
 from Bio import bgzf
 from Bio import File
-from io import StringIO
-
-data = """This
-is
-a multi-line
-file"""
-
-
-class UndoHandleTests(unittest.TestCase):
-    """Tests for the UndoHandle."""
-
-    def test_one(self):
-        """First test."""
-        h = File.UndoHandle(StringIO(data))
-        self.assertEqual(h.readline(), "This\n")
-        self.assertEqual(h.peekline(), "is\n")
-        self.assertEqual(h.readline(), "is\n")
-        # TODO - Meaning of saveline lacking \n?
-        h.saveline("saved\n")
-        self.assertEqual(h.peekline(), "saved\n")
-        h.saveline("another\n")
-        self.assertEqual(h.readline(), "another\n")
-        self.assertEqual(h.readline(), "saved\n")
-        # Test readlines after saveline
-        h.saveline("saved again\n")
-        lines = h.readlines()
-        self.assertEqual(len(lines), 3)
-        self.assertEqual(lines[0], "saved again\n")
-        self.assertEqual(lines[1], "a multi-line\n")
-        self.assertEqual(lines[2], "file")  # no trailing \n
-        # should be empty now
-        self.assertEqual(h.readline(), "")
-        h.saveline("save after empty\n")
-        self.assertEqual(h.readline(), "save after empty\n")
-        self.assertEqual(h.readline(), "")
-
-    def test_read(self):
-        """Test read method."""
-        h = File.UndoHandle(StringIO("some text"))
-        h.saveline("more text")
-        self.assertEqual(h.read(), "more textsome text")
-
-    def test_undohandle_read_block(self):
-        """Test reading in blocks."""
-        for block in [1, 2, 10]:
-            s = StringIO(data)
-            h = File.UndoHandle(s)
-            h.peekline()
-            new = ""
-            while True:
-                tmp = h.read(block)
-                if not tmp:
-                    break
-                new += tmp
-            self.assertEqual(data, new)
-            h.close()
 
 
 class RandomAccess(unittest.TestCase):

--- a/Tests/test_SearchIO_legacy.py
+++ b/Tests/test_SearchIO_legacy.py
@@ -10,14 +10,72 @@ import string
 import unittest
 
 from io import StringIO
-from Bio import File
-
 
 import warnings
 from Bio import BiopythonWarning
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", BiopythonWarning)
     from Bio.SearchIO._legacy import ParserSupport
+
+
+class UndoHandleTests(unittest.TestCase):
+    """Tests for the UndoHandle."""
+
+    def test_one(self):
+        """First test."""
+        data = """\
+This
+is
+a multi-line
+file"""
+        h = ParserSupport.UndoHandle(StringIO(data))
+        self.assertEqual(h.readline(), "This\n")
+        self.assertEqual(h.peekline(), "is\n")
+        self.assertEqual(h.readline(), "is\n")
+        # TODO - Meaning of saveline lacking \n?
+        h.saveline("saved\n")
+        self.assertEqual(h.peekline(), "saved\n")
+        h.saveline("another\n")
+        self.assertEqual(h.readline(), "another\n")
+        self.assertEqual(h.readline(), "saved\n")
+        # Test readlines after saveline
+        h.saveline("saved again\n")
+        lines = h.readlines()
+        self.assertEqual(len(lines), 3)
+        self.assertEqual(lines[0], "saved again\n")
+        self.assertEqual(lines[1], "a multi-line\n")
+        self.assertEqual(lines[2], "file")  # no trailing \n
+        # should be empty now
+        self.assertEqual(h.readline(), "")
+        h.saveline("save after empty\n")
+        self.assertEqual(h.readline(), "save after empty\n")
+        self.assertEqual(h.readline(), "")
+
+    def test_read(self):
+        """Test read method."""
+        h = ParserSupport.UndoHandle(StringIO("some text"))
+        h.saveline("more text")
+        self.assertEqual(h.read(), "more textsome text")
+
+    def test_undohandle_read_block(self):
+        """Test reading in blocks."""
+        data = """\
+This
+is
+a multi-line
+file"""
+        for block in [1, 2, 10]:
+            s = StringIO(data)
+            h = ParserSupport.UndoHandle(s)
+            h.peekline()
+            new = ""
+            while True:
+                tmp = h.read(block)
+                if not tmp:
+                    break
+                new += tmp
+            self.assertEqual(data, new)
+            h.close()
 
 
 class TestParserSupport(unittest.TestCase):
@@ -55,7 +113,7 @@ class TestParserSupport(unittest.TestCase):
         data = """\
 This
 file"""
-        h = File.UndoHandle(StringIO(data))
+        h = ParserSupport.UndoHandle(StringIO(data))
         safe_readline = ParserSupport.safe_readline
         self.assertEqual(safe_readline(h), "This\n")
         self.assertEqual(safe_readline(h), "file")
@@ -66,7 +124,7 @@ file"""
         data = """\
 This
 file"""
-        h = File.UndoHandle(StringIO(data))
+        h = ParserSupport.UndoHandle(StringIO(data))
         self.assertEqual(safe_peekline(h), "This\n")
         h.readline()
         self.assertEqual(safe_peekline(h), "file")
@@ -86,7 +144,7 @@ GTAEVI
 
 
 """
-        h = File.UndoHandle(StringIO(data))
+        h = ParserSupport.UndoHandle(StringIO(data))
         lines = []
         rac = ParserSupport.read_and_call
         rac(h, lines.append)
@@ -106,7 +164,7 @@ MAKLEITLKRSVIGRPEDQRVTVRTLGLKKTNQTVVHEDNAAIRGMINKVSHLVSVKEQ
 MKLHELKPSEGSRKTRNRVGRGIGSGNGKTAGKGHKGQNARSGGGVRPGFEGGQMPLFQRLPKRGFTNIN
 RKEYAVVNLDKLNGFAEGTEVTPELLLETGVISKLNAGVKILGNGKLEKKLTVKANKFSASAKEAVEAAG
 GTAEVI"""
-        h = File.UndoHandle(StringIO(data))
+        h = ParserSupport.UndoHandle(StringIO(data))
         lines = []
         arac = ParserSupport.attempt_read_and_call
         self.assertTrue(arac(h, lines.append, contains="RIBOSOMAL PROTEIN"))


### PR DESCRIPTION
This pull request moves the `UndoHandle` class from `Bio.File` to `Bio.SearchIO._legacy.ParserSupport` as currently UndoHandles are only being used in `Bio.SearchIO._legacy`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
