### PR TITLE
use with in test_XXmotif_tool.py

### DIFF
--- a/Tests/test_XXmotif_tool.py
+++ b/Tests/test_XXmotif_tool.py
@@ -131,12 +131,10 @@ class XXmotifTestNormalConditions(XXmotifTestCase):
 
     def test_fasta_one_sequence(self):
         """Test a fasta input file containing only one sequence."""
-        input_file = "seq.fasta"
-        handle = open(input_file, "w")
         record = list(SeqIO.parse("Registry/seqs.fasta", "fasta"))[0]
-        SeqIO.write(record, handle, "fasta")
-        handle.close()
-        del handle, record
+        input_file = "seq.fasta"
+        with open(input_file, "w") as handle:
+            SeqIO.write(record, handle, "fasta")
 
         cline = XXmotifCommandline(outdir=self.out_dir,
                                    seqfile=input_file)
@@ -159,12 +157,10 @@ class XXmotifTestNormalConditions(XXmotifTestCase):
 
     def test_large_fasta_file(self):
         """Test a large fasta input file."""
-        input_file = "temp_b_nuc.fasta"
-        handle = open(input_file, "w")
         records = list(SeqIO.parse("NBRF/B_nuc.pir", "pir"))
-        SeqIO.write(records, handle, "fasta")
-        handle.close()
-        del handle, records
+        input_file = "temp_b_nuc.fasta"
+        with open(input_file, "w") as handle:
+            SeqIO.write(records, handle, "fasta")
 
         cline = XXmotifCommandline(outdir=self.out_dir,
                                    seqfile=input_file)
@@ -174,10 +170,10 @@ class XXmotifTestNormalConditions(XXmotifTestCase):
 
     def test_input_filename_with_space(self):
         """Test an input filename containing a space."""
+        records = SeqIO.parse("Phylip/hennigian.phy", "phylip")
         input_file = "temp horses.fasta"
-        handle = open(input_file, "w")
-        SeqIO.write(SeqIO.parse("Phylip/hennigian.phy", "phylip"), handle, "fasta")
-        handle.close()
+        with open(input_file, "w") as handle:
+            SeqIO.write(records, handle, "fasta")
 
         cline = XXmotifCommandline(outdir=self.out_dir,
                                    seqfile=input_file)


### PR DESCRIPTION
This pull request uses the `with` statement in test_XXmotif_tool.py to open files.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
