### PR TITLE
Remove most of the Gapped alphabet class usage

### DIFF
--- a/Bio/AlignIO/FastaIO.py
+++ b/Bio/AlignIO/FastaIO.py
@@ -25,7 +25,6 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Align import MultipleSeqAlignment
 from Bio.Alphabet import single_letter_alphabet, generic_dna, generic_protein
-from Bio.Alphabet import Gapped
 
 
 def _extract_alignment_region(alignment_seq_with_flanking, annotation):
@@ -165,16 +164,12 @@ handle.name: {handle.name}
         alignment.append(record)
 
         # TODO - What if a specific alphabet has been requested?
-        # TODO - Use an IUPAC alphabet?
         # TODO - Can FASTA output RNA?
         if alphabet == single_letter_alphabet and "sq_type" in query_tags:
             if query_tags["sq_type"] == "D":
                 record.seq.alphabet = generic_dna
             elif query_tags["sq_type"] == "p":
                 record.seq.alphabet = generic_protein
-        if "-" in q:
-            if not hasattr(record.seq.alphabet, "gap_char"):
-                record.seq.alphabet = Gapped(record.seq.alphabet, "-")
 
         # Match
         # =====
@@ -196,9 +191,6 @@ handle.name: {handle.name}
                 record.seq.alphabet = generic_dna
             elif match_tags["sq_type"] == "p":
                 record.seq.alphabet = generic_protein
-        if "-" in m:
-            if not hasattr(record.seq.alphabet, "gap_char"):
-                record.seq.alphabet = Gapped(record.seq.alphabet, "-")
 
         return alignment
 

--- a/Bio/AlignIO/Interfaces.py
+++ b/Bio/AlignIO/Interfaces.py
@@ -21,7 +21,6 @@ class AlignmentIterator:
     method as well.
     """
 
-    # TODO - Should the default be Gapped(single_letter_alphabet) instead?
     def __init__(self, handle, seq_count=None, alphabet=single_letter_alphabet):
         """Create an AlignmentIterator object.
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1207,11 +1207,12 @@ class Seq:
 
         return Seq(protein, Alphabet.generic_protein)
 
-    def ungap(self, gap=None):
+    def ungap(self, gap="-"):
         """Return a copy of the sequence without the gap character(s).
 
-        The gap character can be specified in two ways - either as an explicit
-        argument, or via the sequence's alphabet. For example:
+        The gap character now defaults to the minus sign, and can only
+        be specified via the method argument. This is no longer possible
+        via sequence's alphabet (as was possible up to Biopython 1.77):
 
         >>> from Bio.Seq import Seq
         >>> from Bio.Alphabet import generic_dna
@@ -1220,79 +1221,14 @@ class Seq:
         Seq('-ATA--TGAAAT-TTGAAAA', DNAAlphabet())
         >>> my_dna.ungap("-")
         Seq('ATATGAAATTTGAAAA', DNAAlphabet())
-
-        If the gap character is not given as an argument, it will be taken from
-        the sequence's alphabet (if defined). Notice that the returned
-        sequence's alphabet is adjusted since it no longer requires a gapped
-        alphabet:
-
-        >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import IUPAC, Gapped, HasStopCodon
-        >>> my_pro = Seq("MVVLE=AD*", HasStopCodon(Gapped(IUPAC.protein, "=")))
-        >>> my_pro
-        Seq('MVVLE=AD*', HasStopCodon(Gapped(IUPACProtein(), '='), '*'))
-        >>> my_pro.ungap()
-        Seq('MVVLEAD*', HasStopCodon(IUPACProtein(), '*'))
-
-        Or, with a simpler gapped DNA example:
-
-        >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import IUPAC, Gapped
-        >>> my_seq = Seq("CGGGTAG=AAAAAA", Gapped(IUPAC.unambiguous_dna, "="))
-        >>> my_seq
-        Seq('CGGGTAG=AAAAAA', Gapped(IUPACUnambiguousDNA(), '='))
-        >>> my_seq.ungap()
-        Seq('CGGGTAGAAAAAA', IUPACUnambiguousDNA())
-
-        As long as it is consistent with the alphabet, although it is
-        redundant, you can still supply the gap character as an argument to
-        this method:
-
-        >>> my_seq
-        Seq('CGGGTAG=AAAAAA', Gapped(IUPACUnambiguousDNA(), '='))
-        >>> my_seq.ungap("=")
-        Seq('CGGGTAGAAAAAA', IUPACUnambiguousDNA())
-
-        However, if the gap character given as the argument disagrees with that
-        declared in the alphabet, an exception is raised:
-
-        >>> my_seq
-        Seq('CGGGTAG=AAAAAA', Gapped(IUPACUnambiguousDNA(), '='))
-        >>> my_seq.ungap("-")
-        Traceback (most recent call last):
-           ...
-        ValueError: Gap '-' does not match '=' from alphabet
-
-        Finally, if a gap character is not supplied, and the alphabet does not
-        define one, an exception is raised:
-
-        >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_dna
-        >>> my_dna = Seq("ATA--TGAAAT-TTGAAAA", generic_dna)
-        >>> my_dna
-        Seq('ATA--TGAAAT-TTGAAAA', DNAAlphabet())
-        >>> my_dna.ungap()
-        Traceback (most recent call last):
-           ...
-        ValueError: Gap character not given and not defined in alphabet
-
         """
         if hasattr(self.alphabet, "gap_char"):
