### PR TITLE
Assume dict is ordered

### DIFF
--- a/Bio/File.py
+++ b/Bio/File.py
@@ -23,22 +23,7 @@ import contextlib
 import itertools
 import platform
 
-try:
-    from collections import UserDict as _dict_base
-except ImportError:
-    from UserDict import DictMixin as _dict_base
-
-# Ordered dict is a language feature from Python 3.7 onwards.
-# CPython 3.6 also already has ordered dicts.
-# PyPy has always had ordered dicts.
-if (
-    sys.version_info >= (3, 7)
-    or platform.python_implementation() == "PyPy"
-    or (sys.version_info == (3, 6) and platform.python_implementation() == "CPython")
-):
-    _dict = dict
-else:
-    from collections import OrderedDict as _dict
+from collections import UserDict as _dict_base
 
 try:
     from sqlite3 import dbapi2 as _sqlite
@@ -329,7 +314,7 @@ class _IndexedSeqFileDict(_dict_base):
             offset_iter = ((key_function(k), o, l) for (k, o, l) in random_access_proxy)
         else:
             offset_iter = random_access_proxy
-        offsets = _dict()
+        offsets = {}
         for key, offset, length in offset_iter:
             # Note - we don't store the length because I want to minimise the
             # memory requirements. With the SQLite backend the length is kept

--- a/Bio/SearchIO/__init__.py
+++ b/Bio/SearchIO/__init__.py
@@ -404,11 +404,8 @@ def to_dict(qresults, key_function=None):
 
     Since Python 3.7, the default dict class maintains key order, meaning
     this dictionary will reflect the order of records given to it. For
-    CPython, this was already implemented in 3.6.
-
-    As of Biopython 1.73, we explicitly use OrderedDict for CPython older
-    than 3.6 (and for other Python older than 3.7) so that you can always
-    assume the record order is preserved.
+    CPython and PyPy, this was already implemented for Python 3.6, so
+    effectively you can always assume the record order is preserved.
     """
     # This comment stops black style adding a blank line here, which causes flake8 D202.
     def _default_key_function(rec):

--- a/Bio/SearchIO/__init__.py
+++ b/Bio/SearchIO/__init__.py
@@ -197,18 +197,10 @@ of the format's documentation.
 """
 
 import sys
-from collections import OrderedDict
 
 from Bio.File import as_handle
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 from Bio.SearchIO._utils import get_processor
-
-
-if sys.version_info < (3, 6):
-    from collections import OrderedDict as _dict
-else:
-    # Default dict is sorted in Python 3.6 onwards
-    _dict = dict
 
 
 __all__ = ("read", "parse", "to_dict", "index", "index_db", "write", "convert")
@@ -425,7 +417,7 @@ def to_dict(qresults, key_function=None):
     if key_function is None:
         key_function = _default_key_function
 
-    qdict = _dict()
+    qdict = {}
     for qresult in qresults:
         key = key_function(qresult)
         if key in qdict:

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -761,11 +761,8 @@ def to_dict(sequences, key_function=None):
 
     Since Python 3.7, the default dict class maintains key order, meaning
     this dictionary will reflect the order of records given to it. For
-    CPython, this was already implemented in 3.6.
-
-    As of Biopython 1.73, we explicitly use OrderedDict for CPython older
-    than 3.6 (and for other Python older than 3.7) so that you can always
-    assume the record order is preserved.
+    CPython and PyPy, this was already implemented for Python 3.6, so
+    effectively you can always assume the record order is preserved.
 
     Example usage, defaulting to using the record.id as key:
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -406,12 +406,6 @@ from . import QualityIO  # FastQ and qual files
 from . import UniprotIO
 from . import XdnaIO
 
-if sys.version_info < (3, 6):
-    from collections import OrderedDict as _dict
-else:
-    # Default dict is sorted in Python 3.6 onwards
-    _dict = dict
-
 # Convention for format names is "mainname-subtype" in lower case.
 # Please use the same names as BioPerl or EMBOSS where possible.
 #
@@ -819,7 +813,7 @@ def to_dict(sequences, key_function=None):
     if key_function is None:
         key_function = _default_key_function
 
-    d = _dict()
+    d = {}
     for record in sequences:
         key = key_function(record)
         if key in d:


### PR DESCRIPTION
Partly addresses #2490, where this was discussed.

Ordered dictionaries are a language feature in Python 3.7 onwards, but we currently support Python 3.6 onwards.

Thankfully the only major implementations of Python 3.6 we are aware of (CPython and PyPy) both implement ordered dictionaries.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
