### PR TITLE
updates to Bio.Graphics tests for python3

### DIFF
--- a/Tests/test_ColorSpiral.py
+++ b/Tests/test_ColorSpiral.py
@@ -20,7 +20,7 @@ try:
     from reportlab.lib.pagesizes import A4
 except ImportError:
     raise MissingPythonDependencyError(
-        "Install reportlab if you want to use Bio.Graphics.")
+        "Install reportlab if you want to use Bio.Graphics.") from None
 
 
 # Biopython Bio.Graphics.ColorSpiral

--- a/Tests/test_GenomeDiagram.py
+++ b/Tests/test_GenomeDiagram.py
@@ -19,7 +19,7 @@ try:
     from reportlab.lib.units import cm
 except ImportError:
     raise MissingPythonDependencyError(
-        "Install reportlab if you want to use Bio.Graphics.")
+        "Install reportlab if you want to use Bio.Graphics.") from None
 
 try:
     # The preferred PIL import has changed over time...

--- a/Tests/test_GraphicsBitmaps.py
+++ b/Tests/test_GraphicsBitmaps.py
@@ -92,18 +92,18 @@ def real_test():
     except OSError as err:
         if "encoder zip not available" in str(err):
             raise MissingExternalDependencyError(
-                "Check zip encoder installed for PIL and ReportLab renderPM")
+                "Check zip encoder installed for PIL and ReportLab renderPM") from None
         else:
-            raise err
+            raise
     except RenderPMError as err:
         if str(err).startswith("Can't setFont("):
             # TODO - can we raise the error BEFORE the unit test function
             # is run? That way it can be skipped in run_tests.py
             raise MissingExternalDependencyError(
                 "Check the fonts needed by ReportLab if you want "
-                "bitmaps from Bio.Graphics\n" + str(err))
+                "bitmaps from Bio.Graphics\n" + str(err)) from None
         else:
-            raise err
+            raise
 
     return True
 

--- a/Tests/test_KGML_graphics.py
+++ b/Tests/test_KGML_graphics.py
@@ -23,7 +23,7 @@ try:
     from reportlab.lib.colors import HexColor
 except ImportError:
     raise MissingExternalDependencyError(
-        "Install reportlab if you want to use Bio.Graphics.")
+        "Install reportlab if you want to use Bio.Graphics.") from None
 
 try:
     c = HexColor("#8080F780")
@@ -32,7 +32,7 @@ except TypeError:
     # unsupported operand type(s) for &: 'int' and 'float'
     # ReportLab 2.7+ also offers hasAlpha=True rather than alpha=True
     raise MissingExternalDependencyError(
-        "Install at least reportlab 2.7 for transparency support.")
+        "Install at least reportlab 2.7 for transparency support.") from None
 
 # Do we have PIL?
 try:
@@ -40,7 +40,7 @@ try:
 except ImportError:
     raise MissingExternalDependencyError(
         "Install Pillow or its predecessor PIL (Python Imaging Library) "
-        "if you want to use bitmaps from KGML.")
+        "if you want to use bitmaps from KGML.") from None
 
 
 # Biopython Bio.KEGG.KGML

--- a/Tests/test_KGML_graphics_online.py
+++ b/Tests/test_KGML_graphics_online.py
@@ -21,7 +21,7 @@ try:
     from reportlab.lib.pagesizes import A4
 except ImportError:
     raise MissingExternalDependencyError(
-        "Install reportlab if you want to use Bio.Graphics.")
+        "Install reportlab if you want to use Bio.Graphics.") from None
 
 # Do we have PIL?
 try:
@@ -29,7 +29,7 @@ try:
 except ImportError:
     raise MissingExternalDependencyError(
         "Install Pillow or its predecessor PIL (Python Imaging Library) "
-        "if you want to use bitmaps from KGML.")
+        "if you want to use bitmaps from KGML.") from None
 
 
 # Biopython Bio.KEGG.KGML


### PR DESCRIPTION
This pull request updates Bio.Graphics tests for python3.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
