### PR TITLE
fix Emboss tests for python3, and one more mutli test in FastaIO

### DIFF
--- a/Tests/test_Emboss.py
+++ b/Tests/test_Emboss.py
@@ -291,7 +291,7 @@ class SeqRetSeqIOTests(unittest.TestCase):
                 raise ValueError(
                     "Disagree on file %s %s in %s format: %s"
                     % (in_format, in_filename, temp_format, err)
-                )
+                ) from None
 
     def check_EMBOSS_to_SeqIO(self, filename, old_format, skip_formats=()):
         """Check SeqIO can read read seqret's conversion output."""
@@ -310,7 +310,7 @@ class SeqRetSeqIOTests(unittest.TestCase):
                 raise ValueError(
                     "Disagree on %s file %s in %s format: %s"
                     % (old_format, filename, new_format, err)
-                )
+                ) from None
 
     def check_SeqIO_with_EMBOSS(
         self, filename, old_format, skip_formats=(), alphabet=None
@@ -415,7 +415,7 @@ class SeqRetAlignIOTests(unittest.TestCase):
                 raise ValueError(
                     "Can't parse %s file %s in %s format."
                     % (old_format, filename, new_format)
-                )
+                ) from None
             handle.close()
             try:
                 self.assertTrue(compare_alignments(old_aligns, new_aligns))