-            if not gap:
-                gap = self.alphabet.gap_char
-            elif gap != self.alphabet.gap_char:
-                raise ValueError(
-                    f"Gap {gap!r} does not match {self.alphabet.gap_char!r}"
-                    " from alphabet"
-                )
-            alpha = Alphabet._ungap(self.alphabet)
+            raise NotImplementedError("We stopped supporting the Gapped class...")
         elif not gap:
-            raise ValueError("Gap character not given and not defined in alphabet")
-        else:
-            alpha = self.alphabet  # modify!
-        if len(gap) != 1 or not isinstance(gap, str):
+            raise ValueError("Gap character required.")
+        elif len(gap) != 1 or not isinstance(gap, str):
             raise ValueError(f"Unexpected gap character, {gap!r}")
-        return Seq(str(self).replace(gap, ""), alpha)
+        return Seq(str(self).replace(gap, ""), self.alphabet)
 
     def join(self, other):
         """Return a merge of the sequences in other, spaced by the sequence from self.
@@ -1828,18 +1764,19 @@ class UnknownSeq(Seq):
             raise ValueError("Proteins cannot be translated!")
         return UnknownSeq(self._length // 3, Alphabet.generic_protein, "X")
 
-    def ungap(self, gap=None):
+    def ungap(self, gap="-"):
         """Return a copy of the sequence without the gap character(s).
 
-        The gap character can be specified in two ways - either as an explicit
-        argument, or via the sequence's alphabet. For example:
+        The gap character now defaults to the minus sign, and can only
+        be specified via the method argument. This is no longer possible
+        via sequence's alphabet (as was possible up to Biopython 1.77):
 
+        >>> from Bio.Alphabet import generic_dna
         >>> from Bio.Seq import UnknownSeq
-        >>> from Bio.Alphabet import Gapped, generic_dna
-        >>> my_dna = UnknownSeq(20, Gapped(generic_dna, "-"))
+        >>> my_dna = UnknownSeq(20, alphabet=generic_dna)
         >>> my_dna
-        UnknownSeq(20, alphabet=Gapped(DNAAlphabet(), '-'), character='N')
-        >>> my_dna.ungap()
+        UnknownSeq(20, alphabet=DNAAlphabet(), character='N')
+        >>> my_dna.ungap()  # using default
         UnknownSeq(20, alphabet=DNAAlphabet(), character='N')
         >>> my_dna.ungap("-")
         UnknownSeq(20, alphabet=DNAAlphabet(), character='N')
@@ -1847,18 +1784,15 @@ class UnknownSeq(Seq):
         If the UnknownSeq is using the gap character, then an empty Seq is
         returned:
 
-        >>> my_gap = UnknownSeq(20, Gapped(generic_dna, "-"), character="-")
+        >>> my_gap = UnknownSeq(20, generic_dna, character="-")
         >>> my_gap
