### PR TITLE
allow SffIO and XdnaIO to accept a file path

### DIFF
--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -94,11 +94,37 @@ class SequenceWriter:
     SequentialSequenceWriter class instead.
     """
 
-    def __init__(self, handle):
+    def __init__(self, target, mode="w"):
         """Create the writer object.
 
         Use the method write_file() to actually record your sequence records.
         """
+        if mode == "w":
+            try:
+                target.write("")
+            except TypeError:
+                # target was opened in binary mode
+                raise ValueError("File must be opened in text mode.") from None
+            except AttributeError:
+                # target is a path
+                handle = open(target, mode)
+            else:
+                handle = target
+        elif mode == "wb":
+            try:
+                target.write(b"")
+            except TypeError:
+                # target was opened in text mode
+                raise ValueError("File must be opened in binary mode.") from None
+            except AttributeError:
+                # target is a path
+                handle = open(target, mode)
+            else:
+                handle = target
+        else:
+            raise RuntimeError("Unknown mode '%s'" % mode)
+
+        self._target = target
         self.handle = handle
 
     def _get_seq_string(self, record):
@@ -156,33 +182,7 @@ class SequentialSequenceWriter(SequenceWriter):
 
     def __init__(self, target, mode="w"):
         """Initialize the class."""
-        if mode == "w":
-            try:
-                target.write("")
-            except TypeError:
-                # target was opened in binary mode
-                raise ValueError("File must be opened in text mode.") from None
-            except AttributeError:
-                # target is a path
-                handle = open(target, mode)
-            else:
-                handle = target
-        elif mode == "wb":
-            try:
-                target.write(b"")
-            except TypeError:
-                # target was opened in text mode
-                raise ValueError("File must be opened in binary mode.") from None
-            except AttributeError:
-                # target is a path
-                handle = open(target, mode)
-            else:
-                handle = target
-        else:
-            raise RuntimeError("Unknown mode '%s'" % mode)
-
-        self._target = target
-        self.handle = handle
+        super().__init__(target, mode)
         self._header_written = False
         self._record_written = False
         self._footer_written = False

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -486,7 +486,7 @@ class SeqXmlWriter(SequentialSequenceWriter):
         """Create Object and start the xml generator.
 
         Arguments:
-         - target - Output stream opened in text mode, or a path to a file.
+         - target - Output stream opened in binary mode, or a path to a file.
          - source - The source program/database of the file, for example
            UniProt.
          - source_version - The version or release number of the source

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -232,8 +232,8 @@ http://www.ncbi.nlm.nih.gov/Traces/trace.cgi?cmd=show&f=formats&m=doc&s=formats
 
 from Bio import Alphabet
 from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
 from Bio.SeqIO.Interfaces import SequenceWriter
+from Bio.SeqRecord import SeqRecord
 import struct
 import sys
 import re
@@ -1134,6 +1134,7 @@ def _check_eof(handle, index_offset, index_length):
 def _SffTrimIterator(handle, alphabet=Alphabet.generic_dna):
     """Iterate over SFF reads (as SeqRecord objects) with trimming (PRIVATE)."""
     return SffIterator(handle, alphabet, trim=True)
+
 
 class SffWriter(SequenceWriter):
     """SFF file writer."""

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -230,10 +230,10 @@ http://www.ncbi.nlm.nih.gov/Traces/trace.cgi?cmd=show&f=formats&m=doc&s=formats
 """
 
 
-from Bio.SeqIO.Interfaces import SequenceWriter
 from Bio import Alphabet
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+from Bio.SeqIO.Interfaces import SequenceWriter
 import struct
 import sys
 import re
@@ -1135,29 +1135,21 @@ def _SffTrimIterator(handle, alphabet=Alphabet.generic_dna):
     """Iterate over SFF reads (as SeqRecord objects) with trimming (PRIVATE)."""
     return SffIterator(handle, alphabet, trim=True)
 
-
 class SffWriter(SequenceWriter):
     """SFF file writer."""
 
-    def __init__(self, handle, index=True, xml=None):
+    def __init__(self, target, index=True, xml=None):
         """Initialize an SFF writer object.
 
         Arguments:
-         - handle - Output handle, in binary write mode.
+         - target - Output stream opened in binary mode, or a path to a file.
          - index - Boolean argument, should we try and write an index?
          - xml - Optional string argument, xml manifest to be recorded
            in the index block (see function ReadRocheXmlManifest for
            reading this data).
 
         """
-        try:
-            # Confirm we have a binary handle,
-            handle.write(b"")
-        except TypeError:
-            raise ValueError(
-                "SFF files must NOT be opened in text mode, binary required."
-            ) from None
-        self.handle = handle
+        SequenceWriter.__init__(self, target, "wb")
         self._xml = xml
         if index:
             self._index = []

--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -216,6 +216,15 @@ def XdnaIterator(source):
 class XdnaWriter(SequenceWriter):
     """Write files in the Xdna format."""
 
+    def __init__(self, target):
+        """Initialize an Xdna writer object.
+
+        Arguments:
+         - target - Output stream opened in binary mode, or a path to a file.
+
+        """
+        SequenceWriter.__init__(self, target, "wb")
+
     def write_file(self, records):
         """Write the specified record to a Xdna file.
 


### PR DESCRIPTION
This pull request allows SffIO and XdnaIO to write to a file path in addition to a file handle.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
