### PR TITLE
use with to open files in test_Uniprot

### DIFF
--- a/Tests/test_Uniprot.py
+++ b/Tests/test_Uniprot.py
@@ -25,8 +25,8 @@ class TestUniprot(unittest.TestCase):
 
         datafile = os.path.join("SwissProt", filename)
 
-        with open(datafile) as test_handle:
-            seq_record = SeqIO.read(test_handle, "uniprot-xml")
+        with open(datafile) as handle:
+            seq_record = SeqIO.read(handle, "uniprot-xml")
 
         self.assertTrue(isinstance(seq_record, SeqRecord))
 
@@ -78,9 +78,8 @@ class TestUniprot(unittest.TestCase):
 
         datafile = os.path.join("SwissProt", filename)
 
-        test_handle = open(datafile)
-        seq_record = SeqIO.read(test_handle, "uniprot-xml")
-        test_handle.close()
+        with open(datafile) as handle:
+            seq_record = SeqIO.read(handle, "uniprot-xml")
 
         self.assertTrue(isinstance(seq_record, SeqRecord))
 
@@ -269,9 +268,8 @@ class TestUniprot(unittest.TestCase):
 
         datafile = os.path.join("SwissProt", filename)
 
-        test_handle = open(datafile)
-        seq_record = SeqIO.read(test_handle, "swiss")
-        test_handle.close()
+        with open(datafile) as handle:
+            seq_record = SeqIO.read(handle, "swiss")
 
         self.assertTrue(isinstance(seq_record, SeqRecord))
 
@@ -289,9 +287,8 @@ class TestUniprot(unittest.TestCase):
 
         datafile = os.path.join("SwissProt", filename)
 
-        test_handle = open(datafile)
-        seq_record = SeqIO.read(test_handle, "swiss")
-        test_handle.close()
+        with open(datafile) as handle:
+            seq_record = SeqIO.read(handle, "swiss")
 
         self.assertTrue(isinstance(seq_record, SeqRecord))
 
@@ -432,9 +429,10 @@ class TestUniprot(unittest.TestCase):
 
     def test_submittedName_allowed(self):
         """Checks if parser supports new XML Element (submittedName)."""
-        for entry in SeqIO.parse(open("SwissProt/R5HY77.xml"), "uniprot-xml"):
-            self.assertEqual(entry.id, "R5HY77")
-            self.assertEqual(entry.description, "Elongation factor Ts")
+        with open("SwissProt/R5HY77.xml") as handle:
+            for entry in SeqIO.parse(handle, "uniprot-xml"):
+                self.assertEqual(entry.id, "R5HY77")
+                self.assertEqual(entry.description, "Elongation factor Ts")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request uses the `with` statement to open files in test_Uniprot.py.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
