### PR TITLE
define StreamModeError, and use it to check formats in SeqRecord

### DIFF
--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -10,13 +10,10 @@ Unless you are writing a new parser or writer for Bio.SeqIO, you should not
 use this module.  It provides base classes to try and simplify things.
 """
 
+from Bio import StreamModeError
 from Bio.Alphabet import generic_alphabet
 from Bio.Seq import Seq, MutableSeq
 from Bio.SeqRecord import SeqRecord
-
-
-class StreamModeError(ValueError):
-    """Incorrect stream mode (text vs binary)"""
 
 
 class SequenceIterator:

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -15,6 +15,10 @@ from Bio.Seq import Seq, MutableSeq
 from Bio.SeqRecord import SeqRecord
 
 
+class StreamModeError(ValueError):
+    """Incorrect stream mode (text vs binary)"""
+
+
 class SequenceIterator:
     """Base class for building SeqRecord iterators.
 
@@ -110,7 +114,7 @@ class SequenceWriter:
                 target.write("")
             except TypeError:
                 # target was opened in binary mode
-                raise ValueError("File must be opened in text mode.") from None
+                raise StreamModeError("File must be opened in text mode.") from None
             except AttributeError:
                 # target is a path
                 handle = open(target, mode)
@@ -121,7 +125,7 @@ class SequenceWriter:
                 target.write(b"")
             except TypeError:
                 # target was opened in text mode
-                raise ValueError("File must be opened in binary mode.") from None
+                raise StreamModeError("File must be opened in binary mode.") from None
             except AttributeError:
                 # target is a path
                 handle = open(target, mode)

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -14,6 +14,7 @@
 # need to be in sync (this is the BioSQL "Database SeqRecord", see
 # also BioSQL.BioSeq.DBSeq which is the "Database Seq" class)
 
+
 _NO_SEQRECORD_COMPARISON = "SeqRecord comparison is deliberately not implemented. Explicitly compare the attributes of interest."
 
 
@@ -755,22 +756,22 @@ class SeqRecord:
             # Follow python convention and default to using __str__
             return str(self)
         from Bio import SeqIO
+        from Bio.SeqIO.Interfaces import StreamModeError
 
         # Easy case, can call string-building function directly
         if format_spec in SeqIO._FormatToString:
             return SeqIO._FormatToString[format_spec](self)
 
-        if format_spec in SeqIO._BinaryFormats:
+        # Harder case, make a temp handle instead
+        from io import StringIO
+        handle = StringIO()
+        try:
+            SeqIO.write(self, handle, format_spec)
+        except StreamModeError:
             raise ValueError(
                 "Binary format %s cannot be used with SeqRecord format method"
                 % format_spec
-            )
-
-        # Harder case, make a temp handle instead
-        from io import StringIO
-
-        handle = StringIO()
-        SeqIO.write(self, handle, format_spec)
+            ) from None
         return handle.getvalue()
 
     def __len__(self):

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -15,6 +15,10 @@
 # also BioSQL.BioSeq.DBSeq which is the "Database Seq" class)
 
 
+from io import StringIO
+from Bio import StreamModeError
+
+
 _NO_SEQRECORD_COMPARISON = "SeqRecord comparison is deliberately not implemented. Explicitly compare the attributes of interest."
 
 
@@ -756,14 +760,12 @@ class SeqRecord:
             # Follow python convention and default to using __str__
             return str(self)
         from Bio import SeqIO
-        from Bio.SeqIO.Interfaces import StreamModeError
 
         # Easy case, can call string-building function directly
         if format_spec in SeqIO._FormatToString:
             return SeqIO._FormatToString[format_spec](self)
 
         # Harder case, make a temp handle instead
-        from io import StringIO
         handle = StringIO()
         try:
             SeqIO.write(self, handle, format_spec)

--- a/Bio/__init__.py
+++ b/Bio/__init__.py
@@ -25,8 +25,6 @@ class MissingExternalDependencyError(Exception):
     tests to allow skipping tests with missing external dependencies.
     """
 
-    pass
-
 
 class MissingPythonDependencyError(MissingExternalDependencyError, ImportError):
     """Missing an external python dependency (subclass of ImportError).
@@ -37,7 +35,14 @@ class MissingPythonDependencyError(MissingExternalDependencyError, ImportError):
     ImportError.
     """
 
-    pass
+
+class StreamModeError(ValueError):
+    """Incorrect stream mode (text vs binary).
+
+    This error should be raised when a stream (file or file-like object)
+    argument is in text mode while the receiving function expects binary mode,
+    or vice versa.
+    """
 
 
 class BiopythonWarning(Warning):
@@ -53,8 +58,6 @@ class BiopythonWarning(Warning):
     Consult the warnings module documentation for more details.
     """
 
-    pass
-
 
 class BiopythonParserWarning(BiopythonWarning):
     """Biopython parser warning.
@@ -69,8 +72,6 @@ class BiopythonParserWarning(BiopythonWarning):
 
     Consult the warnings module documentation for more details.
     """
-
-    pass
 
 
 class BiopythonDeprecationWarning(BiopythonWarning):
@@ -89,8 +90,6 @@ class BiopythonDeprecationWarning(BiopythonWarning):
     of Biopython. To avoid removal of this code, please contact the Biopython
     developers via the mailing list or GitHub.
     """
-
-    pass
 
 
 class BiopythonExperimentalWarning(BiopythonWarning):
@@ -112,8 +111,6 @@ class BiopythonExperimentalWarning(BiopythonWarning):
     If all goes well, experimental code would be promoted to stable in
     a subsequent release, and this warning removed from it.
     """
-
-    pass
 
 
 _parent_dir = os.path.dirname(os.path.dirname(__file__))


### PR DESCRIPTION
This pull request defines a new exception `StreamModeError` in `Bio.SeqIO.Interfaces`, and uses it in `Bio.SeqRecord` to avoid using the private variable `_BinaryFormats`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
