### PR TITLE
Use subprocess.getoutput instead of Bio._py3k

### DIFF
--- a/Bio/Wise/dnal.py
+++ b/Bio/Wise/dnal.py
@@ -19,7 +19,7 @@ Bio.Wise.dnal is for Smith-Waterman DNA alignments
 import re
 
 # Importing with leading underscore as not intended to be exposed
-from Bio._py3k import getoutput as _getoutput
+from subprocess import getoutput as _getoutput
 
 from Bio import Wise
 

--- a/Bio/_py3k/__init__.py
+++ b/Bio/_py3k/__init__.py
@@ -95,29 +95,3 @@ _universal_read_mode = "r"  # text mode does universal new lines
 from urllib.request import urlopen, Request, urlparse, urlcleanup
 from urllib.parse import urlencode, quote
 from urllib.error import URLError, HTTPError
-
-
-if sys.platform == "win32":
-    # Can't use commands.getoutput on Python 2, Unix only/broken:
-    # http://bugs.python.org/issue15073
-    # Can't use subprocess.getoutput on Python 3, Unix only/broken:
-    # http://bugs.python.org/issue10197
-    def getoutput(cmd):
-        import subprocess
-
-        child = subprocess.Popen(
-            cmd,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            universal_newlines=True,
-            shell=False,
-        )
-        stdout, stderr = child.communicate()
-        # Remove trailing \n to match the Unix function,
-        return stdout.rstrip("\n")
-
-
-else:
-    # Use subprocess.getoutput on Python 3,
-    from subprocess import getoutput

--- a/Tests/requires_wise.py
+++ b/Tests/requires_wise.py
@@ -10,7 +10,7 @@
 import sys
 
 from Bio import MissingExternalDependencyError
-from Bio._py3k import getoutput
+from subprocess import getoutput
 
 
 if sys.platform == "win32":

--- a/Tests/test_BWA_tool.py
+++ b/Tests/test_BWA_tool.py
@@ -49,9 +49,9 @@ else:
     # Since "not found" may be in another language, try and be sure this is
     # really the bwa tool's output
     bwa_found = False
-    if "not found" not in output and "bwa" in output \
-            and "alignment via Burrows-Wheeler transformation" in output:
-        bwa_exe = "bwa"
+    if "not found" not in output and "not recognized" not in output:
+        if "bwa" in output and "alignment via Burrows-Wheeler transformation" in output:
+            bwa_exe = "bwa"
     skip_aln_tests = False
     aln_output = getoutput("bwa aln")
     if "unrecognized" in aln_output:

--- a/Tests/test_BWA_tool.py
+++ b/Tests/test_BWA_tool.py
@@ -43,7 +43,7 @@ if sys.platform == "win32":
             if bwa_exe:
                 break
 else:
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     output = getoutput("bwa")
 
     # Since "not found" may be in another language, try and be sure this is

--- a/Tests/test_ClustalOmega_tool.py
+++ b/Tests/test_ClustalOmega_tool.py
@@ -11,7 +11,7 @@ import sys
 import os
 import unittest
 
-from Bio._py3k import getoutput
+from subprocess import getoutput
 
 from Bio import MissingExternalDependencyError
 from Bio import SeqIO

--- a/Tests/test_ClustalOmega_tool.py
+++ b/Tests/test_ClustalOmega_tool.py
@@ -29,8 +29,7 @@ try:
     output = getoutput("clustalo --help")
     if output.startswith("Clustal Omega"):
         clustalo_exe = "clustalo"
-except OSError:
-    # TODO: Use FileNotFoundError once we drop Python 2
+except FileNotFoundError:
     pass
 
 if not clustalo_exe:

--- a/Tests/test_Clustalw_tool.py
+++ b/Tests/test_Clustalw_tool.py
@@ -61,7 +61,7 @@ if sys.platform == "win32":
             if clustalw_exe:
                 break
 else:
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     # Note that clustalw 1.83 and clustalw 2.1 don't obey the --version
     # command, but this does cause them to quit cleanly.  Otherwise they prompt
     # the user for input (causing a lock up).

