### PR TITLE
Drop redundant open(file, "rU") `mode` argument

### DIFF
--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -364,7 +364,7 @@ def parse(handle, format, seq_count=None, alphabet=None):
     if seq_count is not None and not isinstance(seq_count, int):
         raise TypeError("Need integer for seq_count (sequences per alignment)")
 
-    with as_handle(handle, "rU") as fp:
+    with as_handle(handle) as fp:
         # Map the file format to a sequence iterator:
         if format in _FormatToIterator:
             iterator_generator = _FormatToIterator[format]
@@ -471,7 +471,7 @@ def convert(in_file, in_format, out_file, out_format, alphabet=None):
     """
     # TODO - Add optimised versions of important conversions
     # For now just off load the work to SeqIO parse/write
-    with as_handle(in_file, "rU") as in_handle:
+    with as_handle(in_file) as in_handle:
         # Don't open the output file until we've checked the input is OK:
         alignments = parse(in_handle, in_format, None, alphabet)
 

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -688,7 +688,7 @@ class Nexus:
         # file-like object.
         # Note we need to add parsing of the path to dir/filename
         try:
-            with File.as_handle(input, "rU") as fp:
+            with File.as_handle(input) as fp:
                 file_contents = fp.read()
                 self.filename = getattr(fp, "name", "Unknown_nexus_file")
         except (TypeError, OSError, AttributeError):

--- a/Bio/PDB/PDBParser.py
+++ b/Bio/PDB/PDBParser.py
@@ -89,7 +89,7 @@ class PDBParser:
             # Make a StructureBuilder instance (pass id of structure as parameter)
             self.structure_builder.init_structure(id)
 
-            with as_handle(file, mode="rU") as handle:
+            with as_handle(file) as handle:
                 lines = handle.readlines()
                 if not lines:
                     raise ValueError("Empty file.")

--- a/Bio/SCOP/Cla.py
+++ b/Bio/SCOP/Cla.py
@@ -103,7 +103,7 @@ class Index(dict):
         """
         dict.__init__(self)
         self.filename = filename
-        with open(self.filename, "rU") as f:
+        with open(self.filename) as f:
             position = 0
             while True:
                 line = f.readline()
@@ -121,7 +121,7 @@ class Index(dict):
         """Return an item from the indexed file."""
         position = dict.__getitem__(self, key)
 
-        with open(self.filename, "rU") as f:
+        with open(self.filename) as f:
             f.seek(position)
             line = f.readline()
             record = Record(line)

--- a/Bio/SearchIO/__init__.py
+++ b/Bio/SearchIO/__init__.py
@@ -303,7 +303,7 @@ def parse(handle, format=None, **kwargs):
         handle_kwargs["encoding"] = "utf-8"
 
     # and start iterating
-    with as_handle(handle, "rU", **handle_kwargs) as source_file:
+    with as_handle(handle, **handle_kwargs) as source_file:
         generator = iterator(source_file, **kwargs)
         yield from generator
 

--- a/Bio/SeqIO/AceIO.py
+++ b/Bio/SeqIO/AceIO.py
@@ -32,7 +32,7 @@ def AceIterator(handle):
     letter_annotations dictionary under the "phred_quality" key.
 
     >>> from Bio import SeqIO
-    >>> with open("Ace/consed_sample.ace", "rU") as handle:
+    >>> with open("Ace/consed_sample.ace") as handle:
     ...     for record in SeqIO.parse(handle, "ace"):
     ...         print("%s %s... %i" % (record.id, record.seq[:10], len(record)))
     ...         print(max(record.letter_annotations["phred_quality"]))
@@ -47,7 +47,7 @@ def AceIterator(handle):
     prevented output of the gapped sequence as FASTQ format.
 
     >>> from Bio import SeqIO
-    >>> with open("Ace/contig1.ace", "rU") as handle:
+    >>> with open("Ace/contig1.ace") as handle:
     ...     for record in SeqIO.parse(handle, "ace"):
     ...         print("%s ...%s..." % (record.id, record.seq[85:95]))
     ...         print(record.letter_annotations["phred_quality"][85:95])
@@ -60,7 +60,7 @@ def AceIterator(handle):
     90
 
     """
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
 
         for ace_contig in Ace.parse(handle):
             # Convert the ACE contig record into a SeqRecord...

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -174,7 +174,7 @@ def FastaIterator(handle, alphabet=single_letter_alphabet, title2ids=None):
     DELTA
 
     """
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
         if title2ids:
             for title, sequence in SimpleFastaParser(handle):
                 id, name, descr = title2ids(title)
