### PR TITLE
Apply black style to test_PAML* files, version 19.10b0.

### DIFF
--- a/Tests/test_PAML_baseml.py
+++ b/Tests/test_PAML_baseml.py
@@ -30,9 +30,17 @@ class ModTest(unittest.TestCase):
 
     def tearDown(self):
         """Just in case BASEML creates some junk files, do a clean-up."""
-        del_files = [self.out_file, "2base.t",
-                     "in.basemlg", "baseml.ctl", "lnf", "rates", "rst", "rst1",
-                     "rub"]
+        del_files = [
+            self.out_file,
+            "2base.t",
+            "in.basemlg",
+            "baseml.ctl",
+            "lnf",
+            "rates",
+            "rst",
+            "rst1",
+            "rub",
+        ]
         for filename in del_files:
             if os.path.exists(filename):
                 os.remove(filename)
@@ -46,141 +54,137 @@ class ModTest(unittest.TestCase):
         self.bml = baseml.Baseml()
 
     def testAlignmentFileIsValid(self):
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          baseml.Baseml, alignment=[])
+        self.assertRaises(
+            (AttributeError, TypeError, OSError), baseml.Baseml, alignment=[]
+        )
         self.bml.alignment = []
         self.bml.tree = self.tree_file
         self.bml.out_file = self.out_file
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.bml.run)
+        self.assertRaises((AttributeError, TypeError, OSError), self.bml.run)
 
     def testAlignmentExists(self):
-        self.assertRaises((EnvironmentError, IOError), baseml.Baseml,
-                          alignment="nonexistent")
+        self.assertRaises(
+            (EnvironmentError, IOError), baseml.Baseml, alignment="nonexistent"
+        )
         self.bml.alignment = "nonexistent"
         self.bml.tree = self.tree_file
         self.bml.out_file = self.out_file
-        self.assertRaises((EnvironmentError, IOError),
-                          self.bml.run)
+        self.assertRaises((EnvironmentError, IOError), self.bml.run)
 
     def testTreeFileValid(self):
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          baseml.Baseml, tree=[])
+        self.assertRaises((AttributeError, TypeError, OSError), baseml.Baseml, tree=[])
         self.bml.alignment = self.align_file
         self.bml.tree = []
         self.bml.out_file = self.out_file
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.bml.run)
+        self.assertRaises((AttributeError, TypeError, OSError), self.bml.run)
 
     def testTreeExists(self):
-        self.assertRaises((EnvironmentError, IOError), baseml.Baseml,
-                          tree="nonexistent")
+        self.assertRaises(
+            (EnvironmentError, IOError), baseml.Baseml, tree="nonexistent"
+        )
         self.bml.alignment = self.align_file
         self.bml.tree = "nonexistent"
         self.bml.out_file = self.out_file
-        self.assertRaises((EnvironmentError, IOError),
-                          self.bml.run)
+        self.assertRaises((EnvironmentError, IOError), self.bml.run)
 
     def testWorkingDirValid(self):
         self.bml.tree = self.tree_file
         self.bml.alignment = self.align_file
         self.bml.out_file = self.out_file
         self.bml.working_dir = []
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.bml.run)
+        self.assertRaises((AttributeError, TypeError, OSError), self.bml.run)
 
     def testOptionExists(self):
-        self.assertRaises((AttributeError, KeyError),
-                          self.bml.set_options, xxxx=1)
-        self.assertRaises((AttributeError, KeyError),
-                          self.bml.get_option, "xxxx")
+        self.assertRaises((AttributeError, KeyError), self.bml.set_options, xxxx=1)
+        self.assertRaises((AttributeError, KeyError), self.bml.get_option, "xxxx")
 
     def testAlignmentSpecified(self):
         self.bml.tree = self.tree_file
         self.bml.out_file = self.out_file
-        self.assertRaises((AttributeError, ValueError),
-                          self.bml.run)
+        self.assertRaises((AttributeError, ValueError), self.bml.run)
 
     def testTreeSpecified(self):
         self.bml.alignment = self.align_file
         self.bml.out_file = self.out_file
-        self.assertRaises((AttributeError, ValueError),
-                          self.bml.run)
+        self.assertRaises((AttributeError, ValueError), self.bml.run)
 
     def testOutputFileSpecified(self):
         self.bml.alignment = self.align_file
         self.bml.tree = self.tree_file
-        self.assertRaises((AttributeError, ValueError),
-                          self.bml.run)
+        self.assertRaises((AttributeError, ValueError), self.bml.run)
 
     def testPamlErrorsCaught(self):
         self.bml.alignment = self.align_file
         self.bml.tree = self.bad_tree_file
         self.bml.out_file = self.out_file
