### PR TITLE
Fix positional argument to UnknownSeq translate method

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1704,7 +1704,9 @@ class UnknownSeq(Seq):
         """
         return UnknownSeq(self._length, self.alphabet._lower(), self._character.lower())
 
-    def translate(self, **kwargs):
+    def translate(
+        self, table="Standard", stop_symbol="*", to_stop=False, cds=False, gap="-"
+    ):
         """Translate an unknown nucleotide sequence into an unknown protein.
 
         e.g.

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -793,6 +793,9 @@ class StringMethodTests(unittest.TestCase):
                 if str(e) == "Proteins cannot be translated!":
                     continue
                 raise
+            # Try with positional vs named argument:
+            self.assertEqual(example1.translate(11), example1.translate(table=11))
+
             # This is based on the limited example not having stop codons:
             if tran.alphabet not in [extended_protein, protein, generic_protein]:
                 print(tran.alphabet)
@@ -884,7 +887,8 @@ class StringMethodTests(unittest.TestCase):
                             self.assertEqual(values, set("*"))
                         elif t == "X":
                             self.assertGreater(
-                                len(values), 1,
+                                len(values),
+                                1,
                                 "translate('%s') = '%s' not '%s'"
                                 % (c1 + c2 + c3, t, ",".join(values)),
                             )


### PR DESCRIPTION
Copying the Seq object signature is the simplest fix for the following:

```pycon
>>> from Bio.Seq import UnknownSeq
>>> UnknownSeq(6).translate()
UnknownSeq(2, character='X')
>>> UnknownSeq(6).translate(table=11)
UnknownSeq(2, character='X')
>>> UnknownSeq(6).translate(11)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: translate() takes 1 positional argument but 2 were given
```

(This is a precursor to a planned PR to support Python string style translate as well as biological translate)

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
