### PR TITLE
Apply black style to test_SearchIO_* last files, version 19.10b0.

### DIFF
--- a/Tests/test_SearchIO_interproscan_xml.py
+++ b/Tests/test_SearchIO_interproscan_xml.py
@@ -24,7 +24,6 @@ def get_file(filename):
 
 
 class InterproscanXmlCases(unittest.TestCase):
-
     def test_xml_001(self):
         xml_file = get_file("test_001.xml")
         qresults = parse(xml_file, FMT)
@@ -38,13 +37,19 @@ class InterproscanXmlCases(unittest.TestCase):
 
         # test parsed values of qresult
         self.assertEqual("AT5G23090.4", qresult.id)
-        self.assertEqual("pacid=19665592 transcript=AT5G23090.4 locus=AT5G23090 ID=AT5G23090.4.TAIR10 annot-version=TAIR10",
-                         qresult.description)
+        self.assertEqual(
+            "pacid=19665592 transcript=AT5G23090.4 locus=AT5G23090 "
+            "ID=AT5G23090.4.TAIR10 annot-version=TAIR10",
+            qresult.description,
+        )
         self.assertEqual(4, len(qresult))
 
         hit = qresult[0]
         self.assertEqual("PF00808", hit.id)
-        self.assertEqual("Histone-like transcription factor (CBF/NF-Y) and archaeal histone", hit.description)
+        self.assertEqual(
+            "Histone-like transcription factor (CBF/NF-Y) and archaeal histone",
+            hit.description,
+        )
         self.assertEqual("PFAM", hit.attributes["Target"])
         self.assertEqual("31.0", hit.attributes["Target version"])
         self.assertEqual("hmmer3", hit.attributes["Hit type"])
@@ -58,7 +63,12 @@ class InterproscanXmlCases(unittest.TestCase):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(65, hsp.hit_end)
         self.assertEqual(66, hsp.aln_span)
-        self.assertEqual("MDPMDIVGKSKEDASLPKATMTKIIKEMLPPDVRVARDAQDLLIECCVEFINLVSSESNDVCNKEDKRTIAPEHVLKALQVLGFGEYIEEVYAAYEQHKYETMDTQRSVKWNPGAQMTEEEAAAEQQRMFAEARARMNGGVSVPQPEHPETDQRSPQS", str(hsp.query.seq))
+        self.assertEqual(
+            "MDPMDIVGKSKEDASLPKATMTKIIKEMLPPDVRVARDAQDLLIECCVEFINLVSSESNDVCNKEDKRTIAPEH"
+            "VLKALQVLGFGEYIEEVYAAYEQHKYETMDTQRSVKWNPGAQMTEEEAAAEQQRMFAEARARMNGGVSVPQPEH"
+            "PETDQRSPQS",
+            str(hsp.query.seq),
+        )
 
         # parse last hit
         hit = qresult[-1]

--- a/Tests/test_SearchIO_legacy.py
+++ b/Tests/test_SearchIO_legacy.py
@@ -14,6 +14,7 @@ from io import StringIO
 
 import warnings
 from Bio import BiopythonWarning
+
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", BiopythonWarning)
     from Bio.SearchIO._legacy import ParserSupport
