### PR TITLE
python3 updates to test_AlignIO_MauveIO

### DIFF
--- a/Tests/test_AlignIO_MauveIO.py
+++ b/Tests/test_AlignIO_MauveIO.py
@@ -22,12 +22,11 @@ class TestMauveIO(unittest.TestCase):
     SIMPLE_FA = os.path.join(MAUVE_TEST_DATA_DIR, "simple.fa")
 
     def test_one(self):
-        handle = open(self.SIMPLE_XMFA)
         ids = []
-        for alignment in MauveIterator(handle):
-            for record in alignment:
-                ids.append(record.id)
-        handle.close()
+        with open(self.SIMPLE_XMFA) as handle:
+            for alignment in MauveIterator(handle):
+                for record in alignment:
+                    ids.append(record.id)
 
         self.assertEqual(ids, ["1/0-5670", "2/0-5670", "1/5670-9940", "2/7140-11410", "1/9940-14910", "2/5670-7140", "2/11410-12880"])
 
@@ -60,13 +59,11 @@ class TestMauveIO(unittest.TestCase):
                          expected.replace(" ", "").replace("\n", ""))
 
     def test_sequence_positions(self):
-        handle = open(self.SIMPLE_FA)
-        seqs = list(SeqIO.parse(handle, "fasta"))
-        handle.close()
+        with open(self.SIMPLE_FA) as handle:
+            seqs = list(SeqIO.parse(handle, "fasta"))
 
-        handle = open(self.SIMPLE_XMFA)
-        aln_list = list(MauveIterator(handle))
-        handle.close()
+        with open(self.SIMPLE_XMFA) as handle:
+            aln_list = list(MauveIterator(handle))
 
         for aln in aln_list:
             for record in aln:
@@ -90,9 +87,8 @@ class TestMauveIO(unittest.TestCase):
                     self.assertEqual(expected, actual)
 
     def test_write_read(self):
-        handle = open(self.SIMPLE_XMFA)
-        aln_list = list(MauveIterator(handle))
-        handle.close()
+        with open(self.SIMPLE_XMFA) as handle:
+            aln_list = list(MauveIterator(handle))
 
         handle = StringIO()
         MauveWriter(handle).write_file(aln_list)


### PR DESCRIPTION
This pull request updates test_AlignIO_MauveIO.py for python3.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
