### PR TITLE
Remove Python 2 references in Tutorial

### DIFF
--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1253,8 +1253,7 @@ caution: Dealing with errors with this style of calling external programs is muc
 complicated.
 It also becomes far harder to diagnose problems, because you can't try running MUSCLE
 manually outside of Biopython (because you don't have the input file to supply).
-There can also be subtle cross platform issues (e.g. Windows versus Linux,
-Python 2 versus Python 3), and how
+There can also be subtle cross platform issues (e.g. Windows versus Linux), and how
 you run your script can have an impact (e.g. at the command line, from IDLE or an
 IDE, or as a GUI script). These are all generic Python issues though, and not
 specific to Biopython.

--- a/Doc/Tutorial/chapter_appendix.tex
+++ b/Doc/Tutorial/chapter_appendix.tex
@@ -86,7 +86,7 @@ handle.close()
 \end{minted}
 
 With our parsers for plain text files, under Python 3 it is
-essential to use gzip in text mode.
+essential to use gzip in text mode (the default is binary mode).
 
 See Section~\ref{sec:SeqIO_compressed} for more examples like this,
 including reading bzip2 compressed files.

--- a/Doc/Tutorial/chapter_appendix.tex
+++ b/Doc/Tutorial/chapter_appendix.tex
@@ -85,8 +85,8 @@ for record in SeqIO.parse(handle, "fasta"):
 handle.close()
 \end{minted}
 
-With our parsers for plain text files, under Python 3 it is
-essential to use gzip in text mode (the default is binary mode).
+With our parsers for plain text files, it is essential to use gzip in
+text mode (the default is binary mode).
 
 See Section~\ref{sec:SeqIO_compressed} for more examples like this,
 including reading bzip2 compressed files.

--- a/Doc/Tutorial/chapter_cluster.tex
+++ b/Doc/Tutorial/chapter_cluster.tex
@@ -705,17 +705,11 @@ For example, you can use
 \end{minted}
 to open a gzipped file, or
 \begin{minted}{pycon}
->>> from urllib.request import urlopen # Python 3 only
+>>> from urllib.request import urlopen
 >>> from io import TextIOWrapper
 >>> handle = TextIOWrapper(urlopen("https://raw.githubusercontent.com/biopython/biopython/master/Tests/Cluster/cyano.txt"))
 \end{minted}
 to open a file stored on the Internet before calling \verb|read|.
-
-Note for Python 2 this can be done by using:
-\begin{minted}{pycon}
->>> from urllib import urlopen # Python 2 only
->>> handle = urlopen("https://raw.githubusercontent.com/biopython/biopython/master/Tests/Cluster/cyano.txt")
-\end{minted}
 
 The \verb|read| command reads the tab-delimited text file \verb|mydatafile.txt| containing gene expression data in the format specified for Michael Eisen's Cluster/TreeView program. In this file format, rows represent genes and columns represent samples or observations. For a simple time course, a minimal input file would look like this:
 

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1298,7 +1298,6 @@ for (seq, section_dict) in [
         except KeyError:
             section_dict[section] = [i]
 # Now find any sub-sequences found in both sequences
-# (Python 2.3 would require slightly different code here)
 matches = set(dict_one).intersection(dict_two)
 print("%i unique matches" % len(matches))
 \end{minted}

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -133,7 +133,7 @@ Since this is a fairly simple XML file, we could extract the information it cont
 >>> record = Entrez.read(handle)
 \end{minted}
 Now \verb+record+ is a dictionary with exactly one key:
-%Not continuing doctest due as only Python 2 will show a u'string' prefix...
+%cont-doctest
 \begin{minted}{pycon}
 >>> record.keys()
 ['DbList']

--- a/Doc/Tutorial/chapter_introduction.tex
+++ b/Doc/Tutorial/chapter_introduction.tex
@@ -140,9 +140,8 @@ file for other options.
   \href{https://github.com/biopython/biopython/blob/master/NEWS.rst}{latest NEWS file on GitHub}.
 
   \item \emph{What is going wrong with my print commands?} \\
-  This tutorial now uses the Python 3 style print \emph{function}.
-  As of Biopython 1.62, we supported both Python 2 and Python 3.
-  As of Biopython 1.77, we only support Python 3.
+  As of Biopython 1.77, we only support Python 3, so this tutorial
+  uses the Python 3 style print \emph{function}.
 
   \item \emph{How do I find out what version of Biopython I have installed?} \\
   Use this:

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -1285,9 +1285,6 @@ C:   0.80   0.00   1.00   0.00   0.00   0.00
 G:   0.00   0.05   0.00   1.00   0.00   1.00
 T:   0.00   0.00   0.00   0.00   1.00   0.00
 <BLANKLINE>
-\end{minted}
-%Can't use next bit in doctest, Windows Python 2.5 and 2.6 put -1.$ not -inf
-\begin{minted}{pycon}
 >>> print(motif.pssm)
         0      1      2      3      4      5
 A:  -0.32   1.93   -inf   -inf   -inf   -inf
@@ -1320,10 +1317,6 @@ A: 3.00
 C: 3.00
 G: 3.00
 T: 3.00
-\end{minted}
-%Can't use this in doctest, Windows Python 2.5 and 2.6 give G/1 as 0.13 not 0.12
-%TODO - Check why...
-\begin{minted}{pycon}
 >>> print(motif.pwm)
         0      1      2      3      4      5
 A:   0.22   0.69   0.09   0.09   0.09   0.09

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -186,8 +186,7 @@ If you really do just need a plain string, for example to write to a file, or in
 
 Since calling \verb|str()| on a \verb|Seq| object returns the full sequence as a string,
 you often don't actually have to do this conversion explicitly.
-Python does this automatically in the print function
-(and the print statement under Python 2):
+Python does this automatically in the print function:
 
 %cont-doctest
 \begin{minted}{pycon}
@@ -768,7 +767,7 @@ Just like the normal Python string, the \verb|Seq| object is ``read only'', or i
 \end{minted}
 
 Observe what happens if you try to edit the sequence:
-%TODO - This is not a doctest as Python 2.4 output omits the object name.
+%cont-doctest
 \begin{minted}{pycon}
 >>> my_seq[5] = "G"
 Traceback (most recent call last):

--- a/Doc/Tutorial/chapter_seqio.tex
+++ b/Doc/Tutorial/chapter_seqio.tex
@@ -375,8 +375,7 @@ Now, suppose we have a gzip compressed file instead? These are very
 commonly used on Linux. We can use Python's \verb|gzip| module to open
 the compressed file for reading - which gives us a handle object:
 
-%TODO: Can we make the doctest code Python version specific?
-%This doctest fails on Python 2.7 due to https://bugs.python.org/issue30012
+%doctest examples
 \begin{minted}{pycon}
 >>> import gzip
 >>> from Bio import SeqIO
@@ -386,21 +385,13 @@ the compressed file for reading - which gives us a handle object:
 67518
 \end{minted}
 
-Similarly if we had a bzip2 compressed file (sadly the function name isn't
-quite as consistent under Python 2):
-
-%TODO: Can we make the doctest code Python version specific?
+Similarly if we had a bzip2 compressed file:
 
 %doctest examples
 \begin{minted}{pycon}
 >>> import bz2
 >>> from Bio import SeqIO
->>> if hasattr(bz2, "open"):
-...     handle = bz2.open("ls_orchid.gbk.bz2", "rt")  # Python 3
-... else:
-...     handle = bz2.BZ2File("ls_orchid.gbk.bz2", "r")  # Python 2
-...
->>> with handle:
+>>> with bz2.open("ls_orchid.gbk.bz2", "rt") as handle:
 ...     print(sum(len(r) for r in SeqIO.parse(handle, "gb")))
 ...
 67518
@@ -610,7 +601,6 @@ we can look at all of the keys we have available:
 ['Z78484.1', 'Z78464.1', 'Z78455.1', 'Z78442.1', 'Z78532.1', 'Z78453.1', ..., 'Z78471.1']
 \end{minted}
 
-You can leave out the ``list(...)`` bit if you are still using Python 2.
 Under Python 3 the dictionary methods like ``.keys()`` and ``.values()``
 are iterators rather than lists.
 

--- a/Doc/Tutorial/chapter_testing.tex
+++ b/Doc/Tutorial/chapter_testing.tex
@@ -91,7 +91,7 @@ If you are interested in using Tox, you could start with the example
 
 \begin{minted}{text}
 [tox]
-envlist = py27,pypy,py36,py37
+envlist = pypy,py36,py37
 
 [testenv]
 changedir = Tests
@@ -101,9 +101,9 @@ deps =
     reportlab
 \end{minted}
 
-Using the template above, executing \texttt{tox} will test your Biopython code against
-Python 2.7, PyPy, Python 3.6 and Python3.7. It assumes that those
-Pythons' executables are named accordingly: ``python2.7`` for Python 2.7, and so on.
+Using the template above, executing \texttt{tox} will test your Biopython
+code against PyPy, Python 3.6 and Python3.7. It assumes that those Pythons'
+executables are named accordingly: ``python3.7`` for Python 3.7, and so on.
 
 
 \section{Writing tests}

--- a/Doc/Tutorial/chapter_uniprot.tex
+++ b/Doc/Tutorial/chapter_uniprot.tex
@@ -13,30 +13,27 @@ In Section~\ref{sec:SeqIO_ExPASy_and_SwissProt}, we described how to extract the
 
 To parse a Swiss-Prot record, we first get a handle to a Swiss-Prot record. There are several ways to do so, depending on where and how the Swiss-Prot record is stored:
 \begin{itemize}
+
 \item Open a Swiss-Prot file locally:
 \begin{minted}{pycon}
 >>> handle = open("myswissprotfile.dat")
 \end{minted} 
+
 \item Open a gzipped Swiss-Prot file:
 \begin{minted}{pycon}
 >>> import gzip
 >>> handle = gzip.open("myswissprotfile.dat.gz", "rt")
 \end{minted}
+
 \item Open a Swiss-Prot file over the internet:
-%--doctest . internet
 \begin{minted}{pycon}
->>> from urllib.request import urlopen # Python 3 only
+>>> from urllib.request import urlopen
 >>> from io import TextIOWrapper
->>> handle = TextIOWrapper(urlopen("https://raw.githubusercontent.com/biopython/biopython/master/Tests/SwissProt/F2CXE6.txt"))
+>>> url = "https://raw.githubusercontent.com/biopython/biopython/master/Tests/SwissProt/F2CXE6.txt"
+>>> handle = TextIOWrapper(urlopen(url))
 \end{minted}
 to open the file stored on the Internet before calling \verb|read|.
 
-Note for Python 2 this can be done by using:
-%--doctest . internet
-\begin{minted}{pycon}
->>> from urllib import urlopen #Python 2 only
->>> handle = urlopen("https://raw.githubusercontent.com/biopython/biopython/master/Tests/SwissProt/F2CXE6.txt")
-\end{minted}
 \item Open a Swiss-Prot file over the internet from the ExPASy database
 (see section \ref{sec:expasy_swissprot}):
 \begin{minted}{pycon}


### PR DESCRIPTION
This pull request is part of the general cleanup with dropping Python 2 support. Note this alters some of the doctests within the LaTeX, and thus the test results are worth verifying.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
