### PR TITLE
Drop most IUPAC alphabets in Seq/SeqRecord docstrings

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -94,15 +94,11 @@ class Seq:
         However, will often want to create your own Seq objects directly:
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import IUPAC
-        >>> my_seq = Seq("MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF",
-        ...              IUPAC.protein)
+        >>> my_seq = Seq("MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF")
         >>> my_seq
-        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF', IUPACProtein())
+        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF')
         >>> print(my_seq)
         MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF
-        >>> my_seq.alphabet
-        IUPACProtein()
         """
         # Enforce string storage
         if not isinstance(data, str):
@@ -290,29 +286,6 @@ class Seq:
         Seq('MELKILV', ProteinAlphabet())
 
         When adding two Seq (like) objects, the alphabets are important.
-        Consider this example:
-
-        >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet.IUPAC import unambiguous_dna, ambiguous_dna
-        >>> unamb_dna_seq = Seq("ACGT", unambiguous_dna)
-        >>> ambig_dna_seq = Seq("ACRGT", ambiguous_dna)
-        >>> unamb_dna_seq
-        Seq('ACGT', IUPACUnambiguousDNA())
-        >>> ambig_dna_seq
-        Seq('ACRGT', IUPACAmbiguousDNA())
-
-        If we add the ambiguous and unambiguous IUPAC DNA alphabets, we get
-        the more general ambiguous IUPAC DNA alphabet:
-
-        >>> unamb_dna_seq + ambig_dna_seq
-        Seq('ACGTACRGT', IUPACAmbiguousDNA())
-
-        However, if the default generic alphabet is included, the result is
-        a generic alphabet:
-
-        >>> Seq("") + ambig_dna_seq
-        Seq('ACRGT')
-
         You can't add RNA and DNA sequences:
 
         >>> from Bio.Alphabet import generic_dna, generic_rna
@@ -425,15 +398,13 @@ class Seq:
         """Return the full sequence as a MutableSeq object.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import IUPAC
-        >>> my_seq = Seq("MKQHKAMIVALIVICITAVVAAL",
-        ...              IUPAC.protein)
+        >>> my_seq = Seq("MKQHKAMIVALIVICITAVVAAL")
         >>> my_seq
-        Seq('MKQHKAMIVALIVICITAVVAAL', IUPACProtein())
+        Seq('MKQHKAMIVALIVICITAVVAAL')
         >>> my_seq.tomutable()
-        MutableSeq('MKQHKAMIVALIVICITAVVAAL', IUPACProtein())
+        MutableSeq('MKQHKAMIVALIVICITAVVAAL')
 
-        Note that the alphabet is preserved.
+        Any alphabet is preserved.
         """
         return MutableSeq(str(self), self.alphabet)
 
@@ -844,13 +815,12 @@ class Seq:
 
         e.g. Removing a nucleotide sequence's polyadenylation (poly-A tail):
 
-        >>> from Bio.Alphabet import IUPAC
         >>> from Bio.Seq import Seq
-        >>> my_seq = Seq("CGGTACGCTTATGTCACGTAGAAAAAA", IUPAC.unambiguous_dna)
+        >>> my_seq = Seq("CGGTACGCTTATGTCACGTAGAAAAAA")
         >>> my_seq
-        Seq('CGGTACGCTTATGTCACGTAGAAAAAA', IUPACUnambiguousDNA())
+        Seq('CGGTACGCTTATGTCACGTAGAAAAAA')
         >>> my_seq.rstrip("A")
-        Seq('CGGTACGCTTATGTCACGTAG', IUPACUnambiguousDNA())
+        Seq('CGGTACGCTTATGTCACGTAG')
 
         See also the strip and lstrip methods.
         """
