### PR TITLE
Apply black style to test_SearchIO_blast*, version 19.10b0.

### DIFF
--- a/Tests/test_SearchIO_blast_tab.py
+++ b/Tests/test_SearchIO_blast_tab.py
@@ -27,15 +27,19 @@ class BlastTabCases(unittest.TestCase):
     def test_tab_2228_tblastn_001(self):
         """Test parsing TBLASTN 2.2.28+ tabular output (tab_2228_tblastn_001)."""
         tab_file = get_file("tab_2228_tblastn_001.txt")
-        qresults = list(parse(tab_file, FMT,
-                              fields=["evalue", "sallseqid", "qseqid"],
-                              comments=True))
+        qresults = list(
+            parse(
+                tab_file, FMT, fields=["evalue", "sallseqid", "qseqid"], comments=True
+            )
+        )
 
         self.assertEqual(1, len(qresults))
         self.assertEqual(10, len(qresults[0].hits))
         # there is one hit with an alternative ID
-        self.assertEqual(qresults[0]["gi|148227873|ref|NM_001095167.1|"],
-                         qresults[0]["gi|55250552|gb|BC086280.1|"])
+        self.assertEqual(
+            qresults[0]["gi|148227873|ref|NM_001095167.1|"],
+            qresults[0]["gi|55250552|gb|BC086280.1|"],
+        )
 
         # check some of the HSPs
         self.assertEqual(0.0, qresults[0][0][0].evalue)
@@ -44,17 +48,19 @@ class BlastTabCases(unittest.TestCase):
     def test_tab_2228_tblastx_001(self):
         """Test parsing TBLASTX 2.2.28+ tabular output (tab_2228_tblastx_001)."""
         tab_file = get_file("tab_2228_tblastx_001.txt")
-        qresults = list(parse(tab_file, FMT,
-                              fields=list(all_fields.values()),
-                              comments=True))
+        qresults = list(
+            parse(tab_file, FMT, fields=list(all_fields.values()), comments=True)
+        )
 
         # this a single query, with 192 hits and 243 hsps
         self.assertEqual(1, len(qresults))
         self.assertEqual(192, len(qresults[0].hits))
         self.assertEqual(243, sum(len(x) for x in qresults[0]))
         # there is one hit with an alternative ID
-        self.assertEqual(qresults[0]["gi|31126987|gb|AY255526.2|"],
-                         qresults[0]["gi|31342050|ref|NM_181083.2|"])
+        self.assertEqual(
+            qresults[0]["gi|31126987|gb|AY255526.2|"],
+            qresults[0]["gi|31342050|ref|NM_181083.2|"],
+        )
 
         # only checking the new fields in 2.2.28+
         hit = qresults[0][0]
@@ -65,9 +71,14 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(["N/A"], hit.blast_names)
         self.assertEqual(["N/A"], hit.super_kingdoms)
         self.assertEqual("Saccharomyces cerevisiae S288c Mon2p (MON2), mRNA", hit.title)
-        self.assertEqual(["Saccharomyces cerevisiae S288c Mon2p (MON2), mRNA",
-                         "Synthetic construct Saccharomyces cerevisiae clone "
-                          "FLH203015.01X MON2, complete sequence"], hit.title_all)
+        self.assertEqual(
+            [
+                "Saccharomyces cerevisiae S288c Mon2p (MON2), mRNA",
+                "Synthetic construct Saccharomyces cerevisiae clone "
+                "FLH203015.01X MON2, complete sequence",
+            ],
+            hit.title_all,
+        )
         self.assertEqual("N/A", hit.strand)
         self.assertEqual(100.0, hit.query_coverage)
 
@@ -399,9 +410,10 @@ class BlastTabCases(unittest.TestCase):
     def test_tab_2226_tblastn_005_comments_false(self):
         """Test parsing TBLASTN 2.2.26+ tabular output with comments (tab_2226_tblastn_005)."""
         tab_file = get_file("tab_2226_tblastn_005.txt")
-        exc_msg = ("Encountered unexpected character '#' at the beginning of"
-                   " a line. Set comments=True if the file is a commented"
-                   " file.")
+        exc_msg = (
+            "Encountered unexpected character '#' at the beginning of a line. "
+            "Set comments=True if the file is a commented file."
+        )
         qresults = parse(tab_file, FMT)
         with self.assertRaises(ValueError, msg=exc_msg):
             next(qresults)
@@ -728,8 +740,12 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(1872, hsp.hit_end)
         self.assertEqual(1e-05, hsp.evalue)
         self.assertEqual(34.7, hsp.bitscore)
-        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq))
-        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq))
+        self.assertEqual(
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)
+        )
+        self.assertEqual(
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)
+        )
         self.assertEqual(78, hsp.bitscore_raw)
         self.assertEqual(15, hsp.ident_num)
         self.assertEqual(26, hsp.pos_num)
@@ -758,8 +774,14 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(1233, hsp.hit_end)
         self.assertEqual(1e-04, hsp.evalue)
         self.assertEqual(31.6, hsp.bitscore)
-        self.assertEqual("GLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL", str(hsp.query.seq))
-        self.assertEqual("GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL", str(hsp.hit.seq))
+        self.assertEqual(
+            "GLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(70.0, hsp.bitscore_raw)
         self.assertEqual(20, hsp.ident_num)
         self.assertEqual(29, hsp.pos_num)
@@ -806,8 +828,14 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(388, hsp.hit_end)
         self.assertEqual(2e-67, hsp.evalue)
         self.assertEqual(199, hsp.bitscore)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq))
-        self.assertEqual("KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", str(hsp.hit.seq))
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(506.0, hsp.bitscore_raw)
         self.assertEqual(94, hsp.ident_num)
         self.assertEqual(96, hsp.pos_num)
@@ -829,8 +857,14 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(754, hsp.hit_end)
         self.assertEqual(4e-05, hsp.evalue)
         self.assertEqual(32.7, hsp.bitscore)
-        self.assertEqual("IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq))
-        self.assertEqual("LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", str(hsp.hit.seq))
+        self.assertEqual(
+            "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(73.0, hsp.bitscore_raw)
         self.assertEqual(21, hsp.ident_num)
         self.assertEqual(33, hsp.pos_num)
@@ -918,8 +952,12 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(1872, hsp.hit_end)
         self.assertEqual(1e-05, hsp.evalue)
         self.assertEqual(34.7, hsp.bitscore)
-        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq))
-        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq))
+        self.assertEqual(
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)
+        )
+        self.assertEqual(
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)
+        )
 
         hit = qresult[-1]
         self.assertEqual("gi|115975252|ref|XM_001180111.1|", hit.id)
@@ -939,8 +977,14 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(1233, hsp.hit_end)
         self.assertEqual(1e-04, hsp.evalue)
         self.assertEqual(31.6, hsp.bitscore)
-        self.assertEqual("GLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL", str(hsp.query.seq))
-        self.assertEqual("GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL", str(hsp.hit.seq))
+        self.assertEqual(
+            "GLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL",
+            str(hsp.hit.seq),
+        )
 
         # check if we've finished iteration over qresults
         self.assertRaises(StopIteration, next, qresults)

--- a/Tests/test_SearchIO_blast_text.py
+++ b/Tests/test_SearchIO_blast_text.py
@@ -18,8 +18,11 @@ FMT = "blast-text"
 
 # This prevents the NCBIStandalone usage warning from
 # printing to screen when running the test suite
-warnings.filterwarnings("ignore", r"Parsing BLAST plain text output "
-                        "file is not a well supported.*", BiopythonWarning)
+warnings.filterwarnings(
+    "ignore",
+    r"Parsing BLAST plain text output file is not a well supported.*",
+    BiopythonWarning,
+)
 
 
 def get_file(filename):
@@ -28,7 +31,6 @@ def get_file(filename):
 
 
 class BaseBlastCases(unittest.TestCase):
-
     def check_common_attrs(self, qresults):
         # check common attributes
         for qresult in qresults:
@@ -40,7 +42,6 @@ class BaseBlastCases(unittest.TestCase):
 
 
 class BlastnCases(BaseBlastCases):
-
     def test_text_2226_blastn_001(self):
         """Test parsing blastn output (text_2226_blastn_001.txt)."""
         blast_file = get_file("text_2226_blastn_001.txt")
@@ -68,7 +69,10 @@ class BlastnCases(BaseBlastCases):
         # test first qresult
         qresult = qresults[0]
         self.assertEqual("gi|356995852:1-490", qresult.id)
