### PR TITLE
Apply black style to test_seq* files, version 19.10b0.

### DIFF
--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -28,13 +28,26 @@ class TestReference(unittest.TestCase):
         rec1 = SeqIO.read(testfile, "genbank")
         rec2 = SeqIO.read(testfile, "genbank")
 
-        self.assertEqual(rec1.annotations["references"][0], rec1.annotations["references"][0])
-        cmp1, cmp2 = rec1.annotations["references"][0], rec2.annotations["references"][0]
+        self.assertEqual(
+            rec1.annotations["references"][0], rec1.annotations["references"][0]
+        )
+        cmp1, cmp2 = (
+            rec1.annotations["references"][0],
+            rec2.annotations["references"][0],
+        )
         self.assertEqual(cmp1, cmp2)
-        self.assertNotEqual(rec1.annotations["references"][0], rec1.annotations["references"][1])
-        self.assertNotEqual(rec1.annotations["references"][0], rec2.annotations["references"][1])
-        self.assertEqual(rec1.annotations["references"][1], rec1.annotations["references"][1])
-        self.assertEqual(rec1.annotations["references"][1], rec2.annotations["references"][1])
+        self.assertNotEqual(
+            rec1.annotations["references"][0], rec1.annotations["references"][1]
+        )
+        self.assertNotEqual(
+            rec1.annotations["references"][0], rec2.annotations["references"][1]
+        )
+        self.assertEqual(
+            rec1.annotations["references"][1], rec1.annotations["references"][1]
+        )
+        self.assertEqual(
+            rec1.annotations["references"][1], rec2.annotations["references"][1]
+        )
 
 
 class TestFeatureLocation(unittest.TestCase):
@@ -120,21 +133,31 @@ class TestCompoundLocation(unittest.TestCase):
         self.assertEqual(loc1, loc2)
 
         loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
-        loc2 = CompoundLocation([FeatureLocation(12, 17, 1), FeatureLocation(23, 42, 1)])
+        loc2 = CompoundLocation(
+            [FeatureLocation(12, 17, 1), FeatureLocation(23, 42, 1)]
+        )
         self.assertEqual(loc1, loc2)
 
     def test_eq_not_identical(self):
         """Test two different locations are not equal."""
         loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
-        loc2 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1) + FeatureLocation(50, 60, 1)
+        loc2 = (
+            FeatureLocation(12, 17, 1)
+            + FeatureLocation(23, 42, 1)
+            + FeatureLocation(50, 60, 1)
+        )
         self.assertNotEqual(loc1, loc2)
 
         loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
         loc2 = FeatureLocation(12, 17, -1) + FeatureLocation(23, 42, -1)
         self.assertNotEqual(loc1, loc2)
 
-        loc1 = CompoundLocation([FeatureLocation(12, 17, 1), FeatureLocation(23, 42, 1)])
-        loc2 = CompoundLocation([FeatureLocation(12, 17, 1), FeatureLocation(23, 42, 1)], "order")
+        loc1 = CompoundLocation(
+            [FeatureLocation(12, 17, 1), FeatureLocation(23, 42, 1)]
+        )
+        loc2 = CompoundLocation(
+            [FeatureLocation(12, 17, 1), FeatureLocation(23, 42, 1)], "order"
+        )
         self.assertNotEqual(loc1, loc2)
 
         loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
@@ -155,7 +178,6 @@ class TestSeqFeature(unittest.TestCase):
 
 
 class TestLocations(unittest.TestCase):
-
     def test_fuzzy(self):
         """Test fuzzy representations."""
         # check the positions alone
@@ -196,19 +218,21 @@ class TestLocations(unittest.TestCase):
 
 
 class TestPositions(unittest.TestCase):
-
     def test_pickle(self):
         """Test pickle behaviour of position instances."""
         # setup
         import pickle
+
         within_pos = WithinPosition(10, left=10, right=13)
         between_pos = BetweenPosition(24, left=20, right=24)
         oneof_pos = OneOfPosition(1888, [ExactPosition(1888), ExactPosition(1901)])
         # test __getnewargs__
         self.assertEqual(within_pos.__getnewargs__(), (10, 10, 13))
         self.assertEqual(between_pos.__getnewargs__(), (24, 20, 24))
-        self.assertEqual(oneof_pos.__getnewargs__(),
-                         (1888, [ExactPosition(1888), ExactPosition(1901)]))
+        self.assertEqual(
+            oneof_pos.__getnewargs__(),
+            (1888, [ExactPosition(1888), ExactPosition(1901)]),
+        )
         # test pickle behaviour
         within_pos2 = pickle.loads(pickle.dumps(within_pos))
         between_pos2 = pickle.loads(pickle.dumps(between_pos))

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -31,11 +31,9 @@ class TestReference(unittest.TestCase):
         self.assertEqual(
             rec1.annotations["references"][0], rec1.annotations["references"][0]
         )