@@ -912,29 +882,28 @@ class Seq:
         """Return the complement sequence by creating a new Seq object.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import IUPAC
-        >>> my_dna = Seq("CCCCCGATAG", IUPAC.unambiguous_dna)
+        >>> my_dna = Seq("CCCCCGATAG")
         >>> my_dna
-        Seq('CCCCCGATAG', IUPACUnambiguousDNA())
+        Seq('CCCCCGATAG')
         >>> my_dna.complement()
-        Seq('GGGGGCTATC', IUPACUnambiguousDNA())
+        Seq('GGGGGCTATC')
 
         You can of course used mixed case sequences,
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_dna
-        >>> my_dna = Seq("CCCCCgatA-GD", generic_dna)
+        >>> my_dna = Seq("CCCCCgatA-GD")
         >>> my_dna
-        Seq('CCCCCgatA-GD', DNAAlphabet())
+        Seq('CCCCCgatA-GD')
         >>> my_dna.complement()
-        Seq('GGGGGctaT-CH', DNAAlphabet())
+        Seq('GGGGGctaT-CH')
 
         Note in the above example, ambiguous character D denotes
         G, A or T so its complement is H (for C, T or A).
 
         Trying to complement a protein sequence raises an exception.
 
-        >>> my_protein = Seq("MAIVMGR", IUPAC.protein)
+        >>> from Bio.Alphabet import generic_protein
+        >>> my_protein = Seq("MAIVMGR", generic_protein)
         >>> my_protein.complement()
         Traceback (most recent call last):
            ...
@@ -964,20 +933,19 @@ class Seq:
         """Return the reverse complement sequence by creating a new Seq object.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import IUPAC
-        >>> my_dna = Seq("CCCCCGATAGNR", IUPAC.ambiguous_dna)
+        >>> my_dna = Seq("CCCCCGATAGNR")
         >>> my_dna
-        Seq('CCCCCGATAGNR', IUPACAmbiguousDNA())
+        Seq('CCCCCGATAGNR')
         >>> my_dna.reverse_complement()
-        Seq('YNCTATCGGGGG', IUPACAmbiguousDNA())
+        Seq('YNCTATCGGGGG')
 
         Note in the above example, since R = G or A, its complement
         is Y (which denotes C or T).
 
         You can of course used mixed case sequences,
 
-        >>> from Bio.Seq import Seq
         >>> from Bio.Alphabet import generic_dna
+        >>> from Bio.Seq import Seq
         >>> my_dna = Seq("CCCCCgatA-G", generic_dna)
         >>> my_dna
         Seq('CCCCCgatA-G', DNAAlphabet())
@@ -986,7 +954,9 @@ class Seq:
 
         Trying to complement a protein sequence raises an exception:
 
-        >>> my_protein = Seq("MAIVMGR", IUPAC.protein)
+        >>> from Bio.Alphabet import generic_protein
+        >>> from Bio.Seq import Seq
+        >>> my_protein = Seq("MAIVMGR", generic_protein)
         >>> my_protein.reverse_complement()
         Traceback (most recent call last):
            ...
@@ -999,17 +969,19 @@ class Seq:
         """Return the RNA sequence from a DNA sequence by creating a new Seq object.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import IUPAC
+        >>> from Bio.Alphabet import generic_dna
         >>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG",
-        ...                  IUPAC.unambiguous_dna)
+        ...                  generic_dna)
         >>> coding_dna
-        Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', IUPACUnambiguousDNA())
+        Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', DNAAlphabet())
         >>> coding_dna.transcribe()
-        Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
+        Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', RNAAlphabet())
 
         Trying to transcribe a protein or RNA sequence raises an exception:
 
-        >>> my_protein = Seq("MAIVMGR", IUPAC.protein)
+        >>> from Bio.Alphabet import generic_protein
+        >>> from Bio.Seq import Seq
+        >>> my_protein = Seq("MAIVMGR", generic_protein)
         >>> my_protein.transcribe()
         Traceback (most recent call last):
            ...
@@ -1032,19 +1004,21 @@ class Seq:
     def back_transcribe(self):
         """Return the DNA sequence from an RNA sequence by creating a new Seq object.
 
+        >>> from Bio.Alphabet import generic_rna
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import IUPAC
         >>> messenger_rna = Seq("AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG",
-        ...                     IUPAC.unambiguous_rna)
+        ...                     generic_rna)
         >>> messenger_rna
-        Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
+        Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', RNAAlphabet())
         >>> messenger_rna.back_transcribe()
-        Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', IUPACUnambiguousDNA())
+        Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', DNAAlphabet())
 
         Trying to back-transcribe a protein or DNA sequence raises an
         exception:
 
-        >>> my_protein = Seq("MAIVMGR", IUPAC.protein)
+        >>> from Bio.Alphabet import generic_protein
+        >>> from Bio.Seq import Seq
+        >>> my_protein = Seq("MAIVMGR", generic_protein)
         >>> my_protein.back_transcribe()
         Traceback (most recent call last):
            ...
