### PR TITLE
Apply black style to test_XXmotif_tool.py, version 19.10b0.

### DIFF
--- a/Tests/test_XXmotif_tool.py
+++ b/Tests/test_XXmotif_tool.py
@@ -23,20 +23,23 @@ os.environ["LANG"] = "C"
 xxmotif_exe = None
 if sys.platform == "win32":
     # TODO
-    raise MissingExternalDependencyError("Testing this on Windows is not implemented yet")
+    raise MissingExternalDependencyError(
+        "Testing this on Windows is not implemented yet"
+    )
 else:
     from subprocess import getoutput
+
     output = getoutput("XXmotif")
     if output.find("== XXmotif version") != -1:
         xxmotif_exe = "XXmotif"
 
 if not xxmotif_exe:
     raise MissingExternalDependencyError(
-        "Install XXmotif if you want to use XXmotif from Biopython.")
+        "Install XXmotif if you want to use XXmotif from Biopython."
+    )
 
 
 class XXmotifTestCase(unittest.TestCase):
-
     def setUp(self):
         self.out_dir = "xxmotif-temp"
         self.files_to_clean = set()
@@ -84,14 +87,12 @@ class XXmotifTestCase(unittest.TestCase):
 
 
 class XXmotifTestErrorConditions(XXmotifTestCase):
-
     def test_empty_file(self):
         """Test a non-existing input file."""
         input_file = "does_not_exist.fasta"
         self.assertFalse(os.path.isfile(input_file))
 
-        cline = XXmotifCommandline(outdir=self.out_dir,
-                                   seqfile=input_file)
+        cline = XXmotifCommandline(outdir=self.out_dir, seqfile=input_file)
 
         try:
             stdout, stderr = cline()
@@ -104,8 +105,7 @@ class XXmotifTestErrorConditions(XXmotifTestCase):
         """Test an input file in an invalid format."""
         input_file = self.copy_and_mark_for_cleanup("Medline/pubmed_result1.txt")
 
-        cline = XXmotifCommandline(outdir=self.out_dir,
-                                   seqfile=input_file)
+        cline = XXmotifCommandline(outdir=self.out_dir, seqfile=input_file)
 
         try:
             stdout, stderr = cline()
@@ -128,7 +128,6 @@ class XXmotifTestErrorConditions(XXmotifTestCase):
 
 
 class XXmotifTestNormalConditions(XXmotifTestCase):
-
     def test_fasta_one_sequence(self):
         """Test a fasta input file containing only one sequence."""
         record = list(SeqIO.parse("Registry/seqs.fasta", "fasta"))[0]
@@ -136,8 +135,7 @@ class XXmotifTestNormalConditions(XXmotifTestCase):
         with open(input_file, "w") as handle:
             SeqIO.write(record, handle, "fasta")
 
-        cline = XXmotifCommandline(outdir=self.out_dir,
-                                   seqfile=input_file)
+        cline = XXmotifCommandline(outdir=self.out_dir, seqfile=input_file)
 
         self.add_file_to_clean(input_file)
         self.standard_test_procedure(cline)
@@ -146,8 +144,7 @@ class XXmotifTestNormalConditions(XXmotifTestCase):
         """Test setting options via properties."""
         input_file = self.copy_and_mark_for_cleanup("Fasta/f002")
 
-        cline = XXmotifCommandline(outdir=self.out_dir,
-                                   seqfile=input_file)
+        cline = XXmotifCommandline(outdir=self.out_dir, seqfile=input_file)
 
         cline.revcomp = True
         cline.pseudo = 20
@@ -162,8 +159,7 @@ class XXmotifTestNormalConditions(XXmotifTestCase):
         with open(input_file, "w") as handle:
             SeqIO.write(records, handle, "fasta")
 
-        cline = XXmotifCommandline(outdir=self.out_dir,
-                                   seqfile=input_file)
+        cline = XXmotifCommandline(outdir=self.out_dir, seqfile=input_file)
 
         self.add_file_to_clean(input_file)
         self.standard_test_procedure(cline)
@@ -175,8 +171,7 @@ class XXmotifTestNormalConditions(XXmotifTestCase):
         with open(input_file, "w") as handle:
             SeqIO.write(records, handle, "fasta")
 
-        cline = XXmotifCommandline(outdir=self.out_dir,
-                                   seqfile=input_file)
+        cline = XXmotifCommandline(outdir=self.out_dir, seqfile=input_file)
 
         self.add_file_to_clean(input_file)
         self.standard_test_procedure(cline)


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black style to test_XXmotif_tool.py, small changes should be fine to merge.