### PR TITLE
Entrez efetch: Bug in id handling?

### DIFF
--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -195,7 +195,7 @@ def efetch(db, **keywords):
             ids = ",".join(map(str, ids))
         except ValueError:
             # string with commas or string not representing an integer
-            ids = ",".join(map(str, [id.strip() for id in ids.split(",")]))
+            ids = ",".join(map(str, (id.strip() for id in ids.split(","))))
 
         variables["id"] = ids
         if ids.count(",") >= 200:

--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -188,14 +188,16 @@ def efetch(db, **keywords):
         pass
     else:
         try:
-            ids = ",".join(ids)
-        except TypeError as e:
-            if isinstance(ids, int):
-                ids = str(ids)
-            else:
-                raise e
-        variables["id"] = ids
+            # ids is a single integer or a string representing a single integer
+            ids = str(int(ids))
+        except TypeError:
+            # ids was not a string; try an iterable:
+            ids = ",".join(map(str, ids))
+        except ValueError:
+            # string with commas or string not representing an integer
+            ids = ",".join(map(str, [id.strip() for id in ids.split(",")]))
 
+        variables["id"] = ids
         if ids.count(",") >= 200:
             # NCBI prefers an HTTP POST instead of an HTTP GET if there are
             # more than about 200 IDs

--- a/Tests/test_Entrez_online.py
+++ b/Tests/test_Entrez_online.py
@@ -74,7 +74,7 @@ class EntrezOnlineCase(unittest.TestCase):
 
     def test_parse_from_url(self):
         """Test Entrez.parse from URL."""
-        handle = Entrez.efetch(db="protein", id={15718680, 157427902, 119703751},
+        handle = Entrez.efetch(db="protein", id="15718680, 157427902, 119703751",
                                retmode="xml")
         self.assertTrue(handle.url.startswith(URL_HEAD + "efetch.fcgi?"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
@@ -234,6 +234,35 @@ class EntrezOnlineCase(unittest.TestCase):
         self.assertEqual(result, expected_result)
         handle.close()
 
+    def test_efetch_ids(self):
+        """Test different options to supply ids."""
+        ids = (
+          [15718680, 157427902],
+          (15718680, 157427902),
+          {15718680, 157427902},
+          ["15718680", "157427902"],
+          ("15718680", "157427902"),
+          {15718680, "157427902"},
+          "15718680, 157427902",
+        )
+        for _id in ids:
+            with Entrez.efetch(db="protein", id=_id, retmode="xml") as handle:
+                # _id can be a set with unpredictable sorting,
+                # thus we test the ids separately
+                self.assertIn("15718680", handle.url)
+                self.assertIn("157427902", handle.url)
+                recs = list(Entrez.parse(handle))
+                self.assertEqual(2, len(recs))
+
+        ids = (
+          [15718680], (15718680), {15718680}, 15718680, "15718680", "15718680,",  
+        )
+        for _id in ids:
+            with Entrez.efetch(db="protein", id=_id, retmode="xml") as handle:
+                self.assertIn("15718680", handle.url)
+                recs = list(Entrez.parse(handle))
+                self.assertEqual(1, len(recs))
+        
     def test_efetch_gds_utf8(self):
         """Test correct handling of encodings in Entrez.efetch."""
         # See issue #1402 in case any encoding issues occur

--- a/Tests/test_Entrez_online.py
+++ b/Tests/test_Entrez_online.py
@@ -237,13 +237,13 @@ class EntrezOnlineCase(unittest.TestCase):
     def test_efetch_ids(self):
         """Test different options to supply ids."""
         ids = (
-          [15718680, 157427902],
-          (15718680, 157427902),
-          {15718680, 157427902},
-          ["15718680", "157427902"],
-          ("15718680", "157427902"),
-          {15718680, "157427902"},
-          "15718680, 157427902",
+            [15718680, 157427902],
+            (15718680, 157427902),
+            {15718680, 157427902},
+            ["15718680", "157427902"],
+            ("15718680", "157427902"),
+            {15718680, "157427902"},
+            "15718680, 157427902",
         )
         for _id in ids:
             with Entrez.efetch(db="protein", id=_id, retmode="xml") as handle:
@@ -255,14 +255,14 @@ class EntrezOnlineCase(unittest.TestCase):
                 self.assertEqual(2, len(recs))
 
         ids = (
-          [15718680], (15718680), {15718680}, 15718680, "15718680", "15718680,",  
+            [15718680], (15718680), {15718680}, 15718680, "15718680", "15718680,",
         )
         for _id in ids:
             with Entrez.efetch(db="protein", id=_id, retmode="xml") as handle:
                 self.assertIn("15718680", handle.url)
                 recs = list(Entrez.parse(handle))
                 self.assertEqual(1, len(recs))
-        
+
     def test_efetch_gds_utf8(self):
         """Test correct handling of encodings in Entrez.efetch."""
         # See issue #1402 in case any encoding issues occur


### PR DESCRIPTION
@peterjc Can you have a look at this? I'm not sure if this PR solves the problem or may have other side effects, I'm not aware of.

During running `test_Entrez_online` I got numerous errors from `Entrez.efetch`. The problem seems to be that if you supply a single id as a string, e.g. `(...id="12345", ...)` this is converted into `"1,2,3,4,5"`. The resulting efetch call seems to be valid, you just got the wrong result (instead of entry 12345 you get the entries 1 to 5).

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
