### PR TITLE
use with to open files in test_PhyloXML.py

### DIFF
--- a/Tests/test_PhyloXML.py
+++ b/Tests/test_PhyloXML.py
@@ -258,10 +258,8 @@ class TreeTests(unittest.TestCase):
 
     def test_Confidence(self):
         """Instantiation of Confidence objects."""
-        # Because we short circult interation, must close handle explicitly
-        handle = open(EX_MADE)
-        tree = next(PhyloXMLIO.parse(handle))
-        handle.close()
+        with open(EX_MADE) as handle:
+            tree = next(PhyloXMLIO.parse(handle))
         self.assertEqual(tree.name, "testing confidence")
         for conf, type, val in zip(tree.confidences,
                                    ("bootstrap", "probability"),
@@ -330,10 +328,8 @@ class TreeTests(unittest.TestCase):
 
         Also checks ProteinDomain type.
         """
-        # Because we short circult interation, must close handle explicitly
-        handle = open(EX_APAF)
-        tree = next(PhyloXMLIO.parse(handle))
-        handle.close()
+        with open(EX_APAF) as handle:
+            tree = next(PhyloXMLIO.parse(handle))
         clade = tree.clade[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         darch = clade.sequences[0].domain_architecture
         self.assertTrue(isinstance(darch, PX.DomainArchitecture))
@@ -408,11 +404,8 @@ class TreeTests(unittest.TestCase):
 
     def test_Reference(self):
         """Instantiation of Reference objects."""
-        # Because we short circult interation, must close handle explicitly
-        # to avoid a ResourceWarning
-        handle = open(EX_DOLLO)
-        tree = next(PhyloXMLIO.parse(handle))
-        handle.close()
+        with open(EX_DOLLO) as handle:
+            tree = next(PhyloXMLIO.parse(handle))
         reference = tree.clade[0, 0, 0, 0, 0, 0].references[0]
         self.assertTrue(isinstance(reference, PX.Reference))
         self.assertEqual(reference.doi, "10.1038/nature06614")
@@ -517,12 +510,10 @@ class WriterTests(unittest.TestCase):
 
     def _rewrite_and_call(self, orig_fname, test_cases):
         """Parse, rewrite and retest a phyloXML example file."""
-        infile = open(orig_fname)
-        phx = PhyloXMLIO.read(infile)
-        infile.close()
-        outfile = open(DUMMY, "w")
-        PhyloXMLIO.write(phx, outfile)
-        outfile.close()
+        with open(orig_fname) as infile:
+            phx = PhyloXMLIO.read(infile)
+        with open(DUMMY, "w") as outfile:
+            PhyloXMLIO.write(phx, outfile)
         for cls, tests in test_cases:
             inst = cls("setUp")
             for test in tests:


### PR DESCRIPTION
This pull request uses the `with` statement to open files in test_PhyloXML.py.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