@@ -210,7 +210,7 @@ def FastaTwoLineIterator(handle, alphabet=single_letter_alphabet):
     Only the default title to ID/name/description parsing offered
     by the relaxed FASTA parser is offered.
     """
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
         for title, sequence in FastaTwoLineParser(handle):
             try:
                 first_word = title.split(None, 1)[0]

--- a/Bio/SeqIO/IgIO.py
+++ b/Bio/SeqIO/IgIO.py
@@ -59,7 +59,7 @@ def IgIterator(handle, alphabet=single_letter_alphabet):
     SYK_SYK length 330
 
     """
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
 
         # Skip any file header text before the first record (;; lines)
         while True:

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -148,7 +148,7 @@ def PdbSeqresIterator(handle):
 
     chains = collections.defaultdict(list)
     metadata = collections.defaultdict(list)
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
         for line in handle:
             empty = False
             rec_name = line[0:6].strip()
@@ -283,7 +283,7 @@ def PdbAtomIterator(handle):
     # Only import PDB when needed, to avoid/delay NumPy dependency in SeqIO
     from Bio.PDB import PDBParser
 
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
         struct = PDBParser().get_structure(None, handle)
         pdb_id = struct.header["idcode"]
         if not pdb_id:
@@ -368,7 +368,7 @@ def CifSeqresIterator(handle):
     # Only import PDB when needed, to avoid/delay NumPy dependency in SeqIO
     from Bio.PDB.MMCIF2Dict import MMCIF2Dict
 
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
 
         chains = collections.defaultdict(list)
         metadata = collections.defaultdict(list)
@@ -498,7 +498,7 @@ def CifAtomIterator(handle):
     # file. We copy the contents of the handle into a StringIO buffer first,
     # so that both MMCIF2Dict and MMCIFParser can consume the handle.
     buffer = StringIO()
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
         shutil.copyfileobj(handle, buffer)
 
     # check if file is empty

--- a/Bio/SeqIO/PhdIO.py
+++ b/Bio/SeqIO/PhdIO.py
@@ -65,7 +65,7 @@ def PhdIterator(handle):
 
     This uses the Bio.Sequencing.Phd module to do the hard work.
     """
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
         phd_records = Phd.parse(handle)
         for phd_record in phd_records:
             # Convert the PHY record into a SeqRecord...

--- a/Bio/SeqIO/PirIO.py
+++ b/Bio/SeqIO/PirIO.py
@@ -141,7 +141,7 @@ def PirIterator(handle):
     HLA:HLA01083 length 188
 
     """
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
         # Skip any text before the first record (e.g. blank lines, comments)
         while True:
             line = handle.readline()

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -888,7 +888,7 @@ def FastqGeneralIterator(handle):
     Using this tricky example file as input, this short bit of code demonstrates
     what this parsing function would return:
 
-    >>> with open("Quality/tricky.fastq", "rU") as handle:
+    >>> with open("Quality/tricky.fastq") as handle:
     ...     for (title, sequence, quality) in FastqGeneralIterator(handle):
     ...         print(title)
     ...         print("%s %s" % (sequence, quality))
