### PR TITLE
Apply black style to T* files, version 19.10b0.

### DIFF
--- a/Tests/test_TCoffee_tool.py
+++ b/Tests/test_TCoffee_tool.py
@@ -76,8 +76,8 @@ class TCoffeeApplication(unittest.TestCase):
         cmdline.output = "pir_aln"
         self.assertEqual(
             str(cmdline),
-            t_coffee_exe + " -output pir_aln "
-            "-infile Fasta/fa01 -outfile Fasta/tc_out.pir -quiet",
+            t_coffee_exe
+            + " -output pir_aln -infile Fasta/fa01 -outfile Fasta/tc_out.pir -quiet",
         )
         stdout, stderr = cmdline()
         # Can get warnings in stderr output
@@ -102,8 +102,8 @@ class TCoffeeApplication(unittest.TestCase):
         cmdline.type = "protein"
         self.assertEqual(
             str(cmdline),
-            t_coffee_exe + " -output clustalw_aln "
-            "-infile Fasta/fa01 -outfile Fasta/tc_out.aln "
+            t_coffee_exe
+            + " -output clustalw_aln -infile Fasta/fa01 -outfile Fasta/tc_out.aln "
             "-type protein -outorder input -gapopen -2 -gapext -5",
         )
         stdout, stderr = cmdline()
@@ -155,8 +155,8 @@ class TCoffeeApplication(unittest.TestCase):
         )
         self.assertEqual(
             str(cmdline),
-            t_coffee_exe + " -output msf_aln "
-            "-infile Fasta/fa01 -outfile Fasta/tc_out.msf -quiet",
+            t_coffee_exe
+            + " -output msf_aln -infile Fasta/fa01 -outfile Fasta/tc_out.msf -quiet",
         )
         stdout, stderr = cmdline()
         # Can get warnings in stderr output

--- a/Tests/test_TCoffee_tool.py
+++ b/Tests/test_TCoffee_tool.py
@@ -15,10 +15,10 @@ os.environ["LANG"] = "C"
 
 t_coffee_exe = None
 if sys.platform == "win32":
-    raise MissingExternalDependencyError(
-        "Testing TCOFFEE on Windows not supported yet")
+    raise MissingExternalDependencyError("Testing TCOFFEE on Windows not supported yet")
 else:
     from subprocess import getoutput
+
     output = getoutput("t_coffee -version")
     if "not found" not in output and "not recognized" not in output:
         if "t_coffee" in output.lower() or "t-coffee" in output.lower():
@@ -26,11 +26,11 @@ else:
 
 if not t_coffee_exe:
     raise MissingExternalDependencyError(
-        "Install TCOFFEE if you want to use the Bio.Align.Applications wrapper.")
+        "Install TCOFFEE if you want to use the Bio.Align.Applications wrapper."
+    )
 
 
 class TCoffeeApplication(unittest.TestCase):
-
     def setUp(self):
         self.infile1 = "Fasta/fa01"
         # TODO: Use a temp dir for the output files:
@@ -64,7 +64,9 @@ class TCoffeeApplication(unittest.TestCase):
         self.assertEqual(len(records), len(align))
         for old, new in zip(records, align):
             self.assertEqual(old.id, new.id)
-            self.assertEqual(str(new.seq).replace("-", ""), str(old.seq).replace("-", ""))
+            self.assertEqual(
+                str(new.seq).replace("-", ""), str(old.seq).replace("-", "")
+            )
 
     def test_TCoffee_pir(self):
         """Round-trip through app and read pir alignment from file."""
@@ -72,8 +74,11 @@ class TCoffeeApplication(unittest.TestCase):
         cmdline.infile = self.infile1
         cmdline.outfile = self.outfile3
         cmdline.output = "pir_aln"
-        self.assertEqual(str(cmdline), t_coffee_exe + " -output pir_aln "
-                         "-infile Fasta/fa01 -outfile Fasta/tc_out.pir -quiet")
+        self.assertEqual(
+            str(cmdline),
+            t_coffee_exe + " -output pir_aln "
+            "-infile Fasta/fa01 -outfile Fasta/tc_out.pir -quiet",
+        )
         stdout, stderr = cmdline()
         # Can get warnings in stderr output
         self.assertNotIn("error", stderr.lower(), stderr)
@@ -82,7 +87,9 @@ class TCoffeeApplication(unittest.TestCase):
         self.assertEqual(len(records), len(align))
         for old, new in zip(records, align):
             self.assertEqual(old.id, new.id)
-            self.assertEqual(str(new.seq).replace("-", ""), str(old.seq).replace("-", ""))
+            self.assertEqual(
+                str(new.seq).replace("-", ""), str(old.seq).replace("-", "")
+            )
 
     def test_TCoffee_clustalw(self):
         """Round-trip through app and read clustalw alignment from file."""
@@ -93,9 +100,12 @@ class TCoffeeApplication(unittest.TestCase):
         cmdline.outorder = "input"
         cmdline.set_parameter("gapext", -5)
         cmdline.type = "protein"
-        self.assertEqual(str(cmdline), t_coffee_exe + " -output clustalw_aln "
-                         "-infile Fasta/fa01 -outfile Fasta/tc_out.aln "
-                         "-type protein -outorder input -gapopen -2 -gapext -5")
+        self.assertEqual(
+            str(cmdline),
+            t_coffee_exe + " -output clustalw_aln "
+            "-infile Fasta/fa01 -outfile Fasta/tc_out.aln "
+            "-type protein -outorder input -gapopen -2 -gapext -5",
+        )
         stdout, stderr = cmdline()
         self.assertTrue(stderr.strip().startswith("PROGRAM: T-COFFEE"))
         align = AlignIO.read(self.outfile4, "clustal")
