### PR TITLE
convert Bio.Cluster to python3 only

### DIFF
--- a/Bio/Cluster/__init__.py
+++ b/Bio/Cluster/__init__.py
@@ -1140,6 +1140,8 @@ def __check_data(data):
         data = numpy.array(data, dtype="d")
     if data.ndim != 2:
         raise ValueError("data should be 2-dimensional")
+    if numpy.isnan(data).any():
+        raise ValueError("data contains NaN values")
     return data
 
 
@@ -1155,10 +1157,13 @@ def __check_mask(mask, shape):
 def __check_weight(weight, ndata):
     if weight is None:
         return numpy.ones(ndata, dtype="d")
-    elif isinstance(weight, numpy.ndarray):
-        return numpy.require(weight, dtype="d", requirements="C")
+    if isinstance(weight, numpy.ndarray):
+        weight = numpy.require(weight, dtype="d", requirements="C")
     else:
-        return numpy.array(weight, dtype="d")
+        weight = numpy.array(weight, dtype="d")
+    if numpy.isnan(weight).any():
+        raise ValueError("weight contains NaN values")
+    return weight
 
 
 def __check_initialid(initialid, npass, nitems):
@@ -1186,27 +1191,28 @@ def __check_index(index):
 def __check_distancematrix(distancematrix):
     if distancematrix is None:
         return distancematrix
-    elif isinstance(distancematrix, numpy.ndarray):
+    if isinstance(distancematrix, numpy.ndarray):
         distancematrix = numpy.require(distancematrix, dtype="d", requirements="C")
-        return distancematrix
     else:
         try:
             distancematrix = numpy.array(distancematrix, dtype="d")
         except ValueError:
-            pass
-        else:
-            return distancematrix
-        n = len(distancematrix)
-        d = [None] * n
-        for i, row in enumerate(distancematrix):
-            if isinstance(row, numpy.ndarray):
-                row = numpy.require(row, dtype="d", requirements="C")
-            else:
-                row = numpy.array(row, dtype="d")
-            if row.ndim != 1:
-                raise ValueError("row %d is not one-dimensional" % i)
-            m = len(row)
-            if m != i:
-                raise ValueError("row %d has incorrect size (%d, expected %d)" % (m, i))
-            d[i] = row
-        return d
+            n = len(distancematrix)
+            d = [None] * n
+            for i, row in enumerate(distancematrix):
+                if isinstance(row, numpy.ndarray):
+                    row = numpy.require(row, dtype="d", requirements="C")
+                else:
+                    row = numpy.array(row, dtype="d")
+                if row.ndim != 1:
+                    raise ValueError("row %d is not one-dimensional" % i)
+                m = len(row)
+                if m != i:
+                    raise ValueError("row %d has incorrect size (%d, expected %d)" % (m, i))
+                if numpy.isnan(row).any():
+                    raise ValueError("distancematrix contains NaN values")
+                d[i] = row
+            return d
+    if numpy.isnan(distancematrix).any():
+        raise ValueError("distancematrix contains NaN values")
+    return distancematrix

--- a/Bio/Cluster/clustermodule.c
+++ b/Bio/Cluster/clustermodule.c
@@ -9,47 +9,6 @@
 /* -- Helper routines ------------------------------------------------------ */
 /* ========================================================================= */
 
-#if PY_MAJOR_VERSION < 3
-static char
-extract_single_character(PyObject* object, const char variable[],
-                         const char allowed[])
-{
-    char c = '\0';
-    const char* data;
-    Py_ssize_t n;
-    if (PyString_Check(object)) {
-        n = PyString_GET_SIZE(object);
-        if (n == 1) {
-            data = PyString_AS_STRING(object);
-            c = data[0];
-        }
-    }
-    else if (PyUnicode_Check(object)) {
-        n = PyUnicode_GET_SIZE(object);
-        if (n == 1) {
-            Py_UNICODE* u = PyUnicode_AS_UNICODE(object);
-            Py_UNICODE ch = u[0];
-            if (ch < 128) c = (char) ch;
-        }
-    }
-    else {
-        PyErr_Format(PyExc_ValueError, "%s should be a string", variable);
-        return 0;
-    }
-    if (!c) {
-        PyErr_Format(PyExc_ValueError,
-                     "%s should be a single character", variable);
-        return 0;
-    }
-    else if (!strchr(allowed, c)) {
-        PyErr_Format(PyExc_ValueError,
-                     "unknown %s function specified (should be one of '%s')",
-                     variable, allowed);
-        return 0;
-    }
-    return c;
-}
-#else
 static char
 extract_single_character(PyObject* object, const char variable[],
                          const char allowed[])
@@ -77,7 +36,6 @@ extract_single_character(PyObject* object, const char variable[],
                  variable, allowed);
     return 0;
 }
-#endif
 
 static int
 distance_converter(PyObject* object, void* pointer)
@@ -139,30 +97,31 @@ data_converter(PyObject* object, void* pointer)
     int nrows;
     int ncols;
     int i;
-    double** values;
+    double** values = data->values;
     Py_buffer* view = &data->view;
     const char* p;
     Py_ssize_t stride;
     const int flag = PyBUF_ND | PyBUF_STRIDES;
 
-    /* data should be initialized to 0 before calling this function. */
-
+    if (object == NULL) goto exit;
     if (object == Py_None) return 1;
+
     if (PyObject_GetBuffer(object, view, flag) == -1) {
         PyErr_SetString(PyExc_RuntimeError,
                         "data matrix has unexpected format.");
         return 0;
     }
+
     if (view->ndim != 2) {
-        PyErr_Format(PyExc_ValueError,
-                     "data matrix has incorrect rank (%d expected 2)",
+        PyErr_Format(PyExc_RuntimeError,
+                     "data matrix has incorrect rank %d (expected 2)",
                      view->ndim);
-        return 0;
+        goto exit;
     }
     if (view->itemsize != sizeof(double)) {
         PyErr_SetString(PyExc_RuntimeError,
                         "data matrix has incorrect data type");
-        return 0;
+        goto exit;
     }
     nrows = (int) view->shape[0];
     ncols = (int) view->shape[1];
@@ -170,38 +129,33 @@ data_converter(PyObject* object, void* pointer)
         PyErr_Format(PyExc_ValueError,
             "data matrix is too large (dimensions = %zd x %zd)",
             view->shape[0], view->shape[1]);
-        return 0;
+        goto exit;
     }
     if (nrows < 1 || ncols < 1) {
         PyErr_SetString(PyExc_ValueError, "data matrix is empty");
-        return 0;
+        goto exit;
     }
     stride = view->strides[0];
     if (view->strides[1] != view->itemsize) {
         PyErr_SetString(PyExc_RuntimeError, "data is not contiguous");
-        return 0;
+        goto exit;
     }
-    values = malloc(nrows*sizeof(double*));
+    values = PyMem_Malloc(nrows*sizeof(double*));
     if (!values) {
         PyErr_NoMemory();
-        return 0;
+        goto exit;
     }
     for (i = 0, p = view->buf; i < nrows; i++, p += stride)
         values[i] = (double*)p;
     data->values = values;
     data->nrows = nrows;
     data->ncols = ncols;
-    return 1;
-}
+    return Py_CLEANUP_SUPPORTED;
 
-static void
-free_data(Data* data)
-{
-    double** values = data->values;
-    Py_buffer* view = &data->view;
-
+exit:
+    if (values) PyMem_Free(values);
     PyBuffer_Release(view);
-    if (values) free(values);
+    return 0;
 }
 
 /* -- mask ----------------------------------------------------------------- */
@@ -218,27 +172,28 @@ mask_converter(PyObject* object, void* pointer)
     int nrows;
     int ncols;
     int i;
-    int** values;
+    int** values = mask->values;
     Py_buffer* view = &mask->view;
     const char* p;
     Py_ssize_t stride;
     const int flag = PyBUF_ND | PyBUF_STRIDES;
 
-    /* data should be initialized to 0 before calling this function. */
-
+    if (object == NULL) goto exit;
     if (object == Py_None) return 1;
+
     if (PyObject_GetBuffer(object, view, flag) == -1) {
         PyErr_SetString(PyExc_RuntimeError, "mask has unexpected format.");
         return 0;
     }
+
     if (view->ndim != 2) {
         PyErr_Format(PyExc_ValueError,
-                     "mask has incorrect rank (%d expected 2)", view->ndim);
-        return 0;
+                     "mask has incorrect rank %d (expected 2)", view->ndim);
+        goto exit;
     }
     if (view->itemsize != sizeof(int)) {
         PyErr_SetString(PyExc_RuntimeError, "mask has incorrect data type");
-        return 0;
+        goto exit;
     }
     nrows = (int) view->shape[0];
     ncols = (int) view->shape[1];
@@ -246,31 +201,27 @@ mask_converter(PyObject* object, void* pointer)
         PyErr_Format(PyExc_ValueError,
                      "mask is too large (dimensions = %zd x %zd)",
                      view->shape[0], view->shape[1]);
-        return 0;
+        goto exit;
     }
     stride = view->strides[0];
     if (view->strides[1] != view->itemsize) {
         PyErr_SetString(PyExc_RuntimeError, "mask is not contiguous");
-        return 0;
+        goto exit;
     }
-    values = malloc(nrows*sizeof(int*));
+    values = PyMem_Malloc(nrows*sizeof(int*));
     if (!values) {
         PyErr_NoMemory();
-        return 0;
+        goto exit;
     }
     for (i = 0, p = view->buf; i < nrows; i++, p += stride)
         values[i] = (int*)p;
     mask->values = values;
-    return 1;
-}
+    return Py_CLEANUP_SUPPORTED;
 
-static void
-free_mask(Mask* mask) {
-    int** values = mask->values;
-    Py_buffer* view = &mask->view;
-
+exit:
+    if (values) PyMem_Free(values);
     PyBuffer_Release(view);
-    if (values) free(values);
+    return 0;
 }
 
 /* -- 1d array ------------------------------------------------------------- */
@@ -282,26 +233,33 @@ vector_converter(PyObject* object, void* pointer)
     int ndata;
     const int flag = PyBUF_ND | PyBUF_C_CONTIGUOUS;
 
+    if (object == NULL) goto exit;
+
     if (PyObject_GetBuffer(object, view, flag) == -1) {
         PyErr_SetString(PyExc_RuntimeError, "unexpected format.");
         return 0;
     }
+
     if (view->ndim != 1) {
-        PyErr_Format(PyExc_ValueError, "incorrect rank (%d expected 1)",
+        PyErr_Format(PyExc_ValueError, "incorrect rank %d (expected 1)",
                      view->ndim);
-        return 0;
+        goto exit;
     }
     if (view->itemsize != sizeof(double)) {
         PyErr_SetString(PyExc_RuntimeError, "array has incorrect data type");
-        return 0;
+        goto exit;
     }
     ndata = (int) view->shape[0];
     if (ndata != view->shape[0]) {
         PyErr_Format(PyExc_ValueError,
                      "array is too large (size = %zd)", view->shape[0]);
-        return 0;
+        goto exit;
     }
-    return 1;
+    return Py_CLEANUP_SUPPORTED;
+
+exit:
+    PyBuffer_Release(view);
+    return 0;
 }
 
 static int
@@ -314,17 +272,15 @@ vector_none_converter(PyObject* object, void* pointer)
 /* -- clusterid ------------------------------------------------------------ */
 
 static int