-        self.assertRaises((EnvironmentError, PamlError),
-                          self.bml.run)
+        self.assertRaises((EnvironmentError, PamlError), self.bml.run)
 
     def testCtlFileValidOnRun(self):
         self.bml.alignment = self.align_file
         self.bml.tree = self.tree_file
         self.bml.out_file = self.out_file
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.bml.run, ctl_file=[])
+        self.assertRaises(
+            (AttributeError, TypeError, OSError), self.bml.run, ctl_file=[]
+        )
 
     def testCtlFileExistsOnRun(self):
         self.bml.alignment = self.align_file
         self.bml.tree = self.tree_file
         self.bml.out_file = self.out_file
-        self.assertRaises((EnvironmentError, IOError),
-                          self.bml.run, ctl_file="nonexistent")
+        self.assertRaises(
+            (EnvironmentError, IOError), self.bml.run, ctl_file="nonexistent"
+        )
 
     def testCtlFileValidOnRead(self):
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.bml.read_ctl_file, [])
-        self.assertRaises((AttributeError, KeyError),
-                          self.bml.read_ctl_file, self.bad_ctl_file1)
-        self.assertRaises(AttributeError,
-                          self.bml.read_ctl_file, self.bad_ctl_file2)
-        target_options = {"noisy": 0,
-                          "verbose": 0,
-                          "runmode": 0,
-                          "model": 6,
-                          "model_options": None,
-                          "Mgene": 1,
-                          "ndata": None,
-                          "clock": 0,
-                          "fix_kappa": 0,
-                          "kappa": 5,
-                          "fix_alpha": 0,
-                          "alpha": 0.5,
-                          "Malpha": 0,
-                          "ncatG": 5,
-                          "fix_rho": 1,
-                          "rho": 0,
-                          "nparK": 0,
-                          "nhomo": 0,
-                          "getSE": 0,
-                          "RateAncestor": 0,
-                          "Small_Diff": 7e-6,
-                          "cleandata": 1,
-                          "icode": None,
-                          "fix_blength": None,
-                          "method": 0}
+        self.assertRaises(
+            (AttributeError, TypeError, OSError), self.bml.read_ctl_file, []
+        )
+        self.assertRaises(
+            (AttributeError, KeyError), self.bml.read_ctl_file, self.bad_ctl_file1
+        )
+        self.assertRaises(AttributeError, self.bml.read_ctl_file, self.bad_ctl_file2)
+        target_options = {
+            "noisy": 0,
+            "verbose": 0,
+            "runmode": 0,
+            "model": 6,
+            "model_options": None,
+            "Mgene": 1,
+            "ndata": None,
+            "clock": 0,
+            "fix_kappa": 0,
+            "kappa": 5,
+            "fix_alpha": 0,
+            "alpha": 0.5,
+            "Malpha": 0,
+            "ncatG": 5,
+            "fix_rho": 1,
+            "rho": 0,
+            "nparK": 0,
+            "nhomo": 0,
+            "getSE": 0,
+            "RateAncestor": 0,
+            "Small_Diff": 7e-6,
+            "cleandata": 1,
+            "icode": None,
+            "fix_blength": None,
+            "method": 0,
+        }
         self.bml.read_ctl_file(self.ctl_file)
         # Compare the dictionary keys:
         self.assertEqual(sorted(self.bml._options), sorted(target_options))
         for key in target_options:
-            self.assertEqual(self.bml._options[key], target_options[key],
-                             "%s: %r vs %r"
-                             % (key, self.bml._options[key], target_options[key]))
+            self.assertEqual(
+                self.bml._options[key],
+                target_options[key],
+                "%s: %r vs %r" % (key, self.bml._options[key], target_options[key]),
+            )
 
     def testCtlFileExistsOnRead(self):
-        self.assertRaises(IOError,
-                          self.bml.read_ctl_file, ctl_file="nonexistent")
+        self.assertRaises(IOError, self.bml.read_ctl_file, ctl_file="nonexistent")
 
     def testResultsValid(self):
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          baseml.read, [])
+        self.assertRaises((AttributeError, TypeError, OSError), baseml.read, [])
 
     def testResultsExist(self):
         self.assertRaises(IOError, baseml.read, "nonexistent")
@@ -202,8 +206,10 @@ class ModTest(unittest.TestCase):
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
             model = results_file[5]
-            version_msg = "Improper parsing for model %s version %s" \
-                          % (model, version.replace("_", "."))
+            version_msg = "Improper parsing for model %s version %s" % (
+                model,
+                version.replace("_", "."),
+            )
             results_path = os.path.join(res_dir, results_file)
             results = baseml.read(results_path)
             # There are 6 top-levels: parameters, tree, lnL, version,
