### PR TITLE
Remove python2 crutch for cmp function

### DIFF
--- a/Bio/SCOP/__init__.py
+++ b/Bio/SCOP/__init__.py
@@ -88,19 +88,15 @@ astralEv_to_sql = {10: "e1", 5: "e0_7", 1: "e0", 0.5: "e_0_3", 0.1: "e_1",
 # Turn black code style on
 # fmt: on
 
-try:
-    # See if the cmp function exists (will on Python 2)
-    _cmp = cmp
-except NameError:
 
-    def _cmp(a, b):
-        """Implement cmp(x,y) for Python 3 (PRIVATE).
+def _cmp(a, b):
+    """Implement cmp(x,y) for Python 3 (PRIVATE).
 
-        Based on Python 3 docs which say if you really need the cmp()
-        functionality, you could use the expression (a > b) -  (a < b)
-        as the equivalent for cmp(a, b)
-        """
-        return (a > b) - (a < b)
+    Based on Python 3 docs which say if you really need the cmp()
+    functionality, you could use the expression (a > b) -  (a < b)
+    as the equivalent for cmp(a, b)
+    """
+    return (a > b) - (a < b)
 
 
 def cmp_sccs(sccs1, sccs2):


### PR DESCRIPTION
This pull request addresses no issues. To be honest, we can explicitly use python3 cmp expression and give up on the function _cmp alltogether.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