-        cmp1, cmp2 = (
-            rec1.annotations["references"][0],
-            rec2.annotations["references"][0],
+        self.assertEqual(
+            rec1.annotations["references"][0], rec2.annotations["references"][0]
         )
-        self.assertEqual(cmp1, cmp2)
         self.assertNotEqual(
             rec1.annotations["references"][0], rec1.annotations["references"][1]
         )

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -23,22 +23,32 @@ class SeqRecordCreation(unittest.TestCase):
 
     def test_annotations(self):
         """Pass in annotations to SeqRecords."""
-        rec = SeqRecord(Seq("ACGT", generic_dna),
-                        id="Test", name="Test", description="Test")
+        rec = SeqRecord(
+            Seq("ACGT", generic_dna), id="Test", name="Test", description="Test"
+        )
         self.assertEqual(rec.annotations, {})
-        rec = SeqRecord(Seq("ACGT", generic_dna),
-                        id="Test", name="Test", description="Test",
-                        annotations={"test": ["a test"]})
+        rec = SeqRecord(
+            Seq("ACGT", generic_dna),
+            id="Test",
+            name="Test",
+            description="Test",
+            annotations={"test": ["a test"]},
+        )
         self.assertEqual(rec.annotations["test"], ["a test"])
 
     def test_letter_annotations(self):
         """Pass in letter annotations to SeqRecords."""
-        rec = SeqRecord(Seq("ACGT", generic_dna),
-                        id="Test", name="Test", description="Test")
+        rec = SeqRecord(
+            Seq("ACGT", generic_dna), id="Test", name="Test", description="Test"
+        )
         self.assertEqual(rec.annotations, {})
-        rec = SeqRecord(Seq("ACGT", generic_dna),
-                        id="Test", name="Test", description="Test",
-                        letter_annotations={"test": [1, 2, 3, 4]})
+        rec = SeqRecord(
+            Seq("ACGT", generic_dna),
+            id="Test",
+            name="Test",
+            description="Test",
+            letter_annotations={"test": [1, 2, 3, 4]},
+        )
         self.assertEqual(rec.letter_annotations["test"], [1, 2, 3, 4])
         # Now try modifying it to a bad value...
         try:
@@ -47,8 +57,9 @@ class SeqRecordCreation(unittest.TestCase):
         except (TypeError, ValueError) as e:
             pass
         # Now try setting it afterwards to a bad value...
-        rec = SeqRecord(Seq("ACGT", generic_dna),
-                        id="Test", name="Test", description="Test")
+        rec = SeqRecord(
+            Seq("ACGT", generic_dna), id="Test", name="Test", description="Test"
+        )
         try:
             rec.letter_annotations = {"test": [1, 2, 3]}
             self.fail("Changing to bad letter_annotations should fail!")
@@ -56,21 +67,31 @@ class SeqRecordCreation(unittest.TestCase):
             pass
         # Now try setting it at creation time to a bad value...
         try:
-            rec = SeqRecord(Seq("ACGT", generic_dna),
-                            id="Test", name="Test", description="Test",
-                            letter_annotations={"test": [1, 2, 3]})
+            rec = SeqRecord(
+                Seq("ACGT", generic_dna),
+                id="Test",
+                name="Test",
+                description="Test",
+                letter_annotations={"test": [1, 2, 3]},
+            )
             self.fail("Wrong length letter_annotations should fail!")
         except (TypeError, ValueError) as e:
             pass
 
     def test_replacing_seq(self):
         """Replacing .seq if .letter_annotation present."""
-        rec = SeqRecord(Seq("ACGT", generic_dna),
-                        id="Test", name="Test", description="Test",
-                        letter_annotations={"example": [1, 2, 3, 4]})
+        rec = SeqRecord(
+            Seq("ACGT", generic_dna),
+            id="Test",
+            name="Test",
+            description="Test",
+            letter_annotations={"example": [1, 2, 3, 4]},
+        )
         try:
             rec.seq = Seq("ACGTACGT", generic_dna)
-            self.fail("Changing .seq length with letter_annotations present should fail!")
+            self.fail(
+                "Changing .seq length with letter_annotations present should fail!"
+            )
         except ValueError as e:
             self.assertEqual(str(e), "You must empty the letter annotations first!")
         # Check we can replace IF the length is the same
@@ -109,17 +130,31 @@ class SeqRecordMethods(unittest.TestCase):
     """Test SeqRecord methods."""
 
     def setUp(self):
-        f0 = SeqFeature(FeatureLocation(0, 26), type="source",
-                        qualifiers={"mol_type": ["fake protein"]})
+        f0 = SeqFeature(
+            FeatureLocation(0, 26),
+            type="source",
+            qualifiers={"mol_type": ["fake protein"]},
+        )
         f1 = SeqFeature(FeatureLocation(0, ExactPosition(10)))
-        f2 = SeqFeature(FeatureLocation(WithinPosition(12, left=12, right=15), BeforePosition(22)))
-        f3 = SeqFeature(FeatureLocation(AfterPosition(16),
-                                        OneOfPosition(26, [ExactPosition(25), AfterPosition(26)])))
-        self.record = SeqRecord(Seq("ABCDEFGHIJKLMNOPQRSTUVWZYX", generic_protein),
-                                id="TestID", name="TestName", description="TestDescr",
-                                dbxrefs=["TestXRef"], annotations={"k": "v"},
-                                letter_annotations={"fake": "X" * 26},
-                                features=[f0, f1, f2, f3])
+        f2 = SeqFeature(
+            FeatureLocation(WithinPosition(12, left=12, right=15), BeforePosition(22))
+        )
+        f3 = SeqFeature(
+            FeatureLocation(
+                AfterPosition(16),
+                OneOfPosition(26, [ExactPosition(25), AfterPosition(26)]),
+            )
+        )
+        self.record = SeqRecord(
+            Seq("ABCDEFGHIJKLMNOPQRSTUVWZYX", generic_protein),
+            id="TestID",
+            name="TestName",
+            description="TestDescr",
+            dbxrefs=["TestXRef"],
+            annotations={"k": "v"},
+            letter_annotations={"fake": "X" * 26},
+            features=[f0, f1, f2, f3],
+        )
 
     def test_iter(self):
         for amino in self.record:
@@ -158,20 +193,25 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX', ProteinAlphabet())"""
 
     def test_format_str_binary(self):
         with self.assertRaisesRegex(
-            ValueError,
-            "Binary format sff cannot be used with SeqRecord format method"
+            ValueError, "Binary format sff cannot be used with SeqRecord format method"
         ):
             f"{self.record:sff}"
 
     def test_format_spaces(self):
-        rec = SeqRecord(Seq("ABCDEFGHIJKLMNOPQRSTUVWZYX", generic_protein),
-                        id="TestID", name="TestName", description="TestDescr")
+        rec = SeqRecord(
+            Seq("ABCDEFGHIJKLMNOPQRSTUVWZYX", generic_protein),
+            id="TestID",
+            name="TestName",
+            description="TestDescr",
+        )
         rec.description = "TestDescr     with5spaces"
         expected = ">TestID TestDescr     with5spaces\nABCDEFGHIJKLMNOPQRSTUVWZYX\n"
         self.assertEqual(expected, rec.format("fasta"))
 
     def test_upper(self):
-        self.assertEqual("ABCDEFGHIJKLMNOPQRSTUVWZYX", str(self.record.lower().upper().seq))
+        self.assertEqual(
+            "ABCDEFGHIJKLMNOPQRSTUVWZYX", str(self.record.lower().upper().seq)
+        )
 
     def test_lower(self):
         self.assertEqual("abcdefghijklmnopqrstuvwzyx", str(self.record.lower().seq))
@@ -268,11 +308,14 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX', ProteinAlphabet())"""
         self.assertEqual(rec.dbxrefs, ["TestXRef", "dummy"])
         self.assertEqual(len(rec.annotations), 0)
         self.assertEqual(len(rec.letter_annotations), 0)
-        self.assertEqual(len(rec.features),
-                         len(self.record.features) + len(other.features))
+        self.assertEqual(
+            len(rec.features), len(self.record.features) + len(other.features)
+        )
         self.assertEqual(rec.features[0].type, "source")
         self.assertEqual(rec.features[0].location.nofuzzy_start, 0)
-        self.assertEqual(rec.features[0].location.nofuzzy_end, len(self.record))  # not +3
+        self.assertEqual(
+            rec.features[0].location.nofuzzy_end, len(self.record)
+        )  # not +3
         i = len(self.record.features)
         self.assertEqual(rec.features[i].type, "source")
         self.assertEqual(rec.features[i].location.nofuzzy_start, len(self.record))
@@ -313,7 +356,9 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX', ProteinAlphabet())"""
         """Simple slice and add to shift."""
         for cut in range(27):
             rec = self.record[cut:] + self.record[:cut]
-            self.assertEqual(str(rec.seq), str(self.record.seq[cut:] + self.record.seq[:cut]))
+            self.assertEqual(
+                str(rec.seq), str(self.record.seq[cut:] + self.record.seq[:cut])
+            )
             self.assertEqual(len(rec), 26)
             self.assertEqual(rec.id, "TestID")
             self.assertEqual(rec.name, "TestName")
@@ -330,14 +375,25 @@ class SeqRecordMethodsMore(unittest.TestCase):
     # This class does not have a setUp defining self.record
 
     def test_reverse_complement_seq(self):
-        s = SeqRecord(Seq("ACTG"), id="TestID", name="TestName",
-                      description="TestDescription", dbxrefs=["TestDbxrefs"],
-                      features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
-                      annotations={"organism": "bombyx"},
-                      letter_annotations={"test": "abcd"})
-        rc = s.reverse_complement(id=True, name=True, description=True,
-                                  dbxrefs=True, features=True, annotations=True,
-                                  letter_annotations=True)
+        s = SeqRecord(
+            Seq("ACTG"),
+            id="TestID",
+            name="TestName",
+            description="TestDescription",
+            dbxrefs=["TestDbxrefs"],
+            features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
+            annotations={"organism": "bombyx"},
+            letter_annotations={"test": "abcd"},
+        )
+        rc = s.reverse_complement(
+            id=True,
+            name=True,
+            description=True,
+            dbxrefs=True,
+            features=True,
+            annotations=True,
+            letter_annotations=True,
+        )
 
         self.assertEqual("CAGT", str(rc.seq))
         self.assertEqual("TestID", rc.id)
@@ -347,37 +403,57 @@ class SeqRecordMethodsMore(unittest.TestCase):
         self.assertEqual("TestName", s.reverse_complement(name="TestName").name)
 
         self.assertEqual("TestDescription", rc.description)
-        self.assertEqual("TestDescription",
-                         s.reverse_complement(description="TestDescription").description)
+        self.assertEqual(
+            "TestDescription",
+            s.reverse_complement(description="TestDescription").description,
+        )
 
         self.assertEqual(["TestDbxrefs"], rc.dbxrefs)
-        self.assertEqual(["TestDbxrefs"],
-                         s.reverse_complement(dbxrefs=["TestDbxrefs"]).dbxrefs)
+        self.assertEqual(
+            ["TestDbxrefs"], s.reverse_complement(dbxrefs=["TestDbxrefs"]).dbxrefs
+        )
 
-        self.assertEqual("[SeqFeature(FeatureLocation(ExactPosition(1), ExactPosition(4)), type='Site')]",
-                         repr(rc.features))
-        rc2 = s.reverse_complement(features=[SeqFeature(FeatureLocation(1, 4), type="Site")])
-        self.assertEqual("[SeqFeature(FeatureLocation(ExactPosition(1), ExactPosition(4)), type='Site')]",
-                         repr(rc2.features))
+        self.assertEqual(
+            "[SeqFeature(FeatureLocation(ExactPosition(1), ExactPosition(4)), type='Site')]",
+            repr(rc.features),
+        )
+        rc2 = s.reverse_complement(
+            features=[SeqFeature(FeatureLocation(1, 4), type="Site")]
+        )
+        self.assertEqual(
+            "[SeqFeature(FeatureLocation(ExactPosition(1), ExactPosition(4)), type='Site')]",
+            repr(rc2.features),
+        )
 
         self.assertEqual({"organism": "bombyx"}, rc.annotations)
-        self.assertEqual({"organism": "bombyx"},
-                         s.reverse_complement(annotations={"organism": "bombyx"}).annotations)
+        self.assertEqual(
+            {"organism": "bombyx"},
+            s.reverse_complement(annotations={"organism": "bombyx"}).annotations,
+        )
 
         self.assertEqual({"test": "dcba"}, rc.letter_annotations)
-        self.assertEqual({"test": "abcd"},
-                         s.reverse_complement(letter_annotations={"test": "abcd"}).letter_annotations)
+        self.assertEqual(
+            {"test": "abcd"},
+            s.reverse_complement(
+                letter_annotations={"test": "abcd"}
+            ).letter_annotations,
+        )
 
     def test_reverse_complement_mutable_seq(self):
         s = SeqRecord(MutableSeq("ACTG"))
         self.assertEqual("CAGT", str(s.reverse_complement().seq))
 
     def test_translate(self):
-        s = SeqRecord(Seq("ATGGTGTAA"), id="TestID", name="TestName",
-                      description="TestDescription", dbxrefs=["TestDbxrefs"],
-                      features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
-                      annotations={"organism": "bombyx"},
-                      letter_annotations={"test": "abcdefghi"})
+        s = SeqRecord(
+            Seq("ATGGTGTAA"),
+            id="TestID",
+            name="TestName",
+            description="TestDescription",
+            dbxrefs=["TestDbxrefs"],
+            features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
+            annotations={"organism": "bombyx"},
+            letter_annotations={"test": "abcdefghi"},
+        )
 
         t = s.translate()
         self.assertEqual(t.seq, "MV*")
@@ -389,8 +465,14 @@ class SeqRecordMethodsMore(unittest.TestCase):
         self.assertFalse(t.annotations)
         self.assertFalse(t.letter_annotations)
 
-        t = s.translate(cds=True, id=True, name=True, description=True,
-                        dbxrefs=True, annotations=True)
+        t = s.translate(
+            cds=True,
+            id=True,
+            name=True,
+            description=True,
+            dbxrefs=True,
+            annotations=True,
+        )
         self.assertEqual(t.seq, "MV")
         self.assertEqual(t.id, "TestID")
         self.assertEqual(t.name, "TestName")
@@ -403,51 +485,63 @@ class SeqRecordMethodsMore(unittest.TestCase):
     def test_lt_exception(self):
         def lt():
             SeqRecord(Seq("A")) < SeqRecord(Seq("A"))
+
         self.assertRaises(NotImplementedError, lt)
 
     def test_le_exception(self):
         def le():
             SeqRecord(Seq("A")) <= SeqRecord(Seq("A"))
+
         self.assertRaises(NotImplementedError, le)
 
     def test_eq_exception(self):
         def equality():
             SeqRecord(Seq("A")) == SeqRecord(Seq("A"))
+
         self.assertRaises(NotImplementedError, equality)
 
     def test_ne_exception(self):
         def notequality():
             SeqRecord(Seq("A")) != SeqRecord(Seq("A"))
+
         self.assertRaises(NotImplementedError, notequality)
 
     def test_gt_exception(self):
         def gt():
             SeqRecord(Seq("A")) > SeqRecord(Seq("A"))
+
         self.assertRaises(NotImplementedError, gt)
 
     def test_ge_exception(self):
         def ge():
             SeqRecord(Seq("A")) >= SeqRecord(Seq("A"))
+
         self.assertRaises(NotImplementedError, ge)
 
     def test_hash_exception(self):
         def hash1():
             hash(SeqRecord(Seq("A")))
+
         self.assertRaises(TypeError, hash1)
 
         def hash2():
             SeqRecord(Seq("A")).__hash__()
+
         self.assertRaises(TypeError, hash2)
 
 
 class TestTranslation(unittest.TestCase):
-
     def setUp(self):
-        self.s = SeqRecord(Seq("ATGGTGTAA"), id="TestID", name="TestName",
-                           description="TestDescription", dbxrefs=["TestDbxrefs"],
-                           features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
-                           annotations={"organism": "bombyx"},
-                           letter_annotations={"test": "abcdefghi"})
+        self.s = SeqRecord(
+            Seq("ATGGTGTAA"),
+            id="TestID",
+            name="TestName",
+            description="TestDescription",
+            dbxrefs=["TestDbxrefs"],
+            features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
+            annotations={"organism": "bombyx"},
+            letter_annotations={"test": "abcdefghi"},
+        )
 
     def test_defaults(self):
         t = self.s.translate()
@@ -461,8 +555,14 @@ class TestTranslation(unittest.TestCase):
         self.assertFalse(t.letter_annotations)
 
     def test_preserve(self):
-        t = self.s.translate(cds=True, id=True, name=True, description=True,
-                             dbxrefs=True, annotations=True)
+        t = self.s.translate(
+            cds=True,
+            id=True,
+            name=True,
+            description=True,
+            dbxrefs=True,
+            annotations=True,
+        )
         self.assertEqual(t.seq, "MV")
         self.assertEqual(t.id, "TestID")
         self.assertEqual(t.name, "TestName")
@@ -477,11 +577,18 @@ class TestTranslation(unittest.TestCase):
         self.assertRaises(TypeError, self.s.translate, letter_annotations=True)
 
     def test_new_annot(self):
-        t = self.s.translate(1, to_stop=True, gap="-",
-                             id="Foo", name="Bar", description="Baz", dbxrefs=["Nope"],
-                             features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
-                             annotations={"a": "team"},
-                             letter_annotations={"aa": ["Met", "Val"]})
+        t = self.s.translate(
+            1,
+            to_stop=True,
+            gap="-",
+            id="Foo",
+            name="Bar",
+            description="Baz",
+            dbxrefs=["Nope"],
+            features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
+            annotations={"a": "team"},
+            letter_annotations={"aa": ["Met", "Val"]},
+        )
         self.assertEqual(t.seq, "MV")
         self.assertEqual(t.id, "Foo")
         self.assertEqual(t.name, "Bar")

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -24,22 +24,25 @@ def u_crc32(seq):
     # NOTE - On Python 2 crc32 could return a signed int, but on Python 3 it is
     # always unsigned
     # Docs suggest should use crc32(x) & 0xffffffff for consistency.
-    return crc32(seq) & 0xffffffff
+    return crc32(seq) & 0xFFFFFFFF
 
 
 class SeqUtilsTests(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         # Example of crc64 collision from Sebastian Bassi using the
         # immunoglobulin lambda light chain variable region from Homo sapiens
         # Both sequences share the same CRC64 checksum: 44CAAD88706CC153
-        cls.str_light_chain_one = ("QSALTQPASVSGSPGQSITISCTGTSSDVGSYNLVSWYQQ"
-                                   "HPGKAPKLMIYEGSKRPSGVSNRFSGSKSGNTASLTISGL"
-                                   "QAEDEADYYCSSYAGSSTLVFGGGTKLTVL")
-        cls.str_light_chain_two = ("QSALTQPASVSGSPGQSITISCTGTSSDVGSYNLVSWYQQ"
-                                   "HPGKAPKLMIYEGSKRPSGVSNRFSGSKSGNTASLTISGL"
-                                   "QAEDEADYYCCSYAGSSTWVFGGGTKLTVL")
+        cls.str_light_chain_one = (
+            "QSALTQPASVSGSPGQSITISCTGTSSDVGSYNLVSWYQQ"
+            "HPGKAPKLMIYEGSKRPSGVSNRFSGSKSGNTASLTISGL"
+            "QAEDEADYYCSSYAGSSTLVFGGGTKLTVL"
+        )
+        cls.str_light_chain_two = (
+            "QSALTQPASVSGSPGQSITISCTGTSSDVGSYNLVSWYQQ"
+            "HPGKAPKLMIYEGSKRPSGVSNRFSGSKSGNTASLTISGL"
+            "QAEDEADYYCCSYAGSSTWVFGGGTKLTVL"
+        )
         X = CodonAdaptationIndex()
         path = os.path.join("CodonUsage", "HighlyExpressedGenes.txt")
         X.generate_index(path)
@@ -72,8 +75,13 @@ class SeqUtilsTests(unittest.TestCase):
                 a = "M" + str(seq[3:].translate(table))
                 b = feature.qualifiers["translation"][0] + "*"
                 self.assertEqual(a, b, "%r vs %r" % (a, b))
-                records.append(SeqRecord(seq, id=feature.qualifiers["protein_id"][0],
-                                         description=feature.qualifiers["product"][0]))
+                records.append(
+                    SeqRecord(
+                        seq,
+                        id=feature.qualifiers["protein_id"][0],
+                        description=feature.qualifiers["product"][0],
+                    )
+                )
 
         with open(dna_fasta_filename, "w") as handle:
             SeqIO.write(records, handle, "fasta")
@@ -83,8 +91,9 @@ class SeqUtilsTests(unittest.TestCase):
         # sequences - which should each be a whole number of codons.
         CAI.generate_index(dna_fasta_filename)
         # Now check codon usage index (CAI) using this species
-        self.assertEqual(record.annotations["source"],
-                         "Yersinia pestis biovar Microtus str. 91001")
+        self.assertEqual(
+            record.annotations["source"], "Yersinia pestis biovar Microtus str. 91001"
+        )
         value = CAI.cai_for_gene("ATGCGTATCGATCGCGATACGATTAGGCGGATG")
         self.assertAlmostEqual(value, 0.67213, places=5)
         os.remove(dna_fasta_filename)
@@ -92,16 +101,34 @@ class SeqUtilsTests(unittest.TestCase):
     def test_crc_checksum_collision(self):
         # Explicit testing of crc64 collision:
         self.assertNotEqual(self.str_light_chain_one, self.str_light_chain_two)
-        self.assertNotEqual(crc32(self.str_light_chain_one), crc32(self.str_light_chain_two))
-        self.assertEqual(crc64(self.str_light_chain_one), crc64(self.str_light_chain_two))
-        self.assertNotEqual(gcg(self.str_light_chain_one), gcg(self.str_light_chain_two))
-        self.assertNotEqual(seguid(self.str_light_chain_one), seguid(self.str_light_chain_two))
+        self.assertNotEqual(
+            crc32(self.str_light_chain_one), crc32(self.str_light_chain_two)
+        )
+        self.assertEqual(
+            crc64(self.str_light_chain_one), crc64(self.str_light_chain_two)
+        )
+        self.assertNotEqual(
+            gcg(self.str_light_chain_one), gcg(self.str_light_chain_two)
+        )
+        self.assertNotEqual(
+            seguid(self.str_light_chain_one), seguid(self.str_light_chain_two)
+        )
 
-    def seq_checksums(self, seq_str, exp_crc32, exp_crc64, exp_gcg, exp_seguid,
-                      exp_simple_LCC, exp_window_LCC):
-        for s in [seq_str,
-                  Seq(seq_str, single_letter_alphabet),
-                  MutableSeq(seq_str, single_letter_alphabet)]:
+    def seq_checksums(
+        self,
+        seq_str,
+        exp_crc32,
+        exp_crc64,
+        exp_gcg,
+        exp_seguid,
+        exp_simple_LCC,
+        exp_window_LCC,
+    ):
+        for s in [
+            seq_str,
+            Seq(seq_str, single_letter_alphabet),
+            MutableSeq(seq_str, single_letter_alphabet),
+        ]:
             self.assertEqual(exp_crc32, u_crc32(s))
             self.assertEqual(exp_crc64, crc64(s))
             self.assertEqual(exp_gcg, gcg(s))
@@ -113,31 +140,82 @@ class SeqUtilsTests(unittest.TestCase):
                 self.assertAlmostEqual(value1, value2, places=2)
 
     def test_checksum1(self):
-        self.seq_checksums(self.str_light_chain_one,
-                           2994980265,
-                           "CRC-44CAAD88706CC153",
-                           9729,
-                           "BpBeDdcNUYNsdk46JoJdw7Pd3BI",
-                           1.03,
-                           (0.00, 1.00, 0.96, 0.96, 0.96, 0.65, 0.43, 0.35, 0.35, 0.35, 0.35, 0.53, 0.59, 0.26))
+        self.seq_checksums(
+            self.str_light_chain_one,
+            2994980265,
+            "CRC-44CAAD88706CC153",
+            9729,
+            "BpBeDdcNUYNsdk46JoJdw7Pd3BI",
+            1.03,
+            (
+                0.00,
+                1.00,
+                0.96,
+                0.96,
+                0.96,
+                0.65,
+                0.43,
+                0.35,
+                0.35,
+                0.35,
+                0.35,
+                0.53,
+                0.59,
+                0.26,
+            ),
+        )
 
     def test_checksum2(self):
-        self.seq_checksums(self.str_light_chain_two,
-                           802105214,
-                           "CRC-44CAAD88706CC153",
-                           9647,
-                           "X5XEaayob1nZLOc7eVT9qyczarY",
-                           1.07,
-                           (0.00, 1.00, 0.96, 0.96, 0.96, 0.65, 0.43, 0.35, 0.35, 0.35, 0.35, 0.53, 0.59, 0.26))
+        self.seq_checksums(
+            self.str_light_chain_two,
+            802105214,
+            "CRC-44CAAD88706CC153",
+            9647,
+            "X5XEaayob1nZLOc7eVT9qyczarY",
+            1.07,
+            (
+                0.00,
+                1.00,
+                0.96,
+                0.96,
+                0.96,
+                0.65,
+                0.43,
+                0.35,
+                0.35,
+                0.35,
+                0.35,
+                0.53,
+                0.59,
+                0.26,
+            ),
+        )
 
     def test_checksum3(self):
-        self.seq_checksums("ATGCGTATCGATCGCGATACGATTAGGCGGAT",
-                           817679856,
-                           "CRC-6234FF451DC6DFC6",
-                           7959,
-                           "8WCUbVjBgiRmM10gfR7XJNjbwnE",
-                           1.98,
-                           (0.00, 2.00, 1.99, 1.99, 2.00, 1.99, 1.97, 1.99, 1.99, 1.99, 1.96, 1.96, 1.96, 1.96))
+        self.seq_checksums(
+            "ATGCGTATCGATCGCGATACGATTAGGCGGAT",
+            817679856,
+            "CRC-6234FF451DC6DFC6",
+            7959,
+            "8WCUbVjBgiRmM10gfR7XJNjbwnE",
+            1.98,
+            (
+                0.00,
+                2.00,
+                1.99,
+                1.99,
+                2.00,
+                1.99,
+                1.97,
+                1.99,
+                1.99,
+                1.99,
+                1.96,
+                1.96,
+                1.96,
+                1.96,
+            ),
+        )
 
     def test_GC(self):
         seq = "ACGGGCTACCGTATAGGCAAGAGATGATGCCC"
@@ -157,7 +235,9 @@ class SeqUtilsTests(unittest.TestCase):
 
     def test_codon_adaptation_index(self):
         X = self.X
-        cai = X.cai_for_gene("ATGAAACGCATTAGCACCACCATTACCACCACCATCACCATTACCACAGGTAACGGTGCGGGCTGA")
+        cai = X.cai_for_gene(
+            "ATGAAACGCATTAGCACCACCATTACCACCACCATCACCATTACCACAGGTAACGGTGCGGGCTGA"
+        )
         self.assertAlmostEqual(cai, 0.6723, places=3)
 
     def test_index(self):

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -34,14 +34,12 @@ class SeqUtilsTests(unittest.TestCase):
         # immunoglobulin lambda light chain variable region from Homo sapiens
         # Both sequences share the same CRC64 checksum: 44CAAD88706CC153
         cls.str_light_chain_one = (
-            "QSALTQPASVSGSPGQSITISCTGTSSDVGSYNLVSWYQQ"
-            "HPGKAPKLMIYEGSKRPSGVSNRFSGSKSGNTASLTISGL"
-            "QAEDEADYYCSSYAGSSTLVFGGGTKLTVL"
+            "QSALTQPASVSGSPGQSITISCTGTSSDVGSYNLVSWYQQHPGKAPKLMIYEGSKRPSGV"
+            "SNRFSGSKSGNTASLTISGLQAEDEADYYCSSYAGSSTLVFGGGTKLTVL"
         )
         cls.str_light_chain_two = (
-            "QSALTQPASVSGSPGQSITISCTGTSSDVGSYNLVSWYQQ"
-            "HPGKAPKLMIYEGSKRPSGVSNRFSGSKSGNTASLTISGL"
-            "QAEDEADYYCCSYAGSSTWVFGGGTKLTVL"
+            "QSALTQPASVSGSPGQSITISCTGTSSDVGSYNLVSWYQQHPGKAPKLMIYEGSKRPSGV"
+            "SNRFSGSKSGNTASLTISGLQAEDEADYYCCSYAGSSTWVFGGGTKLTVL"
         )
         X = CodonAdaptationIndex()
         path = os.path.join("CodonUsage", "HighlyExpressedGenes.txt")

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -232,7 +232,6 @@ class StringMethodTests(unittest.TestCase):
             0,
             0,
             0,
-            0,  # Seq() Tests
             0,
             0,
             0,
@@ -244,7 +243,8 @@ class StringMethodTests(unittest.TestCase):
             0,
             0,
             0,
-        ]  # UnknownSeq() Tests
+            0,
+        ]
         expected *= 2  # MutableSeq() Tests
 
         assert len(self._examples) == len(expected)

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -21,6 +21,10 @@ from Bio.Data.CodonTable import TranslationError, CodonTable
 
 # This is just the standard table with less stop codons
 # (replaced with coding for O as an artificial example)
