### PR TITLE
removed alphabet information from printed alignments

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -42,7 +42,7 @@ class MultipleSeqAlignment:
     >>> from Bio import AlignIO
     >>> align = AlignIO.read("Clustalw/opuntia.aln", "clustal")
     >>> print(align)
-    alignment with 7 rows and 156 columns
+    Alignment with 7 rows and 156 columns
     TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273285|gb|AF191659.1|AF191
     TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273284|gb|AF191658.1|AF191
     TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF191
@@ -83,7 +83,7 @@ class MultipleSeqAlignment:
     Or, take just the first ten columns as a sub-alignment:
 
     >>> print(align[:, :10])
-    alignment with 7 rows and 10 columns
+    Alignment with 7 rows and 10 columns
     TATACATTAA gi|6273285|gb|AF191659.1|AF191
     TATACATTAA gi|6273284|gb|AF191658.1|AF191
     TATACATTAA gi|6273287|gb|AF191661.1|AF191
@@ -97,7 +97,7 @@ class MultipleSeqAlignment:
     and last ten columns:
 
     >>> print(align[:, :10] + align[:, -10:])
-    alignment with 7 rows and 20 columns
+    Alignment with 7 rows and 20 columns
     TATACATTAAGTGTACCAGA gi|6273285|gb|AF191659.1|AF191
     TATACATTAAGTGTACCAGA gi|6273284|gb|AF191658.1|AF191
     TATACATTAAGTGTACCAGA gi|6273287|gb|AF191661.1|AF191
@@ -148,7 +148,7 @@ class MultipleSeqAlignment:
         ...                              annotations={"tool": "demo"},
         ...                              column_annotations={"stats": "CCCXCCC"})
         >>> print(align)
-        alignment with 3 rows and 7 columns
+        Alignment with 3 rows and 7 columns
         AAAACGT Alpha
         AAA-CGT Beta
         AAAAGGT Gamma
@@ -263,7 +263,7 @@ class MultipleSeqAlignment:
         >>> align.add_sequence("Beta",  "ACT-CTAGCTAG")
         >>> align.add_sequence("Gamma", "ACTGCTAGATAG")
         >>> print(align)
-        alignment with 3 rows and 12 columns
+        Alignment with 3 rows and 12 columns
         ACTGCTAGCTAG Alpha
         ACT-CTAGCTAG Beta
         ACTGCTAGATAG Gamma
