### PR TITLE
tinchogb-PDBList-handle-compression

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -328,10 +328,16 @@ class PDBList:
 
         # Skip download if the file already exists
         if not overwrite:
-            if os.path.exists(final_file):
-                if self._verbose:
-                    print("Structure exists: '%s' " % final_file)
-                return final_file
+            if compress:
+                if os.path.exists(filename):
+                    if self._verbose:
+                       print("Structure exists: '%s' " % filename)
+                    return filename
+            else:
+                if os.path.exists(final_file):
+                    if self._verbose:
+                        print("Structure exists: '%s' " % final_file)
+                    return final_file
 
         # Retrieve the file
         if self._verbose:

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -215,7 +215,7 @@ class PDBList:
         return obsolete
 
     def retrieve_pdb_file(
-        self, pdb_code, obsolete=False, pdir=None, file_format=None, overwrite=False
+        self, pdb_code, obsolete=False, pdir=None, file_format=None, overwrite=False, compress=False
     ):
         """Fetch PDB structure file from PDB server, and store it locally.
 
@@ -255,6 +255,9 @@ class PDBList:
 
         :param pdir: put the file in this directory (default: create a PDB-style directory tree)
         :type pdir: string
+
+        :param compress: if set to True, existing structure files will be gzip stored. Default: False
+        :type compress: bool
 
         :return: filename
         :rtype: string
@@ -339,10 +342,13 @@ class PDBList:
         except OSError:
             print("Desired structure doesn't exists")
         else:
-            with gzip.open(filename, "rb") as gz:
-                with open(final_file, "wb") as out:
-                    out.writelines(gz)
-            os.remove(filename)
+            if compress:
+                pass
+            else:
+                with gzip.open(filename, "rb") as gz:
+                    with open(final_file, "wb") as out:
+                        out.writelines(gz)
+                os.remove(filename)
         return final_file
 
     def update_pdb(self, file_format=None):

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -256,7 +256,7 @@ class PDBList:
         :param pdir: put the file in this directory (default: create a PDB-style directory tree)
         :type pdir: string
 
-        :param compress: if set to True, existing structure files will be gzip stored. Default: False
+        :param compress: if set to True, downloaded files will be gzip stored. Default: False
         :type compress: bool
 
         :return: filename
@@ -349,7 +349,7 @@ class PDBList:
             print("Desired structure doesn't exists")
         else:
             if compress:
-                pass
+                return filename
             else:
                 with gzip.open(filename, "rb") as gz:
                     with open(final_file, "wb") as out:

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -51,6 +51,7 @@ possible, especially the following contributors:
 - Sergio Valqui
 - Sujan Dulal (first contribution)
 - Tianyi Shi (first contribution)
+- Martin Gonzalez Buitron (first contribution)
 
 20 December 2019: Biopython 1.76
 ================================


### PR DESCRIPTION
Incorporating a new argument that allows controlling compression (by default uncompressed) in retrieve_pdb_file().

This pull request addresses issue #2849

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
