### PR TITLE
use with statement in SeqIO tests

### DIFF
--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -395,9 +395,8 @@ class TestSeqIO(unittest.TestCase):
             warnings.simplefilter("ignore", PDBConstructionWarning)
 
             # Try as an iterator using handle
-            h = open(t_filename, mode)
-            records = list(SeqIO.parse(handle=h, format=t_format))
-            h.close()
+            with open(t_filename, mode) as h:
+                records = list(SeqIO.parse(handle=h, format=t_format))
             self.assertEqual(
                 len(records),
                 t_count,
@@ -412,54 +411,52 @@ class TestSeqIO(unittest.TestCase):
 
             # Try using the iterator with the next() method
             records3 = []
-            h = open(t_filename, mode)
-            seq_iterator = SeqIO.parse(handle=h, format=t_format)
-            while True:
-                try:
-                    record = next(seq_iterator)
-                except StopIteration:
-                    break
-                self.assertIsNotNone(
-                    record, "Should raise StopIteration, not return None"
-                )
-                records3.append(record)
-            h.close()
+            with open(t_filename, mode) as h:
+                seq_iterator = SeqIO.parse(handle=h, format=t_format)
+                while True:
+                    try:
+                        record = next(seq_iterator)
+                    except StopIteration:
+                        break
+                    self.assertIsNotNone(
+                        record, "Should raise StopIteration, not return None"
+                    )
+                    records3.append(record)
             self.assertEqual(len(records3), t_count)
 
             # Try a mixture of next() and list (a torture test!)
-            h = open(t_filename, mode)
-            seq_iterator = SeqIO.parse(handle=h, format=t_format)
-            try:
-                record = next(seq_iterator)
-            except StopIteration:
-                record = None
-            if record is not None:
-                records4 = [record]
-                records4.extend(list(seq_iterator))
-            else:
-                records4 = []
-            h.close()
+            with open(t_filename, mode) as h:
+                seq_iterator = SeqIO.parse(handle=h, format=t_format)
+                try:
+                    record = next(seq_iterator)
+                except StopIteration:
+                    record = None
+                if record is not None:
+                    records4 = [record]
+                    records4.extend(list(seq_iterator))
+                else:
+                    records4 = []
             self.assertEqual(len(records4), t_count)
 
             # Try a mixture of next() and for loop (a torture test!)
             # with a forward-only-handle
-            if t_format == "abi":
-                # Temp hack
-                h = open(t_filename, mode)
-            else:
-                h = ForwardOnlyHandle(open(t_filename, mode))
-            seq_iterator = SeqIO.parse(h, format=t_format)
-            try:
-                record = next(seq_iterator)
-            except StopIteration:
-                record = None
-            if record is not None:
-                records5 = [record]
-                for record in seq_iterator:
-                    records5.append(record)
-            else:
-                records5 = []
-            h.close()
+            with open(t_filename, mode) as h:
+                if t_format == "abi":
+                    # Temporary hack
+                    fh = h
+                else:
+                    fh = ForwardOnlyHandle(h)
+                seq_iterator = SeqIO.parse(fh, format=t_format)
+                try:
+                    record = next(seq_iterator)
+                except StopIteration:
+                    record = None
+                if record is not None:
+                    records5 = [record]
+                    for record in seq_iterator:
+                        records5.append(record)
+                else:
+                    records5 = []
             self.assertEqual(len(records5), t_count)
 
             for i in range(t_count):
@@ -581,9 +578,8 @@ class TestSeqIO(unittest.TestCase):
                     self.assertIsInstance(base_alpha, given_base.__class__)
                     self.assertEqual(base_alpha, given_base)
                 if t_count == 1:
-                    h = open(t_filename, mode)
-                    record = SeqIO.read(h, t_format, given_alpha)
-                    h.close()
+                    with open(t_filename, mode) as h:
+                        record = SeqIO.read(h, t_format, given_alpha)
                     self.assertIsInstance(base_alpha, given_base.__class__)
                     self.assertEqual(base_alpha, given_base)
             for given_alpha in bad:

--- a/Tests/test_SeqIO_AbiIO.py
+++ b/Tests/test_SeqIO_AbiIO.py
@@ -512,7 +512,7 @@ class TestAbiNonAscii(unittest.TestCase):
 
 class TestAbiWrongMode(unittest.TestCase):
     def setUp(self):
-        open_files(test_data)
+        open_files_wrong_mode(test_data)
 
     def tearDown(self):
         close_files(test_data)
@@ -525,10 +525,10 @@ class TestAbiWrongMode(unittest.TestCase):
 
 class TestAbiFake(unittest.TestCase):
     def setUp(self):
-        open_files(test_data)
+        open_files(test_data_fake)
 
     def tearDown(self):
-        close_files(test_data)
+        close_files(test_data_fake)
 
     def test_file_type(self):
         """Test if error is raised if filetype is not ABIF."""

--- a/Tests/test_SeqIO_AbiIO.py
+++ b/Tests/test_SeqIO_AbiIO.py
@@ -511,23 +511,31 @@ class TestAbiNonAscii(unittest.TestCase):
 
 
 class TestAbiWrongMode(unittest.TestCase):
+    def setUp(self):
+        open_files(test_data)
+
+    def tearDown(self):
+        close_files(test_data)
+
     def test_file_mode(self):
         """Test if exception is raised if file is not opened in 'rb' mode."""
-        open_files_wrong_mode(test_data)
         for trace in test_data:
             self.assertRaises(ValueError, SeqIO.read, test_data[trace]["handle"], "abi")
-        close_files(test_data)
 
 
 class TestAbiFake(unittest.TestCase):
+    def setUp(self):
+        open_files(test_data)
+
+    def tearDown(self):
+        close_files(test_data)
+
     def test_file_type(self):
         """Test if error is raised if filetype is not ABIF."""
-        open_files(test_data_fake)
         for trace in test_data_fake:
             self.assertRaises(
                 IOError, SeqIO.read, test_data_fake[trace]["handle"], "abi"
             )
-        close_files(test_data_fake)
 
 
 if __name__ == "__main__":

--- a/Tests/test_SeqIO_Gck.py
+++ b/Tests/test_SeqIO_Gck.py
@@ -279,12 +279,8 @@ class TestGckWithDGVC(unittest.TestCase):
                 return
 
             try:
-                src = urlopen(
-                    "https://emb.carnegiescience.edu/sites/default/files/DGVC_GCK.zip"
-                )
-                with open("Gck/DGVC_GCK.zip", "wb") as dst:
+                with urlopen("https://emb.carnegiescience.edu/sites/default/files/DGVC_GCK.zip") as src, open("Gck/DGVC_GCK.zip", "wb") as dst:
                     shutil.copyfileobj(src, dst)
-                src.close()
             except HTTPError:
                 self.skipTest("Cannot download the sample files")
                 return
@@ -297,8 +293,8 @@ class TestGckWithDGVC(unittest.TestCase):
     def test_read(self):
         """Read sample files."""
         for sample in self.sample_data.values():
-            f = self.zipdata.open(sample["file"])
-            record = SeqIO.read(f, "gck")
+            with self.zipdata.open(sample["file"]) as f:
+                record = SeqIO.read(f, "gck")
             self.assertEqual(sample["name"], record.name)
             self.assertEqual(sample["id"], record.id)
             self.assertEqual(sample["description"], record.description)
@@ -306,16 +302,13 @@ class TestGckWithDGVC(unittest.TestCase):
             self.assertEqual(sample["topology"], record.annotations["topology"])
 
             self.assertEqual(len(sample["features"]), len(record.features))
-            for i in range(len(sample["features"])):
-                exp_feat = sample["features"][i]
+            for i, exp_feat in enumerate(sample["features"]):
                 read_feat = record.features[i]
                 self.assertEqual(exp_feat["type"], read_feat.type)
                 self.assertEqual(exp_feat["start"], read_feat.location.start)
                 self.assertEqual(exp_feat["end"], read_feat.location.end)
                 self.assertEqual(exp_feat["strand"], read_feat.location.strand)
                 self.assertEqual(exp_feat["label"], read_feat.qualifiers["label"][0])
-
-            f.close()
 
 
 class TestGckWithArtificialData(unittest.TestCase):

--- a/Tests/test_SeqIO_NibIO.py
+++ b/Tests/test_SeqIO_NibIO.py
@@ -10,37 +10,30 @@ from Bio.SeqRecord import SeqRecord
 
 class TestNibReaderWriter(unittest.TestCase):
     def test_read_even(self):
-        handle = open("Nib/test_even.fa")
-        record = SeqIO.read(handle, "fasta")
-        handle.close()
+        with open("Nib/test_even.fa") as handle:
+            record = SeqIO.read(handle, "fasta")
         sequence = str(record.seq)
-        handle = open("Nib/test_even_bigendian.nib", "rb")
-        record = SeqIO.read(handle, "nib")
-        handle.close()
+        with open("Nib/test_even_bigendian.nib", "rb") as handle:
+            record = SeqIO.read(handle, "nib")
         self.assertEqual(sequence, str(record.seq))
-        handle = open("Nib/test_even_littleendian.nib", "rb")
-        record = SeqIO.read(handle, "nib")
-        handle.close()
+        with open("Nib/test_even_littleendian.nib", "rb") as handle:
+            record = SeqIO.read(handle, "nib")
         self.assertEqual(sequence, str(record.seq))
 
     def test_read_odd(self):
-        handle = open("Nib/test_odd.fa")
-        record = SeqIO.read(handle, "fasta")
-        handle.close()
+        with open("Nib/test_odd.fa") as handle:
+            record = SeqIO.read(handle, "fasta")
         sequence = str(record.seq)
-        handle = open("Nib/test_odd_bigendian.nib", "rb")
-        record = SeqIO.read(handle, "nib")
-        handle.close()
+        with open("Nib/test_odd_bigendian.nib", "rb") as handle:
+            record = SeqIO.read(handle, "nib")
         self.assertEqual(sequence, str(record.seq))
-        handle = open("Nib/test_odd_littleendian.nib", "rb")
-        record = SeqIO.read(handle, "nib")
-        handle.close()
+        with open("Nib/test_odd_littleendian.nib", "rb") as handle:
+            record = SeqIO.read(handle, "nib")
         self.assertEqual(sequence, str(record.seq))
 
     def test_write_even(self):
-        handle = open("Nib/test_even.fa")
-        record = SeqIO.read(handle, "fasta")
-        handle.close()
+        with open("Nib/test_even.fa") as handle:
+            record = SeqIO.read(handle, "fasta")
         sequence = str(record.seq)
         handle = BytesIO()
         n = SeqIO.write(record, handle, "nib")
@@ -52,9 +45,8 @@ class TestNibReaderWriter(unittest.TestCase):
         self.assertEqual(sequence, str(record.seq))
 
     def test_write_odd(self):
-        handle = open("Nib/test_odd.fa")
-        record = SeqIO.read(handle, "fasta")
-        handle.close()
+        with open("Nib/test_odd.fa") as handle:
+            record = SeqIO.read(handle, "fasta")
         sequence = str(record.seq)
         handle = BytesIO()
         n = SeqIO.write(record, handle, "nib")

--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -155,33 +155,30 @@ class TestFastqErrors(unittest.TestCase):
         if not formats:
             formats = ["fastq-sanger", "fastq-solexa", "fastq-illumina"]
         for format in formats:
-            handle = open(filename)
-            records = SeqIO.parse(handle, format)
-            for i in range(good_count):
-                record = next(records)  # Make sure no errors!
-                self.assertTrue(isinstance(record, SeqRecord))
-            self.assertRaises(ValueError, next, records)
-            handle.close()
+            with open(filename) as handle:
+                records = SeqIO.parse(handle, format)
+                for i in range(good_count):
+                    record = next(records)  # Make sure no errors!
+                    self.assertTrue(isinstance(record, SeqRecord))
+                self.assertRaises(ValueError, next, records)
 
     def check_general_fails(self, filename, good_count):
-        handle = open(filename)
-        tuples = QualityIO.FastqGeneralIterator(handle)
-        for i in range(good_count):
-            title, seq, qual = next(tuples)  # Make sure no errors!
-        self.assertRaises(ValueError, next, tuples)
-        handle.close()
+        with open(filename) as handle:
+            tuples = QualityIO.FastqGeneralIterator(handle)
+            for i in range(good_count):
+                title, seq, qual = next(tuples)  # Make sure no errors!
+            self.assertRaises(ValueError, next, tuples)
 
     def check_general_passes(self, filename, record_count):
-        handle = open(filename)
-        tuples = QualityIO.FastqGeneralIterator(handle)
-        # This "raw" parser doesn't check the ASCII characters which means
-        # certain invalid FASTQ files will get parsed without errors.
-        count = 0
-        for title, seq, qual in tuples:
-            self.assertEqual(len(seq), len(qual))
-            count += 1
-        self.assertEqual(count, record_count)
-        handle.close()
+        with open(filename) as handle:
+            tuples = QualityIO.FastqGeneralIterator(handle)
+            # This "raw" parser doesn't check the ASCII characters which means
+            # certain invalid FASTQ files will get parsed without errors.
+            count = 0
+            for title, seq, qual in tuples:
+                self.assertEqual(len(seq), len(qual))
+                count += 1
+            self.assertEqual(count, record_count)
 
     def check_all_fail(self, filename, count):
         self.check_fails(filename, count)
@@ -372,9 +369,8 @@ class TestQual(unittest.TestCase):
 
     def test_paired(self):
         """Check FASTQ parsing matches FASTA+QUAL parsing."""
-        with open("Quality/example.fasta") as f:
-            with open("Quality/example.qual") as q:
-                records1 = list(QualityIO.PairedFastaQualIterator(f, q))
+        with open("Quality/example.fasta") as f, open("Quality/example.qual") as q:
+            records1 = list(QualityIO.PairedFastaQualIterator(f, q))
         records2 = list(SeqIO.parse("Quality/example.fastq", "fastq"))
         self.assertTrue(compare_records(records1, records2))
 

--- a/Tests/test_SeqIO_SnapGene.py
+++ b/Tests/test_SeqIO_SnapGene.py
@@ -92,9 +92,8 @@ class TestSnapGene(unittest.TestCase):
 
 class TestCorruptedSnapGene(unittest.TestCase):
     def setUp(self):
-        f = open("SnapGene/sample-d.dna", "rb")
-        self.buffer = f.read()
-        f.close()
+        with open("SnapGene/sample-d.dna", "rb") as f:
+            self.buffer = f.read()
 
     def munge_buffer(self, position, value):
         mod_buffer = bytearray(self.buffer)

--- a/Tests/test_SeqIO_Xdna.py
+++ b/Tests/test_SeqIO_Xdna.py
@@ -120,9 +120,8 @@ class TestXdna(unittest.TestCase):
 class TestInvalidXdna(unittest.TestCase):
 
     def setUp(self):
-        f = open("Xdna/sample-a.xdna", "rb")
-        self.buffer = f.read()
-        f.close()
+        with open("Xdna/sample-a.xdna", "rb") as f:
+            self.buffer = f.read()
 
     def munge_buffer(self, position, value):
         mod_buffer = bytearray(self.buffer)

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -666,10 +666,9 @@ class IndexDictTests(unittest.TestCase):
 
     def test_duplicates_to_dict(self):
         """Index file with duplicate identifiers with Bio.SeqIO.to_dict()."""
-        handle = open("Fasta/dups.fasta")
-        iterator = SeqIO.parse(handle, "fasta")
-        self.assertRaises(ValueError, SeqIO.to_dict, iterator)
-        handle.close()
+        with open("Fasta/dups.fasta") as handle:
+            iterator = SeqIO.parse(handle, "fasta")
+            self.assertRaises(ValueError, SeqIO.to_dict, iterator)
 
 
 class IndexOrderingSingleFile(unittest.TestCase):


### PR DESCRIPTION
This pull request uses the `with` statement to open files in the SeqIO* tests.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
