### PR TITLE
Apply black style to test_AlignIO.py, version 19.10b0.

### DIFF
--- a/Tests/test_AlignIO.py
+++ b/Tests/test_AlignIO.py
@@ -18,8 +18,10 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
 test_write_read_alignment_formats = sorted(AlignIO._FormatToWriter)
-test_write_read_align_with_seq_count = test_write_read_alignment_formats \
-    + ["fasta", "tab"]
+test_write_read_align_with_seq_count = test_write_read_alignment_formats + [
+    "fasta",
+    "tab",
+]
 
 
 class TestAlignIO_exceptions(unittest.TestCase):
@@ -29,13 +31,18 @@ class TestAlignIO_exceptions(unittest.TestCase):
     def test_phylip_reject_duplicate(self):
         """Check that writing duplicated IDs after truncation fails for PHYLIP."""
         handle = StringIO()
-        sequences = [SeqRecord(Seq("AAAA"), id="longsequencename1"),
-                     SeqRecord(Seq("AAAA"), id="longsequencename2"),
-                     SeqRecord(Seq("AAAA"), id="other_sequence"), ]
+        sequences = [
+            SeqRecord(Seq("AAAA"), id="longsequencename1"),
+            SeqRecord(Seq("AAAA"), id="longsequencename2"),
+            SeqRecord(Seq("AAAA"), id="other_sequence"),
+        ]
         alignment = MultipleSeqAlignment(sequences)
         with self.assertRaises(ValueError) as cm:
             AlignIO.write(alignment, handle, "phylip")
-        self.assertEqual("Repeated name 'longsequen' (originally 'longsequencename2'), possibly due to truncation", str(cm.exception))
+        self.assertEqual(
+            "Repeated name 'longsequen' (originally 'longsequencename2'), possibly due to truncation",
+            str(cm.exception),
+        )
 
     def test_parsing_empty_files(self):
         """Check that parsing an empty file returns an empty list."""
@@ -61,7 +68,6 @@ class TestAlignIO_exceptions(unittest.TestCase):
 
 
 class TestAlignIO_reading(unittest.TestCase):
-
     def simple_alignment_comparison(self, alignments, alignments2, fmt):
         self.assertEqual(len(alignments), len(alignments2))
         for a1, a2 in zip(alignments, alignments2):
@@ -97,8 +103,10 @@ class TestAlignIO_reading(unittest.TestCase):
                 if records_per_alignment != len(a):
                     records_per_alignment = None
             # Can we expect this format to work?
-            if not records_per_alignment \
-                    and fmt not in test_write_read_alignment_formats:
+            if (
+                not records_per_alignment
+                and fmt not in test_write_read_alignment_formats
+            ):
                 continue
 
             # Going to write to a handle...
@@ -107,7 +115,10 @@ class TestAlignIO_reading(unittest.TestCase):
             if fmt == "nexus":
                 with self.assertRaises(ValueError) as cm:
                     c = AlignIO.write(alignments, handle=handle, format=fmt)
-                self.assertEqual("We can only write one Alignment to a Nexus file.", str(cm.exception))
+                self.assertEqual(
+                    "We can only write one Alignment to a Nexus file.",
+                    str(cm.exception),
+                )
                 continue
             c = AlignIO.write(alignments, handle=handle, format=fmt)
             self.assertEqual(c, len(alignments))
@@ -116,10 +127,11 @@ class TestAlignIO_reading(unittest.TestCase):
             if records_per_alignment:
                 handle.flush()
                 handle.seek(0)
-                alignments2 = list(AlignIO.parse(
-                    handle=handle,
-                    format=fmt,
-                    seq_count=records_per_alignment))
+                alignments2 = list(
+                    AlignIO.parse(
+                        handle=handle, format=fmt, seq_count=records_per_alignment
+                    )
+                )
                 self.simple_alignment_comparison(alignments, alignments2, fmt)
 
             if fmt in test_write_read_alignment_formats:
@@ -188,7 +200,9 @@ class TestAlignIO_reading(unittest.TestCase):
         handle = StringIO()
         handle.write(data + "\n\n" + data + "\n\n" + data)
         handle.seek(0)
-        self.assertEqual(len(list(AlignIO.parse(handle=handle, format=fmt, seq_count=m))), 3)
+        self.assertEqual(
+            len(list(AlignIO.parse(handle=handle, format=fmt, seq_count=m))), 3
+        )
         handle.close()
 
     def check_read(self, path, fmt, m, k):
@@ -211,7 +225,7 @@ class TestAlignIO_reading(unittest.TestCase):
             name = record.id
             sequence = str(record.seq)
             if len(sequence) > max_len:
-                sequence = sequence[:max_len - 6] + "..." + sequence[-3:]
+                sequence = sequence[: max_len - 6] + "..." + sequence[-3:]
             item = (name, sequence)
             items.append(item)
         self.assertEqual(sequences, sorted(items))
@@ -242,7 +256,10 @@ class TestAlignIO_reading(unittest.TestCase):
         rep_dict = summary.replacement_dictionary()
         with self.assertRaises(ValueError) as cm:
             info_content = summary.information_content()
-        self.assertEqual("Error in alphabet: not Nucleotide or Protein, supply expected frequencies", str(cm.exception))
+        self.assertEqual(
+            "Error in alphabet: not Nucleotide or Protein, supply expected frequencies",
+            str(cm.exception),
+        )
 
     def check_summary_pir(self, alignment):
         summary = AlignInfo.SummaryInfo(alignment)
