### PR TITLE
Apply black style, version 19.10b0. test_SeqIO_convert.py and FastaIO

### DIFF
--- a/Tests/test_SeqIO_FastaIO.py
+++ b/Tests/test_SeqIO_FastaIO.py
@@ -152,26 +152,18 @@ class TestSimpleFastaParsers(unittest.TestCase):
     """Test SimpleFastaParser and FastaTwoLineParser directly."""
 
     # Regular cases input strings and outputs
-    ins_two_line = [">1\nACGT", ">1\nACGT",
-                    ">1\nACGT\n>2\nACGT"]
-    outs_two_line = [[("1", "ACGT")], [("1", "ACGT")],
-                     [("1", "ACGT"), ("2", "ACGT")]]
+    ins_two_line = [">1\nACGT", ">1\nACGT", ">1\nACGT\n>2\nACGT"]
+    outs_two_line = [[("1", "ACGT")], [("1", "ACGT")], [("1", "ACGT"), ("2", "ACGT")]]
 
-    ins_multiline = [">1\nACGT\nACGT",
-                     ">1\nACGT\nACGT\n>2\nACGT\nACGT"]
-    outs_multiline = [[("1", "ACGTACGT")],
-                      [("1", "ACGTACGT"), ("2", "ACGTACGT")]]
+    ins_multiline = [">1\nACGT\nACGT", ">1\nACGT\nACGT\n>2\nACGT\nACGT"]
+    outs_multiline = [[("1", "ACGTACGT")], [("1", "ACGTACGT"), ("2", "ACGTACGT")]]
 
     # Edge case input strings and outputs
-    ins_two_line_edges = [">\nACGT", ">1\n\n",
-                          ">1>1\n\n>1\n\n", ""]
-    outs_two_line_edges = [[("", "ACGT")], [("1", "")],
-                           [("1>1", ""), ("1", "")], []]
+    ins_two_line_edges = [">\nACGT", ">1\n\n", ">1>1\n\n>1\n\n", ""]
+    outs_two_line_edges = [[("", "ACGT")], [("1", "")], [("1>1", ""), ("1", "")], []]
 
-    ins_simple_edges = [">1", ">1\n\n\n",
-                        ">\n>1\n>2"]
-    outs_simple_edges = [[("1", "")], [("1", "")],
-                         [("", ""), ("1", ""), ("2", "")]]
+    ins_simple_edges = [">1", ">1\n\n\n", ">\n>1\n>2"]
+    outs_simple_edges = [[("1", "")], [("1", "")], [("", ""), ("1", ""), ("2", "")]]
 
     def test_regular_SimpleFastaParser(self):
         """Test regular SimpleFastaParser cases."""
@@ -217,15 +209,25 @@ class TestSimpleFastaParsers(unittest.TestCase):
                 list(FastaTwoLineParser(handle))
 
 
-single_nucleic_files = ["Fasta/lupine.nu", "Fasta/elderberry.nu",
-                        "Fasta/phlox.nu", "Fasta/centaurea.nu",
-                        "Fasta/wisteria.nu", "Fasta/sweetpea.nu",
-                        "Fasta/lavender.nu", "Fasta/f001"]
+single_nucleic_files = [
+    "Fasta/lupine.nu",
+    "Fasta/elderberry.nu",
+    "Fasta/phlox.nu",
+    "Fasta/centaurea.nu",
+    "Fasta/wisteria.nu",
+    "Fasta/sweetpea.nu",
+    "Fasta/lavender.nu",
+    "Fasta/f001",
+]
 
 multi_dna_files = ["Quality/example.fasta"]
 
-single_amino_files = ["Fasta/aster.pro", "Fasta/rosemary.pro",
-                      "Fasta/rose.pro", "Fasta/loveliesbleeding.pro"]
+single_amino_files = [
+    "Fasta/aster.pro",
+    "Fasta/rosemary.pro",
+    "Fasta/rose.pro",
+    "Fasta/loveliesbleeding.pro",
+]
 
 multi_amino_files = ["Fasta/f002", "Fasta/fa01"]
 

--- a/Tests/test_SeqIO_convert.py
+++ b/Tests/test_SeqIO_convert.py
@@ -74,9 +74,9 @@ def check_convert_fails(in_filename, in_format, out_format, alphabet=None):
             SeqIO.convert(in_filename, in_format, handle2, out_format, alphabet)
         raise ValueError("Convert should have failed!")
     except ValueError as err2:
-        assert str(err1) == str(err2), \
-            "Different failures, parse/write:\n%s\nconvert:\n%s" \
-            % (err1, err2)
+        assert str(err1) == str(
+            err2
+        ), "Different failures, parse/write:\n%s\nconvert:\n%s" % (err1, err2)
 
 
 # TODO - move this to a shared test module...
