### PR TITLE
frequency table in SummaryInfo does not need to be a FreqTable

### DIFF
--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -18,7 +18,6 @@ import sys
 from Bio import Alphabet
 from Bio.Alphabet import IUPAC
 from Bio.Seq import Seq
-from Bio.SubsMat import FreqTable
 
 
 # Expected random distributions for 20-letter protein, and
@@ -487,7 +486,7 @@ class SummaryInfo:
            first position in the seq is 203 in the initial sequence, for
            the info content, we need to use zero). This defaults to the entire
            length of the first sequence.
-         - e_freq_table - A FreqTable object specifying the expected frequencies
+         - e_freq_table - A dictionary specifying the expected frequencies
            for each letter in the alphabet we are using (e.g. {'G' : 0.4,
            'C' : 0.4, 'T' : 0.1, 'A' : 0.1}). Gap characters should not be
            included, since these should not have expected frequencies.
@@ -529,8 +528,6 @@ class SummaryInfo:
                     "Protein, supply expected frequencies"
                 )
             del base_alpha
-        elif not isinstance(e_freq_table, FreqTable.FreqTable):
-            raise ValueError("e_freq_table should be a FreqTable object")
 
         # determine all of the letters we have to deal with
         all_letters = self._get_all_letters()
@@ -583,8 +580,8 @@ class SummaryInfo:
          - to_ignore - Letters we are specifically supposed to ignore.
          - pseudo_count - Optional argument specifying the Pseudo count (k)
            to add in order to prevent a frequency of 0 for a letter.
-         - e_freq_table - An optional argument specifying the expected
-           frequencies for each letter. This is a SubsMat.FreqTable instance.
+         - e_freq_table - An optional argument specifying a dictionary with
+           the expected frequencies for each letter.
          - random_expected - Optional argument that specify the frequency to use
            when e_freq_table is not defined.
 
@@ -619,9 +616,6 @@ class SummaryInfo:
                 ) from None
 
         if e_freq_table:
-            if not isinstance(e_freq_table, FreqTable.FreqTable):
-                raise ValueError("e_freq_table should be a FreqTable object")
-
             # check if all the residus in freq_info are in e_freq_table
             for key in freq_info:
                 if key != gap_char and key not in e_freq_table:
@@ -662,8 +656,8 @@ class SummaryInfo:
 
         Arguments:
          - obs_freq - The frequencies observed for each letter in the column.
-         - e_freq_table - An optional argument specifying the expected
-           frequencies for each letter. This is a SubsMat.FreqTable instance.
+         - e_freq_table - An optional argument specifying a dictionary with
+           the expected frequencies for each letter.
          - log_base - The base of the logathrim to use in calculating the
            info content.
 
@@ -671,8 +665,6 @@ class SummaryInfo:
         gap_char = self._get_gap_char()
 
         if e_freq_table:
-            if not isinstance(e_freq_table, FreqTable.FreqTable):
-                raise ValueError("e_freq_table should be a FreqTable object")
             # check the expected freq information to make sure it is good
             for key in obs_freq:
                 if key != gap_char and key not in e_freq_table:

--- a/Doc/Tutorial/chapter_advanced.tex
+++ b/Doc/Tutorial/chapter_advanced.tex
@@ -223,7 +223,7 @@ make_log_odds_matrix(
 \label{sec:freq_table}
 
 \begin{minted}{python}
-FreqTable.FreqTable(UserDict.UserDict)
+FreqTable.FreqTable(dict)
 \end{minted}
 
 \begin{enumerate}

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1572,26 +1572,10 @@ info_content = summary_align.information_content(5, 30, chars_to_ignore=["N"])
 
 Wow, that was much easier then the formula above made it look! The variable \verb|info_content| now contains a float value specifying the information content over the specified region (from 5 to 30 of the alignment). We specifically ignore the ambiguity residue 'N' when calculating the information content, since this value is not included in our alphabet (so we shouldn't be interested in looking at it!).
 
-As mentioned above, we can also calculate relative information content by supplying the expected frequencies:
+As mentioned above, we can also calculate relative information content by supplying a dictionary with the expected frequencies:
 
 \begin{minted}{python}
 expect_freq = {"A": 0.3, "G": 0.2, "T": 0.3, "C": 0.2}
-\end{minted}
-
-The expected should not be passed as a raw dictionary, but instead by passed as a \verb|SubsMat.FreqTable| object (see section~\ref{sec:freq_table} for more information about FreqTables). The FreqTable object provides a standard for associating the dictionary with an Alphabet, similar to how the Biopython Seq class works.
-
-To create a FreqTable object, from the frequency dictionary you just need to do:
-
-\begin{minted}{python}
-from Bio.Alphabet import IUPAC
-from Bio.SubsMat import FreqTable
-
-e_freq_table = FreqTable.FreqTable(expect_freq, FreqTable.FREQ, IUPAC.unambiguous_dna)
-\end{minted}
-
-Now that we've got that, calculating the relative information content for our region of the alignment is as simple as:
-
-\begin{minted}{python}
 info_content = summary_align.information_content(
     5, 30, e_freq_table=e_freq_table, chars_to_ignore=["N"]
 )

--- a/Doc/examples/clustal_run.py
+++ b/Doc/examples/clustal_run.py
@@ -21,7 +21,6 @@ from Bio.Alphabet import Gapped, IUPAC
 from Bio.Align.Applications import ClustalwCommandline
 from Bio import AlignIO
 from Bio.Align import AlignInfo
-from Bio.SubsMat import FreqTable
 
 # create the command line to run clustalw
 # this assumes you've got clustalw somewhere on your path, otherwise
@@ -57,12 +56,8 @@ print(my_pssm)
 
 expect_freq = {"A": 0.3, "G": 0.2, "T": 0.3, "C": 0.2}
 
-freq_table_info = FreqTable.FreqTable(
-    expect_freq, FreqTable.FREQ, IUPAC.unambiguous_dna
-)
-
 info_content = summary_align.information_content(
-    5, 30, chars_to_ignore=["N"], e_freq_table=freq_table_info
+    5, 30, chars_to_ignore=["N"], e_freq_table=expect_freq
 )
 
 print("relative info content: %f" % info_content)

--- a/Tests/test_AlignInfo.py
+++ b/Tests/test_AlignInfo.py
@@ -13,7 +13,6 @@ from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio import AlignIO
-from Bio.SubsMat.FreqTable import FreqTable, FREQ
 from Bio.Align.AlignInfo import SummaryInfo
 import math
 
@@ -42,8 +41,7 @@ class AlignInfoTests(unittest.TestCase):
         self.assertNotEqual(c.alphabet, unambiguous_dna)
         self.assertIsInstance(c.alphabet, DNAAlphabet)
 
-        expected = FreqTable({"A": 0.25, "G": 0.25, "T": 0.25, "C": 0.25},
-                             FREQ, unambiguous_dna)
+        expected = {"A": 0.25, "G": 0.25, "T": 0.25, "C": 0.25}
 
         m = summary.pos_specific_score_matrix(chars_to_ignore=["-"],
                                               axis_seq=c)
@@ -134,8 +132,7 @@ X  0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
             SeqRecord(Seq("TTACACGTGCGC", alpha), id="ID008")])
 
         summary = SummaryInfo(dna_align)
-        expected = FreqTable({"A": 0.325, "G": 0.175, "T": 0.325, "C": 0.175},
-                             FREQ, unambiguous_dna)
+        expected = {"A": 0.325, "G": 0.175, "T": 0.325, "C": 0.175}
         ic = summary.information_content(e_freq_table=expected,
                                          log_base=math.exp(1),
                                          pseudo_count=1)

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -28,7 +28,6 @@ from Bio.SeqRecord import SeqRecord
 from Bio.Alphabet import IUPAC
 from Bio.Align import AlignInfo
 from Bio import AlignIO
-from Bio.SubsMat import FreqTable
 from Bio.Align import MultipleSeqAlignment
 
 
@@ -750,9 +749,7 @@ A  7.0 0.0 0.0 0.0
         self.assertAlmostEqual(value, 88.42, places=2)
         value = align_info.information_content(chars_to_ignore=["N"])
         self.assertAlmostEqual(value, 287.55, places=2)
-        e_freq = {"G": 0.25, "C": 0.25, "A": 0.25, "T": 0.25}
-        e_freq_table = FreqTable.FreqTable(e_freq, FreqTable.FREQ,
-                                           IUPAC.unambiguous_dna)
+        e_freq_table = {"G": 0.25, "C": 0.25, "A": 0.25, "T": 0.25}
         value = align_info.information_content(e_freq_table=e_freq_table,
                                                chars_to_ignore=["N"])
         self.assertAlmostEqual(value, 287.55, places=2)


### PR DESCRIPTION
The `information_content` method of the `SummaryInfo` class in `Bio.Align.AlignInfo` insists that the `e_freq_table` argument is a `FreqTable` object, and raises an error if it's not. However, in reality a simple dictionary suffices. Following Python's duck-typing principle, this PR removes the requirement that the `e_freq_table` argument is a `FreqTable` object. Note that `FreqTable` is a subclass of `dict`, and will still be accepted by this method.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
