### PR TITLE
Cope with BLAST DB v5 extensions

### DIFF
--- a/Tests/test_NCBI_BLAST_tools.py
+++ b/Tests/test_NCBI_BLAST_tools.py
@@ -248,8 +248,14 @@ class BlastDB(unittest.TestCase):
         self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.phr"))
         self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.pin"))
         self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.pog"))
-        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.psd"))
-        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.psi"))
+        self.assertTrue(
+            os.path.isfile("GenBank/NC_005816.faa.psd")
+            or os.path.isfile("GenBank/NC_005816.faa.pnd")
+        )
+        self.assertTrue(
+            os.path.isfile("GenBank/NC_005816.faa.psi")
+            or os.path.isfile("GenBank/NC_005816.faa.pni")
+        )
         self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.psq"))
 
     def test_fasta_db_nucl(self):
@@ -288,8 +294,14 @@ class BlastDB(unittest.TestCase):
         self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nhr"))
         self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nin"))
         self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nog"))
-        self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nsd"))
-        self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nsi"))
+        self.assertTrue(
+            os.path.isfile("GenBank/NC_005816.fna.nsd")
+            or os.path.isfile("GenBank/NC_005816.fna.nnd")
+        )
+        self.assertTrue(
+            os.path.isfile("GenBank/NC_005816.fna.nsi")
+            or os.path.isfile("GenBank/NC_005816.fna.nni")
+        )
         self.assertTrue(os.path.isfile("GenBank/NC_005816.fna.nsq"))
 
     # makeblastdb makes files in the same dir as the input, clean these up


### PR DESCRIPTION
With NCBI BLAST+ v2.10.0 the v5 DB became the default, and it has slightly different
file extensions to their v4 DB format.

This closes the main part of issue #2863 (but does not add the new command line switches).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
