### PR TITLE
in test_SeqIO_convert, reuse bits from SeqIOTestBaseClass

### DIFF
--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -97,9 +97,9 @@ class SeqIOTestBaseClass(unittest.TestCase):
             return mode
         raise RuntimeError("Failed to find file mode for %s" % fmt)
 
-    def compare_record(self, old, new, *args, **kwargs):
+    def compare_record(self, old, new, msg=None, *args, **kwargs):
         """Compare old SeqRecord to new SeqRecord."""
-        self.assertEqual(old.id, new.id)
+        self.assertEqual(old.id, new.id, msg=msg)
         self.assertTrue(
             old.description == new.description
             or (old.id + " " + old.description).strip() == new.description
@@ -110,10 +110,12 @@ class SeqIOTestBaseClass(unittest.TestCase):
             pass
         else:
             if len(old.seq) < 200:
-                msg = "'%s' vs '%s'" % (old.seq, new.seq)
+                err_msg = "'%s' vs '%s'" % (old.seq, new.seq)
             else:
-                msg = "'%s...' vs '%s...'" % (old.seq[:100], new.seq[:100])
-            self.assertEqual(str(old.seq), str(new.seq), msg=msg)
+                err_msg = "'%s...' vs '%s...'" % (old.seq[:100], new.seq[:100])
+            if msg is not None:
+                err_msg = "%s: %s" % (msg, err_msg)
+            self.assertEqual(str(old.seq), str(new.seq), msg=err_msg)
 
     def compare_records(self, old_list, new_list, *args, **kwargs):
         """Check if two lists of SeqRecords are equal."""

--- a/Tests/test_SeqIO_convert.py
+++ b/Tests/test_SeqIO_convert.py
@@ -15,6 +15,8 @@ from Bio.SeqIO._convert import _converter as converter_dict
 from io import StringIO
 from Bio.Alphabet import generic_nucleotide, generic_dna
 
+from test_SeqIO import SeqIOTestBaseClass
+
 
 # TODO - share this with the QualityIO tests...
 def truncation_expected(format):
@@ -26,7 +28,7 @@ def truncation_expected(format):
         return None
 
 
-class ConvertTests(unittest.TestCase):
+class ConvertTests(SeqIOTestBaseClass):
 
     # TODO - move compare_record to a shared test module...
     def compare_record(self, old, new, truncate, msg):
@@ -35,26 +37,7 @@ class ConvertTests(unittest.TestCase):
         This will check the mapping between Solexa and PHRED scores.
         It knows to ignore UnknownSeq objects for string matching (i.e. QUAL files).
         """
-        self.assertEqual(old.id, new.id, msg=msg)
-        self.assertTrue(
-            old.description == new.description
-            or (old.id + " " + old.description).strip() == new.description
-            or new.description == "<unknown description>"
-            or new.description == "",
-            msg=msg
-        )
-        self.assertEqual(len(old.seq), len(new.seq), msg=msg)
-        if isinstance(old.seq, UnknownSeq) or isinstance(new.seq, UnknownSeq):
-            pass
-        else:
-            if len(old.seq) < 200:
-                err_msg = "%s: '%s' vs '%s'" % (msg, old.seq, new.seq)
-            else:
-                err_msg = "%s: '%s...' vs '%s...'" % (msg, old.seq[:100], new.seq[:100])
-            # Don't use assertEqual here, as it would show the complete
-            # sequence in case of a failure.
-            self.assertTrue(str(old.seq) == str(new.seq), msg=err_msg)
-
+        super().compare_record(old, new, msg=msg)
         for keyword in ("phred_quality", "solexa_quality"):
             q_old = old.letter_annotations.get(keyword)
             q_new = new.letter_annotations.get(keyword)


### PR DESCRIPTION
Use inheritance in test_SeqIO_convert to reuse bits from SeqIOTestBaseClass

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
