### PR TITLE
Apply black style to test_SearchIO_blast_xml.py , version 19.10b0.

### DIFF
--- a/Tests/test_SearchIO_blast_xml.py
+++ b/Tests/test_SearchIO_blast_xml.py
@@ -32,7 +32,6 @@ def get_file(filename):
 
 
 class BlastnXmlCases(unittest.TestCase):
-
     def test_xml_2212L_blastn_001(self):
         xml_file = get_file("xml_2212L_blastn_001.xml")
         qresults = parse(xml_file, FMT)
@@ -52,8 +51,9 @@ class BlastnXmlCases(unittest.TestCase):
 
         # test parsed values of qresult
         self.assertEqual("gi|1348916|gb|G26684.1|G26684", qresult.id)
-        self.assertEqual("human STS STS_D11570, sequence tagged site",
-                         qresult.description)
+        self.assertEqual(
+            "human STS STS_D11570, sequence tagged site", qresult.description
+        )
         self.assertEqual(285, qresult.seq_len)
         self.assertEqual(371021, qresult.stat_db_num)
         self.assertEqual(1233631384, qresult.stat_db_len)
@@ -65,7 +65,10 @@ class BlastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|9950606|gb|AE004854.1|", hit.id)
-        self.assertEqual("Pseudomonas aeruginosa PAO1, section 415 of 529 of the complete genome", hit.description)
+        self.assertEqual(
+            "Pseudomonas aeruginosa PAO1, section 415 of 529 of the complete genome",
+            hit.description,
+        )
         self.assertEqual(11884, hit.seq_len)
         self.assertEqual(1, len(hit))
         self.assertRaises(IndexError, hit.__getitem__, 1)
@@ -92,7 +95,10 @@ class BlastnXmlCases(unittest.TestCase):
         # parse last hit
         hit = qresult[-1]
         self.assertEqual("gi|15073988|emb|AL591786.1|SME591786", hit.id)
-        self.assertEqual("Sinorhizobium meliloti 1021 complete chromosome; segment 5/12", hit.description)
+        self.assertEqual(
+            "Sinorhizobium meliloti 1021 complete chromosome; segment 5/12",
+            hit.description,
+        )
         self.assertEqual(299350, hit.seq_len)
         self.assertEqual(1, len(hit))
         self.assertRaises(IndexError, hit.__getitem__, 1)
@@ -131,11 +137,13 @@ class BlastnXmlCases(unittest.TestCase):
 
         # test meta variables, only for the first one
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Zheng Zhang, Scott Schwartz, Lukas Wagner, and "
-                         'Webb Miller (2000), \"A greedy algorithm for '
-                         'aligning DNA sequences\", J Comput Biol 2000; '
-                         "7(1-2):203-14.",
-                         qresult.reference)
+        self.assertEqual(
+            "Zheng Zhang, Scott Schwartz, Lukas Wagner, and "
+            'Webb Miller (2000), "A greedy algorithm for '
+            'aligning DNA sequences", J Comput Biol 2000; '
+            "7(1-2):203-14.",
+            qresult.reference,
+        )
         self.assertEqual(1.0, qresult.param_score_match)
         self.assertEqual(-2.0, qresult.param_score_mismatch)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
@@ -161,7 +169,10 @@ class BlastnXmlCases(unittest.TestCase):
         qresult = next(qresults)
         counter += 1
         self.assertEqual("gi|356995852:1-490", qresult.id)
-        self.assertEqual("Mus musculus POU domain, class 5, transcription factor 1 (Pou5f1), transcript variant 1, mRNA", qresult.description)
+        self.assertEqual(
+            "Mus musculus POU domain, class 5, transcription factor 1 (Pou5f1), transcript variant 1, mRNA",
+            qresult.description,
+        )
         self.assertEqual(490, qresult.seq_len)
         self.assertEqual(23, qresult.stat_db_num)
         self.assertEqual(67750, qresult.stat_db_len)
@@ -173,9 +184,12 @@ class BlastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|356995852|ref|NM_013633.3|", hit.id)
-        self.assertEqual("Mus musculus POU "
-                         "domain, class 5, transcription factor 1 (Pou5f1), "
-                         "transcript variant 1, mRNA", hit.description)
+        self.assertEqual(
+            "Mus musculus POU "
+            "domain, class 5, transcription factor 1 (Pou5f1), "
+            "transcript variant 1, mRNA",
+            hit.description,
+        )
         self.assertEqual(1353, hit.seq_len)
         self.assertEqual(1, len(hit))
         self.assertRaises(IndexError, hit.__getitem__, 1)
@@ -194,16 +208,28 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(490, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(490, hsp.aln_span)
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq))
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq))
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"],
+        )
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
         # test parsed values of the third qresult
         qresult = next(qresults)
         counter += 1
         self.assertEqual("hg19_dna", qresult.id)
-        self.assertEqual("range=chr1:1207307-1207372 5'pad=0 3'pad=0 strand=+ repeatMasking=none", qresult.description)
+        self.assertEqual(
+            "range=chr1:1207307-1207372 5'pad=0 3'pad=0 strand=+ repeatMasking=none",
+            qresult.description,
+        )
         self.assertEqual(66, qresult.seq_len)
         self.assertEqual(23, qresult.stat_db_num)
         self.assertEqual(67750, qresult.stat_db_len)
@@ -215,9 +241,10 @@ class BlastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|94721341|ref|NM_001040441.1|", hit.id)
-        self.assertEqual("Homo sapiens zinc "
-                         "finger and BTB domain containing 8A (ZBTB8A), mRNA",
-                         hit.description)
+        self.assertEqual(
+            "Homo sapiens zinc finger and BTB domain containing 8A (ZBTB8A), mRNA",
+            hit.description,
+        )
         self.assertEqual(7333, hit.seq_len)
         self.assertEqual(2, len(hit))
 
@@ -235,9 +262,18 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(62, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(62, hsp.aln_span)
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.query.seq))
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq))
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(98.9927, hsp.bitscore)
@@ -253,15 +289,25 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(53, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(53, hsp.aln_span)
-        self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.query.seq))
-        self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.hit.seq))
-        self.assertEqual("|||||||||||||||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.query.seq)
+        )
+        self.assertEqual(
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.hit.seq)
+        )
+        self.assertEqual(
+            "|||||||||||||||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|332865372|ref|XM_003318468.1|", hit.id)
-        self.assertEqual("PREDICTED: Pan "
-                         "troglodytes zinc finger protein 273, transcript "
-                         "variant 1 (ZNF273), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Pan "
+            "troglodytes zinc finger protein 273, transcript "
+            "variant 1 (ZNF273), mRNA",
+            hit.description,
+        )
         self.assertEqual(4430, hit.seq_len)
         self.assertEqual(1, len(hit))
 
@@ -279,9 +325,18 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(64, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(66, hsp.aln_span)
-        self.assertEqual("TCAAGCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.query.seq))
-        self.assertEqual("TCACGCCATTGCACTCCAGCCTGGGCAACAAGAGTGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq))
-        self.assertEqual("||| |||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "TCAAGCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "TCACGCCATTGCACTCCAGCCTGGGCAACAAGAGTGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "||| |||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -297,11 +352,13 @@ class BlastnXmlCases(unittest.TestCase):
         counter += 1
 
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Zheng Zhang, Scott Schwartz, Lukas Wagner, and "
-                         'Webb Miller (2000), \"A greedy algorithm for '
-                         'aligning DNA sequences\", J Comput Biol 2000; '
-                         "7(1-2):203-14.",
-                         qresult.reference)
+        self.assertEqual(
+            "Zheng Zhang, Scott Schwartz, Lukas Wagner, and "
+            'Webb Miller (2000), "A greedy algorithm for '
+            'aligning DNA sequences", J Comput Biol 2000; '
+            "7(1-2):203-14.",
+            qresult.reference,
+        )
         self.assertEqual(1.0, qresult.param_score_match)
         self.assertEqual(-2.0, qresult.param_score_mismatch)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
@@ -336,11 +393,13 @@ class BlastnXmlCases(unittest.TestCase):
         counter += 1
 
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Zheng Zhang, Scott Schwartz, Lukas Wagner, and "
-                         'Webb Miller (2000), \"A greedy algorithm for '
-                         'aligning DNA sequences\", J Comput Biol 2000; '
-                         "7(1-2):203-14.",
-                         qresult.reference)
+        self.assertEqual(
+            "Zheng Zhang, Scott Schwartz, Lukas Wagner, and "
+            'Webb Miller (2000), "A greedy algorithm for '
+            'aligning DNA sequences", J Comput Biol 2000; '
+            "7(1-2):203-14.",
+            qresult.reference,
+        )
         self.assertEqual(1.0, qresult.param_score_match)
         self.assertEqual(-2.0, qresult.param_score_mismatch)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
@@ -351,9 +410,11 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual("db/minirefseq_mrna", qresult.target)
 
         self.assertEqual("gi|356995852:1-490", qresult.id)
-        self.assertEqual("Mus musculus POU domain, class 5, transcription "
-                         "factor 1 (Pou5f1), transcript variant 1, mRNA",
-                         qresult.description)
+        self.assertEqual(
+            "Mus musculus POU domain, class 5, transcription "
+            "factor 1 (Pou5f1), transcript variant 1, mRNA",
+            qresult.description,
+        )
         self.assertEqual(490, qresult.seq_len)
         self.assertEqual(23, qresult.stat_db_num)
         self.assertEqual(67750, qresult.stat_db_len)
@@ -365,9 +426,12 @@ class BlastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|356995852|ref|NM_013633.3|", hit.id)
-        self.assertEqual("Mus musculus POU "
-                         "domain, class 5, transcription factor 1 (Pou5f1), "
-                         "transcript variant 1, mRNA", hit.description)
+        self.assertEqual(
+            "Mus musculus POU "
+            "domain, class 5, transcription factor 1 (Pou5f1), "
+            "transcript variant 1, mRNA",
+            hit.description,
+        )
         self.assertEqual(1353, hit.seq_len)
         self.assertEqual(1, len(hit))
         self.assertRaises(IndexError, hit.__getitem__, 1)
@@ -386,9 +450,18 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(490, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(490, hsp.aln_span)
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq))
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq))
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"],
+        )
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
         # check if we've finished iteration over qresults
@@ -403,9 +476,10 @@ class BlastnXmlCases(unittest.TestCase):
         qresult = next(qresults)
         counter += 1
         self.assertEqual("hg19_dna", qresult.id)
-        self.assertEqual("range=chr1:1207307-1207372 5'pad=0 3'pad=0 "
-                         "strand=+ repeatMasking=none",
-                         qresult.description)
+        self.assertEqual(
+            "range=chr1:1207307-1207372 5'pad=0 3'pad=0 strand=+ repeatMasking=none",
+            qresult.description,
+        )
         self.assertEqual(66, qresult.seq_len)
         self.assertEqual(23, qresult.stat_db_num)
         self.assertEqual(67750, qresult.stat_db_len)
@@ -417,9 +491,10 @@ class BlastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|94721341|ref|NM_001040441.1|", hit.id)
-        self.assertEqual("Homo sapiens zinc "
-                         "finger and BTB domain containing 8A (ZBTB8A), mRNA",
-                         hit.description)
+        self.assertEqual(
+            "Homo sapiens zinc finger and BTB domain containing 8A (ZBTB8A), mRNA",
+            hit.description,
+        )
         self.assertEqual(7333, hit.seq_len)
         self.assertEqual(2, len(hit))
 
@@ -437,9 +512,18 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(62, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(62, hsp.aln_span)
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.query.seq))
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq))
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(98.9927, hsp.bitscore)
@@ -455,15 +539,25 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(53, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(53, hsp.aln_span)
-        self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.query.seq))
-        self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.hit.seq))
-        self.assertEqual("|||||||||||||||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.query.seq)
+        )
+        self.assertEqual(
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.hit.seq)
+        )
+        self.assertEqual(
+            "|||||||||||||||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|332865372|ref|XM_003318468.1|", hit.id)
-        self.assertEqual("PREDICTED: Pan "
-                         "troglodytes zinc finger protein 273, transcript "
-                         "variant 1 (ZNF273), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Pan "
+            "troglodytes zinc finger protein 273, transcript "
+            "variant 1 (ZNF273), mRNA",
+            hit.description,
+        )
         self.assertEqual(4430, hit.seq_len)
         self.assertEqual(1, len(hit))
 