@@ -236,8 +242,10 @@ class ModTest(unittest.TestCase):
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
             model = results_file[5]
-            version_msg = "Improper parsing for model %s version %s" \
-                          % (model, version.replace("_", "."))
+            version_msg = "Improper parsing for model %s version %s" % (
+                model,
+                version.replace("_", "."),
+            )
             results_path = os.path.join(res_dir, results_file)
             results = baseml.read(results_path)
             # There are 6 top-levels: parameters, tree, lnL, version,
@@ -256,8 +264,10 @@ class ModTest(unittest.TestCase):
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
             n = results_file[5]
-            version_msg = "Improper parsing for nhomo %s version %s" \
-                          % (n, version.replace("_", "."))
+            version_msg = "Improper parsing for nhomo %s version %s" % (
+                n,
+                version.replace("_", "."),
+            )
             results_path = os.path.join(res_dir, results_file)
             results = baseml.read(results_path)
             # There are 6 top-levels: parameters, tree, lnL, version,
@@ -277,8 +287,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "baseml", "SE")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = "Improper parsing for version %s" \
-                          % version.replace("_", ".")
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = baseml.read(results_path)
             # There are 6 top-levels: parameters, tree, lnL, version,

--- a/Tests/test_PAML_codeml.py
+++ b/Tests/test_PAML_codeml.py
@@ -43,8 +43,17 @@ class ModTest(unittest.TestCase):
 
     def tearDown(self):
         """Just in case CODEML creates some junk files, do a clean-up."""
-        del_files = [self.out_file, "2NG.dN", "2NG.dS", "2NG.t", "codeml.ctl",
-                     "lnf", "rst", "rst1", "rub"]
+        del_files = [
+            self.out_file,
+            "2NG.dN",
+            "2NG.dS",
+            "2NG.t",
+            "codeml.ctl",
+            "lnf",
+            "rst",
+            "rst1",
+            "rub",
+        ]
         for filename in del_files:
             if os.path.exists(filename):
                 os.remove(filename)
@@ -58,34 +67,34 @@ class ModTest(unittest.TestCase):
         self.cml = codeml.Codeml()
 
     def testAlignmentFileIsValid(self):
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          codeml.Codeml, alignment=[])
+        self.assertRaises(
+            (AttributeError, TypeError, OSError), codeml.Codeml, alignment=[]
+        )
         self.cml.alignment = []
         self.cml.tree = self.tree_file
         self.cml.out_file = self.out_file
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.cml.run)
+        self.assertRaises((AttributeError, TypeError, OSError), self.cml.run)
 
     def testAlignmentExists(self):
-        self.assertRaises((EnvironmentError, IOError), codeml.Codeml,
-                          alignment="nonexistent")
+        self.assertRaises(
+            (EnvironmentError, IOError), codeml.Codeml, alignment="nonexistent"
+        )
         self.cml.alignment = "nonexistent"
         self.cml.tree = self.tree_file
         self.cml.out_file = self.out_file
         self.assertRaises(IOError, self.cml.run)
 
     def testTreeFileValid(self):
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          codeml.Codeml, tree=[])
+        self.assertRaises((AttributeError, TypeError, OSError), codeml.Codeml, tree=[])
         self.cml.alignment = self.align_file
         self.cml.tree = []
         self.cml.out_file = self.out_file
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.cml.run)
+        self.assertRaises((AttributeError, TypeError, OSError), self.cml.run)
 
     def testTreeExists(self):
-        self.assertRaises((EnvironmentError, IOError), codeml.Codeml,
-                          tree="nonexistent")
+        self.assertRaises(
+            (EnvironmentError, IOError), codeml.Codeml, tree="nonexistent"
+        )
         self.cml.alignment = self.align_file
         self.cml.tree = "nonexistent"
         self.cml.out_file = self.out_file
@@ -96,111 +105,109 @@ class ModTest(unittest.TestCase):
         self.cml.alignment = self.align_file
         self.cml.out_file = self.out_file
         self.cml.working_dir = []
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.cml.run)
+        self.assertRaises((AttributeError, TypeError, OSError), self.cml.run)
 
     def testOptionExists(self):
-        self.assertRaises((AttributeError, KeyError),
-                          self.cml.set_options, xxxx=1)
-        self.assertRaises((AttributeError, KeyError),
-                          self.cml.get_option, "xxxx")
+        self.assertRaises((AttributeError, KeyError), self.cml.set_options, xxxx=1)
+        self.assertRaises((AttributeError, KeyError), self.cml.get_option, "xxxx")
 
     def testAlignmentSpecified(self):
         self.cml.tree = self.tree_file
         self.cml.out_file = self.out_file