-check_clusterid(Py_buffer clusterid) {
+check_clusterid(Py_buffer clusterid, int nitems) {
     int i, j;
     int *p = clusterid.buf;
     int nclusters = 0;
     int* number;
-    const int nitems = (int) clusterid.shape[0];
 
     if (nitems != clusterid.shape[0]) {
-        PyErr_Format(PyExc_ValueError,
-                     "clusterid array is too large (size = %zd)",
-                     clusterid.shape[0]);
+        PyErr_Format(PyExc_ValueError, "incorrect size (%zd, expected %d)",
+                     clusterid.shape[0], nitems);
         return 0;
     }
     for (i = 0; i < nitems; i++) {
@@ -347,7 +303,7 @@ check_clusterid(Py_buffer clusterid) {
         number[j]++;
     }
     for (j = 0; j < nclusters; j++) if (number[j] == 0) break;
-    free(number);
+    PyMem_Free(number);
     if (j < nclusters) {
         PyErr_Format(PyExc_ValueError, "cluster %d is empty", j);
         return 0;
@@ -378,24 +334,24 @@ _convert_list_to_distancematrix(PyObject* list, Distancematrix* distances)
         PyErr_SetString(PyExc_ValueError, "distance matrix is too large");
         return 0;
     }
-    values = malloc(n*sizeof(double*));
+    values = PyMem_Malloc(n*sizeof(double*));
     if (!values) {
         PyErr_NoMemory();
         return 0;
     }
     distances->values = values;
-    views = malloc(n*sizeof(Py_buffer));
+    views = PyMem_Malloc(n*sizeof(Py_buffer));
     if (!views) {
         PyErr_NoMemory();
         return 0;
     }
-    distances->views = views;
     view = views;
     for (i = 0; i < n; i++, view++) {
         PyObject* item = PyList_GET_ITEM(list, i);
         view->len = -1;
         if (PyObject_GetBuffer(item, view, flag) == -1) {
             PyErr_Format(PyExc_RuntimeError, "failed to parse row %d.", i);
+            view--;
             break;
         }
         if (view->ndim != 1) {
@@ -418,7 +374,8 @@ _convert_list_to_distancematrix(PyObject* list, Distancematrix* distances)
         values[i] = view->buf;
     }
     if (i < n) {
-        for ( ; i >= 0; i--, view--) PyBuffer_Release(view);
+        for ( ; view >= views; view--) PyBuffer_Release(view);
+        PyMem_Free(views);
         return 0;
     }
     distances->n = n;
@@ -443,8 +400,10 @@ _convert_array_to_distancematrix(PyObject* array, Distancematrix* distances)
                         "distance matrix has unexpected format.");
         return 0;
     }
+
     if (view->len == 0) {
-        PyErr_SetString(PyExc_RuntimeError, "distance matrix is empty");
+        PyBuffer_Release(view);
+        PyErr_SetString(PyExc_ValueError, "distance matrix is empty");
         return 0;
     }
     if (view->itemsize != sizeof(double)) {
@@ -467,7 +426,7 @@ _convert_array_to_distancematrix(PyObject* array, Distancematrix* distances)
             return 0;
         }
         distances->n = n;
-        values = malloc(n*sizeof(double*));
+        values = PyMem_Malloc(n*sizeof(double*));
         if (!values) {
             PyErr_NoMemory();
             return 0;
@@ -489,7 +448,7 @@ _convert_array_to_distancematrix(PyObject* array, Distancematrix* distances)
                             "distance matrix is not square.");
             return 0;
         }
-        values = malloc(n*sizeof(double*));
+        values = PyMem_Malloc(n*sizeof(double*));
         if (!values) {
             PyErr_NoMemory();
             return 0;
@@ -499,7 +458,7 @@ _convert_array_to_distancematrix(PyObject* array, Distancematrix* distances)
     }
     else {
         PyErr_Format(PyExc_ValueError,
-                     "data matrix has incorrect rank (%d; expected 1 or 2)",
+                     "distance matrix has incorrect rank %d (expected 1 or 2)",
                      view->ndim);
         return 0;
     }
@@ -510,34 +469,36 @@ static int
 distancematrix_converter(PyObject* argument, void* pointer)
 {
     Distancematrix* distances = pointer;
+    double** values;
 
+    if (argument == NULL) goto exit;
     if (argument == Py_None) return 1;
     if (PyList_Check(argument)) {
-        return _convert_list_to_distancematrix(argument, distances);
+        if (_convert_list_to_distancematrix(argument, distances))
+            return Py_CLEANUP_SUPPORTED;
     }
     else {
-        return _convert_array_to_distancematrix(argument, distances);
+        if (_convert_array_to_distancematrix(argument, distances))
+            return Py_CLEANUP_SUPPORTED;
     }
-}
 
-static void
-free_distancematrix(Distancematrix* distances)
-{
-    double** values = distances->values;
-
-    if (values == NULL) return;
+exit:
+    values = distances->values;
+    if (values == NULL) return 0;
     else {
         int i;
         const int n = distances->n;
         Py_buffer* views = distances->views;
         if (views) {
             for (i = 0; i < n; i++) PyBuffer_Release(&views[i]);
-            free(views);
+            PyMem_Free(views);
         }
-        else
+        else if (distances->view.len) {
             PyBuffer_Release(&distances->view);
-        free(values);
+        }
+        PyMem_Free(values);
     }
+    return 0;
 }
 
 /* -- celldata ------------------------------------------------------------- */
@@ -555,40 +516,40 @@ celldata_converter(PyObject* argument, void* pointer)
 {
     int i, n;
     double* p;
-    double** pp;
-    double*** ppp;
+    Celldata* celldata = pointer;
+    double*** ppp = celldata->values;
+    double** pp = ppp ? ppp[0] : NULL;
     int nx;
     int ny;
     int nz;
-    Celldata* celldata = pointer;
     Py_buffer* view = &celldata->view;
     const int flag = PyBUF_ND | PyBUF_C_CONTIGUOUS;
+
+    if (argument == NULL) goto exit;
 
     if (PyObject_GetBuffer(argument, view, flag) == -1) {
         PyErr_SetString(PyExc_RuntimeError,
                         "celldata array has unexpected format.");
         return 0;
     }
+
     nx = (int) view->shape[0];
     ny = (int) view->shape[1];
     nz = (int) view->shape[2];
     if (nx != view->shape[0] || ny != view->shape[1] || nz != view->shape[2]) {
-        PyBuffer_Release(view);
         PyErr_SetString(PyExc_RuntimeError, "celldata array too large");
-        return 0;
+        goto exit;
     }
     if (view->itemsize != sizeof(double)) {
         PyErr_SetString(PyExc_RuntimeError,
                         "celldata array has incorrect data type");
-        return 0;
+        goto exit;
     }
-    pp = malloc(nx*ny*sizeof(double*));
-    ppp = malloc(nx*sizeof(double**));
+    pp = PyMem_Malloc(nx*ny*sizeof(double*));
+    ppp = PyMem_Malloc(nx*sizeof(double**));
     if (!pp || !ppp) {
-        if (pp) free(pp);
-        if (ppp) free(ppp);
         PyErr_NoMemory();
-        return 0;
+        goto exit;
     }
     p = view->buf;
     n = nx * ny;
@@ -598,19 +559,15 @@ celldata_converter(PyObject* argument, void* pointer)
     celldata->nx = nx;
     celldata->ny = ny;
     celldata->nz = nz;
-    return 1;
+    return Py_CLEANUP_SUPPORTED;
+
+exit:
+    if (pp) PyMem_Free(pp);
+    if (ppp) PyMem_Free(ppp);
+    PyBuffer_Release(view);
+    return 0;
 }
 
-static void
-free_celldata(Celldata* celldata)
-{
-    double*** ppp = celldata->values;
-
-    if (!ppp) return;
-    free(ppp[0]);
-    free(ppp);
-    PyBuffer_Release(&celldata->view);
-}
 
 /* -- index ---------------------------------------------------------------- */
 
@@ -621,27 +578,34 @@ index_converter(PyObject* argument, void* pointer)
     int n;
     const int flag = PyBUF_ND | PyBUF_C_CONTIGUOUS;
 
+    if (argument == NULL) goto exit;
+
     if (PyObject_GetBuffer(argument, view, flag) == -1) {
         PyErr_SetString(PyExc_RuntimeError, "unexpected format.");
         return 0;
     }
+
     if (view->ndim != 1) {
-        PyErr_Format(PyExc_ValueError, "incorrect rank (%d expected 1)",
+        PyErr_Format(PyExc_ValueError, "incorrect rank %d (expected 1)",
                      view->ndim);
-        return 0;
+        goto exit;
     }
     if (view->itemsize != sizeof(int)) {
         PyErr_SetString(PyExc_RuntimeError,
                         "argument has incorrect data type");
-        return 0;
+        goto exit;
     }
     n = (int) view->shape[0];
     if (n != view->shape[0]) {
         PyErr_Format(PyExc_ValueError,
             "array size is too large (size = %zd)", view->shape[0]);
-        return 0;
+        goto exit;
     }
-    return 1;
+    return Py_CLEANUP_SUPPORTED;
+
+exit:
+    PyBuffer_Release(view);
+    return 0;
 }
 
 /* -- index2d ------------------------------------------------------------- */
@@ -653,33 +617,39 @@ index2d_converter(PyObject* argument, void* pointer)
     int n;
     const int flag = PyBUF_ND | PyBUF_C_CONTIGUOUS;
 
+    if (argument == NULL) goto exit;
+
     if (PyObject_GetBuffer(argument, view, flag) == -1) {
         PyErr_SetString(PyExc_RuntimeError, "unexpected format.");
         return 0;
     }
+
     if (view->ndim != 2) {
-        PyErr_Format(PyExc_ValueError, "incorrect rank (%d expected 2)",
+        PyErr_Format(PyExc_ValueError, "incorrect rank %d (expected 2)",
                      view->ndim);
-        return 0;
+        goto exit;
     }
     if (view->itemsize != sizeof(int)) {
         PyErr_SetString(PyExc_RuntimeError,
                         "argument has incorrect data type");
-        PyBuffer_Release(view);
-        return 0;
+        goto exit;
     }
     n = (int) view->shape[0];
     if (n != view->shape[0]) {
         PyErr_Format(PyExc_ValueError,
             "array size is too large (size = %zd)", view->shape[0]);
-        return 0;
+        goto exit;
     }
     if (view->shape[1] != 2) {
         PyErr_Format(PyExc_ValueError,
-            "expected 2 columns (found %zd columns)", view->shape[0]);
-        return 0;
+            "array has %zd columns (expected 2)", view->shape[1]);
+        goto exit;
     }
-    return 1;
+    return Py_CLEANUP_SUPPORTED;
+
+exit:
+    PyBuffer_Release(view);
+    return 0;
 }
 
 /* ========================================================================= */
@@ -714,11 +684,7 @@ PyNode_repr(PyNode* self)
 
     sprintf(string, "(%d, %d): %g",
                    self->node.left, self->node.right, self->node.distance);
-#if PY_MAJOR_VERSION >= 3
     return PyUnicode_FromString(string);
-#else
-    return PyString_FromString(string);
-#endif
 }
 
 static char PyNode_left__doc__[] =
@@ -729,11 +695,7 @@ PyNode_getleft(PyNode* self, void* closure)
 {
     int left = self->node.left;
 
-#if PY_MAJOR_VERSION >= 3
     return PyLong_FromLong((long)left);
-#else
-    return PyInt_FromLong((long)left);
-#endif
 }
 
 static int
@@ -754,11 +716,7 @@ PyNode_getright(PyNode* self, void* closure)
 {
     int right = self->node.right;
 
-#if PY_MAJOR_VERSION >= 3
     return PyLong_FromLong((long)right);
-#else
-    return PyInt_FromLong((long)right);
-#endif
 }
 
 static int
@@ -860,7 +818,7 @@ typedef struct {
 static void
 PyTree_dealloc(PyTree* self)
 {
-    if (self->n) free(self->nodes);
+    if (self->n) PyMem_Free(self->nodes);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -907,7 +865,7 @@ PyTree_new(PyTypeObject *type, PyObject* args, PyObject* kwds)
         PyErr_SetString(PyExc_ValueError, "List is empty");
         return NULL;
     }
-    nodes = malloc(n*sizeof(Node));
+    nodes = PyMem_Malloc(n*sizeof(Node));
     if (!nodes) {
         Py_DECREF(self);
         return PyErr_NoMemory();
@@ -916,7 +874,7 @@ PyTree_new(PyTypeObject *type, PyObject* args, PyObject* kwds)
         PyNode* p;
         PyObject* row = PyList_GET_ITEM(arg, i);
         if (!PyType_IsSubtype(Py_TYPE(row), &PyNodeType)) {
-            free(nodes);
+            PyMem_Free(nodes);
             Py_DECREF(self);
             PyErr_Format(PyExc_TypeError,
                          "Row %d in list is not a Node object", i);
@@ -926,9 +884,9 @@ PyTree_new(PyTypeObject *type, PyObject* args, PyObject* kwds)
         nodes[i] = p->node;
     }
     /* --- Check if this is a bona fide tree ------------------------------- */
-    flag = malloc((2*n+1)*sizeof(int));
+    flag = PyMem_Malloc((2*n+1)*sizeof(int));
     if (!flag) {
-        free(nodes);
+        PyMem_Free(nodes);
         Py_DECREF(self);
         return PyErr_NoMemory();
     }
@@ -951,10 +909,10 @@ PyTree_new(PyTypeObject *type, PyObject* args, PyObject* kwds)
         if (flag[j]) break;
         flag[j] = 1;
     }
-    free(flag);
+    PyMem_Free(flag);
     if (i < n) {
         /* break encountered */
-        free(nodes);
+        PyMem_Free(nodes);
         Py_DECREF(self);
         PyErr_SetString(PyExc_ValueError, "Inconsistent tree");
         return NULL;
@@ -973,27 +931,18 @@ PyTree_str(PyTree* self)
     Node node;
     PyObject* line;
     PyObject* output;
-#if PY_MAJOR_VERSION >= 3
     PyObject* temp;
 
     output = PyUnicode_FromString("");
-#else
-    output = PyString_FromString("");
-#endif
     for (i = 0; i < n; i++) {
         node = self->nodes[i];
         sprintf(string, "(%d, %d): %g", node.left, node.right, node.distance);
         if (i < n-1) strcat(string, "\n");
-#if PY_MAJOR_VERSION >= 3
         line = PyUnicode_FromString(string);
-#else
-        line = PyString_FromString(string);
-#endif
         if (!line) {
             Py_DECREF(output);
             return NULL;
         }
-#if PY_MAJOR_VERSION >= 3
         temp = PyUnicode_Concat(output, line);
         if (!temp) {
             Py_DECREF(output);
@@ -1001,13 +950,6 @@ PyTree_str(PyTree* self)
             return NULL;
         }
         output = temp;
-#else
-        PyString_ConcatAndDel(&output, line);
-        if (!output) {
-            Py_DECREF(line);
-            return NULL;
-        }
-#endif
     }
     return output;
 }
@@ -1041,13 +983,8 @@ PyTree_subscript(PyTree* self, PyObject* item)
     else if (PySlice_Check(item)) {
         Py_ssize_t i, j;
         Py_ssize_t start, stop, step, slicelength;
-#if PY_MAJOR_VERSION < 3
-        if (PySlice_GetIndicesEx((PySliceObject*)item, self->n, &start, &stop,
-                                 &step, &slicelength) == -1) return NULL;
-#else
         if (PySlice_GetIndicesEx(item, self->n, &start, &stop, &step,
                                  &slicelength) == -1) return NULL;
-#endif
         if (slicelength == 0) return PyList_New(0);
         else {
             PyNode* node;
@@ -1135,8 +1072,9 @@ PyTree_cut(PyTree* self, PyObject* args)
         goto exit;
     }
     ok = cuttree(n, self->nodes, nclusters, indices.buf);
+
 exit:
-    PyBuffer_Release(&indices);
+    index_converter(NULL, &indices);
     if (ok == -1) return NULL;
     if (ok == 0) return PyErr_NoMemory();
     Py_INCREF(Py_None);
@@ -1174,10 +1112,16 @@ PyTree_sort(PyTree* self, PyObject* args)
                         "indices array inconsistent with tree");
         goto exit;
     }