@@ -2489,14 +2463,14 @@ class MutableSeq:
     def toseq(self):
         """Return the full sequence as a new immutable Seq object.
 
+        >>> from Bio.Alphabet import generic_protein
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import IUPAC
         >>> my_mseq = MutableSeq("MKQHKAMIVALIVICITAVVAAL",
-        ...                      IUPAC.protein)
+        ...                      generic_protein)
         >>> my_mseq
-        MutableSeq('MKQHKAMIVALIVICITAVVAAL', IUPACProtein())
+        MutableSeq('MKQHKAMIVALIVICITAVVAAL', ProteinAlphabet())
         >>> my_mseq.toseq()
-        Seq('MKQHKAMIVALIVICITAVVAAL', IUPACProtein())
+        Seq('MKQHKAMIVALIVICITAVVAAL', ProteinAlphabet())
 
         Note that the alphabet is preserved.
         """

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -125,9 +125,7 @@ class SeqRecord:
 
     >>> from Bio.Seq import Seq
     >>> from Bio.SeqRecord import SeqRecord
-    >>> from Bio.Alphabet import IUPAC
-    >>> record = SeqRecord(Seq("MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF",
-    ...                         IUPAC.protein),
+    >>> record = SeqRecord(Seq("MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF"),
     ...                    id="YP_025292.1", name="HokC",
     ...                    description="toxic membrane protein")
     >>> print(record)
@@ -135,7 +133,7 @@ class SeqRecord:
     Name: HokC
     Description: toxic membrane protein
     Number of features: 0
-    Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF', IUPACProtein())
+    Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF')
 
     If you want to save SeqRecord objects to a sequence file, use Bio.SeqIO
     for this.  For the special case where you want the SeqRecord turned into
@@ -373,10 +371,8 @@ class SeqRecord:
         >>> from Bio.Seq import Seq
         >>> from Bio.SeqRecord import SeqRecord
         >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
-        >>> from Bio.Alphabet import IUPAC
         >>> rec = SeqRecord(Seq("MAAGVKQLADDRTLLMAGVSHDLRTPLTRIRLAT"
-        ...                     "EMMSEQDGYLAESINKDIEECNAIIEQFIDYLR",
-        ...                     IUPAC.protein),
+        ...                     "EMMSEQDGYLAESINKDIEECNAIIEQFIDYLR"),
         ...                 id="1JOY", name="EnvZ",
         ...                 description="Homodimeric domain of EnvZ from E. coli")
         >>> rec.letter_annotations["secondary_structure"] = "  S  SSSSSSHHHHHTTTHHHHHHHHHHHHHHHHHHHHHHTHHHHHHHHHHHHHHHHHHHHHTT  "
@@ -391,7 +387,7 @@ class SeqRecord:
         Description: Homodimeric domain of EnvZ from E. coli
         Number of features: 1
         Per letter annotation for: secondary_structure
-        Seq('MAAGVKQLADDRTLLMAGVSHDLRTPLTRIRLATEMMSEQDGYLAESINKDIEE...YLR', IUPACProtein())
+        Seq('MAAGVKQLADDRTLLMAGVSHDLRTPLTRIRLATEMMSEQDGYLAESINKDIEE...YLR')
         >>> rec.letter_annotations["secondary_structure"]
         '  S  SSSSSSHHHHHTTTHHHHHHHHHHHHHHHHHHHHHHTHHHHHHHHHHHHHHHHHHHHHTT  '
         >>> print(rec.features[0].location)
@@ -407,7 +403,7 @@ class SeqRecord:
         Description: Homodimeric domain of EnvZ from E. coli
         Number of features: 1
         Per letter annotation for: secondary_structure
-        Seq('RTLLMAGVSHDLRTPLTRIRLATEMMSEQD', IUPACProtein())
+        Seq('RTLLMAGVSHDLRTPLTRIRLATEMMSEQD')
         >>> sub.letter_annotations["secondary_structure"]
         'HHHHHTTTHHHHHHHHHHHHHHHHHHHHHH'
         >>> print(sub.features[0].location)
@@ -422,7 +418,7 @@ class SeqRecord:
         Description: Homodimeric domain of EnvZ from E. coli
         Number of features: 0
         Per letter annotation for: secondary_structure
