### PR TITLE
Apply black style to test_AlignIO* files, version 19.10b0.

### DIFF
--- a/Tests/test_AlignIO_ClustalIO.py
+++ b/Tests/test_AlignIO_ClustalIO.py
@@ -12,8 +12,8 @@ from Bio.AlignIO.ClustalIO import ClustalIterator, ClustalWriter
 
 # This is a truncated version of the example in Tests/cw02.aln
 # Notice the inclusion of sequence numbers (right hand side)
-aln_example1 = \
-"""CLUSTAL W (1.81) multiple sequence alignment
+aln_example1 = """\
+CLUSTAL W (1.81) multiple sequence alignment
 
 
 gi|4959044|gb|AAD34209.1|AF069      MENSDSNDKGSDQSAAQRRSQMDRLDREEAFYQFVNNLSEEDYRLMRDNN 50
@@ -40,8 +40,8 @@ gi|671626|emb|CAA85685.1|           VAYVKTFQGP 151
 # This example is a truncated version of the dataset used here:
 # http://virgil.ruc.dk/kurser/Sekvens/Treedraw.htm
 # with the last record repeated twice (deliberate toture test)
-aln_example2 = \
-"""CLUSTAL X (1.83) multiple sequence alignment
+aln_example2 = """\
+CLUSTAL X (1.83) multiple sequence alignment
 
 
 V_Harveyi_PATH                 --MKNWIKVAVAAIA--LSAA------------------TVQAATEVKVG
@@ -80,8 +80,8 @@ HISJ_E_COLI                    LKAKKIDAIMSSLSITEKRQQEIAFTDKLYAADSRLV
 """  # noqa : W291
 
 
-aln_example3 = \
-"""CLUSTAL 2.0.9 multiple sequence alignment
+aln_example3 = """\
+CLUSTAL 2.0.9 multiple sequence alignment
 
 
 Test1seq             ------------------------------------------------------------
@@ -145,17 +145,16 @@ AT3G20900.1-CDS      GCTGGGGATGGAGAGGGAACAGAGTAG
                      *************************  
 """  # noqa : W291
 
-aln_example4 = \
-"""Kalign (2.0) alignment in ClustalW format
+aln_example4 = """\
+Kalign (2.0) alignment in ClustalW format
 
 Test1seq             GCTGGGGATGGAGAGGGAACAGAGTT-
 AT3G20900.1-SEQ      GCTGGGGATGGAGAGGGAACAGAGTAG
 
-"""  # noqa: E122 not clear to me, why this comes up here
+"""
 
 
 class TestClustalIO(unittest.TestCase):
-
     def test_one(self):
         alignments = list(ClustalIterator(StringIO(aln_example1)))
         self.assertEqual(1, len(alignments))
@@ -164,12 +163,14 @@ class TestClustalIO(unittest.TestCase):
         self.assertEqual(2, len(alignment))
         self.assertEqual(alignment[0].id, "gi|4959044|gb|AAD34209.1|AF069")
         self.assertEqual(alignment[1].id, "gi|671626|emb|CAA85685.1|")
-        self.assertEqual(str(alignment[0].seq),
-                         "MENSDSNDKGSDQSAAQRRSQMDRLDREEAFYQFVNNLSEEDYRLMRDNN"
-                         "LLGTPGESTEEELLRRLQQIKEGPPPQSPDENRAGESSDDVTNSDSIIDW"
-                         "LNSVRQTGNTTRSRQRGNQSWRAVSRTNPNSGDFRFSLEINVNRNNGSQT"
-                         "SENESEPSTRRLSVENMESSSQRQMENSASESASARPSRAERNSTEAVTE"
-                         "VPTTRAQRRA")
+        self.assertEqual(
+            str(alignment[0].seq),
+            "MENSDSNDKGSDQSAAQRRSQMDRLDREEAFYQFVNNLSEEDYRLMRDNN"
+            "LLGTPGESTEEELLRRLQQIKEGPPPQSPDENRAGESSDDVTNSDSIIDW"
+            "LNSVRQTGNTTRSRQRGNQSWRAVSRTNPNSGDFRFSLEINVNRNNGSQT"
+            "SENESEPSTRRLSVENMESSSQRQMENSASESASARPSRAERNSTEAVTE"
+            "VPTTRAQRRA",
+        )
 
     def test_two(self):
         alignments = list(ClustalIterator(StringIO(aln_example2)))