+    if (order.shape[0] != n + 1) {
+        PyErr_Format(PyExc_ValueError,
+            "order array has incorrect size %zd (expected %d)",
+            order.shape[0], n + 1);
+        goto exit;
+    }
     ok = sorttree(n, self->nodes, order.buf, indices.buf);
 exit:
-    PyBuffer_Release(&order);
-    PyBuffer_Release(&indices);
+    index_converter(NULL, &indices);
+    vector_converter(NULL, &order);
     if (ok == -1) return NULL;
     if (ok == 0) return PyErr_NoMemory();
     Py_INCREF(Py_None);
@@ -1253,11 +1197,7 @@ static char version__doc__[] =
 static PyObject*
 py_version(PyObject* self)
 {
-#if PY_MAJOR_VERSION >= 3
     return PyUnicode_FromString( CLUSTERVERSION );
-#else
-    return PyString_FromString( CLUSTERVERSION );
-#endif
 }
 
 /* kcluster */
@@ -1348,7 +1288,7 @@ py_kcluster(PyObject* self, PyObject* args, PyObject* keywords)
                                      &npass,
                                      method_kcluster_converter, &method,
                                      distance_converter, &dist,
-                                     index_converter, &clusterid)) goto exit;
+                                     index_converter, &clusterid)) return NULL;
     if (!data.values) {
         PyErr_SetString(PyExc_RuntimeError, "data is None");
         goto exit;
@@ -1360,7 +1300,7 @@ py_kcluster(PyObject* self, PyObject* args, PyObject* keywords)
     if (data.nrows != mask.view.shape[0] ||
         data.ncols != mask.view.shape[1]) {
         PyErr_Format(PyExc_ValueError,
-            "mask has incorrect dimensions (%zd x %zd, expected %d x %d)",
+            "mask has incorrect dimensions %zd x %zd (expected %d x %d)",
             mask.view.shape[0], mask.view.shape[1], data.nrows, data.ncols);
         goto exit;
     }
@@ -1369,7 +1309,7 @@ py_kcluster(PyObject* self, PyObject* args, PyObject* keywords)
     ndata = transpose ? nrows : ncols;
     nitems = transpose ? ncols : nrows;
     if (weight.shape[0] != ndata) {
-        PyErr_Format(PyExc_RuntimeError,
+        PyErr_Format(PyExc_ValueError,
                      "weight has incorrect size %zd (expected %d)",
                      weight.shape[0], ndata);
         goto exit;
@@ -1388,10 +1328,10 @@ py_kcluster(PyObject* self, PyObject* args, PyObject* keywords)
         goto exit;
     }
     else if (npass == 0) {
-        int n = check_clusterid(clusterid);
+        int n = check_clusterid(clusterid, nitems);
         if (n == 0) goto exit;
         if (n != nclusters) {
-            PyErr_SetString(PyExc_RuntimeError,
+            PyErr_SetString(PyExc_ValueError,
                             "more clusters requested than found in clusterid");
             goto exit;
         }
@@ -1410,10 +1350,10 @@ py_kcluster(PyObject* self, PyObject* args, PyObject* keywords)
              &error,
              &ifound);
 exit:
-    free_data(&data);
-    free_mask(&mask);
-    PyBuffer_Release(&weight);
-    PyBuffer_Release(&clusterid);
+    data_converter(NULL, &data);
+    mask_converter(NULL, &mask);
+    vector_converter(NULL, &weight);
+    index_converter(NULL, &clusterid);
     if (ifound) return Py_BuildValue("di", error, ifound);
     return NULL;
 }
@@ -1490,13 +1430,13 @@ py_kmedoids(PyObject* self, PyObject* args, PyObject* keywords)
                                      distancematrix_converter, &distances,
                                      &nclusters,
                                      &npass,
-                                     index_converter, &clusterid)) goto exit;
+                                     index_converter, &clusterid)) return NULL;
     if (npass < 0) {
         PyErr_SetString(PyExc_RuntimeError, "expected a non-negative integer");
         goto exit;
     }
     else if (npass == 0) {
-        int n = check_clusterid(clusterid);
+        int n = check_clusterid(clusterid, distances.n);
         if (n == 0) goto exit;
         if (n != nclusters) {
             PyErr_SetString(PyExc_RuntimeError,
@@ -1523,8 +1463,8 @@ py_kmedoids(PyObject* self, PyObject* args, PyObject* keywords)
              &ifound);
 
 exit:
-    free_distancematrix(&distances);
-    PyBuffer_Release(&clusterid);
+    distancematrix_converter(NULL, &distances);
+    index_converter(NULL, &clusterid);
     switch (ifound) {
         case -2:
             return NULL;
@@ -1659,7 +1599,7 @@ py_treecluster(PyObject* self, PyObject* args, PyObject* keywords)
                                      method_treecluster_converter, &method,
                                      distance_converter, &dist,
                                      distancematrix_converter, &distances))
-        goto exit;
+        return NULL;
 
     if (tree->n != 0) {
         PyErr_SetString(PyExc_RuntimeError, "expected an empty tree");
@@ -1744,10 +1684,10 @@ py_treecluster(PyObject* self, PyObject* args, PyObject* keywords)
     tree->n = nitems-1;
 
 exit:
-    free_data(&data);
-    free_mask(&mask);
-    if (weight.buf) PyBuffer_Release(&weight);
-    free_distancematrix(&distances);
+    data_converter(NULL, &data);
+    mask_converter(NULL, &mask);
+    vector_none_converter(NULL, &weight);
+    distancematrix_converter(NULL, &distances);
     if (tree == NULL || tree->n == 0) return NULL;
     Py_INCREF(Py_None);
     return Py_None;
@@ -1840,7 +1780,7 @@ py_somcluster(PyObject* self, PyObject* args, PyObject* keywords)
                                      &transpose,
                                      &inittau,
                                      &niter,
-                                     distance_converter, &dist)) goto exit;
+                                     distance_converter, &dist)) return NULL;
     if (niter < 1) {
         PyErr_SetString(PyExc_ValueError,
                       "number of iterations (niter) should be positive");
@@ -1892,10 +1832,10 @@ py_somcluster(PyObject* self, PyObject* args, PyObject* keywords)
     result = Py_None;
 
 exit:
-    free_data(&data);
-    PyBuffer_Release(&weight);
-    free_celldata(&celldata);
-    PyBuffer_Release(&indices);
+    data_converter(NULL, &data);
+    vector_converter(NULL, &weight);
+    index2d_converter(NULL, &indices);
+    celldata_converter(NULL, &celldata);
     return result;
 }
 /* end of wrapper for somcluster */
@@ -1985,7 +1925,7 @@ py_clusterdistance(PyObject* self, PyObject* args, PyObject* keywords)
                                      index_converter, &index2,
                                      method_clusterdistance_converter, &method,
                                      distance_converter, &dist,
-                                     &transpose)) goto exit;
+                                     &transpose)) return NULL;
     if (!data.values) {
         PyErr_SetString(PyExc_RuntimeError, "data is None");
         goto exit;
@@ -2028,11 +1968,11 @@ py_clusterdistance(PyObject* self, PyObject* args, PyObject* keywords)
     else
         result = PyFloat_FromDouble(distance);
 exit:
-    free_data(&data);
-    free_mask(&mask);
-    PyBuffer_Release(&weight);
-    PyBuffer_Release(&index1);
-    PyBuffer_Release(&index2);
+    data_converter(NULL, &data);
+    mask_converter(NULL, &mask);
+    vector_converter(NULL, &weight);
+    index_converter(NULL, &index1);
+    index_converter(NULL, &index2);
     return result;
 }
 /* end of wrapper for clusterdistance */
@@ -2101,7 +2041,7 @@ py_clustercentroids(PyObject* self, PyObject* args, PyObject* keywords)
                                      method_kcluster_converter, &method,
                                      &transpose,
                                      data_converter, &cdata,
-                                     mask_converter, &cmask)) goto exit;
+                                     mask_converter, &cmask)) return NULL;
     if (!data.values) {
         PyErr_SetString(PyExc_RuntimeError, "data is None");
         goto exit;
@@ -2118,10 +2058,15 @@ py_clustercentroids(PyObject* self, PyObject* args, PyObject* keywords)
             mask.view.shape[0], mask.view.shape[1], data.nrows, data.ncols);
         goto exit;
     }
-    nclusters = check_clusterid(clusterid);
+    if (transpose == 0) {
+        nclusters = check_clusterid(clusterid, nrows);
+        nrows = nclusters;
+    }
+    else {
+        nclusters = check_clusterid(clusterid, ncols);
+        ncols = nclusters;
+    }
     if (nclusters == 0) goto exit;