@@ -272,7 +272,7 @@ class MultipleSeqAlignment:
         """
         rows = len(self._records)
         lines = [
-            "alignment with %i rows and %i columns"
+            "Alignment with %i rows and %i columns"
             % (rows, self.get_alignment_length())
         ]
         if rows <= 20:
@@ -502,7 +502,7 @@ class MultipleSeqAlignment:
 
         >>> align = MultipleSeqAlignment([a, b, c])
         >>> print(align)
-        alignment with 3 rows and 7 columns
+        Alignment with 3 rows and 7 columns
         AAAACGT Alpha
         AAA-CGT Beta
         AAAAGGT Gamma
@@ -511,7 +511,7 @@ class MultipleSeqAlignment:
 
         >>> align.extend([d, e])
         >>> print(align)
-        alignment with 5 rows and 7 columns
+        Alignment with 5 rows and 7 columns
         AAAACGT Alpha
         AAA-CGT Beta
         AAAAGGT Gamma
@@ -553,7 +553,7 @@ class MultipleSeqAlignment:
         >>> from Bio import AlignIO
         >>> align = AlignIO.read("Clustalw/opuntia.aln", "clustal")
         >>> print(align)
-        alignment with 7 rows and 156 columns
+        Alignment with 7 rows and 156 columns
         TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273285|gb|AF191659.1|AF191
         TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273284|gb|AF191658.1|AF191
         TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF191
@@ -574,7 +574,7 @@ class MultipleSeqAlignment:
 
         >>> align.append(dummy)
         >>> print(align)
-        alignment with 8 rows and 156 columns
+        Alignment with 8 rows and 156 columns
         TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273285|gb|AF191659.1|AF191
         TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273284|gb|AF191658.1|AF191
         TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF191
@@ -639,12 +639,12 @@ class MultipleSeqAlignment:
         Now, let's look at these two alignments:
 
         >>> print(left)
-        alignment with 3 rows and 5 columns
+        Alignment with 3 rows and 5 columns
         AAAAC Alpha
         AAA-C Beta
         AAAAG Gamma
         >>> print(right)
-        alignment with 3 rows and 2 columns
+        Alignment with 3 rows and 2 columns
         GT Alpha
         GT Beta
         GT Gamma
@@ -653,7 +653,7 @@ class MultipleSeqAlignment:
 
         >>> combined = left + right
         >>> print(combined)
-        alignment with 3 rows and 7 columns
+        Alignment with 3 rows and 7 columns
         AAAACGT Alpha
         AAA-CGT Beta
         AAAAGGT Gamma
@@ -754,7 +754,7 @@ class MultipleSeqAlignment:
 
         >>> sub_alignment = align[2:5]
         >>> print(sub_alignment)
-        alignment with 3 rows and 7 columns
+        Alignment with 3 rows and 7 columns
         AAAAGGT Gamma
         AAAACGT Delta
         AAA-GGT Epsilon
@@ -764,7 +764,7 @@ class MultipleSeqAlignment:
 
         >>> sub_alignment = align[::2]
         >>> print(sub_alignment)
-        alignment with 3 rows and 7 columns
+        Alignment with 3 rows and 7 columns
         AAAACGT Alpha
         AAAAGGT Gamma
         AAA-GGT Epsilon
@@ -773,7 +773,7 @@ class MultipleSeqAlignment:
 
         >>> rev_alignment = align[::-1]
         >>> print(rev_alignment)
-        alignment with 5 rows and 7 columns
+        Alignment with 5 rows and 7 columns
         AAA-GGT Epsilon
         AAAACGT Delta
         AAAAGGT Gamma
@@ -809,7 +809,7 @@ class MultipleSeqAlignment:
         However, in general you get a sub-alignment,
 
         >>> print(align[1:5, 3:6])
-        alignment with 4 rows and 3 columns
+        Alignment with 4 rows and 3 columns
         -CG Beta
         AGG Gamma
         ACG Delta
@@ -882,7 +882,7 @@ class MultipleSeqAlignment:
         If you simple try and add these without sorting, you get this:
 
         >>> print(align1 + align2)
-        alignment with 3 rows and 8 columns
+        Alignment with 3 rows and 8 columns
         ACGTCGGT <unknown id>
         ACGGCGTT <unknown id>
         ACGCCGCT Chicken
@@ -895,7 +895,7 @@ class MultipleSeqAlignment:
         >>> align1.sort()
         >>> align2.sort()
         >>> print(align1 + align2)
-        alignment with 3 rows and 8 columns
+        Alignment with 3 rows and 8 columns
         ACGCCGCT Chicken
         ACGTCGTT Human
         ACGGCGGT Mouse
@@ -905,13 +905,13 @@ class MultipleSeqAlignment:
 
         >>> from Bio.SeqUtils import GC
         >>> print(align1)
-        alignment with 3 rows and 4 columns
+        Alignment with 3 rows and 4 columns
         ACGC Chicken
         ACGT Human
         ACGG Mouse
         >>> align1.sort(key = lambda record: GC(record.seq))
         >>> print(align1)
-        alignment with 3 rows and 4 columns
+        Alignment with 3 rows and 4 columns
         ACGT Human
         ACGC Chicken
         ACGG Mouse
@@ -921,7 +921,7 @@ class MultipleSeqAlignment:
 
         >>> align1.sort(reverse=True)
         >>> print(align1)
-        alignment with 3 rows and 4 columns
+        Alignment with 3 rows and 4 columns
         ACGG Mouse
         ACGT Human
         ACGC Chicken

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -42,7 +42,7 @@ class MultipleSeqAlignment:
     >>> from Bio import AlignIO
     >>> align = AlignIO.read("Clustalw/opuntia.aln", "clustal")
     >>> print(align)
-    SingleLetterAlphabet() alignment with 7 rows and 156 columns
+    alignment with 7 rows and 156 columns
     TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273285|gb|AF191659.1|AF191
     TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273284|gb|AF191658.1|AF191
     TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF191
@@ -83,7 +83,7 @@ class MultipleSeqAlignment:
     Or, take just the first ten columns as a sub-alignment:
 
     >>> print(align[:, :10])
-    SingleLetterAlphabet() alignment with 7 rows and 10 columns
+    alignment with 7 rows and 10 columns
     TATACATTAA gi|6273285|gb|AF191659.1|AF191
     TATACATTAA gi|6273284|gb|AF191658.1|AF191
     TATACATTAA gi|6273287|gb|AF191661.1|AF191
@@ -97,7 +97,7 @@ class MultipleSeqAlignment:
     and last ten columns:
 
     >>> print(align[:, :10] + align[:, -10:])
-    SingleLetterAlphabet() alignment with 7 rows and 20 columns
+    alignment with 7 rows and 20 columns
     TATACATTAAGTGTACCAGA gi|6273285|gb|AF191659.1|AF191
     TATACATTAAGTGTACCAGA gi|6273284|gb|AF191658.1|AF191
     TATACATTAAGTGTACCAGA gi|6273287|gb|AF191661.1|AF191
@@ -148,7 +148,7 @@ class MultipleSeqAlignment:
         ...                              annotations={"tool": "demo"},
         ...                              column_annotations={"stats": "CCCXCCC"})
         >>> print(align)
-        DNAAlphabet() alignment with 3 rows and 7 columns
+        alignment with 3 rows and 7 columns
         AAAACGT Alpha
         AAA-CGT Beta
         AAAAGGT Gamma
@@ -263,7 +263,7 @@ class MultipleSeqAlignment:
         >>> align.add_sequence("Beta",  "ACT-CTAGCTAG")
         >>> align.add_sequence("Gamma", "ACTGCTAGATAG")
         >>> print(align)
-        Gapped(IUPACUnambiguousDNA(), '-') alignment with 3 rows and 12 columns
+        alignment with 3 rows and 12 columns
         ACTGCTAGCTAG Alpha
         ACT-CTAGCTAG Beta
         ACTGCTAGATAG Gamma
@@ -272,8 +272,8 @@ class MultipleSeqAlignment:
         """
         rows = len(self._records)
         lines = [
-            "%s alignment with %i rows and %i columns"
-            % (str(self._alphabet), rows, self.get_alignment_length())
+            "alignment with %i rows and %i columns"
+            % (rows, self.get_alignment_length())
         ]
         if rows <= 20:
             lines.extend(self._str_line(rec) for rec in self._records)
@@ -298,17 +298,16 @@ class MultipleSeqAlignment:
         """
         # A doctest for __repr__ would be nice, but __class__ comes out differently
         # if run via the __main__ trick.
-        return "<%s instance (%i records of length %i, %s) at %x>" % (
+        return "<%s instance (%i records of length %i) at %x>" % (
             self.__class__,
             len(self._records),
             self.get_alignment_length(),
-            repr(self._alphabet),
             id(self),
         )
         # This version is useful for doing eval(repr(alignment)),
         # but it can be VERY long:
-        # return "%s(%s, %s)" \
-        #       % (self.__class__, repr(self._records), repr(self._alphabet))
+        # return "%s(%s)" \
+        #       % (self.__class__, repr(self._records))
 
     def format(self, format_spec):
         """Return the alignment as a string in the specified file format [DEPRECATED].
