### PR TITLE
Seq.join failure - AttributeError: module 'collections' has no attribute 'abc'

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1904,7 +1904,7 @@ class UnknownSeq(Seq):
         also UnknownSeqs with the same character as the spacer, similar to how the
         addition of an UnknownSeq and another UnknownSeq would work.
         """
-        if not isinstance(other, collections.Iterable):  # doesn't detect single strings
+        if not isinstance(other, collections.abc.Iterable):  # doesn't detect single strings
             raise ValueError("Input must be an iterable")
         if isinstance(other, str):
             raise ValueError("Input must be an iterable")

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1904,7 +1904,9 @@ class UnknownSeq(Seq):
         also UnknownSeqs with the same character as the spacer, similar to how the
         addition of an UnknownSeq and another UnknownSeq would work.
         """
-        if not isinstance(other, collections.abc.Iterable):  # doesn't detect single strings
+        if not isinstance(
+            other, collections.abc.Iterable
+        ):  # doesn't detect single strings
             raise ValueError("Input must be an iterable")
         if isinstance(other, str):
             raise ValueError("Input must be an iterable")

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -23,7 +23,7 @@ See also the Seq_ wiki and the chapter in our tutorial:
 import array
 import sys
 import warnings
-import collections
+import collections.abc
 
 from Bio import BiopythonWarning
 from Bio import Alphabet


### PR DESCRIPTION
This pull request addresses something I missed in #2288, and which would break on Python 3.9

``
Bio/Seq.py:1907: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
``

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