@@ -481,9 +575,18 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(64, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(66, hsp.aln_span)
-        self.assertEqual("TCAAGCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.query.seq))
-        self.assertEqual("TCACGCCATTGCACTCCAGCCTGGGCAACAAGAGTGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq))
-        self.assertEqual("||| |||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "TCAAGCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "TCACGCCATTGCACTCCAGCCTGGGCAACAAGAGTGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "||| |||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -500,11 +603,13 @@ class BlastnXmlCases(unittest.TestCase):
 
         # test meta variables, only for the first one
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Zheng Zhang, Scott Schwartz, Lukas Wagner, and "
-                         'Webb Miller (2000), \"A greedy algorithm for '
-                         'aligning DNA sequences\", J Comput Biol 2000; '
-                         "7(1-2):203-14.",
-                         qresult.reference)
+        self.assertEqual(
+            "Zheng Zhang, Scott Schwartz, Lukas Wagner, and "
+            'Webb Miller (2000), "A greedy algorithm for '
+            'aligning DNA sequences", J Comput Biol 2000; '
+            "7(1-2):203-14.",
+            qresult.reference,
+        )
         self.assertEqual(1.0, qresult.param_score_match)
         self.assertEqual(-2.0, qresult.param_score_mismatch)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
@@ -530,9 +635,11 @@ class BlastnXmlCases(unittest.TestCase):
         qresult = next(qresults)
         counter += 1
         self.assertEqual("gi|356995852:1-490", qresult.id)
-        self.assertEqual("Mus musculus POU domain, class 5, transcription "
-                         "factor 1 (Pou5f1), transcript variant 1, mRNA",
-                         qresult.description)
+        self.assertEqual(
+            "Mus musculus POU domain, class 5, transcription "
+            "factor 1 (Pou5f1), transcript variant 1, mRNA",
+            qresult.description,
+        )
         self.assertEqual(490, qresult.seq_len)
         self.assertEqual(2933984, qresult.stat_db_num)
         self.assertEqual(4726730735, qresult.stat_db_len)
@@ -544,9 +651,12 @@ class BlastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|356995852|ref|NM_013633.3|", hit.id)
-        self.assertEqual("Mus musculus POU "
-                         "domain, class 5, transcription factor 1 (Pou5f1), "
-                         "transcript variant 1, mRNA", hit.description)
+        self.assertEqual(
+            "Mus musculus POU "
+            "domain, class 5, transcription factor 1 (Pou5f1), "
+            "transcript variant 1, mRNA",
+            hit.description,
+        )
         self.assertEqual(1353, hit.seq_len)
         self.assertEqual(1, len(hit))
         self.assertRaises(IndexError, hit.__getitem__, 1)
@@ -565,17 +675,28 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(490, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(490, hsp.aln_span)
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq))
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq))
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"],
+        )
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
         # test parsed values of the third qresult
         qresult = next(qresults)
         counter += 1
         self.assertEqual("hg19_dna", qresult.id)
-        self.assertEqual("range=chr1:1207307-1207372 5'pad=0 3'pad=0 "
-                         "strand=+ repeatMasking=none", qresult.description)
+        self.assertEqual(
+            "range=chr1:1207307-1207372 5'pad=0 3'pad=0 strand=+ repeatMasking=none",
+            qresult.description,
+        )
         self.assertEqual(66, qresult.seq_len)
         self.assertEqual(2933984, qresult.stat_db_num)
         self.assertEqual(4726730735, qresult.stat_db_len)
@@ -587,9 +708,11 @@ class BlastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|332237160|ref|XM_003267724.1|", hit.id)
-        self.assertEqual("PREDICTED: Nomascus leucogenys ATG14 autophagy "
-                         "related 14 homolog (S. cerevisiae) (ATG14), mRNA",
-                         hit.description)
+        self.assertEqual(
+            "PREDICTED: Nomascus leucogenys ATG14 autophagy "
+            "related 14 homolog (S. cerevisiae) (ATG14), mRNA",
+            hit.description,
+        )
         self.assertEqual(4771, hit.seq_len)
         self.assertEqual(1, len(hit))
 
@@ -607,15 +730,26 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(62, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(62, hsp.aln_span)
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.query.seq))
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq))
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|332254616|ref|XM_003276378.1|", hit.id)
-        self.assertEqual("PREDICTED: Nomascus leucogenys S100P binding "
-                         "protein, transcript variant 2 (S100PBP), mRNA",
-                         hit.description)
+        self.assertEqual(
+            "PREDICTED: Nomascus leucogenys S100P binding "
+            "protein, transcript variant 2 (S100PBP), mRNA",
+            hit.description,
+        )
         self.assertEqual(4345, hit.seq_len)
         self.assertEqual(1, len(hit))
 
