### PR TITLE
Kwargs in pairwise aligner constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ Doc/_minted-Tutorial/
 Doc/Tutorial.txt
 Doc/Tutorial.pdf
 Doc/Tutorial.html
+Doc/Tutorial.pyg
 Doc/biopdb_faq.pdf
 Doc/install/Installation.txt
 Doc/install/Installation.pdf

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1530,6 +1530,13 @@ class PairwiseAligner(_aligners.PairwiseAligner):
     """
 
     def __init__(self, **kwargs):
+        """Initialize a new PairwiseAligner with the keyword arguments as attributes.
+
+        This function subclasses `_aligners.PairwiseAligner` and loops over all
+        the keyword arguments that are given in the constructor to set them
+        as attributes on the object. This will call the `__setattr__` method to
+        do that.
+        """
         super().__init__()
         for name, value in kwargs.items():
             setattr(self, name, value)

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -16,12 +16,10 @@ class, used in the Bio.AlignIO module.
 
 import warnings
 
-from Bio import BiopythonDeprecationWarning
+from Bio import Alphabet, BiopythonDeprecationWarning
+from Bio.Align import _aligners
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord, _RestrictedDict
-from Bio import Alphabet
-
-from Bio.Align import _aligners
 
 # Import errors may occur here if a compiled aligners.c file
 # (_aligners.pyd or _aligners.so) is missing or if the user is
@@ -1509,7 +1507,31 @@ class PairwiseAligner(_aligners.PairwiseAligner):
     -EVL-
     <BLANKLINE>
 
+    You can also set the value of attributes directly during construction
+    of the PairwiseAligner object by providing them as keyword arguemnts:
+
+    >>> aligner = Align.PairwiseAligner(mode='global', match_score=2, mismatch_score=-1)
+    >>> for alignment in aligner.align("TACCG", "ACG"):
+    ...     print("Score = %.1f:" % alignment.score)
+    ...     print(alignment)
+    ...
+    Score = 6.0:
+    TACCG
+    -||-|
+    -AC-G
+    <BLANKLINE>
+    Score = 6.0:
+    TACCG
+    -|-||
+    -A-CG
+    <BLANKLINE>
+
     """
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        for name, value in kwargs.items():
+            setattr(self, name, value)
 
     def __setattr__(self, key, value):
         if key not in dir(_aligners.PairwiseAligner):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -16,7 +16,8 @@ class, used in the Bio.AlignIO module.
 
 import warnings
 
-from Bio import Alphabet, BiopythonDeprecationWarning
+from Bio import Alphabet
+from Bio import BiopythonDeprecationWarning
 from Bio.Align import _aligners
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord, _RestrictedDict

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1636,6 +1636,21 @@ The \verb+PairwiseAligner+ object \verb+aligner+
 (see Section~\ref{sec:pairwise-aligner})
 stores the alignment parameters to be used for the pairwise alignments.
 
+These attributes can be set in the constructor of the object or after the object
+is made.
+
+%cont-doctest
+\begin{minted}{pycon}
+>>> aligner = Align.PairwiseAligner(match_score=1.0)
+\end{minted}
+
+Or, equivalently:
+
+%cont-doctest
+\begin{minted}{pycon}
+>>> aligner.match_score = 1.0
+\end{minted}
+
 Use the \verb+aligner.score+ method to calculate the alignment score between
 two sequences:
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -40,6 +40,7 @@ possible, especially the following contributors:
 - Rob Miller
 - Sergio Valqui
 - Sujan Dulal (first contribution)
+- Hielke Walinga (first contribution)
 
 20 December 2019: Biopython 1.76
 ================================

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -35,12 +35,12 @@ possible, especially the following contributors:
 - Austin Varela (first contribution)
 - Chris Rands
 - Deepak Khatri
+- Hielke Walinga (first contribution)
 - Kai Blin
 - Peter Cock
 - Rob Miller
 - Sergio Valqui
 - Sujan Dulal (first contribution)
-- Hielke Walinga (first contribution)
 
 20 December 2019: Biopython 1.76
 ================================

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2256,6 +2256,37 @@ A---AAT-TG-AAGAGTTTGATC-ATGGCTCAG-A-TTGAACGCTGGCGGCAG-GCCTAA-CACATGCAAGTCGA-ACGG
         self.assertAlmostEqual(alignment.score, 1286.0)
 
 
+class TestKeywordArgumentsConstructor(unittest.TestCase):
+    def test_confusing_arguments(self):
+        aligner = Align.PairwiseAligner(
+            mode="local",
+            open_gap_score=-0.3,
+            extend_gap_score=-0.1,
+            target_open_gap_score=-0.2,
+        )
+        self.assertEqual(
+            str(aligner),
+            """\
+Pairwise sequence aligner with parameters
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  target_internal_open_gap_score: -0.200000
+  target_internal_extend_gap_score: -0.100000
+  target_left_open_gap_score: -0.200000
+  target_left_extend_gap_score: -0.100000
+  target_right_open_gap_score: -0.200000
+  target_right_extend_gap_score: -0.100000
+  query_internal_open_gap_score: -0.300000
+  query_internal_extend_gap_score: -0.100000
+  query_left_open_gap_score: -0.300000
+  query_left_extend_gap_score: -0.100000
+  query_right_open_gap_score: -0.300000
+  query_right_extend_gap_score: -0.100000
+  mode: local
+""",
+        )
+
+
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)
     unittest.main(testRunner=runner)


### PR DESCRIPTION
This pull request addresses issue #2328 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Next to implementing the feature as suggested in the issue. I have added the following as well: 

 * Added part in docstring.
 * Added part in Tutorial.
 * Added test.

Additional clean-ups:

 * Black reformat and import sorting on Bio/Align/__init__.py
 * Black reformat and import sorting on Tests/test_pairwise_aligner.py
 * Added Doc/Tutorial.pyg to .gitignore (not yet included left-over after building Tutorial).