### PR TITLE
pairwise aligner alphabet typo

### DIFF
--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -1782,7 +1782,7 @@ set_alphabet(Aligner* self, PyObject* alphabet)
             k = PyUnicode_GET_LENGTH(item);
             if (k != 1) break;
             if (PyUnicode_KIND(item) != PyUnicode_1BYTE_KIND) break;
-            character = PyUnicode_DATA(alphabet);
+            character = PyUnicode_DATA(item);
             j = *character;
             if (j < 0 || j >= 128) break;
             if (mapping[j] != MISSING_LETTER) {


### PR DESCRIPTION
This pull request fixes a typo in the pairwise aligner alphabet code.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