@@ -178,10 +179,12 @@ class TestClustalIO(unittest.TestCase):
         alignment = alignments[0]
         self.assertEqual(9, len(alignment))
         self.assertEqual(alignment[-1].id, "HISJ_E_COLI")
-        self.assertEqual(str(alignment[-1].seq),
-                         "MKKLVLSLSLVLAFSSATAAF-------------------AAIPQNIRIG"
-                         "TDPTYAPFESKNS-QGELVGFDIDLAKELCKRINTQCTFVENPLDALIPS"
-                         "LKAKKIDAIMSSLSITEKRQQEIAFTDKLYAADSRLV")
+        self.assertEqual(
+            str(alignment[-1].seq),
+            "MKKLVLSLSLVLAFSSATAAF-------------------AAIPQNIRIG"
+            "TDPTYAPFESKNS-QGELVGFDIDLAKELCKRINTQCTFVENPLDALIPS"
+            "LKAKKIDAIMSSLSITEKRQQEIAFTDKLYAADSRLV",
+        )
 
     def test_cat_one_two(self):
         alignments = list(ClustalIterator(StringIO(aln_example2 + aln_example1)))
@@ -197,13 +200,17 @@ class TestClustalIO(unittest.TestCase):
 
     def test_write_read(self):
         """Checking write/read."""
-        alignments = (list(ClustalIterator(StringIO(aln_example1)))
-                      + list(ClustalIterator(StringIO(aln_example2))) * 2)
+        alignments = (
+            list(ClustalIterator(StringIO(aln_example1)))
+            + list(ClustalIterator(StringIO(aln_example2))) * 2
+        )
         handle = StringIO()
         self.assertEqual(3, ClustalWriter(handle).write_file(alignments))
         handle.seek(0)
         for i, a in enumerate(ClustalIterator(handle)):
-            self.assertEqual(a.get_alignment_length(), alignments[i].get_alignment_length())
+            self.assertEqual(
+                a.get_alignment_length(), alignments[i].get_alignment_length()
+            )
 
     def test_write_read_single(self):
         """Testing write/read when there is only one sequence."""

--- a/Tests/test_AlignIO_EmbossIO.py
+++ b/Tests/test_AlignIO_EmbossIO.py
@@ -12,8 +12,8 @@ from io import StringIO
 from Bio.AlignIO.EmbossIO import EmbossIterator
 
 # http://emboss.sourceforge.net/docs/themes/alnformats/align.simple
-simple_example = \
-"""########################################
+simple_example = """\
+########################################
 # Program:  alignret
 # Rundate:  Wed Jan 16 17:16:13 2002
 # Report_file: stdout
@@ -63,8 +63,8 @@ IXI_237           94 SRPNRFAPTLMSSCLTSTTGPPAYAGDRSHE    124
 """  # noqa: E122 not clear to me, why this comes up here
 
 # http://emboss.sourceforge.net/docs/themes/alnformats/align.pair
-pair_example = \
-"""########################################
+pair_example = """\
+########################################
 # Program:  water
 # Rundate:  Wed Jan 16 17:23:19 2002
 # Report_file: stdout
@@ -106,8 +106,8 @@ IXI_235           82 SRPNRFAPTLMSSCITSTTGPPAWAGDRSHE    112
 
 """  # noqa : W291
 
-pair_example2 = \
-"""########################################
+pair_example2 = """\
+########################################
 # Program: needle
 # Rundate: Sun 27 Apr 2007 17:20:35
 # Commandline: needle
@@ -369,7 +369,6 @@ asis             311 -----------------    311
 
 
 class TestEmbossIO(unittest.TestCase):
-
     def test_pair_example(self):
         alignments = list(EmbossIterator(StringIO(pair_example)))
         self.assertEqual(len(alignments), 1)
@@ -380,7 +379,9 @@ class TestEmbossIO(unittest.TestCase):
         alignments = list(EmbossIterator(StringIO(simple_example)))
         self.assertEqual(len(alignments), 1)
         self.assertEqual(len(alignments[0]), 4)
-        self.assertEqual([r.id for r in alignments[0]], ["IXI_234", "IXI_235", "IXI_236", "IXI_237"])
+        self.assertEqual(
+            [r.id for r in alignments[0]], ["IXI_234", "IXI_235", "IXI_236", "IXI_237"]
+        )
 
     def test_pair_plus_simple(self):
         alignments = list(EmbossIterator(StringIO(pair_example + simple_example)))
