### PR TITLE
pairwise2: namedtuple and keyword parameters

### DIFF
--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -246,6 +246,7 @@ type ``help(pairwise2.align.localds)`` at the Python prompt.
 """  # noqa: W291
 
 import warnings
+from collections import namedtuple
 
 from Bio import BiopythonWarning
 
@@ -960,6 +961,8 @@ def _clean_alignments(alignments):
     Remove duplicates, make sure begin and end are set correctly, remove
     empty alignments.
     """
+    Alignment = namedtuple('Alignment',
+                           ('sequence1, sequence2, score, start, end'))
     unique_alignments = []
     for align in alignments:
         if align not in unique_alignments:
@@ -976,7 +979,7 @@ def _clean_alignments(alignments):
         if begin >= end:
             del unique_alignments[i]
             continue
-        unique_alignments[i] = seqA, seqB, score, begin, end
+        unique_alignments[i] = Alignment(seqA, seqB, score, begin, end)
         i += 1
     return unique_alignments
 

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -57,14 +57,19 @@ All the different alignment functions are contained in an object
 ``align``. For example:
 
     >>> from Bio import pairwise2
-    >>> alignments = pairwise2.align.globalxx("ACCGT", "ACG")
+    >>> alignments = pairwise2.align.globalxx(sequenceA="ACCGT",
+    ...                                       sequenceB="ACG")
 
-will return a list of the alignments between the two strings. Each alignment
+Keywords can be ommitted, so this call is identical:
+
+    >>> alignments = pairwise2.align.globalxx("ACGT", "ACG")
+
+The result is a list of the alignments between the two strings. Each alignment
 is a named tuple consisting of the two aligned sequences, the score and the
 start and end positions of the alignment:
 
    >>> print(alignments)
-   [Alignment(sequence1='ACGT', sequence2='ACG-', score=3.0, start=0, end=4)]
+   [Alignment(seqA='ACCGT', seqB='A-CG-', score=3.0, start=0, end=5), ...
 
 You can access each element of an aligment by index or name:
 
@@ -265,7 +270,7 @@ from collections import namedtuple
 from Bio import BiopythonWarning
 
 
-MAX_ALIGNMENTS = 1000   # maximum alignments recovered in traceback
+MAX_ALIGNMENTS = 1000  # maximum alignments recovered in traceback
 
 
 class align:
@@ -367,11 +372,11 @@ class align:
             if penalty_doc:
                 doc += "\n%s\n" % penalty_doc
             doc += ("""\
-\nalignments is a list of tuples (seqA, seqB, score, begin, end).
-seqA and seqB are strings showing the alignment between the
-sequences.  score is the score of the alignment.  begin and end
-are indexes into seqA and seqB that indicate the where the
-alignment occurs.
+\nalignments is a list of named tuples (seqA, seqB, score,
+begin, end). seqA and seqB are strings showing the alignment
+between the sequences.  score is the score of the alignment.
+begin and end are indexes of seqA and seqB that indicate
+where the alignment occurs.
 """)
             self.__doc__ = doc
 
@@ -384,12 +389,6 @@ alignment occurs.
             keywds = keywds.copy()
 
             # Replace possible "keywords" with arguments:
-            """
-            for n, name in enumerate(self.param_names):
-                if name in keywds:
-                    args = args[:n] + (keywds[name],) + args[n:]
-                    del keywds[name]
-            """
             for key in keywds.copy():
                 if key in self.param_names:
                     _index = self.param_names.index(key)
@@ -402,11 +401,8 @@ alignment occurs.
                                  "force_generic",
                                  "score_only",
                                  "one_alignment_only"):
-                    raise ValueError("unknown parameter %r"
-                                     % key)
+                    raise ValueError("unknown parameter %r" % key)
                     
