### PR TITLE
remove alphabets from Introduction

### DIFF
--- a/Doc/Tutorial/chapter_introduction.tex
+++ b/Doc/Tutorial/chapter_introduction.tex
@@ -176,8 +176,7 @@ file for other options.
   \item \emph{What is wrong with my sequence comparisons?} \\
   There was a major change in Biopython 1.65 making the \verb|Seq| and
   \verb|MutableSeq| classes (and subclasses) use simple string-based
-  comparison (ignoring the alphabet other than if giving a warning),
-  which you can do explicitly with \verb|str(seq1) == str(seq2)|.
+  comparison which you can do explicitly with \verb|str(seq1) == str(seq2)|.
 
   Older versions of Biopython would use instance-based comparison
   for \verb|Seq| objects which you can do explicitly with
@@ -185,10 +184,6 @@ file for other options.
 
   If you still need to support old versions of Biopython, use these
   explicit forms to avoid problems. See Section~\ref{sec:seq-comparison}.
-
-  \item \emph{Why is the} \verb|Seq| \emph{object missing the upper \& lower methods described in this Tutorial?} \\
-  You need Biopython 1.53 or later.  Alternatively, use \verb|str(my_seq).upper()| to get an upper case string.
-  If you need a Seq object, try \verb|Seq(str(my_seq).upper())| but be careful about blindly re-using the same alphabet.
 
   \item \emph{What file formats do} \verb|Bio.SeqIO| \emph{and} \verb|Bio.AlignIO| \emph{read and write?} \\
   Check the built in docstrings (\texttt{from Bio import SeqIO}, then \texttt{help(SeqIO)}), or see \url{http://biopython.org/wiki/SeqIO} and \url{http://biopython.org/wiki/AlignIO} on the wiki for the latest listing.


### PR DESCRIPTION
This pull request removes alphabets from the Introduction in the tutorial

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
