### PR TITLE
Drop IUPAC alphabets from GenBank/EMBL parser

### DIFF
--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -41,11 +41,12 @@ Exceptions:
 """
 
 import re
-
-# other Biopython stuff
-from Bio import SeqFeature
 import warnings
+
 from Bio import BiopythonParserWarning
+from Bio.Alphabet import generic_dna, generic_rna, generic_protein, generic_alphabet
+from Bio.Seq import Seq, UnknownSeq
+from Bio import SeqFeature
 
 # other Bio.GenBank stuff
 from .utils import FeatureValueCleaner
@@ -1350,10 +1351,6 @@ class _FeatureConsumer(_BaseGenBankConsumer):
 
     def record_end(self, content):
         """Clean up when we've finished the record."""
-        from Bio import Alphabet
-        from Bio.Alphabet import IUPAC
-        from Bio.Seq import Seq, UnknownSeq
-
         # Try and append the version number to the accession for the full id
         if not self.data.id:
             if "accessions" in self.data.annotations:
@@ -1372,7 +1369,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         # first, determine the alphabet
         # we default to an generic alphabet if we don't have a
         # seq type or have strange sequence information.
-        seq_alphabet = Alphabet.generic_alphabet
+        seq_alphabet = generic_alphabet
 
         # now set the sequence
         sequence = "".join(self._seq_data)
@@ -1391,19 +1388,19 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         if self._seq_type:
             # mRNA is really also DNA, since it is actually cDNA
             if "DNA" in self._seq_type.upper() or "MRNA" in self._seq_type.upper():
-                seq_alphabet = IUPAC.ambiguous_dna
+                seq_alphabet = generic_dna
             # are there ever really RNA sequences in GenBank?
             elif "RNA" in self._seq_type.upper():
                 # Even for data which was from RNA, the sequence string
                 # is usually given as DNA (T not U).  Bug 2408
                 if "T" in sequence and "U" not in sequence:
-                    seq_alphabet = IUPAC.ambiguous_dna
+                    seq_alphabet = generic_dna
                 else:
-                    seq_alphabet = IUPAC.ambiguous_rna
+                    seq_alphabet = generic_rna
             elif (
                 "PROTEIN" in self._seq_type.upper() or self._seq_type == "PRT"
             ):  # PRT is used in EMBL-bank for patents
-                seq_alphabet = IUPAC.protein  # or extended protein?
+                seq_alphabet = generic_protein
             # work around ugly GenBank records which have circular or
             # linear but no indication of sequence type
             elif self._seq_type in ["circular", "linear", "unspecified"]:

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -678,7 +678,7 @@ def read(handle, format, alphabet=None):
     >>> print("Sequence length %i" % len(record))
     Sequence length 86436
     >>> print("Sequence alphabet %s" % record.seq.alphabet)
-    Sequence alphabet IUPACAmbiguousDNA()
+    Sequence alphabet DNAAlphabet()
 
     If the handle contains no records, or more than one record,
     an exception is raised.  For example:

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -1123,7 +1123,7 @@ class SeqRecord:
         >>> print("%s %i" % (plasmid.id, len(plasmid)))
         pBAD30 4923
         >>> plasmid.seq
-        Seq('GCTAGCGGAGTGTATACTGGCTTACTATGTTGGCACTGATGAGGGTGTCAGTGA...ATG', IUPACAmbiguousDNA())
+        Seq('GCTAGCGGAGTGTATACTGGCTTACTATGTTGGCACTGATGAGGGTGTCAGTGA...ATG', DNAAlphabet())
         >>> len(plasmid.features)
         13
 
@@ -1133,7 +1133,7 @@ class SeqRecord:
         >>> print("%s %i" % (rc_plasmid.id, len(rc_plasmid)))
         pBAD30_rc 4923
         >>> rc_plasmid.seq
-        Seq('CATGGGCAAATATTATACGCAAGGCGACAAGGTGCTGATGCCGCTGGCGATTCA...AGC', IUPACAmbiguousDNA())
+        Seq('CATGGGCAAATATTATACGCAAGGCGACAAGGTGCTGATGCCGCTGGCGATTCA...AGC', DNAAlphabet())
         >>> len(rc_plasmid.features)
         13
 

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -433,7 +433,7 @@ Selenipedium aequinoctiale maturase K (matK) gene, partial cds; chloroplast
 >>> print(len(record.features))
 3
 >>> print(repr(record.seq))
-Seq('ATTTTTTACGAACCTGTGGAAATTTTTGGTTATGACAATAAATCTAGTTTAGTA...GAA', IUPACAmbiguousDNA())
+Seq('ATTTTTTACGAACCTGTGGAAATTTTTGGTTATGACAATAAATCTAGTTTAGTA...GAA', DNAAlphabet())
 \end{minted}
 
 Note that a more typical use would be to save the sequence data to a local file, and \emph{then} parse it with \verb|Bio.SeqIO|.  This can save you having to re-download the same file repeatedly while working on your script, and places less load on the NCBI's servers.  For example:

--- a/Doc/Tutorial/chapter_seqio.tex
+++ b/Doc/Tutorial/chapter_seqio.tex
@@ -137,11 +137,11 @@ print(len(first_record))
 Found 94 records
 The last record
 Z78439.1
-Seq('CATTGTTGAGATCACATAATAATTGATCGAGTTAATCTGGAGGATCTGTTTACT...GCC', IUPACAmbiguousDNA())
+Seq('CATTGTTGAGATCACATAATAATTGATCGAGTTAATCTGGAGGATCTGTTTACT...GCC', DNAAlphabet())
 592
 The first record
 Z78533.1
-Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGATGAGACCGTGG...CGC', IUPACAmbiguousDNA())
+Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGATGAGACCGTGG...CGC', DNAAlphabet())
 740
 \end{minted}
 
@@ -618,7 +618,7 @@ We can access a single \verb|SeqRecord| object via the keys and manipulate the o
 >>> print(seq_record.description)
 P.supardii 5.8S rRNA gene and ITS1 and ITS2 DNA
 >>> print(repr(seq_record.seq))
-Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGTTGAGATCACAT...GGT', IUPACAmbiguousDNA())
+Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGTTGAGATCACAT...GGT', DNAAlphabet())
 \end{minted}
 
 So, it is very easy to create an in memory ``database'' of our GenBank records.  Next we'll try this for the FASTA file instead.
@@ -756,7 +756,7 @@ As an example, let's use the same GenBank file as before:
 >>> print(seq_record.description)
 P.supardii 5.8S rRNA gene and ITS1 and ITS2 DNA
 >>> seq_record.seq
-Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGTTGAGATCACAT...GGT', IUPACAmbiguousDNA())
+Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGTTGAGATCACAT...GGT', DNAAlphabet())
 >>> orchid_dict.close()
 \end{minted}
 


### PR DESCRIPTION
This pull request addresses in part issue #2046.

These file formats (and several others) still use the ``Bio.Alphabet`` classes to record the molecule type (DNA/RNA/Protein/other) and as yet we don't have a replacement for this agreed.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
