### PR TITLE
doctests and alphabets in chapter_seq_annot

### DIFF
--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -511,20 +511,19 @@ The \verb+"LinkSetDb"+ key contains the search results, stored as a list consist
 %cont-doctest
 \begin{minted}{pycon}
 >>> len(record[0]["LinkSetDb"])
-8
+7
 \end{minted}
 \noindent The exact numbers should increase over time:
 \begin{minted}{pycon}
 >>> for linksetdb in record[0]["LinkSetDb"]:
 ...     print(linksetdb["DbTo"], linksetdb["LinkName"], len(linksetdb["Link"]))
 ...
-pubmed pubmed_pubmed 162
-pubmed pubmed_pubmed_alsoviewed 3
-pubmed pubmed_pubmed_citedin 430
+pubmed pubmed_pubmed 284
+pubmed pubmed_pubmed_citedin 924
 pubmed pubmed_pubmed_combined 6
 pubmed pubmed_pubmed_five 6
 pubmed pubmed_pubmed_refs 17
-pubmed pubmed_pubmed_reviews 7
+pubmed pubmed_pubmed_reviews 12
 pubmed pubmed_pubmed_reviews_five 6
 \end{minted}
 

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -727,9 +727,6 @@ qualifiers:
     Key: gene, Value: ['pim']
     Key: locus_tag, Value: ['YP_pPCP05']
 <BLANKLINE>
-\end{minted}
-%This one is truncated so can't use for doctest
-\begin{minted}{pycon}
 >>> print(record.features[21])
 type: CDS
 location: [4342:4780](+)
@@ -738,11 +735,12 @@ qualifiers:
     Key: db_xref, Value: ['GI:45478716', 'GeneID:2767712']
     Key: gene, Value: ['pim']
     Key: locus_tag, Value: ['YP_pPCP05']
-    Key: note, Value: ['similar to many previously sequenced pesticin immunity ...']
+    Key: note, Value: ['similar to many previously sequenced pesticin immunity protein entries of Yersinia pestis plasmid pPCP, e.g. gi| 16082683|,ref|NP_395230.1| (NC_003132) , gi|1200166|emb|CAA90861.1| (Z54145 ) , gi|1488655| emb|CAA63439.1| (X92856) , gi|2996219|gb|AAC62543.1| (AF053945) , and gi|5763814|emb|CAB531 67.1| (AL109969)']
     Key: product, Value: ['pesticin immunity protein']
     Key: protein_id, Value: ['NP_995571.1']
     Key: transl_table, Value: ['11']
-    Key: translation, Value: ['MGGGMISKLFCLALIFLSSSGLAEKNTYTAKDILQNLELNTFGNSLSH...']
+    Key: translation, Value: ['MGGGMISKLFCLALIFLSSSGLAEKNTYTAKDILQNLELNTFGNSLSHGIYGKQTTFKQTEFTNIKSNTKKHIALINKDNSWMISLKILGIKRDEYTVCFEDFSLIRPPTYVAIHPLLIKKVKSGNFIVVKEIKKSIPGCTVYYH']
+<BLANKLINE>
 \end{minted}
 
 Let's slice this parent record from 4300 to 4800 (enough to include the \verb|pim|

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -528,8 +528,8 @@ A \verb|SeqFeature| or location object doesn't directly contain a sequence, inst
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
->>> example_parent = Seq("ACCGAGACGGCAAAGGCTAGCATAGGTATGAGACTTCCTTCCTGCCAGTGCTGAGGAACTGGGAGCCTAC")
->>> example_feature = SeqFeature(FeatureLocation(5, 18), type="gene", strand=-1)
+>>> seq = Seq("ACCGAGACGGCAAAGGCTAGCATAGGTATGAGACTTCCTTCCTGCCAGTGCTGAGGAACTGGGAGCCTAC")
+>>> feature = SeqFeature(FeatureLocation(5, 18), type="gene", strand=-1)
 \end{minted}
 
 You could take the parent sequence, slice it to extract 5:18, and then take the reverse complement.
@@ -537,7 +537,7 @@ If you are using Biopython 1.59 or later, the feature location's start and end a
 
 %cont-doctest
 \begin{minted}{pycon}
