### PR TITLE
remove alphabet from PirWriter

### DIFF
--- a/Bio/SeqIO/PirIO.py
+++ b/Bio/SeqIO/PirIO.py
@@ -261,12 +261,15 @@ class PirWriter(SequenceWriter):
         if self.code:
             code = self.code
         else:
-            if isinstance(record.seq.alphabet, type(generic_protein)):
-                code = "P1"
-            elif isinstance(record.seq.alphabet, type(generic_dna)):
+            molecule_type = record.annotations.get("molecule_type")
+            if molecule_type is None:
+                code = "XX"
+            elif "DNA" in molecule_type:
                 code = "D1"
-            elif isinstance(record.seq.alphabet, type(generic_rna)):
+            elif "RNA" in molecule_type:
                 code = "RL"
+            elif "protein" in molecule_type:
+                code = "P1"
             else:
                 code = "XX"
 

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -613,7 +613,7 @@ class SeqXmlWriter(SequenceWriter):
             seqElem = "DNAseq"
         elif "RNA" in molecule_type:
             seqElem = "RNAseq"
-        elif molecule_type == "protein":
+        elif "protein" in molecule_type:
             seqElem = "AAseq"
         else:
             raise ValueError("unknown molecule_type '%s'" % molecule_type)

--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -253,11 +253,13 @@ class XdnaWriter(SequenceWriter):
         self._has_truncated_strings = False
 
         molecule_type = record.annotations.get("molecule_type")
-        if molecule_type == "DNA":
+        if molecule_type is None:
+            seqtype = 0
+        elif "DNA" in molecule_type:
             seqtype = 1
-        elif molecule_type == "RNA":
+        elif "RNA" in molecule_type:
             seqtype = 3
-        elif molecule_type == "protein":
+        elif "protein" in molecule_type:
             seqtype = 4
         else:
             seqtype = 0


### PR DESCRIPTION
This pull request removes alphabet usage from `PirWriter` in `Bio.SeqIO.PirIO`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
