### PR TITLE
remove alphabets from consensus sequences in Bio.Align.AlignInfo

### DIFF
--- a/Tests/test_AlignInfo.py
+++ b/Tests/test_AlignInfo.py
@@ -33,13 +33,9 @@ class AlignInfoTests(unittest.TestCase):
 
         c = summary.dumb_consensus(ambiguous="N")
         self.assertEqual(str(c), "NNNNNNNN")
-        self.assertNotEqual(c.alphabet, unambiguous_dna)
-        self.assertIsInstance(c.alphabet, DNAAlphabet)
 
         c = summary.gap_consensus(ambiguous="N")
         self.assertEqual(str(c), "NNNNNNNN")
-        self.assertNotEqual(c.alphabet, unambiguous_dna)
-        self.assertIsInstance(c.alphabet, DNAAlphabet)
 
         expected = {"A": 0.25, "G": 0.25, "T": 0.25, "C": 0.25}
 


### PR DESCRIPTION
This pull request removes alphabets from consensus sequences in Bio.Align.AlignInfo.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
