### PR TITLE
Apply black style to test_GenBank.py, version 19.10b0; after  v19.3b0 was applied.

### DIFF
--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -394,7 +394,7 @@ class TestRecordParser(unittest.TestCase):
                         ("/protein_id=", '"CAB39890.1"'),
                         ("/db_xref=", '"GI:4538893"'),
                         ("/translation=", '"DKAKDAAAAAGASAQQAGKNISDAAAGGVNFVKEKTG"'),
-                        ),
+                    ),
                 ),
                 ("intron", "49..142", (("/gene=", '"csp14"'), ("/number=", "2"))),
                 ("exon", "143..206", (("/gene=", '"csp14"'), ("/number=", "3"))),
@@ -1519,9 +1519,7 @@ class TestRecordParser(unittest.TestCase):
             record = next(records)
             length = 2007
             locus = "AB000048"
-            definition = (
-                "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
-            )
+            definition = "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
             accession = ["AB000048"]
             titles = (
                 "Evolutionary pattern of feline panleukopenia virus differs from that of canine parvovirus",
@@ -1558,9 +1556,7 @@ class TestRecordParser(unittest.TestCase):
             record = next(records)
             length = 2007
             locus = "AB000049"
-            definition = (
-                "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
-            )
+            definition = "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
             accession = ["AB000049"]
             titles = (
                 "Evolutionary pattern of feline panleukopenia virus differs that of canine parvovirus",
@@ -1597,7 +1593,9 @@ class TestRecordParser(unittest.TestCase):
             record = next(records)
             length = 1755
             locus = "AB000050"
-            definition = "Feline panleukopenia virus DNA for capsid protein 2, complete cds"
+            definition = (
+                "Feline panleukopenia virus DNA for capsid protein 2, complete cds"
+            )
             accession = ["AB000050"]
             titles = (
                 "Evolutionary pattern of feline panleukopenia virus differs from that of canine parvovirus",
@@ -4944,9 +4942,7 @@ qualifiers:
             seq = "ATGTCTGGCAACCAGTATACTGAGGAAGTTATGGAGGGAGTAAATTGGTTAAAG...TAA"
             id = "AB000048.1"
             name = "AB000048"
-            description = (
-                "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
-            )
+            description = "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
             annotations = {
                 "accessions": ["AB000048"],
                 "data_file_division": "VRL",
@@ -5015,9 +5011,7 @@ qualifiers:
             seq = "ATGTCTGGCAACCAGTATACTGAGGAAGTTATGGAGGGAGTAAATTGGTTAAAG...TAA"
             id = "AB000049.1"
             name = "AB000049"
-            description = (
-                "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
-            )
+            description = "Feline panleukopenia virus DNA for nonstructural protein 1, complete cds"
             annotations = {
                 "accessions": ["AB000049"],
                 "data_file_division": "VRL",


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_GenBank.py; small changes as black v19.3b0 was already applied. Should be fine to merge.