### PR TITLE
Use StreamModeError in SeqIO tests

### DIFF
--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -25,6 +25,7 @@ from Bio import Alphabet
 from Bio.Seq import Seq
 from Bio.Seq import UnknownSeq
 from Bio.SeqRecord import SeqRecord
+from Bio import StreamModeError
 from .Interfaces import SequenceWriter
 
 
@@ -402,7 +403,7 @@ class SeqXmlIterator:
             # one specified in the XML file. With a binary handle, the correct
             # encoding is picked up by the parser from the XML file.
             if stream_or_path.read(0) != b"":
-                raise TypeError(
+                raise StreamModeError(
                     "SeqXML files should be opened in binary mode"
                 ) from None
             self.handle = stream_or_path

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -307,7 +307,7 @@ def _sff_file_header(handle):
             flowgram_format,
         ) = struct.unpack(fmt, data)
     except TypeError:
-        raise ValueError("SFF files must NOT be opened in text mode, binary required.")
+        raise StreamModeError("SFF files must be opened in binary mode.")
     if magic_number in [_hsh, _srt, _mft]:
         # Probably user error, calling Bio.SeqIO.parse() twice!
         raise ValueError("Handle seems to be at SFF index block, not start")

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -23,6 +23,7 @@ from Bio.SeqRecord import SeqRecord
 from Bio.Seq import Seq, UnknownSeq
 from Bio import Alphabet
 from Bio.Align import MultipleSeqAlignment
+from Bio import StreamModeError
 
 
 # TODO - Check that desired warnings are issued. Used to do that by capturing
@@ -72,6 +73,29 @@ for format in sorted(AlignIO._FormatToWriter):
         test_write_read_alignment_formats.append(format)
 test_write_read_alignment_formats.remove("gb")  # an alias for genbank
 test_write_read_alignment_formats.remove("fastq-sanger")  # an alias for fastq
+
+
+class SeqIOTestsBaseClass(unittest.TestCase):
+    """Base class for Bio.SeqIO unit tests."""
+
+    modes = {}
+
+    @classmethod
+    def get_mode(cls, fmt):
+        """Determine if file mode should be text ("t") or binary ("b") based on format."""
+        mode = cls.modes.get(fmt)
+        if mode is not None:
+            return mode
+        for mode, stream in (("t", StringIO()), ("b", BytesIO())):
+            try:
+                SeqIO.read(stream, fmt)
+            except StreamModeError:
+                continue
+            except ValueError:  # SeqIO.read will complain that the stream is empty
+                pass
+            cls.modes[fmt] = mode
+            return mode
+        raise RuntimeError("Failed to find file mode for %s" % fmt)
 
 
 class ForwardOnlyHandle:
@@ -161,7 +185,7 @@ class TestZipped(unittest.TestCase):
                 list(SeqIO.parse(handle, "gb"))
 
 
-class TestSeqIO(unittest.TestCase):
+class TestSeqIO(SeqIOTestsBaseClass):
     def setUp(self):
         self.addTypeEqualityFunc(SeqRecord, self.compare_record)
 
@@ -221,10 +245,11 @@ class TestSeqIO(unittest.TestCase):
                 # rather long, and it seems a bit pointless to record them.
                 continue
             # Going to write to a handle...
-            if format in SeqIO._BinaryFormats:
-                handle = BytesIO()
-            else:
+            mode = self.get_mode(format)
+            if mode == "t":
                 handle = StringIO()
+            elif mode == "b":
+                handle = BytesIO()
 
             if unequal_length and format in AlignIO._FormatToWriter:
                 msg = "Sequences must all be the same length"
@@ -353,14 +378,14 @@ class TestSeqIO(unittest.TestCase):
 
             if len(records) > 1:
                 # Try writing just one record (passing a SeqRecord, not a list)
-                if format in SeqIO._BinaryFormats:
-                    handle = BytesIO()
-                else:
+                if mode == "t":
                     handle = StringIO()
+                elif mode == "b":
+                    handle = BytesIO()
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore", BiopythonWarning)
                     SeqIO.write(records[0], handle, format)
