### PR TITLE
Apply black style to test_Phylo* files, version 19.10b0.

### DIFF
--- a/Tests/test_Phylo.py
+++ b/Tests/test_Phylo.py
@@ -42,7 +42,10 @@ class IOTests(unittest.TestCase):
         tree = Phylo.read(EX_NEWICK2, "newick")
         self.assertEqual(len(tree.get_terminals()), 33)
         self.assertEqual(tree.find_any("Homo sapiens").comment, "modern human")
-        self.assertEqual(tree.find_any("Equus caballus").comment, "wild horse; also 'Equus ferus caballus'")
+        self.assertEqual(
+            tree.find_any("Equus caballus").comment,
+            "wild horse; also 'Equus ferus caballus'",
+        )
         self.assertEqual(tree.root.confidence, 80)
         tree = Phylo.read(EX_NEWICK2, "newick", comments_are_confidence=True)
         self.assertEqual(tree.root.confidence, 100)
@@ -76,9 +79,7 @@ class IOTests(unittest.TestCase):
         # Sanity check
         self.assertEqual(tree2.count_terminals(), 4)
         # Check internal node labels were retained
-        internal_names = {c.name
-                          for c in tree2.get_nonterminals()
-                          if c is not None}
+        internal_names = {c.name for c in tree2.get_nonterminals() if c is not None}
         self.assertEqual(internal_names, {"E", "F"})
 
     def test_newick_read_scinot(self):
@@ -123,8 +124,7 @@ class IOTests(unittest.TestCase):
         Phylo.write(tree, mem_file, "newick", format_branch_length="%.0e")
         # Py2.5 compat: Windows with Py2.5- represents this as 1e-001;
         # on all other platforms it's 1e-01
-        self.assertTrue(mem_file.getvalue().strip()
-                        in ["A:1e-01;", "A:1e-001;"])
+        self.assertTrue(mem_file.getvalue().strip() in ["A:1e-01;", "A:1e-001;"])
 
     def test_convert(self):
         """Convert a tree between all supported formats."""
@@ -144,8 +144,7 @@ class IOTests(unittest.TestCase):
         """Try writing phyloxml to a binary handle; fail on Py3."""
         trees = Phylo.parse("PhyloXML/phyloxml_examples.xml", "phyloxml")
         with tempfile.NamedTemporaryFile(mode="wb") as out_handle:
-            self.assertRaises(TypeError, Phylo.write,
-                              trees, out_handle, "phyloxml")
+            self.assertRaises(TypeError, Phylo.write, trees, out_handle, "phyloxml")
 
     def test_convert_phyloxml_text(self):
         """Write phyloxml to a text handle."""
@@ -164,10 +163,10 @@ class IOTests(unittest.TestCase):
 
     def test_int_labels(self):
         """Read newick formatted tree with numeric labels."""
-        tree = Phylo.read(StringIO("(((0:0.1,1:0.1)0.99:0.1,2:0.1)0.98:0.0);"),
-                          "newick")
-        self.assertEqual({leaf.name for leaf in tree.get_terminals()},
-                         {"0", "1", "2"})
+        tree = Phylo.read(
+            StringIO("(((0:0.1,1:0.1)0.99:0.1,2:0.1)0.98:0.0);"), "newick"
+        )
+        self.assertEqual({leaf.name for leaf in tree.get_terminals()}, {"0", "1", "2"})
 
 
 class TreeTests(unittest.TestCase):
@@ -181,7 +180,7 @@ class TreeTests(unittest.TestCase):
             self.assertEqual(tree.total_branch_length(), (N - 1) * 2)
             tree = Phylo.BaseTree.Tree.randomized(N, branch_length=2.0)
             self.assertEqual(tree.total_branch_length(), (N - 1) * 4)
-        tree = Phylo.BaseTree.Tree.randomized(5, branch_stdev=.5)
+        tree = Phylo.BaseTree.Tree.randomized(5, branch_stdev=0.5)
         self.assertEqual(tree.count_terminals(), 5)
 
     def test_root_with_outgroup(self):
@@ -201,30 +200,29 @@ class TreeTests(unittest.TestCase):
         tree.root_with_outgroup("2_BRAFL", outgroup_branch_length=0.5)
         self.assertEqual(orig_num_tips, len(tree.get_terminals()))
         self.assertAlmostEqual(orig_tree_len, tree.total_branch_length())
-        tree.root_with_outgroup("36_BRAFL", "37_BRAFL",
-                                outgroup_branch_length=0.5)
+        tree.root_with_outgroup("36_BRAFL", "37_BRAFL", outgroup_branch_length=0.5)
         self.assertEqual(orig_num_tips, len(tree.get_terminals()))
         self.assertAlmostEqual(orig_tree_len, tree.total_branch_length())
         # On small contrived trees, testing edge cases
         for small_nwk in (
-                "(A,B,(C,D));",
-                "((E,F),((G,H)),(I,J));",
-                "((Q,R),(S,T),(U,V));",
-                "(X,Y);",
-                ):
+            "(A,B,(C,D));",
+            "((E,F),((G,H)),(I,J));",
+            "((Q,R),(S,T),(U,V));",
+            "(X,Y);",
+        ):
             tree = Phylo.read(StringIO(small_nwk), "newick")
             orig_tree_len = tree.total_branch_length()
             for node in list(tree.find_clades()):
                 tree.root_with_outgroup(node)
-                self.assertAlmostEqual(orig_tree_len,
-                                       tree.total_branch_length())
+                self.assertAlmostEqual(orig_tree_len, tree.total_branch_length())
 
     def test_root_at_midpoint(self):
         """Tree.root_at_midpoint: reroot at the tree's midpoint."""
