### PR TITLE
Pyupgrade part 2

### DIFF
--- a/Bio/AlignIO/FastaIO.py
+++ b/Bio/AlignIO/FastaIO.py
@@ -123,14 +123,14 @@ def FastaM10Iterator(handle, alphabet=single_letter_alphabet):
             m = _extract_alignment_region(match_seq, match_tags)
         if len(q) != len(m):
             message = """Darn... amino acids vs nucleotide coordinates?
-            tool: {0}
-            query_seq: {1}
-            query_tags: {2}
-            {3} length: {4}
-            match_seq: {5}
-            match_tags: {6}
-            {7} length: {8}
-            handle.name: {9}
+            tool: {}
+            query_seq: {}
+            query_tags: {}
+            {} length: {}
+            match_seq: {}
+            match_tags: {}
+            {} length: {}
+            handle.name: {}
             """.format(
                 tool,
                 query_seq,

--- a/Bio/AlignIO/PhylipIO.py
+++ b/Bio/AlignIO/PhylipIO.py
@@ -284,7 +284,7 @@ class RelaxedPhylipWriter(PhylipWriter):
         if len(alignment) == 0:
             id_width = 1
         else:
-            id_width = max((len(s.id.strip()) for s in alignment)) + 1
+            id_width = max(len(s.id.strip()) for s in alignment) + 1
         super().write_alignment(alignment, id_width)
 
 

--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -386,8 +386,6 @@ def parse(handle, format, seq_count=None, alphabet=None):
         else:
             raise ValueError("Unknown format '%s'" % format)
 
-        # TODO: As of Python 3.3, can write "yield from i" instead. See PEP380.
-        # For loop imposes some overhead... wait until we drop Python 2.7 to fix it.
         yield from i
 
 

--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -388,8 +388,7 @@ def parse(handle, format, seq_count=None, alphabet=None):
 
         # TODO: As of Python 3.3, can write "yield from i" instead. See PEP380.
         # For loop imposes some overhead... wait until we drop Python 2.7 to fix it.
-        for a in i:
-            yield a
+        yield from i
 
 
 def read(handle, format, seq_count=None, alphabet=None):

--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -328,7 +328,7 @@ class DataHandler:
         if hasattr(handle, "closed") and handle.closed:
             # Should avoid a possible Segmentation Fault, see:
             # http://bugs.python.org/issue4877
-            raise IOError("Can't parse a closed handle")
+            raise OSError("Can't parse a closed handle")
         if sys.version_info[0] >= 3:
             # Another nasty hack to cope with a unicode StringIO handle
             # since the Entrez XML parser expects binary data (bytes)
@@ -425,8 +425,7 @@ class DataHandler:
             raise CorruptedXMLError("Premature end of XML stream")
 
         # Send out the remaining records
-        for record in records:
-            yield record
+        yield from records
 
     def xmlDeclHandler(self, version, encoding, standalone):
         """Set XML handlers when an XML declaration is found."""
@@ -883,14 +882,14 @@ class DataHandler:
         path = os.path.join(self.local_dtd_dir, filename)
         try:
             handle = open(path, "rb")
-        except IOError:
+        except OSError:
             pass
         else:
             return handle
         path = os.path.join(self.global_dtd_dir, filename)
         try:
             handle = open(path, "rb")
-        except IOError:
+        except OSError:
             pass
         else:
             return handle
@@ -902,14 +901,14 @@ class DataHandler:
         path = os.path.join(self.local_xsd_dir, filename)
         try:
             handle = open(path, "rb")
-        except IOError:
+        except OSError:
             pass
         else:
             return handle
         path = os.path.join(self.global_xsd_dir, filename)
         try:
             handle = open(path, "rb")
-        except IOError:
+        except OSError:
             pass
         else:
             return handle
@@ -921,7 +920,7 @@ class DataHandler:
         path = os.path.join(self.local_dtd_dir, filename)
         try:
             handle = open(path, "wb")
-        except IOError:
+        except OSError:
             warnings.warn("Failed to save %s at %s" % (filename, path))
         else:
             handle.write(text)
@@ -933,7 +932,7 @@ class DataHandler:
         path = os.path.join(self.local_xsd_dir, filename)
         try:
             handle = open(path, "wb")
-        except IOError:
+        except OSError:
             warnings.warn("Failed to save %s at %s" % (filename, path))
         else:
             handle.write(text)
@@ -978,7 +977,7 @@ class DataHandler:
             # the internet instead.
             try:
                 handle = _urlopen(url)
-            except IOError:
+            except OSError:
                 raise RuntimeError("Failed to access %s at %s" % (filename, url)) from None
             text = handle.read()
             handle.close()

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1748,7 +1748,7 @@ class GenBankScanner(InsdcScanner):
                         print("Found comment")
                     comment_list = []
                     structured_comment_dict = OrderedDict()
-                    regex = r"([^#]+){0}$".format(self.STRUCTURED_COMMENT_START)
+                    regex = r"([^#]+){}$".format(self.STRUCTURED_COMMENT_START)
                     structured_comment_key = re.search(regex, data)
                     if structured_comment_key is not None:
                         structured_comment_key = structured_comment_key.group(1)
@@ -1762,7 +1762,7 @@ class GenBankScanner(InsdcScanner):
                         data = line[self.GENBANK_INDENT :]
                         if line[0 : self.GENBANK_INDENT] == self.GENBANK_SPACER:
                             if self.STRUCTURED_COMMENT_START in data:
-                                regex = r"([^#]+){0}$".format(
+                                regex = r"([^#]+){}$".format(
                                     self.STRUCTURED_COMMENT_START
                                 )
                                 structured_comment_key = re.search(regex, data)
@@ -1777,7 +1777,7 @@ class GenBankScanner(InsdcScanner):
                                 and self.STRUCTURED_COMMENT_DELIM in data
                             ):
                                 match = re.search(
-                                    r"(.+?)\s*{0}\s*(.+)".format(
+                                    r"(.+?)\s*{}\s*(.+)".format(
                                         self.STRUCTURED_COMMENT_DELIM
                                     ),
                                     data,

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -435,8 +435,7 @@ def _split_compound_loc(compound_loc):
             yield compound_loc
     else:
         # Easy case
-        for part in compound_loc.split(","):
-            yield part
+        yield from compound_loc.split(",")
 
 
 class Iterator:

--- a/Bio/Index.py
+++ b/Bio/Index.py
@@ -65,9 +65,9 @@ class _ShelveIndex(dict):
             # Check to make sure the database is the correct version.
             version = self.data.get(self.__version_key)
             if version is None:
-                raise IOError("Unrecognized index format")
+                raise OSError("Unrecognized index format")
             elif version != self.__version:
-                raise IOError("Version %s doesn't match my version %s"
+                raise OSError("Version %s doesn't match my version %s"
                               % (version, self.__version))
 
     def __del__(self):
@@ -101,7 +101,7 @@ class _InMemoryIndex(dict):
             with open(indexname) as handle:
                 version = self._toobj(handle.readline().rstrip())
                 if version != self.__version:
-                    raise IOError("Version %s doesn't match my version %s"
+                    raise OSError("Version %s doesn't match my version %s"
                                   % (version, self.__version))
                 for line in handle:
                     key, value = line.split()

--- a/Bio/NaiveBayes.py
+++ b/Bio/NaiveBayes.py
@@ -83,8 +83,8 @@ def calculate(nb, observation, scale=False):
 
     # Make sure the observation has the right dimensionality.
     if len(observation) != nb.dimensionality:
-        raise ValueError("observation in {0} dimension, but classifier in {1}".format(len(observation),
-                                                                                      nb.dimensionality))
+        raise ValueError("observation in {} dimension, but classifier in {}".format(len(observation),
+                                                                                    nb.dimensionality))
 
     # Calculate log P(observation|class) for every class.
     n = len(nb.classes)

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -600,7 +600,7 @@ class Commandline:
                     valued_indices = [
                         (n - 1, n, n + 1)
                         for n in range(len(options))
-                        if options[n] == "=" and n != 0 and n != len((options))
+                        if options[n] == "=" and n != 0 and n != len(options)
                     ]
                     indices = []
                     for sl in valued_indices:
@@ -691,7 +691,7 @@ class Nexus:
             with File.as_handle(input, "rU") as fp:
                 file_contents = fp.read()
                 self.filename = getattr(fp, "name", "Unknown_nexus_file")
-        except (TypeError, IOError, AttributeError):
+        except (TypeError, OSError, AttributeError):
             # 2. Assume we have a string from a fh.read()
             if isinstance(input, str):
                 file_contents = input

--- a/Bio/Nexus/Trees.py
+++ b/Bio/Nexus/Trees.py
@@ -211,8 +211,7 @@ class Tree(Nodes.Chain):
             node = self.root
         for n in self.node(node).succ:
             yield n
-            for sn in self._walk(n):
-                yield sn
+            yield from self._walk(n)
 
     def node(self, node_id):
         """Return the instance of node_id.

--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -443,8 +443,7 @@ class DisorderedAtom(DisorderedEntityWrapper):
     # Override parent class __iter__ method
     def __iter__(self):
         """Iterate through disordered atoms."""
-        for i in self.disordered_get_list():
-            yield i
+        yield from self.disordered_get_list()
 
     def __repr__(self):
         """Return disordered atom identifier."""

--- a/Bio/PDB/Chain.py
+++ b/Bio/PDB/Chain.py
@@ -164,11 +164,9 @@ class Chain(Entity):
 
     def get_residues(self):
         """Return residues."""
-        for r in self:
-            yield r
+        yield from self
 
     def get_atoms(self):
         """Return atoms from residues."""
         for r in self.get_residues():
-            for a in r:
-                yield a
+            yield from r

--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -341,7 +341,7 @@ def _make_dssp_dict(handle):
                 O_NH_2_relidx = int(l[72 + shift : 78 + shift])
                 O_NH_2_energy = float(l[79 + shift : 83 + shift])
 
-                acc = int((l[34 + shift : 38 + shift]))
+                acc = int(l[34 + shift : 38 + shift])
                 phi = float(l[103 + shift : 109 + shift])
                 psi = float(l[109 + shift : 115 + shift])
             else:

--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -51,8 +51,7 @@ class Entity:
 
     def __iter__(self):
         """Iterate over children."""
-        for child in self.child_list:
-            yield child
+        yield from self.child_list
 
     # Generic id-based comparison methods considers all parents as well as children
     # Works for all Entities - Atoms have comparable custom operators
@@ -228,8 +227,7 @@ class Entity:
 
     def get_iterator(self):
         """Return iterator over children."""
-        for child in self.child_list:
-            yield child
+        yield from self.child_list
 
     def get_list(self):
         """Return a copy of the list of children."""

--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -121,7 +121,6 @@ class MMCIF2Dict(dict):
                     token_buffer.append(line)
                 yield "\n".join(token_buffer)
             else:
-                for token in self._splitline(line.strip()):
-                    yield token
+                yield from self._splitline(line.strip())
         if empty:
             raise ValueError("Empty file.")

--- a/Bio/PDB/Model.py
+++ b/Bio/PDB/Model.py
@@ -38,17 +38,14 @@ class Model(Entity):
 
     def get_chains(self):
         """Return chains."""
-        for c in self:
-            yield c
+        yield from self
 
     def get_residues(self):
         """Return residues."""
         for c in self.get_chains():
-            for r in c:
-                yield r
+            yield from c
 
     def get_atoms(self):
         """Return atoms."""
         for r in self.get_residues():
-            for a in r:
-                yield a
+            yield from r

--- a/Bio/PDB/NACCESS.py
+++ b/Bio/PDB/NACCESS.py
@@ -190,7 +190,7 @@ class NACCESS_atomic(AbstractAtomPropertyMap):
                     if full_id in self.naccess_atom_dict:
                         asa = self.naccess_atom_dict[full_id]
                         property_dict[full_id] = asa
-                        property_keys.append((full_id))
+                        property_keys.append(full_id)
                         property_list.append((atom, asa))
                         atom.xtra["EXP_NACCESS"] = asa
         AbstractAtomPropertyMap.__init__(

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -338,7 +338,7 @@ class PDBList:
         try:
             _urlcleanup()
             _urlretrieve(url, filename)
-        except IOError:
+        except OSError:
             print("Desired structure doesn't exists")
         else:
             with gzip.open(filename, "rb") as gz:
@@ -469,7 +469,7 @@ class PDBList:
         # Write the list
         if listfile:
             with open(listfile, "w") as outfile:
-                outfile.writelines((x + "\n" for x in entries))
+                outfile.writelines(x + "\n" for x in entries)
 
     def download_obsolete_entries(self, listfile=None, file_format=None):
         """Retrieve all obsolete PDB entries not present in local obsolete PDB copy.
@@ -492,7 +492,7 @@ class PDBList:
         # Write the list
         if listfile:
             with open(listfile, "w") as outfile:
-                outfile.writelines((x + "\n" for x in entries))
+                outfile.writelines(x + "\n" for x in entries)
 
     def get_seqres_file(self, savefile="pdb_seqres.txt"):
         """Retrieve and save a (big) file containing all the sequences of PDB entries."""

--- a/Bio/PDB/Residue.py
+++ b/Bio/PDB/Residue.py
@@ -95,8 +95,7 @@ class Residue(Entity):
 
     def get_atoms(self):
         """Return atoms."""
-        for a in self:
-            yield a
+        yield from self
 
     def get_atom(self):
         """Return atom."""
@@ -105,8 +104,7 @@ class Residue(Entity):
             " in a future release of Biopython. Please use `get_atoms` instead.",
             BiopythonDeprecationWarning,
         )
-        for a in self:
-            yield a
+        yield from self
 
 
 class DisorderedResidue(DisorderedEntityWrapper):

--- a/Bio/PDB/Structure.py
+++ b/Bio/PDB/Structure.py
@@ -24,23 +24,19 @@ class Structure(Entity):
 
     def get_models(self):
         """Return models."""
-        for m in self:
-            yield m
+        yield from self
 
     def get_chains(self):
         """Return chains from models."""
         for m in self.get_models():
-            for c in m:
-                yield c
+            yield from m
 
     def get_residues(self):
         """Return residues from chains."""
         for c in self.get_chains():
-            for r in c:
-                yield r
+            yield from c
 
     def get_atoms(self):
         """Return atoms from residue."""
         for r in self.get_residues():
-            for a in r:
-                yield a
+            yield from r

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -54,11 +54,9 @@ def _preorder_traverse(root, get_children):
     def dfs(elem):
         yield elem
         for v in get_children(elem):
-            for u in dfs(v):
-                yield u
+            yield from dfs(v)
 
-    for elem in dfs(root):
-        yield elem
+    yield from dfs(root)
 
 
 def _postorder_traverse(root, get_children):
@@ -66,12 +64,10 @@ def _postorder_traverse(root, get_children):
     # This comment stops black style adding a blank line here, which causes flake8 D202.
     def dfs(elem):
         for v in get_children(elem):
-            for u in dfs(v):
-                yield u
+            yield from dfs(v)
         yield elem
 
-    for elem in dfs(root):
-        yield elem
+    yield from dfs(root)
 
 
 def _sorted_attrs(elem):

--- a/Bio/Phylo/CDAOIO.py
+++ b/Bio/Phylo/CDAOIO.py
@@ -462,8 +462,7 @@ class Writer:
             for predicate, obj in edge_attributes:
                 yield (nUri(edge_uri), predicate, obj)
 
-        for stmt in statements:
-            yield stmt
+        yield from statements
 
         try:
             clade_attributes = clade.attributes
@@ -475,5 +474,4 @@ class Writer:
 
         if not clade.is_terminal():
             for new_clade in clade.clades:
-                for stmt in self.process_clade(new_clade, parent=clade, root=False):
-                    yield stmt
+                yield from self.process_clade(new_clade, parent=clade, root=False)

--- a/Bio/Phylo/PAML/_paml.py
+++ b/Bio/Phylo/PAML/_paml.py
@@ -30,7 +30,7 @@ class Paml:
             self.working_dir = working_dir
         if alignment is not None:
             if not os.path.exists(alignment):
-                raise IOError("The specified alignment file does not exist.")
+                raise OSError("The specified alignment file does not exist.")
         self.alignment = alignment
         self.out_file = out_file
         self._options = {}  # will be set in subclasses
@@ -98,7 +98,7 @@ class Paml:
         if self.alignment is None:
             raise ValueError("Alignment file not specified.")
         if not os.path.exists(self.alignment):
-            raise IOError("The specified alignment file does not exist.")
+            raise OSError("The specified alignment file does not exist.")
         if self.out_file is None:
             raise ValueError("Output file not specified.")
         if self.working_dir is None:
@@ -116,7 +116,7 @@ class Paml:
             ctl_file = self.ctl_file
         else:
             if not os.path.exists(ctl_file):
-                raise IOError("The specified control file does not exist.")
+                raise OSError("The specified control file does not exist.")
         if verbose:
             result_code = subprocess.call([command, ctl_file])
         else:
@@ -131,6 +131,6 @@ class Paml:
             )
         if result_code < 0:
             # If the paml process is killed by a signal somehow
-            raise EnvironmentError(
+            raise OSError(
                 "The %s process was killed (return code %i)." % (command, result_code)
             )

--- a/Bio/Phylo/PAML/baseml.py
+++ b/Bio/Phylo/PAML/baseml.py
@@ -33,7 +33,7 @@ class Baseml(Paml):
         Paml.__init__(self, alignment, working_dir, out_file)
         if tree is not None:
             if not os.path.exists(tree):
-                raise IOError("The specified tree file does not exist.")
+                raise OSError("The specified tree file does not exist.")
         self.tree = tree
         self.ctl_file = "baseml.ctl"
         self._options = {
@@ -104,7 +104,7 @@ class Baseml(Paml):
         """Parse a control file and load the options into the Baseml instance."""
         temp_options = {}
         if not os.path.isfile(ctl_file):
-            raise IOError("File not found: %r" % ctl_file)
+            raise OSError("File not found: %r" % ctl_file)
         else:
             with open(ctl_file) as ctl_handle:
                 for line in ctl_handle:
@@ -177,7 +177,7 @@ class Baseml(Paml):
         if self.tree is None:
             raise ValueError("Tree file not specified.")
         if not os.path.exists(self.tree):
-            raise IOError("The specified tree file does not exist.")
+            raise OSError("The specified tree file does not exist.")
         Paml.run(self, ctl_file, verbose, command)
         if parse:
             return read(self.out_file)
@@ -188,7 +188,7 @@ def read(results_file):
     """Parse a BASEML results file."""
     results = {}
     if not os.path.exists(results_file):
-        raise IOError("Results file does not exist.")
+        raise OSError("Results file does not exist.")
     with open(results_file) as handle:
         lines = handle.readlines()
     if not lines:

--- a/Bio/Phylo/PAML/codeml.py
+++ b/Bio/Phylo/PAML/codeml.py
@@ -35,7 +35,7 @@ class Codeml(Paml):
         Paml.__init__(self, alignment, working_dir, out_file)
         if tree is not None:
             if not os.path.exists(tree):
-                raise IOError("The specified tree file does not exist.")
+                raise OSError("The specified tree file does not exist.")
         self.tree = tree
         self.ctl_file = "codeml.ctl"
         self._options = {
@@ -102,7 +102,7 @@ class Codeml(Paml):
         """Parse a control file and load the options into the Codeml instance."""
         temp_options = {}
         if not os.path.isfile(ctl_file):
-            raise IOError("File not found: %r" % ctl_file)
+            raise OSError("File not found: %r" % ctl_file)
         else:
             with open(ctl_file) as ctl_handle:
                 for line in ctl_handle:
@@ -187,7 +187,7 @@ class Codeml(Paml):
         if self.tree is None:
             raise ValueError("Tree file not specified.")
         if not os.path.exists(self.tree):
-            raise IOError("The specified tree file does not exist.")
+            raise OSError("The specified tree file does not exist.")
         Paml.run(self, ctl_file, verbose, command)
         if parse:
             return read(self.out_file)
@@ -198,7 +198,7 @@ def read(results_file):
     """Parse a CODEML results file."""
     results = {}
     if not os.path.exists(results_file):
-        raise IOError("Results file does not exist.")
+        raise OSError("Results file does not exist.")
     with open(results_file) as handle:
         lines = handle.readlines()
     if not lines:

--- a/Bio/Phylo/PAML/yn00.py
+++ b/Bio/Phylo/PAML/yn00.py
@@ -67,7 +67,7 @@ class Yn00(Paml):
         """Parse a control file and load the options into the yn00 instance."""
         temp_options = {}
         if not os.path.isfile(ctl_file):
-            raise IOError("File not found: %r" % ctl_file)
+            raise OSError("File not found: %r" % ctl_file)
         else:
             with open(ctl_file) as ctl_handle:
                 for line in ctl_handle:
@@ -121,7 +121,7 @@ def read(results_file):
     """Parse a yn00 results file."""
     results = {}
     if not os.path.exists(results_file):
-        raise IOError("Results file does not exist.")
+        raise OSError("Results file does not exist.")
     with open(results_file) as handle:
         lines = handle.readlines()
     if not lines:

--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -345,7 +345,7 @@ class DistanceMatrix(_Matrix):
                 open in text mode.
 
         """
-        handle.write("    {0}\n".format(len(self.names)))
+        handle.write("    {}\n".format(len(self.names)))
         # Phylip needs space-separated, vertically aligned columns
         name_width = max(12, max(map(len, self.names)) + 1)
         value_fmts = ("{" + str(x) + ":.4f}" for x in range(1, len(self.matrix) + 1))

--- a/Bio/Phylo/_io.py
+++ b/Bio/Phylo/_io.py
@@ -46,8 +46,7 @@ def parse(file, format, **kwargs):
 
     """
     with File.as_handle(file, "r") as fp:
-        for tree in getattr(supported_formats[format], "parse")(fp, **kwargs):
-            yield tree
+        yield from getattr(supported_formats[format], "parse")(fp, **kwargs)
 
 
 def read(file, format, **kwargs):

--- a/Bio/SearchIO/BlastIO/blast_tab.py
+++ b/Bio/SearchIO/BlastIO/blast_tab.py
@@ -231,8 +231,7 @@ class BlastTabParser:
                 )
             iterfunc = self._parse_qresult
 
-        for qresult in iterfunc():
-            yield qresult
+        yield from iterfunc()
 
     def _prep_fields(self, fields):
         """Validate and format the given fields for use by the parser (PRIVATE)."""

--- a/Bio/SearchIO/BlastIO/blast_xml.py
+++ b/Bio/SearchIO/BlastIO/blast_xml.py
@@ -240,8 +240,7 @@ class BlastXmlParser:
 
     def __iter__(self):
         """Iterate over BlastXmlParser object yields query results."""
-        for qresult in self._parse_qresult():
-            yield qresult
+        yield from self._parse_qresult()
 
     def _parse_preamble(self):
         """Parse all tag data prior to the first query result (PRIVATE)."""
@@ -701,7 +700,7 @@ class _BlastXmlGenerator(XMLGenerator):
     def endElement(self, name):
         """End and XML element of the given name."""
         XMLGenerator.endElement(self, name)
-        self.write(u"\n")
+        self.write("\n")
 
     def startParent(self, name, attrs=None):
         """Start an XML element which has children.
@@ -716,7 +715,7 @@ class _BlastXmlGenerator(XMLGenerator):
             attrs = {}
         self.startElement(name, attrs, children=True)
         self._level += self._increment
-        self.write(u"\n")
+        self.write("\n")
         # append the element name, so we can end it later
         self._parent_stack.append(name)
 

--- a/Bio/SearchIO/BlatIO.py
+++ b/Bio/SearchIO/BlatIO.py
@@ -734,15 +734,15 @@ class BlatPslWriter:
                 line.append(hsp.hit_start)
                 line.append(hsp.hit_end)
                 line.append(len(hsp))
-                line.append(",".join((str(x) for x in block_sizes)) + ",")
-                line.append(",".join((str(x) for x in qstarts)) + ",")
-                line.append(",".join((str(x) for x in hstarts)) + ",")
+                line.append(",".join(str(x) for x in block_sizes) + ",")
+                line.append(",".join(str(x) for x in qstarts) + ",")
+                line.append(",".join(str(x) for x in hstarts) + ",")
 
                 if self.pslx:
-                    line.append(",".join((str(x.seq) for x in hsp.query_all)) + ",")
-                    line.append(",".join((str(x.seq) for x in hsp.hit_all)) + ",")
+                    line.append(",".join(str(x.seq) for x in hsp.query_all) + ",")
+                    line.append(",".join(str(x.seq) for x in hsp.hit_all) + ",")
 
-                qresult_lines.append("\t".join((str(x) for x in line)))
+                qresult_lines.append("\t".join(str(x) for x in line))
 
         return "\n".join(qresult_lines) + "\n"
 

--- a/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
+++ b/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
@@ -53,8 +53,7 @@ class Hhsuite2TextParser:
 
     def __iter__(self):
         """Iterate over query results - there will only ever be one."""
-        for qresult in self._parse_qresult():
-            yield qresult
+        yield from self._parse_qresult()
 
     def _read_until(self, bool_func, stop_on_blank=True, max_read_until=MAX_READ_UNTIL):
         """Read the file handle until the given function returns True (PRIVATE)."""

--- a/Bio/SearchIO/HmmerIO/hmmer3_tab.py
+++ b/Bio/SearchIO/HmmerIO/hmmer3_tab.py
@@ -31,8 +31,7 @@ class Hmmer3TabParser:
             self.line = self.handle.readline()
         # if we have result rows, parse it
         if self.line:
-            for qresult in self._parse_qresult():
-                yield qresult
+            yield from self._parse_qresult()
 
     def _parse_row(self):
         """Return a dictionary of parsed row values (PRIVATE)."""

--- a/Bio/SearchIO/HmmerIO/hmmer3_text.py
+++ b/Bio/SearchIO/HmmerIO/hmmer3_text.py
@@ -45,8 +45,7 @@ class Hmmer3TextParser:
 
     def __iter__(self):
         """Iterate over query results."""
-        for qresult in self._parse_qresult():
-            yield qresult
+        yield from self._parse_qresult()
 
     def _read_until(self, bool_func):
         """Read the file handle until the given function returns True (PRIVATE)."""

--- a/Bio/SearchIO/InterproscanIO/interproscan_xml.py
+++ b/Bio/SearchIO/InterproscanIO/interproscan_xml.py
@@ -43,8 +43,7 @@ class InterproscanXmlParser:
 
     def __iter__(self):
         """Iterate qresults."""
-        for qresult in self._parse_qresult():
-            yield qresult
+        yield from self._parse_qresult()
 
     def _parse_header(self):
         """Parse the header for the InterProScan version (PRIVATE)."""

--- a/Bio/SearchIO/__init__.py
+++ b/Bio/SearchIO/__init__.py
@@ -314,8 +314,7 @@ def parse(handle, format=None, **kwargs):
     with as_handle(handle, "rU", **handle_kwargs) as source_file:
         generator = iterator(source_file, **kwargs)
 
-        for qresult in generator:
-            yield qresult
+        yield from generator
 
 
 def read(handle, format=None, **kwargs):

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -230,7 +230,7 @@ class QueryResult(_BaseSearchObject):
 
         def iterhits(self):
             """Return an iterator over the Hit objects."""
-            yield from self._items.itervalues()
+            yield from self._items.values()
 
         def iterhit_keys(self):
             """Return an iterator over the ID of the Hit objects."""
@@ -238,7 +238,7 @@ class QueryResult(_BaseSearchObject):
 
         def iteritems(self):
             """Return an iterator yielding tuples of Hit ID and Hit objects."""
-            yield from self._items.iteritems()
+            yield from self._items.items()
 
     else:
 

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -230,18 +230,15 @@ class QueryResult(_BaseSearchObject):
 
         def iterhits(self):
             """Return an iterator over the Hit objects."""
-            for hit in self._items.itervalues():  # noqa: B301
-                yield hit
+            yield from self._items.itervalues()
 
         def iterhit_keys(self):
             """Return an iterator over the ID of the Hit objects."""
-            for hit_id in self._items:
-                yield hit_id
+            yield from self._items
 
         def iteritems(self):
             """Return an iterator yielding tuples of Hit ID and Hit objects."""
-            for item in self._items.iteritems():  # noqa: B301
-                yield item
+            yield from self._items.iteritems()
 
     else:
 
@@ -266,18 +263,15 @@ class QueryResult(_BaseSearchObject):
 
         def iterhits(self):
             """Return an iterator over the Hit objects."""
-            for hit in self._items.values():
-                yield hit
+            yield from self._items.values()
 
         def iterhit_keys(self):
             """Return an iterator over the ID of the Hit objects."""
-            for hit_id in self._items:
-                yield hit_id
+            yield from self._items
 
         def iteritems(self):
             """Return an iterator yielding tuples of Hit ID and Hit objects."""
-            for item in self._items.items():
-                yield item
+            yield from self._items.items()
 
     def __contains__(self, hit_key):
         """Return True if hit key in items or alternative hit identifiers."""

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -130,11 +130,11 @@ class Seq:
             # Shows the last three letters as it is often useful to see if
             # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
-            return "{0}('{1}...{2}'{3!s})".format(
+            return "{}('{}...{}'{!s})".format(
                 self.__class__.__name__, str(self)[:54], str(self)[-3:], a
             )
         else:
-            return "{0}({1!r}{2!s})".format(self.__class__.__name__, self._data, a)
+            return "{}({!r}{!s})".format(self.__class__.__name__, self._data, a)
 
     def __str__(self):
         """Return the full sequence as a python string, use str(my_seq).
@@ -210,7 +210,7 @@ class Seq:
             # other could be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     ),
                     BiopythonWarning,
@@ -227,7 +227,7 @@ class Seq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     ),
                     BiopythonWarning,
@@ -245,7 +245,7 @@ class Seq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     ),
                     BiopythonWarning,
@@ -263,7 +263,7 @@ class Seq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     ),
                     BiopythonWarning,
@@ -281,7 +281,7 @@ class Seq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     ),
                     BiopythonWarning,
@@ -369,7 +369,7 @@ class Seq:
             # other should be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 raise TypeError(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     )
                 )
