### PR TITLE
need to yield to avoid jumping to finally immediately

### DIFF
--- a/Bio/SeqIO/GckIO.py
+++ b/Bio/SeqIO/GckIO.py
@@ -229,7 +229,8 @@ def GckIterator(source):
             raise ValueError("GCK files must be opened in binary mode.") from None
 
     try:
-        return _parse(handle)
+        records = _parse(handle)
+        yield from records
     finally:
         if handle is not source:
             handle.close()


### PR DESCRIPTION
This pull request fixes Bio.SeqIO.GckIO


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
