### PR TITLE
update test_PDB.py for python3

### DIFF
--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -223,7 +223,7 @@ def dssp_dict_from_pdb_file(in_file, DSSP="dssp"):
 
     """
     # Using universal newlines is important on Python 3, this
-    # gives unicode handles rather than bytes handles.
+    # gives text handles rather than bytes handles.
     # Newer version of DSSP executable is named 'mkdssp',
     # and calling 'dssp' will hence not work in some operating systems
     # (Debian distribution of DSSP includes a symlink for 'dssp' argument)

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -710,22 +710,6 @@ class ParseTest(unittest.TestCase):
         self.assertLessEqual(atom2, atom1)
         self.assertLessEqual(atom2, atom3)
 
-        # In Py2 this will be True/False, in Py3 it will raise a TypeError.
-        try:
-            self.assertTrue(atom1 < res1)  # __gt__ diff. types
-        except TypeError:
-            pass
-
-        try:
-            self.assertTrue(struct > model)  # __gt__ diff. types
-        except TypeError:
-            pass
-
-        try:
-            self.assertFalse(struct >= [])  # __le__ diff. types
-        except TypeError:
-            pass
-
 
 class ParseReal(unittest.TestCase):
     """Testing with real PDB files."""


### PR DESCRIPTION
This pull request removes a test from test_PDB.py that would not work in Python3.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
