### PR TITLE
use with statement

### DIFF
--- a/Tests/test_align_substitution_matrices.py
+++ b/Tests/test_align_substitution_matrices.py
@@ -123,9 +123,8 @@ Z  0.0
         self.assertEqual(frequencies.shape, (len(nucleotide_alphabet), ))
         for letter in letters:
             self.assertAlmostEqual(frequencies[letter], counts[letter])
-        handle = open(path)
-        text = handle.read()
-        handle.close()
+        with open(path) as handle:
+            text = handle.read()
         self.assertEqual(format(frequencies, "%d"), text)
         total = sum(frequencies)
         self.assertAlmostEqual(total, sum(counts.values()))
@@ -149,9 +148,8 @@ Z  0.0
         self.assertEqual(frequencies.shape, (len(nucleotide_alphabet), ))
         for letter in letters:
             self.assertAlmostEqual(frequencies[letter], counts[letter])
-        handle = open(path)
-        text = handle.read()
-        handle.close()
+        with open(path) as handle:
+            text = handle.read()
         self.assertEqual(format(frequencies, "%d"), text)
         total = sum(frequencies)
         self.assertAlmostEqual(total, sum(counts.values()))
@@ -178,9 +176,8 @@ Z  0.0
         self.assertEqual(frequencies.shape, (len(protein_alphabet), ))
         for letter in letters:
             self.assertAlmostEqual(frequencies[letter], counts[letter])
-        handle = open(path)
-        text = handle.read()
-        handle.close()
+        with open(path) as handle:
+            text = handle.read()
         self.assertEqual(format(frequencies, "%d"), text)
         total = sum(frequencies)
         self.assertAlmostEqual(total, sum(counts.values()))
@@ -220,9 +217,8 @@ Z  0.0
         self.assertEqual(frequencies.shape, (len(protein_alphabet), ))
         for letter in letters:
             self.assertAlmostEqual(frequencies[letter], counts[letter])
-        handle = open(path)
-        text = handle.read()
-        handle.close()
+        with open(path) as handle:
+            text = handle.read()
         self.assertEqual(format(frequencies, "%d"), text)
         total = sum(frequencies)
         self.assertAlmostEqual(total, sum(counts.values()))


### PR DESCRIPTION
This pull request uses the `with` statement to open files in test_align_substitution_matrices.py.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
