### PR TITLE
remove alphabet from Xdna writer

### DIFF
--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -252,12 +252,12 @@ class XdnaWriter(SequenceWriter):
 
         self._has_truncated_strings = False
 
-        alptype = Alphabet._get_base_alphabet(record.seq.alphabet)
-        if isinstance(alptype, Alphabet.DNAAlphabet):
+        molecule_type = record.annotations.get("molecule_type")
+        if molecule_type == "DNA":
             seqtype = 1
-        elif isinstance(alptype, Alphabet.RNAAlphabet):
+        elif molecule_type == "RNA":
             seqtype = 3
-        elif isinstance(alptype, Alphabet.ProteinAlphabet):
+        elif molecule_type == "protein":
             seqtype = 4
         else:
             seqtype = 0

--- a/Tests/test_SeqIO_Xdna.py
+++ b/Tests/test_SeqIO_Xdna.py
@@ -177,13 +177,13 @@ class TestXdnaWriter(unittest.TestCase):
 
         record = SeqRecord(Seq("ACGT"))
 
-        for alphabet, expected_byte in [
-            (Alphabet.generic_alphabet, 0),
-            (Alphabet.generic_dna, 1),
-            (Alphabet.generic_rna, 3),
-            (Alphabet.generic_protein, 4),
+        for molecule_type, expected_byte in [
+            (None, 0),
+            ("DNA", 1),
+            ("RNA", 3),
+            ("protein", 4),
         ]:
-            record.seq.alphabet = alphabet
+            record.annotations["molecule_type"] = molecule_type
             h.seek(0, 0)
             SeqIO.write([record], h, "xdna")
             buf = bytearray(h.getvalue())


### PR DESCRIPTION
This pull request removes the alphabet usage from the Xdna writer in Bio.SeqIO.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
