### PR TITLE
generic protein alphabet for all translation output

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -752,23 +752,23 @@ class Seq:
         >>> my_rna = Seq("GUCAUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAGUUG")
         >>> my_aa = my_rna.translate()
         >>> my_aa
-        Seq('VMAIVMGR*KGAR*L', HasStopCodon(ExtendedIUPACProtein(), '*'))
+        Seq('VMAIVMGR*KGAR*L', ProteinAlphabet())
         >>> for pep in my_aa.split("*"):
         ...     pep
-        Seq('VMAIVMGR', HasStopCodon(ExtendedIUPACProtein(), '*'))
-        Seq('KGAR', HasStopCodon(ExtendedIUPACProtein(), '*'))
-        Seq('L', HasStopCodon(ExtendedIUPACProtein(), '*'))
+        Seq('VMAIVMGR', ProteinAlphabet())
+        Seq('KGAR', ProteinAlphabet())
+        Seq('L', ProteinAlphabet())
         >>> for pep in my_aa.split("*", 1):
         ...     pep
-        Seq('VMAIVMGR', HasStopCodon(ExtendedIUPACProtein(), '*'))
-        Seq('KGAR*L', HasStopCodon(ExtendedIUPACProtein(), '*'))
+        Seq('VMAIVMGR', ProteinAlphabet())
+        Seq('KGAR*L', ProteinAlphabet())
 
         See also the rsplit method:
 
         >>> for pep in my_aa.rsplit("*", 1):
         ...     pep
-        Seq('VMAIVMGR*KGAR', HasStopCodon(ExtendedIUPACProtein(), '*'))
-        Seq('L', HasStopCodon(ExtendedIUPACProtein(), '*'))
+        Seq('VMAIVMGR*KGAR', ProteinAlphabet())
+        Seq('L', ProteinAlphabet())
         """
         # If it has one, check the alphabet:
         sep_str = self._get_seq_str_and_check_alphabet(sep)
@@ -1102,24 +1102,24 @@ class Seq:
 
         >>> coding_dna = Seq("GTGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG")
         >>> coding_dna.translate()
-        Seq('VAIVMGR*KGAR*', HasStopCodon(ExtendedIUPACProtein(), '*'))
+        Seq('VAIVMGR*KGAR*', ProteinAlphabet())
         >>> coding_dna.translate(stop_symbol="@")
-        Seq('VAIVMGR@KGAR@', HasStopCodon(ExtendedIUPACProtein(), '@'))
+        Seq('VAIVMGR@KGAR@', ProteinAlphabet())
         >>> coding_dna.translate(to_stop=True)
-        Seq('VAIVMGR', ExtendedIUPACProtein())
+        Seq('VAIVMGR', ProteinAlphabet())
 
         Now using NCBI table 2, where TGA is not a stop codon:
 
         >>> coding_dna.translate(table=2)
-        Seq('VAIVMGRWKGAR*', HasStopCodon(ExtendedIUPACProtein(), '*'))
+        Seq('VAIVMGRWKGAR*', ProteinAlphabet())
         >>> coding_dna.translate(table=2, to_stop=True)
-        Seq('VAIVMGRWKGAR', ExtendedIUPACProtein())
+        Seq('VAIVMGRWKGAR', ProteinAlphabet())
 
         In fact, GTG is an alternative start codon under NCBI table 2, meaning
         this sequence could be a complete CDS:
 
         >>> coding_dna.translate(table=2, cds=True)
-        Seq('MAIVMGRWKGAR', ExtendedIUPACProtein())
+        Seq('MAIVMGRWKGAR', ProteinAlphabet())
 
         It isn't a valid CDS under NCBI table 1, due to both the start codon
         and also the in frame stop codons:
@@ -1134,9 +1134,9 @@ class Seq:
 
         >>> coding_dna2 = Seq("TTGGCCATTGTAATGGGCCGC")
         >>> coding_dna2.translate()
-        Seq('LAIVMGR', ExtendedIUPACProtein())
+        Seq('LAIVMGR', ProteinAlphabet())
         >>> coding_dna2.translate(to_stop=True)
-        Seq('LAIVMGR', ExtendedIUPACProtein())
+        Seq('LAIVMGR', ProteinAlphabet())
 
         When translating gapped sequences, the gap character is inferred from
         the alphabet:
@@ -1144,13 +1144,13 @@ class Seq:
         >>> from Bio.Alphabet import Gapped
         >>> coding_dna3 = Seq("GTG---GCCATT", Gapped(IUPAC.unambiguous_dna))
         >>> coding_dna3.translate()
-        Seq('V-AI', Gapped(ExtendedIUPACProtein(), '-'))
+        Seq('V-AI', ProteinAlphabet())
 
         It is possible to pass the gap character when the alphabet is missing:
 
         >>> coding_dna4 = Seq("GTG---GCCATT")
         >>> coding_dna4.translate(gap='-')
-        Seq('V-AI', Gapped(ExtendedIUPACProtein(), '-'))
+        Seq('V-AI', ProteinAlphabet())
 
         NOTE - Ambiguous codons like "TAN" or "NNN" could be an amino acid
         or a stop codon.  These are translated as "X".  Any invalid codon
@@ -1219,15 +1219,7 @@ class Seq:
             str(self), codon_table, stop_symbol, to_stop, cds, gap=gap
         )
 
-        if gap and gap in protein:
-            alphabet = Alphabet.Gapped(codon_table.protein_alphabet, gap)
-        else:
-            alphabet = codon_table.protein_alphabet
-
-        if stop_symbol in protein:
-            alphabet = Alphabet.HasStopCodon(alphabet, stop_symbol)
-
-        return Seq(protein, alphabet)
+        return Seq(protein, Alphabet.generic_protein)
 
     def ungap(self, gap=None):
         """Return a copy of the sequence without the gap character(s).