-        self.assertEqual("Mus musculus POU domain, class 5, transcriptionfactor 1 (Pou5f1), transcript variant 1, mRNA", qresult.description)
+        self.assertEqual(
+            "Mus musculus POU domain, class 5, transcriptionfactor 1 (Pou5f1), transcript variant 1, mRNA",
+            qresult.description,
+        )
         self.assertEqual(490, qresult.seq_len)
         self.assertEqual("NCBI Transcript Reference Sequences", qresult.target)
         self.assertEqual("blastn", qresult.program)
@@ -77,7 +81,10 @@ class BlastnCases(BaseBlastCases):
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("ref|NM_013633.3|", hit.id)
-        self.assertEqual("Mus musculus POU domain, class 5, transcription factor 1 (Pou5f1), transcript variant 1, mRNA", hit.description)
+        self.assertEqual(
+            "Mus musculus POU domain, class 5, transcription factor 1 (Pou5f1), transcript variant 1, mRNA",
+            hit.description,
+        )
         self.assertEqual(1353, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -97,16 +104,33 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(490, hsp.query_end)
         self.assertEqual(490, hsp.hit_end)
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.query.seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.hit.seq)[:40])
-        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|XR_141831.1|", hit.id)
-        self.assertEqual("PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA ref|XR_105837.2| PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA ref|XR_141464.1| PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA ref|XR_141446.1| PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA ref|XR_105837.2| PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA ref|XR_141464.1| PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA ref|XR_141446.1| PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA",
+            hit.description,
+        )
         self.assertEqual(570, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, second hit, first hsp
@@ -126,12 +150,26 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(80, hsp.hit_start)
         self.assertEqual(490, hsp.query_end)
         self.assertEqual(570, hsp.hit_end)
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.query.seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.hit.seq)[:40])
-        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq)[-40:]
+        )
 
     def test_text_2226_blastn_003(self):
         """Test parsing blastn output (text_2226_blastn_003.txt)."""
@@ -143,7 +181,10 @@ class BlastnCases(BaseBlastCases):
         # test first qresult
         qresult = qresults[0]
         self.assertEqual("hg19_dna", qresult.id)
-        self.assertEqual("range=chr1:1207307-1207372 5'pad=0 3'pad=0 strand=+repeatMasking=none", qresult.description)
+        self.assertEqual(
+            "range=chr1:1207307-1207372 5'pad=0 3'pad=0 strand=+repeatMasking=none",
+            qresult.description,
+        )
         self.assertEqual(66, qresult.seq_len)
         self.assertEqual("NCBI Transcript Reference Sequences", qresult.target)
         self.assertEqual("blastn", qresult.program)
@@ -152,7 +193,10 @@ class BlastnCases(BaseBlastCases):
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("ref|XM_003267724.1|", hit.id)
-        self.assertEqual("PREDICTED: Nomascus leucogenys ATG14 autophagy related 14 homolog (S. cerevisiae) (ATG14), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Nomascus leucogenys ATG14 autophagy related 14 homolog (S. cerevisiae) (ATG14), mRNA",
+            hit.description,
+        )
         self.assertEqual(4771, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -172,16 +216,33 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(2864, hsp.hit_start)
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(2926, hsp.hit_end)
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.query.seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.hit.seq)[:40])
-        self.assertEqual("AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", str(hsp.query.seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|NM_001040441.1|", hit.id)
-        self.assertEqual("Homo sapiens zinc finger and BTB domain containing 8A (ZBTB8A), mRNA", hit.description)
+        self.assertEqual(
+            "Homo sapiens zinc finger and BTB domain containing 8A (ZBTB8A), mRNA",
+            hit.description,
+        )
         self.assertEqual(7333, hit.seq_len)
         self.assertEqual(2, len(hit))
         # first qresult, second hit, first hsp
@@ -201,12 +262,26 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(3676, hsp.hit_start)
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(3738, hsp.hit_end)
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.query.seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.hit.seq)[:40])
-        self.assertEqual("AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", str(hsp.query.seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(53, hsp.aln_span)
@@ -224,12 +299,26 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(2823, hsp.hit_start)
         self.assertEqual(58, hsp.query_end)
         self.assertEqual(2876, hsp.hit_end)
-        self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", str(hsp.query.seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", str(hsp.hit.seq)[:40])
-        self.assertEqual("GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", str(hsp.query.seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("GCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.hit.seq)[-40:]
+        )
 
     def test_text_2226_blastn_004(self):
         """Test parsing blastn output (text_2226_blastn_004.txt)."""
@@ -251,7 +340,10 @@ class BlastnCases(BaseBlastCases):
         # test second qresult
         qresult = qresults[1]
         self.assertEqual("gi|356995852:1-490", qresult.id)
-        self.assertEqual("Mus musculus POU domain, class 5, transcriptionfactor 1 (Pou5f1), transcript variant 1, mRNA", qresult.description)
+        self.assertEqual(
+            "Mus musculus POU domain, class 5, transcriptionfactor 1 (Pou5f1), transcript variant 1, mRNA",
+            qresult.description,
+        )
         self.assertEqual(490, qresult.seq_len)
         self.assertEqual("minirefseq_mrna", qresult.target)
         self.assertEqual("blastn", qresult.program)
@@ -260,7 +352,10 @@ class BlastnCases(BaseBlastCases):
         # second qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|356995852|ref|NM_013633.3|", hit.id)
-        self.assertEqual("Mus musculus POU domain, class 5, transcription factor 1 (Pou5f1), transcript variant 1, mRNA", hit.description)
+        self.assertEqual(
+            "Mus musculus POU domain, class 5, transcription factor 1 (Pou5f1), transcript variant 1, mRNA",
+            hit.description,
+        )
         self.assertEqual(1353, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, first hit, first hsp
@@ -280,16 +375,33 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(490, hsp.query_end)
         self.assertEqual(490, hsp.hit_end)
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.query.seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.hit.seq)[:40])
-        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq)[-40:]
+        )
         # second qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|377833530|ref|XR_141831.1|", hit.id)
-        self.assertEqual("PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA",
+            hit.description,
+        )
         self.assertEqual(570, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, second hit, first hsp
@@ -309,17 +421,34 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(80, hsp.hit_start)
         self.assertEqual(490, hsp.query_end)
         self.assertEqual(570, hsp.hit_end)
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.query.seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.hit.seq)[:40])
-        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq)[-40:]
+        )
 
         # test third qresult
         qresult = qresults[2]
         self.assertEqual("hg19_dna", qresult.id)
-        self.assertEqual("range=chr1:1207307-1207372 5'pad=0 3'pad=0 strand=+repeatMasking=none", qresult.description)
+        self.assertEqual(
+            "range=chr1:1207307-1207372 5'pad=0 3'pad=0 strand=+repeatMasking=none",
+            qresult.description,
+        )
         self.assertEqual(66, qresult.seq_len)
         self.assertEqual("minirefseq_mrna", qresult.target)
         self.assertEqual("blastn", qresult.program)
@@ -328,7 +457,10 @@ class BlastnCases(BaseBlastCases):
         # third qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|94721341|ref|NM_001040441.1|", hit.id)
-        self.assertEqual("Homo sapiens zinc finger and BTB domain containing 8A (ZBTB8A), mRNA", hit.description)
+        self.assertEqual(
+            "Homo sapiens zinc finger and BTB domain containing 8A (ZBTB8A), mRNA",
+            hit.description,
+        )
         self.assertEqual(7333, hit.seq_len)
         self.assertEqual(2, len(hit))
         # third qresult, first hit, first hsp
@@ -348,12 +480,26 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(3676, hsp.hit_start)
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(3738, hsp.hit_end)
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.query.seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.hit.seq)[:40])
-        self.assertEqual("AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", str(hsp.query.seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq)[-40:]
+        )
         # third qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(53, hsp.aln_span)
@@ -371,16 +517,33 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(2823, hsp.hit_start)
         self.assertEqual(58, hsp.query_end)
         self.assertEqual(2876, hsp.hit_end)
