### PR TITLE
Simplified math in SeqUtils.IsoelectricPoint

### DIFF
--- a/Bio/SeqUtils/IsoelectricPoint.py
+++ b/Bio/SeqUtils/IsoelectricPoint.py
@@ -118,14 +118,12 @@ class IsoelectricPoint:
     def _chargeR(self, pH):
         positive_charge = 0.0
         for aa, pK in self.pos_pKs.items():
-            CR = 10 ** (pK - pH)
-            partial_charge = CR / (CR + 1.0)
+            partial_charge = 1.0 / (10 ** (pH - pK) + 1.0)
             positive_charge += self.charged_aas_content[aa] * partial_charge
 
         negative_charge = 0.0
         for aa, pK in self.neg_pKs.items():
-            CR = 10 ** (pH - pK)
-            partial_charge = CR / (CR + 1.0)
+            partial_charge = 1.0 / (10 ** (pK - pH) + 1.0)
             negative_charge += self.charged_aas_content[aa] * partial_charge
 
         return positive_charge - negative_charge

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -263,6 +263,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Thomas Schmitt <https://github.com/wurstbonbon>
 - Thomas Sicheritz-Ponten <thomas at domain cbs.dtu.dk>
 - Tiago Antao <https://github.com/tiagoantao>
+- Tianyi Shi <https://github.com/TianyiShi2001>
 - Tyghe Vallard <https://github.com/necrolyte2>
 - Uri Laserson <https://github.com/laserson>
 - Uwe Schmitt <https://github.com/uweschmitt>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -47,6 +47,7 @@ possible, especially the following contributors:
 - Rob Miller
 - Sergio Valqui
 - Sujan Dulal (first contribution)
+- Tianyi Shi (first contribution)
 
 20 December 2019: Biopython 1.76
 ================================


### PR DESCRIPTION
Simplified math. No need to stick to the 'CR' described by [David L. Tabb](http://fields.scripps.edu/DTASelect/20010710-pI-Algorithm.pdf). 

This improves speed by ~5% without compromising readability. 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)