### PR TITLE
move handle url check outside with block

### DIFF
--- a/Tests/test_KEGG_online.py
+++ b/Tests/test_KEGG_online.py
@@ -155,30 +155,30 @@ class KEGGTests(unittest.TestCase):
     def test_get_hsa_10458_plus_ece_Z5100_as_aaseq(self):
         with kegg_get("hsa:10458+ece:Z5100", "aaseq") as handle:
             data = SeqIO.parse(handle, "fasta")
-            self.assertEqual(handle.url,
-                             "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq")
             self.assertEqual(len(list(data)), 2)
+        self.assertEqual(handle.url,
+                         "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq")
 
     def test_get_hsa_10458_list_ece_Z5100_as_aaseq(self):
         with kegg_get(["hsa:10458", "ece:Z5100"], "aaseq") as handle:
             data = SeqIO.parse(handle, "fasta")
-            self.assertEqual(handle.url,
-                             "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq")
             self.assertEqual(len(list(data)), 2)
+        self.assertEqual(handle.url,
+                         "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq")
 
     def test_get_hsa_10458_plus_ece_Z5100_as_ntseq(self):
         with kegg_get("hsa:10458+ece:Z5100", "ntseq") as handle:
             data = SeqIO.parse(handle, "fasta")
-            self.assertEqual(handle.url,
-                             "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq")
             self.assertEqual(len(list(data)), 2)
+        self.assertEqual(handle.url,
+                         "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq")
 
     def test_get_hsa_10458_list_ece_Z5100_as_ntseq(self):
         with kegg_get(["hsa:10458", "ece:Z5100"], "ntseq") as handle:
             data = SeqIO.parse(handle, "fasta")
-            self.assertEqual(handle.url,
-                             "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq")
             self.assertEqual(len(list(data)), 2)
+        self.assertEqual(handle.url,
+                         "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq")
 
     def test_get_hsa05130_image(self):
         with kegg_get("hsa05130", "image") as handle:


### PR DESCRIPTION
This pull request moves the handle url check outside `with` block in `test_KEGG_online.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