+
+# Turn black code style off
+# fmt: off
+
 special_table = CodonTable(forward_table={
     "TTT": "F", "TTC": "F", "TTA": "L", "TTG": "L",
     "TCT": "S", "TCC": "S", "TCA": "S", "TCG": "S",
@@ -39,7 +43,8 @@ special_table = CodonTable(forward_table={
     "GAT": "D", "GAC": "D", "GAA": "E", "GAG": "E",
     "GGT": "G", "GGC": "G", "GGA": "G", "GGG": "G"},
     start_codons=["TAA", "TAG", "TGA"],
-    stop_codons=["TAG"])
+    stop_codons=["TAG"],
+)
 
 Chilodonella_uncinata_table = CodonTable(forward_table={
     "TTT": "F", "TTC": "F", "TTA": "L", "TTG": "L",
@@ -59,7 +64,11 @@ Chilodonella_uncinata_table = CodonTable(forward_table={
     "GAT": "D", "GAC": "D", "GAA": "E", "GAG": "E",
     "GGT": "G", "GGC": "G", "GGA": "G", "GGG": "G"},
     start_codons=["ATG"],
-    stop_codons=["TAA"])
+    stop_codons=["TAA"],
+)
+
+# Turn black code style on
+# fmt: on
 
 
 class StringMethodTests(unittest.TestCase):
@@ -88,14 +97,13 @@ class StringMethodTests(unittest.TestCase):
         UnknownSeq(12, generic_protein, "X"),
         UnknownSeq(12, character="X"),
         UnknownSeq(12),
-        ]
+    ]
     for seq in _examples[:]:
         if isinstance(seq, Seq):
             _examples.append(seq.tomutable())
     _start_end_values = [0, 1, 2, 1000, -1, -2, -999, None]
 
-    def _test_method(self, method_name, pre_comp_function=None,
-                     start_end=False):
+    def _test_method(self, method_name, pre_comp_function=None, start_end=False):
         """Check this method matches the plain string's method."""
         if pre_comp_function is None:
             # Define a no-op function:
@@ -114,7 +122,11 @@ class StringMethodTests(unittest.TestCase):
                 if not hasattr(example2, method_name):
                     # e.g. MutableSeq does not support find
                     continue
-                if method_name in ("index", "rindex") and isinstance(example1, MutableSeq) and len(example2) > 1:
+                if (
+                    method_name in ("index", "rindex")
+                    and isinstance(example1, MutableSeq)
+                    and len(example2) > 1
+                ):
                     # MutableSeq index only supports single entries
                     continue
                 str2 = str(example2)
@@ -128,12 +140,10 @@ class StringMethodTests(unittest.TestCase):
                 except ValueError:
                     j = ValueError
                 if i != j:
-                    raise ValueError("%s.%s(%s) = %r, not %r"
-                                     % (repr(example1),
-                                        method_name,
-                                        repr(str2),
-                                        i,
-                                        j))
+                    raise ValueError(
+                        "%s.%s(%s) = %r, not %r"
+                        % (repr(example1), method_name, repr(str2), i, j)
+                    )
 
                 try:
                     try:
@@ -145,12 +155,10 @@ class StringMethodTests(unittest.TestCase):
                     except ValueError:
                         j = ValueError
                     if i != j:
-                        raise ValueError("%s.%s(%s) = %r, not %r"
-                                         % (repr(example1),
-                                            method_name,
-                                            repr(example2),
-                                            i,
-                                            j))
+                        raise ValueError(
+                            "%s.%s(%s) = %r, not %r"
+                            % (repr(example1), method_name, repr(example2), i, j)
+                        )
                 except TypeError:
                     # TODO - Check the alphabets do clash!
                     pass
@@ -161,40 +169,49 @@ class StringMethodTests(unittest.TestCase):
                         continue
                     for start in self._start_end_values:
                         try:
-                            i = pre_comp_function(getattr(example1, method_name)(str2, start))
+                            i = pre_comp_function(
+                                getattr(example1, method_name)(str2, start)
+                            )
                         except ValueError:
                             i = ValueError
                         try:
-                            j = pre_comp_function(getattr(str1, method_name)(str2, start))
+                            j = pre_comp_function(
+                                getattr(str1, method_name)(str2, start)
+                            )
                         except ValueError:
                             j = ValueError
                         if i != j:
-                            raise ValueError("%s.%s(%s, %i) = %r, not %r"
-                                             % (repr(example1),
-                                                method_name,
-                                                repr(str2),
-                                                start,
-                                                i,
-                                                j))
+                            raise ValueError(
+                                "%s.%s(%s, %i) = %r, not %r"
+                                % (repr(example1), method_name, repr(str2), start, i, j)
+                            )
 
                         for end in self._start_end_values:
                             try:
-                                i = pre_comp_function(getattr(example1, method_name)(str2, start, end))
+                                i = pre_comp_function(
+                                    getattr(example1, method_name)(str2, start, end)
+                                )
                             except ValueError:
                                 i = ValueError
                             try:
-                                j = pre_comp_function(getattr(str1, method_name)(str2, start, end))
+                                j = pre_comp_function(
+                                    getattr(str1, method_name)(str2, start, end)
+                                )
                             except ValueError:
                                 j = ValueError
                             if i != j:
-                                raise ValueError("%s.%s(%s, %i, %i) = %r, not %r"
-                                                 % (repr(example1),
-                                                    method_name,
-                                                    repr(str2),
-                                                    start,
-                                                    end,
-                                                    i,
-                                                    j))
+                                raise ValueError(
+                                    "%s.%s(%s, %i, %i) = %r, not %r"
+                                    % (
+                                        repr(example1),
+                                        method_name,
+                                        repr(str2),
+                                        start,
+                                        end,
+                                        i,
+                                        j,
+                                    )
+                                )
 
     def test_str_count(self):
         """Check matches the python string count method."""
@@ -203,8 +220,31 @@ class StringMethodTests(unittest.TestCase):
     def test_str_count_overlap_GG(self):
         """Check our count_overlap method using GG."""
         # Testing with self._examples
-        expected = [3, 3, 3, 3, 1, 1, 1, 1, 0, 0, 0, 0,  # Seq() Tests
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]  # UnknownSeq() Tests
+        expected = [
+            3,
+            3,
+            3,
+            3,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,  # Seq() Tests
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]  # UnknownSeq() Tests
         expected *= 2  # MutableSeq() Tests
 
         assert len(self._examples) == len(expected)
@@ -220,23 +260,27 @@ class StringMethodTests(unittest.TestCase):
     def test_count_overlap_start_end_GG(self):
         """Check our count_overlap method using GG with variable ends and starts."""
         # Testing Seq() and MutableSeq() with variable start and end arguments
-        start_end_exp = [(1, 7, 3),
-                         (3, None, 3),
-                         (3, 6, 2),
-                         (4, 6, 1),
-                         (4, -1, 2),
-                         (-5, None, 2),
-                         (-5, 7, 2),
-                         (7, -5, 0),
-                         (-100, None, 3),
-                         (None, 100, 3),
-                         (-100, 1000, 3)]
+        start_end_exp = [
+            (1, 7, 3),
+            (3, None, 3),
+            (3, 6, 2),
+            (4, 6, 1),
+            (4, -1, 2),
+            (-5, None, 2),
+            (-5, 7, 2),
+            (7, -5, 0),
+            (-100, None, 3),
+            (None, 100, 3),
+            (-100, 1000, 3),
+        ]
 
         testing_seq = "GTAGGGGAG"
 
         for start, end, exp in start_end_exp:
             self.assertEqual(Seq(testing_seq).count_overlap("GG", start, end), exp)
-            self.assertEqual(MutableSeq(testing_seq).count_overlap("GG", start, end), exp)
+            self.assertEqual(
+                MutableSeq(testing_seq).count_overlap("GG", start, end), exp
+            )
 
         # Testing Seq() and MutableSeq() with a more heterogeneous sequenece
         self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("GG"), 5)
@@ -250,41 +294,72 @@ class StringMethodTests(unittest.TestCase):
         self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("GG", -2, -10), 0)
 
         # Testing UnknownSeq() with variable start and end arguments
-        alphabet_char_start_end_exp = [(generic_rna, "N", 1, 7, 0),
-                                       (generic_dna, "N", 1, 7, 0),
-                                       (generic_rna, "N", -4, None, 0),
-                                       (generic_dna, "N", -4, None, 0),
-                                       (generic_protein, "X", 1, 7, 0)]
+        alphabet_char_start_end_exp = [
+            (generic_rna, "N", 1, 7, 0),
+            (generic_dna, "N", 1, 7, 0),
+            (generic_rna, "N", -4, None, 0),
+            (generic_dna, "N", -4, None, 0),
+            (generic_protein, "X", 1, 7, 0),
+        ]
 
         for alpha, char, start, end, exp in alphabet_char_start_end_exp:
-            self.assertEqual(UnknownSeq(12, alpha, char).count_overlap("GG", start, end), exp)
+            self.assertEqual(
+                UnknownSeq(12, alpha, char).count_overlap("GG", start, end), exp
+            )
         self.assertEqual(UnknownSeq(12, character="X").count_overlap("GG", 1, 7), 0)
 
         # Testing UnknownSeq() with some more cases including unusual edge cases