@@ -423,7 +423,7 @@ class SeqRetAlignIOTests(unittest.TestCase):
                 raise ValueError(
                     "Disagree on %s file %s in %s format: %s"
                     % (old_format, filename, new_format, err)
-                )
+                ) from None
 
     def check_AlignIO_to_EMBOSS(
         self, in_filename, in_format, skip_formats=(), alphabet=None
@@ -456,7 +456,7 @@ class SeqRetAlignIOTests(unittest.TestCase):
                 raise ValueError(
                     "Disagree on file %s %s in %s format: %s"
                     % (in_format, in_filename, temp_format, err)
-                )
+                ) from None
 
     def check_AlignIO_with_EMBOSS(
         self, filename, old_format, skip_formats=(), alphabet=None

--- a/Tests/test_EmbossPhylipNew.py
+++ b/Tests/test_EmbossPhylipNew.py
@@ -78,7 +78,8 @@ def parse_trees(filename):
     Helper function until we have Bio.Phylo on trunk.
     """
     # TODO - Can this be removed now?
-    data = open("test_file").read()
+    with open("test_file") as handle:
+        data = handle.read()
     for tree_str in data.split(";\n"):
         if tree_str:
             yield Trees.Tree(tree_str + ";")
@@ -183,8 +184,9 @@ class ParsimonyTests(unittest.TestCase):
                                          outtreefile="test_file",
                                          auto=True, stdout=True)
         stdout, stderr = cline()
-        a_taxa = [s.name.replace(" ", "_") for s in
-                  next(AlignIO.parse(open(filename), format))]
+        with open(filename) as handle:
+            a_taxa = [s.name.replace(" ", "_") for s in
+                      next(AlignIO.parse(handle, format))]
         for tree in parse_trees("test_file"):
             t_taxa = [t.replace(" ", "_") for t in tree.get_taxa()]
             self.assertEqual(sorted(a_taxa), sorted(t_taxa))
@@ -239,11 +241,13 @@ class BootstrapTests(unittest.TestCase):
                                     auto=True, filter=True)
         stdout, stderr = cline()
         # the resultant file should have 2 alignments...
-        bs = list(AlignIO.parse(open("test_file"), format))
+        with open("test_file") as handle:
+            bs = list(AlignIO.parse(handle, format))
         self.assertEqual(len(bs), 2)
         # ..and each name in the original alignment...
-        a_names = [s.name.replace(" ", "_") for s in
-                   AlignIO.read(open(filename), format)]
+        with open(filename) as handle:
+            a_names = [s.name.replace(" ", "_") for s in
+                       AlignIO.read(handle, format)]
         # ...should be in each alignment in the bootstrapped file
         for a in bs:
             self.assertEqual(a_names, [s.name.replace(" ", "_") for s in a])

--- a/Tests/test_EmbossPrimer.py
+++ b/Tests/test_EmbossPrimer.py
@@ -31,20 +31,17 @@ class Primer3ParseTest(unittest.TestCase):
         """Make sure that we can use all single target primer3 files."""
         for file in self.test_files:
             # First using read...
-            h = open(file)
-            Primer3.read(h)
-            h.close()
+            with open(file) as handle:
+                Primer3.read(handle)
             # Now using parse...
-            h = open(file)
-            self.assertEqual(1, len(list(Primer3.parse(h))))
-            h.close()
+            with open(file) as handle:
+                self.assertEqual(1, len(list(Primer3.parse(handle))))
 
     def test_indepth_regular_parse(self):
         """Make sure we get the data from normal primer3 files okay."""
         regular_file = self.test_files[0]
-        h = open(regular_file)
-        primer_info = Primer3.read(h)
-        h.close()
+        with open(regular_file) as handle:
+            primer_info = Primer3.read(handle)
 
         self.assertEqual(len(primer_info.primers), 5)
         self.assertEqual(primer_info.comments,
@@ -67,9 +64,8 @@ class Primer3ParseTest(unittest.TestCase):
     def test_in_depth_single_parse(self):
         """Make sure we get info right from a single primer find."""
         file = self.test_files[1]
-        h = open(file)
-        primer_info = Primer3.read(h)
-        h.close()
+        with open(file) as handle:
+            primer_info = Primer3.read(handle)
 
         self.assertEqual(len(primer_info.primers), 5)
         self.assertEqual(primer_info.comments,
@@ -85,9 +81,8 @@ class Primer3ParseTest(unittest.TestCase):
         """Make sure we can parse an internal oligo file correctly."""
         # these files are generated when designing hybridization probes.
         file = self.test_files[4]
-        h = open(file)
-        primer_info = Primer3.read(h)
-        h.close()
+        with open(file) as handle:
+            primer_info = Primer3.read(handle)
 
         self.assertEqual(len(primer_info.primers), 5)
         self.assertEqual(primer_info.comments,
@@ -99,11 +94,10 @@ class Primer3ParseTest(unittest.TestCase):
         self.assertEqual(primer_info.primers[3].internal_start, 16)
         self.assertEqual(primer_info.primers[4].internal_gc, 35.00)
 
-    def test_mutli_record_fwd(self):
+    def test_multi_record_fwd(self):
         """Test parsing multiple primer sets (NirK forward)."""
-        h = open(os.path.join("Emboss", "NirK.primer3"))
-        targets = list(Primer3.parse(h))
-        h.close()
+        with open(os.path.join("Emboss", "NirK.primer3")) as handle:
+            targets = list(Primer3.parse(handle))
 
         self.assertEqual(len(targets), 16)
         for target in targets:
@@ -142,11 +136,10 @@ class Primer3ParseTest(unittest.TestCase):
         self.assertEqual(targets[15].primers[4].forward_seq,
                          "TATCGCAACCACTGAGCAAG")
 
-    def test_mutli_record_full(self):
+    def test_multi_record_full(self):
         """Test parsing multiple primer sets (NirK full)."""
-        h = open(os.path.join("Emboss", "NirK_full.primer3"))
-        targets = list(Primer3.parse(h))
-        h.close()
+        with open(os.path.join("Emboss", "NirK_full.primer3")) as handle:
+            targets = list(Primer3.parse(handle))
 
         self.assertEqual(len(targets), 16)
         for target in targets:
@@ -193,16 +186,14 @@ class PrimersearchParseTest(unittest.TestCase):
     def test_simple_parse(self):
         """Make sure that we can parse all primersearch files."""
         for file in self.test_files:
-            h = open(file)
-            PrimerSearch.read(h)
-            h.close()
+            with open(file) as handle:
+                PrimerSearch.read(handle)
 
     def test_in_depth_normal_parse(self):
         """Make sure the output from a simple primersearch file is correct."""
         file = self.test_files[0]
-        h = open(file)
-        amp_info = PrimerSearch.read(h)
-        h.close()
+        with open(file) as handle:
+            amp_info = PrimerSearch.read(handle)
 
         self.assertEqual(len(amp_info.amplifiers), 1)
         self.assertIn("Test", amp_info.amplifiers)

--- a/Tests/test_SeqIO_FastaIO.py
+++ b/Tests/test_SeqIO_FastaIO.py
@@ -252,7 +252,7 @@ for filename in multi_dna_files:
         f.__doc__ = "Checking multi DNA file %s" % fn
         return f
 
-    setattr(TitleFunctions, "test_mutli_dna_%s" % name, funct(filename))
+    setattr(TitleFunctions, "test_multi_dna_%s" % name, funct(filename))
     del funct
 
 for filename in single_amino_files:
@@ -276,7 +276,7 @@ for filename in multi_amino_files:
         f.__doc__ = "Checking multi protein file %s" % fn
         return f
 
-    setattr(TitleFunctions, "test_mutli_pro_%s" % name, funct(filename))
+    setattr(TitleFunctions, "test_multi_pro_%s" % name, funct(filename))
     del funct
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request updates the Emboss tests for python3, and rebranded mutli tests.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