->>> feature_seq = example_parent[example_feature.location.start:example_feature.location.end].reverse_complement()
+>>> feature_seq = seq[feature.location.start:feature.location.end].reverse_complement()
 >>> print(feature_seq)
 AGCCTTTGCCGTC
 \end{minted}
@@ -546,7 +546,7 @@ This is a simple example so this isn't too bad -- however once you have to deal 
 
 %cont-doctest
 \begin{minted}{pycon}
->>> feature_seq = example_feature.extract(example_parent)
+>>> feature_seq = feature.extract(seq)
 >>> print(feature_seq)
 AGCCTTTGCCGTC
 \end{minted}
@@ -556,13 +556,11 @@ that of the region of sequence it describes.
 
 %cont-doctest
 \begin{minted}{pycon}
->>> print(example_feature.extract(example_parent))
-AGCCTTTGCCGTC
->>> print(len(example_feature.extract(example_parent)))
+>>> print(len(feature_seq))
 13
->>> print(len(example_feature))
+>>> print(len(feature))
 13
->>> print(len(example_feature.location))
+>>> print(len(feature.location))
 13
 \end{minted}
 
@@ -607,7 +605,7 @@ As of Biopython 1.67, \verb|SeqRecord| comparison like \verb|record1 == record2|
 will instead raise an explicit error to avoid people being caught out by this:
 
 %cont-doctest
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> record1 == record2
 Traceback (most recent call last):
 ...
@@ -690,7 +688,7 @@ completely within the new sequence are preserved (with their locations adjusted)
 For example, taking the same GenBank file used earlier:
 
 %doctest ../Tests/GenBank
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.gb", "genbank")
 >>> record
@@ -709,7 +707,7 @@ thirteenth entries in the file, so in Python zero-based counting they are
 entries $11$ and $12$ in the \texttt{features} list:
 
 %cont-doctest
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breakanywhere=true,breaksymbolleft=,breakanywheresymbolpre=]{pycon}
 >>> print(record.features[20])
 type: gene
 location: [4342:4780](+)