@@ -103,15 +113,24 @@ class TCoffeeApplication(unittest.TestCase):
         self.assertEqual(len(records), len(align))
         for old, new in zip(records, align):
             self.assertEqual(old.id, new.id)
-            self.assertEqual(str(new.seq).replace("-", ""), str(old.seq).replace("-", ""))
+            self.assertEqual(
+                str(new.seq).replace("-", ""), str(old.seq).replace("-", "")
+            )
 
     def test_TCoffee_phylip(self):
         """Round-trip through app and read PHYLIP alignment from file."""
-        cmdline = TCoffeeCommandline(t_coffee_exe, infile=self.infile1,
-                                     outfile=self.outfile5,
-                                     quiet=True, output="phylip_aln")
-        self.assertEqual(str(cmdline), t_coffee_exe + " -output phylip_aln "
-                         "-infile Fasta/fa01 -outfile Fasta/tc_out.phy -quiet")
+        cmdline = TCoffeeCommandline(
+            t_coffee_exe,
+            infile=self.infile1,
+            outfile=self.outfile5,
+            quiet=True,
+            output="phylip_aln",
+        )
+        self.assertEqual(
+            str(cmdline),
+            t_coffee_exe + " -output phylip_aln "
+            "-infile Fasta/fa01 -outfile Fasta/tc_out.phy -quiet",
+        )
         stdout, stderr = cmdline()
         # Can get warnings in stderr output
         self.assertNotIn("error", stderr.lower(), stderr)
@@ -121,15 +140,24 @@ class TCoffeeApplication(unittest.TestCase):
         for old, new in zip(records, align):
             # TCoffee does strict 10 character truncation as per original PHYLIP
             self.assertEqual(old.id[:10], new.id[:10])
-            self.assertEqual(str(new.seq).replace("-", ""), str(old.seq).replace("-", ""))
+            self.assertEqual(
+                str(new.seq).replace("-", ""), str(old.seq).replace("-", "")
+            )
 
     def test_TCoffee_msf(self):
         """Round-trip through app and read GCG MSF alignment from file."""
-        cmdline = TCoffeeCommandline(t_coffee_exe, infile=self.infile1,
-                                     outfile=self.outfile6,
-                                     quiet=True, output="msf_aln")
-        self.assertEqual(str(cmdline), t_coffee_exe + " -output msf_aln "
-                         "-infile Fasta/fa01 -outfile Fasta/tc_out.msf -quiet")
+        cmdline = TCoffeeCommandline(
+            t_coffee_exe,
+            infile=self.infile1,
+            outfile=self.outfile6,
+            quiet=True,
+            output="msf_aln",
+        )
+        self.assertEqual(
+            str(cmdline),
+            t_coffee_exe + " -output msf_aln "
+            "-infile Fasta/fa01 -outfile Fasta/tc_out.msf -quiet",
+        )
         stdout, stderr = cmdline()
         # Can get warnings in stderr output
         self.assertNotIn("error", stderr.lower(), stderr)
@@ -138,7 +166,9 @@ class TCoffeeApplication(unittest.TestCase):
         self.assertEqual(len(records), len(align))
         for old, new in zip(records, align):
             self.assertEqual(old.id, new.id)
-            self.assertEqual(str(new.seq).replace("-", ""), str(old.seq).replace("-", ""))
+            self.assertEqual(
+                str(new.seq).replace("-", ""), str(old.seq).replace("-", "")
+            )
 
 
 if __name__ == "__main__":

--- a/Tests/test_TogoWS.py
+++ b/Tests/test_TogoWS.py
@@ -20,6 +20,7 @@ from Bio.SeqUtils.CheckSum import seguid
 from Bio import Medline
 
 import requires_internet
+
 requires_internet.check()
 
 #####################################################################
@@ -28,67 +29,130 @@ requires_internet.check()
 class TogoFields(unittest.TestCase):
     def test_invalid_database(self):
         """Check asking for fields of invalid database fails."""
-        self.assertRaises(IOError, TogoWS._get_fields,
-                          "http://togows.dbcls.jp/entry/invalid?fields")
+        self.assertRaises(
+            IOError, TogoWS._get_fields, "http://togows.dbcls.jp/entry/invalid?fields"
+        )
 
     def test_databases(self):
         """Check supported databases."""
         dbs = set(TogoWS._get_entry_dbs())
-        expected = {"nuccore", "nucest", "nucgss",
-                    "nucleotide", "protein", "gene",
-                    "homologene", "snp",
-                    "mesh", "pubmed",  # 'embl',
-                    "uniprot", "uniparc", "uniref100",
-                    "uniref90", "uniref50", "ddbj",
-                    "dad", "pdb", "compound", "drug",
-                    "enzyme", "genes", "glycan",
-                    "orthology", "reaction", "module",
-                    "pathway"}
-        self.assertTrue(dbs.issuperset(expected),
-                        "Missing DB: %s" % ", ".join(sorted(expected.difference(dbs))))
+        expected = {
+            "nuccore",
+            "nucest",
+            "nucgss",
+            "nucleotide",
+            "protein",
+            "gene",
+            "homologene",
+            "snp",
+            "mesh",
+            "pubmed",  # 'embl',
+            "uniprot",
+            "uniparc",
+            "uniref100",
+            "uniref90",
+            "uniref50",
+            "ddbj",
+            "dad",
+            "pdb",
+            "compound",
+            "drug",
+            "enzyme",
+            "genes",
+            "glycan",
+            "orthology",
+            "reaction",
+            "module",
+            "pathway",
+        }
+        self.assertTrue(
+            dbs.issuperset(expected),
+            "Missing DB: %s" % ", ".join(sorted(expected.difference(dbs))),
+        )
 
     def test_pubmed(self):
         """Check supported fields for pubmed database."""
         fields = set(TogoWS._get_entry_fields("pubmed"))
