### PR TITLE
remove alphabet from test_SeqFeature

### DIFF
--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -11,7 +11,6 @@ import unittest
 from os import path
 
 from Bio import Seq, SeqIO
-from Bio.Alphabet import generic_dna
 from Bio.Data.CodonTable import TranslationError
 from Bio.SeqFeature import FeatureLocation, AfterPosition, BeforePosition
 from Bio.SeqFeature import CompoundLocation, UnknownPosition, SeqFeature
@@ -168,7 +167,7 @@ class TestSeqFeature(unittest.TestCase):
 
     def test_translation_checks_cds(self):
         """Test that a CDS feature is subject to respective checks."""
-        seq = Seq.Seq("GGTTACACTTACCGATAATGTCTCTGATGA", generic_dna)
+        seq = Seq.Seq("GGTTACACTTACCGATAATGTCTCTGATGA")
         f = SeqFeature(FeatureLocation(0, 30), type="CDS")
         f.qualifiers["transl_table"] = [11]
         with self.assertRaises(TranslationError):


### PR DESCRIPTION
This pull request removes alphabets from `test_SeqFeature.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
