### PR TITLE
Graphics general

### DIFF
--- a/Bio/SeqUtils/CheckSum.py
+++ b/Bio/SeqUtils/CheckSum.py
@@ -25,9 +25,6 @@ def crc32(seq):
     1688586483
 
     """
-    # NOTE - On Python 2 returns a signed int, on Python 3 it is unsigned
-    # Docs suggest should use crc32(x) & 0xffffffff for consistency.
-    # TODO - Should we return crc32(x) & 0xffffffff here?
     try:
         # Assume it's a Seq object
         return _crc32(str(seq).encode())

--- a/Tests/test_GraphicsGeneral.py
+++ b/Tests/test_GraphicsGeneral.py
@@ -5,19 +5,7 @@
 # as part of this package.
 """Test for graphics things that don't really deserve there own test module."""
 
-# TODO: Right now this test occasionally fails with a trace like:
-#
-# File "/usr/local/lib/python2.1/site-packages/reportlab/graphics/
-# charts/lineplots.py", line 182, in calcPositions
-#     datum = self.data[rowNo][colNo] # x,y value
-# IndexError: list index out of range
-#
-# This appears to be a problem with reportlab, so I'm not worrying about
-# it right now, unless it starts to happen with real data! If anyone
-# can figure out the data that causes it so I can avoid it, that'd be much
-# appreciated.
 
-# standard library
 import os
 import random
 import unittest

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -20,13 +20,6 @@ from Bio.SeqUtils.CheckSum import crc32, crc64, gcg, seguid
 from Bio.SeqUtils.CodonUsage import CodonAdaptationIndex
 
 
-def u_crc32(seq):
-    # NOTE - On Python 2 crc32 could return a signed int, but on Python 3 it is
-    # always unsigned
-    # Docs suggest should use crc32(x) & 0xffffffff for consistency.
-    return crc32(seq) & 0xFFFFFFFF
-
-
 class SeqUtilsTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -127,7 +120,7 @@ class SeqUtilsTests(unittest.TestCase):
             Seq(seq_str, single_letter_alphabet),
             MutableSeq(seq_str, single_letter_alphabet),
         ]:
-            self.assertEqual(exp_crc32, u_crc32(s))
+            self.assertEqual(exp_crc32, crc32(s))
             self.assertEqual(exp_crc64, crc64(s))
             self.assertEqual(exp_gcg, gcg(s))
             self.assertEqual(exp_seguid, seguid(s))


### PR DESCRIPTION
This pull request removes an ancient comment (from 2001) for test_GraphicsGeneral.py.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