@@ -80,7 +81,6 @@ file"""
 
 
 class TestParserSupport(unittest.TestCase):
-
     def test_TaggingConsumer(self):
 
         h = StringIO()

--- a/Tests/test_SearchIO_model.py
+++ b/Tests/test_SearchIO_model.py
@@ -56,7 +56,6 @@ hit12 = Hit([hsp121])
 
 
 class QueryResultCases(unittest.TestCase):
-
     def setUp(self):
         self.qresult = QueryResult([hit11, hit21, hit31], "query1")
         # set mock attributes
@@ -99,8 +98,7 @@ class QueryResultCases(unittest.TestCase):
 
     def test_repr(self):
         """Test QueryResult.__repr__."""
-        self.assertEqual("QueryResult(id='query1', 3 hits)",
-                         repr(self.qresult))
+        self.assertEqual("QueryResult(id='query1', 3 hits)", repr(self.qresult))
 
     def test_iter(self):
         """Test QueryResult.__iter__."""
@@ -125,22 +123,32 @@ class QueryResultCases(unittest.TestCase):
         """Test QueryResult.items."""
         # items should return tuples of hit key, hit object pair
         items = list(self.qresult.items)
-        self.assertEqual([("hit1", hit11), ("hit2", hit21),
-                         ("hit3", hit31)], items)
+        self.assertEqual([("hit1", hit11), ("hit2", hit21), ("hit3", hit31)], items)
 
     def test_hsps(self):
         """Test QueryResult.hsps."""
         # hsps should return all hsps contained in qresult
         hsps = self.qresult.hsps
-        self.assertEqual([hsp111, hsp112, hsp113, hsp114, hsp211, hsp311,
-                         hsp312, ], hsps)
+        self.assertEqual([hsp111, hsp112, hsp113, hsp114, hsp211, hsp311, hsp312], hsps)
 
     def test_fragments(self):
         """Test QueryResult.fragments."""
         # fragments should return all fragments contained in qresult
         frags = self.qresult.fragments
-        self.assertEqual([frag111, frag112, frag113, frag113b, frag114,
-                         frag114b, frag211, frag311, frag312], frags)
+        self.assertEqual(
+            [
+                frag111,
+                frag112,
+                frag113,
+                frag113b,
+                frag114,
+                frag114b,
+                frag211,
+                frag311,
+                frag312,
+            ],
+            frags,
+        )
 
     def test_contains(self):
         """Test QueryResult.__contains__."""
@@ -233,8 +241,9 @@ class QueryResultCases(unittest.TestCase):
         """Test QueryResult.__setitem__, wrong key type."""
         # item assignment should fail if the key is not string
         self.assertRaises(TypeError, self.qresult.__setitem__, 0, hit41)
-        self.assertRaises(TypeError, self.qresult.__setitem__, slice(0, 2),
-                          [hit41, hit31])
+        self.assertRaises(
+            TypeError, self.qresult.__setitem__, slice(0, 2), [hit41, hit31]
+        )
 
     def test_setitem_wrong_type(self):
         """Test QueryResult.__setitem__, wrong type."""
@@ -420,8 +429,7 @@ class QueryResultCases(unittest.TestCase):
         self.assertEqual([hit11, hit21, hit31], list(self.qresult.hits))
         self.qresult.absorb(hit41)
         self.assertEqual([hit11, hit21, hit31, hit41], list(self.qresult.hits))
-        self.assertEqual(["hit1", "hit2", "hit3", "hit4"],
-                         list(self.qresult.hit_keys))
+        self.assertEqual(["hit1", "hit2", "hit3", "hit4"], list(self.qresult.hit_keys))
 
     def test_absorb_hit_exists(self):
         """Test QueryResult.absorb, hit with the same ID exists."""
@@ -442,8 +450,7 @@ class QueryResultCases(unittest.TestCase):
         self.assertEqual([hit11, hit21, hit31], list(self.qresult.hits))
         self.qresult.append(hit41)
         self.assertEqual([hit11, hit21, hit31, hit41], list(self.qresult.hits))
-        self.assertEqual(["hit1", "hit2", "hit3", "hit4"],
-                         list(self.qresult.hit_keys))
+        self.assertEqual(["hit1", "hit2", "hit3", "hit4"], list(self.qresult.hit_keys))
 
     def test_append_custom_hit_key_function_ok(self):
         """Test QueryResult.append, with custom hit key function."""
@@ -451,8 +458,9 @@ class QueryResultCases(unittest.TestCase):
         # append should assign hit keys according to _hit_key_function
         self.assertEqual(["hit1", "hit2", "hit3"], list(self.qresult.hit_keys))
         self.qresult.append(hit41)
-        self.assertEqual(["hit1", "hit2", "hit3", "hit4_custom"],
-                         list(self.qresult.hit_keys))
+        self.assertEqual(
+            ["hit1", "hit2", "hit3", "hit4_custom"], list(self.qresult.hit_keys)
+        )
 
     def test_append_id_exists(self):
         """Test QueryResult.append, when ID exists."""
@@ -558,11 +566,11 @@ class QueryResultCases(unittest.TestCase):
         self.assertNotIn("hit2", filtered)
         self.assertIn("hit3", filtered)
         # test hsps in hit11
-        self.assertTrue(all(hsp in filtered["hit1"] for hsp in
-                            [hsp111, hsp112, hsp114]))
+        self.assertTrue(
+            all(hsp in filtered["hit1"] for hsp in [hsp111, hsp112, hsp114])
+        )
         # test hsps in hit31
-        self.assertTrue(all(hsp in filtered["hit3"] for hsp in
-                            [hsp311, hsp312]))
+        self.assertTrue(all(hsp in filtered["hit3"] for hsp in [hsp311, hsp312]))
 
     def test_hsp_filter_no_func(self):
         """Test QueryResult.hsp_filter, no arguments."""
@@ -744,7 +752,6 @@ class QueryResultCases(unittest.TestCase):
 
 
 class HitCases(unittest.TestCase):
-
     def setUp(self):
         self.hit = Hit([hsp111, hsp112, hsp113])
         self.hit.evalue = 5e-10
@@ -784,8 +791,7 @@ class HitCases(unittest.TestCase):
     def test_repr(self):
         """Test Hit.__repr__."""
         # test for cases with 1 or other alignment numbers
-        self.assertEqual("Hit(id='hit1', query_id='query1', 3 hsps)",
-                         repr(self.hit))
+        self.assertEqual("Hit(id='hit1', query_id='query1', 3 hsps)", repr(self.hit))
 
     def test_hsps(self):
         """Test Hit.hsps."""
@@ -796,8 +802,7 @@ class HitCases(unittest.TestCase):
         """Test Hit.fragments."""
         # fragments should return the list of fragments in each hsps
         # as a flat list
-        self.assertEqual([frag111, frag112, frag113, frag113b],
-                         self.hit.fragments)
+        self.assertEqual([frag111, frag112, frag113, frag113b], self.hit.fragments)
 
     def test_iter(self):
         """Test Hit.__iter__."""
@@ -1052,7 +1057,6 @@ class HitCases(unittest.TestCase):
 
 
 class HSPSingleFragmentCases(unittest.TestCase):
-
     def setUp(self):
         self.frag = HSPFragment("hit_id", "query_id", "ATCAGT", "AT-ACT")
         self.frag.query_start = 0
@@ -1108,17 +1112,15 @@ class HSPSingleFragmentCases(unittest.TestCase):
         """Test HSP read-only properties."""
         read_onlies = ("range", "span", "strand", "frame", "start", "end")
         for seq_type in ("query", "hit"):
-            self.assertRaises(AttributeError, setattr,
-                              self.hsp, seq_type, "A")
+            self.assertRaises(AttributeError, setattr, self.hsp, seq_type, "A")
             for attr in read_onlies:
-                self.assertRaises(AttributeError, setattr,
-                                  self.hsp, "%s_%s" % (seq_type, attr), 5)
-        self.assertRaises(AttributeError, setattr,
-                          self.hsp, "aln", None)
+                self.assertRaises(
+                    AttributeError, setattr, self.hsp, "%s_%s" % (seq_type, attr), 5
+                )
+        self.assertRaises(AttributeError, setattr, self.hsp, "aln", None)
 
 
 class HSPMultipleFragmentCases(unittest.TestCase):
-
     def setUp(self):
         self.frag1 = HSPFragment("hit_id", "query_id", "ATCAGT", "AT-ACT")
         self.frag1.query_start = 0
@@ -1187,10 +1189,8 @@ class HSPMultipleFragmentCases(unittest.TestCase):
 
     def test_seqs(self):
         """Test HSP sequence properties."""
-        self.assertEqual(["ATCAGT", "GGG"], [str(x.seq) for x in
-                         self.hsp.hit_all])
-        self.assertEqual(["AT-ACT", "CCC"], [str(x.seq) for x in
-                         self.hsp.query_all])
+        self.assertEqual(["ATCAGT", "GGG"], [str(x.seq) for x in self.hsp.hit_all])
+        self.assertEqual(["AT-ACT", "CCC"], [str(x.seq) for x in self.hsp.query_all])
 
     def test_id_desc_set(self):
         """Test HSP query and hit id and description setters."""
@@ -1207,7 +1207,9 @@ class HSPMultipleFragmentCases(unittest.TestCase):
                 else:
                     self.assertEqual(value, "<unknown description>")
                     for fragment in self.hsp:
-                        self.assertEqual(getattr(fragment, attr_name), "<unknown description>")
+                        self.assertEqual(
+                            getattr(fragment, attr_name), "<unknown description>"
+                        )
                 new_value = "new_" + value
                 setattr(self.hsp, attr_name, new_value)
                 self.assertEqual(getattr(self.hsp, attr_name), new_value)
@@ -1255,18 +1257,15 @@ class HSPMultipleFragmentCases(unittest.TestCase):
         read_onlies = ("range_all", "strand_all", "frame_all")
         for seq_type in ("query", "hit"):
             for attr in read_onlies:
-                self.assertRaises(AttributeError, setattr,
-                                  self.hsp, "%s_%s" % (seq_type, attr), 5)
-        self.assertRaises(AttributeError, setattr,
-                          self.hsp, "aln_all", None)
-        self.assertRaises(AttributeError, setattr,
-                          self.hsp, "hit_all", None)
-        self.assertRaises(AttributeError, setattr,
-                          self.hsp, "query_all", None)
+                self.assertRaises(
+                    AttributeError, setattr, self.hsp, "%s_%s" % (seq_type, attr), 5
+                )
+        self.assertRaises(AttributeError, setattr, self.hsp, "aln_all", None)
+        self.assertRaises(AttributeError, setattr, self.hsp, "hit_all", None)
+        self.assertRaises(AttributeError, setattr, self.hsp, "query_all", None)
 
 
 class HSPFragmentWithoutSeqCases(unittest.TestCase):
-
     def setUp(self):
         self.fragment = HSPFragment("hit_id", "query_id")
 
@@ -1299,11 +1298,14 @@ class HSPFragmentWithoutSeqCases(unittest.TestCase):
     def test_repr(self):
         """Test HSPFragment.__repr__, no alignments."""
         # test for minimum repr
-        self.assertEqual("HSPFragment(hit_id='hit_id', query_id='query_id')",
-                         repr(self.fragment))
+        self.assertEqual(
+            "HSPFragment(hit_id='hit_id', query_id='query_id')", repr(self.fragment)
+        )
         self.fragment.aln_span = 5
-        self.assertEqual("HSPFragment(hit_id='hit_id', query_id='query_id', "
-                         "5 columns)", repr(self.fragment))
+        self.assertEqual(
+            "HSPFragment(hit_id='hit_id', query_id='query_id', 5 columns)",
+            repr(self.fragment),
+        )
 
     def test_getitem(self):
         """Test HSPFragment.__getitem__, no alignments."""
@@ -1330,10 +1332,10 @@ class HSPFragmentWithoutSeqCases(unittest.TestCase):
 
 
 class HSPFragmentCases(unittest.TestCase):
-
     def setUp(self):
-        self.fragment = HSPFragment("hit_id", "query_id", "ATGCTAGCTACA",
-                                    "ATG--AGCTAGG")
+        self.fragment = HSPFragment(
+            "hit_id", "query_id", "ATGCTAGCTACA", "ATG--AGCTAGG"
+        )
 
     def test_pickle(self):
         """Test pickling and unpickling of HSPFragment."""
@@ -1357,8 +1359,9 @@ class HSPFragmentCases(unittest.TestCase):
         # init should only work with string or seqrecords
         wrong_query = Seq("ATGC")
         wrong_hit = Seq("ATGC")
-        self.assertRaises(TypeError, HSPFragment, "hit_id", "query_id",
-                          wrong_hit, wrong_query)
+        self.assertRaises(
+            TypeError, HSPFragment, "hit_id", "query_id", wrong_hit, wrong_query
+        )
 
     def test_seqmodel(self):
         """Test HSPFragment sequence attribute types and default values."""
@@ -1410,8 +1413,10 @@ class HSPFragmentCases(unittest.TestCase):
     def test_repr(self):
         """Test HSPFragment.__repr__."""
         # test for minimum repr
-        self.assertEqual("HSPFragment(hit_id='hit_id', query_id='query_id', "
-                         "12 columns)", repr(self.fragment))
+        self.assertEqual(
+            "HSPFragment(hit_id='hit_id', query_id='query_id', 12 columns)",
+            repr(self.fragment),
+        )
 
     def test_getitem(self):
         """Test HSPFragment.__getitem__."""
@@ -1564,8 +1569,13 @@ class HSPFragmentCases(unittest.TestCase):
         read_onlies = ("range", "span")
         for seq_type in ("query", "hit"):
             for attr in read_onlies:
-                self.assertRaises(AttributeError, setattr,
-                                  self.fragment, "%s_%s" % (seq_type, attr), 5)
+                self.assertRaises(
+                    AttributeError,
+                    setattr,
+                    self.fragment,
+                    "%s_%s" % (seq_type, attr),
+                    5,
+                )
 
 
 if __name__ == "__main__":

--- a/Tests/test_SearchIO_write.py
+++ b/Tests/test_SearchIO_write.py
@@ -14,23 +14,23 @@ from search_tests_common import compare_search_obj
 
 
 class WriteCases(unittest.TestCase):
-
     def tearDown(self):
         if os.path.exists(self.out):
             os.remove(self.out)
 
-    def parse_write_and_compare(self, source_file, source_format, out_file,
-                                out_format, **kwargs):
+    def parse_write_and_compare(
+        self, source_file, source_format, out_file, out_format, **kwargs
+    ):
         """Compare parsed QueryResults after they have been written to a file."""
-        source_qresults = list(SearchIO.parse(source_file, source_format,
-                               **kwargs))
+        source_qresults = list(SearchIO.parse(source_file, source_format, **kwargs))
         SearchIO.write(source_qresults, out_file, out_format, **kwargs)
         out_qresults = list(SearchIO.parse(out_file, out_format, **kwargs))
         for source, out in zip(source_qresults, out_qresults):
             self.assertTrue(compare_search_obj(source, out))
 
-    def read_write_and_compare(self, source_file, source_format, out_file,
-                               out_format, **kwargs):
+    def read_write_and_compare(
+        self, source_file, source_format, out_file, out_format, **kwargs
+    ):
         """Compare read QueryResults after it has been written to a file."""
         source_qresult = SearchIO.read(source_file, source_format, **kwargs)
         SearchIO.write(source_qresult, out_file, out_format, **kwargs)
@@ -74,26 +74,70 @@ class BlastTabWriteCases(WriteCases):
     def test_write_single_from_blasttabc(self):
         """Test blast-tabc writing from blast-tabc, BLAST 2.2.26+, single query (tab_2226_tblastn_008.txt)."""
         source = os.path.join("Blast", "tab_2226_tblastn_008.txt")
-        self.parse_write_and_compare(source, self.fmt, self.out, self.fmt, comments=True)
+        self.parse_write_and_compare(
+            source, self.fmt, self.out, self.fmt, comments=True
+        )
         self.read_write_and_compare(source, self.fmt, self.out, self.fmt, comments=True)
 
     def test_write_multiple_from_blasttabc(self):
         """Test blast-tabc writing from blast-tabc, BLAST 2.2.26+, multiple queries (tab_2226_tblastn_005.txt)."""
         source = os.path.join("Blast", "tab_2226_tblastn_005.txt")
-        self.parse_write_and_compare(source, self.fmt, self.out, self.fmt, comments=True)
+        self.parse_write_and_compare(
+            source, self.fmt, self.out, self.fmt, comments=True
+        )
 
     def test_write_multiple_from_blasttabc_allfields(self):
         """Test blast-tabc writing from blast-tabc, BLAST 2.2.28+, multiple queries (tab_2228_tblastx_001.txt)."""
         source = os.path.join("Blast", "tab_2228_tblastx_001.txt")
-        fields = ["qseqid", "qgi", "qacc", "qaccver", "qlen", "sseqid",
-                  "sallseqid", "sgi", "sallgi", "sacc", "saccver", "sallacc",
-                  "slen", "qstart", "qend", "sstart", "send", "qseq", "sseq",
-                  "evalue", "bitscore", "score", "length", "pident", "nident",
-                  "mismatch", "positive", "gapopen", "gaps", "ppos", "frames",
-                  "qframe", "sframe", "btop", "staxids", "sscinames",
-                  "scomnames", "sblastnames", "sskingdoms", "stitle",
-                  "salltitles", "sstrand", "qcovs", "qcovhsp"]
-        self.parse_write_and_compare(source, self.fmt, self.out, self.fmt, comments=True, fields=fields)
+        fields = [
+            "qseqid",
+            "qgi",
+            "qacc",
+            "qaccver",
+            "qlen",
+            "sseqid",
+            "sallseqid",
+            "sgi",
+            "sallgi",
+            "sacc",
+            "saccver",
+            "sallacc",
+            "slen",
+            "qstart",
+            "qend",
+            "sstart",
+            "send",
+            "qseq",
+            "sseq",
+            "evalue",
+            "bitscore",
+            "score",
+            "length",
+            "pident",
+            "nident",
+            "mismatch",
+            "positive",
+            "gapopen",
+            "gaps",
+            "ppos",
+            "frames",
+            "qframe",
+            "sframe",
+            "btop",
+            "staxids",
+            "sscinames",
+            "scomnames",
+            "sblastnames",
+            "sskingdoms",
+            "stitle",
+            "salltitles",
+            "sstrand",
+            "qcovs",
+            "qcovhsp",
+        ]
+        self.parse_write_and_compare(
+            source, self.fmt, self.out, self.fmt, comments=True, fields=fields
+        )
 
 
 class HmmerTabWriteCases(WriteCases):


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to the last files of test_SearchIO_*, with that black style has been applied to all test_SearchIO files. it should be fine to merge.

test_SearchIO_interproscan_xml.py
test_SearchIO_legacy.py
test_SearchIO_model.py
test_SearchIO_write.py