-        substr_start_end_exp = [("G", 100, 105, 0),
-                                ("G", -1, 4, 0),
-                                ("G", 4, -1, 0),
-                                ("G", -8, -2, 0),
-                                ("G", -2, -8, 0),
-                                ("G", 8, 2, 0),
-                                ("G", 2, 8, 0),
-                                ("GG", 8, 2, 0),
-                                ("GG", 2, 8, 0),
-                                ("GG", -5, -1, 0),
-                                ("GG", 1, 5, 0),
-                                ("GGG", None, None, 0),
-                                ("GGGGGGGGG", None, None, 0),
-                                ("GGG", 1, 2, 0)]
+        substr_start_end_exp = [
+            ("G", 100, 105, 0),
+            ("G", -1, 4, 0),
+            ("G", 4, -1, 0),
+            ("G", -8, -2, 0),
+            ("G", -2, -8, 0),
+            ("G", 8, 2, 0),
+            ("G", 2, 8, 0),
+            ("GG", 8, 2, 0),
+            ("GG", 2, 8, 0),
+            ("GG", -5, -1, 0),
+            ("GG", 1, 5, 0),
+            ("GGG", None, None, 0),
+            ("GGGGGGGGG", None, None, 0),
+            ("GGG", 1, 2, 0),
+        ]
 
         for substr, start, end, exp in substr_start_end_exp:
-            self.assertEqual(UnknownSeq(7, character="N").count_overlap(substr, start, end), exp)
+            self.assertEqual(
+                UnknownSeq(7, character="N").count_overlap(substr, start, end), exp
+            )
         self.assertEqual(UnknownSeq(7, character="N").count_overlap("GG", 1), 0)
 
     def test_str_count_overlap_NN(self):
         """Check our count_overlap method using NN."""
         # Testing with self._examples
-        expected = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  # Seq() Tests
-                    0, 0, 0, 0, 0, 11, 11, 11, 0, 0, 0]  # UnknownSeq() Tests
+        expected = [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,  # Seq() Tests
+            0,
+            0,
+            0,
+            0,
+            0,
+            11,
+            11,
+            11,
+            0,
+            0,
+            0,
+        ]  # UnknownSeq() Tests
         expected *= 2  # MutableSeq() Tests
 
         assert len(self._examples) == len(expected)
@@ -300,23 +375,27 @@ class StringMethodTests(unittest.TestCase):
     def test_count_overlap_start_end_NN(self):
         """Check our count_overlap method using NN with variable ends and starts."""
         # Testing Seq() and MutableSeq() with variable start and end arguments
-        start_end_exp = [(1, 7, 0),
-                         (3, None, 0),
-                         (3, 6, 0),
-                         (4, 6, 0),
-                         (4, -1, 0),
-                         (-5, None, 0),
-                         (-5, 7, 0),
-                         (7, -5, 0),
-                         (-100, None, 0),
-                         (None, 100, 0),
-                         (-100, 1000, 0)]
+        start_end_exp = [
+            (1, 7, 0),
+            (3, None, 0),
+            (3, 6, 0),
+            (4, 6, 0),
+            (4, -1, 0),
+            (-5, None, 0),
+            (-5, 7, 0),
+            (7, -5, 0),
+            (-100, None, 0),
+            (None, 100, 0),
+            (-100, 1000, 0),
+        ]
 
         testing_seq = "GTAGGGGAG"
 
         for start, end, exp in start_end_exp:
             self.assertEqual(Seq(testing_seq).count_overlap("NN", start, end), exp)
-            self.assertEqual(MutableSeq(testing_seq).count_overlap("NN", start, end), exp)
+            self.assertEqual(
+                MutableSeq(testing_seq).count_overlap("NN", start, end), exp
+            )
 
         # Testing Seq() and MutableSeq() with a more heterogeneous sequenece
         self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("NN"), 0)
@@ -330,34 +409,42 @@ class StringMethodTests(unittest.TestCase):
         self.assertEqual(Seq("GGGTGGTAGGG").count_overlap("NN", -10, -2), 0)
 
         # Testing UnknownSeq() with variable start and end arguments
-        alphabet_char_start_end_exp = [(generic_rna, "N", 1, 7, 5),
-                                       (generic_dna, "N", 1, 7, 5),
-                                       (generic_rna, "N", -4, None, 3),
-                                       (generic_dna, "N", -4, None, 3),
-                                       (generic_protein, "X", 1, 7, 0)]
+        alphabet_char_start_end_exp = [
+            (generic_rna, "N", 1, 7, 5),
+            (generic_dna, "N", 1, 7, 5),
+            (generic_rna, "N", -4, None, 3),
+            (generic_dna, "N", -4, None, 3),
+            (generic_protein, "X", 1, 7, 0),
+        ]
 
         for alpha, char, start, end, exp in alphabet_char_start_end_exp:
-            self.assertEqual(UnknownSeq(12, alpha, char).count_overlap("NN", start, end), exp)
+            self.assertEqual(
+                UnknownSeq(12, alpha, char).count_overlap("NN", start, end), exp
+            )
         self.assertEqual(UnknownSeq(12, character="X").count_overlap("NN", 1, 7), 0)
 
         # Testing UnknownSeq() with some more cases including unusual edge cases
-        substr_start_end_exp = [("N", 100, 105, 0),
-                                ("N", -1, 4, 0),
-                                ("N", 4, -1, 2),
-                                ("N", -8, -2, 5),
-                                ("N", -2, -8, 0),
-                                ("N", 8, 2, 0),
-                                ("N", 2, 8, 5),
-                                ("NN", 8, 2, 0),
-                                ("NN", 2, 8, 4),
-                                ("NN", -5, -1, 3),
-                                ("NN", 1, 5, 3),
-                                ("NNN", None, None, 5),
-                                ("NNNNNNNNN", None, None, 0),
-                                ("NNN", 1, 2, 0)]
+        substr_start_end_exp = [
+            ("N", 100, 105, 0),
+            ("N", -1, 4, 0),
+            ("N", 4, -1, 2),
+            ("N", -8, -2, 5),
+            ("N", -2, -8, 0),
+            ("N", 8, 2, 0),
+            ("N", 2, 8, 5),
+            ("NN", 8, 2, 0),
+            ("NN", 2, 8, 4),
+            ("NN", -5, -1, 3),
+            ("NN", 1, 5, 3),
+            ("NNN", None, None, 5),
+            ("NNNNNNNNN", None, None, 0),
+            ("NNN", 1, 2, 0),
+        ]
 
         for substr, start, end, exp in substr_start_end_exp:
-            self.assertEqual(UnknownSeq(7, character="N").count_overlap(substr, start, end), exp)
+            self.assertEqual(
+                UnknownSeq(7, character="N").count_overlap(substr, start, end), exp
+            )
         self.assertEqual(UnknownSeq(7, character="N").count_overlap("NN", 1), 5)
 
     def test_str_find(self):
@@ -386,18 +473,24 @@ class StringMethodTests(unittest.TestCase):
             if not hasattr(example1, "startswith"):
                 # e.g. MutableSeq does not support this
                 continue
-            subs = tuple(example1[start:start + 2] for start
-                         in range(0, len(example1) - 2, 3))
+            subs = tuple(
+                example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
+            )
             subs_str = tuple(str(s) for s in subs)
 
-            self.assertEqual(str(example1).startswith(subs_str),
-                             example1.startswith(subs))
-            self.assertEqual(str(example1).startswith(subs_str),
-                             example1.startswith(subs_str))  # strings!
-            self.assertEqual(str(example1).startswith(subs_str, 3),
-                             example1.startswith(subs, 3))
-            self.assertEqual(str(example1).startswith(subs_str, 2, 6),
-                             example1.startswith(subs, 2, 6))
+            self.assertEqual(
+                str(example1).startswith(subs_str), example1.startswith(subs)
+            )
+            self.assertEqual(
+                str(example1).startswith(subs_str), example1.startswith(subs_str)
+            )  # strings!
+            self.assertEqual(
+                str(example1).startswith(subs_str, 3), example1.startswith(subs, 3)
+            )
+            self.assertEqual(
+                str(example1).startswith(subs_str, 2, 6),
+                example1.startswith(subs, 2, 6),
+            )
 
     def test_str_endswith(self):
         """Check matches the python string endswith method."""
@@ -409,18 +502,21 @@ class StringMethodTests(unittest.TestCase):
             if not hasattr(example1, "endswith"):
                 # e.g. MutableSeq does not support this
                 continue
-            subs = tuple(example1[start:start + 2] for start
-                         in range(0, len(example1) - 2, 3))
+            subs = tuple(
+                example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
+            )
             subs_str = tuple(str(s) for s in subs)
 
-            self.assertEqual(str(example1).endswith(subs_str),
-                             example1.endswith(subs))
-            self.assertEqual(str(example1).startswith(subs_str),
-                             example1.startswith(subs_str))  # strings!
-            self.assertEqual(str(example1).endswith(subs_str, 3),
-                             example1.endswith(subs, 3))
-            self.assertEqual(str(example1).endswith(subs_str, 2, 6),
-                             example1.endswith(subs, 2, 6))
+            self.assertEqual(str(example1).endswith(subs_str), example1.endswith(subs))
+            self.assertEqual(
+                str(example1).startswith(subs_str), example1.startswith(subs_str)
+            )  # strings!
+            self.assertEqual(
+                str(example1).endswith(subs_str, 3), example1.endswith(subs, 3)
+            )
+            self.assertEqual(
+                str(example1).endswith(subs_str, 2, 6), example1.endswith(subs, 2, 6)
+            )
 
     def test_str_strip(self):
         """Check matches the python string strip method."""
@@ -434,22 +530,25 @@ class StringMethodTests(unittest.TestCase):
         """Check matches the python string rstrip method."""
         # Calling (r)split should return a list of Seq-like objects, we'll
         # just apply str() to each of them so it matches the string method
-        self._test_method("rstrip",
-                          pre_comp_function=lambda x: [str(y) for y in x])  # noqa: E731
+        self._test_method(
+            "rstrip", pre_comp_function=lambda x: [str(y) for y in x]  # noqa: E731
+        )
 
     def test_str_rsplit(self):
         """Check matches the python string rstrip method."""
         # Calling (r)split should return a list of Seq-like objects, we'll
         # just apply str() to each of them so it matches the string method
-        self._test_method("rstrip",
-                          pre_comp_function=lambda x: [str(y) for y in x])  # noqa: E731
+        self._test_method(
+            "rstrip", pre_comp_function=lambda x: [str(y) for y in x]  # noqa: E731
+        )
 
     def test_str_lsplit(self):
         """Check matches the python string rstrip method."""
         # Calling (r)split should return a list of Seq-like objects, we'll
         # just apply str() to each of them so it matches the string method
-        self._test_method("rstrip",
-                          pre_comp_function=lambda x: [str(y) for y in x])  # noqa: E731
+        self._test_method(
+            "rstrip", pre_comp_function=lambda x: [str(y) for y in x]  # noqa: E731
+        )
 
     def test_str_length(self):
         """Check matches the python string __len__ method."""
@@ -489,10 +588,12 @@ class StringMethodTests(unittest.TestCase):
             with warnings.catch_warnings():
                 # Silence change in behaviour warning
                 warnings.simplefilter("ignore", BiopythonWarning)
-                self.assertEqual(hash(str(example1)), hash(example1),
-                                 "Hash mismatch, %r for %r vs %r for %r"
-                                 % (hash(str(example1)), id(example1),
-                                    hash(example1), example1))
+                self.assertEqual(
+                    hash(str(example1)),
+                    hash(example1),
+                    "Hash mismatch, %r for %r vs %r for %r"
+                    % (hash(str(example1)), id(example1), hash(example1), example1),
+                )
 
     def test_str_comparison(self):
         for example1 in self._examples:
@@ -500,24 +601,36 @@ class StringMethodTests(unittest.TestCase):
                 with warnings.catch_warnings():
                     # Silence alphabet warning
                     warnings.simplefilter("ignore", BiopythonWarning)
-                    self.assertEqual(str(example1) == str(example2),
-                                     example1 == example2,
-                                     "Checking %r == %r" % (example1, example2))
-                    self.assertEqual(str(example1) != str(example2),
-                                     example1 != example2,
-                                     "Checking %r != %r" % (example1, example2))
-                    self.assertEqual(str(example1) < str(example2),
-                                     example1 < example2,
-                                     "Checking %r < %r" % (example1, example2))
-                    self.assertEqual(str(example1) <= str(example2),
-                                     example1 <= example2,
-                                     "Checking %r <= %r" % (example1, example2))
-                    self.assertEqual(str(example1) > str(example2),
-                                     example1 > example2,
-                                     "Checking %r > %r" % (example1, example2))
-                    self.assertEqual(str(example1) >= str(example2),
-                                     example1 >= example2,
-                                     "Checking %r >= %r" % (example1, example2))
+                    self.assertEqual(
+                        str(example1) == str(example2),
+                        example1 == example2,
+                        "Checking %r == %r" % (example1, example2),
+                    )
+                    self.assertEqual(
+                        str(example1) != str(example2),
+                        example1 != example2,
+                        "Checking %r != %r" % (example1, example2),
+                    )
+                    self.assertEqual(
+                        str(example1) < str(example2),
+                        example1 < example2,
+                        "Checking %r < %r" % (example1, example2),
+                    )
+                    self.assertEqual(
+                        str(example1) <= str(example2),
+                        example1 <= example2,
+                        "Checking %r <= %r" % (example1, example2),
+                    )
+                    self.assertEqual(
+                        str(example1) > str(example2),
+                        example1 > example2,
+                        "Checking %r > %r" % (example1, example2),
+                    )
+                    self.assertEqual(
+                        str(example1) >= str(example2),
+                        example1 >= example2,
+                        "Checking %r >= %r" % (example1, example2),
+                    )
 
     def test_str_getitem(self):
         """Check slicing and indexing works like a string."""
@@ -538,8 +651,7 @@ class StringMethodTests(unittest.TestCase):
                             except ValueError:
                                 pass
                         else:
-                            self.assertEqual(str(example1[i:j:step]),
-                                             str1[i:j:step])
+                            self.assertEqual(str(example1[i:j:step]), str1[i:j:step])
 
     def test_tomutable(self):
         """Check obj.tomutable() method."""
@@ -578,8 +690,14 @@ class StringMethodTests(unittest.TestCase):
             # This only does the unambiguous cases
             if any(("U" in str1, "u" in str1, example1.alphabet == generic_rna)):
                 mapping = str.maketrans("ACGUacgu", "UGCAugca")
-            elif any(("T" in str1, "t" in str1, example1.alphabet == generic_dna,
-                     example1.alphabet == generic_nucleotide)):
+            elif any(
+                (
+                    "T" in str1,
+                    "t" in str1,
+                    example1.alphabet == generic_dna,
+                    example1.alphabet == generic_nucleotide,
+                )
+            ):
                 mapping = str.maketrans("ACGTacgt", "TGCAtgca")
             elif "A" not in str1 and "a" not in str1:
                 mapping = str.maketrans("CGcg", "GCgc")
@@ -604,8 +722,14 @@ class StringMethodTests(unittest.TestCase):
             # This only does the unambiguous cases
             if any(("U" in str1, "u" in str1, example1.alphabet == generic_rna)):
                 mapping = str.maketrans("ACGUacgu", "UGCAugca")
