### PR TITLE
Python 3 assumes UTF8, do not need coding line

### DIFF
--- a/Bio/Align/Applications/_ClustalOmega.py
+++ b/Bio/Align/Applications/_ClustalOmega.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011 by Andreas Wilm. All rights reserved.
 # Based on ClustalW wrapper copyright 2009 by Cymon J. Cox.
 #

--- a/Bio/motifs/applications/_xxmotif.py
+++ b/Bio/motifs/applications/_xxmotif.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2012 by Christian Brueffer.  All rights reserved.
 #
 # This code is part of the Biopython distribution and governed by its

--- a/Doc/api/conf.py
+++ b/Doc/api/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """Biopython Sphinx documentation build configuration file.
 
 After generating ``*.rst`` files from the source code, this

--- a/Tests/test_Entrez_online.py
+++ b/Tests/test_Entrez_online.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2012 by Wibowo Arindrarto.  All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included

--- a/Tests/test_Entrez_parser.py
+++ b/Tests/test_Entrez_parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2008-2010 by Michiel de Hoon.  All rights reserved.
 # Revisions copyright 2009-2016 by Peter Cock. All rights reserved.
 # This code is part of the Biopython distribution and governed by its


### PR DESCRIPTION
Subset of #2450 or #2455, things that pyupgrade would fix

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Suggesting @mdehoon as reviewer given recent unicode work from him.

CC @chris-rands 