### PR TITLE
deprecating Bio.FSSP

### DIFF
--- a/Bio/FSSP/__init__.py
+++ b/Bio/FSSP/__init__.py
@@ -3,7 +3,7 @@
 # as part of this package.
 #
 
-"""Parser for FSSP files, used in a database of protein fold classifications.
+"""Parser for FSSP files, used in a database of protein fold classifications (DEPRECATED).
 
 This is a module to handle FSSP files. For now it parses only the header,
 summary and alignment sections.
@@ -21,8 +21,18 @@ Functions
 """
 
 import re
+import warnings
 
 from . import fssp_rec
+
+from Bio import BiopythonDeprecationWarning
+
+warnings.warn(
+    "Bio.FSSP has been deprecated, and we intend to remove it"
+    " in a future release of Biopython. Please contact the Biopython"
+    " developers if you need this module.",
+    BiopythonDeprecationWarning
+)
 
 
 fff_rec = fssp_rec.fff_rec

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -842,3 +842,7 @@ Bio.File
 The UndoHandle class was deprecated in Release 1.77, and moved to
 Bio/SearchIO/_legacy/ParserSupport.py, which was the only module in
 Biopython still using this class.
+
+Bio.FSSP
+-----------
+Deprecated in release 1.77.

--- a/Tests/test_FSSP.py
+++ b/Tests/test_FSSP.py
@@ -3,13 +3,18 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 
-"""Tests for the FSSP module."""
+"""Tests for the FSSP module (DEPRECATED)."""
 
 import os
 import unittest
+import warnings
 
-from Bio import FSSP
-from Bio.FSSP import FSSPTools
+from Bio import BiopythonDeprecationWarning
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonDeprecationWarning)
+    # modules to be tested
+    from Bio import FSSP
+    from Bio.FSSP import FSSPTools
 
 
 class TestGeo(unittest.TestCase):


### PR DESCRIPTION
This pull request addresses deprecates Bio.FSSP, as the FSSP database doesn't seem to exist any more.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