-        UnknownSeq(20, alphabet=Gapped(DNAAlphabet(), '-'), character='-')
-        >>> my_gap.ungap()
+        UnknownSeq(20, alphabet=DNAAlphabet(), character='-')
+        >>> my_gap.ungap()  # using default
         Seq('', DNAAlphabet())
         >>> my_gap.ungap("-")
         Seq('', DNAAlphabet())
-
-        Notice that the returned sequence's alphabet is adjusted to remove any
-        explicit gap character declaration.
         """
-        # Offload the alphabet stuff
+        # Offload the argument validation
         s = Seq(self._character, self.alphabet).ungap(gap)
         if s:
             return UnknownSeq(self._length, s.alphabet, self._character)

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -862,15 +862,15 @@ class Seq:
     def upper(self):
         """Return an upper case copy of the sequence.
 
-        >>> from Bio.Alphabet import HasStopCodon, generic_protein
+        >>> from Bio.Alphabet import generic_protein
         >>> from Bio.Seq import Seq
-        >>> my_seq = Seq("VHLTPeeK*", HasStopCodon(generic_protein))
+        >>> my_seq = Seq("VHLTPeeK*", generic_protein)
         >>> my_seq
-        Seq('VHLTPeeK*', HasStopCodon(ProteinAlphabet(), '*'))
+        Seq('VHLTPeeK*', ProteinAlphabet())
         >>> my_seq.lower()
-        Seq('vhltpeek*', HasStopCodon(ProteinAlphabet(), '*'))
+        Seq('vhltpeek*', ProteinAlphabet())
         >>> my_seq.upper()
-        Seq('VHLTPEEK*', HasStopCodon(ProteinAlphabet(), '*'))
+        Seq('VHLTPEEK*', ProteinAlphabet())
 
         This will adjust the alphabet if required. See also the lower method.
         """

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -883,15 +883,13 @@ class Seq:
         alphabets are upper case only, and thus a generic alphabet must be
         substituted.
 
-        >>> from Bio.Alphabet import Gapped, generic_dna
-        >>> from Bio.Alphabet import IUPAC
+        >>> from Bio.Alphabet.IUPAC import unambiguous_dna
         >>> from Bio.Seq import Seq
-        >>> my_seq = Seq("CGGTACGCTTATGTCACGTAG*AAAAAA",
-        ...          Gapped(IUPAC.unambiguous_dna, "*"))
+        >>> my_seq = Seq("CGGTACGCTTATGTCACGTAGAAAAAA", unambiguous_dna)
         >>> my_seq
-        Seq('CGGTACGCTTATGTCACGTAG*AAAAAA', Gapped(IUPACUnambiguousDNA(), '*'))
+        Seq('CGGTACGCTTATGTCACGTAGAAAAAA', IUPACUnambiguousDNA())
         >>> my_seq.lower()
-        Seq('cggtacgcttatgtcacgtag*aaaaaa', Gapped(DNAAlphabet(), '*'))
+        Seq('cggtacgcttatgtcacgtagaaaaaa', DNAAlphabet())
 
         See also the upper method.
         """

--- a/Bio/SeqIO/AceIO.py
+++ b/Bio/SeqIO/AceIO.py
@@ -14,7 +14,7 @@ the contig consensus sequences in an ACE file as SeqRecord objects.
 
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.Alphabet import generic_nucleotide, generic_dna, generic_rna, Gapped
+from Bio.Alphabet import generic_nucleotide, generic_dna, generic_rna
 from Bio.Sequencing import Ace
 
 
@@ -76,9 +76,7 @@ def AceIterator(source):
             # For consistency with most other file formats, map
             # any * gaps into - gaps.
             assert "-" not in consensus_seq_str
-            consensus_seq = Seq(
-                consensus_seq_str.replace("*", "-"), Gapped(alpha, gap_char="-")
-            )
+            consensus_seq = Seq(consensus_seq_str.replace("*", "-"), alpha)
         else:
             consensus_seq = Seq(consensus_seq_str, alpha)
 

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -33,10 +33,7 @@ from Bio import StreamModeError
 protein_alphas = [Alphabet.generic_protein]
 dna_alphas = [Alphabet.generic_dna]
 rna_alphas = [Alphabet.generic_rna]