-        self.assertRaises((AttributeError, ValueError),
-                          self.cml.run)
+        self.assertRaises((AttributeError, ValueError), self.cml.run)
 
     def testTreeSpecified(self):
         self.cml.alignment = self.align_file
         self.cml.out_file = self.out_file
-        self.assertRaises((AttributeError, ValueError),
-                          self.cml.run)
+        self.assertRaises((AttributeError, ValueError), self.cml.run)
 
     def testOutputFileSpecified(self):
         self.cml.alignment = self.align_file
         self.cml.tree = self.tree_file
-        self.assertRaises((AttributeError, ValueError),
-                          self.cml.run)
+        self.assertRaises((AttributeError, ValueError), self.cml.run)
 
     def testPamlErrorsCaught(self):
         self.cml.alignment = self.align_file
         self.cml.tree = self.bad_tree_file
         self.cml.out_file = self.out_file
-        self.assertRaises((EnvironmentError, PamlError),
-                          self.cml.run)
+        self.assertRaises((EnvironmentError, PamlError), self.cml.run)
 
     def testCtlFileValidOnRun(self):
         self.cml.alignment = self.align_file
         self.cml.tree = self.tree_file
         self.cml.out_file = self.out_file
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.cml.run, ctl_file=[])
+        self.assertRaises(
+            (AttributeError, TypeError, OSError), self.cml.run, ctl_file=[]
+        )
 
     def testCtlFileExistsOnRun(self):
         self.cml.alignment = self.align_file
         self.cml.tree = self.tree_file
         self.cml.out_file = self.out_file
-        self.assertRaises((EnvironmentError, IOError),
-                          self.cml.run, ctl_file="nonexistent")
+        self.assertRaises(
+            (EnvironmentError, IOError), self.cml.run, ctl_file="nonexistent"
+        )
 
     def testCtlFileValidOnRead(self):
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.cml.read_ctl_file, [])
-        self.assertRaises((AttributeError, KeyError),
-                          self.cml.read_ctl_file, self.bad_ctl_file1)
-        self.assertRaises(AttributeError,
-                          self.cml.read_ctl_file, self.bad_ctl_file2)
-        self.assertRaises(TypeError,
-                          self.cml.read_ctl_file, self.bad_ctl_file3)
-        target_options = {"noisy": 0,
-                          "verbose": 0,
-                          "runmode": 0,
-                          "seqtype": 1,
-                          "CodonFreq": 2,
-                          "ndata": None,
-                          "clock": 0,
-                          "aaDist": None,
-                          "aaRatefile": None,
-                          "model": 0,
-                          "NSsites": [0],
-                          "icode": 0,
-                          "Mgene": 0,
-                          "fix_kappa": 0,
-                          "kappa": 4.54006,
-                          "fix_omega": 0,
-                          "omega": 1,
-                          "fix_alpha": 1,
-                          "alpha": 0,
-                          "Malpha": 0,
-                          "ncatG": None,
-                          "getSE": 0,
-                          "RateAncestor": 0,
-                          "Small_Diff": None,
-                          "cleandata": 1,
-                          "fix_blength": 1,
-                          "method": 0,
-                          "rho": None,
-                          "fix_rho": None}
+        self.assertRaises(
+            (AttributeError, TypeError, OSError), self.cml.read_ctl_file, []
+        )
+        self.assertRaises(
+            (AttributeError, KeyError), self.cml.read_ctl_file, self.bad_ctl_file1
+        )
+        self.assertRaises(AttributeError, self.cml.read_ctl_file, self.bad_ctl_file2)
+        self.assertRaises(TypeError, self.cml.read_ctl_file, self.bad_ctl_file3)
+        target_options = {
+            "noisy": 0,
+            "verbose": 0,
+            "runmode": 0,
+            "seqtype": 1,
+            "CodonFreq": 2,
+            "ndata": None,
+            "clock": 0,
+            "aaDist": None,
+            "aaRatefile": None,
+            "model": 0,
+            "NSsites": [0],
+            "icode": 0,
+            "Mgene": 0,
+            "fix_kappa": 0,
+            "kappa": 4.54006,
+            "fix_omega": 0,
+            "omega": 1,
+            "fix_alpha": 1,
+            "alpha": 0,
+            "Malpha": 0,
+            "ncatG": None,
+            "getSE": 0,
+            "RateAncestor": 0,
+            "Small_Diff": None,
+            "cleandata": 1,
+            "fix_blength": 1,
+            "method": 0,
+            "rho": None,
+            "fix_rho": None,
+        }
         self.cml.read_ctl_file(self.ctl_file)
         # Compare the dictionary keys:
         self.assertEqual(sorted(self.cml._options), sorted(target_options))
         for key in target_options:
