### PR TITLE
remove alphabet from quickstart

### DIFF
--- a/Doc/Tutorial/chapter_quick_start.tex
+++ b/Doc/Tutorial/chapter_quick_start.tex
@@ -92,18 +92,18 @@ AATCCGGAGGACCGGTGTACTCAGCTCACCGGGGGCATTGCTCCCGTGGTGACCCTGATTTGTTGTTGGG
 
 It contains 94 records, each has a line starting with ``\verb+>+'' (greater-than symbol) followed by the sequence on one or more lines.  Now try this in Python:
 
-\begin{minted}{python}
-from Bio import SeqIO
-
-for seq_record in SeqIO.parse("ls_orchid.fasta", "fasta"):
-    print(seq_record.id)
-    print(repr(seq_record.seq))
-    print(len(seq_record))
+\begin{minted}{pycon}
+>>> from Bio import SeqIO
+>>> for seq_record in SeqIO.parse("ls_orchid.fasta", "fasta"):
+...     print(seq_record.id)
+...     print(repr(seq_record.seq))
+...     print(len(seq_record))
+...
 \end{minted}
 
 \noindent You should get something like this on your screen:
 
-\begin{minted}{text}
+\begin{minted}{pycon}
 gi|2765658|emb|Z78533.1|CIZ78533
 Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGATGAGACCGTGG...CGC')
 740
@@ -117,28 +117,28 @@ Seq('CATTGTTGAGATCACATAATAATTGATCGAGTTAATCTGGAGGATCTGTTTACT...GCC')
 
 Now let's load the GenBank file \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/ls_orchid.gbk}{ls\_orchid.gbk} instead - notice that the code to do this is almost identical to the snippet used above for the FASTA file - the only difference is we change the filename and the format string:
 
-\begin{minted}{python}
-from Bio import SeqIO
-
-for seq_record in SeqIO.parse("ls_orchid.gbk", "genbank"):
-    print(seq_record.id)
-    print(repr(seq_record.seq))
-    print(len(seq_record))
+\begin{minted}{pycon}
+>>> from Bio import SeqIO
+>>> for seq_record in SeqIO.parse("ls_orchid.gbk", "genbank"):
+...     print(seq_record.id)
+...     print(repr(seq_record.seq))
+...     print(len(seq_record))
+...
 \end{minted}
 
 \noindent This should give:
 
-\begin{minted}{text}
+\begin{minted}{pycon}
 Z78533.1
-Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGATGAGACCGTGG...CGC', IUPACAmbiguousDNA())
+Seq('CGTAACAAGGTTTCCGTAGGTGAACCTGCGGAAGGATCATTGATGAGACCGTGG...CGC')
 740
 ...
 Z78439.1
-Seq('CATTGTTGAGATCACATAATAATTGATCGAGTTAATCTGGAGGATCTGTTTACT...GCC', IUPACAmbiguousDNA())
+Seq('CATTGTTGAGATCACATAATAATTGATCGAGTTAATCTGGAGGATCTGTTTACT...GCC')
 592
 \end{minted}
 
-This time \verb|Bio.SeqIO| has been able to choose a sensible alphabet, IUPAC Ambiguous DNA.  You'll also notice that a shorter string has been used as the \verb|seq_record.id| in this case.
+You'll notice that a shorter string has been used as the \verb|seq_record.id| in this case.
 
 \subsection{I love parsing -- please don't stop talking about it!}
 


### PR DESCRIPTION
This pull request removes alphabets from the quick start chapter in the documentation.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
