### PR TITLE
Update biological methods of Seq object for alphabet changes

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -885,7 +885,7 @@ class Seq:
 
         Here "M" was interpretted as the IUPAC ambiguity code for
         "A" or "C", with complement "K" for "T" or "G". Likewise
-        "A" has complement "T". The letter "I" has not defined
+        "A" has complement "T". The letter "I" has no defined
         meaning under the IUPAC convention, and is unchanged.
         """
         if ("U" in self._data or "u" in self._data) and (
@@ -967,6 +967,9 @@ class Seq:
         Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG')
 
         Trying to transcribe an RNA sequence should have no effect.
+        If you have a nucleotide sequence which might be DNA or RNA
+        (or even a mixture), calling the transcribe method will ensure
+        any T becomes U.
 
         Trying to transcribe a protein sequence will replace any
         T for Threonine with U for Selenocysteine, which has no
@@ -993,10 +996,13 @@ class Seq:
         >>> messenger_rna.back_transcribe()
         Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
 
-        Trying to back-transcribe DNA has no effect, but is
-        meaningless for a protein sequence where any "U" for
-        Selenocysteine will become "T" for Threonine. Older
-        versions of Biopython would raise an exception here:
+        Trying to back-transcribe DNA has no effect, If you have a nucleotide
+        sequence which might be DNA or RNA (or even a mixture), calling the
+        back-transcribe method will ensure any T becomes U.
+
+        Trying to back-transcribe a protein sequence will replace any U for
+        Selenocysteine with T for Threonine, which is biologically meaningless.
+        Older versions of Biopython would raise an exception here:
 
         >>> from Bio.Alphabet import generic_protein
         >>> from Bio.Seq import Seq

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -1164,10 +1164,10 @@ class SeqRecord:
         Note trying to reverse complement a protein SeqRecord raises an
         exception:
 
-        >>> from Bio.Alphabet import generic_protein
         >>> from Bio.Seq import Seq
         >>> from Bio.SeqRecord import SeqRecord
-        >>> protein_rec = SeqRecord(Seq("MAIVMGR", generic_protein), id="Test")
+        >>> protein_rec = SeqRecord(Seq("MAIVMGR"), id="Test",
+        ...                         annotations={"molecule_type": "protein"})
         >>> protein_rec.reverse_complement()
         Traceback (most recent call last):
            ...
@@ -1187,6 +1187,8 @@ class SeqRecord:
         """
         from Bio.Seq import MutableSeq  # Lazy to avoid circular imports
 
+        if "protein" == self.annotations.get("molecule_type", ""):
+            raise ValueError("Proteins do not have complements!")
         if isinstance(self.seq, MutableSeq):
             # Currently the MutableSeq reverse complement is in situ
             answer = SeqRecord(self.seq.toseq().reverse_complement())
