### PR TITLE
don't add tests at runtime in test_AlignIO_convert.py

### DIFF
--- a/Tests/test_AlignIO_convert.py
+++ b/Tests/test_AlignIO_convert.py
@@ -11,70 +11,53 @@ from Bio import AlignIO
 from Bio.Alphabet import generic_protein, generic_nucleotide, generic_dna
 
 
-# Top level function as this makes it easier to use for debugging:
-def check_convert(in_filename, in_format, out_format, alphabet=None):
-    # Write it out using parse/write
-    handle = StringIO()
-    aligns = list(AlignIO.parse(in_filename, in_format, None, alphabet))
-    try:
-        count = AlignIO.write(aligns, handle, out_format)
-    except ValueError:
-        count = 0
-    # Write it out using convert passing filename and handle
-    handle2 = StringIO()
-    try:
-        count2 = AlignIO.convert(in_filename, in_format, handle2, out_format, alphabet)
-    except ValueError:
-        count2 = 0
-    assert count == count2
-    assert handle.getvalue() == handle2.getvalue()
-    # Write it out using convert passing handle and handle
-    handle2 = StringIO()
-    try:
-        with open(in_filename) as handle1:
-            count2 = AlignIO.convert(handle1, in_format, handle2, out_format, alphabet)
-    except ValueError:
-        count2 = 0
-    assert count == count2
-    assert handle.getvalue() == handle2.getvalue()
-    # TODO - convert passing an output filename?
-
-
 class ConvertTests(unittest.TestCase):
-    """Cunning unit test where methods are added at run time."""
 
-    def simple_check(self, filename, in_format, out_format, alphabet):
-        check_convert(filename, in_format, out_format, alphabet)
+    def check_convert(self, in_filename, in_format, out_format, alphabet=None):
+        # Write it out using parse/write
+        msg = "Failed converting %s from %s to %s" % (in_filename, in_format, out_format)
+        handle = StringIO()
+        aligns = list(AlignIO.parse(in_filename, in_format, None, alphabet))
+        try:
+            count = AlignIO.write(aligns, handle, out_format)
+        except ValueError:
+            count = 0
+        # Write it out using convert passing filename and handle
+        handle2 = StringIO()
+        try:
+            count2 = AlignIO.convert(in_filename, in_format, handle2, out_format, alphabet)
+        except ValueError:
+            count2 = 0
+        self.assertEqual(count, count2, msg=msg)
+        self.assertEqual(handle.getvalue(), handle2.getvalue(), msg=msg)
+        # Write it out using convert passing handle and handle
+        handle2 = StringIO()
+        try:
+            with open(in_filename) as handle1:
+                count2 = AlignIO.convert(handle1, in_format, handle2, out_format, alphabet)
+        except ValueError:
+            count2 = 0
+        self.assertEqual(count, count2, msg=msg)
+        self.assertEqual(handle.getvalue(), handle2.getvalue(), msg=msg)
+        # TODO - convert passing an output filename?
 
 
-tests = [
-    ("Clustalw/hedgehog.aln", "clustal", None),
-    ("Nexus/test_Nexus_input.nex", "nexus", None),
-    ("Stockholm/simple.sth", "stockholm", None),
-    ("GFF/multi.fna", "fasta", generic_nucleotide),
-    ("Quality/example.fastq", "fastq", None),
-    ("Quality/example.fastq", "fastq-sanger", generic_dna),
-    ("Fasta/output001.m10", "fasta-m10", None),
-    ("IntelliGenetics/VIF_mase-pro.txt", "ig", generic_protein),
-    ("NBRF/clustalw.pir", "pir", None),
-]
-output_formats = ["fasta"] + sorted(AlignIO._FormatToWriter)
+    def test_convert(self):
+        tests = [("Clustalw/hedgehog.aln", "clustal", None),
+                 ("Nexus/test_Nexus_input.nex", "nexus", None),
+                 ("Stockholm/simple.sth", "stockholm", None),
+                 ("GFF/multi.fna", "fasta", generic_nucleotide),
+                 ("Quality/example.fastq", "fastq", None),
+                 ("Quality/example.fastq", "fastq-sanger", generic_dna),
+                 ("Fasta/output001.m10", "fasta-m10", None),
+                 ("IntelliGenetics/VIF_mase-pro.txt", "ig", generic_protein),
+                 ("NBRF/clustalw.pir", "pir", None),
+                 ]
+        output_formats = ["fasta"] + sorted(AlignIO._FormatToWriter)
+        for filename, in_format, alphabet in tests:
+            for out_format in output_formats:
+                self.check_convert(filename, in_format, out_format, alphabet)
 
-for filename, in_format, alphabet in tests:
-    for out_format in output_formats:
-
-        def funct(fn, fmt1, fmt2, alpha):
-            f = lambda x: x.simple_check(fn, fmt1, fmt2, alpha)  # noqa: E731
-            f.__doc__ = "Convert %s from %s to %s" % (fn, fmt1, fmt2)
-            return f
-
-        setattr(
-            ConvertTests,
-            "test_%s_%s_to_%s"
-            % (filename.replace("/", "_").replace(".", "_"), in_format, out_format),
-            funct(filename, in_format, out_format, alphabet),
-        )
-    del funct
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)

--- a/Tests/test_AlignIO_convert.py
+++ b/Tests/test_AlignIO_convert.py
@@ -41,7 +41,6 @@ class ConvertTests(unittest.TestCase):
         self.assertEqual(handle.getvalue(), handle2.getvalue(), msg=msg)
         # TODO - convert passing an output filename?
 
-
     def test_convert(self):
         tests = [("Clustalw/hedgehog.aln", "clustal", None),
                  ("Nexus/test_Nexus_input.nex", "nexus", None),


### PR DESCRIPTION
This pull request modifies `test_AlignIO_convert.py` in three ways:

- No tests are added at run time;
- Error messages specify the file being tested and the input and out formats (I guess this was the original purpose of adding tests at run time);
- Plain `assert`s are replaced by `unittest` ones.

For comparison, this is what the error message looks like in case of a test failure:

Original:
```
======================================================================
FAIL: test_Clustalw_hedgehog_aln_clustal_to_fasta (__main__.ConvertTests)
Convert Clustalw/hedgehog.aln from clustal to fasta
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_AlignIO_convert.py", line 66, in <lambda>
    f = lambda x: x.simple_check(fn, fmt1, fmt2, alpha)  # noqa: E731
  File "test_AlignIO_convert.py", line 47, in simple_check
    check_convert(filename, in_format, out_format, alphabet)
  File "test_AlignIO_convert.py", line 29, in check_convert
    assert count == count2 + 10
AssertionError
```

New:
```
======================================================================
FAIL: test_convert (__main__.ConvertTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_AlignIO_convert.py", line 59, in test_convert
    self.check_convert(filename, in_format, out_format, alphabet)
  File "test_AlignIO_convert.py", line 31, in check_convert
    self.assertEqual(count, count2+10, msg=msg)
AssertionError: 1 != 11 : Failed converting Clustalw/hedgehog.aln from clustal to fasta

----------------------------------------------------------------------
```

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
