### PR TITLE
Convert string format method usage to f-strings

### DIFF
--- a/Bio/Affy/CelFile.py
+++ b/Bio/Affy/CelFile.py
@@ -224,9 +224,7 @@ def read_v4(f):
     # data.
     def raiseBadHeader(field, expected):
         actual = int(headersMap[field])
-        message = "The header {field} is expected to be 0, not {value}".format(
-            value=actual, field=field
-        )
+        message = f"The header {field} is expected to be 0, not {actual}"
         if actual != expected:
             raise ParserError(message)
 

--- a/Bio/PDB/ResidueDepth.py
+++ b/Bio/PDB/ResidueDepth.py
@@ -500,7 +500,7 @@ def _get_atom_radius(atom, rtype="united"):
         return _atomic_radii[15][typekey]
     else:
         warnings.warn(
-            "{}:{} not in radii library.".format(at_name, resname), BiopythonWarning
+            f"{at_name}:{resname} not in radii library.", BiopythonWarning
         )
         return 0.01
 
@@ -548,7 +548,7 @@ def get_surface(model, PDB_TO_XYZR=None, MSMS="msms"):
             x, y, z = atom.coord
             radius = _get_atom_radius(atom, rtype="united")
             pdb_to_xyzr.write(
-                "{:6.3f}\t{:6.3f}\t{:6.3f}\t{:1.2f}\n".format(x, y, z, radius)
+                f"{x:6.3f}\t{y:6.3f}\t{z:6.3f}\t{radius:1.2f}\n"
             )
 
     # make surface

