### PR TITLE
use with in test_cellosaurus.py

### DIFF
--- a/Tests/test_cellosaurus.py
+++ b/Tests/test_cellosaurus.py
@@ -117,7 +117,7 @@ class TestCellosaurus(unittest.TestCase):
             self.assertEqual(record["SX"], "Female")
             self.assertEqual(record["CA"], "Cancer cell line")
             self.assertRaises(StopIteration, next, records)
-    
+
     def test__str__(self):
         """Test string function."""
         with open("Cellosaurus/cell_lines_3.txt") as handle:

--- a/Tests/test_cellosaurus.py
+++ b/Tests/test_cellosaurus.py
@@ -5,7 +5,6 @@
 
 """Tests for cellosaurus module."""
 
-import os
 import unittest
 
 from Bio.ExPASy import cellosaurus
@@ -14,8 +13,8 @@ from Bio.ExPASy import cellosaurus
 class TestCellosaurus(unittest.TestCase):
     def test_read(self):
         """Test read function."""
-        handle = open("Cellosaurus/cell_lines_1.txt")
-        record = cellosaurus.read(handle)
+        with open("Cellosaurus/cell_lines_1.txt") as handle:
+            record = cellosaurus.read(handle)
         self.assertEqual(record["ID"], "#15310-LN")
         self.assertEqual(record["AC"], "CVCL_E548")
         self.assertEqual(record["SY"], "15310-LN; TER461")
@@ -36,102 +35,100 @@ class TestCellosaurus(unittest.TestCase):
                          "NCBI_TaxID=9606; ! Homo sapiens")
         self.assertEqual(record["SX"], "Female")
         self.assertEqual(record["CA"], "Transformed cell line")
-        handle.close()
 
     def test_parse(self):
         """Test parsing function."""
