### PR TITLE
remove old-style alphabets from Bio.motifs

### DIFF
--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -12,8 +12,6 @@ import os
 import unittest
 import math
 
-from Bio.Alphabet import generic_dna
-from Bio.Alphabet import IUPAC
 from Bio import motifs
 from Bio.Seq import Seq
 
@@ -2235,18 +2233,12 @@ class MotifTestPWM(unittest.TestCase):
         self.assertAlmostEqual(result[4], -20.3014183, places=5)
         self.assertAlmostEqual(result[5], -25.18009186, places=5)
 
-    def test_with_alt_alphabet(self):
-        """Test motif search using alternative instance of alphabet."""
-        self.s = Seq(str(self.s), IUPAC.IUPACUnambiguousDNA())
-        self.test_simple()
-
     def test_with_mixed_case(self):
         """Test if Bio.motifs PWM scoring works with mixed case."""
         counts = self.m.counts
         pwm = counts.normalize(pseudocounts=0.25)
         pssm = pwm.log_odds()
-        # Note we're breaking Seq/Alphabet expectations here:
-        result = pssm.calculate(Seq("AcGTgTGCGtaGTGCGT", self.m.alphabet))
+        result = pssm.calculate(Seq("AcGTgTGCGtaGTGCGT"))
         self.assertEqual(6, len(result))
         self.assertAlmostEqual(result[0], -29.18363571, places=5)
         self.assertAlmostEqual(result[1], -38.3365097, places=5)

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -2270,20 +2270,6 @@ class MotifTestPWM(unittest.TestCase):
         self.assertAlmostEqual(result[5], -25.18009186, places=5)
         self.assertTrue(math.isnan(result[6]), "Expected nan, not %r" % result[6])
 
-    def test_mixed_alphabets(self):
-        """Test creating motif with mixed alphabets."""
-        # TODO - Can we support this?
-        seqs = [
-            Seq("TACAA", IUPAC.unambiguous_dna),
-            Seq("TACGC", IUPAC.ambiguous_dna),
-            Seq("TACAC", IUPAC.extended_dna),
-            Seq("AACCC", IUPAC.unambiguous_dna),
-            Seq("AATGC", IUPAC.unambiguous_dna),
-            Seq("AATGC", generic_dna),
-        ]
-        # ValueError: Alphabets are inconsistent
-        self.assertRaises(ValueError, motifs.create, seqs)
-
     def test_calculate_pseudocounts(self):
         pseudocounts = motifs.jaspar.calculate_pseudocounts(self.m)
         self.assertAlmostEqual(pseudocounts["A"], 1.695582495781317, places=5)


### PR DESCRIPTION
This pull request removes old-style alphabets from Bio.motifs.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
