### PR TITLE
use with statement in test_PDB_MMCIFParser.py

### DIFF
--- a/Tests/test_PDB_MMCIFParser.py
+++ b/Tests/test_PDB_MMCIFParser.py
@@ -266,7 +266,8 @@ class ParseReal(unittest.TestCase):
         structure = parser.get_structure("example", "PDB/1A8O.cif")
         self.assertEqual(len(structure), 1)
 
-        structure = parser.get_structure("example", open("PDB/1A8O.cif"))
+        with open("PDB/1A8O.cif") as handle:
+            structure = parser.get_structure("example", handle)
         self.assertEqual(len(structure), 1)
 
     def test_point_mutations_main(self):


### PR DESCRIPTION
This pull request uses the `with` statement to open files in test_PDB_MMCIFParser.py

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
