### PR TITLE
Apply black style to test_Emboss* files, version 19.10b0.

### DIFF
--- a/Tests/test_Emboss.py
+++ b/Tests/test_Emboss.py
@@ -511,7 +511,7 @@ class PairwiseAlignmentTests(unittest.TestCase):
                 self.assertIn(str(alignment[0].seq).replace("-", ""), query_seq)
                 self.assertIn(
                     str(alignment[1].seq).replace("-", "").upper(),
-                    str(target.seq).upper()
+                    str(target.seq).upper(),
                 )
             else:
                 # Global alignment

--- a/Tests/test_EmbossPhylipNew.py
+++ b/Tests/test_EmbossPhylipNew.py
@@ -21,8 +21,16 @@ from Bio.Emboss.Applications import FTreeDistCommandline, FDNAParsCommandline
 # Try to avoid problems when the OS is in another language
 os.environ["LANG"] = "C"
 
-exes_wanted = ["fdnadist", "fneighbor", "fprotdist", "fprotpars", "fconsense",
-               "fseqboot", "ftreedist", "fdnapars"]
+exes_wanted = [
+    "fdnadist",
+    "fneighbor",
+    "fprotdist",
+    "fprotpars",
+    "fconsense",
+    "fseqboot",
+    "ftreedist",
+    "fdnapars",
+]
 exes = {}  # Dictionary mapping from names to exe locations
 
 if "EMBOSS_ROOT" in os.environ:
@@ -36,6 +44,7 @@ if "EMBOSS_ROOT" in os.environ:
     del path, name
 if sys.platform != "win32":
     from subprocess import getoutput
+
     for name in exes_wanted:
         # This will "just work" if installed on the path as normal on Unix
         output = getoutput("%s -help" % name)
@@ -47,7 +56,8 @@ if sys.platform != "win32":
 if len(exes) < len(exes_wanted):
     raise MissingExternalDependencyError(
         "Install the Emboss package 'PhylipNew' if you want to use the "
-        "Bio.Emboss.Applications wrappers for phylogenetic tools.")
+        "Bio.Emboss.Applications wrappers for phylogenetic tools."
+    )
 
 # #########################################################################
 
@@ -55,14 +65,16 @@ if len(exes) < len(exes_wanted):
 # A few top level functions that are called repeatedly in the test cases
 def write_AlignIO_dna():
     """Convert opuntia.aln to a phylip file."""
-    assert 1 == AlignIO.convert("Clustalw/opuntia.aln", "clustal",
-                                "Phylip/opuntia.phy", "phylip")
+    assert 1 == AlignIO.convert(
+        "Clustalw/opuntia.aln", "clustal", "Phylip/opuntia.phy", "phylip"
+    )
 
 
 def write_AlignIO_protein():
     """Convert hedgehog.aln to a phylip file."""
-    assert 1 == AlignIO.convert("Clustalw/hedgehog.aln", "clustal",
-                                "Phylip/hedgehog.phy", "phylip")
+    assert 1 == AlignIO.convert(
+        "Clustalw/hedgehog.aln", "clustal", "Phylip/hedgehog.phy", "phylip"
+    )
 
 
 def clean_up():
@@ -91,25 +103,38 @@ class DistanceTests(unittest.TestCase):
     def tearDown(self):
         clean_up()
 
-    test_taxa = ["Archaeohip", "Calippus", "Hypohippus", "M._secundu",
-                 "Merychippu", "Mesohippus", "Nannipus", "Neohippari",
-                 "Parahippus", "Pliohippus"]
+    test_taxa = [
+        "Archaeohip",
+        "Calippus",
+        "Hypohippus",
+        "M._secundu",
+        "Merychippu",
+        "Mesohippus",
+        "Nannipus",
+        "Neohippari",
+        "Parahippus",
+        "Pliohippus",
+    ]
 
     def distances_from_alignment(self, filename, DNA=True):
         """Check we can make a distance matrix from a given alignment."""
         self.assertTrue(os.path.isfile(filename), "Missing %s" % filename)
         if DNA:
-            cline = FDNADistCommandline(exes["fdnadist"],
-                                        method="j",
-                                        sequence=filename,
-                                        outfile="test_file",
-                                        auto=True)
+            cline = FDNADistCommandline(
+                exes["fdnadist"],
+                method="j",
+                sequence=filename,
+                outfile="test_file",
+                auto=True,
+            )
         else:
-            cline = FProtDistCommandline(exes["fprotdist"],
-                                         method="j",
-                                         sequence=filename,
-                                         outfile="test_file",
-                                         auto=True)
+            cline = FProtDistCommandline(
+                exes["fprotdist"],
+                method="j",
+                sequence=filename,
+                outfile="test_file",
+                auto=True,
+            )
         stdout, strerr = cline()
         # biopython can't grok distance matrices, so we'll just check it exists
         self.assertTrue(os.path.isfile("test_file"))
@@ -117,10 +142,13 @@ class DistanceTests(unittest.TestCase):
     def tree_from_distances(self, filename):
         """Check we can estimate a tree from a distance matrix."""
         self.assertTrue(os.path.isfile(filename), "Missing %s" % filename)
-        cline = FNeighborCommandline(exes["fneighbor"],
-                                     datafile=filename,
-                                     outtreefile="test_file",
-                                     auto=True, filter=True)
+        cline = FNeighborCommandline(
+            exes["fneighbor"],
+            datafile=filename,
+            outtreefile="test_file",
+            auto=True,
+            filter=True,
+        )
         stdout, stderr = cline()
         for tree in parse_trees("test_file"):
             tree_taxa = [t.replace(" ", "_") for t in tree.get_taxa()]
@@ -174,19 +202,26 @@ class ParsimonyTests(unittest.TestCase):
         """Estimate a parsimony tree from an alignment."""
         self.assertTrue(os.path.isfile(filename), "Missing %s" % filename)
         if DNA:
-            cline = FDNAParsCommandline(exes["fdnapars"],
-                                        sequence=filename,
-                                        outtreefile="test_file",
-                                        auto=True, stdout=True)
+            cline = FDNAParsCommandline(
+                exes["fdnapars"],
+                sequence=filename,
+                outtreefile="test_file",
+                auto=True,
+                stdout=True,
+            )
         else:
-            cline = FProtParsCommandline(exes["fprotpars"],
-                                         sequence=filename,
-                                         outtreefile="test_file",
-                                         auto=True, stdout=True)
+            cline = FProtParsCommandline(
+                exes["fprotpars"],
+                sequence=filename,
+                outtreefile="test_file",
+                auto=True,
+                stdout=True,
+            )
         stdout, stderr = cline()
         with open(filename) as handle:
-            a_taxa = [s.name.replace(" ", "_") for s in
-                      next(AlignIO.parse(handle, format))]
+            a_taxa = [
+                s.name.replace(" ", "_") for s in next(AlignIO.parse(handle, format))
+            ]
         for tree in parse_trees("test_file"):
             t_taxa = [t.replace(" ", "_") for t in tree.get_taxa()]
             self.assertEqual(sorted(a_taxa), sorted(t_taxa))