-    if (transpose == 0) nrows = nclusters;
-    else ncols = nclusters;
     if (cdata.nrows != nrows) {
         PyErr_Format(PyExc_RuntimeError,
                      "cdata has incorrect number of rows (%d, expected %d)",
@@ -2157,11 +2102,11 @@ py_clustercentroids(PyObject* self, PyObject* args, PyObject* keywords)
                              transpose,
                              method);
 exit:
-    free_data(&data);
-    free_mask(&mask);
-    free_data(&cdata);
-    free_mask(&cmask);
-    PyBuffer_Release(&clusterid);
+    data_converter(NULL, &data);
+    mask_converter(NULL, &mask);
+    data_converter(NULL, &cdata);
+    mask_converter(NULL, &cmask);
+    index_converter(NULL, &clusterid);
     if (ok == -1) return NULL;
     if (ok == 0) return PyErr_NoMemory();
     Py_INCREF(Py_None);
@@ -2245,7 +2190,7 @@ py_distancematrix(PyObject* self, PyObject* args, PyObject* keywords)
                                      vector_converter, &weight,
                                      &transpose,
                                      distance_converter, &dist,
-                                     &PyList_Type, &list)) goto exit;
+                                     &PyList_Type, &list)) return NULL;
     if (!data.values) {
         PyErr_SetString(PyExc_RuntimeError, "data is None");
         goto exit;
@@ -2264,7 +2209,7 @@ py_distancematrix(PyObject* self, PyObject* args, PyObject* keywords)
     }
     ndata = (transpose == 0) ? ncols : nrows;
     if (weight.shape[0] != ndata) {
-        PyErr_Format(PyExc_RuntimeError,
+        PyErr_Format(PyExc_ValueError,
                      "weight has incorrect size %zd (expected %d)",
                      weight.shape[0], ndata);
         goto exit;
@@ -2283,10 +2228,10 @@ py_distancematrix(PyObject* self, PyObject* args, PyObject* keywords)
     Py_INCREF(Py_None);
     result = Py_None;
 exit:
-    free_data(&data);
-    free_mask(&mask);
-    PyBuffer_Release(&weight);
-    free_distancematrix(&distances);
+    data_converter(NULL, &data);
+    mask_converter(NULL, &mask);
+    vector_converter(NULL, &weight);
+    distancematrix_converter(NULL, &distances);
     return result;
 }
 /* end of wrapper for distancematrix */
@@ -2346,7 +2291,7 @@ py_pca(PyObject* self, PyObject* args)
                           vector_converter, &mean,
                           data_converter, &coordinates,
                           data_converter, &pc,
-                          vector_converter, &eigenvalues)) goto exit;
+                          vector_converter, &eigenvalues)) return NULL;
 
     values = data.values;
     if (!values) {
@@ -2397,10 +2342,11 @@ py_pca(PyObject* self, PyObject* args)
     error = pca(nrows, ncols, u, v, eigenvalues.buf);
     /* ------------------------------------------------------------------- */
 exit:
-    free_data(&data);
-    free_data(&pc);
-    free_data(&coordinates);
-    PyBuffer_Release(&eigenvalues);
+    data_converter(NULL, &data);
+    vector_converter(NULL, &mean);
+    data_converter(NULL, &pc);
+    data_converter(NULL, &coordinates);
+    vector_converter(NULL, &eigenvalues);
     if (error == 0) {
         Py_INCREF(Py_None);
         return Py_None;
@@ -2460,14 +2406,12 @@ static struct PyMethodDef cluster_methods[] = {
      METH_VARARGS | METH_KEYWORDS,
      pca__doc__
     },
-    {NULL,          NULL, 0, NULL} /* sentinel */
+    {NULL, NULL, 0, NULL} /* sentinel */
 };
 
 /* ========================================================================= */
 /* -- Initialization ------------------------------------------------------- */
 /* ========================================================================= */
-
-#if PY_MAJOR_VERSION >= 3
 
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
@@ -2483,47 +2427,22 @@ static struct PyModuleDef moduledef = {
 
 PyObject *
 PyInit__cluster(void)
-
-#else
-
-void
-init_cluster(void)
-#endif
 {
     PyObject *module;
 
     PyNodeType.tp_new = PyType_GenericNew;
     if (PyType_Ready(&PyNodeType) < 0)
-#if PY_MAJOR_VERSION >= 3
         return NULL;
-#else
-        return;
-#endif
     if (PyType_Ready(&PyTreeType) < 0)
-#if PY_MAJOR_VERSION >= 3
         return NULL;
-#else
-        return;
-#endif
 
-#if PY_MAJOR_VERSION >= 3
     module = PyModule_Create(&moduledef);
     if (module == NULL) return NULL;
-#else
-    module = Py_InitModule4("_cluster",
-                            cluster_methods,
-                            "C Clustering Library",
-                            NULL,
-                            PYTHON_API_VERSION);
-    if (module == NULL) return;
-#endif
 
     Py_INCREF(&PyTreeType);
     Py_INCREF(&PyNodeType);
     PyModule_AddObject(module, "Tree", (PyObject*) &PyTreeType);
     PyModule_AddObject(module, "Node", (PyObject*) &PyNodeType);
 
-#if PY_MAJOR_VERSION >= 3
     return module;
-#endif
 }

--- a/Tests/test_Cluster.py
+++ b/Tests/test_Cluster.py
@@ -307,23 +307,23 @@ class TestCluster(unittest.TestCase):
                      mask=mask, weight=weight,
                      transpose=False, npass=100, method="a", dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^mask has incorrect rank 1 \(expected 2\)$"):
+                "^mask has incorrect rank 1 \\(expected 2\\)$"):
             kcluster(data, nclusters=nclusters,
                      mask=numpy.zeros(3), weight=weight,
                      transpose=False, npass=100, method="a", dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^mask has incorrect dimensions 4 x 3 \(expected 4 x 5\)$"):
+                "^mask has incorrect dimensions 4 x 3 \\(expected 4 x 5\\)$"):
             kcluster(data, nclusters=nclusters,
-                     mask=numpy.zeros((4,3), numpy.int32), weight=weight,
+                     mask=numpy.zeros((4, 3), numpy.int32), weight=weight,
                      transpose=False, npass=100, method="a", dist="e",
                      clusterid=clusterid)
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \(expected 1\)$"):
+                "^incorrect rank 2 \\(expected 1\\)$"):
             kcluster(data, nclusters=nclusters,
-                     mask=mask, weight=numpy.zeros((2,2)),
+                     mask=mask, weight=numpy.zeros((2, 2)),
                      transpose=False, npass=100, method="a", dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^weight has incorrect size 3 \(expected 5\)$"):
+                "^weight has incorrect size 3 \\(expected 5\\)$"):
             kcluster(data, nclusters=nclusters,
                      mask=mask, weight=numpy.zeros(3),
                      transpose=False, npass=100, method="a", dist="e",
@@ -339,7 +339,7 @@ class TestCluster(unittest.TestCase):
                      transpose=False, npass=100, method="a", dist="e",
                      clusterid=clusterid)
         with self.assertRaisesRegex(ValueError,
-                "^incorrect size \(3, expected 4\)$"):
+                "^incorrect size \\(3, expected 4\\)$"):
             kcluster(data, nclusters=nclusters, mask=mask, weight=weight,
                      transpose=False, npass=0, method="a", dist="e",
                      clusterid=clusterid[:3])
@@ -523,7 +523,7 @@ class TestCluster(unittest.TestCase):
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect rank 1 \(expected 2\)$"):
+                "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
             clusterdistance(data=numpy.zeros(3), mask=mask, weight=weight,
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
@@ -547,14 +547,14 @@ class TestCluster(unittest.TestCase):
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(ValueError,
-                "mask has incorrect rank 1 \(expected 2\)"):
+                "mask has incorrect rank 1 \\(expected 2\\)"):
             clusterdistance(data=data, mask=numpy.zeros(3), weight=weight,
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
                 "^mask has incorrect data type$"):
             clusterdistance(data=data,
-                            mask=numpy.ones((2,2), dtype=numpy.int16),
+                            mask=numpy.ones((2, 2), dtype=numpy.int16),
                             weight=weight, index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError, "^mask is not contiguous$"):
@@ -566,8 +566,8 @@ class TestCluster(unittest.TestCase):
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \(expected 1\)$"):
-            clusterdistance(data=data, mask=mask, weight=numpy.zeros((2,2)),
+                "^incorrect rank 2 \\(expected 1\\)$"):
+            clusterdistance(data=data, mask=mask, weight=numpy.zeros((2, 2)),
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
@@ -581,9 +581,9 @@ class TestCluster(unittest.TestCase):
                             index1=None, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \(expected 1\)$"):
+                "^incorrect rank 2 \\(expected 1\\)$"):
             clusterdistance(data=data, mask=mask, weight=weight,
-                            index1=numpy.zeros((2,2)), index2=c2, dist="e",
+                            index1=numpy.zeros((2, 2)), index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
                 "^argument has incorrect data type$"):
@@ -595,9 +595,9 @@ class TestCluster(unittest.TestCase):
                             index1=c1, index2=None, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \(expected 1\)$"):
+                "^incorrect rank 2 \\(expected 1\\)$"):
             clusterdistance(data=data, mask=mask, weight=weight,
-                            index1=c1, index2=numpy.zeros((2,2)), dist="e",
+                            index1=c1, index2=numpy.zeros((2, 2)), dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
                 "^argument has incorrect data type$"):
@@ -742,11 +742,11 @@ class TestCluster(unittest.TestCase):
                         distancematrix=None)
         with self.assertRaisesRegex(RuntimeError,
                 "^data matrix has incorrect data type$"):
-            treecluster(tree, data=numpy.zeros((3,3), numpy.int32), mask=mask,
+            treecluster(tree, data=numpy.zeros((3, 3), numpy.int32), mask=mask,
                         weight=weight, transpose=False, method="a", dist="e",
                         distancematrix=None)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect rank 1 \(expected 2\)$"):
+                "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
             treecluster(tree, data=numpy.zeros(3), mask=mask, weight=weight,
                         transpose=False, method="a", dist="e",
                         distancematrix=None)
@@ -758,7 +758,7 @@ class TestCluster(unittest.TestCase):
         elif TestCluster.module == "Pycluster":
             from Pycluster._cluster import Node, Tree
 
-        nodes = [Node(1, 2, 0.2), Node(0, -1, 0.5), Node(3,-2,0.6)]
+        nodes = [Node(1, 2, 0.2), Node(0, -1, 0.5), Node(3,-2, 0.6)]
         indices = numpy.zeros(4, numpy.int32)
         tree = Tree(nodes)
         with self.assertRaisesRegex(ValueError,
@@ -770,13 +770,13 @@ class TestCluster(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
             tree.sort(indices, "nothing")
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \(expected 1\)$"):
-            tree.sort(indices, numpy.zeros((5,5)))
+                "^incorrect rank 2 \\(expected 1\\)$"):
+            tree.sort(indices, numpy.zeros((5, 5)))
         with self.assertRaisesRegex(ValueError,
-                "^order array has incorrect size 2 \(expected 4\)$"):
+                "^order array has incorrect size 2 \\(expected 4\\)$"):
             tree.sort(indices, numpy.zeros(2))
         with self.assertRaisesRegex(ValueError,
-                "^order array has incorrect size 6 \(expected 4\)$"):
+                "^order array has incorrect size 6 \\(expected 4\\)$"):
             tree.sort(indices, numpy.zeros(6))
 
 
@@ -1646,7 +1646,7 @@ class TestCluster(unittest.TestCase):
                        data=data, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 1 \(expected 2\)$"):
+                "^incorrect rank 1 \\(expected 2\\)$"):
             somcluster(clusterids=numpy.ones(nitems, numpy.int32),
                        celldata=celldata, data=data, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
@@ -1656,7 +1656,7 @@ class TestCluster(unittest.TestCase):
                        celldata=celldata, data=data, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^array has 3 columns \(expected 2\)$"):
+                "^array has 3 columns \\(expected 2\\)$"):
             somcluster(clusterids=numpy.ones((nitems, 3), numpy.int32),
                        celldata=celldata, data=data, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
@@ -1684,11 +1684,11 @@ class TestCluster(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError,
                 "^data matrix has incorrect data type$"):
             somcluster(clusterids=clusterids, celldata=celldata,
-                       data=numpy.zeros((4,5), dtype=numpy.int16),
+                       data=numpy.zeros((4, 5), dtype=numpy.int16),
                        mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect rank 1 \(expected 2\)$"):
+                "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
             somcluster(clusterids=clusterids, celldata=celldata,
                        data=numpy.zeros(4), mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
@@ -1710,7 +1710,7 @@ class TestCluster(unittest.TestCase):
                        data=data, mask=[None], weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^mask has incorrect rank 1 \(expected 2\)$"):
+                "^mask has incorrect rank 1 \\(expected 2\\)$"):
             somcluster(clusterids=clusterids, celldata=celldata,
                        data=data, mask=numpy.array([1, 1, 1]), weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
@@ -1729,9 +1729,9 @@ class TestCluster(unittest.TestCase):
                        data=data, mask=mask, weight=None,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 3 \(expected 1\)$"):
+                "^incorrect rank 3 \\(expected 1\\)$"):
             somcluster(clusterids=clusterids, celldata=celldata,
-                       data=data, mask=mask, weight=numpy.zeros((2,2,2)),
+                       data=data, mask=mask, weight=numpy.zeros((2, 2, 2)),
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError,
                 "^array has incorrect data type$"):
@@ -1751,7 +1751,7 @@ class TestCluster(unittest.TestCase):
                        dist="Pearson")
         with self.assertRaisesRegex(ValueError,
                 "^unknown dist function specified "
-                "\(should be one of 'ebcauxsk'\)$"):
+                "\\(should be one of 'ebcauxsk'\\)$"):
             somcluster(clusterids=clusterids, celldata=celldata,
                        data=data, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="X")
@@ -1852,18 +1852,18 @@ class TestCluster(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "^data matrix is empty$"):
             distancematrix(data[:0,:], mask=mask, weight=weight)
         with self.assertRaisesRegex(ValueError,
-                "^mask has incorrect rank 1 \(expected 2\)$"):
+                "^mask has incorrect rank 1 \\(expected 2\\)$"):
             distancematrix(data, mask=numpy.zeros(3), weight=weight)
         with self.assertRaisesRegex(ValueError,
-                "^mask has incorrect dimensions \(4 x 3, expected 9 x 3\)$"):
+                "^mask has incorrect dimensions \\(4 x 3, expected 9 x 3\\)$"):
             distancematrix(data, mask=mask[:4,:], weight=weight,
                            transpose=False, dist='c',
                            distancematrix=[])
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \(expected 1\)$"):
-            distancematrix(data, mask=mask, weight=numpy.zeros((2,2)))
+                "^incorrect rank 2 \\(expected 1\\)$"):
+            distancematrix(data, mask=mask, weight=numpy.zeros((2, 2)))
         with self.assertRaisesRegex(ValueError,
-                "^weight has incorrect size 4 \(expected 3\)$"):
+                "^weight has incorrect size 4 \\(expected 3\\)$"):
             distancematrix(data, mask=mask, weight=numpy.zeros(4),
                            transpose=False, dist='c', distancematrix=[])
 
