### PR TITLE
Fix urllib urlencode import

### DIFF
--- a/Bio/SCOP/__init__.py
+++ b/Bio/SCOP/__init__.py
@@ -50,6 +50,9 @@ Functions:
 import os
 import re
 
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
 from . import Des
 from . import Cla
 from . import Hie
@@ -943,8 +946,6 @@ def _open(cgi, params=None, get=1):
     that describes whether a GET should be used.
 
     """
-    from urllib.request import urlopen, urlencode
-
     # Open a handle to SCOP.
     if params is None:
         params = {}

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -16,6 +16,9 @@ and MAST programs, as well as files in the TRANSFAC format.
 
 import warnings
 
+from urllib.parse import urlencode
+from urllib.request import urlopen, Request
+
 from Bio import BiopythonDeprecationWarning
 
 
@@ -508,8 +511,6 @@ class Motif:
             'color4': '',
 
         """
-        from urllib.request import urlopen, urlencode, Request
-
         if set(self.alphabet) == set("ACDEFGHIKLMNPQRSTVWY"):
             alpha = "alphabet_protein"
         elif set(self.alphabet) == set("ACGU"):


### PR DESCRIPTION
This pull request fixes a bug accidentally introduced in #2476 - we don't automate the online tests, so hadn't noticed.

With this fix, ``test_SCOP_online.py`` is failing with a 404 error - the old search address no longer works.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
