### PR TITLE
Drop Seq alphabet addition and comparison warnings

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -155,9 +155,6 @@ class Seq:
         Python language, hashes and dictionary support), Biopython now uses
         simple string comparison (with a warning about the change).
 
-        Note that incompatible alphabets (e.g. DNA to RNA) will trigger a
-        warning.
-
         If you still need to support releases prior to Biopython 1.65, please
         just do explicit comparisons:
 
@@ -181,23 +178,10 @@ class Seq:
         True
 
         """
-        if hasattr(other, "alphabet"):
-            # other could be a Seq or a MutableSeq
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                warnings.warn(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
-                    BiopythonWarning,
-                )
         return str(self) == str(other)
 
     def __lt__(self, other):
         """Implement the less-than operand."""
-        if hasattr(other, "alphabet"):
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                warnings.warn(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
-                    BiopythonWarning,
-                )
         if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
             return str(self) < str(other)
         raise TypeError(
@@ -207,12 +191,6 @@ class Seq:
 
     def __le__(self, other):
         """Implement the less-than or equal operand."""
-        if hasattr(other, "alphabet"):
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                warnings.warn(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
-                    BiopythonWarning,
-                )
         if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
             return str(self) <= str(other)
         raise TypeError(
@@ -222,12 +200,6 @@ class Seq:
 
     def __gt__(self, other):
         """Implement the greater-than operand."""
-        if hasattr(other, "alphabet"):
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                warnings.warn(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
-                    BiopythonWarning,
-                )
         if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
             return str(self) > str(other)
         raise TypeError(
@@ -237,12 +209,6 @@ class Seq:
 
     def __ge__(self, other):
         """Implement the greater-than or equal operand."""
-        if hasattr(other, "alphabet"):
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                warnings.warn(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
-                    BiopythonWarning,
-                )
         if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
             return str(self) >= str(other)
         raise TypeError(
@@ -1890,19 +1856,14 @@ class MutableSeq:
         return "".join(self.data)
 
     def __eq__(self, other):
-        """Compare the sequence to another sequence or a string (README).
+        """Compare the sequence to another sequence or a string.
 
-        Currently if compared to another sequence the alphabets must be
-        compatible. Comparing DNA to RNA, or Nucleotide to Protein will raise
-        an exception. Otherwise only the sequence itself is compared, not the
-        precise alphabet.
+        Historically comparing DNA to RNA, or Nucleotide to Protein would
+        raise an exception. This was later downgraded to a warning, but since
+        Biopython 1.78 the alphabet is ignored for comparisons.
 
-        A future release of Biopython will change this (and the Seq object etc)
-        to use simple string comparison. The plan is that comparing sequences
-        with incompatible alphabets (e.g. DNA to RNA) will trigger a warning
-        but not an exception.
-
-        During this transition period, please just do explicit comparisons:
+        If you need to support older Biopython versions, please just do
+        explicit comparisons:
 
         >>> seq1 = MutableSeq("ACGT")
         >>> seq2 = MutableSeq("ACGT")
@@ -1921,26 +1882,14 @@ class MutableSeq:
         True
 
         """
-        if hasattr(other, "alphabet"):
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                warnings.warn(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
-                    BiopythonWarning,
-                )
-            if isinstance(other, MutableSeq):
-                return self.data == other.data
+        if isinstance(other, MutableSeq):
+            return self.data == other.data
         return str(self) == str(other)
 
     def __lt__(self, other):
         """Implement the less-than operand."""