@@ -1883,10 +1883,10 @@ class TestCluster(unittest.TestCase):
             kmedoids([], nclusters=2, npass=1000, clusterid=clusterid)
         with self.assertRaisesRegex(ValueError,
                 "^distance matrix is not square.$"):
-            kmedoids(numpy.zeros((2,3)), npass=1000)
+            kmedoids(numpy.zeros((2, 3)), npass=1000)
         with self.assertRaisesRegex(ValueError,
-                "^distance matrix has incorrect rank 3 \(expected 1 or 2\)$"):
-            kmedoids(numpy.zeros((2,3,4)), npass=1000)
+                "^distance matrix has incorrect rank 3 \\(expected 1 or 2\\)$"):
+            kmedoids(numpy.zeros((2, 3, 4)), npass=1000)
 
     def test_distancematrix_kmedoids(self):
         if TestCluster.module == "Bio.Cluster":
@@ -2055,17 +2055,17 @@ class TestCluster(unittest.TestCase):
         elif TestCluster.module == "Pycluster":
             from Pycluster._cluster import pca
 
-        data = numpy.zeros((4,2))
+        data = numpy.zeros((4, 2))
         columnmean = numpy.zeros(2)
-        pc = numpy.zeros((2,2), dtype="d")
-        coordinates = numpy.zeros((4,2), dtype="d")
+        pc = numpy.zeros((2, 2), dtype="d")
+        coordinates = numpy.zeros((4, 2), dtype="d")
         eigenvalues = numpy.zeros(2, dtype="d")
 
         with self.assertRaisesRegex(RuntimeError,
                 "^data matrix has unexpected format.$"):
             pca([None], columnmean, coordinates, pc, eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect rank 1 \(expected 2\)$"):
+                "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
             pca(numpy.zeros(3), columnmean, coordinates, pc, eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
                 "^data matrix has incorrect data type$"):
@@ -2074,8 +2074,8 @@ class TestCluster(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
             pca(data, "nothing", coordinates, pc, eigenvalues)
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \(expected 1\)$"):
-            pca(data, numpy.zeros((2,2)), coordinates, pc, eigenvalues)
+                "^incorrect rank 2 \\(expected 1\\)$"):
+            pca(data, numpy.zeros((2, 2)), coordinates, pc, eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
                 "^array has incorrect data type$"):
             pca(data, numpy.ones(3, dtype=numpy.int16),
@@ -2084,7 +2084,7 @@ class TestCluster(unittest.TestCase):
                 "^data matrix has unexpected format.$"):
             pca(data, columnmean, [None], pc, eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect rank 1 \(expected 2\)$"):
+                "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
             pca(data, columnmean, numpy.zeros(3), pc, eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
                 "^data matrix has incorrect data type$"):
@@ -2094,7 +2094,7 @@ class TestCluster(unittest.TestCase):
                 "^data matrix has unexpected format.$"):
             pca(data, columnmean, coordinates, [None], eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect rank 1 \(expected 2\)$"):
+                "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
             pca(data, columnmean, coordinates, numpy.zeros(3), eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
                 "^data matrix has incorrect data type$"):
@@ -2103,8 +2103,8 @@ class TestCluster(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
             pca(data, columnmean, coordinates, pc, "nothing")
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \(expected 1\)$"):
-            pca(data, columnmean, coordinates, pc, numpy.zeros((2,2)))
+                "^incorrect rank 2 \\(expected 1\\)$"):
+            pca(data, columnmean, coordinates, pc, numpy.zeros((2, 2)))
         with self.assertRaisesRegex(RuntimeError,
                 "^array has incorrect data type$"):
             pca(data, columnmean, coordinates, pc,

--- a/Tests/test_Cluster.py
+++ b/Tests/test_Cluster.py
@@ -307,50 +307,50 @@ class TestCluster(unittest.TestCase):
                      mask=mask, weight=weight,
                      transpose=False, npass=100, method="a", dist="e")
         with self.assertRaisesRegex(ValueError,
-            "^mask has incorrect rank 1 \\(expected 2\\)$"):
+                                    "^mask has incorrect rank 1 \\(expected 2\\)$"):
             kcluster(data, nclusters=nclusters,
                      mask=numpy.zeros(3), weight=weight,
                      transpose=False, npass=100, method="a", dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^mask has incorrect dimensions 4 x 3 \\(expected 4 x 5\\)$"):
+                                    "^mask has incorrect dimensions 4 x 3 \\(expected 4 x 5\\)$"):
             kcluster(data, nclusters=nclusters,
                      mask=numpy.zeros((4, 3), numpy.int32), weight=weight,
                      transpose=False, npass=100, method="a", dist="e",
                      clusterid=clusterid)
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \\(expected 1\\)$"):
+                                    "^incorrect rank 2 \\(expected 1\\)$"):
             kcluster(data, nclusters=nclusters,
                      mask=mask, weight=numpy.zeros((2, 2)),
                      transpose=False, npass=100, method="a", dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^weight has incorrect size 3 \\(expected 5\\)$"):
+                                    "^weight has incorrect size 3 \\(expected 5\\)$"):
             kcluster(data, nclusters=nclusters,
                      mask=mask, weight=numpy.zeros(3),
                      transpose=False, npass=100, method="a", dist="e",
                      clusterid=clusterid)
         with self.assertRaisesRegex(ValueError,
-                "^nclusters should be positive$"):
+                                    "^nclusters should be positive$"):
             kcluster(data, nclusters=-1, mask=mask, weight=weight,
                      transpose=False, npass=100, method="a", dist="e",
                      clusterid=clusterid)
         with self.assertRaisesRegex(ValueError,
-                "^more clusters than items to be clustered$"):
+                                    "^more clusters than items to be clustered$"):
             kcluster(data, nclusters=1234, mask=mask, weight=weight,
                      transpose=False, npass=100, method="a", dist="e",
                      clusterid=clusterid)
         with self.assertRaisesRegex(ValueError,
-                "^incorrect size \\(3, expected 4\\)$"):
+                                    "^incorrect size \\(3, expected 4\\)$"):
             kcluster(data, nclusters=nclusters, mask=mask, weight=weight,
                      transpose=False, npass=0, method="a", dist="e",
                      clusterid=clusterid[:3])
         with self.assertRaisesRegex(ValueError,
-                "^more clusters requested than found in clusterid$"):
+                                    "^more clusters requested than found in clusterid$"):
             kcluster(data, nclusters=nclusters, mask=mask, weight=weight,
                      transpose=False, npass=0, method="a", dist="e",
                      clusterid=clusterid)
         clusterid = numpy.array([0, -1, 2, 3], numpy.int32)
         with self.assertRaisesRegex(ValueError,
-                "^negative cluster number found$"):
+                                    "^negative cluster number found$"):
             kcluster(data, nclusters=nclusters, mask=mask, weight=weight,
                      transpose=False, npass=0, method="a", dist="e",
                      clusterid=clusterid)
@@ -518,17 +518,17 @@ class TestCluster(unittest.TestCase):
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has unexpected format.$"):
+                                    "^data matrix has unexpected format.$"):
             clusterdistance(data=[None], mask=mask, weight=weight,
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
+                                    "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
             clusterdistance(data=numpy.zeros(3), mask=mask, weight=weight,
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect data type$"):
+                                    "^data matrix has incorrect data type$"):
             clusterdistance(data=numpy.zeros((3, 3), dtype=numpy.int16),
                             mask=mask, weight=weight,
                             index1=c1, index2=c2, dist="e",
@@ -542,17 +542,17 @@ class TestCluster(unittest.TestCase):
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
-                "^mask has unexpected format.$"):
+                                    "^mask has unexpected format.$"):
             clusterdistance(data=data, mask=[None], weight=weight,
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(ValueError,
-                "mask has incorrect rank 1 \\(expected 2\\)"):
+                                    "mask has incorrect rank 1 \\(expected 2\\)"):
             clusterdistance(data=data, mask=numpy.zeros(3), weight=weight,
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
-                "^mask has incorrect data type$"):
+                                    "^mask has incorrect data type$"):
             clusterdistance(data=data,
                             mask=numpy.ones((2, 2), dtype=numpy.int16),
                             weight=weight, index1=c1, index2=c2, dist="e",
@@ -566,12 +566,12 @@ class TestCluster(unittest.TestCase):
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \\(expected 1\\)$"):
+                                    "^incorrect rank 2 \\(expected 1\\)$"):
             clusterdistance(data=data, mask=mask, weight=numpy.zeros((2, 2)),
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
-                "^array has incorrect data type$"):
+                                    "^array has incorrect data type$"):
             clusterdistance(data=data, mask=mask,
                             weight=numpy.ones(3, dtype=numpy.int16),
                             index1=c1, index2=c2, dist="e",
@@ -581,12 +581,12 @@ class TestCluster(unittest.TestCase):
                             index1=None, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \\(expected 1\\)$"):
+                                    "^incorrect rank 2 \\(expected 1\\)$"):
             clusterdistance(data=data, mask=mask, weight=weight,
                             index1=numpy.zeros((2, 2)), index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
-                "^argument has incorrect data type$"):
+                                    "^argument has incorrect data type$"):
             clusterdistance(data=data, mask=mask, weight=weight,
                             index1=numpy.zeros(2, numpy.int16), index2=c2,
                             dist="e", method="a", transpose=False)
@@ -595,12 +595,12 @@ class TestCluster(unittest.TestCase):
                             index1=c1, index2=None, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \\(expected 1\\)$"):
+                                    "^incorrect rank 2 \\(expected 1\\)$"):
             clusterdistance(data=data, mask=mask, weight=weight,
                             index1=c1, index2=numpy.zeros((2, 2)), dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
-                "^argument has incorrect data type$"):
+                                    "^argument has incorrect data type$"):
             clusterdistance(data=data, mask=mask, weight=weight,
                             index1=c1, index2=numpy.zeros(2, numpy.int16),
                             dist="e", method="a", transpose=False)
@@ -725,28 +725,28 @@ class TestCluster(unittest.TestCase):
                             [1, 1, 1, 1, 1]], numpy.int32)
 
         with self.assertRaisesRegex(TypeError,
-                "^argument 1 must be _cluster.Tree, not None$"):
+                                    "^argument 1 must be _cluster.Tree, not None$"):
             treecluster(None, data=data, mask=mask, weight=weight,
                         transpose=False, method="a", dist="e",
                         distancematrix=None)
         tree = Tree()
         with self.assertRaisesRegex(ValueError,
-                "^neither data nor distancematrix was given$"):
+                                    "^neither data nor distancematrix was given$"):
             treecluster(tree, data=None, mask=mask, weight=weight,
                         transpose=False, method="a", dist="e",
                         distancematrix=None)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has unexpected format.$"):
+                                    "^data matrix has unexpected format.$"):
             treecluster(tree, data=[], mask=mask, weight=weight,
                         transpose=False, method="a", dist="e",
                         distancematrix=None)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect data type$"):
+                                    "^data matrix has incorrect data type$"):
             treecluster(tree, data=numpy.zeros((3, 3), numpy.int32), mask=mask,
                         weight=weight, transpose=False, method="a", dist="e",
                         distancematrix=None)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
+                                    "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
             treecluster(tree, data=numpy.zeros(3), mask=mask, weight=weight,
                         transpose=False, method="a", dist="e",
                         distancematrix=None)
@@ -762,21 +762,21 @@ class TestCluster(unittest.TestCase):
         indices = numpy.zeros(4, numpy.int32)
         tree = Tree(nodes)
         with self.assertRaisesRegex(ValueError,
-                "^requested number of clusters should be positive$"):
+                                    "^requested number of clusters should be positive$"):
             tree.cut(indices, -5)
         with self.assertRaisesRegex(ValueError,
-                "^more clusters requested than items available$"):
+                                    "^more clusters requested than items available$"):
             tree.cut(indices, +5)
         with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
             tree.sort(indices, "nothing")
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \\(expected 1\\)$"):
+                                    "^incorrect rank 2 \\(expected 1\\)$"):
             tree.sort(indices, numpy.zeros((5, 5)))
         with self.assertRaisesRegex(ValueError,
-                "^order array has incorrect size 2 \\(expected 4\\)$"):
+                                    "^order array has incorrect size 2 \\(expected 4\\)$"):
             tree.sort(indices, numpy.zeros(2))
         with self.assertRaisesRegex(ValueError,
-                "^order array has incorrect size 6 \\(expected 4\\)$"):
+                                    "^order array has incorrect size 6 \\(expected 4\\)$"):
             tree.sort(indices, numpy.zeros(6))
 
     def test_tree(self):
