### PR TITLE
use with statement in test_motifs

### DIFF
--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -43,9 +43,8 @@ class MotifTestsBasic(unittest.TestCase):
 
     def test_alignace_parsing(self):
         """Test if Bio.motifs can parse AlignAce output files."""
-        handle = open("motifs/alignace.out")
-        record = motifs.parse(handle, "AlignAce")
-        handle.close()
+        with open("motifs/alignace.out") as handle:
+            record = motifs.parse(handle, "AlignAce")
         self.assertEqual(record.version, "AlignACE 4.0 05/13/04")
         self.assertEqual(record.command, "./AlignACE -i test.fa")
         self.assertEqual(len(record.parameters), 7)
@@ -435,9 +434,8 @@ class MotifTestsBasic(unittest.TestCase):
 
     def test_TFoutput(self):
         """Ensure that we can write proper TransFac output files."""
-        output_handle = open(self.TFout, "w")
-        output_handle.write(format(self.m, "transfac"))
-        output_handle.close()
+        with open(self.TFout, "w") as output_handle:
+            output_handle.write(format(self.m, "transfac"))
 
     def test_format(self):
         self.m.name = "Foo"
@@ -534,8 +532,8 @@ class TestMEME(unittest.TestCase):
 
     def test_meme_parser_1(self):
         """Parsing motifs/meme.out file."""
-        handle = open("motifs/meme.out")
-        record = motifs.parse(handle, "meme")
+        with open("motifs/meme.out") as handle:
+            record = motifs.parse(handle, "meme")
         self.assertEqual(record.version, "3.5.7")
         self.assertEqual(record.datafile, "test.fa")
         self.assertEqual(record.alphabet, "ACGT")
@@ -639,12 +637,11 @@ class TestMEME(unittest.TestCase):
         self.assertEqual(str(motif.instances[7]), "CTCAATCGTA")
         self.assertEqual(str(motif.instances[8]), "CTCAATCGTA")
         self.assertEqual(str(motif.instances[9]), "CTCAATCGTA")
-        handle.close()
 
     def test_meme_parser_2(self):
         """Parse motifs/meme.dna.oops.txt file."""
-        handle = open("motifs/meme.dna.oops.txt")
-        record = motifs.parse(handle, "meme")
+        with open("motifs/meme.dna.oops.txt") as handle:
+            record = motifs.parse(handle, "meme")
         self.assertEqual(record.version, "3.0")
         self.assertEqual(record.datafile, "INO_up800.s")
         self.assertEqual(record.alphabet, "ACGT")
@@ -756,12 +753,11 @@ class TestMEME(unittest.TestCase):
         self.assertEqual(str(motif.instances[4]), "GCAGGCACGG")
         self.assertEqual(str(motif.instances[5]), "TCTGGCACTC")
         self.assertEqual(str(motif.instances[6]), "TCTGGCATCG")
-        handle.close()
 
     def test_meme_parser_3(self):
         """Parse motifs/meme.protein.oops.txt file."""
-        handle = open("motifs/meme.protein.oops.txt")
-        record = motifs.parse(handle, "meme")
+        with open("motifs/meme.protein.oops.txt") as handle:
+            record = motifs.parse(handle, "meme")
         self.assertEqual(record.version, "3.0")
         self.assertEqual(record.datafile, "adh.s")
         self.assertEqual(record.alphabet, "ACDEFGHIKLMNPQRSTVWY")
@@ -1145,12 +1141,11 @@ class TestMEME(unittest.TestCase):
         self.assertEqual(str(motif.instances[30]), "KRILVTGVASKLSIAYGIAQAMHREGAEL")
         self.assertEqual(str(motif.instances[31]), "IDTNVTGAAATLSAVLPQMVERKRGHLVG")
         self.assertEqual(str(motif.instances[32]), "TSAMLPGLRQGALRRVAHVTSRMGSLAAN")
-        handle.close()
 
     def test_meme_parser_4(self):
         """Parse motifs/meme.protein.tcm.txt file."""
-        handle = open("motifs/meme.protein.tcm.txt")
-        record = motifs.parse(handle, "meme")
+        with open("motifs/meme.protein.tcm.txt") as handle:
+            record = motifs.parse(handle, "meme")
         self.assertEqual(record.version, "3.0")
         self.assertEqual(record.datafile, "farntrans5.s")
         self.assertEqual(record.alphabet, "ACDEFGHIKLMNPQRSTVWY")
