### PR TITLE
raise a ValueError if a SeqXML file is opened in text mode for writing

### DIFF
--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -443,6 +443,11 @@ class SeqXmlWriter(SequentialSequenceWriter):
         self, handle, source=None, source_version=None, species=None, ncbiTaxId=None
     ):
         """Create Object and start the xml generator."""
+        try:
+            handle.write(b"")
+        except TypeError:
+            raise ValueError("SeqXML files must be opened in binary mode.")
+
         SequentialSequenceWriter.__init__(self, handle)
 
         self.xml_generator = XMLGenerator(handle, "utf-8")


### PR DESCRIPTION
This pull request adds a ValueError if a SeqXML file is opened in text mode.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
