### PR TITLE
removing a hack for a bug that was fixed in 2005 for Python 2.5

### DIFF
--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -157,12 +157,7 @@ class GenericPositionMatrix(dict):
         """Return the consensus sequence."""
         sequence = ""
         for i in range(self.length):
-            try:
-                maximum = float("-inf")
-            except ValueError:
-                # On Python 2.5 or older that was handled in C code,
-                # and failed on Windows XP 32bit
-                maximum = -1e400
+            maximum = -math.inf
             for letter in self.alphabet:
                 count = self[letter][i]
                 if count > maximum:
@@ -176,12 +171,7 @@ class GenericPositionMatrix(dict):
         """Return the anticonsensus sequence."""
         sequence = ""
         for i in range(self.length):
-            try:
-                minimum = float("inf")
-            except ValueError:
-                # On Python 2.5 or older that was handled in C code,
-                # and failed on Windows XP 32bit
-                minimum = 1e400
+            minimum = math.inf
             for letter in self.alphabet:
                 count = self[letter][i]
                 if count < minimum:
@@ -335,19 +325,13 @@ class PositionWeightMatrix(GenericPositionMatrix):
                     if p > 0:
                         logodds = math.log(p / b, 2)
                     else:
-                        # TODO - Ensure this has unittest coverage!
-                        try:
-                            logodds = float("-inf")
-                        except ValueError:
-                            # On Python 2.5 or older that was handled in C code,
-                            # and failed on Windows XP 32bit
-                            logodds = -1e400
+                        logodds = -math.inf
                 else:
                     p = self[letter][i]
                     if p > 0:
-                        logodds = float("inf")
+                        logodds = math.inf
                     else:
-                        logodds = float("nan")
+                        logodds = math.nan
                 values[letter].append(logodds)
         pssm = PositionSpecificScoringMatrix(alphabet, values)
         return pssm


### PR DESCRIPTION
This pull request removes an old hack from Bio.motifs (predating to Bio.Motif) that was needed to get around a bug in Python on 32bits Windows.  This bug seems to have been fixed in 2005 for Python 2.5. See Python bug tracker issue 1378305.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