@@ -633,9 +767,18 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(64, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(66, hsp.aln_span)
-        self.assertEqual("TCAAGCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.query.seq))
-        self.assertEqual("TCATGCCACTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq))
-        self.assertEqual("||| |||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "TCAAGCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "TCATGCCACTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "||| |||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -643,7 +786,6 @@ class BlastnXmlCases(unittest.TestCase):
 
 
 class BlastpXmlCases(unittest.TestCase):
-
     def test_xml_2212L_blastp_001(self):
         xml_file = get_file("xml_2212L_blastp_001.xml")
         qresults = parse(xml_file, FMT)
@@ -663,9 +805,10 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual("nr", qresult.target)
 
         self.assertEqual("gi|49176427|ref|NP_418280.3|", qresult.id)
-        self.assertEqual("component of Sec-independent translocase "
-                         "[Escherichia coli K12]",
-                         qresult.description)
+        self.assertEqual(
+            "component of Sec-independent translocase [Escherichia coli K12]",
+            qresult.description,
+        )
         self.assertEqual(103, qresult.seq_len)
         self.assertEqual(2934173, qresult.stat_db_num)
         self.assertEqual(1011751523, qresult.stat_db_len)
@@ -675,37 +818,56 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(0.14, qresult.stat_entropy)
         self.assertEqual(212, len(qresult))
         # check for alternative ID results
-        self.assertEqual(qresult["gi|49176427|ref|NP_418280.3|"],
-                         qresult["gi|26250604|ref|NP_756644.1|"])
+        self.assertEqual(
+            qresult["gi|49176427|ref|NP_418280.3|"],
+            qresult["gi|26250604|ref|NP_756644.1|"],
+        )
 
-        self.assertEqual(qresult["gi|49176427|ref|NP_418280.3|"],
-                         qresult["gi|30064867|ref|NP_839038.1|"])
+        self.assertEqual(
+            qresult["gi|49176427|ref|NP_418280.3|"],
+            qresult["gi|30064867|ref|NP_839038.1|"],
+        )
 
-        self.assertEqual(qresult["gi|49176427|ref|NP_418280.3|"],
-                         qresult["gi|24115132|ref|NP_709642.1|"])
+        self.assertEqual(
+            qresult["gi|49176427|ref|NP_418280.3|"],
+            qresult["gi|24115132|ref|NP_709642.1|"],
+        )
 
-        self.assertEqual(qresult["gi|49176427|ref|NP_418280.3|"],
-                         qresult["gi|24054404|gb|AAN45349.1|"])
+        self.assertEqual(
+            qresult["gi|49176427|ref|NP_418280.3|"],
+            qresult["gi|24054404|gb|AAN45349.1|"],
+        )
 
-        self.assertEqual(qresult["gi|49176427|ref|NP_418280.3|"],
-                         qresult["gi|2367310|gb|AAC76839.1|"])
+        self.assertEqual(
+            qresult["gi|49176427|ref|NP_418280.3|"],
+            qresult["gi|2367310|gb|AAC76839.1|"],
+        )
 
-        self.assertEqual(qresult["gi|49176427|ref|NP_418280.3|"],
-                         qresult["gi|30043127|gb|AAP18849.1|"])
+        self.assertEqual(
+            qresult["gi|49176427|ref|NP_418280.3|"],
+            qresult["gi|30043127|gb|AAP18849.1|"],
+        )
 
-        self.assertEqual(qresult["gi|49176427|ref|NP_418280.3|"],
-                         qresult["gi|26111035|gb|AAN83218.1|"])
+        self.assertEqual(
+            qresult["gi|49176427|ref|NP_418280.3|"],
+            qresult["gi|26111035|gb|AAN83218.1|"],
+        )
 
-        self.assertEqual(qresult["gi|49176427|ref|NP_418280.3|"],
-                         qresult["gi|3193217|gb|AAC19240.1|"])
+        self.assertEqual(
+            qresult["gi|49176427|ref|NP_418280.3|"],
+            qresult["gi|3193217|gb|AAC19240.1|"],
+        )
 
-        self.assertEqual(qresult["gi|49176427|ref|NP_418280.3|"],
-                         qresult["gi|7444818|pir||E65188"])
+        self.assertEqual(
+            qresult["gi|49176427|ref|NP_418280.3|"], qresult["gi|7444818|pir||E65188"]
+        )
 
         hit = qresult[0]
         self.assertEqual("gi|49176427|ref|NP_418280.3|", hit.id)
-        self.assertEqual("component of Sec-independent translocase "
-                         "[Escherichia coli K12]", hit.description)
+        self.assertEqual(
+            "component of Sec-independent translocase [Escherichia coli K12]",
+            hit.description,
+        )
         self.assertEqual(10, len(hit.id_all))
         self.assertEqual(10, len(hit.description_all))
         self.assertEqual(103, hit.seq_len)
@@ -726,15 +888,26 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(103, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(103, hsp.aln_span)
-        self.assertEqual("MRLCLIIIYHRGTCMGGISIWQXXXXXXXXXXXFGTKKLGSIGSDLGASIKGFKKAMSDDEPKQDKTSQDADFTAKTIADKQADTNQEQAKTEDAKRHDKEQV", str(hsp.query.seq))
-        self.assertEqual("MRLCLIIIYHRGTCMGGISIWQLLIIAVIVVLLFGTKKLGSIGSDLGASIKGFKKAMSDDEPKQDKTSQDADFTAKTIADKQADTNQEQAKTEDAKRHDKEQV", str(hsp.hit.seq))
-        self.assertEqual("MRLCLIIIYHRGTCMGGISIWQLLIIAVIVVLLFGTKKLGSIGSDLGASIKGFKKAMSDDEPKQDKTSQDADFTAKTIADKQADTNQEQAKTEDAKRHDKEQV", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "MRLCLIIIYHRGTCMGGISIWQXXXXXXXXXXXFGTKKLGSIGSDLGASIKGFKKAMSDDEPKQDKTSQDADFTAKTIADKQADTNQEQAKTEDAKRHDKEQV",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "MRLCLIIIYHRGTCMGGISIWQLLIIAVIVVLLFGTKKLGSIGSDLGASIKGFKKAMSDDEPKQDKTSQDADFTAKTIADKQADTNQEQAKTEDAKRHDKEQV",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "MRLCLIIIYHRGTCMGGISIWQLLIIAVIVVLLFGTKKLGSIGSDLGASIKGFKKAMSDDEPKQDKTSQDADFTAKTIADKQADTNQEQAKTEDAKRHDKEQV",
+            hsp.aln_annotation["similarity"],
+        )
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
         # parse last hit
         hit = qresult[-1]
         self.assertEqual("gi|39593039|emb|CAE64508.1|", hit.id)
-        self.assertEqual("Hypothetical protein CBG09238 [Caenorhabditis briggsae]", hit.description)
+        self.assertEqual(
+            "Hypothetical protein CBG09238 [Caenorhabditis briggsae]", hit.description
+        )
         self.assertEqual(960, hit.seq_len)
         self.assertEqual(1, len(hit))
         self.assertRaises(IndexError, hit.__getitem__, 1)
@@ -753,9 +926,16 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(33, hsp.pos_num)
         self.assertEqual(4, hsp.gap_num)
         self.assertEqual(51, hsp.aln_span)
-        self.assertEqual("KAMSDDEPKQD---KTSQDADFTAKTIADKQADTNQEQAKTEDAKRHDKEQ", str(hsp.query.seq))
-        self.assertEqual("KKEADDKAKKDLEAKTKKEADEKAKKEADEKA-KKEAEAKTKEAEAKTKKE", str(hsp.hit.seq))
-        self.assertEqual("K  +DD+ K+D   KT ++AD  AK  AD++A   + +AKT++A+   K++", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "KAMSDDEPKQD---KTSQDADFTAKTIADKQADTNQEQAKTEDAKRHDKEQ", str(hsp.query.seq)
+        )
+        self.assertEqual(
+            "KKEADDKAKKDLEAKTKKEADEKAKKEADEKA-KKEAEAKTKEAEAKTKKE", str(hsp.hit.seq)
+        )
+        self.assertEqual(
+            "K  +DD+ K+D   KT ++AD  AK  AD++A   + +AKT++A+   K++",
+            hsp.aln_annotation["similarity"],
+        )
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
         # check if we've finished iteration over qresults
@@ -792,7 +972,10 @@ class BlastpXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|151942244|gb|EDN60600.1|", hit.id)
-        self.assertEqual("cytosolic iron-sulfur protein assembly protein [Saccharomyces cerevisiae YJM789]", hit.description)
+        self.assertEqual(
+            "cytosolic iron-sulfur protein assembly protein [Saccharomyces cerevisiae YJM789]",
+            hit.description,
+        )
         self.assertEqual(330, hit.seq_len)
         self.assertEqual(1, len(hit))
         self.assertRaises(IndexError, hit.__getitem__, 1)
@@ -811,15 +994,25 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(27, hsp.pos_num)
         self.assertEqual(2, hsp.gap_num)
         self.assertEqual(50, hsp.aln_span)
-        self.assertEqual("AWNKDRTQIAICPNNHEVHIYE--KSGAKWNKVHELKEHNGQVTGIDWAP", str(hsp.query.seq))
-        self.assertEqual("AWSNDGYYLATCSRDKSVWIWETDESGEEYECISVLQEHSQDVKHVIWHP", str(hsp.hit.seq))
-        self.assertEqual("AW+ D   +A C  +  V I+E  +SG ++  +  L+EH+  V  + W P", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "AWNKDRTQIAICPNNHEVHIYE--KSGAKWNKVHELKEHNGQVTGIDWAP", str(hsp.query.seq)
+        )
+        self.assertEqual(
+            "AWSNDGYYLATCSRDKSVWIWETDESGEEYECISVLQEHSQDVKHVIWHP", str(hsp.hit.seq)
+        )
+        self.assertEqual(
+            "AW+ D   +A C  +  V I+E  +SG ++  +  L+EH+  V  + W P",
+            hsp.aln_annotation["similarity"],
+        )
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
         # parse last hit
         hit = qresult[-1]
         self.assertEqual("gi|151567870|pdb|2PM9|B", hit.id)
-        self.assertEqual("Chain B, Crystal Structure Of Yeast Sec1331 VERTEX ELEMENT OF THE Copii Vesicular Coat", hit.description)
+        self.assertEqual(
+            "Chain B, Crystal Structure Of Yeast Sec1331 VERTEX ELEMENT OF THE Copii Vesicular Coat",
+            hit.description,
+        )
         self.assertEqual(297, hit.seq_len)
         self.assertEqual(2, len(hit))
 
@@ -837,9 +1030,14 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(23, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(42, hsp.aln_span)
-        self.assertEqual("TQIAICPNNHEVHIYEKSGAKWNKVHELKEHNGQVTGIDWAP", str(hsp.query.seq))
+        self.assertEqual(
+            "TQIAICPNNHEVHIYEKSGAKWNKVHELKEHNGQVTGIDWAP", str(hsp.query.seq)
+        )
         self.assertEqual("TILASCSYDGKVMIWKEENGRWSQIAVHAVHSASVNSVQWAP", str(hsp.hit.seq))
-        self.assertEqual("T +A C  + +V I+++   +W+++     H+  V  + WAP", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "T +A C  + +V I+++   +W+++     H+  V  + WAP",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -866,7 +1064,10 @@ class BlastpXmlCases(unittest.TestCase):
 
         # test parsed values of the first qresult
         self.assertEqual("gi|585505|sp|Q08386|MOPB_RHOCA", qresult.id)
-        self.assertEqual("Molybdenum-pterin-binding protein mopB >gi|310278|gb|AAA71913.1| molybdenum-pterin-binding protein", qresult.description)
+        self.assertEqual(
+            "Molybdenum-pterin-binding protein mopB >gi|310278|gb|AAA71913.1| molybdenum-pterin-binding protein",
+            qresult.description,
+        )
         self.assertEqual(270, qresult.seq_len)
         self.assertEqual(27252, qresult.stat_db_num)
         self.assertEqual(13958303, qresult.stat_db_len)
@@ -906,21 +1107,25 @@ class BlastpXmlCases(unittest.TestCase):
 
         # test meta variables, only for the first one
         self.assertEqual("2.2.18", qresult.version)
-        self.assertEqual("~Reference: Altschul, Stephen F., "
-                         "Thomas L. Madden, Alejandro A. Schaffer, "
-                         "~Jinghui Zhang, Zheng Zhang, Webb Miller, "
-                         'and David J. Lipman (1997), ~"Gapped BLAST '
-                         "and PSI-BLAST: a new generation of protein "
-                         'database search~programs",  '
-                         "Nucleic Acids Res. 25:3389-3402.",
-                         qresult.reference)
+        self.assertEqual(
+            "~Reference: Altschul, Stephen F., "
+            "Thomas L. Madden, Alejandro A. Schaffer, "
+            "~Jinghui Zhang, Zheng Zhang, Webb Miller, "
+            'and David J. Lipman (1997), ~"Gapped BLAST '
+            "and PSI-BLAST: a new generation of protein "
+            'database search~programs",  '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(1e-05, qresult.param_evalue_threshold)
         self.assertEqual("F", qresult.param_filter)
         self.assertEqual(11, qresult.param_gap_open)
         self.assertEqual(1, qresult.param_gap_extend)
         self.assertEqual("blastp", qresult.program)
-        self.assertEqual("/Users/pjcock/Downloads/Software/blast-2.2.18/data/nr", qresult.target)
+        self.assertEqual(
+            "/Users/pjcock/Downloads/Software/blast-2.2.18/data/nr", qresult.target
+        )
 
         # test parsed values of the first qresult
         self.assertEqual("Fake", qresult.id)
@@ -928,7 +1133,7 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(9, qresult.seq_len)
         self.assertEqual(6589360, qresult.stat_db_num)
         self.assertEqual(2253133281, qresult.stat_db_len)
-        self.assertEqual(2.02782e+10, qresult.stat_eff_space)
+        self.assertEqual(2.02782e10, qresult.stat_eff_space)
         self.assertEqual(0.041, qresult.stat_kappa)
         self.assertEqual(0.267, qresult.stat_lambda)
         self.assertEqual(0.14, qresult.stat_entropy)
@@ -947,7 +1152,10 @@ class BlastpXmlCases(unittest.TestCase):
         counter += 1
 
         self.assertEqual("2.2.22+", qresult.version)
-        self.assertEqual('Stephen F. Altschul, Thomas L. Madden, Alejandro A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb Miller, and David J. Lipman (1997), "Gapped BLAST and PSI-BLAST: a new generation of protein database search programs", Nucleic Acids Res. 25:3389-3402.', qresult.reference)
+        self.assertEqual(
+            'Stephen F. Altschul, Thomas L. Madden, Alejandro A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb Miller, and David J. Lipman (1997), "Gapped BLAST and PSI-BLAST: a new generation of protein database search programs", Nucleic Acids Res. 25:3389-3402.',
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(1e-06, qresult.param_evalue_threshold)
         self.assertEqual("F", qresult.param_filter)
@@ -987,15 +1195,26 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(107, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(107, hsp.aln_span)
-        self.assertEqual("GGHVNPAVTFGAFVGGNITLLRGIVYIIAQLLGSTVACLLLKFVTNDMAVGVFSLSAGVGVTNALVFEIVMTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI", str(hsp.query.seq))
-        self.assertEqual("GGHVNPAVTFGAFVGGNITLLRGIVYIIAQLLGSTVACLLLKFVTNDMAVGVFSLSAGVGVTNALVFEIVMTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI", str(hsp.hit.seq))
-        self.assertEqual("GGHVNPAVTFGAFVGGNITLLRGIVYIIAQLLGSTVACLLLKFVTNDMAVGVFSLSAGVGVTNALVFEIVMTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "GGHVNPAVTFGAFVGGNITLLRGIVYIIAQLLGSTVACLLLKFVTNDMAVGVFSLSAGVGVTNALVFEIVMTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "GGHVNPAVTFGAFVGGNITLLRGIVYIIAQLLGSTVACLLLKFVTNDMAVGVFSLSAGVGVTNALVFEIVMTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "GGHVNPAVTFGAFVGGNITLLRGIVYIIAQLLGSTVACLLLKFVTNDMAVGVFSLSAGVGVTNALVFEIVMTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI",
+            hsp.aln_annotation["similarity"],
+        )
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
         # parse last hit
         hit = qresult[-1]
         self.assertEqual("gi|162809290|dbj|BAF95576.1|", hit.id)
-        self.assertEqual("tonoplast intrinsic protein [Nicotiana tabacum]", hit.description)
+        self.assertEqual(
+            "tonoplast intrinsic protein [Nicotiana tabacum]", hit.description
+        )
         self.assertEqual(251, hit.seq_len)
         self.assertEqual(1, len(hit))
         self.assertRaises(IndexError, hit.__getitem__, 1)
@@ -1014,9 +1233,18 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(95, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(107, hsp.aln_span)
-        self.assertEqual("GGHVNPAVTFGAFVGGNITLLRGIVYIIAQLLGSTVACLLLKFVTNDMAVGVFSLSAGVGVTNALVFEIVMTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI", str(hsp.query.seq))
-        self.assertEqual("GGHVNPAVTFGAFVGGNITLFRGILYIIAQLLGSTVACFLLEFATGGMSTGAFALSAGVSVWNAFVFEIVMTFGLVYTVYATAIDPKKGDLGVIAPIAIGFIVGANI", str(hsp.hit.seq))
-        self.assertEqual("GGHVNPAVTFGAFVGGNITL RGI+YIIAQLLGSTVAC LL+F T  M+ G F+LSAGV V NA VFEIVMTFGLVYTVYATAIDPKKG LG IAPIAIGFIVGANI", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "GGHVNPAVTFGAFVGGNITLLRGIVYIIAQLLGSTVACLLLKFVTNDMAVGVFSLSAGVGVTNALVFEIVMTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "GGHVNPAVTFGAFVGGNITLFRGILYIIAQLLGSTVACFLLEFATGGMSTGAFALSAGVSVWNAFVFEIVMTFGLVYTVYATAIDPKKGDLGVIAPIAIGFIVGANI",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "GGHVNPAVTFGAFVGGNITL RGI+YIIAQLLGSTVAC LL+F T  M+ G F+LSAGV V NA VFEIVMTFGLVYTVYATAIDPKKG LG IAPIAIGFIVGANI",
+            hsp.aln_annotation["similarity"],
+        )
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
     # def test_xml_2218L_rpsblast_001(self):
@@ -1033,13 +1261,15 @@ class BlastpXmlCases(unittest.TestCase):
 
         # test meta variables, only for the first one
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
-                         'Miller, and David J. Lipman (1997), \"Gapped BLAST '
-                         "and PSI-BLAST: a new generation of protein "
-                         'database search programs\", '
-                         "Nucleic Acids Res. 25:3389-3402.",
-                         qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
+            'Miller, and David J. Lipman (1997), "Gapped BLAST '
+            "and PSI-BLAST: a new generation of protein "
+            'database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("F", qresult.param_filter)
@@ -1064,8 +1294,11 @@ class BlastpXmlCases(unittest.TestCase):
         qresult = next(qresults)
         counter += 1
         self.assertEqual("gi|16080617|ref|NP_391444.1|", qresult.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillus subtilis "
-                         "subsp. subtilis str. 168]", qresult.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillus subtilis "
+            "subsp. subtilis str. 168]",
+            qresult.description,
+        )
         self.assertEqual(102, qresult.seq_len)
         self.assertEqual(20, qresult.stat_db_num)
         self.assertEqual(6406, qresult.stat_db_len)
@@ -1077,9 +1310,10 @@ class BlastpXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|308175296|ref|YP_003922001.1|", hit.id)
-        self.assertEqual("membrane bound "
-                         "lipoprotein [Bacillus amyloliquefaciens DSM 7]",
-                         hit.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillus amyloliquefaciens DSM 7]",
+            hit.description,
+        )
         self.assertEqual(100, hit.seq_len)
         self.assertEqual(1, len(hit))
         self.assertRaises(IndexError, hit.__getitem__, 1)
@@ -1098,9 +1332,18 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(81, hsp.pos_num)
         self.assertEqual(2, hsp.gap_num)
         self.assertEqual(102, hsp.aln_span)
-        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.query.seq))
-        self.assertEqual("MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEGTYVGLADTHTIEVTVDHEPVSFDITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", str(hsp.hit.seq))
-        self.assertEqual("MKK    LFFILLL+GCGV ++KSQGED      + TKEGTYVGLADTHTIEVTVD+EPVS DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEGTYVGLADTHTIEVTVDHEPVSFDITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "MKK    LFFILLL+GCGV ++KSQGED      + TKEGTYVGLADTHTIEVTVD+EPVS DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN",
+            hsp.aln_annotation["similarity"],
+        )
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
         # test parsed values of the third qresult
@@ -1137,9 +1380,18 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(98, hsp.aln_span)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq))
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq))
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(43.5134, hsp.bitscore)
@@ -1155,9 +1407,18 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(48, hsp.pos_num)
         self.assertEqual(6, hsp.gap_num)
         self.assertEqual(100, hsp.aln_span)
-        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNSPKGMIPLKGSTLTS--PCQDFGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq))
-        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGEDPLGAVHLRGCVVTSVESSHDVKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", str(hsp.hit.seq))
-        self.assertEqual("I++G L+K+G     WK    +L ED   + +Y       P G + L+G  +TS     D  K     + +I T  +  ++ QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNSPKGMIPLKGSTLTS--PCQDFGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGEDPLGAVHLRGCVVTSVESSHDVKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "I++G L+K+G     WK    +L ED   + +Y       P G + L+G  +TS     D  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|350596020|ref|XP_003360649.2|", hit.id)
@@ -1179,9 +1440,18 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(96, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(98, hsp.aln_span)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq))
-        self.assertEqual("KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", str(hsp.hit.seq))
-        self.assertEqual("KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -1198,13 +1468,15 @@ class BlastpXmlCases(unittest.TestCase):
 
         # test meta variables, only for the first one
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
-                         'Miller, and David J. Lipman (1997), \"Gapped BLAST '
-                         "and PSI-BLAST: a new generation of protein "
-                         'database search programs\", '
-                         "Nucleic Acids Res. 25:3389-3402.",
-                         qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
+            'Miller, and David J. Lipman (1997), "Gapped BLAST '
+            "and PSI-BLAST: a new generation of protein "
+            'database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("F", qresult.param_filter)
@@ -1239,13 +1511,15 @@ class BlastpXmlCases(unittest.TestCase):
         counter += 1
 
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
-                         'Miller, and David J. Lipman (1997), \"Gapped BLAST '
-                         "and PSI-BLAST: a new generation of protein "
-                         'database search programs\", '
-                         "Nucleic Acids Res. 25:3389-3402.",
-                         qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
+            'Miller, and David J. Lipman (1997), "Gapped BLAST '
+            "and PSI-BLAST: a new generation of protein "
+            'database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("F", qresult.param_filter)
@@ -1255,8 +1529,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual("db/minirefseq_prot", qresult.target)
 
         self.assertEqual("gi|16080617|ref|NP_391444.1|", qresult.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillus subtilis "
-                         "subsp. subtilis str. 168]", qresult.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillus subtilis "
+            "subsp. subtilis str. 168]",
+            qresult.description,
+        )
         self.assertEqual(102, qresult.seq_len)
         self.assertEqual(20, qresult.stat_db_num)
         self.assertEqual(6406, qresult.stat_db_len)
@@ -1268,7 +1545,10 @@ class BlastpXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|308175296|ref|YP_003922001.1|", hit.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillus amyloliquefaciens DSM 7]", hit.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillus amyloliquefaciens DSM 7]",
+            hit.description,
+        )
         self.assertEqual(100, hit.seq_len)
         self.assertEqual(1, len(hit))
         self.assertRaises(IndexError, hit.__getitem__, 1)
@@ -1287,9 +1567,18 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(81, hsp.pos_num)
         self.assertEqual(2, hsp.gap_num)
         self.assertEqual(102, hsp.aln_span)
-        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.query.seq))
-        self.assertEqual("MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEGTYVGLADTHTIEVTVDHEPVSFDITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", str(hsp.hit.seq))
-        self.assertEqual("MKK    LFFILLL+GCGV ++KSQGED      + TKEGTYVGLADTHTIEVTVD+EPVS DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEGTYVGLADTHTIEVTVDHEPVSFDITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "MKK    LFFILLL+GCGV ++KSQGED      + TKEGTYVGLADTHTIEVTVD+EPVS DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN",
+            hsp.aln_annotation["similarity"],
+        )
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
         # check if we've finished iteration over qresults