-        self.assertTrue(fields.issuperset(["abstract", "au", "authors",
-                                           "doi", "mesh", "so",
-                                           "title"]), fields)
+        self.assertTrue(
+            fields.issuperset(
+                ["abstract", "au", "authors", "doi", "mesh", "so", "title"]
+            ),
+            fields,
+        )
 
     def test_ncbi_protein(self):
         """Check supported fields for NCBI protein database."""
         fields = set(TogoWS._get_entry_fields("ncbi-protein"))
-        self.assertTrue(fields.issuperset(["entry_id", "length", "strand",
-                                           "moltype", "linearity", "division",
-                                           "date", "definition", "accession",
-                                           "accessions", "version", "versions",
-                                           "acc_version", "gi", "keywords",
-                                           "organism", "common_name",
-                                           "taxonomy", "comment", "seq"]),
-                        fields)
+        self.assertTrue(
+            fields.issuperset(
+                [
+                    "entry_id",
+                    "length",
+                    "strand",
+                    "moltype",
+                    "linearity",
+                    "division",
+                    "date",
+                    "definition",
+                    "accession",
+                    "accessions",
+                    "version",
+                    "versions",
+                    "acc_version",
+                    "gi",
+                    "keywords",
+                    "organism",
+                    "common_name",
+                    "taxonomy",
+                    "comment",
+                    "seq",
+                ]
+            ),
+            fields,
+        )
 
     def test_ddbj(self):
         """Check supported fields for ddbj database."""
         fields = set(TogoWS._get_entry_fields("ddbj"))
-        self.assertTrue(fields.issuperset(["entry_id", "length", "strand",
-                                           "moltype", "linearity", "division",
-                                           "date", "definition", "accession",
-                                           "accessions", "version", "versions",
-                                           "acc_version", "gi", "keywords",
-                                           "organism", "common_name",
-                                           "taxonomy", "comment", "seq"]),
-                        fields)
+        self.assertTrue(
+            fields.issuperset(
+                [
+                    "entry_id",
+                    "length",
+                    "strand",
+                    "moltype",
+                    "linearity",
+                    "division",
+                    "date",
+                    "definition",
+                    "accession",
+                    "accessions",
+                    "version",
+                    "versions",
+                    "acc_version",
+                    "gi",
+                    "keywords",
+                    "organism",
+                    "common_name",
+                    "taxonomy",
+                    "comment",
+                    "seq",
+                ]
+            ),
+            fields,
+        )
 
     def test_uniprot(self):
         """Check supported fields for uniprot database."""
         fields = set(TogoWS._get_entry_fields("uniprot"))
-        self.assertTrue(fields.issuperset(["definition", "entry_id", "seq"]),
-                        fields)
+        self.assertTrue(fields.issuperset(["definition", "entry_id", "seq"]), fields)
 
     def test_pdb(self):
         """Check supported fields for pdb database."""
         fields = set(TogoWS._get_entry_fields("pdb"))
-        self.assertTrue(fields.issuperset(["accession", "chains", "keywords",
-                                           "models"]), fields)
+        self.assertTrue(
+            fields.issuperset(["accession", "chains", "keywords", "models"]), fields
+        )
 
 
 class TogoEntry(unittest.TestCase):
@@ -98,31 +162,41 @@ class TogoEntry(unittest.TestCase):
         handle = TogoWS.entry("pubmed", "16381885")
         data = Medline.read(handle)
         handle.close()
-        self.assertEqual(data["TI"],
-                         "From genomics to chemical genomics: "
-                         "new developments in KEGG.")
-        self.assertEqual(data["AU"], ["Kanehisa M", "Goto S", "Hattori M",
-                                      "Aoki-Kinoshita KF", "Itoh M",
-                                      "Kawashima S", "Katayama T", "Araki M",
-                                      "Hirakawa M"])
+        self.assertEqual(
+            data["TI"], "From genomics to chemical genomics: new developments in KEGG.",
+        )
+        self.assertEqual(
+            data["AU"],
+            [
+                "Kanehisa M",
+                "Goto S",
+                "Hattori M",
+                "Aoki-Kinoshita KF",
+                "Itoh M",
+                "Kawashima S",
+                "Katayama T",
+                "Araki M",
+                "Hirakawa M",
+            ],
+        )
 
     def test_pubmed_16381885_ti(self):
         """Bio.TogoWS.entry("pubmed", "16381885", field="title")."""
         handle = TogoWS.entry("pubmed", "16381885", field="title")
         data = handle.read().strip()
         handle.close()
-        self.assertEqual(data,
-                         "From genomics to chemical genomics: "
-                         "new developments in KEGG.")
+        self.assertEqual(
+            data, "From genomics to chemical genomics: new developments in KEGG."
+        )
 
     def test_pubmed_16381885_title(self):
         """Bio.TogoWS.entry("pubmed", "16381885", field="title")."""
         handle = TogoWS.entry("pubmed", "16381885", field="title")
         data = handle.read().strip()
         handle.close()
-        self.assertEqual(data,
-                         "From genomics to chemical genomics: "
-                         "new developments in KEGG.")
+        self.assertEqual(
+            data, "From genomics to chemical genomics: new developments in KEGG."
+        )
 
     def test_pubmed_16381885_au(self):
         """Bio.TogoWS.entry("pubmed", "16381885", field="au")."""