@@ -503,7 +502,7 @@ class MultipleSeqAlignment:
 
         >>> align = MultipleSeqAlignment([a, b, c])
         >>> print(align)
-        DNAAlphabet() alignment with 3 rows and 7 columns
+        alignment with 3 rows and 7 columns
         AAAACGT Alpha
         AAA-CGT Beta
         AAAAGGT Gamma
@@ -512,7 +511,7 @@ class MultipleSeqAlignment:
 
         >>> align.extend([d, e])
         >>> print(align)
-        DNAAlphabet() alignment with 5 rows and 7 columns
+        alignment with 5 rows and 7 columns
         AAAACGT Alpha
         AAA-CGT Beta
         AAAAGGT Gamma
@@ -554,7 +553,7 @@ class MultipleSeqAlignment:
         >>> from Bio import AlignIO
         >>> align = AlignIO.read("Clustalw/opuntia.aln", "clustal")
         >>> print(align)
-        SingleLetterAlphabet() alignment with 7 rows and 156 columns
+        alignment with 7 rows and 156 columns
         TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273285|gb|AF191659.1|AF191
         TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273284|gb|AF191658.1|AF191
         TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF191
@@ -575,7 +574,7 @@ class MultipleSeqAlignment:
 
         >>> align.append(dummy)
         >>> print(align)
-        SingleLetterAlphabet() alignment with 8 rows and 156 columns
+        alignment with 8 rows and 156 columns
         TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273285|gb|AF191659.1|AF191
         TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273284|gb|AF191658.1|AF191
         TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF191
@@ -640,12 +639,12 @@ class MultipleSeqAlignment:
         Now, let's look at these two alignments:
 
         >>> print(left)
-        DNAAlphabet() alignment with 3 rows and 5 columns
+        alignment with 3 rows and 5 columns
         AAAAC Alpha
         AAA-C Beta
         AAAAG Gamma
         >>> print(right)
-        DNAAlphabet() alignment with 3 rows and 2 columns
+        alignment with 3 rows and 2 columns
         GT Alpha
         GT Beta
         GT Gamma
@@ -654,7 +653,7 @@ class MultipleSeqAlignment:
 
         >>> combined = left + right
         >>> print(combined)
-        DNAAlphabet() alignment with 3 rows and 7 columns
+        alignment with 3 rows and 7 columns
         AAAACGT Alpha
         AAA-CGT Beta
         AAAAGGT Gamma
@@ -755,7 +754,7 @@ class MultipleSeqAlignment:
 
         >>> sub_alignment = align[2:5]
         >>> print(sub_alignment)
-        DNAAlphabet() alignment with 3 rows and 7 columns
+        alignment with 3 rows and 7 columns
         AAAAGGT Gamma
         AAAACGT Delta
         AAA-GGT Epsilon
@@ -765,7 +764,7 @@ class MultipleSeqAlignment:
 
         >>> sub_alignment = align[::2]
         >>> print(sub_alignment)
-        DNAAlphabet() alignment with 3 rows and 7 columns
+        alignment with 3 rows and 7 columns
         AAAACGT Alpha
         AAAAGGT Gamma
         AAA-GGT Epsilon
@@ -774,7 +773,7 @@ class MultipleSeqAlignment:
 
         >>> rev_alignment = align[::-1]
         >>> print(rev_alignment)
-        DNAAlphabet() alignment with 5 rows and 7 columns
+        alignment with 5 rows and 7 columns
         AAA-GGT Epsilon
         AAAACGT Delta
         AAAAGGT Gamma
@@ -810,7 +809,7 @@ class MultipleSeqAlignment:
         However, in general you get a sub-alignment,
 
         >>> print(align[1:5, 3:6])
-        DNAAlphabet() alignment with 4 rows and 3 columns
+        alignment with 4 rows and 3 columns
         -CG Beta
         AGG Gamma
         ACG Delta
@@ -883,7 +882,7 @@ class MultipleSeqAlignment:
         If you simple try and add these without sorting, you get this:
 
         >>> print(align1 + align2)
-        DNAAlphabet() alignment with 3 rows and 8 columns
+        alignment with 3 rows and 8 columns
         ACGTCGGT <unknown id>
         ACGGCGTT <unknown id>
         ACGCCGCT Chicken
@@ -896,7 +895,7 @@ class MultipleSeqAlignment:
         >>> align1.sort()
         >>> align2.sort()
         >>> print(align1 + align2)
-        DNAAlphabet() alignment with 3 rows and 8 columns
+        alignment with 3 rows and 8 columns
         ACGCCGCT Chicken
         ACGTCGTT Human
         ACGGCGGT Mouse
@@ -906,13 +905,13 @@ class MultipleSeqAlignment:
 
         >>> from Bio.SeqUtils import GC
         >>> print(align1)
-        DNAAlphabet() alignment with 3 rows and 4 columns
+        alignment with 3 rows and 4 columns
         ACGC Chicken
         ACGT Human
         ACGG Mouse
         >>> align1.sort(key = lambda record: GC(record.seq))
         >>> print(align1)
-        DNAAlphabet() alignment with 3 rows and 4 columns
+        alignment with 3 rows and 4 columns
         ACGT Human
         ACGC Chicken
         ACGG Mouse
@@ -922,7 +921,7 @@ class MultipleSeqAlignment:
 
         >>> align1.sort(reverse=True)
         >>> print(align1)
-        DNAAlphabet() alignment with 3 rows and 4 columns
+        alignment with 3 rows and 4 columns
         ACGG Mouse
         ACGT Human
         ACGC Chicken

--- a/Bio/AlignIO/MauveIO.py
+++ b/Bio/AlignIO/MauveIO.py
@@ -51,11 +51,11 @@ would probably load this using the Bio.AlignIO.parse() function:
     >>> for aln in alignments:
     ...     print(aln)
     ...
