### PR TITLE
Use Python 3.1+ assertIsNot method in tests

### DIFF
--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -1585,15 +1585,15 @@ class CopyTests(unittest.TestCase):
 
     def test_atom_copy(self):
         aa = self.a.copy()
-        self.assertFalse(self.a is aa)
-        self.assertFalse(self.a.get_coord() is aa.get_coord())
+        self.assertIsNot(self.a, aa)
+        self.assertIsNot(self.a.get_coord(), aa.get_coord())
 
     def test_entity_copy(self):
         """Make a copy of a residue."""
         for e in (self.s, self.m, self.c, self.r):
             ee = e.copy()
-            self.assertFalse(e is ee)
-            self.assertFalse(e.get_list()[0] is ee.get_list()[0])
+            self.assertIsNot(e, ee)
+            self.assertIsNot(e.get_list()[0], ee.get_list()[0])
 
 
 def eprint(*args, **kwargs):


### PR DESCRIPTION
This pull request addresses an example very similar to issue #2698.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
