### PR TITLE
Hmm alphabet no more

### DIFF
--- a/Bio/HMM/DynamicProgramming.py
+++ b/Bio/HMM/DynamicProgramming.py
@@ -60,7 +60,7 @@ class AbstractDPAlgorithms:
 
         """
         # all of the different letters that the state path can be in
-        state_letters = self._seq.states.alphabet.letters
+        state_letters = self._mm.state_alphabet
 
         # -- initialize the algorithm
         #
@@ -119,7 +119,7 @@ class AbstractDPAlgorithms:
 
         """
         # all of the different letters that the state path can be in
-        state_letters = self._seq.states.alphabet.letters
+        state_letters = self._mm.state_alphabet
 
         # -- initialize the algorithm
         #
@@ -198,7 +198,7 @@ class ScaledDPAlgorithms(AbstractDPAlgorithms):
 
         """
         # all of the different letters the state can have
-        state_letters = self._seq.states.alphabet.letters
+        state_letters = self._mm.state_alphabet
 
         # loop over all of the possible states
         s_value = 0

--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -89,8 +89,8 @@ class MarkovModelBuilder:
            all of the letters for states that can be emitted by the HMM.
 
         """
-        self._state_alphabet = state_alphabet
-        self._emission_alphabet = emission_alphabet
+        self._state_alphabet = tuple(state_alphabet)
+        self._emission_alphabet = tuple(emission_alphabet)
 
         # probabilities for the initial state, initialized by calling
         # set_initial_probabilities (required)
