### PR TITLE
Apply black to remaining Tests/test_E*.py files

### DIFF
--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -190,6 +190,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Marco Galardini <https://github.com/mgalardini>
 - Mark Amery <https://github.com/ExplodingCabbage>
 - Markus Piotrowski <https://github.com/MarkusPiotrowski>
+- Marton Langa <https://github.com/martonlanga>
 - Mateusz Korycinski <https://github.com/mkorycinski>
 - Matt Ruffalo <https://github.com/mruffalo>
 - Matt Shirley <https://github.com/mdshw5>

--- a/Tests/test_EMBL_unittest.py
+++ b/Tests/test_EMBL_unittest.py
@@ -16,6 +16,7 @@ from Bio import BiopythonParserWarning
 class EMBLTests(unittest.TestCase):
     def test_embl_content_after_co(self):
         """Test a ValueError is thrown by content after a CO line."""
+
         def parse_content_after_co():
             rec = SeqIO.read(path.join("EMBL", "xx_after_co.embl"), "embl")
 
@@ -26,7 +27,10 @@ class EMBLTests(unittest.TestCase):
         except ValueError as e:
             self.assertEqual(str(e), "Unexpected content after SQ or CO line: 'XX'")
         else:
-            self.assertTrue(False, "Error message without explanation raised by content after CO line")
+            self.assertTrue(
+                False,
+                "Error message without explanation raised by content after CO line",
+            )
 
     def test_embl_0_line(self):
         """Test SQ line with 0 length sequence."""