-        if hasattr(other, "alphabet"):
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                warnings.warn(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
-                    BiopythonWarning,
-                )
-            if isinstance(other, MutableSeq):
-                return self.data < other.data
+        if isinstance(other, MutableSeq):
+            return self.data < other.data
         if isinstance(other, (str, Seq, UnknownSeq)):
             return str(self) < str(other)
         raise TypeError(
@@ -1950,14 +1899,8 @@ class MutableSeq:
 
     def __le__(self, other):
         """Implement the less-than or equal operand."""
-        if hasattr(other, "alphabet"):
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                warnings.warn(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
-                    BiopythonWarning,
-                )
-            if isinstance(other, MutableSeq):
-                return self.data <= other.data
+        if isinstance(other, MutableSeq):
+            return self.data <= other.data
         if isinstance(other, (str, Seq, UnknownSeq)):
             return str(self) <= str(other)
         raise TypeError(
@@ -1967,14 +1910,8 @@ class MutableSeq:
 
     def __gt__(self, other):
         """Implement the greater-than operand."""
-        if hasattr(other, "alphabet"):
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                warnings.warn(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
-                    BiopythonWarning,
-                )
-            if isinstance(other, MutableSeq):
-                return self.data > other.data
+        if isinstance(other, MutableSeq):
+            return self.data > other.data
         if isinstance(other, (str, Seq, UnknownSeq)):
             return str(self) > str(other)
         raise TypeError(
@@ -1984,14 +1921,8 @@ class MutableSeq:
 
     def __ge__(self, other):
         """Implement the greater-than or equal operand."""
-        if hasattr(other, "alphabet"):
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                warnings.warn(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}",
-                    BiopythonWarning,
-                )
-            if isinstance(other, MutableSeq):
-                return self.data >= other.data
+        if isinstance(other, MutableSeq):
+            return self.data >= other.data
         if isinstance(other, (str, Seq, UnknownSeq)):
             return str(self) >= str(other)
         raise TypeError(

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -278,36 +278,31 @@ class Seq:
         >>> Seq("MELKI", generic_protein) + "LV"
         Seq('MELKILV')
 
-        When adding two Seq (like) objects, the alphabets are important.
-
-        You can't add RNA and DNA sequences:
+        When adding two Seq (like) objects, if they share the
+        same alphabet it is preserved, but otherwise discarded.
+        This means you can add RNA and DNA, or nucleotide and
+        protein if you really want to. This is a change as of
+        Biopython 1.78, this previously raised a TypeError:
 
         >>> from Bio.Alphabet import generic_dna, generic_rna
         >>> Seq("ACGT", generic_dna) + Seq("ACGU", generic_rna)
-        Traceback (most recent call last):
-           ...
-        TypeError: Incompatible alphabets DNAAlphabet() and RNAAlphabet()
-
-        You can't add nucleotide and protein sequences:
+        Seq('ACGTACGU')
 
         >>> from Bio.Alphabet import generic_dna, generic_protein
         >>> Seq("ACGT", generic_dna) + Seq("MELKI", generic_protein)
-        Traceback (most recent call last):
-           ...
-        TypeError: Incompatible alphabets DNAAlphabet() and ProteinAlphabet()
+        Seq('ACGTMELKI')
         """
         if hasattr(other, "alphabet"):
-            # other should be a Seq or a MutableSeq
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                raise TypeError(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}"
-                )
-            # They should be the same sequence type (or one of them is generic)
-            a = Alphabet._consensus_alphabet([self.alphabet, other.alphabet])
-            return self.__class__(str(self) + str(other), a)
+            if other.alphabet == self.alphabet:
+                # Perfect match, preserve the alphabet
+                return self.__class__(str(self) + str(other), self.alphabet)
+            else:
+                # Discard the alphabet
+                return self.__class__(str(self) + str(other))
         elif isinstance(other, str):
             # other is a plain string - use the current alphabet
             return self.__class__(str(self) + other, self.alphabet)
+
         from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
 
         if isinstance(other, SeqRecord):
@@ -329,14 +324,12 @@ class Seq:
         Adding two Seq (like) objects is handled via the __add__ method.
         """
         if hasattr(other, "alphabet"):
-            # other should be a Seq or a MutableSeq
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                raise TypeError(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}"
-                )
-            # They should be the same sequence type (or one of them is generic)
-            a = Alphabet._consensus_alphabet([self.alphabet, other.alphabet])
-            return self.__class__(str(other) + str(self), a)
+            if other.alphabet == self.alphabet:
+                # Perfect match, preserve the alphabet
+                return self.__class__(str(other) + str(self), self.alphabet)
+            else:
+                # Discard the alphabet
+                return self.__class__(str(other) + str(self))
         elif isinstance(other, str):
             # other is a plain string - use the current alphabet
             return self.__class__(other + str(self), self.alphabet)
@@ -1217,14 +1210,11 @@ class Seq:
 
         a = self.alphabet
         if isinstance(other, (Seq, MutableSeq, UnknownSeq)):
-            if a != other.alphabet:
-                if not Alphabet._check_type_compatible([a, other.alphabet]):
-                    raise TypeError(
-                        f"Incompatible alphabets {a!r} and {other.alphabet!r}"
-                    )
-                a = Alphabet._consensus_alphabet([a, other.alphabet])
-            # No point looping over the seq and checking the alphabet again...
-            return self.__class__(str(self).join(str(other)), a)
+            if a == other.alphabet:
+                return self.__class__(str(self).join(str(other)), a)
+            else:
+                # Drop the alphabet
+                return self.__class__(str(self).join(str(other)))
         if isinstance(other, SeqRecord):
             raise TypeError("Iterable cannot be a SeqRecord")
         for c in other:
@@ -1232,14 +1222,11 @@ class Seq:
                 raise TypeError("Iterable cannot contain SeqRecords")
             elif hasattr(c, "alphabet"):
                 if a != c.alphabet:
-                    if not Alphabet._check_type_compatible([a, c.alphabet]):
-                        raise TypeError(
-                            f"Incompatible alphabets {a!r} and {c.alphabet!r}"
-                        )
-                    a = Alphabet._consensus_alphabet([a, c.alphabet])
+                    # Drop the alphabet
+                    a = Alphabet.generic_alphabet
             elif not isinstance(c, str):
                 raise TypeError("Input must be an iterable of Seqs or Strings")
-        temp_data = str(self).join([str(z) for z in other])
+        temp_data = str(self).join([str(_) for _ in other])
         return self.__class__(temp_data, a)
 
 
@@ -1806,11 +1793,7 @@ class UnknownSeq(Seq):
         a = self.alphabet
         if isinstance(other, (Seq, MutableSeq)):
             if a != other.alphabet:
-                if not Alphabet._check_type_compatible([a, other.alphabet]):
-                    raise TypeError(
-                        f"Incompatible alphabets {a!r} and {other.alphabet!r}"
-                    )
-                a = Alphabet._consensus_alphabet([a, other.alphabet])
+                a = Alphabet.generic_alphabet
             if isinstance(other, UnknownSeq) and self._character == other._character:
                 # Special case, can return an UnknownSeq
                 return self.__class__(
@@ -1827,11 +1810,7 @@ class UnknownSeq(Seq):
                 raise TypeError("Iterable cannot contain SeqRecords")
             elif hasattr(c, "alphabet"):
                 if a != c.alphabet:
-                    if not Alphabet._check_type_compatible([a, c.alphabet]):
-                        raise TypeError(
-                            f"Incompatible alphabets {a!r} and {c.alphabet!r}"
-                        )
-                    a = Alphabet._consensus_alphabet([a, c.alphabet])
+                    a = Alphabet.generic_alphabet
                 if not isinstance(c, UnknownSeq):
                     type_is_unknown = False
             elif isinstance(c, str):
@@ -2074,14 +2053,11 @@ class MutableSeq:
 
         Returns a new MutableSeq object.
         """
+        a = self.alphabet
         if hasattr(other, "alphabet"):
-            # other should be a Seq or a MutableSeq
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                raise TypeError(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}"
-                )
-            # They should be the same sequence type (or one of them is generic)
-            a = Alphabet._consensus_alphabet([self.alphabet, other.alphabet])
+            if a != other.alphabet:
+                # Drop alphabet unless agree
+                a = Alphabet.generic_alphabet
             if isinstance(other, MutableSeq):
                 # See test_GAQueens.py for an historic usage of a non-string
                 # alphabet!  Adding the arrays should support this.
@@ -2090,7 +2066,7 @@ class MutableSeq:
                 return self.__class__(str(self) + str(other), a)
         elif isinstance(other, str):
             # other is a plain string - use the current alphabet
-            return self.__class__(str(self) + str(other), self.alphabet)
+            return self.__class__(str(self) + str(other), a)
         else:
             raise TypeError
 
@@ -2102,14 +2078,10 @@ class MutableSeq:
         >>> "LV" + MutableSeq("MELKI", generic_protein)
         MutableSeq('LVMELKI')
         """
+        a = self.alphabet
         if hasattr(other, "alphabet"):
-            # other should be a Seq or a MutableSeq
-            if not Alphabet._check_type_compatible([self.alphabet, other.alphabet]):
-                raise TypeError(
-                    f"Incompatible alphabets {self.alphabet!r} and {other.alphabet!r}"
-                )
-            # They should be the same sequence type (or one of them is generic)
-            a = Alphabet._consensus_alphabet([self.alphabet, other.alphabet])
+            if a != other.alphabet:
+                a = Alphabet.generic_alphabet
             if isinstance(other, MutableSeq):
                 # See test_GAQueens.py for an historic usage of a non-string
                 # alphabet!  Adding the arrays should support this.

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -210,7 +210,10 @@ writing FASTA format sequence files is covered in Chapter~\ref{chapter:seqio}.
 
 \section{Concatenating or adding sequences}
 
-Naturally, you can in principle add any two Seq objects together - just like you can with Python strings to concatenate them.  However, you can't add sequences with incompatible alphabets, such as a protein sequence and a DNA sequence:
+As of Biopython 1.78, you can add any two Seq objects together.
+Any conflicting alphabet attribute will be dropped. This is a
+change in behaviour as older releases would raise a \verb|TypeError|
+for things like adding DNA and protein.
 
 %doctest
 \begin{minted}{pycon}
@@ -219,39 +222,10 @@ Naturally, you can in principle add any two Seq objects together - just like you
 >>> protein_seq = Seq("EVRNAK", generic_protein)
 >>> dna_seq = Seq("ACGT", generic_dna)
 >>> protein_seq + dna_seq
-Traceback (most recent call last):
-...
-TypeError: Incompatible alphabets ProteinAlphabet() and DNAAlphabet()
-\end{minted}
-
-If you \emph{really} wanted to do this, you'd have to first give both sequences generic alphabets (the default):
-
-%cont-doctest
-\begin{minted}{pycon}
->>> from Bio.Alphabet import generic_alphabet
->>> protein_seq.alphabet = generic_alphabet
->>> dna_seq.alphabet = generic_alphabet
->>> protein_seq + dna_seq
 Seq('EVRNAKACGT')
 \end{minted}
 
-Here is an example of adding a nucleotide sequence to a DNA sequence,
-resulting in a nucleotide sequence:
-
-%doctest
-\begin{minted}{pycon}
->>> from Bio.Seq import Seq
->>> from Bio.Alphabet import generic_nucleotide
->>> from Bio.Alphabet import generic_dna
->>> nuc_seq = Seq("GATCGATGC", generic_nucleotide)
->>> dna_seq = Seq("ACGT", generic_dna)
->>> nuc_seq
-Seq('GATCGATGC')
->>> dna_seq
-Seq('ACGT')
->>> nuc_seq + dna_seq
-Seq('GATCGATGCACGT')
-\end{minted}
+Deliberately mixing DNA and protein like this is likely a mistake though...
 
 You may often have many sequences to add together, which can be done with a for loop like this:
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -940,52 +940,54 @@ class StringMethodTests(unittest.TestCase):
         self.assertRaises(TypeError, spacer.join, 5)
         self.assertRaises(TypeError, spacer.join, ["ATG", "ATG", 5, "ATG"])
 
-    def test_join_Seq_TypeError_alpha(self):
-        """Checks that a TypeError is thrown for incompatible alphabets."""
+    def test_join_Seq_mixed_alpha(self):
+        """Check Seq can join incompatible alphabets."""
         spacer = Seq("NNNNN", generic_dna)
-        self.assertRaises(
-            TypeError,
-            spacer.join,
-            [Seq("NNNNN", generic_rna), Seq("NNNNN", generic_rna)],
+        self.assertEqual(
+            "N" * 15,
+            spacer.join([Seq("NNNNN", generic_rna), Seq("NNNNN", generic_rna)]),
         )
-        self.assertRaises(
-            TypeError,
-            spacer.join,
-            [Seq("NNNNN", generic_protein), Seq("NNNNN", generic_protein)],
+        self.assertEqual(
+            "N" * 15,
+            spacer.join([Seq("NNNNN", generic_protein), Seq("NNNNN", generic_protein)]),
         )
 
-    def test_join_UnknownSeq_TypeError_alpha(self):
-        """Checks that a TypeError is thrown for incompatible alphabets."""
+    def test_join_UnknownSeq_mixed_alpha(self):
+        """Check UnknownSeq can join incompatible alphabets."""
         spacer = UnknownSeq(5, character="-", alphabet=generic_dna)
-        self.assertRaises(
-            TypeError,
-            spacer.join,
-            [
-                UnknownSeq(5, character="-", alphabet=generic_rna),
-                UnknownSeq(5, character="-", alphabet=generic_rna),
-            ],
+        self.assertEqual(
+            "-" * 15,
+            spacer.join(
+                [
+                    UnknownSeq(5, character="-", alphabet=generic_rna),
+                    UnknownSeq(5, character="-", alphabet=generic_rna),
+                ]
+            ),
         )
-        self.assertRaises(
-            TypeError,
-            spacer.join,
-            [
-                Seq("NNNNN", generic_protein),
-                UnknownSeq(5, character="-", alphabet=generic_protein),
-            ],
+        self.assertEqual(
+            "N" * 5 + "-" * 10,
+            spacer.join(
+                [
+                    Seq("NNNNN", generic_protein),
+                    UnknownSeq(5, character="-", alphabet=generic_protein),
+                ]
+            ),
         )
 
-    def test_join_MutableSeq_TypeError(self):
-        """Checks that a TypeError is thrown for incompatible alphabets."""
+    def test_join_MutableSeq_mixed(self):
+        """Check MutableSeq can join incompatible alphabets."""
         spacer = MutableSeq("NNNNN", generic_dna)
-        self.assertRaises(
-            TypeError,
-            spacer.join,
-            [MutableSeq("NNNNN", generic_rna), MutableSeq("NNNNN", generic_rna)],
+        self.assertEqual(
+            "N" * 15,
+            spacer.join(
+                [MutableSeq("NNNNN", generic_rna), MutableSeq("NNNNN", generic_rna)]
+            ),
         )
         self.assertRaises(
             TypeError,
-            spacer.join,
-            [Seq("NNNNN", generic_protein), MutableSeq("NNNNN", generic_protein)],
+            spacer.join(
+                [Seq("NNNNN", generic_protein), MutableSeq("NNNNN", generic_protein)]
+            ),
         )
 
     def test_join_Seq(self):
@@ -1006,7 +1008,6 @@ class StringMethodTests(unittest.TestCase):
         for spacer in spacers:
             seq_concatenated = spacer.join(example_strings_seqs)
             self.assertEqual(str(seq_concatenated), str(spacer).join(example_strings))
-            self.assertEqual(seq_concatenated.alphabet, spacer.alphabet)
             # Now try single sequence arguments, should join the letters
             for target in example_strings + example_strings_seqs:
                 self.assertEqual(
@@ -1058,7 +1059,6 @@ class StringMethodTests(unittest.TestCase):
         for spacer in spacers:
             seq_concatenated = spacer.join(example_strings_seqs)
             self.assertEqual(str(seq_concatenated), str(spacer).join(example_strings))
-            self.assertEqual(seq_concatenated.alphabet, spacer.alphabet)
             # Now try single sequence arguments, should join the letters
             for target in example_strings + example_strings_seqs:
                 self.assertEqual(
@@ -1109,7 +1109,6 @@ class StringMethodTests(unittest.TestCase):
         for spacer in spacers:
             seq_concatenated = spacer.join(example_strings_seqs)
             self.assertEqual(str(seq_concatenated), str(spacer).join(example_strings))
-            self.assertEqual(seq_concatenated.alphabet, spacer.alphabet)
 
     def test_join_MutableSeq_with_file(self):
         """Checks if MutableSeq join correctly concatenates sequence from a file with the spacer."""

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -193,13 +193,6 @@ class TestSeqStringMethods(unittest.TestCase):
         with warnings.catch_warnings(record=True):
             hash(self.s)
 
-    def test_equal_comparison_of_incompatible_alphabets(self):
-        """Test __eq__ comparison method."""
-        with warnings.catch_warnings(record=True):
-            Seq.Seq("TCAAAA", IUPAC.ambiguous_dna) == Seq.Seq(
-                "TCAAAA", IUPAC.ambiguous_rna
-            )
-
     def test_not_equal_comparsion(self):
         """Test __ne__ comparison method."""
         self.assertNotEqual(
@@ -211,13 +204,6 @@ class TestSeqStringMethods(unittest.TestCase):
         """Test __lt__ comparison method."""
         self.assertLess(self.s[:-1], self.s)
 
-    def test_less_than_comparison_of_incompatible_alphabets(self):
-        """Test incompatible alphabet __lt__ comparison method."""
-        seq1 = Seq.Seq("TCAAA", IUPAC.ambiguous_dna)
-        seq2 = Seq.Seq("UCAAAA", IUPAC.ambiguous_rna)
-        with self.assertWarns(BiopythonWarning):
-            self.assertLess(seq1, seq2)
-
     def test_less_than_comparison_of_incompatible_types(self):
         """Test incompatible types __lt__ comparison method."""
         with self.assertRaises(TypeError):
@@ -226,13 +212,6 @@ class TestSeqStringMethods(unittest.TestCase):
     def test_less_than_or_equal_comparison(self):
         """Test __le__ comparison method."""
         self.assertLessEqual(self.s, self.s)
-
-    def test_less_than_or_equal_comparison_of_incompatible_alphabets(self):
-        """Test incompatible alphabet __le__ comparison method."""
-        seq1 = Seq.Seq("TCAAA", IUPAC.ambiguous_dna)
-        seq2 = Seq.Seq("UCAAAA", IUPAC.ambiguous_rna)
-        with self.assertWarns(BiopythonWarning):
-            self.assertLessEqual(seq1, seq2)
 
     def test_less_than_or_equal_comparison_of_incompatible_types(self):
         """Test incompatible types __le__ comparison method."""
@@ -243,13 +222,6 @@ class TestSeqStringMethods(unittest.TestCase):
         """Test __gt__ comparison method."""
         self.assertGreater(self.s, self.s[:-1])
 
-    def test_greater_than_comparison_of_incompatible_alphabets(self):
-        """Test incompatible alphabet __gt__ comparison method."""
-        seq1 = Seq.Seq("TCAAA", IUPAC.ambiguous_dna)
-        seq2 = Seq.Seq("UCAAAA", IUPAC.ambiguous_rna)
-        with self.assertWarns(BiopythonWarning):
-            self.assertGreater(seq2, seq1)
-
     def test_greater_than_comparison_of_incompatible_types(self):
         """Test incompatible types __gt__ comparison method."""
         with self.assertRaises(TypeError):
@@ -258,13 +230,6 @@ class TestSeqStringMethods(unittest.TestCase):
     def test_greater_than_or_equal_comparison(self):
         """Test __ge__ comparison method."""
         self.assertGreaterEqual(self.s, self.s)
-
-    def test_greater_than_or_equal_comparison_of_incompatible_alphabets(self):
-        """Test incompatible alphabet __ge__ comparison method."""
-        seq1 = Seq.Seq("TCAAA", IUPAC.ambiguous_dna)
-        seq2 = Seq.Seq("UCAAAA", IUPAC.ambiguous_rna)
-        with self.assertWarns(BiopythonWarning):
-            self.assertGreaterEqual(seq2, seq1)
 
     def test_greater_than_or_equal_comparison_of_incompatible_types(self):
         """Test incompatible types __ge__ comparison method."""
@@ -279,10 +244,6 @@ class TestSeqStringMethods(unittest.TestCase):
         self.assertEqual(
             "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG", str(self.s.__radd__(self.s))
         )
-
-    def test_radd_method_using_incompatible_alphabets(self):
-        rna_seq = Seq.Seq("UCAAAA", IUPAC.ambiguous_rna)
-        self.assertEqual("UCAAAATCAAAAGGATGCATCATG", self.s.__radd__(rna_seq))
 
     def test_radd_method_using_wrong_object(self):
         with self.assertRaises(TypeError):
@@ -568,10 +529,6 @@ class TestMutableSeq(unittest.TestCase):
         """Test __eq__ comparison method."""
         self.assertEqual(self.mutable_s, "TCAAAAGGATGCATCATG")
 
-    def test_equal_comparison_of_incompatible_alphabets(self):
-        with self.assertWarns(BiopythonWarning):
-            self.mutable_s == MutableSeq("UCAAAAGGA", IUPAC.ambiguous_rna)
-
     def test_not_equal_comparison(self):
         """Test __ne__ comparison method."""
         self.assertNotEqual(self.mutable_s, "other thing")
@@ -579,10 +536,6 @@ class TestMutableSeq(unittest.TestCase):
     def test_less_than_comparison(self):
         """Test __lt__ comparison method."""
         self.assertLess(self.mutable_s[:-1], self.mutable_s)
-
-    def test_less_than_comparison_of_incompatible_alphabets(self):
-        with self.assertWarns(BiopythonWarning):
-            self.mutable_s[:-1] < MutableSeq("UCAAAAGGAUGCAUCAUG", IUPAC.ambiguous_rna)
 
     def test_less_than_comparison_of_incompatible_types(self):
         with self.assertRaises(TypeError):
@@ -595,10 +548,6 @@ class TestMutableSeq(unittest.TestCase):
         """Test __le__ comparison method."""
         self.assertLessEqual(self.mutable_s[:-1], self.mutable_s)
 
-    def test_less_than_or_equal_comparison_of_incompatible_alphabets(self):
-        with self.assertWarns(BiopythonWarning):
-            self.mutable_s[:-1] <= MutableSeq("UCAAAAGGAUGCAUCAUG", IUPAC.ambiguous_rna)
-
     def test_less_than_or_equal_comparison_of_incompatible_types(self):
         with self.assertRaises(TypeError):
             self.mutable_s <= 1
@@ -610,10 +559,6 @@ class TestMutableSeq(unittest.TestCase):
         """Test __gt__ comparison method."""
         self.assertGreater(self.mutable_s, self.mutable_s[:-1])
 
-    def test_greater_than_comparison_of_incompatible_alphabets(self):
-        with self.assertWarns(BiopythonWarning):
-            self.mutable_s[:-1] > MutableSeq("UCAAAAGGAUGCAUCAUG", IUPAC.ambiguous_rna)
-
     def test_greater_than_comparison_of_incompatible_types(self):
         with self.assertRaises(TypeError):
             self.mutable_s > 1
@@ -624,10 +569,6 @@ class TestMutableSeq(unittest.TestCase):
     def test_greater_than_or_equal_comparison(self):
         """Test __ge__ comparison method."""
         self.assertGreaterEqual(self.mutable_s, self.mutable_s)
-
-    def test_greater_than_or_equal_comparison_of_incompatible_alphabets(self):
-        with self.assertWarns(BiopythonWarning):
-            self.mutable_s[:-1] >= MutableSeq("UCAAAAGGAUGCAUCAUG", IUPAC.ambiguous_rna)
 
     def test_greater_than_or_equal_comparison_of_incompatible_types(self):
         with self.assertRaises(TypeError):

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -130,16 +130,15 @@ class TestSeq(unittest.TestCase):
         u = self.s + t
         self.assertEqual(str(self.s) + "T", str(u))
 
-    def test_concatenation_error(self):
+    def test_concatenation_mixed(self):
         """DNA Seq objects cannot be concatenated with Protein Seq objects."""
-        with self.assertRaises(TypeError):
-            self.s + Seq.Seq("T", IUPAC.protein)
+        self.assertEqual(self.s + Seq.Seq("T", IUPAC.protein), "TCAAAAGGATGCATCATGT")
 
     def test_concatenation_of_ambiguous_and_unambiguous_dna(self):
         """Concatenate Seq object with ambiguous and unambiguous DNA returns ambiguous Seq."""
         t = Seq.Seq("T", IUPAC.ambiguous_dna)
         u = self.s + t
-        self.assertEqual("IUPACAmbiguousDNA()", str(u.alphabet))
+        self.assertEqual(str(self.s) + "T", u)
 
     def test_ungap(self):
         self.assertEqual("ATCCCA", str(Seq.Seq("ATC-CCA").ungap("-")))
@@ -283,8 +282,7 @@ class TestSeqStringMethods(unittest.TestCase):
 
     def test_radd_method_using_incompatible_alphabets(self):
         rna_seq = Seq.Seq("UCAAAA", IUPAC.ambiguous_rna)
-        with self.assertRaises(TypeError):
-            self.s.__radd__(rna_seq)
+        self.assertEqual("UCAAAATCAAAAGGATGCATCATG", self.s.__radd__(rna_seq))
 
     def test_radd_method_using_wrong_object(self):
         with self.assertRaises(TypeError):
@@ -450,14 +448,15 @@ class TestSeqAddition(unittest.TestCase):
         self.rna.pop(5)
         for a in self.dna:
             for b in self.rna:
-                with self.assertRaises(TypeError):
-                    a + b
-                with self.assertRaises(TypeError):
-                    b + a
-                with self.assertRaises(TypeError):
-                    a += b
-                with self.assertRaises(TypeError):
-                    b += a
+                self.assertEqual(str(a) + str(b), a + b)
+                self.assertEqual(str(b) + str(a), b + a)
+                # Check in place works
+                c = a
+                c += b
+                self.assertEqual(c, str(a) + str(b))
+                c = b
+                c += a
+                self.assertEqual(c, str(b) + str(a))
 
     def test_addition_proteins(self):
         self.protein.pop(2)
@@ -474,13 +473,11 @@ class TestSeqAddition(unittest.TestCase):
                 b += a
                 self.assertEqual(c, b)
 
-    def test_exception_when_adding_protein_with_nucleotides(self):
+    def test_adding_protein_with_nucleotides(self):
         for a in self.protein[0:5]:
             for b in self.dna[0:3] + self.rna[0:4]:
-                with self.assertRaises(TypeError):
-                    a + b
-                with self.assertRaises(TypeError):
-                    a += b
+                self.assertEqual(str(a) + str(b), a + b)
+                a += b
 
     def test_adding_generic_nucleotide_with_other_nucleotides(self):
         for a in self.nuc:
@@ -651,8 +648,10 @@ class TestMutableSeq(unittest.TestCase):
         )
 
     def test_radd_method_incompatible_alphabets(self):
-        with self.assertRaises(TypeError):
-            self.mutable_s.__radd__(MutableSeq("UCAAAAGGA", IUPAC.ambiguous_rna))
+        self.assertEqual(
+            "UCAAAAGGATCAAAAGGATGCATCATG",
+            self.mutable_s.__radd__(MutableSeq("UCAAAAGGA", IUPAC.ambiguous_rna)),
+        )
 
     def test_radd_method_using_seq_object(self):
         self.assertEqual(


### PR DESCRIPTION
This pull request addresses in part issue #2046, assuming we are converging on storing the alphabet type (DNA/RNA/Nuclotide/Protein/etc) on the ``SeqRecord`` and not the ``Seq``, then the ``Seq`` methods will not do any alphabet/molecule type checking.

The first few commits are steps in that direction, more to follow as a follow up pull request and/or additional commits.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