--- a/Tests/test_Clustalw_tool.py
+++ b/Tests/test_Clustalw_tool.py
@@ -68,14 +68,14 @@ else:
     output = getoutput("clustalw2 --version")
     # Since "not found" may be in another language, try and be sure this is
     # really the clustalw tool's output
-    if "not found" not in output and "CLUSTAL" in output \
-       and "Multiple Sequence Alignments" in output:
-        clustalw_exe = "clustalw2"
+    if "not found" not in output and "not recognized" not in output:
+        if "CLUSTAL" in output and "Multiple Sequence Alignments" in output:
+            clustalw_exe = "clustalw2"
     if not clustalw_exe:
         output = getoutput("clustalw --version")
-        if "not found" not in output and "CLUSTAL" in output \
-           and "Multiple Sequence Alignments" in output:
-            clustalw_exe = "clustalw"
+        if "not found" not in output and "not recognized" not in output:
+            if "CLUSTAL" in output and "Multiple Sequence Alignments" in output:
+                clustalw_exe = "clustalw"
 
 if not clustalw_exe:
     raise MissingExternalDependencyError(

--- a/Tests/test_Dialign_tool.py
+++ b/Tests/test_Dialign_tool.py
@@ -20,18 +20,19 @@ if sys.platform == "win32":
 else:
     from subprocess import getoutput
     output = getoutput("dialign2-2")
-    if "not found" not in output and "dialign2-2" in output.lower():
-        dialign_exe = "dialign2-2"
-        if "DIALIGN2_DIR" not in os.environ:
-            raise MissingExternalDependencyError(
-                "Environment variable DIALIGN2_DIR for DIALIGN2-2 missing.")
-        if not os.path.isdir(os.environ["DIALIGN2_DIR"]):
-            raise MissingExternalDependencyError(
-                "Environment variable DIALIGN2_DIR for DIALIGN2-2 is not a valid directory.")
-        if not os.path.isfile(os.path.join(os.environ["DIALIGN2_DIR"], "BLOSUM")):
-            raise MissingExternalDependencyError(
-                "Environment variable DIALIGN2_DIR directory missing BLOSUM file.")
-        # TODO - check for tp400_dna, tp400_prot and tp400_trans too?
+    if "not found" not in output and "not recognized" not in output:
+        if "dialign2-2" in output.lower():
+            dialign_exe = "dialign2-2"
+            if "DIALIGN2_DIR" not in os.environ:
+                raise MissingExternalDependencyError(
+                    "Environment variable DIALIGN2_DIR for DIALIGN2-2 missing.")
+            if not os.path.isdir(os.environ["DIALIGN2_DIR"]):
+                raise MissingExternalDependencyError(
+                    "Environment variable DIALIGN2_DIR for DIALIGN2-2 is not a valid directory.")
+            if not os.path.isfile(os.path.join(os.environ["DIALIGN2_DIR"], "BLOSUM")):
+                raise MissingExternalDependencyError(
+                    "Environment variable DIALIGN2_DIR directory missing BLOSUM file.")
+            # TODO - check for tp400_dna, tp400_prot and tp400_trans too?
 
 if not dialign_exe:
     raise MissingExternalDependencyError(

--- a/Tests/test_Dialign_tool.py
+++ b/Tests/test_Dialign_tool.py
@@ -18,7 +18,7 @@ dialign_exe = None
 if sys.platform == "win32":
     raise MissingExternalDependencyError("DIALIGN2-2 not available on Windows")
 else:
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     output = getoutput("dialign2-2")
     if "not found" not in output and "dialign2-2" in output.lower():
         dialign_exe = "dialign2-2"

--- a/Tests/test_Emboss.py
+++ b/Tests/test_Emboss.py
@@ -44,7 +44,7 @@ if "EMBOSS_ROOT" in os.environ:
             "$EMBOSS_ROOT=%r which does not exist!" % path)
     del path
 if sys.platform != "win32":
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     for name in exes_wanted:
         # This will "just work" if installed on the path as normal on Unix
         output = getoutput("%s -help" % name)

--- a/Tests/test_EmbossPhylipNew.py
+++ b/Tests/test_EmbossPhylipNew.py
@@ -35,7 +35,7 @@ if "EMBOSS_ROOT" in os.environ:
                 exes[name] = os.path.join(path, name + ".exe")
     del path, name
 if sys.platform != "win32":
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     for name in exes_wanted:
         # This will "just work" if installed on the path as normal on Unix
         output = getoutput("%s -help" % name)

--- a/Tests/test_Fasttree_tool.py
+++ b/Tests/test_Fasttree_tool.py
@@ -52,7 +52,7 @@ if sys.platform == "win32":
             if fasttree_exe:
                 break
 else:
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     # Website uses 'FastTree', Nate's system had 'fasttree'
     likely_exes = ["FastTree", "fasttree"]
     for filename in likely_exes:

--- a/Tests/test_MSAProbs_tool.py
+++ b/Tests/test_MSAProbs_tool.py
@@ -14,7 +14,7 @@ from Bio import MissingExternalDependencyError
 from Bio import SeqIO
 from Bio.Align.Applications import MSAProbsCommandline
 from Bio.Application import ApplicationError
-from Bio._py3k import getoutput
+from subprocess import getoutput
 
 #################################################################
 

--- a/Tests/test_MSAProbs_tool.py
+++ b/Tests/test_MSAProbs_tool.py
@@ -26,8 +26,7 @@ try:
     output = getoutput("msaprobs -version")
     if output.startswith("MSAPROBS version"):
         msaprobs_exe = "msaprobs"
-except OSError:
-    # TODO: Use FileNotFoundError once we drop Python 2
+except FileNotFoundError:
     pass
 
 if not msaprobs_exe:

--- a/Tests/test_MafIO_index.py
+++ b/Tests/test_MafIO_index.py
@@ -88,11 +88,7 @@ if sqlite3:
                               "mm9.chr10")
 
         def test_old_file_not_found(self):