@@ -36,8 +40,12 @@ class EMBLTests(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             rec = SeqIO.read("EMBL/embl_with_0_line.embl", "embl")
-            self.assertEqual(len(w), 0, "Unexpected parser warnings: " +
-                             "\n".join(str(warn.message) for warn in w))
+            self.assertEqual(
+                len(w),
+                0,
+                "Unexpected parser warnings: "
+                + "\n".join(str(warn.message) for warn in w),
+            )
             self.assertEqual(len(rec), 1740)
 
     def test_embl_no_coords(self):
@@ -48,8 +56,10 @@ class EMBLTests(unittest.TestCase):
             warnings.simplefilter("always", BiopythonParserWarning)
             rec = SeqIO.read("EMBL/101ma_no_coords.embl", "embl")
             self.assertTrue(w, "Expected parser warning")
-            self.assertEqual([str(_.message) for _ in w],
-                             ["EMBL sequence line missing coordinates"] * 3)
+            self.assertEqual(
+                [str(_.message) for _ in w],
+                ["EMBL sequence line missing coordinates"] * 3,
+            )
             self.assertEqual(len(rec), 154)
             self.assertEqual(rec.seq[:10], "MVLSEGEWQL")
             self.assertEqual(rec.seq[-10:], "AKYKELGYQG")
@@ -60,8 +70,9 @@ class EMBLTests(unittest.TestCase):
             warnings.simplefilter("always", BiopythonParserWarning)
             record = SeqIO.read("EMBL/RepBase23.02.embl", "embl")
             self.assertTrue(w, "Expected parser warning")
-            self.assertEqual([str(_.message) for _ in w],
-                             ["Malformed DR line in EMBL file."])
+            self.assertEqual(
+                [str(_.message) for _ in w], ["Malformed DR line in EMBL file."]
+            )
 
 
 if __name__ == "__main__":

--- a/Tests/test_Enzyme.py
+++ b/Tests/test_Enzyme.py
@@ -14,7 +14,6 @@ from io import StringIO
 
 
 class TestEnzyme(unittest.TestCase):
-
     def test_parse_zero(self):
         handle = StringIO("")
         records = list(Enzyme.parse(handle))
@@ -30,9 +29,11 @@ class TestEnzyme(unittest.TestCase):
     def test_parse_many(self):
         """Check parse function with multiple records."""
         data = ""
-        for filename in ["Enzymes/lipoprotein.txt",
-                         "Enzymes/proline.txt",
-                         "Enzymes/valine.txt"]:
+        for filename in [
+            "Enzymes/lipoprotein.txt",
+            "Enzymes/proline.txt",
+            "Enzymes/valine.txt",
+        ]:
             with open(filename) as handle:
                 data += handle.read()
         handle = StringIO(data)
@@ -53,8 +54,13 @@ class TestEnzyme(unittest.TestCase):
         self.assertEqual(record["AN"][0], "Clearing factor lipase.")
         self.assertEqual(record["AN"][1], "Diacylglycerol lipase.")
         self.assertEqual(record["AN"][2], "Diglyceride lipase.")
-        self.assertEqual(record["CA"], "Triacylglycerol + H(2)O = diacylglycerol + a carboxylate.")
-        self.assertEqual(record["CC"][0], "Hydrolyzes triacylglycerols in chylomicrons and very low-density lipoproteins (VLDL).")
+        self.assertEqual(
+            record["CA"], "Triacylglycerol + H(2)O = diacylglycerol + a carboxylate."
+        )
+        self.assertEqual(
+            record["CC"][0],
+            "Hydrolyzes triacylglycerols in chylomicrons and very low-density lipoproteins (VLDL).",
+        )
         self.assertEqual(record["CC"][1], "Also hydrolyzes diacylglycerol.")
         self.assertEqual(record["PR"], ["PDOC00110"])
         self.assertEqual(record["DR"][0], ["P11151", "LIPL_BOVIN"])
@@ -68,8 +74,10 @@ class TestEnzyme(unittest.TestCase):
         self.assertEqual(record["DR"][8], ["P49923", "LIPL_PIG"])
         self.assertEqual(record["DR"][9], ["Q06000", "LIPL_RAT"])
         self.assertEqual(record["DR"][10], ["Q29524", "LIPL_SHEEP"])
-        self.assertTrue(str(record).startswith("ID: 3.1.1.34\nDE: Lipoprotein lipase.\n"),
-                        "Did not expect:\n%s" % record)
+        self.assertTrue(
+            str(record).startswith("ID: 3.1.1.34\nDE: Lipoprotein lipase.\n"),
+            "Did not expect:\n%s" % record,
+        )
 
     def test_proline(self):
         """Parsing ENZYME record for proline racemase (5.1.1.4)."""
@@ -89,8 +97,10 @@ class TestEnzyme(unittest.TestCase):
         self.assertEqual(record["DR"][6], ["Q9CXA2", "PRCM_MOUSE"])
         self.assertEqual(record["DR"][7], ["Q5RC28", "PRCM_PONAB"])
         self.assertEqual(record["DR"][8], ["Q66II5", "PRCM_XENTR"])
-        self.assertTrue(str(record).startswith("ID: 5.1.1.4\nDE: Proline racemase.\n"),
-                        "Did not expect:\n%s" % record)
+        self.assertTrue(
+            str(record).startswith("ID: 5.1.1.4\nDE: Proline racemase.\n"),
+            "Did not expect:\n%s" % record,
+        )
 
     def test_valine(self):
         """Parsing ENZYME record for valine decarboxylase (4.1.1.14)."""
@@ -103,8 +113,10 @@ class TestEnzyme(unittest.TestCase):
         self.assertEqual(record["CF"], "Pyridoxal 5'-phosphate.")
         self.assertEqual(record["CC"], ["Also acts on L-leucine."])
         self.assertEqual(len(record["DR"]), 0)
-        self.assertTrue(str(record).startswith("ID: 4.1.1.14\nDE: Valine decarboxylase.\n"),
-                        "Did not expect:\n%s" % record)
+        self.assertTrue(
+            str(record).startswith("ID: 4.1.1.14\nDE: Valine decarboxylase.\n"),
+            "Did not expect:\n%s" % record,
+        )
 
     def test_lactate(self):
         """Parsing ENZYME record for lactate racemase (5.1.2.1)."""
@@ -119,8 +131,10 @@ class TestEnzyme(unittest.TestCase):
         self.assertEqual(record["AN"][2], "Lacticoracemase.")
         self.assertEqual(record["CA"], "(S)-lactate = (R)-lactate.")
         self.assertEqual(len(record["DR"]), 0)
-        self.assertTrue(str(record).startswith("ID: 5.1.2.1\nDE: Lactate racemase.\n"),
-                        "Did not expect:\n%s" % record)
+        self.assertTrue(
+            str(record).startswith("ID: 5.1.2.1\nDE: Lactate racemase.\n"),
+            "Did not expect:\n%s" % record,
+        )
 
 
 if __name__ == "__main__":

--- a/Tests/test_ExPASy.py
+++ b/Tests/test_ExPASy.py
@@ -15,6 +15,7 @@ from Bio.ExPASy import Prodoc
 from Bio.ExPASy import Prosite
 
 import requires_internet
+
 requires_internet.check()
 
 
@@ -35,15 +36,19 @@ class ExPASyOnlineTests(unittest.TestCase):
     def test_prosite_html(self):
         with ExPASy.get_prosite_entry("PS00001") as handle:
             html = handle.read()
-        self.assertEqual(handle.url,
-                         "https://prosite.expasy.org/cgi-bin/prosite/get-prosite-entry?PS00001")
+        self.assertEqual(
+            handle.url,
+            "https://prosite.expasy.org/cgi-bin/prosite/get-prosite-entry?PS00001",
+        )
         self.assertIn("<title>PROSITE: PS00001</title>", html)
 
     def test_prodoc_html(self):
         with ExPASy.get_prodoc_entry("PDOC00001") as handle:
             html = handle.read()
-        self.assertEqual(handle.url,
-                         "https://prosite.expasy.org/cgi-bin/prosite/get-prodoc-entry?PDOC00001")
+        self.assertEqual(
+            handle.url,
+            "https://prosite.expasy.org/cgi-bin/prosite/get-prodoc-entry?PDOC00001",
+        )
         self.assertIn("{PS00001; ASN_GLYCOSYLATION}", html)
 
 


### PR DESCRIPTION
This pull request addresses issue #2552

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