@@ -388,14 +389,20 @@ class TestEmbossIO(unittest.TestCase):
         self.assertEqual(len(alignments[0]), 2)
         self.assertEqual(len(alignments[1]), 4)
         self.assertEqual([r.id for r in alignments[0]], ["IXI_234", "IXI_235"])
-        self.assertEqual([r.id for r in alignments[1]], ["IXI_234", "IXI_235", "IXI_236", "IXI_237"])
+        self.assertEqual(
+            [r.id for r in alignments[1]], ["IXI_234", "IXI_235", "IXI_236", "IXI_237"]
+        )
 
     def test_pair_example2(self):
         alignments = list(EmbossIterator(StringIO(pair_example2)))
         self.assertEqual(len(alignments), 5)
         self.assertEqual(len(alignments[0]), 2)
-        self.assertEqual([r.id for r in alignments[0]], ["ref_rec", "gi|94968718|receiver"])
-        self.assertEqual([r.id for r in alignments[4]], ["ref_rec", "gi|94970041|receiver"])
+        self.assertEqual(
+            [r.id for r in alignments[0]], ["ref_rec", "gi|94968718|receiver"]
+        )
+        self.assertEqual(
+            [r.id for r in alignments[4]], ["ref_rec", "gi|94970041|receiver"]
+        )
 
     def test_pair_example3(self):
         alignments = list(EmbossIterator(StringIO(pair_example3)))

--- a/Tests/test_AlignIO_FastaIO.py
+++ b/Tests/test_AlignIO_FastaIO.py
@@ -818,9 +818,7 @@ class FastaIOTests(unittest.TestCase):
             self.assertEqual(alignments[11][0].seq, "AQQQESATTQKAEKEVTRMVIIMVIAFLICW")
             self.assertEqual(alignments[11][0].id, "sp|P08100|OPSD_HUMAN")
             self.assertEqual(alignments[11][0].annotations["original_length"], 348)
-            self.assertEqual(
-                alignments[11][1].seq, "SQQIRNATTMMMTMRVTSFSAFWVVADSCCW"
-            )
+            self.assertEqual(alignments[11][1].seq, "SQQIRNATTMMMTMRVTSFSAFWVVADSCCW")
             self.assertEqual(alignments[11][1].id, "gi|283855822|gb|GQ290312.1|")
             self.assertEqual(alignments[11][1].annotations["original_length"], 983)
 

--- a/Tests/test_AlignIO_MauveIO.py
+++ b/Tests/test_AlignIO_MauveIO.py
@@ -16,8 +16,9 @@ from Bio import SeqIO
 
 
 class TestMauveIO(unittest.TestCase):
-    MAUVE_TEST_DATA_DIR = os.path.join(os.path.dirname(
-        os.path.realpath(__file__)), "Mauve")
+    MAUVE_TEST_DATA_DIR = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "Mauve"
+    )
     SIMPLE_XMFA = os.path.join(MAUVE_TEST_DATA_DIR, "simple.xmfa")
     SIMPLE_FA = os.path.join(MAUVE_TEST_DATA_DIR, "simple.fa")
 
@@ -28,7 +29,18 @@ class TestMauveIO(unittest.TestCase):
                 for record in alignment:
                     ids.append(record.id)
 
-        self.assertEqual(ids, ["1/0-5670", "2/0-5670", "1/5670-9940", "2/7140-11410", "1/9940-14910", "2/5670-7140", "2/11410-12880"])
+        self.assertEqual(
+            ids,
+            [
+                "1/0-5670",
+                "2/0-5670",
+                "1/5670-9940",
+                "2/7140-11410",
+                "1/9940-14910",
+                "2/5670-7140",
+                "2/11410-12880",
+            ],
+        )
 
         expected = """ATTCGCACAT AAGAATGTAC CTTGCTGTAA TTTATACTCA
             GCAGGTGGTG CAGACATCAT AACAAAAGAA GACTCTTGTT GTACTAGATA TTGTGTAGCA
@@ -55,8 +67,10 @@ class TestMauveIO(unittest.TestCase):
             ATGCATATAG GCATTAATTT TCTTGTCTCT TCAGCATGAG CAAGCATTTC TCTCAAATTC
             CAGGATACAG TTCCTAGAAT CTCTTCCTTA GCATTAGGTG CTTCTGAAGG TAGTACATAA
             AATGCAGATT TGCATTTCTT AAGAGCAGTC TTAGCTTCCT CAAGTGTATA """