-nucleotide_alphas = [
-    Alphabet.generic_nucleotide,
-    Alphabet.Gapped(Alphabet.generic_nucleotide),
-]
+nucleotide_alphas = [Alphabet.generic_nucleotide]
 no_alpha_formats = {
     "clustal",
     "emboss",

--- a/Tests/test_codonalign.py
+++ b/Tests/test_codonalign.py
@@ -14,7 +14,7 @@ from Bio import SeqIO
 from Bio import AlignIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.Alphabet import IUPAC, Gapped, generic_dna, generic_protein
+from Bio.Alphabet import IUPAC, generic_dna, generic_protein
 from Bio.Align import MultipleSeqAlignment
 from Bio.Data import CodonTable
 
@@ -140,7 +140,7 @@ class TestBuildAndIO(unittest.TestCase):
             elif i[1] == "index":
                 # Deliberately using a fancy protein alphabet for testing:
                 nucl = SeqIO.index(i[0][0], "fasta", alphabet=IUPAC.IUPACUnambiguousDNA())
-                prot = AlignIO.read(i[0][1], "clustal", alphabet=Gapped(IUPAC.ExtendedIUPACProtein()))
+                prot = AlignIO.read(i[0][1], "clustal", alphabet=generic_protein)
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore")
                     caln = codonalign.build(prot, nucl, alphabet=codonalign.default_codon_alphabet, max_score=20)

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -13,7 +13,6 @@ import unittest
 import math
 
 from Bio.Alphabet import generic_dna
-from Bio.Alphabet import Gapped
 from Bio.Alphabet import IUPAC
 from Bio import motifs
 from Bio.Seq import Seq
@@ -1514,7 +1513,7 @@ class TestMEME(unittest.TestCase):
         self.assertAlmostEqual(motif.background["T"], 0.30569430569430567)
         self.assertAlmostEqual(motif.evalue, 4.1e-09)
         self.assertEqual(motif.alphabet, "ACGT")
-        self.assertEqual(motif.instances, None)
+        self.assertIsNone(motif.instances)
 
     def test_meme_parser_rna(self):
         """Test if Bio.motifs can parse MEME output files using RNA."""
@@ -2278,7 +2277,6 @@ class MotifTestPWM(unittest.TestCase):
             Seq("TACAA", IUPAC.unambiguous_dna),
             Seq("TACGC", IUPAC.ambiguous_dna),
             Seq("TACAC", IUPAC.extended_dna),
-            Seq("TACCC", Gapped(IUPAC.unambiguous_dna)),
             Seq("AACCC", IUPAC.unambiguous_dna),
             Seq("AATGC", IUPAC.unambiguous_dna),
             Seq("AATGC", generic_dna),

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -12,7 +12,7 @@ import warnings
 from Bio import BiopythonWarning
 from Bio import Alphabet
 from Bio import Seq
-from Bio.Alphabet import IUPAC, Gapped
+from Bio.Alphabet import IUPAC
 from Bio.Data.IUPACData import (
     ambiguous_dna_complement,
     ambiguous_rna_complement,
@@ -37,10 +37,10 @@ test_seqs = [
     Seq.Seq("AWGAARCKG", Alphabet.generic_dna),
     Seq.Seq("AUGAAACUG", Alphabet.generic_rna),
     Seq.Seq("ATGAAACTG", IUPAC.unambiguous_dna),
-    Seq.Seq("ATGAAA-CTG", Alphabet.Gapped(IUPAC.unambiguous_dna)),
+    Seq.Seq("ATGAAA-CTG", Alphabet.generic_dna),
     Seq.Seq("ATGAAACTGWN", IUPAC.ambiguous_dna),
     Seq.Seq("AUGAAACUG", Alphabet.generic_rna),
-    Seq.Seq("AUGAAA==CUG", Alphabet.Gapped(Alphabet.generic_rna, "=")),
+    Seq.Seq("AUGAAA==CUG", Alphabet.generic_rna),
     Seq.Seq("AUGAAACUG", IUPAC.unambiguous_rna),
     Seq.Seq("AUGAAACUGWN", IUPAC.ambiguous_rna),
     Seq.Seq("ATGAAACTG", Alphabet.generic_nucleotide),
@@ -51,25 +51,13 @@ test_seqs = [
 ]
 protein_seqs = [
     Seq.Seq("ATCGPK", IUPAC.protein),
-    Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, ".")),
-    Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-")),
-    Seq.Seq(
-        "MEDG-KRXR*",
-        Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"),
-    ),
-    Seq.MutableSeq(
-        "ME-K-DRXR*XU",
-        Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"),
-    ),
-    Seq.Seq(
-        "MEDG-KRXR@",
-        Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"), "@"),
-    ),
-    Seq.Seq("ME-KR@", Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"), "@")),
-    Seq.Seq(
-        "MEDG.KRXR@",
-        Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "@"), "."),
-    ),
+    Seq.Seq("T.CGPK", Alphabet.generic_protein),
+    Seq.Seq("T-CGPK", Alphabet.generic_protein),
+    Seq.Seq("MEDG-KRXR*", Alphabet.generic_protein),
+    Seq.MutableSeq("ME-K-DRXR*XU", Alphabet.generic_protein),
+    Seq.Seq("MEDG-KRXR@", Alphabet.generic_protein),
+    Seq.Seq("ME-KR@", Alphabet.generic_protein),
+    Seq.Seq("MEDG.KRXR@", Alphabet.generic_protein),
 ]
 
 
