### PR TITLE
Fixed a bug in calculating the height of clades when building a UPGMA tree

### DIFF
--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -824,10 +824,10 @@ class DistanceTreeConstructor(TreeConstructor):
     def _height_of(self, clade):
         """Calculate clade height -- the longest path to any terminal (PRIVATE)."""
         if clade.is_terminal():
-            height = 0 
+            height = 0
         else:
             height = max(self._height_of(c) + c.branch_length for c in clade.clades)
-            
+
         return height
 
 

--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -698,15 +698,11 @@ class DistanceTreeConstructor(TreeConstructor):
             inner_clade.clades.append(clade1)
             inner_clade.clades.append(clade2)
             # assign branch length
-            if clade1.is_terminal():
-                clade1.branch_length = min_dist * 1.0 / 2
-            else:
-                clade1.branch_length = min_dist * 1.0 / 2 - self._height_of(clade1)
+            clade1.branch_length = min_dist * \
+                    1.0 / 2 - self._height_of(clade1)
 
-            if clade2.is_terminal():
-                clade2.branch_length = min_dist * 1.0 / 2
-            else:
-                clade2.branch_length = min_dist * 1.0 / 2 - self._height_of(clade2)
+            clade2.branch_length = min_dist * \
+                    1.0 / 2 - self._height_of(clade2)
 
             # update node list
             clades[min_j] = inner_clade
@@ -829,11 +825,10 @@ class DistanceTreeConstructor(TreeConstructor):
 
     def _height_of(self, clade):
         """Calculate clade height -- the longest path to any terminal (PRIVATE)."""
-        height = 0
         if clade.is_terminal():
-            height = clade.branch_length
+            height = 0 
         else:
-            height = height + max(self._height_of(c) for c in clade.clades)
+            height = max(self._height_of(c) + c.branch_length for c in clade.clades)
         return height
 
 

--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -698,11 +698,9 @@ class DistanceTreeConstructor(TreeConstructor):
             inner_clade.clades.append(clade1)
             inner_clade.clades.append(clade2)
             # assign branch length
-            clade1.branch_length = min_dist * \
-                    1.0 / 2 - self._height_of(clade1)
+            clade1.branch_length = min_dist * 1.0 / 2 - self._height_of(clade1)
 
-            clade2.branch_length = min_dist * \
-                    1.0 / 2 - self._height_of(clade2)
+            clade2.branch_length = min_dist * 1.0 / 2 - self._height_of(clade2)
 
             # update node list
             clades[min_j] = inner_clade
@@ -829,6 +827,7 @@ class DistanceTreeConstructor(TreeConstructor):
             height = 0 
         else:
             height = max(self._height_of(c) + c.branch_length for c in clade.clades)
+            
         return height
 
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -242,6 +242,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Sergei Lebedev <https://github.com/superbobry>
 - Sergio Valqui <https://github.com/svalqui>
 - Seth Sims <seth.sims at gmail>
+- She Zhang <https://github.com/shz66>
 - Shuichiro MAKIGAKI <https://github.com/shuichiro-makigaki>
 - Shyam Saladi <https://github.com/smsaladi>
 - Siong Kong <https://github.com/siongkong>


### PR DESCRIPTION
This pull request addresses the issue that the UPGMA constructor yields a tree with wrong branch lengths. In some cases, it may even yield a tree with unequal distances from tips to the root, which violates the constant-rate assumption.

The problem is that `DistanceTreeConstructor._height_of()` returns the wrong clade height. The recursion doesn't work as intended. Please verify the changes. Here is an example that will reproduce the bug:

```
from matplotlib.pyplot import *
from Bio import Phylo
from Bio.Phylo.TreeConstruction import _DistanceMatrix
from scipy.spatial.distance import squareform, pdist
from numpy import *

n = 20
X = 10*random.random((n, 2))

A = squareform(pdist(X))

B = []
for i, row in enumerate(A):
    B.append([int(i) for i in row[:i+1]])

names = [str(i) for i in range(n)]

# UPGMA
dm = _DistanceMatrix(names, B)
constructor = Phylo.TreeConstruction.DistanceTreeConstructor()
tree = constructor.upgma(dm)

Phylo.draw(tree)
```
In this example, 20 points (2D) are randomly generated and their pairwise distances evaluated. The original implementation produces a tree that violates the constant-rate assumption:
![figure1](https://user-images.githubusercontent.com/8532098/79617896-9b97e080-80d6-11ea-93c5-c3b0e55a0008.png)
After the fix, the branch lengths are evaluated correctly:
![figure2](https://user-images.githubusercontent.com/8532098/79617943-b36f6480-80d6-11ea-80b5-e05bf735a542.png)


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
