### PR TITLE
Remove unused imports and 'EmbossWriter' Class

### DIFF
--- a/Bio/AlignIO/EmbossIO.py
+++ b/Bio/AlignIO/EmbossIO.py
@@ -20,49 +20,6 @@ from Bio.Align import MultipleSeqAlignment
 from .Interfaces import AlignmentIterator, SequentialAlignmentWriter
 
 
-class EmbossWriter(SequentialAlignmentWriter):
-    """Emboss alignment writer (WORK IN PROGRESS).
-
-    Writes a simplfied version of the EMBOSS pairs/simple file format.
-    A lot of the information their tools record in their headers is not
-    available and is omitted.
-    """
-
-    def write_header(self):
-        """Write header for the file."""
-        handle = self.handle
-        handle.write("########################################\n")
-        handle.write("# Program: Biopython\n")
-        try:
-            handle.write("# Report_file: %s\n" % handle.name)
-        except AttributeError:
-            pass
-        handle.write("########################################\n")
-
-    def write_footer(self):
-        """Write footer for the file."""
-        handle = self.handle
-        handle.write("#---------------------------------------\n")
-        handle.write("#---------------------------------------\n")
-
-    def write_alignment(self, alignment):
-        """Use this to write (another) single alignment to an open file."""
-        handle = self.handle
-        handle.write("#=======================================\n")
-        handle.write("#\n")
-        handle.write("# Aligned_sequences: %i\n" % len(alignment))
-        for i, record in enumerate(alignment):
-            handle.write("# %i: %s\n" % (i + 1, record.id))
-        handle.write("#\n")
-        handle.write("# Length: %i\n" % alignment.get_alignment_length())
-        handle.write("#\n")
-        handle.write("#=======================================\n")
-        handle.write("\n")
-        raise NotImplementedError(
-            "The subclass should implement the write_alignment method."
-        )
-
-
 class EmbossIterator(AlignmentIterator):
     """Emboss alignment iterator.
 

--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -174,7 +174,6 @@ _FormatToIterator = {  # "fasta" is done via Bio.SeqIO
 }
 
 _FormatToWriter = {  # "fasta" is done via Bio.SeqIO
-    # "emboss" : EmbossIO.EmbossWriter, (unfinished)
     "clustal": ClustalIO.ClustalWriter,
     "maf": MafIO.MafWriter,
     "mauve": MauveIO.MauveWriter,

--- a/Bio/codonalign/codonalphabet.py
+++ b/Bio/codonalign/codonalphabet.py
@@ -11,11 +11,6 @@ alphabet for CodonSeq class.
 
 import copy
 
-try:
-    from itertools import izip
-except ImportError:
-    izip = zip
-
 from Bio.Alphabet import IUPAC, Gapped, HasStopCodon, Alphabet
 from Bio.Data.CodonTable import generic_by_id
 

--- a/Tests/test_AlignIO_EmbossIO.py
+++ b/Tests/test_AlignIO_EmbossIO.py
@@ -9,7 +9,7 @@ import unittest
 
 from io import StringIO
 
-from Bio.AlignIO.EmbossIO import EmbossWriter, EmbossIterator
+from Bio.AlignIO.EmbossIO import EmbossIterator
 
 # http://emboss.sourceforge.net/docs/themes/alnformats/align.simple
 simple_example = \

--- a/Tests/test_Entrez_online.py
+++ b/Tests/test_Entrez_online.py
@@ -18,7 +18,6 @@ from Bio.SeqRecord import SeqRecord
 
 import doctest
 import os
-import locale
 import sys
 import unittest
 

--- a/Tests/test_NMR.py
+++ b/Tests/test_NMR.py
@@ -9,7 +9,6 @@
 import unittest
 import tempfile
 import os
-import filecmp
 
 from Bio.NMR import xpktools
 from Bio.NMR import NOEtools


### PR DESCRIPTION
This pull request addresses issue relates to #2757. Note that most "unused imports" detected by `vulture` were actually false positives. Mostly `__init__.py` files, where imports are typically not used and also some cases where imports just test that a module is available.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
