### PR TITLE
removed Bio.trie warning from website

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,10 +86,6 @@ implementations:
 
 - PyPy3.5 v7.1.1 -- see http://www.pypy.org
 
-  Aside from ``Bio.trie`` (which does not compile as ``marshal.h`` is
-  currently missing under PyPy), everything should work. Older versions
-  of PyPy mostly work too.
-
 Biopython 1.68 was our final release to support Python 2.6, while Biopython
 1.76 was our final release to support Python 2.7.
 


### PR DESCRIPTION
This pull request removed the warning about Bio.trie, which has been removed from Biopython.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