@@ -1296,6 +1298,8 @@ class SeqRecord:
         <BLANKLINE>
 
         """
+        if "protein" == self.annotations.get("molecule_type", ""):
+            raise ValueError("Proteins cannot be translated!")
         answer = SeqRecord(
             self.seq.translate(
                 table=table, stop_symbol=stop_symbol, to_stop=to_stop, cds=cds, gap=gap
@@ -1328,6 +1332,8 @@ class SeqRecord:
         elif annotations:
             # Copy the old annotations
             answer.annotations = self.annotations.copy()
+        # Set/update to protein:
+        answer.annotations["molecule_type"] = "protein"
         if isinstance(letter_annotations, dict):
             answer.letter_annotations = letter_annotations
         elif letter_annotations:

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -6,53 +6,12 @@ Chapter~\ref{chapter:seq_annot} will introduce the related \verb|SeqRecord| obje
 
 Sequences are essentially strings of letters like \verb|AGTACACTGGT|, which seems very natural since this is the most common way that sequences are seen in biological file formats.
 
-There are two important differences between \verb|Seq| objects and standard Python strings.
-First of all, they have different methods.  Although the \verb|Seq| object supports many of the same methods as a plain string, its \verb|translate()| method differs by doing biological translation, and there are also additional biologically relevant methods like \verb|reverse_complement()|.
-Secondly, the \verb|Seq| object has an important attribute, \verb|alphabet|, which is an object describing what the individual characters making up the sequence string ``mean'', and how they should be interpreted.  For example, is \verb|AGTACACTGGT| a DNA sequence, or just a protein sequence that happens to be rich in Alanines, Glycines, Cysteines
-and Threonines?
+The most important difference between \verb|Seq| objects and standard Python strings is they have different methods.
+Although the \verb|Seq| object supports many of the same methods as a plain string, its \verb|translate()| method differs by doing biological translation, and there are also additional biologically relevant methods like \verb|reverse_complement()|.
 
 \section{Sequences and Alphabets}
 
-The \verb|Seq| object defaults to using a generic alphabet object,
-this legacy attribute can usually be ignored:
-
-%doctest
-\begin{minted}{pycon}
->>> from Bio.Seq import Seq
->>> my_seq = Seq("AGTACACTGGT")
->>> my_seq
-Seq('AGTACACTGGT')
->>> my_seq.alphabet
-Alphabet()
-\end{minted}
-
-However, where necessary you can specify the alphabet is DNA:
-
-%doctest
-\begin{minted}{pycon}
->>> from Bio.Seq import Seq
->>> from Bio.Alphabet import generic_dna
->>> my_seq = Seq("AGTACACTGGT", generic_dna)
->>> my_seq
-Seq('AGTACACTGGT')
->>> my_seq.alphabet
-DNAAlphabet()
-\end{minted}
-
-Unless of course, this really is an amino acid sequence:
-
-%doctest
-\begin{minted}{pycon}
->>> from Bio.Seq import Seq
->>> from Bio.Alphabet import generic_protein
->>> my_prot = Seq("AGTACACTGGT", generic_protein)
->>> my_prot
-Seq('AGTACACTGGT')
->>> my_prot.alphabet
-ProteinAlphabet()
-\end{minted}
-
-Likewise there is a \verb|generic_rna| for RNA.
+Historically the \verb|Seq| object had an important attribute, \verb|alphabet|. This was used for an object describing what the individual characters making up the sequence string meant, and how they should be interpreted.  For example, is \verb|AGTACACTGGT| a DNA sequence, or just a protein sequence that happens to be rich in Alanines, Glycines, Cysteines and Threonines? Since Biopython 1.78 this role falls to the ``SeqRecord`` object annotation, discussed in the next chapter.
 
 \section{Sequences act like strings}
 
@@ -211,16 +170,12 @@ writing FASTA format sequence files is covered in Chapter~\ref{chapter:seqio}.
 \section{Concatenating or adding sequences}
 
 As of Biopython 1.78, you can add any two Seq objects together.
-Any conflicting alphabet attribute will be dropped. This is a
-change in behaviour as older releases would raise a \verb|TypeError|
-for things like adding DNA and protein.
 
 %doctest
 \begin{minted}{pycon}
->>> from Bio.Alphabet import generic_dna, generic_protein
 >>> from Bio.Seq import Seq
->>> protein_seq = Seq("EVRNAK", generic_protein)
->>> dna_seq = Seq("ACGT", generic_dna)
+>>> protein_seq = Seq("EVRNAK")
+>>> dna_seq = Seq("ACGT")
 >>> protein_seq + dna_seq
 Seq('EVRNAKACGT')
 \end{minted}
@@ -270,8 +225,7 @@ For example,
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
->>> from Bio.Alphabet import generic_dna
->>> dna_seq = Seq("acgtACGT", generic_dna)
+>>> dna_seq = Seq("acgtACGT")
 >>> dna_seq
 Seq('acgtACGT')
 >>> dna_seq.upper()
@@ -299,8 +253,7 @@ complement of a \verb|Seq| object using its built-in methods:
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
->>> from Bio.Alphabet import generic_dna
->>> my_seq = Seq("GATCGATGGGCCTATATAGGATCGAAAATCGC", generic_dna)
+>>> my_seq = Seq("GATCGATGGGCCTATATAGGATCGAAAATCGC")
 >>> my_seq
 Seq('GATCGATGGGCCTATATAGGATCGAAAATCGC')
 >>> my_seq.complement()
@@ -318,20 +271,21 @@ Python string) is slice it with -1 step:
 Seq('CGCTAAAAGCTAGGATATATCCGGGTAGCTAG')
 \end{minted}
 
-In all of these operations, the alphabet property is maintained. This is very
-useful in case you accidentally end up trying to do something weird like take
-the (reverse)complement of a protein sequence:
+If you do accidentally end up trying to do something weird like taking the
+(reverse)complement of a protein sequence, the results are biologically
+meaningless:
 
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
->>> from Bio.Alphabet import generic_protein
->>> protein_seq = Seq("EVRNAK", generic_protein)
+>>> protein_seq = Seq("EVRNAK")
 >>> protein_seq.complement()
-Traceback (most recent call last):
-...
-ValueError: Proteins do not have complements!
+Seq('EBYNTM')
 \end{minted}
+
+Here the letter ``E'' is not a valid IUPAC ambiguity code for nucleotides,
+so was not complemented. However, ``V'' means ``A'', ``C'' or ``G'' and
+has complement ``B``, and so on.
 
 The example in Section~\ref{sec:SeqIO-reverse-complement} combines the \verb|Seq|
 object's reverse complement method with \verb|Bio.SeqIO| for sequence input/output.
@@ -365,8 +319,7 @@ Now let's actually get down to doing a transcription in Biopython.  First, let's
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
->>> from Bio.Alphabet import generic_dna
->>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG", generic_dna)
+>>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG")
 >>> coding_dna
 Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
 >>> template_dna = coding_dna.reverse_complement()
@@ -395,13 +348,12 @@ If you do want to do a true biological transcription starting with the template 
 Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG')
 \end{minted}
 
-The \verb|Seq| object also includes a back-transcription method for going from the mRNA to the coding strand of the DNA.  Again, this is a simple U $\rightarrow$ T substitution and associated change of alphabet:
+The \verb|Seq| object also includes a back-transcription method for going from the mRNA to the coding strand of the DNA.  Again, this is a simple U $\rightarrow$ T substitution:
 
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
->>> from Bio.Alphabet import generic_rna
->>> messenger_rna = Seq("AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG", generic_rna)
+>>> messenger_rna = Seq("AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG")
 >>> messenger_rna
 Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG')
 >>> messenger_rna.back_transcribe()
@@ -433,8 +385,7 @@ You can also translate directly from the coding strand DNA sequence:
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
->>> from Bio.Alphabet import generic_dna
->>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG", generic_dna)
+>>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG")
 >>> coding_dna
 Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
 >>> coding_dna.translate()
@@ -498,13 +449,11 @@ for example the gene yaaX in \texttt{E. coli} K12:
 %TODO - handle line wrapping in doctest?
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
->>> from Bio.Alphabet import generic_dna
 >>> gene = Seq("GTGAAAAAGATGCAATCTATCGTACTCGCACTTTCCCTGGTTCTGGTCGCTCCCATGGCA"
 ...            "GCACAGGCTGCGGAAATTACGTTAGTCCCGTCAGTAAAATTACAGATAGGCGATCGTGAT"
 ...            "AATCGTGGCTATTACTGGGATGGAGGTCACTGGCGCGACCACGGCTGGTGGAAACAACAT"
 ...            "TATGAATGGCGAGGCAATCGCTGGCACCTACACGGACCGCCGCCACCGCCGCGCCACCAT"
-...            "AAGAAAGCTCCTCATGATCATCACGGCGGTCATGGTCCAGGCAAACATCACCGCTAA",
-...            generic_dna)
+...            "AAGAAAGCTCCTCATGATCATCACGGCGGTCATGGTCCAGGCAAACATCACCGCTAA")
 >>> gene.translate(table="Bacterial")
 Seq('VKKMQSIVLALSLVLVAPMAAQAAEITLVPSVKLQIGDRDNRGYYWDGGHWRDH...HR*',
 ProteinAlpabet())
@@ -637,62 +586,26 @@ the letters in a sequence are context dependent - the letter ``A'' could be part
 of a DNA, RNA or protein sequence. Biopython can track the molecule type, so
 comparing two \verb|Seq| objects could mean considering this too.
 
-Suppose you argue \texttt{Seq("ACGT", generic\_dna)`` and \texttt{Seq("ACGT")}
-should be equal (i.e. comparing DNA and the default generic alphabet).
-Then, logically, \texttt{Seq("ACGT", generic_protein)} and \texttt{Seq("ACGT")}
-should also be equal. Now, in logic if $A=B$ and $B=C$, by transitivity we
-expect $A=C$. So for logical consistency we'd require
-\texttt{Seq("ACGT", generic\_dna)} and \texttt{Seq("ACGT", generic\_protein)}
-to be equal -- which most people would agree is just not right.
-This transitivity also has implications for using \verb|Seq| objects as
-Python dictionary keys.
-
-Now, in everyday use, your sequences will generally all be the same type of
+Should a DNA fragment ``ACG'' and an RNA fragment ``ACG'' be equal? What about
+the peptide ``ACG``? Or the Python string ``ACG``?
+In everyday use, your sequences will generally all be the same type of
 (all DNA, all RNA, or all protein).
-So, what does Biopython do? Well, as of Biopython 1.65, sequence comparison
-only looks at the sequence, essentially ignoring the alphabet:
+Well, as of Biopython 1.65, sequence comparison only looks at the sequence
+and compares like the Python string.
 
 %doctest
 \begin{minted}{pycon}
->>> from Bio.Alphabet import generic_dna
 >>> from Bio.Seq import Seq
->>> seq2 = Seq("ACGT")
->>> seq1 = Seq("ACGT", generic_dna)
->>> str(seq1) == str(seq2)
-True
->>> str(seq1) == str(seq1)
-True
->>> seq1 == seq2
+>>> seq1 = Seq("ACGT")
+>>> "ACGT" == seq1
 True
 >>> seq1 == "ACGT"
 True
 \end{minted}
 
 As an extension to this, using sequence objects as keys in a Python dictionary
-is now equivalent to using the sequence as a plain string for the key.
+is equivalent to using the sequence as a plain string for the key.
 See also Section~\ref{sec:seq-to-string}.
-
-Note if you compare sequences with incompatible alphabets (e.g. DNA vs RNA,
-or nucleotide versus protein), then you will get a warning but for the
-comparison itself only the string of letters in the sequence is used:
-%Can we do a doctest with a warning?
-\begin{minted}{pycon}
->>> from Bio.Seq import Seq
->>> from Bio.Alphabet import generic_dna, generic_protein
->>> dna_seq = Seq("ACGT", generic_dna)
->>> prot_seq = Seq("ACGT", generic_protein)
->>> dna_seq == prot_seq
-BiopythonWarning: Incompatible alphabets DNAAlphabet() and ProteinAlphabet()
-True
-\end{minted}
-
-\noindent
-\emph{WARNING:} Older versions of Biopython instead used to check if the
-\verb|Seq| objects were the same object in memory.
-This is important if you need to support scripts on both old and new
-versions of Biopython. Here make the comparison explicit by wrapping
-your sequence objects with either \verb|str(...)| for string based
-comparison or \verb|id(...)| for object instance based comparison.
 
 \section{MutableSeq objects}
 \label{sec:mutable-seq}
@@ -702,8 +615,7 @@ Just like the normal Python string, the \verb|Seq| object is ``read only'', or i
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
->>> from Bio.Alphabet import generic_dna
->>> my_seq = Seq("GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA", generic_dna)
+>>> my_seq = Seq("GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA")
 \end{minted}
 
 Observe what happens if you try to edit the sequence:
@@ -729,8 +641,7 @@ Alternatively, you can create a \verb|MutableSeq| object directly from a string:
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import MutableSeq
->>> from Bio.Alphabet import generic_dna
->>> mutable_seq = MutableSeq("GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA", generic_dna)
+>>> mutable_seq = MutableSeq("GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA")
 \end{minted}
 
 Either way will give you a sequence object which can be changed:

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -462,7 +462,7 @@ class SeqRecordMethodsMore(unittest.TestCase):
         self.assertEqual(t.description, "<unknown description>")
         self.assertFalse(t.dbxrefs)
         self.assertFalse(t.features)
-        self.assertFalse(t.annotations)
+        self.assertEqual(t.annotations, {"molecule_type": "protein"})
         self.assertFalse(t.letter_annotations)
 
         t = s.translate(
@@ -479,7 +479,9 @@ class SeqRecordMethodsMore(unittest.TestCase):
         self.assertEqual(t.description, "TestDescription")
         self.assertEqual(t.dbxrefs, ["TestDbxrefs"])
         self.assertFalse(t.features)
-        self.assertEqual(t.annotations, {"organism": "bombyx"})
+        self.assertEqual(
+            t.annotations, {"organism": "bombyx", "molecule_type": "protein"}
+        )
         self.assertFalse(t.letter_annotations)
 
     def test_lt_exception(self):
@@ -551,7 +553,7 @@ class TestTranslation(unittest.TestCase):
         self.assertEqual(t.description, "<unknown description>")
         self.assertFalse(t.dbxrefs)
         self.assertFalse(t.features)
-        self.assertFalse(t.annotations)
+        self.assertEqual(t.annotations, {"molecule_type": "protein"})
         self.assertFalse(t.letter_annotations)
 
     def test_preserve(self):
@@ -569,7 +571,9 @@ class TestTranslation(unittest.TestCase):
         self.assertEqual(t.description, "TestDescription")
         self.assertEqual(t.dbxrefs, ["TestDbxrefs"])
         self.assertFalse(t.features)
-        self.assertEqual(t.annotations, {"organism": "bombyx"})
+        self.assertEqual(
+            t.annotations, {"organism": "bombyx", "molecule_type": "protein"}
+        )
         self.assertFalse(t.letter_annotations)
 
         # Should not preserve these
@@ -595,7 +599,7 @@ class TestTranslation(unittest.TestCase):
         self.assertEqual(t.description, "Baz")
         self.assertEqual(t.dbxrefs, ["Nope"])
         self.assertEqual(len(t.features), 1)
-        self.assertEqual(t.annotations, {"a": "team"})
+        self.assertEqual(t.annotations, {"a": "team", "molecule_type": "protein"})
         self.assertEqual(t.letter_annotations, {"aa": ["Met", "Val"]})
 
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -85,7 +85,7 @@ class StringMethodTests(unittest.TestCase):
         Seq("A", generic_protein),
         Seq("A", generic_nucleotide),
         Seq("A", generic_dna),
-        Seq("A", generic_rna),
+        Seq("A", generic_rna),  # This one is a problem for (rev)comp
         UnknownSeq(1),
         UnknownSeq(1, character="n"),
         UnknownSeq(1, generic_rna),
@@ -687,23 +687,11 @@ class StringMethodTests(unittest.TestCase):
                 self.assertEqual(str(e), "Proteins do not have complements!")
                 continue
             str1 = str(example1)
-            # This only does the unambiguous cases
-            if any(("U" in str1, "u" in str1, example1.alphabet == generic_rna)):
+            if "U" in str1 or "u" in str1:
                 mapping = str.maketrans("ACGUacgu", "UGCAugca")
-            elif any(
-                (
-                    "T" in str1,
-                    "t" in str1,
-                    example1.alphabet == generic_dna,
-                    example1.alphabet == generic_nucleotide,
-                )
-            ):
-                mapping = str.maketrans("ACGTacgt", "TGCAtgca")
-            elif "A" not in str1 and "a" not in str1:
-                mapping = str.maketrans("CGcg", "GCgc")
             else:
-                # TODO - look at alphabet?
-                raise ValueError(example1)
+                # Default to DNA, e.g. complement("A") -> "T" not "U"
+                mapping = str.maketrans("ACGTacgt", "TGCAtgca")
             self.assertEqual(str1.translate(mapping), str(comp))
             self.assertEqual(comp.alphabet, example1.alphabet)
 
@@ -719,23 +707,11 @@ class StringMethodTests(unittest.TestCase):
                 self.assertEqual(str(e), "Proteins do not have complements!")
                 continue
             str1 = str(example1)
-            # This only does the unambiguous cases
-            if any(("U" in str1, "u" in str1, example1.alphabet == generic_rna)):
+            if "U" in str1 or "u" in str1:
                 mapping = str.maketrans("ACGUacgu", "UGCAugca")
-            elif any(
-                (
-                    "T" in str1,
-                    "t" in str1,
-                    example1.alphabet == generic_dna,
-                    example1.alphabet == generic_nucleotide,
-                )
-            ):
-                mapping = str.maketrans("ACGTacgt", "TGCAtgca")
-            elif "A" not in str1 and "a" not in str1:
-                mapping = str.maketrans("CGcg", "GCgc")
             else:
-                # TODO - look at alphabet?
-                continue
+                # Defaults to DNA, so reverse_complement("A") --> "T" not "U"
+                mapping = str.maketrans("ACGTacgt", "TGCAtgca")
             self.assertEqual(str1.translate(mapping)[::-1], str(comp))
             self.assertEqual(comp.alphabet, example1.alphabet)
 


### PR DESCRIPTION
Following discussion on #2972 moving recording the molecule type from the ``Seq`` object's alphabet to the ``SeqRecord`` objects's annotation, this updates the type checking of the biological methods accordingly.

i.e. The ``Seq`` object (reverse)complement, (back)transcribe, and translate no longer check the molecule type is appropriate via the alphabet. Instead, the subset of biological methods on the ``SeqRecord`` handle this check.

Note: This does have one drawback - in the absence of an alphabet, taking the complement of a nucleotide sequence with A but neither T or U present defaults to assuming DNA, and thus maps A to T. If the sequence represented RNA, this could be set via the alphabet and thus mapped A to U.

Previously we could do this (e.g. Biopython 1.77):

```pycon
>>> from Bio.Alphabet import generic_rna
>>> from Bio.Seq import Seq
>>> my_rna_seq = Seq("ACG", generic_rna)
>>> my_rna_seq.complement()
Seq('UGC')
>>> my_rna_seq.reverse_complement()
Seq('CGU')
```

Possible work around with the behaviour on this pull request to ensure it has U and not T:

```pycon
>>> from Bio.Seq import Seq
>>> my_rna_seq = Seq("ACG") # no longer setting RNA explicitly here
>>> my_rna_seq.complement() # no alphabet so defaults to DNA
Seq('TGC')
>>> my_rna_seq.complement().transcribe() # explicitly make RNA 
Seq('UGC')
>>> my_rna_seq.reverse_complement()  # no alphabet so defaults to DNA
Seq('CGT')
>>> my_rna_seq.reverse_complement().transcribe()  # explicitly make RNA 
Seq('CGU')
```

But with the old behaviour you can't do this:

```pycon
>>> from Bio.Alphabet import generic_rna
>>> from Bio.Seq import Seq
>>>  my_rna_seq = Seq("ACG", generic_rna)
>>> my_rna_seq.complement().transcribe()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/pc40583/repositories/biopython/Bio/Seq.py", line 946, in transcribe
    raise ValueError("RNA cannot be transcribed!")
ValueError: RNA cannot be transcribed!
```

But this is fine:

```pycon
>>> from Bio.Seq import Seq
>>> my_rna_seq = Seq("ACG") # no longer setting RNA explicitly here
>>> my_rna_seq.complement().transcribe()
Seq('UGC')
```

This pull request addresses in part issue #2046. 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
