### PR TITLE
Bugfix for test_phyml_tool

### DIFF
--- a/Tests/test_phyml_tool.py
+++ b/Tests/test_phyml_tool.py
@@ -20,18 +20,18 @@ os.environ["LANG"] = "C"
 
 phyml_exe = None
 exe_name = "PhyML-3.1_win32.exe" if sys.platform == "win32" else "phyml"
-try:
-    output = getoutput(exe_name + " --version")
-    if "not found" not in output and "not recognized" not in output:
-        if "20" in output or "PhyML" in output:
-            phyml_exe = exe_name
-except FileNotFoundError:
-    pass
+
+output = getoutput(exe_name + " --version")
+# Looks like this:
+#. This is PhyML version 20120412.
+if "20" in output and "PhyML" in output:
+    phyml_exe = exe_name
 
 if not phyml_exe:
     raise MissingExternalDependencyError(
-        "Install PhyML 3.0 or later if you want to use the "
-        "Bio.Phylo.Applications wrapper.")
+        "Couldn't find the PhyML software. Install PhyML 3.0 or later if you want "
+        "to use the Bio.Phylo.Applications wrapper."
+    )
 
 
 # Example Phylip file with 4 aligned protein sequences

--- a/Tests/test_phyml_tool.py
+++ b/Tests/test_phyml_tool.py
@@ -23,7 +23,7 @@ exe_name = "PhyML-3.1_win32.exe" if sys.platform == "win32" else "phyml"
 
 output = getoutput(exe_name + " --version")
 # Looks like this:
-#. This is PhyML version 20120412.
+# . This is PhyML version 20120412.
 if "20" in output and "PhyML" in output:
     phyml_exe = exe_name
 


### PR DESCRIPTION
This logic for testing the existence of the PhyML software will not work on non-English systems:

https://github.com/biopython/biopython/blob/bbe5c788e9b71bd785732d2a6db18a7baa7c4eab/Tests/test_phyml_tool.py#L21-L34

In non-English systems the error message will not contain the terms "not found" and "not recognized" but it will contain the term "PhyML", thus wrongly satisfying both `if` clauses.
Also, after removing the `_py3k` workaround for `getoutput` I cannot see that this will ever throw a `FileNotFoundError`. 

With this PR the test runs fine on my German Windows PC with installed PhyML and is correctly skipped on another German Windows computer which has no PhyML installed.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
