### PR TITLE
Remove workaround for black vs pydocstyle D202

### DIFF
--- a/Bio/KEGG/KGML/KGML_parser.py
+++ b/Bio/KEGG/KGML/KGML_parser.py
@@ -106,7 +106,7 @@ class KGMLParser:
 
     def parse(self):
         """Parse the input elements."""
-        # This comment stops black style adding a blank line here, which causes flake8 D202.
+
         def _parse_pathway(attrib):
             for k, v in attrib.items():
                 self.pathway.__setattr__(k, v)

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -2027,7 +2027,7 @@ class Nexus:
         pos=0: first position
         pos=nchar: last position
         """
-        # This comment stops black style adding a blank line here, which causes flake8 D202.
+
         def _adjust(set, x, d, leftgreedy=False):
             """Adjust character sets if gaps are inserted (PRIVATE).
 

--- a/Bio/Nexus/Trees.py
+++ b/Bio/Nexus/Trees.py
@@ -786,7 +786,7 @@ class Tree(Nodes.Chain):
 
     def root_with_outgroup(self, outgroup=None):
         """Define a tree's root with a reference group outgroup."""
-        # This comment stops black style adding a blank line here, which causes flake8 D202.
+
         def _connect_subtree(parent, child):
             """Attach subtree starting with node child to parent (PRIVATE)."""
             for i, branch in enumerate(self.unrooted):

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -32,7 +32,7 @@ def _level_traverse(root, get_children):
 
 def _preorder_traverse(root, get_children):
     """Traverse a tree in depth-first pre-order (parent before children) (PRIVATE)."""
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def dfs(elem):
         yield elem
         for v in get_children(elem):
@@ -43,7 +43,7 @@ def _preorder_traverse(root, get_children):
 
 def _postorder_traverse(root, get_children):
     """Traverse a tree in depth-first post-order (children before parent) (PRIVATE)."""
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def dfs(elem):
         for v in get_children(elem):
             yield from dfs(v)
@@ -72,7 +72,7 @@ def _sorted_attrs(elem):
 
 def _identity_matcher(target):
     """Match a node to the target object by identity (PRIVATE)."""
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def match(node):
         return node is target
 
@@ -81,7 +81,7 @@ def _identity_matcher(target):
 
 def _class_matcher(target_cls):
     """Match a node if it's an instance of the given class (PRIVATE)."""
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def match(node):
         return isinstance(node, target_cls)
 
@@ -111,7 +111,7 @@ def _attribute_matcher(kwargs):
     match each of the corresponding values -- think 'and', not 'or', for
     multiple keys.
     """
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def match(node):
         if "terminal" in kwargs:
             # Special case: restrict to internal/external/any nodes
@@ -144,7 +144,7 @@ def _attribute_matcher(kwargs):
 
 def _function_matcher(matcher_func):
     """Safer attribute lookup -- returns False instead of raising an error (PRIVATE)."""
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def match(node):
         try:
             return matcher_func(node)
@@ -241,7 +241,7 @@ class TreeElement:
 
     def __repr__(self):
         """Show this object's constructor with its primitive arguments."""
-        # This comment stops black style adding a blank line here, which causes flake8 D202.
+
         def pair_as_kwarg_string(key, val):
             if isinstance(val, str):
                 val = val[:57] + "..." if len(val) > 60 else val
@@ -365,7 +365,7 @@ class TreeMixin:
             depth-first (preorder) by default.
 
         """
-        # This comment stops black style adding a blank line here, which causes flake8 D202.
+
         def match_attrs(elem):
             orig_clades = elem.__dict__.pop("clades")
             found = elem.find_any(target, **kwargs)

--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -248,7 +248,7 @@ class Phylogeny(PhyloElement, BaseTree.Tree):
 
     def to_alignment(self):
         """Construct an alignment from the aligned sequences in this tree."""
-        # This comment stops black style adding a blank line here, which causes flake8 D202.
+
         def is_aligned_seq(elem):
             if isinstance(elem, Sequence) and elem.mol_seq.is_aligned:
                 return True
@@ -1333,7 +1333,7 @@ class Sequence(PhyloElement):
             }
 
         """
-        # This comment stops black style adding a blank line here, which causes flake8 D202.
+
         def clean_dict(dct):
             """Remove None-valued items from a dictionary."""
             return {key: val for key, val in dct.items() if val is not None}

