### PR TITLE
removing alphabets from Bio.Restriction

### DIFF
--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -145,7 +145,7 @@ DNA = Seq
 
 
 class FormattedSeq:
-    """A linear or ciruclar sequence object for restriction analysis.
+    """A linear or circular sequence object for restriction analysis.
 
     Translates a Bio.Seq into a formatted sequence to be used with Restriction.
 
@@ -171,12 +171,10 @@ class FormattedSeq:
             self.data = _check_bases(stringy)
             self.linear = linear
             self.klass = seq.__class__
-            self.alphabet = seq.alphabet
         elif isinstance(seq, FormattedSeq):
             self.lower = seq.lower
             self.data = seq.data
             self.linear = seq.linear
-            self.alphabet = seq.alphabet
             self.klass = seq.klass
         else:
             raise TypeError("expected Seq or MutableSeq, got %s" % type(seq))
@@ -256,8 +254,8 @@ class FormattedSeq:
 
         """
         if self.lower:
-            return self.klass((self.data[i]).lower(), self.alphabet)
-        return self.klass(self.data[i], self.alphabet)
+            return self.klass(self.data[i].lower())
+        return self.klass(self.data[i])
 
 
 class RestrictionType(type):


### PR DESCRIPTION
This pull request removes alphabets from `Bio.Restriction`. The `__getitem__` method of `FormattedSeq` may have had a bug, passing the alphabet while the `__init__` function expected a boolean.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
