### PR TITLE
Update test_NCBI_qblast for changes on remote blast server

### DIFF
--- a/Tests/test_NCBI_qblast.py
+++ b/Tests/test_NCBI_qblast.py
@@ -17,7 +17,7 @@ import unittest
 import warnings
 
 from urllib.error import HTTPError
-from io import StringIO
+from io import BytesIO
 
 from Bio import MissingExternalDependencyError
 from Bio import BiopythonWarning
@@ -280,8 +280,8 @@ class TestQblast(unittest.TestCase):
             self.assertTrue(found_result)
 
     def test_parse_qblast_ref_page(self):
-        with open("Blast/html_msgid_29_blastx_001.html") as f:
-            handle = StringIO(f.read())
+        with open("Blast/html_msgid_29_blastx_001.html", "rb") as f:
+            handle = BytesIO(f.read())
         self.assertRaises(ValueError, NCBIWWW._parse_qblast_ref_page, handle)
 
     def test_short_query(self):

--- a/Tests/test_NCBI_qblast.py
+++ b/Tests/test_NCBI_qblast.py
@@ -287,14 +287,14 @@ class TestQblast(unittest.TestCase):
     def test_short_query(self):
         """Test SHORT_QUERY_ADJUST parameter."""
         # Should give no hits:
-        my_search = NCBIWWW.qblast("blastp", "nr", "ICWENRM", hitlist_size=5)
+        my_search = NCBIWWW.qblast("blastp", "nr", "ICWENRMP", hitlist_size=5)
         my_hits = NCBIXML.read(my_search)
         my_search.close()
         self.assertEqual(len(my_hits.alignments), 0)
 
         # Should give hits:
         my_search = NCBIWWW.qblast(
-            "blastp", "nr", "ICWENRM", hitlist_size=5, short_query=True
+            "blastp", "nr", "ICWENRMP", hitlist_size=5, short_query=True
         )
         my_hits = NCBIXML.read(my_search)
         my_search.close()


### PR DESCRIPTION
This pull request addresses issue #2738.

NCBI changed the default protein matrix for short queries from PAM30 to BLOSUM62. This requires to adjust the test for short queries to pass.

This solves #2738.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