-    alignment with 3 rows and 240 columns
+    Alignment with 3 rows and 240 columns
     --------------------------------------------...--- a.fa
     TTTAAACATCCCTCGGCCCGTCGCCCTTTTATAATAGCAGTACG...CTG b.fa/5416-5968
     TTTAAACACCTTTTTGGATG--GCCCAGTTCGTTCAGTTGTG-G...CTT c.fa/9475-10076
-    alignment with 2 rows and 46 columns
+    Alignment with 2 rows and 46 columns
     -----------------------GGGCGAACGTATAAACCATTCTG b.fa/5968-6015
     TTCGGTACCCTCCATGACCCACGAAATGAGGGCCCAGGGTATGCTT c.fa/9428-9476
 

--- a/Bio/AlignIO/MauveIO.py
+++ b/Bio/AlignIO/MauveIO.py
@@ -51,11 +51,11 @@ would probably load this using the Bio.AlignIO.parse() function:
     >>> for aln in alignments:
     ...     print(aln)
     ...
-    SingleLetterAlphabet() alignment with 3 rows and 240 columns
+    alignment with 3 rows and 240 columns
     --------------------------------------------...--- a.fa
     TTTAAACATCCCTCGGCCCGTCGCCCTTTTATAATAGCAGTACG...CTG b.fa/5416-5968
     TTTAAACACCTTTTTGGATG--GCCCAGTTCGTTCAGTTGTG-G...CTT c.fa/9475-10076
-    SingleLetterAlphabet() alignment with 2 rows and 46 columns
+    alignment with 2 rows and 46 columns
     -----------------------GGGCGAACGTATAAACCATTCTG b.fa/5968-6015
     TTCGGTACCCTCCATGACCCACGAAATGAGGGCCCAGGGTATGCTT c.fa/9428-9476
 

--- a/Bio/AlignIO/StockholmIO.py
+++ b/Bio/AlignIO/StockholmIO.py
@@ -33,7 +33,7 @@ using the Bio.AlignIO.read() function:
     >>> from Bio import AlignIO
     >>> align = AlignIO.read("Stockholm/simple.sth", "stockholm")
     >>> print(align)
-    SingleLetterAlphabet() alignment with 2 rows and 104 columns
+    alignment with 2 rows and 104 columns
     UUAAUCGAGCUCAACACUCUUCGUAUAUCCUC-UCAAUAUGG-G...UGU AP001509.1
     AAAAUUGAAUAUCGUUUUACUUGUUUAU-GUCGUGAAU-UGG-C...GAU AE007476.1
     >>> for record in align:
@@ -51,7 +51,7 @@ optional argument to the Bio.AlignIO.read() function:
     >>> align = AlignIO.read("Stockholm/simple.sth", "stockholm",
     ...                      alphabet=generic_rna)
     >>> print(align)
-    RNAAlphabet() alignment with 2 rows and 104 columns
+    alignment with 2 rows and 104 columns
     UUAAUCGAGCUCAACACUCUUCGUAUAUCCUC-UCAAUAUGG-G...UGU AP001509.1
     AAAAUUGAAUAUCGUUUUACUUGUUUAU-GUCGUGAAU-UGG-C...GAU AE007476.1
 

--- a/Bio/AlignIO/StockholmIO.py
+++ b/Bio/AlignIO/StockholmIO.py
@@ -33,7 +33,7 @@ using the Bio.AlignIO.read() function:
     >>> from Bio import AlignIO
     >>> align = AlignIO.read("Stockholm/simple.sth", "stockholm")
     >>> print(align)
-    alignment with 2 rows and 104 columns
+    Alignment with 2 rows and 104 columns
     UUAAUCGAGCUCAACACUCUUCGUAUAUCCUC-UCAAUAUGG-G...UGU AP001509.1
     AAAAUUGAAUAUCGUUUUACUUGUUUAU-GUCGUGAAU-UGG-C...GAU AE007476.1
     >>> for record in align:
@@ -51,7 +51,7 @@ optional argument to the Bio.AlignIO.read() function:
     >>> align = AlignIO.read("Stockholm/simple.sth", "stockholm",
     ...                      alphabet=generic_rna)
     >>> print(align)
-    alignment with 2 rows and 104 columns
+    Alignment with 2 rows and 104 columns
     UUAAUCGAGCUCAACACUCUUCGUAUAUCCUC-UCAAUAUGG-G...UGU AP001509.1
     AAAAUUGAAUAUCGUUUUACUUGUUUAU-GUCGUGAAU-UGG-C...GAU AE007476.1
 

--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -34,7 +34,7 @@ alignment):
 >>> from Bio import AlignIO
 >>> align = AlignIO.read("Phylip/interlaced.phy", "phylip")
 >>> print(align)
-alignment with 3 rows and 384 columns
+Alignment with 3 rows and 384 columns
 -----MKVILLFVLAVFTVFVSS---------------RGIPPE...I-- CYS1_DICDI
 MAHARVLLLALAVLATAAVAVASSSSFADSNPIRPVTDRAASTL...VAA ALEU_HORVU
 ------MWATLPLLCAGAWLLGV--------PVCGAAELSVNSL...PLV CATH_HUMAN
@@ -48,7 +48,7 @@ into a list:
 >>> from Bio import AlignIO
 >>> alignments = list(AlignIO.parse("Emboss/needle.txt", "emboss"))
 >>> print(alignments[2])
-alignment with 2 rows and 120 columns
+Alignment with 2 rows and 120 columns
 -KILIVDDQYGIRILLNEVFNKEGYQTFQAANGLQALDIVTKER...--- ref_rec
 LHIVVVDDDPGTCVYIESVFAELGHTCKSFVRPEAAEEYILTHP...HKE gi|94967506|receiver
 

