### PR TITLE
2 small fixes

### DIFF
--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -835,7 +835,7 @@ def _yn00(seq1, seq2, k, codon_table):
         )
         w = dSdN[1] / dSdN[0]
         if all(
-            map(lambda x: x < tolerance, [abs(i - j) for i, j in zip(dSdN, dSdN_pre)])
+            map(lambda x: x < tolerance, (abs(i - j) for i, j in zip(dSdN, dSdN_pre)))
         ):
             return dSdN[1], dSdN[0]  # dN, dS
         dSdN_pre = dSdN

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -979,9 +979,7 @@ class DictionaryBuilder:
                     if not bl[2]:
                         print("Anyway, %s is not commercially available.\n" % n)
                     else:
-                        print(
-                            "Unfortunately, %s is commercially " % n + " available.\n"
-                        )
+                        print("Unfortunately, %s is commercially available.\n" % n)
 
                     continue
                 # Hyphens and dots can't be used as a Python name, nor as a


### PR DESCRIPTION
1) Fix string https://github.com/biopython/biopython/pull/2511#discussion_r364208449
2) Fix flake8-comphrensions upgrade
```
./Bio/codonalign/codonseq.py:838:13: C407 Unnecessary list comprehension - 'map' can take a generator.
```

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
