### PR TITLE
add from None to get a clear exception message

### DIFF
--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -1147,7 +1147,7 @@ class SffWriter(SequenceWriter):
         except TypeError:
             raise ValueError(
                 "SFF files must NOT be opened in text mode, binary required."
-            )
+            ) from None
         self.handle = handle
         self._xml = xml
         if index:


### PR DESCRIPTION
This pull request fixes an Exception in Bio.SeqIO.SffIO.

`sff` is a binary file format.
Trying to write sequences in `sff` format to a text handle raises a double exception:

```
from Bio.Seq import Seq
from Bio.SeqRecord import SeqRecord
from Bio import SeqIO

sequence = Seq('ACGT')
record = SeqRecord(sequence)
handle = open('mytextfile.txt', 'wt')
SeqIO.write([record], handle, 'sff')
```

gives the following output:

```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/Bio/SeqIO/SffIO.py", line 1146, in __init__
    handle.write(b"")
TypeError: write() argument must be str, not bytes

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 8, in <module>
    SeqIO.write([record], handle, 'sff')
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/Bio/SeqIO/__init__.py", line 551, in write
    count = writer_class(fp).write_file(sequences)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/Bio/SeqIO/SffIO.py", line 1149, in __init__
    "SFF files must NOT be opened in text mode, binary required."
ValueError: SFF files must NOT be opened in text mode, binary required.
```

This is a result of PEP 3134 (starting from python3); python2 would only raise the `ValueError`.
PEP 409 provides a mechanism to suppress the `TypeError` and show the `ValueError` only, by adding `from None` when raising the `ValueError`. Then the script above outputs:
```
Traceback (most recent call last):
  File "test.py", line 8, in <module>
    SeqIO.write([record], handle, 'sff')
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/Bio/SeqIO/__init__.py", line 551, in write
    count = writer_class(fp).write_file(sequences)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/Bio/SeqIO/SffIO.py", line 1150, in __init__
    ) from None
ValueError: SFF files must NOT be opened in text mode, binary required.
```
which is the output that is meaningful to the user.

This PR adds the `from None` for Bio.SeqIO.SffIO, but unfortunately we probably have this issue in 100's of places in Biopython.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
