### PR TITLE
Small LaTeX fix in Biopython Tutorial

### DIFF
--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -143,14 +143,14 @@ object, ie. directly from the PDB file:
 In order to parse a PQR file, proceed in a similar manner as in the case
 of PDB files:
 
-Create a \texttt{PDBParser} object, using the \texttt{is_pqr} flag:
+Create a \texttt{PDBParser} object, using the \texttt{is\_pqr} flag:
 
 \begin{minted}{pycon}
 >>> from Bio.PDB.PDBParser import PDBParser
 >>> pqr_parser = PDBParser(PERMISSIVE=1, is_pqr=True)
 \end{minted}
 
-The \texttt{is_pqr} flag set to \texttt{True} indicates that the file to be parsed is a PQR file, 
+The \texttt{is\_pqr} flag set to \texttt{True} indicates that the file to be parsed is a PQR file, 
 and that the parser should read the atomic charge and radius fields for each atom entry. Following the same procedure as for PQR files, a Structure object is then produced, and the PQR file is parsed.
 
 \begin{minted}{pycon}
@@ -228,7 +228,7 @@ a chain between a start and end residue.
 
 \subsection{Writing PQR files}
 
-Use the \texttt{PDBIO} class as you would for a PDB file, with the flag \texttt{is_pqr=True}. 
+Use the \texttt{PDBIO} class as you would for a PDB file, with the flag \texttt{is\_pqr=True}. 
 The PDBIO methods can be used in the case of PQR files as well.
 
 Example: writing a PQR file


### PR DESCRIPTION
I was trying to edit the Biopython Tutorial, and noticed that running ``make`` in the default directory always causes an error, requiring the user to enter R to finish generating the documentation. This PR fixes the problem so that it is a little easier to edit the tutorial. 

Error:
```
...
(./_minted-Tutorial/41FC845107E552AB47AA881B90236E1867B6D4EEEA70E83368C1BFCE3E2
2EA7D.pygtex)
! Missing $ inserted.
<inserted text> 
                $
l.146 ...Parser} object, using the \texttt{is_pqr}
                                                   flag:
? 

```
Solution:
I changed ``\texttt{is_pqr}`` -> ``\texttt{is\_pqr}`` as recommended in [this Stack Overflow answer](https://stackoverflow.com/a/2476868/12626923)

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
