### PR TITLE
BSD dual license some of Bio.motifs

### DIFF
--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -1,8 +1,11 @@
 # Copyright 2003-2009 by Bartek Wilczynski.  All rights reserved.
 # Copyright 2012-2013 by Michiel JL de Hoon.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
+
 """Tools for sequence motif analysis.
 
 Bio.motifs contains the core Motif class containing various I/O methods

--- a/Bio/motifs/alignace.py
+++ b/Bio/motifs/alignace.py
@@ -1,7 +1,9 @@
 # Copyright 2003 by Bartek Wilczynski.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Parsing AlignACE output files."""
 

--- a/Bio/motifs/applications/__init__.py
+++ b/Bio/motifs/applications/__init__.py
@@ -1,7 +1,11 @@
 # Copyright 2009 by Bartek Wilczynski.  All rights reserved.
 # Revisions copyright 2009 by Peter Cock.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
+
 """Motif command line tool wrappers."""
+
 from ._xxmotif import XXmotifCommandline

--- a/Bio/motifs/applications/_xxmotif.py
+++ b/Bio/motifs/applications/_xxmotif.py
@@ -1,8 +1,10 @@
 # Copyright 2012 by Christian Brueffer.  All rights reserved.
 #
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
+
 """Command line wrapper for the motif finding program XXmotif."""
 
 

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -1,7 +1,10 @@
 # Copyright 2013 by Michiel de Hoon.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
+
 """Support for various forms of sequence motif matrices.
 
 Implementation of frequency (count) matrices, position-weight matrices,

--- a/Bio/motifs/transfac.py
+++ b/Bio/motifs/transfac.py
@@ -1,7 +1,9 @@
 # Copyright 2003 by Bartek Wilczynski.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """Parsing TRANSFAC files."""
 


### PR DESCRIPTION
This pull request addresses in part issue #898, with additional issues #2471 #2472 #2473 logged for the remaining files.

Tracking the history of these files and their contents is complicated given the history of ``Bio.Motifs`` and ``Bio.motifs`` and both renames and copying.

I would like Bartek and/or Michiel to review this please.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