@@ -403,7 +403,7 @@ class Seq:
             # other should be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 raise TypeError(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     )
                 )
@@ -500,7 +500,7 @@ class Seq:
         # Other should be a Seq or a MutableSeq
         if not Alphabet._check_type_compatible([self.alphabet, other_alpha]):
             raise TypeError(
-                "Incompatible alphabets {0!r} and {1!r}".format(
+                "Incompatible alphabets {!r} and {!r}".format(
                     self.alphabet, other_alpha
                 )
             )
@@ -1259,7 +1259,7 @@ class Seq:
                 gap = self.alphabet.gap_char
             elif gap != self.alphabet.gap_char:
                 raise ValueError(
-                    "Gap {0!r} does not match {1!r} from alphabet".format(
+                    "Gap {!r} does not match {!r} from alphabet".format(
                         gap, self.alphabet.gap_char
                     )
                 )
@@ -1353,7 +1353,7 @@ class Seq:
                 gap = self.alphabet.gap_char
             elif gap != self.alphabet.gap_char:
                 raise ValueError(
-                    "Gap {0!r} does not match {1!r} from alphabet".format(
+                    "Gap {!r} does not match {!r} from alphabet".format(
                         gap, self.alphabet.gap_char
                     )
                 )
@@ -1363,7 +1363,7 @@ class Seq:
         else:
             alpha = self.alphabet  # modify!
         if len(gap) != 1 or not isinstance(gap, str):
-            raise ValueError("Unexpected gap character, {0!r}".format(gap))
+            raise ValueError("Unexpected gap character, {!r}".format(gap))
         return Seq(str(self).replace(gap, ""), alpha)
 
     def join(self, other):
@@ -1392,7 +1392,7 @@ class Seq:
                 if a != c.alphabet:
                     if not Alphabet._check_type_compatible([a, c.alphabet]):
                         raise TypeError(
-                            "Incompatible alphabets {0!r} and {1!r}".format(
+                            "Incompatible alphabets {!r} and {!r}".format(
                                 a, c.alphabet
                             )
                         )
@@ -1496,7 +1496,7 @@ class UnknownSeq(Seq):
             a = ""
         else:
             a = ", alphabet=%r" % self.alphabet
-        return "UnknownSeq({0}{1!s}, character={2!r})".format(
+        return "UnknownSeq({}{!s}, character={!r})".format(
             self._length, a, self._character
         )
 
@@ -1978,7 +1978,7 @@ class UnknownSeq(Seq):
                 if a != c.alphabet:
                     if not Alphabet._check_type_compatible([a, c.alphabet]):
                         raise TypeError(
-                            "Incompatible alphabets {0!r} and {1!r}".format(
+                            "Incompatible alphabets {!r} and {!r}".format(
                                 a, c.alphabet
                             )
                         )
@@ -2055,11 +2055,11 @@ class MutableSeq:
             # Shows the last three letters as it is often useful to see if
             # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
-            return "{0}('{1}...{2}'{3!s})".format(
+            return "{}('{}...{}'{!s})".format(
                 self.__class__.__name__, str(self[:54]), str(self[-3:]), a
             )
         else:
-            return "{0}('{1}'{2!s})".format(self.__class__.__name__, str(self), a)
+            return "{}('{}'{!s})".format(self.__class__.__name__, str(self), a)
 
     def __str__(self):
         """Return the full sequence as a python string.
@@ -2107,7 +2107,7 @@ class MutableSeq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     ),
                     BiopythonWarning,
@@ -2126,7 +2126,7 @@ class MutableSeq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     ),
                     BiopythonWarning,
@@ -2146,7 +2146,7 @@ class MutableSeq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     ),
                     BiopythonWarning,
@@ -2166,7 +2166,7 @@ class MutableSeq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     ),
                     BiopythonWarning,
@@ -2186,7 +2186,7 @@ class MutableSeq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     ),
                     BiopythonWarning,
@@ -2269,7 +2269,7 @@ class MutableSeq:
             # other should be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 raise TypeError(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     )
                 )
@@ -2299,7 +2299,7 @@ class MutableSeq:
             # other should be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 raise TypeError(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
+                    "Incompatible alphabets {!r} and {!r}".format(
                         self.alphabet, other.alphabet
                     )
                 )
@@ -2827,15 +2827,15 @@ def _translate_str(
     if cds:
         if str(sequence[:3]).upper() not in table.start_codons:
             raise CodonTable.TranslationError(
-                "First codon '{0}' is not a start codon".format(sequence[:3])
+                "First codon '{}' is not a start codon".format(sequence[:3])
             )
         if n % 3 != 0:
             raise CodonTable.TranslationError(
-                "Sequence length {0} is not a multiple of three".format(n)
+                "Sequence length {} is not a multiple of three".format(n)
             )
         if str(sequence[-3:]).upper() not in stop_codons:
             raise CodonTable.TranslationError(
-                "Final codon '{0}' is not a stop codon".format(sequence[-3:])
+                "Final codon '{}' is not a stop codon".format(sequence[-3:])
             )
         # Don't translate the stop symbol, and manually translate the M
         sequence = sequence[3:-3]
@@ -2875,7 +2875,7 @@ def _translate_str(
                 amino_acids.append(gap)
             else:
                 raise CodonTable.TranslationError(
-                    "Codon '{0}' is invalid".format(codon)
+                    "Codon '{}' is invalid".format(codon)
                 )
     return "".join(amino_acids)
 

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -997,11 +997,9 @@ class FeatureLocation:
         [9, 8, 7, 6, 5]
         """
         if self.strand == -1:
-            for i in range(self._end - 1, self._start - 1, -1):
-                yield i
+            yield from range(self._end - 1, self._start - 1, -1)
         else:
-            for i in range(self._start, self._end):
-                yield i
+            yield from range(self._start, self._end)
 
     def __eq__(self, other):
         """Implement equality by comparing all the location attributes."""
@@ -1365,8 +1363,7 @@ class CompoundLocation:
     def __iter__(self):
         """Iterate over the parent positions within the CompoundLocation object."""
         for loc in self.parts:
-            for pos in loc:
-                yield pos
+            yield from loc
 
     def __eq__(self, other):
         """Check if all parts of CompoundLocation are equal to all parts of other CompoundLocation."""

--- a/Bio/SeqIO/AbiIO.py
+++ b/Bio/SeqIO/AbiIO.py
@@ -375,7 +375,7 @@ def AbiIterator(handle, alphabet=None, trim=False):
             raise ValueError("Empty file.")
 
         if marker != b"ABIF":
-            raise IOError("File should start ABIF, not %r" % marker)
+            raise OSError("File should start ABIF, not %r" % marker)
 
         # dirty hack for handling time information
         times = {"RUND1": "", "RUND2": "", "RUNT1": "", "RUNT2": ""}

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -902,15 +902,15 @@ class GenBankWriter(_InsdcWriter):
                     padding = len(subkey) if len(subkey) > padding else padding
             # Construct output
             for key, data in comment.items():
-                lines.append("##{0}{1}".format(key, self.STRUCTURED_COMMENT_START))
+                lines.append("##{}{}".format(key, self.STRUCTURED_COMMENT_START))
                 for subkey, subdata in data.items():
                     spaces = " " * (padding - len(subkey))
                     lines.append(
-                        "{0}{1}{2}{3}".format(
+                        "{}{}{}{}".format(
                             subkey, spaces, self.STRUCTURED_COMMENT_DELIM, subdata
                         )
                     )
-                lines.append("##{0}{1}".format(key, self.STRUCTURED_COMMENT_END))
+                lines.append("##{}{}".format(key, self.STRUCTURED_COMMENT_END))
         if "comment" in record.annotations:
             comment = record.annotations["comment"]
             if isinstance(comment, str):
@@ -1142,7 +1142,7 @@ class EmblWriter(_InsdcWriter):
                 index = (
                     self.LETTERS_PER_LINE * line_number + self.LETTERS_PER_BLOCK * block
                 )
-                handle.write((" %s" % data[index : index + self.LETTERS_PER_BLOCK]))
+                handle.write(" %s" % data[index : index + self.LETTERS_PER_BLOCK])
             handle.write(
                 str((line_number + 1) * self.LETTERS_PER_LINE).rjust(
                     self.POSITION_PADDING

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -520,8 +520,7 @@ def CifAtomIterator(handle):
 
     buffer.seek(0)
     struct = MMCIFParser().get_structure(pdb_id, buffer)
-    for record in AtomIterator(pdb_id, struct):
-        yield record
+    yield from AtomIterator(pdb_id, struct)
 
 
 if __name__ == "__main__":

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -528,7 +528,7 @@ class Parser:
                     self.ParsedSeqRecord.annotations["sequence_%s" % k] = int(v)
                 else:
                     self.ParsedSeqRecord.annotations["sequence_%s" % k] = v
-            seq = "".join((element.text.split()))
+            seq = "".join(element.text.split())
             self.ParsedSeqRecord.seq = Seq.Seq(seq, self.alphabet)
 
         # ============================================#

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -83,7 +83,7 @@ class _RestrictedDict(dict):
         ):
             raise TypeError(
                 "We only allow python sequences (lists, tuples or "
-                "strings) of length {0}.".format(self._length)
+                "strings) of length {}.".format(self._length)
             )
         dict.__setitem__(self, key, value)
 
@@ -636,16 +636,16 @@ class SeqRecord:
         """
         lines = []
         if self.id:
-            lines.append("ID: {0}".format(self.id))
+            lines.append("ID: {}".format(self.id))
         if self.name:
-            lines.append("Name: {0}".format(self.name))
+            lines.append("Name: {}".format(self.name))
         if self.description:
-            lines.append("Description: {0}".format(self.description))
+            lines.append("Description: {}".format(self.description))
         if self.dbxrefs:
             lines.append("Database cross-references: " + ", ".join(self.dbxrefs))
-        lines.append("Number of features: {0}".format(len(self.features)))
+        lines.append("Number of features: {}".format(len(self.features)))
         for a in self.annotations:
-            lines.append("/{0}={1}".format(a, str(self.annotations[a])))
+            lines.append("/{}={}".format(a, str(self.annotations[a])))
         if self.letter_annotations:
             lines.append(
                 "Per letter annotation for: " + ", ".join(self.letter_annotations)
@@ -684,7 +684,7 @@ class SeqRecord:
         annotations, letter_annotations and features are not shown (as they
         would lead to a very long string).
         """
-        return "{0}(seq={1!r}, id={2!r}, name={3!r}, description={4!r}, dbxrefs={5!r})".format(
+        return "{}(seq={!r}, id={!r}, name={!r}, description={!r}, dbxrefs={!r})".format(
             self.__class__.__name__,
             self.seq,
             self.id,

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -1127,7 +1127,7 @@ def Tm_staluc(s, dnac=50, saltc=50, rna=0):
     elif rna == 1:
         return Tm_NN(s, dnac1=dnac / 2.0, dnac2=dnac / 2.0, Na=saltc, nn_table=RNA_NN2)
     else:
-        raise ValueError("rna={0} not supported".format(rna))
+        raise ValueError("rna={} not supported".format(rna))
 
 
 if __name__ == "__main__":

--- a/Bio/UniProt/GOA.py
+++ b/Bio/UniProt/GOA.py
@@ -184,7 +184,7 @@ def gpi_iterator(handle):
         # return _gpi20iterator(handle)
         raise NotImplementedError("Sorry, parsing GPI version 2 not implemented yet.")
     else:
-        raise ValueError("Unknown GPI version {0}\n".format(inline))
+        raise ValueError("Unknown GPI version {}\n".format(inline))
 
 
 def _gpa10iterator(handle):
@@ -242,7 +242,7 @@ def gpa_iterator(handle):
         # sys.stderr.write("gpa 1.0\n")
         return _gpa10iterator(handle)
     else:
-        raise ValueError("Unknown GPA version {0}\n".format(inline))
+        raise ValueError("Unknown GPA version {}\n".format(inline))
 
 
 def _gaf20iterator(handle):
@@ -347,7 +347,7 @@ def gafbyproteiniterator(handle):
         # sys.stderr.write("gaf 2.1\n")
         return _gaf20byproteiniterator(handle)
     else:
-        raise ValueError("Unknown GAF version {0}\n".format(inline))
+        raise ValueError("Unknown GAF version {}\n".format(inline))
 
 
 def gafiterator(handle):
@@ -399,7 +399,7 @@ def gafiterator(handle):
         # sys.stderr.write("gaf 1.0\n")
         return _gaf10iterator(handle)
     else:
-        raise ValueError("Unknown GAF version {0}\n".format(inline))
+        raise ValueError("Unknown GAF version {}\n".format(inline))
 
 
 def writerec(outrec, handle, fields=GAF20FIELDS):

--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -558,7 +558,7 @@ def _get_codon_rec(pro, nucl, span_mode, alphabet, gap_char="-",
                     warnings.warn("start codon of {} ({} {}) does not "
                                   "correspond to {} "
                                   "({})".format(pro.id, aa, aa_num,
-                                                 nucl.id, this_codon),
+                                                nucl.id, this_codon),
                                   BiopythonWarning)
                 if max_score == 0:
                     raise RuntimeError("max_score reached for {}! Please "

--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -86,8 +86,8 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char="-", unknown="X",
         nucl_num = len(nucl_seqs)
         if pro_num > nucl_num:
             raise ValueError("Higher Number of SeqRecords in Protein Alignment "
-                             "({0}) than the Number of Nucleotide SeqRecords "
-                             "({1}) are found!".format(pro_num, nucl_num))
+                             "({}) than the Number of Nucleotide SeqRecords "
+                             "({}) are found!".format(pro_num, nucl_num))
 
         # Determine the protein sequences and nucl sequences
         # correspondence. If nucl_seqs is a list, tuple or read by
@@ -121,9 +121,9 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char="-", unknown="X",
                                 "Nucleotide Records!")
             corr_method = 2
         else:
-            raise RuntimeError("Number of items in corr_dict ({0}) is less "
+            raise RuntimeError("Number of items in corr_dict ({}) is less "
                                "than number of protein records "
-                               "({1})".format(len(corr_dict), pro_num))
+                               "({})".format(len(corr_dict), pro_num))
 
     # set up pro-nucl correspondence based on corr_method
     # corr_method = 0, consecutive pairing
@@ -136,7 +136,7 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char="-", unknown="X",
         # check if there is pro_id that does not have a nucleotide match
         if pro_id - nucl_id:
             diff = pro_id - nucl_id
-            raise ValueError("Protein Record {0} cannot find a nucleotide "
+            raise ValueError("Protein Record {} cannot find a nucleotide "
                              "sequence match, please check the "
                              "id".format(", ".join(diff)))
         else:
@@ -164,7 +164,7 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char="-", unknown="X",
                                 complete_protein=complete_protein,
                                 anchor_len=anchor_len)
         if not corr_span:
-            raise ValueError("Protein Record {0} and Nucleotide Record {1} do"
+            raise ValueError("Protein Record {} and Nucleotide Record {} do"
                              " not match!".format(pair[0].id, pair[1].id))
         else:
             codon_rec = _get_codon_rec(pair[0], pair[1], corr_span,
@@ -248,7 +248,7 @@ def _check_corr(pro, nucl, gap_char="-", codon_table=default_codon_table,
     if not isinstance(_get_base_alphabet(get_alpha(nucl.seq.alphabet)),
                       NucleotideAlphabet):
         raise TypeError("Alphabet for nucl should be an instance of "
-                        "NucleotideAlphabet, {0} "
+                        "NucleotideAlphabet, {} "
                         "detected".format(str(nucl.seq.alphabet)))
 
     aa2re = _get_aa_regex(codon_table)
@@ -355,7 +355,7 @@ def _check_corr(pro, nucl, gap_char="-", codon_table=default_codon_table,
                         break
                 if qcodon == -1:
                     warnings.warn("first frameshift detection failed for "
-                                  "{0}".format(nucl.id), BiopythonWarning)
+                                  "{}".format(nucl.id), BiopythonWarning)
             # check anchors in the middle
             for i in range(len(anchor_pos) - 1):
                 shift_val = (anchor_pos[i + 1][0] - anchor_pos[i][0]) % \
@@ -374,7 +374,7 @@ def _check_corr(pro, nucl, gap_char="-", codon_table=default_codon_table,
                     qcodon = None
                 elif qcodon == -1:
                     warnings.warn("middle frameshift detection failed for "
-                                  "{0}".format(nucl.id), BiopythonWarning)
+                                  "{}".format(nucl.id), BiopythonWarning)
             # check the last anchor
             if anchor_pos[-1][2] + 1 == len(anchors) - 1:
                 sh_anc = anchors[-1]
@@ -405,15 +405,15 @@ def _check_corr(pro, nucl, gap_char="-", codon_table=default_codon_table,
                         break
                 if qcodon == -1:
                     warnings.warn("last frameshift detection failed for "
-                                  "{0}".format(nucl.id), BiopythonWarning)
+                                  "{}".format(nucl.id), BiopythonWarning)
             # try global match
             full_pro_re = "".join(pro_re)
             match = re.search(full_pro_re, nucl_seq)
             if match:
                 return (match.span(), 2, match)
             else:
-                raise RuntimeError("Protein SeqRecord ({0}) and Nucleotide "
-                                   "SeqRecord ({1}) do not "
+                raise RuntimeError("Protein SeqRecord ({}) and Nucleotide "
+                                   "SeqRecord ({}) do not "
                                    "match!".format(pro.id, nucl.id))
 
 
@@ -544,7 +544,7 @@ def _get_codon_rec(pro, nucl, span_mode, alphabet, gap_char="-",
     aa2re = _get_aa_regex(codon_table)
     if mode in (0, 1):
         if len(pro.seq.ungap(gap_char)) * 3 != (span[1] - span[0]):
-            raise ValueError("Protein Record {0} and Nucleotide Record {1} "
+            raise ValueError("Protein Record {} and Nucleotide Record {} "
                              "do not match!".format(pro.id, nucl.id))
         aa_num = 0
         for aa in pro.seq:
@@ -555,13 +555,13 @@ def _get_codon_rec(pro, nucl, span_mode, alphabet, gap_char="-",
                 if not re.search(_codons2re[codon_table.start_codons],
                                  this_codon.upper()):
                     max_score -= 1
-                    warnings.warn("start codon of {0} ({1} {2}) does not "
-                                  "correspond to {3} "
-                                  "({4})".format(pro.id, aa, aa_num,
+                    warnings.warn("start codon of {} ({} {}) does not "
+                                  "correspond to {} "
+                                  "({})".format(pro.id, aa, aa_num,
                                                  nucl.id, this_codon),
                                   BiopythonWarning)
                 if max_score == 0:
-                    raise RuntimeError("max_score reached for {0}! Please "
+                    raise RuntimeError("max_score reached for {}! Please "
                                        "raise up the tolerance to get an "
                                        "alignment in anyway".format(nucl.id))
                 codon_seq += this_codon
@@ -575,7 +575,7 @@ def _get_codon_rec(pro, nucl, span_mode, alphabet, gap_char="-",
                                   % (pro.id, aa, aa_num, nucl.id, this_codon),
                                   BiopythonWarning)
                 if max_score == 0:
-                    raise RuntimeError("max_score reached for {0}! Please "
+                    raise RuntimeError("max_score reached for {}! Please "
                                        "raise up the tolerance to get an "
                                        "alignment in anyway".format(nucl.id))
                 codon_seq += this_codon
@@ -618,8 +618,8 @@ def _get_codon_rec(pro, nucl, span_mode, alphabet, gap_char="-",
                 if not re.search(_codons2re[codon_table.start_codons],
                                  this_codon.upper()):
                     max_score -= 1
-                    warnings.warn("start codon of {0}({1} {2}) does not "
-                                  "correspond to {3}({4})".format(
+                    warnings.warn("start codon of {}({} {}) does not "
+                                  "correspond to {}({})".format(
                                       pro.id, aa, aa_num, nucl.id, this_codon),
                                   BiopythonWarning)
                     codon_seq += this_codon
@@ -646,13 +646,13 @@ def _get_codon_rec(pro, nucl, span_mode, alphabet, gap_char="-",
                     this_codon = nucl_seq._data[start:end]
                     if not str(Seq(this_codon.upper()).translate(table=codon_table)) == aa:
                         max_score -= 1
-                        warnings.warn("Codon of {0}({1} {2}) does not "
-                                      "correspond to {3}({4})".format(
+                        warnings.warn("Codon of {}({} {}) does not "
+                                      "correspond to {}({})".format(
                                           pro.id, aa, aa_num, nucl.id,
                                           this_codon),
                                       BiopythonWarning)
                 if max_score == 0:
-                    raise RuntimeError("max_score reached for {0}! Please "
+                    raise RuntimeError("max_score reached for {}! Please "
                                        "raise up the tolerance to get an "
                                        "alignment in anyway".format(nucl.id))
                 codon_seq += this_codon

--- a/Bio/codonalign/codonalignment.py
+++ b/Bio/codonalign/codonalignment.py
@@ -194,7 +194,7 @@ class CodonAlignment(MultipleSeqAlignment):
             dn_tree = dn_constructor.nj(dn_dm)
             ds_tree = ds_constructor.nj(ds_dm)
         else:
-            raise RuntimeError("Unknown tree method ({0}). Only NJ and UPGMA "
+            raise RuntimeError("Unknown tree method ({}). Only NJ and UPGMA "
                                "are accepted.".format(tree_method))
         return dn_tree, ds_tree
 

--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -87,7 +87,7 @@ class CodonSeq(Seq):
             for i in self.rf_table:
                 if self._data[i:i + 3] not in alphabet.letters:
                     raise ValueError("Sequence contain codon not in the alphabet "
-                                     "({0})! ".format(self._data[i:i + 3]))
+                                     "({})! ".format(self._data[i:i + 3]))
         else:
             # if gap_char in self._data:
             #    assert  len(self) % 3 == 0, \
@@ -103,7 +103,7 @@ class CodonSeq(Seq):
                 if seq_ungapped[i:i + 3] not in alphabet.letters:
                     raise ValueError("Sequence contain undefined letters "
                                      "from alphabet "
-                                     "({0})!".format(seq_ungapped[i:i + 3]))
+                                     "({})!".format(seq_ungapped[i:i + 3]))
             self.rf_table = rf_table
 
     def __getitem__(self, index):
@@ -188,7 +188,7 @@ class CodonSeq(Seq):
             try:
                 amino_acids.append(codon_table.forward_table[codon])
             except KeyError:
-                raise RuntimeError("Unknown codon detected ({0}). Did you "
+                raise RuntimeError("Unknown codon detected ({}). Did you "
                                    "forget to specify the ungap_seq "
                                    "argument?".format(codon))
         return "".join(amino_acids)
@@ -333,7 +333,7 @@ def cal_dn_ds(codon_seq1, codon_seq2, method="NG86",
                         "that contains CodonSeq as its seq!")
     if len(codon_seq1.get_full_rf_table()) != \
             len(codon_seq2.get_full_rf_table()):
-        raise RuntimeError("full_rf_table length of seq1 ({0}) and seq2 ({1}) "
+        raise RuntimeError("full_rf_table length of seq1 ({}) and seq2 ({}) "
                            "are not the same".format(
                                len(codon_seq1.get_full_rf_table()),
                                len(codon_seq2.get_full_rf_table()))
@@ -345,7 +345,7 @@ def cal_dn_ds(codon_seq1, codon_seq2, method="NG86",
                            "are using ML method")
     if cfreq not in ("F1x4", "F3x4", "F61"):
         import warnings
-        warnings.warn("Unknown cfreq ({0}). Only F1x4, F3x4 and F61 are "
+        warnings.warn("Unknown cfreq ({}). Only F1x4, F3x4 and F61 are "
                       "acceptable. Use F3x4 in the following.".format(cfreq))
         cfreq = "F3x4"
     seq1_codon_lst = _get_codon_list(codon_seq1)
@@ -464,21 +464,21 @@ def _count_diff_NG86(codon1, codon2, codon_table=default_codon_table):
     """
     if not isinstance(codon1, str) or not isinstance(codon2, str):
         raise TypeError("_count_diff_NG86 accepts string object "
-                        "to represent codon ({0}, {1} "
+                        "to represent codon ({}, {} "
                         "detected)".format(type(codon1), type(codon2)))
     if len(codon1) != 3 or len(codon2) != 3:
-        raise RuntimeError("codon should be three letter string ({0}, {1} "
+        raise RuntimeError("codon should be three letter string ({}, {} "
                            "detected)".format(len(codon1), len(codon2)))
     SN = [0, 0]  # synonymous and nonsynonymous counts
     if codon1 == "---" or codon2 == "---":
         return SN
     base_tuple = ("A", "C", "G", "T")
     if not all(i in base_tuple for i in codon1):
-        raise RuntimeError("Unrecognized character detected in codon1 {0} "
+        raise RuntimeError("Unrecognized character detected in codon1 {} "
                            "(Codons consist of "
                            "A, T, C or G)".format(codon1))
     if not all(i in base_tuple for i in codon2):
-        raise RuntimeError("Unrecognized character detected in codon2 {0} "
+        raise RuntimeError("Unrecognized character detected in codon2 {} "
                            "(Codons consist of "
                            "A, T, C or G)".format(codon2))
     if codon1 == codon2:
@@ -904,10 +904,10 @@ def _count_diff_YN00(codon1, codon2, P, codon_lst,
     """
     if not isinstance(codon1, str) or not isinstance(codon2, str):
         raise TypeError("_count_diff_YN00 accepts string object "
-                        "to represent codon ({0}, {1} "
+                        "to represent codon ({}, {} "
                         "detected)".format(type(codon1), type(codon2)))
     if len(codon1) != 3 or len(codon2) != 3:
-        raise RuntimeError("codon should be three letter string ({0}, {1} "
+        raise RuntimeError("codon should be three letter string ({}, {} "
                            "detected)".format(len(codon1), len(codon2)))
     TV = [0, 0, 0, 0]  # transition and transversion counts (synonymous and nonsynonymous)
     site = 0
@@ -915,11 +915,11 @@ def _count_diff_YN00(codon1, codon2, P, codon_lst,
         return TV
     base_tuple = ("A", "C", "G", "T")
     if not all(i in base_tuple for i in codon1):
-        raise RuntimeError("Unrecognized character detected in codon1 {0} "
+        raise RuntimeError("Unrecognized character detected in codon1 {} "
                            "(Codons consist of "
                            "A, T, C or G)".format(codon1))
     if not all(i in base_tuple for i in codon2):
-        raise RuntimeError("Unrecognized character detected in codon2 {0} "
+        raise RuntimeError("Unrecognized character detected in codon2 {} "
                            "(Codons consist of "
                            "A, T, C or G)".format(codon2))
     if codon1 == codon2:

--- a/Bio/motifs/clusterbuster.py
+++ b/Bio/motifs/clusterbuster.py
@@ -63,10 +63,10 @@ def write(motifs):
     """Return the representation of motifs in Cluster Buster position frequency matrix format."""
     lines = []
     for m in motifs:
-        line = ">{0}\n".format(m.name)
+        line = ">{}\n".format(m.name)
         lines.append(line)
         for ACGT_counts in zip(m.counts["A"], m.counts["C"], m.counts["G"], m.counts["T"]):
-            lines.append("{0:0.0f}\t{1:0.0f}\t{2:0.0f}\t{3:0.0f}\n".format(*ACGT_counts))
+            lines.append("{:0.0f}\t{:0.0f}\t{:0.0f}\t{:0.0f}\n".format(*ACGT_counts))
 
     # Finished; glue the lines together.
     text = "".join(lines)

--- a/Bio/motifs/jaspar/__init__.py
+++ b/Bio/motifs/jaspar/__init__.py
@@ -59,40 +59,40 @@ class Motif(motifs.Motif):
 
         We choose to provide only the filled metadata information.
         """
-        tf_name_str = "TF name\t{0}\n".format(self.name)
-        matrix_id_str = "Matrix ID\t{0}\n".format(self.matrix_id)
+        tf_name_str = "TF name\t{}\n".format(self.name)
+        matrix_id_str = "Matrix ID\t{}\n".format(self.matrix_id)
         the_string = "".join([tf_name_str, matrix_id_str])
         if self.collection:
-            collection_str = "Collection\t{0}\n".format(self.collection)
+            collection_str = "Collection\t{}\n".format(self.collection)
             the_string = "".join([the_string, collection_str])
         if self.tf_class:
-            tf_class_str = "TF class\t{0}\n".format(self.tf_class)
+            tf_class_str = "TF class\t{}\n".format(self.tf_class)
             the_string = "".join([the_string, tf_class_str])
         if self.tf_family:
-            tf_family_str = "TF family\t{0}\n".format(self.tf_family)
+            tf_family_str = "TF family\t{}\n".format(self.tf_family)
             the_string = "".join([the_string, tf_family_str])
         if self.species:
-            species_str = "Species\t{0}\n".format(",".join(self.species))
+            species_str = "Species\t{}\n".format(",".join(self.species))
             the_string = "".join([the_string, species_str])
         if self.tax_group:
-            tax_group_str = "Taxonomic group\t{0}\n".format(self.tax_group)
+            tax_group_str = "Taxonomic group\t{}\n".format(self.tax_group)
             the_string = "".join([the_string, tax_group_str])
         if self.acc:
-            acc_str = "Accession\t{0}\n".format(self.acc)
+            acc_str = "Accession\t{}\n".format(self.acc)
             the_string = "".join([the_string, acc_str])
         if self.data_type:
-            data_type_str = "Data type used\t{0}\n".format(self.data_type)
+            data_type_str = "Data type used\t{}\n".format(self.data_type)
             the_string = "".join([the_string, data_type_str])
         if self.medline:
-            medline_str = "Medline\t{0}\n".format(self.medline)
+            medline_str = "Medline\t{}\n".format(self.medline)
             the_string = "".join([the_string, medline_str])
         if self.pazar_id:
-            pazar_id_str = "PAZAR ID\t{0}\n".format(self.pazar_id)
+            pazar_id_str = "PAZAR ID\t{}\n".format(self.pazar_id)
             the_string = "".join([the_string, pazar_id_str])
         if self.comment:
-            comment_str = "Comments\t{0}\n".format(self.comment)
+            comment_str = "Comments\t{}\n".format(self.comment)
             the_string = "".join([the_string, comment_str])
-        matrix_str = "Matrix:\n{0}\n\n".format(self.counts)
+        matrix_str = "Matrix:\n{}\n\n".format(self.counts)
         the_string = "".join([the_string, matrix_str])
         return the_string
 
@@ -161,8 +161,8 @@ def write(motifs, format):
         motif = motifs[0]
         counts = motif.counts
         for letter in letters:
-            terms = ["{0:6.2f}".format(value) for value in counts[letter]]
-            line = "{0}\n".format(" ".join(terms))
+            terms = ["{:6.2f}".format(value) for value in counts[letter]]
+            line = "{}\n".format(" ".join(terms))
             lines.append(line)
     elif format == "jaspar":
         for m in motifs:
@@ -171,11 +171,11 @@ def write(motifs, format):
                 matrix_id = m.matrix_id
             except AttributeError:
                 matrix_id = None
-            line = ">{0} {1}\n".format(matrix_id, m.name)
+            line = ">{} {}\n".format(matrix_id, m.name)
             lines.append(line)
             for letter in letters:
-                terms = ["{0:6.2f}".format(value) for value in counts[letter]]
-                line = "{0} [{1}]\n".format(letter, " ".join(terms))
+                terms = ["{:6.2f}".format(value) for value in counts[letter]]
+                line = "{} [{}]\n".format(letter, " ".join(terms))
                 lines.append(line)
     else:
         raise ValueError("Unknown JASPAR format %s" % format)

--- a/Bio/motifs/jaspar/db.py
+++ b/Bio/motifs/jaspar/db.py
@@ -293,7 +293,7 @@ class JASPAR5:
             latest = row[0]
         else:
             warnings.warn("Failed to fetch latest version number for JASPAR "
-                          "motif with base ID '{0}'. "
+                          "motif with base ID '{}'. "
                           "No JASPAR motif with this base ID appears to exist "
                           "in the database.".format(base_id), BiopythonWarning)
 
@@ -315,7 +315,7 @@ class JASPAR5:
             int_id = row[0]
         else:
             warnings.warn("Failed to fetch internal database ID for JASPAR "
-                          "motif with matrix ID '{0}.{1}'. "
+                          "motif with matrix ID '{}.{}'. "
                           "No JASPAR motif with this matrix ID appears to "
                           "exist.".format(base_id, version), BiopythonWarning)
 
@@ -333,7 +333,7 @@ class JASPAR5:
         # we should probably raise an exception
         if not row:
             warnings.warn("Could not fetch JASPAR motif with internal "
-                          "ID = {0}".format(int_id), BiopythonWarning)
+                          "ID = {}".format(int_id), BiopythonWarning)
             return None
 
         base_id = row[0]

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -406,8 +406,7 @@ class PositionSpecificScoringMatrix(GenericPositionMatrix):
             order = np.argsort(np.append(pos_positions, neg_positions))
             chunk_positions = chunk_positions[order]
             chunk_scores = chunk_scores[order]
-            for pos, score in zip(chunk_positions, chunk_scores):
-                yield pos, score
+            yield from zip(chunk_positions, chunk_scores)
 
     @property
     def max(self):

--- a/Bio/motifs/pfm.py
+++ b/Bio/motifs/pfm.py
@@ -386,10 +386,10 @@ def write(motifs):
     """Return the representation of motifs in Cluster Buster position frequency matrix format."""
     lines = []
     for m in motifs:
-        line = ">{0}\n".format(m.name)
+        line = ">{}\n".format(m.name)
         lines.append(line)
         for ACGT_counts in zip(m.counts["A"], m.counts["C"], m.counts["G"], m.counts["T"]):
-            lines.append("{0:0.0f}\t{1:0.0f}\t{2:0.0f}\t{3:0.0f}\n".format(*ACGT_counts))
+            lines.append("{:0.0f}\t{:0.0f}\t{:0.0f}\t{:0.0f}\n".format(*ACGT_counts))
 
     # Finished; glue the lines together.
     text = "".join(lines)

--- a/Bio/motifs/transfac.py
+++ b/Bio/motifs/transfac.py
@@ -103,14 +103,14 @@ def read(handle, strict=True):
             if len(key) != 2:
                 raise ValueError("The key value of a TRANSFAC motif line "
                                  "should have 2 characters: "
-                                 '"{0:s}"'.format(line))
+                                 '"{:s}"'.format(line))
         if len(key_value) == 2:
             value = key_value[1].strip()
             if strict:
                 if not line.partition("  ")[1]:
                     raise ValueError("A TRANSFAC motif line should have 2 "
                                      "spaces between key and value columns: "
-                                     '"{0:s}"'.format(line))
+                                     '"{:s}"'.format(line))
         if key == "VV":
             record.version = value
         elif key in ("P0", "PO"):  # Old TRANSFAC files use PO instead of P0
@@ -133,7 +133,7 @@ def read(handle, strict=True):
                             raise ValueError("A TRANSFAC motif line should "
                                              "have 2 spaces between key and "
                                              "value columns: "
-                                             '"{0:s}"'.format(line))
+                                             '"{:s}"'.format(line))
                 try:
                     i = int(key)
                 except ValueError:
@@ -143,13 +143,13 @@ def read(handle, strict=True):
                         raise ValueError("A TRANSFAC matrix should start with "
                                          '"01" as first row of the matrix, '
                                          'but this matrix uses "00": '
-                                         '"{0:s}"'.format(line))
+                                         '"{:s}"'.format(line))
                 else:
                     length += 1
                 if i != length:
                     raise ValueError("The TRANSFAC matrix row number does not "
                                      "match the position in the matrix: "
-                                     '"{0:s}"'.format(line))
+                                     '"{:s}"'.format(line))
                 if strict:
                     if len(key) == 1:
                         raise ValueError("A TRANSFAC matrix line should have a "
@@ -159,12 +159,12 @@ def read(handle, strict=True):
                     if len(key_value) != 2:
                         raise ValueError("A TRANSFAC matrix line should have "
                                          "a key and a value: "
-                                         '"{0:s}"'.format(line))
+                                         '"{:s}"'.format(line))
                 values = value.split()[:4]
                 if len(values) != 4:
                     raise ValueError("A TRANSFAC matrix line should have a "
                                      "value for each nucleotide "
-                                     '(A, C, G and T): "{0:s}"'.format(line))
+                                     '(A, C, G and T): "{:s}"'.format(line))
                 for c, v in zip("ACGT", values):
                     counts[c].append(float(v))
         if line == "XX":
@@ -181,9 +181,9 @@ def read(handle, strict=True):
                                  '"]": "{0:s}"'.format(index, line))
             index = int(index[1:-1])
             if len(references) != index - 1:
-                raise ValueError('The index "{0:d}" of the TRANSFAC RN line '
+                raise ValueError('The index "{:d}" of the TRANSFAC RN line '
                                  "does not match the current number of seen "
-                                 'references "{1:d}": "{2:s}"'.format(index, len(references) + 1, line))
+                                 'references "{:d}": "{:s}"'.format(index, len(references) + 1, line))
             reference = {key: value}
             references.append(reference)
         elif key == "//":

--- a/Bio/phenotype/__init__.py
+++ b/Bio/phenotype/__init__.py
@@ -187,8 +187,7 @@ def parse(handle, format):
         else:
             raise ValueError("Unknown format '%s'" % format)
         # This imposes some overhead... wait until we drop Python 2.4 to fix it
-        for r in i:
-            yield r
+        yield from i
 
 
 def read(handle, format):

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -463,9 +463,7 @@ class DictionaryBuilder:
             else:
                 enzlst = []
                 tydct = dict(typestuff.__dict__)
-                tydct = {  # noqa: C404
-                    k: v for k, v in tydct.items() if k in commonattr
-                }
+                tydct = {k: v for k, v in tydct.items() if k in commonattr}
                 enzlst.append(name)
                 typedict[typename] = (bases, enzlst)
             for letter in cls.__dict__["suppl"]:

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -354,7 +354,7 @@ class TypeCompiler:
                     return type.__new__(cls, "type%i" % n, ty, dct)
 
                 def __init__(cls):
-                    super(klass, cls).__init__("type%i" % n, ty, dct)
+                    super().__init__("type%i" % n, ty, dct)
 
             yield klass()
             n += 1
@@ -463,9 +463,9 @@ class DictionaryBuilder:
             else:
                 enzlst = []
                 tydct = dict(typestuff.__dict__)
-                tydct = dict(  # noqa: C404
-                    [(k, v) for k, v in tydct.items() if k in commonattr]
-                )
+                tydct = {  # noqa: C404
+                    k: v for k, v in tydct.items() if k in commonattr
+                }
                 enzlst.append(name)
                 typedict[typename] = (bases, enzlst)
             for letter in cls.__dict__["suppl"]:
@@ -577,7 +577,7 @@ class DictionaryBuilder:
                 "\n\t the name Restriction_Dictionary.old."
             )
             print("\n " + "*" * 78 + " \n")
-        except IOError:
+        except OSError:
             print("\n " + "*" * 78 + " \n")
             print(
                 "\n\t WARNING : Impossible to install the new dictionary."

--- a/Scripts/Restriction/rebase_update.py
+++ b/Scripts/Restriction/rebase_update.py
@@ -46,7 +46,7 @@ def get_files():
         try:
             urlretrieve(file, filename)
             urlcleanup()
-        except IOError as e:
+        except OSError as e:
             print(e)
             print(
                 "Download of Rebase files failed. Please download the files "

--- a/Scripts/scop_pdb.py
+++ b/Scripts/scop_pdb.py
@@ -157,7 +157,7 @@ def main():
                         seqMap.getAtoms(f, out_handle)
                     finally:
                         f.close()
-                except (IOError, KeyError, RuntimeError) as e:
+                except (OSError, KeyError, RuntimeError) as e:
                     sys.stderr.write("I cannot do SCOP domain %s : %s\n" % (id, e))
             finally:
                 out_handle.close()

--- a/Scripts/xbbtools/nextorf.py
+++ b/Scripts/xbbtools/nextorf.py
@@ -186,7 +186,7 @@ class NextOrf:
                             start_site = start_site + f - 1
                         if codon == "XXX":
                             stop = start_site + 3 * (
-                                (int((stop - 1) - start_site) // 3)
+                                int((stop - 1) - start_site) // 3
                             )
                         s = seq[start_site - 1 : stop]
                         CDS.append((start_site, stop, length, s, strand * f))

--- a/Tests/PAML/gen_results.py
+++ b/Tests/PAML/gen_results.py
@@ -48,7 +48,7 @@ def codeml(vers=None, verbose=False):
             # M2a_rel (NSsites 22) was introduced in PAML 4.6
             if test[0] == "m2a_rel" and int(version.split("_")[1][0]) < 6:
                 continue
-            print("\t{0}".format(version.replace("_", ".")))
+            print("\t{}".format(version.replace("_", ".")))
             if test[0] in ["ngene2_mgene02", "ngene2_mgene34"] and \
                version == "4_6":
                 cml.tree = ".".join([cml.tree, "4.6"])
@@ -72,36 +72,36 @@ def baseml(vers=None, verbose=False):
         print(test[0])
         bml = baseml.Baseml()
         for version in versions:
-            print("\t{0}".format(version.replace("_", ".")))
+            print("\t{}".format(version.replace("_", ".")))
             if test[1] is not None:
                 for n in test[1]:
                     if (version in ["4_3", "4_4", "4_4c", "4_5"] and
                             test[0] == "nparK" and n in [3, 4]):
                         continue
-                    print("\t\tn = {0}".format(n))
+                    print("\t\tn = {}".format(n))
                     ctl_file = (os.path.join("Control_files", "baseml",
-                                "{0}{1}.ctl".format(test[0], n)))
+                                "{}{}.ctl".format(test[0], n)))
                     bml.read_ctl_file(ctl_file)
                     bml.alignment = alignment
                     bml.tree = tree
-                    out_file = "{0}{1}-{2}.out".format(test[0], n, version)
+                    out_file = "{}{}-{}.out".format(test[0], n, version)
                     bml.out_file = (os.path.join("Results", "baseml", test[0],
                                     out_file))
-                    bin = "baseml{0}".format(version)
+                    bin = "baseml{}".format(version)
                     bml.run(command=bin, verbose=verbose, parse=False)
             else:
                 if (version in ["4_3", "4_4", "4_4c", "4_5"] and
                         test[0] == "alpha1rho1"):
                     continue
                 ctl_file = (os.path.join("Control_files", "baseml",
-                            "{0}.ctl".format(test[0])))
+                            "{}.ctl".format(test[0])))
                 bml.read_ctl_file(ctl_file)
                 bml.alignment = alignment
                 bml.tree = tree
-                out_file = "{0}-{1}.out".format(test[0], version)
+                out_file = "{}-{}.out".format(test[0], version)
                 bml.out_file = (os.path.join("Results", "baseml", test[0],
                                 out_file))
-                bin = "baseml{0}".format(version)
+                bin = "baseml{}".format(version)
                 bml.run(command=bin, verbose=verbose, parse=False)
 
 
@@ -116,13 +116,13 @@ def yn00(vers=None, verbose=False):
         print(test)
         yn = yn00.Yn00()
         for version in versions:
-            print("\t{0}".format(version.replace("_", ".")))
+            print("\t{}".format(version.replace("_", ".")))
             ctl_file = (os.path.join("Control_files", "yn00",
-                        "{0}.ctl".format(test)))
+                        "{}.ctl".format(test)))
             yn.read_ctl_file(ctl_file)
-            out_file = "{0}-{1}.out".format(test, version)
+            out_file = "{}-{}.out".format(test, version)
             yn.out_file = os.path.join("Results", "yn00", out_file)
-            bin = "yn00{0}".format(version)
+            bin = "yn00{}".format(version)
             yn.run(command=bin, verbose=verbose, parse=False)
 
 

--- a/Tests/test_GenomeDiagram.py
+++ b/Tests/test_GenomeDiagram.py
@@ -306,7 +306,7 @@ class LabelTest(unittest.TestCase):
                 # Originally <type 'exceptions.TypeError'>: makeT1Font() argument 2
                 # must be string, not None
                 renderPM = None
-            except IOError:
+            except OSError:
                 # Probably a library problem, e.g.
                 # IOError: encoder zip not available
                 renderPM = None

--- a/Tests/test_GraphicsBitmaps.py
+++ b/Tests/test_GraphicsBitmaps.py
@@ -89,7 +89,7 @@ def real_test():
     # error here.
     except IndexError:
         pass
-    except IOError as err:
+    except OSError as err:
         if "encoder zip not available" in str(err):
             raise MissingExternalDependencyError(
                 "Check zip encoder installed for PIL and ReportLab renderPM")

--- a/Tests/test_SearchIO_blast_xml.py
+++ b/Tests/test_SearchIO_blast_xml.py
@@ -3210,8 +3210,8 @@ class BlastXmlSpecialCases(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", BiopythonParserWarning)
             qresult = next(qresults)
-            self.assertEqual(exp_warning, len(w), "Expected {0} warning(s), got"
-                             " {1}".format(exp_warning, len(w)))
+            self.assertEqual(exp_warning, len(w), "Expected {} warning(s), got"
+                             " {}".format(exp_warning, len(w)))
 
         self.assertEqual(qresult.blast_id, "Query_1")
         hit1 = qresult[0]
@@ -3231,8 +3231,8 @@ class BlastXmlSpecialCases(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", BiopythonParserWarning)
             qresult = next(qresults)
-            self.assertEqual(exp_warning, len(w), "Expected {0} warning(s), got"
-                             " {1}".format(exp_warning, len(w)))
+            self.assertEqual(exp_warning, len(w), "Expected {} warning(s), got"
+                             " {}".format(exp_warning, len(w)))
 
         self.assertEqual(qresult.blast_id, "Query_1")
         hit1 = qresult[0]
@@ -3252,8 +3252,8 @@ class BlastXmlSpecialCases(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", BiopythonParserWarning)
             qresult = next(qresults)
-            self.assertEqual(exp_warning, len(w), "Expected {0} warning(s), got"
-                             " {1}".format(exp_warning, len(w)))
+            self.assertEqual(exp_warning, len(w), "Expected {} warning(s), got"
+                             " {}".format(exp_warning, len(w)))
 
         self.assertEqual(qresult.id, "Query_1")
         self.assertEqual(qresult.description, "gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds")

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -131,11 +131,7 @@ class TestZipped(unittest.TestCase):
 
     def test_gzip_fastq(self):
         """Testing FASTQ with gzip."""
-        if sys.version_info >= (3,):
-            mode = "rt"
-        else:
-            # Workaround for bug https://bugs.python.org/issue30012
-            mode = "r"  # implicitly text mode, rejects making explicit
+        mode = "rt"
         with gzip.open("Quality/example.fastq.gz", mode) as handle:
             self.assertEqual(3, len(list(SeqIO.parse(handle, "fastq"))))
         if 3 <= sys.version_info[0]:
@@ -147,11 +143,7 @@ class TestZipped(unittest.TestCase):
 
     def test_gzip_fasta(self):
         """Testing FASTA with gzip."""
-        if sys.version_info >= (3,):
-            mode = "rt"
-        else:
-            # Workaround for bug https://bugs.python.org/issue30012
-            mode = "r"  # implicitly text mode, rejects making explicit
+        mode = "rt"
         with gzip.open("Fasta/flowers.pro.gz", mode) as handle:
             self.assertEqual(3, len(list(SeqIO.parse(handle, "fasta"))))
         if 3 <= sys.version_info[0]:
@@ -164,11 +156,7 @@ class TestZipped(unittest.TestCase):
     def test_gzip_genbank(self):
         """Testing GenBank with gzip."""
         # BGZG files are still GZIP files
-        if sys.version_info >= (3,):
-            mode = "rt"
-        else:
-            # Workaround for bug https://bugs.python.org/issue30012
-            mode = "r"  # implicitly text mode, rejects making explicit
+        mode = "rt"
         with gzip.open("GenBank/cor6_6.gb.bgz", mode) as handle:
             self.assertEqual(6, len(list(SeqIO.parse(handle, "gb"))))
         if 3 <= sys.version_info[0]:

--- a/Tests/test_SeqIO_online.py
+++ b/Tests/test_SeqIO_online.py
@@ -45,7 +45,7 @@ class ExPASyTests(unittest.TestCase):
             # This is to catch an error page from our proxy
             if (str(e) == "Failed to find ID in first line" and
                     e.line.startswith("<!DOCTYPE HTML")):
-                raise IOError from None
+                raise OSError from None
         handle.close()
         self.assertEqual(record.id, identifier)
         self.assertEqual(len(record), 394)

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1,4 +1,3 @@
-
 # Copyright 2009 by Peter Cock.  All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -813,12 +813,12 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_complement(self):
         self.mutable_s.complement()
-        self.assertEqual(str("AGTTTTCCTACGTAGTAC"), str(self.mutable_s))
+        self.assertEqual("AGTTTTCCTACGTAGTAC", str(self.mutable_s))
 
     def test_complement_rna(self):
         seq = Seq.MutableSeq("AUGaaaCUG", IUPAC.unambiguous_rna)
         seq.complement()
-        self.assertEqual(str("UACuuuGAC"), str(seq))
+        self.assertEqual("UACuuuGAC", str(seq))
 
     def test_complement_mixed_aphabets(self):
         seq = Seq.MutableSeq("AUGaaaCTG")
@@ -933,7 +933,7 @@ class TestUnknownSeq(unittest.TestCase):
 
     def test_complement(self):
         self.s.complement()
-        self.assertEqual(str("??????"), str(self.s))
+        self.assertEqual("??????", str(self.s))
 
     def test_complement_of_protein(self):
         """Check reverse complement fails on a protein."""


### PR DESCRIPTION
See PR #2450 for background. Here I ran `pyupgrade --keep-percent-format --py3-plus` on the relevant `*py` files. This does not introduce f-strings since that would require the `--py36-plus` flag.

Note, the changes include python 3 changes (e.g. `yield from`,  or `IOError` merged into `OSError ` etc.), but also other changes not related to the python version specifically like removing redundant parentheses and string formatting syntax. See [their github ](https://github.com/asottile/pyupgrade) for a full list of what is checked. Hopefully this is not too large to review

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
