### PR TITLE
remove Jython stuff from Entrez tests

### DIFF
--- a/Tests/test_Entrez_online.py
+++ b/Tests/test_Entrez_online.py
@@ -25,15 +25,6 @@ import unittest
 import requires_internet
 requires_internet.check()
 
-if os.name == "java":
-    try:
-        from xml.parsers.expat import XML_PARAM_ENTITY_PARSING_ALWAYS
-        del XML_PARAM_ENTITY_PARSING_ALWAYS
-    except ImportError:
-        from Bio import MissingPythonDependencyError
-        raise MissingPythonDependencyError("The Bio.Entrez XML parser fails on "
-                                           "Jython, see http://bugs.jython.org/issue1447")
-
 
 # This lets us set the email address to be sent to NCBI Entrez:
 Entrez.email = "biopython@biopython.org"

--- a/Tests/test_Entrez_parser.py
+++ b/Tests/test_Entrez_parser.py
@@ -13,15 +13,6 @@ from io import BytesIO, StringIO
 
 from Bio import Entrez
 
-if os.name == "java":
-    try:
-        from xml.parsers.expat import XML_PARAM_ENTITY_PARSING_ALWAYS
-        del XML_PARAM_ENTITY_PARSING_ALWAYS
-    except ImportError:
-        from Bio import MissingPythonDependencyError
-        raise MissingPythonDependencyError("The Bio.Entrez XML parser fails on "
-                                           "Jython, see http://bugs.jython.org/issue1447")
-
 
 class GeneralTests(unittest.TestCase):
     """General tests for Bio.Entrez."""


### PR DESCRIPTION
This pull request removes the Jython stuff from test_Entrez.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
