### PR TITLE
add __format__ to the Motif class

### DIFF
--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -596,7 +596,7 @@ class Motif:
             raise ValueError("Unknown format type %s" % format_spec)
 
     def format(self, format_spec):
-        """Return a string representation of the Motif in the given format (DEPRECATED).
+        """Return a string representation of the Motif in the given format [DEPRECATED].
 
         This method is deprecated; instead of motif.format(format_spec),
         please use format(motif, format_spec).

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -12,9 +12,11 @@ Bio.motifs contains the core Motif class containing various I/O methods
 as well as methods for motif comparisons and motif searching in sequences.
 It also includes functionality for parsing output from the AlignACE, MEME,
 and MAST programs, as well as files in the TRANSFAC format.
-
-Bio.motifs is replacing the older and now obsolete Bio.Motif module.
 """
+
+import warnings
+
+from Bio import BiopythonDeprecationWarning
 
 
 def create(instances, alphabet=None):
@@ -448,7 +450,7 @@ class Motif:
 
     @property
     def degenerate_consensus(self):
-        """Generate degenerate consesnsus sequence.
+        """Return the degenerate consensus sequence.
 
         Following the rules adapted from
         D. R. Cavener: "Comparison of the consensus sequence flanking
@@ -565,33 +567,46 @@ class Motif:
             im = response.read()
             f.write(im)
 
-    def format(self, format):
+    def __format__(self, format_spec):
         """Return a string representation of the Motif in the given format.
 
-        Currently supported fromats:
+        Currently supported formats:
          - clusterbuster: Cluster Buster position frequency matrix format
          - pfm : JASPAR single Position Frequency Matrix
          - jaspar : JASPAR multiple Position Frequency Matrix
          - transfac : TRANSFAC like files
 
         """
-        if format in ("pfm", "jaspar"):
+        if format_spec in ("pfm", "jaspar"):
             from Bio.motifs import jaspar
 
             motifs = [self]
-            return jaspar.write(motifs, format)
-        elif format == "transfac":
+            return jaspar.write(motifs, format_spec)
+        elif format_spec == "transfac":
             from Bio.motifs import transfac
 
             motifs = [self]
             return transfac.write(motifs)
-        elif format == "clusterbuster":
+        elif format_spec == "clusterbuster":
             from Bio.motifs import clusterbuster
 
             motifs = [self]
             return clusterbuster.write(motifs)
         else:
-            raise ValueError("Unknown format type %s" % format)
+            raise ValueError("Unknown format type %s" % format_spec)
+
+    def format(self, format_spec):
+        """Return a string representation of the Motif in the given format (DEPRECATED).
+
+        This method is deprecated; instead of motif.format(format_spec),
+        please use format(motif, format_spec).
+        """
+        warnings.warn("""\
+Motif.format has been deprecated, and we intend to remove it in a future
+release of Biopython. Instead of motif.format(format_spec), please use
+format(motif, format_spec).
+""", BiopythonDeprecationWarning)
+        return self.__format__(format_spec)
 
 
 def write(motifs, format):

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -88,8 +88,8 @@ Bio.motifs
 ``Bio.motifs.mast`` plain-text parsing deprecated in favor of XML parsing as of
 release 1.74. Also affects ``Bio.motifs.read`` and ``Bio.motifs.parse`` for the
 ``mast`` format.
-The ``format`` method of the ``Motif`` class in ``Bio.motifs`` was deprecated in
-release 1.77, in favor of a ``__format__`` method that can be used from the
+The ``format`` method of the ``Motif`` class in ``Bio.motifs`` was deprecated
+in release 1.77, in favor of a ``__format__`` method that can be used from the
 ``format`` built-in function.
 
 Bio.Restriction.RanaConfig

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -88,6 +88,9 @@ Bio.motifs
 ``Bio.motifs.mast`` plain-text parsing deprecated in favor of XML parsing as of
 release 1.74. Also affects ``Bio.motifs.read`` and ``Bio.motifs.parse`` for the
 ``mast`` format.
+The ``format`` method of the ``Motif`` class in ``Bio.motifs`` was deprecated in
+release 1.77, in favor of a ``__format__`` method that can be used from the
+``format`` built-in function.
 
 Bio.Restriction.RanaConfig
 --------------------------

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -757,7 +757,7 @@ store any additional information about the motif:
 %cont-doctest
 \begin{minted}{pycon}
 >>> motif = record[0]
->>> motif.degenerate_consensus # Using the Bio.motifs.Motif method
+>>> motif.degenerate_consensus # Using the Bio.motifs.Motif property
 Seq('SRACAGGTGKYG')
 >>> motif["ID"] # Using motif as a dictionary
 'motif1'
@@ -865,10 +865,10 @@ in a string and saving it in a file:
 \section{Writing motifs}
 
 Speaking of exporting, let's look at export functions in general.
-We can use the \verb+format+ method to write the motif in the simple JASPAR \verb+pfm+ format:
+We can use the \verb+format+ built-in function to write the motif in the simple JASPAR \verb+pfm+ format:
 %the tabs in the output confuse doctest; don't test
 \begin{minted}{pycon}
->>> print(arnt.format("pfm"))
+>>> print(format(arnt, "pfm"))
   4.00  19.00   0.00   0.00   0.00   0.00
  16.00   0.00  20.00   0.00   0.00   0.00
   0.00   1.00   0.00  20.00   0.00  20.00
@@ -876,7 +876,7 @@ We can use the \verb+format+ method to write the motif in the simple JASPAR \ver
 \end{minted}
 Similarly, we can use \verb+format+ to write the motif in the JASPAR \verb+jaspar+ format:
 \begin{minted}{pycon}
->>> print(arnt.format("jaspar"))
+>>> print(format(arnt, "jaspar"))
 >MA0004.1  Arnt
 A [  4.00  19.00   0.00   0.00   0.00   0.00]
 C [ 16.00   0.00  20.00   0.00   0.00   0.00]
@@ -888,7 +888,7 @@ To write the motif in a TRANSFAC-like matrix format, use
 
 %cont-doctest
 \begin{minted}{pycon}
->>> print(m.format("transfac"))
+>>> print(format(m, "transfac"))
 P0      A      C      G      T
 01      3      0      0      4      W
 02      7      0      0      0      A


### PR DESCRIPTION
This pull request adds a __format__ method to the Motif class in Bio.motifs, and deprecates the format method.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