--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -344,7 +344,7 @@ class DistanceMatrix(_Matrix):
                 open in text mode.
 
         """
-        handle.write("    {0}\n".format(len(self.names)))
+        handle.write(f"    {len(self.names)}\n")
         # Phylip needs space-separated, vertically aligned columns
         name_width = max(12, max(map(len, self.names)) + 1)
         value_fmts = ("{" + str(x) + ":.4f}" for x in range(1, len(self.matrix) + 1))

--- a/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
+++ b/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
@@ -99,7 +99,7 @@ class Hhsuite2TextParser:
         match = re.search(_RE_HIT_BLOCK_DESC, self.line)
         if not match:
             raise RuntimeError(
-                "Unexpected content in HIT_BLOCK_DESC line'{}'".format(self.line)
+                f"Unexpected content in HIT_BLOCK_DESC line'{self.line}'"
             )
         hit_data = {
             "hit_id": match.group(1),
@@ -146,9 +146,7 @@ class Hhsuite2TextParser:
                 except KeyError:
                     # We trigger warnings here as it's not a big enough problem to crash, but indicates something unexpected.
                     warnings.warn(
-                        "HHsuite parser: unable to extract {} from line: {}".format(
-                            key, line
-                        )
+                        f"HHsuite parser: unable to extract {key} from line: {line}"
                     )
 
     def _parse_hit_match_block(self, hit_match_data):

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -126,8 +126,8 @@ class Seq:
             # Shows the last three letters as it is often useful to see if
             # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
-            return "{0}('{1}...{2}'{3!s})".format(
-                self.__class__.__name__, str(self)[:54], str(self)[-3:], a
+            return (
+                f"{self.__class__.__name__}('{str(self)[:54]}...{str(self)[-3:]}'{a!s})"
             )
         else:
             return f"{self.__class__.__name__}({self._data!r}{a!s})"
@@ -222,9 +222,8 @@ class Seq:
         if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
             return str(self) < str(other)
         raise TypeError(
-            "'<' not supported between instances of '{}' and '{}'".format(
-                type(self).__name__, type(other).__name__
-            )
+            f"'<' not supported between instances of '{type(self).__name__}'"
+            f" and '{type(other).__name__}'"
         )
 
     def __le__(self, other):
@@ -238,9 +237,8 @@ class Seq:
         if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
             return str(self) <= str(other)
         raise TypeError(
-            "'<=' not supported between instances of '{}' and '{}'".format(
-                type(self).__name__, type(other).__name__
-            )
+            f"'<=' not supported between instances of '{type(self).__name__}'"
+            f" and '{type(other).__name__}'"
         )
 
     def __gt__(self, other):
@@ -254,9 +252,8 @@ class Seq:
         if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
             return str(self) > str(other)
         raise TypeError(
-            "'>' not supported between instances of '{}' and '{}'".format(
-                type(self).__name__, type(other).__name__
-            )
+            f"'>' not supported between instances of '{type(self).__name__}'"
+            f" and '{type(other).__name__}'"
         )
 
     def __ge__(self, other):
@@ -270,9 +267,8 @@ class Seq:
         if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
             return str(self) >= str(other)
         raise TypeError(
-            "'>=' not supported between instances of '{}' and '{}'".format(
-                type(self).__name__, type(other).__name__
-            )
+            f"'>=' not supported between instances of '{type(self).__name__}'"
+            f" and '{type(other).__name__}'"
         )
 
     def __len__(self):
@@ -401,9 +397,7 @@ class Seq:
         Seq('ATGATG', DNAAlphabet())
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type"
-            )
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(str(self) * other, self.alphabet)
 
     def __rmul__(self, other):
@@ -417,9 +411,7 @@ class Seq:
         Seq('ATGATG', DNAAlphabet())
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type"
-            )
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(str(self) * other, self.alphabet)
 
     def __imul__(self, other):
@@ -436,9 +428,7 @@ class Seq:
         Seq('ATGATG', DNAAlphabet())
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type"
-            )
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(str(self) * other, self.alphabet)
 
     def tomutable(self):  # Needed?  Or use a function?
@@ -1231,9 +1221,8 @@ class Seq:
                 gap = self.alphabet.gap_char
             elif gap != self.alphabet.gap_char:
                 raise ValueError(
-                    "Gap {0!r} does not match {1!r} from alphabet".format(
-                        gap, self.alphabet.gap_char
-                    )
+                    f"Gap {gap!r} does not match {self.alphabet.gap_char!r}"
+                    " from alphabet"
                 )
 
         protein = _translate_str(
@@ -1325,9 +1314,8 @@ class Seq:
                 gap = self.alphabet.gap_char
             elif gap != self.alphabet.gap_char:
                 raise ValueError(
-                    "Gap {0!r} does not match {1!r} from alphabet".format(
-                        gap, self.alphabet.gap_char
-                    )
+                    f"Gap {gap!r} does not match {self.alphabet.gap_char!r}"
+                    " from alphabet"
                 )
             alpha = Alphabet._ungap(self.alphabet)
         elif not gap:
@@ -1519,9 +1507,7 @@ class UnknownSeq(Seq):
         UnknownSeq(6, alphabet=DNAAlphabet(), character='N')
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type"
-            )
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(len(self) * other, self.alphabet)
 
     def __rmul__(self, other):
@@ -1535,9 +1521,7 @@ class UnknownSeq(Seq):
         UnknownSeq(6, alphabet=DNAAlphabet(), character='N')
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type"
-            )
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(len(self) * other, self.alphabet)
 
     def __imul__(self, other):
@@ -1554,9 +1538,7 @@ class UnknownSeq(Seq):
         UnknownSeq(6, alphabet=DNAAlphabet(), character='N')
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type"
-            )
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(len(self) * other, self.alphabet)
 
     def __getitem__(self, index):
@@ -2017,8 +1999,8 @@ class MutableSeq:
             # Shows the last three letters as it is often useful to see if
             # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
-            return "{0}('{1}...{2}'{3!s})".format(
-                self.__class__.__name__, str(self[:54]), str(self[-3:]), a
+            return (
+                f"{self.__class__.__name__}('{str(self[:54])}...{str(self[-3:])}'{a!s})"
             )
         else:
             return f"{self.__class__.__name__}('{str(self)}'{a!s})"
@@ -2089,9 +2071,8 @@ class MutableSeq:
         if isinstance(other, (str, Seq, UnknownSeq)):
             return str(self) < str(other)
         raise TypeError(
-            "'<' not supported between instances of '{}' and '{}'".format(
-                type(self).__name__, type(other).__name__
-            )
+            f"'<' not supported between instances of '{type(self).__name__}'"
+            f" and '{type(other).__name__}'"
         )
 
     def __le__(self, other):
@@ -2107,9 +2088,8 @@ class MutableSeq:
         if isinstance(other, (str, Seq, UnknownSeq)):
             return str(self) <= str(other)
         raise TypeError(
-            "'<=' not supported between instances of '{}' and '{}'".format(
-                type(self).__name__, type(other).__name__
-            )
+            f"'<=' not supported between instances of '{type(self).__name__}'"
+            f" and '{type(other).__name__}'"
         )
 
     def __gt__(self, other):
@@ -2125,9 +2105,8 @@ class MutableSeq:
         if isinstance(other, (str, Seq, UnknownSeq)):
             return str(self) > str(other)
         raise TypeError(
-            "'>' not supported between instances of '{}' and '{}'".format(
-                type(self).__name__, type(other).__name__
-            )
+            f"'>' not supported between instances of '{type(self).__name__}'"
+            f" and '{type(other).__name__}'"
         )
 
     def __ge__(self, other):
@@ -2143,9 +2122,8 @@ class MutableSeq:
         if isinstance(other, (str, Seq, UnknownSeq)):
             return str(self) >= str(other)
         raise TypeError(
-            "'>=' not supported between instances of '{}' and '{}'".format(
-                type(self).__name__, type(other).__name__
-            )
+            f"'>=' not supported between instances of '{type(self).__name__}'"
+            f" and '{type(other).__name__}'"
         )
 
     def __len__(self):
@@ -2264,9 +2242,7 @@ class MutableSeq:
         MutableSeq('ATGATG', DNAAlphabet())
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type"
-            )
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(self.data * other, self.alphabet)
 
     def __rmul__(self, other):
@@ -2283,9 +2259,7 @@ class MutableSeq:
         MutableSeq('ATGATG', DNAAlphabet())
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type"
-            )
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(self.data * other, self.alphabet)
 
     def __imul__(self, other):
@@ -2299,9 +2273,7 @@ class MutableSeq:
         MutableSeq('ATGATG', DNAAlphabet())
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type"
-            )
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(self.data * other, self.alphabet)
 
     def append(self, c):
@@ -2743,17 +2715,14 @@ def _translate_str(
         c = dual_coding[0]
         if to_stop:
             raise ValueError(
-                "You cannot use 'to_stop=True' with this table "
-                "as it contains {} codon(s) which can be both "
-                " STOP and an  amino acid (e.g. '{}' -> '{}' or "
-                "STOP).".format(len(dual_coding), c, forward_table[c])
+                "You cannot use 'to_stop=True' with this table as it contains"
+                f" {len(dual_coding)} codon(s) which can be both  STOP and an"
+                f" amino acid (e.g. '{c}' -> '{forward_table[c]}' or STOP)."
             )
         warnings.warn(
-            "This table contains {} codon(s) which code(s) for both "
-            "STOP and an amino acid (e.g. '{}' -> '{}' or STOP). "
-            "Such codons will be translated as amino acid.".format(
-                len(dual_coding), c, forward_table[c]
-            ),
+            f"This table contains {len(dual_coding)} codon(s) which code(s) for"
+            f" both STOP and an amino acid (e.g. '{c}' -> '{forward_table[c]}'"
+            " or STOP). Such codons will be translated as amino acid.",
             BiopythonWarning,
         )
 
@@ -2807,9 +2776,7 @@ def _translate_str(
                 # Gapped translation
                 amino_acids.append(gap)
             else:
-                raise CodonTable.TranslationError(
-                    f"Codon '{codon}' is invalid"
-                )
+                raise CodonTable.TranslationError(f"Codon '{codon}' is invalid")
     return "".join(amino_acids)
 
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -130,7 +130,7 @@ class Seq:
                 self.__class__.__name__, str(self)[:54], str(self)[-3:], a
             )
         else:
-            return "{0}({1!r}{2!s})".format(self.__class__.__name__, self._data, a)
+            return f"{self.__class__.__name__}({self._data!r}{a!s})"
 
     def __str__(self):
         """Return the full sequence as a python string, use str(my_seq).
