### PR TITLE
Apply black style to test_SearchIO_h* files, version 19.10b0.

### DIFF
--- a/Tests/test_SearchIO_hhsuite2_text.py
+++ b/Tests/test_SearchIO_hhsuite2_text.py
@@ -41,10 +41,13 @@ class HhsuiteCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("2uvo_A", hit.id)
-        self.assertEqual("Agglutinin isolectin 1; carbohydrate-binding protein, hevein domain, chitin-binding,"
-                         " GERM agglutinin, chitin-binding protein; HET: NDG NAG GOL; 1.40A {Triticum aestivum}"
-                         " PDB: 1wgc_A* 2cwg_A* 2x3t_A* 4aml_A* 7wga_A 9wga_A 2wgc_A 1wgt_A 1k7t_A* 1k7v_A* 1k7u_A"
-                         " 2x52_A* 1t0w_A*", hit.description)
+        self.assertEqual(
+            "Agglutinin isolectin 1; carbohydrate-binding protein, hevein domain, chitin-binding,"
+            " GERM agglutinin, chitin-binding protein; HET: NDG NAG GOL; 1.40A {Triticum aestivum}"
+            " PDB: 1wgc_A* 2cwg_A* 2x3t_A* 4aml_A* 7wga_A 9wga_A 2wgc_A 1wgt_A 1k7t_A* 1k7v_A* 1k7u_A"
+            " 2x52_A* 1t0w_A*",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(3.7e-34, hit.evalue)
         self.assertEqual(210.31, hit.score)
@@ -60,20 +63,27 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(171, hsp.hit_end)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(171, hsp.query_end)
-        self.assertEqual("ERCGEQGSNMECPNNLCCSQYGYCGMGGDYCGKGCQNGACWTSKRCGSQAGGATCTNNQCCSQYGYCGFGAEYC"
-                         "GAGCQGGPCRADIKCGSQAGGKLCPNNLCCSQWGFCGLGSEFCGGGCQSGACSTDKPCGKDAGGRVCTNNYCCS"
-                         "KWGSCGIGPGYCGAGCQSGGCDG",
-                         str(hsp.hit.seq))
-        self.assertEqual("ERCGEQGSNMECPNNLCCSQYGYCGMGGDYCGKGCQNGACWTSKRCGSQAGGATCTNNQCCSQYGYCGFGAEYC"
-                         "GAGCQGGPCRADIKCGSQAGGKLCPNNLCCSQWGFCGLGSEFCGGGCQSGACSTDKPCGKDAGGRVCTNNYCCS"
-                         "KWGSCGIGPGYCGAGCQSGGCDG",
-                         str(hsp.query.seq))
+        self.assertEqual(
+            "ERCGEQGSNMECPNNLCCSQYGYCGMGGDYCGKGCQNGACWTSKRCGSQAGGATCTNNQCCSQYGYCGFGAEYC"
+            "GAGCQGGPCRADIKCGSQAGGKLCPNNLCCSQWGFCGLGSEFCGGGCQSGACSTDKPCGKDAGGRVCTNNYCCS"
+            "KWGSCGIGPGYCGAGCQSGGCDG",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "ERCGEQGSNMECPNNLCCSQYGYCGMGGDYCGKGCQNGACWTSKRCGSQAGGATCTNNQCCSQYGYCGFGAEYC"
+            "GAGCQGGPCRADIKCGSQAGGKLCPNNLCCSQWGFCGLGSEFCGGGCQSGACSTDKPCGKDAGGRVCTNNYCCS"
+            "KWGSCGIGPGYCGAGCQSGGCDG",
+            str(hsp.query.seq),
+        )
 
         # Check last hit
         hit = qresult[num_hits - 1]
         self.assertEqual("4z8i_A", hit.id)
-        self.assertEqual("BBTPGRP3, peptidoglycan recognition protein 3; chitin-binding domain, "
-                         "AM hydrolase; 2.70A {Branchiostoma belcheri tsingtauense}", hit.description)
+        self.assertEqual(
+            "BBTPGRP3, peptidoglycan recognition protein 3; chitin-binding domain, "
+            "AM hydrolase; 2.70A {Branchiostoma belcheri tsingtauense}",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(0.11, hit.evalue)
         self.assertEqual(36.29, hit.score)
@@ -93,12 +103,16 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(116, hsp.hit_end)
         self.assertEqual(53, hsp.query_start)
         self.assertEqual(163, hsp.query_end)
-        self.assertEqual("XCXXXXCCXXXXXCXXXXXXCXXXCXXXXCXXXXXCXXX--XXXCXXXXCCXXXXXCXXXXXXCXXXCXXXXCXXXXXCX"
-                         "XX--XXXCXXXXCCXXXXXCXXXXXXCXXX",
-                         str(hsp.hit.seq))
-        self.assertEqual("TCTNNQCCSQYGYCGFGAEYCGAGCQGGPCRADIKCGSQAGGKLCPNNLCCSQWGFCGLGSEFCGGGCQSGACSTDKPCG"
-                         "KDAGGRVCTNNYCCSKWGSCGIGPGYCGAG",
-                         str(hsp.query.seq))
+        self.assertEqual(
+            "XCXXXXCCXXXXXCXXXXXXCXXXCXXXXCXXXXXCXXX--XXXCXXXXCCXXXXXCXXXXXXCXXXCXXXXCXXXXXCX"
+            "XX--XXXCXXXXCCXXXXXCXXXXXXCXXX",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "TCTNNQCCSQYGYCGFGAEYCGAGCQGGPCRADIKCGSQAGGKLCPNNLCCSQWGFCGLGSEFCGGGCQSGACSTDKPCG"
+            "KDAGGRVCTNNYCCSKWGSCGIGPGYCGAG",
+            str(hsp.query.seq),
+        )
 
     def test_2uvo_onlyheader(self):
         """Parsing 4uvo with only header present."""
@@ -132,17 +146,20 @@ class HhsuiteCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("1klr_A", hit.id)
-        self.assertEqual("Zinc finger Y-chromosomal protein; transcription; NMR {Synthetic} SCOP: g.37.1.1 PDB: "
-                         "5znf_A 1kls_A 1xrz_A* 7znf_A", hit.description)
+        self.assertEqual(
+            "Zinc finger Y-chromosomal protein; transcription; NMR {Synthetic} SCOP: g.37.1.1 PDB: "
+            "5znf_A 1kls_A 1xrz_A* 7znf_A",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
-        self.assertEqual(3.4E+04, hit.evalue)
+        self.assertEqual(3.4e04, hit.evalue)
         self.assertEqual(-0.01, hit.score)
         self.assertEqual(1, len(hit))
 
         hsp = hit.hsps[0]
         self.assertTrue(hsp.is_included)
         self.assertEqual(0, hsp.output_index)
-        self.assertEqual(3.4E+04, hsp.evalue)
+        self.assertEqual(3.4e04, hsp.evalue)
         self.assertEqual(-0.01, hsp.score)
         self.assertEqual(0.04, hsp.prob)
         self.assertEqual(23, hsp.hit_start)
@@ -155,10 +172,13 @@ class HhsuiteCases(unittest.TestCase):
         # Check last hit
         hit = qresult[num_hits - 1]
         self.assertEqual("1zfd_A", hit.id)
-        self.assertEqual("SWI5; DNA binding motif, zinc finger DNA binding domain; NMR {Saccharomyces cerevisiae}"
-                         " SCOP: g.37.1.1", hit.description)
+        self.assertEqual(
+            "SWI5; DNA binding motif, zinc finger DNA binding domain; NMR {Saccharomyces cerevisiae}"
+            " SCOP: g.37.1.1",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
-        self.assertEqual(3.6e+04, hit.evalue)
+        self.assertEqual(3.6e04, hit.evalue)
         self.assertEqual(0.03, hit.score)
         self.assertEqual(1, len(hit))
 
@@ -169,7 +189,7 @@ class HhsuiteCases(unittest.TestCase):
 
         self.assertTrue(hsp.is_included)
         self.assertEqual(num_hsps - 1, hsp.output_index)
-        self.assertEqual(3.6e+04, hsp.evalue)
+        self.assertEqual(3.6e04, hsp.evalue)
         self.assertEqual(0.03, hsp.score)
         self.assertEqual(0.03, hsp.prob)
         self.assertEqual(0, hsp.hit_start)
@@ -195,10 +215,13 @@ class HhsuiteCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("5ZIM_A", hit.id)
-        self.assertEqual("Bacteriorhodopsin; proton pump, membrane protein, PROTON; HET: L2P, RET; 1.25A {Halobacterium"
-                         " salinarum}; Related PDB entries: 1R84_A 1KG8_A 1KME_B 1KGB_A 1KG9_A 1KME_A 4X31_A 5ZIL_A 1E0P_A "
-                         "4X32_A 5ZIN_A 1S53_B 1S51_B 1S53_A 1S54_A 1F50_A 1S54_B 1S51_A 1F4Z_A 5J7A_A 1S52_B 1S52_A 4Y9H_A "
-                         "3T45_A 3T45_C 3T45_B 1C3W_A 1L0M_A", hit.description)
+        self.assertEqual(
+            "Bacteriorhodopsin; proton pump, membrane protein, PROTON; HET: L2P, RET; 1.25A {Halobacterium"
+            " salinarum}; Related PDB entries: 1R84_A 1KG8_A 1KME_B 1KGB_A 1KG9_A 1KME_A 4X31_A 5ZIL_A 1E0P_A "
+            "4X32_A 5ZIN_A 1S53_B 1S51_B 1S53_A 1S54_A 1F50_A 1S54_B 1S51_A 1F4Z_A 5J7A_A 1S52_B 1S52_A 4Y9H_A "
+            "3T45_A 3T45_C 3T45_B 1C3W_A 1L0M_A",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(2.1e-48, hit.evalue)
         self.assertEqual(320.44, hit.score)
@@ -214,18 +237,27 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(227, hsp.hit_end)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(226, hsp.query_end)
-        self.assertEqual("GRPEWIWLALGTALMGLGTLYFLVKGMGVSDPDAKKFYAITTLVPAIAFTMYLSMLLGYGLTMVPFGGEQNPIYWARYAD"
-                         "WLFTTPLLLLDLALLVDADQGTILALVGADGIMIGTGLVGALTKVYSYRFVWWAISTAAMLYILYVLFFGFTSKAESMRP"
-                         "EVASTFKVLRNVTVVLWSAYPVVWLIGSEGAGIVPLNIETLLFMVLDVSAKVGFGLILLRSRAIFG", str(hsp.hit.seq))
-        self.assertEqual("GRPEWIWLALGTALMGLGTLYFLVKGMGVSDPDAKKFYAITTLVPAIAFTMYLSMLLGYGLTMVPFGGEQNPIYWARYAD"
-                         "WLFTTPLLLLDLALLVDADQGTILALVGADGIMIGTGLVGALTKVYSYRFVWWAISTAAMLYILYVLFFGFTSKAESMRP"
-                         "EVASTFKVLRNVTVVLWSAYPVVWLIGSEGAGIVPLNIETLLFMVLDVSAKVGFGLILLRSRAIFG", str(hsp.query.seq))
+        self.assertEqual(
+            "GRPEWIWLALGTALMGLGTLYFLVKGMGVSDPDAKKFYAITTLVPAIAFTMYLSMLLGYGLTMVPFGGEQNPIYWARYAD"
+            "WLFTTPLLLLDLALLVDADQGTILALVGADGIMIGTGLVGALTKVYSYRFVWWAISTAAMLYILYVLFFGFTSKAESMRP"
+            "EVASTFKVLRNVTVVLWSAYPVVWLIGSEGAGIVPLNIETLLFMVLDVSAKVGFGLILLRSRAIFG",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "GRPEWIWLALGTALMGLGTLYFLVKGMGVSDPDAKKFYAITTLVPAIAFTMYLSMLLGYGLTMVPFGGEQNPIYWARYAD"
+            "WLFTTPLLLLDLALLVDADQGTILALVGADGIMIGTGLVGALTKVYSYRFVWWAISTAAMLYILYVLFFGFTSKAESMRP"
+            "EVASTFKVLRNVTVVLWSAYPVVWLIGSEGAGIVPLNIETLLFMVLDVSAKVGFGLILLRSRAIFG",
+            str(hsp.query.seq),
+        )
 
         # Check last hit
         hit = qresult[num_hits - 1]
         self.assertEqual("5ABB_Z", hit.id)
-        self.assertEqual("PROTEIN TRANSLOCASE SUBUNIT SECY, PROTEIN; TRANSLATION, RIBOSOME, MEMBRANE PROTEIN, "
-                         "TRANSLOCON; 8.0A {ESCHERICHIA COLI}", hit.description)
+        self.assertEqual(
+            "PROTEIN TRANSLOCASE SUBUNIT SECY, PROTEIN; TRANSLATION, RIBOSOME, MEMBRANE PROTEIN, "
+            "TRANSLOCON; 8.0A {ESCHERICHIA COLI}",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(3.3e-05, hit.evalue)
         self.assertEqual(51.24, hit.score)
@@ -245,8 +277,12 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(65, hsp.hit_end)
         self.assertEqual(7, hsp.query_start)
         self.assertEqual(59, hsp.query_end)
-        self.assertEqual("FWLVTAALLASTVFFFVERDRVS-AKWKTSLTVSGLVTGIAFWHYMYMRGVW", str(hsp.hit.seq))
-        self.assertEqual("LALGTALMGLGTLYFLVKGMGVSDPDAKKFYAITTLVPAIAFTMYLSMLLGY", str(hsp.query.seq))
+        self.assertEqual(
+            "FWLVTAALLASTVFFFVERDRVS-AKWKTSLTVSGLVTGIAFWHYMYMRGVW", str(hsp.hit.seq)
+        )
+        self.assertEqual(
+            "LALGTALMGLGTLYFLVKGMGVSDPDAKKFYAITTLVPAIAFTMYLSMLLGY", str(hsp.query.seq)
+        )
 
     def test_q9bsu1(self):
         """Parsing hhsearch_q9bsu1_uniclust_w_ss_pfamA_30.hhr file."""
@@ -258,14 +294,19 @@ class HhsuiteCases(unittest.TestCase):
 
         num_hits = 12
         self.assertEqual("HHSUITE", qresult.program)
-        self.assertEqual("sp|Q9BSU1|CP070_HUMAN UPF0183 protein C16orf70 OS=Homo sapiens OX=9606 GN=C16orf70"
-                         " PE=1 SV=1", qresult.id)
+        self.assertEqual(
+            "sp|Q9BSU1|CP070_HUMAN UPF0183 protein C16orf70 OS=Homo sapiens OX=9606 GN=C16orf70"
+            " PE=1 SV=1",
+            qresult.id,
+        )
         self.assertEqual(422, qresult.seq_len)
         self.assertEqual(num_hits, len(qresult))
 
         hit = qresult[0]
         self.assertEqual("PF03676.13", hit.id)
-        self.assertEqual("UPF0183 ; Uncharacterised protein family (UPF0183)", hit.description)
+        self.assertEqual(
+            "UPF0183 ; Uncharacterised protein family (UPF0183)", hit.description
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(2e-106, hit.evalue)
         self.assertEqual(822.75, hit.score)
@@ -281,23 +322,29 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(395, hsp.hit_end)
         self.assertEqual(10, hsp.query_start)
         self.assertEqual(407, hsp.query_end)
-        self.assertEqual("SLGNEQWEFTLGMPLAQAVAILQKHCRIIKNVQVLYSEQSPLSHDLILNLTQDGIKLMFDAFNQRLKVIEVCDLTKVKLK"
-                         "YCGVHFNSQAIAPTIEQIDQSFGATHPGVYNSAEQLFHLNFRGLSFSFQLDSWTEAPKYEPNFAHGLASLQIPHGATVKR"
-                         "MYIYSGNSLQDTKAPMMPLSCFLGNVYAESVDVLRDGTGPAGLRLRLLAAGCGPGLLADAKMRVFERSVYFGDSCQDVLS"
-                         "MLGSPHKVFYKSEDKMKIHSPSPHKQVPSKCNDYFFNYFTLGVDILFDANTHKVKKFVLHTNYPGHYNFNIYHRCEFKIP"
-                         "LAIKKENADGQTE--TCTTYSKWDNIQELLGHPVEKPVVLHRSSSPNNTNPFGSTFCFGLQRMIFEVMQNNHIASVTLY",
-                         str(hsp.query.seq))
-        self.assertEqual("EQWE----FALGMPLAQAISILQKHCRIIKNVQVLYSEQMPLSHDLILNLTQDGIKLLFDACNQRLKVIEVYDLTKVKLK"
-                         "YCGVHFNSQAIAPTIEQIDQSFGATHPGVYNAAEQLFHLNFRGLSFSFQLDSWSEAPKYEPNFAHGLASLQIPHGATVKR"
-                         "MYIYSGNNLQETKAPAMPLACFLGNVYAECVEVLRDGAGPLGLKLRLLTAGCGPGVLADTKVRAVERSIYFGDSCQDVLS"
-                         "ALGSPHKVFYKSEDKMKIHSPSPHKQVPSKCNDYFFNYYILGVDILFDSTTHLVKKFVLHTNFPGHYNFNIYHRCDFKIP"
-                         "LIIKKDGADAHSEDCILTTYSKWDQIQELLGHPMEKPVVLHRSSSANNTNPFGSTFCFGLQRMIFEVMQNNHIASVTLY",
-                         str(hsp.hit.seq))
+        self.assertEqual(
+            "SLGNEQWEFTLGMPLAQAVAILQKHCRIIKNVQVLYSEQSPLSHDLILNLTQDGIKLMFDAFNQRLKVIEVCDLTKVKLK"
+            "YCGVHFNSQAIAPTIEQIDQSFGATHPGVYNSAEQLFHLNFRGLSFSFQLDSWTEAPKYEPNFAHGLASLQIPHGATVKR"
+            "MYIYSGNSLQDTKAPMMPLSCFLGNVYAESVDVLRDGTGPAGLRLRLLAAGCGPGLLADAKMRVFERSVYFGDSCQDVLS"
+            "MLGSPHKVFYKSEDKMKIHSPSPHKQVPSKCNDYFFNYFTLGVDILFDANTHKVKKFVLHTNYPGHYNFNIYHRCEFKIP"
+            "LAIKKENADGQTE--TCTTYSKWDNIQELLGHPVEKPVVLHRSSSPNNTNPFGSTFCFGLQRMIFEVMQNNHIASVTLY",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "EQWE----FALGMPLAQAISILQKHCRIIKNVQVLYSEQMPLSHDLILNLTQDGIKLLFDACNQRLKVIEVYDLTKVKLK"
+            "YCGVHFNSQAIAPTIEQIDQSFGATHPGVYNAAEQLFHLNFRGLSFSFQLDSWSEAPKYEPNFAHGLASLQIPHGATVKR"
+            "MYIYSGNNLQETKAPAMPLACFLGNVYAECVEVLRDGAGPLGLKLRLLTAGCGPGVLADTKVRAVERSIYFGDSCQDVLS"
+            "ALGSPHKVFYKSEDKMKIHSPSPHKQVPSKCNDYFFNYYILGVDILFDSTTHLVKKFVLHTNFPGHYNFNIYHRCDFKIP"
+            "LIIKKDGADAHSEDCILTTYSKWDQIQELLGHPMEKPVVLHRSSSANNTNPFGSTFCFGLQRMIFEVMQNNHIASVTLY",
+            str(hsp.hit.seq),
+        )
 
         # Check last hit
         hit = qresult[num_hits - 1]
         self.assertEqual("PF10049.8", hit.id)
-        self.assertEqual("DUF2283 ; Protein of unknown function (DUF2283)", hit.description)
+        self.assertEqual(
+            "DUF2283 ; Protein of unknown function (DUF2283)", hit.description
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(78, hit.evalue)
         self.assertEqual(19.81, hit.score)
@@ -336,8 +383,11 @@ class HhsuiteCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("4P79_A", hit.id)
-        self.assertEqual("cell adhesion protein; cell adhesion, tight junction, membrane; HET: OLC"
-                         ", MSE; 2.4A {Mus musculus}", hit.description)
+        self.assertEqual(
+            "cell adhesion protein; cell adhesion, tight junction, membrane; HET: OLC"
+            ", MSE; 2.4A {Mus musculus}",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(6.8e-32, hit.evalue)
         self.assertEqual(194.63, hit.score)
@@ -353,20 +403,29 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(198, hsp.hit_end)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(198, hsp.query_end)
-        self.assertEqual("GSEFMSVAVETFGFFMSALGLLMLGLTLSNSYWRVSTVHGNVITTNTIFENLWYSCATDSLGVSNCWDFPSMLALSGYVQ"
-                         "GCRALMITAILLGFLGLFLGMVGLRATNVGNMDLSKKAKLLAIAGTLHILAGACGMVAISWYAVNITTDFFNPLYAGTKY"
-                         "ELGPALYLGWSASLLSILGGICVFSTAAASSKEEPATR", str(hsp.query.seq))
-        self.assertEqual("GSEFMSVAVETFGFFMSALGLLMLGLTLSNSYWRVSTVHGNVITTNTIFENLWYSCATDSLGVSNCWDFPSMLALSGYVQ"
-                         "GCRALMITAILLGFLGLFLGMVGLRATNVGNMDLSKKAKLLAIAGTLHILAGACGMVAISWYAVNITTDFFNPLYAGTKY"
-                         "ELGPALYLGWSASLLSILGGICVFSTAAASSKEEPATR", str(hsp.hit.seq))
+        self.assertEqual(
+            "GSEFMSVAVETFGFFMSALGLLMLGLTLSNSYWRVSTVHGNVITTNTIFENLWYSCATDSLGVSNCWDFPSMLALSGYVQ"
+            "GCRALMITAILLGFLGLFLGMVGLRATNVGNMDLSKKAKLLAIAGTLHILAGACGMVAISWYAVNITTDFFNPLYAGTKY"
+            "ELGPALYLGWSASLLSILGGICVFSTAAASSKEEPATR",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "GSEFMSVAVETFGFFMSALGLLMLGLTLSNSYWRVSTVHGNVITTNTIFENLWYSCATDSLGVSNCWDFPSMLALSGYVQ"
+            "GCRALMITAILLGFLGLFLGMVGLRATNVGNMDLSKKAKLLAIAGTLHILAGACGMVAISWYAVNITTDFFNPLYAGTKY"
+            "ELGPALYLGWSASLLSILGGICVFSTAAASSKEEPATR",
+            str(hsp.hit.seq),
+        )
 
         # Check last hit
         hit = qresult[num_hits - 1]
         self.assertEqual("5YQ7_F", hit.id)
-        self.assertEqual("Beta subunit of light-harvesting 1; Photosynthetic core complex, PHOTOSYNTHESIS; "
-                         "HET: MQE, BCL, HEM, KGD, BPH;{Roseiflexus castenholzii}; Related PDB entries: 5YQ7_V"
-                         " 5YQ7_3 5YQ7_T 5YQ7_J 5YQ7_9 5YQ7_N 5YQ7_A 5YQ7_P 5YQ7_H 5YQ7_D 5YQ7_5 5YQ7_7 5YQ7_1 "
-                         "5YQ7_R", hit.description)
+        self.assertEqual(
+            "Beta subunit of light-harvesting 1; Photosynthetic core complex, PHOTOSYNTHESIS; "
+            "HET: MQE, BCL, HEM, KGD, BPH;{Roseiflexus castenholzii}; Related PDB entries: 5YQ7_V"
+            " 5YQ7_3 5YQ7_T 5YQ7_J 5YQ7_9 5YQ7_N 5YQ7_A 5YQ7_P 5YQ7_H 5YQ7_D 5YQ7_5 5YQ7_7 5YQ7_1 "
+            "5YQ7_R",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(6.7, hit.evalue)
         self.assertEqual(20.51, hit.score)
@@ -399,15 +458,19 @@ class HhsuiteCases(unittest.TestCase):
 
         num_hits = 22
         self.assertEqual("HHSUITE", qresult.program)
-        self.assertEqual("sp|Q9BSU1|CP070_HUMAN UPF0183 protein C16orf70 OS=Homo sapiens OX=9606 GN=C16orf70"
-                         " PE=1 SV=1",
-                         qresult.id)
+        self.assertEqual(
+            "sp|Q9BSU1|CP070_HUMAN UPF0183 protein C16orf70 OS=Homo sapiens OX=9606 GN=C16orf70"
+            " PE=1 SV=1",
+            qresult.id,
+        )
         self.assertEqual(422, qresult.seq_len)
         self.assertEqual(num_hits, len(qresult))
 
         hit = qresult[0]
         self.assertEqual("PF03676.14", hit.id)
-        self.assertEqual("UPF0183 ; Uncharacterised protein family (UPF0183)", hit.description)
+        self.assertEqual(
+            "UPF0183 ; Uncharacterised protein family (UPF0183)", hit.description
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(9.9e-102, hit.evalue)
         self.assertEqual(792.76, hit.score)
@@ -423,26 +486,35 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(394, hsp.hit_end)
         self.assertEqual(21, hsp.query_start)
         self.assertEqual(407, hsp.query_end)
-        self.assertEqual("GMHFSQSVAIIQSQVGTIRGVQVLYSDQNPLSVDLVINMPQDGMRLIFDPVAQRLKIIEIYNMKLVKLRYSGMCFNSPEI"
-                         "TPSIEQVEHCFGATHPGLYDSQRHLFALNFRGLSFYFPVDS-----KFEPGYAHGLGSLQFPNGGSPVVSRTTIYYGSQH"
-                         "QLSSNTSSRVSGVPLPDLPLSCYRQQLHLRRCDVLRNTTSTMGLRLHMFTEGT--SRALEPSQVALVRVVRFGDSCQGVA"
-                         "RALGAPARLYYKADDKMRIHRPTARRR-PPPASDYLFNYFTLGLDVLFDARTNQVKKFVLHTNYPGHYNFNMYHRCEFEL"
-                         "TVQPD-KSEAHSLVESGGGVAVTAYSKWEVVSRAL-RVCERPVVLNRASSTNTTNPFGSTFCYGYQDIIFEVMSNNYIAS"
-                         "ITLY", str(hsp.hit.seq))
-        self.assertEqual("GMPLAQAVAILQKHCRIIKNVQVLYSEQSPLSHDLILNLTQDGIKLMFDAFNQRLKVIEVCDLTKVKLKYCGVHFNSQAI"
-                         "APTIEQIDQSFGATHPGVYNSAEQLFHLNFRGLSFSFQLDSWTEAPKYEPNFAHGLASLQIPHGA--TVKRMYIYSGNSL"
-                         "Q---------DTKA-PMMPLSCFLGNVYAESVDVLRDGTGPAGLRLRLLAAGCGPGLLADAKMRVFERSVYFGDSCQDVL"
-                         "SMLGSPHKVFYKSEDKMKIHSPSPHKQVPSKCNDYFFNYFTLGVDILFDANTHKVKKFVLHTNYPGHYNFNIYHRCEFKI"
-                         "PLAIKKENADG------QTETCTTYSKWDNIQELLGHPVEKPVVLHRSSSPNNTNPFGSTFCFGLQRMIFEVMQNNHIAS"
-                         "VTLY", str(hsp.query.seq))
+        self.assertEqual(
+            "GMHFSQSVAIIQSQVGTIRGVQVLYSDQNPLSVDLVINMPQDGMRLIFDPVAQRLKIIEIYNMKLVKLRYSGMCFNSPEI"
+            "TPSIEQVEHCFGATHPGLYDSQRHLFALNFRGLSFYFPVDS-----KFEPGYAHGLGSLQFPNGGSPVVSRTTIYYGSQH"
+            "QLSSNTSSRVSGVPLPDLPLSCYRQQLHLRRCDVLRNTTSTMGLRLHMFTEGT--SRALEPSQVALVRVVRFGDSCQGVA"
+            "RALGAPARLYYKADDKMRIHRPTARRR-PPPASDYLFNYFTLGLDVLFDARTNQVKKFVLHTNYPGHYNFNMYHRCEFEL"
+            "TVQPD-KSEAHSLVESGGGVAVTAYSKWEVVSRAL-RVCERPVVLNRASSTNTTNPFGSTFCYGYQDIIFEVMSNNYIAS"
+            "ITLY",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "GMPLAQAVAILQKHCRIIKNVQVLYSEQSPLSHDLILNLTQDGIKLMFDAFNQRLKVIEVCDLTKVKLKYCGVHFNSQAI"
+            "APTIEQIDQSFGATHPGVYNSAEQLFHLNFRGLSFSFQLDSWTEAPKYEPNFAHGLASLQIPHGA--TVKRMYIYSGNSL"
+            "Q---------DTKA-PMMPLSCFLGNVYAESVDVLRDGTGPAGLRLRLLAAGCGPGLLADAKMRVFERSVYFGDSCQDVL"
+            "SMLGSPHKVFYKSEDKMKIHSPSPHKQVPSKCNDYFFNYFTLGVDILFDANTHKVKKFVLHTNYPGHYNFNIYHRCEFKI"
+            "PLAIKKENADG------QTETCTTYSKWDNIQELLGHPVEKPVVLHRSSSPNNTNPFGSTFCFGLQRMIFEVMQNNHIAS"
+            "VTLY",
+            str(hsp.query.seq),
+        )
 
         # Check last hit
         hit = qresult[num_hits - 1]
         self.assertEqual("4IL7_A", hit.id)
-        self.assertEqual("Putative uncharacterized protein; partial jelly roll fold, hypothetical; 1.4A "
-                         "{Sulfolobus turreted icosahedral virus}", hit.description)
+        self.assertEqual(
+            "Putative uncharacterized protein; partial jelly roll fold, hypothetical; 1.4A "
+            "{Sulfolobus turreted icosahedral virus}",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
-        self.assertEqual(6.8e+02, hit.evalue)
+        self.assertEqual(6.8e02, hit.evalue)
         self.assertEqual(22.72, hit.score)
         self.assertEqual(1, len(hit))
 
@@ -453,17 +525,23 @@ class HhsuiteCases(unittest.TestCase):
         hsp = qresult.hsps[-1]
         self.assertTrue(hsp.is_included)
         self.assertEqual(num_hsps - 1, hsp.output_index)
-        self.assertEqual(3.9e+02, hsp.evalue)
+        self.assertEqual(3.9e02, hsp.evalue)
         self.assertEqual(22.84, hsp.score)
         self.assertEqual(21.56, hsp.prob)
         self.assertEqual(7, hsp.hit_start)
         self.assertEqual(96, hsp.hit_end)
         self.assertEqual(18, hsp.query_start)
         self.assertEqual(114, hsp.query_end)
-        self.assertEqual("FTLGMPLAQAVAILQKHCRIIKNVQVLYSEQSPLSHDLILNLTQDGIKLMFDAFNQRLKVIEVCDLTKVKLKYCGVH-FN"
-                         "SQAIAPTIEQIDQSFGA", str(hsp.query.seq))
-        self.assertEqual("IQFGMDRTLVWQLAGADQSCSDQVERIICYNNPDH-------YGPQGHFFFNA-ADKLIHKRQMELFPAPKPTMRLATYN"
-                         "KTQTGMTEAQFWAAVPS", str(hsp.hit.seq))
+        self.assertEqual(
+            "FTLGMPLAQAVAILQKHCRIIKNVQVLYSEQSPLSHDLILNLTQDGIKLMFDAFNQRLKVIEVCDLTKVKLKYCGVH-FN"
+            "SQAIAPTIEQIDQSFGA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "IQFGMDRTLVWQLAGADQSCSDQVERIICYNNPDH-------YGPQGHFFFNA-ADKLIHKRQMELFPAPKPTMRLATYN"
+            "KTQTGMTEAQFWAAVPS",
+            str(hsp.hit.seq),
+        )
 
 
 if __name__ == "__main__":

--- a/Tests/test_SearchIO_hmmer2_text.py
+++ b/Tests/test_SearchIO_hmmer2_text.py
@@ -45,12 +45,18 @@ class HmmpfamTests(unittest.TestCase):
         self.assertEqual("..", hsp.query_endtype)
         self.assertAlmostEqual(71.2, hsp.bitscore)
         self.assertAlmostEqual(2.2e-17, hsp.evalue)
-        self.assertEqual("lfVgNLppdvteedLkdlFskfGpivsikivrDiiekpketgkskGfaFVeFeseedAekAlealnG.kelggrklrv",
-                         str(hsp.hit.seq))
-        self.assertEqual("lf+g+L + +t+e Lk++F+k G iv++ +++D     + t++s+Gf+F+++  ++  + A +    +++++gr+++ ",
-                         str(hsp.aln_annotation["similarity"]))
-        self.assertEqual("LFIGGLDYRTTDENLKAHFEKWGNIVDVVVMKD-----PRTKRSRGFGFITYSHSSMIDEAQK--SRpHKIDGRVVEP",
-                         str(hsp.query.seq))
+        self.assertEqual(
+            "lfVgNLppdvteedLkdlFskfGpivsikivrDiiekpketgkskGfaFVeFeseedAekAlealnG.kelggrklrv",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "lf+g+L + +t+e Lk++F+k G iv++ +++D     + t++s+Gf+F+++  ++  + A +    +++++gr+++ ",
+            str(hsp.aln_annotation["similarity"]),
+        )
+        self.assertEqual(
+            "LFIGGLDYRTTDENLKAHFEKWGNIVDVVVMKD-----PRTKRSRGFGFITYSHSSMIDEAQK--SRpHKIDGRVVEP",
+            str(hsp.query.seq),
+        )
 
         hsp = hit[1]
         self.assertEqual(2, hsp.domain_index)
@@ -62,19 +68,28 @@ class HmmpfamTests(unittest.TestCase):
         self.assertEqual("..", hsp.query_endtype)
         self.assertAlmostEqual(75.5, hsp.bitscore)
         self.assertAlmostEqual(1.1e-18, hsp.evalue)
-        self.assertEqual("lfVgNLppdvteedLkdlFskfGpivsikivrDiiekpketgkskGfaFVeFeseedAekAlealnGkelggrklrv",
-                         str(hsp.hit.seq))
-        self.assertEqual("lfVg L  d +e+ ++d+F++fG iv+i+iv+D     ketgk +GfaFVeF++++ ++k +     ++l+g+ + v",
-                         str(hsp.aln_annotation["similarity"]))
-        self.assertEqual("LFVGALKDDHDEQSIRDYFQHFGNIVDINIVID-----KETGKKRGFAFVEFDDYDPVDKVVL-QKQHQLNGKMVDV",
-                         str(hsp.query.seq))
+        self.assertEqual(
+            "lfVgNLppdvteedLkdlFskfGpivsikivrDiiekpketgkskGfaFVeFeseedAekAlealnGkelggrklrv",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "lfVg L  d +e+ ++d+F++fG iv+i+iv+D     ketgk +GfaFVeF++++ ++k +     ++l+g+ + v",
+            str(hsp.aln_annotation["similarity"]),
+        )
+        self.assertEqual(
+            "LFVGALKDDHDEQSIRDYFQHFGNIVDINIVID-----KETGKKRGFAFVEFDDYDPVDKVVL-QKQHQLNGKMVDV",
+            str(hsp.query.seq),
+        )
 
     def test_hmmpfam_22(self):
         """Test parsing hmmpfam 2.2 file (text_22_hmmpfam_001.out)."""
         results = parse(path.join("Hmmer", "text_22_hmmpfam_001.out"), self.fmt)
         res = next(results)
         self.assertEqual("gi|1522636|gb|AAC37060.1|", res.id)
-        self.assertEqual("M. jannaschii predicted coding region MJECS02 [Methanococcus jannaschii]", res.description)
+        self.assertEqual(
+            "M. jannaschii predicted coding region MJECS02 [Methanococcus jannaschii]",
+            res.description,
+        )
         self.assertEqual("[none]", res.accession)
         self.assertEqual("hmmpfam", res.program)
         self.assertEqual("2.2g", res.version)
@@ -99,12 +114,27 @@ class HmmpfamTests(unittest.TestCase):
         self.assertEqual("..", hsp.query_endtype)
         self.assertAlmostEqual(-105.2, hsp.bitscore)
         self.assertAlmostEqual(0.0022, hsp.evalue)
-        self.assertEqual("lrnELentLWavADkLRGsmDaseYKdyVLGLlFlKYiSdkFlerrieieerktdtesepsldyakledqyeqlededlekedfyqkkGvFilPsqlFwdfikeaeknkldedigtdldkifseledqialgypaSeedfkGlfpdldfnsnkLgskaqarnetLtelidlfselelgtPmHNG.dfeelgikDlfGDaYEYLLgkFAeneGKsGGeFYTPqeVSkLiaeiLtigqpsegdfsIYDPAcGSGSLllqaskflgehdgkrnaisyYGQEsn",
-                         str(hsp.hit.seq))
-        self.assertEqual(" ++EL+++  av+   R              L+F K++ dk      +i+         p +   + +++y   ++   ++ ++y ++      + lF++++   e ++  ++++ + +    ++      + +       Glf ++++  ++ +s+   +ne ++e+i+ +++ +++     G++ +el   D++G +YE L+   Ae   K+ G +YTP e++  ia+ + i+  ++                  +++ ++    k+n+i +    s+",
-                         str(hsp.aln_annotation["similarity"]))
-        self.assertEqual("NTSELDKKKFAVLLMNR--------------LIFIKFLEDK------GIV---------PRDLLRRTYEDY---KKSNVLI-NYYDAY-L----KPLFYEVLNTPEDER--KENIRT-NPYYKDIPYL---N-G-------GLFRSNNV--PNELSFTIKDNEIIGEVINFLERYKFTLSTSEGsEEVELNP-DILGYVYEKLINILAEKGQKGLGAYYTPDEITSYIAKNT-IEPIVVE----------------RFKEIIK--NWKINDINF----ST",
-                         str(hsp.query.seq))
+        self.assertEqual(
+            "lrnELentLWavADkLRGsmDaseYKdyVLGLlFlKYiSdkFlerrieieerktdtesepsldyakledqyeql"
+            "ededlekedfyqkkGvFilPsqlFwdfikeaeknkldedigtdldkifseledqialgypaSeedfkGlfpdld"
+            "fnsnkLgskaqarnetLtelidlfselelgtPmHNG.dfeelgikDlfGDaYEYLLgkFAeneGKsGGeFYTPq"
+            "eVSkLiaeiLtigqpsegdfsIYDPAcGSGSLllqaskflgehdgkrnaisyYGQEsn",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            " ++EL+++  av+   R              L+F K++ dk      +i+         p +   + +++y   "
+            "++   ++ ++y ++      + lF++++   e ++  ++++ + +    ++      + +       Glf +++"
+            "+  ++ +s+   +ne ++e+i+ +++ +++     G++ +el   D++G +YE L+   Ae   K+ G +YTP "
+            "e++  ia+ + i+  ++                  +++ ++    k+n+i +    s+",
+            str(hsp.aln_annotation["similarity"]),
+        )
+        self.assertEqual(
+            "NTSELDKKKFAVLLMNR--------------LIFIKFLEDK------GIV---------PRDLLRRTYEDY---"
+            "KKSNVLI-NYYDAY-L----KPLFYEVLNTPEDER--KENIRT-NPYYKDIPYL---N-G-------GLFRSNN"
+            "V--PNELSFTIKDNEIIGEVINFLERYKFTLSTSEGsEEVELNP-DILGYVYEKLINILAEKGQKGLGAYYTPD"
+            "EITSYIAKNT-IEPIVVE----------------RFKEIIK--NWKINDINF----ST",
+            str(hsp.query.seq),
+        )
 
     def test_hmmpfam_23(self):
         """Test parsing hmmpfam 2.3 file (text_23_hmmpfam_001.out)."""
@@ -136,12 +166,11 @@ class HmmpfamTests(unittest.TestCase):
         self.assertEqual("..", hsp.query_endtype)
         self.assertAlmostEqual(1.3, hsp.bitscore)
         self.assertAlmostEqual(3, hsp.evalue)
-        self.assertEqual("lPwelgLaevhqtLvengLRdrVsLia",
-                         str(hsp.hit.seq))
-        self.assertEqual("+P  l++ +vh  L++ gLR + s+ +",
-                         str(hsp.aln_annotation["similarity"]))
-        self.assertEqual("IPPLLAVGAVHHHLINKGLRQEASILV",
-                         str(hsp.query.seq))
+        self.assertEqual("lPwelgLaevhqtLvengLRdrVsLia", str(hsp.hit.seq))
+        self.assertEqual(
+            "+P  l++ +vh  L++ gLR + s+ +", str(hsp.aln_annotation["similarity"])
+        )
+        self.assertEqual("IPPLLAVGAVHHHLINKGLRQEASILV", str(hsp.query.seq))
 
         hsp = hit[1]
         self.assertEqual(2, hsp.domain_index)
@@ -177,7 +206,9 @@ class HmmpfamTests(unittest.TestCase):
         self.assertEqual("[none]", res.accession)
         self.assertEqual("hmmpfam", res.program)
         self.assertEqual("2.3.2", res.version)
-        self.assertEqual("antismash/specific_modules/lantipeptides/ClassIVLanti.hmm", res.target)
+        self.assertEqual(
+            "antismash/specific_modules/lantipeptides/ClassIVLanti.hmm", res.target
+        )
         self.assertEqual(1, len(res))
 
         hit = res[0]
@@ -200,12 +231,18 @@ class HmmpfamTests(unittest.TestCase):
         self.assertAlmostEqual(1, hsp.evalue)
         self.assertEqual(len(hsp.query.seq), len(hsp.hit.seq))
         self.assertEqual(len(hsp.query.seq), len(hsp.aln_annotation["similarity"]))
-        self.assertEqual("msEEqLKAFiAKvqaDtsLqEqLKaEGADvvaiAKAaGFtitteDLnahiqakeLsdeeLEgvaGg",
-                         str(hsp.hit.seq))
-        self.assertEqual("        F+                           G  +t   Ln                   ",
-                         str(hsp.aln_annotation["similarity"]))
-        self.assertEqual("-------CFL---------------------------GCLVTNWVLNRS-----------------",
-                         str(hsp.query.seq))
+        self.assertEqual(
+            "msEEqLKAFiAKvqaDtsLqEqLKaEGADvvaiAKAaGFtitteDLnahiqakeLsdeeLEgvaGg",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "        F+                           G  +t   Ln                   ",
+            str(hsp.aln_annotation["similarity"]),
+        )
+        self.assertEqual(
+            "-------CFL---------------------------GCLVTNWVLNRS-----------------",
+            str(hsp.query.seq),
+        )
 
     def test_hmmpfam_23_break_in_end_of_seq(self):
         """Test parsing hmmpfam 2.3 file with a line break in the end of seq marker.
@@ -259,21 +296,29 @@ class HmmpfamTests(unittest.TestCase):
         self.assertEqual(108, hsp.query_start)
         self.assertEqual(271, hsp.query_end)
         self.assertEqual("..", hsp.query_endtype)
-        self.assertEqual("ENHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQG--",
-                         str(hsp.query.seq)[:40])
-        self.assertEqual("+++++  L+++++e++k+ewP++Wp+ + +l  l++++  ",
-                         str(hsp.aln_annotation["similarity"])[:40])
-        self.assertEqual("WVSMSHITA-ENCkLLEILCLLL----NEQELQLGAAECL",
-                         str(hsp.query.seq)[-40:])
+        self.assertEqual(
+            "ENHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQG--", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "+++++  L+++++e++k+ewP++Wp+ + +l  l++++  ",
+            str(hsp.aln_annotation["similarity"])[:40],
+        )
+        self.assertEqual(
+            "WVSMSHITA-ENCkLLEILCLLL----NEQELQLGAAECL", str(hsp.query.seq)[-40:]
+        )
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(178, hsp.hit_end)
         self.assertEqual("[]", hsp.hit_endtype)
-        self.assertEqual("pkflrnKLalalaelakqewPsnWpsffpdlvsllsssss",
-                         str(hsp.hit.seq)[:40])
-        self.assertEqual("W+++++i + ++++ll++l+ lL    +  +l++ A+eCL",
-                         str(hsp.aln_annotation["similarity"])[-40:])
-        self.assertEqual("Wipiglianvnpi.llnllfslLsgpesdpdlreaAveCL",
-                         str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "pkflrnKLalalaelakqewPsnWpsffpdlvsllsssss", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "W+++++i + ++++ll++l+ lL    +  +l++ A+eCL",
+            str(hsp.aln_annotation["similarity"])[-40:],
+        )
+        self.assertEqual(
+            "Wipiglianvnpi.llnllfslLsgpesdpdlreaAveCL", str(hsp.hit.seq)[-40:]
+        )
 
         # fourth qresult, second from last hit
         hit = res[-2]
@@ -343,7 +388,9 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual("SEED", hsp.query_id)
         self.assertEqual("<unknown description>", hsp.query_description)
         self.assertEqual("PAB2_ARATH", hsp.hit_id)
-        self.assertEqual("P42731 POLYADENYLATE-BINDING PROTEIN 2 (PO", hsp.hit_description)
+        self.assertEqual(
+            "P42731 POLYADENYLATE-BINDING PROTEIN 2 (PO", hsp.hit_description
+        )
         self.assertEqual(3, hsp.domain_index)
         self.assertAlmostEqual(109.1, hsp.bitscore)
         self.assertAlmostEqual(3e-28, hsp.evalue)
@@ -359,7 +406,9 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual("SEED", hsp.query_id)
         self.assertEqual("<unknown description>", hsp.query_description)
         self.assertEqual("PAB2_ARATH", hsp.hit_id)
-        self.assertEqual("P42731 POLYADENYLATE-BINDING PROTEIN 2 (PO", hsp.hit_description)
+        self.assertEqual(
+            "P42731 POLYADENYLATE-BINDING PROTEIN 2 (PO", hsp.hit_description
+        )
         self.assertEqual(1, hsp.domain_index)
         self.assertAlmostEqual(92.1, hsp.bitscore)
         self.assertAlmostEqual(3.9e-23, hsp.evalue)
@@ -375,7 +424,7 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual("O00369", hit.id)
         self.assertEqual("O00369 L1 ELEMENT L1.20 P40 AND PUTATIVE P", hit.description)
         self.assertAlmostEqual(-23.8, hit.bitscore)
-        self.assertAlmostEqual(9.9e+02, hit.evalue)
+        self.assertAlmostEqual(9.9e02, hit.evalue)
         self.assertEqual(1, hit.domain_obs_num)
         self.assertEqual(1, len(hit))
 
@@ -384,10 +433,12 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual("SEED", hsp.query_id)
         self.assertEqual("<unknown description>", hsp.query_description)
         self.assertEqual("O00369", hsp.hit_id)
-        self.assertEqual("O00369 L1 ELEMENT L1.20 P40 AND PUTATIVE P", hsp.hit_description)
+        self.assertEqual(
+            "O00369 L1 ELEMENT L1.20 P40 AND PUTATIVE P", hsp.hit_description
+        )
         self.assertEqual(1, hsp.domain_index)
         self.assertAlmostEqual(-23.8, hsp.bitscore)
-        self.assertAlmostEqual(9.9e+02, hsp.evalue)
+        self.assertAlmostEqual(9.9e02, hsp.evalue)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(77, hsp.query_end)
         self.assertEqual("[]", hsp.query_endtype)
@@ -428,18 +479,30 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(337, hsp.query_end)
         self.assertEqual("[]", hsp.query_endtype)
-        self.assertEqual("lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", str(hsp.query.seq)[:40])
-        self.assertEqual("IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", str(hsp.query.seq)[-40:])
+        self.assertEqual(
+            "lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", str(hsp.query.seq)[-40:]
+        )
         self.assertEqual(337, len(hsp.query.seq))
-        self.assertEqual("+P+++DWRe kg  VtpVK+QG qCGSCWAFSa g lEg+",
-                         str(hsp.aln_annotation["similarity"])[:40])
-        self.assertEqual("+VKNSWG++WG++GY++ia+++n    n+CG+a+ asypi",
-                         str(hsp.aln_annotation["similarity"])[-40:])
+        self.assertEqual(
+            "+P+++DWRe kg  VtpVK+QG qCGSCWAFSa g lEg+",
+            str(hsp.aln_annotation["similarity"])[:40],
+        )
+        self.assertEqual(
+            "+VKNSWG++WG++GY++ia+++n    n+CG+a+ asypi",
+            str(hsp.aln_annotation["similarity"])[-40:],
+        )
         self.assertEqual(113, hsp.hit_start)
         self.assertEqual(332, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
-        self.assertEqual("IPKTVDWRE-KG-CVTPVKNQG-QCGSCWAFSASGCLEGQ", str(hsp.hit.seq)[:40])
-        self.assertEqual("LVKNSWGKEWGMDGYIKIAKDRN----NHCGLATAASYPI", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "IPKTVDWRE-KG-CVTPVKNQG-QCGSCWAFSASGCLEGQ", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "LVKNSWGKEWGMDGYIKIAKDRN----NHCGLATAASYPI", str(hsp.hit.seq)[-40:]
+        )
         self.assertEqual(337, len(hsp.hit.seq))
 
         # last hit
@@ -463,18 +526,30 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(337, hsp.query_end)
         self.assertEqual("[]", hsp.query_endtype)
-        self.assertEqual("lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", str(hsp.query.seq)[:40])
-        self.assertEqual("IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", str(hsp.query.seq)[-40:])
+        self.assertEqual(
+            "lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", str(hsp.query.seq)[:40]
+        )
+        self.assertEqual(
+            "IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", str(hsp.query.seq)[-40:]
+        )
         self.assertEqual(337, len(hsp.query.seq))
-        self.assertEqual("+Pe +DWR+ kg aVtpVK+QG +CGSCWAFSav ++Eg+",
-                         str(hsp.aln_annotation["similarity"])[:40])
-        self.assertEqual("++KNSWGt WGEnGY+ri+Rg+++s ++ CG+ ++  yp+",
-                         str(hsp.aln_annotation["similarity"])[-40:])
+        self.assertEqual(
+            "+Pe +DWR+ kg aVtpVK+QG +CGSCWAFSav ++Eg+",
+            str(hsp.aln_annotation["similarity"])[:40],
+        )
+        self.assertEqual(
+            "++KNSWGt WGEnGY+ri+Rg+++s ++ CG+ ++  yp+",
+            str(hsp.aln_annotation["similarity"])[-40:],
+        )
         self.assertEqual(133, hsp.hit_start)
         self.assertEqual(343, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
-        self.assertEqual("IPEYVDWRQ-KG-AVTPVKNQG-SCGSCWAFSAVVTIEGI", str(hsp.hit.seq)[:40])
-        self.assertEqual("LIKNSWGTGWGENGYIRIKRGTGNS-YGVCGLYTSSFYPV", str(hsp.hit.seq)[-40:])
+        self.assertEqual(
+            "IPEYVDWRQ-KG-AVTPVKNQG-SCGSCWAFSAVVTIEGI", str(hsp.hit.seq)[:40]
+        )
+        self.assertEqual(
+            "LIKNSWGTGWGENGYIRIKRGTGNS-YGVCGLYTSSFYPV", str(hsp.hit.seq)[-40:]
+        )
         self.assertEqual(337, len(hsp.hit.seq))
 
 

--- a/Tests/test_SearchIO_hmmer3_domtab.py
+++ b/Tests/test_SearchIO_hmmer3_domtab.py
@@ -230,7 +230,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("gi|22748937|ref|NP_065801.1|", hsp.query_id)
         self.assertEqual(2, hsp.domain_index)
         self.assertEqual(0.35, hsp.evalue_cond)
-        self.assertEqual(2.4e+03, hsp.evalue)
+        self.assertEqual(2.4e03, hsp.evalue)
         self.assertEqual(-1.8, hsp.bitscore)
         self.assertEqual(0.0, hsp.bias)
         self.assertEqual(111, hsp.hit_start)
@@ -271,7 +271,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("gi|22748937|ref|NP_065801.1|", hsp.query_id)
         self.assertEqual(2, hsp.domain_index)
         self.assertEqual(1.2, hsp.evalue_cond)
-        self.assertEqual(8e+03, hsp.evalue)
+        self.assertEqual(8e03, hsp.evalue)
         self.assertEqual(-3.3, hsp.bitscore)
         self.assertEqual(0.0, hsp.bias)
         self.assertEqual(56, hsp.hit_start)
@@ -372,7 +372,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("gi|125490392|ref|NP_038661.2|", hsp.query_id)
         self.assertEqual(2, hsp.domain_index)
         self.assertEqual(0.19, hsp.evalue_cond)
-        self.assertEqual(5.2e+02, hsp.evalue)
+        self.assertEqual(5.2e02, hsp.evalue)
         self.assertEqual(0.8, hsp.bitscore)
         self.assertEqual(0.0, hsp.bias)
         self.assertEqual(38, hsp.hit_start)
@@ -581,7 +581,10 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(8.5e-147, hit.evalue)
         self.assertEqual(492.3, hit.bitscore)
         self.assertEqual(0.0, hit.bias)
-        self.assertEqual("Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=1 SV=1", hit.description)
+        self.assertEqual(
+            "Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=1 SV=1",
+            hit.description,
+        )
         hsp = hit.hsps[0]
         self.assertEqual("sp|Q9WUT3|KS6A2_MOUSE", hsp.hit_id)
         self.assertEqual("Pkinase", hsp.query_id)
@@ -620,7 +623,10 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(8.4e-147, hit.evalue)
         self.assertEqual(492.3, hit.bitscore)
         self.assertEqual(0.0, hit.bias)
-        self.assertEqual("Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=2 SV=1", hit.description)
+        self.assertEqual(
+            "Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=2 SV=1",
+            hit.description,
+        )
         hsp = hit.hsps[0]
         self.assertEqual("sp|Q9WUT3|KS6A2_MOUSE", hsp.hit_id)
         self.assertEqual("Pkinase", hsp.query_id)

--- a/Tests/test_SearchIO_hmmer3_domtab_index.py
+++ b/Tests/test_SearchIO_hmmer3_domtab_index.py
@@ -52,7 +52,6 @@ Ig_2                 PF13895.1     80 gi|126362951:116-221 -            106   3.
 
 
 class HmmerDomtabIndexCases(CheckIndex):
-
     def test_hmmerdomtab_30_hmmscan_001(self):
         """Test hmmscan-domtab indexing, HMMER 3.0, multiple queries."""
         filename = os.path.join("Hmmer", "domtab_30_hmmscan_001.out")

--- a/Tests/test_SearchIO_hmmer3_tab.py
+++ b/Tests/test_SearchIO_hmmer3_tab.py
@@ -457,7 +457,10 @@ class HmmsearchCases(unittest.TestCase):
         self.assertEqual(2, hit.domain_obs_num)
         self.assertEqual(2, hit.domain_reported_num)
         self.assertEqual(2, hit.domain_included_num)
-        self.assertEqual("Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=1 SV=1", hit.description)
+        self.assertEqual(
+            "Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=1 SV=1",
+            hit.description,
+        )
         hsp = hit.hsps[0]
         self.assertEqual(1.2e-72, hsp.evalue)
         self.assertEqual(249.3, hsp.bitscore)
@@ -479,7 +482,10 @@ class HmmsearchCases(unittest.TestCase):
         self.assertEqual(2, hit.domain_obs_num)
         self.assertEqual(2, hit.domain_reported_num)
         self.assertEqual(2, hit.domain_included_num)
-        self.assertEqual("Ribosomal protein S6 kinase 2 alpha OS=Gallus gallus GN=RPS6KA PE=2 SV=1", hit.description)
+        self.assertEqual(
+            "Ribosomal protein S6 kinase 2 alpha OS=Gallus gallus GN=RPS6KA PE=2 SV=1",
+            hit.description,
+        )
         hsp = hit.hsps[-1]
         self.assertEqual(7.6e-72, hsp.evalue)
         self.assertEqual(246.7, hsp.bitscore)

--- a/Tests/test_SearchIO_hmmer3_text.py
+++ b/Tests/test_SearchIO_hmmer3_text.py
@@ -50,7 +50,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("/home/bow/db/hmmer/protdb/Pfam-A.hmm", qresult.target)
         self.assertEqual("3.1b1", qresult.version)
         self.assertEqual("gi|125490392|ref|NP_038661.2|", qresult.id)
-        self.assertEqual("POU domain, class 5, transcription factor 1 isoform 1 [Mus musculus]", qresult.description)
+        self.assertEqual(
+            "POU domain, class 5, transcription factor 1 isoform 1 [Mus musculus]",
+            qresult.description,
+        )
         self.assertEqual(352, qresult.seq_len)
         self.assertEqual(5, len(qresult))
 
@@ -82,12 +85,18 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(205, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.97, hsp.acc_avg)
-        self.assertEqual("eldleeleefakefkqrrikLgltqadvgsalgalyGkefsqttIcrFEalqLslknmckLkpllekWLeeae",
-                         str(hsp.hit.seq))
-        self.assertEqual("KALQKELEQFAKLLKQKRITLGYTQADVGLTLGVLFGKVFSQTTICRFEALQLSLKNMCKLRPLLEKWVEEAD",
-                         str(hsp.query.seq))
-        self.assertEqual("67899******************************************************************96",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "eldleeleefakefkqrrikLgltqadvgsalgalyGkefsqttIcrFEalqLslknmckLkpllekWLeeae",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KALQKELEQFAKLLKQKRITLGYTQADVGLTLGVLFGKVFSQTTICRFEALQLSLKNMCKLRPLLEKWVEEAD",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "67899******************************************************************96",
+            hsp.aln_annotation["PP"],
+        )
 
         # last hit
         hit = qresult[4]
@@ -118,12 +127,18 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(294, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.77, hsp.acc_avg)
-        self.assertEqual("adlaavleelnkakkeevdlvvlGcPhlsleeleelaellkgrkkkvsvelvvttsravlsk",
-                         str(hsp.hit.seq))
-        self.assertEqual("QARKRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEK--DVVRVWFCNRRQKGKR",
-                         str(hsp.query.seq))
-        self.assertEqual("345666667778888899************************99..9999999988876554",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "adlaavleelnkakkeevdlvvlGcPhlsleeleelaellkgrkkkvsvelvvttsravlsk",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "QARKRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEK--DVVRVWFCNRRQKGKR",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "345666667778888899************************99..9999999988876554",
+            hsp.aln_annotation["PP"],
+        )
 
         # test if we've properly finished iteration
         self.assertRaises(StopIteration, next, qresults)
@@ -186,14 +201,22 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(113, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.97, hsp.acc_avg)
-        self.assertEqual("HHHHHHHHHHHHCHHHHHHHHHHHHHHHHHSGGGGGGGCCCTTTT.HHHHHTSCHHHHHHHHHHHHHHHHHHCTTSHHHHHHHHHHHHHHHHTT-.--HHHHCCHHHHH",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("qkalvkaswekvkanaeeigaeilkrlfkaypdtkklFkkfgdls.aedlksspkfkahakkvlaaldeavknldnddnlkaalkklgarHakrg.vdpanfklfgeal",
-                         str(hsp.hit.seq))
-        self.assertEqual("EWQLVLNVWGKVEADIPGHGQEVLIRLFKGHPETLEKFDKFKHLKsEDEMKASEDLKKHGATVLTALGGILKK---KGHHEAEIKPLAQSHATKHkIPVKYLEFISECI",
-                         str(hsp.query.seq))
-        self.assertEqual("5789*********************************************************************...6899***********************999998",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "HHHHHHHHHHHHCHHHHHHHHHHHHHHHHHSGGGGGGGCCCTTTT.HHHHHTSCHHHHHHHHHHHHHHHHHHCTTSHHHHHHHHHHHHHHHHTT-.--HHHHCCHHHHH",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "qkalvkaswekvkanaeeigaeilkrlfkaypdtkklFkkfgdls.aedlksspkfkahakkvlaaldeavknldnddnlkaalkklgarHakrg.vdpanfklfgeal",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "EWQLVLNVWGKVEADIPGHGQEVLIRLFKGHPETLEKFDKFKHLKsEDEMKASEDLKKHGATVLTALGGILKK---KGHHEAEIKPLAQSHATKHkIPVKYLEFISECI",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "5789*********************************************************************...6899***********************999998",
+            hsp.aln_annotation["PP"],
+        )
 
         # test third result
         qresult = next(qresults)
@@ -203,7 +226,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("/home/bow/db/hmmer/Pfam-A.hmm", qresult.target)
         self.assertEqual("3.0", qresult.version)
         self.assertEqual("gi|126362951:116-221", qresult.id)
-        self.assertEqual("leukocyte immunoglobulin-like receptor subfamily B member 1 isoform 2 precursor [Homo sapiens]", qresult.description)
+        self.assertEqual(
+            "leukocyte immunoglobulin-like receptor subfamily B member 1 isoform 2 precursor [Homo sapiens]",
+            qresult.description,
+        )
         self.assertEqual(106, qresult.seq_len)
         self.assertEqual(2, len(qresult))
 
@@ -235,12 +261,18 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(88, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.94, hsp.acc_avg)
-        self.assertEqual("kPvisvspsptvtsggnvtLtCsaeggpppptisWy.....ietppelqgsegssssestLtissvtsedsgtYtCva",
-                         str(hsp.hit.seq))
-        self.assertEqual("KPTLSAQPSPVVNSGGNVILQCDSQVA--FDGFSLCkegedEHPQCLNSQPHARGSSRAIFSVGPVSPSRRWWYRCYA",
-                         str(hsp.query.seq))
-        self.assertEqual("8************************99..78888888****************************************9",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "kPvisvspsptvtsggnvtLtCsaeggpppptisWy.....ietppelqgsegssssestLtissvtsedsgtYtCva",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KPTLSAQPSPVVNSGGNVILQCDSQVA--FDGFSLCkegedEHPQCLNSQPHARGSSRAIFSVGPVSPSRRWWYRCYA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "8************************99..78888888****************************************9",
+            hsp.aln_annotation["PP"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("Ig_2", hit.id)
@@ -269,12 +301,18 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(104, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.71, hsp.acc_avg)
-        self.assertEqual("kpvlvapp.svvtegenvtLtCsapgnptprvqwykdg.vels......qsqnq........lfipnvsaedsgtYtCra....rnseggktstsveltv",
-                         str(hsp.hit.seq))
-        self.assertEqual("KPTLSAQPsPVVNSGGNVILQCDSQVA-FDGFSLCKEGeDEHPqclnsqP---HargssraiFSVGPVSPSRRWWYRCYAydsnSPYEWSLPSDLLELLV",
-                         str(hsp.query.seq))
-        self.assertEqual("799998885779*************85.899***9988655554443320...134455543444669************88443344588888888766",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "kpvlvapp.svvtegenvtLtCsapgnptprvqwykdg.vels......qsqnq........lfipnvsaedsgtYtCra....rnseggktstsveltv",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KPTLSAQPsPVVNSGGNVILQCDSQVA-FDGFSLCKEGeDEHPqclnsqP---HargssraiFSVGPVSPSRRWWYRCYAydsnSPYEWSLPSDLLELLV",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "799998885779*************85.899***9988655554443320...134455543444669************88443344588888888766",
+            hsp.aln_annotation["PP"],
+        )
 
         # test fourth result
         qresult = next(qresults)
@@ -316,14 +354,22 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(271, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.98, hsp.acc_avg)
-        self.assertEqual("HHHHHHHHHHHHHHHHHHTTTTSTTHHHHHHHHHHG-HHHHHHHHHHHHHHHHHHCCS-TTTS-CCCHHHHHHHCHHHHHHHHHHHHHHHC-TT-..................HHHHHHHHHHHHHHCTTS-CHHCHCS...HHHHHCHHCCSCCCHHHHHHHH",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("kflrnklaealaelflqeypnqWpsffddllsllssspsglelllriLkvlpeEiadfsrskleqerrnelkdllrsqvqkilelllqileqsvskk...............sselveatLkclsswvswidiglivnsp..llsllfqlLndpelreaAvecL",
-                         str(hsp.hit.seq))
-        self.assertEqual("NHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQGETQTELVMFILLRLAEDVVTF--QTLPPQRRRDIQQTLTQNMERIFSFLLNTLQENVNKYqqvktdtsqeskaqaNCRVGVAALNTLAGYIDWVSMSHITAENckLLEILCLLLNEQELQLGAAECL",
-                         str(hsp.query.seq))
-        self.assertEqual("89******************************************************99..79*********************************99*****************************************8889*********************8",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "HHHHHHHHHHHHHHHHHHTTTTSTTHHHHHHHHHHG-HHHHHHHHHHHHHHHHHHCCS-TTTS-CCCHHHHHHHCHHHHHHHHHHHHHHHC-TT-..................HHHHHHHHHHHHHHCTTS-CHHCHCS...HHHHHCHHCCSCCCHHHHHHHH",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "kflrnklaealaelflqeypnqWpsffddllsllssspsglelllriLkvlpeEiadfsrskleqerrnelkdllrsqvqkilelllqileqsvskk...............sselveatLkclsswvswidiglivnsp..llsllfqlLndpelreaAvecL",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "NHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQGETQTELVMFILLRLAEDVVTF--QTLPPQRRRDIQQTLTQNMERIFSFLLNTLQENVNKYqqvktdtsqeskaqaNCRVGVAALNTLAGYIDWVSMSHITAENckLLEILCLLLNEQELQLGAAECL",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "89******************************************************99..79*********************************99*****************************************8889*********************8",
+            hsp.aln_annotation["PP"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(2, hsp.domain_index)
@@ -331,7 +377,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(-1.8, hsp.bitscore)
         self.assertEqual(0.0, hsp.bias)
         self.assertEqual(0.35, hsp.evalue_cond)
-        self.assertEqual(2.4e+03, hsp.evalue)
+        self.assertEqual(2.4e03, hsp.evalue)
         self.assertEqual(111, hsp.hit_start)
         self.assertEqual(139, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
@@ -342,14 +388,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(529, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.86, hsp.acc_avg)
-        self.assertEqual("HHCTTS-CHHCHCS.HHHHHCHHCCSCC",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("swvswidiglivnspllsllfqlLndpe",
-                         str(hsp.hit.seq))
-        self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE",
-                         str(hsp.query.seq))
-        self.assertEqual("899*********98.8888899998776",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual("HHCTTS-CHHCHCS.HHHHHCHHCCSCC", hsp.aln_annotation["CS"])
+        self.assertEqual("swvswidiglivnspllsllfqlLndpe", str(hsp.hit.seq))
+        self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", str(hsp.query.seq))
+        self.assertEqual("899*********98.8888899998776", hsp.aln_annotation["PP"])
 
         hit = qresult[-1]
         self.assertEqual("IBN_N", hit.id)
@@ -379,14 +421,22 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(100, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.87, hsp.acc_avg)
-        self.assertEqual("HHHHHHHSCTHHHHHHHHHHHTTTSTHHHHHHHHHHHHHHHHHSCCHHHHHHHHCS-HHHHHHHHHHHHHHH",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("qLnqlekqkPgflsallqilanksldlevRqlAalyLknlItkhWkseeaqrqqqlpeeekelIrnnllnll",
-                         str(hsp.hit.seq))
-        self.assertEqual("FCEEFKEKCPICVPCGLRLA-EKTQVAIVRHFGLQILEHVVKFRWN--------GMSRLEKVYLKNSVMELI",
-                         str(hsp.query.seq))
-        self.assertEqual("56788886699*********.6555899******************........999999****99999887",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "HHHHHHHSCTHHHHHHHHHHHTTTSTHHHHHHHHHHHHHHHHHSCCHHHHHHHHCS-HHHHHHHHHHHHHHH",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "qLnqlekqkPgflsallqilanksldlevRqlAalyLknlItkhWkseeaqrqqqlpeeekelIrnnllnll",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "FCEEFKEKCPICVPCGLRLA-EKTQVAIVRHFGLQILEHVVKFRWN--------GMSRLEKVYLKNSVMELI",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "56788886699*********.6555899******************........999999****99999887",
+            hsp.aln_annotation["PP"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(2, hsp.domain_index)
@@ -394,7 +444,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(-3.3, hsp.bitscore)
         self.assertEqual(0.0, hsp.bias)
         self.assertEqual(1.2, hsp.evalue_cond)
-        self.assertEqual(8e+03, hsp.evalue)
+        self.assertEqual(8e03, hsp.evalue)
         self.assertEqual(56, hsp.hit_start)
         self.assertEqual(75, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
@@ -405,14 +455,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(187, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.85, hsp.acc_avg)
-        self.assertEqual("HCS-HHHHHHHHHHHHHHH",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("qqlpeeekelIrnnllnll",
-                         str(hsp.hit.seq))
-        self.assertEqual("QTLPPQRRRDIQQTLTQNM",
-                         str(hsp.query.seq))
-        self.assertEqual("6899*******99998865",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual("HCS-HHHHHHHHHHHHHHH", hsp.aln_annotation["CS"])
+        self.assertEqual("qqlpeeekelIrnnllnll", str(hsp.hit.seq))
+        self.assertEqual("QTLPPQRRRDIQQTLTQNM", str(hsp.query.seq))
+        self.assertEqual("6899*******99998865", hsp.aln_annotation["PP"])
 
         # test fifth result
         qresult = next(qresults)
@@ -422,7 +468,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("/home/bow/db/hmmer/Pfam-A.hmm", qresult.target)
         self.assertEqual("3.0", qresult.version)
         self.assertEqual("gi|125490392|ref|NP_038661.2|", qresult.id)
-        self.assertEqual("POU domain, class 5, transcription factor 1 isoform 1 [Mus musculus]", qresult.description)
+        self.assertEqual(
+            "POU domain, class 5, transcription factor 1 isoform 1 [Mus musculus]",
+            qresult.description,
+        )
         self.assertEqual(352, qresult.seq_len)
         self.assertEqual(5, len(qresult))
 
@@ -454,12 +503,18 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(205, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.97, hsp.acc_avg)
-        self.assertEqual("eldleeleefakefkqrrikLgltqadvgsalgalyGkefsqttIcrFEalqLslknmckLkpllekWLeeae",
-                         str(hsp.hit.seq))
-        self.assertEqual("KALQKELEQFAKLLKQKRITLGYTQADVGLTLGVLFGKVFSQTTICRFEALQLSLKNMCKLRPLLEKWVEEAD",
-                         str(hsp.query.seq))
-        self.assertEqual("67899******************************************************************96",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "eldleeleefakefkqrrikLgltqadvgsalgalyGkefsqttIcrFEalqLslknmckLkpllekWLeeae",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KALQKELEQFAKLLKQKRITLGYTQADVGLTLGVLFGKVFSQTTICRFEALQLSLKNMCKLRPLLEKWVEEAD",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "67899******************************************************************96",
+            hsp.aln_annotation["PP"],
+        )
 
         hit = qresult[1]
         self.assertEqual("Homeobox", hit.id)
@@ -489,14 +544,22 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(280, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.98, hsp.acc_avg)
-        self.assertEqual("SS--SS--HHHHHHHHHHCCTSSS--HHHHHHHHHH----HHHHHHHHHHHHHHHHH",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("rrkRttftkeqleeLeelFeknrypsaeereeLAkklgLterqVkvWFqNrRakekk",
-                         str(hsp.hit.seq))
-        self.assertEqual("KRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQKGKR",
-                         str(hsp.query.seq))
-        self.assertEqual("79****************************************************997",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "SS--SS--HHHHHHHHHHCCTSSS--HHHHHHHHHH----HHHHHHHHHHHHHHHHH",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "rrkRttftkeqleeLeelFeknrypsaeereeLAkklgLterqVkvWFqNrRakekk",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQKGKR",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "79****************************************************997",
+            hsp.aln_annotation["PP"],
+        )
 
         hit = qresult[2]
         self.assertEqual("HTH_31", hit.id)
@@ -526,12 +589,13 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(184, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.96, hsp.acc_avg)
-        self.assertEqual("aLGarLralReraGLtqeevAerlg......vSastlsrlE",
-                         str(hsp.hit.seq))
-        self.assertEqual("QFAKLLKQKRITLGYTQADVGLTLGvlfgkvFSQTTICRFE",
-                         str(hsp.query.seq))
-        self.assertEqual("6999***********************************99",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual("aLGarLralReraGLtqeevAerlg......vSastlsrlE", str(hsp.hit.seq))
+        self.assertEqual(
+            "QFAKLLKQKRITLGYTQADVGLTLGvlfgkvFSQTTICRFE", str(hsp.query.seq)
+        )
+        self.assertEqual(
+            "6999***********************************99", hsp.aln_annotation["PP"]
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -539,7 +603,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(0.8, hsp.bitscore)
         self.assertEqual(0.0, hsp.bias)
         self.assertEqual(0.19, hsp.evalue_cond)
-        self.assertEqual(5.2e+02, hsp.evalue)
+        self.assertEqual(5.2e02, hsp.evalue)
         self.assertEqual(38, hsp.hit_start)
         self.assertEqual(62, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
@@ -550,12 +614,9 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(270, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.86, hsp.acc_avg)
-        self.assertEqual("rgrpsaavlaalaralgldpaera",
-                         str(hsp.hit.seq))
-        self.assertEqual("CPKPSLQQITHIANQLGLEKDVVR",
-                         str(hsp.query.seq))
-        self.assertEqual("678**************9988765",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual("rgrpsaavlaalaralgldpaera", str(hsp.hit.seq))
+        self.assertEqual("CPKPSLQQITHIANQLGLEKDVVR", str(hsp.query.seq))
+        self.assertEqual("678**************9988765", hsp.aln_annotation["PP"])
 
         hit = qresult[3]
         self.assertEqual("Homeobox_KN", hit.id)
@@ -585,12 +646,9 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(277, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.91, hsp.acc_avg)
-        self.assertEqual("hnPYPskevkeelakqTglsrkqidnWFiNaRr",
-                         str(hsp.hit.seq))
-        self.assertEqual("KCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQ",
-                         str(hsp.query.seq))
-        self.assertEqual("56779*************************996",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual("hnPYPskevkeelakqTglsrkqidnWFiNaRr", str(hsp.hit.seq))
+        self.assertEqual("KCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQ", str(hsp.query.seq))
+        self.assertEqual("56779*************************996", hsp.aln_annotation["PP"])
 
         hit = qresult[4]
         self.assertEqual("DUF521", hit.id)
@@ -620,12 +678,18 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(294, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.77, hsp.acc_avg)
-        self.assertEqual("adlaavleelnkakkeevdlvvlGcPhlsleeleelaellkgrkkkvsvelvvttsravlsk",
-                         str(hsp.hit.seq))
-        self.assertEqual("QARKRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEK--DVVRVWFCNRRQKGKR",
-                         str(hsp.query.seq))
-        self.assertEqual("345666667778888899************************99..9999999988876554",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "adlaavleelnkakkeevdlvvlGcPhlsleeleelaellkgrkkkvsvelvvttsravlsk",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "QARKRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEK--DVVRVWFCNRRQKGKR",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "345666667778888899************************99..9999999988876554",
+            hsp.aln_annotation["PP"],
+        )
 
         # test if we've properly finished iteration
         self.assertRaises(StopIteration, next, qresults)
@@ -698,14 +762,22 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(113, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.97, hsp.acc_avg)
-        self.assertEqual("HHHHHHHHHHHHCHHHHHHHHHHHHHHHHHSGGGGGGGCCCTTTT.HHHHHTSCHHHHHHHHHHHHHHHHHHCTTSHHHHHHHHHHHHHHHHTT-.--HHHHCCHHHHH",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("qkalvkaswekvkanaeeigaeilkrlfkaypdtkklFkkfgdls.aedlksspkfkahakkvlaaldeavknldnddnlkaalkklgarHakrg.vdpanfklfgeal",
-                         str(hsp.hit.seq))
-        self.assertEqual("EWQLVLNVWGKVEADIPGHGQEVLIRLFKGHPETLEKFDKFKHLKsEDEMKASEDLKKHGATVLTALGGILKK---KGHHEAEIKPLAQSHATKHkIPVKYLEFISECI",
-                         str(hsp.query.seq))
-        self.assertEqual("5789*********************************************************************...6899***********************999998",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "HHHHHHHHHHHHCHHHHHHHHHHHHHHHHHSGGGGGGGCCCTTTT.HHHHHTSCHHHHHHHHHHHHHHHHHHCTTSHHHHHHHHHHHHHHHHTT-.--HHHHCCHHHHH",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "qkalvkaswekvkanaeeigaeilkrlfkaypdtkklFkkfgdls.aedlksspkfkahakkvlaaldeavknldnddnlkaalkklgarHakrg.vdpanfklfgeal",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "EWQLVLNVWGKVEADIPGHGQEVLIRLFKGHPETLEKFDKFKHLKsEDEMKASEDLKKHGATVLTALGGILKK---KGHHEAEIKPLAQSHATKHkIPVKYLEFISECI",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "5789*********************************************************************...6899***********************999998",
+            hsp.aln_annotation["PP"],
+        )
 
         # test if we've properly finished iteration
         self.assertRaises(StopIteration, next, qresults)
@@ -725,7 +797,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("/home/bow/db/hmmer/Pfam-A.hmm", qresult.target)
         self.assertEqual("3.0", qresult.version)
         self.assertEqual("gi|126362951:116-221", qresult.id)
-        self.assertEqual("leukocyte immunoglobulin-like receptor subfamily B member 1 isoform 2 precursor [Homo sapiens]", qresult.description)
+        self.assertEqual(
+            "leukocyte immunoglobulin-like receptor subfamily B member 1 isoform 2 precursor [Homo sapiens]",
+            qresult.description,
+        )
         self.assertEqual(106, qresult.seq_len)
         self.assertEqual(2, len(qresult))
 
@@ -757,12 +832,18 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(88, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.94, hsp.acc_avg)
-        self.assertEqual("kPvisvspsptvtsggnvtLtCsaeggpppptisWy.....ietppelqgsegssssestLtissvtsedsgtYtCva",
-                         str(hsp.hit.seq))
-        self.assertEqual("KPTLSAQPSPVVNSGGNVILQCDSQVA--FDGFSLCkegedEHPQCLNSQPHARGSSRAIFSVGPVSPSRRWWYRCYA",
-                         str(hsp.query.seq))
-        self.assertEqual("8************************99..78888888****************************************9",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "kPvisvspsptvtsggnvtLtCsaeggpppptisWy.....ietppelqgsegssssestLtissvtsedsgtYtCva",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KPTLSAQPSPVVNSGGNVILQCDSQVA--FDGFSLCkegedEHPQCLNSQPHARGSSRAIFSVGPVSPSRRWWYRCYA",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "8************************99..78888888****************************************9",
+            hsp.aln_annotation["PP"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("Ig_2", hit.id)
@@ -791,12 +872,18 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(104, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.71, hsp.acc_avg)
-        self.assertEqual("kpvlvapp.svvtegenvtLtCsapgnptprvqwykdg.vels......qsqnq........lfipnvsaedsgtYtCra....rnseggktstsveltv",
-                         str(hsp.hit.seq))
-        self.assertEqual("KPTLSAQPsPVVNSGGNVILQCDSQVA-FDGFSLCKEGeDEHPqclnsqP---HargssraiFSVGPVSPSRRWWYRCYAydsnSPYEWSLPSDLLELLV",
-                         str(hsp.query.seq))
-        self.assertEqual("799998885779*************85.899***9988655554443320...134455543444669************88443344588888888766",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "kpvlvapp.svvtegenvtLtCsapgnptprvqwykdg.vels......qsqnq........lfipnvsaedsgtYtCra....rnseggktstsveltv",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KPTLSAQPsPVVNSGGNVILQCDSQVA-FDGFSLCKEGeDEHPqclnsqP---HargssraiFSVGPVSPSRRWWYRCYAydsnSPYEWSLPSDLLELLV",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "799998885779*************85.899***9988655554443320...134455543444669************88443344588888888766",
+            hsp.aln_annotation["PP"],
+        )
 
         # test if we've properly finished iteration
         self.assertRaises(StopIteration, next, qresults)
@@ -848,14 +935,22 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(271, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.98, hsp.acc_avg)
-        self.assertEqual("HHHHHHHHHHHHHHHHHHTTTTSTTHHHHHHHHHHG-HHHHHHHHHHHHHHHHHHCCS-TTTS-CCCHHHHHHHCHHHHHHHHHHHHHHHC-TT-..................HHHHHHHHHHHHHHCTTS-CHHCHCS...HHHHHCHHCCSCCCHHHHHHHH",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("kflrnklaealaelflqeypnqWpsffddllsllssspsglelllriLkvlpeEiadfsrskleqerrnelkdllrsqvqkilelllqileqsvskk...............sselveatLkclsswvswidiglivnsp..llsllfqlLndpelreaAvecL",
-                         str(hsp.hit.seq))
-        self.assertEqual("NHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQGETQTELVMFILLRLAEDVVTF--QTLPPQRRRDIQQTLTQNMERIFSFLLNTLQENVNKYqqvktdtsqeskaqaNCRVGVAALNTLAGYIDWVSMSHITAENckLLEILCLLLNEQELQLGAAECL",
-                         str(hsp.query.seq))
-        self.assertEqual("89******************************************************99..79*********************************99*****************************************8889*********************8",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "HHHHHHHHHHHHHHHHHHTTTTSTTHHHHHHHHHHG-HHHHHHHHHHHHHHHHHHCCS-TTTS-CCCHHHHHHHCHHHHHHHHHHHHHHHC-TT-..................HHHHHHHHHHHHHHCTTS-CHHCHCS...HHHHHCHHCCSCCCHHHHHHHH",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "kflrnklaealaelflqeypnqWpsffddllsllssspsglelllriLkvlpeEiadfsrskleqerrnelkdllrsqvqkilelllqileqsvskk...............sselveatLkclsswvswidiglivnsp..llsllfqlLndpelreaAvecL",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "NHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQGETQTELVMFILLRLAEDVVTF--QTLPPQRRRDIQQTLTQNMERIFSFLLNTLQENVNKYqqvktdtsqeskaqaNCRVGVAALNTLAGYIDWVSMSHITAENckLLEILCLLLNEQELQLGAAECL",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "89******************************************************99..79*********************************99*****************************************8889*********************8",
+            hsp.aln_annotation["PP"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(2, hsp.domain_index)
@@ -863,7 +958,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(-1.8, hsp.bitscore)
         self.assertEqual(0.0, hsp.bias)
         self.assertEqual(0.35, hsp.evalue_cond)
-        self.assertEqual(2.4e+03, hsp.evalue)
+        self.assertEqual(2.4e03, hsp.evalue)
         self.assertEqual(111, hsp.hit_start)
         self.assertEqual(139, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
@@ -874,14 +969,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(529, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.86, hsp.acc_avg)
-        self.assertEqual("HHCTTS-CHHCHCS.HHHHHCHHCCSCC",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("swvswidiglivnspllsllfqlLndpe",
-                         str(hsp.hit.seq))
-        self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE",
-                         str(hsp.query.seq))
-        self.assertEqual("899*********98.8888899998776",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual("HHCTTS-CHHCHCS.HHHHHCHHCCSCC", hsp.aln_annotation["CS"])
+        self.assertEqual("swvswidiglivnspllsllfqlLndpe", str(hsp.hit.seq))
+        self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", str(hsp.query.seq))
+        self.assertEqual("899*********98.8888899998776", hsp.aln_annotation["PP"])
 
         hit = qresult[-1]
         self.assertEqual("IBN_N", hit.id)
@@ -911,14 +1002,22 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(100, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.87, hsp.acc_avg)
-        self.assertEqual("HHHHHHHSCTHHHHHHHHHHHTTTSTHHHHHHHHHHHHHHHHHSCCHHHHHHHHCS-HHHHHHHHHHHHHHH",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("qLnqlekqkPgflsallqilanksldlevRqlAalyLknlItkhWkseeaqrqqqlpeeekelIrnnllnll",
-                         str(hsp.hit.seq))
-        self.assertEqual("FCEEFKEKCPICVPCGLRLA-EKTQVAIVRHFGLQILEHVVKFRWN--------GMSRLEKVYLKNSVMELI",
-                         str(hsp.query.seq))
-        self.assertEqual("56788886699*********.6555899******************........999999****99999887",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "HHHHHHHSCTHHHHHHHHHHHTTTSTHHHHHHHHHHHHHHHHHSCCHHHHHHHHCS-HHHHHHHHHHHHHHH",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "qLnqlekqkPgflsallqilanksldlevRqlAalyLknlItkhWkseeaqrqqqlpeeekelIrnnllnll",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "FCEEFKEKCPICVPCGLRLA-EKTQVAIVRHFGLQILEHVVKFRWN--------GMSRLEKVYLKNSVMELI",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "56788886699*********.6555899******************........999999****99999887",
+            hsp.aln_annotation["PP"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(2, hsp.domain_index)
@@ -926,7 +1025,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(-3.3, hsp.bitscore)
         self.assertEqual(0.0, hsp.bias)
         self.assertEqual(1.2, hsp.evalue_cond)
-        self.assertEqual(8e+03, hsp.evalue)
+        self.assertEqual(8e03, hsp.evalue)
         self.assertEqual(56, hsp.hit_start)
         self.assertEqual(75, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
@@ -937,14 +1036,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(187, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.85, hsp.acc_avg)
-        self.assertEqual("HCS-HHHHHHHHHHHHHHH",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("qqlpeeekelIrnnllnll",
-                         str(hsp.hit.seq))
-        self.assertEqual("QTLPPQRRRDIQQTLTQNM",
-                         str(hsp.query.seq))
-        self.assertEqual("6899*******99998865",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual("HCS-HHHHHHHHHHHHHHH", hsp.aln_annotation["CS"])
+        self.assertEqual("qqlpeeekelIrnnllnll", str(hsp.hit.seq))
+        self.assertEqual("QTLPPQRRRDIQQTLTQNM", str(hsp.query.seq))
+        self.assertEqual("6899*******99998865", hsp.aln_annotation["PP"])
 
         # test if we've properly finished iteration
         self.assertRaises(StopIteration, next, qresults)
@@ -964,7 +1059,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("/home/bow/db/hmmer/Pfam-A.hmm", qresult.target)
         self.assertEqual("3.0", qresult.version)
         self.assertEqual("gi|125490392|ref|NP_038661.2|", qresult.id)
-        self.assertEqual("POU domain, class 5, transcription factor 1 isoform 1 [Mus musculus]", qresult.description)
+        self.assertEqual(
+            "POU domain, class 5, transcription factor 1 isoform 1 [Mus musculus]",
+            qresult.description,
+        )
         self.assertEqual(352, qresult.seq_len)
         self.assertEqual(5, len(qresult))
 
@@ -996,12 +1094,18 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(205, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.97, hsp.acc_avg)
-        self.assertEqual("eldleeleefakefkqrrikLgltqadvgsalgalyGkefsqttIcrFEalqLslknmckLkpllekWLeeae",
-                         str(hsp.hit.seq))
-        self.assertEqual("KALQKELEQFAKLLKQKRITLGYTQADVGLTLGVLFGKVFSQTTICRFEALQLSLKNMCKLRPLLEKWVEEAD",
-                         str(hsp.query.seq))
-        self.assertEqual("67899******************************************************************96",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "eldleeleefakefkqrrikLgltqadvgsalgalyGkefsqttIcrFEalqLslknmckLkpllekWLeeae",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KALQKELEQFAKLLKQKRITLGYTQADVGLTLGVLFGKVFSQTTICRFEALQLSLKNMCKLRPLLEKWVEEAD",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "67899******************************************************************96",
+            hsp.aln_annotation["PP"],
+        )
 
         hit = qresult[1]
         self.assertEqual("Homeobox", hit.id)
@@ -1031,14 +1135,22 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(280, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.98, hsp.acc_avg)
-        self.assertEqual("SS--SS--HHHHHHHHHHCCTSSS--HHHHHHHHHH----HHHHHHHHHHHHHHHHH",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("rrkRttftkeqleeLeelFeknrypsaeereeLAkklgLterqVkvWFqNrRakekk",
-                         str(hsp.hit.seq))
-        self.assertEqual("KRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQKGKR",
-                         str(hsp.query.seq))
-        self.assertEqual("79****************************************************997",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "SS--SS--HHHHHHHHHHCCTSSS--HHHHHHHHHH----HHHHHHHHHHHHHHHHH",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "rrkRttftkeqleeLeelFeknrypsaeereeLAkklgLterqVkvWFqNrRakekk",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "KRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQKGKR",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "79****************************************************997",
+            hsp.aln_annotation["PP"],
+        )
 
         hit = qresult[2]
         self.assertEqual("HTH_31", hit.id)
@@ -1068,12 +1180,13 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(184, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.96, hsp.acc_avg)
-        self.assertEqual("aLGarLralReraGLtqeevAerlg......vSastlsrlE",
-                         str(hsp.hit.seq))
-        self.assertEqual("QFAKLLKQKRITLGYTQADVGLTLGvlfgkvFSQTTICRFE",
-                         str(hsp.query.seq))
-        self.assertEqual("6999***********************************99",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual("aLGarLralReraGLtqeevAerlg......vSastlsrlE", str(hsp.hit.seq))
+        self.assertEqual(
+            "QFAKLLKQKRITLGYTQADVGLTLGvlfgkvFSQTTICRFE", str(hsp.query.seq)
+        )
+        self.assertEqual(
+            "6999***********************************99", hsp.aln_annotation["PP"]
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -1081,7 +1194,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(0.8, hsp.bitscore)
         self.assertEqual(0.0, hsp.bias)
         self.assertEqual(0.19, hsp.evalue_cond)
-        self.assertEqual(5.2e+02, hsp.evalue)
+        self.assertEqual(5.2e02, hsp.evalue)
         self.assertEqual(38, hsp.hit_start)
         self.assertEqual(62, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
@@ -1092,12 +1205,9 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(270, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.86, hsp.acc_avg)
-        self.assertEqual("rgrpsaavlaalaralgldpaera",
-                         str(hsp.hit.seq))
-        self.assertEqual("CPKPSLQQITHIANQLGLEKDVVR",
-                         str(hsp.query.seq))
-        self.assertEqual("678**************9988765",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual("rgrpsaavlaalaralgldpaera", str(hsp.hit.seq))
+        self.assertEqual("CPKPSLQQITHIANQLGLEKDVVR", str(hsp.query.seq))
+        self.assertEqual("678**************9988765", hsp.aln_annotation["PP"])
 
         hit = qresult[3]
         self.assertEqual("Homeobox_KN", hit.id)
@@ -1127,12 +1237,9 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(277, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.91, hsp.acc_avg)
-        self.assertEqual("hnPYPskevkeelakqTglsrkqidnWFiNaRr",
-                         str(hsp.hit.seq))
-        self.assertEqual("KCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQ",
-                         str(hsp.query.seq))
-        self.assertEqual("56779*************************996",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual("hnPYPskevkeelakqTglsrkqidnWFiNaRr", str(hsp.hit.seq))
+        self.assertEqual("KCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQ", str(hsp.query.seq))
+        self.assertEqual("56779*************************996", hsp.aln_annotation["PP"])
 
         hit = qresult[4]
         self.assertEqual("DUF521", hit.id)
@@ -1162,12 +1269,18 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(294, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.77, hsp.acc_avg)
-        self.assertEqual("adlaavleelnkakkeevdlvvlGcPhlsleeleelaellkgrkkkvsvelvvttsravlsk",
-                         str(hsp.hit.seq))
-        self.assertEqual("QARKRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEK--DVVRVWFCNRRQKGKR",
-                         str(hsp.query.seq))
-        self.assertEqual("345666667778888899************************99..9999999988876554",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "adlaavleelnkakkeevdlvvlGcPhlsleeleelaellkgrkkkvsvelvvttsravlsk",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "QARKRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEK--DVVRVWFCNRRQKGKR",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "345666667778888899************************99..9999999988876554",
+            hsp.aln_annotation["PP"],
+        )
 
         # test if we've properly finished iteration
         self.assertRaises(StopIteration, next, qresults)
@@ -1187,7 +1300,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("/home/bow/db/hmmer/Pfam-A.hmm", qresult.target)
         self.assertEqual("3.0", qresult.version)
         self.assertEqual("gi|125490392|ref|NP_038661.2|", qresult.id)
-        self.assertEqual("POU domain, class 5, transcription factor 1 isoform 1 [Mus musculus]", qresult.description)
+        self.assertEqual(
+            "POU domain, class 5, transcription factor 1 isoform 1 [Mus musculus]",
+            qresult.description,
+        )
         self.assertEqual(352, qresult.seq_len)
         self.assertEqual(5, len(qresult))
 
@@ -1284,7 +1400,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(0.8, hsp.bitscore)
         self.assertEqual(0.0, hsp.bias)
         self.assertEqual(0.19, hsp.evalue_cond)
-        self.assertEqual(5.2e+02, hsp.evalue)
+        self.assertEqual(5.2e02, hsp.evalue)
         self.assertEqual(38, hsp.hit_start)
         self.assertEqual(62, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
@@ -1404,14 +1520,22 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(271, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.98, hsp.acc_avg)
-        self.assertEqual("HHHHHHHHHHHHHHHHHHTTTTSTTHHHHHHHHHHG-HHHHHHHHHHHHHHHHHHCCS-TTTS-CCCHHHHHHHCHHHHHHHHHHHHHHHC-TT-..................HHHHHHHHHHHHHHCTTS-CHHCHCS...HHHHHCHHCCSCCCHHHHHHHH",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("kflrnklaealaelflqeypnqWpsffddllsllssspsglelllriLkvlpeEiadfsrskleqerrnelkdllrsqvqkilelllqileqsvskk...............sselveatLkclsswvswidiglivnsp..llsllfqlLndpelreaAvecL",
-                         str(hsp.hit.seq))
-        self.assertEqual("NHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQGETQTELVMFILLRLAEDVVTF--QTLPPQRRRDIQQTLTQNMERIFSFLLNTLQENVNKYqqvktdtsqeskaqaNCRVGVAALNTLAGYIDWVSMSHITAENckLLEILCLLLNEQELQLGAAECL",
-                         str(hsp.query.seq))
-        self.assertEqual("89******************************************************99..79*********************************99*****************************************8889*********************8",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "HHHHHHHHHHHHHHHHHHTTTTSTTHHHHHHHHHHG-HHHHHHHHHHHHHHHHHHCCS-TTTS-CCCHHHHHHHCHHHHHHHHHHHHHHHC-TT-..................HHHHHHHHHHHHHHCTTS-CHHCHCS...HHHHHCHHCCSCCCHHHHHHHH",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "kflrnklaealaelflqeypnqWpsffddllsllssspsglelllriLkvlpeEiadfsrskleqerrnelkdllrsqvqkilelllqileqsvskk...............sselveatLkclsswvswidiglivnsp..llsllfqlLndpelreaAvecL",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "NHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQGETQTELVMFILLRLAEDVVTF--QTLPPQRRRDIQQTLTQNMERIFSFLLNTLQENVNKYqqvktdtsqeskaqaNCRVGVAALNTLAGYIDWVSMSHITAENckLLEILCLLLNEQELQLGAAECL",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "89******************************************************99..79*********************************99*****************************************8889*********************8",
+            hsp.aln_annotation["PP"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(2, hsp.domain_index)
@@ -1419,7 +1543,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(-1.8, hsp.bitscore)
         self.assertEqual(0.0, hsp.bias)
         self.assertEqual(0.35, hsp.evalue_cond)
-        self.assertEqual(2.4e+03, hsp.evalue)
+        self.assertEqual(2.4e03, hsp.evalue)
         self.assertEqual(111, hsp.hit_start)
         self.assertEqual(139, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
@@ -1430,14 +1554,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(529, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.86, hsp.acc_avg)
-        self.assertEqual("HHCTTS-CHHCHCS.HHHHHCHHCCSCC",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("swvswidiglivnspllsllfqlLndpe",
-                         str(hsp.hit.seq))
-        self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE",
-                         str(hsp.query.seq))
-        self.assertEqual("899*********98.8888899998776",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual("HHCTTS-CHHCHCS.HHHHHCHHCCSCC", hsp.aln_annotation["CS"])
+        self.assertEqual("swvswidiglivnspllsllfqlLndpe", str(hsp.hit.seq))
+        self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", str(hsp.query.seq))
+        self.assertEqual("899*********98.8888899998776", hsp.aln_annotation["PP"])
 
         hit = qresult[-1]
         self.assertEqual("IBN_N", hit.id)
@@ -1467,14 +1587,22 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(100, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.87, hsp.acc_avg)
-        self.assertEqual("HHHHHHHSCTHHHHHHHHHHHTTTSTHHHHHHHHHHHHHHHHHSCCHHHHHHHHCS-HHHHHHHHHHHHHHH",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("qLnqlekqkPgflsallqilanksldlevRqlAalyLknlItkhWkseeaqrqqqlpeeekelIrnnllnll",
-                         str(hsp.hit.seq))
-        self.assertEqual("FCEEFKEKCPICVPCGLRLA-EKTQVAIVRHFGLQILEHVVKFRWN--------GMSRLEKVYLKNSVMELI",
-                         str(hsp.query.seq))
-        self.assertEqual("56788886699*********.6555899******************........999999****99999887",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "HHHHHHHSCTHHHHHHHHHHHTTTSTHHHHHHHHHHHHHHHHHSCCHHHHHHHHCS-HHHHHHHHHHHHHHH",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "qLnqlekqkPgflsallqilanksldlevRqlAalyLknlItkhWkseeaqrqqqlpeeekelIrnnllnll",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "FCEEFKEKCPICVPCGLRLA-EKTQVAIVRHFGLQILEHVVKFRWN--------GMSRLEKVYLKNSVMELI",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "56788886699*********.6555899******************........999999****99999887",
+            hsp.aln_annotation["PP"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(2, hsp.domain_index)
@@ -1482,7 +1610,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(-3.3, hsp.bitscore)
         self.assertEqual(0.0, hsp.bias)
         self.assertEqual(1.2, hsp.evalue_cond)
-        self.assertEqual(8e+03, hsp.evalue)
+        self.assertEqual(8e03, hsp.evalue)
         self.assertEqual(56, hsp.hit_start)
         self.assertEqual(75, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
@@ -1493,14 +1621,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(187, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.85, hsp.acc_avg)
-        self.assertEqual("HCS-HHHHHHHHHHHHHHH",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("qqlpeeekelIrnnllnll",
-                         str(hsp.hit.seq))
-        self.assertEqual("QTLPPQRRRDIQQTLTQNM",
-                         str(hsp.query.seq))
-        self.assertEqual("6899*******99998865",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual("HCS-HHHHHHHHHHHHHHH", hsp.aln_annotation["CS"])
+        self.assertEqual("qqlpeeekelIrnnllnll", str(hsp.hit.seq))
+        self.assertEqual("QTLPPQRRRDIQQTLTQNM", str(hsp.query.seq))
+        self.assertEqual("6899*******99998865", hsp.aln_annotation["PP"])
 
         # test if we've properly finished iteration
         self.assertRaises(StopIteration, next, qresults)
@@ -1565,8 +1689,7 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(len(qresults), 2)
 
         # Test whether proper query id is read
-        self.assertListEqual([x.id for x in qresults], ["infile_sto",
-                                                        "infile_sto2"])
+        self.assertListEqual([x.id for x in qresults], ["infile_sto", "infile_sto2"])
 
         # Test if proper number of hits is read
         self.assertListEqual([len(x.hits) for x in qresults], [10, 10])
@@ -1584,9 +1707,11 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(108, len(qresult))
 
         # making sure all query IDs are equal
-        self.assertEqual("Protein-arginine kinase activator protein "
-                         "OS=Bacillus subtilis (strain 168) GN=mcsA "
-                         "PE=1 SV=1", qresult.description)
+        self.assertEqual(
+            "Protein-arginine kinase activator protein "
+            "OS=Bacillus subtilis (strain 168) GN=mcsA PE=1 SV=1",
+            qresult.description,
+        )
 
         # and all hits have no descriptions
         for hit in qresult:
@@ -1616,8 +1741,10 @@ class HmmersearchCases(unittest.TestCase):
         # first hit, first hsp
         hit = qresult[0]
         self.assertEqual("sp|Q9WUT3|KS6A2_MOUSE", hit.id)
-        self.assertEqual("Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=1 SV=1",
-                         hit.description)
+        self.assertEqual(
+            "Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=1 SV=1",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(8.5e-147, hit.evalue)
         self.assertEqual(492.3, hit.bitscore)
@@ -1643,14 +1770,22 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(318, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.95, hsp.acc_avg)
-        self.assertEqual("EEEEEEEEEETTEEEEEEEE...TTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("yelleklGsGsfGkVykakk...kktgkkvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-                         str(hsp.query.seq))
-        self.assertEqual("FELLKVLGQGSYGKVFLVRKvtgSDAGQLYAMKVLKKATLKVRDRVRSKMERDILAEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHGLGIIYRDLKPENILLDEEGHIKITDFGLSKEATDHDKRAYSFCGTIEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGSLPFQGK---DRKETMALILKAKLGMPQFLS----AEAQSLLRALFKRNPCNRLGagvdgVEEIKRHPFF",
-                         str(hsp.hit.seq))
-        self.assertEqual("67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "EEEEEEEEEETTEEEEEEEE...TTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "yelleklGsGsfGkVykakk...kktgkkvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "FELLKVLGQGSYGKVFLVRKvtgSDAGQLYAMKVLKKATLKVRDRVRSKMERDILAEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHGLGIIYRDLKPENILLDEEGHIKITDFGLSKEATDHDKRAYSFCGTIEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGSLPFQGK---DRKETMALILKAKLGMPQFLS----AEAQSLLRALFKRNPCNRLGagvdgVEEIKRHPFF",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
+            hsp.aln_annotation["PP"],
+        )
 
     def test_30_hmmsearch_001(self):
         """Parsing hmmersearch 3.0 (text_30_hmmsearch_001)."""
@@ -1692,8 +1827,10 @@ class HmmersearchCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("sp|Q9WUT3|KS6A2_MOUSE", hit.id)
-        self.assertEqual("Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=2 SV=1",
-                         hit.description)
+        self.assertEqual(
+            "Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=2 SV=1",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(8.4e-147, hit.evalue)
         self.assertEqual(492.3, hit.bitscore)
@@ -1719,14 +1856,22 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(318, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.95, hsp.acc_avg)
-        self.assertEqual("EEEEEEEEEETTEEEEEEEE...TTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("yelleklGsGsfGkVykakk...kktgkkvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-                         str(hsp.query.seq))
-        self.assertEqual("FELLKVLGQGSYGKVFLVRKvtgSDAGQLYAMKVLKKATLKVRDRVRSKMERDILAEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHGLGIIYRDLKPENILLDEEGHIKITDFGLSKEATDHDKRAYSFCGTIEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGSLPFQGK---DRKETMALILKAKLGMPQFLS----AEAQSLLRALFKRNPCNRLGagvdgVEEIKRHPFF",
-                         str(hsp.hit.seq))
-        self.assertEqual("67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "EEEEEEEEEETTEEEEEEEE...TTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "yelleklGsGsfGkVykakk...kktgkkvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "FELLKVLGQGSYGKVFLVRKvtgSDAGQLYAMKVLKKATLKVRDRVRSKMERDILAEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHGLGIIYRDLKPENILLDEEGHIKITDFGLSKEATDHDKRAYSFCGTIEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGSLPFQGK---DRKETMALILKAKLGMPQFLS----AEAQSLLRALFKRNPCNRLGagvdgVEEIKRHPFF",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
+            hsp.aln_annotation["PP"],
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -1745,19 +1890,29 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(672, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.97, hsp.acc_avg)
-        self.assertEqual("EEEEEEEEEETTEEEEEEEETTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHH.SSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEE....EE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTTHHHHHTSGGG",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
-                         str(hsp.query.seq))
-        self.assertEqual("YEIKEDIGVGSYSVCKRCVHKATDAEYAVKIIDKSKRDPSE------EIEILLRYgQHPNIITLKDVYDDGKYVYLVMELMRGGELLDRILRQRCFSEREASDVLYTIARTMDYLHSQGVVHRDLKPSNILYMDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDVWSLGILLYTMLAGFTPFANGPDDTPEEILARIGSGKYALSGGNWDSISDAAKDVVSKMLHVDPQQRLTAVQVLKHPWI",
-                         str(hsp.hit.seq))
-        self.assertEqual("7899***********************************98......9*******99**************************************************************************98544444888**********************************.***************************************************************************************7",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "EEEEEEEEEETTEEEEEEEETTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHH.SSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEE....EE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTTHHHHHTSGGG",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "YEIKEDIGVGSYSVCKRCVHKATDAEYAVKIIDKSKRDPSE------EIEILLRYgQHPNIITLKDVYDDGKYVYLVMELMRGGELLDRILRQRCFSEREASDVLYTIARTMDYLHSQGVVHRDLKPSNILYMDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDVWSLGILLYTMLAGFTPFANGPDDTPEEILARIGSGKYALSGGNWDSISDAAKDVVSKMLHVDPQQRLTAVQVLKHPWI",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "7899***********************************98......9*******99**************************************************************************98544444888**********************************.***************************************************************************************7",
+            hsp.aln_annotation["PP"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("sp|P18654|KS6A3_MOUSE", hit.id)
-        self.assertEqual("Ribosomal protein S6 kinase alpha-3 OS=Mus musculus GN=Rps6ka3 PE=1 SV=2",
-                         hit.description)
+        self.assertEqual(
+            "Ribosomal protein S6 kinase alpha-3 OS=Mus musculus GN=Rps6ka3 PE=1 SV=2",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(5e-144, hit.evalue)
         self.assertEqual(483.2, hit.bitscore)
@@ -1783,14 +1938,22 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(327, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.95, hsp.acc_avg)
-        self.assertEqual("EEEEEEEEEETTEEEEEEEETTTTE...EEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("yelleklGsGsfGkVykakkkktgk...kvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-                         str(hsp.query.seq))
-        self.assertEqual("FELLKVLGQGSFGKVFLVKKISGSDarqLYAMKVLKKATLKVRDRVRTKMERDILVEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHSLGIIYRDLKPENILLDEEGHIKLTDFGLSKESIDHEKKAYSFCGTVEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGTLPFQGK---DRKETMTMILKAKLGMPQFLS----PEAQSLLRMLFKRNPANRLGagpdgVEEIKRHSFF",
-                         str(hsp.hit.seq))
-        self.assertEqual("67899**********8888876655455****************999999****************************************************************************************************9***********************.******************************...999999999999988888866....9******************9888888999999886",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "EEEEEEEEEETTEEEEEEEETTTTE...EEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "yelleklGsGsfGkVykakkkktgk...kvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "FELLKVLGQGSFGKVFLVKKISGSDarqLYAMKVLKKATLKVRDRVRTKMERDILVEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHSLGIIYRDLKPENILLDEEGHIKLTDFGLSKESIDHEKKAYSFCGTVEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGTLPFQGK---DRKETMTMILKAKLGMPQFLS----PEAQSLLRMLFKRNPANRLGagpdgVEEIKRHSFF",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "67899**********8888876655455****************999999****************************************************************************************************9***********************.******************************...999999999999988888866....9******************9888888999999886",
+            hsp.aln_annotation["PP"],
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -1809,14 +1972,22 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(679, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.97, hsp.acc_avg)
-        self.assertEqual("EEEEEEEEEETTEEEEEEEETTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHH.SSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEE....EE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTTHHHHHTSGGG",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
-                         str(hsp.query.seq))
-        self.assertEqual("YEVKEDIGVGSYSVCKRCIHKATNMEFAVKIIDKSKRDPTE------EIEILLRYgQHPNIITLKDVYDDGKYVYVVTELMKGGELLDKILRQKFFSEREASAVLFTITKTVEYLHAQGVVHRDLKPSNILYVDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDIWSLGVLLYTMLTGYTPFANGPDDTPEEILARIGSGKFSLSGGYWNSVSDTAKDLVSKMLHVDPHQRLTAALVLRHPWI",
-                         str(hsp.hit.seq))
-        self.assertEqual("7899***********************************88......9*******99**********************************9***************************************98554444888**********************************.***************************************************************************************7",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "EEEEEEEEEETTEEEEEEEETTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHH.SSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEE....EE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTTHHHHHTSGGG",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "YEVKEDIGVGSYSVCKRCIHKATNMEFAVKIIDKSKRDPTE------EIEILLRYgQHPNIITLKDVYDDGKYVYVVTELMKGGELLDKILRQKFFSEREASAVLFTITKTVEYLHAQGVVHRDLKPSNILYVDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDIWSLGVLLYTMLTGYTPFANGPDDTPEEILARIGSGKFSLSGGYWNSVSDTAKDLVSKMLHVDPHQRLTAALVLRHPWI",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "7899***********************************88......9*******99**********************************9***************************************98554444888**********************************.***************************************************************************************7",
+            hsp.aln_annotation["PP"],
+        )
 
         # test if we've properly finished iteration
         # self.assertRaises(StopIteration, next, qresults)
@@ -1842,8 +2013,10 @@ class HmmersearchCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("sp|Q9WUT3|KS6A2_MOUSE", hit.id)
-        self.assertEqual("Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=2 SV=1",
-                         hit.description)
+        self.assertEqual(
+            "Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=2 SV=1",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(8.4e-147, hit.evalue)
         self.assertEqual(492.3, hit.bitscore)
@@ -1890,8 +2063,10 @@ class HmmersearchCases(unittest.TestCase):
 
         hit = qresult[-1]
         self.assertEqual("sp|P18654|KS6A3_MOUSE", hit.id)
-        self.assertEqual("Ribosomal protein S6 kinase alpha-3 OS=Mus musculus GN=Rps6ka3 PE=1 SV=2",
-                         hit.description)
+        self.assertEqual(
+            "Ribosomal protein S6 kinase alpha-3 OS=Mus musculus GN=Rps6ka3 PE=1 SV=2",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(5e-144, hit.evalue)
         self.assertEqual(483.2, hit.bitscore)
@@ -1960,8 +2135,10 @@ class HmmersearchCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("sp|Q9WUT3|KS6A2_MOUSE", hit.id)
-        self.assertEqual("Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=2 SV=1",
-                         hit.description)
+        self.assertEqual(
+            "Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=2 SV=1",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(8.4e-147, hit.evalue)
         self.assertEqual(492.3, hit.bitscore)
@@ -1987,14 +2164,22 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(318, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.95, hsp.acc_avg)
-        self.assertEqual("EEEEEEEEEETTEEEEEEEE...TTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("yelleklGsGsfGkVykakk...kktgkkvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-                         str(hsp.query.seq))
-        self.assertEqual("FELLKVLGQGSYGKVFLVRKvtgSDAGQLYAMKVLKKATLKVRDRVRSKMERDILAEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHGLGIIYRDLKPENILLDEEGHIKITDFGLSKEATDHDKRAYSFCGTIEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGSLPFQGK---DRKETMALILKAKLGMPQFLS----AEAQSLLRALFKRNPCNRLGagvdgVEEIKRHPFF",
-                         str(hsp.hit.seq))
-        self.assertEqual("67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "EEEEEEEEEETTEEEEEEEE...TTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "yelleklGsGsfGkVykakk...kktgkkvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "FELLKVLGQGSYGKVFLVRKvtgSDAGQLYAMKVLKKATLKVRDRVRSKMERDILAEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHGLGIIYRDLKPENILLDEEGHIKITDFGLSKEATDHDKRAYSFCGTIEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGSLPFQGK---DRKETMALILKAKLGMPQFLS----AEAQSLLRALFKRNPCNRLGagvdgVEEIKRHPFF",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
+            hsp.aln_annotation["PP"],
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -2013,19 +2198,29 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(672, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.97, hsp.acc_avg)
-        self.assertEqual("EEEEEEEEEETTEEEEEEEETTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHH.SSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEE....EE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTTHHHHHTSGGG",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
-                         str(hsp.query.seq))
-        self.assertEqual("YEIKEDIGVGSYSVCKRCVHKATDAEYAVKIIDKSKRDPSE------EIEILLRYgQHPNIITLKDVYDDGKYVYLVMELMRGGELLDRILRQRCFSEREASDVLYTIARTMDYLHSQGVVHRDLKPSNILYMDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDVWSLGILLYTMLAGFTPFANGPDDTPEEILARIGSGKYALSGGNWDSISDAAKDVVSKMLHVDPQQRLTAVQVLKHPWI",
-                         str(hsp.hit.seq))
-        self.assertEqual("7899***********************************98......9*******99**************************************************************************98544444888**********************************.***************************************************************************************7",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "EEEEEEEEEETTEEEEEEEETTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHH.SSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEE....EE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTTHHHHHTSGGG",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "YEIKEDIGVGSYSVCKRCVHKATDAEYAVKIIDKSKRDPSE------EIEILLRYgQHPNIITLKDVYDDGKYVYLVMELMRGGELLDRILRQRCFSEREASDVLYTIARTMDYLHSQGVVHRDLKPSNILYMDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDVWSLGILLYTMLAGFTPFANGPDDTPEEILARIGSGKYALSGGNWDSISDAAKDVVSKMLHVDPQQRLTAVQVLKHPWI",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "7899***********************************98......9*******99**************************************************************************98544444888**********************************.***************************************************************************************7",
+            hsp.aln_annotation["PP"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("sp|P18654|KS6A3_MOUSE", hit.id)
-        self.assertEqual("Ribosomal protein S6 kinase alpha-3 OS=Mus musculus GN=Rps6ka3 PE=1 SV=2",
-                         hit.description)
+        self.assertEqual(
+            "Ribosomal protein S6 kinase alpha-3 OS=Mus musculus GN=Rps6ka3 PE=1 SV=2",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(5e-144, hit.evalue)
         self.assertEqual(483.2, hit.bitscore)
@@ -2051,14 +2246,22 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(327, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.95, hsp.acc_avg)
-        self.assertEqual("EEEEEEEEEETTEEEEEEEETTTTE...EEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("yelleklGsGsfGkVykakkkktgk...kvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-                         str(hsp.query.seq))
-        self.assertEqual("FELLKVLGQGSFGKVFLVKKISGSDarqLYAMKVLKKATLKVRDRVRTKMERDILVEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHSLGIIYRDLKPENILLDEEGHIKLTDFGLSKESIDHEKKAYSFCGTVEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGTLPFQGK---DRKETMTMILKAKLGMPQFLS----PEAQSLLRMLFKRNPANRLGagpdgVEEIKRHSFF",
-                         str(hsp.hit.seq))
-        self.assertEqual("67899**********8888876655455****************999999****************************************************************************************************9***********************.******************************...999999999999988888866....9******************9888888999999886",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "EEEEEEEEEETTEEEEEEEETTTTE...EEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "yelleklGsGsfGkVykakkkktgk...kvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "FELLKVLGQGSFGKVFLVKKISGSDarqLYAMKVLKKATLKVRDRVRTKMERDILVEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHSLGIIYRDLKPENILLDEEGHIKLTDFGLSKESIDHEKKAYSFCGTVEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGTLPFQGK---DRKETMTMILKAKLGMPQFLS----PEAQSLLRMLFKRNPANRLGagpdgVEEIKRHSFF",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "67899**********8888876655455****************999999****************************************************************************************************9***********************.******************************...999999999999988888866....9******************9888888999999886",
+            hsp.aln_annotation["PP"],
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -2077,14 +2280,22 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(679, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.97, hsp.acc_avg)
-        self.assertEqual("EEEEEEEEEETTEEEEEEEETTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHH.SSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEE....EE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTTHHHHHTSGGG",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
-                         str(hsp.query.seq))
-        self.assertEqual("YEVKEDIGVGSYSVCKRCIHKATNMEFAVKIIDKSKRDPTE------EIEILLRYgQHPNIITLKDVYDDGKYVYVVTELMKGGELLDKILRQKFFSEREASAVLFTITKTVEYLHAQGVVHRDLKPSNILYVDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDIWSLGVLLYTMLTGYTPFANGPDDTPEEILARIGSGKFSLSGGYWNSVSDTAKDLVSKMLHVDPHQRLTAALVLRHPWI",
-                         str(hsp.hit.seq))
-        self.assertEqual("7899***********************************88......9*******99**********************************9***************************************98554444888**********************************.***************************************************************************************7",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "EEEEEEEEEETTEEEEEEEETTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHH.SSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEE....EE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTTHHHHHTSGGG",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "YEVKEDIGVGSYSVCKRCIHKATNMEFAVKIIDKSKRDPTE------EIEILLRYgQHPNIITLKDVYDDGKYVYVVTELMKGGELLDKILRQKFFSEREASAVLFTITKTVEYLHAQGVVHRDLKPSNILYVDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDIWSLGVLLYTMLTGYTPFANGPDDTPEEILARIGSGKFSLSGGYWNSVSDTAKDLVSKMLHVDPHQRLTAALVLRHPWI",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "7899***********************************88......9*******99**********************************9***************************************98554444888**********************************.***************************************************************************************7",
+            hsp.aln_annotation["PP"],
+        )
 
         # test if we've properly finished iteration
         # self.assertRaises(StopIteration, next, qresults)
@@ -2122,8 +2333,10 @@ class HmmersearchCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("sp|Q9WUT3|KS6A2_MOUSE", hit.id)
-        self.assertEqual("Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=2 SV=1",
-                         hit.description)
+        self.assertEqual(
+            "Ribosomal protein S6 kinase alpha-2 OS=Mus musculus GN=Rps6ka2 PE=2 SV=1",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(8.4e-147, hit.evalue)
         self.assertEqual(492.3, hit.bitscore)
@@ -2149,14 +2362,22 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(318, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.95, hsp.acc_avg)
-        self.assertEqual("EEEEEEEEEETTEEEEEEEE...TTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("yelleklGsGsfGkVykakk...kktgkkvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-                         str(hsp.query.seq))
-        self.assertEqual("FELLKVLGQGSYGKVFLVRKvtgSDAGQLYAMKVLKKATLKVRDRVRSKMERDILAEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHGLGIIYRDLKPENILLDEEGHIKITDFGLSKEATDHDKRAYSFCGTIEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGSLPFQGK---DRKETMALILKAKLGMPQFLS----AEAQSLLRALFKRNPCNRLGagvdgVEEIKRHPFF",
-                         str(hsp.hit.seq))
-        self.assertEqual("67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "EEEEEEEEEETTEEEEEEEE...TTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "yelleklGsGsfGkVykakk...kktgkkvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "FELLKVLGQGSYGKVFLVRKvtgSDAGQLYAMKVLKKATLKVRDRVRSKMERDILAEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHGLGIIYRDLKPENILLDEEGHIKITDFGLSKEATDHDKRAYSFCGTIEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGSLPFQGK---DRKETMALILKAKLGMPQFLS----AEAQSLLRALFKRNPCNRLGagvdgVEEIKRHPFF",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
+            hsp.aln_annotation["PP"],
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -2175,19 +2396,29 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(672, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.97, hsp.acc_avg)
-        self.assertEqual("EEEEEEEEEETTEEEEEEEETTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHH.SSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEE....EE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTTHHHHHTSGGG",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
-                         str(hsp.query.seq))
-        self.assertEqual("YEIKEDIGVGSYSVCKRCVHKATDAEYAVKIIDKSKRDPSE------EIEILLRYgQHPNIITLKDVYDDGKYVYLVMELMRGGELLDRILRQRCFSEREASDVLYTIARTMDYLHSQGVVHRDLKPSNILYMDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDVWSLGILLYTMLAGFTPFANGPDDTPEEILARIGSGKYALSGGNWDSISDAAKDVVSKMLHVDPQQRLTAVQVLKHPWI",
-                         str(hsp.hit.seq))
-        self.assertEqual("7899***********************************98......9*******99**************************************************************************98544444888**********************************.***************************************************************************************7",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "EEEEEEEEEETTEEEEEEEETTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHH.SSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEE....EE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTTHHHHHTSGGG",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "YEIKEDIGVGSYSVCKRCVHKATDAEYAVKIIDKSKRDPSE------EIEILLRYgQHPNIITLKDVYDDGKYVYLVMELMRGGELLDRILRQRCFSEREASDVLYTIARTMDYLHSQGVVHRDLKPSNILYMDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDVWSLGILLYTMLAGFTPFANGPDDTPEEILARIGSGKYALSGGNWDSISDAAKDVVSKMLHVDPQQRLTAVQVLKHPWI",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "7899***********************************98......9*******99**************************************************************************98544444888**********************************.***************************************************************************************7",
+            hsp.aln_annotation["PP"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("sp|P18654|KS6A3_MOUSE", hit.id)
-        self.assertEqual("Ribosomal protein S6 kinase alpha-3 OS=Mus musculus GN=Rps6ka3 PE=1 SV=2",
-                         hit.description)
+        self.assertEqual(
+            "Ribosomal protein S6 kinase alpha-3 OS=Mus musculus GN=Rps6ka3 PE=1 SV=2",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(5e-144, hit.evalue)
         self.assertEqual(483.2, hit.bitscore)
@@ -2213,14 +2444,22 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(327, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.95, hsp.acc_avg)
-        self.assertEqual("EEEEEEEEEETTEEEEEEEETTTTE...EEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("yelleklGsGsfGkVykakkkktgk...kvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-                         str(hsp.query.seq))
-        self.assertEqual("FELLKVLGQGSFGKVFLVKKISGSDarqLYAMKVLKKATLKVRDRVRTKMERDILVEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHSLGIIYRDLKPENILLDEEGHIKLTDFGLSKESIDHEKKAYSFCGTVEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGTLPFQGK---DRKETMTMILKAKLGMPQFLS----PEAQSLLRMLFKRNPANRLGagpdgVEEIKRHSFF",
-                         str(hsp.hit.seq))
-        self.assertEqual("67899**********8888876655455****************999999****************************************************************************************************9***********************.******************************...999999999999988888866....9******************9888888999999886",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "EEEEEEEEEETTEEEEEEEETTTTE...EEEEEEEEHHHCCCCCCHHHHHHHHHHHHHSSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEEEE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTT.....HHHHHTSGGG",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "yelleklGsGsfGkVykakkkktgk...kvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "FELLKVLGQGSFGKVFLVKKISGSDarqLYAMKVLKKATLKVRDRVRTKMERDILVEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHSLGIIYRDLKPENILLDEEGHIKLTDFGLSKESIDHEKKAYSFCGTVEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGTLPFQGK---DRKETMTMILKAKLGMPQFLS----PEAQSLLRMLFKRNPANRLGagpdgVEEIKRHSFF",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "67899**********8888876655455****************999999****************************************************************************************************9***********************.******************************...999999999999988888866....9******************9888888999999886",
+            hsp.aln_annotation["PP"],
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -2239,14 +2478,22 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(679, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.97, hsp.acc_avg)
-        self.assertEqual("EEEEEEEEEETTEEEEEEEETTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHH.SSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEE....EE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTTHHHHHTSGGG",
-                         hsp.aln_annotation["CS"])
-        self.assertEqual("yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
-                         str(hsp.query.seq))
-        self.assertEqual("YEVKEDIGVGSYSVCKRCIHKATNMEFAVKIIDKSKRDPTE------EIEILLRYgQHPNIITLKDVYDDGKYVYVVTELMKGGELLDKILRQKFFSEREASAVLFTITKTVEYLHAQGVVHRDLKPSNILYVDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDIWSLGVLLYTMLTGYTPFANGPDDTPEEILARIGSGKFSLSGGYWNSVSDTAKDLVSKMLHVDPHQRLTAALVLRHPWI",
-                         str(hsp.hit.seq))
-        self.assertEqual("7899***********************************88......9*******99**********************************9***************************************98554444888**********************************.***************************************************************************************7",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "EEEEEEEEEETTEEEEEEEETTTTEEEEEEEEEHHHCCCCCCHHHHHHHHHHHHH.SSSSB--EEEEEEETTEEEEEEE--TS-BHHHHHHHHHST-HHHHHHHHHHHHHHHHHHHHTTEE-S--SGGGEEEETTTEE....EE--GTT.E..EECSS-C-S--S-GGGS-HHHHCCS-CTHHHHHHHHHHHHHHHHHHSS-TTSSSHHCCTHHHHSSHHH......TTS.....HHHHHHHHHHT-SSGGGSTTHHHHHTSGGG",
+            hsp.aln_annotation["CS"],
+        )
+        self.assertEqual(
+            "yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
+            str(hsp.query.seq),
+        )
+        self.assertEqual(
+            "YEVKEDIGVGSYSVCKRCIHKATNMEFAVKIIDKSKRDPTE------EIEILLRYgQHPNIITLKDVYDDGKYVYVVTELMKGGELLDKILRQKFFSEREASAVLFTITKTVEYLHAQGVVHRDLKPSNILYVDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDIWSLGVLLYTMLTGYTPFANGPDDTPEEILARIGSGKFSLSGGYWNSVSDTAKDLVSKMLHVDPHQRLTAALVLRHPWI",
+            str(hsp.hit.seq),
+        )
+        self.assertEqual(
+            "7899***********************************88......9*******99**********************************9***************************************98554444888**********************************.***************************************************************************************7",
+            hsp.aln_annotation["PP"],
+        )
 
         # test if we've properly finished iteration
         self.assertRaises(StopIteration, next, qresults)
@@ -2265,8 +2512,10 @@ class PhmmerCases(unittest.TestCase):
         qresult = qresults[0]
 
         self.assertEqual("phmmer", qresult.program)
-        self.assertEqual("/home/bow/devel/sandbox/biopython-sandbox/db/hmmer/protdb/uniprot_sprot.fasta",
-                         qresult.target)
+        self.assertEqual(
+            "/home/bow/devel/sandbox/biopython-sandbox/db/hmmer/protdb/uniprot_sprot.fasta",
+            qresult.target,
+        )
         self.assertEqual("3.1b2", qresult.version)
         self.assertEqual("sp|Q6GZX4|001R_FRG3G", qresult.id)
         self.assertEqual(256, qresult.seq_len)
@@ -2274,8 +2523,10 @@ class PhmmerCases(unittest.TestCase):
 
         hit = qresult[0]
         self.assertEqual("sp|Q6GZX4|001R_FRG3G", hit.id)
-        self.assertEqual("Putative transcription factor 001R OS=Frog virus 3 (isolate Goorha) GN=FV3-001R PE=4 SV=1",
-                         hit.description)
+        self.assertEqual(
+            "Putative transcription factor 001R OS=Frog virus 3 (isolate Goorha) GN=FV3-001R PE=4 SV=1",
+            hit.description,
+        )
         self.assertTrue(hit.is_included)
         self.assertEqual(1.1e-176, hit.evalue)
         self.assertEqual(590.0, hit.bitscore)
@@ -2301,19 +2552,27 @@ class PhmmerCases(unittest.TestCase):
         self.assertEqual(256, hsp.env_end)
         self.assertEqual("[]", hsp.env_endtype)
         self.assertEqual(1.00, hsp.acc_avg)
-        self.assertEqual("mafsaedvlkeydrrrrmealllslyypndrklldykewspprvqvecpkapvewnnppsekglivghfsgikykgekaqasevdvnkm",
-                         str(hsp.query.seq)[:89])
-        self.assertEqual("MAFSAEDVLKEYDRRRRMEALLLSLYYPNDRKLLDYKEWSPPRVQVECPKAPVEWNNPPSEKGLIVGHFSGIKYKGEKAQASEVDVNKM",
-                         str(hsp.hit.seq)[:89])
-        self.assertEqual("89***************************************************************************************",
-                         hsp.aln_annotation["PP"][:89])
+        self.assertEqual(
+            "mafsaedvlkeydrrrrmealllslyypndrklldykewspprvqvecpkapvewnnppsekglivghfsgikykgekaqasevdvnkm",
+            str(hsp.query.seq)[:89],
+        )
+        self.assertEqual(
+            "MAFSAEDVLKEYDRRRRMEALLLSLYYPNDRKLLDYKEWSPPRVQVECPKAPVEWNNPPSEKGLIVGHFSGIKYKGEKAQASEVDVNKM",
+            str(hsp.hit.seq)[:89],
+        )
+        self.assertEqual(
+            "89***************************************************************************************",
+            hsp.aln_annotation["PP"][:89],
+        )
 
         # last query, last hit
         qresult = qresults[-1]
 
         self.assertEqual("phmmer", qresult.program)
-        self.assertEqual("/home/bow/devel/sandbox/biopython-sandbox/db/hmmer/protdb/uniprot_sprot.fasta",
-                         qresult.target)
+        self.assertEqual(
+            "/home/bow/devel/sandbox/biopython-sandbox/db/hmmer/protdb/uniprot_sprot.fasta",
+            qresult.target,
+        )
         self.assertEqual("3.1b2", qresult.version)
         self.assertEqual("sp|Q197F7|003L_IIV3", qresult.id)
         self.assertEqual(156, qresult.seq_len)
@@ -2321,7 +2580,10 @@ class PhmmerCases(unittest.TestCase):
 
         hit = qresult[-1]
         self.assertEqual("sp|P04060|RNAS1_HYSCR", hit.id)
-        self.assertEqual("Ribonuclease pancreatic OS=Hystrix cristata GN=RNASE1 PE=1 SV=1", hit.description)
+        self.assertEqual(
+            "Ribonuclease pancreatic OS=Hystrix cristata GN=RNASE1 PE=1 SV=1",
+            hit.description,
+        )
         self.assertFalse(hit.is_included)
         self.assertEqual(2.1, hit.evalue)
         self.assertEqual(13.1, hit.bitscore)
@@ -2347,12 +2609,9 @@ class PhmmerCases(unittest.TestCase):
         self.assertEqual(127, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.84, hsp.acc_avg)
-        self.assertEqual("cpqswygspqlereivckmsgaphypnyyp",
-                         str(hsp.query.seq))
-        self.assertEqual("YPDCSYGMSQLERSIVVACEGSPYVPVHFD",
-                         str(hsp.hit.seq))
-        self.assertEqual("68889******************9887764",
-                         hsp.aln_annotation["PP"])
+        self.assertEqual("cpqswygspqlereivckmsgaphypnyyp", str(hsp.query.seq))
+        self.assertEqual("YPDCSYGMSQLERSIVVACEGSPYVPVHFD", str(hsp.hit.seq))
+        self.assertEqual("68889******************9887764", hsp.aln_annotation["PP"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_SearchIO_h* files, 6 files changed.
test_SearchIO_hhsuite2_text.py
test_SearchIO_hmmer2_text.py
test_SearchIO_hmmer3_domtab.py
test_SearchIO_hmmer3_domtab_index.py
test_SearchIO_hmmer3_tab.py
test_SearchIO_hmmer3_text.py