-            self.assertEqual(self.cml._options[key], target_options[key],
-                             "%s: %r vs %r"
-                             % (key, self.cml._options[key], target_options[key]))
+            self.assertEqual(
+                self.cml._options[key],
+                target_options[key],
+                "%s: %r vs %r" % (key, self.cml._options[key], target_options[key]),
+            )
 
     def testCtlFileExistsOnRead(self):
-        self.assertRaises((EnvironmentError, IOError),
-                          self.cml.read_ctl_file, ctl_file="nonexistent")
+        self.assertRaises(
+            (EnvironmentError, IOError), self.cml.read_ctl_file, ctl_file="nonexistent"
+        )
 
     def testResultsValid(self):
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          codeml.read, [])
+        self.assertRaises((AttributeError, TypeError, OSError), codeml.read, [])
 
     def testResultsExist(self):
-        self.assertRaises((EnvironmentError, IOError),
-                          codeml.read, "nonexistent")
+        self.assertRaises((EnvironmentError, IOError), codeml.read, "nonexistent")
 
     def testResultsParsable(self):
         self.assertRaises(ValueError, codeml.read, self.results_file)
@@ -209,8 +216,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "SE")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             self.assertEqual(len(results), 4, version_msg)
@@ -231,8 +237,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "all_NSsites")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             # There should be 4 top-level items: 'codon model', 'model',
@@ -249,23 +254,22 @@ class ModTest(unittest.TestCase):
                 self.assertEqual(len(model), 5, version_msg)
                 self.assertIn("parameters", model, version_msg)
                 params = model["parameters"]
-                self.assertEqual(len(params), SITECLASS_PARAMS[model_num],
-                                 version_msg)
+                self.assertEqual(len(params), SITECLASS_PARAMS[model_num], version_msg)
                 self.assertIn("branches", params, version_msg)
                 branches = params["branches"]
                 # There are 7 branches in the test case (specific to these
                 # test cases)
                 self.assertEqual(len(branches), 7, version_msg)
                 if "site classes" in params:
-                    self.assertEqual(len(params["site classes"]),
-                                     SITECLASSES[model_num], version_msg)
+                    self.assertEqual(
+                        len(params["site classes"]), SITECLASSES[model_num], version_msg
+                    )
 
     def testParseNSsite3(self):
         res_dir = os.path.join(self.results_dir, "codeml", "NSsite3")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             # There should be 5 top-level items: 'codon model', 'model',
@@ -273,8 +277,7 @@ class ModTest(unittest.TestCase):
             # is only there when only one NSsites class is used
             self.assertEqual(len(results), 5, version_msg)
             self.assertIn("site-class model", results, version_msg)
-            self.assertEqual(results["site-class model"], "discrete",
-                             version_msg)
+            self.assertEqual(results["site-class model"], "discrete", version_msg)
             self.assertIn("NSsites", results, version_msg)
             # There should be 1 NSsites classe: 3
             self.assertEqual(len(results["NSsites"]), 1, version_msg)
@@ -285,8 +288,7 @@ class ModTest(unittest.TestCase):
             self.assertEqual(len(model), 5, version_msg)
             self.assertIn("parameters", model, version_msg)
             params = model["parameters"]
-            self.assertEqual(len(params), SITECLASS_PARAMS[3],
-                             version)
+            self.assertEqual(len(params), SITECLASS_PARAMS[3], version)
             self.assertIn("site classes", params, version_msg)
             site_classes = params["site classes"]
             self.assertEqual(len(site_classes), 4, version_msg)
@@ -295,8 +297,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "branchsiteA")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             # There are 5 top-level items in this case:
@@ -316,8 +317,7 @@ class ModTest(unittest.TestCase):
             self.assertIn("site classes", params, version_msg)
             site_classes = params["site classes"]
             # Branch Site A adds another site class
-            self.assertEqual(len(site_classes), SITECLASSES[2] + 1,
-                             version)
+            self.assertEqual(len(site_classes), SITECLASSES[2] + 1, version)
             for class_num in [0, 1, 2, 3]:
                 self.assertIn(class_num, site_classes, version_msg)
                 site_class = site_classes[class_num]
@@ -327,12 +327,10 @@ class ModTest(unittest.TestCase):
                 self.assertEqual(len(branches), 2, version_msg)
 
     def testParseCladeModelC(self):
