### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
     rev: 19.10b0
     hooks:
     -   id: black
+        args: [--check]
         additional_dependencies: [
             'restructuredtext_lint',
             'doc8',
@@ -49,18 +50,11 @@ repos:
         additional_dependencies: [
             'flake8-blind-except',
             'flake8-bugbear',
-            # 'flake8-coding==1.3.2',
             'flake8-commas',
             'flake8-comprehensions',
-            # 'flake8-debugger==3.2.1',
-            # 'flake8-deprecated==1.3',
             'flake8-docstrings',
             'flake8-implicit-str-concat',
-            # 'flake8-isort==2.7.0',
-            # 'flake8-pep3101==1.2.1',
             'flake8-pie',
-            # 'flake8-polyfill==1.0.2',
-            # 'flake8-print==3.1.4',
             'flake8-quotes',
             'flake8-rst-docstrings',
             'flake8-sfs',

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,51 @@
+# pre-commit run --all-files
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-executables-have-shebangs
+    -   id: check-json
+    # -   id: check-yaml
+    -   id: debug-statements
+    # -   id: trailing-whitespace
+    #     files: \.(py|txt|html|css|js)$
+    #     exclude: ^Tests/
+    -   id: end-of-file-fixer
+        files: \.(py|txt|html|css|js)$
+        exclude: ^Tests/
+    -   id: mixed-line-ending
+        files: \.(py|txt|html|css|js)$
+        exclude: ^Tests/
+# -   repo: https://github.com/pre-commit/mirrors-mypy
+#     rev: v0.730
+#     hooks:
+#     -   id: mypy
+#         args: [--ignore-missing-imports]
+# -   repo: https://github.com/asottile/seed-isort-config
+#     rev: v1.9.3
+#     hooks:
+#     -   id: seed-isort-config
+# -   repo: https://github.com/pre-commit/mirrors-isort
+#     rev: v4.3.21
+#     hooks:
+#     -   id: isort
+-   repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+    -   id: black
+        exclude: ^Tests/
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+    -   id: flake8
+        exclude: '^Tests/|hsexpo'
+-   repo: https://github.com/asottile/blacken-docs
+    rev: v1.6.0
+    hooks:
+    -   id: blacken-docs
+        additional_dependencies: [black==19.10b0]
+        exclude: ^.github/
+# -   repo: https://github.com/asottile/pyupgrade
+#     rev: v2.1.0
+#     hooks:
+#     -   id: pyupgrade

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,18 +4,20 @@ repos:
     rev: v2.3.0
     hooks:
     -   id: check-executables-have-shebangs
+        files: \.(py|sh)$
+        exclude: ^Tests/
     -   id: check-json
     # -   id: check-yaml
     -   id: debug-statements
-    # -   id: trailing-whitespace
-    #     files: \.(py|txt|html|css|js)$
+    -   id: trailing-whitespace
+        files: \.py$
     #     exclude: ^Tests/
     -   id: end-of-file-fixer
-        files: \.(py|txt|html|css|js)$
+        files: \.py$
         exclude: ^Tests/
     -   id: mixed-line-ending
-        files: \.(py|txt|html|css|js)$
-        exclude: ^Tests/
+        # files: \.(py|txt|html|css|js)$
+        # exclude: ^Tests/
 # -   repo: https://github.com/pre-commit/mirrors-mypy
 #     rev: v0.730
 #     hooks:
@@ -33,12 +35,38 @@ repos:
     rev: 19.10b0
     hooks:
     -   id: black
-        exclude: ^Tests/
+        additional_dependencies: [
+            'restructuredtext_lint',
+            'doc8',
+            'pygments',
+            'docutils==0.14'
+        ]
+        # exclude: ^Tests/
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:
     -   id: flake8
-        exclude: '^Tests/|hsexpo'
+        additional_dependencies: [
+            'flake8-blind-except',
+            'flake8-bugbear',
+            # 'flake8-coding==1.3.2',
+            'flake8-commas',
+            'flake8-comprehensions',
+            # 'flake8-debugger==3.2.1',
+            # 'flake8-deprecated==1.3',
+            'flake8-docstrings',
+            'flake8-implicit-str-concat',
+            # 'flake8-isort==2.7.0',
+            # 'flake8-pep3101==1.2.1',
+            'flake8-pie',
+            # 'flake8-polyfill==1.0.2',
+            # 'flake8-print==3.1.4',
+            'flake8-quotes',
+            'flake8-rst-docstrings',
+            'flake8-sfs',
+            'pydocstyle>=5.0.0',
+        ]
+        # exclude: '^Tests/'
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.6.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,30 +7,13 @@ repos:
         files: \.(py|sh)$
         exclude: ^Tests/
     -   id: check-json
-    # -   id: check-yaml
     -   id: debug-statements
     -   id: trailing-whitespace
         files: \.py$
-    #     exclude: ^Tests/
     -   id: end-of-file-fixer
         files: \.py$
         exclude: ^Tests/
     -   id: mixed-line-ending
-        # files: \.(py|txt|html|css|js)$
-        # exclude: ^Tests/
-# -   repo: https://github.com/pre-commit/mirrors-mypy
-#     rev: v0.730
-#     hooks:
-#     -   id: mypy
-#         args: [--ignore-missing-imports]
-# -   repo: https://github.com/asottile/seed-isort-config
-#     rev: v1.9.3
-#     hooks:
-#     -   id: seed-isort-config
-# -   repo: https://github.com/pre-commit/mirrors-isort
-#     rev: v4.3.21
-#     hooks:
-#     -   id: isort
 -   repo: https://github.com/psf/black
     rev: 19.10b0
     hooks:
@@ -42,7 +25,6 @@ repos:
             'pygments',
             'docutils==0.14'
         ]
-        # exclude: ^Tests/
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:
@@ -60,14 +42,9 @@ repos:
             'flake8-sfs',
             'pydocstyle>=5.0.0',
         ]
-        # exclude: '^Tests/'
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.6.0
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==19.10b0]
         exclude: ^.github/
-# -   repo: https://github.com/asottile/pyupgrade
-#     rev: v2.1.0
-#     hooks:
-#     -   id: pyupgrade


### PR DESCRIPTION
I have seen that you have agreed in #2008 to use the black formatter - nice!

One tool that helped me in another team to keep code quality high is [pre-commit](https://pre-commit.com/). It is a tool every developer can install locally (but doesn't have to). Before a commit is done, it runs the pre-commit hooks defined in `.pre-commit-config.yaml`.

There are some hooks which I would recommend, but might need to be discussed first:

* [isort](https://github.com/timothycrosley/isort): #2828
* check-yaml: #2825 needs to be fixed first
* [pyupgrade](https://github.com/asottile/pyupgrade): I guess I'll run it and make a PR after this one so that you can see the effect -- see #2510
* mypy: Only useful if you add type annotations ... and I think that is mainly useful for Python 3.6+. I'm not sure if this project still wants to support prior versions.

This PR should only be merged after #2552 is done and #2826 is merged.

## How to use pre-commit

```
# Install it locally
$ pip install pre-commit

# Tell pre-commit to run pre-commit hooks for the current repository
# This only needs to be done once
$ pre-commit install

# Tell pre-commit to run all hooks on all files
pre-commit run --all-files
```

## Checkboxes

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