@@ -88,10 +88,12 @@ def compare_record(old, new, truncate=None):
     """
     if old.id != new.id:
         raise ValueError("'%s' vs '%s' " % (old.id, new.id))
-    if old.description != new.description \
-       and (old.id + " " + old.description).strip() != new.description \
-       and new.description != "<unknown description>" \
-       and new.description != "":
+    if (
+        old.description != new.description
+        and (old.id + " " + old.description).strip() != new.description
+        and new.description != "<unknown description>"
+        and new.description != ""
+    ):
         raise ValueError("'%s' vs '%s' " % (old.description, new.description))
     if len(old.seq) != len(new.seq):
         raise ValueError("%i vs %i" % (len(old.seq), len(new.seq)))
@@ -102,28 +104,40 @@ def compare_record(old, new, truncate=None):
             raise ValueError("'%s' vs '%s'" % (old.seq, new.seq))
         else:
             raise ValueError("'%s...' vs '%s...'" % (old.seq[:100], new.seq[:100]))
-    if "phred_quality" in old.letter_annotations \
-       and "phred_quality" in new.letter_annotations \
-       and old.letter_annotations["phred_quality"] != new.letter_annotations["phred_quality"]:
-        if truncate and [min(q, truncate) for q in old.letter_annotations["phred_quality"]] == \
-                        [min(q, truncate) for q in new.letter_annotations["phred_quality"]]:
+    if (
+        "phred_quality" in old.letter_annotations
+        and "phred_quality" in new.letter_annotations
+        and old.letter_annotations["phred_quality"]
+        != new.letter_annotations["phred_quality"]
+    ):
+        if truncate and [
+            min(q, truncate) for q in old.letter_annotations["phred_quality"]
+        ] == [min(q, truncate) for q in new.letter_annotations["phred_quality"]]:
             pass
         else:
             raise ValueError("Mismatch in phred_quality")
-    if "solexa_quality" in old.letter_annotations \
-       and "solexa_quality" in new.letter_annotations \
-       and old.letter_annotations["solexa_quality"] != new.letter_annotations["solexa_quality"]:
-        if truncate and [min(q, truncate) for q in old.letter_annotations["solexa_quality"]] == \
-                        [min(q, truncate) for q in new.letter_annotations["solexa_quality"]]:
+    if (
+        "solexa_quality" in old.letter_annotations
+        and "solexa_quality" in new.letter_annotations
+        and old.letter_annotations["solexa_quality"]
+        != new.letter_annotations["solexa_quality"]
+    ):
+        if truncate and [
+            min(q, truncate) for q in old.letter_annotations["solexa_quality"]
+        ] == [min(q, truncate) for q in new.letter_annotations["solexa_quality"]]:
             pass
         else:
             raise ValueError("Mismatch in phred_quality")
-    if "phred_quality" in old.letter_annotations \
-       and "solexa_quality" in new.letter_annotations:
+    if (
+        "phred_quality" in old.letter_annotations
+        and "solexa_quality" in new.letter_annotations
+    ):
         # Mapping from Solexa to PHRED is lossy, but so is PHRED to Solexa.
         # Assume "old" is the original, and "new" has been converted.
-        converted = [round(QualityIO.solexa_quality_from_phred(q))
-                     for q in old.letter_annotations["phred_quality"]]
+        converted = [
+            round(QualityIO.solexa_quality_from_phred(q))
+            for q in old.letter_annotations["phred_quality"]
+        ]
         if truncate:
             converted = [min(q, truncate) for q in converted]
         if converted != new.letter_annotations["solexa_quality"]:
@@ -132,12 +146,16 @@ def compare_record(old, new, truncate=None):
             print(converted)
             print(new.letter_annotations["solexa_quality"])
             raise ValueError("Mismatch in phred_quality vs solexa_quality")
-    if "solexa_quality" in old.letter_annotations \
-       and "phred_quality" in new.letter_annotations:
+    if (
+        "solexa_quality" in old.letter_annotations
+        and "phred_quality" in new.letter_annotations
+    ):
         # Mapping from Solexa to PHRED is lossy, but so is PHRED to Solexa.
         # Assume "old" is the original, and "new" has been converted.
-        converted = [round(QualityIO.phred_quality_from_solexa(q))
-                     for q in old.letter_annotations["solexa_quality"]]
+        converted = [
+            round(QualityIO.phred_quality_from_solexa(q))
+            for q in old.letter_annotations["solexa_quality"]
+        ]
         if truncate:
             converted = [min(q, truncate) for q in converted]
         if converted != new.letter_annotations["phred_quality"]:
@@ -191,9 +209,12 @@ for filename, format, alphabet in tests:
             f.__doc__ = "Convert %s from %s to %s" % (fn, fmt1, fmt2)
             return f
 
-        setattr(ConvertTests, "test_%s_%s_to_%s"
-                % (filename.replace("/", "_").replace(".", "_"), in_format, out_format),
-                funct(filename, in_format, out_format, alphabet))
+        setattr(
+            ConvertTests,
+            "test_%s_%s_to_%s"
+            % (filename.replace("/", "_").replace(".", "_"), in_format, out_format),
+            funct(filename, in_format, out_format, alphabet),
+        )
         del funct
 
 # Fail tests:
@@ -225,8 +246,11 @@ for filename, format, alphabet in tests:
     for (in_format, out_format) in converter_dict:
         if in_format != format:
             continue
-        if in_format in ["fastq", "fastq-sanger", "fastq-solexa", "fastq-illumina"] \
-           and out_format in ["fasta", "tab"] and filename.startswith("Quality/error_qual_"):
+        if (
+            in_format in ["fastq", "fastq-sanger", "fastq-solexa", "fastq-illumina"]
+            and out_format in ["fasta", "tab"]
+            and filename.startswith("Quality/error_qual_")
+        ):
             # TODO? These conversions don't check for bad characters in the quality,
             # and in order to pass this strict test they should.
             continue
@@ -236,9 +260,12 @@ for filename, format, alphabet in tests:
             f.__doc__ = "Convert %s from %s to %s" % (fn, fmt1, fmt2)
             return f
 
-        setattr(ConvertTests, "test_%s_%s_to_%s"
-                % (filename.replace("/", "_").replace(".", "_"), in_format, out_format),
-                funct(filename, in_format, out_format, alphabet))
+        setattr(
+            ConvertTests,
+            "test_%s_%s_to_%s"
+            % (filename.replace("/", "_").replace(".", "_"), in_format, out_format),
+            funct(filename, in_format, out_format, alphabet),
+        )
     del funct
 
 


### PR DESCRIPTION

This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to the last 2 files of test_SeqIO*; should be fine to merge.
test_SeqIO_convert.py 
test_SeqIO_FastaIO.py
