### PR TITLE
get rid of BinaryFormats, and dont open a file prematurely

### DIFF
--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -481,19 +481,6 @@ _FormatToWriter = {
     "xdna": XdnaIO.XdnaWriter,
 }
 
-_BinaryFormats = [
-    "sff",
-    "sff-trim",
-    "abi",
-    "abi-trim",
-    "gck",
-    "seqxml",
-    "snapgene",
-    "nib",
-    "seqxml",
-    "xdna",
-]
-
 
 def write(sequences, handle, format):
     """Write complete set of sequences to a file.
@@ -1044,8 +1031,7 @@ def convert(in_file, in_format, out_file, out_format, alphabet=None):
      - alphabet - optional alphabet to assume
 
     **NOTE** - If you provide an output filename, it will be opened which will
-    overwrite any existing file without warning. This may happen if even
-    the conversion is aborted (e.g. an invalid out_format name is given).
+    overwrite any existing file without warning.
 
     For example, going from a filename to a handle:
 
@@ -1063,19 +1049,10 @@ def convert(in_file, in_format, out_file, out_format, alphabet=None):
     GTTGCTTCTGGCGTGGGTGGGGGGG
     <BLANKLINE>
     """
-    in_mode = "rb" if in_format in _BinaryFormats else "r"
 
-    out_mode = "wb" if out_format in _BinaryFormats else "w"
-
-    # This will check the arguments and issue error messages,
-    # after we have opened the file which is a shame.
     from ._convert import _handle_convert  # Lazy import
 
-    with as_handle(in_file, in_mode) as in_handle:
-        with as_handle(out_file, out_mode) as out_handle:
-            count = _handle_convert(
-                in_handle, in_format, out_handle, out_format, alphabet
-            )
+    count = _handle_convert(in_file, in_format, out_file, out_format, alphabet)
     return count
 
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -1049,7 +1049,6 @@ def convert(in_file, in_format, out_file, out_format, alphabet=None):
     GTTGCTTCTGGCGTGGGTGGGGGGG
     <BLANKLINE>
     """
-
     from ._convert import _handle_convert  # Lazy import
 
     count = _handle_convert(in_file, in_format, out_file, out_format, alphabet)

--- a/Bio/SeqIO/_convert.py
+++ b/Bio/SeqIO/_convert.py
@@ -28,6 +28,8 @@ All these file format specific optimisations are handled by this (private) modul
 
 from Bio import BiopythonWarning
 from Bio import SeqIO
+from Bio.File import as_handle
+
 
 # NOTE - Lots of lazy imports further on...
 
@@ -410,14 +412,17 @@ _converter = {
 }
 
 
-def _handle_convert(in_handle, in_format, out_handle, out_format, alphabet=None):
+def _handle_convert(in_file, in_format, out_file, out_format, alphabet=None):
     """Convert handles from one format to another (PRIVATE)."""
+
     try:
         f = _converter[(in_format, out_format)]
     except KeyError:
         f = None
     if f:
-        return f(in_handle, out_handle, alphabet)
+        with as_handle(in_file, "r") as in_handle:
+            with as_handle(out_file, "w") as out_handle:
+                return f(in_handle, out_handle, alphabet)
     else:
-        records = SeqIO.parse(in_handle, in_format, alphabet)
-        return SeqIO.write(records, out_handle, out_format)
+        records = SeqIO.parse(in_file, in_format, alphabet)
+        return SeqIO.write(records, out_file, out_format)

--- a/Bio/SeqIO/_convert.py
+++ b/Bio/SeqIO/_convert.py
@@ -414,7 +414,6 @@ _converter = {
 
 def _handle_convert(in_file, in_format, out_file, out_format, alphabet=None):
     """Convert handles from one format to another (PRIVATE)."""
-
     try:
         f = _converter[(in_format, out_format)]
     except KeyError:


### PR DESCRIPTION
Currently, the `_BinaryFormats` local variable is used only the `convert` function in `Bio.SeqIO.__init__`, and there it is not needed as all file formats that are handled by `convert` are text. This PR removes `_BinaryFormats`, which has the added benefit that files are being opened for writing only after the format is checked.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