@@ -738,14 +736,10 @@ Let's slice this parent record from 4300 to 4800 (enough to include the \verb|pi
 gene/CDS), and see how many features we get:
 
 %cont-doctest
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> sub_record = record[4300:4800]
 >>> sub_record
 SeqRecord(seq=Seq('ATAAATAGATTATTCCAAATAATTTATTTATGTAAGAACAGGATGGGAGGGGGA...TTA'), id='NC_005816.1', name='NC_005816', description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence', dbxrefs=[])
-\end{minted}
-
-%cont-doctest
-\begin{minted}{pycon}
 >>> len(sub_record)
 500
 >>> len(sub_record.features)
@@ -755,7 +749,7 @@ SeqRecord(seq=Seq('ATAAATAGATTATTCCAAATAATTTATTTATGTAAGAACAGGATGGGAGGGGGA...TTA'
 Our sub-record just has two features, the gene and CDS entries for \verb|YP_pPCP05|:
 
 %cont-doctest
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breakanywhere=true,breaksymbolleft=,breakanywheresymbolpre=]{pycon}
 >>> print(sub_record.features[0])
 type: gene
 location: [42:480](+)
@@ -814,7 +808,7 @@ and \texttt{description}, but for practicality these are preserved:
 Let's fix this and then view the sub-record as a reduced GenBank file using
 the \texttt{format} method described above in Section~\ref{sec:SeqRecord-format}:
 
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> sub_record.description = "Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, partial."
 >>> print(sub_record.format("genbank"))
 ...
@@ -837,7 +831,7 @@ For an example with per-letter annotation, we'll use the first record in a
 FASTQ file. Chapter~\ref{chapter:seqio} will explain the \verb|SeqIO| functions:
 
 %doctest ../Tests/Quality
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> from Bio import SeqIO
 >>> record = next(SeqIO.parse("example.fastq", "fastq"))
 >>> len(record)
@@ -854,7 +848,7 @@ record by first slicing the \verb|SeqRecord| before and after the ``extra''
 third \texttt{T}:
 
 %cont-doctest
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> left = record[:20]
 >>> print(left.seq)
 CCCTTCTTGTCTTCAGCGTT
@@ -870,7 +864,7 @@ CTCC
 \noindent Now add the two parts together:
 
 %cont-doctest
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> edited = left + right
 >>> len(edited)
 24
@@ -891,15 +885,11 @@ Now, for an example with features, we'll use a GenBank file.
 Suppose you have a circular genome:
 
 %doctest ../Tests/GenBank
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.gb", "genbank")
 >>> record
 SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG'), id='NC_005816.1', name='NC_005816', description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence', dbxrefs=['Project:58037'])
-\end{minted}
-
-%cont-doctest
-\begin{minted}{pycon}
 >>> len(record)
 9609
 >>> len(record.features)
@@ -913,14 +903,10 @@ dict_keys(['molecule_type', 'topology', 'data_file_division', 'date', 'accession
 You can shift the origin like this:
 
 %cont-doctest
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> shifted = record[2000:] + record[:2000]
 >>> shifted
 SeqRecord(seq=Seq('GATACGCAGTCATATTTTTTACACAATTCTCTAATCCCGACAAGGTCGTAGGTC...GGA'), id='NC_005816.1', name='NC_005816', description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence', dbxrefs=[])
-\end{minted}
-
-%cont-doctest
-\begin{minted}{pycon}
 >>> len(shifted)
 9609
 \end{minted}
@@ -944,7 +930,7 @@ you want to keep the database cross references or the annotations dictionary,
 this must be done explicitly:
 
 %cont-doctest
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> shifted.dbxrefs = record.dbxrefs[:]
 >>> shifted.annotations = record.annotations.copy()
 >>> shifted.dbxrefs
@@ -985,7 +971,7 @@ the new desired value instead.
 Consider this example record:
 
 %doctest ../Tests/GenBank
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.gb", "genbank")
 >>> print("%s %i %i %i %i" % (record.id, len(record), len(record.features), len(record.dbxrefs), len(record.annotations)))
@@ -996,7 +982,7 @@ Here we take the reverse complement and specify a new identifier -- but notice
 how most of the annotation is dropped (but not the features):
 
 %cont-doctest
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> rc = record.reverse_complement(id="TESTING")
 >>> print("%s %i %i %i %i" % (rc.id, len(rc), len(rc.features), len(rc.dbxrefs), len(rc.annotations)))
 TESTING 9609 41 0 0

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -150,11 +150,6 @@ individually -- starting with the \verb|seq| attribute which gives you a
 Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG')
 \end{minted}
 
-\noindent Here \verb|Bio.SeqIO| has defaulted to a generic alphabet, rather
-than guessing that this is DNA. If you know in advance what kind of sequence
-your FASTA file contains, you can tell \verb|Bio.SeqIO| which alphabet to use
-(see Chapter~\ref{chapter:seqio}).
-
 Next, the identifiers and description:
 
 %cont-doctest
@@ -223,9 +218,6 @@ Again, we'll use \verb|Bio.SeqIO| to read this file in, and the code is almost i
 >>> record
 SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG'), id='NC_005816.1', name='NC_005816', description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence', dbxrefs=['Project:58037'])
 \end{minted}
-
-You should be able to spot some differences already! But taking the attributes individually,
-the sequence string is the same as before, but this time \verb|Bio.SeqIO| has been able to automatically assign a more specific alphabet (see Chapter~\ref{chapter:seqio} for details):
 
 %cont-doctest
 \begin{minted}{pycon}
@@ -852,12 +844,8 @@ FASTQ file. Chapter~\ref{chapter:seqio} will explain the \verb|SeqIO| functions:
 25
 >>> print(record.seq)
 CCCTTCTTGTCTTCAGCGTTTCTCC
-\end{minted}
-%TODO - doctest wrapping
-\begin{minted}{pycon}
 >>> print(record.letter_annotations["phred_quality"])
-[26, 26, 18, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 22, 26, 26, 26, 26,
-26, 26, 26, 23, 23]
+[26, 26, 18, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 22, 26, 26, 26, 26, 26, 26, 26, 23, 23]
 \end{minted}
 
 \noindent Let's suppose this was Roche 454 data, and that from other information
@@ -888,11 +876,8 @@ CTCC
 24
 >>> print(edited.seq)
 CCCTTCTTGTCTTCAGCGTTCTCC
-\end{minted}
-\begin{minted}{pycon}
 >>> print(edited.letter_annotations["phred_quality"])
-[26, 26, 18, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 22, 26, 26, 26, 26,
-26, 26, 23, 23]
+[26, 26, 18, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 26, 22, 26, 26, 26, 26, 26, 26, 23, 23]
 \end{minted}
 
 \noindent Easy and intuitive? We hope so! You can make this shorter with just:
@@ -909,14 +894,8 @@ Suppose you have a circular genome:
 \begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.gb", "genbank")
-\end{minted}
-%TODO - doctest wrapping
-\begin{minted}{pycon}
 >>> record
-SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG',
-IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
-description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence.',
-dbxrefs=['Project:10638'])
+SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG'), id='NC_005816.1', name='NC_005816', description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence', dbxrefs=['Project:58037'])
 \end{minted}
 
 %cont-doctest
@@ -927,12 +906,8 @@ dbxrefs=['Project:10638'])
 41
 >>> record.dbxrefs
 ['Project:58037']
