### PR TITLE
Use StreamModeError consistently, and avoid the _BinaryFormats local variable

### DIFF
--- a/Bio/SeqIO/AbiIO.py
+++ b/Bio/SeqIO/AbiIO.py
@@ -26,6 +26,8 @@ from Bio import Alphabet
 from Bio.Alphabet.IUPAC import ambiguous_dna, unambiguous_dna
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+from Bio import StreamModeError
+
 
 # dictionary for determining which tags goes into SeqRecord annotation
 # each key is tag_name + tag_number
@@ -362,7 +364,7 @@ def AbiIterator(source, alphabet=None, trim=False):
     except TypeError:
         handle = source
         if handle.read(0) != b"":
-            raise ValueError("ABI files must be opened in binary mode.") from None
+            raise StreamModeError("ABI files must be opened in binary mode.") from None
 
     try:
 

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -20,6 +20,7 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqIO.Interfaces import SequenceWriter
 from Bio.SeqIO.Interfaces import _clean, _get_seq_string
+from Bio import StreamModeError
 
 
 def SimpleFastaParser(source):
@@ -49,7 +50,7 @@ def SimpleFastaParser(source):
     except TypeError:
         handle = source
         if handle.read(0) != "":
-            raise ValueError("Fasta files must be opened in text mode") from None
+            raise StreamModeError("Fasta files must be opened in text mode") from None
 
     try:
         # Skip any text before the first record (e.g. blank lines, comments)
@@ -122,7 +123,7 @@ def FastaTwoLineParser(source):
     except TypeError:
         handle = source
         if handle.read(0) != "":
-            raise ValueError("Fasta files must be opened in text mode") from None
+            raise StreamModeError("Fasta files must be opened in text mode") from None
 
     idx = -1  # for empty file
     try:

--- a/Bio/SeqIO/GckIO.py
+++ b/Bio/SeqIO/GckIO.py
@@ -17,6 +17,7 @@ from Bio import Alphabet
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation
 from Bio.SeqRecord import SeqRecord
+from Bio import StreamModeError
 
 
 def _read(handle, length):
@@ -226,7 +227,7 @@ def GckIterator(source):
     except TypeError:
         handle = source
         if handle.read(0) != b"":
-            raise ValueError("GCK files must be opened in binary mode.") from None
+            raise StreamModeError("GCK files must be opened in binary mode.") from None
 
     try:
         records = _parse(handle)

--- a/Bio/SeqIO/IgIO.py
+++ b/Bio/SeqIO/IgIO.py
@@ -17,6 +17,7 @@ You are expected to use this module via the Bio.SeqIO functions.
 from Bio.Alphabet import single_letter_alphabet
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+from Bio import StreamModeError
 
 
 def _parse(handle, alphabet):
@@ -114,7 +115,7 @@ def IgIterator(source, alphabet=single_letter_alphabet):
     except TypeError:
         handle = source
         if handle.read(0) != "":
