### PR TITLE
Drop use of Gapped alphabet in AlignInfo and FSSP

### DIFF
--- a/Bio/FSSP/FSSPTools.py
+++ b/Bio/FSSP/FSSPTools.py
@@ -15,7 +15,7 @@ new_sum, new_align = filter(sum, align, 'zscore', 4, 7.5)
 from Bio import FSSP
 import copy
 from Bio.Align import MultipleSeqAlignment
-from Bio import Alphabet
+from Bio.Alphabet import generic_protein
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
@@ -49,12 +49,12 @@ def mult_align(sum_dict, align_dict):
         for j in align_dict.abs(i).pos_align_dict:
             # loop within a position
             mult_align_dict[j] += align_dict.abs(i).pos_align_dict[j].aa
-    alpha = Alphabet.Gapped(Alphabet.IUPAC.extended_protein)
-    fssp_align = MultipleSeqAlignment([], alphabet=alpha)
+    fssp_align = MultipleSeqAlignment([], alphabet=generic_protein)
     for i in sorted(mult_align_dict):
         fssp_align.append(
             SeqRecord(
-                Seq(mult_align_dict[i], alpha), sum_dict[i].pdb2 + sum_dict[i].chain2
+                Seq(mult_align_dict[i], generic_protein),
+                sum_dict[i].pdb2 + sum_dict[i].chain2,
             )
         )
     return fssp_align

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -215,7 +215,7 @@ class TestReading(unittest.TestCase):
     def test_read_write_clustal(self):
         """Test the base alignment stuff."""
         path = os.path.join(os.getcwd(), "Clustalw", "opuntia.aln")
-        alignment = AlignIO.read(path, "clustal", alphabet=Alphabet.Gapped(IUPAC.unambiguous_dna))
+        alignment = AlignIO.read(path, "clustal", alphabet=Alphabet.generic_dna)
         self.assertEqual(len(alignment), 7)
         seq_record = alignment[0]
         self.assertEqual(seq_record.description, "gi|6273285|gb|AF191659.1|AF191")
@@ -243,7 +243,7 @@ class TestReading(unittest.TestCase):
         consensus = align_info.dumb_consensus()
         self.assertIsInstance(consensus, Seq)
         self.assertEqual(consensus, "TATACATTAAAGXAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATATATATATATAATATATTTCAAATTXCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA")
-        dictionary = align_info.replacement_dictionary(["N"])
+        dictionary = align_info.replacement_dictionary(["N", "-"])
         self.assertEqual(len(dictionary), 16)
         self.assertAlmostEqual(dictionary[("A", "A")], 1395.0, places=1)
         self.assertAlmostEqual(dictionary[("A", "C")], 3.0, places=1)
@@ -261,7 +261,7 @@ class TestReading(unittest.TestCase):
         self.assertAlmostEqual(dictionary[("T", "C")], 12.0, places=1)
         self.assertAlmostEqual(dictionary[("T", "G")], 0, places=1)
         self.assertAlmostEqual(dictionary[("T", "T")], 874.0, places=1)
-        matrix = align_info.pos_specific_score_matrix(consensus, ["N"])
+        matrix = align_info.pos_specific_score_matrix(consensus, ["N", "-"])
         self.assertEqual(str(matrix), """\
     A   C   G   T
 T  0.0 0.0 0.0 7.0
@@ -422,7 +422,7 @@ G  0.0 0.0 7.0 0.0
 A  7.0 0.0 0.0 0.0
 """)
 
-        matrix = align_info.pos_specific_score_matrix(chars_to_ignore=["N"])
+        matrix = align_info.pos_specific_score_matrix(chars_to_ignore=["N", "-"])
         self.assertEqual(str(matrix), """\
     A   C   G   T
 T  0.0 0.0 0.0 7.0
@@ -584,7 +584,7 @@ A  7.0 0.0 0.0 0.0
 """)
 
         second_seq = alignment[1].seq
-        matrix = align_info.pos_specific_score_matrix(second_seq, ["N"])
+        matrix = align_info.pos_specific_score_matrix(second_seq, ["N", "-"])
         self.assertEqual(str(matrix), """\
     A   C   G   T
 T  0.0 0.0 0.0 7.0
@@ -919,8 +919,7 @@ A  7.0 0.0 0.0 0.0
 
     def test_read_fasta(self):
         path = os.path.join(os.curdir, "Quality", "example.fasta")
-        alignment = AlignIO.read(path, "fasta",
-                                 alphabet=Alphabet.Gapped(IUPAC.ambiguous_dna))
+        alignment = AlignIO.read(path, "fasta")
         self.assertEqual(len(alignment), 3)
         seq_record = alignment[0]
         self.assertEqual(seq_record.description, "EAS54_6_R1_2_1_413_324")


### PR DESCRIPTION
This pull request addresses issue #2928. The FSSP change is minor, the AlignInfo less so. This might benefit from changes to make ignoring the minus sign default behaviour?

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
