### PR TITLE
Update docstrings to remove `.tostring()` references

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -133,22 +133,7 @@ class Seq:
             return "{0}({1!r}{2!s})".format(self.__class__.__name__, self._data, a)
 
     def __str__(self):
-        """Return the full sequence as a python string, use str(my_seq).
-
-        Note that Biopython 1.44 and earlier would give a truncated
-        version of repr(my_seq) for str(my_seq).  If you are writing code
-        which need to be backwards compatible with really old Biopython,
-        you should continue to use my_seq.tostring() as follows::
-
-            try:
-                # The old way, removed in Biopython 1.73
-                as_string = seq_obj.tostring()
-            except AttributeError:
-                # The new way, needs Biopython 1.45 or later.
-                # Don't use this on Biopython 1.44 or older as truncates
-                as_string = str(seq_obj)
-
-        """
+        """Return the full sequence as a python string, use str(my_seq)."""
         return self._data
 
     def __hash__(self):
@@ -2046,13 +2031,7 @@ class MutableSeq:
             return "{0}('{1}'{2!s})".format(self.__class__.__name__, str(self), a)
 
     def __str__(self):
-        """Return the full sequence as a python string.
-
-        Note that Biopython 1.44 and earlier would give a truncated
-        version of repr(my_seq) for str(my_seq).  If you are writing code
-        which needs to be backwards compatible with old Biopython, you
-        should continue to use my_seq.tostring() rather than str(my_seq).
-        """
+        """Return the full sequence as a python string."""
         # See test_GAQueens.py for an historic usage of a non-string alphabet!
         return "".join(self.data)
 


### PR DESCRIPTION
`tostring()` methods were removed here: https://github.com/biopython/biopython/commit/2f035092baa18a45e98738c6c8fe18e84140636f

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