-            elif any(("T" in str1, "t" in str1, example1.alphabet == generic_dna,
-                     example1.alphabet == generic_nucleotide)):
+            elif any(
+                (
+                    "T" in str1,
+                    "t" in str1,
+                    example1.alphabet == generic_dna,
+                    example1.alphabet == generic_nucleotide,
+                )
+            ):
                 mapping = str.maketrans("ACGTacgt", "TGCAtgca")
             elif "A" not in str1 and "a" not in str1:
                 mapping = str.maketrans("CGcg", "GCgc")
@@ -678,16 +802,17 @@ class StringMethodTests(unittest.TestCase):
     def test_the_translation_of_stops(self):
         """Check obj.translate() method with stop codons."""
         misc_stops = "TAATAGTGAAGAAGG"
-        for nuc in [Seq(misc_stops),
-                    Seq(misc_stops, generic_nucleotide),
-                    Seq(misc_stops, generic_dna),
-                    Seq(misc_stops, unambiguous_dna)]:
+        for nuc in [
+            Seq(misc_stops),
+            Seq(misc_stops, generic_nucleotide),
+            Seq(misc_stops, generic_dna),
+            Seq(misc_stops, unambiguous_dna),
+        ]:
             self.assertEqual("***RR", str(nuc.translate()))
             self.assertEqual("***RR", str(nuc.translate(1)))
             self.assertEqual("***RR", str(nuc.translate("SGC0")))
             self.assertEqual("**W**", str(nuc.translate(table=2)))
-            self.assertEqual("**WRR",
-                             str(nuc.translate(table="Yeast Mitochondrial")))
+            self.assertEqual("**WRR", str(nuc.translate(table="Yeast Mitochondrial")))
             self.assertEqual("**WSS", str(nuc.translate(table=5)))
             self.assertEqual("**WSS", str(nuc.translate(table=9)))
             self.assertEqual("**CRR", str(nuc.translate(table="Euplotid Nuclear")))
@@ -697,11 +822,13 @@ class StringMethodTests(unittest.TestCase):
             self.assertEqual("**GRR", str(nuc.translate(table=25)))
             self.assertEqual("", str(nuc.translate(to_stop=True)))
             self.assertEqual("O*ORR", str(nuc.translate(table=special_table)))
-            self.assertEqual("*QWRR",
-                             str(nuc.translate(table=Chilodonella_uncinata_table)))
+            self.assertEqual(
+                "*QWRR", str(nuc.translate(table=Chilodonella_uncinata_table))
+            )
             # These test the Bio.Seq.translate() function - move these?:
-            self.assertEqual("*QWRR",
-                             translate(str(nuc), table=Chilodonella_uncinata_table))
+            self.assertEqual(
+                "*QWRR", translate(str(nuc), table=Chilodonella_uncinata_table)
+            )
             self.assertEqual("O*ORR", translate(str(nuc), table=special_table))
             self.assertEqual("", translate(str(nuc), to_stop=True))
             self.assertEqual("***RR", translate(str(nuc), table="Bacterial"))
@@ -724,10 +851,12 @@ class StringMethodTests(unittest.TestCase):
     def test_the_translation_of_invalid_codons(self):
         """Check obj.translate() method with invalid codons."""
         for codon in ["TA?", "N-N", "AC_", "Ac_"]:
-            for nuc in [Seq(codon),
-                        Seq(codon, generic_nucleotide),
-                        Seq(codon, generic_dna),
-                        Seq(codon, unambiguous_dna)]:
+            for nuc in [
+                Seq(codon),
+                Seq(codon, generic_nucleotide),
+                Seq(codon, generic_dna),
+                Seq(codon, unambiguous_dna),
+            ]:
                 try:
                     print(nuc.translate())
                     self.fail("Translating %s should fail" % codon)
@@ -736,23 +865,29 @@ class StringMethodTests(unittest.TestCase):
 
     def test_the_translation_of_ambig_codons(self):
         """Check obj.translate() method with ambiguous codons."""
-        for letters, ambig_values in [(ambiguous_dna.letters, ambiguous_dna_values),
-                                      (ambiguous_rna.letters, ambiguous_rna_values)]:
+        for letters, ambig_values in [
+            (ambiguous_dna.letters, ambiguous_dna_values),
+            (ambiguous_rna.letters, ambiguous_rna_values),
+        ]:
             ambig = set(letters)
             for c1 in ambig:
                 for c2 in ambig:
                     for c3 in ambig:
-                        values = {str(Seq(a + b + c).translate())
-                                  for a in ambig_values[c1]
-                                  for b in ambig_values[c2]
-                                  for c in ambig_values[c3]}
+                        values = {
+                            str(Seq(a + b + c).translate())
+                            for a in ambig_values[c1]
+                            for b in ambig_values[c2]
+                            for c in ambig_values[c3]
+                        }
                         t = str(Seq(c1 + c2 + c3).translate())
                         if t == "*":
                             self.assertEqual(values, set("*"))
                         elif t == "X":
-                            self.assertTrue(len(values) > 1,
-                                            "translate('%s') = '%s' not '%s'"
-                                            % (c1 + c2 + c3, t, ",".join(values)))
+                            self.assertTrue(
+                                len(values) > 1,
+                                "translate('%s') = '%s' not '%s'"
+                                % (c1 + c2 + c3, t, ",".join(values)),
+                            )
                         elif t == "Z":
                             self.assertEqual(values, set("EQ"))
                         elif t == "B":
@@ -813,20 +948,50 @@ class StringMethodTests(unittest.TestCase):
     def test_join_Seq_TypeError(self):
         """Checks that a TypeError is thrown for incompatible alphabets."""
         spacer = Seq("NNNNN", generic_dna)
-        self.assertRaises(TypeError, spacer.join, [Seq("NNNNN", generic_rna), Seq("NNNNN", generic_rna)])
-        self.assertRaises(TypeError, spacer.join, [Seq("NNNNN", generic_protein), Seq("NNNNN", generic_protein)])
+        self.assertRaises(
+            TypeError,
+            spacer.join,
+            [Seq("NNNNN", generic_rna), Seq("NNNNN", generic_rna)],
+        )
+        self.assertRaises(
+            TypeError,
+            spacer.join,
+            [Seq("NNNNN", generic_protein), Seq("NNNNN", generic_protein)],
+        )
 
     def test_join_UnknownSeq_TypeError(self):
         """Checks that a TypeError is thrown for incompatible alphabets."""
         spacer = UnknownSeq(5, character="-", alphabet=generic_dna)
-        self.assertRaises(TypeError, spacer.join, [UnknownSeq(5, character="-", alphabet=generic_rna), UnknownSeq(5, character="-", alphabet=generic_rna)])
-        self.assertRaises(TypeError, spacer.join, [Seq("NNNNN", generic_protein), UnknownSeq(5, character="-", alphabet=generic_protein)])
+        self.assertRaises(
+            TypeError,
+            spacer.join,
+            [
+                UnknownSeq(5, character="-", alphabet=generic_rna),
+                UnknownSeq(5, character="-", alphabet=generic_rna),
+            ],
+        )
+        self.assertRaises(
+            TypeError,
+            spacer.join,
+            [
+                Seq("NNNNN", generic_protein),
+                UnknownSeq(5, character="-", alphabet=generic_protein),
+            ],
+        )
 
     def test_join_MutableSeq_TypeError(self):
         """Checks that a TypeError is thrown for incompatible alphabets."""
         spacer = MutableSeq("NNNNN", generic_dna)
-        self.assertRaises(TypeError, spacer.join, [MutableSeq("NNNNN", generic_rna), MutableSeq("NNNNN", generic_rna)])
-        self.assertRaises(TypeError, spacer.join, [Seq("NNNNN", generic_protein), MutableSeq("NNNNN", generic_protein)])
+        self.assertRaises(
+            TypeError,
+            spacer.join,
+            [MutableSeq("NNNNN", generic_rna), MutableSeq("NNNNN", generic_rna)],
+        )
+        self.assertRaises(
+            TypeError,
+            spacer.join,
+            [Seq("NNNNN", generic_protein), MutableSeq("NNNNN", generic_protein)],
+        )
 
     def test_join_Seq(self):
         """Checks if Seq join correctly concatenates sequence with the spacer."""
@@ -875,7 +1040,11 @@ class StringMethodTests(unittest.TestCase):
         # Only expect it to take Seq objects and/or strings in an iterable!
 
         spacer1 = UnknownSeq(0, character="-", alphabet=generic_dna)
-        spacers = [spacer1, UnknownSeq(5, character="-", alphabet=generic_dna), UnknownSeq(5, character="-", alphabet=generic_nucleotide)]
+        spacers = [
+            spacer1,
+            UnknownSeq(5, character="-", alphabet=generic_dna),
+            UnknownSeq(5, character="-", alphabet=generic_nucleotide),
+        ]
 
         example_strings = ["ATG", "ATG", "ATG", "ATG"]
         example_strings_seqs = ["ATG", "ATG", Seq("ATG", generic_dna), "ATG"]
@@ -918,7 +1087,11 @@ class StringMethodTests(unittest.TestCase):
         # Only expect it to take Seq objects and/or strings in an iterable!
 
         spacer1 = MutableSeq("", generic_dna)
-        spacers = [spacer1, MutableSeq("NNNNN", generic_dna), MutableSeq("GGG", generic_nucleotide)]
+        spacers = [
+            spacer1,
+            MutableSeq("NNNNN", generic_dna),
+            MutableSeq("GGG", generic_nucleotide),
+        ]
         example_strings = ["ATG", "ATG", "ATG", "ATG"]
         example_strings_seqs = ["ATG", "ATG", Seq("ATG", generic_dna), "ATG"]
 

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -13,9 +13,12 @@ from Bio import BiopythonWarning
 from Bio import Alphabet
 from Bio import Seq
 from Bio.Alphabet import IUPAC, Gapped
-from Bio.Data.IUPACData import (ambiguous_dna_complement,
-                                ambiguous_rna_complement,
-                                ambiguous_dna_values, ambiguous_rna_values)
+from Bio.Data.IUPACData import (
+    ambiguous_dna_complement,
+    ambiguous_rna_complement,
+    ambiguous_dna_values,
+    ambiguous_rna_values,
+)
 from Bio.Data.CodonTable import TranslationError, standard_dna_table
 from Bio.Seq import MutableSeq
 
@@ -50,20 +53,23 @@ protein_seqs = [
     Seq.Seq("ATCGPK", IUPAC.protein),
     Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, ".")),
     Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-")),
-    Seq.Seq("MEDG-KRXR*",
-            Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"),
-                            "-")),
-    Seq.MutableSeq("ME-K-DRXR*XU",
-                   Alphabet.Gapped(Alphabet.HasStopCodon(
-                       IUPAC.extended_protein, "*"), "-")),
-    Seq.Seq("MEDG-KRXR@",
-            Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"),
-                                  "@")),
-    Seq.Seq("ME-KR@",
-            Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"), "@")),
-    Seq.Seq("MEDG.KRXR@",
-            Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "@"),
-                            ".")),
+    Seq.Seq(
+        "MEDG-KRXR*",
+        Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"),
+    ),
+    Seq.MutableSeq(
+        "ME-K-DRXR*XU",
+        Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"),
+    ),
+    Seq.Seq(
+        "MEDG-KRXR@",
+        Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"), "@"),
+    ),
+    Seq.Seq("ME-KR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"), "@")),
+    Seq.Seq(
+        "MEDG.KRXR@",
+        Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "@"), "."),
+    ),
 ]
 
 
@@ -82,8 +88,9 @@ class TestSeq(unittest.TestCase):
 
     def test_repr(self):
         """Test representation of Seq object."""
-        self.assertEqual("Seq('TCAAAAGGATGCATCATG', IUPACUnambiguousDNA())",
-                         repr(self.s))
+        self.assertEqual(
+            "Seq('TCAAAAGGATGCATCATG', IUPACUnambiguousDNA())", repr(self.s)
+        )
 
     def test_truncated_repr(self):
         seq = "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGA"
@@ -174,8 +181,7 @@ class TestSeqStringMethods(unittest.TestCase):
             Seq.Seq("AUUUCG", IUPAC.ambiguous_rna),
             Seq.MutableSeq("AUUCG", IUPAC.ambiguous_rna),
             Seq.Seq("uCAg", Alphabet.generic_rna),
-            Seq.MutableSeq("UC-AG",
-                           Alphabet.Gapped(Alphabet.generic_rna, "-")),
+            Seq.MutableSeq("UC-AG", Alphabet.Gapped(Alphabet.generic_rna, "-")),
             Seq.Seq("U.CAG", Alphabet.Gapped(Alphabet.generic_rna, ".")),
         ]
         self.nuc = [Seq.Seq("ATCG", Alphabet.generic_nucleotide)]
@@ -184,23 +190,34 @@ class TestSeqStringMethods(unittest.TestCase):
             Seq.Seq("atcGPK", Alphabet.generic_protein),
             Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, ".")),
             Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-")),
-            Seq.Seq("MEDG-KRXR*",
-                    Alphabet.Gapped(
-                        Alphabet.HasStopCodon(IUPAC.extended_protein, "*"),
-                        "-")),
-            Seq.MutableSeq("ME-K-DRXR*XU",
-                           Alphabet.Gapped(
-                               Alphabet.HasStopCodon(IUPAC.extended_protein,
-                                                     "*"), "-")),
-            Seq.Seq("MEDG-KRXR@",
-                    Alphabet.HasStopCodon(
-                        Alphabet.Gapped(IUPAC.extended_protein, "-"), "@")),
-            Seq.Seq("ME-KR@",
-                    Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"),
-                                          "@")),
-            Seq.Seq("MEDG.KRXR@",
-                    Alphabet.Gapped(Alphabet.HasStopCodon(
-                        IUPAC.extended_protein, "@"), ".")),
+            Seq.Seq(
+                "MEDG-KRXR*",
+                Alphabet.Gapped(
+                    Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"
+                ),
+            ),
+            Seq.MutableSeq(
+                "ME-K-DRXR*XU",
+                Alphabet.Gapped(
+                    Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"
+                ),
+            ),
+            Seq.Seq(
+                "MEDG-KRXR@",
+                Alphabet.HasStopCodon(
+                    Alphabet.Gapped(IUPAC.extended_protein, "-"), "@"
+                ),
+            ),
+            Seq.Seq(
+                "ME-KR@",
+                Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"), "@"),
+            ),
+            Seq.Seq(
+                "MEDG.KRXR@",
+                Alphabet.Gapped(
+                    Alphabet.HasStopCodon(IUPAC.extended_protein, "@"), "."
+                ),
+            ),
         ]
         self.test_chars = ["-", Seq.Seq("-"), Seq.Seq("*"), "-X@"]
 