@@ -263,9 +280,20 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "clustal", 2, 601)
         self.check_alignment_rows(
             alignment,
-            [("gi|4959044|gb|AAD34209.1|AF069", "MENSDSNDKGSDQSAAQRRSQMDRLDREEAFYQF...SVV"),
-             ("gi|671626|emb|CAA85685.1|", "---------MSPQTETKASVGFKAGVKEYKLTYY...---")],
-            {"clustal_consensus": "          * *: ::    :.   :*  :  :. : . :*  ::   .:   **                  **:...   *.*** ..          .:*   * *: .* :*        : :* .*                   *::.  .    .:: :*..*  :* .*   .. .  :    .  :    *. .:: : .      .* .  :  *.:     ..::   * .  ::  :  .*.    :.    :. .  .  .* **.*..  :..  *.. .    . ::*                         :.: .*:    :     * ::   ***  . * :. .  .  :  *: .:: :::   ..   . : :   ::  *    *  : .. :.* . ::.  :: * :  :   * *   :..  * ..  * :**                             .  .:. ..   :*.  ..: :. .  .:* * :   : * .             ..*:.  .**   *.*... :  ::   :* .*  ::* : :.  :.    :   "})
+            [
+                (
+                    "gi|4959044|gb|AAD34209.1|AF069",
+                    "MENSDSNDKGSDQSAAQRRSQMDRLDREEAFYQF...SVV",
+                ),
+                (
+                    "gi|671626|emb|CAA85685.1|",
+                    "---------MSPQTETKASVGFKAGVKEYKLTYY...---",
+                ),
+            ],
+            {
+                "clustal_consensus": "          * *: ::    :.   :*  :  :. : . :*  ::   .:   **                  **:...   *.*** ..          .:*   * *: .* :*        : :* .*                   *::.  .    .:: :*..*  :* .*   .. .  :    .  :    *. .:: : .      .* .  :  *.:     ..::   * .  ::  :  .*.    :.    :. .  .  .* **.*..  :..  *.. .    . ::*                         :.: .*:    :     * ::   ***  . * :. .  .  :  *: .:: :::   ..   . : :   ::  *    *  : .. :.* . ::.  :: * :  :   * *   :..  * ..  * :**                             .  .:. ..   :*.  ..: :. .  .:* * :   : * .             ..*:.  .**   *.*... :  ::   :* .*  ::* : :.  :.    :   "
+            },
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_clustal2(self):
@@ -278,12 +306,9 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_write_three_times_and_read(path, "clustal", 7)
         alignment = self.check_read(path, "clustal", 7, 156)
         self.check_alignment_columns(
-            alignment, ["TTTTTTT",
-                        "AAAAAAA",
-                        "TTTTTTT",
-                        "AAAAAAA",
-                        "CCCCCCC",
-                        "AAAAAAA"])
+            alignment,
+            ["TTTTTTT", "AAAAAAA", "TTTTTTT", "AAAAAAA", "CCCCCCC", "AAAAAAA"],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_clustal3(self):
@@ -296,12 +321,8 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_write_three_times_and_read(path, "clustal", 5)
         alignment = self.check_read(path, "clustal", 5, 447)
         self.check_alignment_columns(
-            alignment, ["M----",
-                        "F----",
-                        "N----",
-                        "L----",
-                        "V----",
-                        "---SS"])
+            alignment, ["M----", "F----", "N----", "L----", "V----", "---SS"]
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_clustal4(self):
@@ -315,9 +336,14 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "clustal", 2, 687)
         self.check_alignment_rows(
             alignment,
-            [("AT3G20900.1-CDS", "----------------------------------...TAG"),
-             ("AT3G20900.1-SEQ", "ATGAACAAAGTAGCGAGGAAGAACAAAACATCAG...TAG")],
-            {"clustal_consensus": "                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            *       *  *** ***** *   *  **      *******************************************************************************************************************************************************************************"})
+            [
+                ("AT3G20900.1-CDS", "----------------------------------...TAG"),
+                ("AT3G20900.1-SEQ", "ATGAACAAAGTAGCGAGGAAGAACAAAACATCAG...TAG"),
+            ],
+            {
+                "clustal_consensus": "                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            *       *  *** ***** *   *  **      *******************************************************************************************************************************************************************************"
+            },
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_clustal5(self):
@@ -330,12 +356,16 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_write_three_times_and_read(path, "clustal", 20)
         alignment = self.check_read(path, "clustal", 20, 411)
         self.check_alignment_columns(
-            alignment, ["-M------------------",
-                        "-T------------------",
-                        "-V------------------",
-                        "-L-----------------M",
-                        "-E---------------MMS",
-                        "-------------------T"])
+            alignment,
+            [
+                "-M------------------",
+                "-T------------------",
+                "-V------------------",
+                "-L-----------------M",
+                "-E---------------MMS",
+                "-------------------T",
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_clustal6(self):
@@ -348,12 +378,16 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_write_three_times_and_read(path, "clustal", 20)
         alignment = self.check_read(path, "clustal", 20, 414)
         self.check_alignment_columns(
-            alignment, ["MMMMMMMMMMMMMMMM-M--",
-                        "-----------------T--",
-                        "-----------------V--",
-                        "-----------------L--",
-                        "-S---------------E--",
-                        "-T------------------"])
+            alignment,
+            [
+                "MMMMMMMMMMMMMMMM-M--",
+                "-----------------T--",
+                "-----------------V--",
+                "-----------------L--",
+                "-S---------------E--",
+                "-T------------------",
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_fasta(self):
@@ -367,9 +401,8 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "fasta", 3, 8)
         self.check_alignment_rows(
             alignment,
-            [("test1", "ACGTCGCG"),
-             ("test2", "GGGGCCCC"),
-             ("test3", "AAACACAC")])
+            [("test1", "ACGTCGCG"), ("test2", "GGGGCCCC"), ("test3", "AAACACAC")],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_nexus1(self):
@@ -381,12 +414,16 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_iterator_next_for_loop(path, "nexus", 1)
         alignment = self.check_read(path, "nexus", 9, 48)
         self.check_alignment_columns(
-            alignment, ["AAAAAAAAc",
-                        "-----c?tc",
-                        "CCCCCCCCc",
-                        "--c-?a-tc",
-                        "GGGGGGGGc",
-                        "tt--?ag?c"])
+            alignment,
+            [
+                "AAAAAAAAc",
+                "-----c?tc",
+                "CCCCCCCCc",
+                "--c-?a-tc",
+                "GGGGGGGGc",
+                "tt--?ag?c",
+            ],
+        )
         self.check_summary_simple(alignment)
 
     def test_reading_alignments_nexus2(self):
@@ -399,16 +436,19 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "nexus", 2, 22)
         self.check_alignment_rows(
             alignment,
-            [("Aegotheles", "AAAAAGGCATTGTGGTGGGAAT",),
-             ("Aerodramus", "?????????TTGTGGTGGGAAT")])
+            [
+                ("Aegotheles", "AAAAAGGCATTGTGGTGGGAAT",),
+                ("Aerodramus", "?????????TTGTGGTGGGAAT"),
+            ],
+        )
         self.check_summary_simple(alignment)
 
     def test_reading_alignments_msf1(self):
         path = "msf/DOA_prot.msf"
         with self.assertRaisesRegex(
-                ValueError,
-                "GCG MSF header said alignment length 62, "
-                "but 11 of 12 sequences said Len: 250"
+            ValueError,
+            "GCG MSF header said alignment length 62, "
+            "but 11 of 12 sequences said Len: 250",
         ):
             AlignIO.read(path, "msf")
 
@@ -424,15 +464,20 @@ class TestAlignIO_reading(unittest.TestCase):
         warning_msgs = {str(_.message) for _ in w}
         self.assertIn(
             "One of more alignment sequences were truncated and have been gap padded",
-            warning_msgs)
+            warning_msgs,
+        )
         self.check_alignment_columns(
-            alignment, ["GGGGGGGGGGG",
-                        "LLLLLLLLLLL",
-                        "TTTTTTTTTTT",
-                        "PPPPPPPPPPP",
-                        "FFFFFFSSSSS",
-                        # ...
-                        "LLLLLL----L"])
+            alignment,
+            [
+                "GGGGGGGGGGG",
+                "LLLLLLLLLLL",
+                "TTTTTTTTTTT",
+                "PPPPPPPPPPP",
+                "FFFFFFSSSSS",
+                # ...
+                "LLLLLL----L",
+            ],
+        )
         self.check_summary_simple(alignment)
 
     def test_reading_alignments_stockholm1(self):
