### PR TITLE
Speed up SeqIO.parse() for fastq

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -8,6 +8,31 @@ https://www.open-bio.org/category/obf-projects/biopython/
 
 The latest news is at the top of this file.
 
+(In progress, not yet released): Biopython 1.78
+===============================================
+
+This release of Biopython supports Python 3.6, 3.7 and 3.8. It has also been
+tested on PyPy3.6.1 v7.1.1.
+
+As in recent releases, more of our code is now explicitly available under
+either our original "Biopython License Agreement", or the very similar but
+more commonly used "3-Clause BSD License".  See the ``LICENSE.rst`` file for
+more details.
+
+``Bio.SeqIO.parse()`` is faster with "fastq" format due to small improvements
+in the ``Bio.SeqIO.QualityIO`` module.
+
+Additionally, a number of small bugs and typos have been fixed with further
+additions to the test suite. There has been further work to follow the Python
+PEP8, PEP257 and best practice standard coding style, and more of the code
+style has been reformatted with the ``black`` tool.
+
+Many thanks to the Biopython developers and community for making this release
+possible, especially the following contributors:
+
+- Chris Rands
+- Peter Cock
+
 25 May 2020: Biopython 1.77
 ===========================
 


### PR DESCRIPTION
If I understand the original implementation correctly, this should be identical functionally but substantially faster.

Original:
```
$ time python3 bench.py biofast-data-v1/M_abscessus_HiSeq.fq 
1.77
5682010	568201000	568201000

real	1m23.955s
user	1m22.737s
sys	0m0.783s
```

This branch:
```
$ time python3 bench.py biofast-data-v1/M_abscessus_HiSeq.fq 
1.77
5682010	568201000	568201000

real	1m2.695s
user	1m5.747s
sys	0m0.876s
```

Benchmark script modified from [biofast](https://github.com/lh3/biofast):
```
$ cat bench.py 
import Bio; print(Bio.__version__)

if __name__ == "__main__":
    from Bio import SeqIO
    import sys, re, gzip
    if len(sys.argv) == 1:
        print("Usage: fqcnt.py <in.fq.gz>")
        sys.exit(0)
    fn = sys.argv[1]
    if re.search(r'\.gz$', fn):
        fp = gzip.open(fn, 'rt')
    else:
        fp = open(fn, 'r')
    n, slen = 0, 0
    for seq in SeqIO.parse(fp, "fastq"):
        n += 1
        slen += len(seq)
    print('{}\t{}\t{}'.format(n, slen, slen))
```

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