@@ -220,13 +237,16 @@ class TestSeqStringMethods(unittest.TestCase):
     def test_equal_comparison_of_incompatible_alphabets(self):
         """Test __eq__ comparison method."""
         with warnings.catch_warnings(record=True):
-            Seq.Seq("TCAAAA", IUPAC.ambiguous_dna) == \
-                Seq.Seq("TCAAAA", IUPAC.ambiguous_rna)
+            Seq.Seq("TCAAAA", IUPAC.ambiguous_dna) == Seq.Seq(
+                "TCAAAA", IUPAC.ambiguous_rna
+            )
 
     def test_not_equal_comparsion(self):
         """Test __ne__ comparison method."""
-        self.assertNotEqual(Seq.Seq("TCAAA", IUPAC.ambiguous_dna),
-                            Seq.Seq("TCAAAA", IUPAC.ambiguous_dna))
+        self.assertNotEqual(
+            Seq.Seq("TCAAA", IUPAC.ambiguous_dna),
+            Seq.Seq("TCAAAA", IUPAC.ambiguous_dna),
+        )
 
     def test_less_than_comparison(self):
         """Test __lt__ comparison method."""
@@ -297,8 +317,9 @@ class TestSeqStringMethods(unittest.TestCase):
             self.s + {}
 
     def test_radd_method(self):
-        self.assertEqual("TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG",
-                         str(self.s.__radd__(self.s)))
+        self.assertEqual(
+            "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG", str(self.s.__radd__(self.s))
+        )
 
     def test_radd_method_using_incompatible_alphabets(self):
         rna_seq = Seq.Seq("UCAAAA", IUPAC.ambiguous_rna)
@@ -329,11 +350,10 @@ class TestSeqStringMethods(unittest.TestCase):
 
     def test_append_proteins(self):
         self.test_chars.append(Seq.Seq("K", Alphabet.generic_protein))
-        self.test_chars.append(Seq.Seq("K-",
-                                       Alphabet.Gapped(
-                                           Alphabet.generic_protein, "-")))
-        self.test_chars.append(Seq.Seq("K@",
-                                       Alphabet.Gapped(IUPAC.protein, "@")))
+        self.test_chars.append(
+            Seq.Seq("K-", Alphabet.Gapped(Alphabet.generic_protein, "-"))
+        )
+        self.test_chars.append(Seq.Seq("K@", Alphabet.Gapped(IUPAC.protein, "@")))
 
         self.assertEqual(7, len(self.test_chars))
 
@@ -350,12 +370,9 @@ class TestSeqStringMethods(unittest.TestCase):
             for char in self.test_chars:
                 str_char = str(char)
                 if isinstance(a, Seq.Seq):
-                    self.assertEqual(str(a.strip(char)),
-                                     str(a).strip(str_char))
-                    self.assertEqual(str(a.lstrip(char)),
-                                     str(a).lstrip(str_char))
-                    self.assertEqual(str(a.rstrip(char)),
-                                     str(a).rstrip(str_char))
+                    self.assertEqual(str(a.strip(char)), str(a).strip(str_char))
+                    self.assertEqual(str(a.lstrip(char)), str(a).lstrip(str_char))
+                    self.assertEqual(str(a.rstrip(char)), str(a).rstrip(str_char))
 
     def test_finding_characters(self):
         for a in self.dna + self.rna + self.nuc + self.protein:
@@ -363,11 +380,11 @@ class TestSeqStringMethods(unittest.TestCase):
                 str_char = str(char)
                 if isinstance(a, Seq.Seq):
                     self.assertEqual(a.find(char), str(a).find(str_char))
-                    self.assertEqual(a.find(char, 2, -2),
-                                     str(a).find(str_char, 2, -2))
+                    self.assertEqual(a.find(char, 2, -2), str(a).find(str_char, 2, -2))
                     self.assertEqual(a.rfind(char), str(a).rfind(str_char))
-                    self.assertEqual(a.rfind(char, 2, -2),
-                                     str(a).rfind(str_char, 2, -2))
+                    self.assertEqual(
+                        a.rfind(char, 2, -2), str(a).rfind(str_char, 2, -2)
+                    )
 
     def test_counting_characters(self):
         for a in self.dna + self.rna + self.nuc + self.protein:
@@ -375,23 +392,27 @@ class TestSeqStringMethods(unittest.TestCase):
                 str_char = str(char)
                 if isinstance(a, Seq.Seq):
                     self.assertEqual(a.count(char), str(a).count(str_char))
-                    self.assertEqual(a.count(char, 2, -2),
-                                     str(a).count(str_char, 2, -2))
+                    self.assertEqual(
+                        a.count(char, 2, -2), str(a).count(str_char, 2, -2)
+                    )
 
     def test_splits(self):
         for a in self.dna + self.rna + self.nuc + self.protein:
             for char in self.test_chars:
                 str_char = str(char)
                 if isinstance(a, Seq.Seq):
-                    self.assertEqual([str(x) for x in a.split(char)],
-                                     str(a).split(str_char))
-                    self.assertEqual([str(x) for x in a.rsplit(char)],
-                                     str(a).rsplit(str_char))
+                    self.assertEqual(
+                        [str(x) for x in a.split(char)], str(a).split(str_char)
+                    )
+                    self.assertEqual(
+                        [str(x) for x in a.rsplit(char)], str(a).rsplit(str_char)
+                    )
 
                     for max_sep in [0, 1, 2, 999]:
                         self.assertEqual(
                             [str(x) for x in a.split(char, max_sep)],
-                            str(a).split(str_char, max_sep))
+                            str(a).split(str_char, max_sep),
+                        )
 
 
 class TestSeqAddition(unittest.TestCase):
@@ -407,10 +428,8 @@ class TestSeqAddition(unittest.TestCase):
             Seq.Seq("AUUUCG", IUPAC.ambiguous_rna),
             Seq.MutableSeq("AUUCG", IUPAC.ambiguous_rna),
             Seq.Seq("uCAg", Alphabet.generic_rna),
-            Seq.MutableSeq("UC-AG",
-                           Alphabet.Gapped(Alphabet.generic_rna, "-")),
-            Seq.Seq("U.CAG",
-                    Alphabet.Gapped(Alphabet.generic_rna, ".")),
+            Seq.MutableSeq("UC-AG", Alphabet.Gapped(Alphabet.generic_rna, "-")),
+            Seq.Seq("U.CAG", Alphabet.Gapped(Alphabet.generic_rna, ".")),
             "UGCAU",
         ]
         self.nuc = [
@@ -422,12 +441,18 @@ class TestSeqAddition(unittest.TestCase):
             Seq.Seq("atcGPK", Alphabet.generic_protein),
             Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, ".")),
             Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-")),
-            Seq.Seq("MEDG-KRXR*",
-                    Alphabet.Gapped(Alphabet.HasStopCodon(
-                        IUPAC.extended_protein, "*"), "-")),
-            Seq.MutableSeq("ME-K-DRXR*XU",
-                           Alphabet.Gapped(Alphabet.HasStopCodon(
-                               IUPAC.extended_protein, "*"), "-")),
+            Seq.Seq(
+                "MEDG-KRXR*",
+                Alphabet.Gapped(
+                    Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"
+                ),
+            ),
+            Seq.MutableSeq(
+                "ME-K-DRXR*XU",
+                Alphabet.Gapped(
+                    Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"
+                ),
+            ),
             "TEDDF",
         ]
 
@@ -519,10 +544,14 @@ class TestSeqAddition(unittest.TestCase):
 
     def test_exception_when_added_protein_has_several_stop_codon_types(self):
         """Test resulting protein has stop codon types '*' and '@'."""
-        a = Seq.Seq("MEDG-KRXR@", Alphabet.HasStopCodon(
-            Alphabet.Gapped(IUPAC.extended_protein, "-"), "@"))
-        b = Seq.Seq("MEDG-KRXR*", Alphabet.Gapped(
-            Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"))
+        a = Seq.Seq(
+            "MEDG-KRXR@",
+            Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"), "@"),
+        )
+        b = Seq.Seq(
+            "MEDG-KRXR*",
+            Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"),
+        )
         with self.assertRaises(ValueError):
             a + b
         with self.assertRaises(ValueError):
@@ -604,18 +633,18 @@ class TestMutableSeq(unittest.TestCase):
         self.assertIsInstance(mutable_s, MutableSeq, "Creating MutableSeq")
 
         mutable_s = self.s.tomutable()
-        self.assertIsInstance(mutable_s, MutableSeq,
-                              "Converting Seq to mutable")
+        self.assertIsInstance(mutable_s, MutableSeq, "Converting Seq to mutable")
 
-        array_seq = MutableSeq(array.array("u", "TCAAAAGGATGCATCATG"),
-                               IUPAC.ambiguous_dna)
-        self.assertIsInstance(array_seq, MutableSeq,
-                              "Creating MutableSeq using array")
+        array_seq = MutableSeq(
+            array.array("u", "TCAAAAGGATGCATCATG"), IUPAC.ambiguous_dna
+        )
+        self.assertIsInstance(array_seq, MutableSeq, "Creating MutableSeq using array")
 
     def test_repr(self):
         self.assertEqual(
             "MutableSeq('TCAAAAGGATGCATCATG', IUPACAmbiguousDNA())",
-            repr(self.mutable_s))
+            repr(self.mutable_s),
+        )
 
     def test_truncated_repr(self):
         seq = "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGA"
@@ -643,8 +672,7 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_less_than_comparison_of_incompatible_alphabets(self):
         with self.assertWarns(BiopythonWarning):
-            self.mutable_s[:-1] < MutableSeq("UCAAAAGGAUGCAUCAUG",
-                                             IUPAC.ambiguous_rna)
+            self.mutable_s[:-1] < MutableSeq("UCAAAAGGAUGCAUCAUG", IUPAC.ambiguous_rna)
 
     def test_less_than_comparison_of_incompatible_types(self):
         with self.assertRaises(TypeError):
@@ -659,8 +687,7 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_less_than_or_equal_comparison_of_incompatible_alphabets(self):
         with self.assertWarns(BiopythonWarning):
-            self.mutable_s[:-1] <= MutableSeq("UCAAAAGGAUGCAUCAUG",
-                                              IUPAC.ambiguous_rna)
+            self.mutable_s[:-1] <= MutableSeq("UCAAAAGGAUGCAUCAUG", IUPAC.ambiguous_rna)
 
     def test_less_than_or_equal_comparison_of_incompatible_types(self):
         with self.assertRaises(TypeError):
@@ -675,8 +702,7 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_greater_than_comparison_of_incompatible_alphabets(self):
         with self.assertWarns(BiopythonWarning):
-            self.mutable_s[:-1] > MutableSeq("UCAAAAGGAUGCAUCAUG",
-                                             IUPAC.ambiguous_rna)
+            self.mutable_s[:-1] > MutableSeq("UCAAAAGGAUGCAUCAUG", IUPAC.ambiguous_rna)
 
     def test_greater_than_comparison_of_incompatible_types(self):
         with self.assertRaises(TypeError):
@@ -691,8 +717,7 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_greater_than_or_equal_comparison_of_incompatible_alphabets(self):
         with self.assertWarns(BiopythonWarning):
-            self.mutable_s[:-1] >= MutableSeq("UCAAAAGGAUGCAUCAUG",
-                                              IUPAC.ambiguous_rna)
+            self.mutable_s[:-1] >= MutableSeq("UCAAAAGGAUGCAUCAUG", IUPAC.ambiguous_rna)
 
     def test_greater_than_or_equal_comparison_of_incompatible_types(self):
         with self.assertRaises(TypeError):
@@ -707,17 +732,19 @@ class TestMutableSeq(unittest.TestCase):
             self.mutable_s + 1234
 
     def test_radd_method(self):
-        self.assertEqual("TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG",
-                         self.mutable_s.__radd__(self.mutable_s))
+        self.assertEqual(
+            "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG",
+            self.mutable_s.__radd__(self.mutable_s),
+        )
 
     def test_radd_method_incompatible_alphabets(self):
         with self.assertRaises(TypeError):
-            self.mutable_s.__radd__(MutableSeq("UCAAAAGGA",
-                                               IUPAC.ambiguous_rna))
+            self.mutable_s.__radd__(MutableSeq("UCAAAAGGA", IUPAC.ambiguous_rna))
 
     def test_radd_method_using_seq_object(self):
-        self.assertEqual("TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG",
-                         self.mutable_s.__radd__(self.s))
+        self.assertEqual(
+            "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG", self.mutable_s.__radd__(self.s)
+        )
 
     def test_radd_method_wrong_type(self):
         with self.assertRaises(TypeError):
@@ -736,59 +763,73 @@ class TestMutableSeq(unittest.TestCase):
         self.assertEqual("T", self.mutable_s[0])
 
     def test_setting_slices(self):
-        self.assertEqual(MutableSeq("CAAA", IUPAC.ambiguous_dna),
-                         self.mutable_s[1:5], "Slice mutable seq")
+        self.assertEqual(
+            MutableSeq("CAAA", IUPAC.ambiguous_dna),
+            self.mutable_s[1:5],
+            "Slice mutable seq",
+        )
 
         self.mutable_s[1:3] = "GAT"
-        self.assertEqual(MutableSeq("TGATAAAGGATGCATCATG",
-                                    IUPAC.ambiguous_dna),
-                         self.mutable_s,
-                         "Set slice with string and adding extra nucleotide")
+        self.assertEqual(
+            MutableSeq("TGATAAAGGATGCATCATG", IUPAC.ambiguous_dna),
+            self.mutable_s,
+            "Set slice with string and adding extra nucleotide",
+        )
 
         self.mutable_s[1:3] = self.mutable_s[5:7]
-        self.assertEqual(MutableSeq("TAATAAAGGATGCATCATG",
-                                    IUPAC.ambiguous_dna),
-                         self.mutable_s, "Set slice with MutableSeq")
+        self.assertEqual(
+            MutableSeq("TAATAAAGGATGCATCATG", IUPAC.ambiguous_dna),
+            self.mutable_s,
+            "Set slice with MutableSeq",
+        )
 
         self.mutable_s[1:3] = array.array("u", "GAT")
-        self.assertEqual(MutableSeq("TGATTAAAGGATGCATCATG",
-                                    IUPAC.ambiguous_dna),
-                         self.mutable_s, "Set slice with array")
+        self.assertEqual(
+            MutableSeq("TGATTAAAGGATGCATCATG", IUPAC.ambiguous_dna),
+            self.mutable_s,
+            "Set slice with array",
+        )
 
     def test_setting_item(self):
         self.mutable_s[3] = "G"
-        self.assertEqual(MutableSeq("TCAGAAGGATGCATCATG", IUPAC.ambiguous_dna),
-                         self.mutable_s)
+        self.assertEqual(
+            MutableSeq("TCAGAAGGATGCATCATG", IUPAC.ambiguous_dna), self.mutable_s
+        )
 
     def test_deleting_slice(self):
         del self.mutable_s[4:5]
-        self.assertEqual(MutableSeq("TCAAAGGATGCATCATG", IUPAC.ambiguous_dna),
-                         self.mutable_s)
+        self.assertEqual(
+            MutableSeq("TCAAAGGATGCATCATG", IUPAC.ambiguous_dna), self.mutable_s
+        )
 
     def test_deleting_item(self):
         del self.mutable_s[3]
-        self.assertEqual(MutableSeq("TCAAAGGATGCATCATG", IUPAC.ambiguous_dna),
-                         self.mutable_s)
+        self.assertEqual(
+            MutableSeq("TCAAAGGATGCATCATG", IUPAC.ambiguous_dna), self.mutable_s
+        )
 
     def test_appending(self):
         self.mutable_s.append("C")
-        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGC",
-                                    IUPAC.ambiguous_dna),
-                         self.mutable_s)
+        self.assertEqual(
+            MutableSeq("TCAAAAGGATGCATCATGC", IUPAC.ambiguous_dna), self.mutable_s
+        )
 
     def test_inserting(self):
         self.mutable_s.insert(4, "G")