--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -34,7 +34,7 @@ alignment):
 >>> from Bio import AlignIO
 >>> align = AlignIO.read("Phylip/interlaced.phy", "phylip")
 >>> print(align)
-SingleLetterAlphabet() alignment with 3 rows and 384 columns
+alignment with 3 rows and 384 columns
 -----MKVILLFVLAVFTVFVSS---------------RGIPPE...I-- CYS1_DICDI
 MAHARVLLLALAVLATAAVAVASSSSFADSNPIRPVTDRAASTL...VAA ALEU_HORVU
 ------MWATLPLLCAGAWLLGV--------PVCGAAELSVNSL...PLV CATH_HUMAN
@@ -48,7 +48,7 @@ into a list:
 >>> from Bio import AlignIO
 >>> alignments = list(AlignIO.parse("Emboss/needle.txt", "emboss"))
 >>> print(alignments[2])
-SingleLetterAlphabet() alignment with 2 rows and 120 columns
+alignment with 2 rows and 120 columns
 -KILIVDDQYGIRILLNEVFNKEGYQTFQAANGLQALDIVTKER...--- ref_rec
 LHIVVVDDDPGTCVYIESVFAELGHTCKSFVRPEAAEEYILTHP...HKE gi|94967506|receiver
 

--- a/Bio/SearchIO/_model/hsp.py
+++ b/Bio/SearchIO/_model/hsp.py
@@ -743,7 +743,7 @@ class HSPFragment(_BaseHSP):
     >>> fragment.aln.__class__
     <class 'Bio.Align.MultipleSeqAlignment'>
     >>> print(fragment.aln)
-    alignment with 2 rows and 61 columns
+    Alignment with 2 rows and 61 columns
     CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAG...GGG 33211
     CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAG...GGG gi|262205317|ref|NR_030195.1|
 

--- a/Bio/SearchIO/_model/hsp.py
+++ b/Bio/SearchIO/_model/hsp.py
@@ -743,7 +743,7 @@ class HSPFragment(_BaseHSP):
     >>> fragment.aln.__class__
     <class 'Bio.Align.MultipleSeqAlignment'>
     >>> print(fragment.aln)
-    DNAAlphabet() alignment with 2 rows and 61 columns
+    alignment with 2 rows and 61 columns
     CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAG...GGG 33211
     CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAG...GGG gi|262205317|ref|NR_030195.1|
 

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -82,7 +82,7 @@ This is the seed alignment for the Phage\_Coat\_Gp8 (PF05371) PFAM entry, downlo
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment)
-alignment with 7 rows and 52 columns
+Alignment with 7 rows and 52 columns
 AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRL...SKA COATB_BPIKE/30-81
 AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIKL...SRA Q9T0Q8_BPIKE/1-52
 DGTSTATSYATEAMNSLKTQATDLIDQTWPVVTSVAVAGLAIRL...SKA COATB_BPI22/32-83
@@ -234,21 +234,21 @@ If you wanted to read this in using \verb|Bio.AlignIO| you could use:
 \noindent This would give the following output, again abbreviated for display:
 
 \begin{minted}{text}
-alignment with 5 rows and 6 columns
+Alignment with 5 rows and 6 columns
 AAACCA Alpha
 AAACCC Beta
 ACCCCA Gamma
 CCCAAC Delta
 CCCAAA Epsilon
 
-alignment with 5 rows and 6 columns
+Alignment with 5 rows and 6 columns
 AAACAA Alpha
 AAACCC Beta
 ACCCAA Gamma
 CCCACC Delta
 CCCAAA Epsilon
 
-alignment with 5 rows and 6 columns
+Alignment with 5 rows and 6 columns
 AAAAAC Alpha
 AAACCC Beta
 AACAAC Gamma
@@ -257,7 +257,7 @@ CCCAAC Epsilon
 
 ...
 
-alignment with 5 rows and 6 columns
+Alignment with 5 rows and 6 columns
 AAAACC Alpha
 ACCCCC Beta
 AAAACC Gamma
@@ -695,7 +695,7 @@ it selects some of the rows giving back another alignment object:
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment)
-alignment with 7 rows and 52 columns
+Alignment with 7 rows and 52 columns
 AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRL...SKA COATB_BPIKE/30-81
 AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIKL...SRA Q9T0Q8_BPIKE/1-52
 DGTSTATSYATEAMNSLKTQATDLIDQTWPVVTSVAVAGLAIRL...SKA COATB_BPI22/32-83
@@ -704,7 +704,7 @@ AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPZJ2/1-49
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA Q9T0Q9_BPFD/1-49
 FAADDATSQAKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKL...SRA COATB_BPIF1/22-73
 >>> print(alignment[3:7])
-alignment with 4 rows and 52 columns
+Alignment with 4 rows and 52 columns
 AEGDDP---AKAAFNSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPM13/24-72
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPZJ2/1-49
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA Q9T0Q9_BPFD/1-49
@@ -742,7 +742,7 @@ three rows we extracted earlier, but take just their first six columns:
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment[3:6, :6])
-alignment with 3 rows and 6 columns
+Alignment with 3 rows and 6 columns
 AEGDDP COATB_BPM13/24-72
 AEGDDP COATB_BPZJ2/1-49
 AEGDDP Q9T0Q9_BPFD/1-49
@@ -753,7 +753,7 @@ Leaving the first index as \verb|:| means take all the rows:
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment[:, :6])
-alignment with 7 rows and 6 columns
+Alignment with 7 rows and 6 columns
 AEPNAA COATB_BPIKE/30-81
 AEPNAA Q9T0Q8_BPIKE/1-52
 DGTSTA COATB_BPI22/32-83