@@ -1839,7 +1831,7 @@ class UnknownSeq(Seq):
         NNNNNNNNN
         >>> my_protein = my_seq.translate()
         >>> my_protein
-        Seq('XXX', ExtendedIUPACProtein())
+        Seq('XXX', ProteinAlphabet())
         >>> print(my_protein)
         XXX
 

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -419,13 +419,13 @@ class SeqFeature:
         by giving explicit arguments:
 
         >>> f.translate(seq, cds=False)
-        Seq('GYTYR*CL**', HasStopCodon(ExtendedIUPACProtein(), '*'))
+        Seq('GYTYR*CL**', ProteinAlphabet())
 
         Now use the start_offset argument to change the frame. Note
         this uses python 0-based numbering.
 
         >>> f.translate(seq, start_offset=1, cds=False)
-        Seq('VTLTDNVSD', ExtendedIUPACProtein())
+        Seq('VTLTDNVSD', ProteinAlphabet())
 
         Alternatively use the codon_start qualifier to do the same
         thing. Note: this uses 1-based numbering, which is found
@@ -433,7 +433,7 @@ class SeqFeature:
 
         >>> f.qualifiers['codon_start'] = [2]
         >>> f.translate(seq, cds=False)
-        Seq('VTLTDNVSD', ExtendedIUPACProtein())
+        Seq('VTLTDNVSD', ProteinAlphabet())
         """
         # see if this feature should be translated in a different
         # frame using the "codon_start" qualifier

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -477,7 +477,7 @@ advantage of one of the \verb|Seq| object's biological methods:
 >>> messenger_rna
 Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
 >>> messenger_rna.translate()
-Seq('MAIVMGR*KGAR*', HasStopCodon(IUPACProtein(), '*'))
+Seq('MAIVMGR*KGAR*', ProteinAlphabet())
 \end{minted}
 
 You can also translate directly from the coding strand DNA sequence:
@@ -490,7 +490,7 @@ You can also translate directly from the coding strand DNA sequence:
 >>> coding_dna
 Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', IUPACUnambiguousDNA())
 >>> coding_dna.translate()
-Seq('MAIVMGR*KGAR*', HasStopCodon(IUPACProtein(), '*'))
+Seq('MAIVMGR*KGAR*', ProteinAlphabet())
 \end{minted}
 
 You should notice in the above protein sequences that in addition to the end stop character, there is an internal stop as well.  This was a deliberate choice of example, as it gives an excuse to talk about some optional arguments, including different translation tables (Genetic Codes).
@@ -501,7 +501,7 @@ Suppose we are dealing with a mitochondrial sequence.  We need to tell the trans
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna.translate(table="Vertebrate Mitochondrial")
-Seq('MAIVMGRWKGAR*', HasStopCodon(IUPACProtein(), '*'))
+Seq('MAIVMGRWKGAR*', ProteinAlphabet())
 \end{minted}
 
 You can also specify the table using the NCBI table number which is shorter, and often included in the feature annotation of GenBank files:
@@ -509,7 +509,7 @@ You can also specify the table using the NCBI table number which is shorter, and
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna.translate(table=2)
-Seq('MAIVMGRWKGAR*', HasStopCodon(IUPACProtein(), '*'))
+Seq('MAIVMGRWKGAR*', ProteinAlphabet())
 \end{minted}
 
 Now, you may want to translate the nucleotides up to the first in frame stop codon,
@@ -518,13 +518,13 @@ and then stop (as happens in nature):
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna.translate()
-Seq('MAIVMGR*KGAR*', HasStopCodon(IUPACProtein(), '*'))
+Seq('MAIVMGR*KGAR*', ProteinAlphabet())
 >>> coding_dna.translate(to_stop=True)
-Seq('MAIVMGR', IUPACProtein())
+Seq('MAIVMGR', ProteinAlphabet())
 >>> coding_dna.translate(table=2)
-Seq('MAIVMGRWKGAR*', HasStopCodon(IUPACProtein(), '*'))
+Seq('MAIVMGRWKGAR*', ProteinAlphabet())
 >>> coding_dna.translate(table=2, to_stop=True)
-Seq('MAIVMGRWKGAR', IUPACProtein())
+Seq('MAIVMGRWKGAR', ProteinAlphabet())
 \end{minted}
 \noindent Notice that when you use the \verb|to_stop| argument, the stop codon itself
 is not translated - and the stop symbol is not included at the end of your protein
@@ -535,7 +535,7 @@ You can even specify the stop symbol if you don't like the default asterisk:
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna.translate(table=2, stop_symbol="@")
-Seq('MAIVMGRWKGAR@', HasStopCodon(IUPACProtein(), '@'))
+Seq('MAIVMGRWKGAR@', ProteinAlphabet())
 \end{minted}
 
 Now, suppose you have a complete coding sequence CDS, which is to say a
@@ -559,10 +559,10 @@ for example the gene yaaX in \texttt{E. coli} K12:
 ...            generic_dna)
 >>> gene.translate(table="Bacterial")
 Seq('VKKMQSIVLALSLVLVAPMAAQAAEITLVPSVKLQIGDRDNRGYYWDGGHWRDH...HR*',
-HasStopCodon(ExtendedIUPACProtein(), '*')
+ProteinAlpabet())
 >>> gene.translate(table="Bacterial", to_stop=True)
 Seq('VKKMQSIVLALSLVLVAPMAAQAAEITLVPSVKLQIGDRDNRGYYWDGGHWRDH...HHR',
-ExtendedIUPACProtein())
+ProteinAlphabet())
 \end{minted}
 
 \noindent In the bacterial genetic code \texttt{GTG} is a valid start codon,
@@ -574,7 +574,7 @@ sequence is a complete CDS:
 \begin{minted}{pycon}
 >>> gene.translate(table="Bacterial", cds=True)
 Seq('MKKMQSIVLALSLVLVAPMAAQAAEITLVPSVKLQIGDRDNRGYYWDGGHWRDH...HHR',
-ExtendedIUPACProtein())
+ProteinAlphabet())
 \end{minted}
 
 In addition to telling Biopython to translate an alternative start codon as

--- a/Tests/test_translate.py
+++ b/Tests/test_translate.py
@@ -64,10 +64,10 @@ class TestTranscriptionTranslation(unittest.TestCase):
         s = "TCAAAAAGGTGCATCTAGATG"
         dna = Seq.Seq(s, IUPAC.unambiguous_dna)
         protein = dna.translate(to_stop=True)
-        self.assertIsInstance(protein.alphabet, IUPAC.IUPACProtein)
+        self.assertIs(protein.alphabet, Alphabet.generic_protein)
         self.assertEqual(str(protein), "SKRCI")
         gapped_protein = dna.translate()
-        self.assertIsInstance(gapped_protein.alphabet, Alphabet.HasStopCodon)
+        self.assertIs(gapped_protein.alphabet, Alphabet.generic_protein)
         self.assertEqual(str(gapped_protein), "SKRCI*M")
         # The table used here has "AGG" as a stop codon:
         p2 = dna.translate(table=2, to_stop=True)
@@ -79,7 +79,7 @@ class TestTranscriptionTranslation(unittest.TestCase):
         r = s.replace("T", "U")
         rna = Seq.Seq(r, IUPAC.unambiguous_rna)
         protein = rna.translate(to_stop=True)
-        self.assertIsInstance(protein.alphabet, IUPAC.IUPACProtein)
+        self.assertIs(protein.alphabet, Alphabet.generic_protein)
         self.assertEqual(str(protein), "SKRCI")
         gapped_protein = rna.translate()
         self.assertEqual(str(gapped_protein), "SKRCI*M")


### PR DESCRIPTION
i.e. Stop using the HasStopCodon and Gapped classes, and stop using the ExtendedIUPACProtein class too (since that doesn't cover stop or gap symbols).

See #2928 and more generally #2046.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
