### PR TITLE
Use legacy URLs in SCOP searches, documentation

### DIFF
--- a/Bio/SCOP/__init__.py
+++ b/Bio/SCOP/__init__.py
@@ -924,7 +924,7 @@ def search(
     disp=None,
     dir=None,
     loc=None,
-    cgi="http://scop.mrc-lmb.cam.ac.uk/scop/search.cgi",
+    cgi="http://scop.mrc-lmb.cam.ac.uk/legacy/search.cgi",
     **keywds
 ):
     """Access SCOP search and return a handle to the results.

--- a/Bio/SCOP/__init__.py
+++ b/Bio/SCOP/__init__.py
@@ -22,9 +22,9 @@ The SCOP database aims to provide a manually constructed classification of
 all know protein structures into a hierarchy, the main levels of which
 are family, superfamily and fold.
 
-* "SCOP":http://scop.mrc-lmb.cam.ac.uk/scop/
-* "Introduction":http://scop.mrc-lmb.cam.ac.uk/scop/intro.html
-* "SCOP parsable files":http://scop.mrc-lmb.cam.ac.uk/scop/parse/
+* "SCOP":http://scop.mrc-lmb.cam.ac.uk/legacy/
+* "Introduction":http://scop.mrc-lmb.cam.ac.uk/legacy/intro.html
+* "SCOP parsable files":http://scop.mrc-lmb.cam.ac.uk/legacy/parse/
 
 The Scop object in this module represents the entire SCOP classification. It
 can be built from the three SCOP parsable files, modified is so desired, and
@@ -721,7 +721,7 @@ class Domain(Node):
             n = n.getParent()
 
         # Order does not matter in the hierarchy field. For more info, see
-        # http://scop.mrc-lmb.cam.ac.uk/scop/release-notes.html
+        # http://scop.mrc-lmb.cam.ac.uk/legacy/release-notes.html
         # rec.hierarchy.reverse()
 
         return rec
@@ -931,7 +931,7 @@ def search(
 
     Access search.cgi and return a handle to the results.  See the
     online help file for an explanation of the parameters:
-    http://scop.mrc-lmb.cam.ac.uk/scop/help.html
+    http://scop.mrc-lmb.cam.ac.uk/legacy/help.html
 
     Raises an IOError if there's a network error.
 


### PR DESCRIPTION
This pull request addresses issue #2508

The URLs in Bio.SCOP (in the search function as well as in the documentation) do not work any longer because SCOP has updated its interface. This PR inserts the legacy URLs that SCOP now provides.

Previously, test_SCOP_online.py failed, but it now passes.

```
test_search (__main__.ScopSearch)
Test search. ... ok

----------------------------------------------------------------------
Ran 1 test in 0.433s

OK
```

See issue #2508 for the old and new links and to see the previous issues with test_SCOP_online.


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)