### PR TITLE
remove alphabets from Seq representation

### DIFF
--- a/Bio/Alphabet/Reduced.py
+++ b/Bio/Alphabet/Reduced.py
@@ -38,7 +38,7 @@ or hydrophobic (H) residues:
     >>> for aa in my_protein:
     ...     new_protein += Alphabet.Reduced.hp_model_tab[aa]
     >>> new_protein
-    Seq('HPPPPPHPPHHPHPHPPP', HPModel())
+    Seq('HPPPPPHPPHHPHPHPPP')
 
 The following Alphabet classes are available:
 

--- a/Bio/SearchIO/_model/hsp.py
+++ b/Bio/SearchIO/_model/hsp.py
@@ -727,7 +727,7 @@ class HSPFragment(_BaseHSP):
     Name: aligned query sequence
     Description: mir_1
     Number of features: 0
-    Seq('CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTT...GGG', DNAAlphabet())
+    Seq('CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTT...GGG')
 
     # the hit sequence is a SeqRecord object as well
     >>> fragment.hit.__class__
@@ -737,7 +737,7 @@ class HSPFragment(_BaseHSP):
     Name: aligned hit sequence
     Description: Homo sapiens microRNA 520b (MIR520B), microRNA
     Number of features: 0
-    Seq('CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTT...GGG', DNAAlphabet())
+    Seq('CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTT...GGG')
 
     # when both query and hit are present, we get a MultipleSeqAlignment object
     >>> fragment.aln.__class__

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -119,9 +119,7 @@ class Seq:
             # Shows the last three letters as it is often useful to see if
             # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
-            return (
-                f"{self.__class__.__name__}('{str(self)[:54]}...{str(self)[-3:]}')"
-            )
+            return  f"{self.__class__.__name__}('{str(self)[:54]}...{str(self)[-3:]}')"
         else:
             return f"{self.__class__.__name__}({self._data!r})"
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -119,7 +119,7 @@ class Seq:
             # Shows the last three letters as it is often useful to see if
             # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
-            return  f"{self.__class__.__name__}('{str(self)[:54]}...{str(self)[-3:]}')"
+            return f"{self.__class__.__name__}('{str(self)[:54]}...{str(self)[-3:]}')"
         else:
             return f"{self.__class__.__name__}({self._data!r})"
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -98,7 +98,7 @@ class Seq:
         >>> my_seq = Seq("MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF",
         ...              IUPAC.protein)
         >>> my_seq
-        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF', IUPACProtein())
+        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF')
         >>> print(my_seq)
         MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF
         >>> my_seq.alphabet
@@ -115,20 +115,15 @@ class Seq:
 
     def __repr__(self):
         """Return (truncated) representation of the sequence for debugging."""
-        if self.alphabet is Alphabet.generic_alphabet:
-            # Default used, we can omit it and simplify the representation
-            a = ""
-        else:
-            a = ", %r" % self.alphabet
         if len(self) > 60:
             # Shows the last three letters as it is often useful to see if
             # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
             return (
-                f"{self.__class__.__name__}('{str(self)[:54]}...{str(self)[-3:]}'{a!s})"
+                f"{self.__class__.__name__}('{str(self)[:54]}...{str(self)[-3:]}')"
             )
         else:
-            return f"{self.__class__.__name__}({self._data!r}{a!s})"
+            return f"{self.__class__.__name__}({self._data!r})"
 
     def __str__(self):
         """Return the full sequence as a python string, use str(my_seq).
@@ -287,7 +282,7 @@ class Seq:
         >>> from Bio.Seq import Seq
         >>> from Bio.Alphabet import generic_protein
         >>> Seq("MELKI", generic_protein) + "LV"
-        Seq('MELKILV', ProteinAlphabet())
+        Seq('MELKILV')
 
         When adding two Seq (like) objects, the alphabets are important.
         Consider this example:
@@ -297,15 +292,15 @@ class Seq:
         >>> unamb_dna_seq = Seq("ACGT", unambiguous_dna)
         >>> ambig_dna_seq = Seq("ACRGT", ambiguous_dna)
         >>> unamb_dna_seq
-        Seq('ACGT', IUPACUnambiguousDNA())
+        Seq('ACGT')
         >>> ambig_dna_seq
-        Seq('ACRGT', IUPACAmbiguousDNA())
+        Seq('ACRGT')
 
         If we add the ambiguous and unambiguous IUPAC DNA alphabets, we get
         the more general ambiguous IUPAC DNA alphabet:
 
         >>> unamb_dna_seq + ambig_dna_seq
-        Seq('ACGTACRGT', IUPACAmbiguousDNA())
+        Seq('ACGTACRGT')
 
         However, if the default generic alphabet is included, the result is
         a generic alphabet:
@@ -357,7 +352,7 @@ class Seq:
         >>> from Bio.Seq import Seq
         >>> from Bio.Alphabet import generic_protein
         >>> "LV" + Seq("MELKI", generic_protein)
-        Seq('LVMELKI', ProteinAlphabet())
+        Seq('LVMELKI')
 
         Adding two Seq (like) objects is handled via the __add__ method.
         """
@@ -384,7 +379,7 @@ class Seq:
         >>> Seq('ATG') * 2
         Seq('ATGATG')
         >>> Seq('ATG', generic_dna) * 2
-        Seq('ATGATG', DNAAlphabet())
+        Seq('ATGATG')
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
@@ -398,7 +393,7 @@ class Seq:
         >>> 2 * Seq('ATG')
         Seq('ATGATG')
         >>> 2 * Seq('ATG', generic_dna)
-        Seq('ATGATG', DNAAlphabet())
+        Seq('ATGATG')
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
@@ -415,7 +410,7 @@ class Seq:
         >>> seq = Seq('ATG', generic_dna)
         >>> seq *= 2
         >>> seq
-        Seq('ATGATG', DNAAlphabet())
+        Seq('ATGATG')
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
@@ -429,9 +424,9 @@ class Seq:
         >>> my_seq = Seq("MKQHKAMIVALIVICITAVVAAL",
         ...              IUPAC.protein)
         >>> my_seq
-        Seq('MKQHKAMIVALIVICITAVVAAL', IUPACProtein())
+        Seq('MKQHKAMIVALIVICITAVVAAL')
         >>> my_seq.tomutable()
-        MutableSeq('MKQHKAMIVALIVICITAVVAAL', IUPACProtein())
+        MutableSeq('MKQHKAMIVALIVICITAVVAAL')
 
         Note that the alphabet is preserved.
         """
@@ -751,23 +746,23 @@ class Seq:
         >>> my_rna = Seq("GUCAUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAGUUG")
         >>> my_aa = my_rna.translate()
         >>> my_aa
-        Seq('VMAIVMGR*KGAR*L', ProteinAlphabet())
+        Seq('VMAIVMGR*KGAR*L')
         >>> for pep in my_aa.split("*"):
         ...     pep
-        Seq('VMAIVMGR', ProteinAlphabet())
-        Seq('KGAR', ProteinAlphabet())
-        Seq('L', ProteinAlphabet())
+        Seq('VMAIVMGR')
+        Seq('KGAR')
+        Seq('L')
         >>> for pep in my_aa.split("*", 1):
         ...     pep
-        Seq('VMAIVMGR', ProteinAlphabet())
-        Seq('KGAR*L', ProteinAlphabet())
+        Seq('VMAIVMGR')
+        Seq('KGAR*L')
 
         See also the rsplit method:
 
         >>> for pep in my_aa.rsplit("*", 1):
         ...     pep
-        Seq('VMAIVMGR*KGAR', ProteinAlphabet())
-        Seq('L', ProteinAlphabet())
+        Seq('VMAIVMGR*KGAR')
+        Seq('L')
         """
         # If it has one, check the alphabet:
         sep_str = self._get_seq_str_and_check_alphabet(sep)
@@ -848,9 +843,9 @@ class Seq:
         >>> from Bio.Seq import Seq
         >>> my_seq = Seq("CGGTACGCTTATGTCACGTAGAAAAAA", IUPAC.unambiguous_dna)
         >>> my_seq
-        Seq('CGGTACGCTTATGTCACGTAGAAAAAA', IUPACUnambiguousDNA())
+        Seq('CGGTACGCTTATGTCACGTAGAAAAAA')
         >>> my_seq.rstrip("A")
-        Seq('CGGTACGCTTATGTCACGTAG', IUPACUnambiguousDNA())
+        Seq('CGGTACGCTTATGTCACGTAG')
 
         See also the strip and lstrip methods.
         """
@@ -865,11 +860,11 @@ class Seq:
         >>> from Bio.Seq import Seq
         >>> my_seq = Seq("VHLTPeeK*", generic_protein)
         >>> my_seq
-        Seq('VHLTPeeK*', ProteinAlphabet())
+        Seq('VHLTPeeK*')
         >>> my_seq.lower()
-        Seq('vhltpeek*', ProteinAlphabet())
+        Seq('vhltpeek*')
         >>> my_seq.upper()
-        Seq('VHLTPEEK*', ProteinAlphabet())
+        Seq('VHLTPEEK*')
 
         This will adjust the alphabet if required. See also the lower method.
         """
@@ -886,9 +881,9 @@ class Seq:
         >>> from Bio.Seq import Seq
         >>> my_seq = Seq("CGGTACGCTTATGTCACGTAGAAAAAA", unambiguous_dna)
         >>> my_seq
-        Seq('CGGTACGCTTATGTCACGTAGAAAAAA', IUPACUnambiguousDNA())
+        Seq('CGGTACGCTTATGTCACGTAGAAAAAA')
         >>> my_seq.lower()