-        self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", str(hsp.query.seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", str(hsp.hit.seq)[:40])
-        self.assertEqual("GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", str(hsp.query.seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("GCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.hit.seq)[-40:]
+        )
         # third qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|332237160|ref|XM_003267724.1|", hit.id)
-        self.assertEqual("PREDICTED: Nomascus leucogenys ATG14 autophagy related 14 homolog (S. cerevisiae) (ATG14), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Nomascus leucogenys ATG14 autophagy related 14 homolog (S. cerevisiae) (ATG14), mRNA",
+            hit.description,
+        )
         self.assertEqual(4771, hit.seq_len)
         self.assertEqual(1, len(hit))
         # third qresult, second hit, first hsp
@@ -400,16 +563,29 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(2864, hsp.hit_start)
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(2926, hsp.hit_end)
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.query.seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.hit.seq)[:40])
-        self.assertEqual("AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", str(hsp.query.seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq)[-40:]
+        )
 
 
 class BlastpCases(BaseBlastCases):
-
     def test_text_2226_blastp_001(self):
         """Test parsing blastp output (text_2226_blastp_001.txt)."""
         blast_file = get_file("text_2226_blastp_001.txt")
@@ -437,7 +613,10 @@ class BlastpCases(BaseBlastCases):
         # test first qresult
         qresult = qresults[0]
         self.assertEqual("gi|16080617|ref|NP_391444.1|", qresult.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillussubtilis subsp. subtilis str. 168]", qresult.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillussubtilis subsp. subtilis str. 168]",
+            qresult.description,
+        )
         self.assertEqual(102, qresult.seq_len)
         self.assertEqual("NCBI Protein Reference Sequences", qresult.target)
         self.assertEqual("blastp", qresult.program)