-        self.assertEqual(MutableSeq("TCAAGAAGGATGCATCATG",
-                                    IUPAC.ambiguous_dna),
-                         self.mutable_s)
+        self.assertEqual(
+            MutableSeq("TCAAGAAGGATGCATCATG", IUPAC.ambiguous_dna), self.mutable_s
+        )
 
     def test_popping_last_item(self):
         self.assertEqual("G", self.mutable_s.pop())
 
     def test_remove_items(self):
         self.mutable_s.remove("G")
-        self.assertEqual(MutableSeq("TCAAAAGATGCATCATG", IUPAC.ambiguous_dna),
-                         self.mutable_s, "Remove first G")
+        self.assertEqual(
+            MutableSeq("TCAAAAGATGCATCATG", IUPAC.ambiguous_dna),
+            self.mutable_s,
+            "Remove first G",
+        )
 
         self.assertRaises(ValueError, self.mutable_s.remove, "Z")
 
@@ -803,13 +844,15 @@ class TestMutableSeq(unittest.TestCase):
     def test_reverse(self):
         """Test using reverse method."""
         self.mutable_s.reverse()
-        self.assertEqual(MutableSeq("GTACTACGTAGGAAAACT", IUPAC.ambiguous_dna),
-                         self.mutable_s)
+        self.assertEqual(
+            MutableSeq("GTACTACGTAGGAAAACT", IUPAC.ambiguous_dna), self.mutable_s
+        )
 
     def test_reverse_with_stride(self):
         """Test reverse using -1 stride."""
-        self.assertEqual(MutableSeq("GTACTACGTAGGAAAACT", IUPAC.ambiguous_dna),
-                         self.mutable_s[::-1])
+        self.assertEqual(
+            MutableSeq("GTACTACGTAGGAAAACT", IUPAC.ambiguous_dna), self.mutable_s[::-1]
+        )
 
     def test_complement(self):
         self.mutable_s.complement()
@@ -846,35 +889,40 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_extend_method(self):
         self.mutable_s.extend("GAT")
-        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGGAT",
-                                    IUPAC.ambiguous_dna),
-                         self.mutable_s)
+        self.assertEqual(
+            MutableSeq("TCAAAAGGATGCATCATGGAT", IUPAC.ambiguous_dna), self.mutable_s
+        )
 
     def test_extend_with_mutable_seq(self):
         self.mutable_s.extend(MutableSeq("TTT", IUPAC.ambiguous_dna))
-        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGTTT",
-                                    IUPAC.ambiguous_dna),
-                         self.mutable_s)
+        self.assertEqual(
+            MutableSeq("TCAAAAGGATGCATCATGTTT", IUPAC.ambiguous_dna), self.mutable_s
+        )
 
     def test_delete_stride_slice(self):
-        del self.mutable_s[4:6 - 1]
-        self.assertEqual(MutableSeq("TCAAAGGATGCATCATG", IUPAC.ambiguous_dna),
-                         self.mutable_s)
+        del self.mutable_s[4 : 6 - 1]
+        self.assertEqual(
+            MutableSeq("TCAAAGGATGCATCATG", IUPAC.ambiguous_dna), self.mutable_s
+        )
 
     def test_extract_third_nucleotide(self):
         """Test extracting every third nucleotide (slicing with stride 3)."""
-        self.assertEqual(MutableSeq("TAGTAA", IUPAC.ambiguous_dna),
-                         self.mutable_s[0::3])
-        self.assertEqual(MutableSeq("CAGGTT", IUPAC.ambiguous_dna),
-                         self.mutable_s[1::3])
-        self.assertEqual(MutableSeq("AAACCG", IUPAC.ambiguous_dna),
-                         self.mutable_s[2::3])
+        self.assertEqual(
+            MutableSeq("TAGTAA", IUPAC.ambiguous_dna), self.mutable_s[0::3]
+        )
+        self.assertEqual(
+            MutableSeq("CAGGTT", IUPAC.ambiguous_dna), self.mutable_s[1::3]
+        )
+        self.assertEqual(
+            MutableSeq("AAACCG", IUPAC.ambiguous_dna), self.mutable_s[2::3]
+        )
 
     def test_set_wobble_codon_to_n(self):
         """Test setting wobble codon to N (set slice with stride 3)."""
         self.mutable_s[2::3] = "N" * len(self.mutable_s[2::3])
-        self.assertEqual(MutableSeq("TCNAANGGNTGNATNATN", IUPAC.ambiguous_dna),
-                         self.mutable_s)
+        self.assertEqual(
+            MutableSeq("TCNAANGGNTGNATNATN", IUPAC.ambiguous_dna), self.mutable_s
+        )
 
 
 class TestUnknownSeq(unittest.TestCase):
@@ -883,10 +931,8 @@ class TestUnknownSeq(unittest.TestCase):
 
     def test_construction(self):
         self.assertEqual("??????", str(Seq.UnknownSeq(6)))
-        self.assertEqual("NNNNNN",
-                         str(Seq.UnknownSeq(6, Alphabet.generic_dna)))
-        self.assertEqual("XXXXXX",
-                         str(Seq.UnknownSeq(6, Alphabet.generic_protein)))
+        self.assertEqual("NNNNNN", str(Seq.UnknownSeq(6, Alphabet.generic_dna)))
+        self.assertEqual("XXXXXX", str(Seq.UnknownSeq(6, Alphabet.generic_protein)))
         self.assertEqual("??????", str(Seq.UnknownSeq(6, character="?")))
 
         with self.assertRaises(ValueError):
@@ -899,9 +945,7 @@ class TestUnknownSeq(unittest.TestCase):
         self.assertEqual(6, len(self.s))
 
     def test_repr(self):
-        self.assertEqual(
-            "UnknownSeq(6, character='?')",
-            repr(self.s))
+        self.assertEqual("UnknownSeq(6, character='?')", repr(self.s))
 
     def test_add_method(self):
         seq1 = Seq.UnknownSeq(3, Alphabet.generic_dna)
@@ -926,10 +970,8 @@ class TestUnknownSeq(unittest.TestCase):
         self.assertEqual(3, self.s.count("??"))
         self.assertEqual(0, Seq.UnknownSeq(6, character="N").count("?"))
         self.assertEqual(0, Seq.UnknownSeq(6, character="N").count("??"))
-        self.assertEqual(4,
-                         Seq.UnknownSeq(6, character="?").count("?", start=2))
-        self.assertEqual(2,
-                         Seq.UnknownSeq(6, character="?").count("??", start=2))
+        self.assertEqual(4, Seq.UnknownSeq(6, character="?").count("?", start=2))
+        self.assertEqual(2, Seq.UnknownSeq(6, character="?").count("??", start=2))
 
     def test_complement(self):
         self.s.complement()
@@ -971,14 +1013,12 @@ class TestUnknownSeq(unittest.TestCase):
         self.assertRaises(ValueError, seq.translate)
 
     def test_ungap(self):
-        seq = Seq.UnknownSeq(7,
-                             alphabet=Alphabet.Gapped(Alphabet.DNAAlphabet(),
-                                                      "-"))
+        seq = Seq.UnknownSeq(7, alphabet=Alphabet.Gapped(Alphabet.DNAAlphabet(), "-"))
         self.assertEqual("NNNNNNN", str(seq.ungap("-")))
 
-        seq = Seq.UnknownSeq(20,
-                             alphabet=Alphabet.Gapped(Alphabet.DNAAlphabet(),
-                                                      "-"), character="-")
+        seq = Seq.UnknownSeq(
+            20, alphabet=Alphabet.Gapped(Alphabet.DNAAlphabet(), "-"), character="-"
+        )
         self.assertEqual("", seq.ungap("-"))
 
 
@@ -993,17 +1033,17 @@ class TestComplement(unittest.TestCase):
     def test_complement_ambiguous_dna_values(self):
         for ambig_char, values in sorted(ambiguous_dna_values.items()):
             compl_values = str(
-                Seq.Seq(values, alphabet=IUPAC.ambiguous_dna).complement())
-            ambig_values = (
-                ambiguous_dna_values[ambiguous_dna_complement[ambig_char]])
+                Seq.Seq(values, alphabet=IUPAC.ambiguous_dna).complement()
+            )
+            ambig_values = ambiguous_dna_values[ambiguous_dna_complement[ambig_char]]
             self.assertEqual(set(compl_values), set(ambig_values))
 
     def test_complement_ambiguous_rna_values(self):
         for ambig_char, values in sorted(ambiguous_rna_values.items()):
             compl_values = str(
-                Seq.Seq(values, alphabet=IUPAC.ambiguous_rna).complement())
-            ambig_values = (
-                ambiguous_rna_values[ambiguous_rna_complement[ambig_char]])
+                Seq.Seq(values, alphabet=IUPAC.ambiguous_rna).complement()
+            )
+            ambig_values = ambiguous_rna_values[ambiguous_rna_complement[ambig_char]]
             self.assertEqual(set(compl_values), set(ambig_values))
 
     def test_complement_incompatible_alphabets(self):
@@ -1039,19 +1079,24 @@ class TestReverseComplement(unittest.TestCase):
         test_seqs_copy.pop(21)
 
         for nucleotide_seq in test_seqs_copy:
-            if not isinstance(nucleotide_seq.alphabet,
-                              Alphabet.ProteinAlphabet) and \
-                    isinstance(nucleotide_seq, Seq.Seq):
+            if not isinstance(
+                nucleotide_seq.alphabet, Alphabet.ProteinAlphabet
+            ) and isinstance(nucleotide_seq, Seq.Seq):
                 expected = Seq.reverse_complement(nucleotide_seq)
                 self.assertEqual(
-                    repr(expected), repr(nucleotide_seq.reverse_complement()))
+                    repr(expected), repr(nucleotide_seq.reverse_complement())
+                )
                 self.assertEqual(
-                    repr(expected[::-1]), repr(nucleotide_seq.complement()))
+                    repr(expected[::-1]), repr(nucleotide_seq.complement())
+                )
                 self.assertEqual(
                     str(nucleotide_seq.complement()),
-                    str(Seq.reverse_complement(nucleotide_seq))[::-1])
-                self.assertEqual(str(nucleotide_seq.reverse_complement()),
-                                 str(Seq.reverse_complement(nucleotide_seq)))
+                    str(Seq.reverse_complement(nucleotide_seq))[::-1],
+                )
+                self.assertEqual(
+                    str(nucleotide_seq.reverse_complement()),
+                    str(Seq.reverse_complement(nucleotide_seq)),
+                )
 
     def test_reverse_complement_of_mixed_dna_rna(self):
         seq = "AUGAAACTG"  # U and T
@@ -1080,20 +1125,21 @@ class TestDoubleReverseComplement(unittest.TestCase):
         """Test double reverse complement preserves the sequence."""
         sorted_amb_rna = sorted(ambiguous_rna_values)
         sorted_amb_dna = sorted(ambiguous_dna_values)
-        for sequence in [Seq.Seq("".join(sorted_amb_rna)),
-                         Seq.Seq("".join(sorted_amb_dna)),
-                         Seq.Seq("".join(sorted_amb_rna),
-                                 Alphabet.generic_rna),
-                         Seq.Seq("".join(sorted_amb_dna),
-                                 Alphabet.generic_dna),
-                         Seq.Seq("".join(sorted_amb_rna).replace("X", ""),
-                                 IUPAC.IUPACAmbiguousRNA()),
-                         Seq.Seq("".join(sorted_amb_dna).replace("X", ""),
-                                 IUPAC.IUPACAmbiguousDNA()),
-                         Seq.Seq("AWGAARCKG")]:  # Note no U or T
+        for sequence in [
+            Seq.Seq("".join(sorted_amb_rna)),
+            Seq.Seq("".join(sorted_amb_dna)),
+            Seq.Seq("".join(sorted_amb_rna), Alphabet.generic_rna),
+            Seq.Seq("".join(sorted_amb_dna), Alphabet.generic_dna),
+            Seq.Seq(
+                "".join(sorted_amb_rna).replace("X", ""), IUPAC.IUPACAmbiguousRNA()
+            ),
+            Seq.Seq(
+                "".join(sorted_amb_dna).replace("X", ""), IUPAC.IUPACAmbiguousDNA()
+            ),
+            Seq.Seq("AWGAARCKG"),
+        ]:  # Note no U or T
             reversed_sequence = sequence.reverse_complement()
-            self.assertEqual(str(sequence),
-                             str(reversed_sequence.reverse_complement()))
+            self.assertEqual(str(sequence), str(reversed_sequence.reverse_complement()))
 
 
 class TestSequenceAlphabets(unittest.TestCase):
