### PR TITLE
use assertIn in test_SeqFeature.py

### DIFF
--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -99,19 +99,19 @@ class TestFeatureLocation(unittest.TestCase):
         expected = "must be greater than or equal to start location"
         with self.assertRaises(ValueError) as err:
             FeatureLocation(42, 23, 1)
-        assert expected in str(err.exception)
+        self.assertIn(expected, str(err.exception))
 
         with self.assertRaises(ValueError) as err:
             FeatureLocation(42, 0, 1)
-        assert expected in str(err.exception)
+        self.assertIn(expected, str(err.exception))
 
         with self.assertRaises(ValueError) as err:
             FeatureLocation(BeforePosition(42), AfterPosition(23), -1)
-        assert expected in str(err.exception)
+        self.assertIn(expected, str(err.exception))
 
         with self.assertRaises(ValueError) as err:
             FeatureLocation(42, AfterPosition(0), 1)
-        assert expected in str(err.exception)
+        self.assertIn(expected, str(err.exception))
 
         # Features with UnknownPositions should pass check
         FeatureLocation(42, UnknownPosition())


### PR DESCRIPTION
Trivial change in test_SeqFeature.py to use `assertIn` instead of a plain `assert`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
