### PR TITLE
updated Bio.Restriction for python3

### DIFF
--- a/Bio/Restriction/PrintFormat.py
+++ b/Bio/Restriction/PrintFormat.py
@@ -93,10 +93,6 @@ class PrintFormat:
     Indent = 4
     linesize = PrefWidth - NameWidth
 
-    def __init__(self):
-        """Initialise."""
-        pass
-
     def print_as(self, what="list"):
         """Print the results as specified.
 
@@ -113,8 +109,6 @@ class PrintFormat:
             self.make_format = self._make_number
         else:
             self.make_format = self._make_list
-
-        return
 
     def format_output(self, dct, title="", s1=""):
         """Summarise results as a nicely formatted string.
@@ -154,7 +148,6 @@ class PrintFormat:
         for backwards compatibility.
         """
         print(self.format_output(dct, title, s1))
-        return
 
     def make_format(self, cut=(), title="", nc=(), s1=""):
         """Virtual method used for formatting results.

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -287,8 +287,8 @@ class RestrictionType(type):
             pass
         except Exception:
             raise ValueError(
-                "Problem with regular expression, re.compiled(%s)" % repr(cls.compsite)
-            )
+                "Problem with regular expression, re.compiled(%r)" % cls.compsite
+            ) from None
 
     def __add__(cls, other):
         """Add restriction enzyme to a RestrictionBatch().
@@ -2221,8 +2221,6 @@ class RestrictionBatch(set):
                 return y
             elif isinstance(eval(str(y)), RestrictionType):
                 return eval(y)
-            else:
-                pass
         except (NameError, SyntaxError):
             pass
         raise ValueError("%s is not a RestrictionType" % y.__class__)
@@ -2711,11 +2709,6 @@ AllEnzymes.update(NonComm)
 #   Now, place the enzymes in locals so they can be imported.
 #
 names = [str(x) for x in AllEnzymes]
-try:
-    del x  # noqa
-except NameError:
-    # Scoping changed in Python 3, the variable isn't leaked
-    pass
 locals().update(dict(zip(names, AllEnzymes)))
 __all__ = (
     "FormattedSeq",

--- a/Bio/Restriction/__init__.py
+++ b/Bio/Restriction/__init__.py
@@ -63,23 +63,21 @@ from Bio.Restriction.Restriction import *  # noqa (legacy module arrangement)
 #   the enzymes in the locals() dictionary when evaluating string to see if
 #   it is an enzyme.
 #
-#   This call for some explanations I guess:
+#   This calls for some explanations I guess:
 #       When testing for the presence of a Restriction enzyme in a
 #       RestrictionBatch, the user can use:
 #
 #           1) a class of type 'RestrictionType'
-#           2) a string of the name of the enzyme (it's repr)
+#           2) a string of the name of the enzyme (its repr)
 #               i.e:
 #                   >>> from Bio.Restriction import RestrictionBatch, EcoRI
 #                   >>> MyBatch = RestrictionBatch(EcoRI)
-#                   >>> #!/usr/bin/env python
 #                   >>> EcoRI in MyBatch        # the class EcoRI.
 #                   True
-#                   >>>
 #                   >>> 'EcoRI' in MyBatch      # a string representation
 #                   True
 #
-#   OK, that's how it is suppose to work. And I find it quite useful.
+#   OK, that's how it is supposed to work. And I find it quite useful.
 #
 #   Now if I leave the code here I got:
 #                   >>> from Bio.Restriction import RestrictionBatch, EcoRI


### PR DESCRIPTION
This pull request updates Bio.Restriction for python3. Travis, don't disappoint me.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