-        handle = open("Cellosaurus/cell_lines_2.txt")
-        records = cellosaurus.parse(handle)
-        record = next(records)
-        self.assertEqual(record["ID"], "XP3OS")
-        self.assertEqual(record["AC"], "CVCL_3245")
-        self.assertEqual(record["AS"], "CVCL_F511")
-        self.assertEqual(record["SY"], "XP30S; GM04314")
-        self.assertEqual(record["DR"][0], ("CLO", "CLO_0019557"))
-        self.assertEqual(record["DR"][1], ("Coriell", "GM04314"))
-        self.assertEqual(record["DR"][2], ("JCRB", "JCRB0303"))
-        self.assertEqual(record["DR"][3], ("JCRB", "KURB1002"))
-        self.assertEqual(record["DR"][4], ("JCRB", "KURB1003"))
-        self.assertEqual(record["DR"][5], ("JCRB", "KURB1004"))
-        self.assertEqual(record["RX"][0], "PubMed=1372102;")
-        self.assertEqual(len(record["ST"]), 10)
-        self.assertEqual(record["ST"][0], "Source(s): JCRB")
-        self.assertEqual(record["ST"][1], "Amelogenin: X")
-        self.assertEqual(record["ST"][2], "CSF1PO: 10,11")
-        self.assertEqual(record["ST"][3], "D13S317: 9,11")
-        self.assertEqual(record["ST"][4], "D16S539: 9,12")
-        self.assertEqual(record["ST"][5], "D5S818: 10,11")
-        self.assertEqual(record["ST"][6], "D7S820: 11,12")
-        self.assertEqual(record["ST"][7], "TH01: 7")
-        self.assertEqual(record["ST"][8], "TPOX: 8,11")
-        self.assertEqual(record["ST"][9], "vWA: 14,16")
-        self.assertEqual(record["DI"][0], "NCIt; C3965; Xeroderma pigmentosum,"
-                                          " complementation group A")
-        self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens")
-        self.assertEqual(record["SX"], "Female")
-        self.assertEqual(record["CA"], "Finite cell line")
-        record = next(records)
-        self.assertEqual(record["ID"], "1-5c-4")
-        self.assertEqual(record["AC"], "CVCL_2260")
-        self.assertEqual(record["SY"],
-                         "Clone 1-5c-4; Clone 1-5c-4 WKD of "
-                         "Chang Conjunctiva; "
-                         "Wong-Kilbourne derivative of "
-                         "Chang conjunctiva; ChWK")
-        self.assertEqual(len(record["DR"]), 10)
-        self.assertEqual(record["DR"][0], ("CLO", "CLO_0002500"))
-        self.assertEqual(record["DR"][1], ("CLO", "CLO_0002501"))
-        self.assertEqual(record["DR"][2], ("CLDB", "cl793"))
-        self.assertEqual(record["DR"][3], ("CLDB", "cl794"))
-        self.assertEqual(record["DR"][4], ("CLDB", "cl795"))
-        self.assertEqual(record["DR"][5], ("ATCC", "CCL-20.2"))
-        self.assertEqual(record["DR"][6], ("BioSample", "SAMN03151673"))
-        self.assertEqual(record["DR"][7], ("ECACC", "88021103"))
-        self.assertEqual(record["DR"][8], ("IZSLER", "BS CL 93"))
-        self.assertEqual(record["DR"][9], ("KCLB", "10020.2"))
-        self.assertEqual(record["RX"][0], "PubMed=566722;")
-        self.assertEqual(record["RX"][1], "PubMed=19630270;")
-        self.assertEqual(record["RX"][2], "PubMed=20143388;")
-        self.assertEqual(record["WW"][0], "http://iclac.org/"
-                                          "wp-content/uploads/"
-                                          "Cross-Contaminations-v7_2.pdf")
-        self.assertEqual(record["CC"][0],
-                         "Problematic cell line: Contaminated. "
-                         "Shown to be a HeLa derivative "
-                         "(PubMed 566722, PubMed 20143388).")
-        self.assertEqual(record["CC"][1], "Omics: Transcriptome analysis.")
-        self.assertEqual(record["ST"][0], "Source(s): ATCC; KCLB")
-        self.assertEqual(record["ST"][1], "Amelogenin: X")
-        self.assertEqual(record["ST"][2], "CSF1PO: 9,10")
-        self.assertEqual(record["ST"][3], "D13S317: 12,13.3")
-        self.assertEqual(record["ST"][4], "D16S539: 9,10")
-        self.assertEqual(record["ST"][5], "D3S1358: 15,18")
-        self.assertEqual(record["ST"][6], "D5S818: 11,12")
-        self.assertEqual(record["ST"][7], "D7S820: 8,12")
-        self.assertEqual(record["ST"][8], "FGA: 18,21")
-        self.assertEqual(record["ST"][9], "TH01: 7")
-        self.assertEqual(record["ST"][10], "TPOX: 8,12")
-        self.assertEqual(record["ST"][11], "vWA: 16,18")
-        self.assertEqual(record["DI"][0], "NCIt; C4029; Cervical "
-                                          "adenocarcinoma")
-        self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens")
-        self.assertEqual(record["HI"][0], "CVCL_0030 ! HeLa")
-        self.assertEqual(record["SX"], "Female")
-        self.assertEqual(record["CA"], "Cancer cell line")
-        self.assertRaises(StopIteration, next, records)
-        handle.close()
-
+        with open("Cellosaurus/cell_lines_2.txt") as handle:
+            records = cellosaurus.parse(handle)
+            record = next(records)
+            self.assertEqual(record["ID"], "XP3OS")
+            self.assertEqual(record["AC"], "CVCL_3245")
+            self.assertEqual(record["AS"], "CVCL_F511")
+            self.assertEqual(record["SY"], "XP30S; GM04314")
+            self.assertEqual(record["DR"][0], ("CLO", "CLO_0019557"))
+            self.assertEqual(record["DR"][1], ("Coriell", "GM04314"))
+            self.assertEqual(record["DR"][2], ("JCRB", "JCRB0303"))
+            self.assertEqual(record["DR"][3], ("JCRB", "KURB1002"))
+            self.assertEqual(record["DR"][4], ("JCRB", "KURB1003"))
+            self.assertEqual(record["DR"][5], ("JCRB", "KURB1004"))
+            self.assertEqual(record["RX"][0], "PubMed=1372102;")
+            self.assertEqual(len(record["ST"]), 10)
+            self.assertEqual(record["ST"][0], "Source(s): JCRB")
+            self.assertEqual(record["ST"][1], "Amelogenin: X")
+            self.assertEqual(record["ST"][2], "CSF1PO: 10,11")
+            self.assertEqual(record["ST"][3], "D13S317: 9,11")
+            self.assertEqual(record["ST"][4], "D16S539: 9,12")
+            self.assertEqual(record["ST"][5], "D5S818: 10,11")
+            self.assertEqual(record["ST"][6], "D7S820: 11,12")
+            self.assertEqual(record["ST"][7], "TH01: 7")
+            self.assertEqual(record["ST"][8], "TPOX: 8,11")
+            self.assertEqual(record["ST"][9], "vWA: 14,16")
+            self.assertEqual(record["DI"][0], "NCIt; C3965; Xeroderma pigmentosum,"
+                                              " complementation group A")
+            self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens")
+            self.assertEqual(record["SX"], "Female")
+            self.assertEqual(record["CA"], "Finite cell line")
+            record = next(records)
+            self.assertEqual(record["ID"], "1-5c-4")
+            self.assertEqual(record["AC"], "CVCL_2260")
+            self.assertEqual(record["SY"],
+                             "Clone 1-5c-4; Clone 1-5c-4 WKD of "
+                             "Chang Conjunctiva; "
+                             "Wong-Kilbourne derivative of "
+                             "Chang conjunctiva; ChWK")
+            self.assertEqual(len(record["DR"]), 10)
+            self.assertEqual(record["DR"][0], ("CLO", "CLO_0002500"))
+            self.assertEqual(record["DR"][1], ("CLO", "CLO_0002501"))
+            self.assertEqual(record["DR"][2], ("CLDB", "cl793"))
+            self.assertEqual(record["DR"][3], ("CLDB", "cl794"))
+            self.assertEqual(record["DR"][4], ("CLDB", "cl795"))
+            self.assertEqual(record["DR"][5], ("ATCC", "CCL-20.2"))
+            self.assertEqual(record["DR"][6], ("BioSample", "SAMN03151673"))
+            self.assertEqual(record["DR"][7], ("ECACC", "88021103"))
+            self.assertEqual(record["DR"][8], ("IZSLER", "BS CL 93"))
+            self.assertEqual(record["DR"][9], ("KCLB", "10020.2"))
+            self.assertEqual(record["RX"][0], "PubMed=566722;")
+            self.assertEqual(record["RX"][1], "PubMed=19630270;")
+            self.assertEqual(record["RX"][2], "PubMed=20143388;")
+            self.assertEqual(record["WW"][0], "http://iclac.org/"
+                                              "wp-content/uploads/"
+                                              "Cross-Contaminations-v7_2.pdf")
+            self.assertEqual(record["CC"][0],
+                             "Problematic cell line: Contaminated. "
+                             "Shown to be a HeLa derivative "
+                             "(PubMed 566722, PubMed 20143388).")
+            self.assertEqual(record["CC"][1], "Omics: Transcriptome analysis.")
+            self.assertEqual(record["ST"][0], "Source(s): ATCC; KCLB")
+            self.assertEqual(record["ST"][1], "Amelogenin: X")
+            self.assertEqual(record["ST"][2], "CSF1PO: 9,10")
+            self.assertEqual(record["ST"][3], "D13S317: 12,13.3")
+            self.assertEqual(record["ST"][4], "D16S539: 9,10")
+            self.assertEqual(record["ST"][5], "D3S1358: 15,18")
+            self.assertEqual(record["ST"][6], "D5S818: 11,12")
+            self.assertEqual(record["ST"][7], "D7S820: 8,12")
+            self.assertEqual(record["ST"][8], "FGA: 18,21")
+            self.assertEqual(record["ST"][9], "TH01: 7")
+            self.assertEqual(record["ST"][10], "TPOX: 8,12")
+            self.assertEqual(record["ST"][11], "vWA: 16,18")
+            self.assertEqual(record["DI"][0], "NCIt; C4029; Cervical "
+                                              "adenocarcinoma")
+            self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens")
+            self.assertEqual(record["HI"][0], "CVCL_0030 ! HeLa")
+            self.assertEqual(record["SX"], "Female")
+            self.assertEqual(record["CA"], "Cancer cell line")
+            self.assertRaises(StopIteration, next, records)
+    
     def test__str__(self):
         """Test string function."""
-        handle = open("Cellosaurus/cell_lines_3.txt")
-        record = cellosaurus.read(handle)
-        input = (
+        with open("Cellosaurus/cell_lines_3.txt") as handle:
+            record = cellosaurus.read(handle)
+        text = (
             "ID: ZZ-R 127 AC: CVCL_5418 AS:  SY: ZZ-R DR: [('CCLV', 'CCLV-RIE 0127')] "
             "RX: ['PubMed=19656987;', 'PubMed=19941903;'] WW: [] CC: [] ST: [] DI: [] "
             "OX: ['NCBI_TaxID=9925; ! Capra hircus'] HI: [] OI: [] SX:  CA: "
             "Spontaneously immortalized cell line"
         )
-        self.assertEqual(record.__str__(), input)
+        self.assertEqual(str(record), text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request uses the `with` statement to open files in test_cellosaurus.py.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