@@ -909,7 +909,7 @@ def FastqGeneralIterator(handle):
     is that (provided there are no line breaks in the quality sequence) it
     would prevent the above problem with the "@" character.
     """
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
         # We need to call handle.readline() at least four times per record,
         # so we'll save a property look up each time:
         handle_readline = handle.readline
@@ -1016,7 +1016,7 @@ def FastqPhredIterator(handle, alphabet=single_letter_alphabet, title2ids=None):
 
     Using this module directly you might run:
 
-    >>> with open("Quality/example.fastq", "rU") as handle:
+    >>> with open("Quality/example.fastq") as handle:
     ...     for record in FastqPhredIterator(handle):
     ...         print("%s %s" % (record.id, record.seq))
     EAS54_6_R1_2_1_413_324 CCCTTCTTGTCTTCAGCGTTTCTCC
@@ -1027,7 +1027,7 @@ def FastqPhredIterator(handle, alphabet=single_letter_alphabet, title2ids=None):
     (or "fastq-sanger") as the format:
 
     >>> from Bio import SeqIO
-    >>> with open("Quality/example.fastq", "rU") as handle:
+    >>> with open("Quality/example.fastq") as handle:
     ...     for record in SeqIO.parse(handle, "fastq"):
     ...         print("%s %s" % (record.id, record.seq))
     EAS54_6_R1_2_1_413_324 CCCTTCTTGTCTTCAGCGTTTCTCC
@@ -1111,7 +1111,7 @@ def FastqSolexaIterator(handle, alphabet=single_letter_alphabet, title2ids=None)
 
     Using this module directly you might run:
 
-    >>> with open("Quality/solexa_example.fastq", "rU") as handle:
+    >>> with open("Quality/solexa_example.fastq") as handle:
     ...     for record in FastqSolexaIterator(handle):
     ...         print("%s %s" % (record.id, record.seq))
     SLXA-B3_649_FC8437_R1_1_1_610_79 GATGTGCAATACCTTTGTAGAGGAA
@@ -1124,7 +1124,7 @@ def FastqSolexaIterator(handle, alphabet=single_letter_alphabet, title2ids=None)
     "fastq-solexa" as the format:
 
     >>> from Bio import SeqIO
-    >>> with open("Quality/solexa_example.fastq", "rU") as handle:
+    >>> with open("Quality/solexa_example.fastq") as handle:
     ...     for record in SeqIO.parse(handle, "fastq-solexa"):
     ...         print("%s %s" % (record.id, record.seq))
     SLXA-B3_649_FC8437_R1_1_1_610_79 GATGTGCAATACCTTTGTAGAGGAA
@@ -1160,7 +1160,7 @@ def FastqSolexaIterator(handle, alphabet=single_letter_alphabet, title2ids=None)
     use the Bio.SeqIO.read() function:
 
     >>> from Bio import SeqIO
-    >>> with open("Quality/solexa_faked.fastq", "rU") as handle:
+    >>> with open("Quality/solexa_faked.fastq") as handle:
     ...     record = SeqIO.read(handle, "fastq-solexa")
     >>> print("%s %s" % (record.id, record.seq))
     slxa_0001_1_0001_01 ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTNNNNNN
@@ -1300,7 +1300,7 @@ def QualPhredIterator(handle, alphabet=single_letter_alphabet, title2ids=None):
 
     Using this module directly you might run:
 
-    >>> with open("Quality/example.qual", "rU") as handle:
+    >>> with open("Quality/example.qual") as handle:
     ...     for record in QualPhredIterator(handle):
     ...         print("%s %s" % (record.id, record.seq))
     EAS54_6_R1_2_1_413_324 ?????????????????????????
@@ -1311,7 +1311,7 @@ def QualPhredIterator(handle, alphabet=single_letter_alphabet, title2ids=None):
     as the format:
 
     >>> from Bio import SeqIO
-    >>> with open("Quality/example.qual", "rU") as handle:
+    >>> with open("Quality/example.qual") as handle:
     ...     for record in SeqIO.parse(handle, "qual"):
     ...         print("%s %s" % (record.id, record.seq))
     EAS54_6_R1_2_1_413_324 ?????????????????????????
@@ -1327,7 +1327,7 @@ def QualPhredIterator(handle, alphabet=single_letter_alphabet, title2ids=None):
 
     >>> from Bio import SeqIO
     >>> from Bio.Alphabet import generic_dna
-    >>> with open("Quality/example.qual", "rU") as handle:
+    >>> with open("Quality/example.qual") as handle:
     ...     for record in SeqIO.parse(handle, "qual", alphabet=generic_dna):
     ...         print("%s %s" % (record.id, record.seq))
     EAS54_6_R1_2_1_413_324 NNNNNNNNNNNNNNNNNNNNNNNNN
@@ -1350,7 +1350,7 @@ def QualPhredIterator(handle, alphabet=single_letter_alphabet, title2ids=None):
     scores but will replace them with the lowest possible PHRED score of zero.
     This will trigger a warning, previously it raised a ValueError exception.
     """
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
         # Skip any text before the first record (e.g. blank lines, comments)
         while True:
             line = handle.readline()
