### PR TITLE
Remove lots of Python 2 imports

### DIFF
--- a/Bio/File.py
+++ b/Bio/File.py
@@ -79,17 +79,17 @@ def as_handle(handleish, mode="r", **kwargs):
     >>> from Bio import File
     >>> import os
     >>> with File.as_handle('seqs.fasta', 'w') as fp:
-    ...     # Python2/3 docstring workaround, revise for 'Python 3 only'.
-    ...     _ = fp.write('>test\nACGT')
+    ...     fp.write('>test\nACGT')
     ...
+    10
     >>> fp.closed
     True
 
     >>> handle = open('seqs.fasta', 'w')
     >>> with File.as_handle(handle) as fp:
-    ...     # Python 2/3 docstring workaround, revise for 'Python 3 only'.
-    ...     _ = fp.write('>test\nACGT')
+    ...     fp.write('>test\nACGT')
     ...
+    10
     >>> fp.closed
     False
     >>> fp.close()

--- a/Bio/Index.py
+++ b/Bio/Index.py
@@ -20,12 +20,7 @@ _InMemoryIndex  An in-memory Index class.
 import os
 import array
 import shelve
-
-
-try:
-    import cPickle as pickle  # Only available under Python 2
-except ImportError:
-    import pickle  # Python 3
+import pickle
 
 import warnings
 from Bio import BiopythonDeprecationWarning

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -25,13 +25,7 @@ import array
 import sys
 import warnings
 import collections
-
-try:
-    # Python 3
-    from collections.abc import Iterable as _Iterable
-except ImportError:
-    # Python 2.7
-    from collections import Iterable as _Iterable
+from collections.abc import Iterable as _Iterable
 
 from Bio._py3k import range
 from Bio._py3k import basestring

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -133,11 +133,7 @@ You might use the Bio.SeqIO.convert() function to convert the (trimmed) SFF
 reads into a FASTQ file (or a FASTA file and a QUAL file), e.g.
 
     >>> from Bio import SeqIO
-    >>> try:
-    ...     from StringIO import StringIO # Python 2
-    ... except ImportError:
-    ...     from io import StringIO # Python 3
-    ...
+    >>> from io import StringIO
     >>> out_handle = StringIO()
     >>> count = SeqIO.convert("Roche/E3MFGYR02_random_10_reads.sff", "sff",
     ...                       out_handle, "fastq")

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -1084,11 +1084,7 @@ def convert(in_file, in_format, out_file, out_format, alphabet=None):
     For example, going from a filename to a handle:
 
     >>> from Bio import SeqIO
-    >>> try:
-    ...     from StringIO import StringIO # Python 2
-    ... except ImportError:
-    ...     from io import StringIO # Python 3
-    ...
+    >>> from io import StringIO
     >>> handle = StringIO("")
     >>> SeqIO.convert("Quality/example.fastq", "fastq", handle, "fasta")
     3

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -628,11 +628,7 @@ def parse(handle, format, alphabet=None):
 
     >>> data = ">Alpha\nACCGGATGTA\n>Beta\nAGGCTCGGTTA\n"
     >>> from Bio import SeqIO
-    >>> try:
-    ...     from StringIO import StringIO # Python 2
-    ... except ImportError:
-    ...     from io import StringIO # Python 3
-    ...
+    >>> from io import StringIO
     >>> for record in SeqIO.parse(StringIO(data), "fasta"):
     ...     print("%s %s" % (record.id, record.seq))
     Alpha ACCGGATGTA

--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -101,11 +101,7 @@ gzip
 Notice that the open function has been replaced. You can "fix" this if you
 need to by importing the built-in open function:
 
->>> try:
-...     from __builtin__ import open # Python 2
-... except ImportError:
-...     from builtins import open # Python 3
-...
+>>> from builtins import open
 
 However, what we recommend instead is to use the explicit namespace, e.g.
 
@@ -328,11 +324,7 @@ def BgzfBlocks(handle):
     decompressed length of the blocks contents (limited to 65536 in
     BGZF), as an iterator - one tuple per BGZF block.
 
