### PR TITLE
test_Tutorial.py python3

### DIFF
--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -136,7 +136,7 @@ Now \verb+record+ is a dictionary with exactly one key:
 %cont-doctest
 \begin{minted}{pycon}
 >>> record.keys()
-['DbList']
+dict_keys(['DbList'])
 \end{minted}
 The values stored in this key is the list of database names shown in the XML above:
 %Line-wrapping for display so not using for doctest

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -984,7 +984,7 @@ and one of the features (the source feature) have been lost:
 >>> shifted.dbxrefs
 []
 >>> shifted.annotations.keys()
-[]
+dict_keys([])
 \end{minted}
 
 This is because the \verb|SeqRecord| slicing step is cautious in what annotation

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -56,8 +56,6 @@ import os
 import sys
 import warnings
 
-from lib2to3 import refactor
-from lib2to3.pgen2.tokenize import TokenError
 
 from Bio import BiopythonExperimentalWarning, MissingExternalDependencyError
 
@@ -75,17 +73,6 @@ if "--offline" in sys.argv:
     online = False
 
 warnings.simplefilter("ignore", BiopythonExperimentalWarning)
-
-fixers = refactor.get_fixers_from_package("lib2to3.fixes")
-fixers.remove("lib2to3.fixes.fix_print")  # Already using print function
-rt = refactor.RefactoringTool(fixers)
-assert rt.refactor_docstring(">>> print(2+2)\n4\n", "example1") == ">>> print(2+2)\n4\n"
-assert (
-    rt.refactor_docstring(
-        '>>> print("Two plus two is", 2+2)\nTwo plus two is 4\n', "example2"
-    )
-    == '>>> print("Two plus two is", 2+2)\nTwo plus two is 4\n'
-)
 
 # Cache this to restore the cwd at the end of the tests
 original_path = os.path.abspath(".")
@@ -216,11 +203,6 @@ for latex in files:
         if missing:
             missing_deps.update(missing)
             continue
-
-        try:
-            example = rt.refactor_docstring(example, name)
-        except TokenError:
-            raise ValueError("Problem with %s:\n%s" % (name, example)) from None
 
         def funct(n, d, f):
             global tutorial_base

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -9,9 +9,9 @@
 #
 # %doctest
 # \begin{minted}{pycon}
-# >>> from Bio.Alphabet import generic_dna
 # >>> from Bio.Seq import Seq
-# >>> len("ACGT")
+# >>> s = Seq("ACGT")
+# >>> len(s)
 # 4
 # \end{minted}
 #
@@ -20,7 +20,7 @@
 #
 # %cont-doctest
 # \begin{minted}{pycon}
-# >>> Seq("ACGT") == Seq("ACGT", generic_dna)
+# >>> s == "ACGT"
 # True
 # \end{minted}
 #


### PR DESCRIPTION
This pull request removes python2 stuff from doctests.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