@@ -233,12 +268,15 @@ class BootstrapTests(unittest.TestCase):
         set the output format to use (from [D]na,[p]rotein and [r]na )
         """
         self.assertTrue(os.path.isfile(filename), "Missing %s" % filename)
-        cline = FSeqBootCommandline(exes["fseqboot"],
-                                    sequence=filename,
-                                    outfile="test_file",
-                                    seqtype=align_type,
-                                    reps=2,
-                                    auto=True, filter=True)
+        cline = FSeqBootCommandline(
+            exes["fseqboot"],
+            sequence=filename,
+            outfile="test_file",
+            seqtype=align_type,
+            reps=2,
+            auto=True,
+            filter=True,
+        )
         stdout, stderr = cline()
         # the resultant file should have 2 alignments...
         with open("test_file") as handle:
@@ -246,8 +284,7 @@ class BootstrapTests(unittest.TestCase):
         self.assertEqual(len(bs), 2)
         # ..and each name in the original alignment...
         with open(filename) as handle:
-            a_names = [s.name.replace(" ", "_") for s in
-                       AlignIO.read(handle, format)]
+            a_names = [s.name.replace(" ", "_") for s in AlignIO.read(handle, format)]
         # ...should be in each alignment in the bootstrapped file
         for a in bs:
             self.assertEqual(a_names, [s.name.replace(" ", "_") for s in a])
@@ -279,10 +316,13 @@ class TreeComparisonTests(unittest.TestCase):
 
     def test_fconsense(self):
         """Calculate a consensus tree with fconsense."""
-        cline = FConsenseCommandline(exes["fconsense"],
-                                     intreefile="Phylip/horses.tree",
-                                     outtreefile="test_file",
-                                     auto=True, filter=True)
+        cline = FConsenseCommandline(
+            exes["fconsense"],
+            intreefile="Phylip/horses.tree",
+            outtreefile="test_file",
+            auto=True,
+            filter=True,
+        )
         stdout, stderr = cline()
         # Split the next and get_taxa into two steps to help 2to3 work
         tree1 = next(parse_trees("test_file"))
@@ -293,10 +333,13 @@ class TreeComparisonTests(unittest.TestCase):
 
     def test_ftreedist(self):
         """Calculate the distance between trees with ftreedist."""
-        cline = FTreeDistCommandline(exes["ftreedist"],
-                                     intreefile="Phylip/horses.tree",
-                                     outfile="test_file",
-                                     auto=True, filter=True)
+        cline = FTreeDistCommandline(
+            exes["ftreedist"],
+            intreefile="Phylip/horses.tree",
+            outfile="test_file",
+            auto=True,
+            filter=True,
+        )
         stdout, stderr = cline()
         self.assertTrue(os.path.isfile("test_file"))
 

--- a/Tests/test_EmbossPrimer.py
+++ b/Tests/test_EmbossPrimer.py
@@ -25,7 +25,7 @@ class Primer3ParseTest(unittest.TestCase):
             os.path.join("Emboss", "short.primer3"),
             os.path.join("Emboss", "internal_oligo.primer3"),
             os.path.join("Emboss", "no_oligo.primer3"),
-            ]
+        ]
 
     def test_simple_parse(self):
         """Make sure that we can use all single target primer3 files."""
@@ -44,12 +44,9 @@ class Primer3ParseTest(unittest.TestCase):
             primer_info = Primer3.read(handle)
 
         self.assertEqual(len(primer_info.primers), 5)
-        self.assertEqual(primer_info.comments,
-                         "# PRIMER3 RESULTS FOR AC074298\n")
-        self.assertEqual(primer_info.primers[1].forward_seq,
-                         "CCGGTTTCTCTGGTTGAAAA")
-        self.assertEqual(primer_info.primers[2].reverse_seq,
-                         "TCACATTCCCAAATGTAGATCG")
+        self.assertEqual(primer_info.comments, "# PRIMER3 RESULTS FOR AC074298\n")
+        self.assertEqual(primer_info.primers[1].forward_seq, "CCGGTTTCTCTGGTTGAAAA")
+        self.assertEqual(primer_info.primers[2].reverse_seq, "TCACATTCCCAAATGTAGATCG")
         self.assertEqual(primer_info.primers[0].size, 218)
         self.assertEqual(len(primer_info.primers[0]), 218)
         self.assertEqual(primer_info.primers[3].forward_start, 112)
@@ -68,12 +65,10 @@ class Primer3ParseTest(unittest.TestCase):
             primer_info = Primer3.read(handle)
 
         self.assertEqual(len(primer_info.primers), 5)
-        self.assertEqual(primer_info.comments,
-                         "# PRIMER3 RESULTS FOR 26964-28647#\n")
+        self.assertEqual(primer_info.comments, "# PRIMER3 RESULTS FOR 26964-28647#\n")
         self.assertEqual(primer_info.primers[1].reverse_seq, "")
         self.assertEqual(primer_info.primers[1].internal_seq, "")
-        self.assertEqual(primer_info.primers[3].forward_seq,
-                         "TGTGATTGCTTGAGCTGGAC")
+        self.assertEqual(primer_info.primers[3].forward_seq, "TGTGATTGCTTGAGCTGGAC")
         self.assertEqual(primer_info.primers[3].internal_seq, "")
         self.assertEqual(primer_info.primers[3].forward_start, 253)
 
@@ -85,11 +80,9 @@ class Primer3ParseTest(unittest.TestCase):
             primer_info = Primer3.read(handle)
 
         self.assertEqual(len(primer_info.primers), 5)
-        self.assertEqual(primer_info.comments,
-                         "# EPRIMER3 RESULTS FOR YNL138W-A\n")
+        self.assertEqual(primer_info.comments, "# EPRIMER3 RESULTS FOR YNL138W-A\n")
         self.assertEqual(primer_info.primers[0].internal_length, 22)
-        self.assertEqual(primer_info.primers[1].internal_seq,
-                         "TTGCGCTTTAGTTTGAATTGAA")
+        self.assertEqual(primer_info.primers[1].internal_seq, "TTGCGCTTTAGTTTGAATTGAA")
         self.assertEqual(primer_info.primers[2].internal_tm, 58.62)
         self.assertEqual(primer_info.primers[3].internal_start, 16)
         self.assertEqual(primer_info.primers[4].internal_gc, 35.00)
@@ -103,38 +96,23 @@ class Primer3ParseTest(unittest.TestCase):
         for target in targets:
             self.assertEqual(len(target.primers), 5)
 
-        self.assertEqual(targets[0].primers[0].forward_seq,
-                         "GCAAACTGAAAAGCGGACTC")
-        self.assertEqual(targets[0].primers[1].forward_seq,
-                         "GGGACGTACTTTCGCACAAT")
-        self.assertEqual(targets[0].primers[2].forward_seq,
-                         "GTCTTATGCGTGGTGGAGGT")
-        self.assertEqual(targets[0].primers[3].forward_seq,
-                         "GTACATCAACATCCGCAACG")
-        self.assertEqual(targets[0].primers[4].forward_seq,
-                         "CGTACATCAACATCCGCAAC")
+        self.assertEqual(targets[0].primers[0].forward_seq, "GCAAACTGAAAAGCGGACTC")
+        self.assertEqual(targets[0].primers[1].forward_seq, "GGGACGTACTTTCGCACAAT")
+        self.assertEqual(targets[0].primers[2].forward_seq, "GTCTTATGCGTGGTGGAGGT")
+        self.assertEqual(targets[0].primers[3].forward_seq, "GTACATCAACATCCGCAACG")
+        self.assertEqual(targets[0].primers[4].forward_seq, "CGTACATCAACATCCGCAAC")
 
-        self.assertEqual(targets[1].primers[0].forward_seq,
-                         "GGAAGTGCTTCTCGTTTTCG")
-        self.assertEqual(targets[1].primers[1].forward_seq,
-                         "TACAGAGCGTCACGGATGAG")
-        self.assertEqual(targets[1].primers[2].forward_seq,
-                         "TTGTCATCGTGCTCTTCGTC")
-        self.assertEqual(targets[1].primers[3].forward_seq,
-                         "GACTCCAACCTCAGCTTTCG")
-        self.assertEqual(targets[1].primers[4].forward_seq,
-                         "GGCACGAAGAAGGACAGAAG")
+        self.assertEqual(targets[1].primers[0].forward_seq, "GGAAGTGCTTCTCGTTTTCG")
+        self.assertEqual(targets[1].primers[1].forward_seq, "TACAGAGCGTCACGGATGAG")
+        self.assertEqual(targets[1].primers[2].forward_seq, "TTGTCATCGTGCTCTTCGTC")
+        self.assertEqual(targets[1].primers[3].forward_seq, "GACTCCAACCTCAGCTTTCG")
+        self.assertEqual(targets[1].primers[4].forward_seq, "GGCACGAAGAAGGACAGAAG")
 
-        self.assertEqual(targets[15].primers[0].forward_seq,
-                         "TGCTTGAAAATGACGCACTC")
-        self.assertEqual(targets[15].primers[1].forward_seq,
-                         "CTCGCTGGCTAGGTCATAGG")
-        self.assertEqual(targets[15].primers[2].forward_seq,
-                         "TATCGCACCAAACACGGTAA")
-        self.assertEqual(targets[15].primers[3].forward_seq,
-                         "CGATTACCCTCACCGTCACT")
-        self.assertEqual(targets[15].primers[4].forward_seq,
-                         "TATCGCAACCACTGAGCAAG")
+        self.assertEqual(targets[15].primers[0].forward_seq, "TGCTTGAAAATGACGCACTC")
+        self.assertEqual(targets[15].primers[1].forward_seq, "CTCGCTGGCTAGGTCATAGG")
+        self.assertEqual(targets[15].primers[2].forward_seq, "TATCGCACCAAACACGGTAA")
+        self.assertEqual(targets[15].primers[3].forward_seq, "CGATTACCCTCACCGTCACT")
+        self.assertEqual(targets[15].primers[4].forward_seq, "TATCGCAACCACTGAGCAAG")
 
     def test_multi_record_full(self):
         """Test parsing multiple primer sets (NirK full)."""
@@ -145,38 +123,23 @@ class Primer3ParseTest(unittest.TestCase):
         for target in targets:
             self.assertEqual(len(target.primers), 5)
 
-        self.assertEqual(targets[15].primers[0].forward_seq,
-                         "ACTCACTTCGGCTGAATGCT")
-        self.assertEqual(targets[15].primers[1].forward_seq,
-                         "GGCGATTAGCGCTGTCTATC")
-        self.assertEqual(targets[15].primers[2].forward_seq,
-                         "ACTCACTTCGGCTGAATGCT")
-        self.assertEqual(targets[15].primers[3].forward_seq,
-                         "TAGGCGTATAGACCGGGTTG")
-        self.assertEqual(targets[15].primers[4].forward_seq,
-                         "AGCAAGCTGACCACTGGTTT")
+        self.assertEqual(targets[15].primers[0].forward_seq, "ACTCACTTCGGCTGAATGCT")
+        self.assertEqual(targets[15].primers[1].forward_seq, "GGCGATTAGCGCTGTCTATC")
+        self.assertEqual(targets[15].primers[2].forward_seq, "ACTCACTTCGGCTGAATGCT")
+        self.assertEqual(targets[15].primers[3].forward_seq, "TAGGCGTATAGACCGGGTTG")
+        self.assertEqual(targets[15].primers[4].forward_seq, "AGCAAGCTGACCACTGGTTT")
 
-        self.assertEqual(targets[15].primers[0].reverse_seq,
-                         "CATTTAATCCGGATGCCAAC")
-        self.assertEqual(targets[15].primers[1].reverse_seq,
-                         "TGGCCTTTCTCTCCTCTTCA")
-        self.assertEqual(targets[15].primers[2].reverse_seq,
-                         "ATTTAATCCGGATGCCAACA")
-        self.assertEqual(targets[15].primers[3].reverse_seq,
-                         "CACACATTATTGGCGGTCAC")
-        self.assertEqual(targets[15].primers[4].reverse_seq,
-                         "TCTGAAACCACCAAGGAAGC")
+        self.assertEqual(targets[15].primers[0].reverse_seq, "CATTTAATCCGGATGCCAAC")
+        self.assertEqual(targets[15].primers[1].reverse_seq, "TGGCCTTTCTCTCCTCTTCA")
+        self.assertEqual(targets[15].primers[2].reverse_seq, "ATTTAATCCGGATGCCAACA")
+        self.assertEqual(targets[15].primers[3].reverse_seq, "CACACATTATTGGCGGTCAC")
+        self.assertEqual(targets[15].primers[4].reverse_seq, "TCTGAAACCACCAAGGAAGC")
 
-        self.assertEqual(targets[15].primers[0].internal_seq,
-                         "CCCACCAATATTTGGCTAGC")
-        self.assertEqual(targets[15].primers[1].internal_seq,
-                         "AATCTTCTGTGCACCTTGCC")
-        self.assertEqual(targets[15].primers[2].internal_seq,
-                         "CCCACCAATATTTGGCTAGC")
-        self.assertEqual(targets[15].primers[3].internal_seq,
-                         "TGAGCCTGTGTTCCACACAT")
-        self.assertEqual(targets[15].primers[4].internal_seq,
-                         "CTATGCCCTTCTGCCACAAT")
+        self.assertEqual(targets[15].primers[0].internal_seq, "CCCACCAATATTTGGCTAGC")
+        self.assertEqual(targets[15].primers[1].internal_seq, "AATCTTCTGTGCACCTTGCC")
+        self.assertEqual(targets[15].primers[2].internal_seq, "CCCACCAATATTTGGCTAGC")
+        self.assertEqual(targets[15].primers[3].internal_seq, "TGAGCCTGTGTTCCACACAT")
+        self.assertEqual(targets[15].primers[4].internal_seq, "CTATGCCCTTCTGCCACAAT")
 
 
 class PrimersearchParseTest(unittest.TestCase):
@@ -200,14 +163,16 @@ class PrimersearchParseTest(unittest.TestCase):
         self.assertEqual(len(amp_info.amplifiers["Test"]), 1)
 
         self.assertEqual(amp_info.amplifiers["Test"][0].length, 218)
-        self.assertEqual(amp_info.amplifiers["Test"][0].hit_info,
-                         "AC074298 AC074298 \n"
-                         "\tTelomere associated sequence for Arabidopsis thaliana "
-                         "TEL1N from chromosome I, complete sequence.\n"
-                         "\tCCGGTTTCTCTGGTTGAAAA hits forward strand at 114 "
-                         "with 0 mismatches\n"
-                         "\tTCACATTCCCAAATGTAGATCG hits reverse strand at "
-                         "[114] with 0 mismatches")
+        self.assertEqual(
+            amp_info.amplifiers["Test"][0].hit_info,
+            "AC074298 AC074298 \n"
+            "\tTelomere associated sequence for Arabidopsis thaliana "
+            "TEL1N from chromosome I, complete sequence.\n"
+            "\tCCGGTTTCTCTGGTTGAAAA hits forward strand at 114 "
+            "with 0 mismatches\n"
+            "\tTCACATTCCCAAATGTAGATCG hits reverse strand at "
+            "[114] with 0 mismatches",
+        )
 
 
 class PrimerSearchInputTest(unittest.TestCase):
@@ -223,9 +188,7 @@ class PrimerSearchInputTest(unittest.TestCase):
         p_info.add_primer_set("Test2", "AATA", "TTAT")
 
         output = str(p_info)
-        self.assertEqual(output,
-                         "Test GATC CATG\n"
-                         "Test2 AATA TTAT\n")
+        self.assertEqual(output, "Test GATC CATG\n" "Test2 AATA TTAT\n")
 
 
 if __name__ == "__main__":

--- a/Tests/test_EmbossPrimer.py
+++ b/Tests/test_EmbossPrimer.py
@@ -188,7 +188,7 @@ class PrimerSearchInputTest(unittest.TestCase):
         p_info.add_primer_set("Test2", "AATA", "TTAT")
 
         output = str(p_info)
-        self.assertEqual(output, "Test GATC CATG\n" "Test2 AATA TTAT\n")
+        self.assertEqual(output, "Test GATC CATG\nTest2 AATA TTAT\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_Emboss files, files listed below; it would be good to review it.
test_Emboss.py
test_EmbossPhylipNew.py
test_EmbossPrimer.py
