### PR TITLE
Optimise algorithm of `Bio.SeqUtils.IsoelectricPoint`

### DIFF
--- a/Bio/SeqUtils/IsoelectricPoint.py
+++ b/Bio/SeqUtils/IsoelectricPoint.py
@@ -118,14 +118,12 @@ class IsoelectricPoint:
     def _chargeR(self, pH):
         positive_charge = 0.0
         for aa, pK in self.pos_pKs.items():
-            CR = 10 ** (pK - pH)
-            partial_charge = CR / (CR + 1.0)
+            partial_charge = 1.0 / (10 ** (pH - pK) + 1.0)
             positive_charge += self.charged_aas_content[aa] * partial_charge
 
         negative_charge = 0.0
         for aa, pK in self.neg_pKs.items():
-            CR = 10 ** (pH - pK)
-            partial_charge = CR / (CR + 1.0)
+            partial_charge = 1.0 / (10 ** (pK - pH) + 1.0)
             negative_charge += self.charged_aas_content[aa] * partial_charge
 
         return positive_charge - negative_charge

--- a/Bio/SeqUtils/IsoelectricPoint.py
+++ b/Bio/SeqUtils/IsoelectricPoint.py
@@ -147,10 +147,10 @@ class IsoelectricPoint:
         Arguments:
          - pH: the pH at which the current charge of the protein is computed.
            This pH lies in the centre of the interval (mean of `min_` and `max_`).
-         - min_: the minimum of the interval. Initial value defaults to 4.05,
+         - min\\_: the minimum of the interval. Initial value defaults to 4.05,
            which is below the theoretical minimum, when the protein is composed
            exclusively of aspartate.
-         - max_: the maximum of the the interval. Initial value defaults to 12,
+         - max\\_: the maximum of the the interval. Initial value defaults to 12,
            which is above the theoretical maximum, when the protein is composed
            exclusively of arginine.
         """

--- a/Bio/SeqUtils/IsoelectricPoint.py
+++ b/Bio/SeqUtils/IsoelectricPoint.py
@@ -64,21 +64,17 @@ class IsoelectricPoint:
 
     >>> from Bio.SeqUtils.IsoelectricPoint import IsoelectricPoint as IP
     >>> protein = IP("INGAR")
-    >>> print("IEP of peptide {} is {:.2f}"
-    ...       .format(protein.sequence, protein.pi()))
+    >>> print(f"IEP of peptide {protein.sequence} is {protein.pi():.2f}")
     IEP of peptide INGAR is 9.75
-    >>> print("It's charge at pH 7 is {:.2f}"
-    ...       .format(protein.charge_at_pH(7.0)))
+    >>> print(f"It's charge at pH 7 is {protein.charge_at_pH(7.0):.2f}")
     It's charge at pH 7 is 0.76
 
 
     >>> from Bio.SeqUtils.ProtParam import ProteinAnalysis as PA
     >>> protein = PA("PETER")
-    >>> print("IEP of {}: {:.2f}".format(protein.sequence,
-    ...                                  protein.isoelectric_point()))
+    >>> print(f"IEP of {protein.sequence}: {protein.isoelectric_point():.2f}")
     IEP of PETER: 4.53
-    >>> print("Charge at pH 4.53: {:.2f}"
-    ...       .format(protein.charge_at_pH(4.53)))
+    >>> print(f"Charge at pH 4.53: {protein.charge_at_pH(4.53):.2f}")
     Charge at pH 4.53: 0.00
 
     """

--- a/Bio/SeqUtils/IsoelectricPoint.py
+++ b/Bio/SeqUtils/IsoelectricPoint.py
@@ -139,18 +139,18 @@ class IsoelectricPoint:
     # This is the action function, it tries different pH until the charge of
     # the protein is 0 (or close).
     def pi(self, pH=7.775, min_=4.05, max_=12):
-        """Calculate and return the isoelectric point as float.
+        r"""Calculate and return the isoelectric point as float.
 
         This is a recursive function that uses bisection method.
         Wiki on bisection: https://en.wikipedia.org/wiki/Bisection_method
 
         Arguments:
          - pH: the pH at which the current charge of the protein is computed.
-           This pH lies in the centre of the interval (mean of `min_` and `max_`).
-         - min\\_: the minimum of the interval. Initial value defaults to 4.05,
+           This pH lies at the centre of the interval (mean of `min_` and `max_`).
+         - min\_: the minimum of the interval. Initial value defaults to 4.05,
            which is below the theoretical minimum, when the protein is composed
            exclusively of aspartate.
-         - max\\_: the maximum of the the interval. Initial value defaults to 12,
+         - max\_: the maximum of the the interval. Initial value defaults to 12,
            which is above the theoretical maximum, when the protein is composed
            exclusively of arginine.
         """

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -263,6 +263,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Thomas Schmitt <https://github.com/wurstbonbon>
 - Thomas Sicheritz-Ponten <thomas at domain cbs.dtu.dk>
 - Tiago Antao <https://github.com/tiagoantao>
+- Tianyi Shi <https://github.com/TianyiShi2001>
 - Tyghe Vallard <https://github.com/necrolyte2>
 - Uri Laserson <https://github.com/laserson>
 - Uwe Schmitt <https://github.com/uweschmitt>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -47,6 +47,7 @@ possible, especially the following contributors:
 - Rob Miller
 - Sergio Valqui
 - Sujan Dulal (first contribution)
+- Tianyi Shi (first contribution)
 
 20 December 2019: Biopython 1.76
 ================================


### PR DESCRIPTION
1. Simplified math of the `charge_at_pH()` (originally called `_chargeR()`) method. Slightly [improves speed](https://github.com/biopython/biopython/pull/2645#issuecomment-583564322). (see PR #2645 ) Added comments to explain its derivation, [according to](https://github.com/biopython/biopython/pull/2645#issuecomment-583650570) @MarkusPiotrowski 
2. Simplified the `pi()` method, reducing it from 40 lines of code to 10. Avoids vague variable names e.g. pH1, pH2 and reduces number of variables, thus improving readability. Slightly decreases speed but this is usually negligible. (see issue #2646 )
3. remove the unnecessarily duplicated `_chargeR()` method. (see issue #2647 )
4. Adopted f strings in tests.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
