### PR TITLE
Fix for issue #2502 Sphinx API documentation missing __magic__ methods

### DIFF
--- a/Doc/api/conf.py
+++ b/Doc/api/conf.py
@@ -82,7 +82,7 @@ todo_include_todos = True
 # -- Options for autodoc --------------------------------------------------
 
 # This requires Sphinx 1.8.0b1 or later:
-autodoc_default_values = {
+autodoc_default_options = {
     "members": None,
     "undoc-members": None,
     "special-members": None,

--- a/Doc/api/conf.py
+++ b/Doc/api/conf.py
@@ -81,7 +81,7 @@ todo_include_todos = True
 
 # -- Options for autodoc --------------------------------------------------
 
-# This requires Sphinx 1.8.0b1 or later:
+# This requires Sphinx 1.8 or later:
 autodoc_default_options = {
     "members": None,
     "undoc-members": None,


### PR DESCRIPTION
This pull request addresses issue #2502 

The options variable for version 1.80 and later appears to have changed to `autodoc_default_options`. This patch now builds the docs with special members displayed. 

https://www.sphinx-doc.org/en/1.8/usage/extensions/autodoc.html#confval-autodoc_default_options

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X ] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
