### PR TITLE
No flake8 E123 left in Tests/

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -45,12 +45,12 @@ ignore =
 # ========================
 per-file-ignores =
     Bio/*:F401,F841,D105,B009,B010,B011,C812,C815
-    Tests/*:E123,F401,F841,D101,D102,D103,W504,B009,B010,B011,C812,BLK100
+    Tests/*:F401,F841,D101,D102,D103,W504,B009,B010,B011,C812,BLK100
 
     # Due to a bug in flake8, we need the following lines for running the
     # pre-commit hook. If you made edits above, please change also here!
     /Bio/*:F401,F841,D105,B009,B010,B011,C812,C815
-    /Tests/*:E123,F401,F841,D101,D102,D103,W504,B009,B010,B011,C812,BLK100
+    /Tests/*:F401,F841,D101,D102,D103,W504,B009,B010,B011,C812,BLK100
 
 # =============================
 # per-file-ignores error codes:
@@ -66,9 +66,7 @@ per-file-ignores =
 #           instead callers should raise AssertionError().
 #      C812 missing trailing comma
 #      C815 missing trailing comma in Python 3.5+
-#Tests/*:E123 closing bracket does not match indentation of opening bracket's line
-#             (41 occurences, may be removed by Black)
-#        F401 module imported but unused TODO? (88 occurrences)
+#Tests/*:F401 module imported but unused TODO? (88 occurrences)
 #        F841 local variable is assigned to but never used TODO? (64 occurrences)
 #        D101 missing docstring in public class (207 occurrences)
 #        D102 missing docstring in public method (956 occurrences)

--- a/Tests/test_CAPS.py
+++ b/Tests/test_CAPS.py
@@ -17,13 +17,16 @@ from Bio.Align import MultipleSeqAlignment
 
 def createAlignment(sequences, alphabet):
     """Create an Alignment object from a list of sequences."""
-    return MultipleSeqAlignment((SeqRecord(Seq(s, alphabet), id="sequence%i" % (i + 1))
-                                 for (i, s) in enumerate(sequences)),
-                                alphabet)
+    return MultipleSeqAlignment(
+        (
+            SeqRecord(Seq(s, alphabet), id="sequence%i" % (i + 1))
+            for (i, s) in enumerate(sequences)
+        ),
+        alphabet,
+    )
 
 
 class TestCAPS(unittest.TestCase):
-
     def test_trivial(self):
         enzymes = [EcoRI]
         alignment = ["gaattc", "gaactc"]
@@ -53,7 +56,7 @@ class TestCAPS(unittest.TestCase):
             "TTAGTGAAAATGGAGGATCAAGTagctTTTGGGTTCCGTCCGAACGACGAGGAGCTCGTT"
             "GGTCACTATCTCCGTAACAAAATCGAAGGAAACACTAGCCGCGACGTTGAAGTAGCCATC"
             "AGCGAGGTCAACATCTGTAGCTACGATCCTTGGAACTTGCGCTGTAAGTTCCGAATTTTC",
-            ]
+        ]
         self.assertEqual(len(alignment), 3)
         enzymes = [EcoRI, AluI]
         align = createAlignment(alignment, Alphabet.generic_dna)
@@ -77,15 +80,14 @@ class TestCAPS(unittest.TestCase):
         self.assertEqual(map.dcuts, [])
 
     def test_uneven(self):
-        alignment = ["aaaaaaaaaaaaaa",
-                     "aaaaaaaaaaaaaa",  # we'll change this below
-                     "aaaaaaaaaaaaaa",
-                     ]
+        alignment = [
+            "aaaaaaaaaaaaaa",
+            "aaaaaaaaaaaaaa",  # we'll change this below
+            "aaaaaaaaaaaaaa",
+        ]
         align = createAlignment(alignment, Alphabet.generic_nucleotide)
         align[1].seq = align[1].seq[:8]  # evil
-        self.assertRaises(CAPS.AlignmentHasDifferentLengthsError,
-                          CAPS.CAPSMap,
-                          align)
+        self.assertRaises(CAPS.AlignmentHasDifferentLengthsError, CAPS.CAPSMap, align)
 
 
 if __name__ == "__main__":

--- a/Tests/test_NaiveBayes.py
+++ b/Tests/test_NaiveBayes.py
@@ -13,15 +13,18 @@ from Bio import NaiveBayes
 # Importing NaiveBayes will itself raise MissingPythonDependencyError
 # if NumPy is unavailable.
 import numpy
+
 try:
     hash(numpy.float64(123.456))
 except TypeError:
     # Due to a bug in NumPy 1.12.1, this is unhashable under
     # PyPy3.5 v5.7 beta - it has been fixed in NumPy
     from Bio import MissingPythonDependencyError
+
     raise MissingPythonDependencyError(
         "Please update NumPy if you want to use Bio.NaiveBayes "
-        "(under this version numpy.float64 is unhashable).") from None
+        "(under this version numpy.float64 is unhashable)."
+    ) from None
 del numpy
 
 
@@ -42,7 +45,7 @@ class CarTest(unittest.TestCase):
             ["Yellow", "SUV", "Domestic"],
             ["Red", "SUV", "Imported"],
             ["Red", "Sports", "Imported"],
-            ]
+        ]
 
         ycar = [
             "Yes",
@@ -55,11 +58,15 @@ class CarTest(unittest.TestCase):
             "No",
             "No",
             "Yes",
-            ]
+        ]
 
         carmodel = NaiveBayes.train(xcar, ycar)
-        self.assertEqual("Yes", NaiveBayes.classify(carmodel, ["Red", "Sports", "Domestic"]))
-        self.assertEqual("No", NaiveBayes.classify(carmodel, ["Red", "SUV", "Domestic"]))
+        self.assertEqual(
+            "Yes", NaiveBayes.classify(carmodel, ["Red", "Sports", "Domestic"])
+        )
+        self.assertEqual(
+            "No", NaiveBayes.classify(carmodel, ["Red", "SUV", "Domestic"])
+        )
 
 
 class NaiveBayesTest(unittest.TestCase):


### PR DESCRIPTION
This pull request continues on going flake8/black style work

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