@@ -155,6 +155,8 @@ class MarkovModelBuilder:
         emission_pseudo = copy.deepcopy(self.emission_pseudo)
 
         return HiddenMarkovModel(
+            self._state_alphabet,
+            self._emission_alphabet,
             initial_prob,
             transition_prob,
             emission_prob,
@@ -455,6 +457,8 @@ class HiddenMarkovModel:
 
     def __init__(
         self,
+        state_alphabet,
+        emission_alphabet,
         initial_prob,
         transition_prob,
         emission_prob,
@@ -467,6 +471,10 @@ class HiddenMarkovModel:
         initiating this class directly.
 
         Arguments:
+         - state_alphabet -- A tuple containing all of the letters that can
+           appear in the states.
+         - emission_alphabet -- A tuple containing all of the letters for
+           states that can be emitted by the HMM.
          - initial_prob - A dictionary of initial probabilities for all states.
          - transition_prob -- A dictionary of transition probabilities for all
            possible transitions in the sequence.
@@ -478,6 +486,9 @@ class HiddenMarkovModel:
            when counting for purposes of estimating emission probabilities.
 
         """
+        self.state_alphabet = state_alphabet
+        self.emission_alphabet = emission_alphabet
+
         self.initial_prob = initial_prob
 
         self._transition_pseudo = transition_pseudo

--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -12,7 +12,7 @@ import math
 import random
 from collections import defaultdict
 
-from Bio.Seq import MutableSeq
+from Bio.Seq import Seq
 
 
 def _gen_random_array(n):
@@ -168,7 +168,7 @@ class MarkovModelBuilder:
         """Set initial state probabilities.
 
         initial_prob is a dictionary mapping states to probabilities.
-        Suppose, for example, that the state alphabet is ['A', 'B']. Call
+        Suppose, for example, that the state alphabet is ('A', 'B'). Call
         set_initial_prob({'A': 1}) to guarantee that the initial
         state will be 'A'. Call set_initial_prob({'A': 0.5, 'B': 0.5})
         to make each initial state equally probable.
@@ -564,8 +564,8 @@ class HiddenMarkovModel:
         Arguments:
          - sequence -- A Seq object with the emission sequence that we
            want to decode.
-         - state_alphabet -- The alphabet of the possible state sequences
-           that can be generated.
+         - state_alphabet -- An iterable (e.g., tuple or list) containing
+           all of the letters that can appear in the states
 
         """
         # calculate logarithms of the initial, transition, and emission probs
@@ -637,7 +637,7 @@ class HiddenMarkovModel:
         assert last_state != "", "Didn't find the last state to trace from!"
 
         # --- traceback
-        traceback_seq = MutableSeq("", state_alphabet)
+        traceback_seq = []
 
         loop_seq = list(range(1, len(sequence)))
         loop_seq.reverse()
@@ -654,8 +654,9 @@ class HiddenMarkovModel:
 
         # put the traceback sequence in the proper orientation
         traceback_seq.reverse()
+        traceback_seq = "".join(traceback_seq)
 
-        return traceback_seq.toseq(), state_path_prob
+        return Seq(traceback_seq), state_path_prob
 
     def _log_transform(self, probability):
         """Return log transform of the given probability dictionary (PRIVATE).

--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -83,10 +83,10 @@ class MarkovModelBuilder:
         """Initialize a builder to create Markov Models.
 
         Arguments:
-         - state_alphabet -- An alphabet containing all of the letters that
-           can appear in the states
-         - emission_alphabet -- An alphabet containing all of the letters for
-           states that can be emitted by the HMM.
+         - state_alphabet -- An iterable (e.g., tuple or list) containing
+           all of the letters that can appear in the states
+         - emission_alphabet -- An iterable (e.g., tuple or list) containing
+           all of the letters for states that can be emitted by the HMM.
 
         """
         self._state_alphabet = state_alphabet
@@ -114,8 +114,8 @@ class MarkovModelBuilder:
         are all set to 0.
         """
         all_blank = {}
-        for first_state in first_alphabet.letters:
-            for second_state in second_alphabet.letters:
+        for first_state in first_alphabet:
+            for second_state in second_alphabet:
                 all_blank[(first_state, second_state)] = 0
 
         return all_blank
@@ -129,8 +129,8 @@ class MarkovModelBuilder:
         are all set to the value of the class attribute DEFAULT_PSEUDO.
         """
         all_counts = {}
-        for first_state in first_alphabet.letters:
-            for second_state in second_alphabet.letters:
+        for first_state in first_alphabet:
+            for second_state in second_alphabet:
                 all_counts[(first_state, second_state)] = self.DEFAULT_PSEUDO
 
         return all_counts
@@ -186,13 +186,13 @@ class MarkovModelBuilder:
 
         # ensure that all referenced states are valid
         for state in initial_prob:
-            if state not in self._state_alphabet.letters:
+            if state not in self._state_alphabet:
                 raise ValueError(
                     "State %s was not found in the sequence alphabet" % state
                 )
 
         # distribute the residual probability, if any
-        num_states_not_set = len(self._state_alphabet.letters) - len(self.initial_prob)
+        num_states_not_set = len(self._state_alphabet) - len(self.initial_prob)
         if num_states_not_set < 0:
             raise Exception("Initial probabilities can't exceed # of states")
         prob_sum = sum(self.initial_prob.values())
@@ -200,7 +200,7 @@ class MarkovModelBuilder:
             raise Exception("Total initial probability cannot exceed 1.0")
         if num_states_not_set > 0:
             prob = (1.0 - prob_sum) / num_states_not_set
-            for state in self._state_alphabet.letters:
+            for state in self._state_alphabet:
                 if state not in self.initial_prob:
                     self.initial_prob[state] = prob
 
@@ -224,7 +224,7 @@ class MarkovModelBuilder:
         """
         # set initial state probabilities
         new_initial_prob = float(1) / float(len(self.transition_prob))
-        for state in self._state_alphabet.letters:
+        for state in self._state_alphabet:
             self.initial_prob[state] = new_initial_prob
 
         # set the transitions
@@ -242,8 +242,8 @@ class MarkovModelBuilder:
 
         Returns the dictionary containing the initial probabilities.
         """
-        initial_freqs = _gen_random_array(len(self._state_alphabet.letters))
-        for state in self._state_alphabet.letters:
+        initial_freqs = _gen_random_array(len(self._state_alphabet))
+        for state in self._state_alphabet:
             self.initial_prob[state] = initial_freqs.pop()
 
         return self.initial_prob
@@ -339,7 +339,7 @@ class MarkovModelBuilder:
         """
         # check the sanity of adding these states
         for state in [from_state, to_state]:
-            if state not in self._state_alphabet.letters:
+            if state not in self._state_alphabet:
                 raise ValueError(
                     "State %s was not found in the sequence alphabet" % state
                 )
@@ -564,7 +564,6 @@ class HiddenMarkovModel:
 
         viterbi_probs = {}
         pred_state_seq = {}
-        state_letters = state_alphabet.letters
 
         # --- recursion
         # loop over the training squence (i = 1 .. L)
@@ -573,7 +572,7 @@ class HiddenMarkovModel:
         # (Length - 1) not 1 to Length, like in Durbin et al.
         for i in range(0, len(sequence)):
             # loop over all of the possible i-th states in the state path
-            for cur_state in state_letters:
+            for cur_state in state_alphabet:
                 # e_{l}(x_{i})
                 emission_part = log_emission[(cur_state, sequence[i])]
 
@@ -612,7 +611,7 @@ class HiddenMarkovModel:
         # calculate the probability of the state path
         # loop over all states
         all_probs = {}
-        for state in state_letters:
+        for state in state_alphabet:
             # v_{k}(L)
             all_probs[state] = viterbi_probs[(state, len(sequence) - 1)]
 

--- a/Bio/HMM/Trainer.py
+++ b/Bio/HMM/Trainer.py
@@ -277,7 +277,7 @@ class BaumWelchTrainer(AbstractTrainer):
         emissions = self._markov_model.emission_prob
 
         # loop over the possible combinations of state path letters
-        for k in training_seq.states.alphabet.letters:
+        for k in self._markov_model.initial_prob:
             for l in self._markov_model.transitions_from(k):
                 estimated_counts = 0
                 # now loop over the entire training sequence
@@ -328,9 +328,9 @@ class BaumWelchTrainer(AbstractTrainer):
 
         """
         # loop over the possible combinations of state path letters
-        for k in training_seq.states.alphabet.letters:
+        for k in self._markov_model.state_alphabet:
             # now loop over all of the possible emissions
-            for b in training_seq.emissions.alphabet.letters:
+            for b in self._markov_model.emission_alphabet:
                 expected_times = 0
                 # finally loop over the entire training sequence
                 for i in range(len(training_seq.emissions)):

--- a/Bio/HMM/Trainer.py
+++ b/Bio/HMM/Trainer.py
@@ -33,11 +33,11 @@ class TrainingSequence:
         """Initialize a training sequence.
 
         Arguments:
-         - emissions - A Seq object containing the sequence of emissions in
-           the training sequence, and the alphabet of the sequence.
-         - state_path - A Seq object containing the sequence of states and
-           the alphabet of the states. If there is no known state path, then
-           the sequence of states should be an empty string.
+         - emissions - An iterable (e.g., a tuple, list, or Seq object)
+           containing the sequence of emissions in the training sequence.
+         - state_path - An iterable (e.g., a tuple or list) containing the
+           sequence of states. If there is no known state path, then the
+           sequence of states should be an empty iterable.
 
         """
         if len(state_path) > 0 and len(emissions) != len(state_path):
@@ -277,7 +277,7 @@ class BaumWelchTrainer(AbstractTrainer):
         emissions = self._markov_model.emission_prob
 
         # loop over the possible combinations of state path letters
-        for k in self._markov_model.initial_prob:
+        for k in self._markov_model.state_alphabet:
             for l in self._markov_model.transitions_from(k):
                 estimated_counts = 0
                 # now loop over the entire training sequence

--- a/Tests/test_HMMCasino.py
+++ b/Tests/test_HMMCasino.py
@@ -127,7 +127,7 @@ class TestHMMCasino(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.mm_builder = MarkovModel.MarkovModelBuilder(
-            DiceTypeAlphabet(), DiceRollAlphabet()
+            DiceTypeAlphabet().letters, DiceRollAlphabet().letters
         )
         cls.mm_builder.allow_all_transitions()
         cls.mm_builder.set_random_probabilities()
@@ -144,7 +144,7 @@ class TestHMMCasino(unittest.TestCase):
             print(trained_mm.transition_prob)
             print(trained_mm.emission_prob)
         test_rolls, test_states = generate_rolls(300)
-        predicted_states, prob = trained_mm.viterbi(test_rolls, DiceTypeAlphabet())
+        predicted_states, prob = trained_mm.viterbi(test_rolls, DiceTypeAlphabet().letters)
         if VERBOSE:
             print("Prediction probability: %f" % prob)
             Utilities.pretty_print_prediction(test_rolls, test_states, predicted_states)
@@ -171,7 +171,7 @@ class TestHMMCasino(unittest.TestCase):
             print(trained_mm.transition_prob)
             print(trained_mm.emission_prob)
         test_rolls, test_states = generate_rolls(300)
-        predicted_states, prob = trained_mm.viterbi(test_rolls, DiceTypeAlphabet())
+        predicted_states, prob = trained_mm.viterbi(test_rolls, DiceTypeAlphabet().letters)
         if VERBOSE:
             print("Prediction probability: %f" % prob)
             Utilities.pretty_print_prediction(

--- a/Tests/test_HMMGeneral.py
+++ b/Tests/test_HMMGeneral.py
@@ -382,7 +382,7 @@ class ScaledDPAlgorithmsTest(unittest.TestCase):
 class AbstractTrainerTest(unittest.TestCase):
     def setUp(self):
         # set up a bogus HMM and our trainer
-        hmm = MarkovModel.HiddenMarkovModel({}, {}, {}, {}, {})
+        hmm = MarkovModel.HiddenMarkovModel((), (), {}, {}, {}, {}, {})
         self.test_trainer = Trainer.AbstractTrainer(hmm)
 
     def test_ml_estimator(self):

--- a/Tests/test_HMMGeneral.py
+++ b/Tests/test_HMMGeneral.py
@@ -96,8 +96,7 @@ class MarkovModelBuilderTest(unittest.TestCase):
 
         self.assertEqual(self.mm_builder.transition_prob, expected_prob)
 
-        self.assertEqual(self.mm_builder.transition_pseudo, expected_pseudo
-        )
+        self.assertEqual(self.mm_builder.transition_pseudo, expected_pseudo)
 
     def test_set_initial_probabilities(self):
         self.mm_builder.set_initial_probabilities({})
@@ -408,7 +407,7 @@ class AbstractTrainerTest(unittest.TestCase):
 
         log_prob = self.test_trainer.log_likelihood(probs)
         expected_log_prob = -7.31873556778
-        self.assertAlmostEqual(expected_log_prob,  log_prob)
+        self.assertAlmostEqual(expected_log_prob, log_prob)
 
 
 # run the tests

--- a/Tests/test_HMMGeneral.py
+++ b/Tests/test_HMMGeneral.py
@@ -39,12 +39,6 @@ class LetterAlphabet(Alphabet.Alphabet):
     letters = ["A", "B"]
 
 
-# -- helper functions
-def test_assertion(name, result, expected):
-    """Helper function to test an assertion and print out a reasonable error."""
-    assert result == expected, "Expected %s, got %s for %s" % (expected, result, name)
-
-
 class TrainingSequenceTest(unittest.TestCase):
     """Training sequence tests."""
 
@@ -52,15 +46,15 @@ class TrainingSequenceTest(unittest.TestCase):
         emission_seq = Seq("AB", LetterAlphabet())
         state_seq = Seq("", NumberAlphabet())
         training_seq = Trainer.TrainingSequence(emission_seq, state_seq)
-        assert training_seq.emissions == emission_seq
-        assert training_seq.states == state_seq
+        self.assertEqual(training_seq.emissions, emission_seq)
+        self.assertEqual(training_seq.states, state_seq)
 
     def test_valid_training_sequence(self):
         emission_seq = Seq("AB", LetterAlphabet())
         state_seq = Seq("12", NumberAlphabet())
         training_seq = Trainer.TrainingSequence(emission_seq, state_seq)
-        assert training_seq.emissions == emission_seq
-        assert training_seq.states == state_seq
+        self.assertEqual(training_seq.emissions, emission_seq)
+        self.assertEqual(training_seq.states, state_seq)
 
     def test_invalid_training_sequence(self):
         emission_seq = Seq("AB", LetterAlphabet())
@@ -96,20 +90,10 @@ class MarkovModelBuilderTest(unittest.TestCase):
         }
 
         assertions = []
-        test_assertion(
-            "Transition prob", self.mm_builder.transition_prob, expected_transition_prob
-        )
-        test_assertion(
-            "Transition pseudo",
-            self.mm_builder.transition_pseudo,
-            expected_transition_pseudo,
-        )
-        test_assertion(
-            "Emission prob", self.mm_builder.emission_prob, expected_emission_prob
-        )
-        test_assertion(
-            "Emission pseudo", self.mm_builder.emission_pseudo, expected_emission_pseudo
-        )
+        self.assertEqual(self.mm_builder.transition_prob, expected_transition_prob)
+        self.assertEqual(self.mm_builder.transition_pseudo, expected_transition_pseudo)
+        self.assertEqual(self.mm_builder.emission_prob, expected_emission_prob)
+        self.assertEqual(self.mm_builder.emission_pseudo, expected_emission_pseudo)
 
     def test_allow_all_transitions(self):
         """Testing allow_all_transitions."""
@@ -119,19 +103,14 @@ class MarkovModelBuilderTest(unittest.TestCase):
 
         expected_pseudo = {("2", "1"): 1, ("1", "1"): 1, ("1", "2"): 1, ("2", "2"): 1}
 
-        test_assertion("Probabilities", self.mm_builder.transition_prob, expected_prob)
+        self.assertEqual(self.mm_builder.transition_prob, expected_prob)
 
-        test_assertion(
-            "Pseudo counts", self.mm_builder.transition_pseudo, expected_pseudo
+        self.assertEqual(self.mm_builder.transition_pseudo, expected_pseudo
         )
 
     def test_set_initial_probabilities(self):
         self.mm_builder.set_initial_probabilities({})
-        test_assertion(
-            "Equal initial probabilities by default",
-            self.mm_builder.initial_prob,
-            {"1": 0.5, "2": 0.5},
-        )
+        self.assertEqual(self.mm_builder.initial_prob, {"1": 0.5, "2": 0.5})
 
         # initial probability sum > 1, should raise an exception
         self.assertRaises(
@@ -144,50 +123,26 @@ class MarkovModelBuilderTest(unittest.TestCase):
         )
 
         self.mm_builder.set_initial_probabilities({"1": 0.2})
-        test_assertion(
-            "One default initial probability",
-            self.mm_builder.initial_prob,
-            {"1": 0.2, "2": 0.8},
-        )
+        self.assertEqual(self.mm_builder.initial_prob, {"1": 0.2, "2": 0.8})
 
         self.mm_builder.set_initial_probabilities({"1": 0.9, "2": 0.1})
-        test_assertion(
-            "Set initial probabilities",
-            self.mm_builder.initial_prob,
-            {"1": 0.9, "2": 0.1},
-        )
+        self.assertEqual(self.mm_builder.initial_prob, {"1": 0.9, "2": 0.1})
 
     def test_set_equal_probabilities(self):
         self.mm_builder.allow_transition("1", "2", 0.05)
         self.mm_builder.allow_transition("2", "1", 0.95)
         self.mm_builder.set_equal_probabilities()
 
-        test_assertion(
-            "Equal initial probabilities",
-            self.mm_builder.initial_prob,
-            {"1": 0.5, "2": 0.5},
-        )
-        test_assertion(
-            "Equal transition probabilities",
-            self.mm_builder.transition_prob,
-            {("1", "2"): 0.5, ("2", "1"): 0.5},
-        )
-        test_assertion(
-            "Equal emission probabilities",
-            self.mm_builder.emission_prob,
-            {("2", "A"): 0.25, ("1", "B"): 0.25, ("1", "A"): 0.25, ("2", "B"): 0.25},
-        )
+        self.assertEqual(self.mm_builder.initial_prob, {"1": 0.5, "2": 0.5},)
+        self.assertEqual(self.mm_builder.transition_prob, {("1", "2"): 0.5, ("2", "1"): 0.5})
+        self.assertEqual(self.mm_builder.emission_prob, {("2", "A"): 0.25, ("1", "B"): 0.25, ("1", "A"): 0.25, ("2", "B"): 0.25})
 
     def test_set_random_probabilities(self):
         self.mm_builder.allow_transition("1", "2", 0.05)
         self.mm_builder.allow_transition("2", "1", 0.95)
         self.mm_builder.set_random_probabilities()
 
-        test_assertion(
-            "Number of initial probabilities",
-            len(self.mm_builder.initial_prob),
-            len(self.mm_builder._state_alphabet.letters),
-        )
+        self.assertEqual(len(self.mm_builder.initial_prob), len(self.mm_builder._state_alphabet.letters))
         # To test this more thoroughly, perhaps mock random.random() and
         # verify that it's being called as expected?
 
@@ -210,25 +165,17 @@ class HiddenMarkovModelTest(unittest.TestCase):
         expected_state_1 = ["2"]
         state_1.sort()
         expected_state_1.sort()
-        test_assertion(
-            "States reached by transitions from state 1", state_1, expected_state_1
-        )
+        self.assertEqual(state_1, expected_state_1)
 
         state_2 = self.mm.transitions_from("2")
         expected_state_2 = ["1", "2"]
         state_2.sort()
         expected_state_2.sort()
-        test_assertion(
-            "States reached by transitions from state 2", state_2, expected_state_2
-        )
+        self.assertEqual(state_2, expected_state_2)
 
         fake_state = self.mm.transitions_from("Fake")
         expected_fake_state = []
-        test_assertion(
-            "States reached by transitions from a fake transition",
-            fake_state,
-            expected_fake_state,
-        )
+        self.assertEqual(fake_state, expected_fake_state)
 
     def test_transitions_to(self):
         """Testing the calculation of transitions_to."""
@@ -242,21 +189,17 @@ class HiddenMarkovModelTest(unittest.TestCase):
         expected_state_1 = ["1", "2"]
         state_1.sort()
         expected_state_1.sort()
-        test_assertion("States with transitions to state 1", state_1, expected_state_1)
+        self.assertEqual(state_1, expected_state_1)
 
         state_2 = self.mm.transitions_to("2")
         expected_state_2 = ["1"]
         state_2.sort()
         expected_state_2.sort()
-        test_assertion("States with transitions to state 2", state_2, expected_state_2)
+        self.assertEqual(state_2, expected_state_2)
 
         fake_state = self.mm.transitions_to("Fake")
         expected_fake_state = []
-        test_assertion(
-            "States with transitions to a fake transition",
-            fake_state,
-            expected_fake_state,
-        )
+        self.assertEqual(fake_state, expected_fake_state)
 
     def test_allow_transition(self):
         """Testing allow_transition."""
@@ -268,29 +211,25 @@ class HiddenMarkovModelTest(unittest.TestCase):
         expected_state_1 = ["2"]
         state_1.sort()
         expected_state_1.sort()
-        test_assertion(
-            "States reached by transitions from state 1", state_1, expected_state_1
-        )
+        self.assertEqual(state_1, expected_state_1)
 
         state_2 = self.mm.transitions_from("2")
         expected_state_2 = []
         state_2.sort()
         expected_state_2.sort()
-        test_assertion(
-            "States reached by transitions from state 2", state_2, expected_state_2
-        )
+        self.assertEqual(state_2, expected_state_2)
 
         state_1 = self.mm.transitions_to("1")
         expected_state_1 = []
         state_1.sort()
         expected_state_1.sort()
-        test_assertion("States with transitions to state 1", state_1, expected_state_1)
+        self.assertEqual(state_1, expected_state_1)
 
         state_2 = self.mm.transitions_to("2")
         expected_state_2 = ["1"]
         state_2.sort()
         expected_state_2.sort()
-        test_assertion("States with transitions to state 2", state_2, expected_state_2)
+        self.assertEqual(state_2, expected_state_2)
 
     def test_simple_hmm(self):
         """Test a simple model with 2 states and 2 symbols."""
@@ -361,8 +300,8 @@ class HiddenMarkovModelTest(unittest.TestCase):
         max_prob = math.log(max_prob)
         seq = viterbi[0]
         prob = viterbi[1]
-        test_assertion("state sequence", str(seq), seq_first_state + seq_second_state)
-        test_assertion("log probability", round(prob, 11), round(max_prob, 11))
+        self.assertEqual(str(seq), seq_first_state + seq_second_state)
+        self.assertEqual(round(prob, 11), round(max_prob, 11))
 
     def test_non_ergodic(self):
         """Non-ergodic model (meaning that some transitions are not allowed)."""
@@ -402,7 +341,7 @@ class HiddenMarkovModelTest(unittest.TestCase):
         prob = viterbi[1]
 
         # the most probable path must be from state 1 to state 2
-        test_assertion("most probable path", str(seq), "12")
+        self.assertEqual(str(seq), "12")
 
         # The probability of that path is the probability of starting in
         # state 1, then emitting an A, then transitioning 1 -> 2, then
@@ -414,7 +353,7 @@ class HiddenMarkovModelTest(unittest.TestCase):
             + math.log(prob_1_to_2)
             + math.log(prob_2_B)
         )
-        test_assertion("log probability of most probable path", prob, expected_prob)
+        self.assertEqual(prob, expected_prob)
 
 
 class ScaledDPAlgorithmsTest(unittest.TestCase):
@@ -470,10 +409,7 @@ class AbstractTrainerTest(unittest.TestCase):
         result_tests.append([("C", "C"), float(10) / float(25)])
 
         for test_result in result_tests:
-            assert results[test_result[0]] == test_result[1], (
-                "Got %f, expected %f for %s"
-                % (results[test_result[0]], test_result[1], test_result[0])
-            )
+            self.assertEqual(results[test_result[0]], test_result[1])
 
     def test_log_likelihood(self):
         """Calculate log likelihood."""
@@ -481,9 +417,7 @@ class AbstractTrainerTest(unittest.TestCase):
 
         log_prob = self.test_trainer.log_likelihood(probs)
         expected_log_prob = -7.31873556778
-        assert abs(expected_log_prob - log_prob) < 0.1, (
-            "Bad probability calculated: %s" % log_prob
-        )
+        self.assertAlmostEqual(expected_log_prob,  log_prob)
 
 
 # run the tests

--- a/Tests/test_HMMGeneral.py
+++ b/Tests/test_HMMGeneral.py
@@ -68,7 +68,7 @@ class MarkovModelBuilderTest(unittest.TestCase):
 
     def setUp(self):
         self.mm_builder = MarkovModel.MarkovModelBuilder(
-            NumberAlphabet(), LetterAlphabet()
+            NumberAlphabet().letters, LetterAlphabet().letters
         )
 
     def test_test_initialize(self):
@@ -142,7 +142,7 @@ class MarkovModelBuilderTest(unittest.TestCase):
         self.mm_builder.allow_transition("2", "1", 0.95)
         self.mm_builder.set_random_probabilities()
 
-        self.assertEqual(len(self.mm_builder.initial_prob), len(self.mm_builder._state_alphabet.letters))
+        self.assertEqual(len(self.mm_builder.initial_prob), len(self.mm_builder._state_alphabet))
         # To test this more thoroughly, perhaps mock random.random() and
         # verify that it's being called as expected?
 
@@ -150,7 +150,7 @@ class MarkovModelBuilderTest(unittest.TestCase):
 class HiddenMarkovModelTest(unittest.TestCase):
     def setUp(self):
         self.mm_builder = MarkovModel.MarkovModelBuilder(
-            NumberAlphabet(), LetterAlphabet()
+            NumberAlphabet().letters, LetterAlphabet().letters
         )
 
     def test_transitions_from(self):
@@ -258,7 +258,7 @@ class HiddenMarkovModelTest(unittest.TestCase):
         for first_letter in LetterAlphabet.letters:
             for second_letter in LetterAlphabet.letters:
                 observed_emissions = [first_letter, second_letter]
-                viterbi = model.viterbi(observed_emissions, NumberAlphabet)
+                viterbi = model.viterbi(observed_emissions, NumberAlphabet().letters)
                 self._checkSimpleHmm(
                     prob_initial,
                     prob_transition,
@@ -336,7 +336,7 @@ class HiddenMarkovModelTest(unittest.TestCase):
         # run the Viterbi algorithm to find the most probable state path
         model = self.mm_builder.get_markov_model()
         observed_emissions = ["A", "B"]
-        viterbi = model.viterbi(observed_emissions, NumberAlphabet)
+        viterbi = model.viterbi(observed_emissions, NumberAlphabet().letters)
         seq = viterbi[0]
         prob = viterbi[1]
 
@@ -359,7 +359,7 @@ class HiddenMarkovModelTest(unittest.TestCase):
 class ScaledDPAlgorithmsTest(unittest.TestCase):
     def setUp(self):
         # set up our Markov Model
-        mm_builder = MarkovModel.MarkovModelBuilder(NumberAlphabet(), LetterAlphabet())
+        mm_builder = MarkovModel.MarkovModelBuilder(NumberAlphabet().letters, LetterAlphabet().letters)
         mm_builder.allow_all_transitions()
         mm_builder.set_equal_probabilities()
 

--- a/Tests/test_HMMGeneral.py
+++ b/Tests/test_HMMGeneral.py
@@ -16,7 +16,6 @@ import unittest
 import math
 
 # biopython
-from Bio import Alphabet
 from Bio.Seq import Seq
 
 
@@ -27,38 +26,30 @@ from Bio.HMM import Trainer
 
 
 # create some simple alphabets
-class NumberAlphabet(Alphabet.Alphabet):
-    """Numbers as the states of the model."""
-
-    letters = ["1", "2"]
-
-
-class LetterAlphabet(Alphabet.Alphabet):
-    """Letters as the emissions of the model."""
-
-    letters = ["A", "B"]
+number_alphabet = ("1", "2")  # Numbers as the states of the model.
+letter_alphabet = ("A", "B")  # Letters as the emissions of the model.
 
 
 class TrainingSequenceTest(unittest.TestCase):
     """Training sequence tests."""
 
     def test_empty_state_training_sequence(self):
-        emission_seq = Seq("AB", LetterAlphabet())
-        state_seq = Seq("", NumberAlphabet())
+        emission_seq = Seq("AB")
+        state_seq = ()
         training_seq = Trainer.TrainingSequence(emission_seq, state_seq)
         self.assertEqual(training_seq.emissions, emission_seq)
         self.assertEqual(training_seq.states, state_seq)
 
     def test_valid_training_sequence(self):
-        emission_seq = Seq("AB", LetterAlphabet())
-        state_seq = Seq("12", NumberAlphabet())
+        emission_seq = Seq("AB")
+        state_seq = ("1", "2")
         training_seq = Trainer.TrainingSequence(emission_seq, state_seq)
         self.assertEqual(training_seq.emissions, emission_seq)
         self.assertEqual(training_seq.states, state_seq)
 
     def test_invalid_training_sequence(self):
-        emission_seq = Seq("AB", LetterAlphabet())
-        state_seq = Seq("1", NumberAlphabet())
+        emission_seq = Seq("AB")
+        state_seq = ("1", )
         with self.assertRaises(ValueError):
             Trainer.TrainingSequence(emission_seq, state_seq)
 
@@ -68,7 +59,7 @@ class MarkovModelBuilderTest(unittest.TestCase):
 
     def setUp(self):
         self.mm_builder = MarkovModel.MarkovModelBuilder(
-            NumberAlphabet().letters, LetterAlphabet().letters
+            number_alphabet, letter_alphabet
         )
 
     def test_test_initialize(self):
@@ -150,7 +141,7 @@ class MarkovModelBuilderTest(unittest.TestCase):
 class HiddenMarkovModelTest(unittest.TestCase):
     def setUp(self):
         self.mm_builder = MarkovModel.MarkovModelBuilder(
-            NumberAlphabet().letters, LetterAlphabet().letters
+            number_alphabet, letter_alphabet
         )
 
     def test_transitions_from(self):
@@ -255,10 +246,10 @@ class HiddenMarkovModelTest(unittest.TestCase):
 
         # Check all two letter sequences using a brute force calculation
         model = self.mm_builder.get_markov_model()
-        for first_letter in LetterAlphabet.letters:
-            for second_letter in LetterAlphabet.letters:
+        for first_letter in letter_alphabet:
+            for second_letter in letter_alphabet:
                 observed_emissions = [first_letter, second_letter]
-                viterbi = model.viterbi(observed_emissions, NumberAlphabet().letters)
+                viterbi = model.viterbi(observed_emissions, number_alphabet)
                 self._checkSimpleHmm(
                     prob_initial,
                     prob_transition,
@@ -280,8 +271,8 @@ class HiddenMarkovModelTest(unittest.TestCase):
         letter1 = ord(observed_emissions[0]) - ord("A")
         letter2 = ord(observed_emissions[1]) - ord("A")
 
-        for first_state in NumberAlphabet.letters:
-            for second_state in NumberAlphabet.letters:
+        for first_state in number_alphabet:
+            for second_state in number_alphabet:
                 # compute the probability of the state sequence first_state,
                 # second_state emitting the observed_emissions
                 state1 = ord(first_state) - ord("1")
@@ -336,7 +327,7 @@ class HiddenMarkovModelTest(unittest.TestCase):
         # run the Viterbi algorithm to find the most probable state path
         model = self.mm_builder.get_markov_model()
         observed_emissions = ["A", "B"]
-        viterbi = model.viterbi(observed_emissions, NumberAlphabet().letters)
+        viterbi = model.viterbi(observed_emissions, number_alphabet)
         seq = viterbi[0]
         prob = viterbi[1]
 
@@ -359,15 +350,15 @@ class HiddenMarkovModelTest(unittest.TestCase):
 class ScaledDPAlgorithmsTest(unittest.TestCase):
     def setUp(self):
         # set up our Markov Model
-        mm_builder = MarkovModel.MarkovModelBuilder(NumberAlphabet().letters, LetterAlphabet().letters)
+        mm_builder = MarkovModel.MarkovModelBuilder(number_alphabet, letter_alphabet)
         mm_builder.allow_all_transitions()
         mm_builder.set_equal_probabilities()
 
         mm = mm_builder.get_markov_model()
 
         # now set up a test sequence
-        emission_seq = Seq("ABB", LetterAlphabet())
-        state_seq = Seq("", NumberAlphabet())
+        emission_seq = Seq("ABB")
+        state_seq = ()
         training_seq = Trainer.TrainingSequence(emission_seq, state_seq)
 
         # finally set up the DP


### PR DESCRIPTION
This pull request removes alphabets from `Bio.HMM`, and does some simple cleanups in particular for unit tests.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