@@ -446,9 +491,14 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "stockholm", 2, 104)
         self.check_alignment_rows(
             alignment,
-            [("AE007476.1", "AAAAUUGAAUAUCGUUUUACUUGUUUAU-GUCGU...GAU"),
-             ("AP001509.1", "UUAAUCGAGCUCAACACUCUUCGUAUAUCCUC-U...UGU")],
-            {"secondary_structure": ".................<<<<<<<<...<<<<<<<........>>>>>>>........<<<<<<<.......>>>>>>>..>>>>>>>>..............."})
+            [
+                ("AE007476.1", "AAAAUUGAAUAUCGUUUUACUUGUUUAU-GUCGU...GAU"),
+                ("AP001509.1", "UUAAUCGAGCUCAACACUCUUCGUAUAUCCUC-U...UGU"),
+            ],
+            {
+                "secondary_structure": ".................<<<<<<<<...<<<<<<<........>>>>>>>........<<<<<<<.......>>>>>>>..>>>>>>>>..............."
+            },
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_stockholm2(self):
@@ -461,12 +511,8 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_write_three_times_and_read(path, "stockholm", 6)
         alignment = self.check_read(path, "stockholm", 6, 43)
         self.check_alignment_columns(
-            alignment, ["MMMEEE",
-                        "TQIVVV",
-                        "CHEMMM",
-                        "RVALLL",
-                        "ASDTTT",
-                        "SYSEEE"])
+            alignment, ["MMMEEE", "TQIVVV", "CHEMMM", "RVALLL", "ASDTTT", "SYSEEE"]
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_phylip1(self):
@@ -479,12 +525,8 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_write_three_times_and_read(path, "phylip", 6)
         alignment = self.check_read(path, "phylip", 6, 13)
         self.check_alignment_columns(
-            alignment, ["CCTTCG",
-                        "GGAAAG",
-                        "ATAAAC",
-                        "TTTTAA",
-                        "GAGGAG",
-                        "CTTTTC"])
+            alignment, ["CCTTCG", "GGAAAG", "ATAAAC", "TTTTAA", "GAGGAG", "CTTTTC"]
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_phylip2(self):
@@ -497,12 +539,8 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_write_three_times_and_read(path, "phylip", 6)
         alignment = self.check_read(path, "phylip", 6, 39)
         self.check_alignment_columns(
-            alignment, ["CCTTCG",
-                        "GGAAAG",
-                        "ATAAAC",
-                        "TTTTAA",
-                        "GAGGAG",
-                        "CTTTTC"])
+            alignment, ["CCTTCG", "GGAAAG", "ATAAAC", "TTTTAA", "GAGGAG", "CTTTTC"]
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_phylip3(self):
@@ -515,12 +553,16 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_write_three_times_and_read(path, "phylip", 10)
         alignment = self.check_read(path, "phylip", 10, 40)
         self.check_alignment_columns(
-            alignment, ["CCCCCAAAAA",
-                        "AAAAACCCCC",
-                        "CCCAAAAAAA",
-                        "AAACCAAAAA",
-                        "CCAAAAAAAA",
-                        "AAAAAAAAAA"])
+            alignment,
+            [
+                "CCCCCAAAAA",
+                "AAAAACCCCC",
+                "CCCAAAAAAA",
+                "AAACCAAAAA",
+                "CCAAAAAAAA",
+                "AAAAAAAAAA",
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_phylip4(self):
@@ -533,12 +575,16 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_write_three_times_and_read(path, "phylip", 10)
         alignment = self.check_read(path, "phylip", 10, 40)
         self.check_alignment_columns(
-            alignment, ["AACCCCCCCC",
-                        "AAAACCCCCC",
-                        "AAAAAAAAAC",
-                        "ACAAAAAAAA",
-                        "ACACCCCCCC",
-                        "AAAAAAAAAA"])
+            alignment,
+            [
+                "AACCCCCCCC",
+                "AAAACCCCCC",
+                "AAAAAAAAAC",
+                "ACAAAAAAAA",
+                "ACACCCCCCC",
+                "AAAAAAAAAA",
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_phylip5(self):
@@ -551,12 +597,16 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_write_three_times_and_read(path, "phylip", 10)
         alignment = self.check_read(path, "phylip", 10, 40)
         self.check_alignment_columns(
-            alignment, ["CAAAACAAAC",
-                        "AACAACCACC",
-                        "CAAAACAAAA",
-                        "ACAACACACA",
-                        "CCAAAACCAA",
-                        "AAAAAAAAAA"])
+            alignment,
+            [
+                "CAAAACAAAC",
+                "AACAACCACC",
+                "CAAAACAAAA",
+                "ACAACACACA",
+                "CCAAAACCAA",
+                "AAAAAAAAAA",
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_phylip6(self):
@@ -570,9 +620,12 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "phylip", 3, 384)
         self.check_alignment_rows(
             alignment,
-            [("ALEU_HORVU", "MAHARVLLLALAVLATAAVAVASSSSFADSNPIR...VAA"),
-             ("CATH_HUMAN", "------MWATLPLLCAGAWLLGV--------PVC...PLV"),
-             ("CYS1_DICDI", "-----MKVILLFVLAVFTVFVSS-----------...I--")])
+            [
+                ("ALEU_HORVU", "MAHARVLLLALAVLATAAVAVASSSSFADSNPIR...VAA"),
+                ("CATH_HUMAN", "------MWATLPLLCAGAWLLGV--------PVC...PLV"),
+                ("CYS1_DICDI", "-----MKVILLFVLAVFTVFVSS-----------...I--"),
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_phylip7(self):
@@ -586,10 +639,13 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "phylip", 4, 131)
         self.check_alignment_rows(
             alignment,
-            [("IXI_234", "TSPASIRPPAGPSSRPAMVSSRRTRPSPPGPRRP...SHE"),
-             ("IXI_235", "TSPASIRPPAGPSSR---------RPSPPGPRRP...SHE"),
-             ("IXI_236", "TSPASIRPPAGPSSRPAMVSSR--RPSPPPPRRP...SHE"),
-             ("IXI_237", "TSPASLRPPAGPSSRPAMVSSRR-RPSPPGPRRP...SHE")])
+            [
+                ("IXI_234", "TSPASIRPPAGPSSRPAMVSSRRTRPSPPGPRRP...SHE"),
+                ("IXI_235", "TSPASIRPPAGPSSR---------RPSPPGPRRP...SHE"),
+                ("IXI_236", "TSPASIRPPAGPSSRPAMVSSR--RPSPPPPRRP...SHE"),
+                ("IXI_237", "TSPASLRPPAGPSSRPAMVSSRR-RPSPPGPRRP...SHE"),
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_phylip8(self):
@@ -602,12 +658,16 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_write_three_times_and_read(path, "phylip-relaxed", 12)
         alignment = self.check_read(path, "phylip-relaxed", 12, 898)
         self.check_alignment_columns(
-            alignment, ["AAAAAAAAAAAA",
-                        "AAAAAAAAAAAA",
-                        "GGGGGGGGGGGG",
-                        "TCCCCCCCCCCC",
-                        "TTTTTTTTTTTT",
-                        "TTTTTTTTTTTT"])
+            alignment,
+            [
+                "AAAAAAAAAAAA",
+                "AAAAAAAAAAAA",
+                "GGGGGGGGGGGG",
+                "TCCCCCCCCCCC",
+                "TTTTTTTTTTTT",
+                "TTTTTTTTTTTT",
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_phylip9(self):
@@ -621,9 +681,12 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "phylip-sequential", 3, 384)
         self.check_alignment_rows(
             alignment,
-            [("ALEU_HORVU", "MAHARVLLLALAVLATAAVAVASSSSFADSNPIR...VAA"),
-             ("CATH_HUMAN", "------MWATLPLLCAGAWLLGV--------PVC...PLV"),
-             ("CYS1_DICDI", "-----MKVILLFVLAVFTVFVSS-----------...I--")])
+            [
+                ("ALEU_HORVU", "MAHARVLLLALAVLATAAVAVASSSSFADSNPIR...VAA"),
+                ("CATH_HUMAN", "------MWATLPLLCAGAWLLGV--------PVC...PLV"),
+                ("CYS1_DICDI", "-----MKVILLFVLAVFTVFVSS-----------...I--"),
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_phylip10(self):
@@ -637,10 +700,13 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "phylip-sequential", 4, 131)
         self.check_alignment_rows(
             alignment,
-            [("IXI_234", "TSPASIRPPAGPSSRPAMVSSRRTRPSPPGPRRP...SHE"),
-             ("IXI_235", "TSPASIRPPAGPSSR---------RPSPPGPRRP...SHE"),
-             ("IXI_236", "TSPASIRPPAGPSSRPAMVSSR--RPSPPPPRRP...SHE"),
-             ("IXI_237", "TSPASLRPPAGPSSRPAMVSSRR-RPSPPGPRRP...SHE")])
+            [
+                ("IXI_234", "TSPASIRPPAGPSSRPAMVSSRRTRPSPPGPRRP...SHE"),
+                ("IXI_235", "TSPASIRPPAGPSSR---------RPSPPGPRRP...SHE"),
+                ("IXI_236", "TSPASIRPPAGPSSRPAMVSSR--RPSPPPPRRP...SHE"),
+                ("IXI_237", "TSPASLRPPAGPSSRPAMVSSRR-RPSPPGPRRP...SHE"),
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_emboss1(self):
@@ -653,10 +719,13 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "emboss", 4, 131)
         self.check_alignment_rows(
             alignment,
-            [("IXI_234", "TSPASIRPPAGPSSRPAMVSSRRTRPSPPGPRRP...SHE"),
-             ("IXI_235", "TSPASIRPPAGPSSR---------RPSPPGPRRP...SHE"),
-             ("IXI_236", "TSPASIRPPAGPSSRPAMVSSR--RPSPPPPRRP...SHE"),
-             ("IXI_237", "TSPASLRPPAGPSSRPAMVSSRR-RPSPPGPRRP...SHE")])
+            [
+                ("IXI_234", "TSPASIRPPAGPSSRPAMVSSRRTRPSPPGPRRP...SHE"),
+                ("IXI_235", "TSPASIRPPAGPSSR---------RPSPPGPRRP...SHE"),
+                ("IXI_236", "TSPASIRPPAGPSSRPAMVSSR--RPSPPPPRRP...SHE"),
+                ("IXI_237", "TSPASLRPPAGPSSRPAMVSSRR-RPSPPGPRRP...SHE"),
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_emboss2(self):
@@ -675,24 +744,39 @@ class TestAlignIO_reading(unittest.TestCase):
         self.assertEqual(alignments[4].get_alignment_length(), 125)
         self.check_alignment_rows(
             alignments[0],
-            [("gi|94968718|receiver", "-VLLADDHALVRRGFRLMLED--DPEIEIVAEAG...GET"),
-             ("ref_rec", "KILIVDD----QYGIRILLNEVFNKEGYQTFQAA...---")])
+            [
+                ("gi|94968718|receiver", "-VLLADDHALVRRGFRLMLED--DPEIEIVAEAG...GET"),
+                ("ref_rec", "KILIVDD----QYGIRILLNEVFNKEGYQTFQAA...---"),
+            ],
+        )
         self.check_alignment_rows(
             alignments[1],
-            [("gi|94968761|receiver", "-ILIVDDEANTLASLSRAFRLAGHEATVCDNAVR...LKR"),
-             ("ref_rec", "KILIVDDQYGIRILLNEVFNKEGYQTFQAANGLQ...---")])
+            [
+                ("gi|94968761|receiver", "-ILIVDDEANTLASLSRAFRLAGHEATVCDNAVR...LKR"),
+                ("ref_rec", "KILIVDDQYGIRILLNEVFNKEGYQTFQAANGLQ...---"),
+            ],
+        )
         self.check_alignment_rows(
             alignments[2],
-            [("gi|94967506|receiver", "LHIVVVDDDPGTCVYIESVFAELGHTCKSFVRPE...HKE"),
-             ("ref_rec", "-KILIVDDQYGIRILLNEVFNKEGYQTFQAANGL...---")])
+            [
+                ("gi|94967506|receiver", "LHIVVVDDDPGTCVYIESVFAELGHTCKSFVRPE...HKE"),
+                ("ref_rec", "-KILIVDDQYGIRILLNEVFNKEGYQTFQAANGL...---"),
+            ],
+        )
         self.check_alignment_rows(
             alignments[3],
-            [("gi|94970045|receiver", "-VLLVEDEEALRAAAGDFLETRGYKIMTARDGTE...EVL"),
-             ("ref_rec", "KILIVDDQYGIRILLNEVFNKEGYQTFQAANGLQ...DAV")])
+            [
+                ("gi|94970045|receiver", "-VLLVEDEEALRAAAGDFLETRGYKIMTARDGTE...EVL"),
+                ("ref_rec", "KILIVDDQYGIRILLNEVFNKEGYQTFQAANGLQ...DAV"),
+            ],
+        )
         self.check_alignment_rows(
             alignments[4],
-            [("gi|94970041|receiver", "TVLLVEDEEGVRKLVRGILSRQGYHVLEATSGEE...KRQ"),
-             ("ref_rec", "KILIVDDQYGIRILLNEVFNKEGYQTFQAANGLQ...---")])
+            [
+                ("gi|94970041|receiver", "TVLLVEDEEGVRKLVRGILSRQGYHVLEATSGEE...KRQ"),
+                ("ref_rec", "KILIVDDQYGIRILLNEVFNKEGYQTFQAANGLQ...---"),
+            ],
+        )
         self.check_summary(alignments[0])
         self.check_reverse_write_read(alignments)
 
