### PR TITLE
remove meaningless test

### DIFF
--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -524,12 +524,6 @@ class TestWriteRead(unittest.TestCase):
                    ["fastq", "fastq-sanger", "fastq-illumina", "fastq-solexa",
                     "fasta", "qual", "phd"])
 
-    def test_example_qual(self):
-        """Write and read back example.qual."""
-        self.check(os.path.join("Quality", "example.qual"), "qual",
-                   ["fastq", "fastq-sanger", "fastq-illumina", "fastq-solexa",
-                    "fasta", "qual", "phd"])
-
     def test_solexa_faked(self):
         """Write and read back solexa_faked.fastq."""
         self.check(os.path.join("Quality", "solexa_faked.fastq"), "fastq-solexa",


### PR DESCRIPTION
This pull request removes one test from `test_SeqIO_QualityIO.py` as it does not seem to be meaningful:

```python
    def test_example_qual(self):
        """Write and read back example.qual."""
        self.check(os.path.join("Quality", "example.qual"), "qual",
                   ["fastq", "fastq-sanger", "fastq-illumina", "fastq-solexa",
                    "fasta", "qual", "phd"])

```

This test reads in `example.qual` in the `"qual"` format, writes it out in each of the seven formats, and reads it back in to compare with the record read in the `"qual"` format.

However, none of these formats can interpret the "example.qual" file, and the records all reduce to
```
UnknownSeq(25, alphabet=SingleLetterAlphabet(), character='?')
```

It would be better if the parser raises a ValueError when attempting to read the "example.qual" file in one of these formats.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