@@ -1306,13 +1595,15 @@ class BlastpXmlCases(unittest.TestCase):
         counter += 1
 
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
-                         'Miller, and David J. Lipman (1997), \"Gapped BLAST '
-                         "and PSI-BLAST: a new generation of protein "
-                         'database search programs\", '
-                         "Nucleic Acids Res. 25:3389-3402.",
-                         qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
+            'Miller, and David J. Lipman (1997), "Gapped BLAST '
+            "and PSI-BLAST: a new generation of protein "
+            'database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("F", qresult.param_filter)
@@ -1352,9 +1643,18 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(98, hsp.aln_span)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq))
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq))
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(43.5134, hsp.bitscore)
@@ -1370,9 +1670,18 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(48, hsp.pos_num)
         self.assertEqual(6, hsp.gap_num)
         self.assertEqual(100, hsp.aln_span)
-        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNSPKGMIPLKGSTLTS--PCQDFGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq))
-        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGEDPLGAVHLRGCVVTSVESSHDVKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", str(hsp.hit.seq))
-        self.assertEqual("I++G L+K+G     WK    +L ED   + +Y       P G + L+G  +TS     D  K     + +I T  +  ++ QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNSPKGMIPLKGSTLTS--PCQDFGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGEDPLGAVHLRGCVVTSVESSHDVKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "I++G L+K+G     WK    +L ED   + +Y       P G + L+G  +TS     D  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|350596020|ref|XP_003360649.2|", hit.id)
@@ -1394,9 +1703,18 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(96, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(98, hsp.aln_span)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq))
-        self.assertEqual("KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", str(hsp.hit.seq))
-        self.assertEqual("KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -1413,13 +1731,15 @@ class BlastpXmlCases(unittest.TestCase):
 
         # test meta variables, only for the first one
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
-                         'Miller, and David J. Lipman (1997), \"Gapped BLAST '
-                         "and PSI-BLAST: a new generation of protein "
-                         'database search programs\", '
-                         "Nucleic Acids Res. 25:3389-3402.",
-                         qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
+            'Miller, and David J. Lipman (1997), "Gapped BLAST '
+            "and PSI-BLAST: a new generation of protein "
+            'database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("F", qresult.param_filter)
@@ -1444,7 +1764,10 @@ class BlastpXmlCases(unittest.TestCase):
         qresult = next(qresults)
         counter += 1
         self.assertEqual("gi|16080617|ref|NP_391444.1|", qresult.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168]", qresult.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168]",
+            qresult.description,
+        )
         self.assertEqual(102, qresult.seq_len)
         self.assertEqual(12646943, qresult.stat_db_num)
         self.assertEqual(4397139428, qresult.stat_db_len)
@@ -1454,25 +1777,38 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(0.14, qresult.stat_entropy)
         self.assertEqual(5, len(qresult))
         # check for alternative ID results
-        self.assertEqual(qresult["gi|16080617|ref|NP_391444.1|"],
-                         qresult["gi|221311516|ref|ZP_03593363.1|"])
+        self.assertEqual(
+            qresult["gi|16080617|ref|NP_391444.1|"],
+            qresult["gi|221311516|ref|ZP_03593363.1|"],
+        )
 
-        self.assertEqual(qresult["gi|16080617|ref|NP_391444.1|"],
-                         qresult["gi|221315843|ref|ZP_03597648.1|"])
+        self.assertEqual(
+            qresult["gi|16080617|ref|NP_391444.1|"],
+            qresult["gi|221315843|ref|ZP_03597648.1|"],
+        )
 
-        self.assertEqual(qresult["gi|16080617|ref|NP_391444.1|"],
-                         qresult["gi|221320757|ref|ZP_03602051.1|"])
+        self.assertEqual(
+            qresult["gi|16080617|ref|NP_391444.1|"],
+            qresult["gi|221320757|ref|ZP_03602051.1|"],
+        )
 
-        self.assertEqual(qresult["gi|16080617|ref|NP_391444.1|"],
-                         qresult["gi|221325043|ref|ZP_03606337.1|"])
+        self.assertEqual(
+            qresult["gi|16080617|ref|NP_391444.1|"],
+            qresult["gi|221325043|ref|ZP_03606337.1|"],
+        )
 
-        self.assertEqual(qresult["gi|16080617|ref|NP_391444.1|"],
-                         qresult["gi|321313111|ref|YP_004205398.1|"])
+        self.assertEqual(
+            qresult["gi|16080617|ref|NP_391444.1|"],
+            qresult["gi|321313111|ref|YP_004205398.1|"],
+        )
 
         hit = qresult[0]
         self.assertEqual("gi|16080617|ref|NP_391444.1|", hit.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillus "
-                         "subtilis subsp. subtilis str. 168]", hit.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillus "
+            "subtilis subsp. subtilis str. 168]",
+            hit.description,
+        )
         self.assertEqual(6, len(hit.id_all))
         self.assertEqual(6, len(hit.description_all))
         self.assertEqual(102, hit.seq_len)
@@ -1493,9 +1829,18 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(102, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(102, hsp.aln_span)
-        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.query.seq))
-        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.hit.seq))
-        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
+            hsp.aln_annotation["similarity"],
+        )
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
         # test parsed values of the third qresult
@@ -1532,9 +1877,18 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(98, hsp.aln_span)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq))
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq))
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(43.5134, hsp.bitscore)
@@ -1550,9 +1904,18 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(48, hsp.pos_num)
         self.assertEqual(6, hsp.gap_num)
         self.assertEqual(100, hsp.aln_span)
