### PR TITLE
Remove legacy python 2 next methods

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1370,9 +1370,6 @@ class PairwiseAlignments(object):
         self.alignment = alignment
         return alignment
 
-    if sys.version_info[0] < 3:  # Python 2
-        next = __next__
-
 
 class PairwiseAligner(_aligners.PairwiseAligner):
     """Performs pairwise sequence alignment using dynamic programming.

--- a/Bio/AlignIO/Interfaces.py
+++ b/Bio/AlignIO/Interfaces.py
@@ -63,12 +63,6 @@ class AlignmentIterator(object):
         # into MultipleSeqAlignment objects.                #
         #####################################################
 
-    if sys.version_info[0] < 3:
-
-        def next(self):
-            """Python 2 style alias for Python 3 style __next__ method."""
-            return self.__next__()
-
     def __iter__(self):
         """Iterate over the entries as MultipleSeqAlignment objects.
 

--- a/Bio/Blast/ParseBlastTable.py
+++ b/Bio/Blast/ParseBlastTable.py
@@ -92,11 +92,6 @@ class BlastTableReader(object):
         self._in_header = 1
         return self.table_record
 
-    if sys.version_info[0] < 3:
-        def next(self):
-            """Python 2 style alias for Python 3 style __next__ method."""
-            return self.__next__()
-
     def _consume_entry(self, inline):
         current_entry = BlastTableEntry(inline)
         self.table_record.add_entry(current_entry)

--- a/Bio/File.py
+++ b/Bio/File.py
@@ -182,11 +182,6 @@ class UndoHandle(object):
             raise StopIteration
         return next
 
-    if sys.version_info[0] < 3:
-        def next(self):
-            """Python 2 style alias for Python 3 style __next__ method."""
-            return self.__next__()
-
     def readlines(self, *args, **keywds):
         """Read all the lines from the file as a list of strings."""
         lines = self._saved + self._handle.readlines(*args, **keywds)

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -479,12 +479,6 @@ class Iterator(object):
         except StopIteration:
             return None
 
-    if sys.version_info[0] < 3:
-
-        def next(self):
-            """Python 2 style alias for Python 3 style __next__ method."""
-            return self.__next__()
-
     def __iter__(self):
         """Iterate over the records."""
         return iter(self.__next__, None)

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -104,12 +104,6 @@ class CharBuffer(object):
         else:
             return None
 
-    if sys.version_info[0] < 3:
-
-        def next(self):
-            """Return next item, deprecated Python 2 style alias for Python 3 style __next__ method."""
-            return self.__next__()
-
     def next_nonwhitespace(self):
         """Check for next non whitespace character in NEXUS file."""
         while True:

--- a/Bio/Nexus/StandardData.py
+++ b/Bio/Nexus/StandardData.py
@@ -106,12 +106,6 @@ class StandardData(object):
             self._current_pos += 1
             return return_coding
 
-    if sys.version_info[0] < 3:
-
-        def next(self):
-            """Return next item, deprecated Python 2 style alias for Python 3 style __next__ method."""
-            return self.__next__()
-
     def raw(self):
         """Return the full coding as a python list."""
         return self._data

--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -17,7 +17,6 @@ Journal article:
 """
 
 import re
-import sys
 import warnings
 
 from Bio._py3k import basestring
@@ -788,12 +787,6 @@ class Confidence(PhyloElement):
     def __int__(self):
         """Return integer value of Confidence object."""
         return int(self.value)
-
-    if sys.version_info[0] < 3:
-
-        def __long__(self):
-            """Return long value of Confidence object."""
-            return long(self.value)  # noqa : F821
 
 
 class Date(PhyloElement):

--- a/Bio/PopGen/GenePop/Controller.py
+++ b/Bio/PopGen/GenePop/Controller.py
@@ -159,12 +159,6 @@ class _FileIterator(object):
     def __next__(self):
         return self.func(self)
 
-    if sys.version_info[0] < 3:
-
-        def next(self):
-            """Return next item, a Python 2 style alias for Python 3 style __next__ method."""
-            return self.__next__()
-
     def __del__(self):
         self.stream.close()
         try:

--- a/Bio/SearchIO/_legacy/NCBIStandalone.py
+++ b/Bio/SearchIO/_legacy/NCBIStandalone.py
@@ -1793,12 +1793,6 @@ class Iterator(object):
             return self._parser.parse(StringIO(data))
         return data
 
-    if sys.version_info[0] < 3:
-
-        def next(self):
-            """Python 2 style alias for Python 3 style __next__ method."""
-            return self.__next__()
-
     def __iter__(self):
         return iter(self.__next__, None)
 

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -52,12 +52,6 @@ class SequenceIterator(object):
         """
         raise NotImplementedError("The subclass should implement the __next__ method.")
 
-    if sys.version_info[0] < 3:
-
-        def next(self):
-            """Python 2 style alias for Python 3 style __next__ method."""
-            return self.__next__()
-
     def __iter__(self):
         """Iterate over the entries as a SeqRecord objects.
 

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -426,12 +426,6 @@ class SeqXmlIterator(object):
             self.handle.close()
         raise StopIteration
 
-    if sys.version_info[0] < 3:  # python2
-
-        def next(self):
-            """Python 2 style alias for Python 3 style __next__ method."""
-            return self.__next__()
-
 
 class SeqXmlWriter(SequentialSequenceWriter):
     """Writes SeqRecords into seqXML file.

--- a/Bio/SeqIO/SnapGeneIO.py
+++ b/Bio/SeqIO/SnapGeneIO.py
@@ -58,10 +58,6 @@ class _PacketIterator:
 
         return (type, length, data)
 
-    # Python2 compatibility
-    def next(self):
-        return self.__next__()
-
 
 def _parse_dna_packet(length, data, record):
     """Parse a DNA sequence packet.

--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -702,12 +702,6 @@ class BgzfReader(object):
             raise StopIteration
         return line
 
-    if sys.version_info[0] < 3:
-
-        def next(self):
-            """Python 2 style alias for Python 3 style __next__ method."""
-            return self.__next__()
-
     def __iter__(self):
         """Iterate over the lines in the BGZF file."""
         return self


### PR DESCRIPTION
Part of the general cleanup after dropping Python 2 support.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
