### PR TITLE
Substitution matrices dna

### DIFF
--- a/Bio/Align/substitution_matrices/data/HOXD70
+++ b/Bio/Align/substitution_matrices/data/HOXD70
@@ -1,0 +1,9 @@
+#  F. Chiaromonte, V.B. Yap, W. Miller:
+#  "Scoring pairwise genomic sequence alignments"
+#  Pacific Symposium on Biocomputing 2002: 115-26 (2002).
+#  PMID 11928468
+     A    C    G    T
+A   91 -114  -31 -123
+C -114  100 -125  -31
+G  -31 -125  100 -114
+T -123  -31 -114   91

--- a/Bio/Align/substitution_matrices/data/TRANS
+++ b/Bio/Align/substitution_matrices/data/TRANS
@@ -1,0 +1,12 @@
+#  David Wheeler,
+#  Department of Cell Biology, Baylor College of Medicine, Houston, Texas:
+#  "Weight matrices for sequence similarity scoring."
+#  Version 2.0, May 1996.
+#  David Wheeler defined the Transition/Transversion Matrix as a penalty
+#  matrix; the matrix below is a similarity matrix where
+#  similarity = 5 - penalty.
+   A  T  C  G
+A  5  0  0  4
+T  0  5  4  0
+C  0  4  5  0
+G  4  0  0  5

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1810,7 +1810,7 @@ Alternatively, you can use the \verb+substitution_matrix+ attribute of the \verb
 \begin{minted}{pycon}
 >>> from Bio.Align import substitution_matrices
 >>> substitution_matrices.load()  #doctest: +ELLIPSIS
-['BENNER22', 'BENNER6', 'BENNER74', 'BLOSUM45', 'BLOSUM50', 'BLOSUM62', ..., 'STR']
+['BENNER22', 'BENNER6', 'BENNER74', 'BLOSUM45', 'BLOSUM50', 'BLOSUM62', ..., 'TRANS']
 >>> matrix = substitution_matrices.load("BLOSUM62")
 >>> print(matrix)  #doctest: +ELLIPSIS
 #  Matrix made by matblas from blosum62.iij
@@ -2924,7 +2924,7 @@ To get a full list of available substitution matrices, use \verb+load+ without a
 %cont-doctest
 \begin{minted}{pycon}
 >>> substitution_matrices.load()  #doctest: +ELLIPSIS
-['BENNER22', 'BENNER6', 'BENNER74', 'BLOSUM45', 'BLOSUM50', ..., 'STR']
+['BENNER22', 'BENNER6', 'BENNER74', 'BLOSUM45', 'BLOSUM50', ..., 'TRANS']
 \end{minted}
 
 \hypertarget{codonmatrix}


### PR DESCRIPTION
This pull request adds the HoxD70 matrix and the transversion/transition matrix to the substitution matrices for DNA alignment.
 
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
