### PR TITLE
SeqRecord format now plain text only

### DIFF
--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -749,23 +749,10 @@ class SeqRecord(object):
             return SeqIO._FormatToString[format_spec](self)
 
         if format_spec in SeqIO._BinaryFormats:
-            import sys
-
-            if sys.version_info[0] < 3:
-                import warnings
-                from Bio import BiopythonDeprecationWarning
-
-                warnings.warn(
-                    "Binary format %s cannot be used with SeqRecord format method on Python 3"
-                    % format_spec,
-                    BiopythonDeprecationWarning,
-                )
-                # Continue - Python 2 StringIO will work...
-            else:
-                raise ValueError(
-                    "Binary format %s cannot be used with SeqRecord format method"
-                    % format_spec
-                )
+            raise ValueError(
+                "Binary format %s cannot be used with SeqRecord format method"
+                % format_spec
+            )
 
         # Harder case, make a temp handle instead
         from Bio._py3k import StringIO


### PR DESCRIPTION
This pull request addresses issue #2333 now that we have dropped Python 2, and in part #2420 for ``SeqRecord.py``

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
