### PR TITLE
Let Bio.SeqIO.XdnaIO handle file paths

### DIFF
--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -16,12 +16,10 @@ from struct import pack, unpack
 import warnings
 
 from Bio import Alphabet, BiopythonWarning
-from Bio._utils import _read_header
 from Bio.Seq import Seq
 from Bio.SeqIO.Interfaces import SequenceWriter
 from Bio.SeqFeature import SeqFeature, FeatureLocation, ExactPosition
 from Bio.SeqRecord import SeqRecord
-from Bio.File import as_handle
 
 
 _seq_types = {
@@ -141,12 +139,21 @@ def _read_feature(handle, record):
     record.features.append(feature)
 
 
-def XdnaIterator(handle):
+def XdnaIterator(source):
     """Parse a Xdna file and return a SeqRecord object.
 
-    Note that this is an "iterator" in name only since a Xdna file always
+    Argument source is a file-like object in binary mode or a path to a file.
+
+    Note that this is an "iterator" in name only since an Xdna file always
     contain a single sequence.
+
     """
+    try:
+        handle = open(source, "rb")
+    except TypeError:
+        handle = source
+        if handle.read(0) != b"":
+            raise ValueError("Xdna files must be opened in binary mode.") from None
     # Parse fixed-size header and do some rudimentary checks
     #
     # The "neg_length" value is the length of the part of the sequence
@@ -156,9 +163,13 @@ def XdnaIterator(handle):
     # as I know, so we ignore that value. SerialCloner has no such concept
     # either and always generates files with a neg_length of zero.
 
-    with as_handle(handle, "rb") as handle:
+    try:
 
-        header = _read_header(handle, 112)
+        header = handle.read(112)
+        if not header:
+            raise ValueError("Empty file.")
+        if len(header) < 112:
+            raise ValueError("Improper header, cannot read 112 bytes from handle" % length)
         (version, type, topology, length, neg_length, com_length) = unpack(
             ">BBB25xII60xI12x", header
         )
@@ -196,6 +207,10 @@ def XdnaIterator(handle):
                 num_features -= 1
 
         yield record
+
+    finally:
+        if handle is not source:
+            handle.close()
 
 
 class XdnaWriter(SequenceWriter):

--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -169,7 +169,7 @@ def XdnaIterator(source):
         if not header:
             raise ValueError("Empty file.")
         if len(header) < 112:
-            raise ValueError("Improper header, cannot read 112 bytes from handle" % length)
+            raise ValueError("Improper header, cannot read 112 bytes from handle")
         (version, type, topology, length, neg_length, com_length) = unpack(
             ">BBB25xII60xI12x", header
         )

--- a/Bio/_utils.py
+++ b/Bio/_utils.py
@@ -11,22 +11,6 @@
 import os
 
 
-def _read_header(handle, length):
-    """Read the specified number of characters from the given handle.
-
-    Raise a ValueError("Empty file.") if the length of data read is zero. The
-    reason for having a separate function for the header is it enables raising
-    an empty file error if the length of the data read is zero. This might
-    not always be the case later in the file.
-    """
-    data = handle.read(length)
-    if not data:
-        raise ValueError("Empty file.")
-    if len(data) < length:
-        raise ValueError("Improper header, cannot read %d bytes from handle" % length)
-    return data
-
-
 def trim_str(string, max_len, concat_char):
     """Truncate the given string for display."""
     if len(string) > max_len:


### PR DESCRIPTION
This pull request allows `Bio.SeqIO.XdnaIO` open file handles from paths.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