-        for treefname, fmt in [(EX_APAF, "phyloxml"),
-                               (EX_BCL2, "phyloxml"),
-                               (EX_NEWICK, "newick"),
-                               ]:
+        for treefname, fmt in [
+            (EX_APAF, "phyloxml"),
+            (EX_BCL2, "phyloxml"),
+            (EX_NEWICK, "newick"),
+        ]:
             tree = Phylo.read(treefname, fmt)
             orig_tree_len = tree.total_branch_length()
             # Total branch length does not change
@@ -269,8 +267,9 @@ class MixinTests(unittest.TestCase):
         self.assertEqual(matches[0].scientific_name, "Octopus vulgaris")
         # Iteration and regexps
         tree = self.phylogenies[10]
-        for point, alt in zip(tree.find_elements(geodetic_datum=r"WGS\d{2}"),
-                              (472, 10, 452)):
+        for point, alt in zip(
+            tree.find_elements(geodetic_datum=r"WGS\d{2}"), (472, 10, 452)
+        ):
             self.assertTrue(isinstance(point, PhyloXML.Point))
             self.assertEqual(point.geodetic_datum, "WGS84")
             self.assertAlmostEqual(point.alt, alt)
@@ -295,8 +294,9 @@ class MixinTests(unittest.TestCase):
     def test_find_clades(self):
         """TreeMixin: find_clades() method."""
         # boolean filter
-        for clade, name in zip(self.phylogenies[10].find_clades(name=True),
-                               list("ABCD")):
+        for clade, name in zip(
+            self.phylogenies[10].find_clades(name=True), list("ABCD")
+        ):
             self.assertTrue(isinstance(clade, PhyloXML.Clade))
             self.assertEqual(clade.name, name)
         # finding deeper attributes
@@ -311,16 +311,14 @@ class MixinTests(unittest.TestCase):
     def test_find_terminal(self):
         """TreeMixin: find_elements() with terminal argument."""
         for tree, total, extern, intern in zip(
-                self.phylogenies,
-                (6, 6, 7, 18, 21, 27, 7, 9, 9, 19, 15, 9, 6),
-                (3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 3, 3),
-                (3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3),
-                ):
+            self.phylogenies,
+            (6, 6, 7, 18, 21, 27, 7, 9, 9, 19, 15, 9, 6),
+            (3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 3, 3),
+            (3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3),
+        ):
             self.assertEqual(len(list(tree.find_elements())), total)
-            self.assertEqual(len(list(tree.find_elements(terminal=True))),
-                             extern)
-            self.assertEqual(len(list(tree.find_elements(terminal=False))),
-                             intern)
+            self.assertEqual(len(list(tree.find_elements(terminal=True))), extern)
+            self.assertEqual(len(list(tree.find_elements(terminal=False))), intern)
 
     def test_get_path(self):
         """TreeMixin: get_path() method."""
@@ -357,8 +355,9 @@ class MixinTests(unittest.TestCase):
         tree = self.phylogenies[1]
         depths = tree.depths()
         self.assertEqual(len(depths), 5)
-        for found, expect in zip(sorted(depths.values()),
-                                 [0, 0.060, 0.162, 0.290, 0.400]):
+        for found, expect in zip(
+            sorted(depths.values()), [0, 0.060, 0.162, 0.290, 0.400]
+        ):
             self.assertAlmostEqual(found, expect)
 
     def test_distance(self):
@@ -373,8 +372,9 @@ class MixinTests(unittest.TestCase):
 
     def test_is_bifurcating(self):
         """TreeMixin: is_bifurcating() method."""
-        for tree, is_b in zip(self.phylogenies,
-                              (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1)):
+        for tree, is_b in zip(
+            self.phylogenies, (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1)
+        ):
             self.assertEqual(tree.is_bifurcating(), is_b)
 
     def test_is_monophyletic(self):
@@ -404,9 +404,7 @@ class MixinTests(unittest.TestCase):
         tree = self.phylogenies[1]
         parent = tree.collapse(tree.clade[0])
         self.assertEqual(len(parent), 3)
-        for clade, name, blength in zip(parent,
-                                        ("C", "A", "B"),
-                                        (0.4, 0.162, 0.29)):
+        for clade, name, blength in zip(parent, ("C", "A", "B"), (0.4, 0.162, 0.29)):
             self.assertEqual(clade.name, name)
             self.assertAlmostEqual(clade.branch_length, blength)
 
@@ -435,8 +433,10 @@ class MixinTests(unittest.TestCase):
 
     def test_ladderize(self):
         """TreeMixin: ladderize() method."""
+        # This comment stops black style adding a blank line here, causing flake8 D202.
         def ordered_names(tree):
             return [n.name for n in tree.get_terminals()]
+
         tree = self.phylogenies[10]
         self.assertEqual(ordered_names(tree), list("ABCD"))
         tree.ladderize()
@@ -458,7 +458,7 @@ class MixinTests(unittest.TestCase):
         tree = self.phylogenies[0]
         parent = tree.prune(name="A")
         self.assertEqual(len(parent.clades), 2)
-        for clade, name, blen in zip(parent, "BC", (.29, .4)):
+        for clade, name, blen in zip(parent, "BC", (0.29, 0.4)):
             self.assertTrue(clade.is_terminal())
             self.assertEqual(clade.name, name)
             self.assertAlmostEqual(clade.branch_length, blen)
@@ -469,7 +469,7 @@ class MixinTests(unittest.TestCase):
         parent = tree.prune(name="C")
         self.assertEqual(parent, tree.root)
         self.assertEqual(len(parent.clades), 2)