@@ -1104,11 +1150,9 @@ class TestSequenceAlphabets(unittest.TestCase):
         """
         for nucleotide_seq in test_seqs:
             if "U" in str(nucleotide_seq).upper():
-                self.assertNotIsInstance(nucleotide_seq.alphabet,
-                                         Alphabet.DNAAlphabet)
+                self.assertNotIsInstance(nucleotide_seq.alphabet, Alphabet.DNAAlphabet)
             if "T" in str(nucleotide_seq).upper():
-                self.assertNotIsInstance(nucleotide_seq.alphabet,
-                                         Alphabet.RNAAlphabet)
+                self.assertNotIsInstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet)
 
 
 class TestTranscription(unittest.TestCase):
@@ -1118,7 +1162,8 @@ class TestTranscription(unittest.TestCase):
                 expected = Seq.transcribe(nucleotide_seq)
                 self.assertEqual(
                     str(nucleotide_seq).replace("t", "u").replace("T", "U"),
-                    str(expected))
+                    str(expected),
+                )
 
     def test_transcription_dna_string_into_rna(self):
         seq = "ATGAAACTG"
@@ -1126,10 +1171,13 @@ class TestTranscription(unittest.TestCase):
 
     def test_seq_object_transcription_method(self):
         for nucleotide_seq in test_seqs:
-            if isinstance(nucleotide_seq.alphabet, Alphabet.DNAAlphabet) and \
-                    isinstance(nucleotide_seq, Seq.Seq):
-                self.assertEqual(repr(Seq.transcribe(nucleotide_seq)),
-                                 repr(nucleotide_seq.transcribe()))
+            if isinstance(nucleotide_seq.alphabet, Alphabet.DNAAlphabet) and isinstance(
+                nucleotide_seq, Seq.Seq
+            ):
+                self.assertEqual(
+                    repr(Seq.transcribe(nucleotide_seq)),
+                    repr(nucleotide_seq.transcribe()),
+                )
 
     def test_transcription_of_rna(self):
         """Check transcription fails on RNA."""
@@ -1153,7 +1201,8 @@ class TestTranscription(unittest.TestCase):
                 expected = Seq.back_transcribe(nucleotide_seq)
                 self.assertEqual(
                     str(nucleotide_seq).replace("u", "t").replace("U", "T"),
-                    str(expected))
+                    str(expected),
+                )
 
     def test_back_transcribe_rna_string_into_dna(self):
         seq = "AUGAAACUG"
@@ -1161,11 +1210,11 @@ class TestTranscription(unittest.TestCase):
 
     def test_seq_object_back_transcription_method(self):
         for nucleotide_seq in test_seqs:
-            if isinstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet) and \
-                    isinstance(nucleotide_seq, Seq.Seq):
+            if isinstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet) and isinstance(
+                nucleotide_seq, Seq.Seq
+            ):
                 expected = Seq.back_transcribe(nucleotide_seq)
-                self.assertEqual(repr(nucleotide_seq.back_transcribe()),
-                                 repr(expected))
+                self.assertEqual(repr(nucleotide_seq.back_transcribe()), repr(expected))
 
     def test_back_transcription_of_proteins(self):
         """Check back-transcription fails on a protein."""
@@ -1211,48 +1260,55 @@ class TestTranslating(unittest.TestCase):
 
     def test_translation(self):
         for nucleotide_seq in self.test_seqs:
-            nucleotide_seq = nucleotide_seq[:3 * (len(nucleotide_seq) // 3)]
-            if isinstance(nucleotide_seq, Seq.Seq) and \
-               "X" not in str(nucleotide_seq):
+            nucleotide_seq = nucleotide_seq[: 3 * (len(nucleotide_seq) // 3)]
+            if isinstance(nucleotide_seq, Seq.Seq) and "X" not in str(nucleotide_seq):
                 expected = Seq.translate(nucleotide_seq)
-                self.assertEqual(repr(expected),
-                                 repr(nucleotide_seq.translate()))
+                self.assertEqual(repr(expected), repr(nucleotide_seq.translate()))
 
     def test_alphabets_of_translated_seqs(self):
-
         def triple_pad(s):
             """Add N to ensure length is a multiple of three (whole codons)."""
             while len(s) % 3:
                 s += "N"
             return s
 
-        self.assertEqual("IUPACProtein()",
-                         repr(self.test_seqs[0].translate().alphabet))
-        self.assertEqual("ExtendedIUPACProtein()",
-                         repr(self.test_seqs[1].translate().alphabet))
-        self.assertEqual("ExtendedIUPACProtein()",
-                         repr(self.test_seqs[2].translate().alphabet))
-        self.assertEqual("ExtendedIUPACProtein()",
-                         repr(self.test_seqs[3].translate().alphabet))
-        self.assertEqual("ExtendedIUPACProtein()",
-                         repr(self.test_seqs[10].translate().alphabet))
-        self.assertEqual("ExtendedIUPACProtein()",
-                         repr(self.test_seqs[11].translate().alphabet))
-        self.assertEqual("IUPACProtein()",
-                         repr(self.test_seqs[12].translate().alphabet))
+        self.assertEqual("IUPACProtein()", repr(self.test_seqs[0].translate().alphabet))
+        self.assertEqual(
+            "ExtendedIUPACProtein()", repr(self.test_seqs[1].translate().alphabet)
+        )
+        self.assertEqual(
+            "ExtendedIUPACProtein()", repr(self.test_seqs[2].translate().alphabet)
+        )
+        self.assertEqual(
+            "ExtendedIUPACProtein()", repr(self.test_seqs[3].translate().alphabet)
+        )
+        self.assertEqual(
+            "ExtendedIUPACProtein()", repr(self.test_seqs[10].translate().alphabet)
+        )
+        self.assertEqual(
+            "ExtendedIUPACProtein()", repr(self.test_seqs[11].translate().alphabet)
+        )
+        self.assertEqual(
+            "IUPACProtein()", repr(self.test_seqs[12].translate().alphabet)
+        )
         self.assertEqual(
             "ExtendedIUPACProtein()",
-            repr(triple_pad(self.test_seqs[13]).translate().alphabet))
-        self.assertEqual("ExtendedIUPACProtein()",
-                         repr(self.test_seqs[14].translate().alphabet))
-        self.assertEqual("IUPACProtein()",
-                         repr(self.test_seqs[15].translate().alphabet))
+            repr(triple_pad(self.test_seqs[13]).translate().alphabet),
+        )
+        self.assertEqual(
+            "ExtendedIUPACProtein()", repr(self.test_seqs[14].translate().alphabet)
+        )
+        self.assertEqual(
+            "IUPACProtein()", repr(self.test_seqs[15].translate().alphabet)
+        )
         self.assertEqual(
             "ExtendedIUPACProtein()",
-            repr(triple_pad(self.test_seqs[16]).translate().alphabet))
+            repr(triple_pad(self.test_seqs[16]).translate().alphabet),
+        )
         self.assertEqual(
             "ExtendedIUPACProtein()",
-            repr(triple_pad(self.test_seqs[17]).translate().alphabet))
+            repr(triple_pad(self.test_seqs[17]).translate().alphabet),
+        )
 
     def test_gapped_seq_with_gap_char_given(self):
         seq = Seq.Seq("ATG---AAACTG")
@@ -1303,39 +1359,47 @@ class TestTranslating(unittest.TestCase):
 
     def test_alphabet_of_translated_gapped_seq(self):
         seq = Seq.Seq("ATG---AAACTG", Gapped(IUPAC.unambiguous_dna))
-        self.assertEqual("Gapped(ExtendedIUPACProtein(), '-')",
-                         repr(seq.translate().alphabet))
+        self.assertEqual(
+            "Gapped(ExtendedIUPACProtein(), '-')", repr(seq.translate().alphabet)
+        )
 
         seq = Seq.Seq("ATG---AAACTG", Gapped(IUPAC.unambiguous_dna, "-"))
-        self.assertEqual("Gapped(ExtendedIUPACProtein(), '-')",
-                         repr(seq.translate().alphabet))
+        self.assertEqual(
+            "Gapped(ExtendedIUPACProtein(), '-')", repr(seq.translate().alphabet)
+        )
 
         seq = Seq.Seq("ATG~~~AAACTG", Gapped(IUPAC.unambiguous_dna, "~"))
-        self.assertEqual("Gapped(ExtendedIUPACProtein(), '~')",
-                         repr(seq.translate().alphabet))
+        self.assertEqual(
+            "Gapped(ExtendedIUPACProtein(), '~')", repr(seq.translate().alphabet)
+        )
 
         seq = Seq.Seq("ATG---AAACTG")
-        self.assertEqual("Gapped(ExtendedIUPACProtein(), '-')",
-                         repr(seq.translate(gap="-").alphabet))
+        self.assertEqual(
+            "Gapped(ExtendedIUPACProtein(), '-')", repr(seq.translate(gap="-").alphabet)
+        )
 
         seq = Seq.Seq("ATG~~~AAACTG")
-        self.assertEqual("Gapped(ExtendedIUPACProtein(), '~')",
-                         repr(seq.translate(gap="~").alphabet))
+        self.assertEqual(
+            "Gapped(ExtendedIUPACProtein(), '~')", repr(seq.translate(gap="~").alphabet)
+        )
 
         seq = Seq.Seq("ATG~~~AAACTGTAG")
         self.assertEqual(
             "HasStopCodon(Gapped(ExtendedIUPACProtein(), '~'), '*')",
-            repr(seq.translate(gap="~").alphabet))
+            repr(seq.translate(gap="~").alphabet),
+        )
 
         seq = Seq.Seq("ATG---AAACTGTGA")
         self.assertEqual(
             "HasStopCodon(Gapped(ExtendedIUPACProtein(), '-'), '*')",
-            repr(seq.translate(gap="-").alphabet))
+            repr(seq.translate(gap="-").alphabet),
+        )
 
         seq = Seq.Seq("ATG---AAACTGTGA")
         self.assertEqual(
             "HasStopCodon(Gapped(ExtendedIUPACProtein(), '-'), '@')",
-            repr(seq.translate(gap="-", stop_symbol="@").alphabet))
+            repr(seq.translate(gap="-", stop_symbol="@").alphabet),
+        )
 
     def test_translation_wrong_type(self):
         """Test translation table cannot be CodonTable."""
@@ -1360,17 +1424,15 @@ class TestTranslating(unittest.TestCase):
 
     def test_translation_to_stop(self):
         for nucleotide_seq in self.test_seqs:
-            nucleotide_seq = nucleotide_seq[:3 * (len(nucleotide_seq) // 3)]
-            if isinstance(nucleotide_seq, Seq.Seq) and \
-               "X" not in str(nucleotide_seq):
+            nucleotide_seq = nucleotide_seq[: 3 * (len(nucleotide_seq) // 3)]
+            if isinstance(nucleotide_seq, Seq.Seq) and "X" not in str(nucleotide_seq):
                 short = Seq.translate(nucleotide_seq, to_stop=True)
                 self.assertEqual(
-                    str(short),
-                    str(Seq.translate(nucleotide_seq).split("*")[0]))
+                    str(short), str(Seq.translate(nucleotide_seq).split("*")[0])
+                )
 
         seq = "GTGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG"
-        self.assertEqual("VAIVMGRWKGAR", Seq.translate(seq, table=2,
-                                                       to_stop=True))
+        self.assertEqual("VAIVMGRWKGAR", Seq.translate(seq, table=2, to_stop=True))
 
     def test_translation_on_proteins(self):
         """Check translation fails on a protein."""
@@ -1396,8 +1458,7 @@ class TestTranslating(unittest.TestCase):
             self.assertEqual("B", Seq.translate(codon))
 
     def test_translation_of_leucine(self):
-        for codon in ["WTA", "MTY", "MTT", "MTW", "MTM", "MTH", "MTA", "MTC",
-                      "HTA"]:
+        for codon in ["WTA", "MTY", "MTT", "MTW", "MTM", "MTH", "MTA", "MTC", "HTA"]:
             self.assertEqual("J", Seq.translate(codon))
 
     def test_translation_with_bad_table_argument(self):
@@ -1407,8 +1468,7 @@ class TestTranslating(unittest.TestCase):
 
     def test_translation_with_codon_table_as_table_argument(self):
         table = standard_dna_table
-        self.assertEqual("VAIVMGR", Seq.translate("GTGGCCATTGTAATGGGCCGC",
-                                                  table=table))
+        self.assertEqual("VAIVMGR", Seq.translate("GTGGCCATTGTAATGGGCCGC", table=table))
 
     def test_translation_incomplete_codon(self):
         with self.assertWarns(BiopythonWarning):
@@ -1459,32 +1519,29 @@ class TestStopCodons(unittest.TestCase):
         self.misc_stops = "TAATAGTGAAGAAGG"
 
     def test_stops(self):
-        for nucleotide_seq in [self.misc_stops, Seq.Seq(self.misc_stops),
-                               Seq.Seq(self.misc_stops,
-                                       Alphabet.generic_nucleotide),
-                               Seq.Seq(self.misc_stops,
-                                       Alphabet.DNAAlphabet()),
-                               Seq.Seq(self.misc_stops,
-                                       IUPAC.unambiguous_dna)]:
+        for nucleotide_seq in [
+            self.misc_stops,
+            Seq.Seq(self.misc_stops),
+            Seq.Seq(self.misc_stops, Alphabet.generic_nucleotide),
+            Seq.Seq(self.misc_stops, Alphabet.DNAAlphabet()),
+            Seq.Seq(self.misc_stops, IUPAC.unambiguous_dna),
+        ]:
             self.assertEqual("***RR", str(Seq.translate(nucleotide_seq)))
-            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq,
-                                                        table=1)))
-            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq,
-                                                        table="SGC0")))
-            self.assertEqual("**W**", str(Seq.translate(nucleotide_seq,
-                                                        table=2)))
-            self.assertEqual("**WRR", str(Seq.translate(nucleotide_seq,
-                                          table="Yeast Mitochondrial")))
-            self.assertEqual("**WSS", str(Seq.translate(nucleotide_seq,
-                                                        table=5)))
-            self.assertEqual("**WSS", str(Seq.translate(nucleotide_seq,
-                                                        table=9)))
-            self.assertEqual("**CRR", str(Seq.translate(nucleotide_seq,
-                                          table="Euplotid Nuclear")))
-            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq,
-                                                        table=11)))
-            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq,
-                                                        table="Bacterial")))
+            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table=1)))
+            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table="SGC0")))
+            self.assertEqual("**W**", str(Seq.translate(nucleotide_seq, table=2)))
+            self.assertEqual(
+                "**WRR", str(Seq.translate(nucleotide_seq, table="Yeast Mitochondrial"))
+            )
+            self.assertEqual("**WSS", str(Seq.translate(nucleotide_seq, table=5)))
+            self.assertEqual("**WSS", str(Seq.translate(nucleotide_seq, table=9)))
+            self.assertEqual(
+                "**CRR", str(Seq.translate(nucleotide_seq, table="Euplotid Nuclear"))
+            )
+            self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table=11)))
+            self.assertEqual(
+                "***RR", str(Seq.translate(nucleotide_seq, table="Bacterial"))
+            )
 
     def test_translation_of_stops(self):
         self.assertEqual(Seq.translate("TAT"), "Y")


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to the test_seq* files listed below, test_Seq_objs.py and test_seq.py are files with the most differences in style, it would be good if they can be reviewed.

test_seq.py
test_Seq_objs.py
test_SeqFeature.py
test_SeqRecord.py
test_SeqUtils.py