@@ -1446,12 +1441,11 @@ class TestMEME(unittest.TestCase):
         self.assertEqual(str(motif.instances[18]), "DRKVRLISFIRGNQ")
         self.assertEqual(str(motif.instances[19]), "EVVDPAVDFVLKCY")
         self.assertEqual(str(motif.instances[20]), "IDRKGIYQWLISLK")
-        handle.close()
 
     def test_meme_parser_4_11_4(self):
         """Parse motifs/meme_v_4_11_4.txt file."""
-        handle = open("motifs/meme_v_4_11_4.txt")
-        record = motifs.parse(handle, "meme")
+        with open("motifs/meme_v_4_11_4.txt") as handle:
+            record = motifs.parse(handle, "meme")
         self.assertEqual(record.version, "4.11.4")
         self.assertEqual(record.datafile, "example.fasta")
         self.assertEqual(record.alphabet, "ACGT")
@@ -1555,12 +1549,11 @@ class TestMEME(unittest.TestCase):
         self.assertEqual(str(motif.instances[7]), "CTCAATCGTA")
         self.assertEqual(str(motif.instances[8]), "CTCAATCGTA")
         self.assertEqual(str(motif.instances[9]), "CTCAATCGTA")
-        handle.close()
 
     def test_minimal_meme_parser(self):
         """Parse motifs/minimal_test.meme file."""
-        handle = open("motifs/minimal_test.meme")
-        record = motifs.parse(handle, "minimal")
+        with open("motifs/minimal_test.meme") as handle:
+            record = motifs.parse(handle, "minimal")
         self.assertEqual(record.version, "4")
         self.assertEqual(record.alphabet, "ACGT")
         self.assertEqual(len(record.sequences), 0)
@@ -1579,12 +1572,11 @@ class TestMEME(unittest.TestCase):
         self.assertAlmostEqual(motif.evalue, 4.1e-09)
         self.assertEqual(motif.alphabet, "ACGT")
         self.assertEqual(motif.instances, None)
-        handle.close()
 
     def test_meme_parser_rna(self):
         """Test if Bio.motifs can parse MEME output files using RNA."""
-        handle = open("motifs/meme.rna.oops.txt")
-        record = motifs.parse(handle, "meme")
+        with open("motifs/meme.rna.oops.txt") as handle:
+            record = motifs.parse(handle, "meme")
         self.assertEqual(record.version, "4.11.0")
         self.assertEqual(record.datafile, "rna_samples.fa")
         self.assertEqual(record.alphabet, "ACGU")
@@ -1696,7 +1688,6 @@ class TestMEME(unittest.TestCase):
         self.assertEqual(str(motif.instances[4]), "ACGGUGCUA")
         self.assertEqual(str(motif.instances[5]), "GUGGUGUGA")
         self.assertEqual(str(motif.instances[6]), "GAUUUGUUA")
-        handle.close()
 
 
 class TestMAST(unittest.TestCase):
@@ -1704,8 +1695,8 @@ class TestMAST(unittest.TestCase):
 
     def test_mast_parser_1(self):
         """Parse motifs/mast.crp0.de.oops.txt.xml file."""
-        handle = open("motifs/mast.crp0.de.oops.txt.xml")
-        record = motifs.parse(handle, "MAST")
+        with open("motifs/mast.crp0.de.oops.txt.xml") as handle:
+            record = motifs.parse(handle, "MAST")
         self.assertEqual(record.version, "5.0.1")
         self.assertEqual(record.database, "common/crp0.s")
         self.assertEqual(record.alphabet, "DNA")
@@ -1755,12 +1746,11 @@ class TestMAST(unittest.TestCase):
         self.assertEqual(record.diagrams["ce1cg"], "105")
         self.assertEqual(record.diagrams["trn9cat"], "105")
         self.assertEqual(record.diagrams["uxu1"], "105")
-        handle.close()
 
     def test_mast_parser_2(self):
         """Parse motifs/mast.adh.de.oops.html.xml file."""
-        handle = open("motifs/mast.adh.de.oops.html.xml")
-        record = motifs.parse(handle, "MAST")
+        with open("motifs/mast.adh.de.oops.html.xml") as handle:
+            record = motifs.parse(handle, "MAST")
         self.assertEqual(record.version, "5.0.1")
         self.assertEqual(record.database, "common/adh.s")
         self.assertEqual(record.alphabet, "Protein")