@@ -706,8 +790,11 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "emboss", 2, 3653)
         self.check_alignment_rows(
             alignment,
-            [("asis", "----------------------------------...GAA"),
-             ("asis", "TATTTTTTGGATTTTTTTCTAGATTTTCTAGGTT...GAA")])
+            [
+                ("asis", "----------------------------------...GAA"),
+                ("asis", "TATTTTTTGGATTTTTTTCTAGATTTTCTAGGTT...GAA"),
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_emboss4(self):
@@ -720,8 +807,11 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "emboss", 2, 131)
         self.check_alignment_rows(
             alignment,
-            [("IXI_234", "TSPASIRPPAGPSSRPAMVSSRRTRPSPPGPRRP...SHE"),
-             ("IXI_235", "TSPASIRPPAGPSSR---------RPSPPGPRRP...SHE")])
+            [
+                ("IXI_234", "TSPASIRPPAGPSSRPAMVSSRRTRPSPPGPRRP...SHE"),
+                ("IXI_235", "TSPASIRPPAGPSSR---------RPSPPGPRRP...SHE"),
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_emboss5(self):
@@ -733,9 +823,8 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_iterator_next_for_loop(path, "emboss", 1)
         alignment = self.check_read(path, "emboss", 2, 18)
         self.check_alignment_rows(
-            alignment,
-            [("asis", "CGTTTGAGT-CTGGGATG"),
-             ("asis", "CGTTTGAGTACTGGGATG")])
+            alignment, [("asis", "CGTTTGAGT-CTGGGATG"), ("asis", "CGTTTGAGTACTGGGATG")]
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_emboss6(self):
@@ -748,8 +837,8 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "emboss", 2, 16)
         self.check_alignment_rows(
             alignment,
-            [("AF069992_1", "GPPPQSPDENRAGESS"),
-             ("CAA85685.1", "GVPPEEAGAAVAAESS")])
+            [("AF069992_1", "GPPPQSPDENRAGESS"), ("CAA85685.1", "GVPPEEAGAAVAAESS")],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_emboss7(self):
@@ -767,24 +856,25 @@ class TestAlignIO_reading(unittest.TestCase):
         self.assertEqual(alignments[4].get_alignment_length(), 10)
         self.check_alignment_rows(
             alignments[0],
-            [("HBA_HUMAN", "LSPADKTNVKAAWGKVGAHAGEYGAEALERMFLS...SKY"),
-             ("HBB_HUMAN", "LTPEEKSAVTALWGKV--NVDEVGGEALGRLLVV...HKY")])
+            [
+                ("HBA_HUMAN", "LSPADKTNVKAAWGKVGAHAGEYGAEALERMFLS...SKY"),
+                ("HBB_HUMAN", "LTPEEKSAVTALWGKV--NVDEVGGEALGRLLVV...HKY"),
+            ],
+        )
         self.check_alignment_rows(
             alignments[1],
-            [("HBA_HUMAN", "KKVADALTNAVAH"),
-             ("HBB_HUMAN", "QKVVAGVANALAH")])
+            [("HBA_HUMAN", "KKVADALTNAVAH"), ("HBB_HUMAN", "QKVVAGVANALAH")],
+        )
         self.check_alignment_rows(
             alignments[2],
-            [("HBA_HUMAN", "KLRVDPVNFKLLSHCLLV"),
-             ("HBB_HUMAN", "KVNVDEVGGEALGRLLVV")])
+            [("HBA_HUMAN", "KLRVDPVNFKLLSHCLLV"), ("HBB_HUMAN", "KVNVDEVGGEALGRLLVV")],
+        )
         self.check_alignment_rows(
-            alignments[3],
-            [("HBA_HUMAN", "LSALSDLHAH"),
-             ("HBB_HUMAN", "LGAFSDGLAH")])
+            alignments[3], [("HBA_HUMAN", "LSALSDLHAH"), ("HBB_HUMAN", "LGAFSDGLAH")]
+        )
         self.check_alignment_rows(
-            alignments[4],
-            [("HBA_HUMAN", "VKAAWGKVGA"),
-             ("HBB_HUMAN", "VQAAYQKVVA")])
+            alignments[4], [("HBA_HUMAN", "VKAAWGKVGA"), ("HBB_HUMAN", "VQAAYQKVVA")]
+        )
         self.check_summary(alignments[0])
         self.check_reverse_write_read(alignments)
 