-        for clade, name, blen in zip(parent, "AB", (.102, .23)):
+        for clade, name, blen in zip(parent, "AB", (0.102, 0.23)):
             self.assertTrue(clade.is_terminal())
             self.assertEqual(clade.name, name)
             self.assertAlmostEqual(clade.branch_length, blen)
@@ -484,12 +484,10 @@ class MixinTests(unittest.TestCase):
         self.assertEqual(len(C), 2)
         self.assertEqual(len(tree.get_terminals()), 4)
         self.assertEqual(len(tree.get_nonterminals()), 3)
-        C[0].split(3, .5)
+        C[0].split(3, 0.5)
         self.assertEqual(len(tree.get_terminals()), 6)
         self.assertEqual(len(tree.get_nonterminals()), 4)
-        for clade, name, blen in zip(C[0],
-                                     ("C00", "C01", "C02"),
-                                     (0.5, 0.5, 0.5)):
+        for clade, name, blen in zip(C[0], ("C00", "C01", "C02"), (0.5, 0.5, 0.5)):
             self.assertTrue(clade.is_terminal())
             self.assertEqual(clade.name, name)
             self.assertEqual(clade.branch_length, blen)

--- a/Tests/test_PhyloXML.py
+++ b/Tests/test_PhyloXML.py
@@ -30,6 +30,7 @@ DUMMY = tempfile.mktemp()
 # ---------------------------------------------------------
 # Parser tests
 