@@ -175,49 +163,26 @@ class TestSeqStringMethods(unittest.TestCase):
             Seq.Seq("ATCG", IUPAC.ambiguous_dna),
             Seq.Seq("gtca", Alphabet.generic_dna),
             Seq.MutableSeq("GGTCA", Alphabet.generic_dna),
-            Seq.Seq("CTG-CA", Alphabet.Gapped(IUPAC.unambiguous_dna, "-")),
+            Seq.Seq("CTG-CA", Alphabet.generic_dna),
         ]
         self.rna = [
             Seq.Seq("AUUUCG", IUPAC.ambiguous_rna),
             Seq.MutableSeq("AUUCG", IUPAC.ambiguous_rna),
             Seq.Seq("uCAg", Alphabet.generic_rna),
-            Seq.MutableSeq("UC-AG", Alphabet.Gapped(Alphabet.generic_rna, "-")),
-            Seq.Seq("U.CAG", Alphabet.Gapped(Alphabet.generic_rna, ".")),
+            Seq.MutableSeq("UC-AG", Alphabet.generic_rna),
+            Seq.Seq("U.CAG", Alphabet.generic_rna),
         ]
         self.nuc = [Seq.Seq("ATCG", Alphabet.generic_nucleotide)]
         self.protein = [
             Seq.Seq("ATCGPK", IUPAC.protein),
             Seq.Seq("atcGPK", Alphabet.generic_protein),
-            Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, ".")),
-            Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-")),
-            Seq.Seq(
-                "MEDG-KRXR*",
-                Alphabet.Gapped(
-                    Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"
-                ),
-            ),
-            Seq.MutableSeq(
-                "ME-K-DRXR*XU",
-                Alphabet.Gapped(
-                    Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"
-                ),
-            ),
-            Seq.Seq(
-                "MEDG-KRXR@",
-                Alphabet.HasStopCodon(
-                    Alphabet.Gapped(IUPAC.extended_protein, "-"), "@"
-                ),
-            ),
-            Seq.Seq(
-                "ME-KR@",
-                Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.protein, "-"), "@"),
-            ),
-            Seq.Seq(
-                "MEDG.KRXR@",
-                Alphabet.Gapped(
-                    Alphabet.HasStopCodon(IUPAC.extended_protein, "@"), "."
-                ),
-            ),
+            Seq.Seq("T.CGPK", Alphabet.generic_protein),
+            Seq.Seq("T-CGPK", Alphabet.generic_protein),
+            Seq.Seq("MEDG-KRXR*", Alphabet.generic_protein),
+            Seq.MutableSeq("ME-K-DRXR*XU", Alphabet.generic_protein),
+            Seq.Seq("MEDG-KRXR@", Alphabet.generic_protein),
+            Seq.Seq("ME-KR@", Alphabet.generic_protein),
+            Seq.Seq("MEDG.KRXR@", Alphabet.generic_protein),
         ]
         self.test_chars = ["-", Seq.Seq("-"), Seq.Seq("*"), "-X@"]
 
