### PR TITLE
TravisCI/Tox - Downgrade numpy for pypy3

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -56,6 +56,7 @@ whitelist_externals =
 install_command = pip install --only-binary=scipy {opts} {packages}
 deps =
     setuptools
+    wheel
     numpy
     #Lines startings xxx: are filtered by the environment.
     #Leaving py36 without any dependencies (except numpy)

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -57,7 +57,8 @@ install_command = pip install --only-binary=scipy {opts} {packages}
 deps =
     setuptools
     wheel
-    numpy
+    py36,py37,py38: numpy
+    pypy3: numpy<1.18.0
     #Lines startings xxx: are filtered by the environment.
     #Leaving py36 without any dependencies (except numpy)
     cover: coverage

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -55,6 +55,7 @@ whitelist_externals =
 # (But must compile numpy for PyPy right now)
 install_command = pip install --only-binary=scipy {opts} {packages}
 deps =
+    setuptools
     numpy
     #Lines startings xxx: are filtered by the environment.
     #Leaving py36 without any dependencies (except numpy)


### PR DESCRIPTION
This pull request addresses issue #2426 (pragmatic solution, does not solve root cause)

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