@@ -130,10 +204,20 @@ class TogoEntry(unittest.TestCase):
         handle = TogoWS.entry("pubmed", "16381885", field="au")
         data = handle.read().strip().split("\n")
         handle.close()
-        self.assertEqual(data, ["Kanehisa M", "Goto S", "Hattori M",
-                                "Aoki-Kinoshita KF", "Itoh M",
-                                "Kawashima S", "Katayama T", "Araki M",
-                                "Hirakawa M"])
+        self.assertEqual(
+            data,
+            [
+                "Kanehisa M",
+                "Goto S",
+                "Hattori M",
+                "Aoki-Kinoshita KF",
+                "Itoh M",
+                "Kawashima S",
+                "Katayama T",
+                "Araki M",
+                "Hirakawa M",
+            ],
+        )
 
     def test_pubmed_16381885_authors(self):
         """Bio.TogoWS.entry("pubmed", "16381885", field="authors")."""
@@ -141,25 +225,36 @@ class TogoEntry(unittest.TestCase):
         handle = TogoWS.entry("pubmed", "16381885", field="authors")
         data = handle.read().strip().split("\t")
         handle.close()
-        self.assertEqual(data, ["Kanehisa, M.", "Goto, S.", "Hattori, M.",
-                                "Aoki-Kinoshita, K. F.", "Itoh, M.",
-                                "Kawashima, S.", "Katayama, T.", "Araki, M.",
-                                "Hirakawa, M."])
+        self.assertEqual(
+            data,
+            [
+                "Kanehisa, M.",
+                "Goto, S.",
+                "Hattori, M.",
+                "Aoki-Kinoshita, K. F.",
+                "Itoh, M.",
+                "Kawashima, S.",
+                "Katayama, T.",
+                "Araki, M.",
+                "Hirakawa, M.",
+            ],
+        )
 
     def test_pubmed_16381885_invalid_field(self):
         """Bio.TogoWS.entry("pubmed", "16381885", field="invalid_for_testing")."""
-        self.assertRaises(ValueError, TogoWS.entry,
-                          "pubmed", "16381885", field="invalid_for_testing")
+        self.assertRaises(
+            ValueError, TogoWS.entry, "pubmed", "16381885", field="invalid_for_testing"
+        )
 
     def test_pubmed_16381885_invalid_format(self):
         """Bio.TogoWS.entry("pubmed", "16381885", format="invalid_for_testing")."""
-        self.assertRaises(ValueError, TogoWS.entry,
-                          "pubmed", "16381885", format="invalid_for_testing")
+        self.assertRaises(
+            ValueError, TogoWS.entry, "pubmed", "16381885", format="invalid_for_testing"
+        )
 
     def test_pubmed_invalid_id(self):
         """Bio.TogoWS.entry("pubmed", "invalid_for_testing")."""
-        self.assertRaises(IOError, TogoWS.entry,
-                          "pubmed", "invalid_for_testing")
+        self.assertRaises(IOError, TogoWS.entry, "pubmed", "invalid_for_testing")
 
     def test_pubmed_16381885_and_19850725(self):
         """Bio.TogoWS.entry("pubmed", "16381885,19850725")."""
@@ -167,21 +262,42 @@ class TogoEntry(unittest.TestCase):
         records = list(Medline.parse(handle))
         handle.close()
         self.assertEqual(len(records), 2)
-        self.assertEqual(records[0]["TI"],
-                         "From genomics to chemical genomics: "
-                         "new developments in KEGG.")
-        self.assertEqual(records[0]["AU"], ["Kanehisa M", "Goto S",
-                                            "Hattori M", "Aoki-Kinoshita KF",
-                                            "Itoh M", "Kawashima S",
-                                            "Katayama T", "Araki M",
-                                            "Hirakawa M"])
-        self.assertEqual(records[1]["TI"],
-                         "DDBJ launches a new archive database with "
-                         "analytical tools for next-generation sequence data.")
-        self.assertEqual(records[1]["AU"], ["Kaminuma E", "Mashima J",
-                                            "Kodama Y", "Gojobori T",
-                                            "Ogasawara O", "Okubo K",
-                                            "Takagi T", "Nakamura Y"])
+        self.assertEqual(
+            records[0]["TI"],
+            "From genomics to chemical genomics: new developments in KEGG.",
+        )
+        self.assertEqual(
+            records[0]["AU"],
+            [
+                "Kanehisa M",
+                "Goto S",
+                "Hattori M",
+                "Aoki-Kinoshita KF",
+                "Itoh M",
+                "Kawashima S",
+                "Katayama T",
+                "Araki M",
+                "Hirakawa M",
+            ],
+        )
+        self.assertEqual(
+            records[1]["TI"],
+            "DDBJ launches a new archive database with "
+            "analytical tools for next-generation sequence data.",
+        )
+        self.assertEqual(
+            records[1]["AU"],
+            [
+                "Kaminuma E",
+                "Mashima J",
+                "Kodama Y",
+                "Gojobori T",
+                "Ogasawara O",
+                "Okubo K",
+                "Takagi T",
+                "Nakamura Y",
+            ],
+        )
 
     def test_pubmed_16381885_and_19850725_authors(self):
         """Bio.TogoWS.entry("pubmed", "16381885,19850725", field="authors")."""
@@ -192,20 +308,37 @@ class TogoEntry(unittest.TestCase):
         handle.close()
         self.assertEqual(2, len(names))
         names1, names2 = names