-        self.assertEqual(str(record.seq).replace("-", ""),
-                         expected.replace(" ", "").replace("\n", ""))
+        self.assertEqual(
+            str(record.seq).replace("-", ""),
+            expected.replace(" ", "").replace("\n", ""),
+        )
 
     def test_sequence_positions(self):
         with open(self.SIMPLE_FA) as handle:
@@ -72,8 +86,9 @@ class TestMauveIO(unittest.TestCase):
                     # seqs 0, 1 are ids 1, 2
                     actual = seqs[int(record.name) - 1].seq
                     # Slice out portion mentioned in file
-                    actual = actual[record.annotations["start"]:
-                                    record.annotations["end"]]
+                    actual = actual[
+                        record.annotations["start"] : record.annotations["end"]
+                    ]
 
                     if record.annotations["strand"] < 0:
                         actual = actual.reverse_complement()

--- a/Tests/test_AlignIO_PhylipIO.py
+++ b/Tests/test_AlignIO_PhylipIO.py
@@ -129,22 +129,37 @@ Gorilla   AAACCCTTGC CGGTACGCTT AAACCATTGC CGGTACGCTT AA"""
 
 
 class TestPhylipIO(unittest.TestCase):
-
     def test_one(self):
         handle = StringIO(phylip_text)
         ids = []
         for alignment in PhylipIterator(handle):
             for record in alignment:
                 ids.append(record.id)
-        self.assertEqual(ids, ["V_Harveyi_", "B_subtilis", "B_subtilis",
-                               "YA80_HAEIN", "FLIY_ECOLI", "E_coli_Gln",
-                               "Deinococcu", "HISJ_E_COL"])
+        self.assertEqual(
+            ids,
+            [
+                "V_Harveyi_",
+                "B_subtilis",
+                "B_subtilis",
+                "YA80_HAEIN",
+                "FLIY_ECOLI",
+                "E_coli_Gln",
+                "Deinococcu",
+                "HISJ_E_COL",
+            ],
+        )
 
-        expected = """mkklvlslsl vlafssataa faaipqniri gtdptyapfe sknsqgelvg
+        expected = (
+            """mkklvlslsl vlafssataa faaipqniri gtdptyapfe sknsqgelvg
         fdidlakelc krintqctfv enpldalips lkakkidaim sslsitekrq qeiaftdkly
         aadsrlvvak nsdiqptves lkgkrvgvlq gttqetfgne hwapkgieiv syqgqdniys
         dltagridaafqdevaaseg flkqpvgkdy kfggpsvkde klfgvgtgmg lrkednelre
-        alnkafaemradgtyeklak kyfdfdvygg""".replace(" ", "").replace("\n", "").upper()
+        alnkafaemradgtyeklak kyfdfdvygg""".replace(
+                " ", ""
+            )
+            .replace("\n", "")
+            .upper()
+        )
         self.assertEqual(str(record.seq).replace("-", ""), expected)
 
     def test_two_and_three(self):

--- a/Tests/test_AlignIO_convert.py
+++ b/Tests/test_AlignIO_convert.py
@@ -57,18 +57,23 @@ tests = [
     ("Fasta/output001.m10", "fasta-m10", None),
     ("IntelliGenetics/VIF_mase-pro.txt", "ig", generic_protein),
     ("NBRF/clustalw.pir", "pir", None),
-    ]
+]
 output_formats = ["fasta"] + sorted(AlignIO._FormatToWriter)
 
 for filename, in_format, alphabet in tests:
     for out_format in output_formats:
+
         def funct(fn, fmt1, fmt2, alpha):
             f = lambda x: x.simple_check(fn, fmt1, fmt2, alpha)  # noqa: E731
             f.__doc__ = "Convert %s from %s to %s" % (fn, fmt1, fmt2)
             return f
-        setattr(ConvertTests, "test_%s_%s_to_%s"
-                % (filename.replace("/", "_").replace(".", "_"), in_format, out_format),
-                funct(filename, in_format, out_format, alphabet))
+
+        setattr(
+            ConvertTests,
+            "test_%s_%s_to_%s"
+            % (filename.replace("/", "_").replace(".", "_"), in_format, out_format),
+            funct(filename, in_format, out_format, alphabet),
+        )
     del funct
 
 if __name__ == "__main__":


### PR DESCRIPTION

This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_AlignIO* files listed below, small changes per file should be fine to merge.
test_AlignIO_ClustalIO.py
test_AlignIO_convert.py
test_AlignIO_EmbossIO.py
test_AlignIO_FastaIO.py
test_AlignIO_MauveIO.py
test_AlignIO_PhylipIO.py