### PR TITLE
Remove TODO comments about empty __init__.py

### DIFF
--- a/Bio/HMM/__init__.py
+++ b/Bio/HMM/__init__.py
@@ -3,5 +3,3 @@
 # Please see the LICENSE file that should have been included as part of this
 # package.
 """A selection of Hidden Markov Model code."""
-
-# File needed on Python 2 to import anything else in this directory

--- a/Bio/Phylo/PAML/__init__.py
+++ b/Bio/Phylo/PAML/__init__.py
@@ -6,5 +6,3 @@
 # package.
 
 """Support for PAML."""
-
-# TODO: Remove empty __init__.py once we drop Python 2 support

--- a/Bio/Statistics/__init__.py
+++ b/Bio/Statistics/__init__.py
@@ -2,14 +2,10 @@
 # choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
 # Please see the LICENSE file that should have been included as part of this
 # package.
-"""
-Basic statistics module.
-
-This module is DEPRECATED.
-"""
-# TODO: Remove empty __init__.py once we drop Python 2 support
+"""Basic statistics module (DEPRECATED)."""
 
 import warnings
+
 from Bio import BiopythonDeprecationWarning
 
 warnings.warn(


### PR DESCRIPTION
We could remove these files, but they still serve one small useful role for our API documentation - holding the module docstring, even if it is just one line.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
