### PR TITLE
removed Alphabet from Bio.SubsMat

### DIFF
--- a/Bio/SubsMat/FreqTable.py
+++ b/Bio/SubsMat/FreqTable.py
@@ -31,9 +31,7 @@ Methods:
   (all internal)
 
 Attributes:
-  :alphabet: The IUPAC alphabet set (or any other) whose letters you are using.
-             Common sets are: ``IUPAC.protein`` (20-letter protein), ``IUPAC.unambiguous_dna``
-             (4-letter DNA). See ``Bio.Alphabet`` for more.
+  :alphabet: The letters you are using as indices into the table.
   :data: Frequency dictionary.
   :count: Count dictionary. Empty if no counts are provided.
 
@@ -52,7 +50,6 @@ Example of use:
 
 """
 
-from Bio import Alphabet
 
 COUNT = 1
 FREQ = 2
@@ -86,8 +83,7 @@ class FreqTable(dict):
         else:
             raise ValueError("bad dict_type")
         if not alphabet:
-            self.alphabet = Alphabet.Alphabet()
-            self.alphabet.letters = self._alphabet_from_input()
+            self.alphabet = self._alphabet_from_input()
 
 
 def read_count(f):

--- a/Bio/SubsMat/__init__.py
+++ b/Bio/SubsMat/__init__.py
@@ -116,7 +116,6 @@ import copy
 import math
 
 # BioPython imports
-from Bio import Alphabet
 from Bio.SubsMat import FreqTable
 
 import warnings
@@ -148,7 +147,7 @@ class SeqMat(dict):
         for i in self:
             ab_set.add(i[0])
             ab_set.add(i[1])
-        self.alphabet.letters = "".join(sorted(ab_set))
+        self.alphabet = "".join(sorted(ab_set))
 
     def __init__(self, data=None, alphabet=None, mat_name="", build_later=0):
         """Initialize.
@@ -157,8 +156,8 @@ class SeqMat(dict):
 
         - data: matrix itself
         - mat_name: its name. See below.
-        - alphabet: an instance of Bio.Alphabet, or a subclass. If not
-          supplied, constructor builds its own from that matrix.
+        - alphabet: an iterable over the letters allowed as indices into the
+          matrix. If not supplied, constructor builds its own from that matrix.
         - build_later: skip the matrix size assertion. User will build the
           matrix after creating the instance. Constructor builds a half matrix
           filled with zeroes.
@@ -177,19 +176,17 @@ class SeqMat(dict):
                 self.update(data)
             except ValueError:
                 raise ValueError("Failed to store data in a dictionary")
-        if alphabet is None:
-            alphabet = Alphabet.Alphabet()
-        assert Alphabet.generic_alphabet.contains(alphabet)
-        self.alphabet = alphabet
 
         # If passed alphabet is empty, use the letters in the matrix itself
-        if not self.alphabet.letters:
+        if alphabet is None:
             self._alphabet_from_matrix()
+        else:
+            self.alphabet = "".join(alphabet)
         # Assert matrix size: half or full
         if not build_later:
-            N = len(self.alphabet.letters)
+            N = len(self.alphabet)
             assert len(self) == N ** 2 or len(self) == N * (N + 1) / 2
-        self.ab_list = list(self.alphabet.letters)
+        self.ab_list = list(self.alphabet)
         self.ab_list.sort()
         # Names: a string like "BLOSUM62" or "PAM250"
         self.mat_name = mat_name
@@ -213,9 +210,9 @@ class SeqMat(dict):
         """Convert a full-matrix to a half-matrix (PRIVATE)."""
         # For instance: two entries ('A','C'):13 and ('C','A'):20 will be summed
         # into ('A','C'): 33 and the index ('C','A') will be deleted
-        # alphabet.letters:('A','A') and ('C','C') will remain the same.
+        # ('A','A') and ('C','C') will remain the same.
 
-        N = len(self.alphabet.letters)
+        N = len(self.alphabet)
         # Do nothing if this is already a half-matrix
         if len(self) == N * (N + 1) / 2:
             return
@@ -242,7 +239,7 @@ class SeqMat(dict):
     def sum(self):
         """Return sum of the results."""
         result = {}
-        for letter in self.alphabet.letters:
+        for letter in self.alphabet:
             result[letter] = 0.0
         for pair, value in self.items():
             i1, i2 = pair
@@ -445,7 +442,7 @@ def _build_obs_freq_mat(acc_rep_mat):
 def _exp_freq_table_from_obs_freq(obs_freq_mat):
     """Build expected frequence table from observed frequences (PRIVATE)."""
     exp_freq_table = {}
-    for i in obs_freq_mat.alphabet.letters:
+    for i in obs_freq_mat.alphabet:
         exp_freq_table[i] = 0.0
     for i in obs_freq_mat:
         if i[0] == i[1]:

--- a/Tests/test_SubsMat.py
+++ b/Tests/test_SubsMat.py
@@ -46,7 +46,7 @@ class TestGeo(unittest.TestCase):
         ctab_file = os.path.join("SubsMat", "protein_freq.txt")
         with open(ctab_file) as handle:
             ctab_prot = FreqTable.read_freq(handle)
-        self.assertEqual(self.ftab_prot.alphabet.letters, letters)
+        self.assertEqual(self.ftab_prot.alphabet, letters)
         for letter in letters:
             difference = self.ftab_prot[letter] - ctab_prot[letter]
             self.assertAlmostEqual(abs(difference), 0, places=3)


### PR DESCRIPTION
This pull request removes Bio.Alphabet from Bio.SubsMat, and replaces the alphabet attribute by a string of letters (same as in Bio.motifs for example).

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
