### PR TITLE
remove IGNORE_EXCEPTION_DETAIL in doctest

### DIFF
--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -241,8 +241,7 @@ class TutorialTestCase(unittest.TestCase):
     # Single method to be invoked by run_tests.py
     def test_doctests(self):
         """Run tutorial doctests."""
-        # TODO: Remove IGNORE_EXCEPTION_DETAIL once drop Python 2 support
-        runner = doctest.DocTestRunner(optionflags=doctest.IGNORE_EXCEPTION_DETAIL)
+        runner = doctest.DocTestRunner()
         failures = []
         for test in doctest.DocTestFinder().find(TutorialDocTestHolder):
             failed, success = runner.run(test)


### PR DESCRIPTION
This pull request removes IGNORE_EXCEPTION_DETAIL for doctests.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