-        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNSPKGMIPLKGSTLTS--PCQDFGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq))
-        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGEDPLGAVHLRGCVVTSVESSHDVKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", str(hsp.hit.seq))
-        self.assertEqual("I++G L+K+G     WK    +L ED   + +Y       P G + L+G  +TS     D  K     + +I T  +  ++ QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNSPKGMIPLKGSTLTS--PCQDFGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGEDPLGAVHLRGCVVTSVESSHDVKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "I++G L+K+G     WK    +L ED   + +Y       P G + L+G  +TS     D  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|350596020|ref|XP_003360649.2|", hit.id)
@@ -1574,9 +1937,18 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(96, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(98, hsp.aln_span)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq))
-        self.assertEqual("KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", str(hsp.hit.seq))
-        self.assertEqual("KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -1584,7 +1956,6 @@ class BlastpXmlCases(unittest.TestCase):
 
 
 class BlastxXmlCases(unittest.TestCase):
-
     def test_xml_2212L_blastx_001(self):
         xml_file = get_file("xml_2212L_blastx_001.xml")
         qresults = parse(xml_file, FMT)
@@ -1605,7 +1976,9 @@ class BlastxXmlCases(unittest.TestCase):
 
         # test parsed values of the first qresult
         self.assertEqual("gi|1347369|gb|G25137.1|G25137", qresult.id)
-        self.assertEqual("human STS EST48004, sequence tagged site", qresult.description)
+        self.assertEqual(
+            "human STS EST48004, sequence tagged site", qresult.description
+        )
         self.assertEqual(556, qresult.seq_len)
         self.assertEqual(2934173, qresult.stat_db_num)
         self.assertEqual(1011751523, qresult.stat_db_len)
@@ -1617,7 +1990,9 @@ class BlastxXmlCases(unittest.TestCase):
         # test parsed values of the first hit
         hit = qresult[0]
         self.assertEqual("gi|12654095|gb|AAH00859.1|", hit.id)
-        self.assertEqual("Unknown (protein for IMAGE:3459481) [Homo sapiens]", hit.description)
+        self.assertEqual(
+            "Unknown (protein for IMAGE:3459481) [Homo sapiens]", hit.description
+        )
         self.assertEqual(319, hit.seq_len)
         self.assertEqual(1, len(hit))
 
@@ -1635,14 +2010,26 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(123, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(133, hsp.aln_span)
-        self.assertEqual("DLQLLIKAVNLFPAGTNSRWEVIANYMNIHSSSGVKRTAKDVIGKAKSLQKLDPHQKDDINKKAFDKFKKEHGVVPQADNATPSERFXGPYTDFTPXTTEXQKLXEQALNTYPVNTXERWXXIAVAVPGRXKE", str(hsp.query.seq))
-        self.assertEqual("DLQLLIKAVNLFPAGTNSRWEVIANYMNIHSSSGVKRTAKDVIGKAKSLQKLDPHQKDDINKKAFDKFKKEHGVVPQADNATPSERFEGPYTDFTPWTTEEQKLLEQALKTYPVNTPERWEKIAEAVPGRTKK", str(hsp.hit.seq))
-        self.assertEqual("DLQLLIKAVNLFPAGTNSRWEVIANYMNIHSSSGVKRTAKDVIGKAKSLQKLDPHQKDDINKKAFDKFKKEHGVVPQADNATPSERF GPYTDFTP TTE QKL EQAL TYPVNT ERW  IA AVPGR K+", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "DLQLLIKAVNLFPAGTNSRWEVIANYMNIHSSSGVKRTAKDVIGKAKSLQKLDPHQKDDINKKAFDKFKKEHGVVPQADNATPSERFXGPYTDFTPXTTEXQKLXEQALNTYPVNTXERWXXIAVAVPGRXKE",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "DLQLLIKAVNLFPAGTNSRWEVIANYMNIHSSSGVKRTAKDVIGKAKSLQKLDPHQKDDINKKAFDKFKKEHGVVPQADNATPSERFEGPYTDFTPWTTEEQKLLEQALKTYPVNTPERWEKIAEAVPGRTKK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "DLQLLIKAVNLFPAGTNSRWEVIANYMNIHSSSGVKRTAKDVIGKAKSLQKLDPHQKDDINKKAFDKFKKEHGVVPQADNATPSERF GPYTDFTP TTE QKL EQAL TYPVNT ERW  IA AVPGR K+",
+            hsp.aln_annotation["similarity"],
+        )
 
         # test parsed values of last hit
         hit = qresult[-1]
         self.assertEqual("gi|72081091|ref|XP_800619.1|", hit.id)
-        self.assertEqual("PREDICTED: hypothetical protein XP_795526 [Strongylocentrotus purpuratus]", hit.description)
+        self.assertEqual(
+            "PREDICTED: hypothetical protein XP_795526 [Strongylocentrotus purpuratus]",
+            hit.description,
+        )
         self.assertEqual(337, hit.seq_len)
 
         hsp = hit.hsps[0]
@@ -1658,9 +2045,18 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(21, hsp.ident_num)
         self.assertEqual(37, hsp.pos_num)
         self.assertEqual(3, hsp.gap_num)
-        self.assertEqual("AGTNSRWEVIANYMNI--HSSSGVKRT-AKDVIGKAKSLQKLDPHQKDDINKKAFDKFKKEHGVVPQ", str(hsp.query.seq))
-        self.assertEqual("SSSNSSSKASASSSNVGASSSSGTKKSDSKSSNESSKSKRDKEDHKEGSINRSKDEKVSKEHRVVKE", str(hsp.hit.seq))
-        self.assertEqual("+ +NS  +  A+  N+   SSSG K++ +K     +KS +  + H++  IN+   +K  KEH VV +", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "AGTNSRWEVIANYMNI--HSSSGVKRT-AKDVIGKAKSLQKLDPHQKDDINKKAFDKFKKEHGVVPQ",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "SSSNSSSKASASSSNVGASSSSGTKKSDSKSSNESSKSKRDKEDHKEGSINRSKDEKVSKEHRVVKE",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "+ +NS  +  A+  N+   SSSG K++ +K     +KS +  + H++  IN+   +K  KEH VV +",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -1675,7 +2071,10 @@ class BlastxXmlCases(unittest.TestCase):
         counter += 1
 
         self.assertEqual("2.2.22+", qresult.version)
-        self.assertEqual('Stephen F. Altschul, Thomas L. Madden, Alejandro A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb Miller, and David J. Lipman (1997), "Gapped BLAST and PSI-BLAST: a new generation of protein database search programs", Nucleic Acids Res. 25:3389-3402.', qresult.reference)
+        self.assertEqual(
+            'Stephen F. Altschul, Thomas L. Madden, Alejandro A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb Miller, and David J. Lipman (1997), "Gapped BLAST and PSI-BLAST: a new generation of protein database search programs", Nucleic Acids Res. 25:3389-3402.',
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(0.0001, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -1686,7 +2085,10 @@ class BlastxXmlCases(unittest.TestCase):
 
         # test parsed values of the first qresult
         self.assertEqual("1", qresult.id)
-        self.assertEqual("gi|4104054|gb|AH007193.1|SEG_CVIGS Centaurea vallesiaca 18S ribosomal RNA gene, partial sequence", qresult.description)
+        self.assertEqual(
+            "gi|4104054|gb|AH007193.1|SEG_CVIGS Centaurea vallesiaca 18S ribosomal RNA gene, partial sequence",
+            qresult.description,
+        )
         self.assertEqual(1002, qresult.seq_len)
         self.assertEqual(8994603, qresult.stat_db_num)
         self.assertEqual(-1216159329, qresult.stat_db_len)
@@ -1698,7 +2100,9 @@ class BlastxXmlCases(unittest.TestCase):
         # test parsed values of the first hit
         hit = qresult[0]
         self.assertEqual("gi|149390769|gb|ABR25402.1|", hit.id)
-        self.assertEqual("unknown [Oryza sativa (indica cultivar-group)]", hit.description)
+        self.assertEqual(
+            "unknown [Oryza sativa (indica cultivar-group)]", hit.description
+        )
         self.assertEqual(26, hit.seq_len)
         self.assertEqual(1, len(hit))
 
@@ -1731,13 +2135,15 @@ class BlastxXmlCases(unittest.TestCase):
 
         # test meta variables, only for the first one
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
-                         'Miller, and David J. Lipman (1997), "Gapped BLAST '
-                         "and PSI-BLAST: a new generation of protein "
-                         'database search programs", '
-                         "Nucleic Acids Res. 25:3389-3402.",
-                         qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
+            'Miller, and David J. Lipman (1997), "Gapped BLAST '
+            "and PSI-BLAST: a new generation of protein "
+            'database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -1762,8 +2168,10 @@ class BlastxXmlCases(unittest.TestCase):
         qresult = next(qresults)
         counter += 1
         self.assertEqual("hg19_dna", qresult.id)
-        self.assertEqual("range=chr1:1207057-1207541 5'pad=0 3'pad=0 "
-                         "strand=+ repeatMasking=none", qresult.description)
+        self.assertEqual(
+            "range=chr1:1207057-1207541 5'pad=0 3'pad=0 strand=+ repeatMasking=none",
+            qresult.description,
+        )
         self.assertEqual(485, qresult.seq_len)
         self.assertEqual(20, qresult.stat_db_num)
         self.assertEqual(6406, qresult.stat_db_len)
@@ -1775,7 +2183,10 @@ class BlastxXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|332258565|ref|XP_003278367.1|", hit.id)
-        self.assertEqual("PREDICTED: UPF0764 protein C16orf89-like [Nomascus leucogenys]", hit.description)
+        self.assertEqual(
+            "PREDICTED: UPF0764 protein C16orf89-like [Nomascus leucogenys]",
+            hit.description,
+        )
         self.assertEqual(132, hit.seq_len)
         self.assertEqual(2, len(hit))
 
@@ -1793,9 +2204,18 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(74, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(95, hsp.aln_span)
-        self.assertEqual("LRRSFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq))
-        self.assertEqual("LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLANFLFLVEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", str(hsp.hit.seq))
-        self.assertEqual("LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW+YRH+PP L NF+FLVE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "LRRSFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLANFLFLVEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW+YRH+PP L NF+FLVE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(51.6026, hsp.bitscore)
@@ -1811,13 +2231,24 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(41, hsp.pos_num)
         self.assertEqual(5, hsp.gap_num)
         self.assertEqual(72, hsp.aln_span)
-        self.assertEqual("VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPPHPANXXXXXXXXFLRRSFALVAQAGVQWLDLG", str(hsp.query.seq))
-        self.assertEqual("VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", str(hsp.hit.seq))
-        self.assertEqual("V   RVQ ++L S QPP P FK FS LSL SSW+ R  PPH AN     F F +   F  V QAG++ +  G", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPPHPANXXXXXXXXFLRRSFALVAQAGVQWLDLG",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "V   RVQ ++L S QPP P FK FS LSL SSW+ R  PPH AN     F F +   F  V QAG++ +  G",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|33188429|ref|NP_872601.1|", hit.id)
-        self.assertEqual("histone demethylase UTY isoform 1 [Homo sapiens]", hit.description)
+        self.assertEqual(
+            "histone demethylase UTY isoform 1 [Homo sapiens]", hit.description
+        )
         self.assertEqual(1079, hit.seq_len)
         self.assertEqual(6, len(hit))
 
@@ -1835,9 +2266,18 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(66, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(91, hsp.aln_span)
-        self.assertEqual("SFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQ", str(hsp.query.seq))
-        self.assertEqual("SFQESLRAGMQWCDLSSLQPPPPGFKRFSHLSLPNSWNYRHLPSCPTNFCIFVETGFHHVGQACLELLTSGGLLASASQSAGITGVSHHAR", str(hsp.hit.seq))
-        self.assertEqual("SF    +AG+QW DL   QPPPPGFK FS LS P+SW+YRH+P C  NF   VETGF+HVGQA LE   SG L A ASQS GITGVSHHA+", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "SFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQ",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "SFQESLRAGMQWCDLSSLQPPPPGFKRFSHLSLPNSWNYRHLPSCPTNFCIFVETGFHHVGQACLELLTSGGLLASASQSAGITGVSHHAR",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "SF    +AG+QW DL   QPPPPGFK FS LS P+SW+YRH+P C  NF   VETGF+HVGQA LE   SG L A ASQS GITGVSHHA+",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -1852,12 +2292,14 @@ class BlastxXmlCases(unittest.TestCase):
         counter += 1
 
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
-                         'Miller, and David J. Lipman (1997), "Gapped BLAST '
-                         "and PSI-BLAST: a new generation of protein database "
-                         'search programs", Nucleic Acids Res. 25:3389-3402.',
-                         qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
+            'Miller, and David J. Lipman (1997), "Gapped BLAST '
+            "and PSI-BLAST: a new generation of protein database "
+            'search programs", Nucleic Acids Res. 25:3389-3402.',
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -1890,12 +2332,14 @@ class BlastxXmlCases(unittest.TestCase):
         counter += 1
 
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
-                         'Miller, and David J. Lipman (1997), "Gapped BLAST '
-                         "and PSI-BLAST: a new generation of protein database "
-                         'search programs", Nucleic Acids Res. 25:3389-3402.',
-                         qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
+            'Miller, and David J. Lipman (1997), "Gapped BLAST '
+            "and PSI-BLAST: a new generation of protein database "
+            'search programs", Nucleic Acids Res. 25:3389-3402.',
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -1905,7 +2349,10 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual("db/minirefseq_prot", qresult.target)
 
         self.assertEqual("hg19_dna", qresult.id)
-        self.assertEqual("range=chr1:1207057-1207541 5'pad=0 3'pad=0 strand=+ repeatMasking=none", qresult.description)
+        self.assertEqual(
+            "range=chr1:1207057-1207541 5'pad=0 3'pad=0 strand=+ repeatMasking=none",
+            qresult.description,
+        )
         self.assertEqual(485, qresult.seq_len)
         self.assertEqual(20, qresult.stat_db_num)
         self.assertEqual(6406, qresult.stat_db_len)
@@ -1917,7 +2364,10 @@ class BlastxXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|332258565|ref|XP_003278367.1|", hit.id)
-        self.assertEqual("PREDICTED: UPF0764 protein C16orf89-like [Nomascus leucogenys]", hit.description)
+        self.assertEqual(
+            "PREDICTED: UPF0764 protein C16orf89-like [Nomascus leucogenys]",
+            hit.description,
+        )
         self.assertEqual(132, hit.seq_len)
         self.assertEqual(2, len(hit))
 
@@ -1935,9 +2385,18 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(74, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(95, hsp.aln_span)
-        self.assertEqual("LRRSFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq))
-        self.assertEqual("LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLANFLFLVEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", str(hsp.hit.seq))
-        self.assertEqual("LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW+YRH+PP L NF+FLVE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "LRRSFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLANFLFLVEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW+YRH+PP L NF+FLVE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(51.6026, hsp.bitscore)
@@ -1953,13 +2412,24 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(41, hsp.pos_num)
         self.assertEqual(5, hsp.gap_num)
         self.assertEqual(72, hsp.aln_span)
-        self.assertEqual("VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPPHPANXXXXXXXXFLRRSFALVAQAGVQWLDLG", str(hsp.query.seq))
-        self.assertEqual("VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", str(hsp.hit.seq))
-        self.assertEqual("V   RVQ ++L S QPP P FK FS LSL SSW+ R  PPH AN     F F +   F  V QAG++ +  G", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPPHPANXXXXXXXXFLRRSFALVAQAGVQWLDLG",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "V   RVQ ++L S QPP P FK FS LSL SSW+ R  PPH AN     F F +   F  V QAG++ +  G",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|33188429|ref|NP_872601.1|", hit.id)
-        self.assertEqual("histone demethylase UTY isoform 1 [Homo sapiens]", hit.description)
+        self.assertEqual(
+            "histone demethylase UTY isoform 1 [Homo sapiens]", hit.description
+        )
         self.assertEqual(1079, hit.seq_len)
         self.assertEqual(6, len(hit))
 
@@ -1977,9 +2447,18 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(66, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(91, hsp.aln_span)
-        self.assertEqual("SFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQ", str(hsp.query.seq))
-        self.assertEqual("SFQESLRAGMQWCDLSSLQPPPPGFKRFSHLSLPNSWNYRHLPSCPTNFCIFVETGFHHVGQACLELLTSGGLLASASQSAGITGVSHHAR", str(hsp.hit.seq))
-        self.assertEqual("SF    +AG+QW DL   QPPPPGFK FS LS P+SW+YRH+P C  NF   VETGF+HVGQA LE   SG L A ASQS GITGVSHHA+", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "SFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQ",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "SFQESLRAGMQWCDLSSLQPPPPGFKRFSHLSLPNSWNYRHLPSCPTNFCIFVETGFHHVGQACLELLTSGGLLASASQSAGITGVSHHAR",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "SF    +AG+QW DL   QPPPPGFK FS LS P+SW+YRH+P C  NF   VETGF+HVGQA LE   SG L A ASQS GITGVSHHA+",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -1996,12 +2475,14 @@ class BlastxXmlCases(unittest.TestCase):
 
         # test meta variables, only for the first one
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
-                         'Miller, and David J. Lipman (1997), "Gapped BLAST '
-                         "and PSI-BLAST: a new generation of protein database "
-                         'search programs", Nucleic Acids Res. 25:3389-3402.',
-                         qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, Webb "
+            'Miller, and David J. Lipman (1997), "Gapped BLAST '
+            "and PSI-BLAST: a new generation of protein database "
+            'search programs", Nucleic Acids Res. 25:3389-3402.',
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -2026,8 +2507,10 @@ class BlastxXmlCases(unittest.TestCase):
         qresult = next(qresults)
         counter += 1
         self.assertEqual("hg19_dna", qresult.id)
-        self.assertEqual("range=chr1:1207057-1207541 5'pad=0 3'pad=0 "
-                         "strand=+ repeatMasking=none", qresult.description)
+        self.assertEqual(
+            "range=chr1:1207057-1207541 5'pad=0 3'pad=0 strand=+ repeatMasking=none",
+            qresult.description,
+        )
         self.assertEqual(485, qresult.seq_len)
         self.assertEqual(12646943, qresult.stat_db_num)
         self.assertEqual(4397139428, qresult.stat_db_len)
@@ -2039,8 +2522,10 @@ class BlastxXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|332258565|ref|XP_003278367.1|", hit.id)
-        self.assertEqual("PREDICTED: UPF0764 protein C16orf89-like [Nomascus "
-                         "leucogenys]", hit.description)
+        self.assertEqual(
+            "PREDICTED: UPF0764 protein C16orf89-like [Nomascus leucogenys]",
+            hit.description,
+        )
         self.assertEqual(132, hit.seq_len)
         self.assertEqual(2, len(hit))
 
@@ -2058,9 +2543,18 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(74, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(95, hsp.aln_span)
-        self.assertEqual("LRRSFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq))
-        self.assertEqual("LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLANFLFLVEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", str(hsp.hit.seq))
-        self.assertEqual("LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW+YRH+PP L NF+FLVE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "LRRSFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLANFLFLVEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW+YRH+PP L NF+FLVE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(51.6026, hsp.bitscore)
@@ -2076,13 +2570,24 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(41, hsp.pos_num)
         self.assertEqual(5, hsp.gap_num)
         self.assertEqual(72, hsp.aln_span)
-        self.assertEqual("VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPPHPANXXXXXXXXFLRRSFALVAQAGVQWLDLG", str(hsp.query.seq))
-        self.assertEqual("VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", str(hsp.hit.seq))
-        self.assertEqual("V   RVQ ++L S QPP P FK FS LSL SSW+ R  PPH AN     F F +   F  V QAG++ +  G", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPPHPANXXXXXXXXFLRRSFALVAQAGVQWLDLG",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "V   RVQ ++L S QPP P FK FS LSL SSW+ R  PPH AN     F F +   F  V QAG++ +  G",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|332815399|ref|XP_003309509.1|", hit.id)
-        self.assertEqual("PREDICTED: histone demethylase UTY-like [Pan troglodytes]", hit.description)
+        self.assertEqual(
+            "PREDICTED: histone demethylase UTY-like [Pan troglodytes]", hit.description
+        )
         self.assertEqual(101, hit.seq_len)
         self.assertEqual(2, len(hit))
 
@@ -2100,9 +2605,18 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(62, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(91, hsp.aln_span)
-        self.assertEqual("VAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQPLCE", str(hsp.query.seq))
-        self.assertEqual("VPHAGVQWHNLSSLQPPPSRFKPFSYLSLLSSWDQRRPPPCLVTFVFLIETGFRHVGQAGLKLLTSGDPSASASQSAGIRGVSHCTWPECQ", str(hsp.hit.seq))
-        self.assertEqual("V  AGVQW +L   QPPP  FK FS LS  SSWD R  PPCL+ FVFL+ETGF HVGQAGL+   SG+  A ASQS GI GVSH   P C+", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "VAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQPLCE",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "VPHAGVQWHNLSSLQPPPSRFKPFSYLSLLSSWDQRRPPPCLVTFVFLIETGFRHVGQAGLKLLTSGDPSASASQSAGIRGVSHCTWPECQ",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "V  AGVQW +L   QPPP  FK FS LS  SSWD R  PPCL+ FVFL+ETGF HVGQAGL+   SG+  A ASQS GI GVSH   P C+",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -2110,7 +2624,6 @@ class BlastxXmlCases(unittest.TestCase):
 
 
 class TblastnXmlCases(unittest.TestCase):
-
     def test_xml_2212L_tblastn_001(self):
         xml_file = get_file("xml_2212L_tblastn_001.xml")
         qresults = parse(xml_file, FMT)
@@ -2143,7 +2656,10 @@ class TblastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|58264321|ref|XM_569317.1|", hit.id)
-        self.assertEqual("Filobasidiella neoformans glucose 1-dehydrogenase, putative (CNB05760) mRNA, complete cds", hit.description)
+        self.assertEqual(
+            "Filobasidiella neoformans glucose 1-dehydrogenase, putative (CNB05760) mRNA, complete cds",
+            hit.description,
+        )
         self.assertEqual(904, hit.seq_len)
         self.assertEqual(1, len(hit))
         self.assertRaises(IndexError, hit.__getitem__, 1)
@@ -2162,14 +2678,26 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(143, hsp.pos_num)
         self.assertEqual(9, hsp.gap_num)
         self.assertEqual(252, hsp.aln_span)
-        self.assertEqual("LKDKVVVVTGGSKGLGRAMAVRFGQEQSKVVVNYRSNXXXXXXXXXXXXXXXXGGQAIIVRGDVTKEEDVVNLVETAVKEFGSLDVMINNAGVENPVPSH---ELSLENWNQVIDTNLTGAFLGSREAIKYFVENDIKG-NVINMSSVHEMIPWPLFVHYAASKGGMKLMTETLALEYAPKGIRVNNIGPGAIDTPINAEKFADPEQRADVESMIPMGYIGKPEEIASVAAFLASSQASYVTGITLFADGGM", str(hsp.query.seq))
-        self.assertEqual("LQGKVVAITGCSTGIGRAIAIGAAKNGANVVLHHLGDSTASDIAQVQEECKQAGAKTVVVPGDIAEAKTANEIVSAAVSSFSRIDVLISNAGI---CPFHSFLDLPHPLWKRVQDVNLNGSFYVVQAVANQMAKQEPKGGSIVAVSSISALMGGGEQCHYTPTKAGIKSLMESCAIALGPMGIRCNSVLPGTIETNINKEDLSNPEKRADQIRRVPLGRLGKPEDLVGPTLFFASDLSNYCTGASVLVDGGM", str(hsp.hit.seq))
-        self.assertEqual("L+ KVV +TG S G+GRA+A+   +  + VV+++  +   +   + + E  +AG + ++V GD+ + +    +V  AV  F  +DV+I+NAG+    P H   +L    W +V D NL G+F   +       + + KG +++ +SS+  ++      HY  +K G+K + E+ A+   P GIR N++ PG I+T IN E  ++PE+RAD    +P+G +GKPE++     F AS  ++Y TG ++  DGGM", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "LKDKVVVVTGGSKGLGRAMAVRFGQEQSKVVVNYRSNXXXXXXXXXXXXXXXXGGQAIIVRGDVTKEEDVVNLVETAVKEFGSLDVMINNAGVENPVPSH---ELSLENWNQVIDTNLTGAFLGSREAIKYFVENDIKG-NVINMSSVHEMIPWPLFVHYAASKGGMKLMTETLALEYAPKGIRVNNIGPGAIDTPINAEKFADPEQRADVESMIPMGYIGKPEEIASVAAFLASSQASYVTGITLFADGGM",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "LQGKVVAITGCSTGIGRAIAIGAAKNGANVVLHHLGDSTASDIAQVQEECKQAGAKTVVVPGDIAEAKTANEIVSAAVSSFSRIDVLISNAGI---CPFHSFLDLPHPLWKRVQDVNLNGSFYVVQAVANQMAKQEPKGGSIVAVSSISALMGGGEQCHYTPTKAGIKSLMESCAIALGPMGIRCNSVLPGTIETNINKEDLSNPEKRADQIRRVPLGRLGKPEDLVGPTLFFASDLSNYCTGASVLVDGGM",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "L+ KVV +TG S G+GRA+A+   +  + VV+++  +   +   + + E  +AG + ++V GD+ + +    +V  AV  F  +DV+I+NAG+    P H   +L    W +V D NL G+F   +       + + KG +++ +SS+  ++      HY  +K G+K + E+ A+   P GIR N++ PG I+T IN E  ++PE+RAD    +P+G +GKPE++     F AS  ++Y TG ++  DGGM",
+            hsp.aln_annotation["similarity"],
+        )
 
         # parse last hit
         hit = qresult[-1]
         self.assertEqual("gi|450259|gb|L27825.1|EMEVERA1AA", hit.id)
-        self.assertEqual("Emericella nidulans (verA) gene, complete cds, ORF 1 gene, complete cds, and ORF 2 gene, 5' end", hit.description)
+        self.assertEqual(
+            "Emericella nidulans (verA) gene, complete cds, ORF 1 gene, complete cds, and ORF 2 gene, 5' end",
+            hit.description,
+        )
         self.assertEqual(4310, hit.seq_len)
         self.assertEqual(2, len(hit))
 
@@ -2187,9 +2715,18 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(113, hsp.pos_num)
         self.assertEqual(31, hsp.gap_num)
         self.assertEqual(228, hsp.aln_span)
-        self.assertEqual("LKDKVVVVTGGSKGLGRAMAVRFGQEQSKVVVNYRSNXXXXXXXXXXXXXXGGQAIIVRGDVTKEEDVVNLVETAVKEFGSLDVMINNAGV-----------ENPVPS-HELSLE-----NWNQVIDTNLTGAFLGSREAIKYFVENDIKGNVINMSSVHEMIPW-PLFVHYAASKGGMKLMTETLALEYAPKGIRVNNIGPGAIDTPI----------NAEKFADPE", str(hsp.query.seq))
-        self.assertEqual("LDGKVALVTGAGRGIGAAIAVALGQPGAKVVVNYANSREAAEKVVDEIKSNAQSAISIQADVGDPDAVTKLMDQAVEHFGYLDIVSSNAGIVSFGHVKDVTPDVCVPSPYESPVEL*PQQEFDRVFRVNTRGQFFVAREAYRHLREG---GRIILTSSNTASVKGVPRHAVYSGSKGAIDTFVRCLAIDCGDKKITVNAVAPGAIKTDMFLSVSREYIPNGETFTDEQ", str(hsp.hit.seq))
-        self.assertEqual("L  KV +VTG  +G+G A+AV  GQ  +KVVVNY ++ E A +V  EI+     AI ++ DV   + V  L++ AV+ FG LD++ +NAG+           +  VPS +E  +E      +++V   N  G F  +REA ++  E    G +I  SS    +   P    Y+ SKG +      LA++   K I VN + PGAI T +          N E F D +", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "LKDKVVVVTGGSKGLGRAMAVRFGQEQSKVVVNYRSNXXXXXXXXXXXXXXGGQAIIVRGDVTKEEDVVNLVETAVKEFGSLDVMINNAGV-----------ENPVPS-HELSLE-----NWNQVIDTNLTGAFLGSREAIKYFVENDIKGNVINMSSVHEMIPW-PLFVHYAASKGGMKLMTETLALEYAPKGIRVNNIGPGAIDTPI----------NAEKFADPE",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "LDGKVALVTGAGRGIGAAIAVALGQPGAKVVVNYANSREAAEKVVDEIKSNAQSAISIQADVGDPDAVTKLMDQAVEHFGYLDIVSSNAGIVSFGHVKDVTPDVCVPSPYESPVEL*PQQEFDRVFRVNTRGQFFVAREAYRHLREG---GRIILTSSNTASVKGVPRHAVYSGSKGAIDTFVRCLAIDCGDKKITVNAVAPGAIKTDMFLSVSREYIPNGETFTDEQ",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "L  KV +VTG  +G+G A+AV  GQ  +KVVVNY ++ E A +V  EI+     AI ++ DV   + V  L++ AV+ FG LD++ +NAG+           +  VPS +E  +E      +++V   N  G F  +REA ++  E    G +I  SS    +   P    Y+ SKG +      LA++   K I VN + PGAI T +          N E F D +",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -2206,12 +2743,15 @@ class TblastnXmlCases(unittest.TestCase):
 
         # test meta variables, only for the first one
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
-                         "Webb Miller, and David J. Lipman (1997), "
-                         '"Gapped BLAST and PSI-BLAST: a new generation of '
-                         'protein database search programs", '
-                         "Nucleic Acids Res. 25:3389-3402.", qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
+            "Webb Miller, and David J. Lipman (1997), "
+            '"Gapped BLAST and PSI-BLAST: a new generation of '
+            'protein database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -2236,8 +2776,11 @@ class TblastnXmlCases(unittest.TestCase):
         qresult = next(qresults)
         counter += 1
         self.assertEqual("gi|16080617|ref|NP_391444.1|", qresult.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillus subtilis "
-                         "subsp. subtilis str. 168]", qresult.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillus subtilis "
+            "subsp. subtilis str. 168]",
+            qresult.description,
+        )
         self.assertEqual(102, qresult.seq_len)
         self.assertEqual(23, qresult.stat_db_num)
         self.assertEqual(67750, qresult.stat_db_len)
@@ -2249,7 +2792,10 @@ class TblastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|145479850|ref|XM_001425911.1|", hit.id)
-        self.assertEqual("Paramecium tetraurelia hypothetical protein (GSPATT00004923001) partial mRNA", hit.description)
+        self.assertEqual(
+            "Paramecium tetraurelia hypothetical protein (GSPATT00004923001) partial mRNA",
+            hit.description,
+        )
         self.assertEqual(4632, hit.seq_len)
         self.assertEqual(1, len(hit))
 
@@ -2267,9 +2813,16 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(26, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(43, hsp.aln_span)
-        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq))
-        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq))
-        self.assertEqual("P +   TK+GT +GL   HTI   + +  +SL++ E++  D+D", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)
+        )
+        self.assertEqual(
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)
+        )
+        self.assertEqual(
+            "P +   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
+            hsp.aln_annotation["similarity"],
+        )
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
         # test parsed values of the third qresult
@@ -2288,7 +2841,10 @@ class TblastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|350596019|ref|XM_003360601.2|", hit.id)
-        self.assertEqual("PREDICTED: Sus scrofa pleckstrin-like (LOC100626968), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Sus scrofa pleckstrin-like (LOC100626968), mRNA",
+            hit.description,
+        )
         self.assertEqual(772, hit.seq_len)
         self.assertEqual(2, len(hit))
 
@@ -2306,9 +2862,18 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(96, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(98, hsp.aln_span)
-        self.assertEqual("KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", str(hsp.hit.seq))
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq))
-        self.assertEqual("KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(32.7278, hsp.bitscore)
@@ -2324,13 +2889,25 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(33, hsp.pos_num)
         self.assertEqual(4, hsp.gap_num)
         self.assertEqual(71, hsp.aln_span)
-        self.assertEqual("IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq))
-        self.assertEqual("LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", str(hsp.hit.seq))
-        self.assertEqual("+ +Y       P G I L+G  +TS      GK  F+ +     T  +  +F QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "+ +Y       P G I L+G  +TS      GK  F+ +     T  +  +F QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|365982352|ref|XM_003667962.1|", hit.id)
-        self.assertEqual("Naumovozyma dairenensis CBS 421 hypothetical protein (NDAI0A06120), mRNA", hit.description)
+        self.assertEqual(
+            "Naumovozyma dairenensis CBS 421 hypothetical protein (NDAI0A06120), mRNA",
+            hit.description,
+        )
         self.assertEqual(4932, hit.seq_len)
         self.assertEqual(1, len(hit))
 
@@ -2348,9 +2925,16 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(23, hsp.pos_num)
         self.assertEqual(9, hsp.gap_num)
         self.assertEqual(52, hsp.aln_span)
-        self.assertEqual("GSVFNTWKPMWVVLL---------EDGIEFYKKKSDNSPKGMIPLKGSTLTS", str(hsp.query.seq))
-        self.assertEqual("GSCFPTWDLIFIEVLNPFLKEKLWEADNEEISKFVDLTLKGLVDLYPSHFTS", str(hsp.hit.seq))
-        self.assertEqual("GS F TW  +++ +L         E   E   K  D + KG++ L  S  TS", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "GSVFNTWKPMWVVLL---------EDGIEFYKKKSDNSPKGMIPLKGSTLTS", str(hsp.query.seq)
+        )
+        self.assertEqual(
+            "GSCFPTWDLIFIEVLNPFLKEKLWEADNEEISKFVDLTLKGLVDLYPSHFTS", str(hsp.hit.seq)
+        )
+        self.assertEqual(
+            "GS F TW  +++ +L         E   E   K  D + KG++ L  S  TS",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -2365,12 +2949,15 @@ class TblastnXmlCases(unittest.TestCase):
         counter += 1
 
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
-                         "Webb Miller, and David J. Lipman (1997), "
-                         '"Gapped BLAST and PSI-BLAST: a new generation of '
-                         'protein database search programs", '
-                         "Nucleic Acids Res. 25:3389-3402.", qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
+            "Webb Miller, and David J. Lipman (1997), "
+            '"Gapped BLAST and PSI-BLAST: a new generation of '
+            'protein database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -2402,12 +2989,15 @@ class TblastnXmlCases(unittest.TestCase):
         counter += 1
 
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
-                         "Webb Miller, and David J. Lipman (1997), "
-                         '"Gapped BLAST and PSI-BLAST: a new generation of '
-                         'protein database search programs", '
-                         "Nucleic Acids Res. 25:3389-3402.", qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
+            "Webb Miller, and David J. Lipman (1997), "
+            '"Gapped BLAST and PSI-BLAST: a new generation of '
+            'protein database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -2417,7 +3007,10 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual("db/minirefseq_mrna", qresult.target)
 
         self.assertEqual("gi|16080617|ref|NP_391444.1|", qresult.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168]", qresult.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168]",
+            qresult.description,
+        )
         self.assertEqual(102, qresult.seq_len)
         self.assertEqual(23, qresult.stat_db_num)
         self.assertEqual(67750, qresult.stat_db_len)
@@ -2429,7 +3022,10 @@ class TblastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|145479850|ref|XM_001425911.1|", hit.id)
-        self.assertEqual("Paramecium tetraurelia hypothetical protein (GSPATT00004923001) partial mRNA", hit.description)
+        self.assertEqual(
+            "Paramecium tetraurelia hypothetical protein (GSPATT00004923001) partial mRNA",
+            hit.description,
+        )
         self.assertEqual(4632, hit.seq_len)
         self.assertEqual(1, len(hit))
 
@@ -2447,9 +3043,16 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(26, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(43, hsp.aln_span)
-        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq))
-        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq))
-        self.assertEqual("P +   TK+GT +GL   HTI   + +  +SL++ E++  D+D", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)
+        )
+        self.assertEqual(
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)
+        )
+        self.assertEqual(
+            "P +   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
+            hsp.aln_annotation["similarity"],
+        )
 
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
@@ -2465,12 +3068,15 @@ class TblastnXmlCases(unittest.TestCase):
         counter += 1
 
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
-                         "Webb Miller, and David J. Lipman (1997), "
-                         '"Gapped BLAST and PSI-BLAST: a new generation of '
-                         'protein database search programs", '
-                         "Nucleic Acids Res. 25:3389-3402.", qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
+            "Webb Miller, and David J. Lipman (1997), "
+            '"Gapped BLAST and PSI-BLAST: a new generation of '
+            'protein database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -2492,7 +3098,10 @@ class TblastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|350596019|ref|XM_003360601.2|", hit.id)
-        self.assertEqual("PREDICTED: Sus scrofa pleckstrin-like (LOC100626968), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Sus scrofa pleckstrin-like (LOC100626968), mRNA",
+            hit.description,
+        )
         self.assertEqual(772, hit.seq_len)
         self.assertEqual(2, len(hit))
 
@@ -2510,9 +3119,18 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(96, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(98, hsp.aln_span)
-        self.assertEqual("KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", str(hsp.hit.seq))
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq))
-        self.assertEqual("KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(32.7278, hsp.bitscore)
@@ -2528,13 +3146,25 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(33, hsp.pos_num)
         self.assertEqual(4, hsp.gap_num)
         self.assertEqual(71, hsp.aln_span)
-        self.assertEqual("IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq))
-        self.assertEqual("LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", str(hsp.hit.seq))
-        self.assertEqual("+ +Y       P G I L+G  +TS      GK  F+ +     T  +  +F QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "+ +Y       P G I L+G  +TS      GK  F+ +     T  +  +F QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|365982352|ref|XM_003667962.1|", hit.id)
-        self.assertEqual("Naumovozyma dairenensis CBS 421 hypothetical protein (NDAI0A06120), mRNA", hit.description)
+        self.assertEqual(
+            "Naumovozyma dairenensis CBS 421 hypothetical protein (NDAI0A06120), mRNA",
+            hit.description,
+        )
         self.assertEqual(4932, hit.seq_len)
         self.assertEqual(1, len(hit))
 
@@ -2552,9 +3182,16 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(23, hsp.pos_num)
         self.assertEqual(9, hsp.gap_num)
         self.assertEqual(52, hsp.aln_span)
-        self.assertEqual("GSVFNTWKPMWVVLL---------EDGIEFYKKKSDNSPKGMIPLKGSTLTS", str(hsp.query.seq))
-        self.assertEqual("GSCFPTWDLIFIEVLNPFLKEKLWEADNEEISKFVDLTLKGLVDLYPSHFTS", str(hsp.hit.seq))
-        self.assertEqual("GS F TW  +++ +L         E   E   K  D + KG++ L  S  TS", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "GSVFNTWKPMWVVLL---------EDGIEFYKKKSDNSPKGMIPLKGSTLTS", str(hsp.query.seq)
+        )
+        self.assertEqual(
+            "GSCFPTWDLIFIEVLNPFLKEKLWEADNEEISKFVDLTLKGLVDLYPSHFTS", str(hsp.hit.seq)
+        )
+        self.assertEqual(
+            "GS F TW  +++ +L         E   E   K  D + KG++ L  S  TS",
+            hsp.aln_annotation["similarity"],
+        )
 
         self.assertRaises(StopIteration, next, qresults)
         self.assertEqual(1, counter)
@@ -2570,12 +3207,15 @@ class TblastnXmlCases(unittest.TestCase):
 
         # test meta variables, only for the first one
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
-                         "Webb Miller, and David J. Lipman (1997), "
-                         '"Gapped BLAST and PSI-BLAST: a new generation of '
-                         'protein database search programs", '
-                         "Nucleic Acids Res. 25:3389-3402.", qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
+            "Webb Miller, and David J. Lipman (1997), "
+            '"Gapped BLAST and PSI-BLAST: a new generation of '
+            'protein database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -2600,7 +3240,10 @@ class TblastnXmlCases(unittest.TestCase):
         qresult = next(qresults)
         counter += 1
         self.assertEqual("gi|16080617|ref|NP_391444.1|", qresult.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168]", qresult.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168]",
+            qresult.description,
+        )
         self.assertEqual(102, qresult.seq_len)
         self.assertEqual(2933984, qresult.stat_db_num)
         self.assertEqual(4726730735, qresult.stat_db_len)
@@ -2612,7 +3255,10 @@ class TblastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|145479850|ref|XM_001425911.1|", hit.id)
-        self.assertEqual("Paramecium tetraurelia hypothetical protein (GSPATT00004923001) partial mRNA", hit.description)
+        self.assertEqual(
+            "Paramecium tetraurelia hypothetical protein (GSPATT00004923001) partial mRNA",
+            hit.description,
+        )
         self.assertEqual(4632, hit.seq_len)
         self.assertEqual(1, len(hit))
 
@@ -2630,9 +3276,16 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(26, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(43, hsp.aln_span)
-        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq))
-        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq))
-        self.assertEqual("P +   TK+GT +GL   HTI   + +  +SL++ E++  D+D", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)
+        )
+        self.assertEqual(
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)
+        )
+        self.assertEqual(
+            "P +   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
+            hsp.aln_annotation["similarity"],
+        )
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
         # test parsed values of the third qresult
@@ -2651,7 +3304,10 @@ class TblastnXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|354480463|ref|XM_003502378.1|", hit.id)
-        self.assertEqual("PREDICTED: Cricetulus griseus pleckstrin-like (LOC100773128), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Cricetulus griseus pleckstrin-like (LOC100773128), mRNA",
+            hit.description,
+        )
         self.assertEqual(1119, hit.seq_len)
         self.assertEqual(2, len(hit))
 
@@ -2669,9 +3325,18 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(98, hsp.aln_span)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq))
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq))
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(43.8986, hsp.bitscore)
@@ -2687,13 +3352,24 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(50, hsp.pos_num)
         self.assertEqual(6, hsp.gap_num)
         self.assertEqual(100, hsp.aln_span)
-        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNSPKGMIPLKGSTLTSPCQDF-GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq))
-        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGEDPLGAIHLRGCVVTSVESNHDGKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", str(hsp.hit.seq))
-        self.assertEqual("I++G L+K+G     WK    +L ED   + +Y       P G I L+G  +TS   +  GK+     + +I T  +  ++ QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNSPKGMIPLKGSTLTSPCQDF-GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGEDPLGAIHLRGCVVTSVESNHDGKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "I++G L+K+G     WK    +L ED   + +Y       P G I L+G  +TS   +  GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|390474391|ref|XM_002757683.2|", hit.id)
-        self.assertEqual("PREDICTED: Callithrix jacchus pleckstrin (PLEK), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Callithrix jacchus pleckstrin (PLEK), mRNA", hit.description
+        )
         self.assertEqual(1402, hit.seq_len)
         self.assertEqual(2, len(hit))
 
@@ -2711,9 +3387,18 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(97, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(98, hsp.aln_span)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq))
-        self.assertEqual("KRIREGYLVKKGSMFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq))
-        self.assertEqual("KRIREGYLVKKGS+FNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSMFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGS+FNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -2721,7 +3406,6 @@ class TblastnXmlCases(unittest.TestCase):
 
 
 class TblastxXmlCases(unittest.TestCase):
-
     def test_xml_2212L_tblastx_001(self):
         xml_file = get_file("xml_2212L_tblastx_001.xml")
         qresults = parse(xml_file, FMT)
@@ -2744,7 +3428,9 @@ class TblastxXmlCases(unittest.TestCase):
 
         # test parsed values of the first qresult
         self.assertEqual("gi|1348853|gb|G26621.1|G26621", qresult.id)
-        self.assertEqual("human STS STS_D12006, sequence tagged site", qresult.description)
+        self.assertEqual(
+            "human STS STS_D12006, sequence tagged site", qresult.description
+        )
         self.assertEqual(615, qresult.seq_len)
         self.assertEqual(3533718, qresult.stat_db_num)
         # why is the value negative? is this a blast bug?
@@ -2757,7 +3443,10 @@ class TblastxXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|18072170|gb|AC010333.7|", hit.id)
-        self.assertEqual("Homo sapiens chromosome 16 clone CTD-3037G24, complete sequence", hit.description)
+        self.assertEqual(
+            "Homo sapiens chromosome 16 clone CTD-3037G24, complete sequence",
+            hit.description,
+        )
         self.assertEqual(159870, hit.seq_len)
         self.assertEqual(13, len(hit))
 
@@ -2775,13 +3464,25 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(117, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(118, hsp.aln_span)
-        self.assertEqual("ECXFIMLYIFPARIWST*VICPPEQWL*RRKLSSGQKLLRRCGKTGYIKNNAGLK*PMRFCQGILH*CI*SKSGPIQRMWLKAPFWPFLFLLRALHTFPLFLSKWTK*RVS*VEGHSD", str(hsp.query.seq))
-        self.assertEqual("ECCFIMLYIFPARIWST*VICPPEQWL*RRKLSSGQKLLRRCGKTGYIKNNAGLK*PMRFCQGILH*CI*SKSGPIQRMWLKAPFWPFLFLLRALHTFPLFLSKWTK*RVS*VEGHSD", str(hsp.hit.seq))
-        self.assertEqual("EC FIMLYIFPARIWST*VICPPEQWL*RRKLSSGQKLLRRCGKTGYIKNNAGLK*PMRFCQGILH*CI*SKSGPIQRMWLKAPFWPFLFLLRALHTFPLFLSKWTK*RVS*VEGHSD", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "ECXFIMLYIFPARIWST*VICPPEQWL*RRKLSSGQKLLRRCGKTGYIKNNAGLK*PMRFCQGILH*CI*SKSGPIQRMWLKAPFWPFLFLLRALHTFPLFLSKWTK*RVS*VEGHSD",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "ECCFIMLYIFPARIWST*VICPPEQWL*RRKLSSGQKLLRRCGKTGYIKNNAGLK*PMRFCQGILH*CI*SKSGPIQRMWLKAPFWPFLFLLRALHTFPLFLSKWTK*RVS*VEGHSD",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "EC FIMLYIFPARIWST*VICPPEQWL*RRKLSSGQKLLRRCGKTGYIKNNAGLK*PMRFCQGILH*CI*SKSGPIQRMWLKAPFWPFLFLLRALHTFPLFLSKWTK*RVS*VEGHSD",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|4309961|gb|AC005993.2|AC005993", hit.id)
-        self.assertEqual("Homo sapiens PAC clone RP6-114E22 from 14, complete sequence", hit.description)
+        self.assertEqual(
+            "Homo sapiens PAC clone RP6-114E22 from 14, complete sequence",
+            hit.description,
+        )
         self.assertEqual(143943, hit.seq_len)
         self.assertEqual(1, len(hit))
 
@@ -2801,7 +3502,9 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(28, hsp.aln_span)
         self.assertEqual("PLTKAHRLFQTSIVFYVTCFTASSQQLL", str(hsp.query.seq))
         self.assertEqual("PLNKYHTIFQISLCFYLFCYNMAQKQLL", str(hsp.hit.seq))
-        self.assertEqual("PL K H +FQ S+ FY+ C+  + +QLL", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "PL K H +FQ S+ FY+ C+  + +QLL", hsp.aln_annotation["similarity"]
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -2818,12 +3521,15 @@ class TblastxXmlCases(unittest.TestCase):
 
         # test meta variables, only for the first one
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
-                         "Webb Miller, and David J. Lipman (1997), "
-                         '"Gapped BLAST and PSI-BLAST: a new generation of '
-                         'protein database search programs", '
-                         "Nucleic Acids Res. 25:3389-3402.", qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
+            "Webb Miller, and David J. Lipman (1997), "
+            '"Gapped BLAST and PSI-BLAST: a new generation of '
+            'protein database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -2848,7 +3554,10 @@ class TblastxXmlCases(unittest.TestCase):
         qresult = next(qresults)
         counter += 1
         self.assertEqual("gi|296147483:1-350", qresult.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA, complete cds", qresult.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA, complete cds",
+            qresult.description,
+        )
         self.assertEqual(350, qresult.seq_len)
         self.assertEqual(23, qresult.stat_db_num)
         self.assertEqual(67750, qresult.stat_db_len)
@@ -2860,7 +3569,10 @@ class TblastxXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|296147483|ref|NM_001183135.1|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA, complete cds", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA, complete cds",
+            hit.description,
+        )
         self.assertEqual(4911, hit.seq_len)
         self.assertEqual(8, len(hit))
 
@@ -2878,9 +3590,18 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(116, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(116, hsp.aln_span)
-        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", str(hsp.hit.seq))
-        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", str(hsp.query.seq))
-        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(18.9375, hsp.bitscore)
@@ -2902,7 +3623,10 @@ class TblastxXmlCases(unittest.TestCase):
 
         hit = qresult[-1]
         self.assertEqual("gi|254579534|ref|XM_002495708.1|", hit.id)
-        self.assertEqual("Zygosaccharomyces rouxii hypothetical protein (ZYRO0C02266g) mRNA, complete cds", hit.description)
+        self.assertEqual(
+            "Zygosaccharomyces rouxii hypothetical protein (ZYRO0C02266g) mRNA, complete cds",
+            hit.description,
+        )
         self.assertEqual(4866, hit.seq_len)
         self.assertEqual(6, len(hit))
 
@@ -2920,9 +3644,18 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(72, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(84, hsp.aln_span)
-        self.assertEqual("IRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK", str(hsp.query.seq))
-        self.assertEqual("IRNASDKSIEILKVVHSYEELSRHPDFIVPLVMSCASKNAKLTTISMQCFQKLATVPCIPVDKLSDVLDAFIEANQLAMDIKLK", str(hsp.hit.seq))
-        self.assertEqual("IR+ASDKSIEILK VHS+EEL RHPDF +P V++C S+NAK+TT++MQC Q L+TVP IP  +LS++LDAFIEA  LAM+I+LK", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "IRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "IRNASDKSIEILKVVHSYEELSRHPDFIVPLVMSCASKNAKLTTISMQCFQKLATVPCIPVDKLSDVLDAFIEANQLAMDIKLK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "IR+ASDKSIEILK VHS+EEL RHPDF +P V++C S+NAK+TT++MQC Q L+TVP IP  +LS++LDAFIEA  LAM+I+LK",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -2937,12 +3670,15 @@ class TblastxXmlCases(unittest.TestCase):
         counter += 1
 
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
-                         "Webb Miller, and David J. Lipman (1997), "
-                         '"Gapped BLAST and PSI-BLAST: a new generation of '
-                         'protein database search programs", '
-                         "Nucleic Acids Res. 25:3389-3402.", qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
+            "Webb Miller, and David J. Lipman (1997), "
+            '"Gapped BLAST and PSI-BLAST: a new generation of '
+            'protein database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -2974,12 +3710,15 @@ class TblastxXmlCases(unittest.TestCase):
         counter += 1
 
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
-                         "Webb Miller, and David J. Lipman (1997), "
-                         '"Gapped BLAST and PSI-BLAST: a new generation of '
-                         'protein database search programs", '
-                         "Nucleic Acids Res. 25:3389-3402.", qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
+            "Webb Miller, and David J. Lipman (1997), "
+            '"Gapped BLAST and PSI-BLAST: a new generation of '
+            'protein database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -2989,7 +3728,10 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual("db/minirefseq_mrna", qresult.target)
 
         self.assertEqual("gi|296147483:1-350", qresult.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA, complete cds", qresult.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA, complete cds",
+            qresult.description,
+        )
         self.assertEqual(350, qresult.seq_len)
         self.assertEqual(23, qresult.stat_db_num)
         self.assertEqual(67750, qresult.stat_db_len)
@@ -3001,7 +3743,10 @@ class TblastxXmlCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("gi|296147483|ref|NM_001183135.1|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA, complete cds", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA, complete cds",
+            hit.description,
+        )
         self.assertEqual(4911, hit.seq_len)
         self.assertEqual(8, len(hit))
 
@@ -3019,9 +3764,18 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(116, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(116, hsp.aln_span)
-        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", str(hsp.hit.seq))
-        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", str(hsp.query.seq))
-        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(18.9375, hsp.bitscore)
@@ -3043,7 +3797,10 @@ class TblastxXmlCases(unittest.TestCase):
 
         hit = qresult[-1]
         self.assertEqual("gi|254579534|ref|XM_002495708.1|", hit.id)
-        self.assertEqual("Zygosaccharomyces rouxii hypothetical protein (ZYRO0C02266g) mRNA, complete cds", hit.description)
+        self.assertEqual(
+            "Zygosaccharomyces rouxii hypothetical protein (ZYRO0C02266g) mRNA, complete cds",
+            hit.description,
+        )
         self.assertEqual(4866, hit.seq_len)
         self.assertEqual(6, len(hit))
 
@@ -3061,9 +3818,18 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(72, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(84, hsp.aln_span)
-        self.assertEqual("IRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK", str(hsp.query.seq))
-        self.assertEqual("IRNASDKSIEILKVVHSYEELSRHPDFIVPLVMSCASKNAKLTTISMQCFQKLATVPCIPVDKLSDVLDAFIEANQLAMDIKLK", str(hsp.hit.seq))
-        self.assertEqual("IR+ASDKSIEILK VHS+EEL RHPDF +P V++C S+NAK+TT++MQC Q L+TVP IP  +LS++LDAFIEA  LAM+I+LK", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "IRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "IRNASDKSIEILKVVHSYEELSRHPDFIVPLVMSCASKNAKLTTISMQCFQKLATVPCIPVDKLSDVLDAFIEANQLAMDIKLK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "IR+ASDKSIEILK VHS+EEL RHPDF +P V++C S+NAK+TT++MQC Q L+TVP IP  +LS++LDAFIEA  LAM+I+LK",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -3080,12 +3846,15 @@ class TblastxXmlCases(unittest.TestCase):
 
         # test meta variables, only for the first one
         self.assertEqual("2.2.26+", qresult.version)
-        self.assertEqual("Stephen F. Altschul, Thomas L. Madden, Alejandro "
-                         "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
-                         "Webb Miller, and David J. Lipman (1997), "
-                         '"Gapped BLAST and PSI-BLAST: a new generation of '
-                         'protein database search programs", '
-                         "Nucleic Acids Res. 25:3389-3402.", qresult.reference)
+        self.assertEqual(
+            "Stephen F. Altschul, Thomas L. Madden, Alejandro "
+            "A. Sch&auml;ffer, Jinghui Zhang, Zheng Zhang, "
+            "Webb Miller, and David J. Lipman (1997), "
+            '"Gapped BLAST and PSI-BLAST: a new generation of '
+            'protein database search programs", '
+            "Nucleic Acids Res. 25:3389-3402.",
+            qresult.reference,
+        )
         self.assertEqual("BLOSUM62", qresult.param_matrix)
         self.assertEqual(10.0, qresult.param_evalue_threshold)
         self.assertEqual("L;", qresult.param_filter)
@@ -3110,7 +3879,10 @@ class TblastxXmlCases(unittest.TestCase):
         qresult = next(qresults)
         counter += 1
         self.assertEqual("gi|296147483:1-350", qresult.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA, complete cds", qresult.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA, complete cds",
+            qresult.description,
+        )
         self.assertEqual(350, qresult.seq_len)
         self.assertEqual(2933984, qresult.stat_db_num)
         self.assertEqual(4726730735, qresult.stat_db_len)
@@ -3120,17 +3892,23 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(0, qresult.stat_entropy)
         self.assertEqual(5, len(qresult))
         # check for alternative ID results
-        self.assertEqual(qresult["gi|296147483|ref|NM_001183135.1|"],
-                         qresult["gi|116616412|gb|EF059095.1|"])
+        self.assertEqual(
+            qresult["gi|296147483|ref|NM_001183135.1|"],
+            qresult["gi|116616412|gb|EF059095.1|"],
+        )
 
         hit = qresult[0]
         self.assertEqual("gi|296147483|ref|NM_001183135.1|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Mon2p (MON2) "
-                         "mRNA, complete cds", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA, complete cds",
+            hit.description,
+        )
         self.assertEqual("gi|116616412|gb|EF059095.1|", hit.id_all[1])
-        self.assertEqual("Synthetic construct Saccharomyces cerevisiae "
-                         "clone FLH203015.01X MON2, complete sequence",
-                         hit.description_all[1])
+        self.assertEqual(
+            "Synthetic construct Saccharomyces cerevisiae "
+            "clone FLH203015.01X MON2, complete sequence",
+            hit.description_all[1],
+        )
         self.assertEqual(4911, hit.seq_len)
         self.assertEqual(7, len(hit))
 
@@ -3148,9 +3926,18 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(116, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(116, hsp.aln_span)
-        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", str(hsp.hit.seq))
-        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", str(hsp.query.seq))
-        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(36.3494, hsp.bitscore)
@@ -3172,8 +3959,11 @@ class TblastxXmlCases(unittest.TestCase):
 
         hit = qresult[-1]
         self.assertEqual("gi|254579534|ref|XM_002495708.1|", hit.id)
-        self.assertEqual("Zygosaccharomyces rouxii hypothetical protein "
-                         "(ZYRO0C02266g) mRNA, complete cds", hit.description)
+        self.assertEqual(
+            "Zygosaccharomyces rouxii hypothetical protein "
+            "(ZYRO0C02266g) mRNA, complete cds",
+            hit.description,
+        )
         self.assertEqual(4866, hit.seq_len)
         self.assertEqual(4, len(hit))
 
@@ -3191,9 +3981,18 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(72, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(84, hsp.aln_span)
-        self.assertEqual("IRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK", str(hsp.query.seq))
-        self.assertEqual("IRNASDKSIEILKVVHSYEELSRHPDFIVPLVMSCASKNAKLTTISMQCFQKLATVPCIPVDKLSDVLDAFIEANQLAMDIKLK", str(hsp.hit.seq))
-        self.assertEqual("IR+ASDKSIEILK VHS+EEL RHPDF +P V++C S+NAK+TT++MQC Q L+TVP IP  +LS++LDAFIEA  LAM+I+LK", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "IRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "IRNASDKSIEILKVVHSYEELSRHPDFIVPLVMSCASKNAKLTTISMQCFQKLATVPCIPVDKLSDVLDAFIEANQLAMDIKLK",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "IR+ASDKSIEILK VHS+EEL RHPDF +P V++C S+NAK+TT++MQC Q L+TVP IP  +LS++LDAFIEA  LAM+I+LK",
+            hsp.aln_annotation["similarity"],
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)
@@ -3201,7 +4000,6 @@ class TblastxXmlCases(unittest.TestCase):
 
 
 class BlastXmlSpecialCases(unittest.TestCase):
-
     def test_xml_2226_blastn_006(self):
         xml_file = get_file("xml_2226_blastn_006.xml")
         qresults = parse(xml_file, FMT)
@@ -3210,18 +4008,27 @@ class BlastXmlSpecialCases(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", BiopythonParserWarning)
             qresult = next(qresults)
-            self.assertEqual(exp_warning, len(w), "Expected {0} warning(s), got"
-                             " {1}".format(exp_warning, len(w)))
+            self.assertEqual(
+                exp_warning,
+                len(w),
+                "Expected {0} warning(s), got {1}".format(exp_warning, len(w)),
+            )
 
         self.assertEqual(qresult.blast_id, "Query_1")
         hit1 = qresult[0]
         hit2 = qresult[1]
         self.assertEqual("gnl|BL_ORD_ID|18", hit1.blast_id)
         self.assertEqual("gi|347972582|ref|XM_309352.4|", hit1.id)
-        self.assertEqual("Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds", hit1.description)
+        self.assertEqual(
+            "Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds",
+            hit1.description,
+        )
         self.assertEqual("gnl|BL_ORD_ID|17", hit2.blast_id)
         self.assertEqual("gnl|BL_ORD_ID|17", hit2.id)
-        self.assertEqual("gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds", hit2.description)
+        self.assertEqual(
+            "gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds",
+            hit2.description,
+        )
 
     def test_xml_2226_blastn_006_use_raw_hit_ids(self):
         xml_file = get_file("xml_2226_blastn_006.xml")
@@ -3231,18 +4038,27 @@ class BlastXmlSpecialCases(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", BiopythonParserWarning)
             qresult = next(qresults)
-            self.assertEqual(exp_warning, len(w), "Expected {0} warning(s), got"
-                             " {1}".format(exp_warning, len(w)))
+            self.assertEqual(
+                exp_warning,
+                len(w),
+                "Expected {0} warning(s), got {1}".format(exp_warning, len(w)),
+            )
 
         self.assertEqual(qresult.blast_id, "Query_1")
         hit1 = qresult[0]
         hit2 = qresult[1]
         self.assertEqual("gnl|BL_ORD_ID|18", hit1.blast_id)
         self.assertEqual("gnl|BL_ORD_ID|18", hit1.id)
-        self.assertEqual("gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds", hit1.description)
+        self.assertEqual(
+            "gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds",
+            hit1.description,
+        )
         self.assertEqual("gnl|BL_ORD_ID|17", hit2.blast_id)
         self.assertEqual("gnl|BL_ORD_ID|17", hit2.id)
-        self.assertEqual("gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds", hit2.description)
+        self.assertEqual(
+            "gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds",
+            hit2.description,
+        )
 
     def test_xml_2226_blastn_006_use_raw_query_ids(self):
         xml_file = get_file("xml_2226_blastn_006.xml")
@@ -3252,11 +4068,17 @@ class BlastXmlSpecialCases(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", BiopythonParserWarning)
             qresult = next(qresults)
-            self.assertEqual(exp_warning, len(w), "Expected {0} warning(s), got"
-                             " {1}".format(exp_warning, len(w)))
+            self.assertEqual(
+                exp_warning,
+                len(w),
+                "Expected {0} warning(s), got {1}".format(exp_warning, len(w)),
+            )
 
         self.assertEqual(qresult.id, "Query_1")
-        self.assertEqual(qresult.description, "gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds")
+        self.assertEqual(
+            qresult.description,
+            "gi|347972582|ref|XM_309352.4| Anopheles gambiae str. PEST AGAP011294-PA (DEFI_ANOGA) mRNA, complete cds",
+        )
         self.assertEqual(qresult.blast_id, "Query_1")
 
 


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_SearchIO_blast_xml.py, standard black style changes, is a big file. 