-        self.assertEqual(names1.split("\t"),
-                         ["Kanehisa, M.", "Goto, S.", "Hattori, M.",
-                          "Aoki-Kinoshita, K. F.", "Itoh, M.",
-                          "Kawashima, S.", "Katayama, T.",
-                          "Araki, M.", "Hirakawa, M."])
-        self.assertEqual(names2.split("\t"),
-                         ["Kaminuma, E.", "Mashima, J.", "Kodama, Y.",
-                          "Gojobori, T.", "Ogasawara, O.", "Okubo, K.",
-                          "Takagi, T.", "Nakamura, Y."])
+        self.assertEqual(
+            names1.split("\t"),
+            [
+                "Kanehisa, M.",
+                "Goto, S.",
+                "Hattori, M.",
+                "Aoki-Kinoshita, K. F.",
+                "Itoh, M.",
+                "Kawashima, S.",
+                "Katayama, T.",
+                "Araki, M.",
+                "Hirakawa, M.",
+            ],
+        )
+        self.assertEqual(
+            names2.split("\t"),
+            [
+                "Kaminuma, E.",
+                "Mashima, J.",
+                "Kodama, Y.",
+                "Gojobori, T.",
+                "Ogasawara, O.",
+                "Okubo, K.",
+                "Takagi, T.",
+                "Nakamura, Y.",
+            ],
+        )
 
     def test_invalid_db(self):
         """Bio.TogoWS.entry("invalid_db", "invalid_id")."""
-        self.assertRaises(ValueError, TogoWS.entry,
-                          "invalid_db", "invalid_id")
+        self.assertRaises(ValueError, TogoWS.entry, "invalid_db", "invalid_id")
 
     def test_ddbj_genbank_length(self):
         """Bio.TogoWS.entry("ddbj", "X52960", field="length")."""
@@ -275,13 +408,23 @@ class TogoEntry(unittest.TestCase):
 
     def test_ddbj_genbank_invalid_field(self):
         """Bio.TogoWS.entry("nucleotide", "X52960", field="invalid_for_testing")."""
-        self.assertRaises(ValueError, TogoWS.entry,
-                          "nucleotide", "X52960", field="invalid_for_testing")
+        self.assertRaises(
+            ValueError,
+            TogoWS.entry,
+            "nucleotide",
+            "X52960",
+            field="invalid_for_testing",
+        )
 
     def test_nucleotide_invalid_format(self):
         """Bio.TogoWS.entry("nucleotide", "X52960", format="invalid_for_testing")."""
-        self.assertRaises(ValueError, TogoWS.entry,
-                          "nucleotide", "X52960", format="invalid_for_testing")
+        self.assertRaises(
+            ValueError,
+            TogoWS.entry,
+            "nucleotide",
+            "X52960",
+            format="invalid_for_testing",
+        )
 
     def test_ddbj_gff3(self):
         """Bio.TogoWS.entry("ddbj", "X52960", format="gff")."""
@@ -358,33 +501,35 @@ class TogoSearch(unittest.TestCase):
 
     def test_bad_args_just_limit(self):
         """Reject Bio.TogoWS.search(...) with just limit."""
-        self.assertRaises(ValueError, TogoWS.search,
-                          "pubmed", "lung+cancer", limit=10)
+        self.assertRaises(ValueError, TogoWS.search, "pubmed", "lung+cancer", limit=10)
 
     def test_bad_args_just_offset(self):
         """Reject Bio.TogoWS.search(...) with just offset."""
-        self.assertRaises(ValueError, TogoWS.search,
-                          "pubmed", "lung+cancer", offset=10)
+        self.assertRaises(ValueError, TogoWS.search, "pubmed", "lung+cancer", offset=10)
 
     def test_bad_args_zero_limit(self):
         """Reject Bio.TogoWS.search(...) with zero limit."""
-        self.assertRaises(ValueError, TogoWS.search,
-                          "pubmed", "lung+cancer", offset=1, limit=0)
+        self.assertRaises(
+            ValueError, TogoWS.search, "pubmed", "lung+cancer", offset=1, limit=0
+        )
 
     def test_bad_args_zero_offset(self):
         """Reject Bio.TogoWS.search(...) with zero offset."""
-        self.assertRaises(ValueError, TogoWS.search,
-                          "pubmed", "lung+cancer", offset=0, limit=10)
+        self.assertRaises(
+            ValueError, TogoWS.search, "pubmed", "lung+cancer", offset=0, limit=10
+        )
 
     def test_bad_args_non_int_offset(self):
         """Reject Bio.TogoWS.search(...) with non-integer offset."""
-        self.assertRaises(ValueError, TogoWS.search,
-                          "pubmed", "lung+cancer", offset="test", limit=10)
+        self.assertRaises(
+            ValueError, TogoWS.search, "pubmed", "lung+cancer", offset="test", limit=10
+        )
 
     def test_bad_args_non_int_limit(self):
         """Reject Bio.TogoWS.search(...) with non-integer limit."""
-        self.assertRaises(ValueError, TogoWS.search,
-                          "pubmed", "lung+cancer", offset=1, limit="lots")
+        self.assertRaises(
+            ValueError, TogoWS.search, "pubmed", "lung+cancer", offset=1, limit="lots"
+        )
 
     def test_pubmed_search_togows(self):
         """Bio.TogoWS.search_iter("pubmed", "TogoWS") etc."""
@@ -392,8 +537,11 @@ class TogoSearch(unittest.TestCase):
 
     def test_pubmed_search_bioruby(self):
         """Bio.TogoWS.search_iter("pubmed", "BioRuby") etc."""