-            print(self.param_names)
-            print(args, keywds)
             if len(args) != len(self.param_names):
                 raise TypeError("%s takes exactly %d argument (%d given)"
                                 % (self.function_name, len(self.param_names),
@@ -1002,7 +998,7 @@ def _clean_alignments(alignments):
     empty alignments.
     """
     Alignment = namedtuple('Alignment',
-                           ('sequence1, sequence2, score, start, end'))
+                           ('seqA, seqB, score, start, end'))
     unique_alignments = []
     for align in alignments:
         if align not in unique_alignments:

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -72,14 +72,14 @@ is a named tuple consisting of the two aligned sequences, the score and the
 start and end positions of the alignment:
 
    >>> print(alignments)
-   [Alignment(seqA='ACCGT', seqB='A-CG-', score=3.0, start=0, end=5), ...
+   [Alignment(seqA='ACCGT', seqB='A-CG-', score=3, start=0, end=5), ...
 
 You can access each element of an aligment by index or name:
 
    >>> alignments[0][2]
-   3.0
+   3
    >>> alignments[0].score
-   3.0
+   3
 
 For a nice printout of an alignment, use the ``format_alignment`` method of
 the module:

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -387,12 +387,21 @@ where the alignment occurs.
             to this function into forms appropriate for _align.
             """
             keywds = keywds.copy()
+            #print(args)
+            args = args + (len(self.param_names) - len(args)) * (None,)
+            #print(args)
 
             # Replace possible "keywords" with arguments:
             for key in keywds.copy():
+                # print(key)
                 if key in self.param_names:
                     _index = self.param_names.index(key)
-                    args = args[:_index] + (keywds[key],) + args[_index:]
+                    #print(_index)
+                    args = args[:_index] + (keywds[key],) + args[_index+1:]
+                    #args[_index] = keywds[key]
+                    print(args)
+                    args = tuple(arg for arg in args if arg)
+                    #if key not in ('sequenceA', 'sequenceB'):
                     del keywds[key]
                 elif key not in ("penalize_extend_when_opening",
                                  "penalize_end_gaps",
@@ -407,6 +416,8 @@ where the alignment occurs.
                 raise TypeError("%s takes exactly %d argument (%d given)"
                                 % (self.function_name, len(self.param_names),
                                    len(args)))
+            # print(args)
+            # print(keywds)
             i = 0
             while i < len(self.param_names):
                 if self.param_names[i] in [
@@ -464,6 +475,7 @@ where the alignment occurs.
                 keywds["penalize_end_gaps"] = tuple([value] * 2)
             else:
                 assert n == 2
+            # print(keywds)
             return keywds
 
         def __call__(self, *args, **keywds):

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -38,31 +38,34 @@ the second indicates the parameters for gap penalties.
 
 The match parameters are::
 
-    CODE  DESCRIPTION
+    CODE  DESCRIPTION & OPTIONAL KEYWORDS
     x     No parameters. Identical characters have score of 1, otherwise 0.
     m     A match score is the score of identical chars, otherwise mismatch
-          score.
+          score. Keywords ``match``, ``mismatch``.
     d     A dictionary returns the score of any pair of characters.
-    c     A callback function returns scores.
+          Keyword ``match_dict``.
+    c     A callback function returns scores. Keyword ``match_fn``.
 
 The gap penalty parameters are::
 
-    CODE  DESCRIPTION
+    CODE  DESCRIPTION & OPTIONAL KEYWORDS
     x     No gap penalties.
     s     Same open and extend gap penalties for both sequences.
+          Keywords ``open``, ``extend``.
     d     The sequences have different open and extend gap penalties.
+          Keywords ``openA``, ``extendA``, ``openB``, ``extendB``.
     c     A callback function returns the gap penalties.
+          Keywords ``gap_A_fn``, ``gap_B_fn``.
 
 All the different alignment functions are contained in an object
 ``align``. For example:
 
     >>> from Bio import pairwise2
-    >>> alignments = pairwise2.align.globalxx(sequenceA="ACCGT",
-    ...                                       sequenceB="ACG")
-
-Keywords can be ommitted, so this call is identical:
-
     >>> alignments = pairwise2.align.globalxx("ACCGT", "ACG")
+
+For better readability, the required arguments can be used with optional keywords:
+
+    >>> alignments = pairwise2.align.globalxx(sequenceA="ACCGT", sequenceB="ACG")
 
 The result is a list of the alignments between the two strings. Each alignment
 is a named tuple consisting of the two aligned sequences, the score and the
@@ -207,6 +210,11 @@ Some examples:
     AC-G-
       Score=5
     <BLANKLINE>
+
+- Note that you can use keywords to increase the readability, e.g.:
+
+    >>> a = pairwise2.align.globalms("ACGT", "ACG", match=2, mismatch=-1, open=-.5,
+    ...                              extend=-.1)
 
 - Depending on the penalties, a gap in one sequence may be followed by a gap in
   the other sequence.If you don't like this behaviour, increase the gap-open
@@ -366,6 +374,12 @@ class align:
             # Set the doc string.
             doc = "%s(%s) -> alignments\n" % (
                 self.__name__, ", ".join(self.param_names))
+            doc += """\
+\nThe following parameters can also be used with optional
+keywords of the same name.\n\n
+sequenceA and sequenceB must be of the same type, either
+strings, lists or Biopython sequence objects.\n
+"""
             if match_doc:
                 doc += "\n%s\n" % match_doc
             if penalty_doc:
@@ -991,8 +1005,8 @@ def _clean_alignments(alignments):
     Remove duplicates, make sure begin and end are set correctly, remove
     empty alignments.
     """
-    Alignment = namedtuple('Alignment',
-                           ('seqA, seqB, score, start, end'))
+    Alignment = namedtuple("Alignment",
+                           ("seqA, seqB, score, start, end"))
     unique_alignments = []
     for align in alignments:
         if align not in unique_alignments:

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -62,7 +62,7 @@ All the different alignment functions are contained in an object
 
 Keywords can be ommitted, so this call is identical:
 
-    >>> alignments = pairwise2.align.globalxx("ACGT", "ACG")
+    >>> alignments = pairwise2.align.globalxx("ACCGT", "ACG")
 
 The result is a list of the alignments between the two strings. Each alignment
 is a named tuple consisting of the two aligned sequences, the score and the
@@ -387,37 +387,21 @@ where the alignment occurs.
             to this function into forms appropriate for _align.
             """
             keywds = keywds.copy()
-            #print(args)
-            args = args + (len(self.param_names) - len(args)) * (None,)
-            #print(args)
 
             # Replace possible "keywords" with arguments:
+            args = args + (len(self.param_names) - len(args)) * (None,)
             for key in keywds.copy():
-                # print(key)
                 if key in self.param_names:
                     _index = self.param_names.index(key)
-                    #print(_index)
-                    args = args[:_index] + (keywds[key],) + args[_index+1:]
-                    #args[_index] = keywds[key]
-                    print(args)
-                    args = tuple(arg for arg in args if arg)
-                    #if key not in ('sequenceA', 'sequenceB'):
+                    args = args[:_index] + (keywds[key],) + args[_index:]
                     del keywds[key]
-                elif key not in ("penalize_extend_when_opening",
-                                 "penalize_end_gaps",
-                                 "align_globally",
-                                 "gap_char",
-                                 "force_generic",
-                                 "score_only",
-                                 "one_alignment_only"):
-                    raise ValueError("unknown parameter %r" % key)
-                    
+            args = tuple(arg for arg in args if arg is not None)
+                
             if len(args) != len(self.param_names):
                 raise TypeError("%s takes exactly %d argument (%d given)"
                                 % (self.function_name, len(self.param_names),
                                    len(args)))
-            # print(args)
-            # print(keywds)
+
             i = 0
             while i < len(self.param_names):
                 if self.param_names[i] in [
@@ -475,7 +459,6 @@ where the alignment occurs.
                 keywds["penalize_end_gaps"] = tuple([value] * 2)
             else:
                 assert n == 2
-            # print(keywds)
             return keywds
 
         def __call__(self, *args, **keywds):

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -402,7 +402,7 @@ where the alignment occurs.
             keywds = keywds.copy()
 
             # Replace possible "keywords" with arguments:
-            args = args + (len(self.param_names) - len(args)) * (None,)
+            args += (len(self.param_names) - len(args)) * (None,)
             for key in keywds.copy():
                 if key in self.param_names:
                     _index = self.param_names.index(key)
@@ -1005,8 +1005,7 @@ def _clean_alignments(alignments):
     Remove duplicates, make sure begin and end are set correctly, remove
     empty alignments.
     """
-    Alignment = namedtuple("Alignment",
-                           ("seqA, seqB, score, start, end"))
+    Alignment = namedtuple("Alignment", ("seqA, seqB, score, start, end"))
     unique_alignments = []
     for align in alignments:
         if align not in unique_alignments:

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -328,6 +328,7 @@ class align:
                   "of the gap.  They should return a gap penalty."),
         }
 
+
         def __init__(self, name):
             """Check to make sure the name of the function is reasonable."""
             if name.startswith("global"):
@@ -381,6 +382,31 @@ alignment occurs.
             to this function into forms appropriate for _align.
             """
             keywds = keywds.copy()
+
+            # Replace possible "keywords" with arguments:
+            """
+            for n, name in enumerate(self.param_names):
+                if name in keywds:
+                    args = args[:n] + (keywds[name],) + args[n:]
+                    del keywds[name]
+            """
+            for key in keywds.copy():
+                if key in self.param_names:
+                    _index = self.param_names.index(key)
+                    args = args[:_index] + (keywds[key],) + args[_index:]
+                    del keywds[key]
+                elif key not in ("penalize_extend_when_opening",
+                                 "penalize_end_gaps",
+                                 "align_globally",
+                                 "gap_char",
+                                 "force_generic",
+                                 "score_only",
+                                 "one_alignment_only"):
+                    raise ValueError("unknown parameter %r"
+                                     % key)
+                    
+            print(self.param_names)
+            print(args, keywds)
             if len(args) != len(self.param_names):
                 raise TypeError("%s takes exactly %d argument (%d given)"
                                 % (self.function_name, len(self.param_names),

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -59,8 +59,22 @@ All the different alignment functions are contained in an object
     >>> from Bio import pairwise2
     >>> alignments = pairwise2.align.globalxx("ACCGT", "ACG")
 
-will return a list of the alignments between the two strings. For a nice
-printout, use the ``format_alignment`` method of the module:
+will return a list of the alignments between the two strings. Each alignment
+is a named tuple consisting of the two aligned sequences, the score and the
+start and end positions of the alignment:
+
+   >>> print(alignments)
+   [Alignment(sequence1='ACGT', sequence2='ACG-', score=3.0, start=0, end=4)]
+
+You can access each element of an aligment by index or name:
+
+   >>> alignments[0][2]
+   3.0
+   >>> alignments[0].score
+   3.0
+   
+For a nice printout of an alignment, use the ``format_alignment`` method of
+the module:
 
     >>> from Bio.pairwise2 import format_alignment
     >>> print(format_alignment(*alignments[0]))

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -77,7 +77,7 @@ You can access each element of an aligment by index or name:
    3.0
    >>> alignments[0].score
    3.0
-   
+
 For a nice printout of an alignment, use the ``format_alignment`` method of
 the module:
 
@@ -333,7 +333,6 @@ class align:
                   "of the gap.  They should return a gap penalty."),
         }
 
-
         def __init__(self, name):
             """Check to make sure the name of the function is reasonable."""
             if name.startswith("global"):
@@ -396,7 +395,7 @@ where the alignment occurs.
                     args = args[:_index] + (keywds[key],) + args[_index:]
                     del keywds[key]
             args = tuple(arg for arg in args if arg is not None)
-                
+
             if len(args) != len(self.param_names):
                 raise TypeError("%s takes exactly %d argument (%d given)"
                                 % (self.function_name, len(self.param_names),

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1444,9 +1444,11 @@ they may return different subsets of all valid alignments).
 \texttt{water} (local) and \texttt{needle} (global) from the
 \href{http://emboss.sourceforge.net/}{EMBOSS} suite (see above) and should
 return the same results. The \verb|pairwise2| module has undergone some
-optimization regarding speed and memory consumption recently (Biopython versions \textgreater 1.67) so that for short sequences (global alignments: \textasciitilde 2000 residues, local alignments \textasciitilde 600 residues) it's faster (or equally fast)
-to use \verb|pairwise2| than calling EMBOSS' \texttt{water} or \texttt{needle}
-via the command line tools.
+optimization regarding speed and memory consumption recently (Biopython versions
+\textgreater 1.67) so that for short sequences (global alignments:
+\textasciitilde 2000 residues, local alignments \textasciitilde 600 residues)
+it's faster (or equally fast) to use \verb|pairwise2| than calling EMBOSS' 
+\texttt{water} or \texttt{needle} via the command line tools.
 
 Suppose you want to do a global pairwise alignment between the same two
 hemoglobin sequences from above (\texttt{HBA\_HUMAN}, \texttt{HBB\_HUMAN})
@@ -1482,10 +1484,10 @@ alignments). Have a look at one of these alignments:
 >>> len(alignments)
 80
 >>> print(alignments[0]) # doctest:+ELLIPSIS
-('MV-LSPADKTNV---K-A--A-WGKVGAHAG...YR-', 'MVHL-----T--PEEKSAVTALWGKV----...Y-H', 72.0, 0, 217)
+Alignment(seqA='MV-LSPADKTNV---K-A--A-WGKVGAHAG...YR-', seqB='MVHL-----T--PEEKSAVTALWGKV----...Y-H', score=72.0, start=0, end=217)
 \end{minted}
 
-Each alignment is a tuple consisting of the two aligned sequences, the score, the
+Each alignment is a named tuple consisting of the two aligned sequences, the score, the
 start and the end positions of the alignment (in global alignments the start is
 always 0 and the end the length of the alignment). \verb|Bio.pairwise2| has a
 function \verb|format_alignment| for a nicer printout:
@@ -1498,6 +1500,14 @@ MV-LSPADKTNV---K-A--A-WGKVGAHAG---EY-GA-EALE-RMFLSF----PTTK-TY--F...YR-
 MVHL-----T--PEEKSAVTALWGKV-----NVDE-VG-GEAL-GR--L--LVVYP---WT-QRF...Y-H
   Score=72
 <BLANKLINE>
+\end{minted}
+
+Since Biopython 1.77 the required parameters can be supplied with  keywords. The
+last example can now also be written as:
+
+%doctest examples
+\begin{minted}{pycon}
+>>> alignments = pairwise2.align.globalxx(sequenceA=seq1.seq, sequenceB=seq2.seq)
 \end{minted}
 
 Better alignments are usually obtained by penalizing gaps: higher costs
@@ -2774,15 +2784,15 @@ ValueError: alphabets are inconsistent
 
 \verb+Bio.Align.substitution_matrices+ includes a parser to read one- and two-dimensional \verb+Array+ objects from file. One-dimensional arrays are represented by a simple two-column format, with the first column containing the key and the second column the corresponding value. For example, the file \verb+hg38.chrom.sizes+ (obtained from UCSC), available in the \verb+Tests/Align+ subdirectory of the Biopython distribution, contains the size in nucleotides of each chromosome in human genome assembly hg38:
 \begin{minted}{text}
-chr1	248956422
-chr2	242193529
-chr3	198295559
-chr4	190214555
+chr1    248956422
+chr2    242193529
+chr3    198295559
+chr4    190214555
 ...
-chrUn_KI270385v1	990
-chrUn_KI270423v1	981
-chrUn_KI270392v1	971
-chrUn_KI270394v1	970
+chrUn_KI270385v1    990
+chrUn_KI270423v1    981
+chrUn_KI270392v1    971
+chrUn_KI270394v1    970
 \end{minted}
 To parse this file, use
 

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1505,7 +1505,7 @@ MVHL-----T--PEEKSAVTALWGKV-----NVDE-VG-GEAL-GR--L--LVVYP---WT-QRF...Y-H
 Since Biopython 1.77 the required parameters can be supplied with  keywords. The
 last example can now also be written as:
 
-%doctest examples
+%cont-doctest
 \begin{minted}{pycon}
 >>> alignments = pairwise2.align.globalxx(sequenceA=seq1.seq, sequenceB=seq2.seq)
 \end{minted}

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1502,7 +1502,7 @@ MVHL-----T--PEEKSAVTALWGKV-----NVDE-VG-GEAL-GR--L--LVVYP---WT-QRF...Y-H
 <BLANKLINE>
 \end{minted}
 
-Since Biopython 1.77 the required parameters can be supplied with  keywords. The
+Since Biopython 1.77 the required parameters can be supplied with keywords. The
 last example can now also be written as:
 
 %cont-doctest

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -16,6 +16,9 @@ tested on PyPy3.6.1 v7.1.1-beta0.
 
 **We have dropped support for Python 2 now.**
 
+``pairwise2`` now allows the input of parameters with keywords and returns the
+alignments as a list of ``namedtuples``.
+
 The codon tables have been updated to NCBI genetic code table version 4.5,
 which adds Cephalodiscidae mitochondrial as table 33.
 
@@ -39,6 +42,7 @@ possible, especially the following contributors:
 - Deepak Khatri
 - Hielke Walinga (first contribution)
 - Kai Blin
+- Markus Piotrowski
 - Peter Cock
 - Rob Miller
 - Sergio Valqui

--- a/Tests/pairwise2_testCases.py
+++ b/Tests/pairwise2_testCases.py
@@ -83,8 +83,7 @@ class TestPairwiseKeywordUsage(unittest.TestCase):
     def test_keywords(self):
         """Test equality of calls with and without keywords."""
         aligns = pairwise2.align.globalxx("GAACT", "GAT")
-        aligns_kw = pairwise2.align.globalxx(sequenceA="GAACT",
-                                             sequenceB="GAT")
+        aligns_kw = pairwise2.align.globalxx(sequenceA="GAACT", sequenceB="GAT")
         self.assertEqual(aligns, aligns_kw)
 
         aligns = pairwise2.align.globalmx("GAACT", "GAT", 5, -4)

--- a/Tests/pairwise2_testCases.py
+++ b/Tests/pairwise2_testCases.py
@@ -77,6 +77,23 @@ class TestPairwiseErrorConditions(unittest.TestCase):
             self.assertIn("should not", str(w[-1].message))
 
 
+class TestPairwiseKeywordUsage(unittest.TestCase):
+    """Tests for keyword usage."""
+
+    def test_keywords(self):
+        """Test equality of calls with and without keywords."""
+        aligns = pairwise2.align.globalxx("GAACT", "GAT")
+        aligns_kw = pairwise2.align.globalxx(sequenceA="GAACT",
+                                             sequenceB="GAT")
+        self.assertEqual(aligns, aligns_kw)
+
+        aligns = pairwise2.align.globalmx("GAACT", "GAT", 5, -4)
+        aligns_kw = pairwise2.align.globalmx(sequenceA="GAACT",
+                                             sequenceB="GAT",
+                                             match=5, mismatch=-4)
+        self.assertEqual(aligns, aligns_kw)
+
+
 class TestPairwiseGlobal(unittest.TestCase):
     """Test some usual global alignments."""
 


### PR DESCRIPTION
This pull request addresses issue #2328 and #2221 .

This makes usage of  `pairwise2` more readable and more comfortable.

- Necessary parameters can now also be used with optional keywords. Thus the 'cryptic': 

  ```python
  >>> a = pairwise2.align.globalms("ATG", "AGG", 5, -4, -1, -0.1)
  ```
  can also be typed as:

  ```python
  >>> a = pairwise2.align.globalms("ATG", "AGG", match=5, mismatch=-4, open=-1, extend=-0.1)
  ```

- The alignment result is now a list of namedtuples (before it was a list of simple tuples), which makes it easier to understand and access the output. Before:

  ```python
  >>> a
  [('ATG-', 'A-GG', 8.0, 0, 4), ('AT-G', 'A-GG', 8.0, 0, 4)]
  >>> a[0][2]  # score
  8.0
  ```
  now:
 
  ```python
  >>> a
  [Alignment(seqA='ATG-', seqB='A-GG', score=8.0, start=0, end=4), Alignment(seqA=
  'AT-G', seqB='A-GG', score=8.0, start=0, end=4)]
  >>> a[0].score
  8.0
  ```
  The elements can still be accessed by their index, so this is fully back-compatible.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
