### PR TITLE
Apply black style to test_Entrez_parser.py, version 19.10b0.

### DIFF
--- a/Tests/test_Entrez_parser.py
+++ b/Tests/test_Entrez_parser.py
@@ -74,44 +74,48 @@ class EInfoTest(unittest.TestCase):
         # >>> Bio.Entrez.einfo()
         with open("Entrez/einfo1.xml", "rb") as handle:
             record = Entrez.read(handle)
-        self.assertEqual(record["DbList"], ["pubmed",
-                                            "protein",
-                                            "nucleotide",
-                                            "nuccore",
-                                            "nucgss",
-                                            "nucest",
-                                            "structure",
-                                            "genome",
-                                            "books",
-                                            "cancerchromosomes",
-                                            "cdd",
-                                            "gap",
-                                            "domains",
-                                            "gene",
-                                            "genomeprj",
-                                            "gensat",
-                                            "geo",
-                                            "gds",
-                                            "homologene",
-                                            "journals",
-                                            "mesh",
-                                            "ncbisearch",
-                                            "nlmcatalog",
-                                            "omia",
-                                            "omim",
-                                            "pmc",
-                                            "popset",
-                                            "probe",
-                                            "proteinclusters",
-                                            "pcassay",
-                                            "pccompound",
-                                            "pcsubstance",
-                                            "snp",
-                                            "taxonomy",
-                                            "toolkit",
-                                            "unigene",
-                                            "unists"
-                                            ])
+        self.assertEqual(
+            record["DbList"],
+            [
+                "pubmed",
+                "protein",
+                "nucleotide",
+                "nuccore",
+                "nucgss",
+                "nucest",
+                "structure",
+                "genome",
+                "books",
+                "cancerchromosomes",
+                "cdd",
+                "gap",
+                "domains",
+                "gene",
+                "genomeprj",
+                "gensat",
+                "geo",
+                "gds",
+                "homologene",
+                "journals",
+                "mesh",
+                "ncbisearch",
+                "nlmcatalog",
+                "omia",
+                "omim",
+                "pmc",
+                "popset",
+                "probe",
+                "proteinclusters",
+                "pcassay",
+                "pccompound",
+                "pcsubstance",
+                "snp",
+                "taxonomy",
+                "toolkit",
+                "unigene",
+                "unists",
+            ],
+        )
 
     def test_pubmed1(self):
         """Test parsing database info returned by EInfo."""
@@ -129,7 +133,10 @@ class EInfoTest(unittest.TestCase):
 
         self.assertEqual(record["DbInfo"]["FieldList"][0]["Name"], "ALL")
         self.assertEqual(record["DbInfo"]["FieldList"][0]["FullName"], "All Fields")
-        self.assertEqual(record["DbInfo"]["FieldList"][0]["Description"], "All terms from all searchable fields")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][0]["Description"],
+            "All terms from all searchable fields",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][0]["TermCount"], "70792830")
         self.assertEqual(record["DbInfo"]["FieldList"][0]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][0]["IsNumerical"], "N")
@@ -141,7 +148,10 @@ class EInfoTest(unittest.TestCase):
 
         self.assertEqual(record["DbInfo"]["LinkList"][0]["Name"], "pubmed_books_refs")
         self.assertEqual(record["DbInfo"]["LinkList"][0]["Menu"], "Cited in Books")
-        self.assertEqual(record["DbInfo"]["LinkList"][0]["Description"], "PubMed links associated with Books")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][0]["Description"],
+            "PubMed links associated with Books",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][0]["DbTo"], "books")
 
     def test_pubmed2(self):
@@ -151,6 +161,7 @@ class EInfoTest(unittest.TestCase):
         # Starting some time in 2010, the results returned by Bio.Entrez
         # included some tags that are not part of the corresponding DTD.
         from Bio.Entrez import Parser
+
         with open("Entrez/einfo3.xml", "rb") as handle:
             self.assertRaises(Parser.ValidationError, Entrez.read, handle)
 
@@ -171,7 +182,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(len(record["DbInfo"]["FieldList"]), 45)
         self.assertEqual(record["DbInfo"]["FieldList"][0]["Name"], "ALL")
         self.assertEqual(record["DbInfo"]["FieldList"][0]["FullName"], "All Fields")
-        self.assertEqual(record["DbInfo"]["FieldList"][0]["Description"], "All terms from all searchable fields")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][0]["Description"],
+            "All terms from all searchable fields",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][0]["TermCount"], "89981460")
         self.assertEqual(record["DbInfo"]["FieldList"][0]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][0]["IsNumerical"], "N")
@@ -180,7 +194,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][0]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][1]["Name"], "UID")
         self.assertEqual(record["DbInfo"]["FieldList"][1]["FullName"], "UID")
-        self.assertEqual(record["DbInfo"]["FieldList"][1]["Description"], "Unique number assigned to publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][1]["Description"],
+            "Unique number assigned to publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][1]["TermCount"], "0")
         self.assertEqual(record["DbInfo"]["FieldList"][1]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][1]["IsNumerical"], "Y")
@@ -189,7 +206,9 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][1]["IsHidden"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][2]["Name"], "FILT")
         self.assertEqual(record["DbInfo"]["FieldList"][2]["FullName"], "Filter")
-        self.assertEqual(record["DbInfo"]["FieldList"][2]["Description"], "Limits the records")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][2]["Description"], "Limits the records"
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][2]["TermCount"], "4070")
         self.assertEqual(record["DbInfo"]["FieldList"][2]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][2]["IsNumerical"], "N")
@@ -198,7 +217,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][2]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][3]["Name"], "TITL")
         self.assertEqual(record["DbInfo"]["FieldList"][3]["FullName"], "Title")
-        self.assertEqual(record["DbInfo"]["FieldList"][3]["Description"], "Words in title of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][3]["Description"],
+            "Words in title of publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][3]["TermCount"], "12475481")
         self.assertEqual(record["DbInfo"]["FieldList"][3]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][3]["IsNumerical"], "N")
@@ -207,7 +229,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][3]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][4]["Name"], "WORD")
         self.assertEqual(record["DbInfo"]["FieldList"][4]["FullName"], "Text Word")
-        self.assertEqual(record["DbInfo"]["FieldList"][4]["Description"], "Free text associated with publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][4]["Description"],
+            "Free text associated with publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][4]["TermCount"], "39413498")
         self.assertEqual(record["DbInfo"]["FieldList"][4]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][4]["IsNumerical"], "N")
@@ -216,7 +241,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][4]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][5]["Name"], "MESH")
         self.assertEqual(record["DbInfo"]["FieldList"][5]["FullName"], "MeSH Terms")
-        self.assertEqual(record["DbInfo"]["FieldList"][5]["Description"], "Medical Subject Headings assigned to publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][5]["Description"],
+            "Medical Subject Headings assigned to publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][5]["TermCount"], "554666")
         self.assertEqual(record["DbInfo"]["FieldList"][5]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][5]["IsNumerical"], "N")
@@ -224,8 +252,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][5]["Hierarchy"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][5]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][6]["Name"], "MAJR")
-        self.assertEqual(record["DbInfo"]["FieldList"][6]["FullName"], "MeSH Major Topic")
-        self.assertEqual(record["DbInfo"]["FieldList"][6]["Description"], "MeSH terms of major importance to publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][6]["FullName"], "MeSH Major Topic"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][6]["Description"],
+            "MeSH terms of major importance to publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][6]["TermCount"], "493091")
         self.assertEqual(record["DbInfo"]["FieldList"][6]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][6]["IsNumerical"], "N")
@@ -234,7 +267,9 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][6]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][7]["Name"], "AUTH")
         self.assertEqual(record["DbInfo"]["FieldList"][7]["FullName"], "Author")
-        self.assertEqual(record["DbInfo"]["FieldList"][7]["Description"], "Author(s) of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][7]["Description"], "Author(s) of publication"
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][7]["TermCount"], "11268262")
         self.assertEqual(record["DbInfo"]["FieldList"][7]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][7]["IsNumerical"], "N")
@@ -243,7 +278,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][7]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][8]["Name"], "JOUR")
         self.assertEqual(record["DbInfo"]["FieldList"][8]["FullName"], "Journal")
-        self.assertEqual(record["DbInfo"]["FieldList"][8]["Description"], "Journal abbreviation of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][8]["Description"],
+            "Journal abbreviation of publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][8]["TermCount"], "118354")
         self.assertEqual(record["DbInfo"]["FieldList"][8]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][8]["IsNumerical"], "N")
@@ -252,7 +290,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][8]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][9]["Name"], "AFFL")
         self.assertEqual(record["DbInfo"]["FieldList"][9]["FullName"], "Affiliation")
-        self.assertEqual(record["DbInfo"]["FieldList"][9]["Description"], "Author's institutional affiliation and address")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][9]["Description"],
+            "Author's institutional affiliation and address",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][9]["TermCount"], "17538809")
         self.assertEqual(record["DbInfo"]["FieldList"][9]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][9]["IsNumerical"], "N")
@@ -261,7 +302,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][9]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][10]["Name"], "ECNO")
         self.assertEqual(record["DbInfo"]["FieldList"][10]["FullName"], "EC/RN Number")
-        self.assertEqual(record["DbInfo"]["FieldList"][10]["Description"], "EC number for enzyme or CAS registry number")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][10]["Description"],
+            "EC number for enzyme or CAS registry number",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][10]["TermCount"], "82892")
         self.assertEqual(record["DbInfo"]["FieldList"][10]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][10]["IsNumerical"], "N")
@@ -269,8 +313,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][10]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][10]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][11]["Name"], "SUBS")
-        self.assertEqual(record["DbInfo"]["FieldList"][11]["FullName"], "Substance Name")
-        self.assertEqual(record["DbInfo"]["FieldList"][11]["Description"], "CAS chemical name or MEDLINE Substance Name")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][11]["FullName"], "Substance Name"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][11]["Description"],
+            "CAS chemical name or MEDLINE Substance Name",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][11]["TermCount"], "204197")
         self.assertEqual(record["DbInfo"]["FieldList"][11]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][11]["IsNumerical"], "N")
@@ -278,8 +327,12 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][11]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][11]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][12]["Name"], "PDAT")
-        self.assertEqual(record["DbInfo"]["FieldList"][12]["FullName"], "Publication Date")
-        self.assertEqual(record["DbInfo"]["FieldList"][12]["Description"], "Date of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][12]["FullName"], "Publication Date"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][12]["Description"], "Date of publication"
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][12]["TermCount"], "35200")
         self.assertEqual(record["DbInfo"]["FieldList"][12]["IsDate"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][12]["IsNumerical"], "N")
@@ -288,7 +341,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][12]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][13]["Name"], "EDAT")
         self.assertEqual(record["DbInfo"]["FieldList"][13]["FullName"], "Entrez Date")
-        self.assertEqual(record["DbInfo"]["FieldList"][13]["Description"], "Date publication first accessible through Entrez")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][13]["Description"],
+            "Date publication first accessible through Entrez",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][13]["TermCount"], "33978")
         self.assertEqual(record["DbInfo"]["FieldList"][13]["IsDate"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][13]["IsNumerical"], "N")
@@ -297,7 +353,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][13]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][14]["Name"], "VOL")
         self.assertEqual(record["DbInfo"]["FieldList"][14]["FullName"], "Volume")
-        self.assertEqual(record["DbInfo"]["FieldList"][14]["Description"], "Volume number of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][14]["Description"],
+            "Volume number of publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][14]["TermCount"], "12026")
         self.assertEqual(record["DbInfo"]["FieldList"][14]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][14]["IsNumerical"], "N")
@@ -306,7 +365,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][14]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][15]["Name"], "PAGE")
         self.assertEqual(record["DbInfo"]["FieldList"][15]["FullName"], "Pagination")
-        self.assertEqual(record["DbInfo"]["FieldList"][15]["Description"], "Page number(s) of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][15]["Description"],
+            "Page number(s) of publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][15]["TermCount"], "1274867")
         self.assertEqual(record["DbInfo"]["FieldList"][15]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][15]["IsNumerical"], "N")
@@ -314,8 +376,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][15]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][15]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][16]["Name"], "PTYP")
-        self.assertEqual(record["DbInfo"]["FieldList"][16]["FullName"], "Publication Type")
-        self.assertEqual(record["DbInfo"]["FieldList"][16]["Description"], "Type of publication (e.g., review)")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][16]["FullName"], "Publication Type"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][16]["Description"],
+            "Type of publication (e.g., review)",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][16]["TermCount"], "71")
         self.assertEqual(record["DbInfo"]["FieldList"][16]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][16]["IsNumerical"], "N")
@@ -324,7 +391,9 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][16]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][17]["Name"], "LANG")
         self.assertEqual(record["DbInfo"]["FieldList"][17]["FullName"], "Language")
-        self.assertEqual(record["DbInfo"]["FieldList"][17]["Description"], "Language of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][17]["Description"], "Language of publication"
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][17]["TermCount"], "57")
         self.assertEqual(record["DbInfo"]["FieldList"][17]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][17]["IsNumerical"], "N")
@@ -333,7 +402,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][17]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][18]["Name"], "ISS")
         self.assertEqual(record["DbInfo"]["FieldList"][18]["FullName"], "Issue")
-        self.assertEqual(record["DbInfo"]["FieldList"][18]["Description"], "Issue number of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][18]["Description"],
+            "Issue number of publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][18]["TermCount"], "16835")
         self.assertEqual(record["DbInfo"]["FieldList"][18]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][18]["IsNumerical"], "N")
@@ -341,8 +413,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][18]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][18]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][19]["Name"], "SUBH")
-        self.assertEqual(record["DbInfo"]["FieldList"][19]["FullName"], "MeSH Subheading")
-        self.assertEqual(record["DbInfo"]["FieldList"][19]["Description"], "Additional specificity for MeSH term")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][19]["FullName"], "MeSH Subheading"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][19]["Description"],
+            "Additional specificity for MeSH term",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][19]["TermCount"], "83")
         self.assertEqual(record["DbInfo"]["FieldList"][19]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][19]["IsNumerical"], "N")
@@ -350,8 +427,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][19]["Hierarchy"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][19]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][20]["Name"], "SI")
-        self.assertEqual(record["DbInfo"]["FieldList"][20]["FullName"], "Secondary Source ID")
-        self.assertEqual(record["DbInfo"]["FieldList"][20]["Description"], "Cross-reference from publication to other databases")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][20]["FullName"], "Secondary Source ID"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][20]["Description"],
+            "Cross-reference from publication to other databases",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][20]["TermCount"], "3821402")
         self.assertEqual(record["DbInfo"]["FieldList"][20]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][20]["IsNumerical"], "N")
@@ -360,7 +442,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][20]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][21]["Name"], "MHDA")
         self.assertEqual(record["DbInfo"]["FieldList"][21]["FullName"], "MeSH Date")
-        self.assertEqual(record["DbInfo"]["FieldList"][21]["Description"], "Date publication was indexed with MeSH terms")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][21]["Description"],
+            "Date publication was indexed with MeSH terms",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][21]["TermCount"], "33923")
         self.assertEqual(record["DbInfo"]["FieldList"][21]["IsDate"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][21]["IsNumerical"], "N")
@@ -368,8 +453,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][21]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][21]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][22]["Name"], "TIAB")
-        self.assertEqual(record["DbInfo"]["FieldList"][22]["FullName"], "Title/Abstract")
-        self.assertEqual(record["DbInfo"]["FieldList"][22]["Description"], "Free text associated with Abstract/Title")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][22]["FullName"], "Title/Abstract"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][22]["Description"],
+            "Free text associated with Abstract/Title",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][22]["TermCount"], "35092258")
         self.assertEqual(record["DbInfo"]["FieldList"][22]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][22]["IsNumerical"], "N")
@@ -378,7 +468,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][22]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][23]["Name"], "OTRM")
         self.assertEqual(record["DbInfo"]["FieldList"][23]["FullName"], "Other Term")
-        self.assertEqual(record["DbInfo"]["FieldList"][23]["Description"], "Other terms associated with publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][23]["Description"],
+            "Other terms associated with publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][23]["TermCount"], "333870")
         self.assertEqual(record["DbInfo"]["FieldList"][23]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][23]["IsNumerical"], "N")
@@ -387,7 +480,9 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][23]["IsHidden"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][24]["Name"], "INVR")
         self.assertEqual(record["DbInfo"]["FieldList"][24]["FullName"], "Investigator")
-        self.assertEqual(record["DbInfo"]["FieldList"][24]["Description"], "Investigator")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][24]["Description"], "Investigator"
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][24]["TermCount"], "516245")
         self.assertEqual(record["DbInfo"]["FieldList"][24]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][24]["IsNumerical"], "N")
@@ -395,8 +490,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][24]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][24]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][25]["Name"], "COLN")
-        self.assertEqual(record["DbInfo"]["FieldList"][25]["FullName"], "Corporate Author")
-        self.assertEqual(record["DbInfo"]["FieldList"][25]["Description"], "Corporate Author of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][25]["FullName"], "Corporate Author"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][25]["Description"],
+            "Corporate Author of publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][25]["TermCount"], "132665")
         self.assertEqual(record["DbInfo"]["FieldList"][25]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][25]["IsNumerical"], "N")
@@ -404,8 +504,12 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][25]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][25]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][26]["Name"], "CNTY")
-        self.assertEqual(record["DbInfo"]["FieldList"][26]["FullName"], "Place of Publication")
-        self.assertEqual(record["DbInfo"]["FieldList"][26]["Description"], "Country of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][26]["FullName"], "Place of Publication"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][26]["Description"], "Country of publication"
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][26]["TermCount"], "279")
         self.assertEqual(record["DbInfo"]["FieldList"][26]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][26]["IsNumerical"], "N")
@@ -413,8 +517,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][26]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][26]["IsHidden"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][27]["Name"], "PAPX")
-        self.assertEqual(record["DbInfo"]["FieldList"][27]["FullName"], "Pharmacological Action")
-        self.assertEqual(record["DbInfo"]["FieldList"][27]["Description"], "MeSH pharmacological action pre-explosions")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][27]["FullName"], "Pharmacological Action"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][27]["Description"],
+            "MeSH pharmacological action pre-explosions",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][27]["TermCount"], "420")
         self.assertEqual(record["DbInfo"]["FieldList"][27]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][27]["IsNumerical"], "N")
@@ -423,7 +532,9 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][27]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][28]["Name"], "GRNT")
         self.assertEqual(record["DbInfo"]["FieldList"][28]["FullName"], "Grant Number")
-        self.assertEqual(record["DbInfo"]["FieldList"][28]["Description"], "NIH Grant Numbers")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][28]["Description"], "NIH Grant Numbers"
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][28]["TermCount"], "2588283")
         self.assertEqual(record["DbInfo"]["FieldList"][28]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][28]["IsNumerical"], "N")
@@ -431,8 +542,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][28]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][28]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][29]["Name"], "MDAT")
-        self.assertEqual(record["DbInfo"]["FieldList"][29]["FullName"], "Modification Date")
-        self.assertEqual(record["DbInfo"]["FieldList"][29]["Description"], "Date of last modification")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][29]["FullName"], "Modification Date"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][29]["Description"],
+            "Date of last modification",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][29]["TermCount"], "2777")
         self.assertEqual(record["DbInfo"]["FieldList"][29]["IsDate"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][29]["IsNumerical"], "N")
@@ -440,8 +556,12 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][29]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][29]["IsHidden"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][30]["Name"], "CDAT")
-        self.assertEqual(record["DbInfo"]["FieldList"][30]["FullName"], "Completion Date")
-        self.assertEqual(record["DbInfo"]["FieldList"][30]["Description"], "Date of completion")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][30]["FullName"], "Completion Date"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][30]["Description"], "Date of completion"
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][30]["TermCount"], "9268")
         self.assertEqual(record["DbInfo"]["FieldList"][30]["IsDate"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][30]["IsNumerical"], "N")
@@ -450,7 +570,9 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][30]["IsHidden"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][31]["Name"], "PID")
         self.assertEqual(record["DbInfo"]["FieldList"][31]["FullName"], "Publisher ID")
-        self.assertEqual(record["DbInfo"]["FieldList"][31]["Description"], "Publisher ID")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][31]["Description"], "Publisher ID"
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][31]["TermCount"], "8894288")
         self.assertEqual(record["DbInfo"]["FieldList"][31]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][31]["IsNumerical"], "N")
@@ -459,7 +581,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][31]["IsHidden"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][32]["Name"], "FAUT")
         self.assertEqual(record["DbInfo"]["FieldList"][32]["FullName"], "First Author")
-        self.assertEqual(record["DbInfo"]["FieldList"][32]["Description"], "First Author of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][32]["Description"],
+            "First Author of publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][32]["TermCount"], "6068222")
         self.assertEqual(record["DbInfo"]["FieldList"][32]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][32]["IsNumerical"], "N")
@@ -467,8 +592,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][32]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][32]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][33]["Name"], "FULL")
-        self.assertEqual(record["DbInfo"]["FieldList"][33]["FullName"], "Full Author Name")
-        self.assertEqual(record["DbInfo"]["FieldList"][33]["Description"], "Full Author Name(s) of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][33]["FullName"], "Full Author Name"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][33]["Description"],
+            "Full Author Name(s) of publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][33]["TermCount"], "6419103")
         self.assertEqual(record["DbInfo"]["FieldList"][33]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][33]["IsNumerical"], "N")
@@ -476,8 +606,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][33]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][33]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][34]["Name"], "FINV")
-        self.assertEqual(record["DbInfo"]["FieldList"][34]["FullName"], "Full Investigator Name")
-        self.assertEqual(record["DbInfo"]["FieldList"][34]["Description"], "Full name of investigator")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][34]["FullName"], "Full Investigator Name"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][34]["Description"],
+            "Full name of investigator",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][34]["TermCount"], "243898")
         self.assertEqual(record["DbInfo"]["FieldList"][34]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][34]["IsNumerical"], "N")
@@ -485,8 +620,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][34]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][34]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][35]["Name"], "TT")
-        self.assertEqual(record["DbInfo"]["FieldList"][35]["FullName"], "Transliterated Title")
-        self.assertEqual(record["DbInfo"]["FieldList"][35]["Description"], "Words in transliterated title of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][35]["FullName"], "Transliterated Title"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][35]["Description"],
+            "Words in transliterated title of publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][35]["TermCount"], "2177885")
         self.assertEqual(record["DbInfo"]["FieldList"][35]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][35]["IsNumerical"], "N")
@@ -495,7 +635,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][35]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][36]["Name"], "LAUT")
         self.assertEqual(record["DbInfo"]["FieldList"][36]["FullName"], "Last Author")
-        self.assertEqual(record["DbInfo"]["FieldList"][36]["Description"], "Last Author of publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][36]["Description"],
+            "Last Author of publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][36]["TermCount"], "5655625")
         self.assertEqual(record["DbInfo"]["FieldList"][36]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][36]["IsNumerical"], "N")
@@ -503,8 +646,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][36]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][36]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][37]["Name"], "PPDT")
-        self.assertEqual(record["DbInfo"]["FieldList"][37]["FullName"], "Print Publication Date")
-        self.assertEqual(record["DbInfo"]["FieldList"][37]["Description"], "Date of print publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][37]["FullName"], "Print Publication Date"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][37]["Description"],
+            "Date of print publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][37]["TermCount"], "35164")
         self.assertEqual(record["DbInfo"]["FieldList"][37]["IsDate"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][37]["IsNumerical"], "N")
@@ -512,8 +660,13 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][37]["Hierarchy"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][37]["IsHidden"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][38]["Name"], "EPDT")
-        self.assertEqual(record["DbInfo"]["FieldList"][38]["FullName"], "Electronic Publication Date")
-        self.assertEqual(record["DbInfo"]["FieldList"][38]["Description"], "Date of Electronic publication")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][38]["FullName"], "Electronic Publication Date"
+        )
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][38]["Description"],
+            "Date of Electronic publication",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][38]["TermCount"], "4282")
         self.assertEqual(record["DbInfo"]["FieldList"][38]["IsDate"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][38]["IsNumerical"], "N")
@@ -522,7 +675,9 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][38]["IsHidden"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][39]["Name"], "LID")
         self.assertEqual(record["DbInfo"]["FieldList"][39]["FullName"], "Location ID")
-        self.assertEqual(record["DbInfo"]["FieldList"][39]["Description"], "ELocation ID")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][39]["Description"], "ELocation ID"
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][39]["TermCount"], "56212")
         self.assertEqual(record["DbInfo"]["FieldList"][39]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][39]["IsNumerical"], "N")
@@ -531,7 +686,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][39]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][40]["Name"], "CRDT")
         self.assertEqual(record["DbInfo"]["FieldList"][40]["FullName"], "Create Date")
-        self.assertEqual(record["DbInfo"]["FieldList"][40]["Description"], "Date publication first accessible through Entrez")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][40]["Description"],
+            "Date publication first accessible through Entrez",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][40]["TermCount"], "27563")
         self.assertEqual(record["DbInfo"]["FieldList"][40]["IsDate"], "Y")
         self.assertEqual(record["DbInfo"]["FieldList"][40]["IsNumerical"], "N")
@@ -540,7 +698,10 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][40]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][41]["Name"], "BOOK")
         self.assertEqual(record["DbInfo"]["FieldList"][41]["FullName"], "Book")
-        self.assertEqual(record["DbInfo"]["FieldList"][41]["Description"], "ID of the book that contains the document")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][41]["Description"],
+            "ID of the book that contains the document",
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][41]["TermCount"], "342")
         self.assertEqual(record["DbInfo"]["FieldList"][41]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][41]["IsNumerical"], "N")
@@ -549,7 +710,9 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][41]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][42]["Name"], "ED")
         self.assertEqual(record["DbInfo"]["FieldList"][42]["FullName"], "Editor")
-        self.assertEqual(record["DbInfo"]["FieldList"][42]["Description"], "Section's Editor")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][42]["Description"], "Section's Editor"
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][42]["TermCount"], "335")
         self.assertEqual(record["DbInfo"]["FieldList"][42]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][42]["IsNumerical"], "N")
@@ -567,7 +730,9 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(record["DbInfo"]["FieldList"][43]["IsHidden"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][44]["Name"], "PUBN")
         self.assertEqual(record["DbInfo"]["FieldList"][44]["FullName"], "Publisher")
-        self.assertEqual(record["DbInfo"]["FieldList"][44]["Description"], "Publisher's name")
+        self.assertEqual(
+            record["DbInfo"]["FieldList"][44]["Description"], "Publisher's name"
+        )
         self.assertEqual(record["DbInfo"]["FieldList"][44]["TermCount"], "161")
         self.assertEqual(record["DbInfo"]["FieldList"][44]["IsDate"], "N")
         self.assertEqual(record["DbInfo"]["FieldList"][44]["IsNumerical"], "N")
@@ -577,231 +742,476 @@ class EInfoTest(unittest.TestCase):
         self.assertEqual(len(record["DbInfo"]["LinkList"]), 57)
         self.assertEqual(record["DbInfo"]["LinkList"][0]["Name"], "pubmed_biosample")
         self.assertEqual(record["DbInfo"]["LinkList"][0]["Menu"], "BioSample Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][0]["Description"], "BioSample links")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][0]["Description"], "BioSample links"
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][0]["DbTo"], "biosample")
         self.assertEqual(record["DbInfo"]["LinkList"][1]["Name"], "pubmed_biosystems")
         self.assertEqual(record["DbInfo"]["LinkList"][1]["Menu"], "BioSystem Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][1]["Description"], "Pathways and biological systems (BioSystems) that cite the current articles. Citations are from the BioSystems source databases (KEGG and BioCyc).")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][1]["Description"],
+            "Pathways and biological systems (BioSystems) that cite the current articles. Citations are from the BioSystems source databases (KEGG and BioCyc).",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][1]["DbTo"], "biosystems")
         self.assertEqual(record["DbInfo"]["LinkList"][2]["Name"], "pubmed_books_refs")
         self.assertEqual(record["DbInfo"]["LinkList"][2]["Menu"], "Cited in Books")
-        self.assertEqual(record["DbInfo"]["LinkList"][2]["Description"], "NCBI Bookshelf books that cite the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][2]["Description"],
+            "NCBI Bookshelf books that cite the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][2]["DbTo"], "books")
-        self.assertEqual(record["DbInfo"]["LinkList"][3]["Name"], "pubmed_cancerchromosomes")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][3]["Name"], "pubmed_cancerchromosomes"
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][3]["Menu"], "CancerChrom Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][3]["Description"], "Cancer chromosome records that cite the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][3]["Description"],
+            "Cancer chromosome records that cite the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][3]["DbTo"], "cancerchromosomes")
         self.assertEqual(record["DbInfo"]["LinkList"][4]["Name"], "pubmed_cdd")
         self.assertEqual(record["DbInfo"]["LinkList"][4]["Menu"], "Domain Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][4]["Description"], "Conserved Domain Database (CDD) records that cite the current articles. Citations are from the CDD source database records (PFAM, SMART).")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][4]["Description"],
+            "Conserved Domain Database (CDD) records that cite the current articles. Citations are from the CDD source database records (PFAM, SMART).",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][4]["DbTo"], "cdd")
         self.assertEqual(record["DbInfo"]["LinkList"][5]["Name"], "pubmed_domains")
         self.assertEqual(record["DbInfo"]["LinkList"][5]["Menu"], "3D Domain Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][5]["Description"], "Structural domains in the NCBI Structure database that are parts of the 3D structures reported in the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][5]["Description"],
+            "Structural domains in the NCBI Structure database that are parts of the 3D structures reported in the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][5]["DbTo"], "domains")
         self.assertEqual(record["DbInfo"]["LinkList"][6]["Name"], "pubmed_epigenomics")
         self.assertEqual(record["DbInfo"]["LinkList"][6]["Menu"], "Epigenomics Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][6]["Description"], "Related Epigenomics records")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][6]["Description"],
+            "Related Epigenomics records",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][6]["DbTo"], "epigenomics")
         self.assertEqual(record["DbInfo"]["LinkList"][7]["Name"], "pubmed_gap")
         self.assertEqual(record["DbInfo"]["LinkList"][7]["Menu"], "dbGaP Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][7]["Description"], "Genotypes and Phenotypes (dbGaP) studies that cite the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][7]["Description"],
+            "Genotypes and Phenotypes (dbGaP) studies that cite the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][7]["DbTo"], "gap")
         self.assertEqual(record["DbInfo"]["LinkList"][8]["Name"], "pubmed_gds")
         self.assertEqual(record["DbInfo"]["LinkList"][8]["Menu"], "GEO DataSet Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][8]["Description"], "Gene expression and molecular abundance data reported in the current articles that are also included in the curated Gene Expression Omnibus (GEO) DataSets.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][8]["Description"],
+            "Gene expression and molecular abundance data reported in the current articles that are also included in the curated Gene Expression Omnibus (GEO) DataSets.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][8]["DbTo"], "gds")
         self.assertEqual(record["DbInfo"]["LinkList"][9]["Name"], "pubmed_gene")
         self.assertEqual(record["DbInfo"]["LinkList"][9]["Menu"], "Gene Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][9]["Description"], "Gene records that cite the current articles. Citations in Gene are added manually by NCBI or imported from outside public resources.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][9]["Description"],
+            "Gene records that cite the current articles. Citations in Gene are added manually by NCBI or imported from outside public resources.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][9]["DbTo"], "gene")
-        self.assertEqual(record["DbInfo"]["LinkList"][10]["Name"], "pubmed_gene_bookrecords")
-        self.assertEqual(record["DbInfo"]["LinkList"][10]["Menu"], "Gene (from Bookshelf)")
-        self.assertEqual(record["DbInfo"]["LinkList"][10]["Description"], "Gene records in this citation")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][10]["Name"], "pubmed_gene_bookrecords"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][10]["Menu"], "Gene (from Bookshelf)"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][10]["Description"],
+            "Gene records in this citation",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][10]["DbTo"], "gene")
-        self.assertEqual(record["DbInfo"]["LinkList"][11]["Name"], "pubmed_gene_citedinomim")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][11]["Name"], "pubmed_gene_citedinomim"
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][11]["Menu"], "Gene (OMIM) Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][11]["Description"], "Gene records associated with Online Mendelian Inheritance in Man (OMIM) records that cite the current articles in their reference lists.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][11]["Description"],
+            "Gene records associated with Online Mendelian Inheritance in Man (OMIM) records that cite the current articles in their reference lists.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][11]["DbTo"], "gene")
         self.assertEqual(record["DbInfo"]["LinkList"][12]["Name"], "pubmed_gene_rif")
-        self.assertEqual(record["DbInfo"]["LinkList"][12]["Menu"], "Gene (GeneRIF) Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][12]["Description"], "Gene records that have the current articles as Reference into Function citations (GeneRIFs). NLM staff reviewing the literature while indexing MEDLINE add GeneRIFs manually.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][12]["Menu"], "Gene (GeneRIF) Links"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][12]["Description"],
+            "Gene records that have the current articles as Reference into Function citations (GeneRIFs). NLM staff reviewing the literature while indexing MEDLINE add GeneRIFs manually.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][12]["DbTo"], "gene")
         self.assertEqual(record["DbInfo"]["LinkList"][13]["Name"], "pubmed_genome")
         self.assertEqual(record["DbInfo"]["LinkList"][13]["Menu"], "Genome Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][13]["Description"], "Genome records that include the current articles as references. These are typically the articles that report the sequencing and analysis of the genome.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][13]["Description"],
+            "Genome records that include the current articles as references. These are typically the articles that report the sequencing and analysis of the genome.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][13]["DbTo"], "genome")
         self.assertEqual(record["DbInfo"]["LinkList"][14]["Name"], "pubmed_genomeprj")
         self.assertEqual(record["DbInfo"]["LinkList"][14]["Menu"], "Project Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][14]["Description"], "Genome Project records that cite the current articles. References on Genome Projects include manually added citations and those included on sequences in the project.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][14]["Description"],
+            "Genome Project records that cite the current articles. References on Genome Projects include manually added citations and those included on sequences in the project.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][14]["DbTo"], "genomeprj")
         self.assertEqual(record["DbInfo"]["LinkList"][15]["Name"], "pubmed_gensat")
         self.assertEqual(record["DbInfo"]["LinkList"][15]["Menu"], "GENSAT Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][15]["Description"], "Gene Expression Nervous System Atlas (GENSAT) records that cite the current articles. References on GENSAT records are provided by GENSAT investigators, and also include references on the corresponding NCBI Gene record.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][15]["Description"],
+            "Gene Expression Nervous System Atlas (GENSAT) records that cite the current articles. References on GENSAT records are provided by GENSAT investigators, and also include references on the corresponding NCBI Gene record.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][15]["DbTo"], "gensat")
         self.assertEqual(record["DbInfo"]["LinkList"][16]["Name"], "pubmed_geo")
         self.assertEqual(record["DbInfo"]["LinkList"][16]["Menu"], "GEO Profile Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][16]["Description"], "Gene Expression Omnibus (GEO) Profiles of molecular abundance data. The current articles are references on the Gene record associated with the GEO profile.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][16]["Description"],
+            "Gene Expression Omnibus (GEO) Profiles of molecular abundance data. The current articles are references on the Gene record associated with the GEO profile.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][16]["DbTo"], "geo")
         self.assertEqual(record["DbInfo"]["LinkList"][17]["Name"], "pubmed_homologene")
         self.assertEqual(record["DbInfo"]["LinkList"][17]["Menu"], "HomoloGene Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][17]["Description"], "HomoloGene clusters of homologous genes and sequences that cite the current articles. These are references on the Gene and sequence records in the HomoloGene entry.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][17]["Description"],
+            "HomoloGene clusters of homologous genes and sequences that cite the current articles. These are references on the Gene and sequence records in the HomoloGene entry.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][17]["DbTo"], "homologene")
         self.assertEqual(record["DbInfo"]["LinkList"][18]["Name"], "pubmed_nuccore")
         self.assertEqual(record["DbInfo"]["LinkList"][18]["Menu"], "Nucleotide Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][18]["Description"], "Primary database (GenBank) nucleotide records reported in the current articles as well as Reference Sequences (RefSeqs) that include the articles as references.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][18]["Description"],
+            "Primary database (GenBank) nucleotide records reported in the current articles as well as Reference Sequences (RefSeqs) that include the articles as references.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][18]["DbTo"], "nuccore")
-        self.assertEqual(record["DbInfo"]["LinkList"][19]["Name"], "pubmed_nuccore_refseq")
-        self.assertEqual(record["DbInfo"]["LinkList"][19]["Menu"], "Nucleotide (RefSeq) Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][19]["Description"], "NCBI nucleotide Reference Sequences (RefSeqs) that are cited in the current articles, included in the corresponding Gene Reference into Function, or that include the PubMed articles as references.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][19]["Name"], "pubmed_nuccore_refseq"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][19]["Menu"], "Nucleotide (RefSeq) Links"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][19]["Description"],
+            "NCBI nucleotide Reference Sequences (RefSeqs) that are cited in the current articles, included in the corresponding Gene Reference into Function, or that include the PubMed articles as references.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][19]["DbTo"], "nuccore")
-        self.assertEqual(record["DbInfo"]["LinkList"][20]["Name"], "pubmed_nuccore_weighted")
-        self.assertEqual(record["DbInfo"]["LinkList"][20]["Menu"], "Nucleotide (Weighted) Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][20]["Description"], "Nucleotide records associated with the current articles through the Gene database. These are the related sequences on the Gene record that are added manually by NCBI.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][20]["Name"], "pubmed_nuccore_weighted"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][20]["Menu"], "Nucleotide (Weighted) Links"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][20]["Description"],
+            "Nucleotide records associated with the current articles through the Gene database. These are the related sequences on the Gene record that are added manually by NCBI.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][20]["DbTo"], "nuccore")
         self.assertEqual(record["DbInfo"]["LinkList"][21]["Name"], "pubmed_nucest")
         self.assertEqual(record["DbInfo"]["LinkList"][21]["Menu"], "EST Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][21]["Description"], "Expressed Sequence Tag (EST) nucleotide sequence records reported in the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][21]["Description"],
+            "Expressed Sequence Tag (EST) nucleotide sequence records reported in the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][21]["DbTo"], "nucest")
         self.assertEqual(record["DbInfo"]["LinkList"][22]["Name"], "pubmed_nucgss")
         self.assertEqual(record["DbInfo"]["LinkList"][22]["Menu"], "GSS Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][22]["Description"], "Genome Survey Sequence (GSS) nucleotide records reported in the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][22]["Description"],
+            "Genome Survey Sequence (GSS) nucleotide records reported in the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][22]["DbTo"], "nucgss")
         self.assertEqual(record["DbInfo"]["LinkList"][23]["Name"], "pubmed_omia")
         self.assertEqual(record["DbInfo"]["LinkList"][23]["Menu"], "OMIA Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][23]["Description"], "Online Mendelian Inheritance in Animals (OMIA) records that cite the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][23]["Description"],
+            "Online Mendelian Inheritance in Animals (OMIA) records that cite the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][23]["DbTo"], "omia")
-        self.assertEqual(record["DbInfo"]["LinkList"][24]["Name"], "pubmed_omim_bookrecords")
-        self.assertEqual(record["DbInfo"]["LinkList"][24]["Menu"], "OMIM (from Bookshelf)")
-        self.assertEqual(record["DbInfo"]["LinkList"][24]["Description"], "OMIM records in this citation")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][24]["Name"], "pubmed_omim_bookrecords"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][24]["Menu"], "OMIM (from Bookshelf)"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][24]["Description"],
+            "OMIM records in this citation",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][24]["DbTo"], "omim")
-        self.assertEqual(record["DbInfo"]["LinkList"][25]["Name"], "pubmed_omim_calculated")
-        self.assertEqual(record["DbInfo"]["LinkList"][25]["Menu"], "OMIM (calculated) Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][25]["Description"], "Online Mendelian Inheritance in Man (OMIM) records that include the current articles as references in the light bulb links within or in the citations at the end of the OMIM record. The references available through the light bulb link are collected using the PubMed related articles algorithm to identify records with similar terminology to the OMIM record.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][25]["Name"], "pubmed_omim_calculated"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][25]["Menu"], "OMIM (calculated) Links"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][25]["Description"],
+            "Online Mendelian Inheritance in Man (OMIM) records that include the current articles as references in the light bulb links within or in the citations at the end of the OMIM record. The references available through the light bulb link are collected using the PubMed related articles algorithm to identify records with similar terminology to the OMIM record.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][25]["DbTo"], "omim")
         self.assertEqual(record["DbInfo"]["LinkList"][26]["Name"], "pubmed_omim_cited")
         self.assertEqual(record["DbInfo"]["LinkList"][26]["Menu"], "OMIM (cited) Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][26]["Description"], "Online Mendelian Inheritance in Man (OMIM) records that include the current articles as reference cited at the end of the OMIM record.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][26]["Description"],
+            "Online Mendelian Inheritance in Man (OMIM) records that include the current articles as reference cited at the end of the OMIM record.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][26]["DbTo"], "omim")
         self.assertEqual(record["DbInfo"]["LinkList"][27]["Name"], "pubmed_pcassay")
         self.assertEqual(record["DbInfo"]["LinkList"][27]["Menu"], "BioAssay Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][27]["Description"], "PubChem BioAssay experiments on the biological activities of small molecules that cite the current articles. The depositors of BioAssay data provide these references.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][27]["Description"],
+            "PubChem BioAssay experiments on the biological activities of small molecules that cite the current articles. The depositors of BioAssay data provide these references.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][27]["DbTo"], "pcassay")
         self.assertEqual(record["DbInfo"]["LinkList"][28]["Name"], "pubmed_pccompound")
         self.assertEqual(record["DbInfo"]["LinkList"][28]["Menu"], "Compound Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][28]["Description"], "PubChem chemical compound records that cite the current articles. These references are taken from those provided on submitted PubChem chemical substance records. Multiple substance records may contribute to the PubChem compound record.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][28]["Description"],
+            "PubChem chemical compound records that cite the current articles. These references are taken from those provided on submitted PubChem chemical substance records. Multiple substance records may contribute to the PubChem compound record.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][28]["DbTo"], "pccompound")
-        self.assertEqual(record["DbInfo"]["LinkList"][29]["Name"], "pubmed_pccompound_mesh")
-        self.assertEqual(record["DbInfo"]["LinkList"][29]["Menu"], "Compound (MeSH Keyword)")
-        self.assertEqual(record["DbInfo"]["LinkList"][29]["Description"], "PubChem chemical compound records that are classified under the same Medical Subject Headings (MeSH) controlled vocabulary as the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][29]["Name"], "pubmed_pccompound_mesh"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][29]["Menu"], "Compound (MeSH Keyword)"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][29]["Description"],
+            "PubChem chemical compound records that are classified under the same Medical Subject Headings (MeSH) controlled vocabulary as the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][29]["DbTo"], "pccompound")
-        self.assertEqual(record["DbInfo"]["LinkList"][30]["Name"], "pubmed_pccompound_publisher")
-        self.assertEqual(record["DbInfo"]["LinkList"][30]["Menu"], "Compound (Publisher) Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][30]["Description"], "Link to publisher deposited structures in the PubChem Compound database.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][30]["Name"], "pubmed_pccompound_publisher"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][30]["Menu"], "Compound (Publisher) Links"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][30]["Description"],
+            "Link to publisher deposited structures in the PubChem Compound database.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][30]["DbTo"], "pccompound")
         self.assertEqual(record["DbInfo"]["LinkList"][31]["Name"], "pubmed_pcsubstance")
         self.assertEqual(record["DbInfo"]["LinkList"][31]["Menu"], "Substance Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][31]["Description"], "PubChem chemical substance records that cite the current articles. These references are taken from those provided on submitted PubChem chemical substance records.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][31]["Description"],
+            "PubChem chemical substance records that cite the current articles. These references are taken from those provided on submitted PubChem chemical substance records.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][31]["DbTo"], "pcsubstance")
-        self.assertEqual(record["DbInfo"]["LinkList"][32]["Name"], "pubmed_pcsubstance_bookrecords")
-        self.assertEqual(record["DbInfo"]["LinkList"][32]["Menu"], "PubChem Substance (from Bookshelf)")
-        self.assertEqual(record["DbInfo"]["LinkList"][32]["Description"], "Structures in the PubChem Substance database in this citation")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][32]["Name"], "pubmed_pcsubstance_bookrecords"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][32]["Menu"],
+            "PubChem Substance (from Bookshelf)",
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][32]["Description"],
+            "Structures in the PubChem Substance database in this citation",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][32]["DbTo"], "pcsubstance")
-        self.assertEqual(record["DbInfo"]["LinkList"][33]["Name"], "pubmed_pcsubstance_mesh")
-        self.assertEqual(record["DbInfo"]["LinkList"][33]["Menu"], "Substance (MeSH Keyword)")
-        self.assertEqual(record["DbInfo"]["LinkList"][33]["Description"], "PubChem chemical substance (submitted) records that are classified under the same Medical Subject Headings (MeSH) controlled vocabulary as the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][33]["Name"], "pubmed_pcsubstance_mesh"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][33]["Menu"], "Substance (MeSH Keyword)"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][33]["Description"],
+            "PubChem chemical substance (submitted) records that are classified under the same Medical Subject Headings (MeSH) controlled vocabulary as the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][33]["DbTo"], "pcsubstance")
-        self.assertEqual(record["DbInfo"]["LinkList"][34]["Name"], "pubmed_pcsubstance_publisher")
-        self.assertEqual(record["DbInfo"]["LinkList"][34]["Menu"], "Substance (Publisher) Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][34]["Description"], "Publisher deposited structures in the PubChem Compound database that are reported in the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][34]["Name"], "pubmed_pcsubstance_publisher"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][34]["Menu"], "Substance (Publisher) Links"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][34]["Description"],
+            "Publisher deposited structures in the PubChem Compound database that are reported in the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][34]["DbTo"], "pcsubstance")
         self.assertEqual(record["DbInfo"]["LinkList"][35]["Name"], "pubmed_pepdome")
         self.assertEqual(record["DbInfo"]["LinkList"][35]["Menu"], "Peptidome Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][35]["Description"], "Protein mass spectrometry and other proteomics data from the Peptidome database reported in the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][35]["Description"],
+            "Protein mass spectrometry and other proteomics data from the Peptidome database reported in the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][35]["DbTo"], "pepdome")
         self.assertEqual(record["DbInfo"]["LinkList"][36]["Name"], "pubmed_pmc")
         self.assertEqual(record["DbInfo"]["LinkList"][36]["Menu"], "PMC Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][36]["Description"], "Free full-text versions of the current articles in the PubMed Central database.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][36]["Description"],
+            "Free full-text versions of the current articles in the PubMed Central database.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][36]["DbTo"], "pmc")
-        self.assertEqual(record["DbInfo"]["LinkList"][37]["Name"], "pubmed_pmc_bookrecords")
-        self.assertEqual(record["DbInfo"]["LinkList"][37]["Menu"], "References in PMC for this Bookshelf citation")
-        self.assertEqual(record["DbInfo"]["LinkList"][37]["Description"], "Full text of articles in PubMed Central cited in this record")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][37]["Name"], "pubmed_pmc_bookrecords"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][37]["Menu"],
+            "References in PMC for this Bookshelf citation",
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][37]["Description"],
+            "Full text of articles in PubMed Central cited in this record",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][37]["DbTo"], "pmc")
         self.assertEqual(record["DbInfo"]["LinkList"][38]["Name"], "pubmed_pmc_embargo")
         self.assertEqual(record["DbInfo"]["LinkList"][38]["Menu"], "")
-        self.assertEqual(record["DbInfo"]["LinkList"][38]["Description"], "Embargoed PMC article associated with PubMed")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][38]["Description"],
+            "Embargoed PMC article associated with PubMed",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][38]["DbTo"], "pmc")
         self.assertEqual(record["DbInfo"]["LinkList"][39]["Name"], "pubmed_pmc_local")
         self.assertEqual(record["DbInfo"]["LinkList"][39]["Menu"], "")
-        self.assertEqual(record["DbInfo"]["LinkList"][39]["Description"], "Free full text articles in PMC")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][39]["Description"],
+            "Free full text articles in PMC",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][39]["DbTo"], "pmc")
         self.assertEqual(record["DbInfo"]["LinkList"][40]["Name"], "pubmed_pmc_refs")
         self.assertEqual(record["DbInfo"]["LinkList"][40]["Menu"], "Cited in PMC")
-        self.assertEqual(record["DbInfo"]["LinkList"][40]["Description"], "Full-text articles in the PubMed Central Database that cite the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][40]["Description"],
+            "Full-text articles in the PubMed Central Database that cite the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][40]["DbTo"], "pmc")
         self.assertEqual(record["DbInfo"]["LinkList"][41]["Name"], "pubmed_popset")
         self.assertEqual(record["DbInfo"]["LinkList"][41]["Menu"], "PopSet Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][41]["Description"], "Sets of sequences from population and evolutionary genetic studies in the PopSet database reported in the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][41]["Description"],
+            "Sets of sequences from population and evolutionary genetic studies in the PopSet database reported in the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][41]["DbTo"], "popset")
         self.assertEqual(record["DbInfo"]["LinkList"][42]["Name"], "pubmed_probe")
         self.assertEqual(record["DbInfo"]["LinkList"][42]["Menu"], "Probe Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][42]["Description"], "Molecular reagents in the Probe database that cite the current articles. References in Probe are provided by submitters of the data.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][42]["Description"],
+            "Molecular reagents in the Probe database that cite the current articles. References in Probe are provided by submitters of the data.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][42]["DbTo"], "probe")
         self.assertEqual(record["DbInfo"]["LinkList"][43]["Name"], "pubmed_protein")
         self.assertEqual(record["DbInfo"]["LinkList"][43]["Menu"], "Protein Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][43]["Description"], "Protein translation features of primary database (GenBank) nucleotide records reported in the current articles as well as Reference Sequences (RefSeqs) that include the articles as references.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][43]["Description"],
+            "Protein translation features of primary database (GenBank) nucleotide records reported in the current articles as well as Reference Sequences (RefSeqs) that include the articles as references.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][43]["DbTo"], "protein")
-        self.assertEqual(record["DbInfo"]["LinkList"][44]["Name"], "pubmed_protein_refseq")
-        self.assertEqual(record["DbInfo"]["LinkList"][44]["Menu"], "Protein (RefSeq) Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][44]["Description"], "NCBI protein Reference Sequences (RefSeqs) that are cited in the current articles, included in the corresponding Gene Reference into Function, or that include the PubMed articles as references.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][44]["Name"], "pubmed_protein_refseq"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][44]["Menu"], "Protein (RefSeq) Links"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][44]["Description"],
+            "NCBI protein Reference Sequences (RefSeqs) that are cited in the current articles, included in the corresponding Gene Reference into Function, or that include the PubMed articles as references.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][44]["DbTo"], "protein")
-        self.assertEqual(record["DbInfo"]["LinkList"][45]["Name"], "pubmed_protein_weighted")
-        self.assertEqual(record["DbInfo"]["LinkList"][45]["Menu"], "Protein (Weighted) Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][45]["Description"], "Protein records associated with the current articles through related Gene database records. These are the related sequences on the Gene record that are added manually by NCBI.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][45]["Name"], "pubmed_protein_weighted"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][45]["Menu"], "Protein (Weighted) Links"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][45]["Description"],
+            "Protein records associated with the current articles through related Gene database records. These are the related sequences on the Gene record that are added manually by NCBI.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][45]["DbTo"], "protein")
-        self.assertEqual(record["DbInfo"]["LinkList"][46]["Name"], "pubmed_proteinclusters")
-        self.assertEqual(record["DbInfo"]["LinkList"][46]["Menu"], "Protein Cluster Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][46]["Description"], "Clusters of related proteins from the Protein Clusters database that cite the current articles. Sources of references in Protein Clusters include the associated Gene and Conserved Domain records as well as NCBI added citations.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][46]["Name"], "pubmed_proteinclusters"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][46]["Menu"], "Protein Cluster Links"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][46]["Description"],
+            "Clusters of related proteins from the Protein Clusters database that cite the current articles. Sources of references in Protein Clusters include the associated Gene and Conserved Domain records as well as NCBI added citations.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][46]["DbTo"], "proteinclusters")
         self.assertEqual(record["DbInfo"]["LinkList"][47]["Name"], "pubmed_pubmed")
         self.assertEqual(record["DbInfo"]["LinkList"][47]["Menu"], "Related Citations")
-        self.assertEqual(record["DbInfo"]["LinkList"][47]["Description"], "Calculated set of PubMed citations closely related to the selected article(s) retrieved using a word weight algorithm. Related articles are displayed in ranked order from most to least relevant, with the \u201clinked from\u201d citation displayed first.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][47]["Description"],
+            "Calculated set of PubMed citations closely related to the selected article(s) retrieved using a word weight algorithm. Related articles are displayed in ranked order from most to least relevant, with the \u201clinked from\u201d citation displayed first.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][47]["DbTo"], "pubmed")
-        self.assertEqual(record["DbInfo"]["LinkList"][48]["Name"], "pubmed_pubmed_bookrecords")
-        self.assertEqual(record["DbInfo"]["LinkList"][48]["Menu"], "References for this Bookshelf citation")
-        self.assertEqual(record["DbInfo"]["LinkList"][48]["Description"], "PubMed abstracts for articles cited in this record")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][48]["Name"], "pubmed_pubmed_bookrecords"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][48]["Menu"],
+            "References for this Bookshelf citation",
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][48]["Description"],
+            "PubMed abstracts for articles cited in this record",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][48]["DbTo"], "pubmed")
         self.assertEqual(record["DbInfo"]["LinkList"][49]["Name"], "pubmed_pubmed_refs")
-        self.assertEqual(record["DbInfo"]["LinkList"][49]["Menu"], "References for PMC Articles")
-        self.assertEqual(record["DbInfo"]["LinkList"][49]["Description"], "Citation referenced in PubMed article. Only valid for PubMed citations that are also in PMC.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][49]["Menu"], "References for PMC Articles"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][49]["Description"],
+            "Citation referenced in PubMed article. Only valid for PubMed citations that are also in PMC.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][49]["DbTo"], "pubmed")
         self.assertEqual(record["DbInfo"]["LinkList"][50]["Name"], "pubmed_snp")
         self.assertEqual(record["DbInfo"]["LinkList"][50]["Menu"], "SNP Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][50]["Description"], "Nucleotide polymorphism records from dbSNP that have current articles as submitter-provided references.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][50]["Description"],
+            "Nucleotide polymorphism records from dbSNP that have current articles as submitter-provided references.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][50]["DbTo"], "snp")
         self.assertEqual(record["DbInfo"]["LinkList"][51]["Name"], "pubmed_snp_cited")
         self.assertEqual(record["DbInfo"]["LinkList"][51]["Menu"], "SNP (Cited)")
-        self.assertEqual(record["DbInfo"]["LinkList"][51]["Description"], "Nucleotide polymorphism records from dbSNP that have NCBI dbSNP identifiers reported in the PubMed abstract of the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][51]["Description"],
+            "Nucleotide polymorphism records from dbSNP that have NCBI dbSNP identifiers reported in the PubMed abstract of the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][51]["DbTo"], "snp")
         self.assertEqual(record["DbInfo"]["LinkList"][52]["Name"], "pubmed_sra")
         self.assertEqual(record["DbInfo"]["LinkList"][52]["Menu"], "SRA Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][52]["Description"], "Massively-parallel sequencing project data in the Short Read Archive (SRA) that are reported in the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][52]["Description"],
+            "Massively-parallel sequencing project data in the Short Read Archive (SRA) that are reported in the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][52]["DbTo"], "sra")
         self.assertEqual(record["DbInfo"]["LinkList"][53]["Name"], "pubmed_structure")
         self.assertEqual(record["DbInfo"]["LinkList"][53]["Menu"], "Structure Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][53]["Description"], "Three-dimensional structure records in the NCBI Structure database for data reported in the current articles.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][53]["Description"],
+            "Three-dimensional structure records in the NCBI Structure database for data reported in the current articles.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][53]["DbTo"], "structure")
-        self.assertEqual(record["DbInfo"]["LinkList"][54]["Name"], "pubmed_taxonomy_entrez")
-        self.assertEqual(record["DbInfo"]["LinkList"][54]["Menu"], "Taxonomy via GenBank")
-        self.assertEqual(record["DbInfo"]["LinkList"][54]["Description"], "Taxonomy records associated with the current articles through taxonomic information on related molecular database records (Nucleotide, Protein, Gene, SNP, Structure).")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][54]["Name"], "pubmed_taxonomy_entrez"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][54]["Menu"], "Taxonomy via GenBank"
+        )
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][54]["Description"],
+            "Taxonomy records associated with the current articles through taxonomic information on related molecular database records (Nucleotide, Protein, Gene, SNP, Structure).",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][54]["DbTo"], "taxonomy")
         self.assertEqual(record["DbInfo"]["LinkList"][55]["Name"], "pubmed_unigene")
         self.assertEqual(record["DbInfo"]["LinkList"][55]["Menu"], "UniGene Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][55]["Description"], "UniGene clusters of expressed sequences that are associated with the current articles through references on the clustered sequence records and related Gene records.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][55]["Description"],
+            "UniGene clusters of expressed sequences that are associated with the current articles through references on the clustered sequence records and related Gene records.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][55]["DbTo"], "unigene")
         self.assertEqual(record["DbInfo"]["LinkList"][56]["Name"], "pubmed_unists")
         self.assertEqual(record["DbInfo"]["LinkList"][56]["Menu"], "UniSTS Links")
-        self.assertEqual(record["DbInfo"]["LinkList"][56]["Description"], "Genetic, physical, and sequence mapping reagents in the UniSTS database associated with the current articles through references on sequence tagged site (STS) submissions as well as automated searching of PubMed abstracts and full-text PubMed Central articles for marker names.")
+        self.assertEqual(
+            record["DbInfo"]["LinkList"][56]["Description"],
+            "Genetic, physical, and sequence mapping reagents in the UniSTS database associated with the current articles through references on sequence tagged site (STS) submissions as well as automated searching of PubMed abstracts and full-text PubMed Central articles for marker names.",
+        )
         self.assertEqual(record["DbInfo"]["LinkList"][56]["DbTo"], "unists")
 
     def test_corrupted(self):
@@ -810,6 +1220,7 @@ class EInfoTest(unittest.TestCase):
         # >>> Bio.Entrez.einfo()
         # and manually delete the last couple of lines
         from Bio.Entrez import Parser
+
         with open("Entrez/einfo4.xml", "rb") as handle:
             self.assertRaises(Parser.CorruptedXMLError, Entrez.read, handle)
 
@@ -857,7 +1268,10 @@ class ESearchTest(unittest.TestCase):
         self.assertEqual(record["RetMax"], "100")
         self.assertEqual(record["RetStart"], "0")
         self.assertEqual(record["QueryKey"], "12")
-        self.assertEqual(record["WebEnv"], "0rYFb69LfbTFXfG7-0HPo2BU-ZFWF1s_51WtYR5e0fAzThQCR0WIW12inPQRRIj1xUzSfGgG9ovT9-@263F6CC86FF8F760_0173SID")
+        self.assertEqual(
+            record["WebEnv"],
+            "0rYFb69LfbTFXfG7-0HPo2BU-ZFWF1s_51WtYR5e0fAzThQCR0WIW12inPQRRIj1xUzSfGgG9ovT9-@263F6CC86FF8F760_0173SID",
+        )
         self.assertEqual(len(record["IdList"]), 100)
         self.assertEqual(record["IdList"][0], "18411453")
         self.assertEqual(record["IdList"][1], "18411431")
@@ -961,7 +1375,10 @@ class ESearchTest(unittest.TestCase):
         self.assertEqual(record["IdList"][99], "18409991")
         self.assertEqual(len(record["TranslationSet"]), 1)
         self.assertEqual(record["TranslationSet"][0]["From"], "cancer")
-        self.assertEqual(record["TranslationSet"][0]["To"], '(("neoplasms"[TIAB] NOT Medline[SB]) OR "neoplasms"[MeSH Terms] OR cancer[Text Word])')
+        self.assertEqual(
+            record["TranslationSet"][0]["To"],
+            '(("neoplasms"[TIAB] NOT Medline[SB]) OR "neoplasms"[MeSH Terms] OR cancer[Text Word])',
+        )
         self.assertEqual(len(record["TranslationStack"]), 13)
         self.assertEqual(record["TranslationStack"][0]["Term"], '"neoplasms"[TIAB]')
         self.assertEqual(record["TranslationStack"][0]["Field"], "TIAB")
@@ -977,7 +1394,9 @@ class ESearchTest(unittest.TestCase):
         self.assertEqual(record["TranslationStack"][2].tag, "OP")
         self.assertEqual(record["TranslationStack"][3], "GROUP")
         self.assertEqual(record["TranslationStack"][3].tag, "OP")
-        self.assertEqual(record["TranslationStack"][4]["Term"], '"neoplasms"[MeSH Terms]')
+        self.assertEqual(
+            record["TranslationStack"][4]["Term"], '"neoplasms"[MeSH Terms]'
+        )
         self.assertEqual(record["TranslationStack"][4]["Field"], "MeSH Terms")
         self.assertEqual(record["TranslationStack"][4]["Count"], "1918010")
         self.assertEqual(record["TranslationStack"][4]["Explode"], "Y")
@@ -1007,7 +1426,10 @@ class ESearchTest(unittest.TestCase):
         self.assertEqual(record["TranslationStack"][11].tag, "OP")
         self.assertEqual(record["TranslationStack"][12], "AND")
         self.assertEqual(record["TranslationStack"][12].tag, "OP")
-        self.assertEqual(record["QueryTranslation"], '(("neoplasms"[TIAB] NOT Medline[SB]) OR "neoplasms"[MeSH Terms] OR cancer[Text Word]) AND 2008/02/16[EDAT] : 2008/04/16[EDAT]')
+        self.assertEqual(
+            record["QueryTranslation"],
+            '(("neoplasms"[TIAB] NOT Medline[SB]) OR "neoplasms"[MeSH Terms] OR cancer[Text Word]) AND 2008/02/16[EDAT] : 2008/04/16[EDAT]',
+        )
 
     def test_pubmed3(self):
         """Test parsing XML returned by ESearch from PubMed (third test)."""
@@ -1030,9 +1452,14 @@ class ESearchTest(unittest.TestCase):
         self.assertEqual(record["IdList"][5], "11121072")
         self.assertEqual(len(record["TranslationSet"]), 1)
         self.assertEqual(record["TranslationSet"][0]["From"], "PNAS[ta]")
-        self.assertEqual(record["TranslationSet"][0]["To"], '"Proc Natl Acad Sci U S A"[Journal:__jrid6653]')
+        self.assertEqual(
+            record["TranslationSet"][0]["To"],
+            '"Proc Natl Acad Sci U S A"[Journal:__jrid6653]',
+        )
         self.assertEqual(len(record["TranslationStack"]), 3)
-        self.assertEqual(record["TranslationStack"][0]["Term"], '"Proc Natl Acad Sci U S A"[Journal]')
+        self.assertEqual(
+            record["TranslationStack"][0]["Term"], '"Proc Natl Acad Sci U S A"[Journal]'
+        )
         self.assertEqual(record["TranslationStack"][0]["Field"], "Journal")
         self.assertEqual(record["TranslationStack"][0]["Count"], "91806")
         self.assertEqual(record["TranslationStack"][0]["Explode"], "Y")
@@ -1044,7 +1471,9 @@ class ESearchTest(unittest.TestCase):
         self.assertEqual(record["TranslationStack"][1].tag, "TermSet")
         self.assertEqual(record["TranslationStack"][2], "AND")
         self.assertEqual(record["TranslationStack"][2].tag, "OP")
-        self.assertEqual(record["QueryTranslation"], '"Proc Natl Acad Sci U S A"[Journal] AND 97[vi]')
+        self.assertEqual(
+            record["QueryTranslation"], '"Proc Natl Acad Sci U S A"[Journal] AND 97[vi]'
+        )
 
     def test_journals(self):
         """Test parsing XML returned by ESearch from the Journals database."""
@@ -1079,7 +1508,9 @@ class ESearchTest(unittest.TestCase):
         self.assertEqual(record["IdList"][19], "875")
         self.assertEqual(len(record["TranslationSet"]), 0)
         self.assertEqual(len(record["TranslationStack"]), 2)
-        self.assertEqual(record["TranslationStack"][0]["Term"], "obstetrics[All Fields]")
+        self.assertEqual(
+            record["TranslationStack"][0]["Term"], "obstetrics[All Fields]"
+        )
         self.assertEqual(record["TranslationStack"][0]["Field"], "All Fields")
         self.assertEqual(record["TranslationStack"][0]["Count"], "177")
         self.assertEqual(record["TranslationStack"][0]["Explode"], "Y")
@@ -1122,35 +1553,48 @@ class ESearchTest(unittest.TestCase):
         self.assertEqual(record["IdList"][19], "1413911")
         self.assertEqual(len(record["TranslationSet"]), 1)
         self.assertEqual(record["TranslationSet"][0]["From"], "stem cells")
-        self.assertEqual(record["TranslationSet"][0]["To"], '("stem cells"[MeSH Terms] OR stem cells[Acknowledgments] OR stem cells[Figure/Table Caption] OR stem cells[Section Title] OR stem cells[Body - All Words] OR stem cells[Title] OR stem cells[Abstract])')
+        self.assertEqual(
+            record["TranslationSet"][0]["To"],
+            '("stem cells"[MeSH Terms] OR stem cells[Acknowledgments] OR stem cells[Figure/Table Caption] OR stem cells[Section Title] OR stem cells[Body - All Words] OR stem cells[Title] OR stem cells[Abstract])',
+        )
         self.assertEqual(len(record["TranslationStack"]), 16)
-        self.assertEqual(record["TranslationStack"][0]["Term"], '"stem cells"[MeSH Terms]')
+        self.assertEqual(
+            record["TranslationStack"][0]["Term"], '"stem cells"[MeSH Terms]'
+        )
         self.assertEqual(record["TranslationStack"][0]["Field"], "MeSH Terms")
         self.assertEqual(record["TranslationStack"][0]["Count"], "12224")
         self.assertEqual(record["TranslationStack"][0]["Explode"], "Y")
         self.assertEqual(record["TranslationStack"][0].tag, "TermSet")
-        self.assertEqual(record["TranslationStack"][1]["Term"], "stem cells[Acknowledgments]")
+        self.assertEqual(
+            record["TranslationStack"][1]["Term"], "stem cells[Acknowledgments]"
+        )
         self.assertEqual(record["TranslationStack"][1]["Field"], "Acknowledgments")
         self.assertEqual(record["TranslationStack"][1]["Count"], "79")
         self.assertEqual(record["TranslationStack"][1]["Explode"], "Y")
         self.assertEqual(record["TranslationStack"][1].tag, "TermSet")
         self.assertEqual(record["TranslationStack"][2], "OR")
         self.assertEqual(record["TranslationStack"][2].tag, "OP")
-        self.assertEqual(record["TranslationStack"][3]["Term"], "stem cells[Figure/Table Caption]")
+        self.assertEqual(
+            record["TranslationStack"][3]["Term"], "stem cells[Figure/Table Caption]"
+        )
         self.assertEqual(record["TranslationStack"][3]["Field"], "Figure/Table Caption")
         self.assertEqual(record["TranslationStack"][3]["Count"], "806")
         self.assertEqual(record["TranslationStack"][3]["Explode"], "Y")
         self.assertEqual(record["TranslationStack"][3].tag, "TermSet")
         self.assertEqual(record["TranslationStack"][4], "OR")
         self.assertEqual(record["TranslationStack"][4].tag, "OP")
-        self.assertEqual(record["TranslationStack"][5]["Term"], "stem cells[Section Title]")
+        self.assertEqual(
+            record["TranslationStack"][5]["Term"], "stem cells[Section Title]"
+        )
         self.assertEqual(record["TranslationStack"][5]["Field"], "Section Title")
         self.assertEqual(record["TranslationStack"][5]["Count"], "522")
         self.assertEqual(record["TranslationStack"][5]["Explode"], "Y")
         self.assertEqual(record["TranslationStack"][5].tag, "TermSet")
         self.assertEqual(record["TranslationStack"][6], "OR")
         self.assertEqual(record["TranslationStack"][6].tag, "OP")
-        self.assertEqual(record["TranslationStack"][7]["Term"], "stem cells[Body - All Words]")
+        self.assertEqual(
+            record["TranslationStack"][7]["Term"], "stem cells[Body - All Words]"
+        )
         self.assertEqual(record["TranslationStack"][7]["Field"], "Body - All Words")
         self.assertEqual(record["TranslationStack"][7]["Count"], "13936")
         self.assertEqual(record["TranslationStack"][7]["Explode"], "Y")
@@ -1173,14 +1617,19 @@ class ESearchTest(unittest.TestCase):
         self.assertEqual(record["TranslationStack"][12].tag, "OP")
         self.assertEqual(record["TranslationStack"][13], "GROUP")
         self.assertEqual(record["TranslationStack"][13].tag, "OP")
-        self.assertEqual(record["TranslationStack"][14]["Term"], "free fulltext[filter]")
+        self.assertEqual(
+            record["TranslationStack"][14]["Term"], "free fulltext[filter]"
+        )
         self.assertEqual(record["TranslationStack"][14]["Field"], "filter")
         self.assertEqual(record["TranslationStack"][14]["Count"], "1412839")
         self.assertEqual(record["TranslationStack"][14]["Explode"], "Y")
         self.assertEqual(record["TranslationStack"][14].tag, "TermSet")
         self.assertEqual(record["TranslationStack"][15], "AND")
         self.assertEqual(record["TranslationStack"][15].tag, "OP")
-        self.assertEqual(record["QueryTranslation"], '("stem cells"[MeSH Terms] OR stem cells[Acknowledgments] OR stem cells[Figure/Table Caption] OR stem cells[Section Title] OR stem cells[Body - All Words] OR stem cells[Title] OR stem cells[Abstract]) AND free fulltext[filter]')
+        self.assertEqual(
+            record["QueryTranslation"],
+            '("stem cells"[MeSH Terms] OR stem cells[Acknowledgments] OR stem cells[Figure/Table Caption] OR stem cells[Section Title] OR stem cells[Body - All Words] OR stem cells[Title] OR stem cells[Abstract]) AND free fulltext[filter]',
+        )
 
     def test_nucleotide(self):
         """Test parsing XML returned by ESearch from the Nucleotide database."""
@@ -1232,7 +1681,9 @@ class ESearchTest(unittest.TestCase):
         self.assertEqual(record["IdList"][2], "4104812")
         self.assertEqual(len(record["TranslationSet"]), 0)
         self.assertEqual(len(record["TranslationStack"]), 2)
-        self.assertEqual(record["TranslationStack"][0]["Term"], "000200020[molecular weight]")
+        self.assertEqual(
+            record["TranslationStack"][0]["Term"], "000200020[molecular weight]"
+        )
         self.assertEqual(record["TranslationStack"][0]["Field"], "molecular weight")
         self.assertEqual(record["TranslationStack"][0]["Count"], "3")
         self.assertEqual(record["TranslationStack"][0]["Explode"], "Y")
@@ -1281,7 +1732,10 @@ class EPostTest(unittest.TestCase):
         with open("Entrez/epost1.xml", "rb") as handle:
             record = Entrez.read(handle)
         self.assertEqual(record["QueryKey"], "1")
-        self.assertEqual(record["WebEnv"], "0zYsuLk3zG_lRMkblPBEqnT8nIENUGw4HAy8xXChTnoVm7GEnWY71jv3nz@1FC077F3806DE010_0042SID")
+        self.assertEqual(
+            record["WebEnv"],
+            "0zYsuLk3zG_lRMkblPBEqnT8nIENUGw4HAy8xXChTnoVm7GEnWY71jv3nz@1FC077F3806DE010_0042SID",
+        )
 
     def test_wrong(self):
         """Test parsing XML returned by EPost with incorrect arguments."""
@@ -1298,7 +1752,10 @@ class EPostTest(unittest.TestCase):
             record = Entrez.read(handle)
         self.assertEqual(record["InvalidIdList"], ["-1"])
         self.assertEqual(record["QueryKey"], "1")
-        self.assertEqual(record["WebEnv"], "08AIUeBsfIk6BfdzKnd3GM2RtCudczC9jm5aeb4US0o7azCTQCeCsr-xg0@1EDE54E680D03C40_0011SID")
+        self.assertEqual(
+            record["WebEnv"],
+            "08AIUeBsfIk6BfdzKnd3GM2RtCudczC9jm5aeb4US0o7azCTQCeCsr-xg0@1EDE54E680D03C40_0011SID",
+        )
 
 
 class ESummaryTest(unittest.TestCase):
@@ -1325,7 +1782,10 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(record[0]["AuthorList"][0], "LoPresti PJ")
         self.assertEqual(record[0]["AuthorList"][1], "Hambrick GW Jr")
         self.assertEqual(record[0]["LastAuthor"], "Hambrick GW Jr")
-        self.assertEqual(record[0]["Title"], "Zirconium granuloma following treatment of rhus dermatitis.")
+        self.assertEqual(
+            record[0]["Title"],
+            "Zirconium granuloma following treatment of rhus dermatitis.",
+        )
         self.assertEqual(record[0]["Volume"], "92")
         self.assertEqual(record[0]["Issue"], "2")
         self.assertEqual(record[0]["Pages"], "188-91")
@@ -1359,7 +1819,10 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(record[1]["AuthorList"][1], "Gok MA")
         self.assertEqual(record[1]["AuthorList"][2], "Lennard TW")
         self.assertEqual(record[1]["LastAuthor"], "Lennard TW")
-        self.assertEqual(record[1]["Title"], "Adverse and beneficial effects of plant extracts on skin and skin disorders.")
+        self.assertEqual(
+            record[1]["Title"],
+            "Adverse and beneficial effects of plant extracts on skin and skin disorders.",
+        )
         self.assertEqual(record[1]["Volume"], "20")
         self.assertEqual(record[1]["Issue"], "2")
         self.assertEqual(record[1]["Pages"], "89-103")
@@ -1382,7 +1845,10 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(len(record[1]["References"]), 0)
         self.assertEqual(record[1]["HasAbstract"], 1)
         self.assertEqual(record[1]["PmcRefCount"], 0)
-        self.assertEqual(record[1]["FullJournalName"], "Adverse drug reactions and toxicological reviews")
+        self.assertEqual(
+            record[1]["FullJournalName"],
+            "Adverse drug reactions and toxicological reviews",
+        )
         self.assertEqual(record[1]["ELocationID"], "")
         self.assertEqual(record[1]["SO"], "2001 Jun;20(2):89-103")
 
@@ -1394,7 +1860,10 @@ class ESummaryTest(unittest.TestCase):
         with open("Entrez/esummary2.xml", "rb") as handle:
             record = Entrez.read(handle)
         self.assertEqual(record[0]["Id"], "27731")
-        self.assertEqual(record[0]["Title"], "The American journal of obstetrics and diseases of women and children")
+        self.assertEqual(
+            record[0]["Title"],
+            "The American journal of obstetrics and diseases of women and children",
+        )
         self.assertEqual(record[0]["MedAbbr"], "Am J Obstet Dis Women Child")
         self.assertEqual(record[0]["IsoAbbr"], "")
         self.assertEqual(record[0]["NlmId"], "14820330R")
@@ -1402,14 +1871,18 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(record[0]["eISSN"], "")
         self.assertEqual(record[0]["PublicationStartYear"], "1868")
         self.assertEqual(record[0]["PublicationEndYear"], "1919")
-        self.assertEqual(record[0]["Publisher"], "W.A. Townsend & Adams, $c [1868-1919]")
+        self.assertEqual(
+            record[0]["Publisher"], "W.A. Townsend & Adams, $c [1868-1919]"
+        )
         self.assertEqual(record[0]["Language"], "eng")
         self.assertEqual(record[0]["Country"], "United States")
         self.assertEqual(len(record[0]["BroadHeading"]), 0)
         self.assertEqual(record[0]["ContinuationNotes"], "")
 
         self.assertEqual(record[1]["Id"], "439")
-        self.assertEqual(record[1]["Title"], "American journal of obstetrics and gynecology")
+        self.assertEqual(
+            record[1]["Title"], "American journal of obstetrics and gynecology"
+        )
         self.assertEqual(record[1]["MedAbbr"], "Am J Obstet Gynecol")
         self.assertEqual(record[1]["IsoAbbr"], "Am. J. Obstet. Gynecol.")
         self.assertEqual(record[1]["NlmId"], "0370476")
@@ -1423,7 +1896,10 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(len(record[1]["BroadHeading"]), 2)
         self.assertEqual(record[1]["BroadHeading"][0], "Gynecology")
         self.assertEqual(record[1]["BroadHeading"][1], "Obstetrics")
-        self.assertEqual(record[1]["ContinuationNotes"], "Continues: American journal of obstetrics and diseases of women and children. ")
+        self.assertEqual(
+            record[1]["ContinuationNotes"],
+            "Continues: American journal of obstetrics and diseases of women and children. ",
+        )
 
         self.assertEqual(record[2]["Id"], "735")
         self.assertEqual(record[2]["Title"], "Archives of gynecology and obstetrics")
@@ -1440,10 +1916,15 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(len(record[2]["BroadHeading"]), 2)
         self.assertEqual(record[2]["BroadHeading"][0], "Gynecology")
         self.assertEqual(record[2]["BroadHeading"][1], "Obstetrics")
-        self.assertEqual(record[2]["ContinuationNotes"], "Continues: Archives of gynecology. ")
+        self.assertEqual(
+            record[2]["ContinuationNotes"], "Continues: Archives of gynecology. "
+        )
 
         self.assertEqual(record[3]["Id"], "905")
-        self.assertEqual(record[3]["Title"], "Asia-Oceania journal of obstetrics and gynaecology / AOFOG")
+        self.assertEqual(
+            record[3]["Title"],
+            "Asia-Oceania journal of obstetrics and gynaecology / AOFOG",
+        )
         self.assertEqual(record[3]["MedAbbr"], "Asia Oceania J Obstet Gynaecol")
         self.assertEqual(record[3]["IsoAbbr"], "")
         self.assertEqual(record[3]["NlmId"], "8102781")
@@ -1457,7 +1938,10 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(len(record[3]["BroadHeading"]), 2)
         self.assertEqual(record[3]["BroadHeading"][0], "Gynecology")
         self.assertEqual(record[3]["BroadHeading"][1], "Obstetrics")
-        self.assertEqual(record[3]["ContinuationNotes"], "Continues: Journal of the Asian Federation of Obstetrics and Gynaecology. Continued by: Journal of obstetrics and gynaecology (Tokyo, Japan). ")
+        self.assertEqual(
+            record[3]["ContinuationNotes"],
+            "Continues: Journal of the Asian Federation of Obstetrics and Gynaecology. Continued by: Journal of obstetrics and gynaecology (Tokyo, Japan). ",
+        )
 
     def test_protein(self):
         """Test parsing XML returned by ESummary from the Protein database."""
@@ -1482,8 +1966,12 @@ class ESummaryTest(unittest.TestCase):
 
         self.assertEqual(record[1]["Id"], "28628843")
         self.assertEqual(record[1]["Caption"], "AAO49381")
-        self.assertEqual(record[1]["Title"], "erythroid associated factor [Homo sapiens]")
-        self.assertEqual(record[1]["Extra"], "gi|28628843|gb|AAO49381.1|AF485325_1[28628843]")
+        self.assertEqual(
+            record[1]["Title"], "erythroid associated factor [Homo sapiens]"
+        )
+        self.assertEqual(
+            record[1]["Extra"], "gi|28628843|gb|AAO49381.1|AF485325_1[28628843]"
+        )
         self.assertEqual(record[1]["Gi"], 28628843)
         self.assertEqual(record[1]["CreateDate"], "2003/03/02")
         self.assertEqual(record[1]["UpdateDate"], "2003/03/02")
@@ -1505,7 +1993,10 @@ class ESummaryTest(unittest.TestCase):
             record = Entrez.read(handle)
         self.assertEqual(record[0]["Id"], "28864546")
         self.assertEqual(record[0]["Caption"], "AY207443")
-        self.assertEqual(record[0]["Title"], "Homo sapiens alpha hemoglobin (HBZP) pseudogene 3' UTR/AluJo repeat breakpoint junction")
+        self.assertEqual(
+            record[0]["Title"],
+            "Homo sapiens alpha hemoglobin (HBZP) pseudogene 3' UTR/AluJo repeat breakpoint junction",
+        )
         self.assertEqual(record[0]["Extra"], "gi|28864546|gb|AY207443.1|[28864546]")
         self.assertEqual(record[0]["Gi"], 28864546)
         self.assertEqual(record[0]["CreateDate"], "2003/03/05")
@@ -1519,7 +2010,9 @@ class ESummaryTest(unittest.TestCase):
 
         self.assertEqual(record[1]["Id"], "28800981")
         self.assertEqual(record[1]["Caption"], "AY205604")
-        self.assertEqual(record[1]["Title"], "Homo sapiens hemochromatosis (HFE) mRNA, partial cds")
+        self.assertEqual(
+            record[1]["Title"], "Homo sapiens hemochromatosis (HFE) mRNA, partial cds"
+        )
         self.assertEqual(record[1]["Extra"], "gi|28800981|gb|AY205604.1|[28800981]")
         self.assertEqual(record[1]["Gi"], 28800981)
         self.assertEqual(record[1]["CreateDate"], "2003/03/03")
@@ -1542,7 +2035,9 @@ class ESummaryTest(unittest.TestCase):
             record = Entrez.read(handle)
         self.assertEqual(record[0]["Id"], "19923")
         self.assertEqual(record[0]["PdbAcc"], "1L5J")
-        self.assertEqual(record[0]["PdbDescr"], "Crystal Structure Of E. Coli Aconitase B")
+        self.assertEqual(
+            record[0]["PdbDescr"], "Crystal Structure Of E. Coli Aconitase B"
+        )
         self.assertEqual(record[0]["EC"], "4.2.1.3")
         self.assertEqual(record[0]["Resolution"], "2.4")
         self.assertEqual(record[0]["ExpMethod"], "X-Ray Diffraction")
@@ -1562,7 +2057,9 @@ class ESummaryTest(unittest.TestCase):
 
         self.assertEqual(record[1]["Id"], "12120")
         self.assertEqual(record[1]["PdbAcc"], "1B0K")
-        self.assertEqual(record[1]["PdbDescr"], "S642a:fluorocitrate Complex Of Aconitase")
+        self.assertEqual(
+            record[1]["PdbDescr"], "S642a:fluorocitrate Complex Of Aconitase"
+        )
         self.assertEqual(record[1]["EC"], "4.2.1.3")
         self.assertEqual(record[1]["Resolution"], "2.5")
         self.assertEqual(record[1]["ExpMethod"], "X-Ray Diffraction")
@@ -1634,7 +2131,9 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(record[0]["Map_Gene_Summary_List"][0]["Org"], "Sus scrofa")
         self.assertEqual(record[0]["Map_Gene_Summary_List"][0]["Chr"], " chromosome 7")
         self.assertEqual(record[0]["Map_Gene_Summary_List"][0]["Locus"], "")
-        self.assertEqual(record[0]["EPCR_Summary"], "Found by e-PCR in sequences from Sus scrofa.")
+        self.assertEqual(
+            record[0]["EPCR_Summary"], "Found by e-PCR in sequences from Sus scrofa."
+        )
         self.assertEqual(record[0]["LocusId"], "")
 
         self.assertEqual(record[1]["Id"], "254086")
@@ -1643,7 +2142,9 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(record[1]["Map_Gene_Summary_List"][0]["Org"], "Sus scrofa")
         self.assertEqual(record[1]["Map_Gene_Summary_List"][0]["Chr"], " chromosome 12")
         self.assertEqual(record[1]["Map_Gene_Summary_List"][0]["Locus"], "")
-        self.assertEqual(record[1]["EPCR_Summary"], "Found by e-PCR in sequences from Sus scrofa.")
+        self.assertEqual(
+            record[1]["EPCR_Summary"], "Found by e-PCR in sequences from Sus scrofa."
+        )
         self.assertEqual(record[1]["LocusId"], "")
 
     def test_wrong(self):
@@ -1714,7 +2215,9 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(record["SynonymList"][35], "EC 202-829-5")
         self.assertEqual(record["SynonymList"][36], "1,4-Dichloroformyl benzene")
         self.assertEqual(record["SynonymList"][37], "SCHEMBL68148")
-        self.assertEqual(record["SynonymList"][38], "4-09-00-03318 (Beilstein Handbook Reference)")
+        self.assertEqual(
+            record["SynonymList"][38], "4-09-00-03318 (Beilstein Handbook Reference)"
+        )
         self.assertEqual(record["SynonymList"][39], "KSC174E9T")
         self.assertEqual(record["SynonymList"][40], "CHEMBL1893301")
         self.assertEqual(record["SynonymList"][41], "DTXSID7026653")
@@ -1732,7 +2235,9 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(record["SynonymList"][53], "FCH1319904")
         self.assertEqual(record["SynonymList"][54], "MCULE-9481285116")
         self.assertEqual(record["SynonymList"][55], "RP25985")
-        self.assertEqual(record["SynonymList"][56], "Terephthaloyl chloride, >=99%, flakes")
+        self.assertEqual(
+            record["SynonymList"][56], "Terephthaloyl chloride, >=99%, flakes"
+        )
         self.assertEqual(record["SynonymList"][57], "NCGC00164045-01")
         self.assertEqual(record["SynonymList"][58], "NCGC00164045-02")
         self.assertEqual(record["SynonymList"][59], "NCGC00257127-01")
@@ -1747,7 +2252,10 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(record["SynonymList"][68], "ST51037908")
         self.assertEqual(record["SynonymList"][69], "6804-EP1441224A2")
         self.assertEqual(record["SynonymList"][70], "I01-5090")
-        self.assertEqual(record["SynonymList"][71], "InChI=1/C8H4Cl2O2/c9-7(11)5-1-2-6(4-3-5)8(10)12/h1-4")
+        self.assertEqual(
+            record["SynonymList"][71],
+            "InChI=1/C8H4Cl2O2/c9-7(11)5-1-2-6(4-3-5)8(10)12/h1-4",
+        )
         self.assertEqual(record["SynonymList"][72], "106158-15-0")
         self.assertEqual(record["SynonymList"][73], "108454-76-8")
         self.assertEqual(record["SynonymList"][74], "1640987-72-9")
@@ -1795,7 +2303,9 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(record["InactiveAidCount"], None)
         self.assertEqual(record["TotalAidCount"], 243)
         self.assertEqual(record["InChIKey"], "LXEJRKJRKIFVNY-UHFFFAOYSA-N")
-        self.assertEqual(record["InChI"], "InChI=1S/C8H4Cl2O2/c9-7(11)5-1-2-6(4-3-5)8(10)12/h1-4H")
+        self.assertEqual(
+            record["InChI"], "InChI=1S/C8H4Cl2O2/c9-7(11)5-1-2-6(4-3-5)8(10)12/h1-4H"
+        )
 
 
 class ELinkTest(unittest.TestCase):
@@ -2678,17 +3188,48 @@ class ELinkTest(unittest.TestCase):
 
         self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["Id"], "10611131")
         self.assertEqual(len(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"]), 1)
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Url"], "http://brain.oxfordjournals.org/cgi/pmidlookup?view=long&pmid=10611131")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["IconUrl"], "//www.ncbi.nlm.nih.gov/corehtml/query/egifs/http:--highwire.stanford.edu-icons-externalservices-pubmed-custom-oxfordjournals_final_free.gif")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["SubjectType"], ["publishers/providers"])
-        self.assertEqual(len(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Attribute"]), 3)
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Attribute"][0], "free resource")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Attribute"][1], "full-text online")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Attribute"][2], "publisher of information in url")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["Name"], "HighWire")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["NameAbbr"], "HighWire")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["Id"], "3051")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["Url"], "http://highwire.stanford.edu")
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Url"],
+            "http://brain.oxfordjournals.org/cgi/pmidlookup?view=long&pmid=10611131",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["IconUrl"],
+            "//www.ncbi.nlm.nih.gov/corehtml/query/egifs/http:--highwire.stanford.edu-icons-externalservices-pubmed-custom-oxfordjournals_final_free.gif",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["SubjectType"],
+            ["publishers/providers"],
+        )
+        self.assertEqual(
+            len(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Attribute"]), 3
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Attribute"][0],
+            "free resource",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Attribute"][1],
+            "full-text online",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Attribute"][2],
+            "publisher of information in url",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["Name"],
+            "HighWire",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["NameAbbr"],
+            "HighWire",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["Id"], "3051"
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["Url"],
+            "http://highwire.stanford.edu",
+        )
 
     def test_pubmed4(self):
         """Test parsing pubmed links returned by ELink (fourth test)."""
@@ -2702,58 +3243,195 @@ class ELinkTest(unittest.TestCase):
         self.assertEqual(len(record[0]["IdUrlList"]), 2)
         self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["Id"], "12085856")
         self.assertEqual(len(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"]), 2)
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Category"], ["Medical"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Url"], "http://www.nlm.nih.gov/medlineplus/coronaryarterybypasssurgery.html")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Attribute"], ["free resource"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["SubjectType"], ["consumer health"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["IconUrl"], "//www.ncbi.nlm.nih.gov/corehtml/query/egifs/http:--www.nlm.nih.gov-medlineplus-images-linkout_sm.gif")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["Name"], "MedlinePlus Health Information")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["NameAbbr"], "MEDPLUS")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["Id"], "3162")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["Url"], "http://medlineplus.gov/")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["IconUrl"], "http://www.nlm.nih.gov/medlineplus/images/linkout_sm.gif")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["LinkName"], "Coronary Artery Bypass Surgery")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Category"], ["Education"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Attribute"], ["free resource"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["SubjectType"], ["online tutorials/courses"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Url"], "http://symptomresearch.nih.gov/chapter_1/index.htm")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Provider"]["Name"], "New England Research Institutes Inc.")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Provider"]["NameAbbr"], "NERI")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Provider"]["Id"], "3291")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Provider"]["Url"], "http://www.symptomresearch.com")
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Category"], ["Medical"]
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Url"],
+            "http://www.nlm.nih.gov/medlineplus/coronaryarterybypasssurgery.html",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Attribute"],
+            ["free resource"],
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["SubjectType"],
+            ["consumer health"],
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["IconUrl"],
+            "//www.ncbi.nlm.nih.gov/corehtml/query/egifs/http:--www.nlm.nih.gov-medlineplus-images-linkout_sm.gif",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["Name"],
+            "MedlinePlus Health Information",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["NameAbbr"],
+            "MEDPLUS",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["Id"], "3162"
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["Url"],
+            "http://medlineplus.gov/",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["Provider"]["IconUrl"],
+            "http://www.nlm.nih.gov/medlineplus/images/linkout_sm.gif",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][0]["LinkName"],
+            "Coronary Artery Bypass Surgery",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Category"],
+            ["Education"],
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Attribute"],
+            ["free resource"],
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["SubjectType"],
+            ["online tutorials/courses"],
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Url"],
+            "http://symptomresearch.nih.gov/chapter_1/index.htm",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Provider"]["Name"],
+            "New England Research Institutes Inc.",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Provider"]["NameAbbr"],
+            "NERI",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Provider"]["Id"], "3291"
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][0]["ObjUrl"][1]["Provider"]["Url"],
+            "http://www.symptomresearch.com",
+        )
         self.assertEqual(len(record[0]["IdUrlList"]["IdUrlSet"][1]), 2)
         self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["Id"], "12085853")
         self.assertEqual(len(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"]), 3)
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Category"], ["Medical"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Url"], "http://www.nlm.nih.gov/medlineplus/arrhythmia.html")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["IconUrl"], "//www.ncbi.nlm.nih.gov/corehtml/query/egifs/http:--www.nlm.nih.gov-medlineplus-images-linkout_sm.gif")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Attribute"], ["free resource"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["SubjectType"], ["consumer health"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["LinkName"], "Arrhythmia")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Provider"]["Name"], "MedlinePlus Health Information")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Provider"]["NameAbbr"], "MEDPLUS")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Provider"]["Id"], "3162")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Provider"]["Url"], "http://medlineplus.gov/")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Category"], ["Medical"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Attribute"], ["free resource"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Url"], "http://www.nlm.nih.gov/medlineplus/exerciseandphysicalfitness.html")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["IconUrl"], "//www.ncbi.nlm.nih.gov/corehtml/query/egifs/http:--www.nlm.nih.gov-medlineplus-images-linkout_sm.gif")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["LinkName"], "Exercise and Physical Fitness")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["SubjectType"], ["consumer health"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Provider"]["Name"], "MedlinePlus Health Information")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Provider"]["NameAbbr"], "MEDPLUS")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Provider"]["Id"], "3162")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Provider"]["Url"], "http://medlineplus.gov/")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Category"], ["Medical"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Attribute"], ["free resource"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Url"], "http://www.nlm.nih.gov/medlineplus/pacemakersandimplantabledefibrillators.html")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["IconUrl"], "//www.ncbi.nlm.nih.gov/corehtml/query/egifs/http:--www.nlm.nih.gov-medlineplus-images-linkout_sm.gif")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["LinkName"], "Pacemakers and Implantable Defibrillators")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["SubjectType"], ["consumer health"])
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Provider"]["Name"], "MedlinePlus Health Information")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Provider"]["NameAbbr"], "MEDPLUS")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Provider"]["Id"], "3162")
-        self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Provider"]["Url"], "http://medlineplus.gov/")
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Category"], ["Medical"]
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Url"],
+            "http://www.nlm.nih.gov/medlineplus/arrhythmia.html",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["IconUrl"],
+            "//www.ncbi.nlm.nih.gov/corehtml/query/egifs/http:--www.nlm.nih.gov-medlineplus-images-linkout_sm.gif",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Attribute"],
+            ["free resource"],
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["SubjectType"],
+            ["consumer health"],
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["LinkName"], "Arrhythmia"
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Provider"]["Name"],
+            "MedlinePlus Health Information",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Provider"]["NameAbbr"],
+            "MEDPLUS",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Provider"]["Id"], "3162"
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][0]["Provider"]["Url"],
+            "http://medlineplus.gov/",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Category"], ["Medical"]
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Attribute"],
+            ["free resource"],
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Url"],
+            "http://www.nlm.nih.gov/medlineplus/exerciseandphysicalfitness.html",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["IconUrl"],
+            "//www.ncbi.nlm.nih.gov/corehtml/query/egifs/http:--www.nlm.nih.gov-medlineplus-images-linkout_sm.gif",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["LinkName"],
+            "Exercise and Physical Fitness",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["SubjectType"],
+            ["consumer health"],
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Provider"]["Name"],
+            "MedlinePlus Health Information",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Provider"]["NameAbbr"],
+            "MEDPLUS",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Provider"]["Id"], "3162"
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][1]["Provider"]["Url"],
+            "http://medlineplus.gov/",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Category"], ["Medical"]
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Attribute"],
+            ["free resource"],
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Url"],
+            "http://www.nlm.nih.gov/medlineplus/pacemakersandimplantabledefibrillators.html",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["IconUrl"],
+            "//www.ncbi.nlm.nih.gov/corehtml/query/egifs/http:--www.nlm.nih.gov-medlineplus-images-linkout_sm.gif",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["LinkName"],
+            "Pacemakers and Implantable Defibrillators",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["SubjectType"],
+            ["consumer health"],
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Provider"]["Name"],
+            "MedlinePlus Health Information",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Provider"]["NameAbbr"],
+            "MEDPLUS",
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Provider"]["Id"], "3162"
+        )
+        self.assertEqual(
+            record[0]["IdUrlList"]["IdUrlSet"][1]["ObjUrl"][2]["Provider"]["Url"],
+            "http://medlineplus.gov/",
+        )
 
     def test_pubmed5(self):
         """Test parsing pubmed links returned by ELink (fifth test)."""
@@ -2768,212 +3446,724 @@ class ELinkTest(unittest.TestCase):
         self.assertEqual(len(record[0]["IdCheckList"]), 2)
         self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["Id"], "12169658")
         self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"]), 19)
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][0]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][0]["DbTo"], "biosystems")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][0]["LinkName"], "pubmed_biosystems")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][0]["MenuTag"], "BioSystem Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][0]["HtmlTag"], "BioSystems")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][0]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][1]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][1]["DbTo"], "books")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][1]["LinkName"], "pubmed_books_refs")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][1]["MenuTag"], "Cited in Books")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][1]["HtmlTag"], "Cited in Books")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][1]["Priority"], "185")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][2]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][2]["DbTo"], "cdd")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][2]["LinkName"], "pubmed_cdd")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][2]["MenuTag"], "Domain Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][2]["HtmlTag"], "Domains")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][2]["Priority"], "130")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][3]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][3]["DbTo"], "gene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][3]["LinkName"], "pubmed_gene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][3]["MenuTag"], "Gene Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][3]["HtmlTag"], "Gene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][3]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][4]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][4]["DbTo"], "geoprofiles")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][4]["LinkName"], "pubmed_geoprofiles")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][4]["MenuTag"], "GEO Profile Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][4]["HtmlTag"], "GEO Profiles")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][4]["Priority"], "170")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][5]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][5]["DbTo"], "homologene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][5]["LinkName"], "pubmed_homologene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][5]["MenuTag"], "HomoloGene Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][5]["HtmlTag"], "HomoloGene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][5]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][6]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][6]["DbTo"], "medgen")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][6]["LinkName"], "pubmed_medgen")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][6]["MenuTag"], "MedGen")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][6]["HtmlTag"], "MedGen")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][6]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][7]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][7]["DbTo"], "nuccore")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][7]["LinkName"], "pubmed_nuccore")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][7]["MenuTag"], "Nucleotide Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][7]["HtmlTag"], "Nucleotide")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][7]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][8]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][8]["DbTo"], "nuccore")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][8]["LinkName"], "pubmed_nuccore_refseq")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][8]["MenuTag"], "Nucleotide (RefSeq) Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][8]["HtmlTag"], "Nucleotide (RefSeq)")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][8]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][9]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][9]["DbTo"], "nuccore")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][9]["LinkName"], "pubmed_nuccore_weighted")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][9]["MenuTag"], "Nucleotide (Weighted) Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][9]["HtmlTag"], "Nucleotide (Weighted)")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][9]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][10]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][10]["DbTo"], "pcsubstance")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][10]["LinkName"], "pubmed_pcsubstance_mesh")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][10]["MenuTag"], "Substance (MeSH Keyword)")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][10]["HtmlTag"], "Substance (MeSH Keyword)")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][10]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][11]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][11]["DbTo"], "pmc")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][11]["LinkName"], "pubmed_pmc_refs")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][11]["MenuTag"], "Cited in PMC")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][11]["HtmlTag"], "Cited in PMC")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][11]["Priority"], "180")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][12]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][12]["DbTo"], "protein")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][12]["LinkName"], "pubmed_protein")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][12]["MenuTag"], "Protein Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][12]["HtmlTag"], "Protein")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][12]["Priority"], "140")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][13]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][13]["DbTo"], "protein")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][13]["LinkName"], "pubmed_protein_refseq")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][13]["MenuTag"], "Protein (RefSeq) Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][13]["HtmlTag"], "Protein (RefSeq)")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][13]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][14]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][14]["DbTo"], "protein")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][14]["LinkName"], "pubmed_protein_weighted")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][14]["MenuTag"], "Protein (Weighted) Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][14]["HtmlTag"], "Protein (Weighted)")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][14]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][15]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][15]["DbTo"], "pubmed")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][15]["LinkName"], "pubmed_pubmed")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][15]["MenuTag"], "Related Citations")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][15]["HtmlTag"], "Related Citations")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][15]["Priority"], "1")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][16]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][16]["DbTo"], "taxonomy")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][16]["LinkName"], "pubmed_taxonomy_entrez")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][16]["MenuTag"], "Taxonomy via GenBank")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][16]["HtmlTag"], "Taxonomy via GenBank")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][16]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][17]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][17]["DbTo"], "unigene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][17]["LinkName"], "pubmed_unigene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][17]["MenuTag"], "UniGene Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][17]["HtmlTag"], "UniGene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][17]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][18]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][18]["DbTo"], "LinkOut")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][18]["LinkName"], "ExternalLink")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][18]["MenuTag"], "LinkOut")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][18]["HtmlTag"], "LinkOut")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][18]["Priority"], "255")
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][0]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][0]["DbTo"],
+            "biosystems",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][0]["LinkName"],
+            "pubmed_biosystems",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][0]["MenuTag"],
+            "BioSystem Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][0]["HtmlTag"],
+            "BioSystems",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][0]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][1]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][1]["DbTo"], "books"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][1]["LinkName"],
+            "pubmed_books_refs",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][1]["MenuTag"],
+            "Cited in Books",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][1]["HtmlTag"],
+            "Cited in Books",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][1]["Priority"], "185"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][2]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][2]["DbTo"], "cdd"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][2]["LinkName"],
+            "pubmed_cdd",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][2]["MenuTag"],
+            "Domain Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][2]["HtmlTag"],
+            "Domains",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][2]["Priority"], "130"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][3]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][3]["DbTo"], "gene"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][3]["LinkName"],
+            "pubmed_gene",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][3]["MenuTag"],
+            "Gene Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][3]["HtmlTag"], "Gene"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][3]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][4]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][4]["DbTo"],
+            "geoprofiles",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][4]["LinkName"],
+            "pubmed_geoprofiles",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][4]["MenuTag"],
+            "GEO Profile Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][4]["HtmlTag"],
+            "GEO Profiles",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][4]["Priority"], "170"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][5]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][5]["DbTo"],
+            "homologene",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][5]["LinkName"],
+            "pubmed_homologene",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][5]["MenuTag"],
+            "HomoloGene Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][5]["HtmlTag"],
+            "HomoloGene",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][5]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][6]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][6]["DbTo"], "medgen"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][6]["LinkName"],
+            "pubmed_medgen",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][6]["MenuTag"], "MedGen"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][6]["HtmlTag"], "MedGen"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][6]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][7]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][7]["DbTo"], "nuccore"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][7]["LinkName"],
+            "pubmed_nuccore",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][7]["MenuTag"],
+            "Nucleotide Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][7]["HtmlTag"],
+            "Nucleotide",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][7]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][8]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][8]["DbTo"], "nuccore"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][8]["LinkName"],
+            "pubmed_nuccore_refseq",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][8]["MenuTag"],
+            "Nucleotide (RefSeq) Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][8]["HtmlTag"],
+            "Nucleotide (RefSeq)",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][8]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][9]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][9]["DbTo"], "nuccore"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][9]["LinkName"],
+            "pubmed_nuccore_weighted",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][9]["MenuTag"],
+            "Nucleotide (Weighted) Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][9]["HtmlTag"],
+            "Nucleotide (Weighted)",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][9]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][10]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][10]["DbTo"],
+            "pcsubstance",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][10]["LinkName"],
+            "pubmed_pcsubstance_mesh",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][10]["MenuTag"],
+            "Substance (MeSH Keyword)",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][10]["HtmlTag"],
+            "Substance (MeSH Keyword)",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][10]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][11]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][11]["DbTo"], "pmc"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][11]["LinkName"],
+            "pubmed_pmc_refs",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][11]["MenuTag"],
+            "Cited in PMC",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][11]["HtmlTag"],
+            "Cited in PMC",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][11]["Priority"], "180"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][12]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][12]["DbTo"], "protein"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][12]["LinkName"],
+            "pubmed_protein",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][12]["MenuTag"],
+            "Protein Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][12]["HtmlTag"],
+            "Protein",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][12]["Priority"], "140"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][13]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][13]["DbTo"], "protein"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][13]["LinkName"],
+            "pubmed_protein_refseq",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][13]["MenuTag"],
+            "Protein (RefSeq) Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][13]["HtmlTag"],
+            "Protein (RefSeq)",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][13]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][14]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][14]["DbTo"], "protein"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][14]["LinkName"],
+            "pubmed_protein_weighted",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][14]["MenuTag"],
+            "Protein (Weighted) Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][14]["HtmlTag"],
+            "Protein (Weighted)",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][14]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][15]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][15]["DbTo"], "pubmed"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][15]["LinkName"],
+            "pubmed_pubmed",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][15]["MenuTag"],
+            "Related Citations",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][15]["HtmlTag"],
+            "Related Citations",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][15]["Priority"], "1"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][16]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][16]["DbTo"], "taxonomy"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][16]["LinkName"],
+            "pubmed_taxonomy_entrez",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][16]["MenuTag"],
+            "Taxonomy via GenBank",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][16]["HtmlTag"],
+            "Taxonomy via GenBank",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][16]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][17]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][17]["DbTo"], "unigene"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][17]["LinkName"],
+            "pubmed_unigene",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][17]["MenuTag"],
+            "UniGene Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][17]["HtmlTag"],
+            "UniGene",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][17]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][18]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][18]["DbTo"], "LinkOut"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][18]["LinkName"],
+            "ExternalLink",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][18]["MenuTag"],
+            "LinkOut",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][18]["HtmlTag"],
+            "LinkOut",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][0]["LinkInfo"][18]["Priority"], "255"
+        )
         self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["Id"], "11748140")
         self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"]), 15)
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][0]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][0]["DbTo"], "biosystems")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][0]["LinkName"], "pubmed_biosystems")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][0]["MenuTag"], "BioSystem Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][0]["HtmlTag"], "BioSystems")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][0]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][1]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][1]["DbTo"], "books")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][1]["LinkName"], "pubmed_books_refs")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][1]["MenuTag"], "Cited in Books")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][1]["HtmlTag"], "Cited in Books")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][1]["Priority"], "185")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][2]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][2]["DbTo"], "gene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][2]["LinkName"], "pubmed_gene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][2]["MenuTag"], "Gene Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][2]["HtmlTag"], "Gene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][2]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][3]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][3]["DbTo"], "geoprofiles")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][3]["LinkName"], "pubmed_geoprofiles")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][3]["MenuTag"], "GEO Profile Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][3]["HtmlTag"], "GEO Profiles")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][3]["Priority"], "170")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][4]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][4]["DbTo"], "nuccore")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][4]["LinkName"], "pubmed_nuccore")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][4]["MenuTag"], "Nucleotide Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][4]["HtmlTag"], "Nucleotide")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][4]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][5]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][5]["DbTo"], "nuccore")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][5]["LinkName"], "pubmed_nuccore_refseq")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][5]["MenuTag"], "Nucleotide (RefSeq) Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][5]["HtmlTag"], "Nucleotide (RefSeq)")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][5]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][6]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][6]["DbTo"], "nuccore")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][6]["LinkName"], "pubmed_nuccore_weighted")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][6]["MenuTag"], "Nucleotide (Weighted) Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][6]["HtmlTag"], "Nucleotide (Weighted)")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][6]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][7]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][7]["DbTo"], "pmc")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][7]["LinkName"], "pubmed_pmc_refs")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][7]["MenuTag"], "Cited in PMC")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][7]["HtmlTag"], "Cited in PMC")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][7]["Priority"], "180")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][8]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][8]["DbTo"], "protein")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][8]["LinkName"], "pubmed_protein")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][8]["MenuTag"], "Protein Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][8]["HtmlTag"], "Protein")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][8]["Priority"], "140")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][9]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][9]["DbTo"], "protein")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][9]["LinkName"], "pubmed_protein_refseq")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][9]["MenuTag"], "Protein (RefSeq) Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][9]["HtmlTag"], "Protein (RefSeq)")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][9]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][10]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][10]["DbTo"], "protein")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][10]["LinkName"], "pubmed_protein_weighted")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][10]["MenuTag"], "Protein (Weighted) Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][10]["HtmlTag"], "Protein (Weighted)")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][10]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][11]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][11]["DbTo"], "pubmed")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][11]["LinkName"], "pubmed_pubmed")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][11]["MenuTag"], "Related Citations")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][11]["HtmlTag"], "Related Citations")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][11]["Priority"], "1")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][12]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][12]["DbTo"], "taxonomy")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][12]["LinkName"], "pubmed_taxonomy_entrez")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][12]["MenuTag"], "Taxonomy via GenBank")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][12]["HtmlTag"], "Taxonomy via GenBank")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][12]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][13]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][13]["DbTo"], "unigene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][13]["LinkName"], "pubmed_unigene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][13]["MenuTag"], "UniGene Links")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][13]["HtmlTag"], "UniGene")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][13]["Priority"], "128")
-        self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][14]), 5)
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][14]["DbTo"], "LinkOut")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][14]["LinkName"], "ExternalLink")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][14]["MenuTag"], "LinkOut")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][14]["HtmlTag"], "LinkOut")
-        self.assertEqual(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][14]["Priority"], "255")
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][0]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][0]["DbTo"],
+            "biosystems",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][0]["LinkName"],
+            "pubmed_biosystems",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][0]["MenuTag"],
+            "BioSystem Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][0]["HtmlTag"],
+            "BioSystems",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][0]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][1]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][1]["DbTo"], "books"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][1]["LinkName"],
+            "pubmed_books_refs",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][1]["MenuTag"],
+            "Cited in Books",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][1]["HtmlTag"],
+            "Cited in Books",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][1]["Priority"], "185"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][2]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][2]["DbTo"], "gene"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][2]["LinkName"],
+            "pubmed_gene",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][2]["MenuTag"],
+            "Gene Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][2]["HtmlTag"], "Gene"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][2]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][3]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][3]["DbTo"],
+            "geoprofiles",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][3]["LinkName"],
+            "pubmed_geoprofiles",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][3]["MenuTag"],
+            "GEO Profile Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][3]["HtmlTag"],
+            "GEO Profiles",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][3]["Priority"], "170"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][4]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][4]["DbTo"], "nuccore"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][4]["LinkName"],
+            "pubmed_nuccore",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][4]["MenuTag"],
+            "Nucleotide Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][4]["HtmlTag"],
+            "Nucleotide",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][4]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][5]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][5]["DbTo"], "nuccore"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][5]["LinkName"],
+            "pubmed_nuccore_refseq",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][5]["MenuTag"],
+            "Nucleotide (RefSeq) Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][5]["HtmlTag"],
+            "Nucleotide (RefSeq)",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][5]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][6]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][6]["DbTo"], "nuccore"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][6]["LinkName"],
+            "pubmed_nuccore_weighted",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][6]["MenuTag"],
+            "Nucleotide (Weighted) Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][6]["HtmlTag"],
+            "Nucleotide (Weighted)",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][6]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][7]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][7]["DbTo"], "pmc"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][7]["LinkName"],
+            "pubmed_pmc_refs",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][7]["MenuTag"],
+            "Cited in PMC",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][7]["HtmlTag"],
+            "Cited in PMC",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][7]["Priority"], "180"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][8]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][8]["DbTo"], "protein"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][8]["LinkName"],
+            "pubmed_protein",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][8]["MenuTag"],
+            "Protein Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][8]["HtmlTag"],
+            "Protein",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][8]["Priority"], "140"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][9]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][9]["DbTo"], "protein"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][9]["LinkName"],
+            "pubmed_protein_refseq",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][9]["MenuTag"],
+            "Protein (RefSeq) Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][9]["HtmlTag"],
+            "Protein (RefSeq)",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][9]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][10]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][10]["DbTo"], "protein"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][10]["LinkName"],
+            "pubmed_protein_weighted",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][10]["MenuTag"],
+            "Protein (Weighted) Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][10]["HtmlTag"],
+            "Protein (Weighted)",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][10]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][11]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][11]["DbTo"], "pubmed"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][11]["LinkName"],
+            "pubmed_pubmed",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][11]["MenuTag"],
+            "Related Citations",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][11]["HtmlTag"],
+            "Related Citations",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][11]["Priority"], "1"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][12]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][12]["DbTo"], "taxonomy"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][12]["LinkName"],
+            "pubmed_taxonomy_entrez",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][12]["MenuTag"],
+            "Taxonomy via GenBank",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][12]["HtmlTag"],
+            "Taxonomy via GenBank",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][12]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][13]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][13]["DbTo"], "unigene"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][13]["LinkName"],
+            "pubmed_unigene",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][13]["MenuTag"],
+            "UniGene Links",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][13]["HtmlTag"],
+            "UniGene",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][13]["Priority"], "128"
+        )
+        self.assertEqual(
+            len(record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][14]), 5
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][14]["DbTo"], "LinkOut"
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][14]["LinkName"],
+            "ExternalLink",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][14]["MenuTag"],
+            "LinkOut",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][14]["HtmlTag"],
+            "LinkOut",
+        )
+        self.assertEqual(
+            record[0]["IdCheckList"]["IdLinkSet"][1]["LinkInfo"][14]["Priority"], "255"
+        )
 
     def test_pubmed6(self):
         """Test parsing pubmed links returned by ELink (sixth test)."""
@@ -2990,7 +4180,9 @@ class ELinkTest(unittest.TestCase):
         self.assertEqual(len(record[0]["IdCheckList"]["Id"]), 1)
         self.assertEqual(record[0]["IdCheckList"]["Id"][0], "12068369")
         self.assertEqual(len(record[0]["IdCheckList"]["Id"][0].attributes), 1)
-        self.assertEqual(record[0]["IdCheckList"]["Id"][0].attributes["HasNeighbor"], "Y")
+        self.assertEqual(
+            record[0]["IdCheckList"]["Id"][0].attributes["HasNeighbor"], "Y"
+        )
         self.assertEqual(len(record[0]["IdCheckList"]["IdLinkSet"]), 0)
 
 
@@ -3016,11 +4208,15 @@ class EGQueryTest(unittest.TestCase):
         self.assertEqual(record["eGQueryResult"][2]["DbName"], "journals")
         self.assertEqual(record["eGQueryResult"][2]["MenuName"], "Journals")
         self.assertEqual(record["eGQueryResult"][2]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][2]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][2]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][3]["DbName"], "mesh")
         self.assertEqual(record["eGQueryResult"][3]["MenuName"], "MeSH")
         self.assertEqual(record["eGQueryResult"][3]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][3]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][3]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][4]["DbName"], "books")
         self.assertEqual(record["eGQueryResult"][4]["MenuName"], "Books")
         self.assertEqual(record["eGQueryResult"][4]["Count"], "10")
@@ -3028,99 +4224,147 @@ class EGQueryTest(unittest.TestCase):
         self.assertEqual(record["eGQueryResult"][5]["DbName"], "omim")
         self.assertEqual(record["eGQueryResult"][5]["MenuName"], "OMIM")
         self.assertEqual(record["eGQueryResult"][5]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][5]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][5]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][6]["DbName"], "omia")
         self.assertEqual(record["eGQueryResult"][6]["MenuName"], "OMIA")
         self.assertEqual(record["eGQueryResult"][6]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][6]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][6]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][7]["DbName"], "ncbisearch")
         self.assertEqual(record["eGQueryResult"][7]["MenuName"], "NCBI Web Site")
         self.assertEqual(record["eGQueryResult"][7]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][7]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][7]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][8]["DbName"], "nuccore")
         self.assertEqual(record["eGQueryResult"][8]["MenuName"], "CoreNucleotide")
         self.assertEqual(record["eGQueryResult"][8]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][8]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][8]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][9]["DbName"], "nucgss")
         self.assertEqual(record["eGQueryResult"][9]["MenuName"], "GSS")
         self.assertEqual(record["eGQueryResult"][9]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][9]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][9]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][10]["DbName"], "nucest")
         self.assertEqual(record["eGQueryResult"][10]["MenuName"], "EST")
         self.assertEqual(record["eGQueryResult"][10]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][10]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][10]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][11]["DbName"], "protein")
         self.assertEqual(record["eGQueryResult"][11]["MenuName"], "Protein")
         self.assertEqual(record["eGQueryResult"][11]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][11]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][11]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][12]["DbName"], "genome")
         self.assertEqual(record["eGQueryResult"][12]["MenuName"], "Genome")
         self.assertEqual(record["eGQueryResult"][12]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][12]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][12]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][13]["DbName"], "structure")
         self.assertEqual(record["eGQueryResult"][13]["MenuName"], "Structure")
         self.assertEqual(record["eGQueryResult"][13]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][13]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][13]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][14]["DbName"], "taxonomy")
         self.assertEqual(record["eGQueryResult"][14]["MenuName"], "Taxonomy")
         self.assertEqual(record["eGQueryResult"][14]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][14]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][14]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][15]["DbName"], "snp")
         self.assertEqual(record["eGQueryResult"][15]["MenuName"], "SNP")
         self.assertEqual(record["eGQueryResult"][15]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][15]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][15]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][16]["DbName"], "gene")
         self.assertEqual(record["eGQueryResult"][16]["MenuName"], "Gene")
         self.assertEqual(record["eGQueryResult"][16]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][16]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][16]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][17]["DbName"], "unigene")
         self.assertEqual(record["eGQueryResult"][17]["MenuName"], "UniGene")
         self.assertEqual(record["eGQueryResult"][17]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][17]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][17]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][18]["DbName"], "cdd")
         self.assertEqual(record["eGQueryResult"][18]["MenuName"], "Conserved Domains")
         self.assertEqual(record["eGQueryResult"][18]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][18]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][18]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][19]["DbName"], "domains")
         self.assertEqual(record["eGQueryResult"][19]["MenuName"], "3D Domains")
         self.assertEqual(record["eGQueryResult"][19]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][19]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][19]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][20]["DbName"], "unists")
         self.assertEqual(record["eGQueryResult"][20]["MenuName"], "UniSTS")
         self.assertEqual(record["eGQueryResult"][20]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][20]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][20]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][21]["DbName"], "popset")
         self.assertEqual(record["eGQueryResult"][21]["MenuName"], "PopSet")
         self.assertEqual(record["eGQueryResult"][21]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][21]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][21]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][22]["DbName"], "geo")
         self.assertEqual(record["eGQueryResult"][22]["MenuName"], "GEO Profiles")
         self.assertEqual(record["eGQueryResult"][22]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][22]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][22]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][23]["DbName"], "gds")
         self.assertEqual(record["eGQueryResult"][23]["MenuName"], "GEO DataSets")
         self.assertEqual(record["eGQueryResult"][23]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][23]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][23]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][24]["DbName"], "homologene")
         self.assertEqual(record["eGQueryResult"][24]["MenuName"], "HomoloGene")
         self.assertEqual(record["eGQueryResult"][24]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][24]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][24]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][25]["DbName"], "cancerchromosomes")
         self.assertEqual(record["eGQueryResult"][25]["MenuName"], "CancerChromosomes")
         self.assertEqual(record["eGQueryResult"][25]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][25]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][25]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][26]["DbName"], "pccompound")
         self.assertEqual(record["eGQueryResult"][26]["MenuName"], "PubChem Compound")
         self.assertEqual(record["eGQueryResult"][26]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][26]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][26]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][27]["DbName"], "pcsubstance")
         self.assertEqual(record["eGQueryResult"][27]["MenuName"], "PubChem Substance")
         self.assertEqual(record["eGQueryResult"][27]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][27]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][27]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][28]["DbName"], "pcassay")
         self.assertEqual(record["eGQueryResult"][28]["MenuName"], "PubChem BioAssay")
         self.assertEqual(record["eGQueryResult"][28]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][28]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][28]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][29]["DbName"], "nlmcatalog")
         self.assertEqual(record["eGQueryResult"][29]["MenuName"], "NLM Catalog")
         self.assertEqual(record["eGQueryResult"][29]["Count"], "2")
@@ -3128,23 +4372,33 @@ class EGQueryTest(unittest.TestCase):
         self.assertEqual(record["eGQueryResult"][30]["DbName"], "gensat")
         self.assertEqual(record["eGQueryResult"][30]["MenuName"], "GENSAT")
         self.assertEqual(record["eGQueryResult"][30]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][30]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][30]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][31]["DbName"], "probe")
         self.assertEqual(record["eGQueryResult"][31]["MenuName"], "Probe")
         self.assertEqual(record["eGQueryResult"][31]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][31]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][31]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][32]["DbName"], "genomeprj")
         self.assertEqual(record["eGQueryResult"][32]["MenuName"], "Genome Project")
         self.assertEqual(record["eGQueryResult"][32]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][32]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][32]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][33]["DbName"], "gap")
         self.assertEqual(record["eGQueryResult"][33]["MenuName"], "dbGaP")
         self.assertEqual(record["eGQueryResult"][33]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][33]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][33]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][34]["DbName"], "proteinclusters")
         self.assertEqual(record["eGQueryResult"][34]["MenuName"], "Protein Clusters")
         self.assertEqual(record["eGQueryResult"][34]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][34]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][34]["Status"], "Term or Database is not found"
+        )
 
     def test_egquery2(self):
         """Test parsing XML output returned by EGQuery (second test)."""
@@ -3157,7 +4411,9 @@ class EGQueryTest(unittest.TestCase):
         self.assertEqual(record["eGQueryResult"][0]["DbName"], "pubmed")
         self.assertEqual(record["eGQueryResult"][0]["MenuName"], "PubMed")
         self.assertEqual(record["eGQueryResult"][0]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][0]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][0]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][1]["DbName"], "pmc")
         self.assertEqual(record["eGQueryResult"][1]["MenuName"], "PMC")
         self.assertEqual(record["eGQueryResult"][1]["Count"], "2739")
@@ -3165,7 +4421,9 @@ class EGQueryTest(unittest.TestCase):
         self.assertEqual(record["eGQueryResult"][2]["DbName"], "journals")
         self.assertEqual(record["eGQueryResult"][2]["MenuName"], "Journals")
         self.assertEqual(record["eGQueryResult"][2]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][2]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][2]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][3]["DbName"], "mesh")
         self.assertEqual(record["eGQueryResult"][3]["MenuName"], "MeSH")
         self.assertEqual(record["eGQueryResult"][3]["Count"], "29")
@@ -3181,7 +4439,9 @@ class EGQueryTest(unittest.TestCase):
         self.assertEqual(record["eGQueryResult"][6]["DbName"], "omia")
         self.assertEqual(record["eGQueryResult"][6]["MenuName"], "OMIA")
         self.assertEqual(record["eGQueryResult"][6]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][6]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][6]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][7]["DbName"], "ncbisearch")
         self.assertEqual(record["eGQueryResult"][7]["MenuName"], "NCBI Web Site")
         self.assertEqual(record["eGQueryResult"][7]["Count"], "13")
@@ -3213,7 +4473,9 @@ class EGQueryTest(unittest.TestCase):
         self.assertEqual(record["eGQueryResult"][14]["DbName"], "taxonomy")
         self.assertEqual(record["eGQueryResult"][14]["MenuName"], "Taxonomy")
         self.assertEqual(record["eGQueryResult"][14]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][14]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][14]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][15]["DbName"], "snp")
         self.assertEqual(record["eGQueryResult"][15]["MenuName"], "SNP")
         self.assertEqual(record["eGQueryResult"][15]["Count"], "2013")
@@ -3261,7 +4523,9 @@ class EGQueryTest(unittest.TestCase):
         self.assertEqual(record["eGQueryResult"][26]["DbName"], "pccompound")
         self.assertEqual(record["eGQueryResult"][26]["MenuName"], "PubChem Compound")
         self.assertEqual(record["eGQueryResult"][26]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][26]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][26]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][27]["DbName"], "pcsubstance")
         self.assertEqual(record["eGQueryResult"][27]["MenuName"], "PubChem Substance")
         self.assertEqual(record["eGQueryResult"][27]["Count"], "26")
@@ -3269,7 +4533,9 @@ class EGQueryTest(unittest.TestCase):
         self.assertEqual(record["eGQueryResult"][28]["DbName"], "pcassay")
         self.assertEqual(record["eGQueryResult"][28]["MenuName"], "PubChem BioAssay")
         self.assertEqual(record["eGQueryResult"][28]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][28]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][28]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][29]["DbName"], "nlmcatalog")
         self.assertEqual(record["eGQueryResult"][29]["MenuName"], "NLM Catalog")
         self.assertEqual(record["eGQueryResult"][29]["Count"], "31")
@@ -3277,7 +4543,9 @@ class EGQueryTest(unittest.TestCase):
         self.assertEqual(record["eGQueryResult"][30]["DbName"], "gensat")
         self.assertEqual(record["eGQueryResult"][30]["MenuName"], "GENSAT")
         self.assertEqual(record["eGQueryResult"][30]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][30]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][30]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][31]["DbName"], "probe")
         self.assertEqual(record["eGQueryResult"][31]["MenuName"], "Probe")
         self.assertEqual(record["eGQueryResult"][31]["Count"], "1410")
@@ -3285,15 +4553,21 @@ class EGQueryTest(unittest.TestCase):
         self.assertEqual(record["eGQueryResult"][32]["DbName"], "genomeprj")
         self.assertEqual(record["eGQueryResult"][32]["MenuName"], "Genome Project")
         self.assertEqual(record["eGQueryResult"][32]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][32]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][32]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][33]["DbName"], "gap")
         self.assertEqual(record["eGQueryResult"][33]["MenuName"], "dbGaP")
         self.assertEqual(record["eGQueryResult"][33]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][33]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][33]["Status"], "Term or Database is not found"
+        )
         self.assertEqual(record["eGQueryResult"][34]["DbName"], "proteinclusters")
         self.assertEqual(record["eGQueryResult"][34]["MenuName"], "Protein Clusters")
         self.assertEqual(record["eGQueryResult"][34]["Count"], "0")
-        self.assertEqual(record["eGQueryResult"][34]["Status"], "Term or Database is not found")
+        self.assertEqual(
+            record["eGQueryResult"][34]["Status"], "Term or Database is not found"
+        )
 
 
 class ESpellTest(unittest.TestCase):
@@ -3338,87 +4612,341 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(record[0]["MedlineCitation"]["DateRevised"]["Year"], "2007")
         self.assertEqual(record[0]["MedlineCitation"]["DateRevised"]["Month"], "11")
         self.assertEqual(record[0]["MedlineCitation"]["DateRevised"]["Day"], "15")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"].attributes["PubModel"], "Print")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["ISSN"], "1043-1578")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes["IssnType"], "Print")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"].attributes["CitedMedium"], "Print")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Volume"], "17")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Issue"], "1")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Year"], "1990")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Season"], "Spring")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["Title"], "Social justice (San Francisco, Calif.)")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["ArticleTitle"], "The treatment of AIDS behind the walls of correctional facilities.")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Pagination"]["MedlinePgn"], "113-25")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"].attributes["CompleteYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][0].attributes["ValidYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][0]["LastName"], "Olivero")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][0]["ForeName"], "J Michael")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][0]["Initials"], "JM")
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"].attributes["PubModel"], "Print"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["ISSN"], "1043-1578"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes[
+                "IssnType"
+            ],
+            "Print",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"][
+                "JournalIssue"
+            ].attributes["CitedMedium"],
+            "Print",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "Volume"
+            ],
+            "17",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Issue"],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "PubDate"
+            ]["Year"],
+            "1990",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "PubDate"
+            ]["Season"],
+            "Spring",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["Title"],
+            "Social justice (San Francisco, Calif.)",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["ArticleTitle"],
+            "The treatment of AIDS behind the walls of correctional facilities.",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Pagination"]["MedlinePgn"],
+            "113-25",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"].attributes[
+                "CompleteYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][0].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][0]["LastName"],
+            "Olivero",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][0]["ForeName"],
+            "J Michael",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][0]["Initials"], "JM"
+        )
         self.assertEqual(record[0]["MedlineCitation"]["Article"]["Language"], ["eng"])
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["PublicationTypeList"], ["Journal Article", "Review"])
-        self.assertEqual(record[0]["MedlineCitation"]["MedlineJournalInfo"]["Country"], "United States")
-        self.assertEqual(record[0]["MedlineCitation"]["MedlineJournalInfo"]["MedlineTA"], "Soc Justice")
-        self.assertEqual(record[0]["MedlineCitation"]["MedlineJournalInfo"]["NlmUniqueID"], "9891830")
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["PublicationTypeList"],
+            ["Journal Article", "Review"],
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MedlineJournalInfo"]["Country"],
+            "United States",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MedlineJournalInfo"]["MedlineTA"],
+            "Soc Justice",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MedlineJournalInfo"]["NlmUniqueID"], "9891830"
+        )
         self.assertEqual(record[0]["MedlineCitation"]["CitationSubset"], ["E"])
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][0]["DescriptorName"], "AIDS Serodiagnosis")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][0]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][1]["DescriptorName"], "Acquired Immunodeficiency Syndrome")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][1]["DescriptorName"].attributes["MajorTopicYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][2]["DescriptorName"], "Civil Rights")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][2]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][3]["DescriptorName"], "HIV Seropositivity")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][3]["DescriptorName"].attributes["MajorTopicYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][4]["DescriptorName"], "Humans")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][4]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][5]["DescriptorName"], "Jurisprudence")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][5]["DescriptorName"].attributes["MajorTopicYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][6]["DescriptorName"], "Law Enforcement")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][6]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][7]["DescriptorName"], "Mass Screening")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][7]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][8]["DescriptorName"], "Minority Groups")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][8]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][9]["DescriptorName"], "Organizational Policy")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][9]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][10]["DescriptorName"], "Patient Care")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][10]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][11]["DescriptorName"], "Prejudice")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][11]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][12]["DescriptorName"], "Prisoners")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][12]["DescriptorName"].attributes["MajorTopicYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][13]["DescriptorName"], "Public Policy")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][13]["DescriptorName"].attributes["MajorTopicYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][14]["DescriptorName"], "Quarantine")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][14]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][15]["DescriptorName"], "Social Control, Formal")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][15]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][16]["DescriptorName"], "Statistics as Topic")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][16]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][17]["DescriptorName"], "Stereotyping")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][17]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][18]["DescriptorName"], "United States")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][18]["DescriptorName"].attributes["MajorTopicYN"], "N")
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][0]["DescriptorName"],
+            "AIDS Serodiagnosis",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][0][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][1]["DescriptorName"],
+            "Acquired Immunodeficiency Syndrome",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][1][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][2]["DescriptorName"],
+            "Civil Rights",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][2][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][3]["DescriptorName"],
+            "HIV Seropositivity",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][3][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][4]["DescriptorName"],
+            "Humans",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][4][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][5]["DescriptorName"],
+            "Jurisprudence",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][5][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][6]["DescriptorName"],
+            "Law Enforcement",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][6][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][7]["DescriptorName"],
+            "Mass Screening",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][7][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][8]["DescriptorName"],
+            "Minority Groups",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][8][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][9]["DescriptorName"],
+            "Organizational Policy",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][9][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][10]["DescriptorName"],
+            "Patient Care",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][10][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][11]["DescriptorName"],
+            "Prejudice",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][11][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][12]["DescriptorName"],
+            "Prisoners",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][12][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][13]["DescriptorName"],
+            "Public Policy",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][13][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][14]["DescriptorName"],
+            "Quarantine",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][14][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][15]["DescriptorName"],
+            "Social Control, Formal",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][15][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][16]["DescriptorName"],
+            "Statistics as Topic",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][16][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][17]["DescriptorName"],
+            "Stereotyping",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][17][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][18]["DescriptorName"],
+            "United States",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][18][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
         self.assertEqual(record[0]["MedlineCitation"]["NumberOfReferences"], "63")
         self.assertEqual(record[0]["MedlineCitation"]["OtherID"][0], "31840")
-        self.assertEqual(record[0]["MedlineCitation"]["OtherID"][0].attributes["Source"], "KIE")
-        self.assertEqual(record[0]["MedlineCitation"]["KeywordList"][0].attributes["Owner"], "KIE")
-        self.assertEqual(record[0]["MedlineCitation"]["KeywordList"][0][0], "Health Care and Public Health")
-        self.assertEqual(record[0]["MedlineCitation"]["KeywordList"][0][0].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["KeywordList"][0][1], "Legal Approach")
-        self.assertEqual(record[0]["MedlineCitation"]["KeywordList"][0][1].attributes["MajorTopicYN"], "N")
+        self.assertEqual(
+            record[0]["MedlineCitation"]["OtherID"][0].attributes["Source"], "KIE"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["KeywordList"][0].attributes["Owner"], "KIE"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["KeywordList"][0][0],
+            "Health Care and Public Health",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["KeywordList"][0][0].attributes[
+                "MajorTopicYN"
+            ],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["KeywordList"][0][1], "Legal Approach"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["KeywordList"][0][1].attributes[
+                "MajorTopicYN"
+            ],
+            "N",
+        )
         self.assertEqual(record[0]["MedlineCitation"]["GeneralNote"][0], "14 fn.")
-        self.assertEqual(record[0]["MedlineCitation"]["GeneralNote"][0].attributes["Owner"], "KIE")
-        self.assertEqual(record[0]["MedlineCitation"]["GeneralNote"][1], "KIE BoB Subject Heading: AIDS")
-        self.assertEqual(record[0]["MedlineCitation"]["GeneralNote"][1].attributes["Owner"], "KIE")
+        self.assertEqual(
+            record[0]["MedlineCitation"]["GeneralNote"][0].attributes["Owner"], "KIE"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["GeneralNote"][1],
+            "KIE BoB Subject Heading: AIDS",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["GeneralNote"][1].attributes["Owner"], "KIE"
+        )
         self.assertEqual(record[0]["MedlineCitation"]["GeneralNote"][2], "63 refs.")
-        self.assertEqual(record[0]["MedlineCitation"]["GeneralNote"][2].attributes["Owner"], "KIE")
-        self.assertEqual(record[0]["PubmedData"]["History"][0][0].attributes["PubStatus"], "pubmed")
+        self.assertEqual(
+            record[0]["MedlineCitation"]["GeneralNote"][2].attributes["Owner"], "KIE"
+        )
+        self.assertEqual(
+            record[0]["PubmedData"]["History"][0][0].attributes["PubStatus"], "pubmed"
+        )
         self.assertEqual(record[0]["PubmedData"]["History"][0][0]["Year"], "1990")
         self.assertEqual(record[0]["PubmedData"]["History"][0][0]["Month"], "4")
         self.assertEqual(record[0]["PubmedData"]["History"][0][0]["Day"], "1")
         self.assertEqual(record[0]["PubmedData"]["History"][0][0]["Hour"], "0")
         self.assertEqual(record[0]["PubmedData"]["History"][0][0]["Minute"], "0")
-        self.assertEqual(record[0]["PubmedData"]["History"][0][1].attributes["PubStatus"], "medline")
+        self.assertEqual(
+            record[0]["PubmedData"]["History"][0][1].attributes["PubStatus"], "medline"
+        )
         self.assertEqual(record[0]["PubmedData"]["History"][0][1]["Year"], "2002")
         self.assertEqual(record[0]["PubmedData"]["History"][0][1]["Month"], "7")
         self.assertEqual(record[0]["PubmedData"]["History"][0][1]["Day"], "16")
@@ -3427,7 +4955,9 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(record[0]["PubmedData"]["PublicationStatus"], "ppublish")
         self.assertEqual(len(record[0]["PubmedData"]["ArticleIdList"]), 1)
         self.assertEqual(record[0]["PubmedData"]["ArticleIdList"][0], "12091962")
-        self.assertEqual(record[0]["PubmedData"]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            record[0]["PubmedData"]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(record[1]["MedlineCitation"].attributes["Owner"], "NLM")
         self.assertEqual(record[1]["MedlineCitation"].attributes["Status"], "MEDLINE")
         self.assertEqual(record[1]["MedlineCitation"]["PMID"], "9997")
@@ -3440,74 +4970,295 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(record[1]["MedlineCitation"]["DateRevised"]["Year"], "2003")
         self.assertEqual(record[1]["MedlineCitation"]["DateRevised"]["Month"], "11")
         self.assertEqual(record[1]["MedlineCitation"]["DateRevised"]["Day"], "14")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"].attributes["PubModel"], "Print")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["ISSN"], "0006-3002")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes["IssnType"], "Print")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"].attributes["CitedMedium"], "Print")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Volume"], "446")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Issue"], "1")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Year"], "1976")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Month"], "Sep")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Day"], "28")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["Title"], "Biochimica et biophysica acta")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["ISOAbbreviation"], "Biochim. Biophys. Acta")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["ArticleTitle"], "Magnetic studies of Chromatium flavocytochrome C552. A mechanism for heme-flavin interaction.")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Pagination"]["MedlinePgn"], "179-91")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"], "Electron paramagnetic resonance and magnetic susceptibility studies of Chromatium flavocytochrome C552 and its diheme flavin-free subunit at temperatures below 45 degrees K are reported. The results show that in the intact protein and the subunit the two low-spin (S = 1/2) heme irons are distinguishable, giving rise to separate EPR signals. In the intact protein only, one of the heme irons exists in two different low spin environments in the pH range 5.5 to 10.5, while the other remains in a constant environment. Factors influencing the variable heme iron environment also influence flavin reactivity, indicating the existence of a mechanism for heme-flavin interaction.")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"].attributes["CompleteYN"], "Y")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][0].attributes["ValidYN"], "Y")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][0]["LastName"], "Strekas")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][0]["ForeName"], "T C")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][0]["Initials"], "TC")
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"].attributes["PubModel"], "Print"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["ISSN"], "0006-3002"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes[
+                "IssnType"
+            ],
+            "Print",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"][
+                "JournalIssue"
+            ].attributes["CitedMedium"],
+            "Print",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "Volume"
+            ],
+            "446",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Issue"],
+            "1",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "PubDate"
+            ]["Year"],
+            "1976",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "PubDate"
+            ]["Month"],
+            "Sep",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "PubDate"
+            ]["Day"],
+            "28",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["Title"],
+            "Biochimica et biophysica acta",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["ISOAbbreviation"],
+            "Biochim. Biophys. Acta",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["ArticleTitle"],
+            "Magnetic studies of Chromatium flavocytochrome C552. A mechanism for heme-flavin interaction.",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Pagination"]["MedlinePgn"],
+            "179-91",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"],
+            "Electron paramagnetic resonance and magnetic susceptibility studies of Chromatium flavocytochrome C552 and its diheme flavin-free subunit at temperatures below 45 degrees K are reported. The results show that in the intact protein and the subunit the two low-spin (S = 1/2) heme irons are distinguishable, giving rise to separate EPR signals. In the intact protein only, one of the heme irons exists in two different low spin environments in the pH range 5.5 to 10.5, while the other remains in a constant environment. Factors influencing the variable heme iron environment also influence flavin reactivity, indicating the existence of a mechanism for heme-flavin interaction.",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"].attributes[
+                "CompleteYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][0].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][0]["LastName"],
+            "Strekas",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][0]["ForeName"], "T C"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][0]["Initials"], "TC"
+        )
         self.assertEqual(record[1]["MedlineCitation"]["Article"]["Language"], ["eng"])
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["PublicationTypeList"], ["Journal Article"])
-        self.assertEqual(record[1]["MedlineCitation"]["MedlineJournalInfo"]["Country"], "NETHERLANDS")
-        self.assertEqual(record[1]["MedlineCitation"]["MedlineJournalInfo"]["MedlineTA"], "Biochim Biophys Acta")
-        self.assertEqual(record[1]["MedlineCitation"]["MedlineJournalInfo"]["NlmUniqueID"], "0217513")
-        self.assertEqual(record[1]["MedlineCitation"]["ChemicalList"][0]["RegistryNumber"], "0")
-        self.assertEqual(record[1]["MedlineCitation"]["ChemicalList"][0]["NameOfSubstance"], "Cytochrome c Group")
-        self.assertEqual(record[1]["MedlineCitation"]["ChemicalList"][1]["RegistryNumber"], "0")
-        self.assertEqual(record[1]["MedlineCitation"]["ChemicalList"][1]["NameOfSubstance"], "Flavins")
-        self.assertEqual(record[1]["MedlineCitation"]["ChemicalList"][2]["RegistryNumber"], "14875-96-8")
-        self.assertEqual(record[1]["MedlineCitation"]["ChemicalList"][2]["NameOfSubstance"], "Heme")
-        self.assertEqual(record[1]["MedlineCitation"]["ChemicalList"][3]["RegistryNumber"], "7439-89-6")
-        self.assertEqual(record[1]["MedlineCitation"]["ChemicalList"][3]["NameOfSubstance"], "Iron")
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["PublicationTypeList"],
+            ["Journal Article"],
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MedlineJournalInfo"]["Country"], "NETHERLANDS"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MedlineJournalInfo"]["MedlineTA"],
+            "Biochim Biophys Acta",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MedlineJournalInfo"]["NlmUniqueID"], "0217513"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["ChemicalList"][0]["RegistryNumber"], "0"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["ChemicalList"][0]["NameOfSubstance"],
+            "Cytochrome c Group",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["ChemicalList"][1]["RegistryNumber"], "0"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["ChemicalList"][1]["NameOfSubstance"],
+            "Flavins",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["ChemicalList"][2]["RegistryNumber"],
+            "14875-96-8",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["ChemicalList"][2]["NameOfSubstance"], "Heme"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["ChemicalList"][3]["RegistryNumber"],
+            "7439-89-6",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["ChemicalList"][3]["NameOfSubstance"], "Iron"
+        )
         self.assertEqual(record[1]["MedlineCitation"]["CitationSubset"], ["IM"])
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][0]["DescriptorName"], "Binding Sites")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][0]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][1]["DescriptorName"], "Chromatium")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][1]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][1]["QualifierName"][0], "enzymology")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][1]["QualifierName"][0].attributes["MajorTopicYN"], "Y")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][2]["DescriptorName"], "Cytochrome c Group")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][2]["DescriptorName"].attributes["MajorTopicYN"], "Y")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][3]["DescriptorName"], "Electron Spin Resonance Spectroscopy")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][3]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][4]["DescriptorName"], "Flavins")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][4]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][5]["DescriptorName"], "Heme")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][5]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][6]["DescriptorName"], "Hydrogen-Ion Concentration")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][6]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][7]["DescriptorName"], "Iron")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][7]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][7]["QualifierName"][0], "analysis")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][7]["QualifierName"][0].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][8]["DescriptorName"], "Magnetics")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][8]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][9]["DescriptorName"], "Oxidation-Reduction")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][9]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][10]["DescriptorName"], "Protein Binding")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][10]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][11]["DescriptorName"], "Protein Conformation")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][11]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][12]["DescriptorName"], "Temperature")
-        self.assertEqual(record[1]["MedlineCitation"]["MeshHeadingList"][12]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[1]["PubmedData"]["History"][0][0].attributes["PubStatus"], "pubmed")
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][0]["DescriptorName"],
+            "Binding Sites",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][0][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][1]["DescriptorName"],
+            "Chromatium",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][1][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][1]["QualifierName"][0],
+            "enzymology",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][1]["QualifierName"][
+                0
+            ].attributes["MajorTopicYN"],
+            "Y",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][2]["DescriptorName"],
+            "Cytochrome c Group",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][2][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "Y",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][3]["DescriptorName"],
+            "Electron Spin Resonance Spectroscopy",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][3][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][4]["DescriptorName"],
+            "Flavins",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][4][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][5]["DescriptorName"], "Heme"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][5][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][6]["DescriptorName"],
+            "Hydrogen-Ion Concentration",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][6][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][7]["DescriptorName"], "Iron"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][7][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][7]["QualifierName"][0],
+            "analysis",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][7]["QualifierName"][
+                0
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][8]["DescriptorName"],
+            "Magnetics",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][8][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][9]["DescriptorName"],
+            "Oxidation-Reduction",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][9][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][10]["DescriptorName"],
+            "Protein Binding",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][10][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][11]["DescriptorName"],
+            "Protein Conformation",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][11][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][12]["DescriptorName"],
+            "Temperature",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MeshHeadingList"][12][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[1]["PubmedData"]["History"][0][0].attributes["PubStatus"], "pubmed"
+        )
         self.assertEqual(record[1]["PubmedData"]["History"][0][0]["Year"], "1976")
         self.assertEqual(record[1]["PubmedData"]["History"][0][0]["Month"], "9")
         self.assertEqual(record[1]["PubmedData"]["History"][0][0]["Day"], "28")
-        self.assertEqual(record[1]["PubmedData"]["History"][0][1].attributes["PubStatus"], "medline")
+        self.assertEqual(
+            record[1]["PubmedData"]["History"][0][1].attributes["PubStatus"], "medline"
+        )
         self.assertEqual(record[1]["PubmedData"]["History"][0][1]["Year"], "1976")
         self.assertEqual(record[1]["PubmedData"]["History"][0][1]["Month"], "9")
         self.assertEqual(record[1]["PubmedData"]["History"][0][1]["Day"], "28")
@@ -3516,7 +5267,9 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(record[1]["PubmedData"]["PublicationStatus"], "ppublish")
         self.assertEqual(len(record[1]["PubmedData"]["ArticleIdList"]), 1)
         self.assertEqual(record[1]["PubmedData"]["ArticleIdList"][0], "9997")
-        self.assertEqual(record[1]["PubmedData"]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            record[1]["PubmedData"]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
 
     def test_pubmed2(self):
         """Test parsing XML returned by EFetch, PubMed database (second test)."""
@@ -3538,108 +5291,437 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(record[0]["MedlineCitation"]["DateRevised"]["Year"], "2006")
         self.assertEqual(record[0]["MedlineCitation"]["DateRevised"]["Month"], "11")
         self.assertEqual(record[0]["MedlineCitation"]["DateRevised"]["Day"], "15")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"].attributes["PubModel"], "Print")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["ISSN"], "0011-2240")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes["IssnType"], "Print")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"].attributes["CitedMedium"], "Print")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Volume"], "42")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Issue"], "4")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Year"], "2001")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Month"], "Jun")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["Title"], "Cryobiology")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Journal"]["ISOAbbreviation"], "Cryobiology")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["ArticleTitle"], "Is cryopreservation a homogeneous process? Ultrastructure and motility of untreated, prefreezing, and postthawed spermatozoa of Diplodus puntazzo (Cetti).")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Pagination"]["MedlinePgn"], "244-55")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"], "This study subdivides the cryopreservation procedure for Diplodus puntazzo spermatozoa into three key phases, fresh, prefreezing (samples equilibrated in cryosolutions), and postthawed stages, and examines the ultrastructural anomalies and motility profiles of spermatozoa in each stage, with different cryodiluents. Two simple cryosolutions were evaluated: 0.17 M sodium chloride containing a final concentration of 15% dimethyl sulfoxide (Me(2)SO) (cryosolution A) and 0.1 M sodium citrate containing a final concentration of 10% Me(2)SO (cryosolution B). Ultrastructural anomalies of the plasmatic and nuclear membranes of the sperm head were common and the severity of the cryoinjury differed significantly between the pre- and the postfreezing phases and between the two cryosolutions. In spermatozoa diluted with cryosolution A, during the prefreezing phase, the plasmalemma of 61% of the cells was absent or damaged compared with 24% in the fresh sample (P < 0.001). In spermatozoa diluted with cryosolution B, there was a pronounced increase in the number of cells lacking the head plasmatic membrane from the prefreezing to the postthawed stages (from 32 to 52%, P < 0.01). In both cryosolutions, damages to nuclear membrane were significantly higher after freezing (cryosolution A: 8 to 23%, P < 0.01; cryosolution B: 5 to 38%, P < 0.001). With cryosolution A, the after-activation motility profile confirmed a consistent drop from fresh at the prefreezing stage, whereas freezing and thawing did not affect the motility much further and 50% of the cells were immotile by 60-90 s after activation. With cryosolution B, only the postthawing stage showed a sharp drop of motility profile. This study suggests that the different phases of the cryoprocess should be investigated to better understand the process of sperm damage.")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Abstract"]["CopyrightInformation"], "Copyright 2001 Elsevier Science.")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["Affiliation"], "Dipartimento di Scienze Ambientali, Universit\xe0 degli Studi della Tuscia, 01100 Viterbo, Italy.")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"].attributes["CompleteYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][0].attributes["ValidYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][0]["LastName"], "Taddei")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][0]["ForeName"], "A R")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][0]["Initials"], "AR")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][1].attributes["ValidYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][1]["LastName"], "Barbato")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][1]["ForeName"], "F")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][1]["Initials"], "F")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][2].attributes["ValidYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][2]["LastName"], "Abelli")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][2]["ForeName"], "L")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][2]["Initials"], "L")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][3].attributes["ValidYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][3]["LastName"], "Canese")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][3]["ForeName"], "S")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][3]["Initials"], "S")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][4].attributes["ValidYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][4]["LastName"], "Moretti")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][4]["ForeName"], "F")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][4]["Initials"], "F")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][5].attributes["ValidYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][5]["LastName"], "Rana")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][5]["ForeName"], "K J")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][5]["Initials"], "KJ")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][6].attributes["ValidYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][6]["LastName"], "Fausto")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][6]["ForeName"], "A M")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][6]["Initials"], "AM")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][7].attributes["ValidYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][7]["LastName"], "Mazzini")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][7]["ForeName"], "M")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["AuthorList"][7]["Initials"], "M")
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"].attributes["PubModel"], "Print"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["ISSN"], "0011-2240"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes[
+                "IssnType"
+            ],
+            "Print",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"][
+                "JournalIssue"
+            ].attributes["CitedMedium"],
+            "Print",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "Volume"
+            ],
+            "42",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Issue"],
+            "4",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "PubDate"
+            ]["Year"],
+            "2001",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "PubDate"
+            ]["Month"],
+            "Jun",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["Title"], "Cryobiology"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Journal"]["ISOAbbreviation"],
+            "Cryobiology",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["ArticleTitle"],
+            "Is cryopreservation a homogeneous process? Ultrastructure and motility of untreated, prefreezing, and postthawed spermatozoa of Diplodus puntazzo (Cetti).",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Pagination"]["MedlinePgn"],
+            "244-55",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"],
+            "This study subdivides the cryopreservation procedure for Diplodus puntazzo spermatozoa into three key phases, fresh, prefreezing (samples equilibrated in cryosolutions), and postthawed stages, and examines the ultrastructural anomalies and motility profiles of spermatozoa in each stage, with different cryodiluents. Two simple cryosolutions were evaluated: 0.17 M sodium chloride containing a final concentration of 15% dimethyl sulfoxide (Me(2)SO) (cryosolution A) and 0.1 M sodium citrate containing a final concentration of 10% Me(2)SO (cryosolution B). Ultrastructural anomalies of the plasmatic and nuclear membranes of the sperm head were common and the severity of the cryoinjury differed significantly between the pre- and the postfreezing phases and between the two cryosolutions. In spermatozoa diluted with cryosolution A, during the prefreezing phase, the plasmalemma of 61% of the cells was absent or damaged compared with 24% in the fresh sample (P < 0.001). In spermatozoa diluted with cryosolution B, there was a pronounced increase in the number of cells lacking the head plasmatic membrane from the prefreezing to the postthawed stages (from 32 to 52%, P < 0.01). In both cryosolutions, damages to nuclear membrane were significantly higher after freezing (cryosolution A: 8 to 23%, P < 0.01; cryosolution B: 5 to 38%, P < 0.001). With cryosolution A, the after-activation motility profile confirmed a consistent drop from fresh at the prefreezing stage, whereas freezing and thawing did not affect the motility much further and 50% of the cells were immotile by 60-90 s after activation. With cryosolution B, only the postthawing stage showed a sharp drop of motility profile. This study suggests that the different phases of the cryoprocess should be investigated to better understand the process of sperm damage.",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Abstract"]["CopyrightInformation"],
+            "Copyright 2001 Elsevier Science.",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["Affiliation"],
+            "Dipartimento di Scienze Ambientali, Universit\xe0 degli Studi della Tuscia, 01100 Viterbo, Italy.",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"].attributes[
+                "CompleteYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][0].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][0]["LastName"],
+            "Taddei",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][0]["ForeName"], "A R"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][0]["Initials"], "AR"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][1].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][1]["LastName"],
+            "Barbato",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][1]["ForeName"], "F"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][1]["Initials"], "F"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][2].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][2]["LastName"],
+            "Abelli",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][2]["ForeName"], "L"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][2]["Initials"], "L"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][3].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][3]["LastName"],
+            "Canese",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][3]["ForeName"], "S"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][3]["Initials"], "S"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][4].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][4]["LastName"],
+            "Moretti",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][4]["ForeName"], "F"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][4]["Initials"], "F"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][5].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][5]["LastName"], "Rana"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][5]["ForeName"], "K J"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][5]["Initials"], "KJ"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][6].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][6]["LastName"],
+            "Fausto",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][6]["ForeName"], "A M"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][6]["Initials"], "AM"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][7].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][7]["LastName"],
+            "Mazzini",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][7]["ForeName"], "M"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["AuthorList"][7]["Initials"], "M"
+        )
         self.assertEqual(record[0]["MedlineCitation"]["Article"]["Language"], ["eng"])
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["PublicationTypeList"][0], "Journal Article")
-        self.assertEqual(record[0]["MedlineCitation"]["Article"]["PublicationTypeList"][1], "Research Support, Non-U.S. Gov't")
-        self.assertEqual(record[0]["MedlineCitation"]["MedlineJournalInfo"]["Country"], "United States")
-        self.assertEqual(record[0]["MedlineCitation"]["MedlineJournalInfo"]["MedlineTA"], "Cryobiology")
-        self.assertEqual(record[0]["MedlineCitation"]["MedlineJournalInfo"]["NlmUniqueID"], "0006252")
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["PublicationTypeList"][0],
+            "Journal Article",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["Article"]["PublicationTypeList"][1],
+            "Research Support, Non-U.S. Gov't",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MedlineJournalInfo"]["Country"],
+            "United States",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MedlineJournalInfo"]["MedlineTA"],
+            "Cryobiology",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MedlineJournalInfo"]["NlmUniqueID"], "0006252"
+        )
         self.assertEqual(record[0]["MedlineCitation"]["CitationSubset"], ["IM"])
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][0]["DescriptorName"], "Animals")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][0]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][1]["DescriptorName"], "Cell Membrane")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][1]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][1]["QualifierName"][0], "ultrastructure")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][1]["QualifierName"][0].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][2]["DescriptorName"], "Cryopreservation")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][2]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][2]["QualifierName"][0], "methods")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][2]["QualifierName"][0].attributes["MajorTopicYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][3]["DescriptorName"], "Male")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][3]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][4]["DescriptorName"], "Microscopy, Electron")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][4]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][5]["DescriptorName"], "Microscopy, Electron, Scanning")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][5]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][6]["DescriptorName"], "Nuclear Envelope")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][6]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][6]["QualifierName"][0], "ultrastructure")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][6]["QualifierName"][0].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][7]["DescriptorName"], "Sea Bream")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][7]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][7]["QualifierName"][0], "anatomy & histology")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][7]["QualifierName"][0].attributes["MajorTopicYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][7]["QualifierName"][1], "physiology")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][7]["QualifierName"][1].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][8]["DescriptorName"], "Semen Preservation")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][8]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][8]["QualifierName"][0], "adverse effects")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][8]["QualifierName"][0].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][8]["QualifierName"][1], "methods")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][8]["QualifierName"][1].attributes["MajorTopicYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][9]["DescriptorName"], "Sperm Motility")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][9]["DescriptorName"].attributes["MajorTopicYN"], "Y")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][10]["DescriptorName"], "Spermatozoa")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][10]["DescriptorName"].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][10]["QualifierName"][0], "physiology")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][10]["QualifierName"][0].attributes["MajorTopicYN"], "N")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][10]["QualifierName"][1], "ultrastructure")
-        self.assertEqual(record[0]["MedlineCitation"]["MeshHeadingList"][10]["QualifierName"][1].attributes["MajorTopicYN"], "Y")
-        self.assertEqual(record[0]["PubmedData"]["History"][0][0].attributes["PubStatus"], "pubmed")
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][0]["DescriptorName"],
+            "Animals",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][0][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][1]["DescriptorName"],
+            "Cell Membrane",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][1][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][1]["QualifierName"][0],
+            "ultrastructure",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][1]["QualifierName"][
+                0
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][2]["DescriptorName"],
+            "Cryopreservation",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][2][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][2]["QualifierName"][0],
+            "methods",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][2]["QualifierName"][
+                0
+            ].attributes["MajorTopicYN"],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][3]["DescriptorName"], "Male"
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][3][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][4]["DescriptorName"],
+            "Microscopy, Electron",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][4][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][5]["DescriptorName"],
+            "Microscopy, Electron, Scanning",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][5][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][6]["DescriptorName"],
+            "Nuclear Envelope",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][6][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][6]["QualifierName"][0],
+            "ultrastructure",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][6]["QualifierName"][
+                0
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][7]["DescriptorName"],
+            "Sea Bream",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][7][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][7]["QualifierName"][0],
+            "anatomy & histology",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][7]["QualifierName"][
+                0
+            ].attributes["MajorTopicYN"],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][7]["QualifierName"][1],
+            "physiology",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][7]["QualifierName"][
+                1
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][8]["DescriptorName"],
+            "Semen Preservation",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][8][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][8]["QualifierName"][0],
+            "adverse effects",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][8]["QualifierName"][
+                0
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][8]["QualifierName"][1],
+            "methods",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][8]["QualifierName"][
+                1
+            ].attributes["MajorTopicYN"],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][9]["DescriptorName"],
+            "Sperm Motility",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][9][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][10]["DescriptorName"],
+            "Spermatozoa",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][10][
+                "DescriptorName"
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][10]["QualifierName"][0],
+            "physiology",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][10]["QualifierName"][
+                0
+            ].attributes["MajorTopicYN"],
+            "N",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][10]["QualifierName"][1],
+            "ultrastructure",
+        )
+        self.assertEqual(
+            record[0]["MedlineCitation"]["MeshHeadingList"][10]["QualifierName"][
+                1
+            ].attributes["MajorTopicYN"],
+            "Y",
+        )
+        self.assertEqual(
+            record[0]["PubmedData"]["History"][0][0].attributes["PubStatus"], "pubmed"
+        )
         self.assertEqual(record[0]["PubmedData"]["History"][0][0]["Year"], "2001")
         self.assertEqual(record[0]["PubmedData"]["History"][0][0]["Month"], "12")
         self.assertEqual(record[0]["PubmedData"]["History"][0][0]["Day"], "26")
         self.assertEqual(record[0]["PubmedData"]["History"][0][0]["Hour"], "10")
         self.assertEqual(record[0]["PubmedData"]["History"][0][0]["Minute"], "0")
-        self.assertEqual(record[0]["PubmedData"]["History"][0][1].attributes["PubStatus"], "medline")
+        self.assertEqual(
+            record[0]["PubmedData"]["History"][0][1].attributes["PubStatus"], "medline"
+        )
         self.assertEqual(record[0]["PubmedData"]["History"][0][1]["Year"], "2002")
         self.assertEqual(record[0]["PubmedData"]["History"][0][1]["Month"], "3")
         self.assertEqual(record[0]["PubmedData"]["History"][0][1]["Day"], "5")
@@ -3647,14 +5729,26 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(record[0]["PubmedData"]["History"][0][1]["Minute"], "1")
         self.assertEqual(record[0]["PubmedData"]["PublicationStatus"], "ppublish")
         self.assertEqual(record[0]["PubmedData"]["ArticleIdList"][0], "11748933")
-        self.assertEqual(record[0]["PubmedData"]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(record[0]["PubmedData"]["ArticleIdList"][1], "10.1006/cryo.2001.2328")
-        self.assertEqual(record[0]["PubmedData"]["ArticleIdList"][1].attributes["IdType"], "doi")
-        self.assertEqual(record[0]["PubmedData"]["ArticleIdList"][2], "S0011-2240(01)92328-4")
-        self.assertEqual(record[0]["PubmedData"]["ArticleIdList"][2].attributes["IdType"], "pii")
+        self.assertEqual(
+            record[0]["PubmedData"]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            record[0]["PubmedData"]["ArticleIdList"][1], "10.1006/cryo.2001.2328"
+        )
+        self.assertEqual(
+            record[0]["PubmedData"]["ArticleIdList"][1].attributes["IdType"], "doi"
+        )
+        self.assertEqual(
+            record[0]["PubmedData"]["ArticleIdList"][2], "S0011-2240(01)92328-4"
+        )
+        self.assertEqual(
+            record[0]["PubmedData"]["ArticleIdList"][2].attributes["IdType"], "pii"
+        )
 
         self.assertEqual(record[1]["MedlineCitation"].attributes["Owner"], "NLM")
-        self.assertEqual(record[1]["MedlineCitation"].attributes["Status"], "PubMed-not-MEDLINE")
+        self.assertEqual(
+            record[1]["MedlineCitation"].attributes["Status"], "PubMed-not-MEDLINE"
+        )
         self.assertEqual(record[1]["MedlineCitation"]["PMID"], "11700088")
         self.assertEqual(record[1]["MedlineCitation"]["DateCreated"]["Year"], "2001")
         self.assertEqual(record[1]["MedlineCitation"]["DateCreated"]["Month"], "11")
@@ -3665,58 +5759,202 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(record[1]["MedlineCitation"]["DateRevised"]["Year"], "2003")
         self.assertEqual(record[1]["MedlineCitation"]["DateRevised"]["Month"], "10")
         self.assertEqual(record[1]["MedlineCitation"]["DateRevised"]["Day"], "31")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"].attributes["PubModel"], "Print")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["ISSN"], "1090-7807")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes["IssnType"], "Print")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"].attributes["CitedMedium"], "Print")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Volume"], "153")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Issue"], "1")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Year"], "2001")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Month"], "Nov")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["Title"], "Journal of magnetic resonance (San Diego, Calif. : 1997)")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Journal"]["ISOAbbreviation"], "J. Magn. Reson.")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["ArticleTitle"], "Proton MRI of (13)C distribution by J and chemical shift editing.")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Pagination"]["MedlinePgn"], "117-23")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"], "The sensitivity of (13)C NMR imaging can be considerably favored by detecting the (1)H nuclei bound to (13)C nuclei via scalar J-interaction (X-filter). However, the J-editing approaches have difficulty in discriminating between compounds with similar J-constant as, for example, different glucose metabolites. In such cases, it is almost impossible to get J-edited images of a single-compound distribution, since the various molecules are distinguishable only via their chemical shift. In a recent application of J-editing to high-resolution spectroscopy, it has been shown that a more efficient chemical selectivity could be obtained by utilizing the larger chemical shift range of (13)C. This has been made by introducing frequency-selective (13)C pulses that allow a great capability of indirect chemical separation. Here a double-resonance imaging approach is proposed, based on both J-editing and (13)C chemical shift editing, which achieves a powerful chemical selectivity and is able to produce full maps of specific chemical compounds. Results are presented on a multicompartments sample containing solutions of glucose and lactic and glutamic acid in water.")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Abstract"]["CopyrightInformation"], "Copyright 2001 Academic Press.")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["Affiliation"], "INFM and Department of Physics, University of L'Aquila, I-67100 L'Aquila, Italy.")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"].attributes["CompleteYN"], "Y")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][0].attributes["ValidYN"], "Y")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][0]["LastName"], "Casieri")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][0]["ForeName"], "C")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][0]["Initials"], "C")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][1].attributes["ValidYN"], "Y")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][1]["LastName"], "Testa")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][1]["ForeName"], "C")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][1]["Initials"], "C")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][2].attributes["ValidYN"], "Y")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][2]["LastName"], "Carpinelli")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][2]["ForeName"], "G")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][2]["Initials"], "G")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][3].attributes["ValidYN"], "Y")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][3]["LastName"], "Canese")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][3]["ForeName"], "R")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][3]["Initials"], "R")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][4].attributes["ValidYN"], "Y")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][4]["LastName"], "Podo")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][4]["ForeName"], "F")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][4]["Initials"], "F")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][5].attributes["ValidYN"], "Y")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][5]["LastName"], "De Luca")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][5]["ForeName"], "F")
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["AuthorList"][5]["Initials"], "F")
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"].attributes["PubModel"], "Print"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["ISSN"], "1090-7807"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes[
+                "IssnType"
+            ],
+            "Print",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"][
+                "JournalIssue"
+            ].attributes["CitedMedium"],
+            "Print",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "Volume"
+            ],
+            "153",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Issue"],
+            "1",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "PubDate"
+            ]["Year"],
+            "2001",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "PubDate"
+            ]["Month"],
+            "Nov",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["Title"],
+            "Journal of magnetic resonance (San Diego, Calif. : 1997)",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Journal"]["ISOAbbreviation"],
+            "J. Magn. Reson.",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["ArticleTitle"],
+            "Proton MRI of (13)C distribution by J and chemical shift editing.",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Pagination"]["MedlinePgn"],
+            "117-23",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"],
+            "The sensitivity of (13)C NMR imaging can be considerably favored by detecting the (1)H nuclei bound to (13)C nuclei via scalar J-interaction (X-filter). However, the J-editing approaches have difficulty in discriminating between compounds with similar J-constant as, for example, different glucose metabolites. In such cases, it is almost impossible to get J-edited images of a single-compound distribution, since the various molecules are distinguishable only via their chemical shift. In a recent application of J-editing to high-resolution spectroscopy, it has been shown that a more efficient chemical selectivity could be obtained by utilizing the larger chemical shift range of (13)C. This has been made by introducing frequency-selective (13)C pulses that allow a great capability of indirect chemical separation. Here a double-resonance imaging approach is proposed, based on both J-editing and (13)C chemical shift editing, which achieves a powerful chemical selectivity and is able to produce full maps of specific chemical compounds. Results are presented on a multicompartments sample containing solutions of glucose and lactic and glutamic acid in water.",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Abstract"]["CopyrightInformation"],
+            "Copyright 2001 Academic Press.",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["Affiliation"],
+            "INFM and Department of Physics, University of L'Aquila, I-67100 L'Aquila, Italy.",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"].attributes[
+                "CompleteYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][0].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][0]["LastName"],
+            "Casieri",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][0]["ForeName"], "C"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][0]["Initials"], "C"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][1].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][1]["LastName"],
+            "Testa",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][1]["ForeName"], "C"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][1]["Initials"], "C"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][2].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][2]["LastName"],
+            "Carpinelli",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][2]["ForeName"], "G"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][2]["Initials"], "G"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][3].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][3]["LastName"],
+            "Canese",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][3]["ForeName"], "R"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][3]["Initials"], "R"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][4].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][4]["LastName"], "Podo"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][4]["ForeName"], "F"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][4]["Initials"], "F"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][5].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][5]["LastName"],
+            "De Luca",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][5]["ForeName"], "F"
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["AuthorList"][5]["Initials"], "F"
+        )
         self.assertEqual(record[1]["MedlineCitation"]["Article"]["Language"], ["eng"])
-        self.assertEqual(record[1]["MedlineCitation"]["Article"]["PublicationTypeList"][0], "Journal Article")
-        self.assertEqual(record[1]["MedlineCitation"]["MedlineJournalInfo"]["Country"], "United States")
-        self.assertEqual(record[1]["MedlineCitation"]["MedlineJournalInfo"]["MedlineTA"], "J Magn Reson")
-        self.assertEqual(record[1]["MedlineCitation"]["MedlineJournalInfo"]["NlmUniqueID"], "9707935")
-        self.assertEqual(record[1]["PubmedData"]["History"][0][0].attributes["PubStatus"], "pubmed")
+        self.assertEqual(
+            record[1]["MedlineCitation"]["Article"]["PublicationTypeList"][0],
+            "Journal Article",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MedlineJournalInfo"]["Country"],
+            "United States",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MedlineJournalInfo"]["MedlineTA"],
+            "J Magn Reson",
+        )
+        self.assertEqual(
+            record[1]["MedlineCitation"]["MedlineJournalInfo"]["NlmUniqueID"], "9707935"
+        )
+        self.assertEqual(
+            record[1]["PubmedData"]["History"][0][0].attributes["PubStatus"], "pubmed"
+        )
         self.assertEqual(record[1]["PubmedData"]["History"][0][0]["Year"], "2001")
         self.assertEqual(record[1]["PubmedData"]["History"][0][0]["Month"], "11")
         self.assertEqual(record[1]["PubmedData"]["History"][0][0]["Day"], "9")
         self.assertEqual(record[1]["PubmedData"]["History"][0][0]["Hour"], "10")
         self.assertEqual(record[1]["PubmedData"]["History"][0][0]["Minute"], "0")
-        self.assertEqual(record[1]["PubmedData"]["History"][0][1].attributes["PubStatus"], "medline")
+        self.assertEqual(
+            record[1]["PubmedData"]["History"][0][1].attributes["PubStatus"], "medline"
+        )
         self.assertEqual(record[1]["PubmedData"]["History"][0][1]["Year"], "2001")
         self.assertEqual(record[1]["PubmedData"]["History"][0][1]["Month"], "11")
         self.assertEqual(record[1]["PubmedData"]["History"][0][1]["Day"], "9")
@@ -3724,11 +5962,21 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(record[1]["PubmedData"]["History"][0][1]["Minute"], "1")
         self.assertEqual(record[1]["PubmedData"]["PublicationStatus"], "ppublish")
         self.assertEqual(record[1]["PubmedData"]["ArticleIdList"][0], "11700088")
-        self.assertEqual(record[1]["PubmedData"]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(record[1]["PubmedData"]["ArticleIdList"][1], "10.1006/jmre.2001.2429")
-        self.assertEqual(record[1]["PubmedData"]["ArticleIdList"][1].attributes["IdType"], "doi")
-        self.assertEqual(record[1]["PubmedData"]["ArticleIdList"][2], "S1090-7807(01)92429-2")
-        self.assertEqual(record[1]["PubmedData"]["ArticleIdList"][2].attributes["IdType"], "pii")
+        self.assertEqual(
+            record[1]["PubmedData"]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            record[1]["PubmedData"]["ArticleIdList"][1], "10.1006/jmre.2001.2429"
+        )
+        self.assertEqual(
+            record[1]["PubmedData"]["ArticleIdList"][1].attributes["IdType"], "doi"
+        )
+        self.assertEqual(
+            record[1]["PubmedData"]["ArticleIdList"][2], "S1090-7807(01)92429-2"
+        )
+        self.assertEqual(
+            record[1]["PubmedData"]["ArticleIdList"][2].attributes["IdType"], "pii"
+        )
 
     def test_pubmed_html_tags(self):
         """Test parsing XML returned by EFetch, PubMed database with HTML tags."""
@@ -3740,65 +5988,330 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(len(records), 2)
         self.assertEqual(len(records["PubmedBookArticle"]), 0)
         self.assertEqual(len(records["PubmedArticle"]), 1)
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"].attributes["Status"], "MEDLINE")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"].attributes["Owner"], "NLM")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["PMID"], "27797938")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["PMID"].attributes["Version"], "1")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["DateCompleted"]["Year"], "2017")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["DateCompleted"]["Month"], "08")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["DateCompleted"]["Day"], "03")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["DateRevised"]["Year"], "2018")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["DateRevised"]["Month"], "04")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["DateRevised"]["Day"], "17")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"].attributes["PubModel"], "Print-Electronic")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"]["ISSN"], "1468-3288")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes["IssnType"], "Electronic")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"].attributes["CitedMedium"], "Internet")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Volume"], "66")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Issue"], "6")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Year"], "2017")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Month"], "06")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"]["Title"], "Gut")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"]["ISOAbbreviation"], "Gut")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ArticleTitle"], "Leucocyte telomere length, genetic variants at the <i>TERT</i> gene region and risk of pancreatic cancer.")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Pagination"]["MedlinePgn"], "1116-1122")
-        self.assertEqual(len(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ELocationID"]), 1)
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ELocationID"][0], "10.1136/gutjnl-2016-312510")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ELocationID"][0].attributes["EIdType"], "doi")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ELocationID"][0].attributes["ValidYN"], "Y")
-        self.assertEqual(len(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"]), 2)
-        self.assertEqual(len(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"]), 4)
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][0], "Telomere shortening occurs as an early event in pancreatic tumorigenesis, and genetic variants at the telomerase reverse transcriptase (<i>TERT</i>) gene region have been associated with pancreatic cancer risk. However, it is unknown whether prediagnostic leucocyte telomere length is associated with subsequent risk of pancreatic cancer.")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][0].attributes["Label"], "OBJECTIVE")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][1], "We measured prediagnostic leucocyte telomere length in 386 pancreatic cancer cases and 896 matched controls from five prospective US cohorts. ORs and 95% CIs were calculated using conditional logistic regression. Matching factors included year of birth, cohort (which also matches on sex), smoking status, fasting status and month/year of blood collection. We additionally examined single-nucleotide polymorphisms (SNPs) at the <i>TERT</i> region in relation to pancreatic cancer risk and leucocyte telomere length using logistic and linear regression, respectively.")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][1].attributes["Label"], "DESIGN")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][2], "Shorter prediagnostic leucocyte telomere length was associated with higher risk of pancreatic cancer (comparing extreme quintiles of telomere length, OR 1.72; 95% CI 1.07 to 2.78; p<sub>trend</sub>=0.048). Results remained unchanged after adjustment for diabetes, body mass index and physical activity. Three SNPs at <i>TERT</i> (linkage disequilibrium r<sup>2</sup><0.25) were associated with pancreatic cancer risk, including rs401681 (per minor allele OR 1.33; 95% CI 1.12 to 1.59; p=0.002), rs2736100 (per minor allele OR 1.36; 95% CI 1.13 to 1.63; p=0.001) and rs2736098 (per minor allele OR 0.75; 95% CI 0.63 to 0.90; p=0.002). The minor allele for rs401681 was associated with shorter telomere length (p=0.023).")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][2].attributes["Label"], "RESULTS")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][3], "Prediagnostic leucocyte telomere length and genetic variants at the <i>TERT</i> gene region were associated with risk of pancreatic cancer.")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][3].attributes["Label"], "CONCLUSIONS")
-        self.assertEqual(len(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["AuthorList"]), 22)
-        self.assertEqual(len(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["GrantList"]), 35)
-        self.assertEqual(len(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["PublicationTypeList"]), 5)
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["PublicationTypeList"][0], "Journal Article")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["PublicationTypeList"][0].attributes["UI"], "D016428")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["PublicationTypeList"][1], "Observational Study")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["PublicationTypeList"][1].attributes["UI"], "D064888")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["PublicationTypeList"][2], "Research Support, N.I.H., Extramural")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["PublicationTypeList"][2].attributes["UI"], "D052061")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["PublicationTypeList"][3], "Research Support, U.S. Gov't, Non-P.H.S.")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["PublicationTypeList"][3].attributes["UI"], "D013486")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["PublicationTypeList"][4], "Research Support, Non-U.S. Gov't")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["PublicationTypeList"][4].attributes["UI"], "D013485")
-        self.assertEqual(len(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ArticleDate"]), 1)
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ArticleDate"][0].attributes["DateType"], "Electronic")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ArticleDate"][0]["Year"], "2016")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ArticleDate"][0]["Month"], "10")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ArticleDate"][0]["Day"], "21")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["MedlineJournalInfo"]["Country"], "England")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["MedlineJournalInfo"]["MedlineTA"], "Gut")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["MedlineJournalInfo"]["NlmUniqueID"], "2985108R")
-        self.assertEqual(records["PubmedArticle"][0]["MedlineCitation"]["MedlineJournalInfo"]["ISSNLinking"], "0017-5749")
-        self.assertEqual(len(records["PubmedArticle"][0]["MedlineCitation"]["ChemicalList"]), 2)
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"].attributes["Status"],
+            "MEDLINE",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"].attributes["Owner"], "NLM"
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["PMID"], "27797938"
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["PMID"].attributes[
+                "Version"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["DateCompleted"]["Year"],
+            "2017",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["DateCompleted"]["Month"],
+            "08",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["DateCompleted"]["Day"], "03"
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["DateRevised"]["Year"],
+            "2018",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["DateRevised"]["Month"], "04"
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["DateRevised"]["Day"], "17"
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"].attributes[
+                "PubModel"
+            ],
+            "Print-Electronic",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"][
+                "ISSN"
+            ],
+            "1468-3288",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"][
+                "ISSN"
+            ].attributes["IssnType"],
+            "Electronic",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"][
+                "JournalIssue"
+            ].attributes["CitedMedium"],
+            "Internet",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"][
+                "JournalIssue"
+            ]["Volume"],
+            "66",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"][
+                "JournalIssue"
+            ]["Issue"],
+            "6",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"][
+                "JournalIssue"
+            ]["PubDate"]["Year"],
+            "2017",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"][
+                "JournalIssue"
+            ]["PubDate"]["Month"],
+            "06",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"][
+                "Title"
+            ],
+            "Gut",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Journal"][
+                "ISOAbbreviation"
+            ],
+            "Gut",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ArticleTitle"],
+            "Leucocyte telomere length, genetic variants at the <i>TERT</i> gene region and risk of pancreatic cancer.",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Pagination"][
+                "MedlinePgn"
+            ],
+            "1116-1122",
+        )
+        self.assertEqual(
+            len(
+                records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ELocationID"]
+            ),
+            1,
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ELocationID"][0],
+            "10.1136/gutjnl-2016-312510",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ELocationID"][
+                0
+            ].attributes["EIdType"],
+            "doi",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ELocationID"][
+                0
+            ].attributes["ValidYN"],
+            "Y",
+        )
+        self.assertEqual(
+            len(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"]),
+            2,
+        )
+        self.assertEqual(
+            len(
+                records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"][
+                    "AbstractText"
+                ]
+            ),
+            4,
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"][
+                "AbstractText"
+            ][0],
+            "Telomere shortening occurs as an early event in pancreatic tumorigenesis, and genetic variants at the telomerase reverse transcriptase (<i>TERT</i>) gene region have been associated with pancreatic cancer risk. However, it is unknown whether prediagnostic leucocyte telomere length is associated with subsequent risk of pancreatic cancer.",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"][
+                "AbstractText"
+            ][0].attributes["Label"],
+            "OBJECTIVE",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"][
+                "AbstractText"
+            ][1],
+            "We measured prediagnostic leucocyte telomere length in 386 pancreatic cancer cases and 896 matched controls from five prospective US cohorts. ORs and 95% CIs were calculated using conditional logistic regression. Matching factors included year of birth, cohort (which also matches on sex), smoking status, fasting status and month/year of blood collection. We additionally examined single-nucleotide polymorphisms (SNPs) at the <i>TERT</i> region in relation to pancreatic cancer risk and leucocyte telomere length using logistic and linear regression, respectively.",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"][
+                "AbstractText"
+            ][1].attributes["Label"],
+            "DESIGN",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"][
+                "AbstractText"
+            ][2],
+            "Shorter prediagnostic leucocyte telomere length was associated with higher risk of pancreatic cancer (comparing extreme quintiles of telomere length, OR 1.72; 95% CI 1.07 to 2.78; p<sub>trend</sub>=0.048). Results remained unchanged after adjustment for diabetes, body mass index and physical activity. Three SNPs at <i>TERT</i> (linkage disequilibrium r<sup>2</sup><0.25) were associated with pancreatic cancer risk, including rs401681 (per minor allele OR 1.33; 95% CI 1.12 to 1.59; p=0.002), rs2736100 (per minor allele OR 1.36; 95% CI 1.13 to 1.63; p=0.001) and rs2736098 (per minor allele OR 0.75; 95% CI 0.63 to 0.90; p=0.002). The minor allele for rs401681 was associated with shorter telomere length (p=0.023).",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"][
+                "AbstractText"
+            ][2].attributes["Label"],
+            "RESULTS",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"][
+                "AbstractText"
+            ][3],
+            "Prediagnostic leucocyte telomere length and genetic variants at the <i>TERT</i> gene region were associated with risk of pancreatic cancer.",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["Abstract"][
+                "AbstractText"
+            ][3].attributes["Label"],
+            "CONCLUSIONS",
+        )
+        self.assertEqual(
+            len(
+                records["PubmedArticle"][0]["MedlineCitation"]["Article"]["AuthorList"]
+            ),
+            22,
+        )
+        self.assertEqual(
+            len(records["PubmedArticle"][0]["MedlineCitation"]["Article"]["GrantList"]),
+            35,
+        )
+        self.assertEqual(
+            len(
+                records["PubmedArticle"][0]["MedlineCitation"]["Article"][
+                    "PublicationTypeList"
+                ]
+            ),
+            5,
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"][
+                "PublicationTypeList"
+            ][0],
+            "Journal Article",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"][
+                "PublicationTypeList"
+            ][0].attributes["UI"],
+            "D016428",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"][
+                "PublicationTypeList"
+            ][1],
+            "Observational Study",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"][
+                "PublicationTypeList"
+            ][1].attributes["UI"],
+            "D064888",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"][
+                "PublicationTypeList"
+            ][2],
+            "Research Support, N.I.H., Extramural",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"][
+                "PublicationTypeList"
+            ][2].attributes["UI"],
+            "D052061",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"][
+                "PublicationTypeList"
+            ][3],
+            "Research Support, U.S. Gov't, Non-P.H.S.",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"][
+                "PublicationTypeList"
+            ][3].attributes["UI"],
+            "D013486",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"][
+                "PublicationTypeList"
+            ][4],
+            "Research Support, Non-U.S. Gov't",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"][
+                "PublicationTypeList"
+            ][4].attributes["UI"],
+            "D013485",
+        )
+        self.assertEqual(
+            len(
+                records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ArticleDate"]
+            ),
+            1,
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ArticleDate"][
+                0
+            ].attributes["DateType"],
+            "Electronic",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ArticleDate"][0][
+                "Year"
+            ],
+            "2016",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ArticleDate"][0][
+                "Month"
+            ],
+            "10",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["Article"]["ArticleDate"][0][
+                "Day"
+            ],
+            "21",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["MedlineJournalInfo"][
+                "Country"
+            ],
+            "England",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["MedlineJournalInfo"][
+                "MedlineTA"
+            ],
+            "Gut",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["MedlineJournalInfo"][
+                "NlmUniqueID"
+            ],
+            "2985108R",
+        )
+        self.assertEqual(
+            records["PubmedArticle"][0]["MedlineCitation"]["MedlineJournalInfo"][
+                "ISSNLinking"
+            ],
+            "0017-5749",
+        )
+        self.assertEqual(
+            len(records["PubmedArticle"][0]["MedlineCitation"]["ChemicalList"]), 2
+        )
 
     def test_pubmed_html_escaping(self):
         """Test parsing XML returned by EFetch, PubMed database with HTML tags and HTML escape characters."""
@@ -3815,222 +6328,675 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(len(article["PubmedData"]), 3)
         self.assertEqual(len(article["PubmedData"]["ArticleIdList"]), 5)
         self.assertEqual(article["PubmedData"]["ArticleIdList"][0], "28775130")
-        self.assertEqual(article["PubmedData"]["ArticleIdList"][0].attributes, {"IdType": "pubmed"})
+        self.assertEqual(
+            article["PubmedData"]["ArticleIdList"][0].attributes, {"IdType": "pubmed"}
+        )
         self.assertEqual(article["PubmedData"]["ArticleIdList"][1], "oemed-2017-104431")
-        self.assertEqual(article["PubmedData"]["ArticleIdList"][1].attributes, {"IdType": "pii"})
-        self.assertEqual(article["PubmedData"]["ArticleIdList"][2], "10.1136/oemed-2017-104431")
-        self.assertEqual(article["PubmedData"]["ArticleIdList"][2].attributes, {"IdType": "doi"})
+        self.assertEqual(
+            article["PubmedData"]["ArticleIdList"][1].attributes, {"IdType": "pii"}
+        )
+        self.assertEqual(
+            article["PubmedData"]["ArticleIdList"][2], "10.1136/oemed-2017-104431"
+        )
+        self.assertEqual(
+            article["PubmedData"]["ArticleIdList"][2].attributes, {"IdType": "doi"}
+        )
         self.assertEqual(article["PubmedData"]["ArticleIdList"][3], "PMC5771820")
-        self.assertEqual(article["PubmedData"]["ArticleIdList"][3].attributes, {"IdType": "pmc"})
+        self.assertEqual(
+            article["PubmedData"]["ArticleIdList"][3].attributes, {"IdType": "pmc"}
+        )
         self.assertEqual(article["PubmedData"]["ArticleIdList"][4], "NIHMS932407")
-        self.assertEqual(article["PubmedData"]["ArticleIdList"][4].attributes, {"IdType": "mid"})
+        self.assertEqual(
+            article["PubmedData"]["ArticleIdList"][4].attributes, {"IdType": "mid"}
+        )
         self.assertEqual(article["PubmedData"]["PublicationStatus"], "ppublish")
         self.assertEqual(len(article["PubmedData"]["History"]), 7)
         self.assertEqual(len(article["PubmedData"]["History"][0]), 3)
         self.assertEqual(article["PubmedData"]["History"][0]["Year"], "2017")
         self.assertEqual(article["PubmedData"]["History"][0]["Month"], "03")
         self.assertEqual(article["PubmedData"]["History"][0]["Day"], "10")
-        self.assertEqual(article["PubmedData"]["History"][0].attributes, {"PubStatus": "received"})
+        self.assertEqual(
+            article["PubmedData"]["History"][0].attributes, {"PubStatus": "received"}
+        )
         self.assertEqual(len(article["PubmedData"]["History"][1]), 3)
         self.assertEqual(article["PubmedData"]["History"][1]["Year"], "2017")
         self.assertEqual(article["PubmedData"]["History"][1]["Month"], "06")
         self.assertEqual(article["PubmedData"]["History"][1]["Day"], "13")
-        self.assertEqual(article["PubmedData"]["History"][1].attributes, {"PubStatus": "revised"})
+        self.assertEqual(
+            article["PubmedData"]["History"][1].attributes, {"PubStatus": "revised"}
+        )
         self.assertEqual(len(article["PubmedData"]["History"][2]), 3)
         self.assertEqual(article["PubmedData"]["History"][2]["Year"], "2017")
         self.assertEqual(article["PubmedData"]["History"][2]["Month"], "06")
         self.assertEqual(article["PubmedData"]["History"][2]["Day"], "22")
-        self.assertEqual(article["PubmedData"]["History"][2].attributes, {"PubStatus": "accepted"})
+        self.assertEqual(
+            article["PubmedData"]["History"][2].attributes, {"PubStatus": "accepted"}
+        )
         self.assertEqual(len(article["PubmedData"]["History"][3]), 3)
         self.assertEqual(article["PubmedData"]["History"][3]["Year"], "2019")
         self.assertEqual(article["PubmedData"]["History"][3]["Month"], "02")
         self.assertEqual(article["PubmedData"]["History"][3]["Day"], "01")
-        self.assertEqual(article["PubmedData"]["History"][3].attributes, {"PubStatus": "pmc-release"})
+        self.assertEqual(
+            article["PubmedData"]["History"][3].attributes, {"PubStatus": "pmc-release"}
+        )
         self.assertEqual(len(article["PubmedData"]["History"][4]), 5)
         self.assertEqual(article["PubmedData"]["History"][4]["Year"], "2017")
         self.assertEqual(article["PubmedData"]["History"][4]["Month"], "8")
         self.assertEqual(article["PubmedData"]["History"][4]["Day"], "5")
         self.assertEqual(article["PubmedData"]["History"][4]["Hour"], "6")
         self.assertEqual(article["PubmedData"]["History"][4]["Minute"], "0")
-        self.assertEqual(article["PubmedData"]["History"][4].attributes, {"PubStatus": "pubmed"})
+        self.assertEqual(
+            article["PubmedData"]["History"][4].attributes, {"PubStatus": "pubmed"}
+        )
         self.assertEqual(len(article["PubmedData"]["History"][5]), 5)
         self.assertEqual(article["PubmedData"]["History"][5]["Year"], "2017")
         self.assertEqual(article["PubmedData"]["History"][5]["Month"], "8")
         self.assertEqual(article["PubmedData"]["History"][5]["Day"], "5")
         self.assertEqual(article["PubmedData"]["History"][5]["Hour"], "6")
         self.assertEqual(article["PubmedData"]["History"][5]["Minute"], "0")
-        self.assertEqual(article["PubmedData"]["History"][5].attributes, {"PubStatus": "medline"})
+        self.assertEqual(
+            article["PubmedData"]["History"][5].attributes, {"PubStatus": "medline"}
+        )
         self.assertEqual(len(article["PubmedData"]["History"][6]), 5)
         self.assertEqual(article["PubmedData"]["History"][6]["Year"], "2017")
         self.assertEqual(article["PubmedData"]["History"][6]["Month"], "8")
         self.assertEqual(article["PubmedData"]["History"][6]["Day"], "5")
         self.assertEqual(article["PubmedData"]["History"][6]["Hour"], "6")
         self.assertEqual(article["PubmedData"]["History"][6]["Minute"], "0")
-        self.assertEqual(article["PubmedData"]["History"][6].attributes, {"PubStatus": "entrez"})
+        self.assertEqual(
+            article["PubmedData"]["History"][6].attributes, {"PubStatus": "entrez"}
+        )
         self.assertEqual(len(article["MedlineCitation"]), 12)
         self.assertEqual(len(article["MedlineCitation"]["CitationSubset"]), 0)
-        self.assertEqual(article["MedlineCitation"]["CoiStatement"], "Competing interests: None declared.")
+        self.assertEqual(
+            article["MedlineCitation"]["CoiStatement"],
+            "Competing interests: None declared.",
+        )
         self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"]), 40)
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][0]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][0]["RefSource"], "J Toxicol Environ Health A. 2003 Jun 13;66(11):965-86")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][0]["PMID"], "12775511")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][0].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][1]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][1]["RefSource"], "Ann Intern Med. 2015 May 5;162(9):641-50")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][1]["PMID"], "25798805")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][1].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][2]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][2]["RefSource"], "Cancer Causes Control. 1999 Dec;10(6):583-95")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][2]["PMID"], "10616827")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][2].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][3]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][3]["RefSource"], "Thyroid. 2010 Jul;20(7):755-61")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][3]["PMID"], "20578899")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][3].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][4]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][4]["RefSource"], "Environ Health Perspect. 1999 Mar;107(3):205-11")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][4]["PMID"], "10064550")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][4].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][5]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][5]["RefSource"], "J Clin Endocrinol Metab. 2006 Nov;91(11):4295-301")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][5]["PMID"], "16868053")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][5].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][6]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][6]["RefSource"], "Endocrinology. 1998 Oct;139(10):4252-63")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][6]["PMID"], "9751507")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][6].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][7]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][7]["RefSource"], "Eur J Endocrinol. 2016 Apr;174(4):409-14")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][7]["PMID"], "26863886")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][7].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][8]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][8]["RefSource"], "Eur J Endocrinol. 2000 Nov;143(5):639-47")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][8]["PMID"], "11078988")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][8].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][9]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][9]["RefSource"], "Environ Res. 2016 Nov;151:389-398")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][9]["PMID"], "27540871")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][9].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][10]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][10]["RefSource"], "Am J Epidemiol. 2010 Jan 15;171(2):242-52")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][10]["PMID"], "19951937")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][10].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][11]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][11]["RefSource"], "Thyroid. 1998 Sep;8(9):827-56")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][11]["PMID"], "9777756")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][11].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][12]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][12]["RefSource"], "Curr Opin Pharmacol. 2001 Dec;1(6):626-31")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][12]["PMID"], "11757819")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][12].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][13]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][13]["RefSource"], "Breast Cancer Res Treat. 2012 Jun;133(3):1169-77")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][13]["PMID"], "22434524")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][13].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][14]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][14]["RefSource"], "Int J Environ Res Public Health. 2011 Dec;8(12 ):4608-22")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][14]["PMID"], "22408592")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][14].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][15]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][15]["RefSource"], "Ann Oncol. 2014 Oct;25(10):2025-30")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][15]["PMID"], "25081899")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][15].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][16]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][16]["RefSource"], "Environ Health. 2006 Dec 06;5:32")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][16]["PMID"], "17147831")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][16].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][17]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][17]["RefSource"], "Environ Health Perspect. 1998 Aug;106(8):437-45")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][17]["PMID"], "9681970")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][17].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][18]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][18]["RefSource"], "Arch Intern Med. 2000 Feb 28;160(4):526-34")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][18]["PMID"], "10695693")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][18].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][19]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][19]["RefSource"], "Endocrine. 2011 Jun;39(3):259-65")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][19]["PMID"], "21161440")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][19].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][20]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][20]["RefSource"], "Cancer Epidemiol Biomarkers Prev. 2008 Aug;17(8):1880-3")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][20]["PMID"], "18708375")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][20].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][21]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][21]["RefSource"], "Am J Epidemiol. 2010 Feb 15;171(4):455-64")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][21]["PMID"], "20061368")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][21].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][22]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][22]["RefSource"], "J Clin Endocrinol Metab. 2002 Feb;87(2):489-99")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][22]["PMID"], "11836274")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][22].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][23]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][23]["RefSource"], "J Toxicol Environ Health A. 2015 ;78(21-22):1338-47")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][23]["PMID"], "26555155")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][23].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][24]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][24]["RefSource"], "Toxicol Sci. 2002 Jun;67(2):207-18")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][24]["PMID"], "12011480")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][24].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][25]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][25]["RefSource"], "Natl Cancer Inst Carcinog Tech Rep Ser. 1978;21:1-184")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][25]["PMID"], "12844187")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][25].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][26]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][26]["RefSource"], "Environ Res. 2013 Nov;127:7-15")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][26]["PMID"], "24183346")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][26].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][27]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][27]["RefSource"], "JAMA. 2004 Jan 14;291(2):228-38")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][27]["PMID"], "14722150")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][27].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][28]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][28]["RefSource"], "J Expo Sci Environ Epidemiol. 2010 Sep;20(6):559-69")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][28]["PMID"], "19888312")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][28].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][29]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][29]["RefSource"], "Environ Health Perspect. 1996 Apr;104(4):362-9")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][29]["PMID"], "8732939")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][29].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][30]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][30]["RefSource"], "Lancet. 2012 Mar 24;379(9821):1142-54")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][30]["PMID"], "22273398")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][30].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][31]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][31]["RefSource"], "JAMA. 1995 Mar 8;273(10):808-12")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][31]["PMID"], "7532241")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][31].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][32]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][32]["RefSource"], "Sci Total Environ. 2002 Aug 5;295(1-3):207-15")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][32]["PMID"], "12186288")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][32].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][33]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][33]["RefSource"], "Eur J Endocrinol. 2006 May;154(5):599-611")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][33]["PMID"], "16645005")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][33].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][34]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][34]["RefSource"], "J Occup Environ Med. 2013 Oct;55(10):1171-8")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][34]["PMID"], "24064777")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][34].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][35]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][35]["RefSource"], "Thyroid. 2007 Sep;17(9):811-7")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][35]["PMID"], "17956155")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][35].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][36]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][36]["RefSource"], "Rev Environ Contam Toxicol. 1991;120:1-82")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][36]["PMID"], "1899728")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][36].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][37]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][37]["RefSource"], "Environ Health Perspect. 1997 Oct;105(10):1126-30")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][37]["PMID"], "9349837")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][37].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][38]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][38]["RefSource"], "J Biochem Mol Toxicol. 2005;19(3):175")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][38]["PMID"], "15977190")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][38].attributes, {"RefType": "Cites"})
-        self.assertEqual(len(article["MedlineCitation"]["CommentsCorrectionsList"][39]), 2)
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][39]["RefSource"], "Immunogenetics. 2002 Jun;54(3):141-57")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][39]["PMID"], "12073143")
-        self.assertEqual(article["MedlineCitation"]["CommentsCorrectionsList"][39].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][0]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][0]["RefSource"],
+            "J Toxicol Environ Health A. 2003 Jun 13;66(11):965-86",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][0]["PMID"], "12775511"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][0].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][1]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][1]["RefSource"],
+            "Ann Intern Med. 2015 May 5;162(9):641-50",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][1]["PMID"], "25798805"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][1].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][2]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][2]["RefSource"],
+            "Cancer Causes Control. 1999 Dec;10(6):583-95",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][2]["PMID"], "10616827"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][2].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][3]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][3]["RefSource"],
+            "Thyroid. 2010 Jul;20(7):755-61",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][3]["PMID"], "20578899"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][3].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][4]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][4]["RefSource"],
+            "Environ Health Perspect. 1999 Mar;107(3):205-11",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][4]["PMID"], "10064550"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][4].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][5]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][5]["RefSource"],
+            "J Clin Endocrinol Metab. 2006 Nov;91(11):4295-301",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][5]["PMID"], "16868053"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][5].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][6]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][6]["RefSource"],
+            "Endocrinology. 1998 Oct;139(10):4252-63",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][6]["PMID"], "9751507"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][6].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][7]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][7]["RefSource"],
+            "Eur J Endocrinol. 2016 Apr;174(4):409-14",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][7]["PMID"], "26863886"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][7].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][8]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][8]["RefSource"],
+            "Eur J Endocrinol. 2000 Nov;143(5):639-47",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][8]["PMID"], "11078988"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][8].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][9]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][9]["RefSource"],
+            "Environ Res. 2016 Nov;151:389-398",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][9]["PMID"], "27540871"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][9].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][10]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][10]["RefSource"],
+            "Am J Epidemiol. 2010 Jan 15;171(2):242-52",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][10]["PMID"],
+            "19951937",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][10].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][11]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][11]["RefSource"],
+            "Thyroid. 1998 Sep;8(9):827-56",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][11]["PMID"], "9777756"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][11].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][12]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][12]["RefSource"],
+            "Curr Opin Pharmacol. 2001 Dec;1(6):626-31",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][12]["PMID"],
+            "11757819",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][12].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][13]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][13]["RefSource"],
+            "Breast Cancer Res Treat. 2012 Jun;133(3):1169-77",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][13]["PMID"],
+            "22434524",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][13].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][14]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][14]["RefSource"],
+            "Int J Environ Res Public Health. 2011 Dec;8(12 ):4608-22",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][14]["PMID"],
+            "22408592",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][14].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][15]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][15]["RefSource"],
+            "Ann Oncol. 2014 Oct;25(10):2025-30",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][15]["PMID"],
+            "25081899",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][15].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][16]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][16]["RefSource"],
+            "Environ Health. 2006 Dec 06;5:32",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][16]["PMID"],
+            "17147831",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][16].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][17]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][17]["RefSource"],
+            "Environ Health Perspect. 1998 Aug;106(8):437-45",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][17]["PMID"], "9681970"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][17].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][18]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][18]["RefSource"],
+            "Arch Intern Med. 2000 Feb 28;160(4):526-34",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][18]["PMID"],
+            "10695693",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][18].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][19]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][19]["RefSource"],
+            "Endocrine. 2011 Jun;39(3):259-65",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][19]["PMID"],
+            "21161440",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][19].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][20]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][20]["RefSource"],
+            "Cancer Epidemiol Biomarkers Prev. 2008 Aug;17(8):1880-3",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][20]["PMID"],
+            "18708375",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][20].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][21]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][21]["RefSource"],
+            "Am J Epidemiol. 2010 Feb 15;171(4):455-64",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][21]["PMID"],
+            "20061368",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][21].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][22]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][22]["RefSource"],
+            "J Clin Endocrinol Metab. 2002 Feb;87(2):489-99",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][22]["PMID"],
+            "11836274",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][22].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][23]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][23]["RefSource"],
+            "J Toxicol Environ Health A. 2015 ;78(21-22):1338-47",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][23]["PMID"],
+            "26555155",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][23].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][24]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][24]["RefSource"],
+            "Toxicol Sci. 2002 Jun;67(2):207-18",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][24]["PMID"],
+            "12011480",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][24].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][25]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][25]["RefSource"],
+            "Natl Cancer Inst Carcinog Tech Rep Ser. 1978;21:1-184",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][25]["PMID"],
+            "12844187",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][25].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][26]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][26]["RefSource"],
+            "Environ Res. 2013 Nov;127:7-15",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][26]["PMID"],
+            "24183346",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][26].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][27]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][27]["RefSource"],
+            "JAMA. 2004 Jan 14;291(2):228-38",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][27]["PMID"],
+            "14722150",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][27].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][28]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][28]["RefSource"],
+            "J Expo Sci Environ Epidemiol. 2010 Sep;20(6):559-69",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][28]["PMID"],
+            "19888312",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][28].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][29]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][29]["RefSource"],
+            "Environ Health Perspect. 1996 Apr;104(4):362-9",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][29]["PMID"], "8732939"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][29].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][30]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][30]["RefSource"],
+            "Lancet. 2012 Mar 24;379(9821):1142-54",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][30]["PMID"],
+            "22273398",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][30].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][31]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][31]["RefSource"],
+            "JAMA. 1995 Mar 8;273(10):808-12",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][31]["PMID"], "7532241"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][31].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][32]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][32]["RefSource"],
+            "Sci Total Environ. 2002 Aug 5;295(1-3):207-15",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][32]["PMID"],
+            "12186288",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][32].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][33]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][33]["RefSource"],
+            "Eur J Endocrinol. 2006 May;154(5):599-611",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][33]["PMID"],
+            "16645005",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][33].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][34]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][34]["RefSource"],
+            "J Occup Environ Med. 2013 Oct;55(10):1171-8",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][34]["PMID"],
+            "24064777",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][34].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][35]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][35]["RefSource"],
+            "Thyroid. 2007 Sep;17(9):811-7",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][35]["PMID"],
+            "17956155",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][35].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][36]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][36]["RefSource"],
+            "Rev Environ Contam Toxicol. 1991;120:1-82",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][36]["PMID"], "1899728"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][36].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][37]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][37]["RefSource"],
+            "Environ Health Perspect. 1997 Oct;105(10):1126-30",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][37]["PMID"], "9349837"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][37].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][38]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][38]["RefSource"],
+            "J Biochem Mol Toxicol. 2005;19(3):175",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][38]["PMID"],
+            "15977190",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][38].attributes,
+            {"RefType": "Cites"},
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["CommentsCorrectionsList"][39]), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][39]["RefSource"],
+            "Immunogenetics. 2002 Jun;54(3):141-57",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][39]["PMID"],
+            "12073143",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["CommentsCorrectionsList"][39].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(article["MedlineCitation"]["DateRevised"]["Year"], "2018")
         self.assertEqual(article["MedlineCitation"]["DateRevised"]["Month"], "04")
         self.assertEqual(article["MedlineCitation"]["DateRevised"]["Day"], "25")
@@ -4039,204 +7005,878 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(len(article["MedlineCitation"]["KeywordList"]), 1)
         self.assertEqual(len(article["MedlineCitation"]["KeywordList"][0]), 5)
         self.assertEqual(article["MedlineCitation"]["KeywordList"][0][0], "agriculture")
-        self.assertEqual(article["MedlineCitation"]["KeywordList"][0][0].attributes, {"MajorTopicYN": "N"})
-        self.assertEqual(article["MedlineCitation"]["KeywordList"][0][1], "hypothyroidism")
-        self.assertEqual(article["MedlineCitation"]["KeywordList"][0][1].attributes, {"MajorTopicYN": "N"})
+        self.assertEqual(
+            article["MedlineCitation"]["KeywordList"][0][0].attributes,
+            {"MajorTopicYN": "N"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["KeywordList"][0][1], "hypothyroidism"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["KeywordList"][0][1].attributes,
+            {"MajorTopicYN": "N"},
+        )
         self.assertEqual(article["MedlineCitation"]["KeywordList"][0][2], "pesticides")
-        self.assertEqual(article["MedlineCitation"]["KeywordList"][0][2].attributes, {"MajorTopicYN": "N"})
-        self.assertEqual(article["MedlineCitation"]["KeywordList"][0][3], "thyroid disease")
-        self.assertEqual(article["MedlineCitation"]["KeywordList"][0][3].attributes, {"MajorTopicYN": "N"})
-        self.assertEqual(article["MedlineCitation"]["KeywordList"][0][4], "thyroid stimulating hormone")
-        self.assertEqual(article["MedlineCitation"]["KeywordList"][0][4].attributes, {"MajorTopicYN": "N"})
+        self.assertEqual(
+            article["MedlineCitation"]["KeywordList"][0][2].attributes,
+            {"MajorTopicYN": "N"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["KeywordList"][0][3], "thyroid disease"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["KeywordList"][0][3].attributes,
+            {"MajorTopicYN": "N"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["KeywordList"][0][4],
+            "thyroid stimulating hormone",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["KeywordList"][0][4].attributes,
+            {"MajorTopicYN": "N"},
+        )
         self.assertEqual(len(article["MedlineCitation"]["MedlineJournalInfo"]), 4)
-        self.assertEqual(article["MedlineCitation"]["MedlineJournalInfo"]["MedlineTA"], "Occup Environ Med")
-        self.assertEqual(article["MedlineCitation"]["MedlineJournalInfo"]["Country"], "England")
-        self.assertEqual(article["MedlineCitation"]["MedlineJournalInfo"]["NlmUniqueID"], "9422759")
-        self.assertEqual(article["MedlineCitation"]["MedlineJournalInfo"]["ISSNLinking"], "1351-0711")
-        self.assertEqual(len(article["MedlineCitation"]["MedlineJournalInfo"].attributes), 0)
+        self.assertEqual(
+            article["MedlineCitation"]["MedlineJournalInfo"]["MedlineTA"],
+            "Occup Environ Med",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["MedlineJournalInfo"]["Country"], "England"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["MedlineJournalInfo"]["NlmUniqueID"], "9422759"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["MedlineJournalInfo"]["ISSNLinking"], "1351-0711"
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["MedlineJournalInfo"].attributes), 0
+        )
         self.assertEqual(len(article["MedlineCitation"]["OtherAbstract"]), 0)
         self.assertEqual(len(article["MedlineCitation"]["OtherID"]), 0)
         self.assertEqual(article["MedlineCitation"]["PMID"], "28775130")
         self.assertEqual(len(article["MedlineCitation"]["SpaceFlightMission"]), 0)
         self.assertEqual(len(article["MedlineCitation"]["Article"]["ArticleDate"]), 1)
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["ArticleDate"][0]), 3)
-        self.assertEqual(article["MedlineCitation"]["Article"]["ArticleDate"][0]["Month"], "08")
-        self.assertEqual(article["MedlineCitation"]["Article"]["ArticleDate"][0]["Day"], "03")
-        self.assertEqual(article["MedlineCitation"]["Article"]["ArticleDate"][0]["Year"], "2017")
-        self.assertEqual(article["MedlineCitation"]["Article"]["ArticleDate"][0].attributes, {"DateType": "Electronic"})
+        self.assertEqual(
+            len(article["MedlineCitation"]["Article"]["ArticleDate"][0]), 3
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["ArticleDate"][0]["Month"], "08"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["ArticleDate"][0]["Day"], "03"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["ArticleDate"][0]["Year"], "2017"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["ArticleDate"][0].attributes,
+            {"DateType": "Electronic"},
+        )
         self.assertEqual(len(article["MedlineCitation"]["Article"]["Pagination"]), 1)
-        self.assertEqual(article["MedlineCitation"]["Article"]["Pagination"]["MedlinePgn"], "79-89")
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["Pagination"].attributes), 0)
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Pagination"]["MedlinePgn"], "79-89"
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["Article"]["Pagination"].attributes), 0
+        )
         self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"]), 12)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][0]["LastName"], "Lerro")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][0]["Initials"], "CC")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][0]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][0]["AffiliationInfo"]), 1)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][0]["AffiliationInfo"][0]["Affiliation"], "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][0]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][0]["AffiliationInfo"][0].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][0]["ForeName"], "Catherine C")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][0].attributes, {"ValidYN": "Y"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][1]["LastName"], "Beane Freeman")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][1]["Initials"], "LE")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][1]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][1]["AffiliationInfo"]), 1)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][1]["AffiliationInfo"][0]["Affiliation"], "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][1]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][1]["AffiliationInfo"][0].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][1]["ForeName"], "Laura E")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][1].attributes, {"ValidYN": "Y"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][2]["LastName"], "DellaValle")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][2]["Initials"], "CT")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][2]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][2]["AffiliationInfo"]), 2)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][2]["AffiliationInfo"][0]["Affiliation"], "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][2]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][2]["AffiliationInfo"][0].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][2]["AffiliationInfo"][1]["Affiliation"], "Environmental Working Group, Washington, DC, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][2]["AffiliationInfo"][1]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][2]["AffiliationInfo"][1].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][2]["ForeName"], "Curt T")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][2].attributes, {"ValidYN": "Y"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][3]["LastName"], "Kibriya")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][3]["Initials"], "MG")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][3]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][3]["AffiliationInfo"]), 1)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][3]["AffiliationInfo"][0]["Affiliation"], "Department of Public Health Sciences, The University of Chicago, Chicago, Illinois, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][3]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][3]["AffiliationInfo"][0].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][3]["ForeName"], "Muhammad G")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][3].attributes, {"ValidYN": "Y"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][4]["LastName"], "Aschebrook-Kilfoy")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][4]["Initials"], "B")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][4]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][4]["AffiliationInfo"]), 1)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][4]["AffiliationInfo"][0]["Affiliation"], "Department of Public Health Sciences, The University of Chicago, Chicago, Illinois, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][4]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][4]["AffiliationInfo"][0].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][4]["ForeName"], "Briseis")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][4].attributes, {"ValidYN": "Y"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][5]["LastName"], "Jasmine")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][5]["Initials"], "F")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][5]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][5]["AffiliationInfo"]), 1)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][5]["AffiliationInfo"][0]["Affiliation"], "Department of Public Health Sciences, The University of Chicago, Chicago, Illinois, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][5]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][5]["AffiliationInfo"][0].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][5]["ForeName"], "Farzana")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][5].attributes, {"ValidYN": "Y"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][6]["LastName"], "Koutros")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][6]["Initials"], "S")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][6]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][6]["AffiliationInfo"]), 1)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][6]["AffiliationInfo"][0]["Affiliation"], "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][6]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][6]["AffiliationInfo"][0].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][6]["ForeName"], "Stella")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][6].attributes, {"ValidYN": "Y"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][7]["LastName"], "Parks")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][7]["Initials"], "CG")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][7]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][7]["AffiliationInfo"]), 1)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][7]["AffiliationInfo"][0]["Affiliation"], "National Institute of Environmental Health Sciences, Research Triangle Park, North Carolina, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][7]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][7]["AffiliationInfo"][0].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][7]["ForeName"], "Christine G")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][7].attributes, {"ValidYN": "Y"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][8]["LastName"], "Sandler")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][8]["Initials"], "DP")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][8]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][8]["AffiliationInfo"]), 1)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][8]["AffiliationInfo"][0]["Affiliation"], "National Institute of Environmental Health Sciences, Research Triangle Park, North Carolina, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][8]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][8]["AffiliationInfo"][0].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][8]["ForeName"], "Dale P")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][8].attributes, {"ValidYN": "Y"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][9]["LastName"], "Alavanja")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][9]["Initials"], "MCR")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][9]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][9]["AffiliationInfo"]), 2)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][9]["AffiliationInfo"][0]["Affiliation"], "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][9]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][9]["AffiliationInfo"][0].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][9]["AffiliationInfo"][1]["Affiliation"], "Department of Biology, Hood College, Frederick, Maryland, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][9]["AffiliationInfo"][1]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][9]["AffiliationInfo"][1].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][9]["ForeName"], "Michael C R")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][9].attributes, {"ValidYN": "Y"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][10]["LastName"], "Hofmann")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][10]["Initials"], "JN")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][10]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][10]["AffiliationInfo"]), 1)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][10]["AffiliationInfo"][0]["Affiliation"], "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][10]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][10]["AffiliationInfo"][0].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][10]["ForeName"], "Jonathan N")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][10].attributes, {"ValidYN": "Y"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][11]["LastName"], "Ward")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][11]["Initials"], "MH")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][11]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][11]["AffiliationInfo"]), 1)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][11]["AffiliationInfo"][0]["Affiliation"], "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][11]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["AuthorList"][11]["AffiliationInfo"][0].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][11]["ForeName"], "Mary H")
-        self.assertEqual(article["MedlineCitation"]["Article"]["AuthorList"][11].attributes, {"ValidYN": "Y"})
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][0]["LastName"], "Lerro"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][0]["Initials"], "CC"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][0]["Identifier"], []
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][0][
+                    "AffiliationInfo"
+                ]
+            ),
+            1,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][0]["AffiliationInfo"][
+                0
+            ]["Affiliation"],
+            "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][0]["AffiliationInfo"][
+                0
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][0][
+                    "AffiliationInfo"
+                ][0].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][0]["ForeName"],
+            "Catherine C",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][0].attributes,
+            {"ValidYN": "Y"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][1]["LastName"],
+            "Beane Freeman",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][1]["Initials"], "LE"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][1]["Identifier"], []
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][1][
+                    "AffiliationInfo"
+                ]
+            ),
+            1,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][1]["AffiliationInfo"][
+                0
+            ]["Affiliation"],
+            "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][1]["AffiliationInfo"][
+                0
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][1][
+                    "AffiliationInfo"
+                ][0].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][1]["ForeName"],
+            "Laura E",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][1].attributes,
+            {"ValidYN": "Y"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][2]["LastName"],
+            "DellaValle",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][2]["Initials"], "CT"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][2]["Identifier"], []
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][2][
+                    "AffiliationInfo"
+                ]
+            ),
+            2,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][2]["AffiliationInfo"][
+                0
+            ]["Affiliation"],
+            "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][2]["AffiliationInfo"][
+                0
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][2][
+                    "AffiliationInfo"
+                ][0].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][2]["AffiliationInfo"][
+                1
+            ]["Affiliation"],
+            "Environmental Working Group, Washington, DC, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][2]["AffiliationInfo"][
+                1
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][2][
+                    "AffiliationInfo"
+                ][1].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][2]["ForeName"], "Curt T"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][2].attributes,
+            {"ValidYN": "Y"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][3]["LastName"],
+            "Kibriya",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][3]["Initials"], "MG"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][3]["Identifier"], []
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][3][
+                    "AffiliationInfo"
+                ]
+            ),
+            1,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][3]["AffiliationInfo"][
+                0
+            ]["Affiliation"],
+            "Department of Public Health Sciences, The University of Chicago, Chicago, Illinois, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][3]["AffiliationInfo"][
+                0
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][3][
+                    "AffiliationInfo"
+                ][0].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][3]["ForeName"],
+            "Muhammad G",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][3].attributes,
+            {"ValidYN": "Y"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][4]["LastName"],
+            "Aschebrook-Kilfoy",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][4]["Initials"], "B"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][4]["Identifier"], []
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][4][
+                    "AffiliationInfo"
+                ]
+            ),
+            1,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][4]["AffiliationInfo"][
+                0
+            ]["Affiliation"],
+            "Department of Public Health Sciences, The University of Chicago, Chicago, Illinois, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][4]["AffiliationInfo"][
+                0
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][4][
+                    "AffiliationInfo"
+                ][0].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][4]["ForeName"],
+            "Briseis",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][4].attributes,
+            {"ValidYN": "Y"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][5]["LastName"],
+            "Jasmine",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][5]["Initials"], "F"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][5]["Identifier"], []
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][5][
+                    "AffiliationInfo"
+                ]
+            ),
+            1,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][5]["AffiliationInfo"][
+                0
+            ]["Affiliation"],
+            "Department of Public Health Sciences, The University of Chicago, Chicago, Illinois, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][5]["AffiliationInfo"][
+                0
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][5][
+                    "AffiliationInfo"
+                ][0].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][5]["ForeName"],
+            "Farzana",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][5].attributes,
+            {"ValidYN": "Y"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][6]["LastName"],
+            "Koutros",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][6]["Initials"], "S"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][6]["Identifier"], []
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][6][
+                    "AffiliationInfo"
+                ]
+            ),
+            1,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][6]["AffiliationInfo"][
+                0
+            ]["Affiliation"],
+            "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][6]["AffiliationInfo"][
+                0
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][6][
+                    "AffiliationInfo"
+                ][0].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][6]["ForeName"], "Stella"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][6].attributes,
+            {"ValidYN": "Y"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][7]["LastName"], "Parks"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][7]["Initials"], "CG"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][7]["Identifier"], []
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][7][
+                    "AffiliationInfo"
+                ]
+            ),
+            1,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][7]["AffiliationInfo"][
+                0
+            ]["Affiliation"],
+            "National Institute of Environmental Health Sciences, Research Triangle Park, North Carolina, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][7]["AffiliationInfo"][
+                0
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][7][
+                    "AffiliationInfo"
+                ][0].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][7]["ForeName"],
+            "Christine G",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][7].attributes,
+            {"ValidYN": "Y"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][8]["LastName"],
+            "Sandler",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][8]["Initials"], "DP"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][8]["Identifier"], []
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][8][
+                    "AffiliationInfo"
+                ]
+            ),
+            1,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][8]["AffiliationInfo"][
+                0
+            ]["Affiliation"],
+            "National Institute of Environmental Health Sciences, Research Triangle Park, North Carolina, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][8]["AffiliationInfo"][
+                0
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][8][
+                    "AffiliationInfo"
+                ][0].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][8]["ForeName"], "Dale P"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][8].attributes,
+            {"ValidYN": "Y"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][9]["LastName"],
+            "Alavanja",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][9]["Initials"], "MCR"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][9]["Identifier"], []
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][9][
+                    "AffiliationInfo"
+                ]
+            ),
+            2,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][9]["AffiliationInfo"][
+                0
+            ]["Affiliation"],
+            "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][9]["AffiliationInfo"][
+                0
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][9][
+                    "AffiliationInfo"
+                ][0].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][9]["AffiliationInfo"][
+                1
+            ]["Affiliation"],
+            "Department of Biology, Hood College, Frederick, Maryland, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][9]["AffiliationInfo"][
+                1
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][9][
+                    "AffiliationInfo"
+                ][1].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][9]["ForeName"],
+            "Michael C R",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][9].attributes,
+            {"ValidYN": "Y"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][10]["LastName"],
+            "Hofmann",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][10]["Initials"], "JN"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][10]["Identifier"], []
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][10][
+                    "AffiliationInfo"
+                ]
+            ),
+            1,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][10]["AffiliationInfo"][
+                0
+            ]["Affiliation"],
+            "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][10]["AffiliationInfo"][
+                0
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][10][
+                    "AffiliationInfo"
+                ][0].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][10]["ForeName"],
+            "Jonathan N",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][10].attributes,
+            {"ValidYN": "Y"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][11]["LastName"], "Ward"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][11]["Initials"], "MH"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][11]["Identifier"], []
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][11][
+                    "AffiliationInfo"
+                ]
+            ),
+            1,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][11]["AffiliationInfo"][
+                0
+            ]["Affiliation"],
+            "Division of Cancer Epidemiology and Genetics, National Cancer Institute, Rockville, Maryland, USA.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][11]["AffiliationInfo"][
+                0
+            ]["Identifier"],
+            [],
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["AuthorList"][11][
+                    "AffiliationInfo"
+                ][0].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][11]["ForeName"],
+            "Mary H",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["AuthorList"][11].attributes,
+            {"ValidYN": "Y"},
+        )
         self.assertEqual(len(article["MedlineCitation"]["Article"]["Language"]), 1)
         self.assertEqual(article["MedlineCitation"]["Article"]["Language"][0], "eng")
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["PublicationTypeList"]), 1)
-        self.assertEqual(article["MedlineCitation"]["Article"]["PublicationTypeList"][0], "Journal Article")
-        self.assertEqual(article["MedlineCitation"]["Article"]["PublicationTypeList"][0].attributes, {"UI": "D016428"})
+        self.assertEqual(
+            len(article["MedlineCitation"]["Article"]["PublicationTypeList"]), 1
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["PublicationTypeList"][0],
+            "Journal Article",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["PublicationTypeList"][0].attributes,
+            {"UI": "D016428"},
+        )
         self.assertEqual(len(article["MedlineCitation"]["Article"]["Journal"]), 4)
-        self.assertEqual(article["MedlineCitation"]["Article"]["Journal"]["ISSN"], "1470-7926")
-        self.assertEqual(article["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes, {"IssnType": "Electronic"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["Journal"]["ISOAbbreviation"], "Occup Environ Med")
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]), 3)
-        self.assertEqual(article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Volume"], "75")
-        self.assertEqual(article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Issue"], "2")
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]), 2)
-        self.assertEqual(article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Month"], "Feb")
-        self.assertEqual(article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Year"], "2018")
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"].attributes, {"CitedMedium": "Internet"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["Journal"]["Title"], "Occupational and environmental medicine")
-        self.assertEqual(article["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes, {"IssnType": "Electronic"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["ArticleTitle"], "Occupational pesticide exposure and subclinical hypothyroidism among male pesticide applicators.")
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Journal"]["ISSN"], "1470-7926"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes,
+            {"IssnType": "Electronic"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Journal"]["ISOAbbreviation"],
+            "Occup Environ Med",
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]), 3
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Volume"],
+            "75",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Issue"],
+            "2",
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                    "PubDate"
+                ]
+            ),
+            2,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"][
+                "Month"
+            ],
+            "Feb",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"][
+                "Year"
+            ],
+            "2018",
+        )
+        self.assertEqual(
+            len(
+                article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                    "PubDate"
+                ].attributes
+            ),
+            0,
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"].attributes,
+            {"CitedMedium": "Internet"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Journal"]["Title"],
+            "Occupational and environmental medicine",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes,
+            {"IssnType": "Electronic"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["ArticleTitle"],
+            "Occupational pesticide exposure and subclinical hypothyroidism among male pesticide applicators.",
+        )
         self.assertEqual(len(article["MedlineCitation"]["Article"]["ELocationID"]), 1)
-        self.assertEqual(article["MedlineCitation"]["Article"]["ELocationID"][0], "10.1136/oemed-2017-104431")
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["ELocationID"][0].attributes), 2)
-        self.assertEqual(article["MedlineCitation"]["Article"]["ELocationID"][0].attributes["ValidYN"], "Y")
-        self.assertEqual(article["MedlineCitation"]["Article"]["ELocationID"][0].attributes["EIdType"], "doi")
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"]), 4)
-        self.assertEqual(article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][0], "Animal studies suggest that exposure to pesticides may alter thyroid function; however, few epidemiologic studies have examined this association. We evaluated the relationship between individual pesticides and thyroid function in 679 men enrolled in a substudy of the Agricultural Health Study, a cohort of licensed pesticide applicators.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][0].attributes, {"NlmCategory": "OBJECTIVE", "Label": "OBJECTIVES"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][1], "Self-reported lifetime pesticide use was obtained at cohort enrolment (1993-1997). Intensity-weighted lifetime days were computed for 33 pesticides, which adjusts cumulative days of pesticide use for factors that modify exposure (eg, use of personal protective equipment). Thyroid-stimulating hormone (TSH), thyroxine (T4), triiodothyronine (T3) and antithyroid peroxidase (anti-TPO) autoantibodies were measured in serum collected in 2010-2013. We used multivariate logistic regression to estimate ORs and 95% CIs for subclinical hypothyroidism (TSH &gt;4.5 mIU/L) compared with normal TSH (0.4-<u>&lt;</u>4.5 mIU/L) and for anti-TPO positivity. We also examined pesticide associations with TSH, T4 and T3 in multivariate linear regression models.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][1].attributes, {"NlmCategory": "METHODS", "Label": "METHODS"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][2], "Higher exposure to the insecticide aldrin (third and fourth quartiles of intensity-weighted days vs no exposure) was positively associated with subclinical hypothyroidism (OR<sub>Q3</sub>=4.15, 95% CI 1.56 to 11.01, OR<sub>Q4</sub>=4.76, 95% CI 1.53 to 14.82, p<sub>trend</sub> &lt;0.01), higher TSH (p<sub>trend</sub>=0.01) and lower T4 (p<sub>trend</sub>=0.04). Higher exposure to the herbicide pendimethalin was associated with subclinical hypothyroidism (fourth quartile vs no exposure: OR<sub>Q4</sub>=2.78, 95% CI 1.30 to 5.95, p<sub>trend</sub>=0.02), higher TSH (p<sub>trend</sub>=0.04) and anti-TPO positivity (p<sub>trend</sub>=0.01). The fumigant methyl bromide was inversely associated with TSH (p<sub>trend</sub>=0.02) and positively associated with T4 (p<sub>trend</sub>=0.01).")
-        self.assertEqual(article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][2].attributes, {"NlmCategory": "RESULTS", "Label": "RESULTS"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][3], "Our results suggest that long-term exposure to aldrin, pendimethalin and methyl bromide may alter thyroid function among male pesticide applicators.")
-        self.assertEqual(article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][3].attributes, {"NlmCategory": "CONCLUSIONS", "Label": "CONCLUSIONS"})
-        self.assertEqual(article["MedlineCitation"]["Article"]["Abstract"]["CopyrightInformation"], "\xa9 Article author(s) (or their employer(s) unless otherwise stated in the text of the article) 2018. All rights reserved. No commercial use is permitted unless otherwise expressly granted.")
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["ELocationID"][0],
+            "10.1136/oemed-2017-104431",
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["Article"]["ELocationID"][0].attributes), 2
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["ELocationID"][0].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["ELocationID"][0].attributes[
+                "EIdType"
+            ],
+            "doi",
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"]), 4
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][0],
+            "Animal studies suggest that exposure to pesticides may alter thyroid function; however, few epidemiologic studies have examined this association. We evaluated the relationship between individual pesticides and thyroid function in 679 men enrolled in a substudy of the Agricultural Health Study, a cohort of licensed pesticide applicators.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][
+                0
+            ].attributes,
+            {"NlmCategory": "OBJECTIVE", "Label": "OBJECTIVES"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][1],
+            "Self-reported lifetime pesticide use was obtained at cohort enrolment (1993-1997). Intensity-weighted lifetime days were computed for 33 pesticides, which adjusts cumulative days of pesticide use for factors that modify exposure (eg, use of personal protective equipment). Thyroid-stimulating hormone (TSH), thyroxine (T4), triiodothyronine (T3) and antithyroid peroxidase (anti-TPO) autoantibodies were measured in serum collected in 2010-2013. We used multivariate logistic regression to estimate ORs and 95% CIs for subclinical hypothyroidism (TSH &gt;4.5 mIU/L) compared with normal TSH (0.4-<u>&lt;</u>4.5 mIU/L) and for anti-TPO positivity. We also examined pesticide associations with TSH, T4 and T3 in multivariate linear regression models.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][
+                1
+            ].attributes,
+            {"NlmCategory": "METHODS", "Label": "METHODS"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][2],
+            "Higher exposure to the insecticide aldrin (third and fourth quartiles of intensity-weighted days vs no exposure) was positively associated with subclinical hypothyroidism (OR<sub>Q3</sub>=4.15, 95% CI 1.56 to 11.01, OR<sub>Q4</sub>=4.76, 95% CI 1.53 to 14.82, p<sub>trend</sub> &lt;0.01), higher TSH (p<sub>trend</sub>=0.01) and lower T4 (p<sub>trend</sub>=0.04). Higher exposure to the herbicide pendimethalin was associated with subclinical hypothyroidism (fourth quartile vs no exposure: OR<sub>Q4</sub>=2.78, 95% CI 1.30 to 5.95, p<sub>trend</sub>=0.02), higher TSH (p<sub>trend</sub>=0.04) and anti-TPO positivity (p<sub>trend</sub>=0.01). The fumigant methyl bromide was inversely associated with TSH (p<sub>trend</sub>=0.02) and positively associated with T4 (p<sub>trend</sub>=0.01).",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][
+                2
+            ].attributes,
+            {"NlmCategory": "RESULTS", "Label": "RESULTS"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][3],
+            "Our results suggest that long-term exposure to aldrin, pendimethalin and methyl bromide may alter thyroid function among male pesticide applicators.",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][
+                3
+            ].attributes,
+            {"NlmCategory": "CONCLUSIONS", "Label": "CONCLUSIONS"},
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["Abstract"]["CopyrightInformation"],
+            "\xa9 Article author(s) (or their employer(s) unless otherwise stated in the text of the article) 2018. All rights reserved. No commercial use is permitted unless otherwise expressly granted.",
+        )
         self.assertEqual(len(article["MedlineCitation"]["Article"]["GrantList"]), 3)
         self.assertEqual(len(article["MedlineCitation"]["Article"]["GrantList"][0]), 4)
-        self.assertEqual(article["MedlineCitation"]["Article"]["GrantList"][0]["Acronym"], "CP")
-        self.assertEqual(article["MedlineCitation"]["Article"]["GrantList"][0]["Country"], "United States")
-        self.assertEqual(article["MedlineCitation"]["Article"]["GrantList"][0]["Agency"], "NCI NIH HHS")
-        self.assertEqual(article["MedlineCitation"]["Article"]["GrantList"][0]["GrantID"], "Z01 CP010119")
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["GrantList"][0].attributes), 0)
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["GrantList"][0]["Acronym"], "CP"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["GrantList"][0]["Country"],
+            "United States",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["GrantList"][0]["Agency"],
+            "NCI NIH HHS",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["GrantList"][0]["GrantID"],
+            "Z01 CP010119",
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["Article"]["GrantList"][0].attributes), 0
+        )
         self.assertEqual(len(article["MedlineCitation"]["Article"]["GrantList"][1]), 4)
-        self.assertEqual(article["MedlineCitation"]["Article"]["GrantList"][1]["Acronym"], "ES")
-        self.assertEqual(article["MedlineCitation"]["Article"]["GrantList"][1]["Country"], "United States")
-        self.assertEqual(article["MedlineCitation"]["Article"]["GrantList"][1]["Agency"], "NIEHS NIH HHS")
-        self.assertEqual(article["MedlineCitation"]["Article"]["GrantList"][1]["GrantID"], "Z01 ES049030")
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["GrantList"][1].attributes), 0)
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["GrantList"][1]["Acronym"], "ES"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["GrantList"][1]["Country"],
+            "United States",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["GrantList"][1]["Agency"],
+            "NIEHS NIH HHS",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["GrantList"][1]["GrantID"],
+            "Z01 ES049030",
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["Article"]["GrantList"][1].attributes), 0
+        )
         self.assertEqual(len(article["MedlineCitation"]["Article"]["GrantList"][2]), 4)
-        self.assertEqual(article["MedlineCitation"]["Article"]["GrantList"][2]["Acronym"], "NULL")
-        self.assertEqual(article["MedlineCitation"]["Article"]["GrantList"][2]["Country"], "United States")
-        self.assertEqual(article["MedlineCitation"]["Article"]["GrantList"][2]["Agency"], "Intramural NIH HHS")
-        self.assertEqual(article["MedlineCitation"]["Article"]["GrantList"][2]["GrantID"], "Z99 CA999999")
-        self.assertEqual(len(article["MedlineCitation"]["Article"]["GrantList"][2].attributes), 0)
-        self.assertEqual(article["MedlineCitation"]["Article"]["GrantList"].attributes, {"CompleteYN": "Y"})
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["GrantList"][2]["Acronym"], "NULL"
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["GrantList"][2]["Country"],
+            "United States",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["GrantList"][2]["Agency"],
+            "Intramural NIH HHS",
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["GrantList"][2]["GrantID"],
+            "Z99 CA999999",
+        )
+        self.assertEqual(
+            len(article["MedlineCitation"]["Article"]["GrantList"][2].attributes), 0
+        )
+        self.assertEqual(
+            article["MedlineCitation"]["Article"]["GrantList"].attributes,
+            {"CompleteYN": "Y"},
+        )
 
     def test_pubmed_html_mathml_tags(self):
         """Test parsing XML returned by EFetch, PubMed database, with both HTML and MathML tags."""
@@ -4255,65 +7895,111 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(len(pubmed_article["PubmedData"]), 3)
         self.assertEqual(len(pubmed_article["PubmedData"]["ArticleIdList"]), 3)
         self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][0], "30108519")
-        self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][0].attributes, {"IdType": "pubmed"})
-        self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][1], "10.3389/fphys.2018.01034")
-        self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][1].attributes, {"IdType": "doi"})
+        self.assertEqual(
+            pubmed_article["PubmedData"]["ArticleIdList"][0].attributes,
+            {"IdType": "pubmed"},
+        )
+        self.assertEqual(
+            pubmed_article["PubmedData"]["ArticleIdList"][1], "10.3389/fphys.2018.01034"
+        )
+        self.assertEqual(
+            pubmed_article["PubmedData"]["ArticleIdList"][1].attributes,
+            {"IdType": "doi"},
+        )
         self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][2], "PMC6079548")
-        self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][2].attributes, {"IdType": "pmc"})
+        self.assertEqual(
+            pubmed_article["PubmedData"]["ArticleIdList"][2].attributes,
+            {"IdType": "pmc"},
+        )
         self.assertEqual(pubmed_article["PubmedData"]["PublicationStatus"], "epublish")
         self.assertEqual(len(pubmed_article["PubmedData"]["History"]), 5)
         self.assertEqual(len(pubmed_article["PubmedData"]["History"][0]), 3)
         self.assertEqual(pubmed_article["PubmedData"]["History"][0]["Year"], "2018")
         self.assertEqual(pubmed_article["PubmedData"]["History"][0]["Month"], "05")
         self.assertEqual(pubmed_article["PubmedData"]["History"][0]["Day"], "22")
-        self.assertEqual(pubmed_article["PubmedData"]["History"][0].attributes, {"PubStatus": "received"})
+        self.assertEqual(
+            pubmed_article["PubmedData"]["History"][0].attributes,
+            {"PubStatus": "received"},
+        )
         self.assertEqual(len(pubmed_article["PubmedData"]["History"][1]), 3)
         self.assertEqual(pubmed_article["PubmedData"]["History"][1]["Year"], "2018")
         self.assertEqual(pubmed_article["PubmedData"]["History"][1]["Month"], "07")
         self.assertEqual(pubmed_article["PubmedData"]["History"][1]["Day"], "11")
-        self.assertEqual(pubmed_article["PubmedData"]["History"][1].attributes, {"PubStatus": "accepted"})
+        self.assertEqual(
+            pubmed_article["PubmedData"]["History"][1].attributes,
+            {"PubStatus": "accepted"},
+        )
         self.assertEqual(len(pubmed_article["PubmedData"]["History"][2]), 5)
         self.assertEqual(pubmed_article["PubmedData"]["History"][2]["Year"], "2018")
         self.assertEqual(pubmed_article["PubmedData"]["History"][2]["Month"], "8")
         self.assertEqual(pubmed_article["PubmedData"]["History"][2]["Day"], "16")
         self.assertEqual(pubmed_article["PubmedData"]["History"][2]["Hour"], "6")
         self.assertEqual(pubmed_article["PubmedData"]["History"][2]["Minute"], "0")
-        self.assertEqual(pubmed_article["PubmedData"]["History"][2].attributes, {"PubStatus": "entrez"})
+        self.assertEqual(
+            pubmed_article["PubmedData"]["History"][2].attributes,
+            {"PubStatus": "entrez"},
+        )
         self.assertEqual(len(pubmed_article["PubmedData"]["History"][3]), 5)
         self.assertEqual(pubmed_article["PubmedData"]["History"][3]["Year"], "2018")
         self.assertEqual(pubmed_article["PubmedData"]["History"][3]["Month"], "8")
         self.assertEqual(pubmed_article["PubmedData"]["History"][3]["Day"], "16")
         self.assertEqual(pubmed_article["PubmedData"]["History"][3]["Hour"], "6")
         self.assertEqual(pubmed_article["PubmedData"]["History"][3]["Minute"], "0")
-        self.assertEqual(pubmed_article["PubmedData"]["History"][3].attributes, {"PubStatus": "pubmed"})
+        self.assertEqual(
+            pubmed_article["PubmedData"]["History"][3].attributes,
+            {"PubStatus": "pubmed"},
+        )
         self.assertEqual(len(pubmed_article["PubmedData"]["History"][4]), 5)
         self.assertEqual(pubmed_article["PubmedData"]["History"][4]["Year"], "2018")
         self.assertEqual(pubmed_article["PubmedData"]["History"][4]["Month"], "8")
         self.assertEqual(pubmed_article["PubmedData"]["History"][4]["Day"], "16")
         self.assertEqual(pubmed_article["PubmedData"]["History"][4]["Hour"], "6")
         self.assertEqual(pubmed_article["PubmedData"]["History"][4]["Minute"], "1")
-        self.assertEqual(pubmed_article["PubmedData"]["History"][4].attributes, {"PubStatus": "medline"})
+        self.assertEqual(
+            pubmed_article["PubmedData"]["History"][4].attributes,
+            {"PubStatus": "medline"},
+        )
         medline_citation = pubmed_article["MedlineCitation"]
         self.assertEqual(len(medline_citation), 11)
         self.assertEqual(medline_citation["GeneralNote"], [])
         self.assertEqual(len(medline_citation["KeywordList"]), 1)
         self.assertEqual(len(medline_citation["KeywordList"][0]), 8)
         self.assertEqual(medline_citation["KeywordList"][0][0], "Owles' point")
-        self.assertEqual(medline_citation["KeywordList"][0][0].attributes, {"MajorTopicYN": "N"})
+        self.assertEqual(
+            medline_citation["KeywordList"][0][0].attributes, {"MajorTopicYN": "N"}
+        )
         self.assertEqual(medline_citation["KeywordList"][0][1], "aerobic capacity")
-        self.assertEqual(medline_citation["KeywordList"][0][1].attributes, {"MajorTopicYN": "N"})
+        self.assertEqual(
+            medline_citation["KeywordList"][0][1].attributes, {"MajorTopicYN": "N"}
+        )
         self.assertEqual(medline_citation["KeywordList"][0][2], "aerobic threshold")
-        self.assertEqual(medline_citation["KeywordList"][0][2].attributes, {"MajorTopicYN": "N"})
+        self.assertEqual(
+            medline_citation["KeywordList"][0][2].attributes, {"MajorTopicYN": "N"}
+        )
         self.assertEqual(medline_citation["KeywordList"][0][3], "anaerobic threshold")
-        self.assertEqual(medline_citation["KeywordList"][0][3].attributes, {"MajorTopicYN": "N"})
+        self.assertEqual(
+            medline_citation["KeywordList"][0][3].attributes, {"MajorTopicYN": "N"}
+        )
         self.assertEqual(medline_citation["KeywordList"][0][4], "endurance assessment")
-        self.assertEqual(medline_citation["KeywordList"][0][4].attributes, {"MajorTopicYN": "N"})
+        self.assertEqual(
+            medline_citation["KeywordList"][0][4].attributes, {"MajorTopicYN": "N"}
+        )
         self.assertEqual(medline_citation["KeywordList"][0][5], "lactate threshold")
-        self.assertEqual(medline_citation["KeywordList"][0][5].attributes, {"MajorTopicYN": "N"})
-        self.assertEqual(medline_citation["KeywordList"][0][6], "oxygen endurance performance limit")
-        self.assertEqual(medline_citation["KeywordList"][0][6].attributes, {"MajorTopicYN": "N"})
-        self.assertEqual(medline_citation["KeywordList"][0][7], "submaximal exercise testing")
-        self.assertEqual(medline_citation["KeywordList"][0][7].attributes, {"MajorTopicYN": "N"})
+        self.assertEqual(
+            medline_citation["KeywordList"][0][5].attributes, {"MajorTopicYN": "N"}
+        )
+        self.assertEqual(
+            medline_citation["KeywordList"][0][6], "oxygen endurance performance limit"
+        )
+        self.assertEqual(
+            medline_citation["KeywordList"][0][6].attributes, {"MajorTopicYN": "N"}
+        )
+        self.assertEqual(
+            medline_citation["KeywordList"][0][7], "submaximal exercise testing"
+        )
+        self.assertEqual(
+            medline_citation["KeywordList"][0][7].attributes, {"MajorTopicYN": "N"}
+        )
         self.assertEqual(medline_citation["CitationSubset"], [])
         self.assertEqual(medline_citation["OtherAbstract"], [])
         self.assertEqual(medline_citation["OtherID"], [])
@@ -4326,287 +8012,882 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(medline_citation["DateRevised"]["Day"], "17")
         self.assertEqual(medline_citation["DateRevised"].attributes, {})
         self.assertEqual(len(medline_citation["MedlineJournalInfo"]), 4)
-        self.assertEqual(medline_citation["MedlineJournalInfo"]["Country"], "Switzerland")
-        self.assertEqual(medline_citation["MedlineJournalInfo"]["MedlineTA"], "Front Physiol")
-        self.assertEqual(medline_citation["MedlineJournalInfo"]["NlmUniqueID"], "101549006")
-        self.assertEqual(medline_citation["MedlineJournalInfo"]["ISSNLinking"], "1664-042X")
+        self.assertEqual(
+            medline_citation["MedlineJournalInfo"]["Country"], "Switzerland"
+        )
+        self.assertEqual(
+            medline_citation["MedlineJournalInfo"]["MedlineTA"], "Front Physiol"
+        )
+        self.assertEqual(
+            medline_citation["MedlineJournalInfo"]["NlmUniqueID"], "101549006"
+        )
+        self.assertEqual(
+            medline_citation["MedlineJournalInfo"]["ISSNLinking"], "1664-042X"
+        )
         self.assertEqual(medline_citation["MedlineJournalInfo"].attributes, {})
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"]), 53)
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][0]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][0]["RefSource"], "Stat Med. 2008 Feb 28;27(5):778-80")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][0]["PMID"], "17907247")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][0]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][0].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][0]["RefSource"],
+            "Stat Med. 2008 Feb 28;27(5):778-80",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][0]["PMID"], "17907247"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][0]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][0].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][1]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][1]["RefSource"], "Int J Sports Med. 2009 Jan;30(1):40-45")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][1]["PMID"], "19202577")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][1]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][1].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][1]["RefSource"],
+            "Int J Sports Med. 2009 Jan;30(1):40-45",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][1]["PMID"], "19202577"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][1]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][1].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][2]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][2]["RefSource"], "Med Sci Sports Exerc. 1995 Jun;27(6):863-7")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][2]["PMID"], "7658947")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][2]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][2].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][2]["RefSource"],
+            "Med Sci Sports Exerc. 1995 Jun;27(6):863-7",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][2]["PMID"], "7658947"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][2]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][2].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][3]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][3]["RefSource"], "Eur J Appl Physiol. 2010 Apr;108(6):1153-67")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][3]["PMID"], "20033207")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][3]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][3].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][3]["RefSource"],
+            "Eur J Appl Physiol. 2010 Apr;108(6):1153-67",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][3]["PMID"], "20033207"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][3]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][3].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][4]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][4]["RefSource"], "Med Sci Sports Exerc. 1999 Apr;31(4):578-82")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][4]["PMID"], "10211855")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][4]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][4].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][4]["RefSource"],
+            "Med Sci Sports Exerc. 1999 Apr;31(4):578-82",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][4]["PMID"], "10211855"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][4]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][4].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][5]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][5]["RefSource"], "Br J Sports Med. 1988 Jun;22(2):51-4")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][5]["PMID"], "3167501")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][5]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][5].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][5]["RefSource"],
+            "Br J Sports Med. 1988 Jun;22(2):51-4",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][5]["PMID"], "3167501"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][5]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][5].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][6]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][6]["RefSource"], "Front Physiol. 2017 Jun 08;8:389")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][6]["PMID"], "28642717")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][6]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][6].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][6]["RefSource"],
+            "Front Physiol. 2017 Jun 08;8:389",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][6]["PMID"], "28642717"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][6]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][6].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][7]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][7]["RefSource"], "Med Sci Sports Exerc. 1999 Sep;31(9):1342-5")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][7]["PMID"], "10487378")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][7]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][7].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][7]["RefSource"],
+            "Med Sci Sports Exerc. 1999 Sep;31(9):1342-5",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][7]["PMID"], "10487378"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][7]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][7].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][8]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][8]["RefSource"], "Med Sci Sports Exerc. 1998 Aug;30(8):1304-13")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][8]["PMID"], "9710874")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][8]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][8].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][8]["RefSource"],
+            "Med Sci Sports Exerc. 1998 Aug;30(8):1304-13",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][8]["PMID"], "9710874"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][8]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][8].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][9]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][9]["RefSource"], "Med Sci Sports. 1979 Winter;11(4):338-44")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][9]["PMID"], "530025")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][9]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][9].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][9]["RefSource"],
+            "Med Sci Sports. 1979 Winter;11(4):338-44",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][9]["PMID"], "530025"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][9]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][9].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][10]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][10]["RefSource"], "J Strength Cond Res. 2005 May;19(2):364-8")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][10]["PMID"], "15903376")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][10]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][10].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][10]["RefSource"],
+            "J Strength Cond Res. 2005 May;19(2):364-8",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][10]["PMID"], "15903376"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][10]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][10].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][11]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][11]["RefSource"], "Eur J Appl Physiol Occup Physiol. 1984;53(3):196-9")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][11]["PMID"], "6542852")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][11]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][11].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][11]["RefSource"],
+            "Eur J Appl Physiol Occup Physiol. 1984;53(3):196-9",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][11]["PMID"], "6542852"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][11]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][11].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][12]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][12]["RefSource"], "Eur J Appl Physiol Occup Physiol. 1978 Oct 20;39(4):219-27")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][12]["PMID"], "710387")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][12]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][12].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][12]["RefSource"],
+            "Eur J Appl Physiol Occup Physiol. 1978 Oct 20;39(4):219-27",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][12]["PMID"], "710387"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][12]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][12].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][13]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][13]["RefSource"], "J Appl Physiol Respir Environ Exerc Physiol. 1980 Mar;48(3):523-7")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][13]["PMID"], "7372524")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][13]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][13].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][13]["RefSource"],
+            "J Appl Physiol Respir Environ Exerc Physiol. 1980 Mar;48(3):523-7",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][13]["PMID"], "7372524"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][13]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][13].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][14]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][14]["RefSource"], "Int J Sports Med. 2015 Dec;36(14):1142-8")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][14]["PMID"], "26332904")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][14]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][14].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][14]["RefSource"],
+            "Int J Sports Med. 2015 Dec;36(14):1142-8",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][14]["PMID"], "26332904"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][14]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][14].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][15]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][15]["RefSource"], "J Physiol. 1930 Apr 14;69(2):214-37")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][15]["PMID"], "16994099")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][15]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][15].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][15]["RefSource"],
+            "J Physiol. 1930 Apr 14;69(2):214-37",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][15]["PMID"], "16994099"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][15]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][15].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][16]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][16]["RefSource"], "J Strength Cond Res. 2015 Oct;29(10):2794-801")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][16]["PMID"], "25844867")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][16]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][16].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][16]["RefSource"],
+            "J Strength Cond Res. 2015 Oct;29(10):2794-801",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][16]["PMID"], "25844867"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][16]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][16].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][17]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][17]["RefSource"], "PLoS One. 2018 Mar 13;13(3):e0194313")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][17]["PMID"], "29534108")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][17]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][17].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][17]["RefSource"],
+            "PLoS One. 2018 Mar 13;13(3):e0194313",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][17]["PMID"], "29534108"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][17]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][17].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][18]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][18]["RefSource"], "J Cardiopulm Rehabil Prev. 2012 Nov-Dec;32(6):327-50")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][18]["PMID"], "23103476")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][18]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][18].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][18]["RefSource"],
+            "J Cardiopulm Rehabil Prev. 2012 Nov-Dec;32(6):327-50",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][18]["PMID"], "23103476"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][18]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][18].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][19]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][19]["RefSource"], "Exerc Sport Sci Rev. 1982;10:49-83")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][19]["PMID"], "6811284")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][19]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][19].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][19]["RefSource"],
+            "Exerc Sport Sci Rev. 1982;10:49-83",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][19]["PMID"], "6811284"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][19]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][19].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][20]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][20]["RefSource"], "Int J Sports Physiol Perform. 2010 Sep;5(3):276-91")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][20]["PMID"], "20861519")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][20]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][20].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][20]["RefSource"],
+            "Int J Sports Physiol Perform. 2010 Sep;5(3):276-91",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][20]["PMID"], "20861519"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][20]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][20].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][21]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][21]["RefSource"], "Eur J Appl Physiol Occup Physiol. 1990;60(4):249-53")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][21]["PMID"], "2357979")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][21]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][21].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][21]["RefSource"],
+            "Eur J Appl Physiol Occup Physiol. 1990;60(4):249-53",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][21]["PMID"], "2357979"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][21]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][21].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][22]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][22]["RefSource"], "Med Sci Sports Exerc. 2004 Oct;36(10):1737-42")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][22]["PMID"], "15595295")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][22]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][22].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][22]["RefSource"],
+            "Med Sci Sports Exerc. 2004 Oct;36(10):1737-42",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][22]["PMID"], "15595295"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][22]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][22].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][23]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][23]["RefSource"], "Int J Sports Med. 2016 Jun;37(7):539-46")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][23]["PMID"], "27116348")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][23]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][23].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][23]["RefSource"],
+            "Int J Sports Med. 2016 Jun;37(7):539-46",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][23]["PMID"], "27116348"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][23]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][23].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][24]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][24]["RefSource"], "Scand J Med Sci Sports. 2017 May;27(5):462-473")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][24]["PMID"], "28181710")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][24]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][24].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][24]["RefSource"],
+            "Scand J Med Sci Sports. 2017 May;27(5):462-473",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][24]["PMID"], "28181710"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][24]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][24].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][25]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][25]["RefSource"], "Int J Sports Med. 1983 Nov;4(4):226-30")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][25]["PMID"], "6654546")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][25]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][25].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][25]["RefSource"],
+            "Int J Sports Med. 1983 Nov;4(4):226-30",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][25]["PMID"], "6654546"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][25]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][25].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][26]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][26]["RefSource"], "J Appl Physiol (1985). 1988 Jun;64(6):2622-30")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][26]["PMID"], "3403447")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][26]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][26].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][26]["RefSource"],
+            "J Appl Physiol (1985). 1988 Jun;64(6):2622-30",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][26]["PMID"], "3403447"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][26]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][26].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][27]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][27]["RefSource"], "Med Sci Sports Exerc. 2009 Jan;41(1):3-13")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][27]["PMID"], "19092709")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][27]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][27].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][27]["RefSource"],
+            "Med Sci Sports Exerc. 2009 Jan;41(1):3-13",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][27]["PMID"], "19092709"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][27]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][27].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][28]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][28]["RefSource"], "Int J Sports Med. 2009 Sep;30(9):643-6")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][28]["PMID"], "19569005")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][28]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][28].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][28]["RefSource"],
+            "Int J Sports Med. 2009 Sep;30(9):643-6",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][28]["PMID"], "19569005"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][28]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][28].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][29]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][29]["RefSource"], "Eur J Appl Physiol Occup Physiol. 1988;57(4):420-4")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][29]["PMID"], "3396556")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][29]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][29].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][29]["RefSource"],
+            "Eur J Appl Physiol Occup Physiol. 1988;57(4):420-4",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][29]["PMID"], "3396556"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][29]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][29].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][30]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][30]["RefSource"], "J Physiol. 2004 Jul 1;558(Pt 1):5-30")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][30]["PMID"], "15131240")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][30]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][30].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][30]["RefSource"],
+            "J Physiol. 2004 Jul 1;558(Pt 1):5-30",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][30]["PMID"], "15131240"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][30]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][30].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][31]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][31]["RefSource"], "Int J Sports Med. 1990 Feb;11(1):26-32")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][31]["PMID"], "2318561")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][31]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][31].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][31]["RefSource"],
+            "Int J Sports Med. 1990 Feb;11(1):26-32",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][31]["PMID"], "2318561"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][31]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][31].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][32]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][32]["RefSource"], "J Appl Physiol. 1973 Aug;35(2):236-43")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][32]["PMID"], "4723033")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][32]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][32].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][32]["RefSource"],
+            "J Appl Physiol. 1973 Aug;35(2):236-43",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][32]["PMID"], "4723033"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][32]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][32].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][33]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][33]["RefSource"], "Int J Sports Med. 1987 Dec;8(6):401-6")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][33]["PMID"], "3429086")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][33]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][33].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][33]["RefSource"],
+            "Int J Sports Med. 1987 Dec;8(6):401-6",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][33]["PMID"], "3429086"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][33]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][33].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][34]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][34]["RefSource"], "J Sci Med Sport. 2008 Jun;11(3):280-6")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][34]["PMID"], "17553745")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][34]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][34].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][34]["RefSource"],
+            "J Sci Med Sport. 2008 Jun;11(3):280-6",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][34]["PMID"], "17553745"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][34]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][34].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][35]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][35]["RefSource"], "J Appl Physiol Respir Environ Exerc Physiol. 1984 May;56(5):1260-4")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][35]["PMID"], "6725086")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][35]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][35].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][35]["RefSource"],
+            "J Appl Physiol Respir Environ Exerc Physiol. 1984 May;56(5):1260-4",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][35]["PMID"], "6725086"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][35]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][35].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][36]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][36]["RefSource"], "Int J Sports Med. 2008 Jun;29(6):475-9")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][36]["PMID"], "18302077")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][36]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][36].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][36]["RefSource"],
+            "Int J Sports Med. 2008 Jun;29(6):475-9",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][36]["PMID"], "18302077"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][36]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][36].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][37]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][37]["RefSource"], "Med Sci Sports Exerc. 1985 Feb;17(1):22-34")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][37]["PMID"], "3884959")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][37]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][37].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][37]["RefSource"],
+            "Med Sci Sports Exerc. 1985 Feb;17(1):22-34",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][37]["PMID"], "3884959"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][37]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][37].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][38]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][38]["RefSource"], "Sports Med. 2009;39(6):469-90")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][38]["PMID"], "19453206")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][38]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][38].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][38]["RefSource"],
+            "Sports Med. 2009;39(6):469-90",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][38]["PMID"], "19453206"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][38]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][38].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][39]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][39]["RefSource"], "Int J Sports Med. 2004 Aug;25(6):403-8")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][39]["PMID"], "15346226")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][39]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][39].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][39]["RefSource"],
+            "Int J Sports Med. 2004 Aug;25(6):403-8",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][39]["PMID"], "15346226"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][39]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][39].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][40]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][40]["RefSource"], "J Sports Med Phys Fitness. 2004 Jun;44(2):132-40")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][40]["PMID"], "15470310")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][40]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][40].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][40]["RefSource"],
+            "J Sports Med Phys Fitness. 2004 Jun;44(2):132-40",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][40]["PMID"], "15470310"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][40]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][40].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][41]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][41]["RefSource"], "Int J Sports Med. 1985 Jun;6(3):117-30")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][41]["PMID"], "4030186")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][41]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][41].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][41]["RefSource"],
+            "Int J Sports Med. 1985 Jun;6(3):117-30",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][41]["PMID"], "4030186"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][41]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][41].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][42]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][42]["RefSource"], "Int J Sports Med. 1999 Feb;20(2):122-7")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][42]["PMID"], "10190774")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][42]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][42].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][42]["RefSource"],
+            "Int J Sports Med. 1999 Feb;20(2):122-7",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][42]["PMID"], "10190774"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][42]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][42].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][43]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][43]["RefSource"], "Int J Sports Med. 2006 May;27(5):368-72")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][43]["PMID"], "16729378")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][43]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][43].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][43]["RefSource"],
+            "Int J Sports Med. 2006 May;27(5):368-72",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][43]["PMID"], "16729378"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][43]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][43].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][44]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][44]["RefSource"], "Int J Sports Med. 1985 Jun;6(3):109-16")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][44]["PMID"], "3897079")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][44]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][44].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][44]["RefSource"],
+            "Int J Sports Med. 1985 Jun;6(3):109-16",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][44]["PMID"], "3897079"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][44]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][44].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][45]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][45]["RefSource"], "Pneumologie. 1990 Jan;44(1):2-13")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][45]["PMID"], "2408033")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][45]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][45].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][45]["RefSource"],
+            "Pneumologie. 1990 Jan;44(1):2-13",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][45]["PMID"], "2408033"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][45]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][45].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][46]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][46]["RefSource"], "Eur J Appl Physiol. 2018 Apr;118(4):691-728")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][46]["PMID"], "29322250")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][46]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][46].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][46]["RefSource"],
+            "Eur J Appl Physiol. 2018 Apr;118(4):691-728",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][46]["PMID"], "29322250"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][46]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][46].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][47]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][47]["RefSource"], "J Appl Physiol Respir Environ Exerc Physiol. 1983 Oct;55(4):1178-86")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][47]["PMID"], "6629951")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][47]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][47].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][47]["RefSource"],
+            "J Appl Physiol Respir Environ Exerc Physiol. 1983 Oct;55(4):1178-86",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][47]["PMID"], "6629951"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][47]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][47].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][48]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][48]["RefSource"], "Sports Med. 2014 Nov;44 Suppl 2:S139-47")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][48]["PMID"], "25200666")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][48]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][48].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][48]["RefSource"],
+            "Sports Med. 2014 Nov;44 Suppl 2:S139-47",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][48]["PMID"], "25200666"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][48]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][48].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][49]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][49]["RefSource"], "Front Physiol. 2015 Oct 30;6:308")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][49]["PMID"], "26578980")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][49]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][49].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][49]["RefSource"],
+            "Front Physiol. 2015 Oct 30;6:308",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][49]["PMID"], "26578980"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][49]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][49].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][50]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][50]["RefSource"], "Int J Sports Med. 2013 Mar;34(3):196-9")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][50]["PMID"], "22972242")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][50]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][50].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][50]["RefSource"],
+            "Int J Sports Med. 2013 Mar;34(3):196-9",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][50]["PMID"], "22972242"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][50]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][50].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][51]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][51]["RefSource"], "Int J Sports Med. 1992 Oct;13(7):518-22")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][51]["PMID"], "1459746")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][51]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][51].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][51]["RefSource"],
+            "Int J Sports Med. 1992 Oct;13(7):518-22",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][51]["PMID"], "1459746"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][51]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][51].attributes,
+            {"RefType": "Cites"},
+        )
         self.assertEqual(len(medline_citation["CommentsCorrectionsList"][52]), 2)
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][52]["RefSource"], "Med Sci Sports Exerc. 1993 May;25(5):620-7")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][52]["PMID"], "8492691")
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][52]["PMID"].attributes, {"Version": "1"})
-        self.assertEqual(medline_citation["CommentsCorrectionsList"][52].attributes, {"RefType": "Cites"})
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][52]["RefSource"],
+            "Med Sci Sports Exerc. 1993 May;25(5):620-7",
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][52]["PMID"], "8492691"
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][52]["PMID"].attributes,
+            {"Version": "1"},
+        )
+        self.assertEqual(
+            medline_citation["CommentsCorrectionsList"][52].attributes,
+            {"RefType": "Cites"},
+        )
         article = medline_citation["Article"]
         self.assertEqual(len(article["ELocationID"]), 1)
         self.assertEqual(article["ELocationID"][0], "10.3389/fphys.2018.01034")
-        self.assertEqual(article["ELocationID"][0].attributes, {"EIdType": "doi", "ValidYN": "Y"})
+        self.assertEqual(
+            article["ELocationID"][0].attributes, {"EIdType": "doi", "ValidYN": "Y"}
+        )
         self.assertEqual(len(article["ArticleDate"]), 1)
         self.assertEqual(len(article["ArticleDate"][0]), 3)
         self.assertEqual(article["ArticleDate"][0]["Year"], "2018")
         self.assertEqual(article["ArticleDate"][0]["Month"], "07")
         self.assertEqual(article["ArticleDate"][0]["Day"], "31")
-        self.assertEqual(article["ArticleDate"][0].attributes, {"DateType": "Electronic"})
+        self.assertEqual(
+            article["ArticleDate"][0].attributes, {"DateType": "Electronic"}
+        )
         self.assertEqual(article["Language"], ["eng"])
         self.assertEqual(len(article["Journal"]), 4)
         self.assertEqual(article["Journal"]["ISSN"], "1664-042X")
@@ -4614,14 +8895,21 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(article["Journal"]["JournalIssue"]["Volume"], "9")
         self.assertEqual(article["Journal"]["JournalIssue"]["PubDate"]["Year"], "2018")
         self.assertEqual(article["Journal"]["JournalIssue"]["PubDate"].attributes, {})
-        self.assertEqual(article["Journal"]["JournalIssue"].attributes, {"CitedMedium": "Print"})
+        self.assertEqual(
+            article["Journal"]["JournalIssue"].attributes, {"CitedMedium": "Print"}
+        )
         self.assertEqual(article["Journal"]["Title"], "Frontiers in physiology")
         self.assertEqual(article["Journal"]["ISOAbbreviation"], "Front Physiol")
         self.assertEqual(article["Journal"].attributes, {})
         self.assertEqual(len(article["PublicationTypeList"]), 1)
         self.assertEqual(article["PublicationTypeList"][0], "Journal Article")
-        self.assertEqual(article["PublicationTypeList"][0].attributes, {"UI": "D016428"})
-        self.assertEqual(article["ArticleTitle"], 'A "<i>Blood Relationship"</i> Between the Overlooked Minimum Lactate Equivalent and Maximal Lactate Steady State in Trained Runners. Back to the Old Days?')
+        self.assertEqual(
+            article["PublicationTypeList"][0].attributes, {"UI": "D016428"}
+        )
+        self.assertEqual(
+            article["ArticleTitle"],
+            'A "<i>Blood Relationship"</i> Between the Overlooked Minimum Lactate Equivalent and Maximal Lactate Steady State in Trained Runners. Back to the Old Days?',
+        )
         self.assertEqual(len(article["Pagination"]), 1)
         self.assertEqual(article["Pagination"]["MedlinePgn"], "1034")
         self.assertEqual(article["Pagination"].attributes, {})
@@ -4630,8 +8918,13 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(article["AuthorList"][0]["Identifier"], [])
         self.assertEqual(len(article["AuthorList"][0]["AffiliationInfo"]), 1)
         self.assertEqual(len(article["AuthorList"][0]["AffiliationInfo"][0]), 2)
-        self.assertEqual(article["AuthorList"][0]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(article["AuthorList"][0]["AffiliationInfo"][0]["Affiliation"], "Studies, Research and Sports Medicine Center, Government of Navarre, Pamplona, Spain.")
+        self.assertEqual(
+            article["AuthorList"][0]["AffiliationInfo"][0]["Identifier"], []
+        )
+        self.assertEqual(
+            article["AuthorList"][0]["AffiliationInfo"][0]["Affiliation"],
+            "Studies, Research and Sports Medicine Center, Government of Navarre, Pamplona, Spain.",
+        )
         self.assertEqual(article["AuthorList"][0]["AffiliationInfo"][0].attributes, {})
         self.assertEqual(article["AuthorList"][0]["LastName"], "Garcia-Tabar")
         self.assertEqual(article["AuthorList"][0]["ForeName"], "Ibai")
@@ -4641,15 +8934,22 @@ class EFetchTest(unittest.TestCase):
         self.assertEqual(article["AuthorList"][1]["Identifier"], [])
         self.assertEqual(len(article["AuthorList"][1]["AffiliationInfo"]), 1)
         self.assertEqual(len(article["AuthorList"][1]["AffiliationInfo"][0]), 2)
-        self.assertEqual(article["AuthorList"][1]["AffiliationInfo"][0]["Identifier"], [])
-        self.assertEqual(article["AuthorList"][1]["AffiliationInfo"][0]["Affiliation"], "Studies, Research and Sports Medicine Center, Government of Navarre, Pamplona, Spain.")
+        self.assertEqual(
+            article["AuthorList"][1]["AffiliationInfo"][0]["Identifier"], []
+        )
+        self.assertEqual(
+            article["AuthorList"][1]["AffiliationInfo"][0]["Affiliation"],
+            "Studies, Research and Sports Medicine Center, Government of Navarre, Pamplona, Spain.",
+        )
         self.assertEqual(article["AuthorList"][1]["AffiliationInfo"][0].attributes, {})
         self.assertEqual(article["AuthorList"][1]["LastName"], "Gorostiaga")
         self.assertEqual(article["AuthorList"][1]["ForeName"], "Esteban M")
         self.assertEqual(article["AuthorList"][1]["Initials"], "EM")
         self.assertEqual(article["AuthorList"][1].attributes, {"ValidYN": "Y"})
         self.assertEqual(len(article["Abstract"]), 1)
-        self.assertEqual(article["Abstract"]["AbstractText"][0], """\
+        self.assertEqual(
+            article["Abstract"]["AbstractText"][0],
+            """\
 Maximal Lactate Steady State (MLSS) and Lactate Threshold (LT) are physiologically-related and fundamental concepts within the sports and exercise sciences. Literature supporting their relationship, however, is scarce. Among the recognized LTs, we were particularly interested in the disused "Minimum Lactate Equivalent" (LE<sub>min</sub>), first described in the early 1980s. We hypothesized that velocity at LT, conceptually comprehended as in the old days (LE<sub>min</sub>), could predict velocity at MLSS (<sub>V</sub>MLSS) more accurate than some other blood lactate-related thresholds (BL<sub>R</sub>Ts) routinely used nowadays by many sport science practitioners. Thirteen male endurance-trained [<sub>V</sub>MLSS 15.0 ± 1.1 km·h<sup>-1</sup>; maximal oxygen uptake ( <math xmlns="http://www.w3.org/1998/Math/MathML">
                         <msub>
                             <mrow>
@@ -4705,7 +9005,8 @@ Maximal Lactate Steady State (MLSS) and Lactate Threshold (LT) are physiological
                                 <mi>x</mi>
                             </mrow>
                         </msub>
-                    </math> (<i>r</i> = 0.72-0.79; <i>P</i> < 0.001). These results support LE<sub>min</sub>, an objective submaximal overlooked and underused BL<sub>R</sub>T, to be one of the best single MLSS predictors in endurance trained runners. Our study advocates factors controlling LE<sub>min</sub> to be shared, at least partly, with those controlling MLSS.""")
+                    </math> (<i>r</i> = 0.72-0.79; <i>P</i> < 0.001). These results support LE<sub>min</sub>, an objective submaximal overlooked and underused BL<sub>R</sub>T, to be one of the best single MLSS predictors in endurance trained runners. Our study advocates factors controlling LE<sub>min</sub> to be shared, at least partly, with those controlling MLSS.""",
+        )
 
     def test_pubmed_mathml_tags(self):
         """Test parsing XML returned by EFetch, PubMed database, with extensive MathML tags."""
@@ -4721,38 +9022,139 @@ Maximal Lactate Steady State (MLSS) and Lactate Threshold (LT) are physiological
         pubmed_article = record["PubmedArticle"][0]
         self.assertEqual(len(pubmed_article), 2)
         self.assertEqual(len(pubmed_article["MedlineCitation"].attributes), 2)
-        self.assertEqual(pubmed_article["MedlineCitation"].attributes["Status"], "PubMed-not-MEDLINE")
+        self.assertEqual(
+            pubmed_article["MedlineCitation"].attributes["Status"], "PubMed-not-MEDLINE"
+        )
         self.assertEqual(pubmed_article["MedlineCitation"].attributes["Owner"], "NLM")
         self.assertEqual(pubmed_article["MedlineCitation"]["PMID"], "29963580")
-        self.assertEqual(pubmed_article["MedlineCitation"]["PMID"].attributes["Version"], "1")
-        self.assertEqual(pubmed_article["MedlineCitation"]["DateRevised"].attributes, {})
-        self.assertEqual(pubmed_article["MedlineCitation"]["DateRevised"]["Year"], "2018")
-        self.assertEqual(pubmed_article["MedlineCitation"]["DateRevised"]["Month"], "11")
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["PMID"].attributes["Version"], "1"
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["DateRevised"].attributes, {}
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["DateRevised"]["Year"], "2018"
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["DateRevised"]["Month"], "11"
+        )
         self.assertEqual(pubmed_article["MedlineCitation"]["DateRevised"]["Day"], "14")
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["Article"].attributes), 1)
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"].attributes["PubModel"], "Print-Electronic")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["Journal"].attributes, {})
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes), 1)
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes["IssnType"], "Print")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["Journal"]["ISSN"], "2329-4302")
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"].attributes), 1)
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"].attributes["CitedMedium"], "Print")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Volume"], "5")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["Issue"], "2")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Year"], "2018")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"]["PubDate"]["Month"], "Apr")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["Journal"]["Title"], "Journal of medical imaging (Bellingham, Wash.)")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["Journal"]["ISOAbbreviation"], "J Med Imaging (Bellingham)")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["ArticleTitle"], "Development of a pulmonary imaging biomarker pipeline for phenotyping of chronic lung disease.")
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["Article"]["Pagination"]), 1)
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["Pagination"]["MedlinePgn"], "026002")
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["Article"]["ELocationID"]), 1)
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["ELocationID"][0].attributes["EIdType"], "doi")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["ELocationID"][0].attributes["ValidYN"], "Y")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["ELocationID"][0], "10.1117/1.JMI.5.2.026002")
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["Article"]["Abstract"]), 1)
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"]), 1)
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][0], """\
+        self.assertEqual(
+            len(pubmed_article["MedlineCitation"]["Article"].attributes), 1
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"].attributes["PubModel"],
+            "Print-Electronic",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["Journal"].attributes, {}
+        )
+        self.assertEqual(
+            len(
+                pubmed_article["MedlineCitation"]["Article"]["Journal"][
+                    "ISSN"
+                ].attributes
+            ),
+            1,
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["Journal"]["ISSN"].attributes[
+                "IssnType"
+            ],
+            "Print",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["Journal"]["ISSN"], "2329-4302"
+        )
+        self.assertEqual(
+            len(
+                pubmed_article["MedlineCitation"]["Article"]["Journal"][
+                    "JournalIssue"
+                ].attributes
+            ),
+            1,
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["Journal"][
+                "JournalIssue"
+            ].attributes["CitedMedium"],
+            "Print",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "Volume"
+            ],
+            "5",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "Issue"
+            ],
+            "2",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "PubDate"
+            ]["Year"],
+            "2018",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["Journal"]["JournalIssue"][
+                "PubDate"
+            ]["Month"],
+            "Apr",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["Journal"]["Title"],
+            "Journal of medical imaging (Bellingham, Wash.)",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["Journal"]["ISOAbbreviation"],
+            "J Med Imaging (Bellingham)",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["ArticleTitle"],
+            "Development of a pulmonary imaging biomarker pipeline for phenotyping of chronic lung disease.",
+        )
+        self.assertEqual(
+            len(pubmed_article["MedlineCitation"]["Article"]["Pagination"]), 1
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["Pagination"]["MedlinePgn"],
+            "026002",
+        )
+        self.assertEqual(
+            len(pubmed_article["MedlineCitation"]["Article"]["ELocationID"]), 1
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["ELocationID"][0].attributes[
+                "EIdType"
+            ],
+            "doi",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["ELocationID"][0].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["ELocationID"][0],
+            "10.1117/1.JMI.5.2.026002",
+        )
+        self.assertEqual(
+            len(pubmed_article["MedlineCitation"]["Article"]["Abstract"]), 1
+        )
+        self.assertEqual(
+            len(
+                pubmed_article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"]
+            ),
+            1,
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["Abstract"]["AbstractText"][0],
+            """\
 We designed and generated pulmonary imaging biomarker pipelines to facilitate high-throughput research and point-of-care use in patients with chronic lung disease. Image processing modules and algorithm pipelines were embedded within a graphical user interface (based on the .NET framework) for pulmonary magnetic resonance imaging (MRI) and x-ray computed-tomography (CT) datasets. The software pipelines were generated using C++ and included: (1) inhaled <math xmlns="http://www.w3.org/1998/Math/MathML">
                         <mrow>
                             <mmultiscripts>
@@ -4824,117 +9226,457 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
                             <mtext> </mtext>
                             <mi>MRI</mi>
                         </mrow>
-                    </math> specific ventilation, (5)\u00A0multivolume CT and MRI parametric response maps, and (6)\u00A0MRI and CT texture analysis and radiomics. The image analysis framework was implemented on a desktop workstation/tablet to generate biomarkers of regional lung structure and function related to ventilation, perfusion, lung tissue texture, and integrity as well as multiparametric measures of gas trapping and airspace enlargement. All biomarkers were generated within 10 min with measurement reproducibility consistent with clinical and research requirements. The resultant pulmonary imaging biomarker pipeline provides real-time and automated lung imaging measurements for point-of-care and high-throughput research.""")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"].attributes["CompleteYN"], "Y")
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["Article"]["AuthorList"]), 9)
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0].attributes["ValidYN"], "Y")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0]["LastName"], "Guo")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0]["ForeName"], "Fumin")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0]["Initials"], "F")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0]["AffiliationInfo"][0]["Affiliation"], "University of Western Ontario, Robarts Research Institute, London, Ontario, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0]["AffiliationInfo"][1]["Affiliation"], "University of Western Ontario, Graduate Program in Biomedical Engineering, London, Ontario, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0]["AffiliationInfo"][2]["Affiliation"], "University of Toronto, Sunnybrook Research Institute, Toronto, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1].attributes["ValidYN"], "Y")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1]["LastName"], "Capaldi")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1]["ForeName"], "Dante")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1]["Initials"], "D")
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1]["Identifier"]), 1)
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1]["Identifier"][0].attributes["Source"], "ORCID")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1]["Identifier"][0], "https://orcid.org/0000-0002-4590-7461")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1]["AffiliationInfo"][0]["Affiliation"], "University of Western Ontario, Robarts Research Institute, London, Ontario, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1]["AffiliationInfo"][1]["Affiliation"], "University of Western Ontario, Department of Medical Biophysics, London, Ontario, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][2].attributes["ValidYN"], "Y")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][2]["LastName"], "Kirby")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][2]["ForeName"], "Miranda")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][2]["Initials"], "M")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][2]["AffiliationInfo"][0]["Affiliation"], "University of British Columbia, St. Paul's Hospital, Centre for Heart Lung Innovation, Vancouver, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][3].attributes["ValidYN"], "Y")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][3]["LastName"], "Sheikh")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][3]["ForeName"], "Khadija")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][3]["Initials"], "K")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][3]["AffiliationInfo"][0]["Affiliation"], "University of Western Ontario, Robarts Research Institute, London, Ontario, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][4].attributes["ValidYN"], "Y")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][4]["LastName"], "Svenningsen")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][4]["ForeName"], "Sarah")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][4]["Initials"], "S")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][4]["AffiliationInfo"][0]["Affiliation"], "University of Western Ontario, Robarts Research Institute, London, Ontario, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][5].attributes["ValidYN"], "Y")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][5]["LastName"], "McCormack")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][5]["ForeName"], "David G")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][5]["Initials"], "DG")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][5]["AffiliationInfo"][0]["Affiliation"], "University of Western Ontario, Division of Respirology, Department of Medicine, London, Ontario, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6].attributes["ValidYN"], "Y")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["LastName"], "Fenster")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["ForeName"], "Aaron")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["Initials"], "A")
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["Identifier"]), 1)
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["Identifier"][0].attributes["Source"], "ORCID")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["Identifier"][0], "https://orcid.org/0000-0003-3525-2788")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["AffiliationInfo"][0]["Affiliation"], "University of Western Ontario, Robarts Research Institute, London, Ontario, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["AffiliationInfo"][1]["Affiliation"], "University of Western Ontario, Graduate Program in Biomedical Engineering, London, Ontario, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["AffiliationInfo"][2]["Affiliation"], "University of Western Ontario, Department of Medical Biophysics, London, Ontario, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7].attributes["ValidYN"], "Y")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7]["LastName"], "Parraga")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7]["ForeName"], "Grace")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7]["Initials"], "G")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7]["AffiliationInfo"][0]["Affiliation"], "University of Western Ontario, Robarts Research Institute, London, Ontario, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7]["AffiliationInfo"][1]["Affiliation"], "University of Western Ontario, Graduate Program in Biomedical Engineering, London, Ontario, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7]["AffiliationInfo"][2]["Affiliation"], "University of Western Ontario, Department of Medical Biophysics, London, Ontario, Canada.")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][8].attributes["ValidYN"], "Y")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["AuthorList"][8]["CollectiveName"], "Canadian Respiratory Research Network")
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["Article"]["Language"]), 1)
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["Language"][0], "eng")
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["Article"]["PublicationTypeList"]), 1)
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["PublicationTypeList"][0].attributes["UI"], "D016428")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["PublicationTypeList"][0], "Journal Article")
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["Article"]["ArticleDate"]), 1)
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["ArticleDate"][0].attributes["DateType"], "Electronic")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["ArticleDate"][0]["Year"], "2018")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["ArticleDate"][0]["Month"], "06")
-        self.assertEqual(pubmed_article["MedlineCitation"]["Article"]["ArticleDate"][0]["Day"], "28")
-        self.assertEqual(len(pubmed_article["MedlineCitation"]["MedlineJournalInfo"]), 4)
-        self.assertEqual(pubmed_article["MedlineCitation"]["MedlineJournalInfo"]["Country"], "United States")
-        self.assertEqual(pubmed_article["MedlineCitation"]["MedlineJournalInfo"]["MedlineTA"], "J Med Imaging (Bellingham)")
-        self.assertEqual(pubmed_article["MedlineCitation"]["MedlineJournalInfo"]["NlmUniqueID"], "101643461")
-        self.assertEqual(pubmed_article["MedlineCitation"]["MedlineJournalInfo"]["ISSNLinking"], "2329-4302")
+                    </math> specific ventilation, (5)\u00A0multivolume CT and MRI parametric response maps, and (6)\u00A0MRI and CT texture analysis and radiomics. The image analysis framework was implemented on a desktop workstation/tablet to generate biomarkers of regional lung structure and function related to ventilation, perfusion, lung tissue texture, and integrity as well as multiparametric measures of gas trapping and airspace enlargement. All biomarkers were generated within 10 min with measurement reproducibility consistent with clinical and research requirements. The resultant pulmonary imaging biomarker pipeline provides real-time and automated lung imaging measurements for point-of-care and high-throughput research.""",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"].attributes[
+                "CompleteYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            len(pubmed_article["MedlineCitation"]["Article"]["AuthorList"]), 9
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0]["LastName"],
+            "Guo",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0]["ForeName"],
+            "Fumin",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0]["Initials"],
+            "F",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0][
+                "AffiliationInfo"
+            ][0]["Affiliation"],
+            "University of Western Ontario, Robarts Research Institute, London, Ontario, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0][
+                "AffiliationInfo"
+            ][1]["Affiliation"],
+            "University of Western Ontario, Graduate Program in Biomedical Engineering, London, Ontario, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][0][
+                "AffiliationInfo"
+            ][2]["Affiliation"],
+            "University of Toronto, Sunnybrook Research Institute, Toronto, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1]["LastName"],
+            "Capaldi",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1]["ForeName"],
+            "Dante",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1]["Initials"],
+            "D",
+        )
+        self.assertEqual(
+            len(
+                pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1][
+                    "Identifier"
+                ]
+            ),
+            1,
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1]["Identifier"][
+                0
+            ].attributes["Source"],
+            "ORCID",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1]["Identifier"][
+                0
+            ],
+            "https://orcid.org/0000-0002-4590-7461",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1][
+                "AffiliationInfo"
+            ][0]["Affiliation"],
+            "University of Western Ontario, Robarts Research Institute, London, Ontario, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][1][
+                "AffiliationInfo"
+            ][1]["Affiliation"],
+            "University of Western Ontario, Department of Medical Biophysics, London, Ontario, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][2].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][2]["LastName"],
+            "Kirby",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][2]["ForeName"],
+            "Miranda",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][2]["Initials"],
+            "M",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][2][
+                "AffiliationInfo"
+            ][0]["Affiliation"],
+            "University of British Columbia, St. Paul's Hospital, Centre for Heart Lung Innovation, Vancouver, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][3].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][3]["LastName"],
+            "Sheikh",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][3]["ForeName"],
+            "Khadija",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][3]["Initials"],
+            "K",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][3][
+                "AffiliationInfo"
+            ][0]["Affiliation"],
+            "University of Western Ontario, Robarts Research Institute, London, Ontario, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][4].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][4]["LastName"],
+            "Svenningsen",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][4]["ForeName"],
+            "Sarah",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][4]["Initials"],
+            "S",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][4][
+                "AffiliationInfo"
+            ][0]["Affiliation"],
+            "University of Western Ontario, Robarts Research Institute, London, Ontario, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][5].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][5]["LastName"],
+            "McCormack",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][5]["ForeName"],
+            "David G",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][5]["Initials"],
+            "DG",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][5][
+                "AffiliationInfo"
+            ][0]["Affiliation"],
+            "University of Western Ontario, Division of Respirology, Department of Medicine, London, Ontario, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["LastName"],
+            "Fenster",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["ForeName"],
+            "Aaron",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["Initials"],
+            "A",
+        )
+        self.assertEqual(
+            len(
+                pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6][
+                    "Identifier"
+                ]
+            ),
+            1,
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["Identifier"][
+                0
+            ].attributes["Source"],
+            "ORCID",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6]["Identifier"][
+                0
+            ],
+            "https://orcid.org/0000-0003-3525-2788",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6][
+                "AffiliationInfo"
+            ][0]["Affiliation"],
+            "University of Western Ontario, Robarts Research Institute, London, Ontario, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6][
+                "AffiliationInfo"
+            ][1]["Affiliation"],
+            "University of Western Ontario, Graduate Program in Biomedical Engineering, London, Ontario, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][6][
+                "AffiliationInfo"
+            ][2]["Affiliation"],
+            "University of Western Ontario, Department of Medical Biophysics, London, Ontario, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7]["LastName"],
+            "Parraga",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7]["ForeName"],
+            "Grace",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7]["Initials"],
+            "G",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7][
+                "AffiliationInfo"
+            ][0]["Affiliation"],
+            "University of Western Ontario, Robarts Research Institute, London, Ontario, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7][
+                "AffiliationInfo"
+            ][1]["Affiliation"],
+            "University of Western Ontario, Graduate Program in Biomedical Engineering, London, Ontario, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][7][
+                "AffiliationInfo"
+            ][2]["Affiliation"],
+            "University of Western Ontario, Department of Medical Biophysics, London, Ontario, Canada.",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][8].attributes[
+                "ValidYN"
+            ],
+            "Y",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["AuthorList"][8][
+                "CollectiveName"
+            ],
+            "Canadian Respiratory Research Network",
+        )
+        self.assertEqual(
+            len(pubmed_article["MedlineCitation"]["Article"]["Language"]), 1
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["Language"][0], "eng"
+        )
+        self.assertEqual(
+            len(pubmed_article["MedlineCitation"]["Article"]["PublicationTypeList"]), 1
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["PublicationTypeList"][
+                0
+            ].attributes["UI"],
+            "D016428",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["PublicationTypeList"][0],
+            "Journal Article",
+        )
+        self.assertEqual(
+            len(pubmed_article["MedlineCitation"]["Article"]["ArticleDate"]), 1
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["ArticleDate"][0].attributes[
+                "DateType"
+            ],
+            "Electronic",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["ArticleDate"][0]["Year"],
+            "2018",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["ArticleDate"][0]["Month"],
+            "06",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["Article"]["ArticleDate"][0]["Day"], "28"
+        )
+        self.assertEqual(
+            len(pubmed_article["MedlineCitation"]["MedlineJournalInfo"]), 4
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["MedlineJournalInfo"]["Country"],
+            "United States",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["MedlineJournalInfo"]["MedlineTA"],
+            "J Med Imaging (Bellingham)",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["MedlineJournalInfo"]["NlmUniqueID"],
+            "101643461",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["MedlineJournalInfo"]["ISSNLinking"],
+            "2329-4302",
+        )
         self.assertEqual(len(pubmed_article["MedlineCitation"]["KeywordList"]), 1)
-        self.assertEqual(pubmed_article["MedlineCitation"]["KeywordList"][0].attributes["Owner"], "NOTNLM")
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["KeywordList"][0].attributes["Owner"],
+            "NOTNLM",
+        )
         self.assertEqual(len(pubmed_article["MedlineCitation"]["KeywordList"][0]), 5)
-        self.assertEqual(pubmed_article["MedlineCitation"]["KeywordList"][0][0].attributes["MajorTopicYN"], "N")
-        self.assertEqual(pubmed_article["MedlineCitation"]["KeywordList"][0][0], "asthma")
-        self.assertEqual(pubmed_article["MedlineCitation"]["KeywordList"][0][1].attributes["MajorTopicYN"], "N")
-        self.assertEqual(pubmed_article["MedlineCitation"]["KeywordList"][0][1], "chronic obstructive lung disease")
-        self.assertEqual(pubmed_article["MedlineCitation"]["KeywordList"][0][2].attributes["MajorTopicYN"], "N")
-        self.assertEqual(pubmed_article["MedlineCitation"]["KeywordList"][0][2], "image processing, biomarkers")
-        self.assertEqual(pubmed_article["MedlineCitation"]["KeywordList"][0][3].attributes["MajorTopicYN"], "N")
-        self.assertEqual(pubmed_article["MedlineCitation"]["KeywordList"][0][3], "magnetic resonance imaging")
-        self.assertEqual(pubmed_article["MedlineCitation"]["KeywordList"][0][4].attributes["MajorTopicYN"], "N")
-        self.assertEqual(pubmed_article["MedlineCitation"]["KeywordList"][0][4], "thoracic computed tomography")
-        self.assertEqual(pubmed_article["PubmedData"]["History"][0].attributes["PubStatus"], "received")
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["KeywordList"][0][0].attributes[
+                "MajorTopicYN"
+            ],
+            "N",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["KeywordList"][0][0], "asthma"
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["KeywordList"][0][1].attributes[
+                "MajorTopicYN"
+            ],
+            "N",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["KeywordList"][0][1],
+            "chronic obstructive lung disease",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["KeywordList"][0][2].attributes[
+                "MajorTopicYN"
+            ],
+            "N",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["KeywordList"][0][2],
+            "image processing, biomarkers",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["KeywordList"][0][3].attributes[
+                "MajorTopicYN"
+            ],
+            "N",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["KeywordList"][0][3],
+            "magnetic resonance imaging",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["KeywordList"][0][4].attributes[
+                "MajorTopicYN"
+            ],
+            "N",
+        )
+        self.assertEqual(
+            pubmed_article["MedlineCitation"]["KeywordList"][0][4],
+            "thoracic computed tomography",
+        )
+        self.assertEqual(
+            pubmed_article["PubmedData"]["History"][0].attributes["PubStatus"],
+            "received",
+        )
         self.assertEqual(pubmed_article["PubmedData"]["History"][0]["Year"], "2017")
         self.assertEqual(pubmed_article["PubmedData"]["History"][0]["Month"], "12")
         self.assertEqual(pubmed_article["PubmedData"]["History"][0]["Day"], "12")
-        self.assertEqual(pubmed_article["PubmedData"]["History"][1].attributes["PubStatus"], "accepted")
+        self.assertEqual(
+            pubmed_article["PubmedData"]["History"][1].attributes["PubStatus"],
+            "accepted",
+        )
         self.assertEqual(pubmed_article["PubmedData"]["History"][1]["Year"], "2018")
         self.assertEqual(pubmed_article["PubmedData"]["History"][1]["Month"], "06")
         self.assertEqual(pubmed_article["PubmedData"]["History"][1]["Day"], "14")
-        self.assertEqual(pubmed_article["PubmedData"]["History"][2].attributes["PubStatus"], "pmc-release")
+        self.assertEqual(
+            pubmed_article["PubmedData"]["History"][2].attributes["PubStatus"],
+            "pmc-release",
+        )
         self.assertEqual(pubmed_article["PubmedData"]["History"][2]["Year"], "2019")
         self.assertEqual(pubmed_article["PubmedData"]["History"][2]["Month"], "06")
         self.assertEqual(pubmed_article["PubmedData"]["History"][2]["Day"], "28")
-        self.assertEqual(pubmed_article["PubmedData"]["History"][3].attributes["PubStatus"], "entrez")
+        self.assertEqual(
+            pubmed_article["PubmedData"]["History"][3].attributes["PubStatus"], "entrez"
+        )
         self.assertEqual(pubmed_article["PubmedData"]["History"][3]["Year"], "2018")
         self.assertEqual(pubmed_article["PubmedData"]["History"][3]["Month"], "7")
         self.assertEqual(pubmed_article["PubmedData"]["History"][3]["Day"], "3")
         self.assertEqual(pubmed_article["PubmedData"]["History"][3]["Hour"], "6")
         self.assertEqual(pubmed_article["PubmedData"]["History"][3]["Minute"], "0")
-        self.assertEqual(pubmed_article["PubmedData"]["History"][4].attributes["PubStatus"], "pubmed")
+        self.assertEqual(
+            pubmed_article["PubmedData"]["History"][4].attributes["PubStatus"], "pubmed"
+        )
         self.assertEqual(pubmed_article["PubmedData"]["History"][4]["Year"], "2018")
         self.assertEqual(pubmed_article["PubmedData"]["History"][4]["Month"], "7")
         self.assertEqual(pubmed_article["PubmedData"]["History"][4]["Day"], "3")
         self.assertEqual(pubmed_article["PubmedData"]["History"][4]["Hour"], "6")
         self.assertEqual(pubmed_article["PubmedData"]["History"][4]["Minute"], "0")
-        self.assertEqual(pubmed_article["PubmedData"]["History"][5].attributes["PubStatus"], "medline")
+        self.assertEqual(
+            pubmed_article["PubmedData"]["History"][5].attributes["PubStatus"],
+            "medline",
+        )
         self.assertEqual(pubmed_article["PubmedData"]["History"][5]["Year"], "2018")
         self.assertEqual(pubmed_article["PubmedData"]["History"][5]["Month"], "7")
         self.assertEqual(pubmed_article["PubmedData"]["History"][5]["Day"], "3")
@@ -4942,215 +9684,402 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         self.assertEqual(pubmed_article["PubmedData"]["History"][5]["Minute"], "1")
         self.assertEqual(pubmed_article["PubmedData"]["PublicationStatus"], "ppublish")
         self.assertEqual(len(pubmed_article["PubmedData"]["ArticleIdList"]), 4)
-        self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            pubmed_article["PubmedData"]["ArticleIdList"][0].attributes["IdType"],
+            "pubmed",
+        )
         self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][0], "29963580")
-        self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][1].attributes["IdType"], "doi")
-        self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][1], "10.1117/1.JMI.5.2.026002")
-        self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][2].attributes["IdType"], "pii")
+        self.assertEqual(
+            pubmed_article["PubmedData"]["ArticleIdList"][1].attributes["IdType"], "doi"
+        )
+        self.assertEqual(
+            pubmed_article["PubmedData"]["ArticleIdList"][1], "10.1117/1.JMI.5.2.026002"
+        )
+        self.assertEqual(
+            pubmed_article["PubmedData"]["ArticleIdList"][2].attributes["IdType"], "pii"
+        )
         self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][2], "17360RR")
-        self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][3].attributes["IdType"], "pmc")
+        self.assertEqual(
+            pubmed_article["PubmedData"]["ArticleIdList"][3].attributes["IdType"], "pmc"
+        )
         self.assertEqual(pubmed_article["PubmedData"]["ArticleIdList"][3], "PMC6022861")
         self.assertEqual(len(pubmed_article["PubmedData"]["ReferenceList"]), 1)
         self.assertEqual(len(pubmed_article["PubmedData"]["ReferenceList"][0]), 2)
-        self.assertEqual(len(pubmed_article["PubmedData"]["ReferenceList"][0]["ReferenceList"]), 0)
+        self.assertEqual(
+            len(pubmed_article["PubmedData"]["ReferenceList"][0]["ReferenceList"]), 0
+        )
         references = pubmed_article["PubmedData"]["ReferenceList"][0]["Reference"]
         self.assertEqual(len(references), 49)
         self.assertEqual(references[0]["Citation"], "Radiology. 2015 Jan;274(1):250-9")
         self.assertEqual(len(references[0]["ArticleIdList"]), 1)
         self.assertEqual(references[0]["ArticleIdList"][0], "25144646")
-        self.assertEqual(references[0]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[1]["Citation"], "Nature. 1994 Jul 21;370(6486):199-201")
+        self.assertEqual(
+            references[0]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[1]["Citation"], "Nature. 1994 Jul 21;370(6486):199-201"
+        )
         self.assertEqual(len(references[1]["ArticleIdList"]), 1)
         self.assertEqual(references[1]["ArticleIdList"][0], "8028666")
-        self.assertEqual(references[1]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[2]["Citation"], "Magn Reson Med. 2009 Sep;62(3):656-64")
+        self.assertEqual(
+            references[1]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[2]["Citation"], "Magn Reson Med. 2009 Sep;62(3):656-64"
+        )
         self.assertEqual(len(references[2]["ArticleIdList"]), 1)
         self.assertEqual(references[2]["ArticleIdList"][0], "19585597")
-        self.assertEqual(references[2]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[2]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(references[3]["Citation"], "Radiology. 2016 Feb;278(2):563-77")
         self.assertEqual(len(references[3]["ArticleIdList"]), 1)
         self.assertEqual(references[3]["ArticleIdList"][0], "26579733")
-        self.assertEqual(references[3]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[3]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(references[4]["Citation"], "Radiology. 1991 Jun;179(3):777-81")
         self.assertEqual(len(references[4]["ArticleIdList"]), 1)
         self.assertEqual(references[4]["ArticleIdList"][0], "2027991")
-        self.assertEqual(references[4]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[4]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(references[5]["Citation"], "Radiology. 2010 Jul;256(1):280-9")
         self.assertEqual(len(references[5]["ArticleIdList"]), 1)
         self.assertEqual(references[5]["ArticleIdList"][0], "20574101")
-        self.assertEqual(references[5]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[6]["Citation"], "Phys Med Biol. 2001 May;46(5):R67-99")
+        self.assertEqual(
+            references[5]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[6]["Citation"], "Phys Med Biol. 2001 May;46(5):R67-99"
+        )
         self.assertEqual(len(references[6]["ArticleIdList"]), 1)
         self.assertEqual(references[6]["ArticleIdList"][0], "11384074")
-        self.assertEqual(references[6]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[7]["Citation"], "IEEE Trans Med Imaging. 2011 Nov;30(11):1901-20")
+        self.assertEqual(
+            references[6]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[7]["Citation"], "IEEE Trans Med Imaging. 2011 Nov;30(11):1901-20"
+        )
         self.assertEqual(len(references[7]["ArticleIdList"]), 1)
         self.assertEqual(references[7]["ArticleIdList"][0], "21632295")
-        self.assertEqual(references[7]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[8]["Citation"], "Eur J Cancer. 2012 Mar;48(4):441-6")
+        self.assertEqual(
+            references[7]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[8]["Citation"], "Eur J Cancer. 2012 Mar;48(4):441-6"
+        )
         self.assertEqual(len(references[8]["ArticleIdList"]), 1)
         self.assertEqual(references[8]["ArticleIdList"][0], "22257792")
-        self.assertEqual(references[8]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[9]["Citation"], "Med Phys. 2017 May;44(5):1718-1733")
+        self.assertEqual(
+            references[8]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[9]["Citation"], "Med Phys. 2017 May;44(5):1718-1733"
+        )
         self.assertEqual(len(references[9]["ArticleIdList"]), 1)
         self.assertEqual(references[9]["ArticleIdList"][0], "28206676")
-        self.assertEqual(references[9]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[9]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(references[10]["Citation"], "COPD. 2014 Apr;11(2):125-32")
         self.assertEqual(len(references[10]["ArticleIdList"]), 1)
         self.assertEqual(references[10]["ArticleIdList"][0], "22433011")
-        self.assertEqual(references[10]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[11]["Citation"], "Am J Respir Crit Care Med. 2015 Nov 15;192(10):1215-22")
+        self.assertEqual(
+            references[10]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[11]["Citation"],
+            "Am J Respir Crit Care Med. 2015 Nov 15;192(10):1215-22",
+        )
         self.assertEqual(len(references[11]["ArticleIdList"]), 1)
         self.assertEqual(references[11]["ArticleIdList"][0], "26186608")
-        self.assertEqual(references[11]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[12]["Citation"], "N Engl J Med. 2016 May 12;374(19):1811-21")
+        self.assertEqual(
+            references[11]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[12]["Citation"], "N Engl J Med. 2016 May 12;374(19):1811-21"
+        )
         self.assertEqual(len(references[12]["ArticleIdList"]), 1)
         self.assertEqual(references[12]["ArticleIdList"][0], "27168432")
-        self.assertEqual(references[12]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[13]["Citation"], "Am J Epidemiol. 2002 Nov 1;156(9):871-81")
+        self.assertEqual(
+            references[12]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[13]["Citation"], "Am J Epidemiol. 2002 Nov 1;156(9):871-81"
+        )
         self.assertEqual(len(references[13]["ArticleIdList"]), 1)
         self.assertEqual(references[13]["ArticleIdList"][0], "12397006")
-        self.assertEqual(references[13]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[13]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(references[14]["Citation"], "BMC Cancer. 2014 Dec 11;14:934")
         self.assertEqual(len(references[14]["ArticleIdList"]), 1)
         self.assertEqual(references[14]["ArticleIdList"][0], "25496482")
-        self.assertEqual(references[14]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[15]["Citation"], "Acad Radiol. 2015 Mar;22(3):320-9")
+        self.assertEqual(
+            references[14]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[15]["Citation"], "Acad Radiol. 2015 Mar;22(3):320-9"
+        )
         self.assertEqual(len(references[15]["ArticleIdList"]), 1)
         self.assertEqual(references[15]["ArticleIdList"][0], "25491735")
-        self.assertEqual(references[15]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[15]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(references[16]["Citation"], "Chest. 1999 Dec;116(6):1750-61")
         self.assertEqual(len(references[16]["ArticleIdList"]), 1)
         self.assertEqual(references[16]["ArticleIdList"][0], "10593802")
-        self.assertEqual(references[16]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[17]["Citation"], "Acad Radiol. 2012 Feb;19(2):141-52")
+        self.assertEqual(
+            references[16]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[17]["Citation"], "Acad Radiol. 2012 Feb;19(2):141-52"
+        )
         self.assertEqual(len(references[17]["ArticleIdList"]), 1)
         self.assertEqual(references[17]["ArticleIdList"][0], "22104288")
-        self.assertEqual(references[17]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[17]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(references[18]["Citation"], "Med Phys. 2014 Mar;41(3):033502")
         self.assertEqual(len(references[18]["ArticleIdList"]), 1)
         self.assertEqual(references[18]["ArticleIdList"][0], "24593744")
-        self.assertEqual(references[18]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[19]["Citation"], "Med Phys. 2008 Oct;35(10):4695-707")
+        self.assertEqual(
+            references[18]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[19]["Citation"], "Med Phys. 2008 Oct;35(10):4695-707"
+        )
         self.assertEqual(len(references[19]["ArticleIdList"]), 1)
         self.assertEqual(references[19]["ArticleIdList"][0], "18975715")
-        self.assertEqual(references[19]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[19]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(references[20]["Citation"], "Thorax. 2017 May;72(5):475-477")
         self.assertEqual(len(references[20]["ArticleIdList"]), 1)
         self.assertEqual(references[20]["ArticleIdList"][0], "28258250")
-        self.assertEqual(references[20]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[20]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(references[21]["Citation"], "Nat Med. 1996 Nov;2(11):1236-9")
         self.assertEqual(len(references[21]["ArticleIdList"]), 1)
         self.assertEqual(references[21]["ArticleIdList"][0], "8898751")
-        self.assertEqual(references[21]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[22]["Citation"], "J Magn Reson Imaging. 2015 May;41(5):1465-74")
+        self.assertEqual(
+            references[21]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[22]["Citation"], "J Magn Reson Imaging. 2015 May;41(5):1465-74"
+        )
         self.assertEqual(len(references[22]["ArticleIdList"]), 1)
         self.assertEqual(references[22]["ArticleIdList"][0], "24965907")
-        self.assertEqual(references[22]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[23]["Citation"], "Acad Radiol. 2008 Jun;15(6):776-85")
+        self.assertEqual(
+            references[22]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[23]["Citation"], "Acad Radiol. 2008 Jun;15(6):776-85"
+        )
         self.assertEqual(len(references[23]["ArticleIdList"]), 1)
         self.assertEqual(references[23]["ArticleIdList"][0], "18486013")
-        self.assertEqual(references[23]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[24]["Citation"], "Magn Reson Med. 2000 Aug;44(2):174-9")
+        self.assertEqual(
+            references[23]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[24]["Citation"], "Magn Reson Med. 2000 Aug;44(2):174-9"
+        )
         self.assertEqual(len(references[24]["ArticleIdList"]), 1)
         self.assertEqual(references[24]["ArticleIdList"][0], "10918314")
-        self.assertEqual(references[24]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[25]["Citation"], "Am J Respir Crit Care Med. 2014 Jul 15;190(2):135-44")
+        self.assertEqual(
+            references[24]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[25]["Citation"],
+            "Am J Respir Crit Care Med. 2014 Jul 15;190(2):135-44",
+        )
         self.assertEqual(len(references[25]["ArticleIdList"]), 1)
         self.assertEqual(references[25]["ArticleIdList"][0], "24873985")
-        self.assertEqual(references[25]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[26]["Citation"], "Med Phys. 2016 Jun;43(6):2911-2926")
+        self.assertEqual(
+            references[25]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[26]["Citation"], "Med Phys. 2016 Jun;43(6):2911-2926"
+        )
         self.assertEqual(len(references[26]["ArticleIdList"]), 1)
         self.assertEqual(references[26]["ArticleIdList"][0], "27277040")
-        self.assertEqual(references[26]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[26]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(references[27]["Citation"], "Nat Med. 2009 May;15(5):572-6")
         self.assertEqual(len(references[27]["ArticleIdList"]), 1)
         self.assertEqual(references[27]["ArticleIdList"][0], "19377487")
-        self.assertEqual(references[27]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[28]["Citation"], "Eur J Radiol. 2014 Nov;83(11):2093-101")
+        self.assertEqual(
+            references[27]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[28]["Citation"], "Eur J Radiol. 2014 Nov;83(11):2093-101"
+        )
         self.assertEqual(len(references[28]["ArticleIdList"]), 1)
         self.assertEqual(references[28]["ArticleIdList"][0], "25176287")
-        self.assertEqual(references[28]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[29]["Citation"], "Radiology. 2004 Sep;232(3):739-48")
+        self.assertEqual(
+            references[28]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[29]["Citation"], "Radiology. 2004 Sep;232(3):739-48"
+        )
         self.assertEqual(len(references[29]["ArticleIdList"]), 1)
         self.assertEqual(references[29]["ArticleIdList"][0], "15333795")
-        self.assertEqual(references[29]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[30]["Citation"], "Med Image Anal. 2015 Jul;23(1):43-55")
+        self.assertEqual(
+            references[29]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[30]["Citation"], "Med Image Anal. 2015 Jul;23(1):43-55"
+        )
         self.assertEqual(len(references[30]["ArticleIdList"]), 1)
         self.assertEqual(references[30]["ArticleIdList"][0], "25958028")
-        self.assertEqual(references[30]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[31]["Citation"], "Radiology. 2015 Oct;277(1):192-205")
+        self.assertEqual(
+            references[30]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[31]["Citation"], "Radiology. 2015 Oct;277(1):192-205"
+        )
         self.assertEqual(len(references[31]["ArticleIdList"]), 1)
         self.assertEqual(references[31]["ArticleIdList"][0], "25961632")
-        self.assertEqual(references[31]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[32]["Citation"], "Med Image Anal. 2012 Oct;16(7):1423-35")
+        self.assertEqual(
+            references[31]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[32]["Citation"], "Med Image Anal. 2012 Oct;16(7):1423-35"
+        )
         self.assertEqual(len(references[32]["ArticleIdList"]), 1)
         self.assertEqual(references[32]["ArticleIdList"][0], "22722056")
-        self.assertEqual(references[32]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[33]["Citation"], "Radiology. 2016 May;279(2):597-608")
+        self.assertEqual(
+            references[32]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[33]["Citation"], "Radiology. 2016 May;279(2):597-608"
+        )
         self.assertEqual(len(references[33]["ArticleIdList"]), 1)
         self.assertEqual(references[33]["ArticleIdList"][0], "26744928")
-        self.assertEqual(references[33]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[34]["Citation"], "J Allergy Clin Immunol. 2003 Jun;111(6):1205-11")
+        self.assertEqual(
+            references[33]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[34]["Citation"],
+            "J Allergy Clin Immunol. 2003 Jun;111(6):1205-11",
+        )
         self.assertEqual(len(references[34]["ArticleIdList"]), 1)
         self.assertEqual(references[34]["ArticleIdList"][0], "12789218")
-        self.assertEqual(references[34]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[35]["Citation"], "J Magn Reson Imaging. 2016 Mar;43(3):544-57")
+        self.assertEqual(
+            references[34]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[35]["Citation"], "J Magn Reson Imaging. 2016 Mar;43(3):544-57"
+        )
         self.assertEqual(len(references[35]["ArticleIdList"]), 1)
         self.assertEqual(references[35]["ArticleIdList"][0], "26199216")
-        self.assertEqual(references[35]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[36]["Citation"], "Am J Respir Crit Care Med. 2016 Oct 1;194(7):794-806")
+        self.assertEqual(
+            references[35]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[36]["Citation"],
+            "Am J Respir Crit Care Med. 2016 Oct 1;194(7):794-806",
+        )
         self.assertEqual(len(references[36]["ArticleIdList"]), 1)
         self.assertEqual(references[36]["ArticleIdList"][0], "27482984")
-        self.assertEqual(references[36]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[36]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(references[37]["Citation"], "Radiology. 1996 Nov;201(2):564-8")
         self.assertEqual(len(references[37]["ArticleIdList"]), 1)
         self.assertEqual(references[37]["ArticleIdList"][0], "8888259")
-        self.assertEqual(references[37]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[37]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(references[38]["Citation"], "Thorax. 2014 May;69(5):491-4")
         self.assertEqual(len(references[38]["ArticleIdList"]), 1)
         self.assertEqual(references[38]["ArticleIdList"][0], "24029743")
-        self.assertEqual(references[38]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[39]["Citation"], "J Magn Reson Imaging. 2017 Apr;45(4):1204-1215")
+        self.assertEqual(
+            references[38]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[39]["Citation"], "J Magn Reson Imaging. 2017 Apr;45(4):1204-1215"
+        )
         self.assertEqual(len(references[39]["ArticleIdList"]), 1)
         self.assertEqual(references[39]["ArticleIdList"][0], "27731948")
-        self.assertEqual(references[39]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[40]["Citation"], "J Appl Physiol (1985). 2009 Oct;107(4):1258-65")
+        self.assertEqual(
+            references[39]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[40]["Citation"], "J Appl Physiol (1985). 2009 Oct;107(4):1258-65"
+        )
         self.assertEqual(len(references[40]["ArticleIdList"]), 1)
         self.assertEqual(references[40]["ArticleIdList"][0], "19661452")
-        self.assertEqual(references[40]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[41]["Citation"], "Acad Radiol. 2016 Feb;23(2):176-85")
+        self.assertEqual(
+            references[40]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[41]["Citation"], "Acad Radiol. 2016 Feb;23(2):176-85"
+        )
         self.assertEqual(len(references[41]["ArticleIdList"]), 1)
         self.assertEqual(references[41]["ArticleIdList"][0], "26601971")
-        self.assertEqual(references[41]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[42]["Citation"], "Radiology. 2018 May;287(2):693-704")
+        self.assertEqual(
+            references[41]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[42]["Citation"], "Radiology. 2018 May;287(2):693-704"
+        )
         self.assertEqual(len(references[42]["ArticleIdList"]), 1)
         self.assertEqual(references[42]["ArticleIdList"][0], "29470939")
-        self.assertEqual(references[42]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[43]["Citation"], "Eur Respir J. 2016 Aug;48(2):370-9")
+        self.assertEqual(
+            references[42]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[43]["Citation"], "Eur Respir J. 2016 Aug;48(2):370-9"
+        )
         self.assertEqual(len(references[43]["ArticleIdList"]), 1)
         self.assertEqual(references[43]["ArticleIdList"][0], "27174885")
-        self.assertEqual(references[43]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[44]["Citation"], "Radiology. 2011 Oct;261(1):283-92")
+        self.assertEqual(
+            references[43]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[44]["Citation"], "Radiology. 2011 Oct;261(1):283-92"
+        )
         self.assertEqual(len(references[44]["ArticleIdList"]), 1)
         self.assertEqual(references[44]["ArticleIdList"][0], "21813741")
-        self.assertEqual(references[44]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[45]["Citation"], "Am J Respir Crit Care Med. 2014 Mar 15;189(6):650-7")
+        self.assertEqual(
+            references[44]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[45]["Citation"],
+            "Am J Respir Crit Care Med. 2014 Mar 15;189(6):650-7",
+        )
         self.assertEqual(len(references[45]["ArticleIdList"]), 1)
         self.assertEqual(references[45]["ArticleIdList"][0], "24401150")
-        self.assertEqual(references[45]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[46]["Citation"], "Am J Respir Crit Care Med. 2012 Feb 15;185(4):356-62")
+        self.assertEqual(
+            references[45]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[46]["Citation"],
+            "Am J Respir Crit Care Med. 2012 Feb 15;185(4):356-62",
+        )
         self.assertEqual(len(references[46]["ArticleIdList"]), 1)
         self.assertEqual(references[46]["ArticleIdList"][0], "22095547")
-        self.assertEqual(references[46]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[46]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
         self.assertEqual(references[47]["Citation"], "COPD. 2010 Feb;7(1):32-43")
         self.assertEqual(len(references[47]["ArticleIdList"]), 1)
         self.assertEqual(references[47]["ArticleIdList"][0], "20214461")
-        self.assertEqual(references[47]["ArticleIdList"][0].attributes["IdType"], "pubmed")
-        self.assertEqual(references[48]["Citation"], "Eur Respir J. 2008 Apr;31(4):869-73")
+        self.assertEqual(
+            references[47]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
+        self.assertEqual(
+            references[48]["Citation"], "Eur Respir J. 2008 Apr;31(4):869-73"
+        )
         self.assertEqual(len(references[48]["ArticleIdList"]), 1)
         self.assertEqual(references[48]["ArticleIdList"][0], "18216052")
-        self.assertEqual(references[48]["ArticleIdList"][0].attributes["IdType"], "pubmed")
+        self.assertEqual(
+            references[48]["ArticleIdList"][0].attributes["IdType"], "pubmed"
+        )
 
     def test_omim(self):
         """Test parsing XML returned by EFetch, OMIM database."""
@@ -5164,169 +10093,733 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         self.assertEqual(record[0]["Mim-entry_mimNumber"], "601100")
         self.assertEqual(record[0]["Mim-entry_mimType"], "1")
         self.assertEqual(record[0]["Mim-entry_mimType"].attributes["value"], "star")
-        self.assertEqual(record[0]["Mim-entry_title"], "STRESS 70 PROTEIN CHAPERONE, MICROSOME-ASSOCIATED, 60-KD; STCH")
-        self.assertEqual(record[0]["Mim-entry_copyright"], "Copyright (c) 1966-2008 Johns Hopkins University")
+        self.assertEqual(
+            record[0]["Mim-entry_title"],
+            "STRESS 70 PROTEIN CHAPERONE, MICROSOME-ASSOCIATED, 60-KD; STCH",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_copyright"],
+            "Copyright (c) 1966-2008 Johns Hopkins University",
+        )
         self.assertEqual(record[0]["Mim-entry_symbol"], "STCH")
         self.assertEqual(record[0]["Mim-entry_locus"], "21q11.1")
         self.assertEqual(len(record[0]["Mim-entry_text"]), 2)
         self.assertEqual(record[0]["Mim-entry_text"][0]["Mim-text_label"], "TEXT")
-        self.assertEqual(record[0]["Mim-entry_text"][0]["Mim-text_text"], "The stress-70 chaperone family consists of proteins that bind to denatured or incorrectly folded polypeptides and play a major role in the processing of cytosolic and secretory proteins. {2:Otterson et al. (1994)} cloned a human cDNA encoding a predicted 471-amino acid protein (60 kD) which they designated STCH. {1:Brodsky et al. (1995)} stated that the protein sequence is very similar to that of HSP70 ({140550}) and BiP ({138120}). As with other members of the family, the STCH protein contains an ATPase domain at the amino terminus whose activity was shown to be independent of peptide stimulation. The protein was found to be microsome-associated and constitutively expressed in all cell types examined.")
+        self.assertEqual(
+            record[0]["Mim-entry_text"][0]["Mim-text_text"],
+            "The stress-70 chaperone family consists of proteins that bind to denatured or incorrectly folded polypeptides and play a major role in the processing of cytosolic and secretory proteins. {2:Otterson et al. (1994)} cloned a human cDNA encoding a predicted 471-amino acid protein (60 kD) which they designated STCH. {1:Brodsky et al. (1995)} stated that the protein sequence is very similar to that of HSP70 ({140550}) and BiP ({138120}). As with other members of the family, the STCH protein contains an ATPase domain at the amino terminus whose activity was shown to be independent of peptide stimulation. The protein was found to be microsome-associated and constitutively expressed in all cell types examined.",
+        )
         self.assertEqual(len(record[0]["Mim-entry_text"][0]["Mim-text_neighbors"]), 1)
-        self.assertEqual(record[0]["Mim-entry_text"][0]["Mim-text_neighbors"]["Mim-link"]["Mim-link_num"], "30")
-        self.assertEqual(record[0]["Mim-entry_text"][0]["Mim-text_neighbors"]["Mim-link"]["Mim-link_uids"], "8131751,9358068,10675567,9488737,8757872,11048651,2559088,10982831,2105497,16572726,9083109,17181539,14508011,15028727,10651811,9108392,11599566,2661019,11836248,7594475,12406544,8536694,12389629,10430932,9177027,9837933,8522346,2928112,12834280,8702658")
-        self.assertEqual(record[0]["Mim-entry_text"][0]["Mim-text_neighbors"]["Mim-link"]["Mim-link_numRelevant"], "0")
+        self.assertEqual(
+            record[0]["Mim-entry_text"][0]["Mim-text_neighbors"]["Mim-link"][
+                "Mim-link_num"
+            ],
+            "30",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_text"][0]["Mim-text_neighbors"]["Mim-link"][
+                "Mim-link_uids"
+            ],
+            "8131751,9358068,10675567,9488737,8757872,11048651,2559088,10982831,2105497,16572726,9083109,17181539,14508011,15028727,10651811,9108392,11599566,2661019,11836248,7594475,12406544,8536694,12389629,10430932,9177027,9837933,8522346,2928112,12834280,8702658",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_text"][0]["Mim-text_neighbors"]["Mim-link"][
+                "Mim-link_numRelevant"
+            ],
+            "0",
+        )
         self.assertEqual(record[0]["Mim-entry_text"][1]["Mim-text_label"], "TEXT")
-        self.assertEqual(record[0]["Mim-entry_text"][1]["Mim-text_text"], "{1:Brodsky et al. (1995)} mapped the STCH gene to chromosome 21q11.1 with a high-resolution somatic cell hybrid panel for chromosome 21 and by fluorescence in situ hybridization with a YAC containing the gene. By interspecific backcross analysis, {3:Reeves et al. (1998)} mapped the mouse Stch gene to chromosome 16.")
+        self.assertEqual(
+            record[0]["Mim-entry_text"][1]["Mim-text_text"],
+            "{1:Brodsky et al. (1995)} mapped the STCH gene to chromosome 21q11.1 with a high-resolution somatic cell hybrid panel for chromosome 21 and by fluorescence in situ hybridization with a YAC containing the gene. By interspecific backcross analysis, {3:Reeves et al. (1998)} mapped the mouse Stch gene to chromosome 16.",
+        )
         self.assertEqual(len(record[0]["Mim-entry_text"][1]["Mim-text_neighbors"]), 1)
-        self.assertEqual(record[0]["Mim-entry_text"][1]["Mim-text_neighbors"]["Mim-link"]["Mim-link_num"], "30")
-        self.assertEqual(record[0]["Mim-entry_text"][1]["Mim-text_neighbors"]["Mim-link"]["Mim-link_uids"], "1354597,8244375,8597637,8838809,9143508,1427875,7806216,9852683,7835904,11060461,10083745,7789175,7806232,7513297,8020937,12014109,1769649,2045096,9747039,8034329,8088815,1783375,8275716,8020959,7956352,8020952,10198174,7655454,8750197,11272792")
-        self.assertEqual(record[0]["Mim-entry_text"][1]["Mim-text_neighbors"]["Mim-link"]["Mim-link_numRelevant"], "0")
+        self.assertEqual(
+            record[0]["Mim-entry_text"][1]["Mim-text_neighbors"]["Mim-link"][
+                "Mim-link_num"
+            ],
+            "30",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_text"][1]["Mim-text_neighbors"]["Mim-link"][
+                "Mim-link_uids"
+            ],
+            "1354597,8244375,8597637,8838809,9143508,1427875,7806216,9852683,7835904,11060461,10083745,7789175,7806232,7513297,8020937,12014109,1769649,2045096,9747039,8034329,8088815,1783375,8275716,8020959,7956352,8020952,10198174,7655454,8750197,11272792",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_text"][1]["Mim-text_neighbors"]["Mim-link"][
+                "Mim-link_numRelevant"
+            ],
+            "0",
+        )
         self.assertEqual(record[0]["Mim-entry_hasSummary"], "")
         self.assertEqual(record[0]["Mim-entry_hasSummary"].attributes["value"], "false")
         self.assertEqual(record[0]["Mim-entry_hasSynopsis"], "")
-        self.assertEqual(record[0]["Mim-entry_hasSynopsis"].attributes["value"], "false")
+        self.assertEqual(
+            record[0]["Mim-entry_hasSynopsis"].attributes["value"], "false"
+        )
         self.assertEqual(len(record[0]["Mim-entry_editHistory"]), 6)
-        self.assertEqual(record[0]["Mim-entry_editHistory"][0]["Mim-edit-item_author"], "terry")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][0]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_year"], "1999")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][0]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_month"], "3")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][0]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_day"], "9")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][1]["Mim-edit-item_author"], "carol")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][1]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_year"], "1999")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][1]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_month"], "3")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][1]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_day"], "7")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][2]["Mim-edit-item_author"], "carol")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][2]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_year"], "1998")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][2]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_month"], "7")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][2]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_day"], "8")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][3]["Mim-edit-item_author"], "terry")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][3]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_year"], "1996")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][3]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_month"], "5")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][3]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_day"], "24")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][4]["Mim-edit-item_author"], "mark")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][4]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_year"], "1996")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][4]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_month"], "3")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][4]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_day"], "1")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][5]["Mim-edit-item_author"], "mark")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][5]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_year"], "1996")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][5]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_month"], "3")
-        self.assertEqual(record[0]["Mim-entry_editHistory"][5]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_day"], "1")
-        self.assertEqual(record[0]["Mim-entry_creationDate"]["Mim-edit-item"]["Mim-edit-item_author"], "Alan F. Scott")
-        self.assertEqual(record[0]["Mim-entry_creationDate"]["Mim-edit-item"]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_year"], "1996")
-        self.assertEqual(record[0]["Mim-entry_creationDate"]["Mim-edit-item"]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_month"], "3")
-        self.assertEqual(record[0]["Mim-entry_creationDate"]["Mim-edit-item"]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_day"], "1")
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][0]["Mim-edit-item_author"], "terry"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][0]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_year"
+            ],
+            "1999",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][0]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_month"
+            ],
+            "3",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][0]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_day"
+            ],
+            "9",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][1]["Mim-edit-item_author"], "carol"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][1]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_year"
+            ],
+            "1999",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][1]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_month"
+            ],
+            "3",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][1]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_day"
+            ],
+            "7",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][2]["Mim-edit-item_author"], "carol"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][2]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_year"
+            ],
+            "1998",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][2]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_month"
+            ],
+            "7",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][2]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_day"
+            ],
+            "8",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][3]["Mim-edit-item_author"], "terry"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][3]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_year"
+            ],
+            "1996",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][3]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_month"
+            ],
+            "5",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][3]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_day"
+            ],
+            "24",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][4]["Mim-edit-item_author"], "mark"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][4]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_year"
+            ],
+            "1996",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][4]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_month"
+            ],
+            "3",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][4]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_day"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][5]["Mim-edit-item_author"], "mark"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][5]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_year"
+            ],
+            "1996",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][5]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_month"
+            ],
+            "3",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_editHistory"][5]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_day"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_creationDate"]["Mim-edit-item"][
+                "Mim-edit-item_author"
+            ],
+            "Alan F. Scott",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_creationDate"]["Mim-edit-item"][
+                "Mim-edit-item_modDate"
+            ]["Mim-date"]["Mim-date_year"],
+            "1996",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_creationDate"]["Mim-edit-item"][
+                "Mim-edit-item_modDate"
+            ]["Mim-date"]["Mim-date_month"],
+            "3",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_creationDate"]["Mim-edit-item"][
+                "Mim-edit-item_modDate"
+            ]["Mim-date"]["Mim-date_day"],
+            "1",
+        )
         self.assertEqual(len(record[0]["Mim-entry_references"]), 3)
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_number"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_origNumber"], "1")
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_number"], "1"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_origNumber"], "1"
+        )
         self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_type"], "")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_type"].attributes["value"], "citation")
-        self.assertEqual(len(record[0]["Mim-entry_references"][0]["Mim-reference_authors"]), 6)
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_authors"][0]["Mim-author_name"], "Brodsky, G.")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_authors"][0]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_authors"][1]["Mim-author_name"], "Otterson, G. A.")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_authors"][1]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_authors"][2]["Mim-author_name"], "Parry, B. B.")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_authors"][2]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_authors"][3]["Mim-author_name"], "Hart, I.")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_authors"][3]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_authors"][4]["Mim-author_name"], "Patterson, D.")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_authors"][4]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_authors"][5]["Mim-author_name"], "Kaye, F. J.")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_authors"][5]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_primaryAuthor"], "Brodsky")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_otherAuthors"], "et al.")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_citationTitle"], "Localization of STCH to human chromosome 21q11.1.")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_citationType"], "0")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_volume"], "30")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_journal"], "Genomics")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_pubDate"]["Mim-date"]["Mim-date_year"], "1995")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_pubDate"]["Mim-date"]["Mim-date_month"], "0")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_pubDate"]["Mim-date"]["Mim-date_day"], "0")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_pages"][0]["Mim-page_from"], "627")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_pages"][0]["Mim-page_to"], "628")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_pubmedUID"], "8825657")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_ambiguous"], "")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_ambiguous"].attributes["value"], "false")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_noLink"], "")
-        self.assertEqual(record[0]["Mim-entry_references"][0]["Mim-reference_noLink"].attributes["value"], "false")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_number"], "2")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_origNumber"], "2")
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_type"].attributes[
+                "value"
+            ],
+            "citation",
+        )
+        self.assertEqual(
+            len(record[0]["Mim-entry_references"][0]["Mim-reference_authors"]), 6
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_authors"][0][
+                "Mim-author_name"
+            ],
+            "Brodsky, G.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_authors"][0][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_authors"][1][
+                "Mim-author_name"
+            ],
+            "Otterson, G. A.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_authors"][1][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_authors"][2][
+                "Mim-author_name"
+            ],
+            "Parry, B. B.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_authors"][2][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_authors"][3][
+                "Mim-author_name"
+            ],
+            "Hart, I.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_authors"][3][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_authors"][4][
+                "Mim-author_name"
+            ],
+            "Patterson, D.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_authors"][4][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_authors"][5][
+                "Mim-author_name"
+            ],
+            "Kaye, F. J.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_authors"][5][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_primaryAuthor"],
+            "Brodsky",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_otherAuthors"], "et al."
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_citationTitle"],
+            "Localization of STCH to human chromosome 21q11.1.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_citationType"], "0"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_volume"], "30"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_journal"], "Genomics"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_pubDate"]["Mim-date"][
+                "Mim-date_year"
+            ],
+            "1995",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_pubDate"]["Mim-date"][
+                "Mim-date_month"
+            ],
+            "0",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_pubDate"]["Mim-date"][
+                "Mim-date_day"
+            ],
+            "0",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_pages"][0][
+                "Mim-page_from"
+            ],
+            "627",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_pages"][0][
+                "Mim-page_to"
+            ],
+            "628",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_pubmedUID"], "8825657"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_ambiguous"], ""
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_ambiguous"].attributes[
+                "value"
+            ],
+            "false",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_noLink"], ""
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][0]["Mim-reference_noLink"].attributes[
+                "value"
+            ],
+            "false",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_number"], "2"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_origNumber"], "2"
+        )
         self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_type"], "")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_type"].attributes["value"], "citation")
-        self.assertEqual(len(record[0]["Mim-entry_references"][1]["Mim-reference_authors"]), 6)
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_authors"][0]["Mim-author_name"], "Otterson, G. A.")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_authors"][0]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_authors"][1]["Mim-author_name"], "Flynn, G. C.")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_authors"][1]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_authors"][2]["Mim-author_name"], "Kratzke, R. A.")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_authors"][2]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_authors"][3]["Mim-author_name"], "Coxon, A.")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_authors"][3]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_authors"][4]["Mim-author_name"], "Johnston, P. G.")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_authors"][4]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_authors"][5]["Mim-author_name"], "Kaye, F. J.")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_authors"][5]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_primaryAuthor"], "Otterson")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_otherAuthors"], "et al.")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_citationTitle"], "Stch encodes the 'ATPase core' of a microsomal stress70 protein.")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_citationType"], "0")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_volume"], "13")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_journal"], "EMBO J.")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_pubDate"]["Mim-date"]["Mim-date_year"], "1994")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_pubDate"]["Mim-date"]["Mim-date_month"], "0")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_pubDate"]["Mim-date"]["Mim-date_day"], "0")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_pages"][0]["Mim-page_from"], "1216")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_pages"][0]["Mim-page_to"], "1225")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_pubmedUID"], "8131751")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_ambiguous"], "")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_ambiguous"].attributes["value"], "false")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_noLink"], "")
-        self.assertEqual(record[0]["Mim-entry_references"][1]["Mim-reference_noLink"].attributes["value"], "false")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_number"], "3")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_origNumber"], "3")
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_type"].attributes[
+                "value"
+            ],
+            "citation",
+        )
+        self.assertEqual(
+            len(record[0]["Mim-entry_references"][1]["Mim-reference_authors"]), 6
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_authors"][0][
+                "Mim-author_name"
+            ],
+            "Otterson, G. A.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_authors"][0][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_authors"][1][
+                "Mim-author_name"
+            ],
+            "Flynn, G. C.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_authors"][1][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_authors"][2][
+                "Mim-author_name"
+            ],
+            "Kratzke, R. A.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_authors"][2][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_authors"][3][
+                "Mim-author_name"
+            ],
+            "Coxon, A.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_authors"][3][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_authors"][4][
+                "Mim-author_name"
+            ],
+            "Johnston, P. G.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_authors"][4][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_authors"][5][
+                "Mim-author_name"
+            ],
+            "Kaye, F. J.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_authors"][5][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_primaryAuthor"],
+            "Otterson",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_otherAuthors"], "et al."
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_citationTitle"],
+            "Stch encodes the 'ATPase core' of a microsomal stress70 protein.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_citationType"], "0"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_volume"], "13"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_journal"], "EMBO J."
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_pubDate"]["Mim-date"][
+                "Mim-date_year"
+            ],
+            "1994",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_pubDate"]["Mim-date"][
+                "Mim-date_month"
+            ],
+            "0",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_pubDate"]["Mim-date"][
+                "Mim-date_day"
+            ],
+            "0",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_pages"][0][
+                "Mim-page_from"
+            ],
+            "1216",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_pages"][0][
+                "Mim-page_to"
+            ],
+            "1225",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_pubmedUID"], "8131751"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_ambiguous"], ""
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_ambiguous"].attributes[
+                "value"
+            ],
+            "false",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_noLink"], ""
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][1]["Mim-reference_noLink"].attributes[
+                "value"
+            ],
+            "false",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_number"], "3"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_origNumber"], "3"
+        )
         self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_type"], "")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_type"].attributes["value"], "citation")
-        self.assertEqual(len(record[0]["Mim-entry_references"][2]["Mim-reference_authors"]), 4)
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_authors"][0]["Mim-author_name"], "Reeves, R. H.")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_authors"][0]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_authors"][1]["Mim-author_name"], "Rue, E.")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_authors"][1]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_authors"][2]["Mim-author_name"], "Yu, J.")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_authors"][2]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_authors"][3]["Mim-author_name"], "Kao, F.-T.")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_authors"][3]["Mim-author_index"], "1")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_primaryAuthor"], "Reeves")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_otherAuthors"], "et al.")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_citationTitle"], "Stch maps to mouse chromosome 16, extending the conserved synteny with human chromosome 21.")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_citationType"], "0")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_volume"], "49")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_journal"], "Genomics")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_pubDate"]["Mim-date"]["Mim-date_year"], "1998")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_pubDate"]["Mim-date"]["Mim-date_month"], "0")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_pubDate"]["Mim-date"]["Mim-date_day"], "0")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_pages"][0]["Mim-page_from"], "156")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_pages"][0]["Mim-page_to"], "157")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_pubmedUID"], "9570963")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_ambiguous"], "")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_ambiguous"].attributes["value"], "false")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_noLink"], "")
-        self.assertEqual(record[0]["Mim-entry_references"][2]["Mim-reference_noLink"].attributes["value"], "false")
-        self.assertEqual(record[0]["Mim-entry_attribution"][0]["Mim-edit-item_author"], "Carol A. Bocchini - updated")
-        self.assertEqual(record[0]["Mim-entry_attribution"][0]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_year"], "1999")
-        self.assertEqual(record[0]["Mim-entry_attribution"][0]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_month"], "3")
-        self.assertEqual(record[0]["Mim-entry_attribution"][0]["Mim-edit-item_modDate"]["Mim-date"]["Mim-date_day"], "7")
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_type"].attributes[
+                "value"
+            ],
+            "citation",
+        )
+        self.assertEqual(
+            len(record[0]["Mim-entry_references"][2]["Mim-reference_authors"]), 4
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_authors"][0][
+                "Mim-author_name"
+            ],
+            "Reeves, R. H.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_authors"][0][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_authors"][1][
+                "Mim-author_name"
+            ],
+            "Rue, E.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_authors"][1][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_authors"][2][
+                "Mim-author_name"
+            ],
+            "Yu, J.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_authors"][2][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_authors"][3][
+                "Mim-author_name"
+            ],
+            "Kao, F.-T.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_authors"][3][
+                "Mim-author_index"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_primaryAuthor"],
+            "Reeves",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_otherAuthors"], "et al."
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_citationTitle"],
+            "Stch maps to mouse chromosome 16, extending the conserved synteny with human chromosome 21.",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_citationType"], "0"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_volume"], "49"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_journal"], "Genomics"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_pubDate"]["Mim-date"][
+                "Mim-date_year"
+            ],
+            "1998",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_pubDate"]["Mim-date"][
+                "Mim-date_month"
+            ],
+            "0",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_pubDate"]["Mim-date"][
+                "Mim-date_day"
+            ],
+            "0",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_pages"][0][
+                "Mim-page_from"
+            ],
+            "156",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_pages"][0][
+                "Mim-page_to"
+            ],
+            "157",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_pubmedUID"], "9570963"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_ambiguous"], ""
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_ambiguous"].attributes[
+                "value"
+            ],
+            "false",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_noLink"], ""
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_references"][2]["Mim-reference_noLink"].attributes[
+                "value"
+            ],
+            "false",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_attribution"][0]["Mim-edit-item_author"],
+            "Carol A. Bocchini - updated",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_attribution"][0]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_year"
+            ],
+            "1999",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_attribution"][0]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_month"
+            ],
+            "3",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_attribution"][0]["Mim-edit-item_modDate"]["Mim-date"][
+                "Mim-date_day"
+            ],
+            "7",
+        )
         self.assertEqual(record[0]["Mim-entry_numGeneMaps"], "1")
         self.assertEqual(len(record[0]["Mim-entry_medlineLinks"]), 1)
-        self.assertEqual(record[0]["Mim-entry_medlineLinks"]["Mim-link"]["Mim-link_num"], "3")
-        self.assertEqual(record[0]["Mim-entry_medlineLinks"]["Mim-link"]["Mim-link_uids"], "8825657,8131751,9570963")
-        self.assertEqual(record[0]["Mim-entry_medlineLinks"]["Mim-link"]["Mim-link_numRelevant"], "0")
+        self.assertEqual(
+            record[0]["Mim-entry_medlineLinks"]["Mim-link"]["Mim-link_num"], "3"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_medlineLinks"]["Mim-link"]["Mim-link_uids"],
+            "8825657,8131751,9570963",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_medlineLinks"]["Mim-link"]["Mim-link_numRelevant"], "0"
+        )
         self.assertEqual(len(record[0]["Mim-entry_proteinLinks"]), 1)
-        self.assertEqual(record[0]["Mim-entry_proteinLinks"]["Mim-link"]["Mim-link_num"], "7")
-        self.assertEqual(record[0]["Mim-entry_proteinLinks"]["Mim-link"]["Mim-link_uids"], "148747550,67461586,48928056,30089677,2352621,1351125,460148")
-        self.assertEqual(record[0]["Mim-entry_proteinLinks"]["Mim-link"]["Mim-link_numRelevant"], "0")
+        self.assertEqual(
+            record[0]["Mim-entry_proteinLinks"]["Mim-link"]["Mim-link_num"], "7"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_proteinLinks"]["Mim-link"]["Mim-link_uids"],
+            "148747550,67461586,48928056,30089677,2352621,1351125,460148",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_proteinLinks"]["Mim-link"]["Mim-link_numRelevant"], "0"
+        )
         self.assertEqual(len(record[0]["Mim-entry_nucleotideLinks"]), 1)
-        self.assertEqual(record[0]["Mim-entry_nucleotideLinks"]["Mim-link"]["Mim-link_num"], "5")
-        self.assertEqual(record[0]["Mim-entry_nucleotideLinks"]["Mim-link"]["Mim-link_uids"], "148747549,55741785,48928055,2352620,460147")
-        self.assertEqual(record[0]["Mim-entry_nucleotideLinks"]["Mim-link"]["Mim-link_numRelevant"], "0")
+        self.assertEqual(
+            record[0]["Mim-entry_nucleotideLinks"]["Mim-link"]["Mim-link_num"], "5"
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_nucleotideLinks"]["Mim-link"]["Mim-link_uids"],
+            "148747549,55741785,48928055,2352620,460147",
+        )
+        self.assertEqual(
+            record[0]["Mim-entry_nucleotideLinks"]["Mim-link"]["Mim-link_numRelevant"],
+            "0",
+        )
 
     def test_taxonomy(self):
         """Test parsing XML returned by EFetch, Taxonomy database."""
@@ -5339,7 +10832,9 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         self.assertEqual(record[0]["TaxId"], "9685")
         self.assertEqual(record[0]["ScientificName"], "Felis catus")
         self.assertEqual(record[0]["OtherNames"]["GenbankCommonName"], "domestic cat")
-        self.assertEqual(record[0]["OtherNames"]["Synonym"][0], "Felis silvestris catus")
+        self.assertEqual(
+            record[0]["OtherNames"]["Synonym"][0], "Felis silvestris catus"
+        )
         self.assertEqual(record[0]["OtherNames"]["Synonym"][1], "Felis domesticus")
         self.assertEqual(record[0]["OtherNames"]["CommonName"][0], "cat")
         self.assertEqual(record[0]["OtherNames"]["CommonName"][1], "cats")
@@ -5350,17 +10845,26 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         self.assertEqual(record[0]["GeneticCode"]["GCId"], "1")
         self.assertEqual(record[0]["GeneticCode"]["GCName"], "Standard")
         self.assertEqual(record[0]["MitoGeneticCode"]["MGCId"], "2")
-        self.assertEqual(record[0]["MitoGeneticCode"]["MGCName"], "Vertebrate Mitochondrial")
-        self.assertEqual(record[0]["Lineage"], "cellular organisms; Eukaryota; Fungi/Metazoa group; Metazoa; Eumetazoa; Bilateria; Coelomata; Deuterostomia; Chordata; Craniata; Vertebrata; Gnathostomata; Teleostomi; Euteleostomi; Sarcopterygii; Tetrapoda; Amniota; Mammalia; Theria; Eutheria; Laurasiatheria; Carnivora; Feliformia; Felidae; Felinae; Felis")
+        self.assertEqual(
+            record[0]["MitoGeneticCode"]["MGCName"], "Vertebrate Mitochondrial"
+        )
+        self.assertEqual(
+            record[0]["Lineage"],
+            "cellular organisms; Eukaryota; Fungi/Metazoa group; Metazoa; Eumetazoa; Bilateria; Coelomata; Deuterostomia; Chordata; Craniata; Vertebrata; Gnathostomata; Teleostomi; Euteleostomi; Sarcopterygii; Tetrapoda; Amniota; Mammalia; Theria; Eutheria; Laurasiatheria; Carnivora; Feliformia; Felidae; Felinae; Felis",
+        )
 
         self.assertEqual(record[0]["LineageEx"][0]["TaxId"], "131567")
-        self.assertEqual(record[0]["LineageEx"][0]["ScientificName"], "cellular organisms")
+        self.assertEqual(
+            record[0]["LineageEx"][0]["ScientificName"], "cellular organisms"
+        )
         self.assertEqual(record[0]["LineageEx"][0]["Rank"], "no rank")
         self.assertEqual(record[0]["LineageEx"][1]["TaxId"], "2759")
         self.assertEqual(record[0]["LineageEx"][1]["ScientificName"], "Eukaryota")
         self.assertEqual(record[0]["LineageEx"][1]["Rank"], "superkingdom")
         self.assertEqual(record[0]["LineageEx"][2]["TaxId"], "33154")
-        self.assertEqual(record[0]["LineageEx"][2]["ScientificName"], "Fungi/Metazoa group")
+        self.assertEqual(
+            record[0]["LineageEx"][2]["ScientificName"], "Fungi/Metazoa group"
+        )
         self.assertEqual(record[0]["LineageEx"][2]["Rank"], "no rank")
         self.assertEqual(record[0]["LineageEx"][3]["TaxId"], "33208")
         self.assertEqual(record[0]["LineageEx"][3]["ScientificName"], "Metazoa")
@@ -5450,7 +10954,10 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         self.assertEqual(record[0]["GBSeq_division"], "MAM")
         self.assertEqual(record[0]["GBSeq_update-date"], "14-NOV-2006")
         self.assertEqual(record[0]["GBSeq_create-date"], "05-MAY-1992")
-        self.assertEqual(record[0]["GBSeq_definition"], "B.bovis beta-2-gpI mRNA for beta-2-glycoprotein I")
+        self.assertEqual(
+            record[0]["GBSeq_definition"],
+            "B.bovis beta-2-gpI mRNA for beta-2-glycoprotein I",
+        )
         self.assertEqual(record[0]["GBSeq_primary-accession"], "X60065")
         self.assertEqual(record[0]["GBSeq_accession-version"], "X60065.1")
         self.assertEqual(record[0]["GBSeq_other-seqids"][0], "emb|X60065.1|")
@@ -5458,103 +10965,474 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         self.assertEqual(record[0]["GBSeq_keywords"][0], "beta-2 glycoprotein I")
         self.assertEqual(record[0]["GBSeq_source"], "Bos taurus (cattle)")
         self.assertEqual(record[0]["GBSeq_organism"], "Bos taurus")
-        self.assertEqual(record[0]["GBSeq_taxonomy"], "Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia; Eutheria; Laurasiatheria; Cetartiodactyla; Ruminantia; Pecora; Bovidae; Bovinae; Bos")
+        self.assertEqual(
+            record[0]["GBSeq_taxonomy"],
+            "Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia; Eutheria; Laurasiatheria; Cetartiodactyla; Ruminantia; Pecora; Bovidae; Bovinae; Bos",
+        )
         self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_reference"], "1")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_authors"][0], "Bendixen,E.")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_authors"][1], "Halkier,T.")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_authors"][2], "Magnusson,S.")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_authors"][3], "Sottrup-Jensen,L.")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_authors"][4], "Kristensen,T.")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_title"], "Complete primary structure of bovine beta 2-glycoprotein I: localization of the disulfide bridges")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_journal"], "Biochemistry 31 (14), 3611-3617 (1992)")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_pubmed"], "1567819")
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_authors"][0], "Bendixen,E."
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_authors"][1], "Halkier,T."
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_authors"][2], "Magnusson,S."
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_authors"][3],
+            "Sottrup-Jensen,L.",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_authors"][4], "Kristensen,T."
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_title"],
+            "Complete primary structure of bovine beta 2-glycoprotein I: localization of the disulfide bridges",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_journal"],
+            "Biochemistry 31 (14), 3611-3617 (1992)",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_pubmed"], "1567819"
+        )
         self.assertEqual(record[0]["GBSeq_references"][1]["GBReference_reference"], "2")
-        self.assertEqual(record[0]["GBSeq_references"][1]["GBReference_position"], "1..1136")
-        self.assertEqual(record[0]["GBSeq_references"][1]["GBReference_authors"][0], "Kristensen,T.")
-        self.assertEqual(record[0]["GBSeq_references"][1]["GBReference_title"], "Direct Submission")
-        self.assertEqual(record[0]["GBSeq_references"][1]["GBReference_journal"], "Submitted (11-JUN-1991) T. Kristensen, Dept of Mol Biology, University of Aarhus, C F Mollers Alle 130, DK-8000 Aarhus C, DENMARK")
+        self.assertEqual(
+            record[0]["GBSeq_references"][1]["GBReference_position"], "1..1136"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][1]["GBReference_authors"][0], "Kristensen,T."
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][1]["GBReference_title"], "Direct Submission"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][1]["GBReference_journal"],
+            "Submitted (11-JUN-1991) T. Kristensen, Dept of Mol Biology, University of Aarhus, C F Mollers Alle 130, DK-8000 Aarhus C, DENMARK",
+        )
         self.assertEqual(len(record[0]["GBSeq_feature-table"]), 7)
         self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_key"], "source")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_location"], "1..1136")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_intervals"][0]["GBInterval_from"], "1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_intervals"][0]["GBInterval_to"], "1136")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_intervals"][0]["GBInterval_accession"], "X60065.1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][0]["GBQualifier_name"], "organism")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][0]["GBQualifier_value"], "Bos taurus")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][1]["GBQualifier_name"], "mol_type")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][1]["GBQualifier_value"], "mRNA")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][2]["GBQualifier_name"], "db_xref")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][2]["GBQualifier_value"], "taxon:9913")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][3]["GBQualifier_name"], "clone")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][3]["GBQualifier_value"], "pBB2I")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][4]["GBQualifier_name"], "tissue_type")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][4]["GBQualifier_value"], "liver")
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_location"], "1..1136"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_intervals"][0][
+                "GBInterval_from"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_intervals"][0][
+                "GBInterval_to"
+            ],
+            "1136",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_intervals"][0][
+                "GBInterval_accession"
+            ],
+            "X60065.1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][0][
+                "GBQualifier_name"
+            ],
+            "organism",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][0][
+                "GBQualifier_value"
+            ],
+            "Bos taurus",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][1][
+                "GBQualifier_name"
+            ],
+            "mol_type",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][1][
+                "GBQualifier_value"
+            ],
+            "mRNA",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][2][
+                "GBQualifier_name"
+            ],
+            "db_xref",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][2][
+                "GBQualifier_value"
+            ],
+            "taxon:9913",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][3][
+                "GBQualifier_name"
+            ],
+            "clone",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][3][
+                "GBQualifier_value"
+            ],
+            "pBB2I",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][4][
+                "GBQualifier_name"
+            ],
+            "tissue_type",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][4][
+                "GBQualifier_value"
+            ],
+            "liver",
+        )
         self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_key"], "gene")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_location"], "<1..1136")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_intervals"][0]["GBInterval_from"], "1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_intervals"][0]["GBInterval_to"], "1136")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_intervals"][0]["GBInterval_accession"], "X60065.1")
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_location"], "<1..1136"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_intervals"][0][
+                "GBInterval_from"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_intervals"][0][
+                "GBInterval_to"
+            ],
+            "1136",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_intervals"][0][
+                "GBInterval_accession"
+            ],
+            "X60065.1",
+        )
         self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_partial5"], "")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_partial5"].attributes["value"], "true")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_quals"][0]["GBQualifier_name"], "gene")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_quals"][0]["GBQualifier_value"], "beta-2-gpI")
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_partial5"].attributes[
+                "value"
+            ],
+            "true",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_quals"][0][
+                "GBQualifier_name"
+            ],
+            "gene",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_quals"][0][
+                "GBQualifier_value"
+            ],
+            "beta-2-gpI",
+        )
         self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_key"], "CDS")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_location"], "<1..1029")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_intervals"][0]["GBInterval_from"], "1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_intervals"][0]["GBInterval_to"], "1029")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_intervals"][0]["GBInterval_accession"], "X60065.1")
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_location"], "<1..1029"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_intervals"][0][
+                "GBInterval_from"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_intervals"][0][
+                "GBInterval_to"
+            ],
+            "1029",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_intervals"][0][
+                "GBInterval_accession"
+            ],
+            "X60065.1",
+        )
         self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_partial5"], "")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_partial5"].attributes["value"], "true")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][0]["GBQualifier_name"], "gene")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][0]["GBQualifier_value"], "beta-2-gpI")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][1]["GBQualifier_name"], "codon_start")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][1]["GBQualifier_value"], "1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][2]["GBQualifier_name"], "transl_table")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][2]["GBQualifier_value"], "1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][3]["GBQualifier_name"], "product")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][3]["GBQualifier_value"], "beta-2-glycoprotein I")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][4]["GBQualifier_name"], "protein_id")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][4]["GBQualifier_value"], "CAA42669.1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][5]["GBQualifier_name"], "db_xref")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][5]["GBQualifier_value"], "GI:6")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][6]["GBQualifier_name"], "db_xref")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][6]["GBQualifier_value"], "GOA:P17690")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][7]["GBQualifier_name"], "db_xref")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][7]["GBQualifier_value"], "UniProtKB/Swiss-Prot:P17690")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][8]["GBQualifier_name"], "translation")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][8]["GBQualifier_value"], "PALVLLLGFLCHVAIAGRTCPKPDELPFSTVVPLKRTYEPGEQIVFSCQPGYVSRGGIRRFTCPLTGLWPINTLKCMPRVCPFAGILENGTVRYTTFEYPNTISFSCHTGFYLKGASSAKCTEEGKWSPDLPVCAPITCPPPPIPKFASLSVYKPLAGNNSFYGSKAVFKCLPHHAMFGNDTVTCTEHGNWTQLPECREVRCPFPSRPDNGFVNHPANPVLYYKDTATFGCHETYSLDGPEEVECSKFGNWSAQPSCKASCKLSIKRATVIYEGERVAIQNKFKNGMLHGQKVSFFCKHKEKKCSYTEDAQCIDGTIEIPKCFKEHSSLAFWKTDASDVKPC")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_key"], "sig_peptide")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_location"], "<1..48")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_intervals"][0]["GBInterval_from"], "1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_intervals"][0]["GBInterval_to"], "48")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_intervals"][0]["GBInterval_accession"], "X60065.1")
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_partial5"].attributes[
+                "value"
+            ],
+            "true",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][0][
+                "GBQualifier_name"
+            ],
+            "gene",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][0][
+                "GBQualifier_value"
+            ],
+            "beta-2-gpI",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][1][
+                "GBQualifier_name"
+            ],
+            "codon_start",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][1][
+                "GBQualifier_value"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][2][
+                "GBQualifier_name"
+            ],
+            "transl_table",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][2][
+                "GBQualifier_value"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][3][
+                "GBQualifier_name"
+            ],
+            "product",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][3][
+                "GBQualifier_value"
+            ],
+            "beta-2-glycoprotein I",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][4][
+                "GBQualifier_name"
+            ],
+            "protein_id",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][4][
+                "GBQualifier_value"
+            ],
+            "CAA42669.1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][5][
+                "GBQualifier_name"
+            ],
+            "db_xref",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][5][
+                "GBQualifier_value"
+            ],
+            "GI:6",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][6][
+                "GBQualifier_name"
+            ],
+            "db_xref",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][6][
+                "GBQualifier_value"
+            ],
+            "GOA:P17690",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][7][
+                "GBQualifier_name"
+            ],
+            "db_xref",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][7][
+                "GBQualifier_value"
+            ],
+            "UniProtKB/Swiss-Prot:P17690",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][8][
+                "GBQualifier_name"
+            ],
+            "translation",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][8][
+                "GBQualifier_value"
+            ],
+            "PALVLLLGFLCHVAIAGRTCPKPDELPFSTVVPLKRTYEPGEQIVFSCQPGYVSRGGIRRFTCPLTGLWPINTLKCMPRVCPFAGILENGTVRYTTFEYPNTISFSCHTGFYLKGASSAKCTEEGKWSPDLPVCAPITCPPPPIPKFASLSVYKPLAGNNSFYGSKAVFKCLPHHAMFGNDTVTCTEHGNWTQLPECREVRCPFPSRPDNGFVNHPANPVLYYKDTATFGCHETYSLDGPEEVECSKFGNWSAQPSCKASCKLSIKRATVIYEGERVAIQNKFKNGMLHGQKVSFFCKHKEKKCSYTEDAQCIDGTIEIPKCFKEHSSLAFWKTDASDVKPC",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_key"], "sig_peptide"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_location"], "<1..48"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_intervals"][0][
+                "GBInterval_from"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_intervals"][0][
+                "GBInterval_to"
+            ],
+            "48",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_intervals"][0][
+                "GBInterval_accession"
+            ],
+            "X60065.1",
+        )
         self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_partial5"], "")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_partial5"].attributes["value"], "true")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][0]["GBQualifier_name"], "gene")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][0]["GBQualifier_value"], "beta-2-gpI")
-        self.assertEqual(record[0]["GBSeq_feature-table"][4]["GBFeature_key"], "mat_peptide")
-        self.assertEqual(record[0]["GBSeq_feature-table"][4]["GBFeature_location"], "49..1026")
-        self.assertEqual(record[0]["GBSeq_feature-table"][4]["GBFeature_intervals"][0]["GBInterval_from"], "49")
-        self.assertEqual(record[0]["GBSeq_feature-table"][4]["GBFeature_intervals"][0]["GBInterval_to"], "1026")
-        self.assertEqual(record[0]["GBSeq_feature-table"][4]["GBFeature_intervals"][0]["GBInterval_accession"], "X60065.1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][4]["GBFeature_quals"][0]["GBQualifier_name"], "gene")
-        self.assertEqual(record[0]["GBSeq_feature-table"][4]["GBFeature_quals"][0]["GBQualifier_value"], "beta-2-gpI")
-        self.assertEqual(record[0]["GBSeq_feature-table"][4]["GBFeature_quals"][1]["GBQualifier_name"], "product")
-        self.assertEqual(record[0]["GBSeq_feature-table"][4]["GBFeature_quals"][1]["GBQualifier_value"], "beta-2-glycoprotein I")
-        self.assertEqual(record[0]["GBSeq_feature-table"][5]["GBFeature_key"], "polyA_signal")
-        self.assertEqual(record[0]["GBSeq_feature-table"][5]["GBFeature_location"], "1101..1106")
-        self.assertEqual(record[0]["GBSeq_feature-table"][5]["GBFeature_intervals"][0]["GBInterval_from"], "1101")
-        self.assertEqual(record[0]["GBSeq_feature-table"][5]["GBFeature_intervals"][0]["GBInterval_to"], "1106")
-        self.assertEqual(record[0]["GBSeq_feature-table"][5]["GBFeature_intervals"][0]["GBInterval_accession"], "X60065.1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][5]["GBFeature_quals"][0]["GBQualifier_name"], "gene")
-        self.assertEqual(record[0]["GBSeq_feature-table"][5]["GBFeature_quals"][0]["GBQualifier_value"], "beta-2-gpI")
-        self.assertEqual(record[0]["GBSeq_feature-table"][6]["GBFeature_key"], "polyA_site")
-        self.assertEqual(record[0]["GBSeq_feature-table"][6]["GBFeature_location"], "1130")
-        self.assertEqual(record[0]["GBSeq_feature-table"][6]["GBFeature_intervals"][0]["GBInterval_point"], "1130")
-        self.assertEqual(record[0]["GBSeq_feature-table"][6]["GBFeature_intervals"][0]["GBInterval_accession"], "X60065.1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][6]["GBFeature_quals"][0]["GBQualifier_name"], "gene")
-        self.assertEqual(record[0]["GBSeq_feature-table"][6]["GBFeature_quals"][0]["GBQualifier_value"], "beta-2-gpI")
-        self.assertEqual(record[0]["GBSeq_sequence"], "ccagcgctcgtcttgctgttggggtttctctgccacgttgctatcgcaggacgaacctgccccaagccagatgagctaccgttttccacggtggttccactgaaacggacctatgagcccggggagcagatagtcttctcctgccagccgggctacgtgtcccggggagggatccggcggtttacatgcccgctcacaggactctggcccatcaacacgctgaaatgcatgcccagagtatgtccttttgctgggatcttagaaaacggaacggtacgctatacaacgtttgagtatcccaacaccatcagcttttcttgccacacggggttttatctgaaaggagctagttctgcaaaatgcactgaggaagggaagtggagcccagaccttcctgtctgtgcccctataacctgccctccaccacccatacccaagtttgcaagtctcagcgtttacaagccgttggctgggaacaactccttctatggcagcaaggcagtctttaagtgcttgccacaccacgcgatgtttggaaatgacaccgttacctgcacggaacatgggaactggacgcagttgccagaatgcagggaagtaagatgcccattcccatcaagaccagacaatgggtttgtgaaccatcctgcaaatccagtgctctactataaggacaccgccacctttggctgccatgaaacgtattccttggatggaccggaagaagtagaatgcagcaaattcggaaactggtctgcacagccaagctgtaaagcatcttgtaagttatctattaaaagagctactgtgatatatgaaggagagagagtagctatccagaacaaatttaagaatggaatgctgcatggccaaaaggtttctttcttctgcaagcataaggaaaagaagtgcagctacacagaagatgctcagtgcatagacggcaccatcgagattcccaaatgcttcaaggagcacagttctttagctttctggaaaacggatgcatctgacgtaaaaccatgctaagctggttttcacactgaaaattaaatgtcatgcttatatgtgtctgtctgagaatctgatggaaacggaaaaataaagagactgaatttaccgtgtcaagaaaaaaa")
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_partial5"].attributes[
+                "value"
+            ],
+            "true",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][0][
+                "GBQualifier_name"
+            ],
+            "gene",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][0][
+                "GBQualifier_value"
+            ],
+            "beta-2-gpI",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][4]["GBFeature_key"], "mat_peptide"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][4]["GBFeature_location"], "49..1026"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][4]["GBFeature_intervals"][0][
+                "GBInterval_from"
+            ],
+            "49",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][4]["GBFeature_intervals"][0][
+                "GBInterval_to"
+            ],
+            "1026",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][4]["GBFeature_intervals"][0][
+                "GBInterval_accession"
+            ],
+            "X60065.1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][4]["GBFeature_quals"][0][
+                "GBQualifier_name"
+            ],
+            "gene",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][4]["GBFeature_quals"][0][
+                "GBQualifier_value"
+            ],
+            "beta-2-gpI",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][4]["GBFeature_quals"][1][
+                "GBQualifier_name"
+            ],
+            "product",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][4]["GBFeature_quals"][1][
+                "GBQualifier_value"
+            ],
+            "beta-2-glycoprotein I",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][5]["GBFeature_key"], "polyA_signal"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][5]["GBFeature_location"], "1101..1106"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][5]["GBFeature_intervals"][0][
+                "GBInterval_from"
+            ],
+            "1101",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][5]["GBFeature_intervals"][0][
+                "GBInterval_to"
+            ],
+            "1106",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][5]["GBFeature_intervals"][0][
+                "GBInterval_accession"
+            ],
+            "X60065.1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][5]["GBFeature_quals"][0][
+                "GBQualifier_name"
+            ],
+            "gene",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][5]["GBFeature_quals"][0][
+                "GBQualifier_value"
+            ],
+            "beta-2-gpI",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][6]["GBFeature_key"], "polyA_site"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][6]["GBFeature_location"], "1130"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][6]["GBFeature_intervals"][0][
+                "GBInterval_point"
+            ],
+            "1130",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][6]["GBFeature_intervals"][0][
+                "GBInterval_accession"
+            ],
+            "X60065.1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][6]["GBFeature_quals"][0][
+                "GBQualifier_name"
+            ],
+            "gene",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][6]["GBFeature_quals"][0][
+                "GBQualifier_value"
+            ],
+            "beta-2-gpI",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_sequence"],
+            "ccagcgctcgtcttgctgttggggtttctctgccacgttgctatcgcaggacgaacctgccccaagccagatgagctaccgttttccacggtggttccactgaaacggacctatgagcccggggagcagatagtcttctcctgccagccgggctacgtgtcccggggagggatccggcggtttacatgcccgctcacaggactctggcccatcaacacgctgaaatgcatgcccagagtatgtccttttgctgggatcttagaaaacggaacggtacgctatacaacgtttgagtatcccaacaccatcagcttttcttgccacacggggttttatctgaaaggagctagttctgcaaaatgcactgaggaagggaagtggagcccagaccttcctgtctgtgcccctataacctgccctccaccacccatacccaagtttgcaagtctcagcgtttacaagccgttggctgggaacaactccttctatggcagcaaggcagtctttaagtgcttgccacaccacgcgatgtttggaaatgacaccgttacctgcacggaacatgggaactggacgcagttgccagaatgcagggaagtaagatgcccattcccatcaagaccagacaatgggtttgtgaaccatcctgcaaatccagtgctctactataaggacaccgccacctttggctgccatgaaacgtattccttggatggaccggaagaagtagaatgcagcaaattcggaaactggtctgcacagccaagctgtaaagcatcttgtaagttatctattaaaagagctactgtgatatatgaaggagagagagtagctatccagaacaaatttaagaatggaatgctgcatggccaaaaggtttctttcttctgcaagcataaggaaaagaagtgcagctacacagaagatgctcagtgcatagacggcaccatcgagattcccaaatgcttcaaggagcacagttctttagctttctggaaaacggatgcatctgacgtaaaaccatgctaagctggttttcacactgaaaattaaatgtcatgcttatatgtgtctgtctgagaatctgatggaaacggaaaaataaagagactgaatttaccgtgtcaagaaaaaaa",
+        )
 
     def test_nucleotide2(self):
         """Test parsing XML returned by EFetch, Nucleotide database (second test)."""
@@ -5570,18 +11448,29 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         self.assertEqual(record[0]["TSeq_accver"], "X60065.1")
         self.assertEqual(record[0]["TSeq_taxid"], "9913")
         self.assertEqual(record[0]["TSeq_orgname"], "Bos taurus")
-        self.assertEqual(record[0]["TSeq_defline"], "B.bovis beta-2-gpI mRNA for beta-2-glycoprotein I")
+        self.assertEqual(
+            record[0]["TSeq_defline"],
+            "B.bovis beta-2-gpI mRNA for beta-2-glycoprotein I",
+        )
         self.assertEqual(record[0]["TSeq_length"], "1136")
-        self.assertEqual(record[0]["TSeq_sequence"], "CCAGCGCTCGTCTTGCTGTTGGGGTTTCTCTGCCACGTTGCTATCGCAGGACGAACCTGCCCCAAGCCAGATGAGCTACCGTTTTCCACGGTGGTTCCACTGAAACGGACCTATGAGCCCGGGGAGCAGATAGTCTTCTCCTGCCAGCCGGGCTACGTGTCCCGGGGAGGGATCCGGCGGTTTACATGCCCGCTCACAGGACTCTGGCCCATCAACACGCTGAAATGCATGCCCAGAGTATGTCCTTTTGCTGGGATCTTAGAAAACGGAACGGTACGCTATACAACGTTTGAGTATCCCAACACCATCAGCTTTTCTTGCCACACGGGGTTTTATCTGAAAGGAGCTAGTTCTGCAAAATGCACTGAGGAAGGGAAGTGGAGCCCAGACCTTCCTGTCTGTGCCCCTATAACCTGCCCTCCACCACCCATACCCAAGTTTGCAAGTCTCAGCGTTTACAAGCCGTTGGCTGGGAACAACTCCTTCTATGGCAGCAAGGCAGTCTTTAAGTGCTTGCCACACCACGCGATGTTTGGAAATGACACCGTTACCTGCACGGAACATGGGAACTGGACGCAGTTGCCAGAATGCAGGGAAGTAAGATGCCCATTCCCATCAAGACCAGACAATGGGTTTGTGAACCATCCTGCAAATCCAGTGCTCTACTATAAGGACACCGCCACCTTTGGCTGCCATGAAACGTATTCCTTGGATGGACCGGAAGAAGTAGAATGCAGCAAATTCGGAAACTGGTCTGCACAGCCAAGCTGTAAAGCATCTTGTAAGTTATCTATTAAAAGAGCTACTGTGATATATGAAGGAGAGAGAGTAGCTATCCAGAACAAATTTAAGAATGGAATGCTGCATGGCCAAAAGGTTTCTTTCTTCTGCAAGCATAAGGAAAAGAAGTGCAGCTACACAGAAGATGCTCAGTGCATAGACGGCACCATCGAGATTCCCAAATGCTTCAAGGAGCACAGTTCTTTAGCTTTCTGGAAAACGGATGCATCTGACGTAAAACCATGCTAAGCTGGTTTTCACACTGAAAATTAAATGTCATGCTTATATGTGTCTGTCTGAGAATCTGATGGAAACGGAAAAATAAAGAGACTGAATTTACCGTGTCAAGAAAAAAA")
+        self.assertEqual(
+            record[0]["TSeq_sequence"],
+            "CCAGCGCTCGTCTTGCTGTTGGGGTTTCTCTGCCACGTTGCTATCGCAGGACGAACCTGCCCCAAGCCAGATGAGCTACCGTTTTCCACGGTGGTTCCACTGAAACGGACCTATGAGCCCGGGGAGCAGATAGTCTTCTCCTGCCAGCCGGGCTACGTGTCCCGGGGAGGGATCCGGCGGTTTACATGCCCGCTCACAGGACTCTGGCCCATCAACACGCTGAAATGCATGCCCAGAGTATGTCCTTTTGCTGGGATCTTAGAAAACGGAACGGTACGCTATACAACGTTTGAGTATCCCAACACCATCAGCTTTTCTTGCCACACGGGGTTTTATCTGAAAGGAGCTAGTTCTGCAAAATGCACTGAGGAAGGGAAGTGGAGCCCAGACCTTCCTGTCTGTGCCCCTATAACCTGCCCTCCACCACCCATACCCAAGTTTGCAAGTCTCAGCGTTTACAAGCCGTTGGCTGGGAACAACTCCTTCTATGGCAGCAAGGCAGTCTTTAAGTGCTTGCCACACCACGCGATGTTTGGAAATGACACCGTTACCTGCACGGAACATGGGAACTGGACGCAGTTGCCAGAATGCAGGGAAGTAAGATGCCCATTCCCATCAAGACCAGACAATGGGTTTGTGAACCATCCTGCAAATCCAGTGCTCTACTATAAGGACACCGCCACCTTTGGCTGCCATGAAACGTATTCCTTGGATGGACCGGAAGAAGTAGAATGCAGCAAATTCGGAAACTGGTCTGCACAGCCAAGCTGTAAAGCATCTTGTAAGTTATCTATTAAAAGAGCTACTGTGATATATGAAGGAGAGAGAGTAGCTATCCAGAACAAATTTAAGAATGGAATGCTGCATGGCCAAAAGGTTTCTTTCTTCTGCAAGCATAAGGAAAAGAAGTGCAGCTACACAGAAGATGCTCAGTGCATAGACGGCACCATCGAGATTCCCAAATGCTTCAAGGAGCACAGTTCTTTAGCTTTCTGGAAAACGGATGCATCTGACGTAAAACCATGCTAAGCTGGTTTTCACACTGAAAATTAAATGTCATGCTTATATGTGTCTGTCTGAGAATCTGATGGAAACGGAAAAATAAAGAGACTGAATTTACCGTGTCAAGAAAAAAA",
+        )
         self.assertEqual(record[1]["TSeq_seqtype"], "")
         self.assertEqual(record[1]["TSeq_seqtype"].attributes["value"], "protein")
         self.assertEqual(record[1]["TSeq_gi"], "6")
         self.assertEqual(record[1]["TSeq_accver"], "CAA42669.1")
         self.assertEqual(record[1]["TSeq_taxid"], "9913")
         self.assertEqual(record[1]["TSeq_orgname"], "Bos taurus")
-        self.assertEqual(record[1]["TSeq_defline"], "beta-2-glycoprotein I [Bos taurus]")
+        self.assertEqual(
+            record[1]["TSeq_defline"], "beta-2-glycoprotein I [Bos taurus]"
+        )
         self.assertEqual(record[1]["TSeq_length"], "342")
-        self.assertEqual(record[1]["TSeq_sequence"], "PALVLLLGFLCHVAIAGRTCPKPDELPFSTVVPLKRTYEPGEQIVFSCQPGYVSRGGIRRFTCPLTGLWPINTLKCMPRVCPFAGILENGTVRYTTFEYPNTISFSCHTGFYLKGASSAKCTEEGKWSPDLPVCAPITCPPPPIPKFASLSVYKPLAGNNSFYGSKAVFKCLPHHAMFGNDTVTCTEHGNWTQLPECREVRCPFPSRPDNGFVNHPANPVLYYKDTATFGCHETYSLDGPEEVECSKFGNWSAQPSCKASCKLSIKRATVIYEGERVAIQNKFKNGMLHGQKVSFFCKHKEKKCSYTEDAQCIDGTIEIPKCFKEHSSLAFWKTDASDVKPC")
+        self.assertEqual(
+            record[1]["TSeq_sequence"],
+            "PALVLLLGFLCHVAIAGRTCPKPDELPFSTVVPLKRTYEPGEQIVFSCQPGYVSRGGIRRFTCPLTGLWPINTLKCMPRVCPFAGILENGTVRYTTFEYPNTISFSCHTGFYLKGASSAKCTEEGKWSPDLPVCAPITCPPPPIPKFASLSVYKPLAGNNSFYGSKAVFKCLPHHAMFGNDTVTCTEHGNWTQLPECREVRCPFPSRPDNGFVNHPANPVLYYKDTATFGCHETYSLDGPEEVECSKFGNWSAQPSCKASCKLSIKRATVIYEGERVAIQNKFKNGMLHGQKVSFFCKHKEKKCSYTEDAQCIDGTIEIPKCFKEHSSLAFWKTDASDVKPC",
+        )
 
     def test_protein(self):
         """Test parsing XML returned by EFetch, Protein database."""
@@ -5597,81 +11486,343 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         self.assertEqual(record[0]["GBSeq_division"], "MAM")
         self.assertEqual(record[0]["GBSeq_update-date"], "12-SEP-1993")
         self.assertEqual(record[0]["GBSeq_create-date"], "03-APR-1990")
-        self.assertEqual(record[0]["GBSeq_definition"], "unnamed protein product [Bos taurus]")
+        self.assertEqual(
+            record[0]["GBSeq_definition"], "unnamed protein product [Bos taurus]"
+        )
         self.assertEqual(record[0]["GBSeq_primary-accession"], "CAA35997")
         self.assertEqual(record[0]["GBSeq_accession-version"], "CAA35997.1")
         self.assertEqual(record[0]["GBSeq_other-seqids"][0], "emb|CAA35997.1|")
         self.assertEqual(record[0]["GBSeq_other-seqids"][1], "gi|8")
         self.assertEqual(record[0]["GBSeq_source"], "Bos taurus (cattle)")
         self.assertEqual(record[0]["GBSeq_organism"], "Bos taurus")
-        self.assertEqual(record[0]["GBSeq_taxonomy"], "Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia; Eutheria; Laurasiatheria; Cetartiodactyla; Ruminantia; Pecora; Bovidae; Bovinae; Bos")
+        self.assertEqual(
+            record[0]["GBSeq_taxonomy"],
+            "Eukaryota; Metazoa; Chordata; Craniata; Vertebrata; Euteleostomi; Mammalia; Eutheria; Laurasiatheria; Cetartiodactyla; Ruminantia; Pecora; Bovidae; Bovinae; Bos",
+        )
         self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_reference"], "1")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_position"], "1..100")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_authors"][0], "Kiefer,M.C.")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_authors"][1], "Saphire,A.C.S.")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_authors"][2], "Bauer,D.M.")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_authors"][3], "Barr,P.J.")
-        self.assertEqual(record[0]["GBSeq_references"][0]["GBReference_journal"], "Unpublished")
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_position"], "1..100"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_authors"][0], "Kiefer,M.C."
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_authors"][1], "Saphire,A.C.S."
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_authors"][2], "Bauer,D.M."
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_authors"][3], "Barr,P.J."
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][0]["GBReference_journal"], "Unpublished"
+        )
         self.assertEqual(record[0]["GBSeq_references"][1]["GBReference_reference"], "2")
-        self.assertEqual(record[0]["GBSeq_references"][1]["GBReference_position"], "1..100")
-        self.assertEqual(record[0]["GBSeq_references"][1]["GBReference_authors"][0], "Kiefer,M.C.")
-        self.assertEqual(record[0]["GBSeq_references"][1]["GBReference_title"], "Direct Submission")
-        self.assertEqual(record[0]["GBSeq_references"][1]["GBReference_journal"], "Submitted (30-JAN-1990) Kiefer M.C., Chiron Corporation, 4560 Hortom St, Emeryville CA 94608-2916, U S A")
-        self.assertEqual(record[0]["GBSeq_comment"], "See <X15699> for Human sequence.~Data kindly reviewed (08-MAY-1990) by Kiefer M.C.")
+        self.assertEqual(
+            record[0]["GBSeq_references"][1]["GBReference_position"], "1..100"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][1]["GBReference_authors"][0], "Kiefer,M.C."
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][1]["GBReference_title"], "Direct Submission"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_references"][1]["GBReference_journal"],
+            "Submitted (30-JAN-1990) Kiefer M.C., Chiron Corporation, 4560 Hortom St, Emeryville CA 94608-2916, U S A",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_comment"],
+            "See <X15699> for Human sequence.~Data kindly reviewed (08-MAY-1990) by Kiefer M.C.",
+        )
         self.assertEqual(record[0]["GBSeq_source-db"], "embl accession X51700.1")
         self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_key"], "source")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_location"], "1..100")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_intervals"][0]["GBInterval_from"], "1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_intervals"][0]["GBInterval_to"], "100")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_intervals"][0]["GBInterval_accession"], "CAA35997.1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][0]["GBQualifier_name"], "organism")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][0]["GBQualifier_value"], "Bos taurus")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][1]["GBQualifier_name"], "db_xref")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][1]["GBQualifier_value"], "taxon:9913")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][2]["GBQualifier_name"], "clone")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][2]["GBQualifier_value"], "bBGP-3")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][3]["GBQualifier_name"], "tissue_type")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][3]["GBQualifier_value"], "bone matrix")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][4]["GBQualifier_name"], "clone_lib")
-        self.assertEqual(record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][4]["GBQualifier_value"], "Zap-bb")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_key"], "Protein")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_location"], "1..100")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_intervals"][0]["GBInterval_from"], "1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_intervals"][0]["GBInterval_to"], "100")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_intervals"][0]["GBInterval_accession"], "CAA35997.1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_quals"][0]["GBQualifier_name"], "name")
-        self.assertEqual(record[0]["GBSeq_feature-table"][1]["GBFeature_quals"][0]["GBQualifier_value"], "unnamed protein product")
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_location"], "1..100"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_intervals"][0][
+                "GBInterval_from"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_intervals"][0][
+                "GBInterval_to"
+            ],
+            "100",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_intervals"][0][
+                "GBInterval_accession"
+            ],
+            "CAA35997.1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][0][
+                "GBQualifier_name"
+            ],
+            "organism",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][0][
+                "GBQualifier_value"
+            ],
+            "Bos taurus",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][1][
+                "GBQualifier_name"
+            ],
+            "db_xref",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][1][
+                "GBQualifier_value"
+            ],
+            "taxon:9913",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][2][
+                "GBQualifier_name"
+            ],
+            "clone",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][2][
+                "GBQualifier_value"
+            ],
+            "bBGP-3",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][3][
+                "GBQualifier_name"
+            ],
+            "tissue_type",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][3][
+                "GBQualifier_value"
+            ],
+            "bone matrix",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][4][
+                "GBQualifier_name"
+            ],
+            "clone_lib",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][0]["GBFeature_quals"][4][
+                "GBQualifier_value"
+            ],
+            "Zap-bb",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_key"], "Protein"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_location"], "1..100"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_intervals"][0][
+                "GBInterval_from"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_intervals"][0][
+                "GBInterval_to"
+            ],
+            "100",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_intervals"][0][
+                "GBInterval_accession"
+            ],
+            "CAA35997.1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_quals"][0][
+                "GBQualifier_name"
+            ],
+            "name",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][1]["GBFeature_quals"][0][
+                "GBQualifier_value"
+            ],
+            "unnamed protein product",
+        )
         self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_key"], "Region")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_location"], "33..97")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_intervals"][0]["GBInterval_from"], "33")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_intervals"][0]["GBInterval_to"], "97")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_intervals"][0]["GBInterval_accession"], "CAA35997.1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][0]["GBQualifier_name"], "region_name")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][0]["GBQualifier_value"], "Gla")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][1]["GBQualifier_name"], "note")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][1]["GBQualifier_value"], "Vitamin K-dependent carboxylation/gamma-carboxyglutamic (GLA) domain. This domain is responsible for the high-affinity binding of calcium ions. This domain contains post-translational modifications of many glutamate residues by Vitamin K-dependent...; cl02449")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][2]["GBQualifier_name"], "db_xref")
-        self.assertEqual(record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][2]["GBQualifier_value"], "CDD:92835")
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_location"], "33..97"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_intervals"][0][
+                "GBInterval_from"
+            ],
+            "33",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_intervals"][0][
+                "GBInterval_to"
+            ],
+            "97",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_intervals"][0][
+                "GBInterval_accession"
+            ],
+            "CAA35997.1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][0][
+                "GBQualifier_name"
+            ],
+            "region_name",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][0][
+                "GBQualifier_value"
+            ],
+            "Gla",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][1][
+                "GBQualifier_name"
+            ],
+            "note",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][1][
+                "GBQualifier_value"
+            ],
+            "Vitamin K-dependent carboxylation/gamma-carboxyglutamic (GLA) domain. This domain is responsible for the high-affinity binding of calcium ions. This domain contains post-translational modifications of many glutamate residues by Vitamin K-dependent...; cl02449",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][2][
+                "GBQualifier_name"
+            ],
+            "db_xref",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][2]["GBFeature_quals"][2][
+                "GBQualifier_value"
+            ],
+            "CDD:92835",
+        )
         self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_key"], "CDS")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_location"], "1..100")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_intervals"][0]["GBInterval_from"], "1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_intervals"][0]["GBInterval_to"], "100")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_intervals"][0]["GBInterval_accession"], "CAA35997.1")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][0]["GBQualifier_name"], "coded_by")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][0]["GBQualifier_value"], "X51700.1:28..330")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][1]["GBQualifier_name"], "note")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][1]["GBQualifier_value"], "bone Gla precursor (100 AA)")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][2]["GBQualifier_name"], "db_xref")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][2]["GBQualifier_value"], "GOA:P02820")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][3]["GBQualifier_name"], "db_xref")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][3]["GBQualifier_value"], "InterPro:IPR000294")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][4]["GBQualifier_name"], "db_xref")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][4]["GBQualifier_value"], "InterPro:IPR002384")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][5]["GBQualifier_name"], "db_xref")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][5]["GBQualifier_value"], "PDB:1Q3M")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][6]["GBQualifier_name"], "db_xref")
-        self.assertEqual(record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][6]["GBQualifier_value"], "UniProtKB/Swiss-Prot:P02820")
-        self.assertEqual(record[0]["GBSeq_sequence"], "mrtpmllallalatlclagradakpgdaesgkgaafvskqegsevvkrlrryldhwlgapapypdplepkrevcelnpdcdeladhigfqeayrrfygpv")
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_location"], "1..100"
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_intervals"][0][
+                "GBInterval_from"
+            ],
+            "1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_intervals"][0][
+                "GBInterval_to"
+            ],
+            "100",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_intervals"][0][
+                "GBInterval_accession"
+            ],
+            "CAA35997.1",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][0][
+                "GBQualifier_name"
+            ],
+            "coded_by",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][0][
+                "GBQualifier_value"
+            ],
+            "X51700.1:28..330",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][1][
+                "GBQualifier_name"
+            ],
+            "note",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][1][
+                "GBQualifier_value"
+            ],
+            "bone Gla precursor (100 AA)",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][2][
+                "GBQualifier_name"
+            ],
+            "db_xref",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][2][
+                "GBQualifier_value"
+            ],
+            "GOA:P02820",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][3][
+                "GBQualifier_name"
+            ],
+            "db_xref",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][3][
+                "GBQualifier_value"
+            ],
+            "InterPro:IPR000294",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][4][
+                "GBQualifier_name"
+            ],
+            "db_xref",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][4][
+                "GBQualifier_value"
+            ],
+            "InterPro:IPR002384",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][5][
+                "GBQualifier_name"
+            ],
+            "db_xref",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][5][
+                "GBQualifier_value"
+            ],
+            "PDB:1Q3M",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][6][
+                "GBQualifier_name"
+            ],
+            "db_xref",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_feature-table"][3]["GBFeature_quals"][6][
+                "GBQualifier_value"
+            ],
+            "UniProtKB/Swiss-Prot:P02820",
+        )
+        self.assertEqual(
+            record[0]["GBSeq_sequence"],
+            "mrtpmllallalatlclagradakpgdaesgkgaafvskqegsevvkrlrryldhwlgapapypdplepkrevcelnpdcdeladhigfqeayrrfygpv",
+        )
 
     def test_efetch_schemas(self):
         """Test parsing XML using Schemas."""
@@ -5688,7 +11839,10 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         self.assertEqual(record["Product"], "")
         self.assertEqual(record["Product"].attributes["kingdom"], "Bacteria")
         self.assertEqual(record["Product"].attributes["slen"], "513")
-        self.assertEqual(record["Product"].attributes["name"], "methylmalonate-semialdehyde dehydrogenase (CoA acylating)")
+        self.assertEqual(
+            record["Product"].attributes["name"],
+            "methylmalonate-semialdehyde dehydrogenase (CoA acylating)",
+        )
         self.assertEqual(record["Product"].attributes["org"], "Rhodococcus sp. PML026")
         self.assertEqual(record["Product"].attributes["kingdom_taxid"], "2")
         self.assertEqual(record["Product"].attributes["accver"], "WP_045840896.1")
@@ -5699,7 +11853,10 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         self.assertEqual(protein.attributes["accver"], "KJV04014.1")
         self.assertEqual(protein.attributes["kingdom"], "Bacteria")
         self.assertEqual(protein.attributes["kingdom_taxid"], "2")
-        self.assertEqual(protein.attributes["name"], "methylmalonic acid semialdehyde dehydrogenase mmsa")
+        self.assertEqual(
+            protein.attributes["name"],
+            "methylmalonic acid semialdehyde dehydrogenase mmsa",
+        )
         self.assertEqual(protein.attributes["org"], "Rhodococcus sp. PML026")
         self.assertEqual(protein.attributes["priority"], "0")
         self.assertEqual(protein.attributes["source"], "INSDC")
@@ -5710,30 +11867,41 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         self.assertEqual(len(protein["CDSList"]), 2)
         self.assertEqual(protein["CDSList"][0], "")
         self.assertEqual(protein["CDSList"][0].attributes["kingdom"], "Bacteria")
-        self.assertEqual(protein["CDSList"][0].attributes["assembly"], "GCA_000963615.1")
+        self.assertEqual(
+            protein["CDSList"][0].attributes["assembly"], "GCA_000963615.1"
+        )
         self.assertEqual(protein["CDSList"][0].attributes["start"], "264437")
         self.assertEqual(protein["CDSList"][0].attributes["stop"], "265978")
         self.assertEqual(protein["CDSList"][0].attributes["taxid"], "1356405")
         self.assertEqual(protein["CDSList"][0].attributes["strain"], "PML026")
-        self.assertEqual(protein["CDSList"][0].attributes["org"], "Rhodococcus sp. PML026")
+        self.assertEqual(
+            protein["CDSList"][0].attributes["org"], "Rhodococcus sp. PML026"
+        )
         self.assertEqual(protein["CDSList"][0].attributes["kingdom_taxid"], "2")
         self.assertEqual(protein["CDSList"][0].attributes["accver"], "JZIS01000004.1")
         self.assertEqual(protein["CDSList"][0].attributes["strand"], "-")
         self.assertEqual(protein["CDSList"][1], "")
         self.assertEqual(protein["CDSList"][1].attributes["kingdom"], "Bacteria")
-        self.assertEqual(protein["CDSList"][1].attributes["assembly"], "GCA_000963615.1")
+        self.assertEqual(
+            protein["CDSList"][1].attributes["assembly"], "GCA_000963615.1"
+        )
         self.assertEqual(protein["CDSList"][1].attributes["start"], "264437")
         self.assertEqual(protein["CDSList"][1].attributes["stop"], "265978")
         self.assertEqual(protein["CDSList"][1].attributes["taxid"], "1356405")
         self.assertEqual(protein["CDSList"][1].attributes["strain"], "PML026")
-        self.assertEqual(protein["CDSList"][1].attributes["org"], "Rhodococcus sp. PML026")
+        self.assertEqual(
+            protein["CDSList"][1].attributes["org"], "Rhodococcus sp. PML026"
+        )
         self.assertEqual(protein["CDSList"][1].attributes["kingdom_taxid"], "2")
         self.assertEqual(protein["CDSList"][1].attributes["accver"], "KQ031368.1")
         self.assertEqual(protein["CDSList"][1].attributes["strand"], "-")
         protein = record["ProteinList"][1]
         self.assertEqual(protein.attributes["accver"], "WP_045840896.1")
         self.assertEqual(protein.attributes["source"], "RefSeq")
-        self.assertEqual(protein.attributes["name"], "methylmalonate-semialdehyde dehydrogenase (CoA acylating)")
+        self.assertEqual(
+            protein.attributes["name"],
+            "methylmalonate-semialdehyde dehydrogenase (CoA acylating)",
+        )
         self.assertEqual(protein.attributes["taxid"], "1356405")
         self.assertEqual(protein.attributes["org"], "Rhodococcus sp. PML026")
         self.assertEqual(protein.attributes["kingdom_taxid"], "2")
@@ -5743,12 +11911,16 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         self.assertEqual(protein["CDSList"].tag, "CDSList")
         self.assertEqual(protein["CDSList"].attributes, {})
         self.assertEqual(len(protein["CDSList"]), 1)
-        self.assertEqual(protein["CDSList"][0].attributes["assembly"], "GCF_000963615.1")
+        self.assertEqual(
+            protein["CDSList"][0].attributes["assembly"], "GCF_000963615.1"
+        )
         self.assertEqual(protein["CDSList"][0].attributes["start"], "264437")
         self.assertEqual(protein["CDSList"][0].attributes["stop"], "265978")
         self.assertEqual(protein["CDSList"][0].attributes["taxid"], "1356405")
         self.assertEqual(protein["CDSList"][0].attributes["strain"], "PML026")
-        self.assertEqual(protein["CDSList"][0].attributes["org"], "Rhodococcus sp. PML026")
+        self.assertEqual(
+            protein["CDSList"][0].attributes["org"], "Rhodococcus sp. PML026"
+        )
         self.assertEqual(protein["CDSList"][0].attributes["kingdom_taxid"], "2")
         self.assertEqual(protein["CDSList"][0].attributes["accver"], "NZ_KQ031368.1")
         self.assertEqual(protein["CDSList"][0].attributes["strand"], "-")
@@ -5764,6 +11936,7 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         # To create the GenBank file, use
         # >>> Bio.Entrez.efetch(db='nucleotide', id='NT_019265', rettype='gb')
         from Bio.Entrez import Parser
+
         with open("GenBank/NT_019265.gb", "rb") as handle:
             self.assertRaises(Parser.NotXMLError, Entrez.read, handle)
         with open("GenBank/NT_019265.gb", "rb") as handle:
@@ -5773,6 +11946,7 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
     def test_fasta(self):
         """Test error handling when presented with Fasta non-XML data."""
         from Bio.Entrez import Parser
+
         with open("Fasta/wisteria.nu", "rb") as handle:
             self.assertRaises(Parser.NotXMLError, Entrez.read, handle)
         with open("Fasta/wisteria.nu", "rb") as handle:
@@ -5784,6 +11958,7 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         # To create the HTML file, use
         # >>> Bio.Entrez.efetch(db="pubmed", id="19304878")
         from Bio.Entrez import Parser
+
         with open("Entrez/pubmed3.html", "rb") as handle:
             self.assertRaises(Parser.NotXMLError, Entrez.read, handle)
         # Test if the error is also raised with Entrez.parse
@@ -5796,6 +11971,7 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         # To create the XML file, use
         # >>> Bio.Entrez.efetch(db="journals",id="2830,6011,7473",retmode='xml')
         from Bio.Entrez import Parser
+
         with open("Entrez/journals.xml", "rb") as handle:
             self.assertRaises(Parser.NotXMLError, Entrez.read, handle)
         # Test if the error is also raised with Entrez.parse
@@ -5807,6 +11983,7 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         """Test error handling for a truncated XML declaration."""
         from Bio.Entrez.Parser import CorruptedXMLError
         from io import BytesIO
+
         truncated_xml = b"""<?xml version="1.0"?>
         <!DOCTYPE GBSet PUBLIC "-//NCBI//NCBI GBSeq/EN" "http://www.ncbi.nlm.nih.gov/dtd/NCBI_GBSeq.dtd">
         <GBSet><GBSeq><GBSeq_locus>


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_Entrez_parser, it would be good to review it.