### PR TITLE
Convert `os.system()` to `subprocess.call()`

### DIFF
--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -203,7 +203,7 @@ def dssp_dict_from_pdb_file(in_file, DSSP="dssp"):
         pdb file
 
     DSSP : string
-        DSSP executable (argument to os.system)
+        DSSP executable (argument to subprocess)
 
     Returns
     -------
@@ -406,7 +406,7 @@ class DSSP(AbstractResiduePropertyMap):
         in_file : string
             Either a PDB file or a DSSP file.
         dssp : string
-            The dssp executable (ie. the argument to os.system)
+            The dssp executable (ie. the argument to subprocess)
         acc_array : string
             Accessible surface area (ASA) from either Miller et al. (1987),
             Sander & Rost (1994), or Wilke: Tien et al. 2013, as string

--- a/Bio/PDB/PSEA.py
+++ b/Bio/PDB/PSEA.py
@@ -16,7 +16,7 @@ Comput Appl Biosci 1997 , 13:291-295
 ftp://ftp.lmcp.jussieu.fr/pub/sincris/software/protein/p-sea/
 """
 
-import os
+import subprocess
 
 from Bio.PDB.Polypeptide import is_aa
 
@@ -32,7 +32,7 @@ def run_psea(fname):
 
     Note that P-SEA will write output to the terminal while run.
     """
-    os.system("psea " + fname)
+    subprocess.call(["psea", fname])
     last = fname.split("/")[-1]
     base = last.split(".")[0]
     return base + ".sea"
@@ -84,7 +84,7 @@ def annotate(m, ss_seq):
         raise ValueError("Length mismatch %i %i" % (L, len(ss_seq)))
     for i in range(0, L):
         residues[i].xtra["SS_PSEA"] = ss_seq[i]
-    # os.system("rm "+fname)
+    # subprocess.call(["rm", fname])
 
 
 class PSEA:

--- a/Bio/Wise/__init__.py
+++ b/Bio/Wise/__init__.py
@@ -19,7 +19,6 @@ Bio.Wise.dnal is for Smith-Waterman DNA alignments
 import os
 import sys
 import tempfile
-import subprocess
 
 from Bio import SeqIO
 
@@ -106,8 +105,8 @@ def align(
     if debug:
         sys.stderr.write("%s\n" % cmdline_str)
 
-    status = subprocess.call(cmdline_str, shell=True) >> 8
-
+    status = os.system(cmdline_str, shell=True) >> 8
+    # `status` here will be >1 for error codes >=256
     if status > 1:
         if kbyte != 0:  # possible memory problem; could be None
             sys.stderr.write("INFO trying again with the linear model\n")

--- a/Bio/Wise/__init__.py
+++ b/Bio/Wise/__init__.py
@@ -105,7 +105,8 @@ def align(
     if debug:
         sys.stderr.write("%s\n" % cmdline_str)
 
-    status = os.system(cmdline_str, shell=True) >> 8
+    status = os.system(cmdline_str) >> 8
+
     # `status` here will be >1 for error codes >=256
     if status > 1:
         if kbyte != 0:  # possible memory problem; could be None

--- a/Bio/Wise/__init__.py
+++ b/Bio/Wise/__init__.py
@@ -19,6 +19,7 @@ Bio.Wise.dnal is for Smith-Waterman DNA alignments
 import os
 import sys
 import tempfile
+import subprocess
 
 from Bio import SeqIO
 
@@ -105,7 +106,7 @@ def align(
     if debug:
         sys.stderr.write("%s\n" % cmdline_str)
 
-    status = os.system(cmdline_str) >> 8
+    status = subprocess.call(cmdline_str, shell=True) >> 8
 
     if status > 1:
         if kbyte != 0:  # possible memory problem; could be None

--- a/Scripts/xbbtools/xbb_blast.py
+++ b/Scripts/xbbtools/xbb_blast.py
@@ -15,6 +15,7 @@
 import glob
 import os
 import sys
+import subprocess
 
 import tkinter as tk
 import tkinter.ttk as ttk
@@ -88,12 +89,15 @@ class BlastIt:
         """Test if BLAST binaries are in PATH or let user locate them."""
         if not BlastIt.blast_ok:
             # Test if blast binaries are in path
-            if os.system("blastn -version"):  # Return of non-zero means error
+            if subprocess.call(
+                ["blastn", "-version"]
+            ):  # Return of non-zero means error
                 self.blast_path = filedialog.askdirectory(
                     title="Please locate your BLAST program folder:"
                 )
-                self.blast_path += os.sep
-                if os.system(f"{self.blast_path}blastn -version"):
+                if subprocess.call(
+                    [os.path.join(self.blast_path, "blastn"), "-version"]
+                ):
                     messagebox.showerror(
                         "xbb tools",
                         "Wrong folder or missing BLAST"

--- a/Scripts/xbbtools/xbb_blastbg.py
+++ b/Scripts/xbbtools/xbb_blastbg.py
@@ -15,6 +15,8 @@
 import os
 import tempfile
 import threading
+import subprocess
+
 from tkinter import messagebox
 
 from Bio.Blast.Applications import (
@@ -138,4 +140,6 @@ class BlastWorker(threading.Thread):
 
 
 if __name__ == "__main__":
-    os.system("python xbb_blast.py ATGACAAAGCTAATTATTCACTTGGTTTCAGACTCTTCTGTGCAAACTGC")
+    subprocess.call(
+        ["python", "xbb_blast.py", "ATGACAAAGCTAATTATTCACTTGGTTTCAGACTCTTCTGTGCAAACTGC"]
+    )


### PR DESCRIPTION
The `subprocess` module is preferred to `os.system` these days, see [PEP 324](https://www.python.org/dev/peps/pep-0324/#rationale) and [the docs](https://docs.python.org/3/library/subprocess.html). Also a couple of minor `black` changes post the previous f-string work.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