-        Seq('MAAGVKQLAD', IUPACProtein())
+        Seq('MAAGVKQLAD')
 
         Or for the last ten letters:
 
@@ -432,7 +428,7 @@ class SeqRecord:
         Description: Homodimeric domain of EnvZ from E. coli
         Number of features: 0
         Per letter annotation for: secondary_structure
-        Seq('IIEQFIDYLR', IUPACProtein())
+        Seq('IIEQFIDYLR')
 
         If you omit both, then you get a copy of the original record (although
         lacking the annotations and dbxrefs):
@@ -443,7 +439,7 @@ class SeqRecord:
         Description: Homodimeric domain of EnvZ from E. coli
         Number of features: 1
         Per letter annotation for: secondary_structure
-        Seq('MAAGVKQLADDRTLLMAGVSHDLRTPLTRIRLATEMMSEQDGYLAESINKDIEE...YLR', IUPACProtein())
+        Seq('MAAGVKQLADDRTLLMAGVSHDLRTPLTRIRLATEMMSEQDGYLAESINKDIEE...YLR')
 
         Finally, indexing with a simple integer is shorthand for pulling out
         that letter from the sequence directly:
@@ -617,9 +613,7 @@ class SeqRecord:
 
         >>> from Bio.Seq import Seq
         >>> from Bio.SeqRecord import SeqRecord
-        >>> from Bio.Alphabet import IUPAC
-        >>> record = SeqRecord(Seq("MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF",
-        ...                         IUPAC.protein),
+        >>> record = SeqRecord(Seq("MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF"),
         ...                    id="YP_025292.1", name="HokC",
         ...                    description="toxic membrane protein, small")
         >>> print(str(record))
@@ -627,7 +621,7 @@ class SeqRecord:
         Name: HokC
         Description: toxic membrane protein, small
         Number of features: 0
-        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF', IUPACProtein())
+        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF')
 
         In this example you don't actually need to call str explicity, as the
         print command does this automatically:
@@ -637,7 +631,7 @@ class SeqRecord:
         Name: HokC
         Description: toxic membrane protein, small
         Number of features: 0
-        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF', IUPACProtein())
+        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF')
 
         Note that long sequences are shown truncated.
         """
@@ -706,9 +700,7 @@ class SeqRecord:
 
         >>> from Bio.Seq import Seq
         >>> from Bio.SeqRecord import SeqRecord
-        >>> from Bio.Alphabet import IUPAC
-        >>> record = SeqRecord(Seq("MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF",
-        ...                         IUPAC.protein),
+        >>> record = SeqRecord(Seq("MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF"),
         ...                    id="YP_025292.1", name="HokC",
         ...                    description="toxic membrane protein")
         >>> record.format("fasta")
@@ -1172,10 +1164,10 @@ class SeqRecord:
         Note trying to reverse complement a protein SeqRecord raises an
         exception:
 
-        >>> from Bio.SeqRecord import SeqRecord
+        >>> from Bio.Alphabet import generic_protein
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import IUPAC
-        >>> protein_rec = SeqRecord(Seq("MAIVMGR", IUPAC.protein), id="Test")
+        >>> from Bio.SeqRecord import SeqRecord
+        >>> protein_rec = SeqRecord(Seq("MAIVMGR", generic_protein), id="Test")
         >>> protein_rec.reverse_complement()
         Traceback (most recent call last):
            ...
@@ -1183,10 +1175,9 @@ class SeqRecord:
 
         Also note you can reverse complement a SeqRecord using a MutableSeq:
 
-        >>> from Bio.SeqRecord import SeqRecord
         >>> from Bio.Seq import MutableSeq
-        >>> from Bio.Alphabet import generic_dna
-        >>> rec = SeqRecord(MutableSeq("ACGT", generic_dna), id="Test")
+        >>> from Bio.SeqRecord import SeqRecord
+        >>> rec = SeqRecord(MutableSeq("ACGT"), id="Test")
         >>> rec.seq[0] = "T"
         >>> print("%s %s" % (rec.id, rec.seq))
         Test TCGT


### PR DESCRIPTION
This pull request addresses in part issue #2046. There are a couple of IUPAC Alphabet appearances left which are linked to functional code - this was the low hanging fruit.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
