### PR TITLE
use with in test_GenomeDiagram.py

### DIFF
--- a/Tests/test_GenomeDiagram.py
+++ b/Tests/test_GenomeDiagram.py
@@ -770,7 +770,7 @@ class DiagramTest(unittest.TestCase):
         gdd.write(output_filename, "PDF")
 
         # Also check the write_to_string (bytes string) method matches,
-        with open(output_filename, "rb") as handle
+        with open(output_filename, "rb") as handle:
             assert handle.read() == gdd.write_to_string("PDF")
 
         output_filename = os.path.join("Graphics", "GD_region_linear.svg")

--- a/Tests/test_GenomeDiagram.py
+++ b/Tests/test_GenomeDiagram.py
@@ -771,7 +771,7 @@ class DiagramTest(unittest.TestCase):
 
         # Also check the write_to_string (bytes string) method matches,
         with open(output_filename, "rb") as handle:
-            assert handle.read() == gdd.write_to_string("PDF")
+            self.assertEqual(handle.read(), gdd.write_to_string("PDF"))
 
         output_filename = os.path.join("Graphics", "GD_region_linear.svg")
         gdd.write(output_filename, "SVG")

--- a/Tests/test_GenomeDiagram.py
+++ b/Tests/test_GenomeDiagram.py
@@ -620,9 +620,8 @@ class DiagramTest(unittest.TestCase):
 
     def setUp(self):
         """Test setup, just loads a GenBank file as a SeqRecord."""
-        handle = open(os.path.join("GenBank", "NC_005816.gb"))
-        self.record = SeqIO.read(handle, "genbank")
-        handle.close()
+        with open(os.path.join("GenBank", "NC_005816.gb")) as handle:
+            self.record = SeqIO.read(handle, "genbank")
 
         self.gdd = Diagram("Test Diagram")
         # Add a track of features,
@@ -771,7 +770,8 @@ class DiagramTest(unittest.TestCase):
         gdd.write(output_filename, "PDF")
 
         # Also check the write_to_string (bytes string) method matches,
-        assert open(output_filename, "rb").read() == gdd.write_to_string("PDF")
+        with open(output_filename, "rb") as handle
+            assert handle.read() == gdd.write_to_string("PDF")
 
         output_filename = os.path.join("Graphics", "GD_region_linear.svg")
         gdd.write(output_filename, "SVG")


### PR DESCRIPTION
This pull request uses `with` to open files in `test_GenomeDiagram.py`

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