@@ -446,7 +625,10 @@ class BlastpCases(BaseBlastCases):
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("ref|NP_391444.1|", hit.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168] ref|ZP_03593363.1| membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168] ref|ZP_03597648.1| membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. NCIB 3610] ref|ZP_03602051.1| membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. JH642] ref|ZP_03606337.1| membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. SMY] ref|YP_004205398.1| unnamed protein product [Bacillus subtilis BSn5]", hit.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168] ref|ZP_03593363.1| membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168] ref|ZP_03597648.1| membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. NCIB 3610] ref|ZP_03602051.1| membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. JH642] ref|ZP_03606337.1| membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. SMY] ref|YP_004205398.1| unnamed protein product [Bacillus subtilis BSn5]",
+            hit.description,
+        )
         self.assertEqual(102, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -466,16 +648,33 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(102, hsp.query_end)
         self.assertEqual(102, hsp.hit_end)
-        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", str(hsp.query.seq)[:40])
-        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", str(hsp.hit.seq)[:40])
-        self.assertEqual("DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.query.seq)[-40:])
-        self.assertEqual("DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|YP_003922001.1|", hit.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillus amyloliquefaciens DSM 7]", hit.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillus amyloliquefaciens DSM 7]",
+            hit.description,
+        )
         self.assertEqual(100, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, second hit, first hsp
@@ -495,12 +694,26 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(102, hsp.query_end)
         self.assertEqual(100, hsp.hit_end)
-        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", str(hsp.query.seq)[:40])
-        self.assertEqual("MKK    LFFILLL+GCGV ++KSQGED      + TKEG", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", str(hsp.hit.seq)[:40])
-        self.assertEqual("DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.query.seq)[-40:])
-        self.assertEqual("DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("DITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "MKK    LFFILLL+GCGV ++KSQGED      + TKEG",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "DITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", str(hsp.hit.seq)[-40:]
+        )
 
     def test_text_2226_blastp_003(self):
         """Test parsing blastp output (text_2226_blastp_003.txt)."""
@@ -541,12 +754,26 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(3, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(101, hsp.hit_end)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(100, hsp.aln_span)
@@ -564,16 +791,32 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(245, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(345, hsp.hit_end)
-        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("I++G L+K+G     WK    +L ED   + +Y       ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40])
-        self.assertEqual("FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:])
-        self.assertEqual("  K     + +I T  +  ++ QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("VKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "I++G L+K+G     WK    +L ED   + +Y       ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "VKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|XP_003502426.1|", hit.id)
-        self.assertEqual("PREDICTED: pleckstrin-like [Cricetulus griseus]", hit.description)
+        self.assertEqual(
+            "PREDICTED: pleckstrin-like [Cricetulus griseus]", hit.description
+        )
         self.assertEqual(350, hit.seq_len)
         self.assertEqual(2, len(hit))
         # first qresult, second hit, first hsp
@@ -593,12 +836,26 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(3, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(101, hsp.hit_end)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(100, hsp.aln_span)
@@ -616,12 +873,26 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(245, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(345, hsp.hit_end)
-        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("I++G L+K+G     WK    +L ED   + +Y       ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40])
-        self.assertEqual("GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:])
-        self.assertEqual("GK+     + +I T  +  ++ QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "I++G L+K+G     WK    +L ED   + +Y       ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+        )
 
     def test_text_2226_blastp_004(self):
         """Test parsing blastp output (text_2226_blastp_004.txt)."""
@@ -643,7 +914,10 @@ class BlastpCases(BaseBlastCases):
         # test second qresult
         qresult = qresults[1]
         self.assertEqual("gi|16080617|ref|NP_391444.1|", qresult.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillussubtilis subsp. subtilis str. 168]", qresult.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillussubtilis subsp. subtilis str. 168]",
+            qresult.description,
+        )
         self.assertEqual(102, qresult.seq_len)
         self.assertEqual("minirefseq_prot", qresult.target)
         self.assertEqual("blastp", qresult.program)
@@ -652,7 +926,10 @@ class BlastpCases(BaseBlastCases):
         # second qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|308175296|ref|YP_003922001.1|", hit.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillus amyloliquefaciens DSM 7]", hit.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillus amyloliquefaciens DSM 7]",
+            hit.description,
+        )
         self.assertEqual(100, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, first hit, first hsp
@@ -672,16 +949,33 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(102, hsp.query_end)
         self.assertEqual(100, hsp.hit_end)
-        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", str(hsp.query.seq)[:40])
-        self.assertEqual("MKK    LFFILLL+GCGV ++KSQGED      + TKEG", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", str(hsp.hit.seq)[:40])
-        self.assertEqual("DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.query.seq)[-40:])
-        self.assertEqual("DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("DITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "MKK    LFFILLL+GCGV ++KSQGED      + TKEG",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "DITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", str(hsp.hit.seq)[-40:]
+        )
         # second qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|375363999|ref|YP_005132038.1|", hit.id)
-        self.assertEqual("lytA gene product [Bacillus amyloliquefaciens subsp. plantarum CAU B946]", hit.description)
+        self.assertEqual(
+            "lytA gene product [Bacillus amyloliquefaciens subsp. plantarum CAU B946]",
+            hit.description,
+        )
         self.assertEqual(105, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, second hit, first hsp
@@ -701,12 +995,26 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(101, hsp.query_end)
         self.assertEqual(104, hsp.hit_end)
-        self.assertEqual("MKKFIALLFFILL----LSGCGVNSQKSQGEDVSPDSNIE", str(hsp.query.seq)[:40])
-        self.assertEqual("MKK IA  F ILL    L+ CG   Q  +G   S ++  +", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("MKKTIAASFLILLFSVVLAACGTAEQSKKGSG-SSENQAQ", str(hsp.hit.seq)[:40])
-        self.assertEqual("LDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERA", str(hsp.query.seq)[-40:])
-        self.assertEqual(" + +++ +  L+KF+  DKV+ITY  ND+GQ  +K+IE+A", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("FEFSDDFSDVLNKFSENDKVSITYFTNDKGQKEIKEIEKA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "MKKFIALLFFILL----LSGCGVNSQKSQGEDVSPDSNIE", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "MKK IA  F ILL    L+ CG   Q  +G   S ++  +",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "MKKTIAASFLILLFSVVLAACGTAEQSKKGSG-SSENQAQ", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "LDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            " + +++ +  L+KF+  DKV+ITY  ND+GQ  +K+IE+A",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "FEFSDDFSDVLNKFSENDKVSITYFTNDKGQKEIKEIEKA", str(hsp.hit.seq)[-40:]
+        )
 
         # test third qresult
         qresult = qresults[2]
@@ -740,12 +1048,26 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(3, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(101, hsp.hit_end)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+        )
         # third qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(100, hsp.aln_span)
@@ -763,16 +1085,32 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(245, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(345, hsp.hit_end)
-        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("I++G L+K+G     WK    +L ED   + +Y       ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40])
-        self.assertEqual("FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:])
-        self.assertEqual("  K     + +I T  +  ++ QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("VKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "I++G L+K+G     WK    +L ED   + +Y       ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "VKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+        )
         # third qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|354480464|ref|XP_003502426.1|", hit.id)
-        self.assertEqual("PREDICTED: pleckstrin-like [Cricetulus griseus]", hit.description)
+        self.assertEqual(
+            "PREDICTED: pleckstrin-like [Cricetulus griseus]", hit.description
+        )
         self.assertEqual(350, hit.seq_len)
         self.assertEqual(2, len(hit))
         # third qresult, second hit, first hsp
@@ -792,12 +1130,26 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(3, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(101, hsp.hit_end)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+        )
         # third qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(100, hsp.aln_span)
@@ -815,16 +1167,29 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(245, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(345, hsp.hit_end)
-        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("I++G L+K+G     WK    +L ED   + +Y       ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40])
-        self.assertEqual("GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:])
-        self.assertEqual("GK+     + +I T  +  ++ QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "I++G L+K+G     WK    +L ED   + +Y       ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+        )
 
 
 class BlastxCases(BaseBlastCases):
-
     def test_text_2226_blastx_001(self):
         """Test parsing blastx output (text_2226_blastx_001.txt)."""
         blast_file = get_file("text_2226_blastx_001.txt")
@@ -852,7 +1217,10 @@ class BlastxCases(BaseBlastCases):
         # test first qresult
         qresult = qresults[0]
         self.assertEqual("gi|356995852:1-490", qresult.id)
-        self.assertEqual("Mus musculus POU domain, class 5, transcriptionfactor 1 (Pou5f1), transcript variant 1, mRNA", qresult.description)
+        self.assertEqual(
+            "Mus musculus POU domain, class 5, transcriptionfactor 1 (Pou5f1), transcript variant 1, mRNA",
+            qresult.description,
+        )
         self.assertEqual(490, qresult.seq_len)
         self.assertEqual("NCBI Protein Reference Sequences", qresult.target)
         self.assertEqual("blastx", qresult.program)
@@ -861,7 +1229,10 @@ class BlastxCases(BaseBlastCases):
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("ref|NP_038661.2|", hit.id)
-        self.assertEqual("POU domain, class 5, transcription factor 1 isoform 1 [Mus musculus]", hit.description)
+        self.assertEqual(
+            "POU domain, class 5, transcription factor 1 isoform 1 [Mus musculus]",
+            hit.description,
+        )
         self.assertEqual(352, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -881,12 +1252,26 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(488, hsp.query_end)
         self.assertEqual(140, hsp.hit_end)
-        self.assertEqual("MAGHLAsdfafspppgggdgsagLEPGWVDPRTWLSFQgp", str(hsp.query.seq)[:40])
-        self.assertEqual("MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", str(hsp.hit.seq)[:40])
-        self.assertEqual("NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", str(hsp.query.seq)[-40:])
-        self.assertEqual("NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "MAGHLAsdfafspppgggdgsagLEPGWVDPRTWLSFQgp", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|NP_001009178.1|", hit.id)
@@ -910,12 +1295,26 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(488, hsp.query_end)
         self.assertEqual(140, hsp.hit_end)
-        self.assertEqual("MAGHLAsdfafspppgggdgsagLEPGWVDPRTWLSFQgp", str(hsp.query.seq)[:40])
-        self.assertEqual("MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", str(hsp.hit.seq)[:40])
-        self.assertEqual("NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", str(hsp.query.seq)[-40:])
-        self.assertEqual("NSEG SS PC  RP+AVKLEKVEP+PEESQDMKALQKELE", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("NSEGASSGPCTARPSAVKLEKVEPSPEESQDMKALQKELE", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "MAGHLAsdfafspppgggdgsagLEPGWVDPRTWLSFQgp", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "NSEG SS PC  RP+AVKLEKVEP+PEESQDMKALQKELE",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "NSEGASSGPCTARPSAVKLEKVEPSPEESQDMKALQKELE", str(hsp.hit.seq)[-40:]
+        )
 
     def test_text_2226_blastx_003(self):
         """Test parsing blastx output (text_2226_blastx_003.txt)."""
@@ -927,7 +1326,10 @@ class BlastxCases(BaseBlastCases):
         # test first qresult
         qresult = qresults[0]
         self.assertEqual("hg19_dna", qresult.id)
-        self.assertEqual("range=chr1:1207057-1207541 5'pad=0 3'pad=0 strand=+repeatMasking=none", qresult.description)
+        self.assertEqual(
+            "range=chr1:1207057-1207541 5'pad=0 3'pad=0 strand=+repeatMasking=none",
+            qresult.description,
+        )
         self.assertEqual(485, qresult.seq_len)
         self.assertEqual("NCBI Protein Reference Sequences", qresult.target)
         self.assertEqual("blastx", qresult.program)
@@ -936,7 +1338,10 @@ class BlastxCases(BaseBlastCases):
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("ref|XP_003278367.1|", hit.id)
-        self.assertEqual("PREDICTED: UPF0764 protein C16orf89-like [Nomascus leucogenys]", hit.description)
+        self.assertEqual(
+            "PREDICTED: UPF0764 protein C16orf89-like [Nomascus leucogenys]",
+            hit.description,
+        )
         self.assertEqual(132, hit.seq_len)
         self.assertEqual(2, len(hit))
         # first qresult, first hit, first hsp
@@ -956,12 +1361,26 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(24, hsp.hit_start)
         self.assertEqual(300, hsp.query_end)
         self.assertEqual(119, hsp.hit_end)
-        self.assertEqual("LRRSFALVAQAGVQWLDLGppqpppPGFK*FSCLSHPSSW", str(hsp.query.seq)[:40])
-        self.assertEqual("LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", str(hsp.hit.seq)[:40])
-        self.assertEqual("VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq)[-40:])
-        self.assertEqual("VE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("VEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "LRRSFALVAQAGVQWLDLGppqpppPGFK*FSCLSHPSSW", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "VE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "VEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(72, hsp.aln_span)
@@ -979,16 +1398,32 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(31, hsp.hit_start)
         self.assertEqual(459, hsp.query_end)
         self.assertEqual(98, hsp.hit_end)
-        self.assertEqual("VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", str(hsp.query.seq)[:40])
-        self.assertEqual("V   RVQ ++L S QPP P FK FS LSL SSW+ R  PP", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", str(hsp.hit.seq)[:40])
-        self.assertEqual("WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", str(hsp.query.seq)[-40:])
-        self.assertEqual("W+ R  PPH AN     F F +   F  V QAG++ +  G", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("WEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "V   RVQ ++L S QPP P FK FS LSL SSW+ R  PP",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "W+ R  PPH AN     F F +   F  V QAG++ +  G",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "WEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|NP_001243358.1|", hit.id)
-        self.assertEqual("PDZ and LIM domain protein 5 isoform i [Homo sapiens]", hit.description)
+        self.assertEqual(
+            "PDZ and LIM domain protein 5 isoform i [Homo sapiens]", hit.description
+        )
         self.assertEqual(136, hit.seq_len)
         self.assertEqual(2, len(hit))
         # first qresult, second hit, first hsp
@@ -1008,12 +1443,26 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(29, hsp.hit_start)
         self.assertEqual(279, hsp.query_end)
         self.assertEqual(117, hsp.hit_end)
-        self.assertEqual("VAQAGVQWLDLGppqpppPGFK*FSCLSHPSSWDYRHMPP", str(hsp.query.seq)[:40])
-        self.assertEqual("++ AGVQW +LG PQPP P FK FSCLS PSSWDYRH+PP", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", str(hsp.hit.seq)[:40])
-        self.assertEqual("VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq)[-40:])
-        self.assertEqual("VET F +VGQAGLE P SG+LP  ASQS  ITGVSH A P", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("VETKFPYVGQAGLELPTSGDLPTSASQSAKITGVSHRAWP", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "VAQAGVQWLDLGppqpppPGFK*FSCLSHPSSWDYRHMPP", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "++ AGVQW +LG PQPP P FK FSCLS PSSWDYRH+PP",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "VET F +VGQAGLE P SG+LP  ASQS  ITGVSH A P",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "VETKFPYVGQAGLELPTSGDLPTSASQSAKITGVSHRAWP", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(69, hsp.aln_span)
@@ -1031,12 +1480,26 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(27, hsp.hit_start)
         self.assertEqual(465, hsp.query_end)
         self.assertEqual(91, hsp.hit_end)
-        self.assertEqual("VSVGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCP", str(hsp.query.seq)[:40])
-        self.assertEqual("+++  A VQ  +L S QPP+PEFK FS LSL SSWD R  ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", str(hsp.hit.seq)[:40])
-        self.assertEqual("SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", str(hsp.query.seq)[-40:])
-        self.assertEqual("SL SSWD R  PP  AN     F F +   F  V QAG++", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("SLPSSWDYRHVPPRLAN-----FVFLVETKFPYVGQAGLE", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "VSVGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCP", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "+++  A VQ  +L S QPP+PEFK FS LSL SSWD R  ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "SL SSWD R  PP  AN     F F +   F  V QAG++",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "SLPSSWDYRHVPPRLAN-----FVFLVETKFPYVGQAGLE", str(hsp.hit.seq)[-40:]
+        )
 
     def test_text_2226_blastx_004(self):
         """Test parsing blastx output (text_2226_blastx_004.txt)."""
@@ -1058,7 +1521,10 @@ class BlastxCases(BaseBlastCases):
         # test second qresult
         qresult = qresults[1]
         self.assertEqual("hg19_dna", qresult.id)
-        self.assertEqual("range=chr1:1207057-1207541 5'pad=0 3'pad=0 strand=+repeatMasking=none", qresult.description)
+        self.assertEqual(
+            "range=chr1:1207057-1207541 5'pad=0 3'pad=0 strand=+repeatMasking=none",
+            qresult.description,
+        )
         self.assertEqual(485, qresult.seq_len)
         self.assertEqual("minirefseq_prot", qresult.target)
         self.assertEqual("blastx", qresult.program)
@@ -1067,7 +1533,10 @@ class BlastxCases(BaseBlastCases):
         # second qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|332258565|ref|XP_003278367.1|", hit.id)
-        self.assertEqual("PREDICTED: UPF0764 protein C16orf89-like [Nomascus leucogenys]", hit.description)
+        self.assertEqual(
+            "PREDICTED: UPF0764 protein C16orf89-like [Nomascus leucogenys]",
+            hit.description,
+        )
         self.assertEqual(132, hit.seq_len)
         self.assertEqual(2, len(hit))
         # second qresult, first hit, first hsp
@@ -1087,12 +1556,26 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(24, hsp.hit_start)
         self.assertEqual(300, hsp.query_end)
         self.assertEqual(119, hsp.hit_end)
-        self.assertEqual("LRRSFALVAQAGVQWLDLGppqpppPGFK*FSCLSHPSSW", str(hsp.query.seq)[:40])
-        self.assertEqual("LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", str(hsp.hit.seq)[:40])
-        self.assertEqual("VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq)[-40:])
-        self.assertEqual("VE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("VEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "LRRSFALVAQAGVQWLDLGppqpppPGFK*FSCLSHPSSW", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "VE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "VEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", str(hsp.hit.seq)[-40:]
+        )
         # second qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(72, hsp.aln_span)
@@ -1110,16 +1593,32 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(31, hsp.hit_start)
         self.assertEqual(459, hsp.query_end)
         self.assertEqual(98, hsp.hit_end)
-        self.assertEqual("VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", str(hsp.query.seq)[:40])
-        self.assertEqual("V   RVQ ++L S QPP P FK FS LSL SSW+ R  PP", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", str(hsp.hit.seq)[:40])
-        self.assertEqual("WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", str(hsp.query.seq)[-40:])
-        self.assertEqual("W+ R  PPH AN     F F +   F  V QAG++ +  G", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("WEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "V   RVQ ++L S QPP P FK FS LSL SSW+ R  PP",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "W+ R  PPH AN     F F +   F  V QAG++ +  G",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "WEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", str(hsp.hit.seq)[-40:]
+        )
         # second qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|374093214|ref|NP_001243358.1|", hit.id)
-        self.assertEqual("PDZ and LIM domain protein 5 isoform i [Homo sapiens]", hit.description)
+        self.assertEqual(
+            "PDZ and LIM domain protein 5 isoform i [Homo sapiens]", hit.description
+        )
         self.assertEqual(136, hit.seq_len)
         self.assertEqual(2, len(hit))
         # second qresult, second hit, first hsp
@@ -1139,12 +1638,26 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(29, hsp.hit_start)
         self.assertEqual(279, hsp.query_end)
         self.assertEqual(117, hsp.hit_end)
-        self.assertEqual("VAQAGVQWLDLGppqpppPGFK*FSCLSHPSSWDYRHMPP", str(hsp.query.seq)[:40])
-        self.assertEqual("++ AGVQW +LG PQPP P FK FSCLS PSSWDYRH+PP", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", str(hsp.hit.seq)[:40])
-        self.assertEqual("VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq)[-40:])
-        self.assertEqual("VET F +VGQAGLE P SG+LP  ASQS  ITGVSH A P", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("VETKFPYVGQAGLELPTSGDLPTSASQSAKITGVSHRAWP", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "VAQAGVQWLDLGppqpppPGFK*FSCLSHPSSWDYRHMPP", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "++ AGVQW +LG PQPP P FK FSCLS PSSWDYRH+PP",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "VET F +VGQAGLE P SG+LP  ASQS  ITGVSH A P",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "VETKFPYVGQAGLELPTSGDLPTSASQSAKITGVSHRAWP", str(hsp.hit.seq)[-40:]
+        )
         # second qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(69, hsp.aln_span)
@@ -1162,16 +1675,29 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(27, hsp.hit_start)
         self.assertEqual(465, hsp.query_end)
         self.assertEqual(91, hsp.hit_end)
-        self.assertEqual("VSVGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCP", str(hsp.query.seq)[:40])
-        self.assertEqual("+++  A VQ  +L S QPP+PEFK FS LSL SSWD R  ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", str(hsp.hit.seq)[:40])
-        self.assertEqual("SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", str(hsp.query.seq)[-40:])
-        self.assertEqual("SL SSWD R  PP  AN     F F +   F  V QAG++", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("SLPSSWDYRHVPPRLAN-----FVFLVETKFPYVGQAGLE", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "VSVGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCP", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "+++  A VQ  +L S QPP+PEFK FS LSL SSWD R  ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "SL SSWD R  PP  AN     F F +   F  V QAG++",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "SLPSSWDYRHVPPRLAN-----FVFLVETKFPYVGQAGLE", str(hsp.hit.seq)[-40:]
+        )
 
 
 class TblastnCases(BaseBlastCases):
-
     def test_text_2226_tblastn_001(self):
         """Test parsing tblastn output (text_2226_tblastn_001.txt)."""
         blast_file = get_file("text_2226_tblastn_001.txt")
@@ -1199,7 +1725,10 @@ class TblastnCases(BaseBlastCases):
         # test first qresult
         qresult = qresults[0]
         self.assertEqual("gi|16080617|ref|NP_391444.1|", qresult.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillussubtilis subsp. subtilis str. 168]", qresult.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillussubtilis subsp. subtilis str. 168]",
+            qresult.description,
+        )
         self.assertEqual(102, qresult.seq_len)
         self.assertEqual("NCBI Transcript Reference Sequences", qresult.target)
         self.assertEqual("tblastn", qresult.program)
@@ -1208,7 +1737,10 @@ class TblastnCases(BaseBlastCases):
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("ref|XM_001425911.1|", hit.id)
-        self.assertEqual("Paramecium tetraurelia hypothetical protein (GSPATT00004923001) partial mRNA", hit.description)
+        self.assertEqual(
+            "Paramecium tetraurelia hypothetical protein (GSPATT00004923001) partial mRNA",
+            hit.description,
+        )
         self.assertEqual(4632, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -1228,16 +1760,33 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(1743, hsp.hit_start)
         self.assertEqual(73, hsp.query_end)
         self.assertEqual(1872, hsp.hit_end)
-        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTS", str(hsp.query.seq)[:40])
-        self.assertEqual("P +   TK+GT +GL   HTI   + +  +SL++ E++  ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", str(hsp.hit.seq)[:40])
-        self.assertEqual("NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)[-40:])
-        self.assertEqual("   TK+GT +GL   HTI   + +  +SL++ E++  D+D", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("ATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "P +   TK+GT +GL   HTI   + +  +SL++ E++  ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "ATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|XM_003382561.1|", hit.id)
-        self.assertEqual("PREDICTED: Amphimedon queenslandica CWF19-like protein 1-like (LOC100635130), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Amphimedon queenslandica CWF19-like protein 1-like (LOC100635130), mRNA",
+            hit.description,
+        )
         self.assertEqual(1811, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, second hit, first hsp
@@ -1257,12 +1806,26 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(1105, hsp.hit_start)
         self.assertEqual(94, hsp.query_end)
         self.assertEqual(1318, hsp.hit_end)
-        self.assertEqual("VSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEES", str(hsp.query.seq)[:40])
-        self.assertEqual("+  DS +   +G   GL D H + + + + P S+D  +E ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("IGNDSYLALSKG---GLVDEHVLILPIGHYPSSIDAPQEV", str(hsp.hit.seq)[:40])
-        self.assertEqual("DITEESTSDLDK--------FNSGDKVTITYEKNDEGQLL", str(hsp.query.seq)[-40:])
-        self.assertEqual("D  +E   ++DK        F+S ++  + +E+N   Q L", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("DAPQEVIEEIDKFKVALRKYFSSKNQTCVMFERNFRSQHL", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "VSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEES", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "+  DS +   +G   GL D H + + + + P S+D  +E ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "IGNDSYLALSKG---GLVDEHVLILPIGHYPSSIDAPQEV", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "DITEESTSDLDK--------FNSGDKVTITYEKNDEGQLL", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "D  +E   ++DK        F+S ++  + +E+N   Q L",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "DAPQEVIEEIDKFKVALRKYFSSKNQTCVMFERNFRSQHL", str(hsp.hit.seq)[-40:]
+        )
 
     def test_text_2226_tblastn_003(self):
         """Test parsing tblastn output (text_2226_tblastn_003.txt)."""
@@ -1283,7 +1846,10 @@ class TblastnCases(BaseBlastCases):
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("ref|XM_003502378.1|", hit.id)
-        self.assertEqual("PREDICTED: Cricetulus griseus pleckstrin-like (LOC100773128), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Cricetulus griseus pleckstrin-like (LOC100773128), mRNA",
+            hit.description,
+        )
         self.assertEqual(1119, hit.seq_len)
         self.assertEqual(2, len(hit))
         # first qresult, first hit, first hsp
@@ -1303,12 +1869,26 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(75, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(369, hsp.hit_end)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(100, hsp.aln_span)
@@ -1326,16 +1906,33 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(801, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(1101, hsp.hit_end)
-        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("I++G L+K+G     WK    +L ED   + +Y       ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40])
-        self.assertEqual("GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:])
-        self.assertEqual("GK+     + +I T  +  ++ QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "I++G L+K+G     WK    +L ED   + +Y       ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|XM_003360601.2|", hit.id)
-        self.assertEqual("PREDICTED: Sus scrofa pleckstrin-like (LOC100626968), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Sus scrofa pleckstrin-like (LOC100626968), mRNA",
+            hit.description,
+        )
         self.assertEqual(772, hit.seq_len)
         self.assertEqual(2, len(hit))
         # first qresult, second hit, first hsp
@@ -1355,12 +1952,26 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(94, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(388, hsp.hit_end)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNS", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:])
-        self.assertEqual("FGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("FGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNS",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "FGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "FGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(71, hsp.aln_span)
@@ -1378,12 +1989,26 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(541, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(754, hsp.hit_end)
-        self.assertEqual("IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK-", str(hsp.query.seq)[:40])
-        self.assertEqual("+ +Y       P G I L+G  +TS      GK  F+ + ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", str(hsp.hit.seq)[:40])
-        self.assertEqual("GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:])
-        self.assertEqual("GK  F+ +     T  +  +F QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("GKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK-", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "+ +Y       P G I L+G  +TS      GK  F+ + ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "GK  F+ +     T  +  +F QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+        )
 
     def test_text_2226_tblastn_004(self):
         """Test parsing tblastn output (text_2226_tblastn_004.txt)."""
@@ -1405,7 +2030,10 @@ class TblastnCases(BaseBlastCases):
         # test second qresult
         qresult = qresults[1]
         self.assertEqual("gi|16080617|ref|NP_391444.1|", qresult.id)
-        self.assertEqual("membrane bound lipoprotein [Bacillussubtilis subsp. subtilis str. 168]", qresult.description)
+        self.assertEqual(
+            "membrane bound lipoprotein [Bacillussubtilis subsp. subtilis str. 168]",
+            qresult.description,
+        )
         self.assertEqual(102, qresult.seq_len)
         self.assertEqual("minirefseq_mrna", qresult.target)
         self.assertEqual("tblastn", qresult.program)
@@ -1414,7 +2042,10 @@ class TblastnCases(BaseBlastCases):
         # second qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|145479850|ref|XM_001425911.1|", hit.id)
-        self.assertEqual("Paramecium tetraurelia hypothetical protein (GSPATT00004923001) partial mRNA", hit.description)
+        self.assertEqual(
+            "Paramecium tetraurelia hypothetical protein (GSPATT00004923001) partial mRNA",
+            hit.description,
+        )
         self.assertEqual(4632, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, first hit, first hsp
@@ -1434,16 +2065,33 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(1743, hsp.hit_start)
         self.assertEqual(73, hsp.query_end)
         self.assertEqual(1872, hsp.hit_end)
-        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTS", str(hsp.query.seq)[:40])
-        self.assertEqual("P +   TK+GT +GL   HTI   + +  +SL++ E++  ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", str(hsp.hit.seq)[:40])
-        self.assertEqual("NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)[-40:])
-        self.assertEqual("   TK+GT +GL   HTI   + +  +SL++ E++  D+D", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("ATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "P +   TK+GT +GL   HTI   + +  +SL++ E++  ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "ATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)[-40:]
+        )
         # second qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|72012412|ref|XM_777959.1|", hit.id)
-        self.assertEqual("PREDICTED: Strongylocentrotus purpuratus hypothetical LOC577746 (LOC577746), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Strongylocentrotus purpuratus hypothetical LOC577746 (LOC577746), mRNA",
+            hit.description,
+        )
         self.assertEqual(1593, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, second hit, first hsp
@@ -1463,12 +2111,26 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(1056, hsp.hit_start)
         self.assertEqual(94, hsp.query_end)
         self.assertEqual(1233, hsp.hit_end)
-        self.assertEqual("GLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSG-----", str(hsp.query.seq)[:40])
-        self.assertEqual("GL   HT+ + V +    LD+TEE  ++LD+F S      ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYY", str(hsp.hit.seq)[:40])
-        self.assertEqual("DITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL", str(hsp.query.seq)[-40:])
-        self.assertEqual("D+TEE  ++LD+F S          K  + YE+N   Q L", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("DLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "GLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSG-----", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "GL   HT+ + V +    LD+TEE  ++LD+F S      ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYY", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "DITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "D+TEE  ++LD+F S          K  + YE+N   Q L",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "DLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL", str(hsp.hit.seq)[-40:]
+        )
 
         # test third qresult
         qresult = qresults[2]
@@ -1482,7 +2144,10 @@ class TblastnCases(BaseBlastCases):
         # third qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|350596019|ref|XM_003360601.2|", hit.id)
-        self.assertEqual("PREDICTED: Sus scrofa pleckstrin-like (LOC100626968), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Sus scrofa pleckstrin-like (LOC100626968), mRNA",
+            hit.description,
+        )
         self.assertEqual(772, hit.seq_len)
         self.assertEqual(2, len(hit))
         # third qresult, first hit, first hsp
@@ -1502,12 +2167,26 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(94, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(388, hsp.hit_end)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNS", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:])
-        self.assertEqual("FGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("FGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNS",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "FGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "FGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+        )
         # third qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(71, hsp.aln_span)
@@ -1525,16 +2204,33 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(541, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(754, hsp.hit_end)
-        self.assertEqual("IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK-", str(hsp.query.seq)[:40])
-        self.assertEqual("+ +Y       P G I L+G  +TS      GK  F+ + ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", str(hsp.hit.seq)[:40])
-        self.assertEqual("GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:])
-        self.assertEqual("GK  F+ +     T  +  +F QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("GKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK-", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "+ +Y       P G I L+G  +TS      GK  F+ + ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "GK  F+ +     T  +  +F QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+        )
         # third qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|301779869|ref|XM_002925302.1|", hit.id)
-        self.assertEqual("PREDICTED: Ailuropoda melanoleuca pleckstrin-like (LOC100466932), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Ailuropoda melanoleuca pleckstrin-like (LOC100466932), mRNA",
+            hit.description,
+        )
         self.assertEqual(1144, hit.seq_len)
         self.assertEqual(2, len(hit))
         # third qresult, second hit, first hsp
@@ -1554,12 +2250,26 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(77, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(371, hsp.hit_end)
-        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("KRIREGYLVK+GSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("KRIREGYLVKRGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:])
-        self.assertEqual("FGKRMFV KITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("FGKRMFVFKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "KRIREGYLVK+GSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "KRIREGYLVKRGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "FGKRMFV KITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "FGKRMFVFKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+        )
         # third qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(100, hsp.aln_span)
@@ -1577,16 +2287,29 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(803, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(1103, hsp.hit_end)
-        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40])
-        self.assertEqual("I++G L+K+G     WK    +L ED   + +Y       ", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40])
-        self.assertEqual("QDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:])
-        self.assertEqual("    +   + +I T  +  +F QAA  +ER  W++ I+ A", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("VRKSEEENLFEIITADEVHYFLQAATPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "I++G L+K+G     WK    +L ED   + +Y       ",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "QDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "    +   + +I T  +  +F QAA  +ER  W++ I+ A",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "VRKSEEENLFEIITADEVHYFLQAATPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+        )
 
 
 class TblastxCases(BaseBlastCases):
-
     def test_text_2226_tblastx_001(self):
         """Test parsing tblastx output (text_2226_tblastx_001.txt)."""
         blast_file = get_file("text_2226_tblastx_001.txt")
@@ -1614,7 +2337,10 @@ class TblastxCases(BaseBlastCases):
         # test first qresult
         qresult = qresults[0]
         self.assertEqual("gi|356995852:1-490", qresult.id)
-        self.assertEqual("Mus musculus POU domain, class 5, transcriptionfactor 1 (Pou5f1), transcript variant 1, mRNA", qresult.description)
+        self.assertEqual(
+            "Mus musculus POU domain, class 5, transcriptionfactor 1 (Pou5f1), transcript variant 1, mRNA",
+            qresult.description,
+        )
         self.assertEqual(490, qresult.seq_len)
         self.assertEqual("NCBI Transcript Reference Sequences", qresult.target)
         self.assertEqual("tblastx", qresult.program)
@@ -1623,7 +2349,10 @@ class TblastxCases(BaseBlastCases):
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("ref|NM_013633.3|", hit.id)
-        self.assertEqual("Mus musculus POU domain, class 5, transcription factor 1 (Pou5f1), transcript variant 1, mRNA", hit.description)
+        self.assertEqual(
+            "Mus musculus POU domain, class 5, transcription factor 1 (Pou5f1), transcript variant 1, mRNA",
+            hit.description,
+        )
         self.assertEqual(1353, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -1643,16 +2372,33 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(489, hsp.query_end)
         self.assertEqual(489, hsp.hit_end)
-        self.assertEqual("EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", str(hsp.query.seq)[:40])
-        self.assertEqual("EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", str(hsp.hit.seq)[:40])
-        self.assertEqual("TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", str(hsp.query.seq)[-40:])
-        self.assertEqual("TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|XR_141831.1|", hit.id)
-        self.assertEqual("PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA ref|XR_105837.2| PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA ref|XR_141464.1| PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA ref|XR_141446.1| PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA ref|XR_105837.2| PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA ref|XR_141464.1| PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA ref|XR_141446.1| PREDICTED: Mus musculus predicted gene, 19553 (Gm19553), miscRNA",
+            hit.description,
+        )
         self.assertEqual(570, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, second hit, first hsp
@@ -1672,12 +2418,26 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(81, hsp.hit_start)
         self.assertEqual(489, hsp.query_end)
         self.assertEqual(570, hsp.hit_end)
-        self.assertEqual("EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", str(hsp.query.seq)[:40])
-        self.assertEqual("EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", str(hsp.hit.seq)[:40])
-        self.assertEqual("TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", str(hsp.query.seq)[-40:])
-        self.assertEqual("TQREPPLSPVPTAPMP*SWRRWNQL RSPRT*KPCRRS*N", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("TQREPPLSPVPTAPMP*SWRRWNQLQRSPRT*KPCRRS*N", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "TQREPPLSPVPTAPMP*SWRRWNQL RSPRT*KPCRRS*N",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "TQREPPLSPVPTAPMP*SWRRWNQLQRSPRT*KPCRRS*N", str(hsp.hit.seq)[-40:]
+        )
 
     def test_text_2226_tblastx_003(self):
         """Test parsing tblastx output (text_2226_tblastx_003.txt)."""
@@ -1689,7 +2449,10 @@ class TblastxCases(BaseBlastCases):
         # test first qresult
         qresult = qresults[0]
         self.assertEqual("hg19_dna", qresult.id)
-        self.assertEqual("range=chr1:1207057-1207541 5'pad=0 3'pad=0 strand=+repeatMasking=none", qresult.description)
+        self.assertEqual(
+            "range=chr1:1207057-1207541 5'pad=0 3'pad=0 strand=+repeatMasking=none",
+            qresult.description,
+        )
         self.assertEqual(485, qresult.seq_len)
         self.assertEqual("NCBI Transcript Reference Sequences", qresult.target)
         self.assertEqual("tblastx", qresult.program)
@@ -1698,7 +2461,9 @@ class TblastxCases(BaseBlastCases):
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("ref|NM_002985.2|", hit.id)
-        self.assertEqual("Homo sapiens chemokine (C-C motif) ligand 5 (CCL5), mRNA", hit.description)
+        self.assertEqual(
+            "Homo sapiens chemokine (C-C motif) ligand 5 (CCL5), mRNA", hit.description
+        )
         self.assertEqual(1237, hit.seq_len)
         self.assertEqual(3, len(hit))
         # first qresult, first hit, first hsp
@@ -1718,12 +2483,26 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(622, hsp.hit_start)
         self.assertEqual(459, hsp.query_end)
         self.assertEqual(943, hsp.hit_end)
-        self.assertEqual("VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", str(hsp.query.seq)[:40])
-        self.assertEqual("V  A V+ H+LSSLQPP P FK FS LSL SSWD R  PP", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("VTQAGVKWHNLSSLQPPPPGFKQFSCLSLPSSWDYRRGPP", str(hsp.hit.seq)[:40])
-        self.assertEqual("WLDLGppqpppPGFK*FSCLSHPSSWDYRHMPPCLINFVF", str(hsp.query.seq)[-40:])
-        self.assertEqual("W DLG  Q PPPGF  FSCLS PSSWDYR   P   NF++", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("WRDLGSLQAPPPGFTPFSCLSLPSSWDYRRPLPRPANFLY", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "V  A V+ H+LSSLQPP P FK FS LSL SSWD R  PP",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "VTQAGVKWHNLSSLQPPPPGFKQFSCLSLPSSWDYRRGPP", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "WLDLGppqpppPGFK*FSCLSHPSSWDYRHMPPCLINFVF", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "W DLG  Q PPPGF  FSCLS PSSWDYR   P   NF++",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "WRDLGSLQAPPPGFTPFSCLSLPSSWDYRRPLPRPANFLY", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(44, hsp.aln_span)
@@ -1741,16 +2520,33 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(498, hsp.hit_start)
         self.assertEqual(148, hsp.query_end)
         self.assertEqual(630, hsp.hit_end)
-        self.assertEqual("FCIFSRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEP", str(hsp.query.seq)[:40])
-        self.assertEqual("FCIFSRDGV  CW GWSRTPDL+*S  LGLPKCWDYR EP", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("FCIFSRDGVSSCWPGWSRTPDLK*STHLGLPKCWDYRREP", str(hsp.hit.seq)[:40])
-        self.assertEqual("SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", str(hsp.query.seq)[-40:])
-        self.assertEqual("SRDGV  CW GWSRTPDL+*S  LGLPKCWDYR EPPRPA", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("SRDGVSSCWPGWSRTPDLK*STHLGLPKCWDYRREPPRPA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "FCIFSRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEP", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "FCIFSRDGV  CW GWSRTPDL+*S  LGLPKCWDYR EP",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "FCIFSRDGVSSCWPGWSRTPDLK*STHLGLPKCWDYRREP", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "SRDGV  CW GWSRTPDL+*S  LGLPKCWDYR EPPRPA",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "SRDGVSSCWPGWSRTPDLK*STHLGLPKCWDYRREPPRPA", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|XM_003255417.1|", hit.id)
-        self.assertEqual("PREDICTED: Nomascus leucogenys 5'-nucleotidase, cytosolic II, transcript variant 2 (NT5C2), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Nomascus leucogenys 5'-nucleotidase, cytosolic II, transcript variant 2 (NT5C2), mRNA",
+            hit.description,
+        )
         self.assertEqual(3285, hit.seq_len)
         self.assertEqual(3, len(hit))
         # first qresult, second hit, first hsp
@@ -1770,12 +2566,26 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(2744, hsp.hit_start)
         self.assertEqual(298, hsp.query_end)
         self.assertEqual(3026, hsp.hit_end)
-        self.assertEqual("ETEFRSCCPGWSAMA*SWPTTASTSWIQVILLPQSPE*LG", str(hsp.query.seq)[:40])
-        self.assertEqual("E EFRSCCPGWSAMA SW    S SW+QVIL PQ PE*LG", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("EMEFRSCCPGWSAMAQSWLIATSVSWVQVILWPQPPE*LG", str(hsp.hit.seq)[:40])
-        self.assertEqual("SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", str(hsp.query.seq)[-40:])
-        self.assertEqual("SRDGV PCWSGWSRTPDLR*SACLGLPKCWDYR EPP PA", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("SRDGVSPCWSGWSRTPDLR*SACLGLPKCWDYRREPPCPA", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "ETEFRSCCPGWSAMA*SWPTTASTSWIQVILLPQSPE*LG", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "E EFRSCCPGWSAMA SW    S SW+QVIL PQ PE*LG",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "EMEFRSCCPGWSAMAQSWLIATSVSWVQVILWPQPPE*LG", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "SRDGV PCWSGWSRTPDLR*SACLGLPKCWDYR EPP PA",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "SRDGVSPCWSGWSRTPDLR*SACLGLPKCWDYRREPPCPA", str(hsp.hit.seq)[-40:]
+        )
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(94, hsp.aln_span)
@@ -1793,12 +2603,26 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(2745, hsp.hit_start)
         self.assertEqual(299, hsp.query_end)
         self.assertEqual(3027, hsp.hit_end)
-        self.assertEqual("AGRGGSHL*SQHFGRPRQADYLRSGVRDQPDQHGKTPSLL", str(hsp.query.seq)[:40])
-        self.assertEqual("AG GGS L*SQHFGRPRQAD+LRSGVRDQPDQHG+TPSLL", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("AGHGGSRL*SQHFGRPRQADHLRSGVRDQPDQHGETPSLL", str(hsp.hit.seq)[:40])
-        self.assertEqual("PSYSGD*GRRIT*IQEVEAVVGQDQAIALQPGQQERNSVS", str(hsp.query.seq)[-40:])
-        self.assertEqual("PSYSG *G+RIT* QE E  + QD AIALQPGQQERNS+S", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("PSYSGG*GQRIT*TQETEVAMSQDCAIALQPGQQERNSIS", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "AGRGGSHL*SQHFGRPRQADYLRSGVRDQPDQHGKTPSLL", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "AG GGS L*SQHFGRPRQAD+LRSGVRDQPDQHG+TPSLL",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "AGHGGSRL*SQHFGRPRQADHLRSGVRDQPDQHGETPSLL", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "PSYSGD*GRRIT*IQEVEAVVGQDQAIALQPGQQERNSVS", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "PSYSG *G+RIT* QE E  + QD AIALQPGQQERNS+S",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "PSYSGG*GQRIT*TQETEVAMSQDCAIALQPGQQERNSIS", str(hsp.hit.seq)[-40:]
+        )
 
     def test_text_2226_tblastx_004(self):
         """Test parsing tblastx output (text_2226_tblastx_004.txt)."""
@@ -1820,7 +2644,10 @@ class TblastxCases(BaseBlastCases):
         # test second qresult
         qresult = qresults[1]
         self.assertEqual("gi|296147483:1-350", qresult.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA,complete cds", qresult.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA,complete cds",
+            qresult.description,
+        )
         self.assertEqual(350, qresult.seq_len)
         self.assertEqual("minirefseq_mrna", qresult.target)
         self.assertEqual("tblastx", qresult.program)
@@ -1829,7 +2656,10 @@ class TblastxCases(BaseBlastCases):
         # second qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|296147483|ref|NM_001183135.1|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA, complete cds", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Mon2p (MON2) mRNA, complete cds",
+            hit.description,
+        )
         self.assertEqual(4911, hit.seq_len)
         self.assertEqual(8, len(hit))
         # second qresult, first hit, first hsp
@@ -1849,12 +2679,26 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(1, hsp.hit_start)
         self.assertEqual(349, hsp.query_end)
         self.assertEqual(349, hsp.hit_end)
-        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", str(hsp.query.seq)[:40])
-        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", str(hsp.hit.seq)[:40])
-        self.assertEqual("WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", str(hsp.query.seq)[-40:])
-        self.assertEqual("WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", str(hsp.hit.seq)[-40:]
+        )
         # second qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(116, hsp.aln_span)
@@ -1872,16 +2716,33 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(1, hsp.hit_start)
         self.assertEqual(349, hsp.query_end)
         self.assertEqual(349, hsp.hit_end)
-        self.assertEqual("LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", str(hsp.query.seq)[:40])
-        self.assertEqual("LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", str(hsp.hit.seq)[:40])
-        self.assertEqual("WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", str(hsp.query.seq)[-40:])
-        self.assertEqual("WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", str(hsp.hit.seq)[-40:]
+        )
         # second qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|365982352|ref|XM_003667962.1|", hit.id)
-        self.assertEqual("Naumovozyma dairenensis CBS 421 hypothetical protein (NDAI0A06120), mRNA", hit.description)
+        self.assertEqual(
+            "Naumovozyma dairenensis CBS 421 hypothetical protein (NDAI0A06120), mRNA",
+            hit.description,
+        )
         self.assertEqual(4932, hit.seq_len)
         self.assertEqual(10, len(hit))
         # second qresult, second hit, first hsp
@@ -1901,12 +2762,26 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(87, hsp.hit_start)
         self.assertEqual(348, hsp.query_end)
         self.assertEqual(342, hsp.hit_end)
-        self.assertEqual("TIRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRN", str(hsp.query.seq)[:40])
-        self.assertEqual("TI+HASDKSI+ILK + + EEL RHPDF  P VLAC SRN", hsp.aln_annotation["similarity"][:40])
-        self.assertEqual("TIKHASDKSIDILKTIQNIEELVRHPDFVTPLVLACSSRN", str(hsp.hit.seq)[:40])
-        self.assertEqual("LAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK", str(hsp.query.seq)[-40:])
-        self.assertEqual("+AMQCLQGL++VPSIP SR+ E+LD FIEAT LAMEIQLK", hsp.aln_annotation["similarity"][-40:])
-        self.assertEqual("IAMQCLQGLASVPSIPESRIPEVLDGFIEATQLAMEIQLK", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "TIRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRN", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "TI+HASDKSI+ILK + + EEL RHPDF  P VLAC SRN",
+            hsp.aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "TIKHASDKSIDILKTIQNIEELVRHPDFVTPLVLACSSRN", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "LAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK", str(hsp.query.seq)[-40:]
+        )
+        self.assertEqual(
+            "+AMQCLQGL++VPSIP SR+ E+LD FIEAT LAMEIQLK",
+            hsp.aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "IAMQCLQGLASVPSIPESRIPEVLDGFIEATQLAMEIQLK", str(hsp.hit.seq)[-40:]
+        )
         # second qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(14, hsp.aln_span)
@@ -1948,9 +2823,17 @@ class TblastxCases(BaseBlastCases):
         hsp = qresult.hsps[0]
         self.assertIn("PTSP" + ("-" * 79) + "AYSP", hsp.query)
         hsp = qresult.hsps[1]
-        self.assertTrue(hsp.query.seq.startswith("AYSPTSPAYSPTSPAYSPTSPAYSPTSPAYS----------PTSPAYSPTSPAYSPTSPA"))
+        self.assertTrue(
+            hsp.query.seq.startswith(
+                "AYSPTSPAYSPTSPAYSPTSPAYSPTSPAYS----------PTSPAYSPTSPAYSPTSPA"
+            )
+        )
         hsp = qresult.hsps[2]
-        self.assertTrue(hsp.query.seq.startswith("YSPTSPAYSPTSPAYSPTSPAYSPTSPAYS----------PTSPAYSPTSPAYSPTSPAY"))
+        self.assertTrue(
+            hsp.query.seq.startswith(
+                "YSPTSPAYSPTSPAYSPTSPAYSPTSPAYS----------PTSPAYSPTSPAYSPTSPAY"
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to the rest of test_SearchIO_blast* files, only 2 files:
test_SearchIO_blast_tab.py
test_SearchIO_blast_text.py