-        cladeC_res_dir = os.path.join(self.results_dir, "codeml",
-                                      "clademodelC")
+        cladeC_res_dir = os.path.join(self.results_dir, "codeml", "clademodelC")
         for results_file in os.listdir(cladeC_res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(cladeC_res_dir, results_file)
             results = codeml.read(results_path)
             # 5 top-level items again in this case
@@ -350,8 +348,7 @@ class ModTest(unittest.TestCase):
             self.assertEqual(len(params), SITECLASS_PARAMS[2] - 1, version_msg)
             self.assertIn("site classes", params, version_msg)
             site_classes = params["site classes"]
-            self.assertEqual(len(site_classes), SITECLASSES[2],
-                             version)
+            self.assertEqual(len(site_classes), SITECLASSES[2], version)
             for class_num in [0, 1, 2]:
                 self.assertIn(class_num, site_classes, version_msg)
                 site_class = site_classes[class_num]
@@ -364,8 +361,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "ngene2_mgene02")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             self.assertEqual(len(results), 4, version_msg)
@@ -387,8 +383,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "ngene2_mgene1")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             self.assertEqual(len(results), 4, version_msg)
@@ -405,8 +400,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "ngene2_mgene34")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             self.assertEqual(len(results), 4, version_msg)
@@ -431,8 +425,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "freeratio")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             self.assertEqual(len(results), 4, version_msg)
@@ -459,44 +452,55 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "pairwise")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             # Pairwise models have an extra top-level item: pairwise
             self.assertEqual(len(results), 5, version_msg)
             self.assertIn("pairwise", results, version_msg)
             pairwise = results["pairwise"]
-            self.assertGreaterEqual(len(pairwise), 2, version_msg +
-                                    ": should have at least two sequences")
+            self.assertGreaterEqual(
+                len(pairwise), 2, version_msg + ": should have at least two sequences"
+            )
             for seq1, seq2 in itertools.combinations(pairwise.keys(), 2):
-                self.assertEqual(len(pairwise[seq1][seq2]), 7, version_msg +
-                                 ": wrong number of parameters parsed")
-                self.assertEqual(len(pairwise[seq2][seq1]), 7, version_msg +
-                                 ": wrong number of parameters parsed")
+                self.assertEqual(
+                    len(pairwise[seq1][seq2]),
+                    7,
+                    version_msg + ": wrong number of parameters parsed",
+                )
+                self.assertEqual(
+                    len(pairwise[seq2][seq1]),
+                    7,
+                    version_msg + ": wrong number of parameters parsed",
+                )
 
     def testParseSitesParamsForPairwise(self):
         """Verify that pairwise site estimates are indeed parsed. Fixes #483."""
         res_dir = os.path.join(self.results_dir, "codeml", "pairwise")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             self.assertIn("pairwise", results)
             seqs = list(results["pairwise"].keys())
-            self.assertGreaterEqual(len(seqs), 2, version_msg +
-                                    ": should have at least two sequences")
+            self.assertGreaterEqual(
+                len(seqs), 2, version_msg + ": should have at least two sequences"
+            )
             for seq1, seq2 in itertools.combinations(seqs, 2):
                 params = results["pairwise"][seq1][seq2]
-                self.assertEqual(len(params), 7,
-                                 version_msg + ": wrong number of parsed parameters" +
-                                 " for %s-%s" % (seq1, seq2))
+                self.assertEqual(
+                    len(params),
+                    7,
+                    version_msg
+                    + ": wrong number of parsed parameters"
+                    + " for %s-%s" % (seq1, seq2),
+                )
                 for param in ("t", "S", "N", "omega", "dN", "dS", "lnL"):
-                    self.assertTrue(param in params, version_msg +
-                                    ": '%s' not in parsed parameters"
-                                    % (param))
+                    self.assertTrue(
+                        param in params,
+                        version_msg + ": '%s' not in parsed parameters" % (param),
+                    )
                     self.assertTrue(isinstance(params[param], float))
                     if param != "lnL":
                         self.assertTrue(params[param] >= 0)