@@ -1645,27 +1645,27 @@ class TestCluster(unittest.TestCase):
                        data=data, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 1 \\(expected 2\\)$"):
+                                    "^incorrect rank 1 \\(expected 2\\)$"):
             somcluster(clusterids=numpy.ones(nitems, numpy.int32),
                        celldata=celldata, data=data, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError,
-                "^argument has incorrect data type$"):
+                                    "^argument has incorrect data type$"):
             somcluster(clusterids=numpy.ones((nitems, 2), numpy.int16),
                        celldata=celldata, data=data, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^array has 3 columns \\(expected 2\\)$"):
+                                    "^array has 3 columns \\(expected 2\\)$"):
             somcluster(clusterids=numpy.ones((nitems, 3), numpy.int32),
                        celldata=celldata, data=data, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError,
-                "^celldata array has unexpected format.$"):
+                                    "^celldata array has unexpected format.$"):
             somcluster(clusterids=clusterids, celldata=None,
                        data=data, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError,
-                "^celldata array has incorrect data type$"):
+                                    "^celldata array has incorrect data type$"):
             somcluster(clusterids=clusterids,
                        celldata=numpy.zeros((nxgrid, nygrid, ndata),
                                             dtype=numpy.int32),
@@ -1676,18 +1676,18 @@ class TestCluster(unittest.TestCase):
                        data=None, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has unexpected format.$"):
+                                    "^data matrix has unexpected format.$"):
             somcluster(clusterids=clusterids, celldata=celldata,
                        data=[None], mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect data type$"):
+                                    "^data matrix has incorrect data type$"):
             somcluster(clusterids=clusterids, celldata=celldata,
                        data=numpy.zeros((4, 5), dtype=numpy.int16),
                        mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
+                                    "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
             somcluster(clusterids=clusterids, celldata=celldata,
                        data=numpy.zeros(4), mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
@@ -1704,17 +1704,17 @@ class TestCluster(unittest.TestCase):
                        data=data, mask=None, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError,
-                "^mask has unexpected format.$"):
+                                    "^mask has unexpected format.$"):
             somcluster(clusterids=clusterids, celldata=celldata,
                        data=data, mask=[None], weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^mask has incorrect rank 1 \\(expected 2\\)$"):
+                                    "^mask has incorrect rank 1 \\(expected 2\\)$"):
             somcluster(clusterids=clusterids, celldata=celldata,
                        data=data, mask=numpy.array([1, 1, 1]), weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError,
-                "^mask has incorrect data type$"):
+                                    "^mask has incorrect data type$"):
             somcluster(clusterids=clusterids, celldata=celldata, data=data,
                        mask=numpy.array([[1, 1], [1, 1]], dtype=numpy.int16),
                        weight=weight, transpose=False, inittau=0.02, niter=100,
@@ -1728,12 +1728,12 @@ class TestCluster(unittest.TestCase):
                        data=data, mask=mask, weight=None,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 3 \\(expected 1\\)$"):
+                                    "^incorrect rank 3 \\(expected 1\\)$"):
             somcluster(clusterids=clusterids, celldata=celldata,
                        data=data, mask=mask, weight=numpy.zeros((2, 2, 2)),
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError,
-                "^array has incorrect data type$"):
+                                    "^array has incorrect data type$"):
             somcluster(clusterids=clusterids, celldata=celldata,
                        data=data, mask=mask,
                        weight=numpy.array([1, 1, 1], dtype=numpy.int16),
@@ -1743,14 +1743,14 @@ class TestCluster(unittest.TestCase):
                        data=data, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist=5)
         with self.assertRaisesRegex(ValueError,
-                "^dist should be a single character$"):
+                                    "^dist should be a single character$"):
             somcluster(clusterids=clusterids, celldata=celldata,
                        data=data, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100,
                        dist="Pearson")
         with self.assertRaisesRegex(ValueError,
-                "^unknown dist function specified "
-                "\\(should be one of 'ebcauxsk'\\)$"):
+                                    "^unknown dist function specified "
+                                    "\\(should be one of 'ebcauxsk'\\)$"):
             somcluster(clusterids=clusterids, celldata=celldata,
                        data=data, mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="X")
@@ -1851,18 +1851,18 @@ class TestCluster(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "^data matrix is empty$"):
             distancematrix(data[:0, :], mask=mask, weight=weight)
         with self.assertRaisesRegex(ValueError,
-                "^mask has incorrect rank 1 \\(expected 2\\)$"):
+                                    "^mask has incorrect rank 1 \\(expected 2\\)$"):
             distancematrix(data, mask=numpy.zeros(3), weight=weight)
         with self.assertRaisesRegex(ValueError,
-                "^mask has incorrect dimensions \\(4 x 3, expected 9 x 3\\)$"):
+                                    "^mask has incorrect dimensions \\(4 x 3, expected 9 x 3\\)$"):
             distancematrix(data, mask=mask[:4, :], weight=weight,
                            transpose=False, dist="c",
                            distancematrix=[])
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \\(expected 1\\)$"):
+                                    "^incorrect rank 2 \\(expected 1\\)$"):
             distancematrix(data, mask=mask, weight=numpy.zeros((2, 2)))
         with self.assertRaisesRegex(ValueError,
-                "^weight has incorrect size 4 \\(expected 3\\)$"):
+                                    "^weight has incorrect size 4 \\(expected 3\\)$"):
             distancematrix(data, mask=mask, weight=numpy.zeros(4),
                            transpose=False, dist="c", distancematrix=[])
 
@@ -1875,16 +1875,16 @@ class TestCluster(unittest.TestCase):
 
         clusterid = numpy.zeros(10, numpy.int32)
         with self.assertRaisesRegex(RuntimeError,
-                "^failed to parse row 0.$"):
+                                    "^failed to parse row 0.$"):
             kmedoids([None])
         with self.assertRaisesRegex(ValueError,
-                "^more clusters requested than items to be clustered$"):
+                                    "^more clusters requested than items to be clustered$"):
             kmedoids([], nclusters=2, npass=1000, clusterid=clusterid)
         with self.assertRaisesRegex(ValueError,
-                "^distance matrix is not square.$"):
+                                    "^distance matrix is not square.$"):
             kmedoids(numpy.zeros((2, 3)), npass=1000)
         with self.assertRaisesRegex(ValueError,
-                "^distance matrix has incorrect rank 3 \\(expected 1 or 2\\)$"):
+                                    "^distance matrix has incorrect rank 3 \\(expected 1 or 2\\)$"):
             kmedoids(numpy.zeros((2, 3, 4)), npass=1000)
 
     def test_distancematrix_kmedoids(self):
@@ -2061,51 +2061,51 @@ class TestCluster(unittest.TestCase):
         eigenvalues = numpy.zeros(2, dtype="d")
 
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has unexpected format.$"):
+                                    "^data matrix has unexpected format.$"):
             pca([None], columnmean, coordinates, pc, eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
+                                    "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
             pca(numpy.zeros(3), columnmean, coordinates, pc, eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect data type$"):
+                                    "^data matrix has incorrect data type$"):
             pca(numpy.zeros((3, 3), dtype=numpy.int16),
                 columnmean, coordinates, pc, eigenvalues)
         with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
             pca(data, "nothing", coordinates, pc, eigenvalues)
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \\(expected 1\\)$"):
+                                    "^incorrect rank 2 \\(expected 1\\)$"):
             pca(data, numpy.zeros((2, 2)), coordinates, pc, eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
-                "^array has incorrect data type$"):
+                                    "^array has incorrect data type$"):
             pca(data, numpy.ones(3, dtype=numpy.int16),
                 coordinates, pc, eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has unexpected format.$"):
+                                    "^data matrix has unexpected format.$"):
             pca(data, columnmean, [None], pc, eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
+                                    "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
             pca(data, columnmean, numpy.zeros(3), pc, eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect data type$"):
+                                    "^data matrix has incorrect data type$"):
             pca(data, columnmean, numpy.zeros((3, 3), dtype=numpy.int16),
                 pc, eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has unexpected format.$"):
+                                    "^data matrix has unexpected format.$"):
             pca(data, columnmean, coordinates, [None], eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
+                                    "^data matrix has incorrect rank 1 \\(expected 2\\)$"):
             pca(data, columnmean, coordinates, numpy.zeros(3), eigenvalues)
         with self.assertRaisesRegex(RuntimeError,
-                "^data matrix has incorrect data type$"):
+                                    "^data matrix has incorrect data type$"):
             pca(data, columnmean, coordinates,
                 numpy.zeros((3, 3), dtype=numpy.int16), eigenvalues)
         with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
             pca(data, columnmean, coordinates, pc, "nothing")
         with self.assertRaisesRegex(ValueError,
-                "^incorrect rank 2 \\(expected 1\\)$"):
+                                    "^incorrect rank 2 \\(expected 1\\)$"):
             pca(data, columnmean, coordinates, pc, numpy.zeros((2, 2)))
         with self.assertRaisesRegex(RuntimeError,
-                "^array has incorrect data type$"):
+                                    "^array has incorrect data type$"):
             pca(data, columnmean, coordinates, pc,
                 numpy.ones(3, dtype=numpy.int16))
 

--- a/Tests/test_Cluster.py
+++ b/Tests/test_Cluster.py
@@ -282,6 +282,84 @@ class TestCluster(unittest.TestCase):
         self.assertRaises(TypeError, treecluster, data, mask17)
         self.assertRaises(TypeError, treecluster, data, mask18)
 
+    def test_kcluster_arguments(self):
+        # Test if incorrect arguments are caught by the C code
+        if TestCluster.module == "Bio.Cluster":
+            from Bio.Cluster._cluster import kcluster, clustercentroids
+        elif TestCluster.module == "Pycluster":
+            from Pycluster._cluster import kcluster, clustercentroids
+
+        nclusters = 3
+        weight = numpy.array([1.0, 1.0, 1.0, 1.0, 1.0])
+        data = numpy.array([[1.1, 2.2, 3.3, 4.4, 5.5],
+                            [3.1, 3.2, 1.3, 2.4, 1.5],
+                            [4.1, 2.2, 0.3, 5.4, 0.5],
+                            [9.9, 2.0, 0.0, 5.0, 0.0]])
+        mask = numpy.array([[1, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 1]], numpy.int32)
+        nrows, ncols = data.shape
+        clusterid = numpy.zeros(nrows, numpy.int32)
+
+        with self.assertRaisesRegex(ValueError, "^data matrix is empty$"):
+            kcluster(data[:0, :], nclusters=nclusters,
+                     mask=mask, weight=weight,
+                     transpose=False, npass=100, method="a", dist="e")
+        with self.assertRaisesRegex(ValueError,
+                "^mask has incorrect rank 1 \(expected 2\)$"):
+            kcluster(data, nclusters=nclusters,
+                     mask=numpy.zeros(3), weight=weight,
+                     transpose=False, npass=100, method="a", dist="e")
+        with self.assertRaisesRegex(ValueError,
+                "^mask has incorrect dimensions 4 x 3 \(expected 4 x 5\)$"):
+            kcluster(data, nclusters=nclusters,
+                     mask=numpy.zeros((4,3), numpy.int32), weight=weight,
+                     transpose=False, npass=100, method="a", dist="e",
+                     clusterid=clusterid)
+        with self.assertRaisesRegex(ValueError,
+                "^incorrect rank 2 \(expected 1\)$"):
+            kcluster(data, nclusters=nclusters,
+                     mask=mask, weight=numpy.zeros((2,2)),
+                     transpose=False, npass=100, method="a", dist="e")
+        with self.assertRaisesRegex(ValueError,
+                "^weight has incorrect size 3 \(expected 5\)$"):
+            kcluster(data, nclusters=nclusters,
+                     mask=mask, weight=numpy.zeros(3),
+                     transpose=False, npass=100, method="a", dist="e",
+                     clusterid=clusterid)
+        with self.assertRaisesRegex(ValueError,
+                "^nclusters should be positive$"):
+            kcluster(data, nclusters=-1, mask=mask, weight=weight,
+                     transpose=False, npass=100, method="a", dist="e",
+                     clusterid=clusterid)
+        with self.assertRaisesRegex(ValueError,
+                "^more clusters than items to be clustered$"):
+            kcluster(data, nclusters=1234, mask=mask, weight=weight,
+                     transpose=False, npass=100, method="a", dist="e",
+                     clusterid=clusterid)
+        with self.assertRaisesRegex(ValueError,
+                "^incorrect size \(3, expected 4\)$"):
+            kcluster(data, nclusters=nclusters, mask=mask, weight=weight,
+                     transpose=False, npass=0, method="a", dist="e",
+                     clusterid=clusterid[:3])
+        with self.assertRaisesRegex(ValueError,
+                "^more clusters requested than found in clusterid$"):
+            kcluster(data, nclusters=nclusters, mask=mask, weight=weight,
+                     transpose=False, npass=0, method="a", dist="e",
+                     clusterid=clusterid)
+        clusterid = numpy.array([0, -1, 2, 3], numpy.int32)
+        with self.assertRaisesRegex(ValueError,
+                "^negative cluster number found$"):
+            kcluster(data, nclusters=nclusters, mask=mask, weight=weight,
+                     transpose=False, npass=0, method="a", dist="e",
+                     clusterid=clusterid)
+        clusterid = numpy.array([0, 0, 2, 3], numpy.int32)
+        with self.assertRaisesRegex(ValueError, "^cluster 1 is empty$"):
+            kcluster(data, nclusters=nclusters, mask=mask, weight=weight,
+                     transpose=False, npass=0, method="a", dist="e",
+                     clusterid=clusterid)
+
     def test_kcluster(self):
         if TestCluster.module == "Bio.Cluster":
             from Bio.Cluster import kcluster, clustercentroids
