### PR TITLE
use unittest API in test_SeqIO.py

### DIFF
--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -75,7 +75,7 @@ test_write_read_alignment_formats.remove("gb")  # an alias for genbank
 test_write_read_alignment_formats.remove("fastq-sanger")  # an alias for fastq
 
 
-class SeqIOTestsBaseClass(unittest.TestCase):
+class SeqIOTestBaseClass(unittest.TestCase):
     """Base class for Bio.SeqIO unit tests."""
 
     modes = {}
@@ -185,43 +185,33 @@ class TestZipped(unittest.TestCase):
                 list(SeqIO.parse(handle, "gb"))
 
 
-class TestSeqIO(SeqIOTestsBaseClass):
+class TestSeqIO(SeqIOTestBaseClass):
     def setUp(self):
         self.addTypeEqualityFunc(SeqRecord, self.compare_record)
 
     def compare_record(self, record_one, record_two, msg=None):
         """Attempt strict SeqRecord comparison."""
-        if not isinstance(record_one, SeqRecord):
-            self.failureException(msg)
-        if not isinstance(record_two, SeqRecord):
-            self.failureException(msg)
-        if record_one.seq is None:
-            self.failureException(msg)
-        if record_two.seq is None:
-            self.failureException(msg)
-        if record_one.id != record_two.id:
-            self.failureException(msg)
-        if record_one.name != record_two.name:
-            self.failureException(msg)
-        if record_one.description != record_two.description:
-            self.failureException(msg)
-        if len(record_one) != len(record_two):
-            self.failureException(msg)
+        self.assertIsInstance(record_one, SeqRecord, msg=msg)
+        self.assertIsInstance(record_two, SeqRecord, msg=msg)
+        self.assertIsNotNone(record_one.seq, msg=msg)
+        self.assertIsNotNone(record_two.seq, msg=msg)
+        self.assertEqual(record_one.id, record_two.id, msg=msg)
+        self.assertEqual(record_one.name, record_two.name, msg=msg)
+        self.assertEqual(record_one.description, record_two.description, msg=msg)
+        self.assertEqual(len(record_one), len(record_two), msg=msg)
         if isinstance(record_one.seq, UnknownSeq) and isinstance(
             record_two.seq, UnknownSeq
         ):
             # Jython didn't like us comparing the string of very long UnknownSeq
             # object (out of heap memory error)
-            if record_one.seq._character != record_two.seq._character:
-                self.failureException(msg)
-        elif str(record_one.seq) != str(record_two.seq):
-            self.failureException(msg)
+            self.assertEqual(record_one.seq._character, record_two.seq._character, msg=msg)
+        else:
+            self.assertEqual(str(record_one.seq), str(record_two.seq), msg=msg)
         # TODO - check features and annotation (see code for BioSQL tests)
         for key in set(record_one.letter_annotations).intersection(
             record_two.letter_annotations
         ):
-            if record_one.letter_annotations[key] != record_two.letter_annotations[key]:
-                self.failureException(msg)
+            self.assertEqual(record_one.letter_annotations[key], record_two.letter_annotations[key], msg=msg)
 
     def check_simple_write_read(self, records, t_format, t_count, messages):
         """Check can write/read given records.

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -30,7 +30,7 @@ from Bio import BiopythonParserWarning
 from Bio import MissingPythonDependencyError
 
 from seq_tests_common import compare_record
-from test_SeqIO import SeqIOTestsBaseClass
+from test_SeqIO import SeqIOTestBaseClass
 
 
 CUR_DIR = os.getcwd()
@@ -333,7 +333,7 @@ if sqlite3:
             )
 
 
-class IndexDictTests(SeqIOTestsBaseClass):
+class IndexDictTests(SeqIOTestBaseClass):
 
     tests = [
         ("Ace/contig1.ace", "ace", generic_dna),

--- a/Tests/test_SeqIO_write.py
+++ b/Tests/test_SeqIO_write.py
@@ -16,7 +16,7 @@ from Bio import AlignIO
 from Bio.SeqRecord import SeqRecord
 from Bio.Seq import Seq
 from Bio import Alphabet
-from test_SeqIO import SeqIOTestsBaseClass
+from test_SeqIO import SeqIOTestBaseClass
 
 
 # List of formats including alignment only file formats we can read AND write.
@@ -76,7 +76,7 @@ test_records[4][0][2].annotations["comment"] = (
 test_records[4][0][2].annotations["weight"] = 2.5
 
 
-class WriterTests(SeqIOTestsBaseClass):
+class WriterTests(SeqIOTestBaseClass):
     """Cunning unit test where methods are added at run time."""  # TODO - Let's not be cunning
 
     def check(self, records, format):


### PR DESCRIPTION
This pull request replaces tests in test_SeqIO.py by the unittest functions from the current API.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