-        Seq('cggtacgcttatgtcacgtagaaaaaa', DNAAlphabet())
+        Seq('cggtacgcttatgtcacgtagaaaaaa')
 
         See also the upper method.
         """
@@ -915,9 +910,9 @@ class Seq:
         >>> from Bio.Alphabet import IUPAC
         >>> my_dna = Seq("CCCCCGATAG", IUPAC.unambiguous_dna)
         >>> my_dna
-        Seq('CCCCCGATAG', IUPACUnambiguousDNA())
+        Seq('CCCCCGATAG')
         >>> my_dna.complement()
-        Seq('GGGGGCTATC', IUPACUnambiguousDNA())
+        Seq('GGGGGCTATC')
 
         You can of course used mixed case sequences,
 
@@ -925,9 +920,9 @@ class Seq:
         >>> from Bio.Alphabet import generic_dna
         >>> my_dna = Seq("CCCCCgatA-GD", generic_dna)
         >>> my_dna
-        Seq('CCCCCgatA-GD', DNAAlphabet())
+        Seq('CCCCCgatA-GD')
         >>> my_dna.complement()
-        Seq('GGGGGctaT-CH', DNAAlphabet())
+        Seq('GGGGGctaT-CH')
 
         Note in the above example, ambiguous character D denotes
         G, A or T so its complement is H (for C, T or A).
@@ -967,9 +962,9 @@ class Seq:
         >>> from Bio.Alphabet import IUPAC
         >>> my_dna = Seq("CCCCCGATAGNR", IUPAC.ambiguous_dna)
         >>> my_dna
-        Seq('CCCCCGATAGNR', IUPACAmbiguousDNA())
+        Seq('CCCCCGATAGNR')
         >>> my_dna.reverse_complement()
-        Seq('YNCTATCGGGGG', IUPACAmbiguousDNA())
+        Seq('YNCTATCGGGGG')
 
         Note in the above example, since R = G or A, its complement
         is Y (which denotes C or T).
@@ -980,9 +975,9 @@ class Seq:
         >>> from Bio.Alphabet import generic_dna
         >>> my_dna = Seq("CCCCCgatA-G", generic_dna)
         >>> my_dna
-        Seq('CCCCCgatA-G', DNAAlphabet())
+        Seq('CCCCCgatA-G')
         >>> my_dna.reverse_complement()
-        Seq('C-TatcGGGGG', DNAAlphabet())
+        Seq('C-TatcGGGGG')
 
         Trying to complement a protein sequence raises an exception:
 
@@ -1003,9 +998,9 @@ class Seq:
         >>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG",
         ...                  IUPAC.unambiguous_dna)
         >>> coding_dna
-        Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', IUPACUnambiguousDNA())
+        Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
         >>> coding_dna.transcribe()
-        Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
+        Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG')
 
         Trying to transcribe a protein or RNA sequence raises an exception:
 
@@ -1037,9 +1032,9 @@ class Seq:
         >>> messenger_rna = Seq("AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG",
         ...                     IUPAC.unambiguous_rna)
         >>> messenger_rna
-        Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
+        Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG')
         >>> messenger_rna.back_transcribe()
-        Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', IUPACUnambiguousDNA())
+        Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
 
         Trying to back-transcribe a protein or DNA sequence raises an
         exception:
@@ -1099,24 +1094,24 @@ class Seq:
 
         >>> coding_dna = Seq("GTGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG")
         >>> coding_dna.translate()
-        Seq('VAIVMGR*KGAR*', ProteinAlphabet())
+        Seq('VAIVMGR*KGAR*')
         >>> coding_dna.translate(stop_symbol="@")
-        Seq('VAIVMGR@KGAR@', ProteinAlphabet())
+        Seq('VAIVMGR@KGAR@')
         >>> coding_dna.translate(to_stop=True)
-        Seq('VAIVMGR', ProteinAlphabet())
+        Seq('VAIVMGR')
 
         Now using NCBI table 2, where TGA is not a stop codon:
 
         >>> coding_dna.translate(table=2)
-        Seq('VAIVMGRWKGAR*', ProteinAlphabet())
+        Seq('VAIVMGRWKGAR*')
         >>> coding_dna.translate(table=2, to_stop=True)
-        Seq('VAIVMGRWKGAR', ProteinAlphabet())
+        Seq('VAIVMGRWKGAR')
 
         In fact, GTG is an alternative start codon under NCBI table 2, meaning
         this sequence could be a complete CDS:
 
         >>> coding_dna.translate(table=2, cds=True)
-        Seq('MAIVMGRWKGAR', ProteinAlphabet())
+        Seq('MAIVMGRWKGAR')
 
         It isn't a valid CDS under NCBI table 1, due to both the start codon
         and also the in frame stop codons:
@@ -1131,9 +1126,9 @@ class Seq:
 
         >>> coding_dna2 = Seq("TTGGCCATTGTAATGGGCCGC")
         >>> coding_dna2.translate()
-        Seq('LAIVMGR', ProteinAlphabet())
+        Seq('LAIVMGR')
         >>> coding_dna2.translate(to_stop=True)
-        Seq('LAIVMGR', ProteinAlphabet())
+        Seq('LAIVMGR')
 
         NOTE - Ambiguous codons like "TAN" or "NNN" could be an amino acid
         or a stop codon.  These are translated as "X".  Any invalid codon
@@ -1215,9 +1210,9 @@ class Seq:
         >>> from Bio.Alphabet import generic_dna
         >>> my_dna = Seq("-ATA--TGAAAT-TTGAAAA", generic_dna)
         >>> my_dna
-        Seq('-ATA--TGAAAT-TTGAAAA', DNAAlphabet())
+        Seq('-ATA--TGAAAT-TTGAAAA')
         >>> my_dna.ungap("-")
-        Seq('ATATGAAATTTGAAAA', DNAAlphabet())
+        Seq('ATATGAAATTTGAAAA')
         """
         if hasattr(self.alphabet, "gap_char"):
             raise NotImplementedError("We stopped supporting the Gapped class...")
@@ -1363,12 +1358,7 @@ class UnknownSeq(Seq):
 
     def __repr__(self):
         """Return (truncated) representation of the sequence for debugging."""
-        if self.alphabet is Alphabet.generic_alphabet:
-            # Default used, we can omit it and simplify the representation
-            a = ""
-        else:
-            a = ", alphabet=%r" % self.alphabet
-        return f"UnknownSeq({self._length}{a!s}, character={self._character!r})"
+        return f"UnknownSeq({self._length}, character={self._character!r})"
 
     def __add__(self, other):
         """Add another sequence or string to this sequence.
@@ -1379,7 +1369,7 @@ class UnknownSeq(Seq):
         >>> from Bio.Seq import UnknownSeq
         >>> from Bio.Alphabet import generic_protein
         >>> UnknownSeq(10, generic_protein) + UnknownSeq(5, generic_protein)
-        UnknownSeq(15, alphabet=ProteinAlphabet(), character='X')
+        UnknownSeq(15, character='X')
 
         If the characters differ, an UnknownSeq object cannot be used, so a
         Seq object is returned:
@@ -1388,7 +1378,7 @@ class UnknownSeq(Seq):
         >>> from Bio.Alphabet import generic_protein
         >>> UnknownSeq(10, generic_protein) + UnknownSeq(5, generic_protein,
         ...                                              character="x")
-        Seq('XXXXXXXXXXxxxxx', ProteinAlphabet())
+        Seq('XXXXXXXXXXxxxxx')
 
         If adding a string to an UnknownSeq, a new Seq is returned with the
         same alphabet:
@@ -1396,7 +1386,7 @@ class UnknownSeq(Seq):
         >>> from Bio.Seq import UnknownSeq
         >>> from Bio.Alphabet import generic_protein
         >>> UnknownSeq(5, generic_protein) + "LV"
-        Seq('XXXXXLV', ProteinAlphabet())
+        Seq('XXXXXLV')
         """
         if isinstance(other, UnknownSeq) and other._character == self._character:
             # TODO - Check the alphabets match
@@ -1418,7 +1408,7 @@ class UnknownSeq(Seq):
         >>> UnknownSeq(3) * 2
         UnknownSeq(6, character='?')
         >>> UnknownSeq(3, generic_dna) * 2
-        UnknownSeq(6, alphabet=DNAAlphabet(), character='N')
+        UnknownSeq(6, character='N')
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
@@ -1432,7 +1422,7 @@ class UnknownSeq(Seq):
         >>> 2 * UnknownSeq(3)
         UnknownSeq(6, character='?')
         >>> 2 * UnknownSeq(3, generic_dna)
-        UnknownSeq(6, alphabet=DNAAlphabet(), character='N')
+        UnknownSeq(6, character='N')
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
@@ -1449,7 +1439,7 @@ class UnknownSeq(Seq):
         >>> seq = UnknownSeq(3, generic_dna)
         >>> seq *= 2
         >>> seq
-        UnknownSeq(6, alphabet=DNAAlphabet(), character='N')
+        UnknownSeq(6, character='N')
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
@@ -1675,7 +1665,7 @@ class UnknownSeq(Seq):
         NNNNNNNNNN
         >>> my_rna = my_dna.transcribe()
         >>> my_rna
-        UnknownSeq(10, alphabet=RNAAlphabet(), character='N')
+        UnknownSeq(10, character='N')
         >>> print(my_rna)
         NNNNNNNNNN
         """
@@ -1693,7 +1683,7 @@ class UnknownSeq(Seq):
         NNNNNNNNNNNNNNNNNNNN
         >>> my_dna = my_rna.back_transcribe()
         >>> my_dna
-        UnknownSeq(20, alphabet=DNAAlphabet(), character='N')
+        UnknownSeq(20, character='N')
         >>> print(my_dna)
         NNNNNNNNNNNNNNNNNNNN
         """
