### PR TITLE
removed alphabet from test_CAPS.py

### DIFF
--- a/Tests/test_CAPS.py
+++ b/Tests/test_CAPS.py
@@ -9,20 +9,18 @@ import unittest
 
 from Bio import CAPS
 from Bio.Restriction import EcoRI, AluI
-from Bio import Alphabet
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Align import MultipleSeqAlignment
 
 
-def createAlignment(sequences, alphabet):
+def createAlignment(sequences):
     """Create an Alignment object from a list of sequences."""
     return MultipleSeqAlignment(
         (
-            SeqRecord(Seq(s, alphabet), id="sequence%i" % (i + 1))
+            SeqRecord(Seq(s), id="sequence%i" % (i + 1))
             for (i, s) in enumerate(sequences)
         ),
-        alphabet,
     )
 
 
@@ -30,7 +28,7 @@ class TestCAPS(unittest.TestCase):
     def test_trivial(self):
         enzymes = [EcoRI]
         alignment = ["gaattc", "gaactc"]
-        align = createAlignment(alignment, Alphabet.generic_dna)
+        align = createAlignment(alignment)
         map = CAPS.CAPSMap(align, enzymes)
 
         self.assertEqual(len(map.dcuts), 1)
@@ -59,7 +57,7 @@ class TestCAPS(unittest.TestCase):
         ]
         self.assertEqual(len(alignment), 3)
         enzymes = [EcoRI, AluI]
-        align = createAlignment(alignment, Alphabet.generic_dna)
+        align = createAlignment(alignment)
         map = CAPS.CAPSMap(align, enzymes)
 
         self.assertEqual(len(map.dcuts), 2)
@@ -75,7 +73,7 @@ class TestCAPS(unittest.TestCase):
     def testNoCAPS(self):
         alignment = ["aaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaa"]
         enzymes = []
-        align = createAlignment(alignment, Alphabet.generic_nucleotide)
+        align = createAlignment(alignment)
         map = CAPS.CAPSMap(align, enzymes)
         self.assertEqual(map.dcuts, [])
 
@@ -85,7 +83,7 @@ class TestCAPS(unittest.TestCase):
             "aaaaaaaaaaaaaa",  # we'll change this below
             "aaaaaaaaaaaaaa",
         ]
-        align = createAlignment(alignment, Alphabet.generic_nucleotide)
+        align = createAlignment(alignment)
         align[1].seq = align[1].seq[:8]  # evil
         self.assertRaises(CAPS.AlignmentHasDifferentLengthsError, CAPS.CAPSMap, align)
 


### PR DESCRIPTION
This pull request removes alphabets from `test_CAPS.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
