### PR TITLE
Remove Python 2 specific __div__ and __rdiv__ (PDB, PhyloXML)

### DIFF
--- a/Bio/PDB/vectors.py
+++ b/Bio/PDB/vectors.py
@@ -297,9 +297,6 @@ class Vector:
         a = self._ar / numpy.array(x)
         return Vector(a)
 
-    # For Python 2:
-    __div__ = __truediv__
-
     def __pow__(self, other):
         """Return VectorxVector (cross product) or Vectorxscalar."""
         if isinstance(other, Vector):

--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -711,21 +711,13 @@ class Confidence(PhyloElement):
         """Conduct reverse multiplication between values of two Confidence objects."""
         return other * self.value
 
-    def __div__(self, other):
-        """Conduct division between values of two Confidence objects."""
-        return self.value.__div__(other)
-
-    def __rdiv__(self, other):
-        """Conduct revers division between values of two Confidence objects."""
-        return other.__div__(self.value)
-
     def __truediv__(self, other):
-        """Rational-style division in Py3.0+."""
-        return self.value / other
+        """Conduct division between values of two Confidence objects."""
+        return self.value.__truediv__(other)
 
     def __rtruediv__(self, other):
-        """Conduct revers Rational-style division."""
-        return other / self.value
+        """Conduct reverse division between values of two Confidence objects."""
+        return other.__rtruediv__(self.value)
 
     def __floordiv__(self, other):
         """C-style and old-style division in Py3.0+."""

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -303,7 +303,7 @@ class RestrictionType(type):
         else:
             raise TypeError
 
-    def __div__(cls, other):
+    def __truediv__(cls, other):
         """Override '/' operator to use as search method.
 
         >>> from Bio.Restriction import EcoRI
@@ -314,7 +314,7 @@ class RestrictionType(type):
         """
         return cls.search(other)
 
-    def __rdiv__(cls, other):
+    def __rtruediv__(cls, other):
         """Override division with reversed operands to use as search method.
 
         >>> from Bio.Restriction import EcoRI
@@ -322,20 +322,6 @@ class RestrictionType(type):
         [2]
 
         Returns RE.search(other).
-        """
-        return cls.search(other)
-
-    def __truediv__(cls, other):
-        """Override Python 3 division operator to use as search method.
-
-        Like __div__.
-        """
-        return cls.search(other)
-
-    def __rtruediv__(cls, other):
-        """As __truediv___, with reversed operands.
-
-        Like __rdiv__.
         """
         return cls.search(other)
 


### PR DESCRIPTION
Split out from #2523 to make it easier for @etal to review. The ``PhyloXML`` usage does not seem to have any test coverage...

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