@@ -1708,11 +1698,11 @@ class UnknownSeq(Seq):
         >>> from Bio.Seq import UnknownSeq
         >>> my_seq = UnknownSeq(20, generic_dna, character="n")
         >>> my_seq
-        UnknownSeq(20, alphabet=DNAAlphabet(), character='n')
+        UnknownSeq(20, character='n')
         >>> print(my_seq)
         nnnnnnnnnnnnnnnnnnnn
         >>> my_seq.upper()
-        UnknownSeq(20, alphabet=DNAAlphabet(), character='N')
+        UnknownSeq(20, character='N')
         >>> print(my_seq.upper())
         NNNNNNNNNNNNNNNNNNNN
 
@@ -1729,11 +1719,11 @@ class UnknownSeq(Seq):
         >>> from Bio.Seq import UnknownSeq
         >>> my_seq = UnknownSeq(20, IUPAC.extended_protein)
         >>> my_seq
-        UnknownSeq(20, alphabet=ExtendedIUPACProtein(), character='X')
+        UnknownSeq(20, character='X')
         >>> print(my_seq)
         XXXXXXXXXXXXXXXXXXXX
         >>> my_seq.lower()
-        UnknownSeq(20, alphabet=ProteinAlphabet(), character='x')
+        UnknownSeq(20, character='x')
         >>> print(my_seq.lower())
         xxxxxxxxxxxxxxxxxxxx
 
@@ -1751,7 +1741,7 @@ class UnknownSeq(Seq):
         NNNNNNNNN
         >>> my_protein = my_seq.translate()
         >>> my_protein
-        UnknownSeq(3, alphabet=ProteinAlphabet(), character='X')
+        UnknownSeq(3, character='X')
         >>> print(my_protein)
         XXX
 
@@ -1762,7 +1752,7 @@ class UnknownSeq(Seq):
         NNNNNNNNN
         >>> my_protein = my_seq.translate()
         >>> my_protein
-        Seq('XXX', ProteinAlphabet())
+        Seq('XXX')
         >>> print(my_protein)
         XXX
 
@@ -1784,22 +1774,22 @@ class UnknownSeq(Seq):
         >>> from Bio.Seq import UnknownSeq
         >>> my_dna = UnknownSeq(20, alphabet=generic_dna)
         >>> my_dna
-        UnknownSeq(20, alphabet=DNAAlphabet(), character='N')
+        UnknownSeq(20, character='N')
         >>> my_dna.ungap()  # using default
-        UnknownSeq(20, alphabet=DNAAlphabet(), character='N')
+        UnknownSeq(20, character='N')
         >>> my_dna.ungap("-")
-        UnknownSeq(20, alphabet=DNAAlphabet(), character='N')
+        UnknownSeq(20, character='N')
 
         If the UnknownSeq is using the gap character, then an empty Seq is
         returned:
 
         >>> my_gap = UnknownSeq(20, generic_dna, character="-")
         >>> my_gap
-        UnknownSeq(20, alphabet=DNAAlphabet(), character='-')
+        UnknownSeq(20, character='-')
         >>> my_gap.ungap()  # using default
-        Seq('', DNAAlphabet())
+        Seq('')
         >>> my_gap.ungap("-")
-        Seq('', DNAAlphabet())
+        Seq('')
         """
         # Offload the argument validation
         s = Seq(self._character, self.alphabet).ungap(gap)
@@ -1893,17 +1883,17 @@ class MutableSeq:
     >>> from Bio.Alphabet import generic_dna
     >>> my_seq = MutableSeq("ACTCGTCGTCG", generic_dna)
     >>> my_seq
-    MutableSeq('ACTCGTCGTCG', DNAAlphabet())
+    MutableSeq('ACTCGTCGTCG')
     >>> my_seq[5]
     'T'
     >>> my_seq[5] = "A"
     >>> my_seq
-    MutableSeq('ACTCGACGTCG', DNAAlphabet())
+    MutableSeq('ACTCGACGTCG')
     >>> my_seq[5]
     'A'
     >>> my_seq[5:8] = "NNN"
     >>> my_seq
-    MutableSeq('ACTCGNNNTCG', DNAAlphabet())
+    MutableSeq('ACTCGNNNTCG')
     >>> len(my_seq)
     11
 
@@ -1926,20 +1916,15 @@ class MutableSeq:
 
     def __repr__(self):
         """Return (truncated) representation of the sequence for debugging."""
-        if self.alphabet is Alphabet.generic_alphabet:
-            # Default used, we can omit it and simplify the representation
-            a = ""
-        else:
-            a = ", %r" % self.alphabet
         if len(self) > 60:
             # Shows the last three letters as it is often useful to see if
             # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
             return (
-                f"{self.__class__.__name__}('{str(self[:54])}...{str(self[-3:])}'{a!s})"
+                f"{self.__class__.__name__}('{str(self[:54])}...{str(self[-3:])}')"
             )
         else:
-            return f"{self.__class__.__name__}('{str(self)}'{a!s})"
+            return f"{self.__class__.__name__}('{str(self)}')"
 
     def __str__(self):
         """Return the full sequence as a python string.
@@ -2142,7 +2127,7 @@ class MutableSeq:
         >>> from Bio.Seq import MutableSeq
         >>> from Bio.Alphabet import generic_protein
         >>> "LV" + MutableSeq("MELKI", generic_protein)
-        MutableSeq('LVMELKI', ProteinAlphabet())
+        MutableSeq('LVMELKI')
         """
         if hasattr(other, "alphabet"):
             # other should be a Seq or a MutableSeq
@@ -2175,7 +2160,7 @@ class MutableSeq:
         >>> MutableSeq('ATG') * 2
         MutableSeq('ATGATG')
         >>> MutableSeq('ATG', generic_dna) * 2
-        MutableSeq('ATGATG', DNAAlphabet())
+        MutableSeq('ATGATG')
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
@@ -2192,7 +2177,7 @@ class MutableSeq:
         >>> 2 * MutableSeq('ATG')
         MutableSeq('ATGATG')
         >>> 2 * MutableSeq('ATG', generic_dna)
-        MutableSeq('ATGATG', DNAAlphabet())
+        MutableSeq('ATGATG')
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
@@ -2206,7 +2191,7 @@ class MutableSeq:
         >>> seq = MutableSeq('ATG', generic_dna)
         >>> seq *= 2
         >>> seq
-        MutableSeq('ATGATG', DNAAlphabet())
+        MutableSeq('ATGATG')
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
@@ -2494,9 +2479,9 @@ class MutableSeq:
         >>> my_mseq = MutableSeq("MKQHKAMIVALIVICITAVVAAL",
         ...                      IUPAC.protein)
         >>> my_mseq
-        MutableSeq('MKQHKAMIVALIVICITAVVAAL', IUPACProtein())
+        MutableSeq('MKQHKAMIVALIVICITAVVAAL')
         >>> my_mseq.toseq()
-        Seq('MKQHKAMIVALIVICITAVVAAL', IUPACProtein())
+        Seq('MKQHKAMIVALIVICITAVVAAL')
 
         Note that the alphabet is preserved.
         """

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1918,9 +1918,7 @@ class MutableSeq:
             # Shows the last three letters as it is often useful to see if
             # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
-            return (
-                f"{self.__class__.__name__}('{str(self[:54])}...{str(self[-3:])}')"
-            )
+            return f"{self.__class__.__name__}('{str(self[:54])}...{str(self[-3:])}')"
         else:
             return f"{self.__class__.__name__}('{str(self)}')"
 

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -344,7 +344,7 @@ class SeqFeature:
         >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL", generic_protein)
         >>> f = SeqFeature(FeatureLocation(8, 15), type="domain")
         >>> f.extract(seq)
-        Seq('VALIVIC', ProteinAlphabet())
+        Seq('VALIVIC')
 
         If the FeatureLocation is None, e.g. when parsing invalid locus
         locations in the GenBank parser, extract() will raise a ValueError.
@@ -419,13 +419,13 @@ class SeqFeature:
         by giving explicit arguments:
 
         >>> f.translate(seq, cds=False)
-        Seq('GYTYR*CL**', ProteinAlphabet())
+        Seq('GYTYR*CL**')
 
         Now use the start_offset argument to change the frame. Note
         this uses python 0-based numbering.
 
         >>> f.translate(seq, start_offset=1, cds=False)
-        Seq('VTLTDNVSD', ProteinAlphabet())
+        Seq('VTLTDNVSD')
 
         Alternatively use the codon_start qualifier to do the same
         thing. Note: this uses 1-based numbering, which is found
@@ -433,7 +433,7 @@ class SeqFeature:
 
         >>> f.qualifiers['codon_start'] = [2]
         >>> f.translate(seq, cds=False)
-        Seq('VTLTDNVSD', ProteinAlphabet())
+        Seq('VTLTDNVSD')
         """
         # see if this feature should be translated in a different
         # frame using the "codon_start" qualifier
@@ -490,7 +490,7 @@ class SeqFeature:
         >>> len(f)
         7
         >>> f.extract(seq)
-        Seq('VALIVIC', ProteinAlphabet())
+        Seq('VALIVIC')
         >>> len(f.extract(seq))
         7
 
@@ -1109,7 +1109,7 @@ class FeatureLocation:
         >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL", generic_protein)
         >>> feature_loc = FeatureLocation(8, 15)
         >>> feature_loc.extract(seq)
-        Seq('VALIVIC', ProteinAlphabet())
+        Seq('VALIVIC')
 
         """
         if self.ref or self.ref_db:
@@ -1529,7 +1529,7 @@ class CompoundLocation:
         >>> fl2 = FeatureLocation(10, 15)
         >>> fl3 = CompoundLocation([fl1,fl2])
         >>> fl3.extract(seq)
-        Seq('QHKAMILIVIC', ProteinAlphabet())
+        Seq('QHKAMILIVIC')
 
         """
         # This copes with mixed strand features & all on reverse:

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -124,7 +124,7 @@ Name: EAS54_6_R1_2_1_443_348
 Description: EAS54_6_R1_2_1_443_348
 Number of features: 0
 Per letter annotation for: phred_quality
-Seq('GTTGCTTCTGGCGTGGGTGGGGGGG', SingleLetterAlphabet())
+Seq('GTTGCTTCTGGCGTGGGTGGGGGGG')
 >>> print(record.letter_annotations["phred_quality"])
 [26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 24, 26, 22, 26, 26, 13, 22, 26, 18, 24, 18, 18, 18, 18]
 
@@ -181,7 +181,7 @@ Name: EAS54_6_R1_2_1_443_348
 Description: EAS54_6_R1_2_1_443_348
 Number of features: 0
 Per letter annotation for: phred_quality
-Seq('TTCTGGCGTG', SingleLetterAlphabet())
+Seq('TTCTGGCGTG')
 >>> print(sub_rec.letter_annotations["phred_quality"])
 [26, 26, 26, 26, 26, 26, 24, 26, 22, 26]
 >>> print(sub_rec.format("fastq"))
@@ -217,7 +217,7 @@ Name: EAS54_6_R1_2_1_443_348
 Description: EAS54_6_R1_2_1_443_348
 Number of features: 0
 Per letter annotation for: phred_quality
-UnknownSeq(25, alphabet=SingleLetterAlphabet(), character='?')
+UnknownSeq(25, character='?')
 >>> print(record.letter_annotations["phred_quality"])
 [26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 24, 26, 22, 26, 26, 13, 22, 26, 18, 24, 18, 18, 18, 18]
 

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -135,7 +135,7 @@ class SeqRecord:
     Name: HokC
     Description: toxic membrane protein
     Number of features: 0
-    Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF', IUPACProtein())
+    Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF')
 
     If you want to save SeqRecord objects to a sequence file, use Bio.SeqIO
     for this.  For the special case where you want the SeqRecord turned into
@@ -391,7 +391,7 @@ class SeqRecord:
         Description: Homodimeric domain of EnvZ from E. coli
         Number of features: 1
         Per letter annotation for: secondary_structure
-        Seq('MAAGVKQLADDRTLLMAGVSHDLRTPLTRIRLATEMMSEQDGYLAESINKDIEE...YLR', IUPACProtein())
+        Seq('MAAGVKQLADDRTLLMAGVSHDLRTPLTRIRLATEMMSEQDGYLAESINKDIEE...YLR')
         >>> rec.letter_annotations["secondary_structure"]
         '  S  SSSSSSHHHHHTTTHHHHHHHHHHHHHHHHHHHHHHTHHHHHHHHHHHHHHHHHHHHHTT  '
         >>> print(rec.features[0].location)
@@ -407,7 +407,7 @@ class SeqRecord:
         Description: Homodimeric domain of EnvZ from E. coli
         Number of features: 1
         Per letter annotation for: secondary_structure
-        Seq('RTLLMAGVSHDLRTPLTRIRLATEMMSEQD', IUPACProtein())
+        Seq('RTLLMAGVSHDLRTPLTRIRLATEMMSEQD')
         >>> sub.letter_annotations["secondary_structure"]
         'HHHHHTTTHHHHHHHHHHHHHHHHHHHHHH'
         >>> print(sub.features[0].location)
@@ -422,7 +422,7 @@ class SeqRecord:
         Description: Homodimeric domain of EnvZ from E. coli
         Number of features: 0
         Per letter annotation for: secondary_structure
-        Seq('MAAGVKQLAD', IUPACProtein())
+        Seq('MAAGVKQLAD')
 
         Or for the last ten letters:
 
@@ -432,7 +432,7 @@ class SeqRecord:
         Description: Homodimeric domain of EnvZ from E. coli
         Number of features: 0
         Per letter annotation for: secondary_structure
-        Seq('IIEQFIDYLR', IUPACProtein())
+        Seq('IIEQFIDYLR')
 
         If you omit both, then you get a copy of the original record (although
         lacking the annotations and dbxrefs):
@@ -443,7 +443,7 @@ class SeqRecord:
         Description: Homodimeric domain of EnvZ from E. coli
         Number of features: 1
         Per letter annotation for: secondary_structure
-        Seq('MAAGVKQLADDRTLLMAGVSHDLRTPLTRIRLATEMMSEQDGYLAESINKDIEE...YLR', IUPACProtein())
+        Seq('MAAGVKQLADDRTLLMAGVSHDLRTPLTRIRLATEMMSEQDGYLAESINKDIEE...YLR')
 
         Finally, indexing with a simple integer is shorthand for pulling out
         that letter from the sequence directly:
@@ -627,7 +627,7 @@ class SeqRecord:
         Name: HokC
         Description: toxic membrane protein, small
         Number of features: 0
-        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF', IUPACProtein())
+        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF')
 
         In this example you don't actually need to call str explicity, as the
         print command does this automatically:
@@ -637,7 +637,7 @@ class SeqRecord:
         Name: HokC
         Description: toxic membrane protein, small
         Number of features: 0
-        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF', IUPACProtein())
+        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF')
 
         Note that long sequences are shown truncated.
         """
@@ -680,12 +680,12 @@ class SeqRecord:
         ...                 description="ssDNA-binding protein",
         ...                 dbxrefs=["ASAP:13298", "GI:16131885", "GeneID:948570"])
         >>> print(repr(rec))
-        SeqRecord(seq=Seq('MASRGVNKVILVGNLGQDPEVRYMPNGGAVANITLATSESWRDKATGEMKEQTE...IPF', ProteinAlphabet()), id='NP_418483.1', name='b4059', description='ssDNA-binding protein', dbxrefs=['ASAP:13298', 'GI:16131885', 'GeneID:948570'])
+        SeqRecord(seq=Seq('MASRGVNKVILVGNLGQDPEVRYMPNGGAVANITLATSESWRDKATGEMKEQTE...IPF'), id='NP_418483.1', name='b4059', description='ssDNA-binding protein', dbxrefs=['ASAP:13298', 'GI:16131885', 'GeneID:948570'])
 
         At the python prompt you can also use this shorthand:
 
         >>> rec
