### PR TITLE
Python 3 should always have ElementTree

### DIFF
--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -71,15 +71,6 @@ def UniprotIterator(
                     " (or XML as a string, but that's deprecated)"
                 )
 
-        if ElementTree is None:
-            from Bio import MissingExternalDependencyError
-
-            raise MissingExternalDependencyError(
-                "No ElementTree module was found. "
-                "Use Python 2.5+, lxml or elementtree if you "
-                "want to use Bio.SeqIO.UniprotIO."
-            )
-
         for event, elem in ElementTree.iterparse(handle, events=("start", "end")):
             if event == "end" and elem.tag == NS + "entry":
                 yield Parser(


### PR DESCRIPTION
Minor cleanup which should have been part of #2435.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
