### PR TITLE
removed _binary_to_string_handle

### DIFF
--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -624,7 +624,7 @@ def _open(cgi, params=None, post=None, ecitmatch=False):
     subtype = handle.headers.get_content_subtype()
     if subtype == "plain":
         url = handle.url
-        handle = io.TextIOWrapper(handle, encoding="utf8")
+        handle = io.TextIOWrapper(handle, encoding="UTF-8")
         handle.url = url
     return handle
 

--- a/Bio/ExPASy/__init__.py
+++ b/Bio/ExPASy/__init__.py
@@ -16,9 +16,8 @@ Functions:
 
 """
 
-# Importing these functions with leading underscore as not intended for reuse
+import io
 from urllib.request import urlopen
-from Bio._py3k import _binary_to_string_handle
 
 
 def get_prodoc_entry(
@@ -41,7 +40,8 @@ def get_prodoc_entry(
     For a non-existing key XXX, ExPASy returns an HTML-formatted page
     containing this text: 'There is currently no PROSITE entry for'
     """
-    return _binary_to_string_handle(urlopen("%s?%s" % (cgi, id)))
+    url = "%s?%s" % (cgi, id)
+    return _open(url)
 
 
 def get_prosite_entry(
@@ -64,7 +64,8 @@ def get_prosite_entry(
     For a non-existing key XXX, ExPASy returns an HTML-formatted page
     containing this text: 'There is currently no PROSITE entry for'
     """
-    return _binary_to_string_handle(urlopen("%s?%s" % (cgi, id)))
+    url = "%s?%s" % (cgi, id)
+    return _open(url)
 
 
 def get_prosite_raw(id, cgi=None):
@@ -92,7 +93,7 @@ def get_prosite_raw(id, cgi=None):
 
     """
     url = "https://prosite.expasy.org/%s.txt" % id
-    return _binary_to_string_handle(urlopen(url))
+    return _open(url)
 
 
 def get_sprot_raw(id):
@@ -120,4 +121,11 @@ def get_sprot_raw(id):
 
     """  # noqa: W291
     url = "http://www.uniprot.org/uniprot/%s.txt" % id
-    return _binary_to_string_handle(urlopen(url))
+    return _open(url)
+
+
+def _open(url):
+    handle = urlopen(url)
+    text_handle = io.TextIOWrapper(handle, encoding="UTF-8")
+    text_handle.url = handle.url
+    return text_handle

--- a/Bio/KEGG/REST.py
+++ b/Bio/KEGG/REST.py
@@ -29,8 +29,8 @@ Nucleic Acids Res. 28, 29-34 (2000).
 
 """
 
+import io
 from urllib.request import urlopen
-from Bio._py3k import _binary_to_string_handle
 
 
 def _q(op, arg1, arg2=None, arg3=None):
@@ -46,7 +46,9 @@ def _q(op, arg1, arg2=None, arg3=None):
     if "image" == arg2:
         return resp
 
-    return _binary_to_string_handle(resp)
+    handle = io.TextIOWrapper(resp, encoding="UTF-8")
+    handle.url = resp.url
+    return handle
 
 
 # http://www.kegg.jp/kegg/rest/keggapi.html

--- a/Bio/_py3k/__init__.py
+++ b/Bio/_py3k/__init__.py
@@ -13,31 +13,3 @@ go away.
 # From the point of view of pep8 and flake8, there are lots of issues with
 # this file. This line tells flake8 to ignore it for quality assurance:
 # flake8: noqa
-
-import io
-
-# Python 3.4 onwards, the standard library wrappers should work:
-def _binary_to_string_handle(handle):
-    """Treat a binary (bytes) handle like a text (unicode) handle (PRIVATE)."""
-    try:
-        # If this is a network handle from urllib,
-        # the HTTP headers may tell us the encoding.
-        encoding = handle.headers.get_content_charset()
-    except AttributeError:
-        encoding = None
-    if encoding is None:
-        # The W3C recommendation is:
-        # When no explicit charset parameter is provided by the sender,
-        # media subtypes of the "text" type are defined to have a default
-        # charset value of "ISO-8859-1" when received via HTTP.
-        # "ISO-8859-1" is also known as 'latin-1'
-        # See the following for more detail:
-        # https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7.1
-        encoding = "latin-1"
-    wrapped = io.TextIOWrapper(io.BufferedReader(handle), encoding=encoding)
-    try:
-        # If wrapping an online handle, this is nice to have:
-        wrapped.url = handle.url
-    except AttributeError:
-        pass
-    return wrapped


### PR DESCRIPTION
This pull request removes _binary_to_string_handle from Bio._py3k and the modules that used it (Bio.KEGG, Bio.ExPASy, Bio.TogoWS). Some minor cleanup along the way.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