@@ -769,7 +769,7 @@ This brings us to a neat way to remove a section. Notice columns
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment[:, 6:9])
-alignment with 7 rows and 3 columns
+Alignment with 7 rows and 3 columns
 TNY COATB_BPIKE/30-81
 TNY Q9T0Q8_BPIKE/1-52
 TSY COATB_BPI22/32-83
@@ -784,7 +784,7 @@ TSQ COATB_BPIF1/22-73
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment[:, 9:])
-alignment with 7 rows and 43 columns
+Alignment with 7 rows and 43 columns
 ATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRLFKKFSSKA COATB_BPIKE/30-81
 ATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIKLFKKFVSRA Q9T0Q8_BPIKE/1-52
 ATEAMNSLKTQATDLIDQTWPVVTSVAVAGLAIRLFKKFSSKA COATB_BPI22/32-83
@@ -801,7 +801,7 @@ by column. This lets you do this as a way to remove a block of columns:
 \begin{minted}{pycon}
 >>> edited = alignment[:, :6] + alignment[:, 9:]
 >>> print(edited)
-alignment with 7 rows and 49 columns
+Alignment with 7 rows and 49 columns
 AEPNAAATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRLFKKFSSKA COATB_BPIKE/30-81
 AEPNAAATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIKLFKKFVSRA Q9T0Q8_BPIKE/1-52
 DGTSTAATEAMNSLKTQATDLIDQTWPVVTSVAVAGLAIRLFKKFSSKA COATB_BPI22/32-83
@@ -821,7 +821,7 @@ alignment rows alphabetically by id:
 \begin{minted}{pycon}
 >>> edited.sort()
 >>> print(edited)
-alignment with 7 rows and 49 columns
+Alignment with 7 rows and 49 columns
 DGTSTAATEAMNSLKTQATDLIDQTWPVVTSVAVAGLAIRLFKKFSSKA COATB_BPI22/32-83
 FAADDAAKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKLFKKFVSRA COATB_BPIF1/22-73
 AEPNAAATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRLFKKFSSKA COATB_BPIKE/30-81
@@ -1005,7 +1005,7 @@ You should be able to work out how to read in the alignment using
 >>> from Bio import AlignIO
 >>> align = AlignIO.read("opuntia.aln", "clustal")
 >>> print(align)
-alignment with 7 rows and 906 columns
+Alignment with 7 rows and 906 columns
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273285|gb|AF191659.1|AF191
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273284|gb|AF191658.1|AF191
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF191
@@ -1140,7 +1140,7 @@ Remember that MUSCLE defaults to using FASTA as the output format:
 >>> from Bio import AlignIO
 >>> align = AlignIO.read(StringIO(stdout), "fasta")
 >>> print(align)
-alignment with 7 rows and 906 columns
+Alignment with 7 rows and 906 columns
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273289|gb|AF191663.1|AF191663
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273291|gb|AF191665.1|AF191665
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273290|gb|AF191664.1|AF191664
@@ -1168,7 +1168,7 @@ with handles instead:
 >>> from Bio import AlignIO
 >>> align = AlignIO.read(child.stdout, "fasta")
 >>> print(align)
-alignment with 7 rows and 906 columns
+Alignment with 7 rows and 906 columns
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273289|gb|AF191663.1|AF191663
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273291|gb|AF191665.1|AF191665
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273290|gb|AF191664.1|AF191664
@@ -1238,7 +1238,7 @@ start to run, and we can ask for the output:
 >>> from Bio import AlignIO
 >>> align = AlignIO.read(child.stdout, "clustal")
 >>> print(align)
-alignment with 6 rows and 900 columns
+Alignment with 6 rows and 900 columns
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273290|gb|AF191664.1|AF19166
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273289|gb|AF191663.1|AF19166
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF19166
@@ -1283,7 +1283,7 @@ a string using \texttt{StringIO} (see Section~\ref{sec:appendix-handles}):
 >>> from Bio import AlignIO
 >>> align = AlignIO.read(StringIO(stdout), "clustal")
 >>> print(align)
-alignment with 6 rows and 900 columns
+Alignment with 6 rows and 900 columns
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273290|gb|AF191664.1|AF19166
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273289|gb|AF191663.1|AF19166
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF19166
@@ -1399,7 +1399,7 @@ discussed earlier in this chapter, as the \texttt{emboss} format:
 >>> from Bio import AlignIO
 >>> align = AlignIO.read("needle.txt", "emboss")
 >>> print(align)
-alignment with 2 rows and 149 columns
+Alignment with 2 rows and 149 columns
 MV-LSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTY...KYR HBA_HUMAN
 MVHLTPEEKSAVTALWGKV--NVDEVGGEALGRLLVVYPWTQRF...KYH HBB_HUMAN
 \end{minted}

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -82,7 +82,7 @@ This is the seed alignment for the Phage\_Coat\_Gp8 (PF05371) PFAM entry, downlo
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment)
-SingleLetterAlphabet() alignment with 7 rows and 52 columns
+alignment with 7 rows and 52 columns
 AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRL...SKA COATB_BPIKE/30-81
 AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIKL...SRA Q9T0Q8_BPIKE/1-52
 DGTSTATSYATEAMNSLKTQATDLIDQTWPVVTSVAVAGLAIRL...SKA COATB_BPI22/32-83
@@ -234,21 +234,21 @@ If you wanted to read this in using \verb|Bio.AlignIO| you could use:
 \noindent This would give the following output, again abbreviated for display:
 
 \begin{minted}{text}
-SingleLetterAlphabet() alignment with 5 rows and 6 columns
+alignment with 5 rows and 6 columns
 AAACCA Alpha
 AAACCC Beta
 ACCCCA Gamma
 CCCAAC Delta
 CCCAAA Epsilon
 
