### PR TITLE
xbbtools: Remove subprocess call to Python interpreter

### DIFF
--- a/Scripts/xbbtools/xbb_blastbg.py
+++ b/Scripts/xbbtools/xbb_blastbg.py
@@ -15,9 +15,8 @@
 import os
 import tempfile
 import threading
-import subprocess
 
-from tkinter import messagebox
+from tkinter import Tk, messagebox
 
 from Bio.Blast.Applications import (
     NcbiblastnCommandline,
@@ -140,6 +139,9 @@ class BlastWorker(threading.Thread):
 
 
 if __name__ == "__main__":
-    subprocess.call(
-        ["python", "xbb_blast.py", "ATGACAAAGCTAATTATTCACTTGGTTTCAGACTCTTCTGTGCAAACTGC"]
-    )
+    from xbb_blast import BlastIt
+
+    win = Tk()
+    win.title("Dummy windows for BLAST test")
+    test = BlastIt("ATGACAAAGCTAATTATTCACTTGGTTTCAGACTCTTCTGTGCAAACTGC")
+    win.mainloop()


### PR DESCRIPTION
This pull request addresses an issue discussed in #2568. It will remove a direct call of the Python interpreter (which may be different on different OS).


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