@@ -206,9 +206,7 @@ class Seq:
             # other could be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    ),
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
                     BiopythonWarning,
                 )
         return str(self) == str(other)
@@ -218,9 +216,7 @@ class Seq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    ),
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
                     BiopythonWarning,
                 )
         if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
@@ -236,9 +232,7 @@ class Seq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    ),
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
                     BiopythonWarning,
                 )
         if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
@@ -254,9 +248,7 @@ class Seq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    ),
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
                     BiopythonWarning,
                 )
         if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
@@ -272,9 +264,7 @@ class Seq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    ),
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
                     BiopythonWarning,
                 )
         if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
@@ -357,9 +347,7 @@ class Seq:
             # other should be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 raise TypeError(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    )
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}"
                 )
             # They should be the same sequence type (or one of them is generic)
             a = Alphabet._consensus_alphabet([self.alphabet, other.alphabet])
@@ -391,9 +379,7 @@ class Seq:
             # other should be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 raise TypeError(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    )
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}"
                 )
             # They should be the same sequence type (or one of them is generic)
             a = Alphabet._consensus_alphabet([self.alphabet, other.alphabet])
@@ -416,7 +402,7 @@ class Seq:
         """
         if not isinstance(other, int):
             raise TypeError(
-                "can't multiply {} by non-int type".format(self.__class__.__name__)
+                f"can't multiply {self.__class__.__name__} by non-int type"
             )
         return self.__class__(str(self) * other, self.alphabet)
 
@@ -432,7 +418,7 @@ class Seq:
         """
         if not isinstance(other, int):
             raise TypeError(
-                "can't multiply {} by non-int type".format(self.__class__.__name__)
+                f"can't multiply {self.__class__.__name__} by non-int type"
             )
         return self.__class__(str(self) * other, self.alphabet)
 
@@ -451,7 +437,7 @@ class Seq:
         """
         if not isinstance(other, int):
             raise TypeError(
-                "can't multiply {} by non-int type".format(self.__class__.__name__)
+                f"can't multiply {self.__class__.__name__} by non-int type"
             )
         return self.__class__(str(self) * other, self.alphabet)
 
@@ -488,9 +474,7 @@ class Seq:
         # Other should be a Seq or a MutableSeq
         if not Alphabet._check_type_compatible([self.alphabet, other_alpha]):
             raise TypeError(
-                "Incompatible alphabets {0!r} and {1!r}".format(
-                    self.alphabet, other_alpha
-                )
+                f"Incompatible alphabets {self.alphabet!r} and {other_alpha!r}"
             )
         # Return as a string
         return str(other_sequence)
@@ -1351,7 +1335,7 @@ class Seq:
         else:
             alpha = self.alphabet  # modify!
         if len(gap) != 1 or not isinstance(gap, str):
-            raise ValueError("Unexpected gap character, {0!r}".format(gap))
+            raise ValueError(f"Unexpected gap character, {gap!r}")
         return Seq(str(self).replace(gap, ""), alpha)
 
     def join(self, other):
@@ -1380,9 +1364,7 @@ class Seq:
                 if a != c.alphabet:
                     if not Alphabet._check_type_compatible([a, c.alphabet]):
                         raise TypeError(
-                            "Incompatible alphabets {0!r} and {1!r}".format(
-                                a, c.alphabet
-                            )
+                            f"Incompatible alphabets {a!r} and {c.alphabet!r}"
                         )
                     a = Alphabet._consensus_alphabet([a, c.alphabet])
             elif not isinstance(c, str):
@@ -1484,9 +1466,7 @@ class UnknownSeq(Seq):
             a = ""
         else:
             a = ", alphabet=%r" % self.alphabet
-        return "UnknownSeq({0}{1!s}, character={2!r})".format(
-            self._length, a, self._character
-        )
+        return f"UnknownSeq({self._length}{a!s}, character={self._character!r})"
 
     def __add__(self, other):
         """Add another sequence or string to this sequence.
