### PR TITLE
Adopt f-strings in Bio.UniProt, flynt v.0.40.1.

### DIFF
--- a/Bio/UniProt/GOA.py
+++ b/Bio/UniProt/GOA.py
@@ -418,7 +418,7 @@ def writerec(outrec, handle, fields=GAF20FIELDS):
         else:
             outstr += outrec[field] + "\t"
     outstr += outrec[fields[-1]] + "\n"
-    handle.write(f"{outstr}")
+    handle.write(outstr)
 
 
 def writebyproteinrec(outprotrec, handle, fields=GAF20FIELDS):

--- a/Bio/UniProt/GOA.py
+++ b/Bio/UniProt/GOA.py
@@ -184,7 +184,7 @@ def gpi_iterator(handle):
         # return _gpi20iterator(handle)
         raise NotImplementedError("Sorry, parsing GPI version 2 not implemented yet.")
     else:
-        raise ValueError("Unknown GPI version {0}\n".format(inline))
+        raise ValueError(f"Unknown GPI version {inline}\n")
 
 
 def _gpa10iterator(handle):
@@ -242,7 +242,7 @@ def gpa_iterator(handle):
         # sys.stderr.write("gpa 1.0\n")
         return _gpa10iterator(handle)
     else:
-        raise ValueError("Unknown GPA version {0}\n".format(inline))
+        raise ValueError(f"Unknown GPA version {inline}\n")
 
 
 def _gaf20iterator(handle):
@@ -347,7 +347,7 @@ def gafbyproteiniterator(handle):
         # sys.stderr.write("gaf 2.1\n")
         return _gaf20byproteiniterator(handle)
     else:
-        raise ValueError("Unknown GAF version {0}\n".format(inline))
+        raise ValueError(f"Unknown GAF version {inline}\n")
 
 
 def gafiterator(handle):
@@ -399,7 +399,7 @@ def gafiterator(handle):
         # sys.stderr.write("gaf 1.0\n")
         return _gaf10iterator(handle)
     else:
-        raise ValueError("Unknown GAF version {0}\n".format(inline))
+        raise ValueError(f"Unknown GAF version {inline}\n")
 
 
 def writerec(outrec, handle, fields=GAF20FIELDS):
@@ -418,7 +418,7 @@ def writerec(outrec, handle, fields=GAF20FIELDS):
         else:
             outstr += outrec[field] + "\t"
     outstr += outrec[fields[-1]] + "\n"
-    handle.write("%s" % outstr)
+    handle.write(f"{outstr}")
 
 
 def writebyproteinrec(outprotrec, handle, fields=GAF20FIELDS):


### PR DESCRIPTION
This pull request addresses issue #2510 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

I'm reviewing Bio/UniProt/GOA.py, this PR updates to the newer f-string format, is a small change should be fine to merge.
Run flynt over Bio.UniProt and Tests/test_UniProt_GOA.py these are all changes for Bio.Uniprot related to f-strings.