### PR TITLE
Apply black style to test_SearchIO_exonerate*, version 19.10b0.

### DIFF
--- a/Tests/test_SearchIO_exonerate.py
+++ b/Tests/test_SearchIO_exonerate.py
@@ -23,7 +23,7 @@ def get_file(filename):
 class ExonerateSpcCases(unittest.TestCase):
 
     coord = ("start", "end")
-    coords = ("inter_ranges", )
+    coords = ("inter_ranges",)
     stype = ("hit_", "query_")
 
     def check_vulgar_text(self, vulgar, text):
@@ -56,11 +56,15 @@ class ExonerateSpcCases(unittest.TestCase):
 
     def test_vulgar_text_similar_c2c(self):
         """Compares vulgar-text coordinate parsing for the coding2coding model."""
-        self.check_vulgar_text("exn_22_o_vulgar_fshifts.exn", "exn_22_m_coding2coding_fshifts.exn")
+        self.check_vulgar_text(
+            "exn_22_o_vulgar_fshifts.exn", "exn_22_m_coding2coding_fshifts.exn"
+        )
 
     def test_vulgar_text_similar_p2d(self):
         """Compares vulgar-text coordinate parsing for the protein2dna model."""
-        self.check_vulgar_text("exn_22_o_vulgar_fshifts2.exn", "exn_22_m_protein2dna_fshifts.exn")
+        self.check_vulgar_text(
+            "exn_22_o_vulgar_fshifts2.exn", "exn_22_m_protein2dna_fshifts.exn"
+        )
 
 
 class ExonerateTextCases(unittest.TestCase):
@@ -80,14 +84,20 @@ class ExonerateTextCases(unittest.TestCase):
                 self.assertEqual(qresult.id, hsp.query_id)
 
         self.assertEqual("gi|296143771|ref|NM_001180731.1|", qresult.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds", qresult.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds",
+            qresult.description,
+        )
         self.assertEqual("exonerate", qresult.program)
         self.assertEqual("affine:local:dna2dna", qresult.model)
         self.assertEqual(3, len(qresult))
         # first hit
         hit = qresult[0]
         self.assertEqual("gi|330443520|ref|NC_001136.10|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome IV, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome IV, complete sequence",
+            hit.description,
+        )
         self.assertEqual(1, len(hit.hsps))
         # first hit, first hsp
         hsp = qresult[0].hsps[0]
@@ -106,17 +116,34 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # second hit
         hit = qresult[1]
         self.assertEqual("gi|330443688|ref|NC_001145.3|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome XIII, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome XIII, complete sequence",
+            hit.description,
+        )
         self.assertEqual(1, len(hit.hsps))
         # second hit, first hsp
         hsp = qresult[1].hsps[0]