@@ -798,8 +888,17 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "emboss", 2, 1450)
         self.check_alignment_rows(
             alignment,
-            [("hg38_chrX_131691529_131830643_47210_48660", "GGCAGGTGCATAGCTTGAGCCTAGGAGTTCAAGT...AAA"),
-             ("mm10_chrX_50555743_50635321_27140_27743", "G--------------------------TTCAAGG...AAA")])
+            [
+                (
+                    "hg38_chrX_131691529_131830643_47210_48660",
+                    "GGCAGGTGCATAGCTTGAGCCTAGGAGTTCAAGT...AAA",
+                ),
+                (
+                    "mm10_chrX_50555743_50635321_27140_27743",
+                    "G--------------------------TTCAAGG...AAA",
+                ),
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_fasta_m10_1(self):
@@ -813,23 +912,59 @@ class TestAlignIO_reading(unittest.TestCase):
         self.assertEqual(alignments[0].get_alignment_length(), 108)
         self.check_alignment_rows(
             alignments[0],
-            [("gi|10955263|ref|NP_052604.1|", "SGSNT-RRRAISRPVRLTAEED---QEIRKRAAE...LSR"),
-             ("gi|152973457|ref|YP_001338508.1|", "AGSGAPRRRGSGLASRISEQSEALLQEAAKHAAE...LSR")])
+            [
+                (
+                    "gi|10955263|ref|NP_052604.1|",
+                    "SGSNT-RRRAISRPVRLTAEED---QEIRKRAAE...LSR",
+                ),
+                (
+                    "gi|152973457|ref|YP_001338508.1|",
+                    "AGSGAPRRRGSGLASRISEQSEALLQEAAKHAAE...LSR",
+                ),
+            ],
+        )
         self.assertEqual(alignments[1].get_alignment_length(), 64)
         self.check_alignment_rows(
             alignments[1],
-            [("gi|10955263|ref|NP_052604.1|", "AAECGKTVSGFLRAAALGKKVNSLTDDRVLKEV-...AIT"),
-             ("gi|152973588|ref|YP_001338639.1|", "ASRQGCTVGG--KMDSVQDKASDKDKERVMKNIN...TLT")])
+            [
+                (
+                    "gi|10955263|ref|NP_052604.1|",
+                    "AAECGKTVSGFLRAAALGKKVNSLTDDRVLKEV-...AIT",
+                ),
+                (
+                    "gi|152973588|ref|YP_001338639.1|",
+                    "ASRQGCTVGG--KMDSVQDKASDKDKERVMKNIN...TLT",
+                ),
+            ],
+        )
         self.assertEqual(alignments[2].get_alignment_length(), 38)
         self.check_alignment_rows(
             alignments[2],
-            [("gi|10955264|ref|NP_052605.1|", "MKKDKKYQIEAIKNKDKTLFIVYATDIYSPSEFFSKIE"),
-             ("gi|152973462|ref|YP_001338513.1|", "IKKDLGVSFLKLKNREKTLIVDALKKKYPVAELLSVLQ")])
+            [
+                (
+                    "gi|10955264|ref|NP_052605.1|",
+                    "MKKDKKYQIEAIKNKDKTLFIVYATDIYSPSEFFSKIE",
+                ),
+                (
+                    "gi|152973462|ref|YP_001338513.1|",
+                    "IKKDLGVSFLKLKNREKTLIVDALKKKYPVAELLSVLQ",
+                ),
+            ],
+        )
         self.assertEqual(alignments[3].get_alignment_length(), 43)
         self.check_alignment_rows(
             alignments[3],
-            [("gi|10955265|ref|NP_052606.1|", "SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDV...TYC"),
-             ("gi|152973545|ref|YP_001338596.1|", "SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDM...EYC")])
+            [
+                (
+                    "gi|10955265|ref|NP_052606.1|",
+                    "SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDV...TYC",
+                ),
+                (
+                    "gi|152973545|ref|YP_001338596.1|",
+                    "SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDM...EYC",
+                ),
+            ],
+        )
         self.check_summary(alignments[0])
         self.check_reverse_write_read(alignments)
 
@@ -844,23 +979,59 @@ class TestAlignIO_reading(unittest.TestCase):
         self.assertEqual(alignments[0].get_alignment_length(), 88)
         self.check_alignment_rows(
             alignments[0],
-            [("gi|10955263|ref|NP_052604.1|", "SGSNTRRRAISRPVR--LTAEEDQEIRKRAAECG...AEV"),
-             ("gi|162139799|ref|NP_309634.2|", "SQRSTRRKPENQPTRVILFNKPYDVLPQFTDEAG...VQV")])
+            [
+                (
+                    "gi|10955263|ref|NP_052604.1|",
+                    "SGSNTRRRAISRPVR--LTAEEDQEIRKRAAECG...AEV",
+                ),
+                (
+                    "gi|162139799|ref|NP_309634.2|",
+                    "SQRSTRRKPENQPTRVILFNKPYDVLPQFTDEAG...VQV",
+                ),
+            ],
+        )
         self.assertEqual(alignments[1].get_alignment_length(), 53)
         self.check_alignment_rows(
             alignments[1],
-            [("gi|10955263|ref|NP_052604.1|", "EIRKRAAECGKTVSGFLRAAA-LGKKV----NSL...KKL"),
-             ("gi|15831859|ref|NP_310632.1|", "EIKPRGTSKGEAIAAFMQEAPFIGRTPVFLGDDL...VKI")])
+            [
+                (
+                    "gi|10955263|ref|NP_052604.1|",
+                    "EIRKRAAECGKTVSGFLRAAA-LGKKV----NSL...KKL",
+                ),
+                (
+                    "gi|15831859|ref|NP_310632.1|",
+                    "EIKPRGTSKGEAIAAFMQEAPFIGRTPVFLGDDL...VKI",
+                ),
+            ],
+        )
         self.assertEqual(alignments[2].get_alignment_length(), 92)
         self.check_alignment_rows(
             alignments[2],
-            [("gi|10955264|ref|NP_052605.1|", "SEFFSKIESDLKKKKSKGDVFFDLIIPNG-----...ATS"),
-             ("gi|15829419|ref|NP_308192.1|", "TELNSELAKAMKVDAQRG-AFVSQVLPNSSAAKA...QSS")])
+            [
+                (
+                    "gi|10955264|ref|NP_052605.1|",
+                    "SEFFSKIESDLKKKKSKGDVFFDLIIPNG-----...ATS",
+                ),
+                (
+                    "gi|15829419|ref|NP_308192.1|",
+                    "TELNSELAKAMKVDAQRG-AFVSQVLPNSSAAKA...QSS",
+                ),
+            ],
+        )
         self.assertEqual(alignments[5].get_alignment_length(), 157)
         self.check_alignment_rows(
             alignments[5],
-            [("gi|10955265|ref|NP_052606.1|", "QYIMTTSNGDRVRAKIYKRGSIQFQGKYLQIASL...REI"),
-             ("gi|15833861|ref|NP_312634.1|", "EFIRLLSDHDQFEKDQISELTVAANALKLEVAK-...KKV")])
+            [
+                (
+                    "gi|10955265|ref|NP_052606.1|",
+                    "QYIMTTSNGDRVRAKIYKRGSIQFQGKYLQIASL...REI",
+                ),
+                (
+                    "gi|15833861|ref|NP_312634.1|",
+                    "EFIRLLSDHDQFEKDQISELTVAANALKLEVAK-...KKV",
+                ),
+            ],
+        )
         self.check_summary(alignments[0])
         self.check_reverse_write_read(alignments)
 