-SingleLetterAlphabet() alignment with 5 rows and 6 columns
+alignment with 5 rows and 6 columns
 AAACAA Alpha
 AAACCC Beta
 ACCCAA Gamma
 CCCACC Delta
 CCCAAA Epsilon
 
-SingleLetterAlphabet() alignment with 5 rows and 6 columns
+alignment with 5 rows and 6 columns
 AAAAAC Alpha
 AAACCC Beta
 AACAAC Gamma
@@ -257,7 +257,7 @@ CCCAAC Epsilon
 
 ...
 
-SingleLetterAlphabet() alignment with 5 rows and 6 columns
+alignment with 5 rows and 6 columns
 AAAACC Alpha
 ACCCCC Beta
 AAAACC Gamma
@@ -695,7 +695,7 @@ it selects some of the rows giving back another alignment object:
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment)
-SingleLetterAlphabet() alignment with 7 rows and 52 columns
+alignment with 7 rows and 52 columns
 AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRL...SKA COATB_BPIKE/30-81
 AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIKL...SRA Q9T0Q8_BPIKE/1-52
 DGTSTATSYATEAMNSLKTQATDLIDQTWPVVTSVAVAGLAIRL...SKA COATB_BPI22/32-83
@@ -704,7 +704,7 @@ AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPZJ2/1-49
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA Q9T0Q9_BPFD/1-49
 FAADDATSQAKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKL...SRA COATB_BPIF1/22-73
 >>> print(alignment[3:7])
-SingleLetterAlphabet() alignment with 4 rows and 52 columns
+alignment with 4 rows and 52 columns
 AEGDDP---AKAAFNSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPM13/24-72
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPZJ2/1-49
 AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA Q9T0Q9_BPFD/1-49
@@ -742,7 +742,7 @@ three rows we extracted earlier, but take just their first six columns:
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment[3:6, :6])
-SingleLetterAlphabet() alignment with 3 rows and 6 columns
+alignment with 3 rows and 6 columns
 AEGDDP COATB_BPM13/24-72
 AEGDDP COATB_BPZJ2/1-49
 AEGDDP Q9T0Q9_BPFD/1-49
@@ -753,7 +753,7 @@ Leaving the first index as \verb|:| means take all the rows:
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment[:, :6])
-SingleLetterAlphabet() alignment with 7 rows and 6 columns
+alignment with 7 rows and 6 columns
 AEPNAA COATB_BPIKE/30-81
 AEPNAA Q9T0Q8_BPIKE/1-52
 DGTSTA COATB_BPI22/32-83
@@ -769,7 +769,7 @@ This brings us to a neat way to remove a section. Notice columns
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment[:, 6:9])
-SingleLetterAlphabet() alignment with 7 rows and 3 columns
+alignment with 7 rows and 3 columns
 TNY COATB_BPIKE/30-81
 TNY Q9T0Q8_BPIKE/1-52
 TSY COATB_BPI22/32-83
@@ -784,7 +784,7 @@ TSQ COATB_BPIF1/22-73
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(alignment[:, 9:])
-SingleLetterAlphabet() alignment with 7 rows and 43 columns
+alignment with 7 rows and 43 columns
 ATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRLFKKFSSKA COATB_BPIKE/30-81
 ATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIKLFKKFVSRA Q9T0Q8_BPIKE/1-52
 ATEAMNSLKTQATDLIDQTWPVVTSVAVAGLAIRLFKKFSSKA COATB_BPI22/32-83
@@ -801,7 +801,7 @@ by column. This lets you do this as a way to remove a block of columns:
 \begin{minted}{pycon}
 >>> edited = alignment[:, :6] + alignment[:, 9:]
 >>> print(edited)
-SingleLetterAlphabet() alignment with 7 rows and 49 columns
+alignment with 7 rows and 49 columns
 AEPNAAATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRLFKKFSSKA COATB_BPIKE/30-81
 AEPNAAATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIKLFKKFVSRA Q9T0Q8_BPIKE/1-52
 DGTSTAATEAMNSLKTQATDLIDQTWPVVTSVAVAGLAIRLFKKFSSKA COATB_BPI22/32-83
@@ -821,7 +821,7 @@ alignment rows alphabetically by id:
 \begin{minted}{pycon}
 >>> edited.sort()
 >>> print(edited)
-SingleLetterAlphabet() alignment with 7 rows and 49 columns
+alignment with 7 rows and 49 columns
 DGTSTAATEAMNSLKTQATDLIDQTWPVVTSVAVAGLAIRLFKKFSSKA COATB_BPI22/32-83
 FAADDAAKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKLFKKFVSRA COATB_BPIF1/22-73
 AEPNAAATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRLFKKFSSKA COATB_BPIKE/30-81
@@ -1005,7 +1005,7 @@ You should be able to work out how to read in the alignment using
 >>> from Bio import AlignIO
 >>> align = AlignIO.read("opuntia.aln", "clustal")
 >>> print(align)
-SingleLetterAlphabet() alignment with 7 rows and 906 columns
+alignment with 7 rows and 906 columns
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273285|gb|AF191659.1|AF191
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273284|gb|AF191658.1|AF191
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF191
@@ -1140,7 +1140,7 @@ Remember that MUSCLE defaults to using FASTA as the output format:
 >>> from Bio import AlignIO
 >>> align = AlignIO.read(StringIO(stdout), "fasta")
 >>> print(align)
-SingleLetterAlphabet() alignment with 7 rows and 906 columns
+alignment with 7 rows and 906 columns
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273289|gb|AF191663.1|AF191663
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273291|gb|AF191665.1|AF191665
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273290|gb|AF191664.1|AF191664
@@ -1168,7 +1168,7 @@ with handles instead:
 >>> from Bio import AlignIO
 >>> align = AlignIO.read(child.stdout, "fasta")
 >>> print(align)
