### PR TITLE
Apply black style to test_l* files, version 19.10b0.

### DIFF
--- a/Tests/test_LogisticRegression.py
+++ b/Tests/test_LogisticRegression.py
@@ -13,8 +13,10 @@ try:
     from numpy import linalg  # missing in PyPy's micronumpy
 except ImportError:
     from Bio import MissingExternalDependencyError
+
     raise MissingExternalDependencyError(
-        "Install NumPy if you want to use Bio.LogisticRegression.") from None
+        "Install NumPy if you want to use Bio.LogisticRegression."
+    ) from None
 
 import unittest
 import copy
@@ -22,41 +24,27 @@ import copy
 from Bio import LogisticRegression
 
 
-xs = [[-53, -200.78],
-      [117, -267.14],
-      [57, -163.47],
-      [16, -190.30],
-      [11, -220.94],
-      [85, -193.94],
-      [16, -182.71],
-      [15, -180.41],
-      [-26, -181.73],
-      [58, -259.87],
-      [126, -414.53],
-      [191, -249.57],
-      [113, -265.28],
-      [145, -312.99],
-      [154, -213.83],
-      [147, -380.85],
-      [93, -291.13]]
+xs = [
+    [-53, -200.78],
+    [117, -267.14],
+    [57, -163.47],
+    [16, -190.30],
+    [11, -220.94],
+    [85, -193.94],
+    [16, -182.71],
+    [15, -180.41],
+    [-26, -181.73],
+    [58, -259.87],
+    [126, -414.53],
+    [191, -249.57],
+    [113, -265.28],
+    [145, -312.99],
+    [154, -213.83],
+    [147, -380.85],
+    [93, -291.13],
+]
 
-ys = [1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      1,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0,
-      0]
+ys = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0]
 
 
 def show_progress(iteration, loglikelihood):
@@ -65,25 +53,21 @@ def show_progress(iteration, loglikelihood):
 
 
 class TestLogisticRegression(unittest.TestCase):
-
     def test_xs_and_ys_input_parameter_lengths(self):
         modified_xs = copy.copy(xs)
         modified_xs.pop()
-        self.assertRaises(ValueError,
-                          LogisticRegression.train, modified_xs, ys)
+        self.assertRaises(ValueError, LogisticRegression.train, modified_xs, ys)
 
     def test_ys_input_class_assignments(self):
         modified_ys = copy.copy(ys)
         modified_ys.pop()
         modified_ys.append(2)
-        self.assertRaises(ValueError,
-                          LogisticRegression.train, xs, modified_ys)
+        self.assertRaises(ValueError, LogisticRegression.train, xs, modified_ys)
 
     def test_dimensionality_of_input_xs(self):
         modified_xs = copy.copy(xs)
         modified_xs[0] = []
-        self.assertRaises(ValueError,
-                          LogisticRegression.train, modified_xs, ys)
+        self.assertRaises(ValueError, LogisticRegression.train, modified_xs, ys)
 
     def test_calculate_model(self):
         model = LogisticRegression.train(xs, ys)
@@ -128,7 +112,7 @@ class TestLogisticRegression(unittest.TestCase):
         correct = 0
         predictions = [1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0]
         for i in range(len(predictions)):
-            model = LogisticRegression.train(xs[:i] + xs[i + 1:], ys[:i] + ys[i + 1:])
+            model = LogisticRegression.train(xs[:i] + xs[i + 1 :], ys[:i] + ys[i + 1 :])
             prediction = LogisticRegression.classify(model, xs[i])
             self.assertEqual(prediction, predictions[i])
             if prediction == ys[i]:

--- a/Tests/test_lowess.py
+++ b/Tests/test_lowess.py
@@ -8,23 +8,33 @@ try:
     from numpy import array, median
 except ImportError:
     from Bio import MissingExternalDependencyError
+
     raise MissingExternalDependencyError(
-        "Install NumPy if you want to use Bio.Statistics.lowess.") from None
+        "Install NumPy if you want to use Bio.Statistics.lowess."
+    ) from None
 
 from Bio.Statistics.lowess import lowess
 import unittest
 
 
 class test_lowess(unittest.TestCase):
-
     def test_Precomputed(self):
         x = array([0.0, 1.0, 2.0, 3.0, 5.0, 9.0, 11.0])
         y = x ** 2
         # Precalculated smooth output
-        ys = array([-2.96219015, 1.72680044, 6.58686813,
-                    11.62986671, 28.18598762, 86.85271581, 116.83893423])
+        ys = array(
+            [
+                -2.96219015,
+                1.72680044,
+                6.58686813,
+                11.62986671,
+                28.18598762,
+                86.85271581,
+                116.83893423,
+            ]
+        )
         # Smooth output calculated by the lowess function
-        output = lowess(x, y, f=2. / 3., iter=3)
+        output = lowess(x, y, f=2.0 / 3.0, iter=3)
         for precomputed, calculated in zip(ys, output):
             self.assertAlmostEqual(precomputed, calculated, places=4)
 


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to the 2 files below, small change should be fine to merge.
test_LogisticRegression.py
test_lowess.py