### PR TITLE
Use chain.from_iterable in query.py

### DIFF
--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -414,9 +414,7 @@ class QueryResult(_BaseSearchObject):
     @property
     def hsps(self):
         """Access the HSP objects contained in the QueryResult."""
-        return sorted(
-            chain.from_iterable(self.hits), key=lambda hsp: hsp.output_index
-        )
+        return sorted(chain.from_iterable(self.hits), key=lambda hsp: hsp.output_index)
 
     @property
     def fragments(self):

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -415,13 +415,13 @@ class QueryResult(_BaseSearchObject):
     def hsps(self):
         """Access the HSP objects contained in the QueryResult."""
         return sorted(
-            (hsp for hsp in chain(*self.hits)), key=lambda hsp: hsp.output_index
+            chain.from_iterable(self.hits), key=lambda hsp: hsp.output_index
         )
 
     @property
     def fragments(self):
         """Access the HSPFragment objects contained in the QueryResult."""
-        return list(chain(*self.hsps))
+        return list(chain.from_iterable(self.hsps))
 
     # public methods #
     def absorb(self, hit):


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.