### PR TITLE
Fix using FastaWriter directly

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -338,6 +338,9 @@ class FastaTwoLineWriter(FastaWriter):
     This means we write the sequence information  without line
     wrapping, and will always write a blank line for an empty
     sequence.
+
+    Please use the ``as_fasta_2line`` function instead, or the top level
+    ``Bio.SeqIO.write()`` function instead using ``format="fasta"``.
     """
 
     def __init__(self, handle, record2title=None):

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -18,7 +18,7 @@ You are expected to use this module via the Bio.SeqIO functions.
 from Bio.Alphabet import single_letter_alphabet
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from .Interfaces import SequenceIterator, SequentialSequenceWriter
+from .Interfaces import SequenceIterator, SequenceWriter
 from .Interfaces import _clean, _get_seq_string
 
 
@@ -253,7 +253,7 @@ class FastaTwoLineIterator(SequenceIterator):
             )
 
 
-class FastaWriter(SequentialSequenceWriter):
+class FastaWriter(SequenceWriter):
     """Class to write Fasta format files (OBSOLETE).
 
     Please use the ``as_fasta`` function instead, or the top level
@@ -303,10 +303,6 @@ class FastaWriter(SequentialSequenceWriter):
 
     def write_record(self, record):
         """Write a single Fasta record to the file."""
-        assert self._header_written
-        assert not self._footer_written
-        self._record_written = True
-
         if self.record2title:
             title = self.clean(self.record2title(record))
         else:

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -18,7 +18,8 @@ You are expected to use this module via the Bio.SeqIO functions.
 from Bio.Alphabet import single_letter_alphabet
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from .Interfaces import SequenceIterator, SequenceWriter, _clean, _get_seq_string
+from .Interfaces import SequenceIterator, SequentialSequenceWriter
+from .Interfaces import _clean, _get_seq_string
 
 
 def SimpleFastaParser(handle):
@@ -252,7 +253,7 @@ class FastaTwoLineIterator(SequenceIterator):
             )
 
 
-class FastaWriter(SequenceWriter):
+class FastaWriter(SequentialSequenceWriter):
     """Class to write Fasta format files (OBSOLETE).
 
     Please use the ``as_fasta`` function instead, or the top level

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -10,6 +10,9 @@ Unless you are writing a new parser or writer for Bio.SeqIO, you should not
 use this module.  It provides base classes to try and simplify things.
 """
 
+import warnings
+from Bio import BiopythonDeprecationWarning
+
 from Bio import StreamModeError
 from Bio.Alphabet import generic_alphabet
 from Bio.Seq import Seq, MutableSeq
@@ -253,10 +256,15 @@ class SequenceWriter:
 
 
 class SequentialSequenceWriter(SequenceWriter):
-    """Base class for sequence writers (OBSOLETE). This class should be subclassed.
+    """Base class for sequential sequence writers (DEPRECATED).
 
-    It is intended for sequential file formats with an (optional)
-    header, repeated records, and an (optional) footer.
+    This class should be subclassed. It is no longer used.
+    It was intended for sequential file formats with an (optional)
+    header, repeated records, and an (optional) footer. It would
+    enforce callign the methods in appropriate order. To update
+    code using ``SequentialSequenceWriter``, just subclass
+    ``SequenceWriter`` and drop the ``._header_written`` etc
+    checks (or reimplement them).
 
     In this case (as with interlaced file formats), the user may
     simply call the write_file() method and be done.
@@ -280,6 +288,11 @@ class SequentialSequenceWriter(SequenceWriter):
         self._header_written = False
         self._record_written = False
         self._footer_written = False
+        warnings.warn(
+            "SequentialSequenceWriter has been deprecated, any class "
+            "subclassing it will need to subclass SequenceWriter instead.",
+            BiopythonDeprecationWarning,
+        )
 
     def write_header(self):
         """Write the file header.

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -256,6 +256,9 @@ Bio.SeqIO.Interfaces
 Unused class InterlacedSequenceIterator was deprecated in Release 1.61, and
 removed in Release 1.64.
 
+Class SequentialSequenceWriter was declared obsolete in Release 1.77, and
+deprecated in Release 1.78.
+
 Bio.HotRand
 -----------
 Obsolete file Bio/HotRand.py was deprecated in Release 1.61, and removed in


### PR DESCRIPTION
This got broken during the Python 2/3 cleanup and our tests didn't call the class directly.

This pull request addresses issue #2931

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
