### PR TITLE
Fixed "MMCIF2Dict ValueError: Opening quote in middle of word #2261"

### DIFF
--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -78,15 +78,14 @@ class MMCIF2Dict(dict):
                     in_token = False
                     yield line[start_i:i]
             elif c in self.quote_chars:
-                if not quote_open_char:
-                    if in_token:
+                if not quote_open_char and in_token and i < len(line) - 1:
+                    if line[i + 1] not in self.whitespace_chars:
                         raise ValueError("Opening quote in middle of word: " + line)
+                if not quote_open_char and not in_token:
                     quote_open_char = c
                     in_token = True
                     start_i = i + 1
-                elif c == quote_open_char and (
-                    i + 1 == len(line) or line[i + 1] in self.whitespace_chars
-                ):
+                elif c == quote_open_char and (i + 1 == len(line) or line[i + 1] in self.whitespace_chars):
                     quote_open_char = None
                     in_token = False
                     yield line[start_i:i]

--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -85,7 +85,9 @@ class MMCIF2Dict(dict):
                     quote_open_char = c
                     in_token = True
                     start_i = i + 1
-                elif c == quote_open_char and (i + 1 == len(line) or line[i + 1] in self.whitespace_chars):
+                elif c == quote_open_char and (
+                    i + 1 == len(line) or line[i + 1] in self.whitespace_chars
+                ):
                     quote_open_char = None
                     in_token = False
                     yield line[start_i:i]

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -26,6 +26,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Andrea Pierleoni <andrea at the Italian domain biocomp dot unibo>
 - Andrea Rizzi <https://github.com/andrrizzi>
 - Andreas Kuntzagk <andreas.kuntzagk at domain mdc-berlin.de>
+- Andrei Istrate <andrei at ebi.ac.uk>
 - Andres Colubri <andres dot colubri at gmail dot com>
 - Andrew Dalke <dalke at domain dalke scientific dot com>
 - Andrew Guy <https://github.com/andrewguy>

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -26,7 +26,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Andrea Pierleoni <andrea at the Italian domain biocomp dot unibo>
 - Andrea Rizzi <https://github.com/andrrizzi>
 - Andreas Kuntzagk <andreas.kuntzagk at domain mdc-berlin.de>
-- Andrei Istrate <andrei at ebi.ac.uk>
+- Andrei Istrate <andrei at ebi dot ac dot uk>
 - Andres Colubri <andres dot colubri at gmail dot com>
 - Andrew Dalke <dalke at domain dalke scientific dot com>
 - Andrew Guy <https://github.com/andrewguy>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -37,6 +37,7 @@ style has been reformatted with the ``black`` tool.
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
+- Andrei Istrate (first contribution)
 - Andrey Raspopov
 - Austin Varela (first contribution)
 - Chris Rands

--- a/Tests/test_PDB_MMCIF2Dict.py
+++ b/Tests/test_PDB_MMCIF2Dict.py
@@ -218,6 +218,8 @@ class MMCIF2dictTests(unittest.TestCase):
             list(mmcif._splitline('foo "bar\' a" b')), ["foo", "bar' a", "b"]
         )
         self.assertEqual(list(mmcif._splitline("foo '' b")), ["foo", "", "b"])
+        self.assertEqual(list(mmcif._splitline("foo bar' b")), ["foo", "bar'", "b"])
+        self.assertEqual(list(mmcif._splitline("foo bar b'")), ["foo", "bar", "b'"])
 
         # A hash (#) starts a comment iff it is preceded by whitespace or is at
         # the beginning of a line:


### PR DESCRIPTION
This pull request addresses issue #2261 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
