### PR TITLE
trim_str is no longer used

### DIFF
--- a/Bio/_utils.py
+++ b/Bio/_utils.py
@@ -11,13 +11,6 @@
 import os
 
 
-def trim_str(string, max_len, concat_char):
-    """Truncate the given string for display."""
-    if len(string) > max_len:
-        return string[: max_len - len(concat_char)] + concat_char
-    return string
-
-
 def find_test_dir(start_dir=None):
     """Find the absolute path of Biopython's Tests directory.
 


### PR DESCRIPTION
This pull request removes the `trim_str` utility function from `Bio/_utils.py`, as currently it is not used anywhere.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
