### PR TITLE
motifs alphabet has no letters

### DIFF
--- a/Bio/motifs/jaspar/db.py
+++ b/Bio/motifs/jaspar/db.py
@@ -283,7 +283,7 @@ class JASPAR5:
             just use the first column sum.
             """
             if min_sites:
-                num_sites = sum(motif.counts[nt][0] for nt in motif.alphabet.letters)
+                num_sites = sum(motif.counts[nt][0] for nt in motif.alphabet)
                 if num_sites < min_sites:
                     continue
 


### PR DESCRIPTION
The alphabet of a `Motif` object is a plain string, not an old-school alphabet with letters.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
