### PR TITLE
Seqxml windows bug

### DIFF
--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -357,6 +357,13 @@ class SeqXmlIterator:
         try:
             handle = open(stream_or_path, 'rb')
         except TypeError:  # not a path, assume we received a stream
+            # Make sure we got a binary handle. If we got a text handle, then
+            # the parser will still run but unicode characters will be garbled
+            # if the text handle was opened with a different encoding than the
+            # one specified in the XML file. With a binary handle, the correct
+            # encoding is picked up by the parser from the XML file.
+            if stream_or_path.read(0) != b"":
+                raise TypeError("SeqXML files should be opened in binary mode") from None
             self.handle = stream_or_path
             self.should_close_handle = False
         else:  # we received a path

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -355,7 +355,7 @@ class SeqXmlIterator:
         self.parser.setContentHandler(content_handler)
         self.parser.setFeature(handler.feature_namespaces, True)
         try:
-            handle = open(stream_or_path)
+            handle = open(stream_or_path, 'rb')
         except TypeError:  # not a path, assume we received a stream
             self.handle = stream_or_path
             self.should_close_handle = False

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -355,7 +355,7 @@ class SeqXmlIterator:
         self.parser.setContentHandler(content_handler)
         self.parser.setFeature(handler.feature_namespaces, True)
         try:
-            handle = open(stream_or_path, 'rb')
+            handle = open(stream_or_path, "rb")
         except TypeError:  # not a path, assume we received a stream
             # Make sure we got a binary handle. If we got a text handle, then
             # the parser will still run but unicode characters will be garbled

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -499,6 +499,7 @@ _BinaryFormats = [
     "seqxml",
     "snapgene",
     "nib",
+    "seqxml",
     "xdna",
 ]
 

--- a/Tests/test_SeqIO_SeqXML.py
+++ b/Tests/test_SeqIO_SeqXML.py
@@ -52,10 +52,10 @@ class TestDetailedRead(unittest.TestCase):
             self.records["dna"][2].description,
             'some special characters in the description\n<tag> "quoted string"'
         )
-    if sys.platform != "win32":
-        def test_unicode_characters_desc(self):
-            """Test special unicode characters in the description."""
-            self.assertEqual(self.records["rna"][2].description, "åÅüöÖßøä¢£$€香肠")
+
+    def test_unicode_characters_desc(self):
+        """Test special unicode characters in the description."""
+        self.assertEqual(self.records["rna"][2].description, "åÅüöÖßøä¢£$€香肠")
 
     def test_full_characters_set_read(self):
         """Read full characters set for each type."""

--- a/Tests/test_SeqIO_SeqXML.py
+++ b/Tests/test_SeqIO_SeqXML.py
@@ -10,7 +10,7 @@ import sys
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from io import StringIO
+from io import BytesIO
 
 
 def assert_equal_records(testCase, record_a, record_b):
@@ -169,7 +169,7 @@ class TestReadAndWrite(unittest.TestCase):
 
     def _write_parse_and_compare(self, read1_records):
 
-        handle = StringIO()
+        handle = BytesIO()
 
         SeqIO.write(read1_records, handle, "seqxml")
 
@@ -186,26 +186,27 @@ class TestReadAndWrite(unittest.TestCase):
         record = SeqIO.read("SwissProt/sp016", "swiss")
         self.assertEqual(record.annotations["organism"], "Homo sapiens (Human)")
         self.assertEqual(record.annotations["ncbi_taxid"], ["9606"])
-        handle = StringIO()
+        handle = BytesIO()
         SeqIO.write(record, handle, "seqxml")
         handle.seek(0)
         output = handle.getvalue()
-        self.assertIn("Homo sapiens (Human)", output)
-        self.assertIn("9606", output)
-        if '<species name="Homo sapiens (Human)" ncbiTaxID="9606"/>' in output:
+        text = output.decode("UTF-8")
+        self.assertIn("Homo sapiens (Human)", text)
+        self.assertIn("9606", text)
+        if '<species name="Homo sapiens (Human)" ncbiTaxID="9606"/>' in text:
             # Good, but don't get this (do we?)
             pass
-        elif '<species name="Homo sapiens (Human)" ncbiTaxID="9606"></species>' in output:
+        elif '<species name="Homo sapiens (Human)" ncbiTaxID="9606"></species>' in text:
             # Not as concise, but fine (seen on C Python)
             pass
-        elif '<species ncbiTaxID="9606" name="Homo sapiens (Human)"></species>' in output:
+        elif '<species ncbiTaxID="9606" name="Homo sapiens (Human)"></species>' in text:
             # Jython uses a different order
             pass
-        elif '<species ncbiTaxID="9606" name="Homo sapiens (Human)"/>' in output:
+        elif '<species ncbiTaxID="9606" name="Homo sapiens (Human)"/>' in text:
             # This would be fine too, but don't get this (do we?)
             pass
         else:
-            raise ValueError("Mising expected <species> tag: %r" % output)
+            raise ValueError("Mising expected <species> tag: %r" % text)
 
 
 class TestReadCorruptFiles(unittest.TestCase):


### PR DESCRIPTION
This pull request fixes Bio.SeqIO.SeqXmlIO by opening SeqXML files in binary mode to avoid encoding issues. This allows the bug previously observed on Windows to be fixed. Before applying this PR, the bug can be triggered on any platform by setting
```
LC_ALL=en_US.ISO8859-15    
```
(or anything else that is not UTF-8) in your terminal.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