@@ -350,10 +315,8 @@ class TestSeqStringMethods(unittest.TestCase):
 
     def test_append_proteins(self):
         self.test_chars.append(Seq.Seq("K", Alphabet.generic_protein))
-        self.test_chars.append(
-            Seq.Seq("K-", Alphabet.Gapped(Alphabet.generic_protein, "-"))
-        )
-        self.test_chars.append(Seq.Seq("K@", Alphabet.Gapped(IUPAC.protein, "@")))
+        self.test_chars.append(Seq.Seq("K-", Alphabet.generic_protein))
+        self.test_chars.append(Seq.Seq("K@", Alphabet.generic_protein))
 
         self.assertEqual(7, len(self.test_chars))
 
@@ -421,15 +384,15 @@ class TestSeqAddition(unittest.TestCase):
             Seq.Seq("ATCG", IUPAC.ambiguous_dna),
             Seq.Seq("gtca", Alphabet.generic_dna),
             Seq.MutableSeq("GGTCA", Alphabet.generic_dna),
-            Seq.Seq("CTG-CA", Alphabet.Gapped(IUPAC.unambiguous_dna, "-")),
+            Seq.Seq("CTG-CA", Alphabet.generic_dna),
             "TGGTCA",
         ]
         self.rna = [
             Seq.Seq("AUUUCG", IUPAC.ambiguous_rna),
             Seq.MutableSeq("AUUCG", IUPAC.ambiguous_rna),
             Seq.Seq("uCAg", Alphabet.generic_rna),
-            Seq.MutableSeq("UC-AG", Alphabet.Gapped(Alphabet.generic_rna, "-")),
-            Seq.Seq("U.CAG", Alphabet.Gapped(Alphabet.generic_rna, ".")),
+            Seq.MutableSeq("UC-AG", Alphabet.generic_rna),
+            Seq.Seq("U.CAG", Alphabet.generic_rna),
             "UGCAU",
         ]
         self.nuc = [
@@ -439,20 +402,10 @@ class TestSeqAddition(unittest.TestCase):
         self.protein = [
             Seq.Seq("ATCGPK", IUPAC.protein),
             Seq.Seq("atcGPK", Alphabet.generic_protein),
-            Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, ".")),
-            Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-")),
-            Seq.Seq(
-                "MEDG-KRXR*",
-                Alphabet.Gapped(
-                    Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"
-                ),
-            ),
-            Seq.MutableSeq(
-                "ME-K-DRXR*XU",
-                Alphabet.Gapped(
-                    Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"
-                ),
-            ),
+            Seq.Seq("T.CGPK", Alphabet.generic_protein),
+            Seq.Seq("T-CGPK", Alphabet.generic_protein),
+            Seq.Seq("MEDG-KRXR*", Alphabet.generic_protein),
+            Seq.MutableSeq("ME-K-DRXR*XU", Alphabet.generic_protein),
             "TEDDF",
         ]
 
@@ -483,13 +436,6 @@ class TestSeqAddition(unittest.TestCase):
                 c = b + a
                 b += a
                 self.assertEqual(c, b)
-
-    def test_exception_when_added_rna_has_more_than_one_gap_type(self):
-        """Test resulting sequence has gap types '-' and '.'."""
-        with self.assertRaises(ValueError):
-            self.rna[3] + self.rna[4]
-        with self.assertRaises(ValueError):
-            self.rna[3] += self.rna[4]
 
     def test_addition_dna_with_dna(self):
         for a in self.dna:
@@ -532,30 +478,6 @@ class TestSeqAddition(unittest.TestCase):
                 c = b + a
                 b += a
                 self.assertEqual(c, b)