@@ -135,17 +162,34 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ACCTAAGAGGAAGGTGGGCAGACCAGGCAGAAAA-AGGAT", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||| |||| |||||   ||| | |  ||| |||  | |||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ACCGAAGAAGAAGGGTAGCAAAACTAGCAAAAAGCAAGAT", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("AAGTTATGTGGAACA--TAGGCTCATGGAACGCTCCCAGT", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("| ||   | | ||||  ||   |||   || | ||| |||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("ATGT--GGGGAAACAATTACCTTCACCAAATGATCCAAGT", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ACCTAAGAGGAAGGTGGGCAGACCAGGCAGAAAA-AGGAT", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||| |||| |||||   ||| | |  ||| |||  | |||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ACCGAAGAAGAAGGGTAGCAAAACTAGCAAAAAGCAAGAT", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "AAGTTATGTGGAACA--TAGGCTCATGGAACGCTCCCAGT", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "| ||   | | ||||  ||   |||   || | ||| |||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "ATGT--GGGGAAACAATTACCTTCACCAAATGATCCAAGT", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # third hit
         hit = qresult[2]
         self.assertEqual("gi|330443715|ref|NC_001146.8|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome XIV, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome XIV, complete sequence",
+            hit.description,
+        )
         self.assertEqual(1, len(hit.hsps))
         # third hit, first hsp
         hsp = qresult[2].hsps[0]
@@ -164,12 +208,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ATGTTGCTAAATAAAGATGGAACACCTAAGAGGAAGGTG-", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||| || || || | |||||   |   |||| ||    | ", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGATGATATATTA-GATGGGG-ATG-AAGATGAGCCAGA", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("G-TATAGAAGTACAGCCGCACACTCAAGAGAATGAGAAAG", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("| |  |||||   | | | | |   | ||| | |||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("GTTGAAGAAGCCAAACGGAAGAAAGACGAGGA-GAGAAAG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGTTGCTAAATAAAGATGGAACACCTAAGAGGAAGGTG-", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||| || || || | |||||   |   |||| ||    | ",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGATGATATATTA-GATGGGG-ATG-AAGATGAGCCAGA", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "G-TATAGAAGTACAGCCGCACACTCAAGAGAATGAGAAAG", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "| |  |||||   | | | | |   | ||| | |||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GTTGAAGAAGCCAAACGGAAGAAAGACGAGGA-GAGAAAG", str(hsp.hit_all[0].seq)[-40:]
+        )
 
     def test_exn_22_m_cdna2genome(self):
         """Test parsing exonerate output (exn_22_m_cdna2genome.exn)."""
@@ -184,14 +242,20 @@ class ExonerateTextCases(unittest.TestCase):
                 self.assertEqual(qresult.id, hsp.query_id)
 
         self.assertEqual("gi|296143771|ref|NM_001180731.1|", qresult.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds", qresult.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds",
+            qresult.description,
+        )
         self.assertEqual("exonerate", qresult.program)
         self.assertEqual("cdna2genome", qresult.model)
         self.assertEqual(2, len(qresult))
         # first hit
         hit = qresult[0]
         self.assertEqual("gi|330443520|ref|NC_001136.10|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome IV, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome IV, complete sequence",
+            hit.description,
+        )
         self.assertEqual(2, len(hit.hsps))
         # first hit, first hsp
         hsp = qresult[0].hsps[0]
@@ -210,12 +274,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -234,17 +312,34 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # second hit
         hit = qresult[1]
         self.assertEqual("gi|330443688|ref|NC_001145.3|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome XIII, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome XIII, complete sequence",
+            hit.description,
+        )
         self.assertEqual(1, len(hit.hsps))
         # second hit, first hsp
         hsp = qresult[1].hsps[0]
@@ -255,28 +350,73 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(85010, hsp.hit_start)
         self.assertEqual(516, hsp.query_end)
         self.assertEqual(667216, hsp.hit_end)
-        self.assertEqual([(0, 65), (65, 225), (225, 320), (320, 346), (346, 516)], hsp.query_range_all)
-        self.assertEqual([(85010, 85066), (253974, 254135), (350959, 351052), (473170, 473201), (667040, 667216)], hsp.hit_range_all)
-        self.assertEqual([(65, 65), (225, 225), (320, 320), (346, 346)], hsp.query_inter_ranges)
-        self.assertEqual([(85066, 253974), (254135, 350959), (351052, 473170), (473201, 667040)], hsp.hit_inter_ranges)
+        self.assertEqual(
+            [(0, 65), (65, 225), (225, 320), (320, 346), (346, 516)],
+            hsp.query_range_all,
+        )
+        self.assertEqual(
+            [
+                (85010, 85066),
+                (253974, 254135),
+                (350959, 351052),
+                (473170, 473201),
+                (667040, 667216),
+            ],
+            hsp.hit_range_all,
+        )
+        self.assertEqual(
+            [(65, 65), (225, 225), (320, 320), (346, 346)], hsp.query_inter_ranges
+        )
+        self.assertEqual(
+            [(85066, 253974), (254135, 350959), (351052, 473170), (473201, 667040)],
+            hsp.hit_inter_ranges,
+        )
         self.assertEqual([], hsp.query_split_codons)
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(5, len(hsp.query_all))
         self.assertEqual(5, len(hsp.hit_all))
         # first block
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||  ||  | ||||   | ||||||  |||| | | | ", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGGTGAACCT-CTTCAAGACGGTCAG--AATA-A-TCAA", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("AGCAAATATATTTAGCAGGTGACATGAAGAAGCAAATGTT", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||  |||| | | | ||||    ||||||||||||| | |", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("AG--AATA-A-TCAACAGG----ATGAAGAAGCAAAAGAT", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||  ||  | ||||   | ||||||  |||| | | | ",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGGTGAACCT-CTTCAAGACGGTCAG--AATA-A-TCAA", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "AGCAAATATATTTAGCAGGTGACATGAAGAAGCAAATGTT", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||  |||| | | | ||||    ||||||||||||| | |",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "AG--AATA-A-TCAACAGG----ATGAAGAAGCAAAAGAT", str(hsp.hit_all[0].seq)[-40:]
+        )
         # last block
-        self.assertEqual("TATTAGCCTTCC--TCGATGATCTGCA--A-GAACAACAG", str(hsp.query_all[-1].seq)[:40])
-        self.assertEqual("|  |||| || |  ||||| | || ||  | ||| | |  ", hsp[-1].aln_annotation["similarity"][:40])
-        self.assertEqual("TCATAGCGTTACGTTCGAT-ACCTTCACTACGAAGATCCA", str(hsp.hit_all[-1].seq)[:40])
-        self.assertEqual("AAGTATAGAAGTACAGCCGCACACTCAAGAGAATGAGAAA", str(hsp.query_all[-1].seq)[-40:])
-        self.assertEqual("   |||||||||||||     ||  ||| | ||  | |||", hsp[-1].aln_annotation["similarity"][-40:])
-        self.assertEqual("TTCTATAGAAGTACAGTTATTCAAACAAAAAAAAAAAAAA", str(hsp.hit_all[-1].seq)[-40:])
+        self.assertEqual(
+            "TATTAGCCTTCC--TCGATGATCTGCA--A-GAACAACAG", str(hsp.query_all[-1].seq)[:40]
+        )
+        self.assertEqual(
+            "|  |||| || |  ||||| | || ||  | ||| | |  ",
+            hsp[-1].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "TCATAGCGTTACGTTCGAT-ACCTTCACTACGAAGATCCA", str(hsp.hit_all[-1].seq)[:40]
+        )
+        self.assertEqual(
+            "AAGTATAGAAGTACAGCCGCACACTCAAGAGAATGAGAAA", str(hsp.query_all[-1].seq)[-40:]
+        )
+        self.assertEqual(
+            "   |||||||||||||     ||  ||| | ||  | |||",
+            hsp[-1].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "TTCTATAGAAGTACAGTTATTCAAACAAAAAAAAAAAAAA", str(hsp.hit_all[-1].seq)[-40:]
+        )
 
     def test_exn_22_m_coding2coding(self):
         """Test parsing exonerate output (exn_22_m_coding2coding.exn)."""
@@ -291,14 +431,20 @@ class ExonerateTextCases(unittest.TestCase):
                 self.assertEqual(qresult.id, hsp.query_id)
 
         self.assertEqual("gi|296143771|ref|NM_001180731.1|", qresult.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds", qresult.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds",
+            qresult.description,
+        )
         self.assertEqual("exonerate", qresult.program)
         self.assertEqual("coding2coding", qresult.model)
         self.assertEqual(2, len(qresult))
         # first hit
         hit = qresult[0]
         self.assertEqual("gi|330443520|ref|NC_001136.10|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome IV, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome IV, complete sequence",
+            hit.description,
+        )
         self.assertEqual(2, len(hit.hsps))
         # first hit, first hsp
         hsp = qresult[0].hsps[0]
@@ -317,12 +463,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -341,17 +501,34 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # second hit
         hit = qresult[1]
         self.assertEqual("gi|330443688|ref|NC_001145.3|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome XIII, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome XIII, complete sequence",
+            hit.description,
+        )
         self.assertEqual(1, len(hit.hsps))
         # second hit, first hsp
         hsp = qresult[1].hsps[0]
@@ -370,12 +547,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("TGCTACCACATTCTCGAAGAGATCTCCTCCCTACCAAAAT", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||+!  .!.|||   !!:...||+:!::!:!  ||+||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("TGTTCGGAAATTTGGGATAGAATAACAACACATCCGAAAT", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("CAAAGCTCGCGACTTACAGAGTGCTCTGGTTAGACAGCTC", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("!!!.||+...|||:!:||+   |||+||  !!::!!.:!:", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("CAATGCAGAAGACGTTCAATTAGCTTTGAATAAGCATATG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "TGCTACCACATTCTCGAAGAGATCTCCTCCCTACCAAAAT", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||+!  .!.|||   !!:...||+:!::!:!  ||+||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "TGTTCGGAAATTTGGGATAGAATAACAACACATCCGAAAT", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "CAAAGCTCGCGACTTACAGAGTGCTCTGGTTAGACAGCTC", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "!!!.||+...|||:!:||+   |||+||  !!::!!.:!:",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "CAATGCAGAAGACGTTCAATTAGCTTTGAATAAGCATATG", str(hsp.hit_all[0].seq)[-40:]
+        )
 
     def test_exn_22_m_coding2genome(self):
         """Test parsing exonerate output (exn_22_m_coding2genome.exn)."""
@@ -390,14 +581,20 @@ class ExonerateTextCases(unittest.TestCase):
                 self.assertEqual(qresult.id, hsp.query_id)
 
         self.assertEqual("gi|296143771|ref|NM_001180731.1|", qresult.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds", qresult.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds",
+            qresult.description,
+        )
         self.assertEqual("exonerate", qresult.program)
         self.assertEqual("coding2genome", qresult.model)
         self.assertEqual(2, len(qresult))
         # first hit
         hit = qresult[0]
         self.assertEqual("gi|330443520|ref|NC_001136.10|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome IV, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome IV, complete sequence",
+            hit.description,
+        )
         self.assertEqual(2, len(hit.hsps))
         # first hit, first hsp
         hsp = qresult[0].hsps[0]
@@ -416,12 +613,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -440,17 +651,34 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # second hit
         hit = qresult[1]
         self.assertEqual("gi|330443688|ref|NC_001145.3|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome XIII, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome XIII, complete sequence",
+            hit.description,
+        )
         self.assertEqual(1, len(hit.hsps))
         # second hit, first hsp
         hsp = qresult[1].hsps[0]
@@ -469,12 +697,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("TGCTACCACATTCTCGAAGAGATCTCCTCCCTACCAAAAT", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||+!  .!.|||   !!:...||+:!::!:!  ||+||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("TGTTCGGAAATTTGGGATAGAATAACAACACATCCGAAAT", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("CAAAGCTCGCGACTTACAGAGTGCTCTGGTTAGACAGCTC", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("!!!.||+...|||:!:||+   |||+||  !!::!!.:!:", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("CAATGCAGAAGACGTTCAATTAGCTTTGAATAAGCATATG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "TGCTACCACATTCTCGAAGAGATCTCCTCCCTACCAAAAT", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||+!  .!.|||   !!:...||+:!::!:!  ||+||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "TGTTCGGAAATTTGGGATAGAATAACAACACATCCGAAAT", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "CAAAGCTCGCGACTTACAGAGTGCTCTGGTTAGACAGCTC", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "!!!.||+...|||:!:||+   |||+||  !!::!!.:!:",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "CAATGCAGAAGACGTTCAATTAGCTTTGAATAAGCATATG", str(hsp.hit_all[0].seq)[-40:]
+        )
 
     def test_exn_22_m_dna2protein(self):
         """Test parsing exonerate output (exn_22_m_dna2protein.exn)."""
@@ -510,7 +752,9 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual("NSPFXKGPLASVQNPVYHKQPLNPAPNAETH", str(hsp[0].query.seq)[:40])
-        self.assertEqual(["|||", "...", " !!", " !!", "! !"], hsp[0].aln_annotation["similarity"][:5])
+        self.assertEqual(
+            ["|||", "...", " !!", " !!", "! !"], hsp[0].aln_annotation["similarity"][:5]
+        )
         self.assertEqual("NQSVPKRPAGSVQNPVYHNQPLNPAPSRDPH", str(hsp[0].hit.seq)[:40])
 
     def test_exn_22_m_est2genome(self):
@@ -526,14 +770,20 @@ class ExonerateTextCases(unittest.TestCase):
                 self.assertEqual(qresult.id, hsp.query_id)
 
         self.assertEqual("gi|296143771|ref|NM_001180731.1|", qresult.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds", qresult.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds",
+            qresult.description,
+        )
         self.assertEqual("exonerate", qresult.program)
         self.assertEqual("est2genome", qresult.model)
         self.assertEqual(2, len(qresult))
         # first hit
         hit = qresult[0]
         self.assertEqual("gi|330443520|ref|NC_001136.10|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome IV, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome IV, complete sequence",
+            hit.description,
+        )
         self.assertEqual(1, len(hit.hsps))
         # first hit, first hsp
         hsp = qresult[0].hsps[0]
@@ -552,17 +802,34 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # second hit
         hit = qresult[1]
         self.assertEqual("gi|330443688|ref|NC_001145.3|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome XIII, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome XIII, complete sequence",
+            hit.description,
+        )
         self.assertEqual(2, len(hit.hsps))
         # second hit, first hsp
         hsp = qresult[1].hsps[0]
@@ -573,24 +840,47 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(85010, hsp.hit_start)
         self.assertEqual(346, hsp.query_end)
         self.assertEqual(473201, hsp.hit_end)
-        self.assertEqual([(0, 65), (65, 225), (225, 320), (320, 346)], hsp.query_range_all)
-        self.assertEqual([(85010, 85066), (253974, 254135), (350959, 351052), (473170, 473201)], hsp.hit_range_all)
+        self.assertEqual(
+            [(0, 65), (65, 225), (225, 320), (320, 346)], hsp.query_range_all
+        )
+        self.assertEqual(
+            [(85010, 85066), (253974, 254135), (350959, 351052), (473170, 473201)],
+            hsp.hit_range_all,
+        )
         self.assertEqual([(65, 65), (225, 225), (320, 320)], hsp.query_inter_ranges)
-        self.assertEqual([(85066, 253974), (254135, 350959), (351052, 473170)], hsp.hit_inter_ranges)
+        self.assertEqual(
+            [(85066, 253974), (254135, 350959), (351052, 473170)], hsp.hit_inter_ranges
+        )
         self.assertEqual([], hsp.query_split_codons)
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(4, len(hsp.query_all))
         self.assertEqual(4, len(hsp.hit_all))
         # first block
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||  ||  | ||||   | ||||||  |||| | | | ", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGGTGAACCT-CTTCAAGACGGTCAG--AATA-A-TCAA", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("AGCAAATATATTTAGCAGGTGACATGAAGAAGCAAATGTT", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||  |||| | | | ||||    ||||||||||||| | |", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("AG--AATA-A-TCAACAGG----ATGAAGAAGCAAAAGAT", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||  ||  | ||||   | ||||||  |||| | | | ",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGGTGAACCT-CTTCAAGACGGTCAG--AATA-A-TCAA", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "AGCAAATATATTTAGCAGGTGACATGAAGAAGCAAATGTT", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||  |||| | | | ||||    ||||||||||||| | |",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "AG--AATA-A-TCAACAGG----ATGAAGAAGCAAAAGAT", str(hsp.hit_all[0].seq)[-40:]
+        )
         # last block
         self.assertEqual("AGCTAAGAATTCTGATGATG-----AAAGAA", str(hsp.query_all[-1].seq))
-        self.assertEqual("|   |||||||||||| |||     ||||||", hsp[-1].aln_annotation["similarity"])
+        self.assertEqual(
+            "|   |||||||||||| |||     ||||||", hsp[-1].aln_annotation["similarity"]
+        )
         self.assertEqual("ATGGAAGAATTCTGATAATGCTGTAAAAGAA", str(hsp.hit_all[-1].seq))
 
         # second hit, second hsp
@@ -603,7 +893,9 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(406, hsp.query_end)
         self.assertEqual(130198, hsp.hit_end)
         self.assertEqual([(25, 183), (183, 252), (252, 406)], hsp.query_range_all)
-        self.assertEqual([(130038, 130198), (120612, 120681), (11338, 11487)], hsp.hit_range_all)
+        self.assertEqual(
+            [(130038, 130198), (120612, 120681), (11338, 11487)], hsp.hit_range_all
+        )
         self.assertEqual([(183, 183), (252, 252)], hsp.query_inter_ranges)
         self.assertEqual([(120681, 130038), (11487, 120612)], hsp.hit_inter_ranges)
         self.assertEqual([], hsp.query_split_codons)
@@ -611,19 +903,47 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(3, len(hsp.query_all))
         self.assertEqual(3, len(hsp.hit_all))
         # first block
-        self.assertEqual("AGCAAATATATTTA-GCAGGTGACATGAAGAAGCAAATGT", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("| |||| |||   | ||||   | | || |||| | |  |", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ACCAAAGATAACAAGGCAG--AAAAAGAGGAAGAAGAAAT", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("AG-GACTGCCCAGAATAGGGCAGCTCAACGAGCGTTCCGA", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("|| |||  ||||||  ||   |||  || ||   ||| ||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("AGTGAC--CCCAGAGGAGCCAAGCAAAAAGA---TTCGGA", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "AGCAAATATATTTA-GCAGGTGACATGAAGAAGCAAATGT", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "| |||| |||   | ||||   | | || |||| | |  |",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ACCAAAGATAACAAGGCAG--AAAAAGAGGAAGAAGAAAT", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "AG-GACTGCCCAGAATAGGGCAGCTCAACGAGCGTTCCGA", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "|| |||  ||||||  ||   |||  || ||   ||| ||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "AGTGAC--CCCAGAGGAGCCAAGCAAAAAGA---TTCGGA", str(hsp.hit_all[0].seq)[-40:]
+        )
         # last block
-        self.assertEqual("AATAAGACTACCACGGACTTTTTACTATGTTCTTTAAAAA", str(hsp.query_all[-1].seq)[:40])
-        self.assertEqual("|||||||  | ||| |    |||| | |  | | ||    ", hsp[-1].aln_annotation["similarity"][:40])
-        self.assertEqual("AATAAGAGCAACACAG----TTTA-TCTTATATGTA----", str(hsp.hit_all[-1].seq)[:40])
-        self.assertEqual("CTGCAAGAACAACAGAAAAGGGAAAACGAAAAAGGAACAA", str(hsp.query_all[-1].seq)[-40:])
-        self.assertEqual("|  | | || |  | || ||  ||||||||  ||  ||||", hsp[-1].aln_annotation["similarity"][-40:])
-        self.assertEqual("CCACTAAAAAATTATAAGAGCCAAAACGAAGTAGATACAA", str(hsp.hit_all[-1].seq)[-40:])
+        self.assertEqual(
+            "AATAAGACTACCACGGACTTTTTACTATGTTCTTTAAAAA", str(hsp.query_all[-1].seq)[:40]
+        )
+        self.assertEqual(
+            "|||||||  | ||| |    |||| | |  | | ||    ",
+            hsp[-1].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "AATAAGAGCAACACAG----TTTA-TCTTATATGTA----", str(hsp.hit_all[-1].seq)[:40]
+        )
+        self.assertEqual(
+            "CTGCAAGAACAACAGAAAAGGGAAAACGAAAAAGGAACAA", str(hsp.query_all[-1].seq)[-40:]
+        )
+        self.assertEqual(
+            "|  | | || |  | || ||  ||||||||  ||  ||||",
+            hsp[-1].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "CCACTAAAAAATTATAAGAGCCAAAACGAAGTAGATACAA", str(hsp.hit_all[-1].seq)[-40:]
+        )
 
     def test_exn_22_m_genome2genome(self):
         """Test parsing exonerate output (exn_22_m_genome2genome.exn)."""
@@ -638,14 +958,20 @@ class ExonerateTextCases(unittest.TestCase):
                 self.assertEqual(qresult.id, hsp.query_id)
 
         self.assertEqual("sacCer3_dna", qresult.id)
-        self.assertEqual("range=chrIV:1319469-1319997 5'pad=0 3'pad=0 strand=+ repeatMasking=none", qresult.description)
+        self.assertEqual(
+            "range=chrIV:1319469-1319997 5'pad=0 3'pad=0 strand=+ repeatMasking=none",
+            qresult.description,
+        )
         self.assertEqual("exonerate", qresult.program)
         self.assertEqual("genome2genome", qresult.model)
         self.assertEqual(3, len(qresult))
         # first hit
         hit = qresult[0]
         self.assertEqual("gi|330443520|ref|NC_001136.10|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome IV, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome IV, complete sequence",
+            hit.description,
+        )
         self.assertEqual(2, len(hit.hsps))
         # first hit, first hsp
         hsp = qresult[0].hsps[0]
@@ -664,12 +990,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ATCCCTTATCTCTTTATCTTGTTGCCTGGTTCTCTTTTCC", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATCCCTTATCTCTTTATCTTGTTGCCTGGTTCTCTTTTCC", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("ACGGCAATACCTGGCATGTGATTGTCGGAAAGAACTTTGG", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("ACGGCAATACCTGGCATGTGATTGTCGGAAAGAACTTTGG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATCCCTTATCTCTTTATCTTGTTGCCTGGTTCTCTTTTCC", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATCCCTTATCTCTTTATCTTGTTGCCTGGTTCTCTTTTCC", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "ACGGCAATACCTGGCATGTGATTGTCGGAAAGAACTTTGG", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "ACGGCAATACCTGGCATGTGATTGTCGGAAAGAACTTTGG", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -688,17 +1028,34 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("CCAAAGTTCTTTCCGACAATCACATGCCAGGTATTGCCGT", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("CCAAAGTTCTTTCCGACAATCACATGCCAGGTATTGCCGT", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("GGAAAAGAGAACCAGGCAACAAGATAAAGAGATAAGGGAT", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("GGAAAAGAGAACCAGGCAACAAGATAAAGAGATAAGGGAT", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "CCAAAGTTCTTTCCGACAATCACATGCCAGGTATTGCCGT", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "CCAAAGTTCTTTCCGACAATCACATGCCAGGTATTGCCGT", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "GGAAAAGAGAACCAGGCAACAAGATAAAGAGATAAGGGAT", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GGAAAAGAGAACCAGGCAACAAGATAAAGAGATAAGGGAT", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # second hit
         hit = qresult[1]
         self.assertEqual("gi|330443489|ref|NC_001135.5|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome III, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome III, complete sequence",
+            hit.description,
+        )
         self.assertEqual(1, len(hit.hsps))
         # second hit, first hsp
         hsp = qresult[1].hsps[0]
@@ -709,30 +1066,66 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(23668, hsp.hit_start)
         self.assertEqual(491, hsp.query_end)
         self.assertEqual(115569, hsp.hit_end)
-        self.assertEqual([(462, 491), (413, 462), (378, 413), (302, 378), (162, 302)], hsp.query_range_all)
-        self.assertEqual([(23668, 23697), (32680, 32732), (42287, 42325), (97748, 97821), (115419, 115569)], hsp.hit_range_all)
-        self.assertEqual([(462, 462), (413, 413), (378, 378), (302, 302)], hsp.query_inter_ranges)
-        self.assertEqual([(23697, 32680), (32732, 42287), (42325, 97748), (97821, 115419)], hsp.hit_inter_ranges)
+        self.assertEqual(
+            [(462, 491), (413, 462), (378, 413), (302, 378), (162, 302)],
+            hsp.query_range_all,
+        )
+        self.assertEqual(
+            [
+                (23668, 23697),
+                (32680, 32732),
+                (42287, 42325),
+                (97748, 97821),
+                (115419, 115569),
+            ],
+            hsp.hit_range_all,
+        )
+        self.assertEqual(
+            [(462, 462), (413, 413), (378, 378), (302, 302)], hsp.query_inter_ranges
+        )
+        self.assertEqual(
+            [(23697, 32680), (32732, 42287), (42325, 97748), (97821, 115419)],
+            hsp.hit_inter_ranges,
+        )
         self.assertEqual([(378, 379), (376, 378)], hsp.query_split_codons)
         self.assertEqual([(42324, 42325), (97748, 97750)], hsp.hit_split_codons)
         self.assertEqual(5, len(hsp.query_all))
         self.assertEqual(5, len(hsp.hit_all))
         # first block
         self.assertEqual("CCCTTTAAATGGAGATTACAAACTAGCGA", str(hsp.query_all[0].seq))
-        self.assertEqual("||  | ||| | |||  ||||| |  | |", hsp[0].aln_annotation["similarity"])
+        self.assertEqual(
+            "||  | ||| | |||  ||||| |  | |", hsp[0].aln_annotation["similarity"]
+        )
         self.assertEqual("CCGCTGAAAGGAAGAGAACAAAGTTACAA", str(hsp.hit_all[0].seq))
         # last block
-        self.assertEqual("TTTTCTTTACTAAC-TCGAGGAAGAGTGAGGTTTTCTTCC", str(hsp.query_all[-1].seq)[:40])
-        self.assertEqual("| ||    || | | |  |||||| |||| | | |  |||", hsp[-1].aln_annotation["similarity"][:40])
-        self.assertEqual("TCTTGAAGACCAGCATGTAGGAAG-GTGATGATATGCTCC", str(hsp.hit_all[-1].seq)[:40])
-        self.assertEqual("TTTGTGTGTGTACATTTGAATATATATATTTAC-TAACAA", str(hsp.query_all[-1].seq)[-40:])
-        self.assertEqual(" |||  ||| |   |||||||||||||   | | ||||||", hsp[-1].aln_annotation["similarity"][-40:])
-        self.assertEqual("ATTGATTGTTTTGTTTTGAATATATATTGATGCTTAACAA", str(hsp.hit_all[-1].seq)[-40:])
+        self.assertEqual(
+            "TTTTCTTTACTAAC-TCGAGGAAGAGTGAGGTTTTCTTCC", str(hsp.query_all[-1].seq)[:40]
+        )
+        self.assertEqual(
+            "| ||    || | | |  |||||| |||| | | |  |||",
+            hsp[-1].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "TCTTGAAGACCAGCATGTAGGAAG-GTGATGATATGCTCC", str(hsp.hit_all[-1].seq)[:40]
+        )
+        self.assertEqual(
+            "TTTGTGTGTGTACATTTGAATATATATATTTAC-TAACAA", str(hsp.query_all[-1].seq)[-40:]
+        )
+        self.assertEqual(
+            " |||  ||| |   |||||||||||||   | | ||||||",
+            hsp[-1].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "ATTGATTGTTTTGTTTTGAATATATATTGATGCTTAACAA", str(hsp.hit_all[-1].seq)[-40:]
+        )
 
         # third hit
         hit = qresult[2]
         self.assertEqual("gi|330443667|ref|NC_001143.9|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome XI, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome XI, complete sequence",
+            hit.description,
+        )
         self.assertEqual(1, len(hit.hsps))
         # third hit, first hsp
         hsp = qresult[2].hsps[0]
@@ -743,25 +1136,62 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(71883, hsp.hit_start)
         self.assertEqual(529, hsp.query_end)
         self.assertEqual(641760, hsp.hit_end)
-        self.assertEqual([(449, 529), (319, 388), (198, 284), (161, 198), (78, 114)], hsp.query_range_all)
-        self.assertEqual([(641682, 641760), (487327, 487387), (386123, 386207), (208639, 208677), (71883, 71917)], hsp.hit_range_all)
-        self.assertEqual([(388, 449), (284, 319), (198, 198), (114, 161)], hsp.query_inter_ranges)
-        self.assertEqual([(487387, 641682), (386207, 487327), (208677, 386123), (71917, 208639)], hsp.hit_inter_ranges)
+        self.assertEqual(
+            [(449, 529), (319, 388), (198, 284), (161, 198), (78, 114)],
+            hsp.query_range_all,
+        )
+        self.assertEqual(
+            [
+                (641682, 641760),
+                (487327, 487387),
+                (386123, 386207),
+                (208639, 208677),
+                (71883, 71917),
+            ],
+            hsp.hit_range_all,
+        )
+        self.assertEqual(
+            [(388, 449), (284, 319), (198, 198), (114, 161)], hsp.query_inter_ranges
+        )
+        self.assertEqual(
+            [(487387, 641682), (386207, 487327), (208677, 386123), (71917, 208639)],
+            hsp.hit_inter_ranges,
+        )
         self.assertEqual([(198, 200), (197, 198)], hsp.query_split_codons)
         self.assertEqual([(386123, 386125), (208676, 208677)], hsp.hit_split_codons)
         self.assertEqual(5, len(hsp.query_all))
         self.assertEqual(5, len(hsp.hit_all))
         # first block
-        self.assertEqual("ATCCCTTATCTCTTTATCTTGTTGCCTGGTTCTCTTTTCC", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||       |||  |||||   ||||  ", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATCCCTTATCTCTTCTAAAGATTGTGTGGTT---TTTT--", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("AAATGGAGATTACAA---ACTAGCGAA-ACTGCAGAAAAG", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("  ||     || |||    || || ||  || || | |||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("GCATATTTTTTCCAACCTTCTTGCCAATTCTTCA-ACAAG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATCCCTTATCTCTTTATCTTGTTGCCTGGTTCTCTTTTCC", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||       |||  |||||   ||||  ",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATCCCTTATCTCTTCTAAAGATTGTGTGGTT---TTTT--", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "AAATGGAGATTACAA---ACTAGCGAA-ACTGCAGAAAAG", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "  ||     || |||    || || ||  || || | |||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GCATATTTTTTCCAACCTTCTTGCCAATTCTTCA-ACAAG", str(hsp.hit_all[0].seq)[-40:]
+        )
         # last block
-        self.assertEqual("TAAAGATGCTCTGGACAAGTACCAGTTGGAAAGAGA", str(hsp.query_all[-1].seq))
-        self.assertEqual(" ||||||  |||  || | |  ||||||||||||||", hsp[-1].aln_annotation["similarity"])
-        self.assertEqual("AAAAGATTTTCT--ACGACTTGCAGTTGGAAAGAGA", str(hsp.hit_all[-1].seq))
+        self.assertEqual(
+            "TAAAGATGCTCTGGACAAGTACCAGTTGGAAAGAGA", str(hsp.query_all[-1].seq)
+        )
+        self.assertEqual(
+            " ||||||  |||  || | |  ||||||||||||||", hsp[-1].aln_annotation["similarity"]
+        )
+        self.assertEqual(
+            "AAAAGATTTTCT--ACGACTTGCAGTTGGAAAGAGA", str(hsp.hit_all[-1].seq)
+        )
 
     def test_exn_22_m_ungapped(self):
         """Test parsing exonerate output (exn_22_m_ungapped.exn)."""
@@ -776,14 +1206,20 @@ class ExonerateTextCases(unittest.TestCase):
                 self.assertEqual(qresult.id, hsp.query_id)
 
         self.assertEqual("gi|296143771|ref|NM_001180731.1|", qresult.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds", qresult.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds",
+            qresult.description,
+        )
         self.assertEqual("exonerate", qresult.program)
         self.assertEqual("ungapped:dna2dna", qresult.model)
         self.assertEqual(2, len(qresult))
         # first hit
         hit = qresult[0]
         self.assertEqual("gi|330443520|ref|NC_001136.10|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome IV, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome IV, complete sequence",
+            hit.description,
+        )
         self.assertEqual(1, len(hit.hsps))
         # first hit, first hsp
         hsp = qresult[0].hsps[0]
@@ -802,17 +1238,34 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # second hit
         hit = qresult[1]
         self.assertEqual("gi|330443688|ref|NC_001145.3|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome XIII, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome XIII, complete sequence",
+            hit.description,
+        )
         self.assertEqual(2, len(hit.hsps))
         # second hit, first hsp
         hsp = qresult[1].hsps[0]
@@ -831,12 +1284,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("TTGACTCTGAAGCTAAGAGTAGGAGGACTGCCCAGAATAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("| ||  ||||| |||||   | |||||||||||| ||| |", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("TGGATCCTGAAACTAAGCAGAAGAGGACTGCCCAAAATCG", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("CCAAAATGAAGAGTTTGCAAGAGAGGGTAGAGTTACTAGA", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("  || ||||||   ||| |  ||| |||| |     ||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("GGAAGATGAAGGAATTGGAGAAGAAGGTACAAAGTTTAGA", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "TTGACTCTGAAGCTAAGAGTAGGAGGACTGCCCAGAATAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "| ||  ||||| |||||   | |||||||||||| ||| |",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "TGGATCCTGAAACTAAGCAGAAGAGGACTGCCCAAAATCG", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "CCAAAATGAAGAGTTTGCAAGAGAGGGTAGAGTTACTAGA", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "  || ||||||   ||| |  ||| |||| |     ||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GGAAGATGAAGGAATTGGAGAAGAAGGTACAAAGTTTAGA", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # second hit, second hsp
         hsp = qresult[1].hsps[1]
@@ -855,12 +1322,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("CCAAAATATTCATCGTTGGACATAGATGATTTATGCAGCG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("|| ||||| |||    | ||  | |||| ||||||   ||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("CCGAAATACTCAGATATTGATGTCGATGGTTTATGTTCCG", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("ATTTATGCAGCGAATTAATAATCAAGGCAAAATGTACAGA", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual(" ||||||   |||  ||||    |||||||||||| ||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("GTTTATGTTCCGAGCTAATGGCAAAGGCAAAATGTTCAGA", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "CCAAAATATTCATCGTTGGACATAGATGATTTATGCAGCG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "|| ||||| |||    | ||  | |||| ||||||   ||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "CCGAAATACTCAGATATTGATGTCGATGGTTTATGTTCCG", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "ATTTATGCAGCGAATTAATAATCAAGGCAAAATGTACAGA", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            " ||||||   |||  ||||    |||||||||||| ||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GTTTATGTTCCGAGCTAATGGCAAAGGCAAAATGTTCAGA", str(hsp.hit_all[0].seq)[-40:]
+        )
 
     def test_exn_22_m_ungapped_trans(self):
         """Test parsing exonerate output (exn_22_m_ungapped_trans.exn)."""
@@ -875,14 +1356,20 @@ class ExonerateTextCases(unittest.TestCase):
                 self.assertEqual(qresult.id, hsp.query_id)
 
         self.assertEqual("gi|296143771|ref|NM_001180731.1|", qresult.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds", qresult.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds",
+            qresult.description,
+        )
         self.assertEqual("exonerate", qresult.program)
         self.assertEqual("ungapped:codon", qresult.model)
         self.assertEqual(1, len(qresult))
         # first hit
         hit = qresult[0]
         self.assertEqual("gi|330443520|ref|NC_001136.10|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome IV, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome IV, complete sequence",
+            hit.description,
+        )
         self.assertEqual(3, len(hit.hsps))
         # first hit, first hsp
         hsp = qresult[0].hsps[0]
@@ -901,12 +1388,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -925,12 +1426,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # first hit, third hsp
         hsp = qresult[0].hsps[2]
@@ -949,12 +1464,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_split_codons)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", str(hsp.hit_all[0].seq)[-40:]
+        )
 
     def test_exn_22_m_ner(self):
         """Test parsing exonerate output (exn_22_m_ner.exn)."""
@@ -969,14 +1498,20 @@ class ExonerateTextCases(unittest.TestCase):
                 self.assertEqual(qresult.id, hsp.query_id)
 
         self.assertEqual("gi|296143771|ref|NM_001180731.1|", qresult.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds", qresult.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds",
+            qresult.description,
+        )
         self.assertEqual("exonerate", qresult.program)
         self.assertEqual("NER:affine:local:dna2dna", qresult.model)
         self.assertEqual(2, len(qresult))
         # first hit
         hit = qresult[0]
         self.assertEqual("gi|330443520|ref|NC_001136.10|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome IV, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome IV, complete sequence",
+            hit.description,
+        )
         self.assertEqual(2, len(hit.hsps))
         # first hit, first hsp
         hsp = qresult[0].hsps[0]
@@ -993,12 +1528,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_inter_ranges[:5])
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -1009,10 +1558,34 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(183946, hsp.hit_start)
         self.assertEqual(1192, hsp.query_end)
         self.assertEqual(184603, hsp.hit_end)
-        self.assertEqual([(509, 514), (537, 547), (567, 595), (607, 617), (636, 650)], hsp.query_range_all[:5])
-        self.assertEqual([(183946, 183951), (183977, 183987), (184002, 184030), (184044, 184054), (184066, 184080)], hsp.hit_range_all[:5])
-        self.assertEqual([(514, 537), (547, 567), (595, 607), (617, 636), (650, 667)], hsp.query_inter_ranges[:5])
-        self.assertEqual([(183951, 183977), (183987, 184002), (184030, 184044), (184054, 184066), (184080, 184092)], hsp.hit_inter_ranges[:5])
+        self.assertEqual(
+            [(509, 514), (537, 547), (567, 595), (607, 617), (636, 650)],
+            hsp.query_range_all[:5],
+        )
+        self.assertEqual(
+            [
+                (183946, 183951),
+                (183977, 183987),
+                (184002, 184030),
+                (184044, 184054),
+                (184066, 184080),
+            ],
+            hsp.hit_range_all[:5],
+        )
+        self.assertEqual(
+            [(514, 537), (547, 567), (595, 607), (617, 636), (650, 667)],
+            hsp.query_inter_ranges[:5],
+        )
+        self.assertEqual(
+            [
+                (183951, 183977),
+                (183987, 184002),
+                (184030, 184044),
+                (184054, 184066),
+                (184080, 184092),
+            ],
+            hsp.hit_inter_ranges[:5],
+        )
         self.assertEqual(24, len(hsp.query_all))
         self.assertEqual(24, len(hsp.hit_all))
         # first block
@@ -1021,13 +1594,18 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual("TGAGA", str(hsp.hit_all[0].seq))
         # last block
         self.assertEqual("GACTGCAAAATAGTAGTCAAAGCTC", str(hsp.query_all[-1].seq))
-        self.assertEqual("||| | ||||||||||||| | |||", hsp[-1].aln_annotation["similarity"])
+        self.assertEqual(
+            "||| | ||||||||||||| | |||", hsp[-1].aln_annotation["similarity"]
+        )
         self.assertEqual("GACGGTAAAATAGTAGTCACACCTC", str(hsp.hit_all[-1].seq))
 
         # second hit
         hit = qresult[1]
         self.assertEqual("gi|330443681|ref|NC_001144.5|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome XII, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome XII, complete sequence",
+            hit.description,
+        )
         self.assertEqual(1, len(hit.hsps))
         # second hit, first hsp
         hsp = qresult[1].hsps[0]
@@ -1038,10 +1616,34 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(297910, hsp.hit_start)
         self.assertEqual(1230, hsp.query_end)
         self.assertEqual(318994, hsp.hit_end)
-        self.assertEqual([(110, 117), (148, 159), (169, 182), (184, 197), (227, 244)], hsp.query_range_all[:5])
-        self.assertEqual([(297910, 297917), (297946, 297957), (297970, 297983), (297992, 298004), (298019, 298038)], hsp.hit_range_all[:5])
-        self.assertEqual([(117, 148), (159, 169), (182, 184), (197, 227), (244, 255)], hsp.query_inter_ranges[:5])
-        self.assertEqual([(297917, 297946), (297957, 297970), (297983, 297992), (298004, 298019), (298038, 298049)], hsp.hit_inter_ranges[:5])
+        self.assertEqual(
+            [(110, 117), (148, 159), (169, 182), (184, 197), (227, 244)],
+            hsp.query_range_all[:5],
+        )
+        self.assertEqual(
+            [
+                (297910, 297917),
+                (297946, 297957),
+                (297970, 297983),
+                (297992, 298004),
+                (298019, 298038),
+            ],
+            hsp.hit_range_all[:5],
+        )
+        self.assertEqual(
+            [(117, 148), (159, 169), (182, 184), (197, 227), (244, 255)],
+            hsp.query_inter_ranges[:5],
+        )
+        self.assertEqual(
+            [
+                (297917, 297946),
+                (297957, 297970),
+                (297983, 297992),
+                (298004, 298019),
+                (298038, 298049),
+            ],
+            hsp.hit_inter_ranges[:5],
+        )
         self.assertEqual(33, len(hsp.query_all))
         self.assertEqual(33, len(hsp.hit_all))
         # first block
@@ -1092,12 +1694,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_inter_ranges)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ATGAGCGGTGAATTAGCAAATTACAAAAGACTTGAGAAAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGAGCGGTGAATTAGCAAATTACAAAAGACTTGAGAAAG", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("CAGAAGAGCAGCCATCCACCCCTACTTCCAAGAATCATAA", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("CAGAAGAGCAGCCATCCACCCCTACTTCCAAGAATCATAA", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGAGCGGTGAATTAGCAAATTACAAAAGACTTGAGAAAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGAGCGGTGAATTAGCAAATTACAAAAGACTTGAGAAAG", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "CAGAAGAGCAGCCATCCACCCCTACTTCCAAGAATCATAA", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "CAGAAGAGCAGCCATCCACCCCTACTTCCAAGAATCATAA", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # first qresult, second hit
         hit = qresult[1]
@@ -1119,12 +1735,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_inter_ranges)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("GAGCGGTGAATTAGCAAATTACAAAAGACTTGAGAAAGTC", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||  |  || | || |||  |  ||  | || ||  | ", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("GAGC--TCTATGAACAGATTTAAGCAG-TTAGAAAAGCTT", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("C-AGAAGAGCAGCCATCCACCCCTACTTCCAAGAATCATA", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("| || ||      ||| ||||| |  ||   ||| |  ||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("CAAGCAGGCTCTGCAT-CACCCTTGGTTTGCAGAGTACTA", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "GAGCGGTGAATTAGCAAATTACAAAAGACTTGAGAAAGTC", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||  |  || | || |||  |  ||  | || ||  | ",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "GAGC--TCTATGAACAGATTTAAGCAG-TTAGAAAAGCTT", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "C-AGAAGAGCAGCCATCCACCCCTACTTCCAAGAATCATA", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "| || ||      ||| ||||| |  ||   ||| |  ||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "CAAGCAGGCTCTGCAT-CACCCTTGGTTTGCAGAGTACTA", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # first qresult, third hit
         hit = qresult[2]
@@ -1147,15 +1777,31 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(2, len(hsp.query_all))
         self.assertEqual(2, len(hsp.hit_all))
         # first block
-        self.assertEqual("AGAAAGTCGGTGAAGGTACATACGGTGTTGTTTATAAAGC", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||| ||||| ||||| || |  ||||||||    | ", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("AGAAAGTTGGTGAGGGTACTTATGCGGTTGTTTA-CTTGG", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("CGATCAGATTTTCAAG--ATATTCAGAGTATTGGGAACGC", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("|||||| |  |  |||  |  ||||| |  || || || |", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("CGATCAAA--TGGAAGTAACGTTCAGGGCCTTAGGGACAC", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "AGAAAGTCGGTGAAGGTACATACGGTGTTGTTTATAAAGC", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||| ||||| ||||| || |  ||||||||    | ",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "AGAAAGTTGGTGAGGGTACTTATGCGGTTGTTTA-CTTGG", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "CGATCAGATTTTCAAG--ATATTCAGAGTATTGGGAACGC", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "|||||| |  |  |||  |  ||||| |  || || || |",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "CGATCAAA--TGGAAGTAACGTTCAGGGCCTTAGGGACAC", str(hsp.hit_all[0].seq)[-40:]
+        )
         # last block
         self.assertEqual("CGAATGAAGCTA-TATGGCCAGATATTGTCT", str(hsp.query_all[-1].seq))
-        self.assertEqual("| ||   || ||  ||||||||||||| |||", hsp[-1].aln_annotation["similarity"])
+        self.assertEqual(
+            "| ||   || ||  ||||||||||||| |||", hsp[-1].aln_annotation["similarity"]
+        )
         self.assertEqual("CAAACCGAGATAGAATGGCCAGATATTCTCT", str(hsp.hit_all[-1].seq))
 
         # test second qresult
@@ -1184,12 +1830,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([], hsp.hit_inter_ranges)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+        )
 
         # second qresult, second hit
         hit = qresult[1]
@@ -1205,22 +1865,45 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(85010, hsp.hit_start)
         self.assertEqual(346, hsp.query_end)
         self.assertEqual(473201, hsp.hit_end)
-        self.assertEqual([(0, 65), (65, 225), (225, 320), (320, 346)], hsp.query_range_all)
-        self.assertEqual([(85010, 85066), (253974, 254135), (350959, 351052), (473170, 473201)], hsp.hit_range_all)
+        self.assertEqual(
+            [(0, 65), (65, 225), (225, 320), (320, 346)], hsp.query_range_all
+        )
+        self.assertEqual(
+            [(85010, 85066), (253974, 254135), (350959, 351052), (473170, 473201)],
+            hsp.hit_range_all,
+        )
         self.assertEqual([(65, 65), (225, 225), (320, 320)], hsp.query_inter_ranges)
-        self.assertEqual([(85066, 253974), (254135, 350959), (351052, 473170)], hsp.hit_inter_ranges)
+        self.assertEqual(
+            [(85066, 253974), (254135, 350959), (351052, 473170)], hsp.hit_inter_ranges
+        )
         self.assertEqual(4, len(hsp.query_all))
         self.assertEqual(4, len(hsp.hit_all))
         # first block
-        self.assertEqual("ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("||||  ||  | ||||   | ||||||  |||| | | | ", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ATGGTGAACCT-CTTCAAGACGGTCAG--AATA-A-TCAA", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("AGCAAATATATTTAGCAGGTGACATGAAGAAGCAAATGTT", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("||  |||| | | | ||||    ||||||||||||| | |", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("AG--AATA-A-TCAACAGG----ATGAAGAAGCAAAAGAT", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "||||  ||  | ||||   | ||||||  |||| | | | ",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ATGGTGAACCT-CTTCAAGACGGTCAG--AATA-A-TCAA", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "AGCAAATATATTTAGCAGGTGACATGAAGAAGCAAATGTT", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "||  |||| | | | ||||    ||||||||||||| | |",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "AG--AATA-A-TCAACAGG----ATGAAGAAGCAAAAGAT", str(hsp.hit_all[0].seq)[-40:]
+        )
         # last block
         self.assertEqual("AGCTAAGAATTCTGATGATG-----AAAGAA", str(hsp.query_all[-1].seq))
-        self.assertEqual("|   |||||||||||| |||     ||||||", hsp[-1].aln_annotation["similarity"])
+        self.assertEqual(
+            "|   |||||||||||| |||     ||||||", hsp[-1].aln_annotation["similarity"]
+        )
         self.assertEqual("ATGGAAGAATTCTGATAATGCTGTAAAAGAA", str(hsp.hit_all[-1].seq))
 
         # second qresult, second hit, second hsp
@@ -1234,25 +1917,55 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(406, hsp.query_end)
         self.assertEqual(130198, hsp.hit_end)
         self.assertEqual([(25, 183), (183, 252), (252, 406)], hsp.query_range_all)
-        self.assertEqual([(130038, 130198), (120612, 120681), (11338, 11487)], hsp.hit_range_all)
+        self.assertEqual(
+            [(130038, 130198), (120612, 120681), (11338, 11487)], hsp.hit_range_all
+        )
         self.assertEqual([(183, 183), (252, 252)], hsp.query_inter_ranges)
         self.assertEqual([(120681, 130038), (11487, 120612)], hsp.hit_inter_ranges)
         self.assertEqual(3, len(hsp.query_all))
         self.assertEqual(3, len(hsp.hit_all))
         # first block
-        self.assertEqual("AGCAAATATATTTA-GCAGGTGACATGAAGAAGCAAATGT", str(hsp.query_all[0].seq)[:40])
-        self.assertEqual("| |||| |||   | ||||   | | || |||| | |  |", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ACCAAAGATAACAAGGCAG--AAAAAGAGGAAGAAGAAAT", str(hsp.hit_all[0].seq)[:40])
-        self.assertEqual("AG-GACTGCCCAGAATAGGGCAGCTCAACGAGCGTTCCGA", str(hsp.query_all[0].seq)[-40:])
-        self.assertEqual("|| |||  ||||||  ||   |||  || ||   ||| ||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("AGTGAC--CCCAGAGGAGCCAAGCAAAAAGA---TTCGGA", str(hsp.hit_all[0].seq)[-40:])
+        self.assertEqual(
+            "AGCAAATATATTTA-GCAGGTGACATGAAGAAGCAAATGT", str(hsp.query_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "| |||| |||   | ||||   | | || |||| | |  |",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ACCAAAGATAACAAGGCAG--AAAAAGAGGAAGAAGAAAT", str(hsp.hit_all[0].seq)[:40]
+        )
+        self.assertEqual(
+            "AG-GACTGCCCAGAATAGGGCAGCTCAACGAGCGTTCCGA", str(hsp.query_all[0].seq)[-40:]
+        )
+        self.assertEqual(
+            "|| |||  ||||||  ||   |||  || ||   ||| ||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "AGTGAC--CCCAGAGGAGCCAAGCAAAAAGA---TTCGGA", str(hsp.hit_all[0].seq)[-40:]
+        )
         # last block
-        self.assertEqual("AATAAGACTACCACGGACTTTTTACTATGTTCTTTAAAAA", str(hsp.query_all[-1].seq)[:40])
-        self.assertEqual("|||||||  | ||| |    |||| | |  | | ||    ", hsp[-1].aln_annotation["similarity"][:40])
-        self.assertEqual("AATAAGAGCAACACAG----TTTA-TCTTATATGTA----", str(hsp.hit_all[-1].seq)[:40])
-        self.assertEqual("CTGCAAGAACAACAGAAAAGGGAAAACGAAAAAGGAACAA", str(hsp.query_all[-1].seq)[-40:])
-        self.assertEqual("|  | | || |  | || ||  ||||||||  ||  ||||", hsp[-1].aln_annotation["similarity"][-40:])
-        self.assertEqual("CCACTAAAAAATTATAAGAGCCAAAACGAAGTAGATACAA", str(hsp.hit_all[-1].seq)[-40:])
+        self.assertEqual(
+            "AATAAGACTACCACGGACTTTTTACTATGTTCTTTAAAAA", str(hsp.query_all[-1].seq)[:40]
+        )
+        self.assertEqual(
+            "|||||||  | ||| |    |||| | |  | | ||    ",
+            hsp[-1].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "AATAAGAGCAACACAG----TTTA-TCTTATATGTA----", str(hsp.hit_all[-1].seq)[:40]
+        )
+        self.assertEqual(
+            "CTGCAAGAACAACAGAAAAGGGAAAACGAAAAAGGAACAA", str(hsp.query_all[-1].seq)[-40:]
+        )
+        self.assertEqual(
+            "|  | | || |  | || ||  ||||||||  ||  ||||",
+            hsp[-1].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "CCACTAAAAAATTATAAGAGCCAAAACGAAGTAGATACAA", str(hsp.hit_all[-1].seq)[-40:]
+        )
 
     def test_exn_22_m_coding2coding_fshifts(self):
         """Test parsing exonerate output (exn_22_m_coding2coding_fshifts.exn)."""
@@ -1267,14 +1980,20 @@ class ExonerateTextCases(unittest.TestCase):
                 self.assertEqual(qresult.id, hsp.query_id)
 
         self.assertEqual("gi|296143771|ref|NM_001180731.1|", qresult.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds", qresult.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds",
+            qresult.description,
+        )
         self.assertEqual("exonerate", qresult.program)
         self.assertEqual("coding2coding", qresult.model)
         self.assertEqual(1, len(qresult))
         # first hit
         hit = qresult[0]
         self.assertEqual("gi|296143771|ref|NM_001180731.1|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds",
+            hit.description,
+        )
         self.assertEqual(2, len(hit))
         # first hit, first hsp
         hsp = qresult[0][0]
@@ -1285,8 +2004,12 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(465, hsp.hit_start)
         self.assertEqual(160, hsp.query_end)
         self.assertEqual(630, hsp.hit_end)
-        self.assertEqual([(0, 93), (94, 127), (127, 139), (139, 160)], hsp.query_range_all)
-        self.assertEqual([(465, 558), (558, 591), (593, 605), (609, 630)], hsp.hit_range_all)
+        self.assertEqual(
+            [(0, 93), (94, 127), (127, 139), (139, 160)], hsp.query_range_all
+        )
+        self.assertEqual(
+            [(465, 558), (558, 591), (593, 605), (609, 630)], hsp.hit_range_all
+        )
         self.assertEqual([(93, 94), (127, 127), (139, 139)], hsp.query_inter_ranges)
         self.assertEqual([(558, 558), (591, 593), (605, 609)], hsp.hit_inter_ranges)
         self.assertEqual([1, 2, 2, 2], hsp.query_frame_all)
@@ -1295,12 +2018,26 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(4, len(hsp.hit_all))
         self.assertEqual(4, len(hsp.aln_annotation_all))
         # first block
-        self.assertEqual("ACTGTGAACACAAGTATAGAAGTACAGCCGCACACTCAAG", str(hsp[0].query.seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("ACTGTGAACACAAGTATAGAAGTACAGCCGCACACTCAAG", str(hsp[0].hit.seq)[:40])
-        self.assertEqual("TATGTGGAACATAGGCTCATGGAACGCTCCCAGTTTAACC", str(hsp[0].query.seq)[-40:])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[0].aln_annotation["similarity"][-40:])
-        self.assertEqual("TATGTGGAACATAGGCTCATGGAACGCTCCCAGTTTAACC", str(hsp[0].hit.seq)[-40:])
+        self.assertEqual(
+            "ACTGTGAACACAAGTATAGAAGTACAGCCGCACACTCAAG", str(hsp[0].query.seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "ACTGTGAACACAAGTATAGAAGTACAGCCGCACACTCAAG", str(hsp[0].hit.seq)[:40]
+        )
+        self.assertEqual(
+            "TATGTGGAACATAGGCTCATGGAACGCTCCCAGTTTAACC", str(hsp[0].query.seq)[-40:]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[0].aln_annotation["similarity"][-40:],
+        )
+        self.assertEqual(
+            "TATGTGGAACATAGGCTCATGGAACGCTCCCAGTTTAACC", str(hsp[0].hit.seq)[-40:]
+        )
         # last block
         self.assertEqual("GACGAAAGTATTAATGGTAGT", str(hsp[-1].query.seq))
         self.assertEqual("|||||||||||||||||||||", hsp[-1].aln_annotation["similarity"])
@@ -1325,13 +2062,27 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(2, len(hsp.hit_all))
         self.assertEqual(2, len(hsp.aln_annotation_all))
         # first block
-        self.assertEqual("TACCATTAATACTTTCGTCATGGT<-><->AACGGCATGT", str(hsp[0].query.seq)[:40])
-        self.assertEqual("||||||||||||||||||||+ !       ...  !:!!|", hsp[0].aln_annotation["similarity"][:40])
-        self.assertEqual("TACCATTAATACTTTCGTCACCGATGGTAACGGCACCTGT", str(hsp[0].hit.seq)[:40])
+        self.assertEqual(
+            "TACCATTAATACTTTCGTCATGGT<-><->AACGGCATGT", str(hsp[0].query.seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||+ !       ...  !:!!|",
+            hsp[0].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "TACCATTAATACTTTCGTCACCGATGGTAACGGCACCTGT", str(hsp[0].hit.seq)[:40]
+        )
         # last block
-        self.assertEqual("TGGTTAAACTGGGAGCGTTCCATGAGCCTATGTTCCACAT", str(hsp[-1].query.seq)[:40])
-        self.assertEqual("||||||||||||||||||||||||||||||||||||||||", hsp[-1].aln_annotation["similarity"][:40])
-        self.assertEqual("TGGTTAAACTGGGAGCGTTCCATGAGCCTATGTTCCACAT", str(hsp[-1].hit.seq)[:40])
+        self.assertEqual(
+            "TGGTTAAACTGGGAGCGTTCCATGAGCCTATGTTCCACAT", str(hsp[-1].query.seq)[:40]
+        )
+        self.assertEqual(
+            "||||||||||||||||||||||||||||||||||||||||",
+            hsp[-1].aln_annotation["similarity"][:40],
+        )
+        self.assertEqual(
+            "TGGTTAAACTGGGAGCGTTCCATGAGCCTATGTTCCACAT", str(hsp[-1].hit.seq)[:40]
+        )
 
     def test_exn_22_m_protein2dna_fshifts(self):
         """Test parsing exonerate output (exn_22_m_protein2dna_fshifts.exn)."""
@@ -1346,14 +2097,21 @@ class ExonerateTextCases(unittest.TestCase):
                 self.assertEqual(qresult.id, hsp.query_id)
 
         self.assertEqual("sp|P24813|YAP2_YEAST", qresult.id)
-        self.assertEqual("AP-1-like transcription activator YAP2 OS=Saccharomyces cerevisiae (strain ATCC 204508 / S288c) GN=CAD1 PE=1 SV=2", qresult.description)
+        self.assertEqual(
+            "AP-1-like transcription activator YAP2 OS=Saccharomyces cerevisiae (strain"
+            " ATCC 204508 / S288c) GN=CAD1 PE=1 SV=2",
+            qresult.description,
+        )
         self.assertEqual("exonerate", qresult.program)
         self.assertEqual("protein2dna:local", qresult.model)
         self.assertEqual(1, len(qresult))
         # first hit
         hit = qresult[0]
         self.assertEqual("gi|296143771|ref|NM_001180731.1|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c Cad1p (CAD1) mRNA, complete cds",
+            hit.description,
+        )
         self.assertEqual(2, len(hit))
         # first hit, first hsp
         hsp = qresult[0][0]
@@ -1374,10 +2132,18 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(2, len(hsp.hit_all))
         self.assertEqual(2, len(hsp.aln_annotation_all))
         # first block
-        self.assertEqual("HTKTIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYS", str(hsp[0].query.seq)[:40])
-        self.assertEqual("HTKTIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYS", str(hsp[0].hit.seq)[:40])
-        self.assertEqual("TIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYSSLD", str(hsp[0].query.seq)[-40:])
-        self.assertEqual("TIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYSSLD", str(hsp[0].hit.seq)[-40:])
+        self.assertEqual(
+            "HTKTIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYS", str(hsp[0].query.seq)[:40]
+        )
+        self.assertEqual(
+            "HTKTIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYS", str(hsp[0].hit.seq)[:40]
+        )
+        self.assertEqual(
+            "TIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYSSLD", str(hsp[0].query.seq)[-40:]
+        )
+        self.assertEqual(
+            "TIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYSSLD", str(hsp[0].hit.seq)[-40:]
+        )
         # last block
         self.assertEqual("IDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", str(hsp[-1].query.seq))
         self.assertEqual("IDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", str(hsp[-1].hit.seq))
@@ -1400,10 +2166,18 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(1, len(hsp.aln_annotation_all))
-        self.assertEqual("KGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKRIDSEAK", str(hsp[0].query.seq)[:40])
-        self.assertEqual("KGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKRIDSEAK", str(hsp[0].hit.seq)[:40])
-        self.assertEqual("RKVGRPGRKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKS", str(hsp[0].query.seq)[-40:])
-        self.assertEqual("RKVGRPGRKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKS", str(hsp[0].hit.seq)[-40:])
+        self.assertEqual(
+            "KGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKRIDSEAK", str(hsp[0].query.seq)[:40]
+        )
+        self.assertEqual(
+            "KGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKRIDSEAK", str(hsp[0].hit.seq)[:40]
+        )
+        self.assertEqual(
+            "RKVGRPGRKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKS", str(hsp[0].query.seq)[-40:]
+        )
+        self.assertEqual(
+            "RKVGRPGRKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKS", str(hsp[0].hit.seq)[-40:]
+        )
 
     def test_exn_22_m_protein2genome(self):
         """Test parsing exonerate output (exn_22_m_protein2genome.exn)."""
@@ -1418,14 +2192,21 @@ class ExonerateTextCases(unittest.TestCase):
                 self.assertEqual(qresult.id, hsp.query_id)
 
         self.assertEqual("sp|P24813|YAP2_YEAST", qresult.id)
-        self.assertEqual("AP-1-like transcription activator YAP2 OS=Saccharomyces cerevisiae (strain ATCC 204508 / S288c) GN=CAD1 PE=1 SV=2", qresult.description)
+        self.assertEqual(
+            "AP-1-like transcription activator YAP2 OS=Saccharomyces cerevisiae (strain"
+            " ATCC 204508 / S288c) GN=CAD1 PE=1 SV=2",
+            qresult.description,
+        )
         self.assertEqual("exonerate", qresult.program)
         self.assertEqual("protein2genome:local", qresult.model)
         self.assertEqual(3, len(qresult))
         # first hit
         hit = qresult[0]
         self.assertEqual("gi|330443520|ref|NC_001136.10|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome IV, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome IV, complete sequence",
+            hit.description,
+        )
         self.assertEqual(1, len(hit))
         # first hit, first hsp
         hsp = qresult[0][0]
@@ -1436,29 +2217,47 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1318048, hsp.hit_start)
         self.assertEqual(409, hsp.query_end)
         self.assertEqual(1319275, hsp.hit_end)
-        self.assertEqual("MGNILRKGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKR", str(hsp[0].query.seq)[:40])
-        self.assertEqual("MGNILRKGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKR", str(hsp[0].hit.seq)[:40])
-        self.assertEqual("SSLDIDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", str(hsp[0].query.seq)[-40:])
-        self.assertEqual("SSLDIDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", str(hsp[0].hit.seq)[-40:])
+        self.assertEqual(
+            "MGNILRKGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKR", str(hsp[0].query.seq)[:40]
+        )
+        self.assertEqual(
+            "MGNILRKGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKR", str(hsp[0].hit.seq)[:40]
+        )
+        self.assertEqual(
+            "SSLDIDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", str(hsp[0].query.seq)[-40:]
+        )
+        self.assertEqual(
+            "SSLDIDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", str(hsp[0].hit.seq)[-40:]
+        )
 
         # last hit
         hit = qresult[-1]
         self.assertEqual("gi|330443590|ref|NC_001140.6|", hit.id)
-        self.assertEqual("Saccharomyces cerevisiae S288c chromosome VIII, complete sequence", hit.description)
+        self.assertEqual(
+            "Saccharomyces cerevisiae S288c chromosome VIII, complete sequence",
+            hit.description,
+        )
         self.assertEqual(1, len(hit))
         # last hit, first hsp
         hsp = qresult[-1][0]
         self.assertEqual(122, hsp.score)
         self.assertEqual([0, 0], hsp.query_strand_all)
         self.assertEqual([-1, -1], hsp.hit_strand_all)
-        self.assertEqual("RKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKSLQERX", str(hsp[0].query.seq))
+        self.assertEqual(
+            "RKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKSLQERX", str(hsp[0].query.seq)
+        )
         self.assertEqual("NENVPDDSKAKKKAQNRAAQKAFRERKEARMKELQDKX", str(hsp[0].hit.seq))
         self.assertEqual("!.!", hsp.aln_annotation_all[0]["similarity"][0])
         self.assertEqual(":!", hsp.aln_annotation_all[0]["similarity"][-1])
         self.assertEqual("AAT", hsp.aln_annotation_all[0]["hit_annotation"][0])
         self.assertEqual("TT", hsp.aln_annotation_all[0]["hit_annotation"][-1])
-        self.assertEqual("XELLEQKDAQNKTTTDFLLCSLKSLLSEITKYRAKNSDDERILAFLDDLQE", str(hsp[-1].query.seq))
-        self.assertEqual("XNKILNRDPQFMSNSSFHQCVSLDSINTIEKDEEKNSDDDAGLQAATDARE", str(hsp[-1].hit.seq))
+        self.assertEqual(
+            "XELLEQKDAQNKTTTDFLLCSLKSLLSEITKYRAKNSDDERILAFLDDLQE",
+            str(hsp[-1].query.seq),
+        )
+        self.assertEqual(
+            "XNKILNRDPQFMSNSSFHQCVSLDSINTIEKDEEKNSDDDAGLQAATDARE", str(hsp[-1].hit.seq)
+        )
         self.assertEqual("!", hsp.aln_annotation_all[-1]["similarity"][0])
         self.assertEqual("|||", hsp.aln_annotation_all[-1]["similarity"][-1])
         self.assertEqual("A", hsp.aln_annotation_all[-1]["hit_annotation"][0])
@@ -1548,11 +2347,30 @@ class ExonerateVulgarCases(unittest.TestCase):
         self.assertEqual(23668, hsp.hit_start)
         self.assertEqual(491, hsp.query_end)
         self.assertEqual(115569, hsp.hit_end)
-        self.assertEqual([(462, 491), (413, 462), (378, 413), (302, 378), (162, 302)], hsp.query_range_all[:5])
-        self.assertEqual([(23668, 23697), (32680, 32732), (42287, 42325), (97748, 97821), (115419, 115569)], hsp.hit_range_all[:5])
+        self.assertEqual(
+            [(462, 491), (413, 462), (378, 413), (302, 378), (162, 302)],
+            hsp.query_range_all[:5],
+        )
+        self.assertEqual(
+            [
+                (23668, 23697),
+                (32680, 32732),
+                (42287, 42325),
+                (97748, 97821),
+                (115419, 115569),
+            ],
+            hsp.hit_range_all[:5],
+        )
         self.assertEqual([(378, 379), (376, 378)], hsp.query_split_codons)
         self.assertEqual([(42324, 42325), (97748, 97750)], hsp.hit_split_codons)
-        self.assertEqual(" M 29 29 5 0 2 I 0 8979 3 0 2 M 32 32 G 0 2 M 2 2 G 0 1 M 15 15 5 0 2 I 0 9551 3 0 2 M 3 3 G 1 0 M 5 5 G 0 2 M 3 3 G 0 1 M 4 4 G 0 1 M 18 18 S 1 1 5 0 2 I 0 55419 3 0 2 S 2 2 C 3 3 M 22 22 G 3 0 M 46 46 5 0 2 I 0 17594 3 0 2 M 14 14 G 0 1 M 9 9 G 1 0 M 15 15 G 0 3 M 17 17 G 0 3 M 1 1 G 0 1 M 13 13 G 0 1 M 6 6 G 1 0 M 12 12 G 0 2 M 45 45 G 0 1 M 6 6", hsp.vulgar_comp)
+        self.assertEqual(
+            " M 29 29 5 0 2 I 0 8979 3 0 2 M 32 32 G 0 2 M 2 2 G 0 1 M 15 15 5 0 2 I 0 "
+            "9551 3 0 2 M 3 3 G 1 0 M 5 5 G 0 2 M 3 3 G 0 1 M 4 4 G 0 1 M 18 18 S 1 1 "
+            "5 0 2 I 0 55419 3 0 2 S 2 2 C 3 3 M 22 22 G 3 0 M 46 46 5 0 2 I 0 17594 "
+            "3 0 2 M 14 14 G 0 1 M 9 9 G 1 0 M 15 15 G 0 3 M 17 17 G 0 3 M 1 1 G 0 1 "
+            "M 13 13 G 0 1 M 6 6 G 1 0 M 12 12 G 0 2 M 45 45 G 0 1 M 6 6",
+            hsp.vulgar_comp,
+        )
         # third hit
         hit = qresult[2]
         self.assertEqual("gi|330443667|ref|NC_001143.9|", hit.id)
@@ -1567,11 +2385,33 @@ class ExonerateVulgarCases(unittest.TestCase):
         self.assertEqual(71883, hsp.hit_start)
         self.assertEqual(529, hsp.query_end)
         self.assertEqual(641760, hsp.hit_end)
-        self.assertEqual([(449, 529), (319, 388), (198, 284), (161, 198), (78, 114)], hsp.query_range_all[:5])
-        self.assertEqual([(641682, 641760), (487327, 487387), (386123, 386207), (208639, 208677), (71883, 71917)], hsp.hit_range_all[:5])
+        self.assertEqual(
+            [(449, 529), (319, 388), (198, 284), (161, 198), (78, 114)],
+            hsp.query_range_all[:5],
+        )
+        self.assertEqual(
+            [
+                (641682, 641760),
+                (487327, 487387),
+                (386123, 386207),
+                (208639, 208677),
+                (71883, 71917),
+            ],
+            hsp.hit_range_all[:5],
+        )
         self.assertEqual([(198, 200), (197, 198)], hsp.query_split_codons)
         self.assertEqual([(386123, 386125), (208676, 208677)], hsp.hit_split_codons)
-        self.assertEqual(" M 31 31 G 3 0 M 4 4 G 2 0 M 19 19 G 0 3 M 9 9 G 0 1 M 6 6 G 1 0 M 5 5 5 2 2 I 0 154244 I 57 0 I 0 47 3 2 2 M 25 25 G 5 0 M 4 4 G 1 0 M 3 3 G 3 0 M 4 4 G 1 0 M 9 9 G 0 1 M 14 14 5 2 2 I 0 101116 I 31 0 3 2 2 M 23 23 G 0 1 M 15 15 G 1 0 M 9 9 G 1 0 M 2 2 G 1 0 M 14 14 C 18 18 S 2 2 5 0 2 I 0 177442 3 0 2 S 1 1 C 12 12 M 2 2 G 0 1 M 22 22 5 2 2 I 0 136697 I 7 0 I 0 6 I 1 0 I 0 1 I 1 0 I 0 1 I 1 0 I 0 1 I 1 0 I 0 1 I 2 0 I 0 1 I 1 0 I 0 1 I 1 0 I 0 1 I 3 0 I 0 1 I 2 0 I 0 1 I 1 0 I 0 1 I 1 0 I 0 1 I 2 0 I 0 2 I 2 0 I 0 2 I 17 0 3 2 2 M 12 12 G 2 0 M 22 22", hsp.vulgar_comp)
+        self.assertEqual(
+            " M 31 31 G 3 0 M 4 4 G 2 0 M 19 19 G 0 3 M 9 9 G 0 1 M 6 6 G 1 0 M 5 5 5 "
+            "2 2 I 0 154244 I 57 0 I 0 47 3 2 2 M 25 25 G 5 0 M 4 4 G 1 0 M 3 3 G 3 0 "
+            "M 4 4 G 1 0 M 9 9 G 0 1 M 14 14 5 2 2 I 0 101116 I 31 0 3 2 2 M 23 23 G "
+            "0 1 M 15 15 G 1 0 M 9 9 G 1 0 M 2 2 G 1 0 M 14 14 C 18 18 S 2 2 5 0 2 I "
+            "0 177442 3 0 2 S 1 1 C 12 12 M 2 2 G 0 1 M 22 22 5 2 2 I 0 136697 I 7 0 "
+            "I 0 6 I 1 0 I 0 1 I 1 0 I 0 1 I 1 0 I 0 1 I 1 0 I 0 1 I 2 0 I 0 1 I 1 0 "
+            "I 0 1 I 1 0 I 0 1 I 3 0 I 0 1 I 2 0 I 0 1 I 1 0 I 0 1 I 1 0 I 0 1 I 2 0 "
+            "I 0 2 I 2 0 I 0 2 I 17 0 3 2 2 M 12 12 G 2 0 M 22 22",
+            hsp.vulgar_comp,
+        )
 
     def test_exn_22_o_vulgar_fshifts(self):
         """Test parsing exonerate output (exn_22_o_vulgar_fshifts.exn)."""
@@ -1603,11 +2443,17 @@ class ExonerateVulgarCases(unittest.TestCase):
         self.assertEqual(465, hsp.hit_start)
         self.assertEqual(160, hsp.query_end)
         self.assertEqual(630, hsp.hit_end)
-        self.assertEqual([(0, 93), (94, 127), (127, 139), (139, 160)], hsp.query_range_all[:5])
-        self.assertEqual([(465, 558), (558, 591), (593, 605), (609, 630)], hsp.hit_range_all[:5])
+        self.assertEqual(
+            [(0, 93), (94, 127), (127, 139), (139, 160)], hsp.query_range_all[:5]
+        )
+        self.assertEqual(
+            [(465, 558), (558, 591), (593, 605), (609, 630)], hsp.hit_range_all[:5]
+        )
         self.assertEqual([], hsp.query_split_codons)
         self.assertEqual([], hsp.hit_split_codons)
-        self.assertEqual(" C 93 93 F 1 0 C 33 33 F 0 2 C 12 12 F 0 4 C 21 21", hsp.vulgar_comp)
+        self.assertEqual(
+            " C 93 93 F 1 0 C 33 33 F 0 2 C 12 12 F 0 4 C 21 21", hsp.vulgar_comp
+        )
         # first hit, second hsp
         hsp = qresult[0][1]
         self.assertEqual(201, hsp.score)
@@ -1683,7 +2529,12 @@ class ExonerateCigarCases(unittest.TestCase):
         self.assertEqual(23668, hsp.hit_start)
         self.assertEqual(491, hsp.query_end)
         self.assertEqual(115569, hsp.hit_end)
-        self.assertEqual("  M 29 D 8983 M 32 D 2 M 2 D 1 M 15 D 9555 M 3 I 1 M 5 D 2 M 3 D 1 M 4 D 1 M 18 M 1 D 55423 M 5 M 22 I 3 M 46 D 17598 M 14 D 1 M 9 I 1 M 15 D 3 M 17 D 3 M 1 D 1 M 13 D 1 M 6 I 1 M 12 D 2 M 45 D 1 M 6", hsp.cigar_comp)
+        self.assertEqual(
+            "  M 29 D 8983 M 32 D 2 M 2 D 1 M 15 D 9555 M 3 I 1 M 5 D 2 M 3 D 1 M 4 D "
+            "1 M 18 M 1 D 55423 M 5 M 22 I 3 M 46 D 17598 M 14 D 1 M 9 I 1 M 15 D 3 M "
+            "17 D 3 M 1 D 1 M 13 D 1 M 6 I 1 M 12 D 2 M 45 D 1 M 6",
+            hsp.cigar_comp,
+        )
         # third hit
         hit = qresult[2]
         self.assertEqual("gi|330443667|ref|NC_001143.9|", hit.id)
@@ -1698,7 +2549,14 @@ class ExonerateCigarCases(unittest.TestCase):
         self.assertEqual(71883, hsp.hit_start)
         self.assertEqual(529, hsp.query_end)
         self.assertEqual(641760, hsp.hit_end)
-        self.assertEqual("  M 31 I 3 M 4 I 2 M 19 D 3 M 9 D 1 M 6 I 1 M 7 D 154244 I 57 D 47 M 27 I 5 M 4 I 1 M 3 I 3 M 4 I 1 M 9 D 1 M 16 D 101116 I 31 M 25 D 1 M 15 I 1 M 9 I 1 M 2 I 1 M 14 M 20 D 177446 M 13 M 2 D 1 M 24 D 136697 I 7 D 6 I 1 D 1 I 1 D 1 I 1 D 1 I 1 D 1 I 2 D 1 I 1 D 1 I 1 D 1 I 3 D 1 I 2 D 1 I 1 D 1 I 1 D 1 I 2 D 2 I 2 D 2 I 17 M 14 I 2 M 22", hsp.cigar_comp)
+        self.assertEqual(
+            "  M 31 I 3 M 4 I 2 M 19 D 3 M 9 D 1 M 6 I 1 M 7 D 154244 I 57 D 47 M 27 I "
+            "5 M 4 I 1 M 3 I 3 M 4 I 1 M 9 D 1 M 16 D 101116 I 31 M 25 D 1 M 15 I 1 M "
+            "9 I 1 M 2 I 1 M 14 M 20 D 177446 M 13 M 2 D 1 M 24 D 136697 I 7 D 6 I 1 D "
+            "1 I 1 D 1 I 1 D 1 I 1 D 1 I 2 D 1 I 1 D 1 I 1 D 1 I 3 D 1 I 2 D 1 I 1 D 1 "
+            "I 1 D 1 I 2 D 2 I 2 D 2 I 17 M 14 I 2 M 22",
+            hsp.cigar_comp,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_SearchIO_exonerate* files, only one file affected, it should be fine to merge.
test_SearchIO_exonerate.py
