### PR TITLE
Apply black style to test_Entrez* files, version 19.10b0.

### DIFF
--- a/Tests/test_Entrez.py
+++ b/Tests/test_Entrez.py
@@ -38,12 +38,16 @@ class TestURLConstruction(unittest.TestCase):
     def test_construct_cgi_ecitmatch(self):
         citation = {
             "journal_title": "proc natl acad sci u s a",
-            "year": "1991", "volume": "88", "first_page": "3248",
-            "author_name": "mann bj", "key": "citation_1"
+            "year": "1991",
+            "volume": "88",
+            "first_page": "3248",
+            "author_name": "mann bj",
+            "key": "citation_1",
         }
         cgi = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/ecitmatch.cgi"
-        variables = Entrez._update_ecitmatch_variables({"db": "pubmed",
-                                                        "bdata": [citation]})
+        variables = Entrez._update_ecitmatch_variables(
+            {"db": "pubmed", "bdata": [citation]}
+        )
         post = False
 
         params = Entrez._construct_params(variables)
@@ -58,8 +62,7 @@ class TestURLConstruction(unittest.TestCase):
         params = Entrez._construct_params(params=None)
         options = Entrez._encode_options(ecitmatch=False, params=params)
         result_url = Entrez._construct_cgi(cgi, post=False, options=options)
-        self.assertTrue(result_url.startswith(URL_HEAD + "einfo.fcgi?"),
-                        result_url)
+        self.assertTrue(result_url.startswith(URL_HEAD + "einfo.fcgi?"), result_url)
         self.assertIn(URL_TOOL, result_url)
         self.assertIn(URL_EMAIL, result_url)
 
@@ -85,16 +88,20 @@ class TestURLConstruction(unittest.TestCase):
 
     def test_construct_cgi_elink1(self):
         cgi = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi"