+
 def _test_read_factory(source, count):
     """Generate a test method for read()ing the given source.
 
@@ -102,63 +103,27 @@ class ParseTests(unittest.TestCase):
     test_parse_dollo = _test_parse_factory(EX_DOLLO, 1)
 
     # lvl-2 clades, sub-clade counts, lvl-3 clades
-    test_shape_apaf = _test_shape_factory(EX_APAF,
-                                          (((2, (2, 2)),
-                                            (2, (2, 2)),
-                                            ),
-                                           ),
-                                          )
-    test_shape_bcl2 = _test_shape_factory(EX_BCL2,
-                                          (((2, (2, 2)),
-                                            (2, (2, 2)),
-                                            ),
-                                           ),
-                                          )
-    test_shape_phylo = _test_shape_factory(EX_PHYLO,
-                                           (((2, (0, 0)),
-                                               (0, ()),
-                                             ),
-                                            ((2, (0, 0)),
-                                             (0, ()),
-                                             ),
-                                            ((2, (0, 0)),
-                                             (0, ()),
-                                             ),
-                                            ((2, (0, 0)),
-                                             (0, ()),
-                                             ),
-                                            ((2, (0, 0)),
-                                             (0, ()),
-                                             ),
-                                            ((2, (0, 0)),
-                                             (0, ()),
-                                             ),
-                                            ((2, (0, 0)),
-                                             (0, ()),
-                                             ),
-                                            ((2, (0, 0)),
-                                             (0, ()),
-                                             ),
-                                            ((2, (0, 0)),
-                                             (0, ()),
-                                             ),
-                                            ((0, ()),
-                                             (2, (0, 0)),
-                                             ),
-                                            ((3, (0, 0, 0)),
-                                             (0, ()),
-                                             ),
-                                            ((2, (0, 0)),
-                                             (0, ()),
-                                             ),
-                                            ((2, (0, 0)),
-                                               (0, ()),
-                                             ),
-                                            ),
-                                           )
-    test_shape_dollo = _test_shape_factory(EX_DOLLO,
-                                           (((2, (2, 2)),
-                                             (2, (2, 2)),),),)
+    test_shape_apaf = _test_shape_factory(EX_APAF, (((2, (2, 2)), (2, (2, 2)),),),)
+    test_shape_bcl2 = _test_shape_factory(EX_BCL2, (((2, (2, 2)), (2, (2, 2)),),),)
+    test_shape_phylo = _test_shape_factory(
+        EX_PHYLO,
+        (
+            ((2, (0, 0)), (0, ()),),
+            ((2, (0, 0)), (0, ()),),
+            ((2, (0, 0)), (0, ()),),
+            ((2, (0, 0)), (0, ()),),
+            ((2, (0, 0)), (0, ()),),
+            ((2, (0, 0)), (0, ()),),
+            ((2, (0, 0)), (0, ()),),
+            ((2, (0, 0)), (0, ()),),
+            ((2, (0, 0)), (0, ()),),
+            ((0, ()), (2, (0, 0)),),
+            ((3, (0, 0, 0)), (0, ()),),
+            ((2, (0, 0)), (0, ()),),
+            ((2, (0, 0)), (0, ()),),
+        ),
+    )
+    test_shape_dollo = _test_shape_factory(EX_DOLLO, (((2, (2, 2)), (2, (2, 2)),),),)
 
 
 class TreeTests(unittest.TestCase):
@@ -183,11 +148,15 @@ class TreeTests(unittest.TestCase):
         self.assertEqual(otr.tag, "alignment")
         self.assertEqual(otr.namespace, "http://example.org/align")
         self.assertEqual(len(otr.children), 3)
-        for child, name, value in zip(otr,
-                                      ("A", "B", "C"),
-                                      ("acgtcgcggcccgtggaagtcctctcct",
-                                       "aggtcgcggcctgtggaagtcctctcct",
-                                       "taaatcgc--cccgtgg-agtccc-cct")):
+        for child, name, value in zip(
+            otr,
+            ("A", "B", "C"),
+            (
+                "acgtcgcggcccgtggaagtcctctcct",
+                "aggtcgcggcctgtggaagtcctctcct",
+                "taaatcgc--cccgtgg-agtccc-cct",
+            ),
+        ):
             self.assertEqual(child.tag, "seq")
             self.assertEqual(child.attributes["name"], name)
             self.assertEqual(child.value, value)
@@ -197,12 +166,12 @@ class TreeTests(unittest.TestCase):
         trees = list(PhyloXMLIO.parse(EX_PHYLO))
         # Monitor lizards
         self.assertEqual(trees[9].name, "monitor lizards")
-        self.assertEqual(trees[9].description,
-                         "a pylogeny of some monitor lizards")
+        self.assertEqual(trees[9].description, "a pylogeny of some monitor lizards")
         self.assertEqual(trees[9].rooted, True)
         # Network (unrooted)
-        self.assertEqual(trees[6].name,
-                         "network, node B is connected to TWO nodes: AB and C")
+        self.assertEqual(
+            trees[6].name, "network, node B is connected to TWO nodes: AB and C"
+        )
         self.assertEqual(trees[6].rooted, False)
 
     def test_Clade(self):
@@ -211,10 +180,11 @@ class TreeTests(unittest.TestCase):
         clade_ab, clade_c = tree.clade.clades
         clade_a, clade_b = clade_ab.clades
         for clade, id_source, name, blen in zip(
-                (clade_ab, clade_a, clade_b, clade_c),
-                ("ab", "a", "b", "c"),
-                ("AB", "A", "B", "C"),
-                (0.06, 0.102, 0.23, 0.4)):
+            (clade_ab, clade_a, clade_b, clade_c),
+            ("ab", "a", "b", "c"),
+            ("AB", "A", "B", "C"),
+            (0.06, 0.102, 0.23, 0.4),
+        ):
             self.assertTrue(isinstance(clade, PX.Clade))
             self.assertEqual(clade.id_source, id_source)
             self.assertEqual(clade.name, name)
@@ -237,11 +207,11 @@ class TreeTests(unittest.TestCase):
         self.assertTrue(isinstance(bchars, PX.BinaryCharacters))
         self.assertEqual(bchars.type, "parsimony inferred")
         for name, count, value in (
-                ("gained", 2, ["Cofilin_ADF", "Gelsolin"]),
-                ("lost", 0, []),
-                ("present", 2, ["Cofilin_ADF", "Gelsolin"]),
-                ("absent", None, []),
-                ):
+            ("gained", 2, ["Cofilin_ADF", "Gelsolin"]),
+            ("lost", 0, []),
+            ("present", 2, ["Cofilin_ADF", "Gelsolin"]),
+            ("absent", None, []),
+        ):
             self.assertEqual(getattr(bchars, name + "_count"), count)
             self.assertEqual(getattr(bchars, name), value)
 
@@ -263,16 +233,15 @@ class TreeTests(unittest.TestCase):
         tree = next(PhyloXMLIO.parse(handle))
         handle.close()
         self.assertEqual(tree.name, "testing confidence")
-        for conf, type, val in zip(tree.confidences,
-                                   ("bootstrap", "probability"),
-                                   (89.0, 0.71)):
+        for conf, type, val in zip(
+            tree.confidences, ("bootstrap", "probability"), (89.0, 0.71)
+        ):
             self.assertTrue(isinstance(conf, PX.Confidence))
             self.assertEqual(conf.type, type)
             self.assertAlmostEqual(conf.value, val)
         self.assertEqual(tree.clade.name, "b")
         self.assertAlmostEqual(tree.clade.width, 0.2)
-        for conf, val in zip(tree.clade[0].confidences,
-                             (0.9, 0.71)):
+        for conf, val in zip(tree.clade[0].confidences, (0.9, 0.71)):
             self.assertTrue(isinstance(conf, PX.Confidence))
             self.assertEqual(conf.type, "probability")
             self.assertAlmostEqual(conf.value, val)
@@ -284,10 +253,11 @@ class TreeTests(unittest.TestCase):
         devonian = tree.clade[0, 1].date
         ediacaran = tree.clade[1].date
         for date, desc, val in zip(
-                (silurian, devonian, ediacaran),
-                # (10, 20, 30), # range is deprecated
-                ("Silurian", "Devonian", "Ediacaran"),
-                (425, 320, 600)):
+            (silurian, devonian, ediacaran),
+            # (10, 20, 30), # range is deprecated
+            ("Silurian", "Devonian", "Ediacaran"),
+            (425, 320, 600),
+        ):
             self.assertTrue(isinstance(date, PX.Date))
             self.assertEqual(date.unit, "mya")
             # self.assertAlmostEqual(date.range, rang)
@@ -310,7 +280,7 @@ class TreeTests(unittest.TestCase):
                 "Hirschweg, Winterthur, Switzerland",
                 "Nagoya, Aichi, Japan",
                 "ETH Zürich",
-                "San Diego"
+                "San Diego",
             ),
             (47.481277, 35.155904, 47.376334, 32.880933),
             (8.769303, 136.915863, 8.548108, -117.217543),
@@ -338,20 +308,37 @@ class TreeTests(unittest.TestCase):
         darch = clade.sequences[0].domain_architecture
         self.assertTrue(isinstance(darch, PX.DomainArchitecture))
         self.assertEqual(darch.length, 1249)
-        for domain, start, end, conf, value in zip(darch.domains,
-                                                   (6, 109, 605, 647, 689, 733,
-                                                    872, 993, 1075, 1117, 1168),
-                                                   (90, 414, 643, 685, 729,
-                                                    771, 910, 1031, 1113, 1155,
-                                                    1204),
-                                                   (7.0e-26, 7.2e-117, 2.4e-6,
-                                                    1.1e-12, 2.4e-7, 4.7e-14,
-                                                    2.5e-8, 4.6e-6, 6.3e-7,
-                                                    1.4e-7, 0.3),
-                                                   ("CARD", "NB-ARC", "WD40",
-                                                    "WD40", "WD40", "WD40",
-                                                    "WD40", "WD40", "WD40",
-                                                    "WD40", "WD40")):
+        for domain, start, end, conf, value in zip(
+            darch.domains,
+            (6, 109, 605, 647, 689, 733, 872, 993, 1075, 1117, 1168),
+            (90, 414, 643, 685, 729, 771, 910, 1031, 1113, 1155, 1204),
+            (
+                7.0e-26,
+                7.2e-117,
+                2.4e-6,
+                1.1e-12,
+                2.4e-7,
+                4.7e-14,
+                2.5e-8,
+                4.6e-6,
+                6.3e-7,
+                1.4e-7,
+                0.3,
+            ),
+            (
+                "CARD",
+                "NB-ARC",
+                "WD40",
+                "WD40",
+                "WD40",
+                "WD40",
+                "WD40",
+                "WD40",
+                "WD40",
+                "WD40",
+                "WD40",
+            ),
+        ):
             self.assertTrue(isinstance(domain, PX.ProteinDomain))
             self.assertEqual(domain.start + 1, start)
             self.assertEqual(domain.end, end)
@@ -378,13 +365,11 @@ class TreeTests(unittest.TestCase):
             self.assertEqual(len(poly.points), 3)
         self.assertEqual(dist.polygons[0].points[0].alt_unit, "m")
         for point, lati, longi, alti in zip(
-                chain(dist.polygons[0].points, dist.polygons[1].points),
-                (47.481277, 35.155904, 47.376334, 40.481277, 25.155904,
-                    47.376334),
-                (8.769303, 136.915863, 8.548108, 8.769303, 136.915863,
-                    7.548108),
-                (472, 10, 452, 42, 10, 452),
-                ):
+            chain(dist.polygons[0].points, dist.polygons[1].points),
+            (47.481277, 35.155904, 47.376334, 40.481277, 25.155904, 47.376334),
+            (8.769303, 136.915863, 8.548108, 8.769303, 136.915863, 7.548108),
+            (472, 10, 452, 42, 10, 452),
+        ):
             self.assertTrue(isinstance(point, PX.Point))
             self.assertEqual(point.geodetic_datum, "WGS84")
             self.assertEqual(point.lat, lati)
@@ -395,9 +380,8 @@ class TreeTests(unittest.TestCase):
         """Instantiation of Property objects."""
         tree = list(PhyloXMLIO.parse(EX_PHYLO))[8]
         for prop, id_ref, value in zip(
-                tree.properties,
-                ("id_a", "id_b", "id_c"),
-                ("1200", "2300", "200")):
+            tree.properties, ("id_a", "id_b", "id_c"), ("1200", "2300", "200")
+        ):
             self.assertTrue(isinstance(prop, PX.Property))
             self.assertEqual(prop.id_ref, id_ref)
             self.assertEqual(prop.datatype, "xsd:integer")
@@ -438,20 +422,25 @@ class TreeTests(unittest.TestCase):
         seq2 = trees[5].clade[0, 1].sequences[0]
         seq3 = trees[5].clade[1].sequences[0]
         for seq, sym, acc, name, mol_seq, ann_refs in zip(
-                (seq1, seq2, seq3),
-                ("ADHX", "RT4I1", "ADHB"),
-                ("P81431", "Q54II4", "Q04945"),
-                ("Alcohol dehydrogenase class-3",
-                 "Reticulon-4-interacting protein 1 homolog, "
-                 "mitochondrial precursor",
-                 "NADH-dependent butanol dehydrogenase B"),
-                ("TDATGKPIKCMAAIAWEAKKPLSIEEVEVAPPKSGEVRIKILHSGVCHTD",
-                 "MKGILLNGYGESLDLLEYKTDLPVPKPIKSQVLIKIHSTSINPLDNVMRK",
-                 "MVDFEYSIPTRIFFGKDKINVLGRELKKYGSKVLIVYGGGSIKRNGIYDK"),
-                (("EC:1.1.1.1", "GO:0004022"),
-                 ("GO:0008270", "GO:0016491"),
-                 ("GO:0046872", "KEGG:Tetrachloroethene degradation")),
-                ):
+            (seq1, seq2, seq3),
+            ("ADHX", "RT4I1", "ADHB"),
+            ("P81431", "Q54II4", "Q04945"),
+            (
+                "Alcohol dehydrogenase class-3",
+                "Reticulon-4-interacting protein 1 homolog, mitochondrial precursor",
+                "NADH-dependent butanol dehydrogenase B",
+            ),
+            (
+                "TDATGKPIKCMAAIAWEAKKPLSIEEVEVAPPKSGEVRIKILHSGVCHTD",
+                "MKGILLNGYGESLDLLEYKTDLPVPKPIKSQVLIKIHSTSINPLDNVMRK",
+                "MVDFEYSIPTRIFFGKDKINVLGRELKKYGSKVLIVYGGGSIKRNGIYDK",
+            ),
+            (
+                ("EC:1.1.1.1", "GO:0004022"),
+                ("GO:0008270", "GO:0016491"),
+                ("GO:0046872", "KEGG:Tetrachloroethene degradation"),
+            ),
+        ):
             self.assertTrue(isinstance(seq, PX.Sequence))
             self.assertEqual(seq.symbol, sym)
             self.assertEqual(seq.accession.source, "UniProtKB")
@@ -465,9 +454,11 @@ class TreeTests(unittest.TestCase):
         """Instantiation of SequenceRelation objects."""
         tree = list(PhyloXMLIO.parse(EX_PHYLO))[4]
         for seqrel, id_ref_0, id_ref_1, type in zip(
-                tree.sequence_relations,
-                ("x", "x", "y"), ("y", "z", "z"),
-                ("paralogy", "orthology", "orthology")):
+            tree.sequence_relations,
+            ("x", "x", "y"),
+            ("y", "z", "z"),
+            ("paralogy", "orthology", "orthology"),
+        ):
             self.assertTrue(isinstance(seqrel, PX.SequenceRelation))
             self.assertEqual(seqrel.id_ref_0, id_ref_0)
             self.assertEqual(seqrel.id_ref_1, id_ref_1)
@@ -501,12 +492,14 @@ class TreeTests(unittest.TestCase):
         uri = tree.clade.taxonomies[0].uri
         self.assertTrue(isinstance(uri, PX.Uri))
         self.assertEqual(uri.desc, "EMBL REPTILE DATABASE")
-        self.assertEqual(uri.value,
-                         "http://www.embl-heidelberg.de/~uetz/families/Varanidae.html")
+        self.assertEqual(
+            uri.value, "http://www.embl-heidelberg.de/~uetz/families/Varanidae.html"
+        )
 
 
 # ---------------------------------------------------------
 # Serialization tests
+
 
 class WriterTests(unittest.TestCase):
     """Tests for serialization of objects to phyloXML format.