@@ -875,18 +1046,39 @@ class TestAlignIO_reading(unittest.TestCase):
         self.assertEqual(alignments[0].get_alignment_length(), 55)
         self.check_alignment_rows(
             alignments[0],
-            [("gi|10955263|ref|NP_052604.1|", "VRLTAEEDQ--EIRKRAAECG-KTVSGFLRAAAL...LGA"),
-             ("gi|152973837|ref|YP_001338874.1|", "ISISNNKDQYEELQKEQGERDLKTVDQLVRIAAA...IAA")])
+            [
+                (
+                    "gi|10955263|ref|NP_052604.1|",
+                    "VRLTAEEDQ--EIRKRAAECG-KTVSGFLRAAAL...LGA",
+                ),
+                (
+                    "gi|152973837|ref|YP_001338874.1|",
+                    "ISISNNKDQYEELQKEQGERDLKTVDQLVRIAAA...IAA",
+                ),
+            ],
+        )
         self.assertEqual(alignments[1].get_alignment_length(), 22)
         self.check_alignment_rows(
             alignments[1],
-            [("gi|10955265|ref|NP_052606.1|", "DDRANLFEFLSEEGITITEDNN"),
-             ("gi|152973840|ref|YP_001338877.1|", "DDAEHLFRTLSSR-LDALQDGN")])
+            [
+                ("gi|10955265|ref|NP_052606.1|", "DDRANLFEFLSEEGITITEDNN"),
+                ("gi|152973840|ref|YP_001338877.1|", "DDAEHLFRTLSSR-LDALQDGN"),
+            ],
+        )
         self.assertEqual(alignments[2].get_alignment_length(), 63)
         self.check_alignment_rows(
             alignments[2],
-            [("gi|10955264|ref|NP_052605.1|", "VYTSFN---GEKFSSYTLNKVTKTDEYNDLSELS...KGI"),
-             ("gi|152973841|ref|YP_001338878.1|", "VFGSFEQPKGEHLSGQVSEQ--RDTAFADQNEQV...QAM")])
+            [
+                (
+                    "gi|10955264|ref|NP_052605.1|",
+                    "VYTSFN---GEKFSSYTLNKVTKTDEYNDLSELS...KGI",
+                ),
+                (
+                    "gi|152973841|ref|YP_001338878.1|",
+                    "VFGSFEQPKGEHLSGQVSEQ--RDTAFADQNEQV...QAM",
+                ),
+            ],
+        )
         self.check_summary(alignments[0])
         self.check_reverse_write_read(alignments)
 
@@ -900,8 +1092,17 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "fasta-m10", 2, 102)
         self.check_alignment_rows(
             alignment,
-            [("ref|NC_002127.1|:c1351-971", "AAAAAAGATAAAAAATATCAAATAGAAGCAATAA...TCA"),
-             ("ref|NC_002695.1|:1970775-1971404", "AGAGAAAATAAAACAAGTAATAAAATATTAATGG...ACA")])
+            [
+                (
+                    "ref|NC_002127.1|:c1351-971",
+                    "AAAAAAGATAAAAAATATCAAATAGAAGCAATAA...TCA",
+                ),
+                (
+                    "ref|NC_002695.1|:1970775-1971404",
+                    "AGAGAAAATAAAACAAGTAATAAAATATTAATGG...ACA",
+                ),
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_fasta_m10_5(self):
@@ -914,8 +1115,17 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "fasta-m10", 2, 110)
         self.check_alignment_rows(
             alignment,
-            [("gi|10955264|ref|NP_052605.1|", "IKNKDKTLFIVYAT-DIYSPSEFFSKIESDLKKK...LSK"),
-             ("gi|10955282|ref|NP_052623.1|", "IKDELPVAFCSWASLDLECEVKYINDVTSLYAKD...MSE")])
+            [
+                (
+                    "gi|10955264|ref|NP_052605.1|",
+                    "IKNKDKTLFIVYAT-DIYSPSEFFSKIESDLKKK...LSK",
+                ),
+                (
+                    "gi|10955282|ref|NP_052623.1|",
+                    "IKDELPVAFCSWASLDLECEVKYINDVTSLYAKD...MSE",
+                ),
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_fasta_m10_6(self):
@@ -928,8 +1138,14 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "fasta-m10", 2, 131)
         self.check_alignment_rows(
             alignment,
-            [("gi|116660610|gb|EG558221.1|EG558221", "GCAACGCTTCAAGAACTGGAATTAGGAACCGTGA...CAT"),
-             ("query", "GCAACGCTTCAAGAACTGGAATTAGGAACCGTGA...CAT")])
+            [
+                (
+                    "gi|116660610|gb|EG558221.1|EG558221",
+                    "GCAACGCTTCAAGAACTGGAATTAGGAACCGTGA...CAT",
+                ),
+                ("query", "GCAACGCTTCAAGAACTGGAATTAGGAACCGTGA...CAT"),
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_fasta_m10_7(self):
@@ -943,23 +1159,59 @@ class TestAlignIO_reading(unittest.TestCase):
         self.assertEqual(alignments[0].get_alignment_length(), 108)
         self.check_alignment_rows(
             alignments[0],
-            [("gi|10955263|ref|NP_052604.1|", "SGSNT-RRRAISRPVRLTAEED---QEIRKRAAE...LSR"),
-             ("gi|152973457|ref|YP_001338508.1|", "AGSGAPRRRGSGLASRISEQSEALLQEAAKHAAE...LSR")])
+            [
+                (
+                    "gi|10955263|ref|NP_052604.1|",
+                    "SGSNT-RRRAISRPVRLTAEED---QEIRKRAAE...LSR",
+                ),
+                (
+                    "gi|152973457|ref|YP_001338508.1|",
+                    "AGSGAPRRRGSGLASRISEQSEALLQEAAKHAAE...LSR",
+                ),
+            ],
+        )
         self.assertEqual(alignments[1].get_alignment_length(), 64)
         self.check_alignment_rows(
             alignments[1],
-            [("gi|10955263|ref|NP_052604.1|", "AAECGKTVSGFLRAAALGKKVNSLTDDRVLKEV-...AIT"),
-             ("gi|152973588|ref|YP_001338639.1|", "ASRQGCTVGG--KMDSVQDKASDKDKERVMKNIN...TLT")])
+            [
+                (
+                    "gi|10955263|ref|NP_052604.1|",
+                    "AAECGKTVSGFLRAAALGKKVNSLTDDRVLKEV-...AIT",
+                ),
+                (
+                    "gi|152973588|ref|YP_001338639.1|",
+                    "ASRQGCTVGG--KMDSVQDKASDKDKERVMKNIN...TLT",
+                ),
+            ],
+        )
         self.assertEqual(alignments[2].get_alignment_length(), 45)
         self.check_alignment_rows(
             alignments[2],
-            [("gi|10955263|ref|NP_052604.1|", "EIRKRAAECGKTVSGFLRAAA-----LGKKVNSL...VMR"),
-             ("gi|152973480|ref|YP_001338531.1|", "ELVKLIADMGISVRALLRKNVEPYEELGLEEDKF...MLQ")])
+            [
+                (
+                    "gi|10955263|ref|NP_052604.1|",
+                    "EIRKRAAECGKTVSGFLRAAA-----LGKKVNSL...VMR",
+                ),
+                (
+                    "gi|152973480|ref|YP_001338531.1|",
+                    "ELVKLIADMGISVRALLRKNVEPYEELGLEEDKF...MLQ",
+                ),
+            ],
+        )
         self.assertEqual(alignments[8].get_alignment_length(), 64)
         self.check_alignment_rows(
             alignments[8],
-            [("gi|10955265|ref|NP_052606.1|", "ISGTYKGIDFLIKLMPSGGNTTIGRASGQNNTYF...FSD"),
-             ("gi|152973505|ref|YP_001338556.1|", "IDGVITAFD-LRTGMNISKDKVVAQIQGMDPVW-...YPD")])
+            [
+                (
+                    "gi|10955265|ref|NP_052606.1|",
+                    "ISGTYKGIDFLIKLMPSGGNTTIGRASGQNNTYF...FSD",
+                ),
+                (
+                    "gi|152973505|ref|YP_001338556.1|",
+                    "IDGVITAFD-LRTGMNISKDKVVAQIQGMDPVW-...YPD",
+                ),
+            ],
+        )
         self.check_summary(alignments[0])
         self.check_reverse_write_read(alignments)
 
