### PR TITLE
Remove redundant __ne__ functions for python 3

### DIFF
--- a/Bio/Crystal/__init__.py
+++ b/Bio/Crystal/__init__.py
@@ -87,10 +87,6 @@ class Hetero:
     def __eq__(self, other):
         return self.data == other.data
 
-    def __ne__(self, other):
-        """Return true iff self is not equal to other."""
-        return not self.__eq__(other)
-
     def __repr__(self):
         return "%s" % self.data
 

--- a/Bio/Pathway/Rep/Graph.py
+++ b/Bio/Pathway/Rep/Graph.py
@@ -31,10 +31,6 @@ class Graph:
             and self._edge_map == g._edge_map
         )
 
-    def __ne__(self, g):
-        """Return true if g is not equal to this graph."""
-        return not self.__eq__(g)
-
     def __repr__(self):
         """Return a unique string representation of this graph."""
         s = "<Graph: "

--- a/Bio/Pathway/Rep/MultiGraph.py
+++ b/Bio/Pathway/Rep/MultiGraph.py
@@ -30,10 +30,6 @@ class MultiGraph:
             and self._label_map == g._label_map
         )
 
-    def __ne__(self, g):
-        """Return true if g is not equal to this graph."""
-        return not self.__eq__(g)
-
     def __repr__(self):
         """Return a unique string representation of this graph."""
         s = "<MultiGraph: "

--- a/Bio/Pathway/__init__.py
+++ b/Bio/Pathway/__init__.py
@@ -94,10 +94,6 @@ class Reaction:
             and self.reversible == r.reversible
         )
 
-    def __ne__(self, r):
-        """Return true iff self is not equal to r."""
-        return not self.__eq__(r)
-
     def __hash__(self):
         """Return a hashcode for self."""
         t = tuple(self.species())

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -656,11 +656,6 @@ class Reference:
             and self.location == other.location
         )
 
-    def __ne__(self, other):
-        """Implement the not-equal operand."""
-        # This is needed for py2, but not for py3.
-        return not self == other
-
 
 # --- Handling feature locations
 
@@ -1011,11 +1006,6 @@ class FeatureLocation:
             and self.ref == other.ref
             and self.ref_db == other.ref_db
         )
-
-    def __ne__(self, other):
-        """Implement the not-equal operand."""
-        # This is needed for py2, but not for py3.
-        return not self == other
 
     def _shift(self, offset):
         """Return a copy of the FeatureLocation shifted by an offset (PRIVATE)."""
@@ -1376,11 +1366,6 @@ class CompoundLocation:
             if self_part != other_part:
                 return False
         return True
-
-    def __ne__(self, other):
-        """Implement the not-equal operand."""
-        # This is needed for py2, but not for py3.
-        return not self == other
 
     def _shift(self, offset):
         """Return a copy of the CompoundLocation shifted by an offset (PRIVATE)."""

--- a/Bio/phenotype/phen_micro.py
+++ b/Bio/phenotype/phen_micro.py
@@ -409,9 +409,6 @@ class PlateRecord:
         else:
             return False
 
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def __add__(self, plate):
         """Add another PlateRecord object.
 
@@ -744,9 +741,6 @@ class WellRecord:
             return True
         else:
             return False
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
     def __add__(self, well):
         """Add another WellRecord object.


### PR DESCRIPTION
In python 3, `__ne__` defaults to the inverse of `__eq__` so it does not need to be defined explicitly in these simple cases. Where `__ne__` is defined in other ways, I didn't change anything.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
