### PR TITLE
REMARK 465 parsing accept 1 or more spaces

### DIFF
--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -161,7 +161,7 @@ def _parse_remark_465(line):
         return None
     residue = {}
     if " " in match.group(1):
-        model, residue["res_name"] = match.group(1).split(" ")
+        model, residue["res_name"] = match.group(1).split()
         residue["model"] = int(model)
     else:
         residue["model"] = None

--- a/Tests/test_PDB_parse_pdb_header.py
+++ b/Tests/test_PDB_parse_pdb_header.py
@@ -80,7 +80,7 @@ class ParseReal(unittest.TestCase):
             },
         )
 
-        info = _parse_remark_465("1  DG B     9 ")
+        info = _parse_remark_465("1  DG B     9")
         self.assertEqual(
             info,
             {

--- a/Tests/test_PDB_parse_pdb_header.py
+++ b/Tests/test_PDB_parse_pdb_header.py
@@ -80,6 +80,18 @@ class ParseReal(unittest.TestCase):
             },
         )
 
+        info = _parse_remark_465("1  DG B     9 ")
+        self.assertEqual(
+            info,
+            {
+                "model": 1,
+                "res_name": "DG",
+                "chain": "B",
+                "ssseq": 9,
+                "insertion": None,
+            },
+        )
+
     def test_parse_header_line(self):
         """Unit test for parsing and converting fields in HEADER record."""
         header = parse_pdb_header("PDB/header.pdb")


### PR DESCRIPTION
This pull request addresses issue #2819.  The issue with PDB file 3CMY appears to be that the missing residue line that breaks refers to a DNA base instead of a standard residue.  The regex captures this, however the split did not handle multiple spaces.  I believe this works as intended; the previous test cases pass, and have added an additional test case from 3CMY.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
