### PR TITLE
don't need _BinaryFormats any more in SeqIO.write

### DIFF
--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -563,9 +563,7 @@ def write(sequences, handle, format):
         return count
 
     if format in _FormatToIterator or format in AlignIO._FormatToIterator:
-        raise ValueError(
-            "Reading format '%s' is supported, but not writing" % format
-        )
+        raise ValueError("Reading format '%s' is supported, but not writing" % format)
 
     raise ValueError("Unknown format '%s'" % format)
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -499,10 +499,9 @@ def write(sequences, handle, format):
     """Write complete set of sequences to a file.
 
     Arguments:
-     - sequences - A list (or iterator) of SeqRecord objects, or (if using
-       Biopython 1.54 or later) a single SeqRecord.
-     - handle    - File handle object to write to, or filename as string
-       (note older versions of Biopython only took a handle).
+     - sequences - A list (or iterator) of SeqRecord objects, or a single
+       SeqRecord.
+     - handle    - File handle object to write to, or filename as string.
      - format    - lower case string describing the file format to write.
 
     Note if providing a file handle, your code should close the handle
@@ -530,45 +529,45 @@ def write(sequences, handle, format):
         # This raised an exception in older versions of Biopython
         sequences = [sequences]
 
-    mode = "wb" if format in _BinaryFormats else "w"
-
-    with as_handle(handle, mode) as fp:
-        # Map the file format to a writer function/class
-        if format in _FormatToString:
-            format_function = _FormatToString[format]
-            count = 0
+    # Map the file format to a writer function/class
+    format_function = _FormatToString.get(format)
+    if format_function is not None:
+        count = 0
+        with as_handle(handle, 'w') as fp:
             for record in sequences:
                 fp.write(format_function(record))
                 count += 1
-        elif format in _FormatToWriter:
-            writer_class = _FormatToWriter[format]
-            count = writer_class(fp).write_file(sequences)
-        elif format in AlignIO._FormatToWriter:
-            # Try and turn all the records into a single alignment,
-            # and write that using Bio.AlignIO
-            alignment = MultipleSeqAlignment(sequences)
-            alignment_count = AlignIO.write([alignment], fp, format)
-            if alignment_count != 1:
-                raise RuntimeError(
-                    "Internal error - the underlying writer "
-                    "should have returned 1, not %r" % alignment_count
-                )
-            count = len(alignment)
-            del alignment_count, alignment
-        elif format in _FormatToIterator or format in AlignIO._FormatToIterator:
-            raise ValueError(
-                "Reading format '%s' is supported, but not writing" % format
-            )
-        else:
-            raise ValueError("Unknown format '%s'" % format)
+        return count
 
+    writer_class = _FormatToWriter.get(format)
+    if writer_class is not None:
+        count = writer_class(handle).write_file(sequences)
         if not isinstance(count, int):
             raise RuntimeError(
                 "Internal error - the underlying %s writer "
                 "should have returned the record count, not %r" % (format, count)
             )
+        return count
 
-    return count
+    if format in AlignIO._FormatToWriter:
+        # Try and turn all the records into a single alignment,
+        # and write that using Bio.AlignIO
+        alignment = MultipleSeqAlignment(sequences)
+        alignment_count = AlignIO.write([alignment], handle, format)
+        if alignment_count != 1:
+            raise RuntimeError(
+                "Internal error - the underlying writer "
+                "should have returned 1, not %r" % alignment_count
+            )
+        count = len(alignment)
+        return count
+
+    if format in _FormatToIterator or format in AlignIO._FormatToIterator:
+        raise ValueError(
+            "Reading format '%s' is supported, but not writing" % format
+        )
+
+    raise ValueError("Unknown format '%s'" % format)
 
 
 def parse(handle, format, alphabet=None):

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -533,7 +533,7 @@ def write(sequences, handle, format):
     format_function = _FormatToString.get(format)
     if format_function is not None:
         count = 0
-        with as_handle(handle, 'w') as fp:
+        with as_handle(handle, "w") as fp:
             for record in sequences:
                 fp.write(format_function(record))
                 count += 1


### PR DESCRIPTION
This pull request makes use of the new writer capabilities to remove the dependence of `SeqIO.write` on `_BinaryFormats`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