@@ -534,11 +527,16 @@ class WriterTests(unittest.TestCase):
         orig_fname = EX_APAF
         try:
             EX_APAF = DUMMY
-            self._rewrite_and_call(orig_fname, (
-                (ParseTests, [
-                    "test_read_apaf", "test_parse_apaf", "test_shape_apaf"]),
-                (TreeTests, ["test_DomainArchitecture"]),
-                ))
+            self._rewrite_and_call(
+                orig_fname,
+                (
+                    (
+                        ParseTests,
+                        ["test_read_apaf", "test_parse_apaf", "test_shape_apaf"],
+                    ),
+                    (TreeTests, ["test_DomainArchitecture"]),
+                ),
+            )
         finally:
             EX_APAF = orig_fname
 
@@ -548,11 +546,16 @@ class WriterTests(unittest.TestCase):
         orig_fname = EX_BCL2
         try:
             EX_BCL2 = DUMMY
-            self._rewrite_and_call(orig_fname, (
-                (ParseTests, [
-                    "test_read_bcl2", "test_parse_bcl2", "test_shape_bcl2"]),
-                (TreeTests, ["test_Confidence"]),
-                ))
+            self._rewrite_and_call(
+                orig_fname,
+                (
+                    (
+                        ParseTests,
+                        ["test_read_bcl2", "test_parse_bcl2", "test_shape_bcl2"],
+                    ),
+                    (TreeTests, ["test_Confidence"]),
+                ),
+            )
         finally:
             EX_BCL2 = orig_fname
 