@@ -974,23 +1226,44 @@ class TestAlignIO_reading(unittest.TestCase):
         self.assertEqual(alignments[0].get_alignment_length(), 65)
         self.check_alignment_rows(
             alignments[0],
-            [("gi|283855822|gb|GQ290312.1|", "IPHQLPHALRHRPAQEAAHASQLHPAQPGCGQPL...GLL"),
-             ("sp|Q9NSY1|BMP2K_HUMAN", "LQHRHPHQQQQQQQQQQQQQQQQQQQQQQQQQQQ...QML")])
+            [
+                (
+                    "gi|283855822|gb|GQ290312.1|",
+                    "IPHQLPHALRHRPAQEAAHASQLHPAQPGCGQPL...GLL",
+                ),
+                ("sp|Q9NSY1|BMP2K_HUMAN", "LQHRHPHQQQQQQQQQQQQQQQQQQQQQQQQQQQ...QML"),
+            ],
+        )
         self.assertEqual(alignments[1].get_alignment_length(), 201)
         self.check_alignment_rows(
             alignments[1],
-            [("gi|57163782|ref|NM_001009242.1|", "GPELLRALLQQNGCGTQPLRVPTVLPG*AMAVLH...QKS"),
-             ("sp|Q9NSY1|BMP2K_HUMAN", "GPEIL---LGQ-GPPQQPPQQHRVLQQLQQGDWR...NRS")])
+            [
+                (
+                    "gi|57163782|ref|NM_001009242.1|",
+                    "GPELLRALLQQNGCGTQPLRVPTVLPG*AMAVLH...QKS",
+                ),
+                ("sp|Q9NSY1|BMP2K_HUMAN", "GPEIL---LGQ-GPPQQPPQQHRVLQQLQQGDWR...NRS"),
+            ],
+        )
         self.assertEqual(alignments[2].get_alignment_length(), 348)
         self.check_alignment_rows(
             alignments[2],
-            [("gi|57163782|ref|NM_001009242.1|", "MNGTEGPNFYVPFSNKTGVVRSPFEYPQYYLAEP...APA"),
-             ("sp|P08100|OPSD_HUMAN", "MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEP...APA")])
+            [
+                (
+                    "gi|57163782|ref|NM_001009242.1|",
+                    "MNGTEGPNFYVPFSNKTGVVRSPFEYPQYYLAEP...APA",
+                ),
+                ("sp|P08100|OPSD_HUMAN", "MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEP...APA"),
+            ],
+        )
         self.assertEqual(alignments[11].get_alignment_length(), 31)
         self.check_alignment_rows(
             alignments[11],
-            [("gi|283855822|gb|GQ290312.1|", "SQQIRNATTMMMTMRVTSFSAFWVVADSCCW"),
-             ("sp|P08100|OPSD_HUMAN", "AQQQESATTQKAEKEVTRMVIIMVIAFLICW")])
+            [
+                ("gi|283855822|gb|GQ290312.1|", "SQQIRNATTMMMTMRVTSFSAFWVVADSCCW"),
+                ("sp|P08100|OPSD_HUMAN", "AQQQESATTQKAEKEVTRMVIIMVIAFLICW"),
+            ],
+        )
         self.check_summary(alignments[0])
         self.check_reverse_write_read(alignments)
 
@@ -1003,12 +1276,17 @@ class TestAlignIO_reading(unittest.TestCase):
         self.check_iterator_next_for_loop(path, "ig", 1)
         self.check_write_three_times_and_read(path, "ig", 16)
         alignment = self.check_read(path, "ig", 16, 298)
-        self.check_alignment_columns(alignment, ["MMMMMMMMMMMMMMMM",
-                                                 "EEEEEEETEEEENEEE",
-                                                 "NNNNNNNAEEEEQRKK",
-                                                 "--------DEEEEE--",
-                                                 "--------KKKKKK--",
-                                                 "HHHHHHH-AAAAL-R-"])
+        self.check_alignment_columns(
+            alignment,
+            [
+                "MMMMMMMMMMMMMMMM",
+                "EEEEEEETEEEENEEE",
+                "NNNNNNNAEEEEQRKK",
+                "--------DEEEEE--",
+                "--------KKKKKK--",
+                "HHHHHHH-AAAAL-R-",
+            ],
+        )
         self.check_summary(alignment)
 
     def test_reading_alignments_pir(self):
@@ -1022,8 +1300,17 @@ class TestAlignIO_reading(unittest.TestCase):
         alignment = self.check_read(path, "pir", 2, 2527)
         self.check_alignment_rows(
             alignment,
-            [("804Angiostrongylus_cantonensis", "----------------------------------...---"),
-             ("815Parelaphostrongylus_odocoil", "----------------------------------...---")])
+            [
+                (
+                    "804Angiostrongylus_cantonensis",
+                    "----------------------------------...---",
+                ),
+                (
+                    "815Parelaphostrongylus_odocoil",
+                    "----------------------------------...---",
+                ),
+            ],
+        )
         self.check_summary_pir(alignment)
 
     def test_reading_alignments_maf1(self):
@@ -1037,15 +1324,21 @@ class TestAlignIO_reading(unittest.TestCase):
         self.assertEqual(alignments[0].get_alignment_length(), 5486)
         self.check_alignment_rows(
             alignments[0],
-            [("NM_006987", "gcacagcctttactccctgactgcgtttatattc...CCG"),
-             ("mm3", "gcacagcctttactccctgactgcgtttatattc...TTG"),
-             ("rn3", "gcacagcctttactccctgactgcgtttatattc...CCG")])
+            [
+                ("NM_006987", "gcacagcctttactccctgactgcgtttatattc...CCG"),
+                ("mm3", "gcacagcctttactccctgactgcgtttatattc...TTG"),
+                ("rn3", "gcacagcctttactccctgactgcgtttatattc...CCG"),
+            ],
+        )
         self.assertEqual(alignments[1].get_alignment_length(), 5753)
         self.check_alignment_rows(
             alignments[1],
-            [("NM_018289", "tttgtccatgttggtcaggctggtctcgaactcc...GGT"),
-             ("mm3", "tttgtccatgttggtcaggctggtctcgaactcc...GGT"),
-             ("rn3", "tttgtccatgttggtcaggctggtctcgaactcc...GGT")])
+            [
+                ("NM_018289", "tttgtccatgttggtcaggctggtctcgaactcc...GGT"),
+                ("mm3", "tttgtccatgttggtcaggctggtctcgaactcc...GGT"),
+                ("rn3", "tttgtccatgttggtcaggctggtctcgaactcc...GGT"),
+            ],
+        )
         self.check_summary(alignments[1])
         self.check_reverse_write_read(alignments)
 
@@ -1060,29 +1353,24 @@ class TestAlignIO_reading(unittest.TestCase):
         self.assertEqual(len(alignments[0]), 5)
         self.assertEqual(alignments[0].get_alignment_length(), 42)
         self.check_alignment_columns(
-            alignments[0], ["AAA--",
-                            "AAAAA",
-                            "AAAAA",
-                            "---T-",
-                            "GGGGG",
-                            "GGGGG"])
+            alignments[0], ["AAA--", "AAAAA", "AAAAA", "---T-", "GGGGG", "GGGGG"]
+        )
         self.assertEqual(len(alignments[1]), 5)
         self.assertEqual(alignments[1].get_alignment_length(), 6)
         self.check_alignment_columns(
-            alignments[1], ["TTTTt",
-                            "AAAAa",
-                            "AAAAa",
-                            "AAAAg",
-                            "GGGGg",
-                            "AAAAa"])
+            alignments[1], ["TTTTt", "AAAAa", "AAAAa", "AAAAg", "GGGGg", "AAAAa"]
+        )
         self.assertEqual(len(alignments[2]), 4)
         self.assertEqual(alignments[2].get_alignment_length(), 13)
         self.check_alignment_rows(
             alignments[2],
-            [("baboon", "gcagctgaaaaca"),
-             ("hg16.chr7", "gcagctgaaaaca"),
-             ("mm4.chr6", "ACAGCTGAAAATA"),
-             ("panTro1.chr6", "gcagctgaaaaca")])
+            [
+                ("baboon", "gcagctgaaaaca"),
+                ("hg16.chr7", "gcagctgaaaaca"),
+                ("mm4.chr6", "ACAGCTGAAAATA"),
+                ("panTro1.chr6", "gcagctgaaaaca"),
+            ],
+        )
         self.check_summary(alignments[1])
         self.check_reverse_write_read(alignments)
 
