### PR TITLE
use with in SCOP tests

### DIFF
--- a/Tests/test_SCOP_Cla.py
+++ b/Tests/test_SCOP_Cla.py
@@ -19,20 +19,16 @@ class ClaTests(unittest.TestCase):
 
     def testParse(self):
         """Test if all records in a CLA file are being read."""
-        f = open(self.filename)
-        try:
-            count = 0
+        count = 0
+        with open(self.filename) as f:
             records = Cla.parse(f)
             for record in records:
                 count += 1
-            self.assertEqual(count, 14)
-        finally:
-            f.close()
+        self.assertEqual(count, 14)
 
     def testStr(self):
         """Test if we can convert each record to a string correctly."""
-        f = open(self.filename)
-        try:
+        with open(self.filename) as f:
             for line in f:
                 record = Cla.Record(line)
                 # The SCOP Classification file format which can be found at
@@ -51,8 +47,6 @@ class ClaTests(unittest.TestCase):
                                  len(expected_hierarchy))
                 for key, actual_value in actual_hierarchy.items():
                     self.assertEqual(actual_value, expected_hierarchy[key])
-        finally:
-            f.close()
 
     def testError(self):
         """Test if a corrupt record raises the appropriate exception."""

--- a/Tests/test_SCOP_Des.py
+++ b/Tests/test_SCOP_Des.py
@@ -17,26 +17,20 @@ class DesTests(unittest.TestCase):
 
     def testParse(self):
         """Test if all records in a DES file are being read."""
-        f = open(self.filename)
-        try:
-            count = 0
+        count = 0
+        with open(self.filename) as f:
             records = Des.parse(f)
             for record in records:
                 count += 1
-            self.assertEqual(count, 20)
-        finally:
-            f.close()
+        self.assertEqual(count, 20)
 
     def testStr(self):
         """Test if we can convert each record to a string correctly."""
-        f = open(self.filename)
-        try:
+        with open(self.filename) as f:
             for line in f:
                 record = Des.Record(line)
                 # End of line is platform dependent. Strip it off
                 self.assertEqual(str(record).rstrip(), line.rstrip())
-        finally:
-            f.close()
 
     def testError(self):
         """Test if a corrupt record raises the appropriate exception."""

--- a/Tests/test_SCOP_Dom.py
+++ b/Tests/test_SCOP_Dom.py
@@ -19,25 +19,19 @@ class DomTests(unittest.TestCase):
 
     def testParse(self):
         """Test if all records in a DOM file are being read."""
-        f = open(self.filename)
-        try:
-            count = 0
+        count = 0
+        with open(self.filename) as f:
             for record in Dom.parse(f):
                 count += 1
-            self.assertEqual(count, 10)
-        finally:
-            f.close()
+        self.assertEqual(count, 10)
 
     def testStr(self):
         """Test if we can convert each record to a string correctly."""
-        f = open(self.filename)
-        try:
+        with open(self.filename) as f:
             for line in f:
                 record = Dom.Record(line)
                 # End of line is platform dependent. Strip it off
                 self.assertEqual(str(record).rstrip(), line.rstrip())
-        finally:
-            f.close()
 
     def testError(self):
         """Test if a corrupt record raises the appropriate exception."""

--- a/Tests/test_SCOP_Hie.py
+++ b/Tests/test_SCOP_Hie.py
@@ -17,25 +17,19 @@ class HieTests(unittest.TestCase):
 
     def testParse(self):
         """Test if all records in a HIE file are being read."""
-        f = open(self.filename)
-        try:
-            count = 0
+        count = 0
+        with open(self.filename) as f:
             for record in Hie.parse(f):
                 count += 1
-            self.assertEqual(count, 21)
-        finally:
-            f.close()
+        self.assertEqual(count, 21)
 
     def testStr(self):
         """Test if we can convert each record to a string correctly."""
-        f = open(self.filename)
-        try:
+        with open(self.filename) as f:
             for line in f:
                 record = Hie.Record(line)
                 # End of line is platform dependent. Strip it off
                 self.assertEqual(str(record).rstrip(), line.rstrip())
-        finally:
-            f.close()
 
     def testError(self):
         """Test if a corrupt record raises the appropriate exception."""

--- a/Tests/test_SCOP_Scop.py
+++ b/Tests/test_SCOP_Scop.py
@@ -37,19 +37,12 @@ class ScopTests(unittest.TestCase):
         return True
 
     def testParse(self):
-        f = open("./SCOP/dir.cla.scop.txt_test")
-        try:
+        with open("./SCOP/dir.cla.scop.txt_test") as f:
             cla = f.read()
-            f.close()
-
-            f = open("./SCOP/dir.des.scop.txt_test")
+        with open("./SCOP/dir.des.scop.txt_test") as f:
             des = f.read()
-            f.close()
-
-            f = open("./SCOP/dir.hie.scop.txt_test")
+        with open("./SCOP/dir.hie.scop.txt_test") as f:
             hie = f.read()
-        finally:
-            f.close()
 
         scop = Scop(StringIO(cla), StringIO(des), StringIO(hie))
 


### PR DESCRIPTION
This pull request uses the `with` statement in SCOP tests.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