-            # TODO: Switch to FileNotFoundError once we drop Python 2 support
-            # Under Python 2, we expect IOError.
-            # Under Python 3, we expect FileNotFoundError which is a subclass
-            # of OSError, and that has IOError as an alias so this works.
-            self.assertRaises(IOError,
+            self.assertRaises(FileNotFoundError,
                               MafIndex,
                               "MAF/ucsc_mm9_chr11.mafindex",
                               "MAF/ucsc_mm9_chr11.maf",

--- a/Tests/test_Mafft_tool.py
+++ b/Tests/test_Mafft_tool.py
@@ -19,8 +19,9 @@ if sys.platform == "win32":
 else:
     from subprocess import getoutput
     output = getoutput("mafft -help")
-    if "not found" not in output and "MAFFT" in output:
-        mafft_exe = "mafft"
+    if "not found" not in output and "not recognized" not in output:
+        if "MAFFT" in output:
+            mafft_exe = "mafft"
 if not mafft_exe:
     raise MissingExternalDependencyError(
         "Install MAFFT if you want to use the Bio.Align.Applications wrapper.")

--- a/Tests/test_Mafft_tool.py
+++ b/Tests/test_Mafft_tool.py
@@ -17,7 +17,7 @@ mafft_exe = None
 if sys.platform == "win32":
     raise MissingExternalDependencyError("Testing with MAFFT not implemented on Windows yet")
 else:
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     output = getoutput("mafft -help")
     if "not found" not in output and "MAFFT" in output:
         mafft_exe = "mafft"

--- a/Tests/test_Muscle_tool.py
+++ b/Tests/test_Muscle_tool.py
@@ -49,7 +49,7 @@ if sys.platform == "win32":
         if muscle_exe:
             break
 else:
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     output = getoutput("muscle -version")
     # Since "not found" may be in another language, try and be sure this is
     # really the MUSCLE tool's output

--- a/Tests/test_Muscle_tool.py
+++ b/Tests/test_Muscle_tool.py
@@ -53,9 +53,9 @@ else:
     output = getoutput("muscle -version")
     # Since "not found" may be in another language, try and be sure this is
     # really the MUSCLE tool's output
-    if "not found" not in output and "MUSCLE" in output \
-       and "Edgar" in output:
-        muscle_exe = "muscle"
+    if "not found" not in output and "not recognized" not in output:
+        if "MUSCLE" in output and "Edgar" in output:
+            muscle_exe = "muscle"
 
 if not muscle_exe:
     raise MissingExternalDependencyError(

--- a/Tests/test_PDB_ResidueDepth.py
+++ b/Tests/test_PDB_ResidueDepth.py
@@ -15,7 +15,7 @@ from Bio.PDB import PDBParser, ResidueDepth
 from Bio import MissingExternalDependencyError
 from Bio.PDB.PDBExceptions import PDBConstructionWarning
 
-from Bio._py3k import getoutput
+from subprocess import getoutput
 msms_exe = None
 try:
     output = getoutput("msms -h")

--- a/Tests/test_Prank_tool.py
+++ b/Tests/test_Prank_tool.py
@@ -39,8 +39,9 @@ if sys.platform == "win32":
 else:
     from subprocess import getoutput
     output = getoutput("prank")
-    if "not found" not in output and "prank" in output.lower():
-        prank_exe = "prank"
+    if "not found" not in output and "not recognized" not in output:
+        if "prank" in output.lower():
+            prank_exe = "prank"
 if not prank_exe:
     raise MissingExternalDependencyError(
         "Install PRANK if you want to use the Bio.Align.Applications wrapper.")

--- a/Tests/test_Prank_tool.py
+++ b/Tests/test_Prank_tool.py
@@ -37,7 +37,7 @@ if sys.platform == "win32":
         if prank_exe:
             break
 else:
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     output = getoutput("prank")
     if "not found" not in output and "prank" in output.lower():
         prank_exe = "prank"

--- a/Tests/test_Probcons_tool.py
+++ b/Tests/test_Probcons_tool.py
@@ -20,8 +20,9 @@ if sys.platform == "win32":
 else:
     from subprocess import getoutput
     output = getoutput("probcons")
-    if "not found" not in output and "probcons" in output.lower():
-        probcons_exe = "probcons"
+    if "not found" not in output and "not recognized" not in output:
+        if "probcons" in output.lower():
+            probcons_exe = "probcons"
 
 if not probcons_exe:
     raise MissingExternalDependencyError(

--- a/Tests/test_Probcons_tool.py
+++ b/Tests/test_Probcons_tool.py
@@ -18,7 +18,7 @@ probcons_exe = None
 if sys.platform == "win32":
     raise MissingExternalDependencyError("PROBCONS not available on Windows")
 else:
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     output = getoutput("probcons")
     if "not found" not in output and "probcons" in output.lower():
         probcons_exe = "probcons"

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -24,13 +24,6 @@ from io import StringIO
 
 from Bio._py3k import _universal_read_mode
 
-try:
-    # Defined on Python 3
-    FileNotFoundError
-except NameError:
-    # Python 2 does not have this,
-    FileNotFoundError = IOError
-
 from Bio.SeqRecord import SeqRecord
 from Bio import SeqIO
 from Bio.SeqIO._index import _FormatToRandomAccess

--- a/Tests/test_TCoffee_tool.py
+++ b/Tests/test_TCoffee_tool.py
@@ -20,10 +20,9 @@ if sys.platform == "win32":
 else:
     from subprocess import getoutput
     output = getoutput("t_coffee -version")
-    if "not found" not in output \
-       and ("t_coffee" in output.lower()
-            or "t-coffee" in output.lower()):
-        t_coffee_exe = "t_coffee"
+    if "not found" not in output and "not recognized" not in output:
+        if "t_coffee" in output.lower() or "t-coffee" in output.lower():
+            t_coffee_exe = "t_coffee"
 
 if not t_coffee_exe:
     raise MissingExternalDependencyError(

--- a/Tests/test_TCoffee_tool.py
+++ b/Tests/test_TCoffee_tool.py
@@ -18,7 +18,7 @@ if sys.platform == "win32":
     raise MissingExternalDependencyError(
         "Testing TCOFFEE on Windows not supported yet")
 else:
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     output = getoutput("t_coffee -version")
     if "not found" not in output \
        and ("t_coffee" in output.lower()

--- a/Tests/test_XXmotif_tool.py
+++ b/Tests/test_XXmotif_tool.py
@@ -25,7 +25,7 @@ if sys.platform == "win32":
     # TODO
     raise MissingExternalDependencyError("Testing this on Windows is not implemented yet")
 else:
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     output = getoutput("XXmotif")
     if output.find("== XXmotif version") != -1:
         xxmotif_exe = "XXmotif"

--- a/Tests/test_phyml_tool.py
+++ b/Tests/test_phyml_tool.py
@@ -22,8 +22,9 @@ phyml_exe = None
 exe_name = "PhyML-3.1_win32.exe" if sys.platform == "win32" else "phyml"
 try:
     output = getoutput(exe_name + " --version")
-    if "not found" not in output and ("20" in output or "PhyML" in output):
-        phyml_exe = exe_name
+    if "not found" not in output and "not recognized" not in output:
+        if "20" in output or "PhyML" in output:
+            phyml_exe = exe_name
 except FileNotFoundError:
     pass
 

--- a/Tests/test_phyml_tool.py
+++ b/Tests/test_phyml_tool.py
@@ -24,12 +24,7 @@ try:
     output = getoutput(exe_name + " --version")
     if "not found" not in output and ("20" in output or "PhyML" in output):
         phyml_exe = exe_name
-except OSError:
-    # TODO: Use FileNotFoundError once we drop Python 2
-    # Python 2.6 or 2.7 on Windows XP:
-    # WindowsError: [Error 2] The system cannot find the file specified
-    # Python 3.3 or 3.4 on Windows XP:
-    # FileNotFoundError: [WinError 2] The system cannot find the file specified
+except FileNotFoundError:
     pass
 
 if not phyml_exe:

--- a/Tests/test_phyml_tool.py
+++ b/Tests/test_phyml_tool.py
@@ -9,7 +9,7 @@ import sys
 import os
 import unittest
 
-from Bio._py3k import getoutput
+from subprocess import getoutput
 
 from Bio import Phylo
 from Bio.Phylo.Applications import PhymlCommandline

--- a/Tests/test_raxml_tool.py
+++ b/Tests/test_raxml_tool.py
@@ -14,7 +14,7 @@ from Bio import MissingExternalDependencyError
 
 raxml_exe = None
 try:
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     output = getoutput("raxmlHPC -v")
     if "not found" not in output and "This is RAxML" in output:
         raxml_exe = "raxmlHPC"

--- a/Tests/test_raxml_tool.py
+++ b/Tests/test_raxml_tool.py
@@ -18,8 +18,7 @@ try:
     output = getoutput("raxmlHPC -v")
     if "not found" not in output and "This is RAxML" in output:
         raxml_exe = "raxmlHPC"
-except OSError:
-    # TODO: Use FileNotFoundError once we drop Python 2
+except FileNotFoundError:
     pass
 
 if not raxml_exe:

--- a/Tests/test_raxml_tool.py
+++ b/Tests/test_raxml_tool.py
@@ -16,8 +16,9 @@ raxml_exe = None
 try:
     from subprocess import getoutput
     output = getoutput("raxmlHPC -v")
-    if "not found" not in output and "This is RAxML" in output:
-        raxml_exe = "raxmlHPC"
+    if "not found" not in output and "not recognized" not in output:
+        if "This is RAxML" in output:
+            raxml_exe = "raxmlHPC"
 except FileNotFoundError:
     pass
 

--- a/Tests/test_samtools_tool.py
+++ b/Tests/test_samtools_tool.py
@@ -56,7 +56,7 @@ if sys.platform == "win32":
             if samtools_exe:
                 break
 else:
-    from Bio._py3k import getoutput
+    from subprocess import getoutput
     output = getoutput("samtools")
 
     # Since "not found" may be in another language, try and be sure this is


### PR DESCRIPTION
According to http://bugs.python.org/issue10197 this was fixed in Python 3.3, so we can just
use subprocess.getoutput everywhere.

This pull request addresses in part issue #2420

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