@@ -1097,30 +1385,18 @@ class TestAlignIO_reading(unittest.TestCase):
         self.assertEqual(len(alignments[0]), 5)
         self.assertEqual(alignments[0].get_alignment_length(), 42)
         self.check_alignment_columns(
-            alignments[0], ["AAA--",
-                            "AAAAA",
-                            "AAAAA",
-                            "---T-",
-                            "GGGGG",
-                            "GGGGG"])
+            alignments[0], ["AAA--", "AAAAA", "AAAAA", "---T-", "GGGGG", "GGGGG"]
+        )
         self.assertEqual(len(alignments[1]), 5)
         self.assertEqual(alignments[1].get_alignment_length(), 6)
         self.check_alignment_columns(
-            alignments[1], ["TTTTt",
-                            "AAAAa",
-                            "AAAAa",
-                            "AAAAg",
-                            "GGGGg",
-                            "AAAAa"])
+            alignments[1], ["TTTTt", "AAAAa", "AAAAa", "AAAAg", "GGGGg", "AAAAa"]
+        )
         self.assertEqual(len(alignments[2]), 4)
         self.assertEqual(alignments[2].get_alignment_length(), 13)
         self.check_alignment_columns(
-            alignments[2], ["gggA",
-                            "cccC",
-                            "aaaA",
-                            "gggG",
-                            "cccC",
-                            "aaaA"])
+            alignments[2], ["gggA", "cccC", "aaaA", "gggG", "cccC", "aaaA"]
+        )
         self.check_summary(alignments[2])
         self.check_reverse_write_read(alignments)
 
@@ -1136,34 +1412,32 @@ class TestAlignIO_reading(unittest.TestCase):
         self.assertEqual(alignments[0].get_alignment_length(), 164)
         self.check_alignment_rows(
             alignments[0],
-            [("mm9.chr10", "TCATAGGTATTTATTTTTAAATATGGTTTGCTTT...GTT"),
-             ("oryCun1.scaffold_133159", "TCACAGATATTTACTATTAAATATGGTTTGTTAT...GTT")])
+            [
+                ("mm9.chr10", "TCATAGGTATTTATTTTTAAATATGGTTTGCTTT...GTT"),
+                ("oryCun1.scaffold_133159", "TCACAGATATTTACTATTAAATATGGTTTGTTAT...GTT"),
+            ],
+        )
         self.assertEqual(len(alignments[1]), 4)
         self.assertEqual(alignments[1].get_alignment_length(), 466)
         self.check_alignment_rows(
             alignments[1],
-            [("hg18.chr6", "AGTCTTCATAAGTGGAAATATAAGTTTTAATTAT...TTC"),
-             ("mm9.chr10", "AGTCTTTCCAATGGGACCTGTGAGTCCTAACTAT...CTG"),
-             ("panTro2.chr6", "AGTCTTCATAAGTGGAAATATAAGTTTTAATTAT...TTC"),
-             ("ponAbe2.chr6", "AGTCTTCATAAGTGGAAATATAAGTTTTAATTAT...TTC")])
+            [
+                ("hg18.chr6", "AGTCTTCATAAGTGGAAATATAAGTTTTAATTAT...TTC"),
+                ("mm9.chr10", "AGTCTTTCCAATGGGACCTGTGAGTCCTAACTAT...CTG"),
+                ("panTro2.chr6", "AGTCTTCATAAGTGGAAATATAAGTTTTAATTAT...TTC"),
+                ("ponAbe2.chr6", "AGTCTTCATAAGTGGAAATATAAGTTTTAATTAT...TTC"),
+            ],
+        )
         self.assertEqual(len(alignments[2]), 5)
         self.assertEqual(alignments[2].get_alignment_length(), 127)
         self.check_alignment_columns(
-            alignments[2], ["TTTTT",
-                            "GGGGG",
-                            "GGGGG",
-                            "GGGGG",
-                            "TTTTC",
-                            "CCCCC"])
+            alignments[2], ["TTTTT", "GGGGG", "GGGGG", "GGGGG", "TTTTC", "CCCCC"]
+        )
         self.assertEqual(len(alignments[47]), 6)
         self.assertEqual(alignments[47].get_alignment_length(), 46)
         self.check_alignment_columns(
-            alignments[47], ["TTTTTT",
-                             "GGGGGG",
-                             "TTTTTT",
-                             "TTTTTT",
-                             "TGGGAT",
-                             "tTTTT-"])
+            alignments[47], ["TTTTTT", "GGGGGG", "TTTTTT", "TTTTTT", "TGGGAT", "tTTTT-"]
+        )
         self.check_summary(alignments[47])
         self.check_reverse_write_read(alignments)
 
@@ -1179,26 +1453,34 @@ class TestAlignIO_reading(unittest.TestCase):
         self.assertEqual(alignments[0].get_alignment_length(), 5670)
         self.check_alignment_rows(
             alignments[0],
-            [("1/0-5670", "ATATTAGGTTTTTACCTACCCAGGAAAAGCCAAC...AAT"),
-             ("2/0-5670", "ATATTAGGTTTTTACCTACCCAGGAAAAGCCAAC...AAT")])
+            [
+                ("1/0-5670", "ATATTAGGTTTTTACCTACCCAGGAAAAGCCAAC...AAT"),
+                ("2/0-5670", "ATATTAGGTTTTTACCTACCCAGGAAAAGCCAAC...AAT"),
+            ],
+        )
         self.assertEqual(len(alignments[1]), 2)
         self.assertEqual(alignments[1].get_alignment_length(), 4420)
         self.check_alignment_rows(
             alignments[1],
-            [("1/5670-9940", "GAACATCAGCACCTGAGTTGCTAAAGTCATTTAG...CTC"),
-             ("2/7140-11410", "GAACATCAGCACCTGAGTTGCTAAAGTCATTTAG...CTC")])
+            [
+                ("1/5670-9940", "GAACATCAGCACCTGAGTTGCTAAAGTCATTTAG...CTC"),
+                ("2/7140-11410", "GAACATCAGCACCTGAGTTGCTAAAGTCATTTAG...CTC"),
+            ],
+        )
         self.assertEqual(len(alignments[2]), 1)
         self.assertEqual(alignments[2].get_alignment_length(), 4970)
         self.check_alignment_rows(
             alignments[2],
-            [("1/9940-14910", "TCTACCAACCACCACAGACATCAATCACTTCTGC...GAC")])
+            [("1/9940-14910", "TCTACCAACCACCACAGACATCAATCACTTCTGC...GAC")],
+        )
         self.assertEqual(len(alignments[3]), 1)
         self.assertEqual(alignments[3].get_alignment_length(), 1470)
         self.assertEqual(len(alignments[4]), 1)
         self.assertEqual(alignments[4].get_alignment_length(), 1470)
         self.check_alignment_rows(
             alignments[4],
-            [("2/11410-12880", "ATTCGCACATAAGAATGTACCTTGCTGTAATTTA...ATA")])
+            [("2/11410-12880", "ATTCGCACATAAGAATGTACCTTGCTGTAATTTA...ATA")],
+        )
         self.check_summary(alignments[4])
         self.check_reverse_write_read(alignments)
 


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_AlignIO.py, It would be good to review it.