### PR TITLE
Apply black style to test_SearchIO_fasta*, version 19.10b0.

### DIFF
--- a/Tests/test_SearchIO_fasta_m10.py
+++ b/Tests/test_SearchIO_fasta_m10.py
@@ -22,7 +22,6 @@ def get_file(filename):
 
 
 class Fasta34Cases(unittest.TestCase):
-
     def test_output002(self):
         """Test parsing fasta34 output (output002.m10)."""
         m10_file = get_file("output002.m10")
@@ -43,12 +42,18 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual("34.26", qresult.version)
         self.assertEqual("NC_002695.faa", qresult.target)
         self.assertEqual(107, qresult.seq_len)
-        self.assertEqual("plasmid mobilization [Escherichia coli O157:H7 s 107 aa", qresult.description)
+        self.assertEqual(
+            "plasmid mobilization [Escherichia coli O157:H7 s 107 aa",
+            qresult.description,
+        )
         self.assertEqual(2, len(qresult))
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|162139799|ref|NP_309634.2|", hit.id)
-        self.assertEqual("23S rRNA pseudouridine synthase E [Escherichia coli O157:H7 str. Sakai]", hit.description)
+        self.assertEqual(
+            "23S rRNA pseudouridine synthase E [Escherichia coli O157:H7 str. Sakai]",
+            hit.description,
+        )
         self.assertEqual(207, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -65,16 +70,25 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(88, hsp.aln_span)
         self.assertEqual(4, hsp.query_start)
         self.assertEqual(89, hsp.query_end)
-        self.assertEqual("SGSNTRRRAISRPVR--LTAEEDQEIRKRAAECG-KTVSGFLRAAALGKKVNSLTDDRVLKEVMRLGALQKKLFIDGKRVGDREYAEV", str(hsp.query.seq))
+        self.assertEqual(
+            "SGSNTRRRAISRPVR--LTAEEDQEIRKRAAECG-KTVSGFLRAAALGKKVNSLTDDRVLKEVMRLGALQKKLFIDGKRVGDREYAEV",
+            str(hsp.query.seq),
+        )
         self.assertEqual(15, hsp.hit_start)
         self.assertEqual(103, hsp.hit_end)
-        self.assertEqual("SQRSTRRKPENQPTRVILFNKPYDVLPQFTDEAGRKTLKEFIPVQGVYAAGRLDRDSEGLLVLTNNGALQARLTQPGKRTGKIYYVQV", str(hsp.hit.seq))
+        self.assertEqual(
+            "SQRSTRRKPENQPTRVILFNKPYDVLPQFTDEAGRKTLKEFIPVQGVYAAGRLDRDSEGLLVLTNNGALQARLTQPGKRTGKIYYVQV",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|15831859|ref|NP_310632.1|", hit.id)
-        self.assertEqual("trehalose-6-phosphate phosphatase [Escherichia coli O157:H7 str. Sakai]", hit.description)
+        self.assertEqual(
+            "trehalose-6-phosphate phosphatase [Escherichia coli O157:H7 str. Sakai]",
+            hit.description,
+        )
         self.assertEqual(266, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, second hit, first hsp
@@ -91,10 +105,14 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(53, hsp.aln_span)
         self.assertEqual(26, hsp.query_start)
         self.assertEqual(74, hsp.query_end)
-        self.assertEqual("EIRKRAAECGKTVSGFLRAAA-LGKKV----NSLTDDRVLKEVMRLGALQKKL", str(hsp.query.seq))
+        self.assertEqual(
+            "EIRKRAAECGKTVSGFLRAAA-LGKKV----NSLTDDRVLKEVMRLGALQKKL", str(hsp.query.seq)
+        )
         self.assertEqual(166, hsp.hit_start)
         self.assertEqual(219, hsp.hit_end)
-        self.assertEqual("EIKPRGTSKGEAIAAFMQEAPFIGRTPVFLGDDLTDESGFAVVNRLGGMSVKI", str(hsp.hit.seq))
+        self.assertEqual(
+            "EIKPRGTSKGEAIAAFMQEAPFIGRTPVFLGDDLTDESGFAVVNRLGGMSVKI", str(hsp.hit.seq)
+        )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
 
@@ -105,12 +123,17 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual("34.26", qresult.version)
         self.assertEqual("NC_002695.faa", qresult.target)
         self.assertEqual(126, qresult.seq_len)
-        self.assertEqual("hypothetical protein pOSAK1_02 [Escherichia coli O157:H7 s 126 aa", qresult.description)
+        self.assertEqual(
+            "hypothetical protein pOSAK1_02 [Escherichia coli O157:H7 s 126 aa",
+            qresult.description,
+        )
         self.assertEqual(2, len(qresult))
         # second qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|15829419|ref|NP_308192.1|", hit.id)
-        self.assertEqual("serine endoprotease [Escherichia coli O157:H7 str. Sakai]", hit.description)
+        self.assertEqual(
+            "serine endoprotease [Escherichia coli O157:H7 str. Sakai]", hit.description
+        )
         self.assertEqual(474, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, first hit, first hsp
@@ -127,16 +150,25 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(92, hsp.aln_span)
         self.assertEqual(30, hsp.query_start)
         self.assertEqual(117, hsp.query_end)
-        self.assertEqual("SEFFSKIESDLKKKKSKGDVFFDLIIPNG-----GKKDRYVYTSFNGEKFSSYTLNKVTKTDEYNDLSELSASFFKKNFDKINVNLLSKATS", str(hsp.query.seq))
+        self.assertEqual(
+            "SEFFSKIESDLKKKKSKGDVFFDLIIPNG-----GKKDRYVYTSFNGEKFSSYTLNKVTKTDEYNDLSELSASFFKKNFDKINVNLLSKATS",
+            str(hsp.query.seq),
+        )
         self.assertEqual(295, hsp.hit_start)
         self.assertEqual(384, hsp.hit_end)
-        self.assertEqual("TELNSELAKAMKVDAQRG-AFVSQVLPNSSAAKAGIKAGDVITSLNGKPISSFAALRA-QVGTMPVGSKLTLGLLRDG-KQVNVNLELQQSS", str(hsp.hit.seq))
+        self.assertEqual(
+            "TELNSELAKAMKVDAQRG-AFVSQVLPNSSAAKAGIKAGDVITSLNGKPISSFAALRA-QVGTMPVGSKLTLGLLRDG-KQVNVNLELQQSS",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
         # second qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|15832592|ref|NP_311365.1|", hit.id)
-        self.assertEqual("phosphoribosylaminoimidazole-succinocarboxamide synthase [Escherichia coli O157:H7 str. Sakai]", hit.description)
+        self.assertEqual(
+            "phosphoribosylaminoimidazole-succinocarboxamide synthase [Escherichia coli O157:H7 str. Sakai]",
+            hit.description,
+        )
         self.assertEqual(237, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, second hit, first hsp
@@ -153,10 +185,16 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(73, hsp.aln_span)
         self.assertEqual(50, hsp.query_start)
         self.assertEqual(123, hsp.query_end)
-        self.assertEqual("FFDLIIPNGGKKDRYVYTSFNGEKFSSYTLNKVTKTDEYNDLSELSASFFKKNFDKINVNLLSKATSFALKKG", str(hsp.query.seq))
+        self.assertEqual(
+            "FFDLIIPNGGKKDRYVYTSFNGEKFSSYTLNKVTKTDEYNDLSELSASFFKKNFDKINVNLLSKATSFALKKG",
+            str(hsp.query.seq),
+        )
         self.assertEqual(116, hsp.hit_start)
         self.assertEqual(185, hsp.hit_end)
-        self.assertEqual("LFDLFLKNDAMHDPMVNESYC-ETFGWVSKENLARMKE---LTYKANDVLKKLFDDAGLILVDFKLEFGLYKG", str(hsp.hit.seq))
+        self.assertEqual(
+            "LFDLFLKNDAMHDPMVNESYC-ETFGWVSKENLARMKE---LTYKANDVLKKLFDDAGLILVDFKLEFGLYKG",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
 
@@ -167,12 +205,18 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual("34.26", qresult.version)
         self.assertEqual("NC_002695.faa", qresult.target)
         self.assertEqual(346, qresult.seq_len)
-        self.assertEqual("hypothetical protein pOSAK1_03 [Escherichia coli O157:H7 s 346 aa", qresult.description)
+        self.assertEqual(
+            "hypothetical protein pOSAK1_03 [Escherichia coli O157:H7 s 346 aa",
+            qresult.description,
+        )
         self.assertEqual(2, len(qresult))
         # third qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|38704138|ref|NP_311957.2|", hit.id)
-        self.assertEqual("hypothetical protein ECs3930 [Escherichia coli O157:H7 str. Sakai]", hit.description)
+        self.assertEqual(
+            "hypothetical protein ECs3930 [Escherichia coli O157:H7 str. Sakai]",
+            hit.description,
+        )
         self.assertEqual(111, hit.seq_len)
         self.assertEqual(1, len(hit))
         # third qresult, first hit, first hsp
@@ -189,16 +233,25 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(63, hsp.aln_span)
         self.assertEqual(187, hsp.query_start)
         self.assertEqual(246, hsp.query_end)
-        self.assertEqual("VDIKK-ETIESELHSKLPKSIDKIHEDIKKQLSCSLI--MKKID-VEMEDYSTYCFSALRAIE", str(hsp.query.seq))
+        self.assertEqual(
+            "VDIKK-ETIESELHSKLPKSIDKIHEDIKKQLSCSLI--MKKID-VEMEDYSTYCFSALRAIE",
+            str(hsp.query.seq),
+        )
         self.assertEqual(13, hsp.hit_start)
         self.assertEqual(76, hsp.hit_end)
-        self.assertEqual("IDPKKIEQIARQVHESMPKGIREFGEDVEKKIRQTLQAQLTRLDLVSREEFDVQTQVLLRTRE", str(hsp.hit.seq))
+        self.assertEqual(
+            "IDPKKIEQIARQVHESMPKGIREFGEDVEKKIRQTLQAQLTRLDLVSREEFDVQTQVLLRTRE",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
         # third qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|15833861|ref|NP_312634.1|", hit.id)
-        self.assertEqual("hypothetical protein ECs4607 [Escherichia coli O157:H7 str. Sakai]", hit.description)
+        self.assertEqual(
+            "hypothetical protein ECs4607 [Escherichia coli O157:H7 str. Sakai]",
+            hit.description,
+        )
         self.assertEqual(330, hit.seq_len)
         self.assertEqual(1, len(hit))
         # third qresult, second hit, first hsp
@@ -215,10 +268,16 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(157, hsp.aln_span)
         self.assertEqual(130, hsp.query_start)
         self.assertEqual(281, hsp.query_end)
-        self.assertEqual("QYIMTTSNGDRVRAKIYKRGSIQFQGKYLQIASLINDFMCSILNMKEIVEQKNKEFNVDI---KKETI-ESELHSKLPKSIDKIHEDIKKQLSCSLIMKKIDV-EMEDYSTYCFSALRA-IEGFIYQILNDVCNPSSSKNLGEYFTENKPKYIIREI", str(hsp.query.seq))
+        self.assertEqual(
+            "QYIMTTSNGDRVRAKIYKRGSIQFQGKYLQIASLINDFMCSILNMKEIVEQKNKEFNVDI---KKETI-ESELHSKLPKSIDKIHEDIKKQLSCSLIMKKIDV-EMEDYSTYCFSALRA-IEGFIYQILNDVCNPSSSKNLGEYFTENKPKYIIREI",
+            str(hsp.query.seq),
+        )
         self.assertEqual(9, hsp.hit_start)
         self.assertEqual(155, hsp.hit_end)
-        self.assertEqual("EFIRLLSDHDQFEKDQISELTVAANALKLEVAK--NNY-----NMKYSFDTQTERRMIELIREQKDLIPEKYLHQSGIKKL-KLHED---EFSSLLVDAERQVLEGSSFVLCCGEKINSTISELLSKKITDLTHPTESFTLSEYFSYDVYEEIFKKV", str(hsp.hit.seq))
+        self.assertEqual(
+            "EFIRLLSDHDQFEKDQISELTVAANALKLEVAK--NNY-----NMKYSFDTQTERRMIELIREQKDLIPEKYLHQSGIKKL-KLHED---EFSSLLVDAERQVLEGSSFVLCCGEKINSTISELLSKKITDLTHPTESFTLSEYFSYDVYEEIFKKV",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
 
@@ -242,12 +301,18 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual("34.26", qresult.version)
         self.assertEqual("NC_002127.faa", qresult.target)
         self.assertEqual(183, qresult.seq_len)
-        self.assertEqual("hypothetical protein KPN_pKPN7p10262 [Klebsiella pneumoniae subsp. pneumonia 183 aa", qresult.description)
+        self.assertEqual(
+            "hypothetical protein KPN_pKPN7p10262 [Klebsiella pneumoniae subsp. pneumonia 183 aa",
+            qresult.description,
+        )
         self.assertEqual(1, len(qresult))
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|10955263|ref|NP_052604.1|", hit.id)
-        self.assertEqual("plasmid mobilization [Escherichia coli O157:H7 str. Sakai]", hit.description)
+        self.assertEqual(
+            "plasmid mobilization [Escherichia coli O157:H7 str. Sakai]",
+            hit.description,
+        )
         self.assertEqual(107, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -264,10 +329,15 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(55, hsp.aln_span)
         self.assertEqual(86, hsp.query_start)
         self.assertEqual(141, hsp.query_end)
-        self.assertEqual("ISISNNKDQYEELQKEQGERDLKTVDQLVRIAAAGGGLRLSASTKTVDQLVRIAA", str(hsp.query.seq))
+        self.assertEqual(
+            "ISISNNKDQYEELQKEQGERDLKTVDQLVRIAAAGGGLRLSASTKTVDQLVRIAA",
+            str(hsp.query.seq),
+        )
         self.assertEqual(17, hsp.hit_start)
         self.assertEqual(69, hsp.hit_end)
-        self.assertEqual("VRLTAEEDQ--EIRKRAAECG-KTVSGFLRAAALGKKVNSLTDDRVLKEVMRLGA", str(hsp.hit.seq))
+        self.assertEqual(
+            "VRLTAEEDQ--EIRKRAAECG-KTVSGFLRAAALGKKVNSLTDDRVLKEVMRLGA", str(hsp.hit.seq)
+        )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
 
@@ -278,7 +348,10 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual("34.26", qresult.version)
         self.assertEqual("NC_002127.faa", qresult.target)
         self.assertEqual(76, qresult.seq_len)
-        self.assertEqual("hypothetical protein KPN_pKPN7p10263 [Klebsiella pneumoniae subsp. pneumonia 76 aa", qresult.description)
+        self.assertEqual(
+            "hypothetical protein KPN_pKPN7p10263 [Klebsiella pneumoniae subsp. pneumonia 76 aa",
+            qresult.description,
+        )
         self.assertEqual(0, len(qresult))
 
         # test third qresult
@@ -288,7 +361,10 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual("34.26", qresult.version)
         self.assertEqual("NC_002127.faa", qresult.target)
         self.assertEqual(112, qresult.seq_len)
-        self.assertEqual("hypothetical protein KPN_pKPN7p10264 [Klebsiella pneumoniae subsp. pneumonia 112 aa", qresult.description)
+        self.assertEqual(
+            "hypothetical protein KPN_pKPN7p10264 [Klebsiella pneumoniae subsp. pneumonia 112 aa",
+            qresult.description,
+        )
         self.assertEqual(0, len(qresult))
 
         # test fourth qresult
@@ -298,12 +374,18 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual("34.26", qresult.version)
         self.assertEqual("NC_002127.faa", qresult.target)
         self.assertEqual(63, qresult.seq_len)
-        self.assertEqual("RNA one modulator-like protein [Klebsiella pneumoniae subsp. pneumoniae  63 aa", qresult.description)
+        self.assertEqual(
+            "RNA one modulator-like protein [Klebsiella pneumoniae subsp. pneumoniae  63 aa",
+            qresult.description,
+        )
         self.assertEqual(1, len(qresult))
         # fourth qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|10955265|ref|NP_052606.1|", hit.id)
-        self.assertEqual("hypothetical protein pOSAK1_03 [Escherichia coli O157:H7 str. Sakai]", hit.description)
+        self.assertEqual(
+            "hypothetical protein pOSAK1_03 [Escherichia coli O157:H7 str. Sakai]",
+            hit.description,
+        )
         self.assertEqual(346, hit.seq_len)
         self.assertEqual(1, len(hit))
         # fourth qresult, first hit, first hsp
@@ -334,12 +416,18 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual("34.26", qresult.version)
         self.assertEqual("NC_002127.faa", qresult.target)
         self.assertEqual(133, qresult.seq_len)
-        self.assertEqual("Excl1 protein [Klebsiella pneumoniae subsp. pneumoniae  133 aa", qresult.description)
+        self.assertEqual(
+            "Excl1 protein [Klebsiella pneumoniae subsp. pneumoniae  133 aa",
+            qresult.description,
+        )
         self.assertEqual(1, len(qresult))
         # fifth qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|10955264|ref|NP_052605.1|", hit.id)
-        self.assertEqual("hypothetical protein pOSAK1_02 [Escherichia coli O157:H7 str. Sakai]", hit.description)
+        self.assertEqual(
+            "hypothetical protein pOSAK1_02 [Escherichia coli O157:H7 str. Sakai]",
+            hit.description,
+        )
         self.assertEqual(126, hit.seq_len)
         self.assertEqual(1, len(hit))
         # fifth qresult, first hit, first hsp
@@ -356,16 +444,21 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(63, hsp.aln_span)
         self.assertEqual(48, hsp.query_start)
         self.assertEqual(109, hsp.query_end)
-        self.assertEqual("VFGSFEQPKGEHLSGQVSEQ--RDTAFADQNEQVIRHLKQEIEHLNTLLLSKDSHIDSLKQAM", str(hsp.query.seq))
+        self.assertEqual(
+            "VFGSFEQPKGEHLSGQVSEQ--RDTAFADQNEQVIRHLKQEIEHLNTLLLSKDSHIDSLKQAM",
+            str(hsp.query.seq),
+        )
         self.assertEqual(65, hsp.hit_start)
         self.assertEqual(124, hsp.hit_end)
-        self.assertEqual("VYTSFN---GEKFSSYTLNKVTKTDEYNDLSELSASFFKKNFDKINVNLLSKATSF-ALKKGI", str(hsp.hit.seq))
+        self.assertEqual(
+            "VYTSFN---GEKFSSYTLNKVTKTDEYNDLSELSASFFKKNFDKINVNLLSKATSF-ALKKGI",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
 
 
 class Fasta35Cases(unittest.TestCase):
-
     def test_output001(self):
         """Test parsing fasta35 output (output001.m10)."""
         m10_file = get_file("output001.m10")
@@ -386,12 +479,18 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual("35.03", qresult.version)
         self.assertEqual("NC_009649.faa", qresult.target)
         self.assertEqual(107, qresult.seq_len)
-        self.assertEqual("plasmid mobilization [Escherichia coli O157:H7 s 107 aa", qresult.description)
+        self.assertEqual(
+            "plasmid mobilization [Escherichia coli O157:H7 s 107 aa",
+            qresult.description,
+        )
         self.assertEqual(2, len(qresult))
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|152973457|ref|YP_001338508.1|", hit.id)
-        self.assertEqual("ATPase with chaperone activity, ATP-binding subunit [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]", hit.description)
+        self.assertEqual(
+            "ATPase with chaperone activity, ATP-binding subunit [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]",
+            hit.description,
+        )
         self.assertEqual(931, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -408,16 +507,25 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(108, hsp.aln_span)
         self.assertEqual(4, hsp.query_start)
         self.assertEqual(103, hsp.query_end)
-        self.assertEqual("SGSNT-RRRAISRPVRLTAEED---QEIRKRAAECGKTVSGFLRAAALGKKVNSLTDDRVLKEVM-----RLGALQKKLFIDGKRVGDREYAEVLIAITEYHRALLSR", str(hsp.query.seq))
+        self.assertEqual(
+            "SGSNT-RRRAISRPVRLTAEED---QEIRKRAAECGKTVSGFLRAAALGKKVNSLTDDRVLKEVM-----RLGALQKKLFIDGKRVGDREYAEVLIAITEYHRALLSR",
+            str(hsp.query.seq),
+        )
         self.assertEqual(95, hsp.hit_start)
         self.assertEqual(195, hsp.hit_end)
-        self.assertEqual("AGSGAPRRRGSGLASRISEQSEALLQEAAKHAAEFGRS------EVDTEHLLLALADSDVVKTILGQFKIKVDDLKRQIESEAKR-GDKPF-EGEIGVSPRVKDALSR", str(hsp.hit.seq))
+        self.assertEqual(
+            "AGSGAPRRRGSGLASRISEQSEALLQEAAKHAAEFGRS------EVDTEHLLLALADSDVVKTILGQFKIKVDDLKRQIESEAKR-GDKPF-EGEIGVSPRVKDALSR",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|152973588|ref|YP_001338639.1|", hit.id)
-        self.assertEqual("F pilus assembly protein [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]", hit.description)
+        self.assertEqual(
+            "F pilus assembly protein [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]",
+            hit.description,
+        )
         self.assertEqual(459, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, second hit, first hsp
@@ -434,10 +542,16 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(64, hsp.aln_span)
         self.assertEqual(31, hsp.query_start)
         self.assertEqual(94, hsp.query_end)
-        self.assertEqual("AAECGKTVSGFLRAAALGKKVNSLTDDRVLKEV-MRLGALQKKLFIDGKRVGDREYAEVLIAIT", str(hsp.query.seq))
+        self.assertEqual(
+            "AAECGKTVSGFLRAAALGKKVNSLTDDRVLKEV-MRLGALQKKLFIDGKRVGDREYAEVLIAIT",
+            str(hsp.query.seq),
+        )
         self.assertEqual(190, hsp.hit_start)
         self.assertEqual(248, hsp.hit_end)
-        self.assertEqual("ASRQGCTVGG--KMDSVQDKASDKDKERVMKNINIMWNALSKNRLFDG----NKELKEFIMTLT", str(hsp.hit.seq))
+        self.assertEqual(
+            "ASRQGCTVGG--KMDSVQDKASDKDKERVMKNINIMWNALSKNRLFDG----NKELKEFIMTLT",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
 
@@ -448,12 +562,18 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual("35.03", qresult.version)
         self.assertEqual("NC_009649.faa", qresult.target)
         self.assertEqual(126, qresult.seq_len)
-        self.assertEqual("hypothetical protein pOSAK1_02 [Escherichia coli O157:H7 s 126 aa", qresult.description)
+        self.assertEqual(
+            "hypothetical protein pOSAK1_02 [Escherichia coli O157:H7 s 126 aa",
+            qresult.description,
+        )
         self.assertEqual(1, len(qresult))
         # second qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|152973462|ref|YP_001338513.1|", hit.id)
-        self.assertEqual("hypothetical protein KPN_pKPN3p05904 [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]", hit.description)
+        self.assertEqual(
+            "hypothetical protein KPN_pKPN3p05904 [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]",
+            hit.description,
+        )
         self.assertEqual(101, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, first hit, first hsp
@@ -484,12 +604,18 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual("35.03", qresult.version)
         self.assertEqual("NC_009649.faa", qresult.target)
         self.assertEqual(346, qresult.seq_len)
-        self.assertEqual("hypothetical protein pOSAK1_03 [Escherichia coli O157:H7 s 346 aa", qresult.description)
+        self.assertEqual(
+            "hypothetical protein pOSAK1_03 [Escherichia coli O157:H7 s 346 aa",
+            qresult.description,
+        )
         self.assertEqual(1, len(qresult))
         # third qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|152973545|ref|YP_001338596.1|", hit.id)
-        self.assertEqual("putative plasmid SOS inhibition protein A [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]", hit.description)
+        self.assertEqual(
+            "putative plasmid SOS inhibition protein A [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]",
+            hit.description,
+        )
         self.assertEqual(242, hit.seq_len)
         self.assertEqual(1, len(hit))
         # third qresult, first hit, first hsp
@@ -506,10 +632,14 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(43, hsp.aln_span)
         self.assertEqual(196, hsp.query_start)
         self.assertEqual(238, hsp.query_end)
-        self.assertEqual("SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDVEMEDYSTYC", str(hsp.query.seq))
+        self.assertEqual(
+            "SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDVEMEDYSTYC", str(hsp.query.seq)
+        )
         self.assertEqual(51, hsp.hit_start)
         self.assertEqual(94, hsp.hit_end)
-        self.assertEqual("SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDMLISSHGEYC", str(hsp.hit.seq))
+        self.assertEqual(
+            "SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDMLISSHGEYC", str(hsp.hit.seq)
+        )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
 
@@ -564,12 +694,23 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(102, hsp.aln_span)
         self.assertEqual(3, hsp.query_start)
         self.assertEqual(105, hsp.query_end)
-        self.assertEqual("AAAAAAGATAAAAAATATCAAATAGAAGCAATAAAAAATAAAGATAAAACTTTATTTATTGTCTATGCTACTGATATTTATAGCCCGAGCGAATTTTTCTCA", str(hsp.query.seq))
+        self.assertEqual(
+            "AAAAAAGATAAAAAATATCAAATAGAAGCAATAAAAAATAAAGATAAAACTTTATTTATTGTCTATGCTACTGATATTTATAGCCCGAGCGAATTTTTCTCA",
+            str(hsp.query.seq),
+        )
         self.assertEqual(312, hsp.hit_start)
         self.assertEqual(414, hsp.hit_end)
-        self.assertEqual("AGAGAAAATAAAACAAGTAATAAAATATTAATGGAAAAAATAAATTCTTGTTTATTTAGACCTGATTCTAATCACTTTTCTTGCCCGGAGTCATTTTTGACA", str(hsp.hit.seq))
+        self.assertEqual(
+            "AGAGAAAATAAAACAAGTAATAAAATATTAATGGAAAAAATAAATTCTTGTTTATTTAGACCTGATTCTAATCACTTTTCTTGCCCGGAGTCATTTTTGACA",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(1, hsp.query_strand)
-        self.assertEqual({"similarity": ": : :: :::::: :  : : : :  :  :::  :::: : : ::     ::::::::      :: ::: : :  ::: : :::::     ::::::  ::"}, hsp.aln_annotation)
+        self.assertEqual(
+            {
+                "similarity": ": : :: :::::: :  : : : :  :  :::  :::: : : ::     ::::::::      :: ::: : :  ::: : :::::     ::::::  ::"
+            },
+            hsp.aln_annotation,
+        )
 
         # test third qresult
         qresult = qresults[2]
@@ -601,7 +742,10 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual("35.03", qresult.version)
         self.assertEqual("NC_002128.faa", qresult.target)
         self.assertEqual(107, qresult.seq_len)
-        self.assertEqual("plasmid mobilization [Escherichia coli O157:H7 s 107 aa", qresult.description)
+        self.assertEqual(
+            "plasmid mobilization [Escherichia coli O157:H7 s 107 aa",
+            qresult.description,
+        )
         self.assertEqual(0, len(qresult))
 
         # test second qresult
@@ -611,12 +755,17 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual("35.03", qresult.version)
         self.assertEqual("NC_002128.faa", qresult.target)
         self.assertEqual(126, qresult.seq_len)
-        self.assertEqual("hypothetical protein pOSAK1_02 [Escherichia coli O157:H7 s 126 aa", qresult.description)
+        self.assertEqual(
+            "hypothetical protein pOSAK1_02 [Escherichia coli O157:H7 s 126 aa",
+            qresult.description,
+        )
         self.assertEqual(1, len(qresult))
         # second qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|10955282|ref|NP_052623.1|", hit.id)
-        self.assertEqual("hemolysin C [Escherichia coli O157:H7 str. Sakai]", hit.description)
+        self.assertEqual(
+            "hemolysin C [Escherichia coli O157:H7 str. Sakai]", hit.description
+        )
         self.assertEqual(163, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, first hit, first hsp
@@ -631,10 +780,16 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(110, hsp.aln_span)
         self.assertEqual(11, hsp.query_start)
         self.assertEqual(114, hsp.query_end)
-        self.assertEqual("IKNKDKTLFIVYAT-DIYSPSEFFSKIESDLKKKKSKGDV--FFDLIIPNGGKKD--RYVYTSFNGEKFSSYTLNKVTKTDEYNDL--SELSASFFKKNFDKINVNLLSK", str(hsp.query.seq))
+        self.assertEqual(
+            "IKNKDKTLFIVYAT-DIYSPSEFFSKIESDLKKKKSKGDV--FFDLIIPNGGKKD--RYVYTSFNGEKFSSYTLNKVTKTDEYNDL--SELSASFFKKNFDKINVNLLSK",
+            str(hsp.query.seq),
+        )
         self.assertEqual(38, hsp.hit_start)
         self.assertEqual(148, hsp.hit_end)
-        self.assertEqual("IKDELPVAFCSWASLDLECEVKYINDVTSLYAKDWMSGERKWFIDWIAPFGHNMELYKYMRKKYPYELFRAIRLDESSKTGKIAEFHGGGIDKKLASKIFRQYHHELMSE", str(hsp.hit.seq))
+        self.assertEqual(
+            "IKDELPVAFCSWASLDLECEVKYINDVTSLYAKDWMSGERKWFIDWIAPFGHNMELYKYMRKKYPYELFRAIRLDESSKTGKIAEFHGGGIDKKLASKIFRQYHHELMSE",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
 
@@ -645,7 +800,10 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual("35.03", qresult.version)
         self.assertEqual("NC_002128.faa", qresult.target)
         self.assertEqual(346, qresult.seq_len)
-        self.assertEqual("hypothetical protein pOSAK1_03 [Escherichia coli O157:H7 s 346 aa", qresult.description)
+        self.assertEqual(
+            "hypothetical protein pOSAK1_03 [Escherichia coli O157:H7 s 346 aa",
+            qresult.description,
+        )
         self.assertEqual(0, len(qresult))
 
     def test_output006(self):
@@ -673,7 +831,10 @@ class Fasta35Cases(unittest.TestCase):
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|116660610|gb|EG558221.1|EG558221", hit.id)
-        self.assertEqual("CR03001A07 Root CR03 cDNA library Catharanthus roseus cDNA clone CR03001A07 5', mRNA sequence", hit.description)
+        self.assertEqual(
+            "CR03001A07 Root CR03 cDNA library Catharanthus roseus cDNA clone CR03001A07 5', mRNA sequence",
+            hit.description,
+        )
         self.assertEqual(573, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -689,16 +850,26 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(131, hsp.aln_span)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(131, hsp.query_end)
-        self.assertEqual("GCAACGCTTCAAGAACTGGAATTAGGAACCGTGACAACGATTAATGAGGAGATTTATGAAGAGGGTTCTTCGATTTTAGGCCAATCGGAAGGAATTATGTAGCAAGTCCATCAGAAAATGGAAGAAGTCAT", str(hsp.query.seq))
+        self.assertEqual(
+            "GCAACGCTTCAAGAACTGGAATTAGGAACCGTGACAACGATTAATGAGGAGATTTATGAAGAGGGTTCTTCGATTTTAGGCCAATCGGAAGGAATTATGTAGCAAGTCCATCAGAAAATGGAAGAAGTCAT",
+            str(hsp.query.seq),
+        )
         self.assertEqual(359, hsp.hit_start)
         self.assertEqual(490, hsp.hit_end)
-        self.assertEqual("GCAACGCTTCAAGAACTGGAATTAGGAACCGTGACAACGATTAATGAGGAGATTTATGAAGAGGGTTCTTCGATTTTAGGCCAATCGGAAGGAATTATGTAGCAAGTCCATCAGAAAATGGAAGTAGTCAT", str(hsp.hit.seq))
+        self.assertEqual(
+            "GCAACGCTTCAAGAACTGGAATTAGGAACCGTGACAACGATTAATGAGGAGATTTATGAAGAGGGTTCTTCGATTTTAGGCCAATCGGAAGGAATTATGTAGCAAGTCCATCAGAAAATGGAAGTAGTCAT",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(-1, hsp.query_strand)
-        self.assertEqual({"similarity": ":::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: ::::::"}, hsp.aln_annotation)
+        self.assertEqual(
+            {
+                "similarity": ":::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: ::::::"
+            },
+            hsp.aln_annotation,
+        )
 
 
 class Fasta36Cases(unittest.TestCase):
-
     def test_output007(self):
         """Test parsing fasta36 output (output007.m10)."""
         m10_file = get_file("output007.m10")
@@ -719,12 +890,17 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual("36.3.4", qresult.version)
         self.assertEqual("NC_009649.faa", qresult.target)
         self.assertEqual(107, qresult.seq_len)
-        self.assertEqual("plasmid mobilization [Escherichia coli O157:H7 s", qresult.description)
+        self.assertEqual(
+            "plasmid mobilization [Escherichia coli O157:H7 s", qresult.description
+        )
         self.assertEqual(3, len(qresult))
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|152973457|ref|YP_001338508.1|", hit.id)
-        self.assertEqual("ATPase with chaperone activity, ATP-binding subunit [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]", hit.description)
+        self.assertEqual(
+            "ATPase with chaperone activity, ATP-binding subunit [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]",
+            hit.description,
+        )
         self.assertEqual(931, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -741,16 +917,30 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(108, hsp.aln_span)
         self.assertEqual(4, hsp.query_start)
         self.assertEqual(103, hsp.query_end)
-        self.assertEqual("SGSNT-RRRAISRPVRLTAEED---QEIRKRAAECGKTVSGFLRAAALGKKVNSLTDDRVLKEVM-----RLGALQKKLFIDGKRVGDREYAEVLIAITEYHRALLSR", str(hsp.query.seq))
+        self.assertEqual(
+            "SGSNT-RRRAISRPVRLTAEED---QEIRKRAAECGKTVSGFLRAAALGKKVNSLTDDRVLKEVM-----RLGALQKKLFIDGKRVGDREYAEVLIAITEYHRALLSR",
+            str(hsp.query.seq),
+        )
         self.assertEqual(95, hsp.hit_start)
         self.assertEqual(195, hsp.hit_end)
-        self.assertEqual("AGSGAPRRRGSGLASRISEQSEALLQEAAKHAAEFGRS------EVDTEHLLLALADSDVVKTILGQFKIKVDDLKRQIESEAKR-GDKPF-EGEIGVSPRVKDALSR", str(hsp.hit.seq))
+        self.assertEqual(
+            "AGSGAPRRRGSGLASRISEQSEALLQEAAKHAAEFGRS------EVDTEHLLLALADSDVVKTILGQFKIKVDDLKRQIESEAKR-GDKPF-EGEIGVSPRVKDALSR",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
-        self.assertEqual({"similarity": ".::..-:::. .   :.. . .---::  :.::: :..------ .   . . .:.:. :.: ..-----..  :....  ..::-::. .-:  :...   .  :::"}, hsp.aln_annotation)
+        self.assertEqual(
+            {
+                "similarity": ".::..-:::. .   :.. . .---::  :.::: :..------ .   . . .:.:. :.: ..-----..  :....  ..::-::. .-:  :...   .  :::"
+            },
+            hsp.aln_annotation,
+        )
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|152973588|ref|YP_001338639.1|", hit.id)
-        self.assertEqual("F pilus assembly protein [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]", hit.description)
+        self.assertEqual(
+            "F pilus assembly protein [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]",
+            hit.description,
+        )
         self.assertEqual(459, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, second hit, first hsp
@@ -767,16 +957,30 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(64, hsp.aln_span)
         self.assertEqual(31, hsp.query_start)
         self.assertEqual(94, hsp.query_end)
-        self.assertEqual("AAECGKTVSGFLRAAALGKKVNSLTDDRVLKEV-MRLGALQKKLFIDGKRVGDREYAEVLIAIT", str(hsp.query.seq))
+        self.assertEqual(
+            "AAECGKTVSGFLRAAALGKKVNSLTDDRVLKEV-MRLGALQKKLFIDGKRVGDREYAEVLIAIT",
+            str(hsp.query.seq),
+        )
         self.assertEqual(190, hsp.hit_start)
         self.assertEqual(248, hsp.hit_end)
-        self.assertEqual("ASRQGCTVGG--KMDSVQDKASDKDKERVMKNINIMWNALSKNRLFDG----NKELKEFIMTLT", str(hsp.hit.seq))
+        self.assertEqual(
+            "ASRQGCTVGG--KMDSVQDKASDKDKERVMKNINIMWNALSKNRLFDG----NKELKEFIMTLT",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
-        self.assertEqual({"similarity": ":.. : ::.:--.  ..  :...   .::.:..-.  .::.:. ..::----..:  : ....:"}, hsp.aln_annotation)
+        self.assertEqual(
+            {
+                "similarity": ":.. : ::.:--.  ..  :...   .::.:..-.  .::.:. ..::----..:  : ....:"
+            },
+            hsp.aln_annotation,
+        )
         # first qresult, third hit
         hit = qresult[2]
         self.assertEqual("gi|152973480|ref|YP_001338531.1|", hit.id)
-        self.assertEqual("Arsenate reductase (Arsenical pump modifier) [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]", hit.description)
+        self.assertEqual(
+            "Arsenate reductase (Arsenical pump modifier) [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]",
+            hit.description,
+        )
         self.assertEqual(141, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, third hit, first hsp
@@ -793,12 +997,19 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(45, hsp.aln_span)
         self.assertEqual(26, hsp.query_start)
         self.assertEqual(66, hsp.query_end)
-        self.assertEqual("EIRKRAAECGKTVSGFLRAAA-----LGKKVNSLTDDRVLKEVMR", str(hsp.query.seq))
+        self.assertEqual(
+            "EIRKRAAECGKTVSGFLRAAA-----LGKKVNSLTDDRVLKEVMR", str(hsp.query.seq)
+        )
         self.assertEqual(42, hsp.hit_start)
         self.assertEqual(87, hsp.hit_end)
-        self.assertEqual("ELVKLIADMGISVRALLRKNVEPYEELGLEEDKFTDDQLIDFMLQ", str(hsp.hit.seq))
+        self.assertEqual(
+            "ELVKLIADMGISVRALLRKNVEPYEELGLEEDKFTDDQLIDFMLQ", str(hsp.hit.seq)
+        )
         self.assertEqual(0, hsp.query_strand)
-        self.assertEqual({"similarity": ":. :  :. : .: ..::  .-----:: . ...:::...  ..."}, hsp.aln_annotation)
+        self.assertEqual(
+            {"similarity": ":. :  :. : .: ..::  .-----:: . ...:::...  ..."},
+            hsp.aln_annotation,
+        )
 
         # test second qresult
         qresult = qresults[1]
@@ -807,12 +1018,18 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual("36.3.4", qresult.version)
         self.assertEqual("NC_009649.faa", qresult.target)
         self.assertEqual(126, qresult.seq_len)
-        self.assertEqual("hypothetical protein pOSAK1_02 [Escherichia coli O157:H7 s", qresult.description)
+        self.assertEqual(
+            "hypothetical protein pOSAK1_02 [Escherichia coli O157:H7 s",
+            qresult.description,
+        )
         self.assertEqual(4, len(qresult))
         # second qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|152973462|ref|YP_001338513.1|", hit.id)
-        self.assertEqual("hypothetical protein KPN_pKPN3p05904 [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]", hit.description)
+        self.assertEqual(
+            "hypothetical protein KPN_pKPN3p05904 [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]",
+            hit.description,
+        )
         self.assertEqual(101, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, first hit, first hsp
@@ -834,11 +1051,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(81, hsp.hit_end)
         self.assertEqual("IKKDLGVSFLKLKNREKTLIVDALKKKYPVAELLSVLQ", str(hsp.hit.seq))
         self.assertEqual(0, hsp.query_strand)
-        self.assertEqual({"similarity": ".:::   ..  .::..:::..      :  .:..: .."}, hsp.aln_annotation)
+        self.assertEqual(
+            {"similarity": ".:::   ..  .::..:::..      :  .:..: .."}, hsp.aln_annotation
+        )
         # second qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|152973509|ref|YP_001338560.1|", hit.id)
-        self.assertEqual("probable sensor kinase (silver resistance) [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]", hit.description)
+        self.assertEqual(
+            "probable sensor kinase (silver resistance) [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]",
+            hit.description,
+        )
         self.assertEqual(448, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, second hit, first hsp
@@ -864,7 +1086,10 @@ class Fasta36Cases(unittest.TestCase):
         # second qresult, third hit
         hit = qresult[2]
         self.assertEqual("gi|152973581|ref|YP_001338632.1|", hit.id)
-        self.assertEqual("inner membrane protein [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]", hit.description)
+        self.assertEqual(
+            "inner membrane protein [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]",
+            hit.description,
+        )
         self.assertEqual(84, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, third hit, first hsp
@@ -886,11 +1111,17 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(84, hsp.hit_end)
         self.assertEqual("ESVVFILMAGFAMSVCYLFFSVLEKVINARKSKDESIYHD", str(hsp.hit.seq))
         self.assertEqual(0, hsp.query_strand)
-        self.assertEqual({"similarity": "....::..:   .:   -::: .:. .. .::: .-.. :"}, hsp.aln_annotation)
+        self.assertEqual(
+            {"similarity": "....::..:   .:   -::: .:. .. .::: .-.. :"},
+            hsp.aln_annotation,
+        )
         # second qresult, fourth hit
         hit = qresult[3]
         self.assertEqual("gi|152973536|ref|YP_001338587.1|", hit.id)
-        self.assertEqual("putative inner membrane protein [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]", hit.description)
+        self.assertEqual(
+            "putative inner membrane protein [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]",
+            hit.description,
+        )
         self.assertEqual(84, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, fourth hit, first hsp
@@ -912,7 +1143,9 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(36, hsp.hit_end)
         self.assertEqual("ASFSKEEQDKVAVDKVAADVAWQERMNKPV", str(hsp.hit.seq))
         self.assertEqual(0, hsp.query_strand)
-        self.assertEqual({"similarity": "::: :.. ::. :. ..  ...  . . :."}, hsp.aln_annotation)
+        self.assertEqual(
+            {"similarity": "::: :.. ::. :. ..  ...  . . :."}, hsp.aln_annotation
+        )
 
         # test third qresult
         qresult = qresults[2]
@@ -921,12 +1154,18 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual("36.3.4", qresult.version)
         self.assertEqual("NC_009649.faa", qresult.target)
         self.assertEqual(346, qresult.seq_len)
-        self.assertEqual("hypothetical protein pOSAK1_03 [Escherichia coli O157:H7 s", qresult.description)
+        self.assertEqual(
+            "hypothetical protein pOSAK1_03 [Escherichia coli O157:H7 s",
+            qresult.description,
+        )
         self.assertEqual(2, len(qresult))
         # third qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|152973545|ref|YP_001338596.1|", hit.id)
-        self.assertEqual("putative plasmid SOS inhibition protein A [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]", hit.description)
+        self.assertEqual(
+            "putative plasmid SOS inhibition protein A [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]",
+            hit.description,
+        )
         self.assertEqual(242, hit.seq_len)
         self.assertEqual(1, len(hit))
         # third qresult, first hit, first hsp
@@ -943,16 +1182,26 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(43, hsp.aln_span)
         self.assertEqual(196, hsp.query_start)
         self.assertEqual(238, hsp.query_end)
-        self.assertEqual("SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDVEMEDYSTYC", str(hsp.query.seq))
+        self.assertEqual(
+            "SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDVEMEDYSTYC", str(hsp.query.seq)
+        )
         self.assertEqual(51, hsp.hit_start)
         self.assertEqual(94, hsp.hit_end)
-        self.assertEqual("SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDMLISSHGEYC", str(hsp.hit.seq))
+        self.assertEqual(
+            "SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDMLISSHGEYC", str(hsp.hit.seq)
+        )
         self.assertEqual(0, hsp.query_strand)
-        self.assertEqual({"similarity": ":...: . . :  ::.: : .:: -. . . .:. . ... ::"}, hsp.aln_annotation)
+        self.assertEqual(
+            {"similarity": ":...: . . :  ::.: : .:: -. . . .:. . ... ::"},
+            hsp.aln_annotation,
+        )
         # third qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|152973505|ref|YP_001338556.1|", hit.id)
-        self.assertEqual("putative membrane fusion protein SilB [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]", hit.description)
+        self.assertEqual(
+            "putative membrane fusion protein SilB [Klebsiella pneumoniae subsp. pneumoniae MGH 78578]",
+            hit.description,
+        )
         self.assertEqual(430, hit.seq_len)
         self.assertEqual(1, len(hit))
         # third qresult, second hit, first hsp
@@ -969,12 +1218,23 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(64, hsp.aln_span)
         self.assertEqual(39, hsp.query_start)
         self.assertEqual(101, hsp.query_end)
-        self.assertEqual("ISGTYKGIDFLIKLMPSGGNTTIGRASGQNNTYFDEIALIIKENCLY--SDTKNFEYTIPKFSD", str(hsp.query.seq))
+        self.assertEqual(
+            "ISGTYKGIDFLIKLMPSGGNTTIGRASGQNNTYFDEIALIIKENCLY--SDTKNFEYTIPKFSD",
+            str(hsp.query.seq),
+        )
         self.assertEqual(221, hsp.hit_start)
         self.assertEqual(281, hsp.hit_end)
-        self.assertEqual("IDGVITAFD-LRTGMNISKDKVVAQIQGMDPVW---ISAAVPESIAYLLKDTSQFEISVPAYPD", str(hsp.hit.seq))
+        self.assertEqual(
+            "IDGVITAFD-LRTGMNISKDKVVAQIQGMDPVW---ISAAVPESIAYLLKDTSQFEISVPAYPD",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
-        self.assertEqual({"similarity": ":.:.  ..:-:   :  . . .... .:.. ..---:.  . :.  :--.::..:: ..: . :"}, hsp.aln_annotation)
+        self.assertEqual(
+            {
+                "similarity": ":.:.  ..:-:   :  . . .... .:.. ..---:.  . :.  :--.::..:: ..: . :"
+            },
+            hsp.aln_annotation,
+        )
 
     def test_output008(self):
         """Test parsing tfastx36 output (output008.m10)."""
@@ -996,7 +1256,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual("36.3.4", qresult.version)
         self.assertEqual("rhodopsin_nucs.fasta", qresult.target)
         self.assertEqual(406, qresult.seq_len)
-        self.assertEqual("Endoplasmic reticulum resident protein 44 OS=Homo sapiens GN=ERP44", qresult.description)
+        self.assertEqual(
+            "Endoplasmic reticulum resident protein 44 OS=Homo sapiens GN=ERP44",
+            qresult.description,
+        )
         self.assertEqual(0, len(qresult))
 
         # test second qresult
@@ -1006,12 +1269,18 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual("36.3.4", qresult.version)
         self.assertEqual("rhodopsin_nucs.fasta", qresult.target)
         self.assertEqual(1161, qresult.seq_len)
-        self.assertEqual("BMP-2-inducible protein kinase OS=Homo sapiens GN=BMP2K", qresult.description)
+        self.assertEqual(
+            "BMP-2-inducible protein kinase OS=Homo sapiens GN=BMP2K",
+            qresult.description,
+        )
         self.assertEqual(2, len(qresult))
         # second qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|283855822|gb|GQ290312.1|", hit.id)
-        self.assertEqual("Myotis ricketti voucher GQX10 rhodopsin (RHO) mRNA, partial cds", hit.description)
+        self.assertEqual(
+            "Myotis ricketti voucher GQX10 rhodopsin (RHO) mRNA, partial cds",
+            hit.description,
+        )
         self.assertEqual(983, hit.seq_len)
         self.assertEqual(1, len(hit))
         # second qresult, first hit, first hsp
@@ -1028,12 +1297,23 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(65, hsp.aln_span)
         self.assertEqual(452, hsp.query_start)
         self.assertEqual(514, hsp.query_end)
-        self.assertEqual("LQHRHPHQQQQQQQQQQQQQQQQQQQQQQQQQQQH---HHHHHHHLLQDAYMQQYQHATQQQQML", str(hsp.query.seq))
+        self.assertEqual(
+            "LQHRHPHQQQQQQQQQQQQQQQQQQQQQQQQQQQH---HHHHHHHLLQDAYMQQYQHATQQQQML",
+            str(hsp.query.seq),
+        )
         self.assertEqual(122, hsp.hit_start)
         self.assertEqual(317, hsp.hit_end)
-        self.assertEqual("IPHQLPHALRHRPAQEAAHASQLHPAQPGCGQPLHGLWRLHHHPVYLYAWILRLRGHGMQSGGLL", str(hsp.hit.seq))
+        self.assertEqual(
+            "IPHQLPHALRHRPAQEAAHASQLHPAQPGCGQPLHGLWRLHHHPVYLYAWILRLRGHGMQSGGLL",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
-        self.assertEqual({"similarity": ". :. ::  ...  :.  . .: .  :    :  :---. :::   :    ..   :. :.  .:"}, hsp.aln_annotation)
+        self.assertEqual(
+            {
+                "similarity": ". :. ::  ...  :.  . .: .  :    :  :---. :::   :    ..   :. :.  .:"
+            },
+            hsp.aln_annotation,
+        )
         # second qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|57163782|ref|NM_001009242.1|", hit.id)
@@ -1054,12 +1334,23 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(201, hsp.aln_span)
         self.assertEqual(417, hsp.query_start)
         self.assertEqual(599, hsp.query_end)
-        self.assertEqual("GPEIL---LGQ-GPPQQPPQQHRVLQQLQQGDWRLQQLH-------LQHRHPHQQQQQQQQQQQQQQQQQQQQQQQQQQQH-----HHHHHH-HLLQDAYMQQYQHATQQQQMLQQQF-LMHSVYQPQPSASQYPTMMPQYQQAFFQQQMLAQHQPSQQQASPEYLTSPQEFSPALVSYTSSLPA-QVGTIMDSSYSANRS", str(hsp.query.seq))
+        self.assertEqual(
+            "GPEIL---LGQ-GPPQQPPQQHRVLQQLQQGDWRLQQLH-------LQHRHPHQQQQQQQQQQQQQQQQQQQQQQQQQQQH-----HHHHHH-HLLQDAYMQQYQHATQQQQMLQQQF-LMHSVYQPQPSASQYPTMMPQYQQAFFQQQMLAQHQPSQQQASPEYLTSPQEFSPALVSYTSSLPA-QVGTIMDSSYSANRS",
+            str(hsp.query.seq),
+        )
         self.assertEqual(14, hsp.hit_start)
         self.assertEqual(595, hsp.hit_end)
-        self.assertEqual("GPELLRALLQQNGCGTQPLRVPTVLPG*AMAVLHAGRLHVPAHRAWLPHQLPHALRHGPAQEAAHASQLHPAQPGRG*PLHGLRWLHHHPLH/PLCMDTLSLGPQDAIWRASLPHWAVKLPCGLWWSWPLSGTWWCVSP*ATSA------LGRTMP*WASLSPGSWHWPALHPPSLVGPGTSLKACSVHAGSTTTHSSQKS", str(hsp.hit.seq))
+        self.assertEqual(
+            "GPELLRALLQQNGCGTQPLRVPTVLPG*AMAVLHAGRLHVPAHRAWLPHQLPHALRHGPAQEAAHASQLHPAQPGRG*PLHGLRWLHHHPLH/PLCMDTLSLGPQDAIWRASLPHWAVKLPCGLWWSWPLSGTWWCVSP*ATSA------LGRTMP*WASLSPGSWHWPALHPPSLVGPGTSLKACSVHAGSTTTHSSQKS",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
-        self.assertEqual({"similarity": ":::.:---: :-:   :: .   ::    ..  .  .::-------: :. ::  ..   :.  . .: .  :  .    :-----:::  :- : .:.     : :  . .. .   -:  ...   : .. .  . :   .:------:.. .:   . ::     :    :.::.  .:: :-.: .   ...:...:"}, hsp.aln_annotation)
+        self.assertEqual(
+            {
+                "similarity": ":::.:---: :-:   :: .   ::    ..  .  .::-------: :. ::  ..   :.  . .: .  :  .    :-----:::  :- : .:.     : :  . .. .   -:  ...   : .. .  . :   .:------:.. .:   . ::     :    :.::.  .:: :-.: .   ...:...:"
+            },
+            hsp.aln_annotation,
+        )
 
         # test third qresult
         qresult = qresults[2]
@@ -1068,7 +1359,9 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual("36.3.4", qresult.version)
         self.assertEqual("rhodopsin_nucs.fasta", qresult.target)
         self.assertEqual(1382, qresult.seq_len)
-        self.assertEqual("Insulin receptor OS=Homo sapiens GN=INSR", qresult.description)
+        self.assertEqual(
+            "Insulin receptor OS=Homo sapiens GN=INSR", qresult.description
+        )
         self.assertEqual(0, len(qresult))
 
         # test fourth qresult
@@ -1100,16 +1393,30 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(348, hsp.aln_span)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(348, hsp.query_end)
-        self.assertEqual("MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGDDEASATVSKTETSQVAPA", str(hsp.query.seq))
+        self.assertEqual(
+            "MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGDDEASATVSKTETSQVAPA",
+            str(hsp.query.seq),
+        )
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(1044, hsp.hit_end)
-        self.assertEqual("MNGTEGPNFYVPFSNKTGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVFGGFTTTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLVGWSRYIPEGMQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIVIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTLPAFFAKSSSIYNPVIYIMMNKQFRNCMLTTLCCGKNPLGDDEASTTGSKTETSQVAPA", str(hsp.hit.seq))
+        self.assertEqual(
+            "MNGTEGPNFYVPFSNKTGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVFGGFTTTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLVGWSRYIPEGMQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIVIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTLPAFFAKSSSIYNPVIYIMMNKQFRNCMLTTLCCGKNPLGDDEASTTGSKTETSQVAPA",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
-        self.assertEqual({"similarity": "::::::::::::::: :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::.::::.:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::.:::::::::.::::::::::::::::::::::::::::::::::.:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::.:::::::..:::::::::::::::::::::.:::::::::::::.: :::::::::::"}, hsp.aln_annotation)
+        self.assertEqual(
+            {
+                "similarity": "::::::::::::::: :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::.::::.:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::.:::::::::.::::::::::::::::::::::::::::::::::.:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::.:::::::..:::::::::::::::::::::.:::::::::::::.: :::::::::::"
+            },
+            hsp.aln_annotation,
+        )
         # fourth qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|18148870|dbj|AB062417.1|", hit.id)
-        self.assertEqual("Synthetic construct Bos taurus gene for rhodopsin, complete cds", hit.description)
+        self.assertEqual(
+            "Synthetic construct Bos taurus gene for rhodopsin, complete cds",
+            hit.description,
+        )
         self.assertEqual(1047, hit.seq_len)
         self.assertEqual(1, len(hit))
         # fourth qresult, second hit, first hsp
@@ -1126,18 +1433,32 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(348, hsp.aln_span)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(348, hsp.query_end)
-        self.assertEqual("MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGDDEASATVSKTETSQVAPA", str(hsp.query.seq))
+        self.assertEqual(
+            "MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGDDEASATVSKTETSQVAPA",
+            str(hsp.query.seq),
+        )
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(1044, hsp.hit_end)
-        self.assertEqual("MNGTEGPNFYVPFSNKTGVVRSPFEAPQYYLAEPWQFSMLAAYMFLLIMLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVFGGFTTTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLVGWSRYIPEGMQCSCGIDYYTPHEETNNESFVIYMFVVHFIIPLIVIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWLPYAGVAFYIFTHQGSDFGPIFMTIPAFFAKTSAVYNPVIYIMMNKQFRNCMVTTLCCGKNPLGDDEASTTVSKTETSQVAPA", str(hsp.hit.seq))
+        self.assertEqual(
+            "MNGTEGPNFYVPFSNKTGVVRSPFEAPQYYLAEPWQFSMLAAYMFLLIMLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVFGGFTTTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLVGWSRYIPEGMQCSCGIDYYTPHEETNNESFVIYMFVVHFIIPLIVIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWLPYAGVAFYIFTHQGSDFGPIFMTIPAFFAKTSAVYNPVIYIMMNKQFRNCMVTTLCCGKNPLGDDEASTTVSKTETSQVAPA",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # fourth qresult, third hit
         hit = qresult[2]
         self.assertEqual("gi|283855822|gb|GQ290312.1|", hit.id)
-        self.assertEqual("Myotis ricketti voucher GQX10 rhodopsin (RHO) mRNA, partial cds", hit.description)
+        self.assertEqual(
+            "Myotis ricketti voucher GQX10 rhodopsin (RHO) mRNA, partial cds",
+            hit.description,
+        )
         self.assertEqual(983, hit.seq_len)
         self.assertEqual(2, len(hit))
-        self.assertEqual({"similarity": "::::::::::::::: ::::::::: ::::::::::::::::::::::.::::::::::::::::::::::::::::::::::::::.::::.:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::.:::::::::.:::::::::: . :.:::::::::::::: ::.:.:::::::::::::::::::::::::::::::::::::::::::::::.:::.:::::::::::.::::::::::::::..:.:::::::::::::::::.::.:::::::::::::.:::::::::::::"}, hsp.aln_annotation)
+        self.assertEqual(
+            {
+                "similarity": "::::::::::::::: ::::::::: ::::::::::::::::::::::.::::::::::::::::::::::::::::::::::::::.::::.:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::.:::::::::.:::::::::: . :.:::::::::::::: ::.:.:::::::::::::::::::::::::::::::::::::::::::::::.:::.:::::::::::.::::::::::::::..:.:::::::::::::::::.::.:::::::::::::.:::::::::::::"
+            },
+            hsp.aln_annotation,
+        )
         # fourth qresult, third hit, first hsp
         hsp = qresult[2].hsps[0]
         self.assertEqual(2138, hsp.initn_score)
@@ -1152,12 +1473,23 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(326, hsp.aln_span)
         self.assertEqual(10, hsp.query_start)
         self.assertEqual(336, hsp.query_end)
-        self.assertEqual("VPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGDDEASAT", str(hsp.query.seq))
+        self.assertEqual(
+            "VPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGDDEASAT",
+            str(hsp.query.seq),
+        )
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(978, hsp.hit_end)
-        self.assertEqual("VPFSNKTGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVANLFMVFGGFTTTLYTSMHGYFVFGATGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGLAFTWVMALACAAPPLAGWSRYIPEGMQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIVIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVVAFLICWLPYASVAFYIFTHQGSNFGPVFMTIPAFFAKSSSIYNPVIYIMMNKQFRNCMLTTLCCGKNPLGDDEASTT", str(hsp.hit.seq))
+        self.assertEqual(
+            "VPFSNKTGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVANLFMVFGGFTTTLYTSMHGYFVFGATGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGLAFTWVMALACAAPPLAGWSRYIPEGMQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIVIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVVAFLICWLPYASVAFYIFTHQGSNFGPVFMTIPAFFAKSSSIYNPVIYIMMNKQFRNCMLTTLCCGKNPLGDDEASTT",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
-        self.assertEqual({"similarity": "::::: ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::.::::.::::.:::::.::::::: :::::::::::::::::::::::::::::::::::::::::::::::::.:::::::::::::::::::::::::.::::::::::::::::::::::::::::::::::.::::::::::::::::::::::::::::::::::::::::.::::::.:::::::::::::::::::.:::::::::::..:::::::::::::::::::::.:::::::::::::.:"}, hsp.aln_annotation)
+        self.assertEqual(
+            {
+                "similarity": "::::: ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::.::::.::::.:::::.::::::: :::::::::::::::::::::::::::::::::::::::::::::::::.:::::::::::::::::::::::::.::::::::::::::::::::::::::::::::::.::::::::::::::::::::::::::::::::::::::::.::::::.:::::::::::::::::::.:::::::::::..:::::::::::::::::::::.:::::::::::::.:"
+            },
+            hsp.aln_annotation,
+        )
         # fourth qresult, third hit, second hsp
         hsp = qresult[2].hsps[1]
         self.assertEqual(74, hsp.initn_score)
@@ -1197,15 +1529,24 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(354, hsp.aln_span)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(348, hsp.query_end)
-        self.assertEqual("MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGDDEAS-ATVSKTE-----TSQVAPA", str(hsp.query.seq))
+        self.assertEqual(
+            "MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGDDEAS-ATVSKTE-----TSQVAPA",
+            str(hsp.query.seq),
+        )
         self.assertEqual(41, hsp.hit_start)
         self.assertEqual(1103, hsp.hit_end)
-        self.assertEqual("MNGTEGPNFYIPMSNKTGVVRSPFEYPQYYLAEPWQYSILCAYMFLLILLGFPINFMTLYVTIQHKKLRTPLNYILLNLAFANHFMVLCGFTVTMYSSMNGYFILGATGCYVEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFSENHAVMGVAFTWIMALSCAVPPLLGWSRYIPEGMQCSCGVDYYTLKPEVNNESFVIYMFVVHFTIPLIIIFFCYGRLVCTVKEAAAQQQESATTQKAEKEVTRMVIIMVVFFLICWVPYASVAFFIFSNQGSEFGPIFMTVPAFFAKSSSIYNPVIYIMLNKQFRNCMITTLCCGKNPFGEDDASSAATSKTEASSVSSSQVSPA", str(hsp.hit.seq))
+        self.assertEqual(
+            "MNGTEGPNFYIPMSNKTGVVRSPFEYPQYYLAEPWQYSILCAYMFLLILLGFPINFMTLYVTIQHKKLRTPLNYILLNLAFANHFMVLCGFTVTMYSSMNGYFILGATGCYVEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFSENHAVMGVAFTWIMALSCAVPPLLGWSRYIPEGMQCSCGVDYYTLKPEVNNESFVIYMFVVHFTIPLIIIFFCYGRLVCTVKEAAAQQQESATTQKAEKEVTRMVIIMVVFFLICWVPYASVAFFIFSNQGSEFGPIFMTVPAFFAKSSSIYNPVIYIMLNKQFRNCMITTLCCGKNPFGEDDASSAATSKTEASSVSSSQVSPA",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # fourth qresult, fifth hit
         hit = qresult[4]
         self.assertEqual("gi|12583664|dbj|AB043817.1|", hit.id)
-        self.assertEqual("Conger myriaster conf gene for fresh water form rod opsin, complete cds", hit.description)
+        self.assertEqual(
+            "Conger myriaster conf gene for fresh water form rod opsin, complete cds",
+            hit.description,
+        )
         self.assertEqual(1344, hit.seq_len)
         self.assertEqual(1, len(hit))
         # fourth qresult, fifth hit, first hsp
@@ -1222,15 +1563,24 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(347, hsp.aln_span)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(346, hsp.query_end)
-        self.assertEqual("MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGD-DEASATVSKTETSQVA", str(hsp.query.seq))
+        self.assertEqual(
+            "MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGD-DEASATVSKTETSQVA",
+            str(hsp.query.seq),
+        )
         self.assertEqual(22, hsp.hit_start)
         self.assertEqual(1063, hsp.hit_end)
-        self.assertEqual("MNGTEGPNFYIPMSNATGVVRSPFEYPQYYLAEPWAFSALSAYMFFLIIAGFPINFLTLYVTIEHKKLRTPLNYILLNLAVADLFMVFGGFTTTMYTSMHGYFVFGPTGCNIEGFFATLGGEIALWCLVVLAIERWMVVCKPVTNFRFGESHAIMGVMVTWTMALACALPPLFGWSRYIPEGLQCSCGIDYYTRAPGINNESFVIYMFTCHFSIPLAVISFCYGRLVCTVKEAAAQQQESETTQRAEREVTRMVVIMVISFLVCWVPYASVAWYIFTHQGSTFGPIFMTIPSFFAKSSALYNPMIYICMNKQFRHCMITTLCCGKNPFEEEDGASATSSKTEASSVS", str(hsp.hit.seq))
+        self.assertEqual(
+            "MNGTEGPNFYIPMSNATGVVRSPFEYPQYYLAEPWAFSALSAYMFFLIIAGFPINFLTLYVTIEHKKLRTPLNYILLNLAVADLFMVFGGFTTTMYTSMHGYFVFGPTGCNIEGFFATLGGEIALWCLVVLAIERWMVVCKPVTNFRFGESHAIMGVMVTWTMALACALPPLFGWSRYIPEGLQCSCGIDYYTRAPGINNESFVIYMFTCHFSIPLAVISFCYGRLVCTVKEAAAQQQESETTQRAEREVTRMVVIMVISFLVCWVPYASVAWYIFTHQGSTFGPIFMTIPSFFAKSSALYNPMIYICMNKQFRHCMITTLCCGKNPFEEEDGASATSSKTEASSVS",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # fourth qresult, sixth hit
         hit = qresult[5]
         self.assertEqual("gi|283855845|gb|GQ290303.1|", hit.id)
-        self.assertEqual("Cynopterus brachyotis voucher 20020434 rhodopsin (RHO) gene, exons 1 through 5 and partial cds", hit.description)
+        self.assertEqual(
+            "Cynopterus brachyotis voucher 20020434 rhodopsin (RHO) gene, exons 1 through 5 and partial cds",
+            hit.description,
+        )
         self.assertEqual(4301, hit.seq_len)
         self.assertEqual(4, len(hit))
         # fourth qresult, sixth hit, first hsp
@@ -1247,10 +1597,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(111, hsp.aln_span)
         self.assertEqual(10, hsp.query_start)
         self.assertEqual(121, hsp.query_end)
-        self.assertEqual("VPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGG", str(hsp.query.seq))
+        self.assertEqual(
+            "VPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGG",
+            str(hsp.query.seq),
+        )
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(333, hsp.hit_end)
-        self.assertEqual("VPFSNKTGVVRSPFEHPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVFGGFTTTLYTSLHGYFVFGPTGCNLEGFFATLGG", str(hsp.hit.seq))
+        self.assertEqual(
+            "VPFSNKTGVVRSPFEHPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVFGGFTTTLYTSLHGYFVFGPTGCNLEGFFATLGG",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # fourth qresult, sixth hit, second hsp
         hsp = qresult[5].hsps[1]
@@ -1266,10 +1622,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(172, hsp.aln_span)
         self.assertEqual(176, hsp.query_start)
         self.assertEqual(312, hsp.query_end)
-        self.assertEqual("RYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKE------------------------------------AAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQ", str(hsp.query.seq))
+        self.assertEqual(
+            "RYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKE------------------------------------AAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQ",
+            str(hsp.query.seq),
+        )
         self.assertEqual(2854, hsp.hit_start)
         self.assertEqual(3368, hsp.hit_end)
-        self.assertEqual(r"RYIPEGMQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIVIFFCYGQLVFTVKEVRSCVGHWGHAH*VNGAQLHSQSCHSLDT*PCVPA\AAAQQQESATTQKAEKEVTRMVIIMVIAFLICWLPYAGVAFYIFTHQGSNFGPIFMTLPAFFAKSSSIYNPVIYIMMNKQ", str(hsp.hit.seq))
+        self.assertEqual(
+            r"RYIPEGMQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIVIFFCYGQLVFTVKEVRSCVGHWGHAH*VNGAQLHSQSCHSLDT*PCVPA\AAAQQQESATTQKAEKEVTRMVIIMVIAFLICWLPYAGVAFYIFTHQGSNFGPIFMTLPAFFAKSSSIYNPVIYIMMNKQ",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # fourth qresult, sixth hit, third hsp
         hsp = qresult[5].hsps[2]
@@ -1285,10 +1647,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(73, hsp.aln_span)
         self.assertEqual(118, hsp.query_start)
         self.assertEqual(189, hsp.query_end)
-        self.assertEqual("LGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSR--YIPEGLQCSCGI", str(hsp.query.seq))
+        self.assertEqual(
+            "LGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSR--YIPEGLQCSCGI",
+            str(hsp.query.seq),
+        )
         self.assertEqual(1403, hsp.hit_start)
         self.assertEqual(1619, hsp.hit_end)
-        self.assertEqual("LAGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGLALTWVMALACAAPPLVGWSR*WH*TEG-KCL*GL", str(hsp.hit.seq))
+        self.assertEqual(
+            "LAGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGLALTWVMALACAAPPLVGWSR*WH*TEG-KCL*GL",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # fourth qresult, sixth hit, fourth hsp
         hsp = qresult[5].hsps[3]
@@ -1340,7 +1708,9 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual("36.3.5c", qresult.version)
         self.assertEqual("mrnalib.fasta", qresult.target)
         self.assertEqual(99, qresult.seq_len)
-        self.assertEqual("Mus musculus myoglobin (Mb), transcript varia", qresult.description)
+        self.assertEqual(
+            "Mus musculus myoglobin (Mb), transcript varia", qresult.description
+        )
         self.assertEqual(1, len(qresult))
         # second qresult, first hit
         hit = qresult[0]
@@ -1379,7 +1749,9 @@ class Fasta36Cases(unittest.TestCase):
         # third qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|47271416|ref|NM_131257.2|", hit.id)
-        self.assertEqual("Danio rerio hemoglobin alpha adult-1 (hbaa1), mRNA", hit.description)
+        self.assertEqual(
+            "Danio rerio hemoglobin alpha adult-1 (hbaa1), mRNA", hit.description
+        )
         self.assertEqual(597, hit.seq_len)
         self.assertEqual(1, len(hit))
         # third qresult, first hit, first hsp
@@ -1403,7 +1775,10 @@ class Fasta36Cases(unittest.TestCase):
         # third qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|332859474|ref|XM_001156938.2|", hit.id)
-        self.assertEqual("PREDICTED: Pan troglodytes myoglobin, transcript variant 11 (MB), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Pan troglodytes myoglobin, transcript variant 11 (MB), mRNA",
+            hit.description,
+        )
         self.assertEqual(762, hit.seq_len)
         self.assertEqual(1, len(hit))
         # third qresult, second hit, first hsp
@@ -1427,7 +1802,10 @@ class Fasta36Cases(unittest.TestCase):
         # third qresult, third hit
         hit = qresult[2]
         self.assertEqual("gi|332211534|ref|XM_003254825.1|", hit.id)
-        self.assertEqual("PREDICTED: Nomascus leucogenys hemoglobin subunit gamma-2-like (LOC100581638), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Nomascus leucogenys hemoglobin subunit gamma-2-like (LOC100581638), mRNA",
+            hit.description,
+        )
         self.assertEqual(805, hit.seq_len)
         self.assertEqual(1, len(hit))
         # third qresult, third hit, first hsp
@@ -1475,7 +1853,10 @@ class Fasta36Cases(unittest.TestCase):
         # third qresult, fifth hit
         hit = qresult[4]
         self.assertEqual("gi|297689475|ref|XM_002822130.1|", hit.id)
-        self.assertEqual("PREDICTED: Pongo abelii hemoglobin subunit gamma-like (LOC100439631), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Pongo abelii hemoglobin subunit gamma-like (LOC100439631), mRNA",
+            hit.description,
+        )
         self.assertEqual(1158, hit.seq_len)
         self.assertEqual(2, len(hit))
         # third qresult, fifth hit, first hsp
@@ -1558,12 +1939,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual("36.3.5c", qresult.version)
         self.assertEqual("mrnalib.fasta", qresult.target)
         self.assertEqual(99, qresult.seq_len)
-        self.assertEqual("Mus musculus myoglobin (Mb), transcript varia", qresult.description)
+        self.assertEqual(
+            "Mus musculus myoglobin (Mb), transcript varia", qresult.description
+        )
         self.assertEqual(5, len(qresult))
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|284005422|ref|NM_001171502.1|", hit.id)
-        self.assertEqual("Oryctolagus cuniculus hemoglobin, zeta (HBZ_2), mRNA", hit.description)
+        self.assertEqual(
+            "Oryctolagus cuniculus hemoglobin, zeta (HBZ_2), mRNA", hit.description
+        )
         self.assertEqual(429, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -1579,7 +1964,9 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(42, hsp.aln_span)
         self.assertEqual(33, hsp.query_start)
         self.assertEqual(75, hsp.query_end)
-        self.assertEqual("CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", str(hsp.query.seq))
+        self.assertEqual(
+            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", str(hsp.query.seq)
+        )
         self.assertEqual(11, hsp.hit_start)
         self.assertEqual(52, hsp.hit_end)
         self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", str(hsp.hit.seq))
@@ -1587,7 +1974,9 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|284005386|ref|NM_001171415.1|", hit.id)
-        self.assertEqual("Oryctolagus cuniculus zeta globin (HBZ0), mRNA", hit.description)
+        self.assertEqual(
+            "Oryctolagus cuniculus zeta globin (HBZ0), mRNA", hit.description
+        )
         self.assertEqual(429, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, second hit, first hsp
@@ -1603,7 +1992,9 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(42, hsp.aln_span)
         self.assertEqual(33, hsp.query_start)
         self.assertEqual(75, hsp.query_end)
-        self.assertEqual("CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", str(hsp.query.seq))
+        self.assertEqual(
+            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", str(hsp.query.seq)
+        )
         self.assertEqual(11, hsp.hit_start)
         self.assertEqual(52, hsp.hit_end)
         self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", str(hsp.hit.seq))
@@ -1611,7 +2002,10 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, third hit
         hit = qresult[2]
         self.assertEqual("gi|284005381|ref|NM_001171414.1|", hit.id)
-        self.assertEqual("Oryctolagus cuniculus hemoglobin subunit zeta (RA_M008_JSM295ECF), mRNA", hit.description)
+        self.assertEqual(
+            "Oryctolagus cuniculus hemoglobin subunit zeta (RA_M008_JSM295ECF), mRNA",
+            hit.description,
+        )
         self.assertEqual(429, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, third hit, first hsp
@@ -1627,7 +2021,9 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(42, hsp.aln_span)
         self.assertEqual(33, hsp.query_start)
         self.assertEqual(75, hsp.query_end)
-        self.assertEqual("CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", str(hsp.query.seq))
+        self.assertEqual(
+            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", str(hsp.query.seq)
+        )
         self.assertEqual(11, hsp.hit_start)
         self.assertEqual(52, hsp.hit_end)
         self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", str(hsp.hit.seq))
@@ -1659,7 +2055,10 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, fifth hit
         hit = qresult[4]
         self.assertEqual("gi|291415427|ref|XM_002723908.1|", hit.id)
-        self.assertEqual("PREDICTED: Oryctolagus cuniculus zeta globin-like (LOC100357627), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Oryctolagus cuniculus zeta globin-like (LOC100357627), mRNA",
+            hit.description,
+        )
         self.assertEqual(423, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, fifth hit, first hsp
@@ -1675,7 +2074,9 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(42, hsp.aln_span)
         self.assertEqual(33, hsp.query_start)
         self.assertEqual(75, hsp.query_end)
-        self.assertEqual("CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", str(hsp.query.seq))
+        self.assertEqual(
+            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", str(hsp.query.seq)
+        )
         self.assertEqual(11, hsp.hit_start)
         self.assertEqual(52, hsp.hit_end)
         self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", str(hsp.hit.seq))
@@ -1706,7 +2107,10 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|77681427|ref|NM_001016495.2|", hit.id)
-        self.assertEqual("Xenopus (Silurana) tropicalis hemoglobin, epsilon 1 (hbe1), mRNA", hit.description)
+        self.assertEqual(
+            "Xenopus (Silurana) tropicalis hemoglobin, epsilon 1 (hbe1), mRNA",
+            hit.description,
+        )
         self.assertEqual(554, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -1730,7 +2134,9 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|53749657|ref|NM_182940.2|", hit.id)
-        self.assertEqual("Danio rerio hemoglobin alpha embryonic-1 (hbae1), mRNA", hit.description)
+        self.assertEqual(
+            "Danio rerio hemoglobin alpha embryonic-1 (hbae1), mRNA", hit.description
+        )
         self.assertEqual(564, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, second hit, first hsp
@@ -1778,7 +2184,10 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, fourth hit
         hit = qresult[3]
         self.assertEqual("gi|296217287|ref|XM_002754912.1|", hit.id)
-        self.assertEqual("PREDICTED: Callithrix jacchus hemoglobin subunit gamma-like (LOC100389093), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Callithrix jacchus hemoglobin subunit gamma-like (LOC100389093), mRNA",
+            hit.description,
+        )
         self.assertEqual(627, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, fourth hit, first hsp
@@ -1802,7 +2211,10 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, fifth hit
         hit = qresult[4]
         self.assertEqual("gi|332211540|ref|XM_003254828.1|", hit.id)
-        self.assertEqual("PREDICTED: Nomascus leucogenys hemoglobin subunit gamma-1-like, transcript variant 2 (LOC100582529), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Nomascus leucogenys hemoglobin subunit gamma-1-like, transcript variant 2 (LOC100582529), mRNA",
+            hit.description,
+        )
         self.assertEqual(640, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, fifth hit, first hsp
@@ -1826,7 +2238,9 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, sixth hit
         hit = qresult[5]
         self.assertEqual("gi|147903656|ref|NM_001086277.1|", hit.id)
-        self.assertEqual("Xenopus laevis hemoglobin, alpha 2 (hba2), mRNA", hit.description)
+        self.assertEqual(
+            "Xenopus laevis hemoglobin, alpha 2 (hba2), mRNA", hit.description
+        )
         self.assertEqual(677, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, sixth hit, first hsp
@@ -1850,7 +2264,9 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, seventh hit
         hit = qresult[6]
         self.assertEqual("gi|380013536|ref|XM_003690762.1|", hit.id)
-        self.assertEqual("PREDICTED: Apis florea globin-like (LOC100870092), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Apis florea globin-like (LOC100870092), mRNA", hit.description
+        )
         self.assertEqual(707, hit.seq_len)
         self.assertEqual(3, len(hit))
         # first qresult, seventh hit, first hsp
@@ -1910,7 +2326,10 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, eighth hit
         hit = qresult[7]
         self.assertEqual("gi|332211538|ref|XM_003254827.1|", hit.id)
-        self.assertEqual("PREDICTED: Nomascus leucogenys hemoglobin subunit gamma-1-like, transcript variant 1 (LOC100582529), mRNA", hit.description)
+        self.assertEqual(
+            "PREDICTED: Nomascus leucogenys hemoglobin subunit gamma-1-like, transcript variant 1 (LOC100582529), mRNA",
+            hit.description,
+        )
         self.assertEqual(713, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, eighth hit, first hsp
@@ -1984,10 +2403,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(71, hsp.aln_span)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(66, hsp.query_end)
-        self.assertEqual("PNGSVPPIY-----VPPGYAPQVIEDNGVRRVVVVPQAPEFHPGSHTVLHRSPHPPLPGFIPVPTMMPPPP", str(hsp.query.seq))
+        self.assertEqual(
+            "PNGSVPPIY-----VPPGYAPQVIEDNGVRRVVVVPQAPEFHPGSHTVLHRSPHPPLPGFIPVPTMMPPPP",
+            str(hsp.query.seq),
+        )
         self.assertEqual(10704, hsp.hit_start)
         self.assertEqual(10775, hsp.hit_end)
-        self.assertEqual("PEKKVPPAVPKKPEAPPAKVPEAPKEVVPEKKIAVPKKPEVPPAKVPEVPKKPVIEEKPVIPVPKKVESPP", str(hsp.hit.seq))
+        self.assertEqual(
+            "PEKKVPPAVPKKPEAPPAKVPEAPKEVVPEKKIAVPKKPEVPPAKVPEVPKKPVIEEKPVIPVPKKVESPP",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
 
         # test third qresult
@@ -2002,7 +2427,10 @@ class Fasta36Cases(unittest.TestCase):
         # third qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|260806189|ref|XP_002597967.1|", hit.id)
-        self.assertEqual("hypothetical protein BRAFLDRAFT_79792 [Branchiostoma floridae]", hit.description)
+        self.assertEqual(
+            "hypothetical protein BRAFLDRAFT_79792 [Branchiostoma floridae]",
+            hit.description,
+        )
         self.assertEqual(23830, hit.seq_len)
         self.assertEqual(1, len(hit))
         # third qresult, first hit, first hsp
@@ -2019,15 +2447,24 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(79, hsp.aln_span)
         self.assertEqual(1, hsp.query_start)
         self.assertEqual(79, hsp.query_end)
-        self.assertEqual("LSNIVKPVASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVG-EETNITLNDLKPAMDY", str(hsp.query.seq))
+        self.assertEqual(
+            "LSNIVKPVASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVG-EETNITLNDLKPAMDY",
+            str(hsp.query.seq),
+        )
         self.assertEqual(22430, hsp.hit_start)
         self.assertEqual(22499, hsp.hit_end)
-        self.assertEqual("VSNI-RPAASDISPHTLTLTWDTP------EDDGGSLITSYVVEMFDVS---DGKWQTLTTTCRRPPYPVKGLNPSATY", str(hsp.hit.seq))
+        self.assertEqual(
+            "VSNI-RPAASDISPHTLTLTWDTP------EDDGGSLITSYVVEMFDVS---DGKWQTLTTTCRRPPYPVKGLNPSATY",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # third qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|348553521|ref|XP_003462575.1|", hit.id)
-        self.assertEqual("PREDICTED: receptor-type tyrosine-protein phosphatase F isoform 1 [Cavia porcellus]", hit.description)
+        self.assertEqual(
+            "PREDICTED: receptor-type tyrosine-protein phosphatase F isoform 1 [Cavia porcellus]",
+            hit.description,
+        )
         self.assertEqual(1899, hit.seq_len)
         self.assertEqual(1, len(hit))
         # third qresult, second hit, first hsp
@@ -2052,7 +2489,10 @@ class Fasta36Cases(unittest.TestCase):
         # third qresult, third hit
         hit = qresult[2]
         self.assertEqual("gi|348553523|ref|XP_003462576.1|", hit.id)
-        self.assertEqual("PREDICTED: receptor-type tyrosine-protein phosphatase F isoform 2 [Cavia porcellus]", hit.description)
+        self.assertEqual(
+            "PREDICTED: receptor-type tyrosine-protein phosphatase F isoform 2 [Cavia porcellus]",
+            hit.description,
+        )
         self.assertEqual(1908, hit.seq_len)
         self.assertEqual(1, len(hit))
         # third qresult, third hit, first hsp
@@ -2077,7 +2517,9 @@ class Fasta36Cases(unittest.TestCase):
         # third qresult, fourth hit
         hit = qresult[3]
         self.assertEqual("gi|221124183|ref|XP_002154464.1|", hit.id)
-        self.assertEqual("PREDICTED: similar to FAD104 [Hydra magnipapillata]", hit.description)
+        self.assertEqual(
+            "PREDICTED: similar to FAD104 [Hydra magnipapillata]", hit.description
+        )
         self.assertEqual(860, hit.seq_len)
         self.assertEqual(1, len(hit))
         # third qresult, fourth hit, first hsp
@@ -2094,10 +2536,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(70, hsp.aln_span)
         self.assertEqual(9, hsp.query_start)
         self.assertEqual(79, hsp.query_end)
-        self.assertEqual("ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY", str(hsp.query.seq))
+        self.assertEqual(
+            "ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
+            str(hsp.query.seq),
+        )
         self.assertEqual(615, hsp.hit_start)
         self.assertEqual(673, hsp.hit_end)
-        self.assertEqual("ASSISYHSIKLKWGHQSS-------KKSI-----LNHTLQMQNKSGSFNTVYSGMDTSFTLSKLKELTPY", str(hsp.hit.seq))
+        self.assertEqual(
+            "ASSISYHSIKLKWGHQSS-------KKSI-----LNHTLQMQNKSGSFNTVYSGMDTSFTLSKLKELTPY",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
 
     def test_output014(self):
@@ -2165,10 +2613,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(71, hsp.aln_span)
         self.assertEqual(5, hsp.query_start)
         self.assertEqual(66, hsp.query_end)
-        self.assertEqual("PPIY----VPPGYA---PQVIEDNGVRRVVVVPQAPEFH---PGSHTVLHRSPHPPLPGFIPVPTMMPPPP", str(hsp.query.seq))
+        self.assertEqual(
+            "PPIY----VPPGYA---PQVIEDNGVRRVVVVPQAPEFH---PGSHTVLHRSPHPPLPGFIPVPTMMPPPP",
+            str(hsp.query.seq),
+        )
         self.assertEqual(128, hsp.hit_start)
         self.assertEqual(195, hsp.hit_end)
-        self.assertEqual("PPLLQQTATPPQGAQIVPPVCALHHPQQQLALMAAMQHHHPLPPPHA-LHHAPLPPPP---PLPLNPGPPP", str(hsp.hit.seq))
+        self.assertEqual(
+            "PPLLQQTATPPQGAQIVPPVCALHHPQQQLALMAAMQHHHPLPPPHA-LHHAPLPPPP---PLPLNPGPPP",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, second hit
         hit = qresult[1]
@@ -2190,10 +2644,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(68, hsp.aln_span)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(66, hsp.query_end)
-        self.assertEqual("PNGSVPPIY--VPPGYAPQVIEDNGVRRVVVVPQAPEFHPGSHTVLHRSPHPPLPGFIPVPTMMPPPP", str(hsp.query.seq))
+        self.assertEqual(
+            "PNGSVPPIY--VPPGYAPQVIEDNGVRRVVVVPQAPEFHPGSHTVLHRSPHPPLPGFIPVPTMMPPPP",
+            str(hsp.query.seq),
+        )
         self.assertEqual(10780, hsp.hit_start)
         self.assertEqual(10848, hsp.hit_end)
-        self.assertEqual("PEKKVPPKKPEAPPAKVPEVPKEVVTEKKVAVPKKPEVPPAKVPEVPKKPVIEEKPAIPVVEKVASPP", str(hsp.hit.seq))
+        self.assertEqual(
+            "PEKKVPPKKPEAPPAKVPEVPKEVVTEKKVAVPKKPEVPPAKVPEVPKKPVIEEKPAIPVVEKVASPP",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
 
     def test_output016(self):
@@ -2222,7 +2682,9 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, first hit
         hit = qresult[0]
         self.assertEqual("gi|167518632|ref|XP_001743656.1|", hit.id)
-        self.assertEqual("hypothetical protein [Monosiga brevicollis MX1]", hit.description)
+        self.assertEqual(
+            "hypothetical protein [Monosiga brevicollis MX1]", hit.description
+        )
         self.assertEqual(1145, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, first hit, first hsp
@@ -2247,7 +2709,10 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|9507013|ref|NP_062122.1|", hit.id)
-        self.assertEqual("receptor-type tyrosine-protein phosphatase F precursor [Rattus norvegicus]", hit.description)
+        self.assertEqual(
+            "receptor-type tyrosine-protein phosphatase F precursor [Rattus norvegicus]",
+            hit.description,
+        )
         self.assertEqual(1898, hit.seq_len)
         self.assertEqual(2, len(hit))
         # first qresult, second hit, first hsp
@@ -2264,10 +2729,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(71, hsp.aln_span)
         self.assertEqual(8, hsp.query_start)
         self.assertEqual(79, hsp.query_end)
-        self.assertEqual("VASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY", str(hsp.query.seq))
+        self.assertEqual(
+            "VASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
+            str(hsp.query.seq),
+        )
         self.assertEqual(325, hsp.hit_start)
         self.assertEqual(385, hsp.hit_end)
-        self.assertEqual("VVTETTATSVTLTWD------SGNTEPVS---FYG--IQYRAAGTDGPFQEVDGVASTRYSIGGLSPFSEY", str(hsp.hit.seq))
+        self.assertEqual(
+            "VVTETTATSVTLTWD------SGNTEPVS---FYG--IQYRAAGTDGPFQEVDGVASTRYSIGGLSPFSEY",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
@@ -2291,7 +2762,10 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, third hit
         hit = qresult[2]
         self.assertEqual("gi|115648048|ref|NP_035343.2|", hit.id)
-        self.assertEqual("receptor-type tyrosine-protein phosphatase F precursor [Mus musculus]", hit.description)
+        self.assertEqual(
+            "receptor-type tyrosine-protein phosphatase F precursor [Mus musculus]",
+            hit.description,
+        )
         self.assertEqual(1898, hit.seq_len)
         self.assertEqual(2, len(hit))
         # first qresult, third hit, first hsp
@@ -2308,10 +2782,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(82, hsp.aln_span)
         self.assertEqual(7, hsp.query_start)
         self.assertEqual(80, hsp.query_end)
-        self.assertEqual("PVASDIQARTVVLTWSPPSSL-INGETDESS-----VP---ELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH", str(hsp.query.seq))
+        self.assertEqual(
+            "PVASDIQARTVVLTWSPPSSL-INGETDESS-----VP---ELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH",
+            str(hsp.query.seq),
+        )
         self.assertEqual(497, hsp.hit_start)
         self.assertEqual(579, hsp.hit_end)
-        self.assertEqual("PPSPTIQVKTQQGVPAQPADFQANAESDTRIQLSWLLPPQERIVKYELVYWAAEDEGQQHKVTFDPTSSYTLEDLKPDTLYH", str(hsp.hit.seq))
+        self.assertEqual(
+            "PPSPTIQVKTQQGVPAQPADFQANAESDTRIQLSWLLPPQERIVKYELVYWAAEDEGQQHKVTFDPTSSYTLEDLKPDTLYH",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, third hit, second hsp
         hsp = qresult[2].hsps[1]
@@ -2327,15 +2807,24 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(71, hsp.aln_span)
         self.assertEqual(8, hsp.query_start)
         self.assertEqual(79, hsp.query_end)
-        self.assertEqual("VASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY", str(hsp.query.seq))
+        self.assertEqual(
+            "VASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
+            str(hsp.query.seq),
+        )
         self.assertEqual(325, hsp.hit_start)
         self.assertEqual(385, hsp.hit_end)
-        self.assertEqual("VVTETTATSVTLTWD------SGNTEPVS---FYG--IQYRAAGTDGPFQEVDGVASTRYSIGGLSPFSEY", str(hsp.hit.seq))
+        self.assertEqual(
+            "VVTETTATSVTLTWD------SGNTEPVS---FYG--IQYRAAGTDGPFQEVDGVASTRYSIGGLSPFSEY",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, fourth hit
         hit = qresult[3]
         self.assertEqual("gi|354481005|ref|XP_003502693.1|", hit.id)
-        self.assertEqual("PREDICTED: LOW QUALITY PROTEIN: receptor-type tyrosine-protein phosphatase F-like [Cricetulus griseus]", hit.description)
+        self.assertEqual(
+            "PREDICTED: LOW QUALITY PROTEIN: receptor-type tyrosine-protein phosphatase F-like [Cricetulus griseus]",
+            hit.description,
+        )
         self.assertEqual(1898, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, fourth hit, first hsp
@@ -2360,7 +2849,9 @@ class Fasta36Cases(unittest.TestCase):
         # first qresult, fifth hit
         hit = qresult[4]
         self.assertEqual("gi|328789682|ref|XP_003251305.1|", hit.id)
-        self.assertEqual("PREDICTED: LOW QUALITY PROTEIN: twitchin [Apis mellifera]", hit.description)
+        self.assertEqual(
+            "PREDICTED: LOW QUALITY PROTEIN: twitchin [Apis mellifera]", hit.description
+        )
         self.assertEqual(8619, hit.seq_len)
         self.assertEqual(1, len(hit))
         # first qresult, fifth hit, first hsp
@@ -2377,15 +2868,24 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(70, hsp.aln_span)
         self.assertEqual(9, hsp.query_start)
         self.assertEqual(79, hsp.query_end)
-        self.assertEqual("ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY", str(hsp.query.seq))
+        self.assertEqual(
+            "ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
+            str(hsp.query.seq),
+        )
         self.assertEqual(4760, hsp.hit_start)
         self.assertEqual(4823, hsp.hit_end)
-        self.assertEqual("ASDVHAEGCTLTWKPP------EDDGGQPIDKYVVEKMDEATGRWVPAGETD-GPQTSLQVEGLTPGHKY", str(hsp.hit.seq))
+        self.assertEqual(
+            "ASDVHAEGCTLTWKPP------EDDGGQPIDKYVVEKMDEATGRWVPAGETD-GPQTSLQVEGLTPGHKY",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit
         hit = qresult[5]
         self.assertEqual("gi|260828627|ref|XP_002609264.1|", hit.id)
-        self.assertEqual("hypothetical protein BRAFLDRAFT_124749 [Branchiostoma floridae]", hit.description)
+        self.assertEqual(
+            "hypothetical protein BRAFLDRAFT_124749 [Branchiostoma floridae]",
+            hit.description,
+        )
         self.assertEqual(4389, hit.seq_len)
         self.assertEqual(7, len(hit))
         # first qresult, sixth hit, first hsp
@@ -2402,10 +2902,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(70, hsp.aln_span)
         self.assertEqual(9, hsp.query_start)
         self.assertEqual(79, hsp.query_end)
-        self.assertEqual("ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY", str(hsp.query.seq))
+        self.assertEqual(
+            "ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
+            str(hsp.query.seq),
+        )
         self.assertEqual(2241, hsp.hit_start)
         self.assertEqual(2302, hsp.hit_end)
-        self.assertEqual("ANAVDSQSIRINWQPPTE-PNGN--------VLGYNIFYTTEGESGNNQQTVGPDDTTYVIEGLRPATQY", str(hsp.hit.seq))
+        self.assertEqual(
+            "ANAVDSQSIRINWQPPTE-PNGN--------VLGYNIFYTTEGESGNNQQTVGPDDTTYVIEGLRPATQY",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit, second hsp
         hsp = qresult[5].hsps[1]
@@ -2421,10 +2927,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(72, hsp.aln_span)
         self.assertEqual(8, hsp.query_start)
         self.assertEqual(79, hsp.query_end)
-        self.assertEqual("VASDIQA-RTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY", str(hsp.query.seq))
+        self.assertEqual(
+            "VASDIQA-RTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
+            str(hsp.query.seq),
+        )
         self.assertEqual(2818, hsp.hit_start)
         self.assertEqual(2881, hsp.hit_end)
-        self.assertEqual("VTADGQAPDTVVVTWQSPAET-NGD--------LLGYYIYYQVVGSTETSQAETGPDETTYSISGLRPATEY", str(hsp.hit.seq))
+        self.assertEqual(
+            "VTADGQAPDTVVVTWQSPAET-NGD--------LLGYYIYYQVVGSTETSQAETGPDETTYSISGLRPATEY",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit, third hsp
         hsp = qresult[5].hsps[2]
@@ -2440,10 +2952,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(72, hsp.aln_span)
         self.assertEqual(8, hsp.query_start)
         self.assertEqual(79, hsp.query_end)
-        self.assertEqual("VASDIQA-RTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY", str(hsp.query.seq))
+        self.assertEqual(
+            "VASDIQA-RTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
+            str(hsp.query.seq),
+        )
         self.assertEqual(3300, hsp.hit_start)
         self.assertEqual(3363, hsp.hit_end)
-        self.assertEqual("VTAEGQAPDTITVTWQSPAET-NGD--------LLGYYIYYQVVGSTEDVRAEAGPEETTYSISGLRPATEY", str(hsp.hit.seq))
+        self.assertEqual(
+            "VTAEGQAPDTITVTWQSPAET-NGD--------LLGYYIYYQVVGSTEDVRAEAGPEETTYSISGLRPATEY",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit, fourth hsp
         hsp = qresult[5].hsps[3]
@@ -2459,10 +2977,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(68, hsp.aln_span)
         self.assertEqual(12, hsp.query_start)
         self.assertEqual(80, hsp.query_end)
-        self.assertEqual("IQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH", str(hsp.query.seq))
+        self.assertEqual(
+            "IQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH",
+            str(hsp.query.seq),
+        )
         self.assertEqual(3686, hsp.hit_start)
         self.assertEqual(3747, hsp.hit_end)
-        self.assertEqual("IDSTTIELQWMPPSP------DEQN-GVIKGYKILYKKVGEEGENEEDAGLLDLMYTLSDLEKWTEYN", str(hsp.hit.seq))
+        self.assertEqual(
+            "IDSTTIELQWMPPSP------DEQN-GVIKGYKILYKKVGEEGENEEDAGLLDLMYTLSDLEKWTEYN",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit, fifth hsp
         hsp = qresult[5].hsps[4]
@@ -2478,10 +3002,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(70, hsp.aln_span)
         self.assertEqual(9, hsp.query_start)
         self.assertEqual(79, hsp.query_end)
-        self.assertEqual("ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY", str(hsp.query.seq))
+        self.assertEqual(
+            "ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
+            str(hsp.query.seq),
+        )
         self.assertEqual(3398, hsp.hit_start)
         self.assertEqual(3459, hsp.hit_end)
-        self.assertEqual("ASSLGSEAIEVSWQPPPQS-NGE--------ILGYRLHYQIVGEESASTQEVEGYETFYLLRGLRPVTEY", str(hsp.hit.seq))
+        self.assertEqual(
+            "ASSLGSEAIEVSWQPPPQS-NGE--------ILGYRLHYQIVGEESASTQEVEGYETFYLLRGLRPVTEY",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit, sixth hsp
         hsp = qresult[5].hsps[5]
@@ -2497,10 +3027,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(70, hsp.aln_span)
         self.assertEqual(9, hsp.query_start)
         self.assertEqual(79, hsp.query_end)
-        self.assertEqual("ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY", str(hsp.query.seq))
+        self.assertEqual(
+            "ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
+            str(hsp.query.seq),
+        )
         self.assertEqual(2145, hsp.hit_start)
         self.assertEqual(2206, hsp.hit_end)
-        self.assertEqual("ATPVDPRTVRVEWQPPQQ-PNGE--------IQGYNIYYRTTESDEDALQQAGAQDIFLTLTGLSPFTEY", str(hsp.hit.seq))
+        self.assertEqual(
+            "ATPVDPRTVRVEWQPPQQ-PNGE--------IQGYNIYYRTTESDEDALQQAGAQDIFLTLTGLSPFTEY",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit, seventh hsp
         hsp = qresult[5].hsps[6]
@@ -2516,10 +3052,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(68, hsp.aln_span)
         self.assertEqual(12, hsp.query_start)
         self.assertEqual(79, hsp.query_end)
-        self.assertEqual("IQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGE-ETNITLNDLKPAMDY", str(hsp.query.seq))
+        self.assertEqual(
+            "IQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGE-ETNITLNDLKPAMDY",
+            str(hsp.query.seq),
+        )
         self.assertEqual(3497, hsp.hit_start)
         self.assertEqual(3555, hsp.hit_end)
-        self.assertEqual("VEPTTITVDWQPPLE-INGV--------LLGYKVIYMPENA-AEFSTVELGPAELSTMLLDLEPATTY", str(hsp.hit.seq))
+        self.assertEqual(
+            "VEPTTITVDWQPPLE-INGV--------LLGYKVIYMPENA-AEFSTVELGPAELSTMLLDLEPATTY",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, seventh hit
         hit = qresult[6]
@@ -2541,15 +3083,23 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(67, hsp.aln_span)
         self.assertEqual(8, hsp.query_start)
         self.assertEqual(73, hsp.query_end)
-        self.assertEqual("VASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYV-GEETNITL-NDL", str(hsp.query.seq))
+        self.assertEqual(
+            "VASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYV-GEETNITL-NDL",
+            str(hsp.query.seq),
+        )
         self.assertEqual(775, hsp.hit_start)
         self.assertEqual(835, hsp.hit_end)
-        self.assertEqual("VASGRTNQSIMVQWQPPP-----ETEHNGV--LRGYILRYRLAGLPGEYQQRNITSPEVNYCLVTDL", str(hsp.hit.seq))
+        self.assertEqual(
+            "VASGRTNQSIMVQWQPPP-----ETEHNGV--LRGYILRYRLAGLPGEYQQRNITSPEVNYCLVTDL",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, eighth hit
         hit = qresult[7]
         self.assertEqual("gi|332864595|ref|XP_518946.3|", hit.id)
-        self.assertEqual("PREDICTED: protein sidekick-1 [Pan troglodytes]", hit.description)
+        self.assertEqual(
+            "PREDICTED: protein sidekick-1 [Pan troglodytes]", hit.description
+        )
         self.assertEqual(2213, hit.seq_len)
         self.assertEqual(2, len(hit))
         # first qresult, eighth hit, first hsp
@@ -2566,10 +3116,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(77, hsp.aln_span)
         self.assertEqual(4, hsp.query_start)
         self.assertEqual(80, hsp.query_end)
-        self.assertEqual("IVKPVASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEE-TNITLNDLKPAMDYH", str(hsp.query.seq))
+        self.assertEqual(
+            "IVKPVASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEE-TNITLNDLKPAMDYH",
+            str(hsp.query.seq),
+        )
         self.assertEqual(674, hsp.hit_start)
         self.assertEqual(740, hsp.hit_end)
-        self.assertEqual("LASPNSS--HSHAVVLSWVRP---FDGNS-----PILY-YIVELSENNSPWKVHLSNVGPEMTGITVSGLTPARTYQ", str(hsp.hit.seq))
+        self.assertEqual(
+            "LASPNSS--HSHAVVLSWVRP---FDGNS-----PILY-YIVELSENNSPWKVHLSNVGPEMTGITVSGLTPARTYQ",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, eighth hit, second hsp
         hsp = qresult[7].hsps[1]
@@ -2585,10 +3141,16 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(67, hsp.aln_span)
         self.assertEqual(8, hsp.query_start)
         self.assertEqual(73, hsp.query_end)
-        self.assertEqual("VASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYV-GEETNITL-NDL", str(hsp.query.seq))
+        self.assertEqual(
+            "VASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYV-GEETNITL-NDL",
+            str(hsp.query.seq),
+        )
         self.assertEqual(775, hsp.hit_start)
         self.assertEqual(835, hsp.hit_end)
-        self.assertEqual("VASGRTNQSIMVQWQPPP-----ETEHNGV--LRGYILRYRLAGLPGEYQQRNITSPEVNYCLVTDL", str(hsp.hit.seq))
+        self.assertEqual(
+            "VASGRTNQSIMVQWQPPP-----ETEHNGV--LRGYILRYRLAGLPGEYQQRNITSPEVNYCLVTDL",
+            str(hsp.hit.seq),
+        )
         self.assertEqual(0, hsp.query_strand)
 
 


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_SearchIO_fasta* files, only one file affected, it should be fine to merge.
test_SearchIO_fasta_m10.py