### PR TITLE
Use unittest in test_PopGen_GenePop.py    

### DIFF
--- a/Tests/test_PopGen_GenePop.py
+++ b/Tests/test_PopGen_GenePop.py
@@ -64,14 +64,7 @@ class AppTest(unittest.TestCase):
         """Test Nm estimation."""
         ctrl = GenePopController()
         path = os.path.join("PopGen", "big.gen")
-        ( mean_sample_size,
-            mean_priv_alleles,
-            mig10,
-            mig25,
-            mig50,
-            mig_corrected,
-        ) = ctrl.estimate_nm(path)
-
+        mean_sample_size, mean_priv_alleles, mig10, mig25, mig50, mig_corrected = ctrl.estimate_nm(path)
         self.assertAlmostEqual(mean_sample_size, 28.0)
         self.assertAlmostEqual(mean_priv_alleles, 0.016129)
         self.assertAlmostEqual(mig10, 52.5578)

--- a/Tests/test_PopGen_GenePop.py
+++ b/Tests/test_PopGen_GenePop.py
@@ -35,9 +35,8 @@ class AppTest(unittest.TestCase):
     def test_allele_genotype_frequencies(self):
         """Test genepop execution on basic allele and genotype frequencies."""
         ctrl = GenePopController()
-        pop_iter, locus_iter = ctrl.calc_allele_genotype_freqs(
-            "PopGen" + os.sep + "big.gen"
-        )
+        path = os.path.join("PopGen", "big.gen")
+        pop_iter, locus_iter = ctrl.calc_allele_genotype_freqs(path)
         # print("%s %s" % (pop, loci))
         # for popc in pop_iter:
         #    pop_name, loci_content = popc
@@ -53,56 +52,52 @@ class AppTest(unittest.TestCase):
     def test_calc_diversities_fis_with_identity(self):
         """Test calculations of diversities."""
         ctrl = GenePopController()
-        iter, avg_fis, avg_Qintra = ctrl.calc_diversities_fis_with_identity(
-            "PopGen" + os.sep + "big.gen"
-        )
+        path = os.path.join("PopGen", "big.gen")
+        iter, avg_fis, avg_Qintra = ctrl.calc_diversities_fis_with_identity(path)
         liter = list(iter)
-        assert len(liter) == 37
-        assert liter[0][0] == "Locus1"
-        assert len(avg_fis) == 10
-        assert len(avg_Qintra) == 10
+        self.assertEqual(len(liter), 37)
+        self.assertEqual(liter[0][0], "Locus1")
+        self.assertEqual(len(avg_fis), 10)
+        self.assertEqual(len(avg_Qintra), 10)
 
     def test_estimate_nm(self):
         """Test Nm estimation."""
         ctrl = GenePopController()
-        (
-            mean_sample_size,
+        path = os.path.join("PopGen", "big.gen")
+        ( mean_sample_size,
             mean_priv_alleles,
             mig10,
             mig25,
             mig50,
             mig_corrected,
-        ) = ctrl.estimate_nm("PopGen" + os.sep + "big.gen")
-        assert (
-            mean_sample_size,
-            mean_priv_alleles,
-            mig10,
-            mig25,
-            mig50,
-            mig_corrected,
-        ) == (28.0, 0.016129, 52.5578, 15.3006, 8.94583, 13.6612)
+        ) = ctrl.estimate_nm(path)
+
+        self.assertAlmostEqual(mean_sample_size, 28.0)
+        self.assertAlmostEqual(mean_priv_alleles, 0.016129)
+        self.assertAlmostEqual(mig10, 52.5578)
+        self.assertAlmostEqual(mig25, 15.3006)
+        self.assertAlmostEqual(mig50, 8.94583)
+        self.assertAlmostEqual(mig_corrected, 13.6612)
 
     def test_fst_all(self):
         """Test genepop execution on all fst."""
         ctrl = GenePopController()
-        (allFis, allFst, allFit), itr = ctrl.calc_fst_all(
-            "PopGen" + os.sep + "c2line.gen"
-        )
+        path = os.path.join("PopGen", "c2line.gen")
+        (allFis, allFst, allFit), itr = ctrl.calc_fst_all(path)
         results = list(itr)
-        assert len(results) == 3
-        assert results[0][0] == "136255903"
-        assert results[1][3] - 0.33 < 0.01
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0][0], "136255903")
+        self.assertAlmostEqual(results[1][3], 0.335846)
 
     def test_haploidy(self):
         """Test haploidy."""
         ctrl = GenePopController()
-        (allFis, allFst, allFit), itr = ctrl.calc_fst_all(
-            "PopGen" + os.sep + "haplo.gen"
-        )
+        path = os.path.join("PopGen", "haplo.gen")
+        (allFis, allFst, allFit), itr = ctrl.calc_fst_all(path)
         litr = list(itr)
-        assert not isinstance(allFst, int)
-        assert len(litr) == 37
-        assert litr[36][0] == "Locus37"
+        self.assertNotIsInstance(allFst, int)
+        self.assertEqual(len(litr), 37)
+        self.assertEqual(litr[36][0], "Locus37")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In test_PopGen_GenePop.py, use `unittest` asserts instead of plain ones.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