@@ -562,10 +565,13 @@ class WriterTests(unittest.TestCase):
         orig_fname = EX_MADE
         try:
             EX_MADE = DUMMY
-            self._rewrite_and_call(orig_fname, (
-                (ParseTests, ["test_read_made", "test_parse_made"]),
-                (TreeTests, ["test_Confidence", "test_Polygon"]),
-                ))
+            self._rewrite_and_call(
+                orig_fname,
+                (
+                    (ParseTests, ["test_read_made", "test_parse_made"]),
+                    (TreeTests, ["test_Confidence", "test_Polygon"]),
+                ),
+            )
         finally:
             EX_MADE = orig_fname
 
@@ -575,19 +581,34 @@ class WriterTests(unittest.TestCase):
         orig_fname = EX_PHYLO
         try:
             EX_PHYLO = DUMMY
-            self._rewrite_and_call(orig_fname, (
-                (ParseTests, [
-                    "test_read_phylo", "test_parse_phylo", "test_shape_phylo"]),
-                (TreeTests, [
-                    "test_Phyloxml", "test_Other",
-                    "test_Phylogeny", "test_Clade",
-                    "test_Annotation", "test_CladeRelation",
-                    "test_Date", "test_Distribution",
-                    "test_Events", "test_Property",
-                    "test_Sequence", "test_SequenceRelation",
-                    "test_Taxonomy", "test_Uri",
-                    ]),
-                ))
+            self._rewrite_and_call(
+                orig_fname,
+                (
+                    (
+                        ParseTests,
+                        ["test_read_phylo", "test_parse_phylo", "test_shape_phylo"],
+                    ),
+                    (
+                        TreeTests,
+                        [
+                            "test_Phyloxml",
+                            "test_Other",
+                            "test_Phylogeny",
+                            "test_Clade",
+                            "test_Annotation",
+                            "test_CladeRelation",
+                            "test_Date",
+                            "test_Distribution",
+                            "test_Events",
+                            "test_Property",
+                            "test_Sequence",
+                            "test_SequenceRelation",
+                            "test_Taxonomy",
+                            "test_Uri",
+                        ],
+                    ),
+                ),
+            )
         finally:
             EX_PHYLO = orig_fname
 
@@ -597,16 +618,20 @@ class WriterTests(unittest.TestCase):
         orig_fname = EX_DOLLO
         try:
             EX_DOLLO = DUMMY
-            self._rewrite_and_call(orig_fname, (
-                (ParseTests, ["test_read_dollo", "test_parse_dollo"]),
-                (TreeTests, ["test_BinaryCharacters"]),
-                ))
+            self._rewrite_and_call(
+                orig_fname,
+                (
+                    (ParseTests, ["test_read_dollo", "test_parse_dollo"]),
+                    (TreeTests, ["test_BinaryCharacters"]),
+                ),
+            )
         finally:
             EX_DOLLO = orig_fname
 
 
 # ---------------------------------------------------------
 # Method tests
