### PR TITLE
Implement `makeblastdb -blastdb_version` flag

### DIFF
--- a/Bio/Blast/Applications.py
+++ b/Bio/Blast/Applications.py
@@ -1453,6 +1453,14 @@ class NcbimakeblastdbCommandline(AbstractCommandline):
             ),
             # makeblastdb specific options
             _Option(
+                ["-blastdb_version", "blastdb_version"],
+                "Version of BLAST database to be created. "
+                "Tip: use BLAST database version 4 on 32 bit CPU. "
+                "Default = 5",
+                equate=False,
+                checker_function=lambda x: x == 4 or x == 5
+            ),
+            _Option(
                 ["-dbtype", "dbtype"],
                 "Molecule type of target db ('nucl' or 'prot').",
                 equate=False,

--- a/Bio/Blast/Applications.py
+++ b/Bio/Blast/Applications.py
@@ -1458,7 +1458,7 @@ class NcbimakeblastdbCommandline(AbstractCommandline):
                 "Tip: use BLAST database version 4 on 32 bit CPU. "
                 "Default = 5",
                 equate=False,
-                checker_function=lambda x: x == 4 or x == 5
+                checker_function=lambda x: x == 4 or x == 5,
             ),
             _Option(
                 ["-dbtype", "dbtype"],

--- a/Tests/test_NCBI_BLAST_tools.py
+++ b/Tests/test_NCBI_BLAST_tools.py
@@ -258,6 +258,54 @@ class BlastDB(unittest.TestCase):
         )
         self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.psq"))
 
+    def test_fasta_db_prot_legacy(self):
+        """Test makeblastdb wrapper with protein database legacy, version 4."""
+        global exe_names
+        cline = Applications.NcbimakeblastdbCommandline(
+            exe_names["makeblastdb"],
+            blastdb_version=4,
+            input_file="GenBank/NC_005816.faa",
+            dbtype="prot",
+            hash_index=True,
+            max_file_sz="20MB",
+            parse_seqids=True,
+            taxid=10,
+        )
+
+        self.assertEqual(
+            str(cline),
+            _escape_filename(exe_names["makeblastdb"])
+            + " -blastdb_version 4"
+            " -dbtype prot -in GenBank/NC_005816.faa"
+            " -parse_seqids -hash_index -max_file_sz 20MB"
+            " -taxid 10",
+        )
+
+        child = subprocess.Popen(
+            str(cline),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            shell=(sys.platform != "win32"),
+        )
+        stdoutdata, stderrdata = child.communicate()
+        return_code = child.returncode
+
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.phd"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.phi"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.phr"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.pin"))
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.pog"))
+        self.assertTrue(
+            os.path.isfile("GenBank/NC_005816.faa.psd")
+            or os.path.isfile("GenBank/NC_005816.faa.pnd")
+        )
+        self.assertTrue(
+            os.path.isfile("GenBank/NC_005816.faa.psi")
+            or os.path.isfile("GenBank/NC_005816.faa.pni")
+        )
+        self.assertTrue(os.path.isfile("GenBank/NC_005816.faa.psq"))
+
     def test_fasta_db_nucl(self):
         """Test makeblastdb wrapper with nucleotide database."""
         global exe_names


### PR DESCRIPTION
This pull request is more or less related to issue #2863 and Debian bug#960756.

This patch includes the implementation of the new flag `-blastdb_version` that landed in newer versions of `makeblastdb`.  This flag allows users to choose between version 5, the default, and 4, the legacy versions.  Note that the protein test flag is duplicated to make sure the legacy flag works as well, but maybe there are cleaner ways to try this flag.

-- 
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
