### PR TITLE
Remove python 2 branch in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -276,21 +276,14 @@ for line in open("Bio/__init__.py"):
     if line.startswith("__version__"):
         exec(line.strip())
 
-# We now load in our reStructuredText README.rst file to pass
-# explicitly in the metadata since at time of writing PyPI
-# did not do this for us.
+# We now load in our reStructuredText README.rst file to pass explicitly in the
+# metadata, since at time of writing PyPI did not do this for us.
 #
-# Without declaring an encoding, if there was a problematic
-# character in the file, it would work on Python 2 but might
-# fail on Python 3 depending on the user's locale. By explicitly
-# checking ASCII (could use latin1 or UTF8 if needed later),
-# if any invalid character does appear in our README, this will
-# fail and alert us immediately on either platform.
-with open("README.rst", "rb") as handle:
-    # Only Python 3's open has an encoding argument.
-    # Opening in binary and doing decoding like this to work
-    # on both Python 2 and 3.
-    readme_rst = handle.read().decode("ascii")
+# Must make encoding explicit to avoid any conflict with the local default.
+# Currently keeping README as ASCII (might switch to UTF8 later if needed).
+# If any invalid character does appear in README, this will fail and alert us.
+with open("README.rst", encoding="ascii") as handle:
+    readme_rst = handle.read()
 
 setup(
     name="biopython",

--- a/setup.py
+++ b/setup.py
@@ -80,10 +80,7 @@ def osx_clang_fix():
     # see http://lists.open-bio.org/pipermail/biopython-dev/2014-April/011240.html
     if sys.platform != "darwin":
         return
-    if sys.version_info[0] >= 3:
-        from subprocess import getoutput
-    else:
-        from commands import getoutput
+    from subprocess import getoutput
     from distutils.ccompiler import new_compiler
     from distutils.sysconfig import customize_compiler
 

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,6 @@ import os
 try:
     from setuptools import setup
     from setuptools import Command
-    from setuptools.command.install import install
-    from setuptools.command.build_py import build_py
-    from setuptools.command.build_ext import build_ext
     from setuptools import Extension
 except ImportError:
     sys.exit(
@@ -48,7 +45,6 @@ if "bdist_wheel" in sys.argv:
             "for bdist_wheel to work. Try running: pip install wheel"
         )
 
-_CHECKED = None
 
 # Make sure we have the right Python version.
 if sys.version_info[:2] < (3, 6):
@@ -57,64 +53,6 @@ if sys.version_info[:2] < (3, 6):
         "Python %d.%d detected.\n" % sys.version_info[:2]
     )
     sys.exit(1)
-
-
-def check_dependencies_once():
-    """Check dependencies, will cache and re-use the result."""
-    # Call check_dependencies, but cache the result for subsequent
-    # calls.
-    global _CHECKED
-    if _CHECKED is None:
-        _CHECKED = check_dependencies()
-    return _CHECKED
-
-
-def check_dependencies():
-    """Return whether the installation should continue."""
-    # There should be some way for the user to tell specify not to
-    # check dependencies.  For example, it probably should not if
-    # the user specified "-q".  However, I'm not sure where
-    # distutils stores that information.  Also, install has a
-    # --force option that gets saved in self.user_options.  It
-    # means overwrite previous installations.  If the user has
-    # forced an installation, should we also ignore dependencies?
-
-    # Currently there are no compile time dependencies
-    return True
-
-
-class install_biopython(install):
-    """Override the standard install to check for dependencies.
-
-    This will just run the normal install, and then print warning messages
-    if packages are missing.
-    """
-
-    def run(self):
-        """Run the installation."""
-        if check_dependencies_once():
-            # Run the normal install.
-            install.run(self)
-
-
-class build_py_biopython(build_py):
-    """Biopython builder."""
-
-    def run(self):
-        """Run the build."""
-        if not check_dependencies_once():
-            return
-        build_py.run(self)
-
-
-class build_ext_biopython(build_ext):
-    """Biopython extension builder."""
-
-    def run(self):
-        """Run the build."""
-        if not check_dependencies_once():
-            return
-        build_ext.run(self)
 
 
 class test_biopython(Command):
@@ -313,12 +251,7 @@ setup(
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    cmdclass={
-        "install": install_biopython,
-        "build_py": build_py_biopython,
-        "build_ext": build_ext_biopython,
-        "test": test_biopython,
-    },
+    cmdclass={"test": test_biopython},
     packages=PACKAGES,
     ext_modules=EXTENSIONS,
     include_package_data=True,  # done via MANIFEST.in under setuptools


### PR DESCRIPTION
This pull request addresses issue #2490 - but I had overlooked it until now.

I wonder if we can drop the entire osx_clang_fix code yet? i.e. -Qunused-arguments special casing on macOS.


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