-            raise ValueError(
+            raise StreamModeError(
                 "IntelliGenetics files must be opened in text mode."
             ) from None
 

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -94,7 +94,9 @@ def GenBankIterator(source):
     except TypeError:
         handle = source
         if handle.read(0) != "":
-            raise StreamModeError("GenBank files must be opened in text mode.") from None
+            raise StreamModeError(
+                "GenBank files must be opened in text mode."
+            ) from None
 
     try:
         records = GenBankScanner(debug=0).parse_records(handle)

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -40,6 +40,8 @@ from Bio.GenBank.Scanner import GenBankScanner, EmblScanner, _ImgtScanner
 from Bio import Alphabet
 from Bio.SeqIO.Interfaces import SequenceWriter
 from Bio import SeqFeature
+from Bio import StreamModeError
+
 
 # NOTE
 # ====
@@ -92,7 +94,7 @@ def GenBankIterator(source):
     except TypeError:
         handle = source
         if handle.read(0) != "":
-            raise ValueError("GenBank files must be opened in text mode.") from None
+            raise StreamModeError("GenBank files must be opened in text mode.") from None
 
     try:
         records = GenBankScanner(debug=0).parse_records(handle)
@@ -150,7 +152,7 @@ def EmblIterator(source):
     except TypeError:
         handle = source
         if handle.read(0) != "":
-            raise ValueError("EMBL files must be opened in text mode.") from None
+            raise StreamModeError("EMBL files must be opened in text mode.") from None
 
     try:
         records = EmblScanner(debug=0).parse_records(handle)
@@ -175,7 +177,7 @@ def ImgtIterator(source):
     except TypeError:
         handle = source
         if handle.read(0) != "":
-            raise ValueError("IMGT files must be opened in text mode.") from None
+            raise StreamModeError("IMGT files must be opened in text mode.") from None
 
     try:
         records = _ImgtScanner(debug=0).parse_records(handle)
@@ -199,7 +201,7 @@ def GenBankCdsFeatureIterator(source, alphabet=Alphabet.generic_protein):
     except TypeError:
         handle = source
         if handle.read(0) != "":
-            raise ValueError("GenBank files must be opened in text mode.") from None
+            raise StreamModeError("GenBank files must be opened in text mode.") from None
 
     try:
         records = GenBankScanner(debug=0).parse_cds_features(handle, alphabet)
@@ -223,7 +225,7 @@ def EmblCdsFeatureIterator(source, alphabet=Alphabet.generic_protein):
     except TypeError:
         handle = source
         if handle.read(0) != "":
-            raise ValueError("EMBL files must be opened in text mode.") from None
+            raise StreamModeError("EMBL files must be opened in text mode.") from None
 
     try:
         records = EmblScanner(debug=0).parse_cds_features(handle, alphabet)

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -203,7 +203,9 @@ def GenBankCdsFeatureIterator(source, alphabet=Alphabet.generic_protein):
     except TypeError:
         handle = source
         if handle.read(0) != "":
-            raise StreamModeError("GenBank files must be opened in text mode.") from None
+            raise StreamModeError(
+                "GenBank files must be opened in text mode."
+            ) from None
 
     try:
         records = GenBankScanner(debug=0).parse_cds_features(handle, alphabet)

--- a/Bio/SeqIO/NibIO.py
+++ b/Bio/SeqIO/NibIO.py
@@ -43,6 +43,8 @@ description at https://genome.ucsc.edu/FAQ/FAQformat.html.
 from Bio.SeqIO.Interfaces import SequenceWriter
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+from Bio import StreamModeError
+
 import struct
 import sys
 
@@ -83,7 +85,7 @@ def NibIterator(source, alphabet=None):
     except TypeError:
         handle = source
         if handle.read(0) != b"":
-            raise ValueError("nib files must be opened in binary mode.") from None
+            raise StreamModeError("nib files must be opened in binary mode.") from None
 
     try:
         word = handle.read(4)

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -15,6 +15,7 @@ from Bio.Alphabet import generic_protein
 from Bio.Data.SCOPData import protein_letters_3to1
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+from Bio import StreamModeError
 
 
 def AtomIterator(pdb_id, structure):
@@ -150,7 +151,7 @@ def PdbSeqresIterator(source):
     except TypeError:
         handle = source
         if handle.read(0) != "":
-            raise ValueError("PDB files must be opened in text mode.") from None
+            raise StreamModeError("PDB files must be opened in text mode.") from None
 
     try:
         rec_name = None

--- a/Bio/SeqIO/PirIO.py
+++ b/Bio/SeqIO/PirIO.py
@@ -97,6 +97,7 @@ from Bio.Alphabet import (
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqIO.Interfaces import SequenceWriter
+from Bio import StreamModeError
 
 
 _pir_alphabets = {
@@ -135,7 +136,7 @@ def PirIterator(source):
     except TypeError:
         handle = source
         if handle.read(0) != "":
-            raise ValueError("PIR files must be opened in binary mode.") from None
+            raise StreamModeError("PIR files must be opened in binary mode.") from None
 
     try:
         # Skip any text before the first record (e.g. blank lines, comments)

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -236,6 +236,8 @@ from Bio import Alphabet
 from Bio.Seq import Seq
 from Bio.SeqIO.Interfaces import SequenceWriter
 from Bio.SeqRecord import SeqRecord
+from Bio import StreamModeError
+
 
 _null = b"\0"
 _sff = b".sff"
@@ -986,7 +988,7 @@ def SffIterator(source, alphabet=Alphabet.generic_dna, trim=False):
         handle = open(source, "rb")
     except TypeError:
         if source.read(0) != b"":
-            raise ValueError("SFF files must be opened in binary mode.") from None
+            raise StreamModeError("SFF files must be opened in binary mode.") from None
         try:
             if 0 != source.tell():
                 raise ValueError("Not at start of file, offset %i" % source.tell())

--- a/Bio/SeqIO/SnapGeneIO.py
+++ b/Bio/SeqIO/SnapGeneIO.py
@@ -20,6 +20,7 @@ from Bio import Alphabet
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation
 from Bio.SeqRecord import SeqRecord
+from Bio import StreamModeError
 
 
 def _iterate(handle):
@@ -250,7 +251,7 @@ def SnapGeneIterator(source):
     except TypeError:
         handle = source
         if handle.read(0) != b"":
-            raise ValueError("SnapGene files must be opened in binary mode.") from None
+            raise StreamModeError("SnapGene files must be opened in binary mode.") from None
 
     record = SeqRecord(None)
 

--- a/Bio/SeqIO/SnapGeneIO.py
+++ b/Bio/SeqIO/SnapGeneIO.py
@@ -251,7 +251,9 @@ def SnapGeneIterator(source):
     except TypeError:
         handle = source
         if handle.read(0) != b"":
-            raise StreamModeError("SnapGene files must be opened in binary mode.") from None
+            raise StreamModeError(
+                "SnapGene files must be opened in binary mode."
+            ) from None
 
     record = SeqRecord(None)
 

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -38,6 +38,7 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqIO.Interfaces import SequenceWriter
 from Bio.SeqIO.Interfaces import _clean, _get_seq_string
+from Bio import StreamModeError
 
 
 def TabIterator(source, alphabet=single_letter_alphabet):
@@ -77,7 +78,7 @@ def TabIterator(source, alphabet=single_letter_alphabet):
     except TypeError:
         handle = source
         if handle.read(0) != "":
-            raise ValueError(
+            raise StreamModeError(
                 "Tab-separated plain-text files must be opened in text mode."
             ) from None
     try:

--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -20,6 +20,7 @@ from Bio.Seq import Seq
 from Bio.SeqIO.Interfaces import SequenceWriter
 from Bio.SeqFeature import SeqFeature, FeatureLocation, ExactPosition
 from Bio.SeqRecord import SeqRecord
+from Bio import StreamModeError
 
 
 _seq_types = {
@@ -153,7 +154,7 @@ def XdnaIterator(source):
     except TypeError:
         handle = source
         if handle.read(0) != b"":
-            raise ValueError("Xdna files must be opened in binary mode.") from None
+            raise StreamModeError("Xdna files must be opened in binary mode.") from None
     # Parse fixed-size header and do some rudimentary checks
     #
     # The "neg_length" value is the length of the part of the sequence

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -355,13 +355,13 @@ class IndexDictTests(unittest.TestCase):
 
     @classmethod
     def get_mode(cls, fmt):
+        """Determine file mode ("rt" or "rb") based on format."""
         mode = cls.modes.get(fmt)
         if mode is not None:
             return mode
-        streams = {"rt": StringIO(), "rb": BytesIO()}
-        for mode in streams:
+        for mode, stream in (("rt", StringIO()), ("rb", BytesIO())):
             try:
-                SeqIO.read(streams[mode], fmt)
+                SeqIO.read(stream, fmt)
             except StreamModeError:
                 continue
             except ValueError:


### PR DESCRIPTION
This pull request uses the new StreamModeError consistently for `SeqIO` parsers, and uses it to automatically detect the appropriate file mode in `test_SeqIO_index.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