-\end{minted}
-%TODO - doctest wrapping
-\begin{minted}{pycon}
 >>> record.annotations.keys()
-['comment', 'sequence_version', 'source', 'taxonomy', 'keywords', 'references',
-'accessions', 'data_file_division', 'date', 'organism', 'gi']
+dict_keys(['molecule_type', 'topology', 'data_file_division', 'date', 'accessions', 'sequence_version', 'gi', 'keywords', 'source', 'organism', 'taxonomy', 'references', 'comment'])
 \end{minted}
 
 You can shift the origin like this:
@@ -940,14 +915,8 @@ You can shift the origin like this:
 %cont-doctest
 \begin{minted}{pycon}
 >>> shifted = record[2000:] + record[:2000]
-\end{minted}
-%TODO - doctest wrapping
-\begin{minted}{pycon}
 >>> shifted
-SeqRecord(seq=Seq('GATACGCAGTCATATTTTTTACACAATTCTCTAATCCCGACAAGGTCGTAGGTC...GGA',
-IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
-description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence.',
-dbxrefs=[])
+SeqRecord(seq=Seq('GATACGCAGTCATATTTTTTACACAATTCTCTAATCCCGACAAGGTCGTAGGTC...GGA'), id='NC_005816.1', name='NC_005816', description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence', dbxrefs=[])
 \end{minted}
 
 %cont-doctest
@@ -974,14 +943,14 @@ it preserves (erroneously propagating annotation can cause major problems). If
 you want to keep the database cross references or the annotations dictionary,
 this must be done explicitly:
 
+%cont-doctest
 \begin{minted}{pycon}
 >>> shifted.dbxrefs = record.dbxrefs[:]
 >>> shifted.annotations = record.annotations.copy()
 >>> shifted.dbxrefs
-['Project:10638']
+['Project:58037']
 >>> shifted.annotations.keys()
-['comment', 'sequence_version', 'source', 'taxonomy', 'keywords', 'references',
-'accessions', 'data_file_division', 'date', 'organism', 'gi']
+dict_keys(['molecule_type', 'topology', 'data_file_division', 'date', 'accessions', 'sequence_version', 'gi', 'keywords', 'source', 'organism', 'taxonomy', 'references', 'comment'])
 \end{minted}
 
 Also note that in an example like this, you should probably change the record

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -158,7 +158,7 @@ your FASTA file contains, you can tell \verb|Bio.SeqIO| which alphabet to use
 Next, the identifiers and description:
 
 %cont-doctest
-\begin{minted}{pycon}
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> record.id
 'gi|45478711|ref|NC_005816.1|'
 >>> record.name
@@ -183,6 +183,7 @@ TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGGGGGTAATCTGCTCTCC
 Note that none of the other annotation attributes get populated when reading a
 FASTA file:
 
+%cont-doctest
 \begin{minted}{pycon}
 >>> record.dbxrefs
 []
@@ -215,38 +216,39 @@ PROJECT     GenomeProject:10638
 
 Again, we'll use \verb|Bio.SeqIO| to read this file in, and the code is almost identical to that for used above for the FASTA file (see Chapter~\ref{chapter:seqio} for details):
 
-\begin{minted}{pycon}
+%doctest ../Tests/GenBank
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.gb", "genbank")
 >>> record
-SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG',
-IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
-description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence.',
-dbxrefs=['Project:10638'])
+SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG'), id='NC_005816.1', name='NC_005816', description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence', dbxrefs=['Project:58037'])
 \end{minted}
 
 You should be able to spot some differences already! But taking the attributes individually,
 the sequence string is the same as before, but this time \verb|Bio.SeqIO| has been able to automatically assign a more specific alphabet (see Chapter~\ref{chapter:seqio} for details):
 