@@ -1882,8 +1882,8 @@ def PairedFastaQualIterator(
     can't be used to read the two files together - but this function can!
     For example,
 
-    >>> with open("Quality/example.fasta", "rU") as f:
-    ...     with open("Quality/example.qual", "rU") as q:
+    >>> with open("Quality/example.fasta") as f:
+    ...     with open("Quality/example.qual") as q:
     ...         for record in PairedFastaQualIterator(f, q):
     ...             print("%s %s" % (record.id, record.seq))
     ...
@@ -1903,8 +1903,8 @@ def PairedFastaQualIterator(
     this function to convert paired FASTA and QUAL files into FASTQ files:
 
     >>> from Bio import SeqIO
-    >>> with open("Quality/example.fasta", "rU") as f:
-    ...     with open("Quality/example.qual", "rU") as q:
+    >>> with open("Quality/example.fasta") as f:
+    ...     with open("Quality/example.qual") as q:
     ...         SeqIO.write(PairedFastaQualIterator(f, q), "Quality/temp.fastq", "fastq")
     ...
     3

--- a/Bio/SeqIO/SwissIO.py
+++ b/Bio/SeqIO/SwissIO.py
@@ -73,7 +73,7 @@ def SwissIterator(handle):
     Rather than calling it directly, you are expected to use this
     parser via Bio.SeqIO.parse(..., format="swiss") instead.
     """
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
         swiss_records = SwissProt.parse(handle)
 
         for swiss_record in swiss_records:

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -73,7 +73,7 @@ def TabIterator(handle, alphabet=single_letter_alphabet):
     gi|45478721|ref|NP_995576.1| length 90
 
     """
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
         for line in handle:
             try:
                 title, seq = line.split("\t")  # will fail if more than one tab!

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -43,7 +43,7 @@ def UniprotIterator(
     return_raw_comments = True --> comment fields are returned as complete XML to allow further processing
     skip_parsing_errors = True --> if parsing errors are found, skip to next entry
     """
-    with as_handle(handle, "rU") as handle:
+    with as_handle(handle) as handle:
 
         # check if file is empty
         if handle.readline() == "":

--- a/Bio/phenotype/__init__.py
+++ b/Bio/phenotype/__init__.py
@@ -178,7 +178,7 @@ def parse(handle, format):
     if format != format.lower():
         raise ValueError("Format string '%s' should be lower case" % format)
 
-    with as_handle(handle, "rU") as fp:
+    with as_handle(handle) as fp:
         # Map the file format to a sequence iterator:
         if format in _FormatToIterator:
             iterator_generator = _FormatToIterator[format]

--- a/Tests/test_KGML_graphics.py
+++ b/Tests/test_KGML_graphics.py
@@ -108,7 +108,7 @@ class KGMLPathwayTest(unittest.TestCase):
         # We test rendering of the original KEGG KGML using only local
         # files.
         for p in self.data:
-            with open(p.infilename, "rU") as f:
+            with open(p.infilename) as f:
                 pathway = read(f)
                 pathway.image = p.pathway_image
                 kgml_map = KGMLCanvas(pathway)

--- a/Tests/test_KGML_graphics_online.py
+++ b/Tests/test_KGML_graphics_online.py
@@ -74,7 +74,7 @@ class KGMLPathwayOnlineTest(unittest.TestCase):
         """
         # We test rendering of the original KEGG KGML using imported files
         for p in self.data:
-            with open(p.infilename, "rU") as f:
+            with open(p.infilename) as f:
                 pathway = read(f)
                 kgml_map = KGMLCanvas(pathway, import_imagemap=True)
                 kgml_map.draw(p.output_stem + "_importmap.pdf")

--- a/Tests/test_KGML_nographics.py
+++ b/Tests/test_KGML_nographics.py
@@ -83,7 +83,7 @@ class KGMLPathwayTest(unittest.TestCase):
         """
         for p in self.data:
             # Test opening file
-            with open(p.infilename, "rU") as f:
+            with open(p.infilename) as f:
                 pathway = read(f)
                 # Do we have the correct number of elements of each type
                 self.assertEqual((len(pathway.entries),
@@ -95,7 +95,7 @@ class KGMLPathwayTest(unittest.TestCase):
             with open(p.outfilename, "w") as f:
                 f.write(pathway.get_KGML())
             # Can we read the file we wrote?
-            with open(p.outfilename, "rU") as f:
+            with open(p.outfilename) as f:
                 pathway = read(f)
                 # Do we have the correct number of elements of each type
                 self.assertEqual((len(pathway.entries),

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -590,7 +590,7 @@ class ParseTest(unittest.TestCase):
         try:
             io.save(filename)
             # Check if there are lines besides 'ATOM', 'TER' and 'END'
-            with open(filename, "rU") as handle:
+            with open(filename) as handle:
                 record_set = {l[0:6] for l in handle}
             record_set -= {
                 "ATOM  ",


### PR DESCRIPTION
As noted in https://github.com/biopython/biopython/pull/2564#discussion_r368020173, "U" (universal newlines) mode was deprecated in Python 3.4 and the `newline=None` default argument handles it instead. I did the replacement with `sed`

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
