### PR TITLE
Clarify BGZF text mode encoding limitations

### DIFF
--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -30,11 +30,6 @@ from seq_tests_common import compare_record
 
 from Bio import BiopythonParserWarning
 from Bio import MissingPythonDependencyError
-try:
-    from test_bgzf import _have_bug17666
-    do_bgzf = _have_bug17666()
-except MissingPythonDependencyError:
-    do_bgzf = False
 
 CUR_DIR = os.getcwd()
 
@@ -694,7 +689,7 @@ tests = [
 for filename1, format, alphabet in tests:
     assert format in _FormatToRandomAccess
     tasks = [(filename1, None)]
-    if do_bgzf and os.path.isfile(filename1 + ".bgz"):
+    if os.path.isfile(filename1 + ".bgz"):
         tasks.append((filename1 + ".bgz", "bgzf"))
     for filename2, comp in tasks:
 

--- a/Tests/test_bgzf.py
+++ b/Tests/test_bgzf.py
@@ -117,21 +117,19 @@ class BgzfTests(unittest.TestCase):
         self.assertEqual(old, new)
 
     def check_by_line(self, old_file, new_file, old_gzip=False):
-        for mode in ["r", "rb"]:
-            if old_gzip:
-                h = gzip.open(old_file, mode)
-            else:
-                h = open(old_file, mode)
-            old = h.read()
+        if old_gzip:
+            with gzip.open(old_file) as handle:
+                old = handle.read()
+        else:
+            with open(old_file, "rb") as handle:
+                old = handle.read()
+        for mode in ["rb", "r"]:
             if "b" in mode:
-                if isinstance(old, str):
-                    import codecs
-                    old = codecs.latin_1_encode(old)[0]
+                assert isinstance(old, bytes)
             else:
-                if isinstance(old, bytes):
-                    import codecs
-                    old = codecs.latin_1_decode(old)[0]
-            h.close()
+                # BGZF text mode is hard coded as latin1
+                # and does not do universal new line mode
+                old = old.decode("latin1")
 
             for cache in [1, 10]:
                 h = bgzf.BgzfReader(new_file, mode, max_cache=cache)
@@ -148,23 +146,19 @@ class BgzfTests(unittest.TestCase):
                 self.assertEqual(old, new)
 
     def check_by_char(self, old_file, new_file, old_gzip=False):
-        for mode in ["r", "rb"]:
-            if old_gzip:
-                h = gzip.open(old_file, mode)
-            else:
-                h = open(old_file, mode)
-            old = h.read()
-            # Seems gzip can return bytes even if mode="r",
-            # perhaps a bug in Python 3.2?
+        if old_gzip:
+            with gzip.open(old_file) as handle:
+                old = handle.read()
+        else:
+            with open(old_file, "rb") as handle:
+                old = handle.read()
+        for mode in ["rb", "r"]:
             if "b" in mode:
-                if isinstance(old, str):
-                    import codecs
-                    old = codecs.latin_1_encode(old)[0]
+                assert isinstance(old, bytes)
             else:
-                if isinstance(old, bytes):
-                    import codecs
-                    old = codecs.latin_1_decode(old)[0]
-            h.close()
+                # BGZF text mode is hard coded as latin1
+                # and does not do universal new line mode
+                old = old.decode("latin1")
 
             for cache in [1, 10]:
                 h = bgzf.BgzfReader(new_file, mode, max_cache=cache)

--- a/Tests/test_bgzf.py
+++ b/Tests/test_bgzf.py
@@ -16,34 +16,6 @@ from random import shuffle
 from Bio import bgzf
 
 
-def _have_bug17666():
-    """Debug function to check if Python's gzip is broken (PRIVATE).
-
-    Checks for http://bugs.python.org/issue17666 expected in Python 2.7.4,
-    3.2.4 and 3.3.1 only.
-    """
-    from io import BytesIO
-
-    h = gzip.GzipFile(fileobj=BytesIO(bgzf._bgzf_eof))
-    try:
-        data = h.read()
-        h.close()
-        assert not data, "Should be zero length, not %i" % len(data)
-        return False
-    except TypeError as err:
-        # TypeError: integer argument expected, got 'tuple'
-        return True
-
-
-if _have_bug17666():
-    from Bio import MissingPythonDependencyError
-
-    raise MissingPythonDependencyError(
-        "Your Python has a broken gzip library, see "
-        "http://bugs.python.org/issue17666 for details"
-    )
-
-
 class BgzfTests(unittest.TestCase):
     def setUp(self):
         self.temp_file = "temp.bgzf"


### PR DESCRIPTION
This pull request addresses issue #2512, and documents a limitation (very reasonably under Python 2, but likely a surprise under Python 3) that BGZF in text mode does not do universal new lines mode.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