+%cont-doctest
 \begin{minted}{pycon}
 >>> record.seq
-Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG', IUPACAmbiguousDNA())
+Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG')
 \end{minted}
 
 The \verb|name| comes from the LOCUS line, while the \verb|id| includes the version suffix.
 The description comes from the DEFINITION line:
 
+%cont-doctest
 \begin{minted}{pycon}
 >>> record.id
 'NC_005816.1'
 >>> record.name
 'NC_005816'
 >>> record.description
-'Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence.'
+'Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence'
 \end{minted}
 
 GenBank files don't have any per-letter annotations:
 
+%cont-doctest
 \begin{minted}{pycon}
 >>> record.letter_annotations
 {}
@@ -254,25 +256,28 @@ GenBank files don't have any per-letter annotations:
 
 Most of the annotations information gets recorded in the \verb|annotations| dictionary, for example:
 
+%cont-doctest
 \begin{minted}{pycon}
 >>> len(record.annotations)
-11
+13
 >>> record.annotations["source"]
 'Yersinia pestis biovar Microtus str. 91001'
 \end{minted}
 
 The \verb|dbxrefs| list gets populated from any PROJECT or DBLINK lines:
 
+%cont-doctest
 \begin{minted}{pycon}
 >>> record.dbxrefs
-['Project:10638']
+['Project:58037']
 \end{minted}
 
 Finally, and perhaps most interestingly, all the entries in the features table (e.g. the genes or CDS features) get recorded as \verb|SeqFeature| objects in the \verb|features| list.
 
+%cont-doctest
 \begin{minted}{pycon}
 >>> len(record.features)
-29
+41
 \end{minted}
 
 \noindent We'll talk about \verb|SeqFeature| objects next, in

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -144,6 +144,7 @@ Now, let's have a look at the key attributes of this \verb|SeqRecord|
 individually -- starting with the \verb|seq| attribute which gives you a
 \verb|Seq| object:
 
+%cont-doctest
 \begin{minted}{pycon}
 >>> record.seq
 Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG')
@@ -156,13 +157,14 @@ your FASTA file contains, you can tell \verb|Bio.SeqIO| which alphabet to use
 
 Next, the identifiers and description:
 
+%cont-doctest
 \begin{minted}{pycon}
 >>> record.id
 'gi|45478711|ref|NC_005816.1|'
 >>> record.name
 'gi|45478711|ref|NC_005816.1|'
 >>> record.description
-'gi|45478711|ref|NC_005816.1| Yersinia pestis biovar Microtus ... pPCP1, complete sequence'
+'gi|45478711|ref|NC_005816.1| Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence'
 \end{minted}
 
 As you can see above, the first word of the FASTA record's title line (after

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -709,7 +709,6 @@ SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG'
 41
 \end{minted}
 
-
 For this example we're going to focus in on the \verb|pim| gene, \verb|YP_pPCP05|.
 If you have a look at the GenBank file directly you'll find this gene/CDS has
 location string \texttt{4343..4780}, or in Python counting \texttt{4342:4780}.
@@ -749,14 +748,8 @@ gene/CDS), and see how many features we get:
 %cont-doctest
 \begin{minted}{pycon}
 >>> sub_record = record[4300:4800]
