### PR TITLE
allow FastaIO and SeqXmlIO to open a file for writing

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -252,12 +252,11 @@ class FastaWriter(SequentialSequenceWriter):
     ``Bio.SeqIO.write()`` function instead using ``format="fasta"``.
     """
 
-    def __init__(self, handle, wrap=60, record2title=None):
+    def __init__(self, target, wrap=60, record2title=None):
         """Create a Fasta writer (OBSOLETE).
 
         Arguments:
-         - handle - Handle to an output file, e.g. as returned
-           by open(filename, "w")
+         - target - Output stream opened in text mode, or a path to a file.
          - wrap -   Optional line length used to wrap sequence lines.
            Defaults to wrapping the sequence at 60 characters
            Use zero (or None) for no wrapping, giving a single
@@ -287,8 +286,7 @@ class FastaWriter(SequentialSequenceWriter):
             handle.close()
 
         """
-        SequentialSequenceWriter.__init__(self, handle)
-        self.wrap = None
+        SequentialSequenceWriter.__init__(self, target)
         if wrap:
             if wrap < 1:
                 raise ValueError

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -481,16 +481,23 @@ class SeqXmlWriter(SequentialSequenceWriter):
     """
 
     def __init__(
-        self, handle, source=None, source_version=None, species=None, ncbiTaxId=None
+        self, target, source=None, source_version=None, species=None, ncbiTaxId=None
     ):
-        """Create Object and start the xml generator."""
-        try:
-            handle.write(b"")
-        except TypeError:
-            raise ValueError("SeqXML files must be opened in binary mode.")
+        """Create Object and start the xml generator.
 
-        SequentialSequenceWriter.__init__(self, handle)
+        Arguments:
+         - target - Output stream opened in text mode, or a path to a file.
+         - source - The source program/database of the file, for example
+           UniProt.
+         - source_version - The version or release number of the source
+           program or database from which the data originated.
+         - species - The scientific name of the species of origin of all
+           entries in the file.
+         - ncbiTaxId - The NCBI taxonomy identifier of the species of origin.
 
+        """
+        SequentialSequenceWriter.__init__(self, target, "wb")
+        handle = self.handle
         self.xml_generator = XMLGenerator(handle, "utf-8")
         self.xml_generator.startDocument()
         self.source = source
@@ -501,7 +508,6 @@ class SeqXmlWriter(SequentialSequenceWriter):
     def write_header(self):
         """Write root node with document metadata."""
         SequentialSequenceWriter.write_header(self)
-
         attrs = {
             "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
             "xsi:noNamespaceSchemaLocation": "http://www.seqxml.org/0.4/seqxml.xsd",


### PR DESCRIPTION
This pull request allows `Bio.SeqIO.FastaIO` and `Bio.SeqIO.SeqXmlIO` to open a file for writing. Most of the work is done in `Bio.SeqIO.Interfaces`. Other writers to follow.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