-
-    def test_exception_when_added_protein_has_more_than_one_gap_type(self):
-        """Test resulting protein has gap types '-' and '.'."""
-        a = Seq.Seq("T.CGPK", Alphabet.Gapped(IUPAC.protein, "."))
-        b = Seq.Seq("T-CGPK", Alphabet.Gapped(IUPAC.protein, "-"))
-        with self.assertRaises(ValueError):
-            a + b
-        with self.assertRaises(ValueError):
-            a += b
-
-    def test_exception_when_added_protein_has_several_stop_codon_types(self):
-        """Test resulting protein has stop codon types '*' and '@'."""
-        a = Seq.Seq(
-            "MEDG-KRXR@",
-            Alphabet.HasStopCodon(Alphabet.Gapped(IUPAC.extended_protein, "-"), "@"),
-        )
-        b = Seq.Seq(
-            "MEDG-KRXR*",
-            Alphabet.Gapped(Alphabet.HasStopCodon(IUPAC.extended_protein, "*"), "-"),
-        )
-        with self.assertRaises(ValueError):
-            a + b
-        with self.assertRaises(ValueError):
-            a += b
 
     def test_exception_when_adding_protein_with_nucleotides(self):
         for a in self.protein[0:5]:
@@ -1016,9 +938,7 @@ class TestUnknownSeq(unittest.TestCase):
         seq = Seq.UnknownSeq(7, alphabet=Alphabet.generic_dna)
         self.assertEqual("NNNNNNN", str(seq.ungap("-")))
 
-        seq = Seq.UnknownSeq(
-            20, alphabet=Alphabet.generic_dna, character="-"
-        )
+        seq = Seq.UnknownSeq(20, alphabet=Alphabet.generic_dna, character="-")
         self.assertEqual("", seq.ungap("-"))
 
 
@@ -1280,45 +1200,46 @@ class TestTranslating(unittest.TestCase):
         self.assertIs(self.test_seqs[11].translate().alphabet, Alphabet.generic_protein)
         self.assertIs(self.test_seqs[12].translate().alphabet, Alphabet.generic_protein)
 
-        self.assertIs(triple_pad(self.test_seqs[13]).translate().alphabet, Alphabet.generic_protein)
+        self.assertIs(
+            triple_pad(self.test_seqs[13]).translate().alphabet,
+            Alphabet.generic_protein,
+        )
 
         self.assertIs(self.test_seqs[14].translate().alphabet, Alphabet.generic_protein)
         self.assertIs(self.test_seqs[15].translate().alphabet, Alphabet.generic_protein)
 
-        self.assertIs(triple_pad(self.test_seqs[16]).translate().alphabet, Alphabet.generic_protein)
-        self.assertIs(triple_pad(self.test_seqs[17]).translate().alphabet, Alphabet.generic_protein)
+        self.assertIs(
+            triple_pad(self.test_seqs[16]).translate().alphabet,
+            Alphabet.generic_protein,
+        )
+        self.assertIs(
+            triple_pad(self.test_seqs[17]).translate().alphabet,
+            Alphabet.generic_protein,
+        )
 
     def test_gapped_seq_with_gap_char_given(self):
         seq = Seq.Seq("ATG---AAACTG")
         self.assertEqual("M-KL", seq.translate(gap="-"))
         self.assertRaises(TranslationError, seq.translate, gap="~")
 
-    def test_gapped_seq_with_stop_codon_and_gap_char_given(self):
         seq = Seq.Seq("GTG---GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG")
         self.assertEqual("V-AIVMGR*KGAR*", seq.translate(gap="-"))
         self.assertRaises(TranslationError, seq.translate, gap=None)
 
-    def test_gapped_seq_with_gap_char_given_and_inferred_from_alphabet(self):
-        seq = Seq.Seq("ATG---AAACTG", Gapped(IUPAC.unambiguous_dna))
+        seq = Seq.Seq("ATG---AAACTG", Alphabet.generic_dna)
         self.assertEqual("M-KL", seq.translate(gap="-"))
-        self.assertRaises(ValueError, seq.translate, gap="~")
 
-        seq = Seq.Seq("ATG~~~AAACTG", Gapped(IUPAC.unambiguous_dna))
-        self.assertRaises(ValueError, seq.translate, gap="~")
+        seq = Seq.Seq("ATG~~~AAACTG", Alphabet.generic_dna)
         self.assertRaises(TranslationError, seq.translate, gap="-")
 