--- a/Bio/Phylo/PhyloXMLIO.py
+++ b/Bio/Phylo/PhyloXMLIO.py
@@ -98,7 +98,7 @@ def write(obj, file, encoding=DEFAULT_ENCODING, indent=True):
             either an open handle or a file name.
 
     """
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def fix_single(tree):
         if isinstance(tree, PX.Phylogeny):
             return tree
@@ -515,7 +515,7 @@ class Parser:
 
     def binary_characters(self, elem):
         """Create binary characters object."""
-        # This comment stops black style adding a blank line here, which causes flake8 D202.
+
         def bc_getter(elem):
             """Get binary characters from subnodes."""
             return _get_children_text(elem, "bc")
@@ -685,7 +685,7 @@ def _clean_attrib(obj, attrs):
 
 def _handle_complex(tag, attribs, subnodes, has_text=False):
     """Handle to serialize nodes with subnodes (PRIVATE)."""
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def wrapped(self, obj):
         """Wrap nodes and subnodes as elements."""
         elem = ElementTree.Element(tag, _clean_attrib(obj, attribs))
@@ -709,7 +709,7 @@ def _handle_complex(tag, attribs, subnodes, has_text=False):
 
 def _handle_simple(tag):
     """Handle to serialize simple nodes (PRIVATE)."""
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def wrapped(self, obj):
         """Wrap node as element."""
         elem = ElementTree.Element(tag)

--- a/Bio/PopGen/GenePop/__init__.py
+++ b/Bio/PopGen/GenePop/__init__.py
@@ -24,7 +24,7 @@ from copy import deepcopy
 
 def get_indiv(line):
     """Extract the details of the individual information on the line."""
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def int_no_zero(val):
         """Return integer of val, or None if is zero."""
         v = int(val)

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -2226,7 +2226,7 @@ class RestrictionBatch(set):
         It works but it is slow, so it has really an interest when splitting
         over multiple conditions.
         """
-        # This comment stops black style adding a blank line here, which causes flake8 D202.
+
         def splittest(element):
             for klass in classes:
                 b = bool.get(klass.__name__, True)

--- a/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
+++ b/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
@@ -164,7 +164,7 @@ class Hhsuite2TextParser:
             T ss_pred             cccchHHHHHHHHHHHHHHHHHHHHhcCCCCCCccccC
 
         """
-        # This comment stops black style adding a blank line here, which causes flake8 D202.
+
         def match_is_valid(match):
             """Return True if match is not a Consensus column (PRIVATE).
 

--- a/Bio/SearchIO/__init__.py
+++ b/Bio/SearchIO/__init__.py
@@ -402,7 +402,7 @@ def to_dict(qresults, key_function=None):
     CPython and PyPy, this was already implemented for Python 3.6, so
     effectively you can always assume the record order is preserved.
     """
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def _default_key_function(rec):
         return rec.id
 

--- a/Bio/SearchIO/_utils.py
+++ b/Bio/SearchIO/_utils.py
@@ -68,7 +68,7 @@ def singleitem(attr=None, doc=""):
     Returns a property that fetches the given attribute from
     the first item in a SearchIO container object.
     """
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def getter(self):
         if len(self._items) > 1:
             raise ValueError("More than one HSPFragment objects found in HSP")
@@ -85,7 +85,7 @@ def allitems(attr=None, doc=""):
     Returns a property that fetches the given attributes from
     all items in a SearchIO container object.
     """
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def getter(self):
         if attr is None:
             return self._items
@@ -104,7 +104,7 @@ def fullcascade(attr, doc=""):
     that it only sets attributes to items in the object, not the object itself.
 
     """
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def getter(self):
         return getattr(self._items[0], attr)
 
@@ -128,7 +128,7 @@ def optionalcascade(cont_attr, item_attr, doc=""):
     the setter cascades any new value given to the items' values.
 
     """
-    # This comment stops black style adding a blank line here, which causes flake8 D202.
+
     def getter(self):
         if self._items:
             # don't use self._items here, so QueryResult can use this property

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -902,7 +902,7 @@ class ParseReal(unittest.TestCase):
 
     def test_model_numbering(self):
         """Preserve model serial numbers during I/O."""
-        # comment for D202 flake8 vs black disagreement
+
         def confirm_numbering(struct):
             self.assertEqual(len(struct), 3)
             for idx, model in enumerate(struct):

--- a/Tests/test_PDB_KDTree.py
+++ b/Tests/test_PDB_KDTree.py
@@ -37,7 +37,7 @@ class NeighborTest(unittest.TestCase):
 
         Based on the self test in Bio.PDB.NeighborSearch.
         """
-        # This comment stops black style adding a blank line here, which causes flake8 D202.
+
         class RandomAtom:
             def __init__(self):
                 self.coord = 100 * random(3)

--- a/Tests/test_Phylo.py
+++ b/Tests/test_Phylo.py
@@ -438,7 +438,7 @@ class MixinTests(unittest.TestCase):
 
     def test_ladderize(self):
         """TreeMixin: ladderize() method."""
-        # This comment stops black style adding a blank line here, causing flake8 D202.
+
         def ordered_names(tree):
             return [n.name for n in tree.get_terminals()]
 


### PR DESCRIPTION
See https://github.com/psf/black/issues/709 and https://github.com/PyCQA/pydocstyle/pull/395 - pydocstyle v5.0.0 (and thus flake8 D202) was relaxed to accept the blank lines added by black.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
