### PR TITLE
PDBParser throws TypeError on duplicated Residues

### DIFF
--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -211,7 +211,9 @@ class Entity:
         """Add a child to the Entity."""
         entity_id = entity.get_id()
         if self.has_id(entity_id):
-            raise PDBConstructionException("%s defined twice" % entity_id)
+            raise PDBConstructionException(
+                f"{entity_id} defined twice"
+            )
         entity.set_parent(self)
         self.child_list.append(entity)
         self.child_dict[entity_id] = entity
@@ -220,7 +222,9 @@ class Entity:
         """Add a child to the Entity at a specified position."""
         entity_id = entity.get_id()
         if self.has_id(entity_id):
-            raise PDBConstructionException("%s defined twice" % entity_id)
+            raise PDBConstructionException(
+                f"{entity_id} defined twice"
+            )
         entity.set_parent(self)
         self.child_list[pos:pos] = [entity]
         self.child_dict[entity_id] = entity

--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -211,9 +211,7 @@ class Entity:
         """Add a child to the Entity."""
         entity_id = entity.get_id()
         if self.has_id(entity_id):
-            raise PDBConstructionException(
-                f"{entity_id} defined twice"
-            )
+            raise PDBConstructionException(f"{entity_id} defined twice")
         entity.set_parent(self)
         self.child_list.append(entity)
         self.child_dict[entity_id] = entity
@@ -222,9 +220,7 @@ class Entity:
         """Add a child to the Entity at a specified position."""
         entity_id = entity.get_id()
         if self.has_id(entity_id):
-            raise PDBConstructionException(
-                f"{entity_id} defined twice"
-            )
+            raise PDBConstructionException(f"{entity_id} defined twice")
         entity.set_parent(self)
         self.child_list[pos:pos] = [entity]
         self.child_dict[entity_id] = entity

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -901,6 +901,43 @@ class ParseReal(unittest.TestCase):
             "O O O O O O O O O O O O O O O O O O O O O",
         )
 
+
+    def test_duplicated_residue_permissive(self):
+        """Throw (silent) exception on duplicated residue."""
+
+        data = (
+            "HETATM 6289  O   HOH     5      28.182  -5.239  31.370  1.00 22.99           O\n"
+            "HETATM 6513  O   HOH     6      21.829   3.361  14.003  1.00 14.25           O\n"
+            "HETATM 6607  O   HOH     5      33.861  40.044  18.022  1.00 18.73           O\n"
+            "END\n"
+        )
+        parser = PDBParser()
+        with warnings.catch_warnings(record=True) as w:
+            s = parser.get_structure("example", StringIO(data))
+            self.assertEqual(len(w), 1)
+
+        reslist = list(s.get_residues())
+        n_res = len(reslist)
+        resids = [r.id[1] for r in reslist]
+        self.assertEqual(n_res, 2)
+        self.assertEqual(resids, [5, 6])
+
+
+    def test_duplicated_residue_strict(self):
+        """Throw exception on duplicated residue."""
+
+        data = (
+            "HETATM 6289  O   HOH     5      28.182  -5.239  31.370  1.00 22.99           O\n"
+            "HETATM 6513  O   HOH     6      21.829   3.361  14.003  1.00 14.25           O\n"
+            "HETATM 6607  O   HOH     5      33.861  40.044  18.022  1.00 18.73           O\n"
+            "END\n"
+        )
+
+        parser = PDBParser(PERMISSIVE=False)
+        with self.assertRaises(PDBConstructionException):
+            s = parser.get_structure("example", StringIO(data))
+
+
     def test_model_numbering(self):
         """Preserve model serial numbers during I/O."""
 

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -901,16 +901,15 @@ class ParseReal(unittest.TestCase):
             "O O O O O O O O O O O O O O O O O O O O O",
         )
 
-
     def test_duplicated_residue_permissive(self):
         """Throw (silent) exception on duplicated residue."""
-
         data = (
             "HETATM 6289  O   HOH     5      28.182  -5.239  31.370  1.00 22.99           O\n"
             "HETATM 6513  O   HOH     6      21.829   3.361  14.003  1.00 14.25           O\n"
             "HETATM 6607  O   HOH     5      33.861  40.044  18.022  1.00 18.73           O\n"
             "END\n"
         )
+
         parser = PDBParser()
         with warnings.catch_warnings(record=True) as w:
             s = parser.get_structure("example", StringIO(data))
@@ -922,10 +921,8 @@ class ParseReal(unittest.TestCase):
         self.assertEqual(n_res, 2)
         self.assertEqual(resids, [5, 6])
 
-
     def test_duplicated_residue_strict(self):
         """Throw exception on duplicated residue."""
-
         data = (
             "HETATM 6289  O   HOH     5      28.182  -5.239  31.370  1.00 22.99           O\n"
             "HETATM 6513  O   HOH     6      21.829   3.361  14.003  1.00 14.25           O\n"
@@ -936,7 +933,6 @@ class ParseReal(unittest.TestCase):
         parser = PDBParser(PERMISSIVE=False)
         with self.assertRaises(PDBConstructionException):
             s = parser.get_structure("example", StringIO(data))
-
 
     def test_model_numbering(self):
         """Preserve model serial numbers during I/O."""


### PR DESCRIPTION
This pull request addresses an upcoming issue communicated personally from a user. I'll link to it as soon as it's created. EDIT: #2892 

The problem here is that Residue.id is a tuple, and that trips the old `%s` formatting when raising an Exception. I guess these particular lines were missed during the f-string overhaul. Converting to f-strings seems to restore the expected behavior. 

I can reproduce the problem and test the fix with a simple test file with the following lines:
```
HETATM 6289  O   HOH     5      28.182  -5.239  31.370  1.00 22.99           O
HETATM 6513  O   HOH     6      21.829   3.361  14.003  1.00 14.25           O
HETATM 6607  O   HOH     5      33.861  40.044  18.022  1.00 18.73           O
END
```

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