@@ -505,8 +509,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "aa_model0")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             # Amino Acid analysis has different top-levels:
@@ -527,8 +530,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "aa_pairwise")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             # Pairwise AA analysis has one top-level fewer than non-pairwise
@@ -544,8 +546,9 @@ class ModTest(unittest.TestCase):
 
         In response to bug #453, where trees like (A, (B, C)); weren't being caught.
         """
-        res_file = os.path.join(self.results_dir, "codeml",
-                                "tree_regexp_versatility.out")
+        res_file = os.path.join(
+            self.results_dir, "codeml", "tree_regexp_versatility.out"
+        )
         results = codeml.read(res_file)
         self.assertIn("NSsites", results)
         nssites = results["NSsites"]
@@ -559,8 +562,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "m2a_rel")
         for results_file in os.listdir(res_dir):
             version = results_file.split("-")[1].split(".")[0]
-            version_msg = ("Improper parsing for version %s"
-                           % version.replace("_", "."))
+            version_msg = "Improper parsing for version %s" % version.replace("_", ".")
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             self.assertIn("NSsites", results)
@@ -568,8 +570,7 @@ class ModTest(unittest.TestCase):
             model = results["NSsites"][22]
             self.assertEqual(len(model), 5, version_msg)
             params = model["parameters"]
-            self.assertEqual(len(params), SITECLASS_PARAMS[22],
-                             version_msg)
+            self.assertEqual(len(params), SITECLASS_PARAMS[22], version_msg)
 
 
 if __name__ == "__main__":

--- a/Tests/test_PAML_tools.py
+++ b/Tests/test_PAML_tools.py
@@ -30,12 +30,14 @@ def which(program):
         # For Windows, the user is instructed to move the programs to a folder
         # and then to add the folder to the system path. Just in case they didn't
         # do that, we can check for it in Program Files.
-        likely_dirs = ["",  # Current dir
-                       prog_files,
-                       os.path.join(prog_files, "paml41"),
-                       os.path.join(prog_files, "paml43"),
-                       os.path.join(prog_files, "paml44"),
-                       os.path.join(prog_files, "paml45")] + sys.path
+        likely_dirs = [
+            "",  # Current dir
+            prog_files,
+            os.path.join(prog_files, "paml41"),
+            os.path.join(prog_files, "paml43"),
+            os.path.join(prog_files, "paml44"),
+            os.path.join(prog_files, "paml45"),
+        ] + sys.path
         os_path.extend(likely_dirs)
     for path in os.environ["PATH"].split(os.pathsep):
         exe_file = os.path.join(path, program)
@@ -52,7 +54,8 @@ else:
 for binary in binaries:
     if which(binary) is None:
         raise MissingExternalDependencyError(
-            "Install PAML if you want to use the Bio.Phylo.PAML wrapper.")
+            "Install PAML if you want to use the Bio.Phylo.PAML wrapper."
+        )
 
 
 class Common(unittest.TestCase):

--- a/Tests/test_PAML_yn00.py
+++ b/Tests/test_PAML_yn00.py
@@ -31,8 +31,7 @@ class ModTest(unittest.TestCase):
 
     def tearDown(self):
         """Just in case yn00 creates some junk files, do a clean-up."""
-        del_files = [self.out_file, "2YN.dN", "2YN.dS", "2YN.t", "rst",
-                     "rst1", "rub"]
+        del_files = [self.out_file, "2YN.dN", "2YN.dS", "2YN.t", "rst", "rst1", "rub"]
         for filename in del_files:
             if os.path.exists(filename):
                 os.remove(filename)
@@ -46,16 +45,15 @@ class ModTest(unittest.TestCase):
         self.yn00 = yn00.Yn00()
 
     def testAlignmentFileIsValid(self):
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          yn00.Yn00, alignment=[])
+        self.assertRaises((AttributeError, TypeError, OSError), yn00.Yn00, alignment=[])
         self.yn00.alignment = []
         self.yn00.out_file = self.out_file
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.yn00.run)
+        self.assertRaises((AttributeError, TypeError, OSError), self.yn00.run)
 
     def testAlignmentExists(self):
-        self.assertRaises((EnvironmentError, IOError), yn00.Yn00,
-                          alignment="nonexistent")
+        self.assertRaises(
+            (EnvironmentError, IOError), yn00.Yn00, alignment="nonexistent"
+        )
         self.yn00.alignment = "nonexistent"
         self.yn00.out_file = self.out_file
         self.assertRaises(IOError, self.yn00.run)
@@ -64,24 +62,19 @@ class ModTest(unittest.TestCase):
         self.yn00.alignment = self.align_file
         self.yn00.out_file = self.out_file
         self.yn00.working_dir = []
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.yn00.run)
+        self.assertRaises((AttributeError, TypeError, OSError), self.yn00.run)
 
     def testOptionExists(self):
-        self.assertRaises((AttributeError, KeyError),
-                          self.yn00.set_options, xxxx=1)
-        self.assertRaises((AttributeError, KeyError),
-                          self.yn00.get_option, "xxxx")
+        self.assertRaises((AttributeError, KeyError), self.yn00.set_options, xxxx=1)
+        self.assertRaises((AttributeError, KeyError), self.yn00.get_option, "xxxx")
 
     def testAlignmentSpecified(self):
         self.yn00.out_file = self.out_file
-        self.assertRaises((AttributeError, ValueError),
-                          self.yn00.run)
+        self.assertRaises((AttributeError, ValueError), self.yn00.run)
 
     def testOutputFileSpecified(self):
         self.yn00.alignment = self.align_file
-        self.assertRaises((AttributeError, ValueError),
-                          self.yn00.run)
+        self.assertRaises((AttributeError, ValueError), self.yn00.run)
 
     # def testPamlErrorsCaught(self):
     #     self.yn00.alignment = self.align_file
@@ -92,41 +85,41 @@ class ModTest(unittest.TestCase):
     def testCtlFileValidOnRun(self):
         self.yn00.alignment = self.align_file
         self.yn00.out_file = self.out_file
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.yn00.run, ctl_file=[])
+        self.assertRaises(
+            (AttributeError, TypeError, OSError), self.yn00.run, ctl_file=[]
+        )
 
     def testCtlFileExistsOnRun(self):
         self.yn00.alignment = self.align_file
         self.yn00.out_file = self.out_file
-        self.assertRaises(IOError,
-                          self.yn00.run, ctl_file="nonexistent")
+        self.assertRaises(IOError, self.yn00.run, ctl_file="nonexistent")
 
     def testCtlFileValidOnRead(self):
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          self.yn00.read_ctl_file, [])
-        self.assertRaises((AttributeError, KeyError),
-                          self.yn00.read_ctl_file, self.bad_ctl_file1)
-        self.assertRaises(AttributeError,
-                          self.yn00.read_ctl_file, self.bad_ctl_file2)
-        target_options = {"verbose": 1,
-                          "icode": 0,
-                          "weighting": 0,
-                          "commonf3x4": 0,
-                          "ndata": 1}
+        self.assertRaises(
+            (AttributeError, TypeError, OSError), self.yn00.read_ctl_file, []
+        )
+        self.assertRaises(
+            (AttributeError, KeyError), self.yn00.read_ctl_file, self.bad_ctl_file1
+        )
+        self.assertRaises(AttributeError, self.yn00.read_ctl_file, self.bad_ctl_file2)
+        target_options = {
+            "verbose": 1,
+            "icode": 0,
+            "weighting": 0,
+            "commonf3x4": 0,
+            "ndata": 1,
+        }
         self.yn00.read_ctl_file(self.ctl_file)
         self.assertEqual(self.yn00._options, target_options)
 
     def testCtlFileExistsOnRead(self):
-        self.assertRaises(IOError,
-                          self.yn00.read_ctl_file, ctl_file="nonexistent")
+        self.assertRaises(IOError, self.yn00.read_ctl_file, ctl_file="nonexistent")
 
     def testResultsValid(self):
-        self.assertRaises((AttributeError, TypeError, OSError),
-                          yn00.read, [])
+        self.assertRaises((AttributeError, TypeError, OSError), yn00.read, [])
 
     def testResultsExist(self):
-        self.assertRaises((EnvironmentError, IOError),
-                          yn00.read, "nonexistent")
+        self.assertRaises((EnvironmentError, IOError), yn00.read, "nonexistent")
 
     def testResultsParsable(self):
         self.assertRaises(ValueError, yn00.read, self.results_file)
@@ -148,7 +141,9 @@ class ModTest(unittest.TestCase):
             # ...each of which is compared to the other six.
             self.assertEqual({len(v) for v in results.values()}, {6})
             # ...each of which has five measures.
-            self.assertEqual({len(v) for taxa in results.values() for v in taxa.values()}, {5})
+            self.assertEqual(
+                {len(v) for taxa in results.values() for v in taxa.values()}, {5}
+            )
 
     def testParseDottedNames(self):
         pattern = os.path.join(self.results_dir, "yn00", "yn00_dotted-*")
@@ -159,7 +154,9 @@ class ModTest(unittest.TestCase):
             # ...each of which is compared to the other six.
             self.assertEqual({len(v) for v in results.values()}, {4})
             # ...each of which has five measures.
-            self.assertEqual({len(v) for taxa in results.values() for v in taxa.values()}, {5})
+            self.assertEqual(
+                {len(v) for taxa in results.values() for v in taxa.values()}, {5}
+            )
             self.assertEqual(len(results["Homo.sapie"]), 4)
             self.assertEqual(len(results["Homo.sapie"]["Pan.troglo"]), 5)
 
@@ -172,7 +169,9 @@ class ModTest(unittest.TestCase):
             # ...each of which is compared to the other six.
             self.assertEqual({len(v) for v in results.values()}, {6})
             # ...each of which has five measures.
-            self.assertEqual({len(v) for taxa in results.values() for v in taxa.values()}, {5})
+            self.assertEqual(
+                {len(v) for taxa in results.values() for v in taxa.values()}, {5}
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_PAML* files, 4 files. it should be fine to merge.
test_PAML_baseml.py
test_PAML_codeml.py
test_PAML_tools.py
test_PAML_yn00.py
