### PR TITLE
I don't think this is useful, other than to scare off users

### DIFF
--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -4,20 +4,6 @@ import os
 import string
 import numpy
 
-from Bio import BiopythonExperimentalWarning
-
-
-import warnings
-
-warnings.warn(
-    "Bio.Align.substitution_matrices is an experimental module "
-    "which may still undergo significant changes. In particular, "
-    "the location of this module may change, and the Array class "
-    "defined in this module may be moved to other existing or new "
-    "modules in Biopython.",
-    BiopythonExperimentalWarning,
-)
-
 
 class Array(numpy.ndarray):
     """numpy array subclass indexed by integers and by letters."""


### PR DESCRIPTION
This pull request removes the `BiopythonExperimentalWarning` from `Bio/Align/substitution_matrices`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