-\end{minted}
-%TODO - Line wrapping for doctest?
-\begin{minted}{pycon}
 >>> sub_record
-SeqRecord(seq=Seq('ATAAATAGATTATTCCAAATAATTTATTTATGTAAGAACAGGATGGGAGGGGGA...TTA',
-IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
-description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence.',
-dbxrefs=[])
+SeqRecord(seq=Seq('ATAAATAGATTATTCCAAATAATTTATTTATGTAAGAACAGGATGGGAGGGGGA...TTA'), id='NC_005816.1', name='NC_005816', description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence', dbxrefs=[])
 \end{minted}
 
 %cont-doctest
@@ -779,9 +772,6 @@ qualifiers:
     Key: gene, Value: ['pim']
     Key: locus_tag, Value: ['YP_pPCP05']
 <BLANKLINE>
-\end{minted}
-%As above, output is truncated so cannot test this as a doctest:
-\begin{minted}{pycon}
 >>> print(sub_record.features[1])
 type: CDS
 location: [42:480](+)
@@ -790,11 +780,12 @@ qualifiers:
     Key: db_xref, Value: ['GI:45478716', 'GeneID:2767712']
     Key: gene, Value: ['pim']
     Key: locus_tag, Value: ['YP_pPCP05']
-    Key: note, Value: ['similar to many previously sequenced pesticin immunity ...']
+    Key: note, Value: ['similar to many previously sequenced pesticin immunity protein entries of Yersinia pestis plasmid pPCP, e.g. gi| 16082683|,ref|NP_395230.1| (NC_003132) , gi|1200166|emb|CAA90861.1| (Z54145 ) , gi|1488655| emb|CAA63439.1| (X92856) , gi|2996219|gb|AAC62543.1| (AF053945) , and gi|5763814|emb|CAB531 67.1| (AL109969)']
     Key: product, Value: ['pesticin immunity protein']
     Key: protein_id, Value: ['NP_995571.1']
     Key: transl_table, Value: ['11']
-    Key: translation, Value: ['MGGGMISKLFCLALIFLSSSGLAEKNTYTAKDILQNLELNTFGNSLSH...']
+    Key: translation, Value: ['MGGGMISKLFCLALIFLSSSGLAEKNTYTAKDILQNLELNTFGNSLSHGIYGKQTTFKQTEFTNIKSNTKKHIALINKDNSWMISLKILGIKRDEYTVCFEDFSLIRPPTYVAIHPLLIKKVKSGNFIVVKEIKKSIPGCTVYYH']
+<BLANKLINE>
 \end{minted}
 
 \noindent Notice that their locations have been adjusted to reflect the new parent sequence!

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -132,15 +132,12 @@ Back in Chapter~\ref{chapter:quick_start} you will have seen the function \verb|
 used to loop over all the records in a file as \verb|SeqRecord| objects. The \verb|Bio.SeqIO| module
 has a sister function for use on files which contain just one record which we'll use here (see Chapter~\ref{chapter:seqio} for details):
 
-%TODO - line wrapping for doctest?
-\begin{minted}{pycon}
+%doctest ../Tests/GenBank
+\begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.fna", "fasta")
 >>> record
-SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG'),
-id='gi|45478711|ref|NC_005816.1|', name='gi|45478711|ref|NC_005816.1|',
-description='gi|45478711|ref|NC_005816.1| Yersinia pestis biovar Microtus ... sequence',
-dbxrefs=[])
+SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG'), id='gi|45478711|ref|NC_005816.1|', name='gi|45478711|ref|NC_005816.1|', description='gi|45478711|ref|NC_005816.1| Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence', dbxrefs=[])
 \end{minted}
 
 Now, let's have a look at the key attributes of this \verb|SeqRecord|

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -654,32 +654,31 @@ The \verb|format()| method of the \verb|SeqRecord| class gives a string
 containing your record formatted using one of the output file formats
 supported by \verb|Bio.SeqIO|, such as FASTA:
 
-\begin{minted}{python}
-from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
-from Bio.Alphabet import generic_protein
-
-record = SeqRecord(
-    Seq(
-        "MMYQQGCFAGGTVLRLAKDLAENNRGARVLVVCSEITAVTFRGPSETHLDSMVGQALFGD"
-        "GAGAVIVGSDPDLSVERPLYELVWTGATLLPDSEGAIDGHLREVGLTFHLLKDVPGLISK"
-        "NIEKSLKEAFTPLGISDWNSTFWIAHPGGPAILDQVEAKLGLKEEKMRATREVLSEYGNM"
-        "SSAC",
-        generic_protein,
-    ),
-    id="gi|14150838|gb|AAK54648.1|AF376133_1",
-    description="chalcone synthase [Cucumis sativus]",
-)
-
-print(record.format("fasta"))
+%doctest
+\begin{minted}{pycon}
+>>> from Bio.Seq import Seq
+>>> from Bio.SeqRecord import SeqRecord
+>>> record = SeqRecord(
+...     Seq(
+...         "MMYQQGCFAGGTVLRLAKDLAENNRGARVLVVCSEITAVTFRGPSETHLDSMVGQALFGD"
+...         "GAGAVIVGSDPDLSVERPLYELVWTGATLLPDSEGAIDGHLREVGLTFHLLKDVPGLISK"
+...         "NIEKSLKEAFTPLGISDWNSTFWIAHPGGPAILDQVEAKLGLKEEKMRATREVLSEYGNM"
+...         "SSAC"
+...     ),
+...     id="gi|14150838|gb|AAK54648.1|AF376133_1",
+...     description="chalcone synthase [Cucumis sativus]",
+... )
+>>> print(record.format("fasta"))
 \end{minted}
 \noindent which should give:
-\begin{minted}{text}
+%cont-doctest
+\begin{minted}{pycon}
 >gi|14150838|gb|AAK54648.1|AF376133_1 chalcone synthase [Cucumis sativus]
 MMYQQGCFAGGTVLRLAKDLAENNRGARVLVVCSEITAVTFRGPSETHLDSMVGQALFGD
 GAGAVIVGSDPDLSVERPLYELVWTGATLLPDSEGAIDGHLREVGLTFHLLKDVPGLISK
 NIEKSLKEAFTPLGISDWNSTFWIAHPGGPAILDQVEAKLGLKEEKMRATREVLSEYGNM
 SSAC
+<BLANKLINE>
 \end{minted}
 
 This \verb|format| method takes a single mandatory argument, a lower case string which is
@@ -702,18 +701,8 @@ For example, taking the same GenBank file used earlier:
 \begin{minted}{pycon}
 >>> from Bio import SeqIO
 >>> record = SeqIO.read("NC_005816.gb", "genbank")
-\end{minted}
-%TODO - support line wrapping in doctest
-\begin{minted}{pycon}
 >>> record
-SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG',
-IUPACAmbiguousDNA()), id='NC_005816.1', name='NC_005816',
-description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence',
-dbxrefs=['Project:58037'])
-\end{minted}
-
-%cont-doctest
-\begin{minted}{pycon}
+SeqRecord(seq=Seq('TGTAACGAACGGTGCAATAGTGATCCACACCCAACGCCTGAAATCAGATCCAGG...CTG'), id='NC_005816.1', name='NC_005816', description='Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, complete sequence', dbxrefs=['Project:58037'])
 >>> len(record)
 9609
 >>> len(record.features)

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -106,9 +106,10 @@ for latex in os.listdir(os.path.join(tutorial_base, "Tutorial/")):
 def _extract(handle):
     line = handle.readline()
     if line != "\\begin{minted}{pycon}\n":
-        raise ValueError(
-            "Any '%doctest' or '%cont-doctest' line should be followed by '\\begin{minted}{pycon}'"
-        )
+        if not (line.startswith("\\begin{minted}[") and line.endswith("]{pycon}\n")):
+            raise ValueError(
+                "Any '%doctest' or '%cont-doctest' line should be followed by '\\begin{minted}{pycon}' or '\\begin{minted}[options]{pycon}'"
+            )
     lines = []
     while True:
         line = handle.readline()


### PR DESCRIPTION
This pull request adds doctests and removes alphabets from chapter_seq_annot

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
