### PR TITLE
removed alphabets from Bio.SeqUtils

### DIFF
--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -125,7 +125,7 @@ class ProteinAnalysis:
 
     def molecular_weight(self):
         """Calculate MW from Protein sequence."""
-        return molecular_weight(self.sequence, monoisotopic=self.monoisotopic)
+        return molecular_weight(self.sequence, seq_type="protein", monoisotopic=self.monoisotopic)
 
     def aromaticity(self):
         """Calculate the aromaticity according to Lobry, 1994.

--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -125,7 +125,9 @@ class ProteinAnalysis:
 
     def molecular_weight(self):
         """Calculate MW from Protein sequence."""
-        return molecular_weight(self.sequence, seq_type="protein", monoisotopic=self.monoisotopic)
+        return molecular_weight(
+            self.sequence, seq_type="protein", monoisotopic=self.monoisotopic
+        )
 
     def aromaticity(self):
         """Calculate the aromaticity according to Lobry, 1994.

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -13,8 +13,7 @@
 import re
 from math import pi, sin, cos
 
-from Bio.Seq import Seq, MutableSeq
-from Bio import Alphabet
+from Bio.Seq import Seq
 from Bio.Data import IUPACData
 
 
@@ -315,7 +314,7 @@ def seq1(seq, custom_map=None, undef_code="X"):
 
 
 def molecular_weight(
-    seq, seq_type=None, double_stranded=False, circular=False, monoisotopic=False
+    seq, seq_type="DNA", double_stranded=False, circular=False, monoisotopic=False
 ):
     """Calculate the molecular mass of DNA, RNA or protein sequences as float.
 
@@ -324,16 +323,11 @@ def molecular_weight(
 
     Arguments:
      - seq: String or Biopython sequence object.
-     - seq_type: The default (None) is to take the alphabet from the seq
-       argument, or assume DNA if the seq argument is a string. Override this
-       with a string 'DNA', 'RNA', or 'protein'.
+     - seq_type: The default is to assume DNA; override this with a string
+       "DNA", "RNA", or "protein".
      - double_stranded: Calculate the mass for the double stranded molecule?
      - circular: Is the molecule circular (has no ends)?
      - monoisotopic: Use the monoisotopic mass tables?
-
-    Note that for backwards compatibility, if the seq argument is a string,
-    or Seq object with a generic alphabet, and no seq_type is specified
-    (i.e. left as None), then DNA is assumed.
 
     >>> print("%0.2f" % molecular_weight("AGC"))
     949.61
@@ -349,60 +343,8 @@ def molecular_weight(
     >>> print("%0.2f" % molecular_weight("AGC", "protein"))
     249.29
 
-    Or, with the sequence alphabet:
-
-    >>> from Bio.Seq import Seq
-    >>> from Bio.Alphabet import generic_dna, generic_rna, generic_protein
-    >>> print("%0.2f" % molecular_weight(Seq("AGC", generic_dna)))
-    949.61
-    >>> print("%0.2f" % molecular_weight(Seq("AGC", generic_rna)))
-    997.61
-    >>> print("%0.2f" % molecular_weight(Seq("AGC", generic_protein)))
-    249.29
-
-    Also note that contradictory sequence alphabets and seq_type will also
-    give an exception:
-
-    >>> from Bio.Seq import Seq
-    >>> from Bio.Alphabet import generic_dna
-    >>> print("%0.2f" % molecular_weight(Seq("AGC", generic_dna), "RNA"))
-    Traceback (most recent call last):
-      ...
-    ValueError: seq_type='RNA' contradicts DNA from seq alphabet
-
     """
     # Rewritten by Markus Piotrowski, 2014
-
-    # Find the alphabet type
-    tmp_type = ""
-    if isinstance(seq, (Seq, MutableSeq)):
-        base_alphabet = Alphabet._get_base_alphabet(seq.alphabet)
-        if isinstance(base_alphabet, Alphabet.DNAAlphabet):
-            tmp_type = "DNA"
-        elif isinstance(base_alphabet, Alphabet.RNAAlphabet):
-            tmp_type = "RNA"
-        elif isinstance(base_alphabet, Alphabet.ProteinAlphabet):
-            tmp_type = "protein"
-        elif isinstance(base_alphabet, Alphabet.ThreeLetterProtein):
-            tmp_type = "protein"
-            # Convert to one-letter sequence. Have to use a string for seq1
-            seq = Seq(seq1(str(seq)), alphabet=Alphabet.ProteinAlphabet())
-        elif not isinstance(base_alphabet, Alphabet.Alphabet):
-            raise TypeError(
-                "%s is not a valid alphabet for mass calculations" % base_alphabet
-            )
-        else:
-            tmp_type = "DNA"  # backward compatibity
-        if seq_type and tmp_type and tmp_type != seq_type:
-            raise ValueError(
-                "seq_type=%r contradicts %s from seq alphabet" % (seq_type, tmp_type)
-            )
-        seq_type = tmp_type
-    elif isinstance(seq, str):
-        if seq_type is None:
-            seq_type = "DNA"  # backward compatibity
-    else:
-        raise TypeError("Expected a string or Seq object, not seq=%r" % seq)
 
     seq = "".join(str(seq).split()).upper()  # Do the minimum formatting
 

--- a/Tests/test_ProtParam.py
+++ b/Tests/test_ProtParam.py
@@ -51,7 +51,7 @@ class ProtParamTest(unittest.TestCase):
         # This test is somehow useless, since ProteinAnalysis.molecular_weight
         # is internally calling SeqUtils.molecular_weight.
         mw_1 = self.analysis.molecular_weight()
-        mw_2 = molecular_weight(Seq(self.seq_text, IUPAC.protein))
+        mw_2 = molecular_weight(Seq(self.seq_text), seq_type="protein")
         self.assertAlmostEqual(mw_1, mw_2)
 
     def test_get_monoisotopic_molecular_weight_identical(self):
@@ -60,7 +60,7 @@ class ProtParamTest(unittest.TestCase):
         # is internally calling SeqUtils.molecular_weight.
         self.analysis = ProtParam.ProteinAnalysis(self.seq_text, monoisotopic=True)
         mw_1 = self.analysis.molecular_weight()
-        mw_2 = molecular_weight(Seq(self.seq_text, IUPAC.protein), monoisotopic=True)
+        mw_2 = molecular_weight(Seq(self.seq_text), seq_type="protein", monoisotopic=True)
         self.assertAlmostEqual(mw_1, mw_2)
 
     def test_aromaticity(self):


### PR DESCRIPTION
This pull request removes alphabets from `Bio.SeqUtils`.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