-SingleLetterAlphabet() alignment with 7 rows and 906 columns
+alignment with 7 rows and 906 columns
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273289|gb|AF191663.1|AF191663
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273291|gb|AF191665.1|AF191665
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273290|gb|AF191664.1|AF191664
@@ -1238,7 +1238,7 @@ start to run, and we can ask for the output:
 >>> from Bio import AlignIO
 >>> align = AlignIO.read(child.stdout, "clustal")
 >>> print(align)
-SingleLetterAlphabet() alignment with 6 rows and 900 columns
+alignment with 6 rows and 900 columns
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273290|gb|AF191664.1|AF19166
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273289|gb|AF191663.1|AF19166
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF19166
@@ -1283,7 +1283,7 @@ a string using \texttt{StringIO} (see Section~\ref{sec:appendix-handles}):
 >>> from Bio import AlignIO
 >>> align = AlignIO.read(StringIO(stdout), "clustal")
 >>> print(align)
-SingleLetterAlphabet() alignment with 6 rows and 900 columns
+alignment with 6 rows and 900 columns
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273290|gb|AF191664.1|AF19166
 TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273289|gb|AF191663.1|AF19166
 TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAG...AGA gi|6273287|gb|AF191661.1|AF19166
@@ -1399,7 +1399,7 @@ discussed earlier in this chapter, as the \texttt{emboss} format:
 >>> from Bio import AlignIO
 >>> align = AlignIO.read("needle.txt", "emboss")
 >>> print(align)
-SingleLetterAlphabet() alignment with 2 rows and 149 columns
+alignment with 2 rows and 149 columns
 MV-LSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTY...KYR HBA_HUMAN
 MVHLTPEEKSAVTALWGKV--NVDEVGGEALGRLLVVYPWTQRF...KYH HBB_HUMAN
 \end{minted}

--- a/Doc/Tutorial/chapter_searchio.tex
+++ b/Doc/Tutorial/chapter_searchio.tex
@@ -741,7 +741,7 @@ It should not surprise you now that the \verb|HSP| object has an
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(blast_hsp.aln)
-alignment with 2 rows and 61 columns
+Alignment with 2 rows and 61 columns
 CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAG...GGG 42291
 CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAG...GGG gi|262205317|ref|NR_030195.1|
 \end{minted}

--- a/Doc/Tutorial/chapter_searchio.tex
+++ b/Doc/Tutorial/chapter_searchio.tex
@@ -741,7 +741,7 @@ It should not surprise you now that the \verb|HSP| object has an
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(blast_hsp.aln)
-DNAAlphabet() alignment with 2 rows and 61 columns
+alignment with 2 rows and 61 columns
 CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAG...GGG 42291
 CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAG...GGG gi|262205317|ref|NR_030195.1|
 \end{minted}

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -941,7 +941,7 @@ A  7.0 0.0 0.0 0.0
         self.assertIsInstance(consensus, Seq)
         self.assertEqual(consensus, "NTNGCNTNNNNNGNNGGNTGGNTCN")
         self.assertEqual(str(alignment), """\
-alignment with 3 rows and 25 columns
+Alignment with 3 rows and 25 columns
 CCCTTCTTGTCTTCAGCGTTTCTCC EAS54_6_R1_2_1_413_324
 TTGGCAGGCCAAGGCCGATGGATCA EAS54_6_R1_2_1_540_792
 GTTGCTTCTGGCGTGGGTGGGGGGG EAS54_6_R1_2_1_443_348""")

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -941,7 +941,7 @@ A  7.0 0.0 0.0 0.0
         self.assertIsInstance(consensus, Seq)
         self.assertEqual(consensus, "NTNGCNTNNNNNGNNGGNTGGNTCN")
         self.assertEqual(str(alignment), """\
-Gapped(IUPACAmbiguousDNA(), '-') alignment with 3 rows and 25 columns
+alignment with 3 rows and 25 columns
 CCCTTCTTGTCTTCAGCGTTTCTCC EAS54_6_R1_2_1_413_324
 TTGGCAGGCCAAGGCCGATGGATCA EAS54_6_R1_2_1_540_792
 GTTGCTTCTGGCGTGGGTGGGGGGG EAS54_6_R1_2_1_443_348""")


### PR DESCRIPTION
Currently, printing a sequence alignment shows the associated alphabet in the first line:
```
>>> print(alignment)
SingleLetterAlphabet() alignment with 7 rows and 52 columns
AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRL...SKA COATB_BPIKE/30-81
AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIKL...SRA Q9T0Q8_BPIKE/1-52
DGTSTATSYATEAMNSLKTQATDLIDQTWPVVTSVAVAGLAIRL...SKA COATB_BPI22/32-83
AEGDDP---AKAAFNSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPM13/24-72
AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPZJ2/1-49
AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA Q9T0Q9_BPFD/1-49
FAADDATSQAKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKL...SRA COATB_BPIF1/22-73
```

This pull request removes the alphabet information, showing the following instead:
```
>>> print(alignment)
alignment with 7 rows and 52 columns
AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIRL...SKA COATB_BPIKE/30-81
AEPNAATNYATEAMDSLKTQAIDLISQTWPVVTTVVVAGLVIKL...SRA Q9T0Q8_BPIKE/1-52
DGTSTATSYATEAMNSLKTQATDLIDQTWPVVTSVAVAGLAIRL...SKA COATB_BPI22/32-83
AEGDDP---AKAAFNSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPM13/24-72
AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA COATB_BPZJ2/1-49
AEGDDP---AKAAFDSLQASATEYIGYAWAMVVVIVGATIGIKL...SKA Q9T0Q9_BPFD/1-49
FAADDATSQAKAAFDSLTAQATEMSGYAWALVVLVVGATVGIKL...SRA COATB_BPIF1/22-73
```

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