@@ -1840,12 +1830,11 @@ class TestMAST(unittest.TestCase):
         self.assertEqual(record.diagrams["FABI_ECOLI"], "1-[1]-161-[1]-76")
         self.assertEqual(record.diagrams["GUTD_ECOLI"], "147-[2]-10-[1]-78")
         self.assertEqual(record.diagrams["CSGA_MYXXA"], "12-[1]-53-[2]-77")
-        handle.close()
 
     def test_mast_parser_3(self):
         """Parse motifs/mast.Klf1-200.cd.oops.xml.xml file."""
-        handle = open("motifs/mast.Klf1-200.cd.oops.xml.xml")
-        record = motifs.parse(handle, "MAST")
+        with open("motifs/mast.Klf1-200.cd.oops.xml.xml") as handle:
+            record = motifs.parse(handle, "MAST")
         self.assertEqual(record.version, "5.0.1")
         self.assertEqual(record.database, "common/Klf1-200.fa")
         self.assertEqual(record.alphabet, "DNA")
@@ -2085,7 +2074,6 @@ class TestMAST(unittest.TestCase):
         self.assertEqual(record.diagrams["chr5:105994747-105995247"], "93-[+2]-153-[-2]-194")
         self.assertEqual(record.diagrams["chr17:84209565-84210065"], "64-[-2]-406")
         self.assertEqual(record.diagrams["chr7:16507689-16508189"], "231-[+2]-239")
-        handle.close()
 
 
 class TestTransfac(unittest.TestCase):
@@ -2093,8 +2081,8 @@ class TestTransfac(unittest.TestCase):
 
     def test_transfac_parser(self):
         """Parse motifs/transfac.dat file."""
-        handle = open("motifs/transfac.dat")
-        record = motifs.parse(handle, "TRANSFAC")
+        with open("motifs/transfac.dat") as handle:
+            record = motifs.parse(handle, "TRANSFAC")
         motif = record[0]
         self.assertEqual(motif["ID"], "motif1")
         self.assertEqual(len(motif.counts), 4)
@@ -2193,7 +2181,6 @@ class TestTransfac(unittest.TestCase):
         self.assertEqual(motif.counts["T", 8], 5)
         self.assertEqual(motif.counts["T", 9], 3)
         self.assertEqual(str(motif.counts.degenerate_consensus), "RSCAGAGGTY")
-        handle.close()
 
     def test_permissive_transfac_parser(self):
         """Parse the TRANSFAC-like file motifs/MA0056.1.transfac."""
@@ -2203,11 +2190,10 @@ class TestTransfac(unittest.TestCase):
         # transcription factor binding profiles and its web framework.
         # Nucleic Acids Res. 2018; 46:D260-D266,
         path = "motifs/MA0056.1.transfac"
-        handle = open(path)
-        self.assertRaises(ValueError, motifs.parse, handle, "TRANSFAC")
-        handle.close()
-        handle = open(path)
-        records = motifs.parse(handle, "TRANSFAC", strict=False)
+        with open(path) as handle:
+            self.assertRaises(ValueError, motifs.parse, handle, "TRANSFAC")
+        with open(path) as handle:
+            records = motifs.parse(handle, "TRANSFAC", strict=False)
         motif = records[0]
         self.assertEqual(sorted(motif.keys()), ["AC", "DE", "ID"])
         self.assertEqual(motif["AC"], "MA0056.1")
@@ -2239,7 +2225,6 @@ class TestTransfac(unittest.TestCase):
         self.assertEqual(motif.counts["T", 3], 1.0)
         self.assertEqual(motif.counts["T", 4], 0.0)
         self.assertEqual(motif.counts["T", 5], 0.0)
-        handle.close()
 
 
 class MotifTestPWM(unittest.TestCase):
@@ -2247,9 +2232,8 @@ class MotifTestPWM(unittest.TestCase):
 
     def setUp(self):
         """Define motif and sequence for tests."""
-        handle = open("motifs/SRF.pfm")
-        self.m = motifs.read(handle, "pfm")
-        handle.close()
+        with open("motifs/SRF.pfm") as handle:
+            self.m = motifs.read(handle, "pfm")
         self.s = Seq("ACGTGTGCGTAGTGCGT", self.m.alphabet)
 
     def test_simple(self):


### PR DESCRIPTION
This pull request uses the `with` statement in test_motifs.py

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