@@ -1540,7 +1520,7 @@ class UnknownSeq(Seq):
         """
         if not isinstance(other, int):
             raise TypeError(
-                "can't multiply {} by non-int type".format(self.__class__.__name__)
+                f"can't multiply {self.__class__.__name__} by non-int type"
             )
         return self.__class__(len(self) * other, self.alphabet)
 
@@ -1556,7 +1536,7 @@ class UnknownSeq(Seq):
         """
         if not isinstance(other, int):
             raise TypeError(
-                "can't multiply {} by non-int type".format(self.__class__.__name__)
+                f"can't multiply {self.__class__.__name__} by non-int type"
             )
         return self.__class__(len(self) * other, self.alphabet)
 
@@ -1575,7 +1555,7 @@ class UnknownSeq(Seq):
         """
         if not isinstance(other, int):
             raise TypeError(
-                "can't multiply {} by non-int type".format(self.__class__.__name__)
+                f"can't multiply {self.__class__.__name__} by non-int type"
             )
         return self.__class__(len(self) * other, self.alphabet)
 
@@ -1966,9 +1946,7 @@ class UnknownSeq(Seq):
                 if a != c.alphabet:
                     if not Alphabet._check_type_compatible([a, c.alphabet]):
                         raise TypeError(
-                            "Incompatible alphabets {0!r} and {1!r}".format(
-                                a, c.alphabet
-                            )
+                            f"Incompatible alphabets {a!r} and {c.alphabet!r}"
                         )
                     a = Alphabet._consensus_alphabet([a, c.alphabet])
                 if not isinstance(c, UnknownSeq):
@@ -2043,7 +2021,7 @@ class MutableSeq:
                 self.__class__.__name__, str(self[:54]), str(self[-3:]), a
             )
         else:
-            return "{0}('{1}'{2!s})".format(self.__class__.__name__, str(self), a)
+            return f"{self.__class__.__name__}('{str(self)}'{a!s})"
 
     def __str__(self):
         """Return the full sequence as a python string.
@@ -2091,9 +2069,7 @@ class MutableSeq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    ),
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
                     BiopythonWarning,
                 )
             if isinstance(other, MutableSeq):
@@ -2105,9 +2081,7 @@ class MutableSeq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    ),
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
                     BiopythonWarning,
                 )
             if isinstance(other, MutableSeq):
@@ -2125,9 +2099,7 @@ class MutableSeq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    ),
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
                     BiopythonWarning,
                 )
             if isinstance(other, MutableSeq):
@@ -2145,9 +2117,7 @@ class MutableSeq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    ),
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
                     BiopythonWarning,
                 )
             if isinstance(other, MutableSeq):
@@ -2165,9 +2135,7 @@ class MutableSeq:
         if hasattr(other, "alphabet"):
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 warnings.warn(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    ),
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
                     BiopythonWarning,
                 )
             if isinstance(other, MutableSeq):
@@ -2238,9 +2206,7 @@ class MutableSeq:
             # other should be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 raise TypeError(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    )
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}"
                 )
             # They should be the same sequence type (or one of them is generic)
             a = Alphabet._consensus_alphabet([self.alphabet, other.alphabet])
@@ -2268,9 +2234,7 @@ class MutableSeq:
             # other should be a Seq or a MutableSeq
             if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
                 raise TypeError(
-                    "Incompatible alphabets {0!r} and {1!r}".format(
-                        self.alphabet, other.alphabet
-                    )
+                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}"
                 )
             # They should be the same sequence type (or one of them is generic)
             a = Alphabet._consensus_alphabet([self.alphabet, other.alphabet])
@@ -2301,7 +2265,7 @@ class MutableSeq:
         """
         if not isinstance(other, int):
             raise TypeError(
-                "can't multiply {} by non-int type".format(self.__class__.__name__)
+                f"can't multiply {self.__class__.__name__} by non-int type"
             )
         return self.__class__(self.data * other, self.alphabet)
 
@@ -2320,7 +2284,7 @@ class MutableSeq:
         """
         if not isinstance(other, int):
             raise TypeError(
-                "can't multiply {} by non-int type".format(self.__class__.__name__)
+                f"can't multiply {self.__class__.__name__} by non-int type"
             )
         return self.__class__(self.data * other, self.alphabet)
 