+
 
 class MethodTests(unittest.TestCase):
     """Tests for methods on specific classes/objects."""
@@ -637,20 +662,26 @@ class MethodTests(unittest.TestCase):
             accession=PX.Accession("P81431", source="UniProtKB"),
             name="Alcohol dehydrogenase class-3",
             # location=None,
-            mol_seq=PX.MolSeq(
-                "TDATGKPIKCMAAIAWEAKKPLSIEEVEVAPPKSGEVRIKILHSGVCHTD"),
+            mol_seq=PX.MolSeq("TDATGKPIKCMAAIAWEAKKPLSIEEVEVAPPKSGEVRIKILHSGVCHTD"),
             uri=None,
-            annotations=[PX.Annotation(ref="EC:1.1.1.1"),
-                         PX.Annotation(ref="GO:0004022")],
+            annotations=[
+                PX.Annotation(ref="EC:1.1.1.1"),
+                PX.Annotation(ref="GO:0004022"),
+            ],
             domain_architecture=PX.DomainArchitecture(
                 length=50,
-                domains=[PX.ProteinDomain(*args) for args in (
-                    # value, start, end, confidence
-                    ("FOO", 0, 5, 7.0e-26),
-                    ("BAR", 8, 13, 7.2e-117),
-                    ("A-OK", 21, 34, 2.4e-06),
-                    ("WD40", 40, 50, 0.3))],
-                ))
+                domains=[
+                    PX.ProteinDomain(*args)
+                    for args in (
+                        # value, start, end, confidence
+                        ("FOO", 0, 5, 7.0e-26),
+                        ("BAR", 8, 13, 7.2e-117),
+                        ("A-OK", 21, 34, 2.4e-06),
+                        ("WD40", 40, 50, 0.3),
+                    )
+                ],
+            ),
+        )
         srec = pseq.to_seqrecord()
         # TODO: check seqrec-specific traits (see args)
         #   Seq(letters, alphabet), id, name, description, features
@@ -664,10 +695,12 @@ class MethodTests(unittest.TestCase):
         self.assertEqual(len(aln), 0)
         # Add sequences to the terminals
         alphabet = Alphabet.Gapped(Alphabet.generic_dna)
-        for tip, seqstr in zip(tree.get_terminals(),
-                               ("AA--TTA", "AA--TTG", "AACCTTC")):
-            tip.sequences.append(PX.Sequence.from_seqrecord(
-                SeqRecord(Seq(seqstr, alphabet), id=str(tip))))
+        for tip, seqstr in zip(tree.get_terminals(), ("AA--TTA", "AA--TTG", "AACCTTC")):
+            tip.sequences.append(
+                PX.Sequence.from_seqrecord(
+                    SeqRecord(Seq(seqstr, alphabet), id=str(tip))
+                )
+            )
         # Check the alignment
         aln = tree.to_alignment()
         self.assertTrue(isinstance(aln, MultipleSeqAlignment))
@@ -683,8 +716,7 @@ class MethodTests(unittest.TestCase):
         self.assertEqual(tree.clade[0, 1], tree.clade.clades[0].clades[1])
         self.assertEqual(tree.clade[1], tree.clade.clades[1])
         self.assertEqual(len(tree.clade[:]), len(tree.clade.clades))
-        self.assertEqual(len(tree.clade[0, :]),
-                         len(tree.clade.clades[0].clades))
+        self.assertEqual(len(tree.clade[0, :]), len(tree.clade.clades[0].clades))
 
     def test_phyloxml_getitem(self):
         """Phyloxml.__getitem__: get phylogenies by name or index."""
@@ -750,6 +782,7 @@ class MethodTests(unittest.TestCase):
         self.assertEqual(white.to_hex(), "#ffffff")
         green = PX.BranchColor(14, 192, 113)
         self.assertEqual(green.to_hex(), "#0ec071")
+
 
 # ---------------------------------------------------------
 

--- a/Tests/test_Phylo_CDAO.py
+++ b/Tests/test_Phylo_CDAO.py
@@ -72,11 +72,11 @@ def _test_write_factory(source):
                 pass
             else:
                 # Can't sort lists with None on Python 3 ...