-        variables = {"cmd": "neighbor_history", "db": "nucleotide",
-                     "dbfrom": "protein", "id": "22347800,48526535",
-                     "query_key": None, "webenv": None}
+        variables = {
+            "cmd": "neighbor_history",
+            "db": "nucleotide",
+            "dbfrom": "protein",
+            "id": "22347800,48526535",
+            "query_key": None,
+            "webenv": None,
+        }
         post = False
 
         params = Entrez._construct_params(variables)
         options = Entrez._encode_options(ecitmatch=False, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
-        self.assertTrue(result_url.startswith(URL_HEAD + "elink.fcgi?"),
-                        result_url)
+        self.assertTrue(result_url.startswith(URL_HEAD + "elink.fcgi?"), result_url)
         self.assertIn(URL_TOOL, result_url)
         self.assertIn(URL_EMAIL, result_url)
         self.assertIn("id=22347800%2C48526535", result_url)
@@ -103,33 +110,36 @@ class TestURLConstruction(unittest.TestCase):
     def test_construct_cgi_elink2(self):
         """Commas: Link from protein to gene."""
         cgi = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi"
-        variables = {"db": "gene", "dbfrom": "protein",
-                     "id": "15718680,157427902,119703751"}
+        variables = {
+            "db": "gene",
+            "dbfrom": "protein",
+            "id": "15718680,157427902,119703751",
+        }
         post = False
 
         params = Entrez._construct_params(variables)
         options = Entrez._encode_options(ecitmatch=False, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
-        self.assertTrue(result_url.startswith(URL_HEAD + "elink.fcgi"),
-                        result_url)
+        self.assertTrue(result_url.startswith(URL_HEAD + "elink.fcgi"), result_url)
         self.assertIn(URL_TOOL, result_url)
         self.assertIn(URL_EMAIL, result_url)
-        self.assertIn("id=15718680%2C157427902%2C119703751", result_url,
-                      result_url)
+        self.assertIn("id=15718680%2C157427902%2C119703751", result_url, result_url)
         self.assertIn(URL_API_KEY, result_url)
 
     def test_construct_cgi_elink3(self):
         """Multiple ID entries: Find one-to-one links from protein to gene."""
         cgi = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi"
-        variables = {"db": "gene", "dbfrom": "protein",
-                     "id": ["15718680", "157427902", "119703751"]}
+        variables = {
+            "db": "gene",
+            "dbfrom": "protein",
+            "id": ["15718680", "157427902", "119703751"],
+        }
         post = False
 
         params = Entrez._construct_params(variables)
         options = Entrez._encode_options(ecitmatch=False, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
-        self.assertTrue(result_url.startswith(URL_HEAD + "elink.fcgi"),
-                        result_url)
+        self.assertTrue(result_url.startswith(URL_HEAD + "elink.fcgi"), result_url)
         self.assertIn(URL_TOOL, result_url)
         self.assertIn(URL_EMAIL, result_url)
         self.assertIn("id=15718680", result_url)
@@ -139,26 +149,28 @@ class TestURLConstruction(unittest.TestCase):
 
     def test_construct_cgi_efetch(self):
         cgi = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
-        variables = {"db": "protein", "id": "15718680,157427902,119703751",
-                     "retmode": "xml"}
+        variables = {
+            "db": "protein",
+            "id": "15718680,157427902,119703751",
+            "retmode": "xml",
+        }
         post = False
 
         params = Entrez._construct_params(variables)
         options = Entrez._encode_options(ecitmatch=False, params=params)
         result_url = Entrez._construct_cgi(cgi, post=post, options=options)
-        self.assertTrue(result_url.startswith(URL_HEAD + "efetch.fcgi?"),
-                        result_url)
+        self.assertTrue(result_url.startswith(URL_HEAD + "efetch.fcgi?"), result_url)
         self.assertIn(URL_TOOL, result_url)
         self.assertIn(URL_EMAIL, result_url)
-        self.assertIn("id=15718680%2C157427902%2C119703751", result_url,
-                      result_url)
+        self.assertIn("id=15718680%2C157427902%2C119703751", result_url, result_url)
         self.assertIn(URL_API_KEY, result_url)
 
 
 class CustomDirectoryTest(unittest.TestCase):
     """Offline unit test for custom directory feature.
 
-    Allow user to specify a custom directory for Entrez DTD/XSD files by setting Parser.DataHandler.directory.
+    Allow user to specify a custom directory for Entrez DTD/XSD files by setting
+    Parser.DataHandler.directory.
     """
 
     def test_custom_directory(self):
@@ -171,12 +183,19 @@ class CustomDirectoryTest(unittest.TestCase):
         # Create a temporary directory
         tmpdir = tempfile.mkdtemp()
         # Set the custom directory to the temporary directory.
-        # This assignment statement will also initialize the local DTD and XSD directories.
+        # This assignment statement will also initialize the local DTD and XSD
+        # directories.
         handler.directory = tmpdir
 
         # Confirm that the two temp directories are named what we want.
-        self.assertEqual(handler.local_dtd_dir, os.path.join(handler.directory, "Bio", "Entrez", "DTDs"))
-        self.assertEqual(handler.local_xsd_dir, os.path.join(handler.directory, "Bio", "Entrez", "XSDs"))
+        self.assertEqual(
+            handler.local_dtd_dir,
+            os.path.join(handler.directory, "Bio", "Entrez", "DTDs"),
+        )
+        self.assertEqual(
+            handler.local_xsd_dir,
+            os.path.join(handler.directory, "Bio", "Entrez", "XSDs"),
+        )
 
         # And that they were created.
         self.assertTrue(os.path.isdir(handler.local_dtd_dir))

--- a/Tests/test_Entrez_online.py
+++ b/Tests/test_Entrez_online.py
@@ -22,6 +22,7 @@ import sys
 import unittest
 
 import requires_internet
+
 requires_internet.check()
 
 
@@ -36,7 +37,6 @@ URL_API_KEY = "api_key=5cfd4026f9df285d6cfc723c662d74bcbe09"
 
 
 class EntrezOnlineCase(unittest.TestCase):
-
     def test_no_api_key(self):
         """Test Entrez.read without API key."""
         cached = Entrez.api_key
@@ -73,8 +73,9 @@ class EntrezOnlineCase(unittest.TestCase):
 
     def test_parse_from_url(self):
         """Test Entrez.parse from URL."""
-        handle = Entrez.efetch(db="protein", id="15718680, 157427902, 119703751",
-                               retmode="xml")
+        handle = Entrez.efetch(
+            db="protein", id="15718680, 157427902, 119703751", retmode="xml"
+        )
         self.assertTrue(handle.url.startswith(URL_HEAD + "efetch.fcgi?"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
@@ -88,9 +89,14 @@ class EntrezOnlineCase(unittest.TestCase):
 
     def test_webenv_search(self):
         """Test Entrez.search from link webenv history."""
-        handle = Entrez.elink(db="nucleotide", dbfrom="protein",
-                              id="22347800,48526535", webenv=None, query_key=None,
-                              cmd="neighbor_history")
+        handle = Entrez.elink(
+            db="nucleotide",
+            dbfrom="protein",
+            id="22347800,48526535",
+            webenv=None,
+            query_key=None,
+            cmd="neighbor_history",
+        )
         self.assertTrue(handle.url.startswith(URL_HEAD + "elink.fcgi?"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
@@ -102,10 +108,15 @@ class EntrezOnlineCase(unittest.TestCase):
 
         webenv = record["WebEnv"]
         query_key = record["LinkSetDbHistory"][0]["QueryKey"]
-        handle = Entrez.esearch(db="nucleotide", term=None,
-                                retstart=0, retmax=10,
-                                webenv=webenv, query_key=query_key,
-                                usehistory="y")
+        handle = Entrez.esearch(
+            db="nucleotide",
+            term=None,
+            retstart=0,
+            retmax=10,
+            webenv=webenv,
+            query_key=query_key,
+            usehistory="y",
+        )
         self.assertTrue(handle.url.startswith(URL_HEAD + "esearch.fcgi?"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
@@ -116,8 +127,9 @@ class EntrezOnlineCase(unittest.TestCase):
 
     def test_seqio_from_url(self):
         """Test Entrez into SeqIO.read from URL."""
-        handle = Entrez.efetch(db="nucleotide", id="186972394", rettype="gb",
-                               retmode="text")
+        handle = Entrez.efetch(
+            db="nucleotide", id="186972394", rettype="gb", retmode="text"
+        )
         url = handle.url
         self.assertTrue(url.startswith(URL_HEAD + "efetch.fcgi?"), url)
         self.assertIn(URL_TOOL, url)
@@ -132,8 +144,9 @@ class EntrezOnlineCase(unittest.TestCase):
 
     def test_medline_from_url(self):
         """Test Entrez into Medline.read from URL."""
-        handle = Entrez.efetch(db="pubmed", id="19304878", rettype="medline",
-                               retmode="text")
+        handle = Entrez.efetch(
+            db="pubmed", id="19304878", rettype="medline", retmode="text"
+        )
         url = handle.url
         self.assertTrue(url.startswith(URL_HEAD + "efetch.fcgi?"), url)
         self.assertIn(URL_TOOL, url)
@@ -166,8 +179,9 @@ class EntrezOnlineCase(unittest.TestCase):
     def test_elink(self):
         """Test Entrez.elink with multiple ids, both comma separated and as list."""
         # Commas: Link from protein to gene
-        handle = Entrez.elink(db="gene", dbfrom="protein",
-                              id="15718680,157427902,119703751")
+        handle = Entrez.elink(
+            db="gene", dbfrom="protein", id="15718680,157427902,119703751"
+        )
         self.assertTrue(handle.url.startswith(URL_HEAD + "elink.fcgi"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
@@ -176,8 +190,9 @@ class EntrezOnlineCase(unittest.TestCase):
         handle.close()
 
         # Multiple ID entries: Find one-to-one links from protein to gene
-        handle = Entrez.elink(db="gene", dbfrom="protein",
-                              id=["15718680", "157427902", "119703751"])
+        handle = Entrez.elink(
+            db="gene", dbfrom="protein", id=["15718680", "157427902", "119703751"]
+        )
         self.assertTrue(handle.url.startswith(URL_HEAD + "elink.fcgi"), handle.url)
         self.assertIn(URL_TOOL, handle.url)
         self.assertIn(URL_EMAIL, handle.url)
@@ -197,7 +212,10 @@ class EntrezOnlineCase(unittest.TestCase):
         handle.close()
 
     def test_egquery(self):
-        """Test Entrez.egquery which searches in all Entrez databases for a single text query."""
+        """Test Entrez.egquery.
+
+        which searches in all Entrez databases for a single text query.
+        """
         handle = Entrez.egquery(term="biopython")
         record = Entrez.read(handle)
         handle.close()
@@ -222,14 +240,19 @@ class EntrezOnlineCase(unittest.TestCase):
         """Test Entrez.ecitmatch to search for a citation."""
         citation = {
             "journal_title": "proc natl acad sci u s a",
-            "year": "1991", "volume": "88", "first_page": "3248",
-            "author_name": "mann bj", "key": "citation_1"
+            "year": "1991",
+            "volume": "88",
+            "first_page": "3248",
+            "author_name": "mann bj",
+            "key": "citation_1",
         }
         handle = Entrez.ecitmatch(db="pubmed", bdata=[citation])
         url = handle.url
         self.assertIn("retmode=xml", url)
         result = handle.read()
-        expected_result = "proc natl acad sci u s a|1991|88|3248|mann bj|citation_1|2014248\n"
+        expected_result = (
+            "proc natl acad sci u s a|1991|88|3248|mann bj|citation_1|2014248\n"
+        )
         self.assertEqual(result, expected_result)
         handle.close()
 
@@ -254,7 +277,12 @@ class EntrezOnlineCase(unittest.TestCase):
                 self.assertEqual(2, len(recs))
 
         ids = (
-            [15718680], (15718680), {15718680}, 15718680, "15718680", "15718680,",
+            [15718680],
+            (15718680),
+            {15718680},
+            15718680,
+            "15718680",
+            "15718680,",
         )
         for _id in ids:
             with Entrez.efetch(db="protein", id=_id, retmode="xml") as handle:


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_Entrez files listed below, small changes should be fine to merge.
test_Entrez.py
test_Entrez_online.py