-                    if format not in SeqIO._BinaryFormats:
+                    if mode == "t":
                         self.assertEqual(handle.getvalue(), records[0].format(format))
         if debug:
             self.fail(
@@ -380,11 +405,7 @@ class TestSeqIO(unittest.TestCase):
         expected_alignment,
         expected_messages,
     ):
-        if t_format in SeqIO._BinaryFormats:
-            mode = "rb"
-        else:
-            mode = "r"
-
+        mode = "r" + self.get_mode(t_format)
         with warnings.catch_warnings():
             # e.g. BiopythonParserWarning: Dropping bond qualifier in feature
             # location
@@ -5500,24 +5521,25 @@ class TestSeqIO(unittest.TestCase):
     def test_empty_file(self):
         """Check parsers can cope with an empty file."""
         for t_format in SeqIO._FormatToIterator:
-            if t_format in SeqIO._BinaryFormats:
+            mode = self.get_mode(t_format)
+            if mode == "t":
+                handle = StringIO()
+                if t_format in (
+                    "uniprot-xml",
+                    "pdb-seqres",
+                    "pdb-atom",
+                    "cif-atom",
+                    "cif-seqres",
+                ):
+                    with self.assertRaisesRegex(ValueError, "Empty file."):
+                        list(SeqIO.parse(handle, t_format))
+                else:
+                    records = list(SeqIO.parse(handle, t_format))
+                    self.assertEqual(len(records), 0)
+            elif mode == "b":
                 handle = BytesIO()
                 with self.assertRaisesRegex(ValueError, "Empty file."):
                     list(SeqIO.parse(handle, t_format))
-            elif t_format in (
-                "uniprot-xml",
-                "pdb-seqres",
-                "pdb-atom",
-                "cif-atom",
-                "cif-seqres",
-            ):
-                handle = StringIO()
-                with self.assertRaisesRegex(ValueError, "Empty file."):
-                    list(SeqIO.parse(handle, t_format))
-            else:
-                handle = StringIO()
-                records = list(SeqIO.parse(handle, t_format))
-                self.assertEqual(len(records), 0)
 
 
 if __name__ == "__main__":

--- a/Tests/test_SeqIO_write.py
+++ b/Tests/test_SeqIO_write.py
@@ -16,6 +16,7 @@ from Bio import AlignIO
 from Bio.SeqRecord import SeqRecord
 from Bio.Seq import Seq
 from Bio import Alphabet
+from test_SeqIO import SeqIOTestsBaseClass
 
 
 # List of formats including alignment only file formats we can read AND write.
@@ -75,7 +76,7 @@ test_records[4][0][2].annotations["comment"] = (
 test_records[4][0][2].annotations["weight"] = 2.5
 
 
-class WriterTests(unittest.TestCase):
+class WriterTests(SeqIOTestsBaseClass):
     """Cunning unit test where methods are added at run time."""  # TODO - Let's not be cunning
 
     def check(self, records, format):
@@ -116,10 +117,11 @@ class WriterTests(unittest.TestCase):
             self.check_simple(records, format)
 
     def check_simple(self, records, format):
-        if format in SeqIO._BinaryFormats:
-            handle = BytesIO()
-        else:
+        mode = self.get_mode(format)
+        if mode == "t":
             handle = StringIO()
+        elif mode == "b":
+            handle = BytesIO()
         count = SeqIO.write(records, handle, format)
         self.assertEqual(count, len(records))
         # Now read them back...
@@ -138,10 +140,11 @@ class WriterTests(unittest.TestCase):
         handle.close()
 
     def check_write_fails(self, records, format, err_type, err_msg=""):
-        if format in SeqIO._BinaryFormats:
-            handle = BytesIO()
-        else:
+        mode = self.get_mode(format)
+        if mode == "t":
             handle = StringIO()
+        elif mode == "b":
+            handle = BytesIO()
         if err_msg:
             try:
                 with warnings.catch_warnings():


### PR DESCRIPTION
This pull request uses StreamModeError to get rid of the the _BinaryFormats private variable in `test_SeqIO.py` and `test_SeqIO_write.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
