### PR TITLE
Use Bio.Align.substitution_matrices instead of Bio.SubsMat in TreeConstruction

### DIFF
--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -464,8 +464,7 @@ class DistanceCalculator:
             if model == "blastn":
                 name = "NUC.4.4"
             else:
-                name = model
-            # name passed to substitution_matrices.load is not case-sensitive
+                name = model.upper()
             self.scoring_matrix = substitution_matrices.load(name)
         else:
             raise ValueError(

--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -428,7 +428,7 @@ class DistanceCalculator:
     blastn = [[5], [-4, 5], [-4, -4, 5], [-4, -4, -4, 5]]
 
     # transition/transversion scoring matrix
-    trans = [[6], [-5, 6], [-5, -1, 6], [-1, -5, -5, 6]]
+    trans = [[5], [0, 5], [0, 4, 5], [4, 0, 0, 5]]
 
     protein_alphabet = [
         "A",

--- a/Tests/test_TreeConstruction.py
+++ b/Tests/test_TreeConstruction.py
@@ -153,7 +153,7 @@ class DistanceCalculatorTest(unittest.TestCase):
 
         calculator = DistanceCalculator("trans")
         dm = calculator.get_distance(aln)
-        self.assertEqual(dm["Alpha", "Beta"], 1 - (49 * 1.0 / 78))
+        self.assertEqual(dm["Alpha", "Beta"], 1 - (54 * 1.0 / 65))
 
         calculator = DistanceCalculator("blosum62")
         dm = calculator.get_distance(aln)


### PR DESCRIPTION
This pull request addresses issue #2917 by replacing `Bio.SubsMat` in `Bio/Phylo/TreeConstruction.py` by `Bio.Align.substitution_matrices`.

This could be pushed further by using the same matrices also in `ParsimonyScorer`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