-                self.assertFalse(
-                    None in p1, "Bad input values for %s: %r" % (prop_name, p1)
+                self.assertNotIn(
+                    None, p1, "Bad input values for %s: %r" % (prop_name, p1)
                 )
-                self.assertFalse(
-                    None in p2, "Bad output values for %s: %r" % (prop_name, p2)
+                self.assertNotIn(
+                    None, p2, "Bad output values for %s: %r" % (prop_name, p2)
                 )
                 self.assertEqual(sorted(p1), sorted(p2))
 

--- a/Tests/test_Phylo_CDAO.py
+++ b/Tests/test_Phylo_CDAO.py
@@ -13,10 +13,13 @@ from Bio import MissingExternalDependencyError
 
 import Bio.Phylo as bp
 from Bio.Phylo import CDAO
+
 try:
     from Bio.Phylo import CDAOIO
 except ImportError:
-    raise MissingExternalDependencyError("Install RDFlib if you want to use the CDAO tree format.") from None
+    raise MissingExternalDependencyError(
+        "Install RDFlib if you want to use the CDAO tree format."
+    ) from None
 
 # Example CDAO files
 cdao_files = ("test.cdao",)
@@ -27,6 +30,7 @@ DUMMY = tempfile.mktemp()
 
 # ---------------------------------------------------------
 # Parser tests
+
 
 def _test_parse_factory(source):
     """Generate a test method for parse()ing the given source.
@@ -68,8 +72,12 @@ def _test_write_factory(source):
                 pass
             else:
                 # Can't sort lists with None on Python 3 ...
-                self.assertFalse(None in p1, "Bad input values for %s: %r" % (prop_name, p1))
-                self.assertFalse(None in p2, "Bad output values for %s: %r" % (prop_name, p2))
+                self.assertFalse(
+                    None in p1, "Bad input values for %s: %r" % (prop_name, p1)
+                )
+                self.assertFalse(
+                    None in p2, "Bad output values for %s: %r" % (prop_name, p2)
+                )
                 self.assertEqual(sorted(p1), sorted(p2))
 
     test_write.__doc__ = "Write and re-parse the phylogenies in %s." % source

--- a/Tests/test_Phylo_NeXML.py
+++ b/Tests/test_Phylo_NeXML.py
@@ -47,6 +47,7 @@ DUMMY = tempfile.mktemp()
 # ---------------------------------------------------------
 # Parser tests
 
+
 def _test_parse_factory(source):
     """Generate a test method for parse()ing the given source.
 
@@ -86,8 +87,16 @@ def _test_write_factory(source):
             t2 = next(NeXMLIO.Parser(infile).parse())
 
         def assert_property(prop_name):
-            p1 = sorted(getattr(n, prop_name) for n in t1.get_terminals() if getattr(n, prop_name))
-            p2 = sorted(getattr(n, prop_name) for n in t2.get_terminals() if getattr(n, prop_name))
+            p1 = sorted(
+                getattr(n, prop_name)
+                for n in t1.get_terminals()
+                if getattr(n, prop_name)
+            )
+            p2 = sorted(
+                getattr(n, prop_name)
+                for n in t2.get_terminals()
+                if getattr(n, prop_name)
+            )
             self.assertEqual(p1, p2)
 
         for prop_name in ("name", "branch_length", "confidence"):
@@ -99,6 +108,7 @@ def _test_write_factory(source):
 
 class ParseTests(unittest.TestCase):
     """Tests for proper parsing of example NeXML files."""
+
     # Methods added at run time...
 
 
@@ -110,6 +120,7 @@ for n, ex in enumerate(nexml_files):
 
 class WriterTests(unittest.TestCase):
     """NeXML writer tests."""
+
     # Methods added at run time...
 
 

--- a/Tests/test_Phylo_matplotlib.py
+++ b/Tests/test_Phylo_matplotlib.py
@@ -17,7 +17,8 @@ try:
     import matplotlib
 except ImportError:
     raise MissingExternalDependencyError(
-        "Install matplotlib if you want to use Bio.Phylo._utils.") from None
+        "Install matplotlib if you want to use Bio.Phylo._utils."
+    ) from None
 
 # Don't use the Wx backend for matplotlib, use the simpler postscript
 # backend -- we're not going to display or save the plot anyway, so it
@@ -29,7 +30,8 @@ try:
 except ImportError:
     # Can fail here with font problems
     raise MissingExternalDependencyError(
-        "Install matplotlib if you want to use Bio.Phylo._utils.") from None
+        "Install matplotlib if you want to use Bio.Phylo._utils."
+    ) from None
 
 
 # Example PhyloXML file
@@ -42,14 +44,16 @@ class UtilTests(unittest.TestCase):
 
     def test_draw(self):
         """Run the tree layout algorithm, but don't display it."""
-        pyplot.ioff()   # Turn off interactive display
+        pyplot.ioff()  # Turn off interactive display
         dollo = Phylo.read(EX_DOLLO, "phyloxml")
         apaf = Phylo.read(EX_APAF, "phyloxml")
         Phylo.draw(dollo, do_show=False)
         Phylo.draw(apaf, do_show=False)
         # Fancier options
         Phylo.draw(apaf, do_show=False, branch_labels={apaf.root: "Root"})
-        Phylo.draw(apaf, do_show=False, branch_labels=lambda c: c.branch_length)  # noqa: E731
+        Phylo.draw(
+            apaf, do_show=False, branch_labels=lambda c: c.branch_length  # noqa: E731
+        )
 
     def test_draw_with_label_colors_dict(self):
         """Layout tree with label colors as dict.
@@ -57,7 +61,7 @@ class UtilTests(unittest.TestCase):
         Run the tree layout algorithm with a label_colors argument passed in
         as a dictionary. Don't display tree.
         """
-        pyplot.ioff()   # Turn off interactive display
+        pyplot.ioff()  # Turn off interactive display
         dollo = Phylo.read(EX_DOLLO, "phyloxml")
         apaf = Phylo.read(EX_APAF, "phyloxml")
         label_colors_dollo = {
@@ -77,7 +81,7 @@ class UtilTests(unittest.TestCase):
         Run the tree layout algorithm with a label_colors argument passed in
         as a callable. Don't display tree.
         """
-        pyplot.ioff()   # Turn off interactive display
+        pyplot.ioff()  # Turn off interactive display
         dollo = Phylo.read(EX_DOLLO, "phyloxml")
         apaf = Phylo.read(EX_APAF, "phyloxml")
 

--- a/Tests/test_Phylo_networkx.py
+++ b/Tests/test_Phylo_networkx.py
@@ -18,7 +18,8 @@ try:
     import networkx
 except ImportError:
     raise MissingExternalDependencyError(
-        "Install networkx if you wish to use it with Bio.Phylo") from None
+        "Install networkx if you wish to use it with Bio.Phylo"
+    ) from None
 
 # Example PhyloXML file
 EX_DOLLO = "PhyloXML/o_tol_332_d_dollo.xml"


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_Phylo* files, 6 files. it should be fine to merge.
test_Phylo.py
test_Phylo_CDAO.py
test_Phylo_matplotlib.py
test_Phylo_networkx.py
test_Phylo_NeXML.py
test_PhyloXML.py