-        SeqRecord(seq=Seq('MASRGVNKVILVGNLGQDPEVRYMPNGGAVANITLATSESWRDKATGEMKEQTE...IPF', ProteinAlphabet()), id='NP_418483.1', name='b4059', description='ssDNA-binding protein', dbxrefs=['ASAP:13298', 'GI:16131885', 'GeneID:948570'])
+        SeqRecord(seq=Seq('MASRGVNKVILVGNLGQDPEVRYMPNGGAVANITLATSESWRDKATGEMKEQTE...IPF'), id='NP_418483.1', name='b4059', description='ssDNA-binding protein', dbxrefs=['ASAP:13298', 'GI:16131885', 'GeneID:948570'])
 
         Note that long sequences are shown truncated. Also note that any
         annotations, letter_annotations and features are not shown (as they
@@ -1123,7 +1123,7 @@ class SeqRecord:
         >>> print("%s %i" % (plasmid.id, len(plasmid)))
         pBAD30 4923
         >>> plasmid.seq
-        Seq('GCTAGCGGAGTGTATACTGGCTTACTATGTTGGCACTGATGAGGGTGTCAGTGA...ATG', IUPACAmbiguousDNA())
+        Seq('GCTAGCGGAGTGTATACTGGCTTACTATGTTGGCACTGATGAGGGTGTCAGTGA...ATG')
         >>> len(plasmid.features)
         13
 
@@ -1133,7 +1133,7 @@ class SeqRecord:
         >>> print("%s %i" % (rc_plasmid.id, len(rc_plasmid)))
         pBAD30_rc 4923
         >>> rc_plasmid.seq
-        Seq('CATGGGCAAATATTATACGCAAGGCGACAAGGTGCTGATGCCGCTGGCGATTCA...AGC', IUPACAmbiguousDNA())
+        Seq('CATGGGCAAATATTATACGCAAGGCGACAAGGTGCTGATGCCGCTGGCGATTCA...AGC')
         >>> len(rc_plasmid.features)
         13
 

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -432,8 +432,8 @@ EU490707
 Selenipedium aequinoctiale maturase K (matK) gene, partial cds; chloroplast
 >>> print(len(record.features))
 3
->>> print(repr(record.seq))
-Seq('ATTTTTTACGAACCTGTGGAAATTTTTGGTTATGACAATAAATCTAGTTTAGTA...GAA', IUPACAmbiguousDNA())
+>>> record.seq
+Seq('ATTTTTTACGAACCTGTGGAAATTTTTGGTTATGACAATAAATCTAGTTTAGTA...GAA')
 \end{minted}
 
 Note that a more typical use would be to save the sequence data to a local file, and \emph{then} parse it with \verb|Bio.SeqIO|.  This can save you having to re-download the same file repeatedly while working on your script, and places less load on the NCBI's servers.  For example:

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -661,7 +661,7 @@ in which the motif was found, providing some information on each instance:
 >>> len(motif.instances)
 7
 >>> motif.instances[0]
-Instance('GCGGCATGTGAAA', 'ACGT')
+Instance('GCGGCATGTGAAA')
 >>> motif.instances[0].motif_name
 'GSKGCATGTGAAA'
 >>> motif.instances[0].sequence_name

--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -878,15 +878,14 @@ objects as well.
 The first thing to do is to extract all polypeptides from the structure
 (as above). The sequence of each polypeptide can then easily
 be obtained from the \texttt{Polypeptide} objects. The sequence is
-represented as a Biopython \texttt{Seq} object, and its alphabet is
-defined by a \texttt{ProteinAlphabet} object.
+represented as a Biopython \texttt{Seq} object.
 
 Example:
 
 \begin{minted}{pycon}
 >>> seq = polypeptide.get_sequence()
->>> print(seq)
-Seq('SNVVE...', <class Bio.Alphabet.ProteinAlphabet>)
+>>> seq
+Seq('SNDIYFNFQRFNETNLILQRDASVSSSGQLRLTNLN')
 \end{minted}
 
 \section{Analyzing structures}

--- a/Doc/Tutorial/chapter_quick_start.tex
+++ b/Doc/Tutorial/chapter_quick_start.tex
@@ -28,13 +28,9 @@ Most of the time when we think about sequences we have in my mind a string of le
 Seq('AGTACACTGGT')
 >>> print(my_seq)
 AGTACACTGGT
->>> my_seq.alphabet
-Alphabet()
 \end{minted}
 
-What we have here is a sequence object with a \emph{generic} alphabet - reflecting the fact we have \emph{not} specified if this is a DNA or protein sequence (okay, a protein with a lot of Alanines, Glycines, Cysteines and Threonines!).  We'll talk more about alphabets in Chapter~\ref{chapter:seq_objects}.
-
-In addition to having an alphabet, the \verb|Seq| object differs from the Python string in the methods it supports.  You can't do this with a plain string:
+The \verb|Seq| object differs from the Python string in the methods it supports.  You can't do this with a plain string:
 
 %cont-doctest
 \begin{minted}{pycon}
@@ -109,15 +105,13 @@ for seq_record in SeqIO.parse("ls_orchid.fasta", "fasta"):
 
 \begin{minted}{text}
 gi|2765658|emb|Z78533.1|CIZ78533
-Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGATGAGACCGTGG...CGC', SingleLetterAlphabet())
+Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGATGAGACCGTGG...CGC')
 740
 ...
 gi|2765564|emb|Z78439.1|PBZ78439
-Seq('CATTGTTGAGATCACATAATAATTGATCGAGTTAATCTGGAGGATCTGTTTACT...GCC', SingleLetterAlphabet())
+Seq('CATTGTTGAGATCACATAATAATTGATCGAGTTAATCTGGAGGATCTGTTTACT...GCC')
 592
 \end{minted}
-
-Notice that the FASTA format does not specify the alphabet, so \verb|Bio.SeqIO| has defaulted to the rather generic \verb|SingleLetterAlphabet()| rather than something DNA specific.
 
 \subsection{Simple GenBank parsing example}
 

--- a/Doc/Tutorial/chapter_searchio.tex
+++ b/Doc/Tutorial/chapter_searchio.tex
@@ -725,9 +725,9 @@ of our HSP are not just regular strings:
 %cont-doctest
 \begin{minted}{pycon}
 >>> blast_hsp.query
-SeqRecord(seq=Seq('CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTT...GGG', DNAAlphabet()), id='42291', name='aligned query sequence', description='mystery_seq', dbxrefs=[])
+SeqRecord(seq=Seq('CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTT...GGG'), id='42291', name='aligned query sequence', description='mystery_seq', dbxrefs=[])
 >>> blast_hsp.hit
-SeqRecord(seq=Seq('CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTT...GGG', DNAAlphabet()), id='gi|262205317|ref|NR_030195.1|', name='aligned hit sequence', description='Homo sapiens microRNA 520b (MIR520B), microRNA', dbxrefs=[])
+SeqRecord(seq=Seq('CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTT...GGG'), id='gi|262205317|ref|NR_030195.1|', name='aligned hit sequence', description='Homo sapiens microRNA 520b (MIR520B), microRNA', dbxrefs=[])
 \end{minted}
 
 They are \verb|SeqRecord| objects you saw earlier in
@@ -958,7 +958,7 @@ Some examples:
 >>> blast_frag.hit_strand       # hit sequence strand
 1
 >>> blast_frag.hit              # hit sequence, as a SeqRecord object
-SeqRecord(seq=Seq('CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTT...GGG', DNAAlphabet()), id='gi|262205317|ref|NR_030195.1|', name='aligned hit sequence', description='Homo sapiens microRNA 520b (MIR520B), microRNA', dbxrefs=[])
+SeqRecord(seq=Seq('CCCTCTACAGGGAAGCGCTTTCTGTTGTCTGAAAGAAAAGAAAGTGCTTCCTTT...GGG'), id='gi|262205317|ref|NR_030195.1|', name='aligned hit sequence', description='Homo sapiens microRNA 520b (MIR520B), microRNA', dbxrefs=[])
 \end{minted}
 
 \section{A note about standards and conventions}

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -137,8 +137,8 @@ has a sister function for use on files which contain just one record which we'll
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.fna", "fasta")
 >>> record
-SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG',
-SingleLetterAlphabet()), id='gi|45478711|ref|NC_005816.1|', name='gi|45478711|ref|NC_005816.1|',
+SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG'),
+id='gi|45478711|ref|NC_005816.1|', name='gi|45478711|ref|NC_005816.1|',
 description='gi|45478711|ref|NC_005816.1| Yersinia pestis biovar Microtus ... sequence',
 dbxrefs=[])
 \end{minted}
@@ -149,7 +149,7 @@ individually -- starting with the \verb|seq| attribute which gives you a
 
 \begin{minted}{pycon}
 >>> record.seq
-Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG', SingleLetterAlphabet())
+Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG')
 \end{minted}
 
 \noindent Here \verb|Bio.SeqIO| has defaulted to a generic alphabet, rather

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -40,7 +40,7 @@ However, where possible you should specify the alphabet explicitly when creating
 >>> from Bio.Alphabet import IUPAC
 >>> my_seq = Seq("AGTACACTGGT", IUPAC.unambiguous_dna)
 >>> my_seq
-Seq('AGTACACTGGT', IUPACUnambiguousDNA())
+Seq('AGTACACTGGT')
 >>> my_seq.alphabet
 IUPACUnambiguousDNA()
 \end{minted}
@@ -53,7 +53,7 @@ Unless of course, this really is an amino acid sequence:
 >>> from Bio.Alphabet import IUPAC
 >>> my_prot = Seq("AGTACACTGGT", IUPAC.protein)
 >>> my_prot
-Seq('AGTACACTGGT', IUPACProtein())
+Seq('AGTACACTGGT')
 >>> my_prot.alphabet
 IUPACProtein()
 \end{minted}
@@ -144,9 +144,9 @@ A more complicated example, let's get a slice of the sequence:
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
->>> my_seq = Seq("GATCGATGGGCCTATATAGGATCGAAAATCGC", IUPAC.unambiguous_dna)
+>>> my_seq = Seq("GATCGATGGGCCTATATAGGATCGAAAATCGC")
 >>> my_seq[4:12]
-Seq('GATGGGCC', IUPACUnambiguousDNA())
+Seq('GATGGGCC')
 \end{minted}
 
 Two things are interesting to note. First, this follows the normal conventions for Python strings.  So the first element of the sequence is 0 (which is normal for computer science, but not so normal for biology). When you do a slice the first item is included (i.e.~4 in this case) and the last is excluded (12 in this case), which is the way things work in Python, but of course not necessarily the way everyone in the world would expect. The main goal is to stay consistent with what Python does.