-        self.check("pubmed", "BioRuby", ["22994508", "22399473",
-                                         "20739307", "20015970", "14693808"])
+        self.check(
+            "pubmed",
+            "BioRuby",
+            ["22994508", "22399473", "20739307", "20015970", "14693808"],
+        )
 
     def test_pubmed_search_porin(self):
         """Bio.TogoWS.search_iter("pubmed", "human porin") etc.
@@ -404,13 +552,13 @@ class TogoSearch(unittest.TestCase):
         """
         self.check("pubmed", "human porin", ["21189321", "21835183"])
 
-# TogoWS search for PDBj currently unavailable
-#    def test_pdb_search_porin(self):
-#        """Bio.TogoWS.search_iter("pdb", "porin") etc
-#
-#        Count was about 161 at time of writing.
-#        """
-#        self.check("pdb", "porin", ["2j1n", "2vqg", "3m8b", "2k0l"])
+    # TogoWS search for PDBj currently unavailable
+    #    def test_pdb_search_porin(self):
+    #        """Bio.TogoWS.search_iter("pdb", "porin") etc
+    #
+    #        Count was about 161 at time of writing.
+    #        """
+    #        self.check("pdb", "porin", ["2j1n", "2vqg", "3m8b", "2k0l"])
 
     def test_uniprot_search_lung_cancer(self):
         """Bio.TogoWS.search_iter("uniprot", "terminal+lung+cancer", limit=150) etc.
@@ -430,8 +578,10 @@ class TogoSearch(unittest.TestCase):
         except HTTPError as err:
             raise ValueError("%s from %s" % (err, err.url)) from None
         if expected_matches and search_count < len(expected_matches):
-            raise ValueError("Only %i matches, expected at least %i"
-                             % (search_count, len(expected_matches)))
+            raise ValueError(
+                "Only %i matches, expected at least %i"
+                % (search_count, len(expected_matches))
+            )
         if search_count > 5000 and not limit:
             print("%i results, skipping" % search_count)
             return
@@ -444,8 +594,9 @@ class TogoSearch(unittest.TestCase):
         search_iter = list(TogoWS.search_iter(database, search_term, limit))
         self.assertEqual(count, len(search_iter))
         for match in expected_matches:
-            self.assertTrue(match in search_iter,
-                            "Expected %s in results but not" % match)
+            self.assertTrue(
+                match in search_iter, "Expected %s in results but not" % match
+            )
 
 
 class TogoConvert(unittest.TestCase):
@@ -453,12 +604,20 @@ class TogoConvert(unittest.TestCase):
 
     def test_invalid_format(self):
         """Check convert file format checking."""
-        self.assertRaises(ValueError, TogoWS.convert,
-                          StringIO("PLACEHOLDER"),
-                          "genbank", "invalid_for_testing")
-        self.assertRaises(ValueError, TogoWS.convert,
-                          StringIO("PLACEHOLDER"),
-                          "invalid_for_testing", "fasta")
+        self.assertRaises(
+            ValueError,
+            TogoWS.convert,
+            StringIO("PLACEHOLDER"),
+            "genbank",
+            "invalid_for_testing",
+        )
+        self.assertRaises(
+            ValueError,
+            TogoWS.convert,
+            StringIO("PLACEHOLDER"),
+            "invalid_for_testing",
+            "fasta",
+        )
 
     def test_genbank_to_fasta(self):
         """Conversion of GenBank to FASTA."""
@@ -467,6 +626,7 @@ class TogoConvert(unittest.TestCase):
         with open(filename) as handle:
             new = SeqIO.read(TogoWS.convert(handle, "genbank", "fasta"), "fasta")
         self.assertEqual(str(old.seq), str(new.seq))
+
 
 #    def test_genbank_to_embl(self):
 #        """Conversion of GenBank to EMBL."""

--- a/Tests/test_TreeConstruction.py
+++ b/Tests/test_TreeConstruction.py
@@ -40,26 +40,43 @@ class DistanceMatrixTest(unittest.TestCase):
         self.assertEqual(dm.names[0], "Alpha")
         self.assertEqual(dm.matrix[2][1], 3)
         self.assertEqual(len(dm), 4)
-        self.assertEqual(repr(dm),
-                         "DistanceMatrix(names=['Alpha', 'Beta', 'Gamma', 'Delta'], "
-                         "matrix=[[0], [1, 0], [2, 3, 0], [4, 5, 6, 0]])")
+        self.assertEqual(
+            repr(dm),
+            "DistanceMatrix(names=['Alpha', 'Beta', 'Gamma', 'Delta'], "
+            "matrix=[[0], [1, 0], [2, 3, 0], [4, 5, 6, 0]])",
+        )
 
     def test_bad_construction(self):
-        self.assertRaises(TypeError, DistanceMatrix,
-                          ["Alpha", 100, "Gamma", "Delta"],
-                          [[0], [0.1, 0], [0.2, 0.3, 0], [0.4, 0.5, 0.6, 0]])
-        self.assertRaises(TypeError, DistanceMatrix,
-                          ["Alpha", "Beta", "Gamma", "Delta"],
-                          [[0], ["a"], [0.2, 0.3], [0.4, 0.5, 0.6]])
-        self.assertRaises(ValueError, DistanceMatrix,
-                          ["Alpha", "Alpha", "Gamma", "Delta"],
-                          [[0], [0.1], [0.2, 0.3], [0.4, 0.5, 0.6]])
-        self.assertRaises(ValueError, DistanceMatrix,
-                          ["Alpha", "Beta", "Gamma", "Delta"],
-                          [[0], [0.2, 0], [0.4, 0.5, 0.6]])
-        self.assertRaises(ValueError, DistanceMatrix,
-                          ["Alpha", "Beta", "Gamma", "Delta"],
-                          [[0], [0.1], [0.2, 0.3, 0.4], [0.4, 0.5, 0.6]])
+        self.assertRaises(
+            TypeError,
+            DistanceMatrix,
+            ["Alpha", 100, "Gamma", "Delta"],
+            [[0], [0.1, 0], [0.2, 0.3, 0], [0.4, 0.5, 0.6, 0]],
+        )
+        self.assertRaises(
+            TypeError,
+            DistanceMatrix,
+            ["Alpha", "Beta", "Gamma", "Delta"],
+            [[0], ["a"], [0.2, 0.3], [0.4, 0.5, 0.6]],
+        )
+        self.assertRaises(
+            ValueError,
+            DistanceMatrix,
+            ["Alpha", "Alpha", "Gamma", "Delta"],
+            [[0], [0.1], [0.2, 0.3], [0.4, 0.5, 0.6]],
+        )
+        self.assertRaises(
+            ValueError,
+            DistanceMatrix,
+            ["Alpha", "Beta", "Gamma", "Delta"],
+            [[0], [0.2, 0], [0.4, 0.5, 0.6]],
+        )
+        self.assertRaises(
+            ValueError,
+            DistanceMatrix,
+            ["Alpha", "Beta", "Gamma", "Delta"],
+            [[0], [0.1], [0.2, 0.3, 0.4], [0.4, 0.5, 0.6]],
+        )
 
     def test_good_manipulation(self):
         dm = DistanceMatrix(self.names, self.matrix)
@@ -146,12 +163,12 @@ class DistanceCalculatorTest(unittest.TestCase):
         aln = AlignIO.read(StringIO(">Alpha\nA-A--\n>Gamma\n-Y-Y-"), "fasta")
         # With a proper scoring matrix -- no matches
         dmat = DistanceCalculator("blosum62").get_distance(aln)
-        self.assertEqual(dmat["Alpha", "Alpha"], 0.)
-        self.assertEqual(dmat["Alpha", "Gamma"], 1.)
+        self.assertEqual(dmat["Alpha", "Alpha"], 0.0)
+        self.assertEqual(dmat["Alpha", "Gamma"], 1.0)
         # Comparing characters only -- 4 misses, 1 match
         dmat = DistanceCalculator().get_distance(aln)
-        self.assertEqual(dmat["Alpha", "Alpha"], 0.)
-        self.assertAlmostEqual(dmat["Alpha", "Gamma"], 4. / 5.)
+        self.assertEqual(dmat["Alpha", "Alpha"], 0.0)
+        self.assertAlmostEqual(dmat["Alpha", "Gamma"], 4.0 / 5.0)
 
 
 class DistanceTreeConstructorTest(unittest.TestCase):
@@ -214,40 +231,62 @@ class ParsimonyScorerTest(unittest.TestCase):
         self.assertEqual(score, 2 + 1 + 2 + 2 + 1 + 1 + 1 + 3)
 
         alphabet = ["A", "T", "C", "G"]
-        step_matrix = [[0],
-                       [2.5, 0],
-                       [2.5, 1, 0],
-                       [1, 2.5, 2.5, 0]]
+        step_matrix = [[0], [2.5, 0], [2.5, 1, 0], [1, 2.5, 2.5, 0]]
         matrix = _Matrix(alphabet, step_matrix)
         scorer = ParsimonyScorer(matrix)
         score = scorer.get_score(tree, aln)
         self.assertEqual(score, 3.5 + 2.5 + 3.5 + 3.5 + 2.5 + 1 + 2.5 + 4.5)
 
-        alphabet = ["A", "C", "D", "E", "F", "G", "H", "I", "K", "L", "M", "N",
-                    "P", "Q", "R", "1", "2", "T", "V", "W", "Y", "*", "-"]
-        step_matrix = [[0],
-                       [2, 0],
-                       [1, 2, 0],
-                       [1, 2, 1, 0],
-                       [2, 1, 2, 2, 0],
-                       [1, 1, 1, 1, 2, 0],
-                       [2, 2, 1, 2, 2, 2, 0],
-                       [2, 2, 2, 2, 1, 2, 2, 0],
-                       [2, 2, 2, 1, 2, 2, 2, 1, 0],
-                       [2, 2, 2, 2, 1, 2, 1, 1, 2, 0],
-                       [2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 0],
-                       [2, 2, 1, 2, 2, 2, 1, 1, 1, 2, 2, 0],
-                       [1, 2, 2, 2, 2, 2, 1, 2, 2, 1, 2, 2, 0],
-                       [2, 2, 2, 1, 2, 2, 1, 2, 1, 1, 2, 2, 1, 0],
-                       [2, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1, 2, 1, 1, 0],
-                       [1, 1, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2, 1, 2, 2, 0],
-                       [2, 1, 2, 2, 2, 1, 2, 1, 2, 2, 2, 1, 2, 2, 1, 2, 0],
-                       [1, 2, 2, 2, 2, 2, 2, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 0],
-                       [1, 2, 1, 1, 1, 1, 2, 1, 2, 1, 1, 2, 2, 2, 2, 2, 2, 2, 0],
-                       [2, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 3, 2, 2, 1, 1, 2, 2, 2, 0],
-                       [2, 1, 1, 2, 1, 2, 1, 2, 2, 2, 3, 1, 2, 2, 2, 1, 2, 2, 2, 2, 0],
-                       [2, 1, 2, 1, 2, 1, 2, 2, 1, 1, 2, 2, 2, 1, 1, 1, 2, 2, 2, 1, 1, 0],
-                       [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0]]
+        alphabet = [
+            "A",
+            "C",
+            "D",
+            "E",
+            "F",
+            "G",
+            "H",
+            "I",
+            "K",
+            "L",
+            "M",
+            "N",
+            "P",
+            "Q",
+            "R",
+            "1",
+            "2",
+            "T",
+            "V",
+            "W",
+            "Y",
+            "*",
+            "-",
+        ]
+        step_matrix = [
+            [0],
+            [2, 0],
+            [1, 2, 0],
+            [1, 2, 1, 0],
+            [2, 1, 2, 2, 0],
+            [1, 1, 1, 1, 2, 0],
+            [2, 2, 1, 2, 2, 2, 0],
+            [2, 2, 2, 2, 1, 2, 2, 0],
+            [2, 2, 2, 1, 2, 2, 2, 1, 0],
+            [2, 2, 2, 2, 1, 2, 1, 1, 2, 0],
+            [2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 0],
+            [2, 2, 1, 2, 2, 2, 1, 1, 1, 2, 2, 0],
+            [1, 2, 2, 2, 2, 2, 1, 2, 2, 1, 2, 2, 0],
+            [2, 2, 2, 1, 2, 2, 1, 2, 1, 1, 2, 2, 1, 0],
+            [2, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1, 2, 1, 1, 0],
+            [1, 1, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2, 1, 2, 2, 0],
+            [2, 1, 2, 2, 2, 1, 2, 1, 2, 2, 2, 1, 2, 2, 1, 2, 0],
+            [1, 2, 2, 2, 2, 2, 2, 1, 1, 2, 1, 1, 1, 2, 1, 1, 1, 0],
+            [1, 2, 1, 1, 1, 1, 2, 1, 2, 1, 1, 2, 2, 2, 2, 2, 2, 2, 0],
+            [2, 1, 2, 2, 2, 1, 2, 2, 2, 1, 2, 3, 2, 2, 1, 1, 2, 2, 2, 0],
+            [2, 1, 1, 2, 1, 2, 1, 2, 2, 2, 3, 1, 2, 2, 2, 1, 2, 2, 2, 2, 0],
+            [2, 1, 2, 1, 2, 1, 2, 2, 1, 1, 2, 2, 2, 1, 1, 1, 2, 2, 2, 1, 1, 0],
+            [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0],
+        ]
 
         matrix = _Matrix(alphabet, step_matrix)
         scorer = ParsimonyScorer(matrix)
@@ -261,10 +300,7 @@ class NNITreeSearcherTest(unittest.TestCase):
     def test_get_neighbors(self):
         tree = Phylo.read("./TreeConstruction/upgma.tre", "newick")
         alphabet = ["A", "T", "C", "G"]
-        step_matrix = [[0],
-                       [2.5, 0],
-                       [2.5, 1, 0],
-                       [1, 2.5, 2.5, 0]]
+        step_matrix = [[0], [2.5, 0], [2.5, 1, 0], [1, 2.5, 2.5, 0]]
         matrix = _Matrix(alphabet, step_matrix)
         scorer = ParsimonyScorer(matrix)
         searcher = NNITreeSearcher(scorer)
@@ -281,10 +317,7 @@ class ParsimonyTreeConstructorTest(unittest.TestCase):
         tree1 = Phylo.read("./TreeConstruction/upgma.tre", "newick")
         tree2 = Phylo.read("./TreeConstruction/nj.tre", "newick")
         alphabet = ["A", "T", "C", "G"]
-        step_matrix = [[0],
-                       [2.5, 0],
-                       [2.5, 1, 0],
-                       [1, 2.5, 2.5, 0]]
+        step_matrix = [[0], [2.5, 0], [2.5, 1, 0], [1, 2.5, 2.5, 0]]
         matrix = _Matrix(alphabet, step_matrix)
         scorer = ParsimonyScorer(matrix)
         searcher = NNITreeSearcher(scorer)

--- a/Tests/test_translate.py
+++ b/Tests/test_translate.py
@@ -14,7 +14,6 @@ from Bio.Alphabet import IUPAC
 
 
 class TestTranscriptionTranslation(unittest.TestCase):
-
     def test_transcription(self):
         s = "ATA"
         dna = Seq.Seq(s, IUPAC.unambiguous_dna)
@@ -23,11 +22,17 @@ class TestTranscriptionTranslation(unittest.TestCase):
         s = "GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCATATT"
         dna = Seq.Seq(s, IUPAC.unambiguous_dna)
         rna = dna.transcribe()
-        self.assertEqual(str(rna), "GAAAAUUCAUUUUCUUUGGACUUUCUCUGAAAUCCGAGUCCUAGGAAAGAUGCGUGAGAUUCUUCAUAUU")
+        self.assertEqual(
+            str(rna),
+            "GAAAAUUCAUUUUCUUUGGACUUUCUCUGAAAUCCGAGUCCUAGGAAAGAUGCGUGAGAUUCUUCAUAUU",
+        )
         s = "GAAAAUUCAUUUUCUUUGGACUUUCUCUGAAAUCCGAGUCCUAGGAAAGAUGCGUGAGAUUCUUCAUAUU"
         rna = Seq.Seq(s, IUPAC.unambiguous_rna)
         dna = rna.back_transcribe()
-        self.assertEqual(str(dna), "GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCATATT")
+        self.assertEqual(
+            str(dna),
+            "GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCATATT",
+        )
 
     def test_translation(self):
         s = ""


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_T* files, 4 files. it should be fine to merge.
test_TCoffee_tool.py
test_TogoWS.py
test_translate.py
test_TreeConstruction.py

Skipped file test_Tutorial.py as is failing, I'll check what can be done.