-    >>> try:
-    ...     from __builtin__ import open # Python 2
-    ... except ImportError:
-    ...     from builtins import open # Python 3
-    ...
+    >>> from builtins import open
     >>> handle = open("SamBam/ex1.bam", "rb")
     >>> for values in BgzfBlocks(handle):
     ...     print("Raw start %i, raw length %i; data start %i, data length %i" % values)
@@ -465,11 +457,7 @@ class BgzfReader(object):
     Let's use the BgzfBlocks function to have a peak at the BGZF blocks
     in an example BAM file,
 
-    >>> try:
-    ...     from __builtin__ import open # Python 2
-    ... except ImportError:
-    ...     from builtins import open # Python 3
-    ...
+    >>> from builtins import open
     >>> handle = open("SamBam/ex1.bam", "rb")
     >>> for values in BgzfBlocks(handle):
     ...     print("Raw start %i, raw length %i; data start %i, data length %i" % values)

--- a/Doc/examples/getgene.py
+++ b/Doc/examples/getgene.py
@@ -38,11 +38,7 @@ import os
 import re
 import string
 import sys
-
-try:
-    import gdbm  # Python 2
-except ImportError:
-    from dbm import gnu as gdbm  # Python 3
+from dbm import gnu as gdbm
 
 
 class DB_Index(object):

--- a/Doc/examples/www_blast.py
+++ b/Doc/examples/www_blast.py
@@ -11,11 +11,7 @@ This code is described in great detail in the BLAST section of the Biopython
 documentation.
 """
 # standard library
-
-try:
-    from StringIO import StringIO  # Python 2
-except ImportError:
-    from io import StringIO  # Python 3
+from io import StringIO
 
 # biopython
 from Bio import SeqIO

--- a/Scripts/GenBank/check_output.py
+++ b/Scripts/GenBank/check_output.py
@@ -14,15 +14,10 @@ Usage:
 python check_output.py <name of file to parse>
 """
 # standard modules
-
 import sys
 import os
 import gzip
-
-try:
-    from StringIO import StringIO  # Python 2
-except ImportError:
-    from io import StringIO  # Python 3
+from io import StringIO
 
 # biopython
 from Bio import GenBank

--- a/Scripts/Restriction/rebase_update.py
+++ b/Scripts/Restriction/rebase_update.py
@@ -17,13 +17,7 @@ The Rebase EMBOSS files are used by ``ranacompiler.py`` to build the updated
 
 import os
 from datetime import date
-
-try:
-    # Python 2
-    from urllib import urlretrieve, urlcleanup
-except ImportError:
-    # Python 3
-    from urllib.request import urlretrieve, urlcleanup
+from urllib.request import urlretrieve, urlcleanup
 
 
 # Rebase ftp location, do not modify these addresses:

--- a/Scripts/SeqGui/SeqGui.py
+++ b/Scripts/SeqGui/SeqGui.py
@@ -17,17 +17,11 @@ from several codon tables which are implemented in Biopython.
 It runs as a standalone application.
 
 """
-
+import tkinter as tk
+import tkinter.ttk as ttk
 
 from Bio.Seq import translate, transcribe, back_transcribe
 from Bio.Data import CodonTable
-
-try:  # Python 2
-    import Tkinter as tk
-    import ttk
-except ImportError:  # Python 3
-    import tkinter as tk
-    import tkinter.ttk as ttk
 
 
 main_window = tk.Tk()

--- a/Scripts/xbbtools/xbb_blast.py
+++ b/Scripts/xbbtools/xbb_blast.py
@@ -16,16 +16,10 @@ import glob
 import os
 import sys
 
-try:  # Python 2
-    import Tkinter as tk
-    import ttk
-    import tkFileDialog as filedialog
-    import tkMessageBox as messagebox
-except ImportError:  # Python 3
-    import tkinter as tk
-    import tkinter.ttk as ttk
-    from tkinter import filedialog
-    from tkinter import messagebox
+import tkinter as tk
+import tkinter.ttk as ttk
+from tkinter import filedialog
+from tkinter import messagebox
 
 
 from xbb_utils import NotePad

--- a/Scripts/xbbtools/xbb_blastbg.py
+++ b/Scripts/xbbtools/xbb_blastbg.py
@@ -15,11 +15,7 @@
 import os
 import tempfile
 import threading
-
-try:
-    import tkMessageBox as messagebox  # Python 2
-except ImportError:
-    from tkinter import messagebox  # Python 3
+from tkinter import messagebox
 
 from Bio.Blast.Applications import (
     NcbiblastnCommandline,

--- a/Scripts/xbbtools/xbb_help.py
+++ b/Scripts/xbbtools/xbb_help.py
@@ -11,12 +11,8 @@
 
 """Help code for graphical Xbbtools tool."""
 
-try:  # Python 2
-    import Tkinter as tk
-    import ScrolledText as scrolledtext
-except ImportError:  # Python 3
-    import tkinter as tk
-    from tkinter import scrolledtext
+import tkinter as tk
+from tkinter import scrolledtext
 
 
 class xbbtools_help(tk.Toplevel):

--- a/Scripts/xbbtools/xbb_search.py
+++ b/Scripts/xbbtools/xbb_search.py
@@ -12,16 +12,9 @@
 """Search code for graphical Xbbtools tool."""
 
 import re
-
-
-try:  # Python 2
-    import Tkinter as tk
-    import ttk
-    import tkColorChooser as colorchooser
-except ImportError:  # Python 3
-    import tkinter as tk
-    import tkinter.ttk as ttk
-    from tkinter import colorchooser
+import tkinter as tk
+import tkinter.ttk as ttk
+from tkinter import colorchooser
 
 from Bio.Data.IUPACData import ambiguous_dna_values
 from Bio.Seq import reverse_complement

--- a/Scripts/xbbtools/xbb_utils.py
+++ b/Scripts/xbbtools/xbb_utils.py
@@ -11,14 +11,9 @@
 
 """Utility code for graphical Xbbtools tool."""
 
-try:  # Python 2
-    import Tkinter as tk
-    import ttk
-    import tkFileDialog as filedialog
-except ImportError:  # Python 3
-    import tkinter as tk
-    import tkinter.ttk as ttk
-    from tkinter import filedialog
+import tkinter as tk
+import tkinter.ttk as ttk
+from tkinter import filedialog
 
 
 class NotePad(tk.Toplevel):

--- a/Scripts/xbbtools/xbb_widget.py
+++ b/Scripts/xbbtools/xbb_widget.py
@@ -15,15 +15,9 @@
 import re
 import sys
 import time
-
-try:  # Python 2
-    import Tkinter as tk
-    import ttk
-    import tkFileDialog as filedialog
-except ImportError:  # Python 3
-    import tkinter as tk
-    import tkinter.ttk as ttk
-    from tkinter import filedialog
+import tkinter as tk
+import tkinter.ttk as ttk
+from tkinter import filedialog
 
 from Bio.Data import CodonTable
 from Bio.SeqIO.FastaIO import SimpleFastaParser

--- a/Scripts/xbbtools/xbbtools.py
+++ b/Scripts/xbbtools/xbbtools.py
@@ -12,11 +12,7 @@
 """Main code entry point for graphical Xbbtools tool."""
 
 import sys
-
-try:
-    import Tkinter as tk  # Python 2
-except ImportError:
-    import tkinter as tk  # Python 3
+import tkinter as tk
 
 from xbb_widget import xbb_widget
 

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -3,17 +3,13 @@
 # as part of this package.
 """Dealing with storage of biopython objects in a BioSQL relational db."""
 
+import configparser
 import os
 import platform
 import sys
 import tempfile
 import time
 import unittest
-
-try:
-    import configparser  # Python 3
-except ImportError:
-    import ConfigParser as configparser  # Python 2
 
 from Bio._py3k import StringIO
 from Bio._py3k import zip

--- a/Tests/pairwise2_testCases.py
+++ b/Tests/pairwise2_testCases.py
@@ -767,11 +767,7 @@ class TestOtherFunctions(unittest.TestCase):
     def test_print_matrix(self):
         """``print_matrix`` prints nested lists as nice matrices."""
         import sys
-
-        try:  # Python 2
-            from StringIO import StringIO
-        except ImportError:  # Python 3
-            from io import StringIO
+        from io import StringIO
         out = StringIO()
         sys.stdout = out
         pairwise2.print_matrix([[0.0, -1.0, -1.5, -2.0], [-1.0, 4.0, 3.0, 2.5],

--- a/Tests/test_Restriction.py
+++ b/Tests/test_Restriction.py
@@ -4,6 +4,7 @@
 #
 
 """Testing code for Restriction enzyme classes of Biopython."""
+import unittest
 
 from Bio.Restriction import Analysis, Restriction, RestrictionBatch
 from Bio.Restriction import CommOnly, NonComm, AllEnzymes
@@ -13,18 +14,6 @@ from Bio.Restriction import FormattedSeq
 from Bio.Seq import Seq, MutableSeq
 from Bio.Alphabet.IUPAC import IUPACAmbiguousDNA
 from Bio import BiopythonWarning
-
-
-from sys import version_info
-if version_info[0] < 3:
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        from Bio import MissingPythonDependencyError
-        raise MissingPythonDependencyError("Under Python 2 this test needs "
-                                           "the unittest2 library")
-else:
-    import unittest
 
 
 class SequenceTesting(unittest.TestCase):

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -13,16 +13,7 @@ import sys
 import unittest
 import warnings
 
-
-try:
-    from StringIO import StringIO  # Python 2
-
-    # Can't use cStringIO, quoting the documentation,
-    #   "Unlike the StringIO module, this module is not able to accept
-    #    Unicode strings that cannot be encoded as plain ASCII strings."
-    # Therefore can't use from Bio._py3k import StringIO
-except ImportError:
-    from io import StringIO  # Python 3
+from io import StringIO
 from io import BytesIO
 
 from Bio import BiopythonWarning, BiopythonParserWarning

--- a/Tests/test_SubsMat.py
+++ b/Tests/test_SubsMat.py
@@ -12,12 +12,8 @@ except ImportError:
     raise MissingExternalDependencyError(
         "Install NumPy if you want to use Bio.SubsMat.")
 
-try:
-    import cPickle as pickle  # Only available on Python 2
-except ImportError:
-    import pickle
-
 import os
+import pickle
 import unittest
 
 

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -6,7 +6,7 @@
 
 import array
 import copy
-import sys
+import unittest
 import warnings
 
 from Bio import BiopythonWarning
@@ -18,21 +18,6 @@ from Bio.Data.IUPACData import (ambiguous_dna_complement,
                                 ambiguous_dna_values, ambiguous_rna_values)
 from Bio.Data.CodonTable import TranslationError, standard_dna_table
 from Bio.Seq import MutableSeq
-
-# Remove unittest2 import after dropping support for Python 2
-if sys.version_info[0] < 3:
-    try:
-        import unittest2 as unittest
-    except ImportError:
-        from Bio import MissingPythonDependencyError
-        raise MissingPythonDependencyError("Under Python 2 this test needs the unittest2 library")
-else:
-    import unittest
-
-if sys.version_info[0] == 3:
-    array_indicator = "u"
-else:
-    array_indicator = "c"
 
 test_seqs = [
     Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna),
@@ -622,8 +607,7 @@ class TestMutableSeq(unittest.TestCase):
         self.assertIsInstance(mutable_s, MutableSeq,
                               "Converting Seq to mutable")
 
-        array_seq = MutableSeq(array.array(array_indicator,
-                                           "TCAAAAGGATGCATCATG"),
+        array_seq = MutableSeq(array.array("u", "TCAAAAGGATGCATCATG"),
                                IUPAC.ambiguous_dna)
         self.assertIsInstance(array_seq, MutableSeq,
                               "Creating MutableSeq using array")
@@ -766,7 +750,7 @@ class TestMutableSeq(unittest.TestCase):
                                     IUPAC.ambiguous_dna),
                          self.mutable_s, "Set slice with MutableSeq")
 
-        self.mutable_s[1:3] = array.array(array_indicator, "GAT")
+        self.mutable_s[1:3] = array.array("u", "GAT")
         self.assertEqual(MutableSeq("TGATTAAAGGATGCATCATG",
                                     IUPAC.ambiguous_dna),
                          self.mutable_s, "Set slice with array")


### PR DESCRIPTION
Found by searching for ``ImportError``, deliberately not tackling the ``Bio._py3k`` cases already logged as issue #2420.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