@@ -158,11 +158,11 @@ Also like a Python string, you can do slices with a start, stop and \emph{stride
 %cont-doctest
 \begin{minted}{pycon}
 >>> my_seq[0::3]
-Seq('GCTGTAGTAAG', IUPACUnambiguousDNA())
+Seq('GCTGTAGTAAG')
 >>> my_seq[1::3]
-Seq('AGGCATGCATC', IUPACUnambiguousDNA())
+Seq('AGGCATGCATC')
 >>> my_seq[2::3]
-Seq('TAGCTAAGAC', IUPACUnambiguousDNA())
+Seq('TAGCTAAGAC')
 \end{minted}
 
 Another stride trick you might have seen with a Python string is the use of a -1 stride to reverse the string.  You can do this with a \verb|Seq| object too:
@@ -170,7 +170,7 @@ Another stride trick you might have seen with a Python string is the use of a -1
 %cont-doctest
 \begin{minted}{pycon}
 >>> my_seq[::-1]
-Seq('CGCTAAAAGCTAGGATATATCCGGGTAGCTAG', IUPACUnambiguousDNA())
+Seq('CGCTAAAAGCTAGGATATATCCGGGTAGCTAG')
 \end{minted}
 
 \section{Turning Seq objects into strings}
@@ -253,11 +253,11 @@ Here is an example of adding a generic nucleotide sequence to an unambiguous IUP
 >>> nuc_seq = Seq("GATCGATGC", generic_nucleotide)
 >>> dna_seq = Seq("ACGT", IUPAC.unambiguous_dna)
 >>> nuc_seq
-Seq('GATCGATGC', NucleotideAlphabet())
+Seq('GATCGATGC')
 >>> dna_seq
-Seq('ACGT', IUPACUnambiguousDNA())
+Seq('ACGT')
 >>> nuc_seq + dna_seq
-Seq('GATCGATGCACGT', NucleotideAlphabet())
+Seq('GATCGATGCACGT')
 \end{minted}
 
 You may often have many sequences to add together, which can be done with a for loop like this:
@@ -272,7 +272,7 @@ You may often have many sequences to add together, which can be done with a for 
 ...      concatenated += s
 ...
 >>> concatenated
-Seq('ACGTAACCGGTT', DNAAlphabet())
+Seq('ACGTAACCGGTT')
 \end{minted}
 
 Or, a more elegant approach is to the use built in \verb|sum| function with its optional start value argument (which otherwise defaults to zero):
@@ -283,7 +283,7 @@ Or, a more elegant approach is to the use built in \verb|sum| function with its 
 >>> from Bio.Alphabet import generic_dna
 >>> list_of_seqs = [Seq("ACGT", generic_dna), Seq("AACC", generic_dna), Seq("GGTT", generic_dna)]
 >>> sum(list_of_seqs, Seq("", generic_dna))
-Seq('ACGTAACCGGTT', DNAAlphabet())
+Seq('ACGTAACCGGTT')
 \end{minted}
 
 Like Python strings, Biopython \verb|Seq| also has a \verb|.join| method:
@@ -309,11 +309,11 @@ For example,
 >>> from Bio.Alphabet import generic_dna
 >>> dna_seq = Seq("acgtACGT", generic_dna)
 >>> dna_seq
-Seq('acgtACGT', DNAAlphabet())
+Seq('acgtACGT')
 >>> dna_seq.upper()
-Seq('ACGTACGT', DNAAlphabet())
+Seq('ACGTACGT')
 >>> dna_seq.lower()
-Seq('acgtacgt', DNAAlphabet())
+Seq('acgtacgt')
 \end{minted}
 
 These are useful for doing case insensitive matching:
@@ -335,9 +335,9 @@ sequences only, thus:
 >>> from Bio.Alphabet import IUPAC
 >>> dna_seq = Seq("ACGT", IUPAC.unambiguous_dna)
 >>> dna_seq
-Seq('ACGT', IUPACUnambiguousDNA())
+Seq('ACGT')
 >>> dna_seq.lower()
-Seq('acgt', DNAAlphabet())
+Seq('acgt')
 \end{minted}
 
 
@@ -353,11 +353,11 @@ complement of a \verb|Seq| object using its built-in methods:
 >>> from Bio.Alphabet import IUPAC
 >>> my_seq = Seq("GATCGATGGGCCTATATAGGATCGAAAATCGC", IUPAC.unambiguous_dna)
 >>> my_seq
-Seq('GATCGATGGGCCTATATAGGATCGAAAATCGC', IUPACUnambiguousDNA())
+Seq('GATCGATGGGCCTATATAGGATCGAAAATCGC')
 >>> my_seq.complement()
-Seq('CTAGCTACCCGGATATATCCTAGCTTTTAGCG', IUPACUnambiguousDNA())
+Seq('CTAGCTACCCGGATATATCCTAGCTTTTAGCG')
 >>> my_seq.reverse_complement()
-Seq('GCGATTTTCGATCCTATATAGGCCCATCGATC', IUPACUnambiguousDNA())
+Seq('GCGATTTTCGATCCTATATAGGCCCATCGATC')
 \end{minted}
 
 As mentioned earlier, an easy way to just reverse a \verb|Seq| object (or a
@@ -366,7 +366,7 @@ Python string) is slice it with -1 step:
 %cont-doctest
 \begin{minted}{pycon}
 >>> my_seq[::-1]
-Seq('CGCTAAAAGCTAGGATATATCCGGGTAGCTAG', IUPACUnambiguousDNA())
+Seq('CGCTAAAAGCTAGGATATATCCGGGTAGCTAG')
 \end{minted}
 
 In all of these operations, the alphabet property is maintained. This is very
@@ -419,10 +419,10 @@ Now let's actually get down to doing a transcription in Biopython.  First, let's
 >>> from Bio.Alphabet import IUPAC
 >>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG", IUPAC.unambiguous_dna)
 >>> coding_dna
-Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', IUPACUnambiguousDNA())
+Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
 >>> template_dna = coding_dna.reverse_complement()
 >>> template_dna
-Seq('CTATCGGGCACCCTTTCAGCGGCCCATTACAATGGCCAT', IUPACUnambiguousDNA())
+Seq('CTATCGGGCACCCTTTCAGCGGCCCATTACAATGGCCAT')
 \end{minted}
 \noindent These should match the figure above - remember by convention nucleotide sequences are normally read from the 5' to 3' direction, while in the figure the template strand is shown reversed.
 
@@ -431,10 +431,10 @@ Now let's transcribe the coding strand into the corresponding mRNA, using the \v
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna
-Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', IUPACUnambiguousDNA())
+Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
 >>> messenger_rna = coding_dna.transcribe()
 >>> messenger_rna
-Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
+Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG')
 \end{minted}
 \noindent As you can see, all this does is switch T $\rightarrow$ U, and adjust the alphabet.
 
@@ -443,7 +443,7 @@ If you do want to do a true biological transcription starting with the template 
 %cont-doctest
 \begin{minted}{pycon}
 >>> template_dna.reverse_complement().transcribe()
-Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
+Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG')
 \end{minted}
 
 The \verb|Seq| object also includes a back-transcription method for going from the mRNA to the coding strand of the DNA.  Again, this is a simple U $\rightarrow$ T substitution and associated change of alphabet:
@@ -454,9 +454,9 @@ The \verb|Seq| object also includes a back-transcription method for going from t
 >>> from Bio.Alphabet import IUPAC
 >>> messenger_rna = Seq("AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG", IUPAC.unambiguous_rna)
 >>> messenger_rna
-Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
+Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG')
 >>> messenger_rna.back_transcribe()
-Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', IUPACUnambiguousDNA())
+Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
 \end{minted}
 
 \emph{Note:} The \verb|Seq| object's \verb|transcribe| and \verb|back_transcribe| methods
@@ -473,11 +473,11 @@ advantage of one of the \verb|Seq| object's biological methods:
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.Alphabet import IUPAC
->>> messenger_rna = Seq("AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG", IUPAC.unambiguous_rna)
+>>> messenger_rna = Seq("AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG")
 >>> messenger_rna
-Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG', IUPACUnambiguousRNA())
+Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG')
 >>> messenger_rna.translate()
-Seq('MAIVMGR*KGAR*', ProteinAlphabet())
+Seq('MAIVMGR*KGAR*')
 \end{minted}
 
 You can also translate directly from the coding strand DNA sequence:
@@ -488,9 +488,9 @@ You can also translate directly from the coding strand DNA sequence:
 >>> from Bio.Alphabet import IUPAC
 >>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG", IUPAC.unambiguous_dna)
 >>> coding_dna
-Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG', IUPACUnambiguousDNA())
+Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
 >>> coding_dna.translate()
-Seq('MAIVMGR*KGAR*', ProteinAlphabet())
+Seq('MAIVMGR*KGAR*')
 \end{minted}
 
 You should notice in the above protein sequences that in addition to the end stop character, there is an internal stop as well.  This was a deliberate choice of example, as it gives an excuse to talk about some optional arguments, including different translation tables (Genetic Codes).
@@ -501,7 +501,7 @@ Suppose we are dealing with a mitochondrial sequence.  We need to tell the trans
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna.translate(table="Vertebrate Mitochondrial")
-Seq('MAIVMGRWKGAR*', ProteinAlphabet())
+Seq('MAIVMGRWKGAR*')
 \end{minted}
 
 You can also specify the table using the NCBI table number which is shorter, and often included in the feature annotation of GenBank files:
@@ -509,7 +509,7 @@ You can also specify the table using the NCBI table number which is shorter, and
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna.translate(table=2)
-Seq('MAIVMGRWKGAR*', ProteinAlphabet())
+Seq('MAIVMGRWKGAR*')
 \end{minted}
 
 Now, you may want to translate the nucleotides up to the first in frame stop codon,
@@ -518,13 +518,13 @@ and then stop (as happens in nature):
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna.translate()
-Seq('MAIVMGR*KGAR*', ProteinAlphabet())
+Seq('MAIVMGR*KGAR*')
 >>> coding_dna.translate(to_stop=True)
-Seq('MAIVMGR', ProteinAlphabet())
+Seq('MAIVMGR')
 >>> coding_dna.translate(table=2)
-Seq('MAIVMGRWKGAR*', ProteinAlphabet())
+Seq('MAIVMGRWKGAR*')
 >>> coding_dna.translate(table=2, to_stop=True)
-Seq('MAIVMGRWKGAR', ProteinAlphabet())
+Seq('MAIVMGRWKGAR')
 \end{minted}
 \noindent Notice that when you use the \verb|to_stop| argument, the stop codon itself
 is not translated - and the stop symbol is not included at the end of your protein
@@ -535,7 +535,7 @@ You can even specify the stop symbol if you don't like the default asterisk:
 %cont-doctest
 \begin{minted}{pycon}
 >>> coding_dna.translate(table=2, stop_symbol="@")
-Seq('MAIVMGRWKGAR@', ProteinAlphabet())
+Seq('MAIVMGRWKGAR@')
 \end{minted}
 
 Now, suppose you have a complete coding sequence CDS, which is to say a
@@ -561,8 +561,7 @@ for example the gene yaaX in \texttt{E. coli} K12:
 Seq('VKKMQSIVLALSLVLVAPMAAQAAEITLVPSVKLQIGDRDNRGYYWDGGHWRDH...HR*',
 ProteinAlpabet())
 >>> gene.translate(table="Bacterial", to_stop=True)
-Seq('VKKMQSIVLALSLVLVAPMAAQAAEITLVPSVKLQIGDRDNRGYYWDGGHWRDH...HHR',
-ProteinAlphabet())
+Seq('VKKMQSIVLALSLVLVAPMAAQAAEITLVPSVKLQIGDRDNRGYYWDGGHWRDH...HHR')
 \end{minted}
 
 \noindent In the bacterial genetic code \texttt{GTG} is a valid start codon,
@@ -573,8 +572,7 @@ sequence is a complete CDS:
 %TODO - handle line wrapping in doctest?
 \begin{minted}{pycon}
 >>> gene.translate(table="Bacterial", cds=True)
-Seq('MKKMQSIVLALSLVLVAPMAAQAAEITLVPSVKLQIGDRDNRGYYWDGGHWRDH...HHR',
-ProteinAlphabet())
+Seq('MKKMQSIVLALSLVLVAPMAAQAAEITLVPSVKLQIGDRDNRGYYWDGGHWRDH...HHR')
 \end{minted}
 
 In addition to telling Biopython to translate an alternative start codon as
@@ -790,7 +788,7 @@ However, you can convert it into a mutable sequence (a \verb|MutableSeq| object)
 \begin{minted}{pycon}
 >>> mutable_seq = my_seq.tomutable()
 >>> mutable_seq
-MutableSeq('GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA', IUPACUnambiguousDNA())
+MutableSeq('GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA')
 \end{minted}
 
 Alternatively, you can create a \verb|MutableSeq| object directly from a string:
@@ -807,16 +805,16 @@ Either way will give you a sequence object which can be changed:
 %cont-doctest
 \begin{minted}{pycon}
 >>> mutable_seq
-MutableSeq('GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA', IUPACUnambiguousDNA())
+MutableSeq('GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA')
 >>> mutable_seq[5] = "C"
 >>> mutable_seq
-MutableSeq('GCCATCGTAATGGGCCGCTGAAAGGGTGCCCGA', IUPACUnambiguousDNA())
+MutableSeq('GCCATCGTAATGGGCCGCTGAAAGGGTGCCCGA')
 >>> mutable_seq.remove("T")
 >>> mutable_seq
-MutableSeq('GCCACGTAATGGGCCGCTGAAAGGGTGCCCGA', IUPACUnambiguousDNA())
+MutableSeq('GCCACGTAATGGGCCGCTGAAAGGGTGCCCGA')
 >>> mutable_seq.reverse()
 >>> mutable_seq
-MutableSeq('AGCCCGTGGGAAAGTCGCCGGGTAATGCACCG', IUPACUnambiguousDNA())
+MutableSeq('AGCCCGTGGGAAAGTCGCCGGGTAATGCACCG')
 \end{minted}
 
 Do note that unlike the \verb|Seq| object, the \verb|MutableSeq| object's methods like \verb|reverse_complement()| and \verb|reverse()| act in-situ!
@@ -829,7 +827,7 @@ Once you have finished editing your a \verb|MutableSeq| object, it's easy to get
 \begin{minted}{pycon}
 >>> new_seq = mutable_seq.toseq()
 >>> new_seq
-Seq('AGCCCGTGGGAAAGTCGCCGGGTAATGCACCG', IUPACUnambiguousDNA())
+Seq('AGCCCGTGGGAAAGTCGCCGGGTAATGCACCG')
 \end{minted}
 
 You can also get a string from a \verb|MutableSeq| object just like from a \verb|Seq| object (Section~\ref{sec:seq-to-string}).
@@ -863,7 +861,7 @@ the letter defaults to ``N'' and for proteins ``X'', rather than just ``?''.
 >>> from Bio.Alphabet import IUPAC
 >>> unk_dna = UnknownSeq(20, alphabet=IUPAC.ambiguous_dna)
 >>> unk_dna
-UnknownSeq(20, alphabet=IUPACAmbiguousDNA(), character='N')
+UnknownSeq(20, character='N')
 >>> print(unk_dna)
 NNNNNNNNNNNNNNNNNNNN
 \end{minted}
@@ -874,16 +872,16 @@ memory saving \verb|UnknownSeq| objects where appropriate as you might expect:
 %cont-doctest
 \begin{minted}{pycon}
 >>> unk_dna
-UnknownSeq(20, alphabet=IUPACAmbiguousDNA(), character='N')
+UnknownSeq(20, character='N')
 >>> unk_dna.complement()
-UnknownSeq(20, alphabet=IUPACAmbiguousDNA(), character='N')
+UnknownSeq(20, character='N')
 >>> unk_dna.reverse_complement()
-UnknownSeq(20, alphabet=IUPACAmbiguousDNA(), character='N')
+UnknownSeq(20, character='N')
 >>> unk_dna.transcribe()
-UnknownSeq(20, alphabet=IUPACAmbiguousRNA(), character='N')
+UnknownSeq(20, character='N')
 >>> unk_protein = unk_dna.translate()
 >>> unk_protein
-UnknownSeq(6, alphabet=ProteinAlphabet(), character='X')
+UnknownSeq(6, character='X')
 >>> print(unk_protein)
 XXXXXX
 >>> len(unk_protein)

--- a/Doc/Tutorial/chapter_seqio.tex
+++ b/Doc/Tutorial/chapter_seqio.tex
@@ -137,11 +137,11 @@ print(len(first_record))
 Found 94 records
 The last record
 Z78439.1
-Seq('CATTGTTGAGATCACATAATAATTGATCGAGTTAATCTGGAGGATCTGTTTACT...GCC', IUPACAmbiguousDNA())
+Seq('CATTGTTGAGATCACATAATAATTGATCGAGTTAATCTGGAGGATCTGTTTACT...GCC')
 592
 The first record
 Z78533.1
-Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGATGAGACCGTGG...CGC', IUPACAmbiguousDNA())
+Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGATGAGACCGTGG...CGC')
 740
 \end{minted}
 
@@ -177,7 +177,7 @@ Number of features: 5
 /date=30-NOV-2006
 /organism=Cypripedium irapeanum
 /gi=2765658
-Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGATGAGACCGTGG...CGC', IUPACAmbiguousDNA())
+Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGATGAGACCGTGG...CGC')
 \end{minted}
 
 This gives a human readable summary of most of the annotation data for the \verb|SeqRecord|.
@@ -535,7 +535,7 @@ print(seq_record.annotations["keywords"])
 O23729
 CHS3_BROFI
 RecName: Full=Chalcone synthase 3; EC=2.3.1.74; AltName: Full=Naringenin-chalcone synthase 3;
-Seq('MAPAMEEIRQAQRAEGPAAVLAIGTSTPPNALYQADYPDYYFRITKSEHLTELK...GAE', ProteinAlphabet())
+Seq('MAPAMEEIRQAQRAEGPAAVLAIGTSTPPNALYQADYPDYYFRITKSEHLTELK...GAE')
 Length 394
 ['Acyltransferase', 'Flavonoid biosynthesis', 'Transferase']
 \end{minted}
@@ -617,8 +617,8 @@ We can access a single \verb|SeqRecord| object via the keys and manipulate the o
 >>> seq_record = orchid_dict["Z78475.1"]
 >>> print(seq_record.description)
 P.supardii 5.8S rRNA gene and ITS1 and ITS2 DNA
->>> print(repr(seq_record.seq))
-Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGTTGAGATCACAT...GGT', IUPACAmbiguousDNA())
+>>> seq_record.seq
+Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGTTGAGATCACAT...GGT')
 \end{minted}
 
 So, it is very easy to create an in memory ``database'' of our GenBank records.  Next we'll try this for the FASTA file instead.
@@ -756,7 +756,7 @@ As an example, let's use the same GenBank file as before:
 >>> print(seq_record.description)
 P.supardii 5.8S rRNA gene and ITS1 and ITS2 DNA
 >>> seq_record.seq
-Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGTTGAGATCACAT...GGT', IUPACAmbiguousDNA())
+Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGTTGAGATCACAT...GGT')
 >>> orchid_dict.close()
 \end{minted}
 

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -173,12 +173,12 @@ Database cross-references: TestXRef
 Number of features: 4
 /k=v
 Per letter annotation for: fake
-Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX', ProteinAlphabet())"""
+Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX')"""
         self.assertEqual(expected.lstrip(), str(self.record))
 
     def test_repr(self):
         expected = (
-            "SeqRecord(seq=Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX', ProteinAlphabet()), "
+            "SeqRecord(seq=Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX'), "
             "id='TestID', name='TestName', description='TestDescr', dbxrefs=['TestXRef'])"
         )
         self.assertEqual(expected, repr(self.record))

--- a/Tests/test_SwissProt.py
+++ b/Tests/test_SwissProt.py
@@ -30,7 +30,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(seq_record.description, "N33 PROTEIN.")
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MGARGAPSRRRQAGRRLRYLPTGSFPFLLLLLLLCIQLGGGQKKKENLLAEKVE...DFE', ProteinAlphabet())",
+            "Seq('MGARGAPSRRRQAGRRLRYLPTGSFPFLLLLLLLCIQLGGGQKKKENLLAEKVE...DFE')",
         )
 
         with open(datafile) as test_handle:
@@ -161,7 +161,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(seq_record.description, "CYSTEINE STRING PROTEIN (CSP).")
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MADQRQRSLSTSGESLYHVLGLDKNATSDDIKKSYRKLALKYHPDKNPDNPEAA...GFN', ProteinAlphabet())",
+            "Seq('MADQRQRSLSTSGESLYHVLGLDKNATSDDIKKSYRKLALKYHPDKNPDNPEAA...GFN')",
         )
 
         with open(datafile) as test_handle:
@@ -279,7 +279,7 @@ class TestSwissProt(unittest.TestCase):
         )
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MDDREDLVYQAKLAEQAERYDEMVESMKKVAGMDVELTVEERNLLSVAYKNVIG...ENQ', ProteinAlphabet())",
+            "Seq('MDDREDLVYQAKLAEQAERYDEMVESMKKVAGMDVELTVEERNLLSVAYKNVIG...ENQ')",
         )
 
         with open(datafile) as test_handle:
@@ -502,7 +502,7 @@ class TestSwissProt(unittest.TestCase):
         )
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MTVKWIEAVALSDILEGDVLGVTVEGKELALYEVEGEIYATDNLCTHGSARMSD...DLS', ProteinAlphabet())",
+            "Seq('MTVKWIEAVALSDILEGDVLGVTVEGKELALYEVEGEIYATDNLCTHGSARMSD...DLS')",
         )
 
         with open(datafile) as test_handle:
@@ -650,7 +650,7 @@ class TestSwissProt(unittest.TestCase):
         )
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MNLLLTLLTNTTLALLLVFIAFWLPQLNVYAEKTSPYECGFDPMGSARLPFSMK...WAE', ProteinAlphabet())",
+            "Seq('MNLLLTLLTNTTLALLLVFIAFWLPQLNVYAEKTSPYECGFDPMGSARLPFSMK...WAE')",
         )
 
         with open(datafile) as test_handle:
@@ -753,7 +753,7 @@ class TestSwissProt(unittest.TestCase):
         )
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MTPHTHVRGPGDILQLTMAFYGSRALISAVELDLFTLLAGKPLPLGELCERAGI...KPR', ProteinAlphabet())",
+            "Seq('MTPHTHVRGPGDILQLTMAFYGSRALISAVELDLFTLLAGKPLPLGELCERAGI...KPR')",
         )
 
         with open(datafile) as test_handle:
@@ -846,7 +846,7 @@ class TestSwissProt(unittest.TestCase):
         )
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MANAGLQLLGFILAFLGWIGAIVSTALPQWRIYSYAGDNIVTAQAMYEGLWMSC...DYV', ProteinAlphabet())",
+            "Seq('MANAGLQLLGFILAFLGWIGAIVSTALPQWRIYSYAGDNIVTAQAMYEGLWMSC...DYV')",
         )
 
         with open(datafile) as test_handle:
@@ -983,7 +983,7 @@ class TestSwissProt(unittest.TestCase):
         )
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MAVMAPRTLVLLLSGALALTQTWAGSHSMRYFFTSVSRPGRGEPRFIAVGYVDD...CKV', ProteinAlphabet())",
+            "Seq('MAVMAPRTLVLLLSGALALTQTWAGSHSMRYFFTSVSRPGRGEPRFIAVGYVDD...CKV')",
         )
 
         with open(datafile) as test_handle:
@@ -1782,7 +1782,7 @@ class TestSwissProt(unittest.TestCase):
         )
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MAPAMEEIRQAQRAEGPAAVLAIGTSTPPNALYQADYPDYYFRITKSEHLTELK...GAE', ProteinAlphabet())",
+            "Seq('MAPAMEEIRQAQRAEGPAAVLAIGTSTPPNALYQADYPDYYFRITKSEHLTELK...GAE')",
         )
 
         with open(datafile) as test_handle:
@@ -1881,7 +1881,7 @@ class TestSwissProt(unittest.TestCase):
         )
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MDKLDANVSSEEGFGSVEKVVLLTFLSTVILMAILGNLLVMVAVCWDRQLRKIK...SDT', ProteinAlphabet())",
+            "Seq('MDKLDANVSSEEGFGSVEKVVLLTFLSTVILMAILGNLLVMVAVCWDRQLRKIK...SDT')",
         )
 
         with open(datafile) as test_handle:
@@ -2194,7 +2194,7 @@ class TestSwissProt(unittest.TestCase):
         )
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MDKLDANVSSEEGFGSVEKVVLLTFLSTVILMAILGNLLVMVAVCWDRQLRKIK...SDT', ProteinAlphabet())",
+            "Seq('MDKLDANVSSEEGFGSVEKVVLLTFLSTVILMAILGNLLVMVAVCWDRQLRKIK...SDT')",
         )
 
         with open(datafile) as test_handle:
@@ -2600,7 +2600,7 @@ class TestSwissProt(unittest.TestCase):
         )
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MGRRVPALRQLLVLAVLLLKPSQLQSRELSGSRCPEPCDCAPDGALRCPGPRAG...LTH', ProteinAlphabet())",
+            "Seq('MGRRVPALRQLLVLAVLLLKPSQLQSRELSGSRCPEPCDCAPDGALRCPGPRAG...LTH')",
         )
 
         with open(datafile) as test_handle:
@@ -3133,7 +3133,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(seq_record.description, "UBIQUITIN.")
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MQIFVKTLTGKTITLEVESSDTIDNVKTKIQDKEGIPPDQQRLIFAGKQLEDGR...GGN', ProteinAlphabet())",
+            "Seq('MQIFVKTLTGKTITLEVESSDTIDNVKTKIQDKEGIPPDQQRLIFAGKQLEDGR...GGN')",
         )
 
         with open(datafile) as test_handle:
@@ -3228,7 +3228,7 @@ class TestSwissProt(unittest.TestCase):
         )
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MGSKMASASRVVQVVKPHTPLIRFPDRRDNPKPNVSEALRSAGLPSHSSVISQH...GPE', ProteinAlphabet())",
+            "Seq('MGSKMASASRVVQVVKPHTPLIRFPDRRDNPKPNVSEALRSAGLPSHSSVISQH...GPE')",
         )
 
         with open(datafile) as test_handle:
@@ -3324,7 +3324,7 @@ class TestSwissProt(unittest.TestCase):
         )
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MTQSNPNEQNVELNRTSLYWGLLLIFVLAVLFSNYFFN', ProteinAlphabet())",
+            "Seq('MTQSNPNEQNVELNRTSLYWGLLLIFVLAVLFSNYFFN')",
         )
 
         with open(datafile) as test_handle:
@@ -3454,7 +3454,7 @@ class TestSwissProt(unittest.TestCase):
         self.assertEqual(seq_record.description, "")
         self.assertEqual(
             repr(seq_record.seq),
-            "Seq('MSFQAPRRLLELAGQSLLRDQALAISVLDELPRELFPRLFVEAFTSRRCEVLKV...TPC', ProteinAlphabet())",
+            "Seq('MSFQAPRRLLELAGQSLLRDQALAISVLDELPRELFPRLFVEAFTSRRCEVLKV...TPC')",
         )
 
         with open(datafile) as test_handle:

--- a/Tests/test_Uniprot.py
+++ b/Tests/test_Uniprot.py
@@ -33,7 +33,7 @@ class TestUniprot(unittest.TestCase):
         self.assertEqual(seq_record.id, "Q91G55")
         self.assertEqual(seq_record.name, "043L_IIV6")
         self.assertEqual(seq_record.description, "Uncharacterized protein 043L")
-        self.assertEqual(repr(seq_record.seq), "Seq('MDLINNKLNIEIQKFCLDLEKKYNINYNNLIDLWFNKESTERLIKCEVNLENKI...IPI', ProteinAlphabet())")
+        self.assertEqual(repr(seq_record.seq), "Seq('MDLINNKLNIEIQKFCLDLEKKYNINYNNLIDLWFNKESTERLIKCEVNLENKI...IPI')")
 
         # self.assertEqual(seq_record.accessions, ['Q91G55']) #seq_record.accessions does not exist
         # self.assertEqual(seq_record.organism_classification, ['Eukaryota', 'Metazoa', 'Chordata', 'Craniata', 'Vertebrata', 'Mammalia', 'Eutheria', 'Primates', 'Catarrhini', 'Hominidae', 'Homo'])
@@ -89,7 +89,7 @@ class TestUniprot(unittest.TestCase):
                          "FMRFamide-like neuropeptides 13")
         self.assertEqual(repr(seq_record.seq),
                          "Seq('MMTSLLTISMFVVAIQAFDSSEIRMLDEQYDTKNPFFQF"
-                         "LENSKRSDRPTRAMD...GRK', ProteinAlphabet())")
+                         "LENSKRSDRPTRAMD...GRK')")
 
         self.assertEqual(len(seq_record.annotations["references"]), 7)
         self.assertEqual(seq_record.annotations["references"][5].authors,

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -76,16 +76,11 @@ class TestSeq(unittest.TestCase):
 
     def test_repr(self):
         """Test representation of Seq object."""
-        self.assertEqual(
-            "Seq('TCAAAAGGATGCATCATG', IUPACUnambiguousDNA())", repr(self.s)
-        )
+        self.assertEqual("Seq('TCAAAAGGATGCATCATG')", repr(self.s))
 
     def test_truncated_repr(self):
         seq = "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGA"
-        expected = (
-            "Seq('TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATG...GGA', "
-            "IUPACAmbiguousDNA())"
-        )
+        expected = "Seq('TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATG...GGA')"
         self.assertEqual(expected, repr(Seq.Seq(seq, IUPAC.ambiguous_dna)))
 
     def test_length(self):
@@ -563,16 +558,12 @@ class TestMutableSeq(unittest.TestCase):
         self.assertIsInstance(array_seq, MutableSeq, "Creating MutableSeq using array")
 
     def test_repr(self):
-        self.assertEqual(
-            "MutableSeq('TCAAAAGGATGCATCATG', IUPACAmbiguousDNA())",
-            repr(self.mutable_s),
-        )
+        self.assertEqual("MutableSeq('TCAAAAGGATGCATCATG')", repr(self.mutable_s))
 
     def test_truncated_repr(self):
         seq = "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGA"
         expected = (
-            "MutableSeq('TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATG...GGA', "
-            "IUPACAmbiguousDNA())"
+            "MutableSeq('TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATG...GGA')"
         )
         self.assertEqual(expected, repr(MutableSeq(seq, IUPAC.ambiguous_dna)))
 


### PR DESCRIPTION
This pull request removes alphabets from `Seq.__repr__`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
