### PR TITLE
Remove Python 2 only __nonzero__ and __cmp__

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -941,14 +941,6 @@ class PairwiseAlignment(object):
         self.score = score
         self.path = path
 
-    # For Python2 only
-    def __cmp__(self, other):
-        if self.path < other.path:
-            return -1
-        if self.path > other.path:
-            return +1
-        return 0
-
     def __eq__(self, other):
         return self.path == other.path
 

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -1114,7 +1114,6 @@ class Clade(TreeElement, TreeMixin):
         """Return the number of clades directy under the root."""
         return len(self.clades)
 
-    # Python 3:
     def __bool__(self):
         """Boolean value of an instance of this class (True).
 
@@ -1123,9 +1122,6 @@ class Clade(TreeElement, TreeMixin):
         Clade instances to always be considered True.
         """
         return True
-
-    # Python 2:
-    __nonzero__ = __bool__
 
     def __str__(self):
         """Return name of the class instance."""

--- a/Bio/SearchIO/_model/hit.py
+++ b/Bio/SearchIO/_model/hit.py
@@ -157,13 +157,9 @@ class Hit(_BaseSearchObject):
         """Return number of hsps."""
         return len(self.hsps)
 
-    # Python 3:
     def __bool__(self):
         """Return True if there are hsps."""
         return bool(self.hsps)
-
-    # Python 2:
-    __nonzero__ = __bool__
 
     def __contains__(self, hsp):
         """Return True if hsp in items."""

--- a/Bio/SearchIO/_model/hsp.py
+++ b/Bio/SearchIO/_model/hsp.py
@@ -311,13 +311,9 @@ class HSP(_BaseHSP):
         """Return number of HSPs items."""
         return len(self._items)
 
-    # Python 3:
     def __bool__(self):
         """Return True if it has HSPs."""
         return bool(self._items)
-
-    # Python 2:
-    __nonzero__ = __bool__
 
     def __str__(self):
         """Return a human readable summary of the HSP object."""

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -292,13 +292,9 @@ class QueryResult(_BaseSearchObject):
         """Return the number of items."""
         return len(self._items)
 
-    # Python 3:
     def __bool__(self):
         """Return True if there are items."""
         return bool(self._items)
-
-    # Python 2:
-    __nonzero__ = __bool__
 
     def __repr__(self):
         """Return string representation of the QueryResult object."""

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -161,8 +161,8 @@ class Seq(object):
     def __hash__(self):
         """Hash for comparison.
 
-        See the __cmp__ documentation - this has changed from past
-        versions of Biopython!
+        See Seq object comparison documentation - this has changed
+        from past versions of Biopython!
         """
         # TODO - remove this warning in a future release
         warnings.warn(

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -466,7 +466,6 @@ class SeqFeature(object):
             gap=gap,
         )
 
-    # Python 3:
     def __bool__(self):
         """Boolean value of an instance of this class (True).
 
@@ -480,9 +479,6 @@ class SeqFeature(object):
         length is zero (in order to better match normal python behaviour)!
         """
         return True
-
-    # Python 2:
-    __nonzero__ = __bool__
 
     def __len__(self):
         """Return the length of the region where the feature is located.

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -818,10 +818,6 @@ class SeqRecord(object):
     # See github issue 929 for related discussion.
     __hash__ = None
 
-    # Note Python 3 does not use __cmp__ and there is no need to
-    # define __cmp__ on Python 2 as have all of  _lt__ etc defined.
-
-    # Python 3:
     def __bool__(self):
         """Boolean value of an instance of this class (True).
 
@@ -836,9 +832,6 @@ class SeqRecord(object):
         object behaviour)!
         """
         return True
-
-    # Python 2:
-    __nonzero__ = __bool__
 
     def __add__(self, other):
         """Add another sequence or string to this sequence.

--- a/Tests/test_SearchIO_model.py
+++ b/Tests/test_SearchIO_model.py
@@ -165,7 +165,7 @@ class QueryResultCases(unittest.TestCase):
 
     def test_bool(self):
         """Test QueryResult.__bool__."""
-        # nonzero should return true only if the qresult has hits
+        # should return true only if the qresult has hits
         self.assertTrue(self.qresult)
         blank_qresult = QueryResult()
         self.assertFalse(blank_qresult)
@@ -811,8 +811,8 @@ class HitCases(unittest.TestCase):
         # len() on Hit objects should return how many hsps it has
         self.assertEqual(3, len(self.hit))
 
-    def test_nonzero(self):
-        """Test Hit.__nonzero__."""
+    def test_bool(self):
+        """Test Hit.__bool__."""
         # bool() on Hit objects should return True only if hsps is filled
         # which is always true
         self.assertTrue(self.hit)

--- a/Tests/test_SearchIO_model.py
+++ b/Tests/test_SearchIO_model.py
@@ -163,8 +163,8 @@ class QueryResultCases(unittest.TestCase):
         # len() should return the number of hits contained
         self.assertEqual(3, len(self.qresult))
 
-    def test_nonzero(self):
-        """Test QueryResult.__nonzero__."""
+    def test_bool(self):
+        """Test QueryResult.__bool__."""
         # nonzero should return true only if the qresult has hits
         self.assertTrue(self.qresult)
         blank_qresult = QueryResult()


### PR DESCRIPTION
Given we have dropped Python 2 support, this pull request follows from #2434 tackling ``__cmp__`` (replaced by rich object comparison methods) and ``__nonzero__`` (essentially replaced by ``__bool__``). Quoting  https://docs.python.org/3/whatsnew/3.0.html#ordering-comparisons

> The ``cmp()`` function should be treated as gone, and the ``__cmp__()`` special method is no longer supported. Use ``__lt__()`` for sorting, ``__eq__()`` with ``__hash__()``, and other rich comparisons as needed.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