@@ -412,6 +490,121 @@ class TestCluster(unittest.TestCase):
             for j in range(ncols):
                 self.assertAlmostEqual(cdata[mapping[i], j], correct[i, j])
 
+    def test_clusterdistance_arguments(self):
+        # Test if incorrect arguments are caught by the C code
+        if TestCluster.module == "Bio.Cluster":
+            from Bio.Cluster._cluster import clusterdistance
+        elif TestCluster.module == "Pycluster":
+            from Pycluster._cluster import clusterdistance
+
+        # First data set
+        weight = numpy.array([1.0, 1.0, 1.0, 1.0, 1.0])
+        data = numpy.array([[1.1, 2.2, 3.3, 4.4, 5.5],
+                            [3.1, 3.2, 1.3, 2.4, 1.5],
+                            [4.1, 2.2, 0.3, 5.4, 0.5],
+                            [9.9, 2.0, 0.0, 5.0, 0.0]])
+        mask = numpy.array([[1, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 1]], numpy.int32)
+
+        # Cluster assignments
+        c1 = numpy.array([0], numpy.int32)
+        c2 = numpy.array([1, 2], numpy.int32)
+        c3 = numpy.array([3], numpy.int32)
+
+        with self.assertRaisesRegex(RuntimeError, "^data is None$"):
+            clusterdistance(data=None, mask=mask, weight=weight,
+                            index1=c1, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has unexpected format.$"):
+            clusterdistance(data=[None], mask=mask, weight=weight,
+                            index1=c1, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has incorrect rank 1 \(expected 2\)$"):
+            clusterdistance(data=numpy.zeros(3), mask=mask, weight=weight,
+                            index1=c1, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has incorrect data type$"):
+            clusterdistance(data=numpy.zeros((3, 3), dtype=numpy.int16),
+                            mask=mask, weight=weight,
+                            index1=c1, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(ValueError, "^data matrix is empty$"):
+            clusterdistance(data=data[:0], mask=mask, weight=weight,
+                            index1=c1, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(RuntimeError, "^data is not contiguous$"):
+            clusterdistance(data=data[:,::2], mask=mask, weight=weight,
+                            index1=c1, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(RuntimeError,
+                "^mask has unexpected format.$"):
+            clusterdistance(data=data, mask=[None], weight=weight,
+                            index1=c1, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(ValueError,
+                "mask has incorrect rank 1 \(expected 2\)"):
+            clusterdistance(data=data, mask=numpy.zeros(3), weight=weight,
+                            index1=c1, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(RuntimeError,
+                "^mask has incorrect data type$"):
+            clusterdistance(data=data,
+                            mask=numpy.ones((2,2), dtype=numpy.int16),
+                            weight=weight, index1=c1, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(RuntimeError, "^mask is not contiguous$"):
+            clusterdistance(data=data, mask=mask[:,::2], weight=weight,
+                            index1=c1, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
+            clusterdistance(data=data, mask=mask, weight="nothing",
+                            index1=c1, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(ValueError,
+                "^incorrect rank 2 \(expected 1\)$"):
+            clusterdistance(data=data, mask=mask, weight=numpy.zeros((2,2)),
+                            index1=c1, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(RuntimeError,
+                "^array has incorrect data type$"):
+            clusterdistance(data=data, mask=mask,
+                            weight=numpy.ones(3, dtype=numpy.int16),
+                            index1=c1, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
+            clusterdistance(data=data, mask=mask, weight=weight,
+                            index1=None, index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(ValueError,
+                "^incorrect rank 2 \(expected 1\)$"):
+            clusterdistance(data=data, mask=mask, weight=weight,
+                            index1=numpy.zeros((2,2)), index2=c2, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(RuntimeError,
+                "^argument has incorrect data type$"):
+            clusterdistance(data=data, mask=mask, weight=weight,
+                            index1=numpy.zeros(2, numpy.int16), index2=c2,
+                            dist="e", method="a", transpose=False)
+        with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
+            clusterdistance(data=data, mask=mask, weight=weight,
+                            index1=c1, index2=None, dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(ValueError,
+                "^incorrect rank 2 \(expected 1\)$"):
+            clusterdistance(data=data, mask=mask, weight=weight,
+                            index1=c1, index2=numpy.zeros((2,2)), dist="e",
+                            method="a", transpose=False)
+        with self.assertRaisesRegex(RuntimeError,
+                "^argument has incorrect data type$"):
+            clusterdistance(data=data, mask=mask, weight=weight,
+                            index1=c1, index2=numpy.zeros(2, numpy.int16),
+                            dist="e", method="a", transpose=False)
+
     def test_clusterdistance(self):
         if TestCluster.module == "Bio.Cluster":
             from Bio.Cluster import clusterdistance
@@ -514,6 +707,78 @@ class TestCluster(unittest.TestCase):
                                    index1=c2, index2=c3, dist="e",
                                    method="a", transpose=False)
         self.assertAlmostEqual(distance, 0.360, places=3)
+
+    def test_treecluster_arguments(self):
+        # Test if incorrect arguments are caught by the C code
+        if TestCluster.module == "Bio.Cluster":
+            from Bio.Cluster._cluster import treecluster, Tree
+        elif TestCluster.module == "Pycluster":
+            from Pycluster._cluster import treecluster, Tree
+        weight = numpy.array([1.0, 1.0, 1.0, 1.0, 1.0])
+        data = numpy.array([[1.1, 2.2, 3.3, 4.4, 5.5],
+                            [3.1, 3.2, 1.3, 2.4, 1.5],
+                            [4.1, 2.2, 0.3, 5.4, 0.5],
+                            [9.7, 2.0, 0.0, 5.0, 0.0]])
+        mask = numpy.array([[1, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 1]], numpy.int32)
+
+        with self.assertRaisesRegex(TypeError,
+                "^argument 1 must be _cluster.Tree, not None$"):
+            treecluster(None, data=data, mask=mask, weight=weight,
+                        transpose=False, method="a", dist="e",
+                        distancematrix=None)
+        tree = Tree()
+        with self.assertRaisesRegex(ValueError,
+	        "^neither data nor distancematrix was given$"):
+            treecluster(tree, data=None, mask=mask, weight=weight,
+                        transpose=False, method="a", dist="e",
+                        distancematrix=None)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has unexpected format.$"):
+            treecluster(tree, data=[], mask=mask, weight=weight,
+                        transpose=False, method="a", dist="e",
+                        distancematrix=None)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has incorrect data type$"):
+            treecluster(tree, data=numpy.zeros((3,3), numpy.int32), mask=mask,
+                        weight=weight, transpose=False, method="a", dist="e",
+                        distancematrix=None)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has incorrect rank 1 \(expected 2\)$"):
+            treecluster(tree, data=numpy.zeros(3), mask=mask, weight=weight,
+                        transpose=False, method="a", dist="e",
+                        distancematrix=None)
+
+    def test_tree_arguments(self):
+        # Test if incorrect arguments are caught by the C code
+        if TestCluster.module == "Bio.Cluster":
+            from Bio.Cluster._cluster import Node, Tree
+        elif TestCluster.module == "Pycluster":
+            from Pycluster._cluster import Node, Tree
+
+        nodes = [Node(1, 2, 0.2), Node(0, -1, 0.5), Node(3,-2,0.6)]
+        indices = numpy.zeros(4, numpy.int32)
+        tree = Tree(nodes)
+        with self.assertRaisesRegex(ValueError,
+                "^requested number of clusters should be positive$"):
+            tree.cut(indices, -5)
+        with self.assertRaisesRegex(ValueError,
+                "^more clusters requested than items available$"):
+            tree.cut(indices, +5)
+        with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
+            tree.sort(indices, "nothing")
+        with self.assertRaisesRegex(ValueError,
+                "^incorrect rank 2 \(expected 1\)$"):
+            tree.sort(indices, numpy.zeros((5,5)))
+        with self.assertRaisesRegex(ValueError,
+                "^order array has incorrect size 2 \(expected 4\)$"):
+            tree.sort(indices, numpy.zeros(2))
+        with self.assertRaisesRegex(ValueError,
+                "^order array has incorrect size 6 \(expected 4\)$"):
+            tree.sort(indices, numpy.zeros(6))
+
 
     def test_tree(self):
         if TestCluster.module == "Bio.Cluster":
@@ -1355,6 +1620,142 @@ class TestCluster(unittest.TestCase):
         self.assertEqual(indices[11], 1)
         self.assertEqual(indices[12], 0)
 
+    def test_somcluster_arguments(self):
+        # Test if incorrect arguments are caught by the C code
+        if TestCluster.module == "Bio.Cluster":
+            from Bio.Cluster._cluster import somcluster
+        elif TestCluster.module == "Pycluster":
+            from Pycluster._cluster import somcluster
+
+        weight = numpy.array([1.0, 1.0, 1.0, 1.0, 1.0])
+        data = numpy.array([[1.1, 2.2, 3.3, 4.4, 5.5],
+                            [3.1, 3.2, 1.3, 2.4, 1.5],
+                            [4.1, 2.2, 0.3, 5.4, 0.5],
+                            [9.9, 2.0, 0.0, 5.0, 0.0]])
+        mask = numpy.array([[1, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 1]], numpy.int32)
+        nitems, ndata = data.shape
+        nxgrid, nygrid = 10, 10
+        clusterids = numpy.ones((nitems, 2), numpy.int32)
+        celldata = numpy.zeros((nxgrid, nygrid, ndata), dtype="d")
+
+        with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
+            somcluster(clusterids=None, celldata=celldata,
+                       data=data, mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(ValueError,
+                "^incorrect rank 1 \(expected 2\)$"):
+            somcluster(clusterids=numpy.ones(nitems, numpy.int32),
+                       celldata=celldata, data=data, mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(RuntimeError,
+                "^argument has incorrect data type$"):
+            somcluster(clusterids=numpy.ones((nitems, 2), numpy.int16),
+                       celldata=celldata, data=data, mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(ValueError,
+                "^array has 3 columns \(expected 2\)$"):
+            somcluster(clusterids=numpy.ones((nitems, 3), numpy.int32),
+                       celldata=celldata, data=data, mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(RuntimeError,
+                "^celldata array has unexpected format.$"):
+            somcluster(clusterids=clusterids, celldata=None,
+                       data=data, mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(RuntimeError,
+                "^celldata array has incorrect data type$"):
+            somcluster(clusterids=clusterids,
+                       celldata=numpy.zeros((nxgrid, nygrid, ndata),
+                                            dtype=numpy.int32),
+                       data=data, mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(RuntimeError, "^data is None$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=None, mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has unexpected format.$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=[None], mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has incorrect data type$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=numpy.zeros((4,5), dtype=numpy.int16),
+                       mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has incorrect rank 1 \(expected 2\)$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=numpy.zeros(4), mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(ValueError, "^data matrix is empty$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=data[:0], mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(RuntimeError, "^data is not contiguous$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=data[:,::2], mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(RuntimeError, "^mask is None$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=data, mask=None, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(RuntimeError,
+                "^mask has unexpected format.$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=data, mask=[None], weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(ValueError,
+                "^mask has incorrect rank 1 \(expected 2\)$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=data, mask=numpy.array([1, 1, 1]), weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(RuntimeError,
+                "^mask has incorrect data type$"):
+            somcluster(clusterids=clusterids, celldata=celldata, data=data,
+                       mask=numpy.array([[1, 1], [1, 1]], dtype=numpy.int16),
+                       weight=weight, transpose=False, inittau=0.02, niter=100,
+                       dist="e")
+        with self.assertRaisesRegex(RuntimeError, "^mask is not contiguous$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=data, mask=mask[:,::2], weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=data, mask=mask, weight=None,
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(ValueError,
+                "^incorrect rank 3 \(expected 1\)$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=data, mask=mask, weight=numpy.zeros((2,2,2)),
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(RuntimeError,
+                "^array has incorrect data type$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=data, mask=mask,
+                       weight=numpy.array([1, 1, 1], dtype=numpy.int16),
+                       transpose=False, inittau=0.02, niter=100, dist="e")
+        with self.assertRaisesRegex(ValueError, "^dist should be a string$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=data, mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist=5)
+        with self.assertRaisesRegex(ValueError,
+                "^dist should be a single character$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=data, mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100,
+                       dist="Pearson")
+        with self.assertRaisesRegex(ValueError,
+                "^unknown dist function specified "
+                "\(should be one of 'ebcauxsk'\)$"):
+            somcluster(clusterids=clusterids, celldata=celldata,
+                       data=data, mask=mask, weight=weight,
+                       transpose=False, inittau=0.02, niter=100, dist="X")
+
     def test_somcluster(self):
         if TestCluster.module == "Bio.Cluster":
             from Bio.Cluster import somcluster
@@ -1421,6 +1822,71 @@ class TestCluster(unittest.TestCase):
                                          inittau=0.02, niter=100, dist="e")
         self.assertEqual(len(clusterid), len(data))
         self.assertEqual(len(clusterid[0]), 2)
+
+    def test_distancematrix_arguments(self):
+        # Test if incorrect arguments are caught by the C code
+        if TestCluster.module == "Bio.Cluster":
+            from Bio.Cluster._cluster import distancematrix
+        elif TestCluster.module == "Pycluster":
+            from Pycluster._cluster import distancematrix
+
+        data = numpy.array([[2.2, 3.3, 4.4],
+                            [2.1, 1.4, 5.6],
+                            [7.8, 9.0, 1.2],
+                            [4.5, 2.3, 1.5],
+                            [4.2, 2.4, 1.9],
+                            [3.6, 3.1, 9.3],
+                            [2.3, 1.2, 3.9],
+                            [4.2, 9.6, 9.3],
+                            [1.7, 8.9, 1.1]])
+        mask = numpy.array([[1, 1, 1],
+                            [1, 1, 1],
+                            [0, 1, 1],
+                            [1, 1, 1],
+                            [1, 1, 1],
+                            [0, 1, 0],
+                            [1, 1, 1],
+                            [1, 0, 1],
+                            [1, 1, 1]], numpy.int32)
+        weight = numpy.array([2.0, 1.0, 0.5])
+        with self.assertRaisesRegex(ValueError, "^data matrix is empty$"):
+            distancematrix(data[:0,:], mask=mask, weight=weight)
+        with self.assertRaisesRegex(ValueError,
+                "^mask has incorrect rank 1 \(expected 2\)$"):
+            distancematrix(data, mask=numpy.zeros(3), weight=weight)
+        with self.assertRaisesRegex(ValueError,
+                "^mask has incorrect dimensions \(4 x 3, expected 9 x 3\)$"):
+            distancematrix(data, mask=mask[:4,:], weight=weight,
+                           transpose=False, dist='c',
+                           distancematrix=[])
+        with self.assertRaisesRegex(ValueError,
+                "^incorrect rank 2 \(expected 1\)$"):
+            distancematrix(data, mask=mask, weight=numpy.zeros((2,2)))
+        with self.assertRaisesRegex(ValueError,
+                "^weight has incorrect size 4 \(expected 3\)$"):
+            distancematrix(data, mask=mask, weight=numpy.zeros(4),
+                           transpose=False, dist='c', distancematrix=[])
+
+    def test_kmedoids_arguments(self):
+        # Test if incorrect arguments are caught by the C code
+        if TestCluster.module == "Bio.Cluster":
+            from Bio.Cluster._cluster import distancematrix, kmedoids
+        elif TestCluster.module == "Pycluster":
+            from Pycluster._cluster import distancematrix, kmedoids
+
+        clusterid = numpy.zeros(10, numpy.int32)
+        with self.assertRaisesRegex(RuntimeError,
+                "^failed to parse row 0.$"):
+            kmedoids([None])
+        with self.assertRaisesRegex(ValueError,
+                "^more clusters requested than items to be clustered$"):
+            kmedoids([], nclusters=2, npass=1000, clusterid=clusterid)
+        with self.assertRaisesRegex(ValueError,
+                "^distance matrix is not square.$"):
+            kmedoids(numpy.zeros((2,3)), npass=1000)
+        with self.assertRaisesRegex(ValueError,
+                "^distance matrix has incorrect rank 3 \(expected 1 or 2\)$"):
+            kmedoids(numpy.zeros((2,3,4)), npass=1000)
 
     def test_distancematrix_kmedoids(self):
         if TestCluster.module == "Bio.Cluster":
@@ -1582,6 +2048,67 @@ class TestCluster(unittest.TestCase):
         self.assertAlmostEqual(matrix[1][0], 10.47166667, places=3)
         self.assertAlmostEqual(matrix[2][0], 8.61571429, places=3)
         self.assertAlmostEqual(matrix[2][1], 21.24428571, places=3)
+
+    def test_pca_arguments(self):
+        if TestCluster.module == "Bio.Cluster":
+            from Bio.Cluster._cluster import pca
+        elif TestCluster.module == "Pycluster":
+            from Pycluster._cluster import pca
+
+        data = numpy.zeros((4,2))
+        columnmean = numpy.zeros(2)
+        pc = numpy.zeros((2,2), dtype="d")
+        coordinates = numpy.zeros((4,2), dtype="d")
+        eigenvalues = numpy.zeros(2, dtype="d")
+
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has unexpected format.$"):
+            pca([None], columnmean, coordinates, pc, eigenvalues)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has incorrect rank 1 \(expected 2\)$"):
+            pca(numpy.zeros(3), columnmean, coordinates, pc, eigenvalues)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has incorrect data type$"):
+            pca(numpy.zeros((3, 3), dtype=numpy.int16),
+                columnmean, coordinates, pc, eigenvalues)
+        with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
+            pca(data, "nothing", coordinates, pc, eigenvalues)
+        with self.assertRaisesRegex(ValueError,
+                "^incorrect rank 2 \(expected 1\)$"):
+            pca(data, numpy.zeros((2,2)), coordinates, pc, eigenvalues)
+        with self.assertRaisesRegex(RuntimeError,
+                "^array has incorrect data type$"):
+            pca(data, numpy.ones(3, dtype=numpy.int16),
+                coordinates, pc, eigenvalues)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has unexpected format.$"):
+            pca(data, columnmean, [None], pc, eigenvalues)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has incorrect rank 1 \(expected 2\)$"):
+            pca(data, columnmean, numpy.zeros(3), pc, eigenvalues)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has incorrect data type$"):
+            pca(data, columnmean, numpy.zeros((3, 3), dtype=numpy.int16),
+                pc, eigenvalues)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has unexpected format.$"):
+            pca(data, columnmean, coordinates, [None], eigenvalues)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has incorrect rank 1 \(expected 2\)$"):
+            pca(data, columnmean, coordinates, numpy.zeros(3), eigenvalues)
+        with self.assertRaisesRegex(RuntimeError,
+                "^data matrix has incorrect data type$"):
+            pca(data, columnmean, coordinates,
+                numpy.zeros((3, 3), dtype=numpy.int16), eigenvalues)
+        with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
+            pca(data, columnmean, coordinates, pc, "nothing")
+        with self.assertRaisesRegex(ValueError,
+                "^incorrect rank 2 \(expected 1\)$"):
+            pca(data, columnmean, coordinates, pc, numpy.zeros((2,2)))
+        with self.assertRaisesRegex(RuntimeError,
+                "^array has incorrect data type$"):
+            pca(data, columnmean, coordinates, pc,
+                numpy.ones(3, dtype=numpy.int16))
 
     def test_pca(self):
         if TestCluster.module == "Bio.Cluster":

--- a/Tests/test_Cluster.py
+++ b/Tests/test_Cluster.py
@@ -307,7 +307,7 @@ class TestCluster(unittest.TestCase):
                      mask=mask, weight=weight,
                      transpose=False, npass=100, method="a", dist="e")
         with self.assertRaisesRegex(ValueError,
-                "^mask has incorrect rank 1 \\(expected 2\\)$"):
+            "^mask has incorrect rank 1 \\(expected 2\\)$"):
             kcluster(data, nclusters=nclusters,
                      mask=numpy.zeros(3), weight=weight,
                      transpose=False, npass=100, method="a", dist="e")

--- a/Tests/test_Cluster.py
+++ b/Tests/test_Cluster.py
@@ -538,7 +538,7 @@ class TestCluster(unittest.TestCase):
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError, "^data is not contiguous$"):
-            clusterdistance(data=data[:,::2], mask=mask, weight=weight,
+            clusterdistance(data=data[:, ::2], mask=mask, weight=weight,
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError,
@@ -558,7 +558,7 @@ class TestCluster(unittest.TestCase):
                             weight=weight, index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError, "^mask is not contiguous$"):
-            clusterdistance(data=data, mask=mask[:,::2], weight=weight,
+            clusterdistance(data=data, mask=mask[:, ::2], weight=weight,
                             index1=c1, index2=c2, dist="e",
                             method="a", transpose=False)
         with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
@@ -731,7 +731,7 @@ class TestCluster(unittest.TestCase):
                         distancematrix=None)
         tree = Tree()
         with self.assertRaisesRegex(ValueError,
-	        "^neither data nor distancematrix was given$"):
+                "^neither data nor distancematrix was given$"):
             treecluster(tree, data=None, mask=mask, weight=weight,
                         transpose=False, method="a", dist="e",
                         distancematrix=None)
@@ -758,7 +758,7 @@ class TestCluster(unittest.TestCase):
         elif TestCluster.module == "Pycluster":
             from Pycluster._cluster import Node, Tree
 
-        nodes = [Node(1, 2, 0.2), Node(0, -1, 0.5), Node(3,-2, 0.6)]
+        nodes = [Node(1, 2, 0.2), Node(0, -1, 0.5), Node(3, -2, 0.6)]
         indices = numpy.zeros(4, numpy.int32)
         tree = Tree(nodes)
         with self.assertRaisesRegex(ValueError,
@@ -778,7 +778,6 @@ class TestCluster(unittest.TestCase):
         with self.assertRaisesRegex(ValueError,
                 "^order array has incorrect size 6 \\(expected 4\\)$"):
             tree.sort(indices, numpy.zeros(6))
-
 
     def test_tree(self):
         if TestCluster.module == "Bio.Cluster":
@@ -1698,7 +1697,7 @@ class TestCluster(unittest.TestCase):
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError, "^data is not contiguous$"):
             somcluster(clusterids=clusterids, celldata=celldata,
-                       data=data[:,::2], mask=mask, weight=weight,
+                       data=data[:, ::2], mask=mask, weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError, "^mask is None$"):
             somcluster(clusterids=clusterids, celldata=celldata,
@@ -1722,7 +1721,7 @@ class TestCluster(unittest.TestCase):
                        dist="e")
         with self.assertRaisesRegex(RuntimeError, "^mask is not contiguous$"):
             somcluster(clusterids=clusterids, celldata=celldata,
-                       data=data, mask=mask[:,::2], weight=weight,
+                       data=data, mask=mask[:, ::2], weight=weight,
                        transpose=False, inittau=0.02, niter=100, dist="e")
         with self.assertRaisesRegex(RuntimeError, "^unexpected format.$"):
             somcluster(clusterids=clusterids, celldata=celldata,
@@ -1850,14 +1849,14 @@ class TestCluster(unittest.TestCase):
                             [1, 1, 1]], numpy.int32)
         weight = numpy.array([2.0, 1.0, 0.5])
         with self.assertRaisesRegex(ValueError, "^data matrix is empty$"):
-            distancematrix(data[:0,:], mask=mask, weight=weight)
+            distancematrix(data[:0, :], mask=mask, weight=weight)
         with self.assertRaisesRegex(ValueError,
                 "^mask has incorrect rank 1 \\(expected 2\\)$"):
             distancematrix(data, mask=numpy.zeros(3), weight=weight)
         with self.assertRaisesRegex(ValueError,
                 "^mask has incorrect dimensions \\(4 x 3, expected 9 x 3\\)$"):
-            distancematrix(data, mask=mask[:4,:], weight=weight,
-                           transpose=False, dist='c',
+            distancematrix(data, mask=mask[:4, :], weight=weight,
+                           transpose=False, dist="c",
                            distancematrix=[])
         with self.assertRaisesRegex(ValueError,
                 "^incorrect rank 2 \\(expected 1\\)$"):
@@ -1865,7 +1864,7 @@ class TestCluster(unittest.TestCase):
         with self.assertRaisesRegex(ValueError,
                 "^weight has incorrect size 4 \\(expected 3\\)$"):
             distancematrix(data, mask=mask, weight=numpy.zeros(4),
-                           transpose=False, dist='c', distancematrix=[])
+                           transpose=False, dist="c", distancematrix=[])
 
     def test_kmedoids_arguments(self):
         # Test if incorrect arguments are caught by the C code


### PR DESCRIPTION
This pull request converts Bio.Cluster to python3.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