-    def test_gapped_seq_with_gap_char_given_and_inferred_from_alphabet2(self):
-        """Test using stop codon in sequence."""
-        seq = Seq.Seq("ATG---AAACTGTAG", Gapped(IUPAC.unambiguous_dna))
+        seq = Seq.Seq("ATG---AAACTGTAG", Alphabet.generic_dna)
         self.assertEqual("M-KL*", seq.translate(gap="-"))
-        self.assertRaises(ValueError, seq.translate, gap="~")
 
-        seq = Seq.Seq("ATG---AAACTGTAG", Gapped(IUPAC.unambiguous_dna))
+        seq = Seq.Seq("ATG---AAACTGTAG", Alphabet.generic_dna)
         self.assertEqual("M-KL@", seq.translate(gap="-", stop_symbol="@"))
-        self.assertRaises(ValueError, seq.translate, gap="~")
+        self.assertRaises(TranslationError, seq.translate, gap="~")
 
-        seq = Seq.Seq("ATG~~~AAACTGTAG", Gapped(IUPAC.unambiguous_dna))
-        self.assertRaises(ValueError, seq.translate, gap="~")
+        seq = Seq.Seq("ATG~~~AAACTGTAG", Alphabet.generic_dna)
         self.assertRaises(TranslationError, seq.translate, gap="-")
 
     def test_gapped_seq_no_gap_char_given(self):
@@ -1326,13 +1247,13 @@ class TestTranslating(unittest.TestCase):
         self.assertRaises(TranslationError, seq.translate, gap=None)
 
     def test_alphabet_of_translated_gapped_seq(self):
-        seq = Seq.Seq("ATG---AAACTG", Gapped(IUPAC.unambiguous_dna))
+        seq = Seq.Seq("ATG---AAACTG", Alphabet.generic_dna)
         self.assertIs(seq.translate().alphabet, Alphabet.generic_protein)
 
-        seq = Seq.Seq("ATG---AAACTG", Gapped(IUPAC.unambiguous_dna, "-"))
+        seq = Seq.Seq("ATG---AAACTG", Alphabet.generic_dna)
         self.assertIs(seq.translate().alphabet, Alphabet.generic_protein)
 
-        seq = Seq.Seq("ATG~~~AAACTG", Gapped(IUPAC.unambiguous_dna, "~"))
+        seq = Seq.Seq("ATG~~~AAACTG", Alphabet.generic_dna)
         self.assertIs(seq.translate(gap="~").alphabet, Alphabet.generic_protein)
 
         seq = Seq.Seq("ATG---AAACTG")

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -165,7 +165,7 @@ class TestSeq(unittest.TestCase):
             Seq.Seq("ATC-CCA").ungap("--")
 
         with self.assertRaises(ValueError):
-            Seq.Seq("ATC-CCA").ungap()
+            Seq.Seq("ATC-CCA").ungap(gap=None)
 
 
 class TestSeqStringMethods(unittest.TestCase):
@@ -1013,11 +1013,11 @@ class TestUnknownSeq(unittest.TestCase):
         self.assertRaises(ValueError, seq.translate)
 
     def test_ungap(self):
-        seq = Seq.UnknownSeq(7, alphabet=Alphabet.Gapped(Alphabet.DNAAlphabet(), "-"))
+        seq = Seq.UnknownSeq(7, alphabet=Alphabet.generic_dna)
         self.assertEqual("NNNNNNN", str(seq.ungap("-")))
 
         seq = Seq.UnknownSeq(
-            20, alphabet=Alphabet.Gapped(Alphabet.DNAAlphabet(), "-"), character="-"
+            20, alphabet=Alphabet.generic_dna, character="-"
         )
         self.assertEqual("", seq.ungap("-"))
 


### PR DESCRIPTION
This pull request addresses most of issue #2928, cross reference #2046. There are still a traces of the ``AlphabetEncoder`` classes to track down but some are in areas of the code I am less familiar with.

As with #2929 for the ``.translate(...)`` method, the sequence object's ``.ungap(...)`` method argument is now the only way to set the gap character to be removed, and it defaults to the minus sign.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
