### PR TITLE
allow opening SwissProt files by name

### DIFF
--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -224,36 +224,60 @@ class FeatureTable(SeqFeature):
     """
 
 
-def parse(handle):
-    """Read multiple SwissProt records from file handle.
+def parse(source):
+    """Read multiple SwissProt records from file.
+
+    Argument source is a file-like object or a path to a file.
 
     Returns a generator object which yields Bio.SwissProt.Record() objects.
     """
-    while True:
-        record = _read(handle)
-        if not record:
-            return
-        yield record
+    handle = _open(source)
+    try:
+        while True:
+            record = _read(handle)
+            if not record:
+                return
+            yield record
+    finally:
+        if handle is not source:
+            handle.close()
 
 
-def read(handle):
-    """Read one SwissProt record from file handle.
+def read(source):
+    """Read one SwissProt record from file.
+
+    Argument source is a file-like object or a path to a file.
 
     Returns a Record() object.
     """
-    record = _read(handle)
-    if not record:
-        raise ValueError("No SwissProt record found")
-    # We should have reached the end of the record by now.
-    # Try to read one more line to be sure:
+    handle = _open(source)
     try:
-        next(handle)
-    except StopIteration:
-        return record
-    raise ValueError("More than one SwissProt record found")
+        record = _read(handle)
+        if not record:
+            raise ValueError("No SwissProt record found")
+        # We should have reached the end of the record by now.
+        # Try to read one more line to be sure:
+        try:
+            next(handle)
+        except StopIteration:
+            return record
+        raise ValueError("More than one SwissProt record found")
+    finally:
+        if handle is not source:
+            handle.close()
 
 
 # Everything below is considered private
+
+
+def _open(source):
+    try:
+        handle = open(source)
+    except TypeError:
+        handle = source
+        if handle.read(0) != "":
+            raise ValueError("SwissProt files must be opened in text mode.")
+    return handle
 
 
 def _read(handle):


### PR DESCRIPTION
This pull request enables `SwissProt.read` and `SwissProt.parse` to accept file names in addition to file handles.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