@@ -2336,7 +2300,7 @@ class MutableSeq:
         """
         if not isinstance(other, int):
             raise TypeError(
-                "can't multiply {} by non-int type".format(self.__class__.__name__)
+                f"can't multiply {self.__class__.__name__} by non-int type"
             )
         return self.__class__(self.data * other, self.alphabet)
 
@@ -2796,15 +2760,15 @@ def _translate_str(
     if cds:
         if str(sequence[:3]).upper() not in table.start_codons:
             raise CodonTable.TranslationError(
-                "First codon '{0}' is not a start codon".format(sequence[:3])
+                f"First codon '{sequence[:3]}' is not a start codon"
             )
         if n % 3 != 0:
             raise CodonTable.TranslationError(
-                "Sequence length {0} is not a multiple of three".format(n)
+                f"Sequence length {n} is not a multiple of three"
             )
         if str(sequence[-3:]).upper() not in stop_codons:
             raise CodonTable.TranslationError(
-                "Final codon '{0}' is not a stop codon".format(sequence[-3:])
+                f"Final codon '{sequence[-3:]}' is not a stop codon"
             )
         # Don't translate the stop symbol, and manually translate the M
         sequence = sequence[3:-3]
@@ -2844,7 +2808,7 @@ def _translate_str(
                 amino_acids.append(gap)
             else:
                 raise CodonTable.TranslationError(
-                    "Codon '{0}' is invalid".format(codon)
+                    f"Codon '{codon}' is invalid"
                 )
     return "".join(amino_acids)
 

--- a/Bio/SeqIO/GckIO.py
+++ b/Bio/SeqIO/GckIO.py
@@ -25,7 +25,7 @@ def _read(handle, length):
     """Read the specified number of bytes from the given handle."""
     data = handle.read(length)
     if len(data) < length:
-        raise ValueError("Cannot read {} bytes from handle".format(length))
+        raise ValueError(f"Cannot read {length} bytes from handle")
     return data
 
 

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -900,15 +900,13 @@ class GenBankWriter(_InsdcWriter):
                     padding = len(subkey) if len(subkey) > padding else padding
             # Construct output
             for key, data in comment.items():
-                lines.append("##{0}{1}".format(key, self.STRUCTURED_COMMENT_START))
+                lines.append(f"##{key}{self.STRUCTURED_COMMENT_START}")
                 for subkey, subdata in data.items():
                     spaces = " " * (padding - len(subkey))
                     lines.append(
-                        "{0}{1}{2}{3}".format(
-                            subkey, spaces, self.STRUCTURED_COMMENT_DELIM, subdata
-                        )
+                        f"{subkey}{spaces}{self.STRUCTURED_COMMENT_DELIM}{subdata}"
                     )
-                lines.append("##{0}{1}".format(key, self.STRUCTURED_COMMENT_END))
+                lines.append(f"##{key}{self.STRUCTURED_COMMENT_END}")
         if "comment" in record.annotations:
             comment = record.annotations["comment"]
             if isinstance(comment, str):

--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -237,7 +237,7 @@ class XdnaWriter(SequenceWriter):
         if record.description.startswith(record.id):
             comment = record.description
         else:
-            comment = "{} {}".format(record.id, record.description)
+            comment = f"{record.id} {record.description}"
 
         # Write header
         self.handle.write(
@@ -273,7 +273,7 @@ class XdnaWriter(SequenceWriter):
         drop = len(record.features) - len(features)
         if drop > 0:
             warnings.warn(
-                "Dropping {} features with fuzzy locations".format(drop),
+                f"Dropping {drop} features with fuzzy locations",
                 BiopythonWarning,
             )
 
@@ -282,7 +282,7 @@ class XdnaWriter(SequenceWriter):
         if len(features) > 255:
             drop = len(features) - 255
             warnings.warn(
-                "Too many features, dropping the last {}".format(drop), BiopythonWarning
+                f"Too many features, dropping the last {drop}", BiopythonWarning
             )
             features = features[:255]
 

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -636,16 +636,16 @@ class SeqRecord:
         """
         lines = []
         if self.id:
-            lines.append("ID: {0}".format(self.id))
+            lines.append(f"ID: {self.id}")
         if self.name:
-            lines.append("Name: {0}".format(self.name))
+            lines.append(f"Name: {self.name}")
         if self.description:
-            lines.append("Description: {0}".format(self.description))
+            lines.append(f"Description: {self.description}")
         if self.dbxrefs:
             lines.append("Database cross-references: " + ", ".join(self.dbxrefs))
-        lines.append("Number of features: {0}".format(len(self.features)))
+        lines.append(f"Number of features: {len(self.features)}")
         for a in self.annotations:
-            lines.append("/{0}={1}".format(a, str(self.annotations[a])))
+            lines.append(f"/{a}={str(self.annotations[a])}")
         if self.letter_annotations:
             lines.append(
                 "Per letter annotation for: " + ", ".join(self.letter_annotations)

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -1127,7 +1127,7 @@ def Tm_staluc(s, dnac=50, saltc=50, rna=0):
     elif rna == 1:
         return Tm_NN(s, dnac1=dnac / 2.0, dnac2=dnac / 2.0, Na=saltc, nn_table=RNA_NN2)
     else:
-        raise ValueError("rna={0} not supported".format(rna))
+        raise ValueError(f"rna={rna} not supported")
 
 
 if __name__ == "__main__":

--- a/Bio/UniProt/GOA.py
+++ b/Bio/UniProt/GOA.py
@@ -184,7 +184,7 @@ def gpi_iterator(handle):
         # return _gpi20iterator(handle)
         raise NotImplementedError("Sorry, parsing GPI version 2 not implemented yet.")
     else:
-        raise ValueError("Unknown GPI version {0}\n".format(inline))
+        raise ValueError(f"Unknown GPI version {inline}\n")
 
 
 def _gpa10iterator(handle):
@@ -242,7 +242,7 @@ def gpa_iterator(handle):
         # sys.stderr.write("gpa 1.0\n")
         return _gpa10iterator(handle)
     else:
-        raise ValueError("Unknown GPA version {0}\n".format(inline))
+        raise ValueError(f"Unknown GPA version {inline}\n")
 
 
 def _gaf20iterator(handle):
@@ -347,7 +347,7 @@ def gafbyproteiniterator(handle):
         # sys.stderr.write("gaf 2.1\n")
         return _gaf20byproteiniterator(handle)
     else:
-        raise ValueError("Unknown GAF version {0}\n".format(inline))
+        raise ValueError(f"Unknown GAF version {inline}\n")
 
 
 def gafiterator(handle):
@@ -399,7 +399,7 @@ def gafiterator(handle):
         # sys.stderr.write("gaf 1.0\n")
         return _gaf10iterator(handle)
     else:
-        raise ValueError("Unknown GAF version {0}\n".format(inline))
+        raise ValueError(f"Unknown GAF version {inline}\n")
 
 
 def writerec(outrec, handle, fields=GAF20FIELDS):

--- a/Bio/motifs/clusterbuster.py
+++ b/Bio/motifs/clusterbuster.py
@@ -67,7 +67,7 @@ def write(motifs):
     """Return the representation of motifs in Cluster Buster position frequency matrix format."""
     lines = []
     for m in motifs:
-        line = ">{0}\n".format(m.name)
+        line = f">{m.name}\n"
         lines.append(line)
         for ACGT_counts in zip(
             m.counts["A"], m.counts["C"], m.counts["G"], m.counts["T"]

--- a/Bio/motifs/jaspar/__init__.py
+++ b/Bio/motifs/jaspar/__init__.py
@@ -73,40 +73,40 @@ class Motif(motifs.Motif):
 
         We choose to provide only the filled metadata information.
         """
-        tf_name_str = "TF name\t{0}\n".format(self.name)
-        matrix_id_str = "Matrix ID\t{0}\n".format(self.matrix_id)
+        tf_name_str = f"TF name\t{self.name}\n"
+        matrix_id_str = f"Matrix ID\t{self.matrix_id}\n"
         the_string = "".join([tf_name_str, matrix_id_str])
         if self.collection:
-            collection_str = "Collection\t{0}\n".format(self.collection)
+            collection_str = f"Collection\t{self.collection}\n"
             the_string = "".join([the_string, collection_str])
         if self.tf_class:
-            tf_class_str = "TF class\t{0}\n".format(self.tf_class)
+            tf_class_str = f"TF class\t{self.tf_class}\n"
             the_string = "".join([the_string, tf_class_str])
         if self.tf_family:
-            tf_family_str = "TF family\t{0}\n".format(self.tf_family)
+            tf_family_str = f"TF family\t{self.tf_family}\n"
             the_string = "".join([the_string, tf_family_str])
         if self.species:
-            species_str = "Species\t{0}\n".format(",".join(self.species))
+            species_str = f"Species\t{','.join(self.species)}\n"
             the_string = "".join([the_string, species_str])
         if self.tax_group:
-            tax_group_str = "Taxonomic group\t{0}\n".format(self.tax_group)
+            tax_group_str = f"Taxonomic group\t{self.tax_group}\n"
             the_string = "".join([the_string, tax_group_str])
         if self.acc:
-            acc_str = "Accession\t{0}\n".format(self.acc)
+            acc_str = f"Accession\t{self.acc}\n"
             the_string = "".join([the_string, acc_str])
         if self.data_type:
-            data_type_str = "Data type used\t{0}\n".format(self.data_type)
+            data_type_str = f"Data type used\t{self.data_type}\n"
             the_string = "".join([the_string, data_type_str])
         if self.medline:
-            medline_str = "Medline\t{0}\n".format(self.medline)
+            medline_str = f"Medline\t{self.medline}\n"
             the_string = "".join([the_string, medline_str])
         if self.pazar_id:
-            pazar_id_str = "PAZAR ID\t{0}\n".format(self.pazar_id)
+            pazar_id_str = f"PAZAR ID\t{self.pazar_id}\n"
             the_string = "".join([the_string, pazar_id_str])
         if self.comment:
-            comment_str = "Comments\t{0}\n".format(self.comment)
+            comment_str = f"Comments\t{self.comment}\n"
             the_string = "".join([the_string, comment_str])
-        matrix_str = "Matrix:\n{0}\n\n".format(self.counts)
+        matrix_str = f"Matrix:\n{self.counts}\n\n"
         the_string = "".join([the_string, matrix_str])
         return the_string
 
@@ -175,8 +175,8 @@ def write(motifs, format):
         motif = motifs[0]
         counts = motif.counts
         for letter in letters:
-            terms = ["{0:6.2f}".format(value) for value in counts[letter]]
-            line = "{0}\n".format(" ".join(terms))
+            terms = [f"{value:6.2f}" for value in counts[letter]]
+            line = f"{' '.join(terms)}\n"
             lines.append(line)
     elif format == "jaspar":
         for m in motifs:
@@ -185,11 +185,11 @@ def write(motifs, format):
                 matrix_id = m.matrix_id
             except AttributeError:
                 matrix_id = None
-            line = ">{0} {1}\n".format(matrix_id, m.name)
+            line = f">{matrix_id} {m.name}\n"
             lines.append(line)
             for letter in letters:
-                terms = ["{0:6.2f}".format(value) for value in counts[letter]]
-                line = "{0} [{1}]\n".format(letter, " ".join(terms))
+                terms = [f"{value:6.2f}" for value in counts[letter]]
+                line = f"{letter} [{' '.join(terms)}]\n"
                 lines.append(line)
     else:
         raise ValueError("Unknown JASPAR format %s" % format)

--- a/Bio/motifs/jaspar/db.py
+++ b/Bio/motifs/jaspar/db.py
@@ -357,7 +357,7 @@ class JASPAR5:
         # we should probably raise an exception
         if not row:
             warnings.warn(
-                "Could not fetch JASPAR motif with internal ID = {0}".format(int_id),
+                f"Could not fetch JASPAR motif with internal ID = {int_id}",
                 BiopythonWarning,
             )
             return None

--- a/Bio/motifs/mast.py
+++ b/Bio/motifs/mast.py
@@ -112,18 +112,18 @@ def __make_diagram(record, sequence_tree):
         return str(sequence_length)
     if record.strand_handling == "combine":
         motif_strs = [
-            "[{}{}]".format("-" if hit_ele.get("rc") == "y" else "+", hit_motif.name)
+            f"[{'-' if hit_ele.get('rc') == 'y' else '+'}{hit_motif.name}]"
             for hit_ele, hit_motif in zip(hit_eles, hit_motifs)
         ]
     elif record.strand_handling == "unstranded":
         motif_strs = [
-            "[{}]".format(hit_motif.name)
+            f"[{hit_motif.name}]"
             for hit_ele, hit_motif in zip(hit_eles, hit_motifs)
         ]
     else:
         # TODO - more strand_handling possibilities?
         raise Exception(
-            "Strand handling option {} not parsable".format(record.strand_handling)
+            f"Strand handling option {record.strand_handling} not parsable"
         )
     tail_length = (
         sequence_length - int(hit_eles[-1].get("pos")) - hit_motifs[-1].length + 1

--- a/Bio/motifs/pfm.py
+++ b/Bio/motifs/pfm.py
@@ -404,7 +404,7 @@ def write(motifs):
     """Return the representation of motifs in Cluster Buster position frequency matrix format."""
     lines = []
     for m in motifs:
-        line = ">{0}\n".format(m.name)
+        line = f">{m.name}\n"
         lines.append(line)
         for ACGT_counts in zip(
             m.counts["A"], m.counts["C"], m.counts["G"], m.counts["T"]

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -1000,10 +1000,8 @@ class DictionaryBuilder:
                     dna = Seq(enzymedict[other][0], generic_dna)
                     sense2 = regex(dna)
                     antisense2 = regex(dna.reverse_complement())
-                    sense = "(?=(?P<{}>{})|{})".format(other, sense1, sense2)
-                    antisense = "(?=(?P<{}_as>{}|{}))".format(
-                        other, antisense1, antisense2
-                    )
+                    sense = f"(?=(?P<{other}>{sense1})|{sense2})"
+                    antisense = f"(?=(?P<{other}_as>{antisense1}|{antisense2}))"
                     reg = sense + "|" + antisense
                     line[1] = line[1] + "|" + enzymedict[other][0]
                     line[-1] = reg

--- a/Scripts/SeqGui/SeqGui.py
+++ b/Scripts/SeqGui/SeqGui.py
@@ -116,13 +116,13 @@ def clear_output():
 def apply_operation():
     """Do the selected operation."""
     codon_table = codon_list.get(codon_list.curselection())
-    print("Code: {}".format(codon_table))
+    print(f"Code: {codon_table}")
 
     seq = "".join(input_text.get(1.0, tk.END).split())
-    print("Input sequence: {}".format(seq))
+    print(f"Input sequence: {seq}")
 
     operation = transform_var.get()
-    print("Operation: {}".format(operation))
+    print(f"Operation: {operation}")
 
     if operation == "transcribe":
         result = transcribe(seq)
@@ -135,7 +135,7 @@ def apply_operation():
 
     output_text.delete(1.0, tk.END)
     output_text.insert(tk.END, result)
-    print("Result: {}".format(result))
+    print(f"Result: {result}")
     return
 
 

--- a/Scripts/xbbtools/xbb_blast.py
+++ b/Scripts/xbbtools/xbb_blast.py
@@ -93,7 +93,7 @@ class BlastIt:
                     title="Please locate your BLAST program folder:"
                 )
                 self.blast_path += os.sep
-                if os.system("{}blastn -version".format(self.blast_path)):
+                if os.system(f"{self.blast_path}blastn -version"):
                     messagebox.showerror(
                         "xbb tools",
                         "Wrong folder or missing BLAST"

--- a/Scripts/xbbtools/xbb_translations.py
+++ b/Scripts/xbbtools/xbb_translations.py
@@ -79,7 +79,7 @@ class xbb_translations:
         protein += (((length - (abs(frame) - 1)) % 3) + 2) * " "
         if frame < 0:
             protein = protein[::-1]
-        res = self.header_nice("Frame {} translation".format(frame), seq)
+        res = self.header_nice(f"Frame {frame} translation", seq)
         for i in range(0, length, 60):
             subseq = seq[i : i + 60]
             p = i // 3

--- a/Tests/PAML/gen_results.py
+++ b/Tests/PAML/gen_results.py
@@ -48,7 +48,7 @@ def codeml(vers=None, verbose=False):
             # M2a_rel (NSsites 22) was introduced in PAML 4.6
             if test[0] == "m2a_rel" and int(version.split("_")[1][0]) < 6:
                 continue
-            print("\t{0}".format(version.replace("_", ".")))
+            print(f"\t{version.replace('_', '.')}")
             if test[0] in ["ngene2_mgene02", "ngene2_mgene34"] and \
                version == "4_6":
                 cml.tree = ".".join([cml.tree, "4.6"])
@@ -72,36 +72,36 @@ def baseml(vers=None, verbose=False):
         print(test[0])
         bml = baseml.Baseml()
         for version in versions:
-            print("\t{0}".format(version.replace("_", ".")))
+            print(f"\t{version.replace('_', '.')}")
             if test[1] is not None:
                 for n in test[1]:
                     if (version in ["4_3", "4_4", "4_4c", "4_5"] and
                             test[0] == "nparK" and n in [3, 4]):
                         continue
-                    print("\t\tn = {0}".format(n))
+                    print(f"\t\tn = {n}")
                     ctl_file = (os.path.join("Control_files", "baseml",
-                                "{0}{1}.ctl".format(test[0], n)))
+                                f"{test[0]}{n}.ctl"))
                     bml.read_ctl_file(ctl_file)
                     bml.alignment = alignment
                     bml.tree = tree
-                    out_file = "{0}{1}-{2}.out".format(test[0], n, version)
+                    out_file = f"{test[0]}{n}-{version}.out"
                     bml.out_file = (os.path.join("Results", "baseml", test[0],
                                     out_file))
-                    bin = "baseml{0}".format(version)
+                    bin = f"baseml{version}"
                     bml.run(command=bin, verbose=verbose, parse=False)
             else:
                 if (version in ["4_3", "4_4", "4_4c", "4_5"] and
                         test[0] == "alpha1rho1"):
                     continue
                 ctl_file = (os.path.join("Control_files", "baseml",
-                            "{0}.ctl".format(test[0])))
+                            f"{test[0]}.ctl"))
                 bml.read_ctl_file(ctl_file)
                 bml.alignment = alignment
                 bml.tree = tree
-                out_file = "{0}-{1}.out".format(test[0], version)
+                out_file = f"{test[0]}-{version}.out"
                 bml.out_file = (os.path.join("Results", "baseml", test[0],
                                 out_file))
-                bin = "baseml{0}".format(version)
+                bin = f"baseml{version}"
                 bml.run(command=bin, verbose=verbose, parse=False)
 
 
@@ -116,13 +116,13 @@ def yn00(vers=None, verbose=False):
         print(test)
         yn = yn00.Yn00()
         for version in versions:
-            print("\t{0}".format(version.replace("_", ".")))
+            print(f"\t{version.replace('_', '.')}")
             ctl_file = (os.path.join("Control_files", "yn00",
-                        "{0}.ctl".format(test)))
+                        f"{test}.ctl"))
             yn.read_ctl_file(ctl_file)
-            out_file = "{0}-{1}.out".format(test, version)
+            out_file = f"{test}-{version}.out"
             yn.out_file = os.path.join("Results", "yn00", out_file)
-            bin = "yn00{0}".format(version)
+            bin = f"yn00{version}"
             yn.run(command=bin, verbose=verbose, parse=False)
 
 

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -154,14 +154,14 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX', ProteinAlphabet())"""
 
     def test_format_str(self):
         expected = ">TestID TestDescr\nABCDEFGHIJKLMNOPQRSTUVWZYX\n"
-        self.assertEqual(expected, "{:fasta}".format(self.record))
+        self.assertEqual(expected, f"{self.record:fasta}")
 
     def test_format_str_binary(self):
         with self.assertRaisesRegex(
             ValueError,
             "Binary format sff cannot be used with SeqRecord format method"
         ):
-            "{:sff}".format(self.record)
+            f"{self.record:sff}"
 
     def test_format_spaces(self):
         rec = SeqRecord(Seq("ABCDEFGHIJKLMNOPQRSTUVWZYX", generic_protein),


### PR DESCRIPTION
This pull request is mainly for discussion/illustration for issue #2510, the question of if we should adopt f-strings.

This shows what it would be like to replace the string format method (the second major string formatting style in Python, used in a minority of Biopython) with f-strings (the third major method added in Python 3.6, not yet used in Biopython), while leaving the C-style percent operator formatting alone (the original string formatting style, used in most of Biopython).

This might be a happy compromise over moving everything to f-strings (as showcased in #2510)? i.e. Allow legacy percent operator _or_ the new f-strings?

This was done with a modified version of flynt v0.38, where I disabled method ``visit_BinOp`` in the class ``flynt.transform.FstringifyTransformer.FstringifyTransformer`` - and would be easy to repeat later if required.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
