### PR TITLE
Drop alphabet in Seq object method return values

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -717,21 +717,14 @@ class Seq:
         Seq('vhltpeek*')
         >>> my_seq.upper()
         Seq('VHLTPEEK*')
-
-        This will adjust the alphabet if required. See also the lower method.
         """
-        return Seq(str(self).upper(), self.alphabet._upper())
+        return Seq(str(self).upper())
 
     def lower(self):
         """Return a lower case copy of the sequence.
 
-        This will adjust the alphabet if required. Note that the IUPAC
-        alphabets are upper case only, and thus a generic alphabet must be
-        substituted.
-
-        >>> from Bio.Alphabet.IUPAC import unambiguous_dna
         >>> from Bio.Seq import Seq
-        >>> my_seq = Seq("CGGTACGCTTATGTCACGTAGAAAAAA", unambiguous_dna)
+        >>> my_seq = Seq("CGGTACGCTTATGTCACGTAGAAAAAA")
         >>> my_seq
         Seq('CGGTACGCTTATGTCACGTAGAAAAAA')
         >>> my_seq.lower()
@@ -739,7 +732,7 @@ class Seq:
 
         See also the upper method.
         """
-        return Seq(str(self).lower(), self.alphabet._lower())
+        return Seq(str(self).lower())
 
     def encode(self, encoding="utf-8", errors="strict"):
         """Return an encoded version of the sequence as a bytes object.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -231,7 +231,7 @@ class Seq:
             return self._data[index]
         else:
             # Return the (sub)sequence as another Seq object
-            return Seq(self._data[index], self.alphabet)
+            return Seq(self._data[index])
 
     def __add__(self, other):
         """Add another sequence or string to this sequence.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -903,7 +903,7 @@ class Seq:
             ttable = _dna_complement_table
         # Much faster on really long sequences than the previous loop based
         # one. Thanks to Michael Palmer, University of Waterloo.
-        return Seq(str(self).translate(ttable), self.alphabet)
+        return Seq(str(self).translate(ttable))
 
     def reverse_complement(self):
         """Return the reverse complement sequence by creating a new Seq object.
@@ -991,7 +991,7 @@ class Seq:
                 raise ValueError("Mixed RNA/DNA found")
             else:
                 raise ValueError("DNA found, RNA expected")
-        return Seq(str(self).translate(_rna_complement_table), self.alphabet)
+        return Seq(str(self).translate(_rna_complement_table))
 
     def reverse_complement_rna(self):
         """Reverse complement of an RNA sequence.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1031,7 +1031,7 @@ class Seq:
         >>> my_protein.transcribe()
         Seq('MAIVMGRU')
         """
-        return Seq(str(self).replace("T", "U").replace("t", "u"), Alphabet.generic_rna)
+        return Seq(str(self).replace("T", "U").replace("t", "u"))
 
     def back_transcribe(self):
         """Return the DNA sequence from an RNA sequence by creating a new Seq object.
@@ -1059,7 +1059,7 @@ class Seq:
         >>> my_protein.back_transcribe()
         Seq('MAIVMGRT')
         """
-        return Seq(str(self).replace("U", "T").replace("u", "t"), Alphabet.generic_dna)
+        return Seq(str(self).replace("U", "T").replace("u", "t"))
 
     def translate(
         self, table="Standard", stop_symbol="*", to_stop=False, cds=False, gap="-"

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -305,10 +305,7 @@ class Seq:
         """Multiply Seq by integer.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_dna
         >>> Seq('ATG') * 2
-        Seq('ATGATG')
-        >>> Seq('ATG', generic_dna) * 2
         Seq('ATGATG')
         """
         if not isinstance(other, int):
@@ -319,10 +316,7 @@ class Seq:
         """Multiply integer by Seq.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_dna
         >>> 2 * Seq('ATG')
-        Seq('ATGATG')
-        >>> 2 * Seq('ATG', generic_dna)
         Seq('ATGATG')
         """
         if not isinstance(other, int):
@@ -336,8 +330,7 @@ class Seq:
         included to match the behaviour for regular Python strings.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_dna
-        >>> seq = Seq('ATG', generic_dna)
+        >>> seq = Seq('ATG')
         >>> seq *= 2
         >>> seq
         Seq('ATGATG')
@@ -359,28 +352,6 @@ class Seq:
         Any alphabet is preserved.
         """
         return MutableSeq(str(self), self.alphabet)
-
-    def _get_seq_str_and_check_alphabet(self, other_sequence):
-        """Convert string/Seq/MutableSeq to string, checking alphabet (PRIVATE).
-
-        For a string argument, returns the string.
-
-        For a Seq or MutableSeq, it checks the alphabet is compatible
-        (raising an exception if it isn't), and then returns a string.
-        """
-        try:
-            other_alpha = other_sequence.alphabet
-        except AttributeError:
-            # Assume other_sequence is a string
-            return other_sequence
-
-        # Other should be a Seq or a MutableSeq
-        if not Alphabet._check_type_compatible([self.alphabet, other_alpha]):
-            raise TypeError(
-                f"Incompatible alphabets {self.alphabet!r} and {other_alpha!r}"
-            )
-        # Return as a string
-        return str(other_sequence)
 
     def count(self, sub, start=0, end=sys.maxsize):
         """Return a non-overlapping count, like that of a python string.
@@ -425,9 +396,7 @@ class Seq:
         An overlapping search, as implemented in .count_overlap(),
         would give the answer as three!
         """
-        # If it has one, check the alphabet:
-        sub_str = self._get_seq_str_and_check_alphabet(sub)
-        return str(self).count(sub_str, start, end)
+        return str(self).count(str(sub), start, end)
 
     def count_overlap(self, sub, start=0, end=sys.maxsize):
         """Return an overlapping count.
@@ -479,7 +448,7 @@ class Seq:
         HOWEVER, do not use this method for such cases because the
         count() method is much for efficient.
         """
-        sub_str = self._get_seq_str_and_check_alphabet(sub)
+        sub_str = str(sub)
         self_str = str(self)
         overlap_count = 0
         while True:
@@ -495,30 +464,13 @@ class Seq:
         e.g.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_dna, generic_rna, generic_protein
-        >>> my_dna = Seq("ATATGAAATTTGAAAA", generic_dna)
+        >>> my_dna = Seq("ATATGAAATTTGAAAA")
         >>> "AAA" in my_dna
         True
         >>> Seq("AAA") in my_dna
         True
-        >>> Seq("AAA", generic_dna) in my_dna
-        True
-
-        Like other Seq methods, this will raise a type error if another Seq
-        (or Seq like) object with an incompatible alphabet is used:
-
-        >>> Seq("AAA", generic_rna) in my_dna
-        Traceback (most recent call last):
-           ...
-        TypeError: Incompatible alphabets DNAAlphabet() and RNAAlphabet()
-        >>> Seq("AAA", generic_protein) in my_dna
-        Traceback (most recent call last):
-           ...
-        TypeError: Incompatible alphabets DNAAlphabet() and ProteinAlphabet()
         """
-        # If it has one, check the alphabet:
-        sub_str = self._get_seq_str_and_check_alphabet(char)
-        return sub_str in str(self)
+        return str(char) in str(self)
 
     def find(self, sub, start=0, end=sys.maxsize):
         """Find method, like that of a python string.
@@ -542,9 +494,7 @@ class Seq:
         >>> my_rna.find("AUG")
         3
         """
-        # If it has one, check the alphabet:
-        sub_str = self._get_seq_str_and_check_alphabet(sub)
-        return str(self).find(sub_str, start, end)
+        return str(self).find(str(sub), start, end)
 
     def rfind(self, sub, start=0, end=sys.maxsize):
         """Find from right method, like that of a python string.
@@ -568,9 +518,7 @@ class Seq:
         >>> my_rna.rfind("AUG")
         15
         """
-        # If it has one, check the alphabet:
-        sub_str = self._get_seq_str_and_check_alphabet(sub)
-        return str(self).rfind(sub_str, start, end)
+        return str(self).rfind(str(sub), start, end)
 
     def index(self, sub, start=0, end=sys.maxsize):
         """Like find() but raise ValueError when the substring is not found.
@@ -584,15 +532,11 @@ class Seq:
                    ...
         ValueError: substring not found...
         """
-        # If it has one, check the alphabet:
-        sub_str = self._get_seq_str_and_check_alphabet(sub)
-        return str(self).index(sub_str, start, end)
+        return str(self).index(str(sub), start, end)
 
     def rindex(self, sub, start=0, end=sys.maxsize):
         """Like rfind() but raise ValueError when the substring is not found."""
-        # If it has one, check the alphabet:
-        sub_str = self._get_seq_str_and_check_alphabet(sub)
-        return str(self).rindex(sub_str, start, end)
+        return str(self).rindex(str(sub), start, end)
 
     def startswith(self, prefix, start=0, end=sys.maxsize):
         """Return True if the Seq starts with the given prefix, False otherwise.
@@ -616,13 +560,11 @@ class Seq:
         >>> my_rna.startswith(("UCC", "UCA", "UCG"), 1)
         True
         """
-        # If it has one, check the alphabet:
         if isinstance(prefix, tuple):
-            prefix_strs = tuple(self._get_seq_str_and_check_alphabet(p) for p in prefix)
+            prefix_strs = tuple(str(p) for p in prefix)
             return str(self).startswith(prefix_strs, start, end)
         else:
-            prefix_str = self._get_seq_str_and_check_alphabet(prefix)
-            return str(self).startswith(prefix_str, start, end)
+            return str(self).startswith(str(prefix), start, end)
 
     def endswith(self, suffix, start=0, end=sys.maxsize):
         """Return True if the Seq ends with the given suffix, False otherwise.
@@ -646,13 +588,11 @@ class Seq:
         >>> my_rna.endswith(("UCC", "UCA", "UUG"))
         True
         """
-        # If it has one, check the alphabet:
         if isinstance(suffix, tuple):
-            suffix_strs = tuple(self._get_seq_str_and_check_alphabet(p) for p in suffix)
+            suffix_strs = tuple(str(p) for p in suffix)
             return str(self).endswith(suffix_strs, start, end)
         else:
-            suffix_str = self._get_seq_str_and_check_alphabet(suffix)
-            return str(self).endswith(suffix_str, start, end)
+            return str(self).endswith(str(suffix), start, end)
 
     def split(self, sep=None, maxsplit=-1):
         """Split method, like that of a python string.
@@ -692,11 +632,9 @@ class Seq:
         Seq('VMAIVMGR*KGAR')
         Seq('L')
         """
-        # If it has one, check the alphabet:
-        sep_str = self._get_seq_str_and_check_alphabet(sep)
-        # TODO - If the sep is the defined stop symbol, or gap char,
-        # should we adjust the alphabet?
-        return [Seq(part, self.alphabet) for part in str(self).split(sep_str, maxsplit)]
+        return [
+            Seq(part, self.alphabet) for part in str(self).split(str(sep), maxsplit)
+        ]
 
     def rsplit(self, sep=None, maxsplit=-1):
         """Do a right split method, like that of a python string.
@@ -716,10 +654,8 @@ class Seq:
 
         See also the split method.
         """
-        # If it has one, check the alphabet:
-        sep_str = self._get_seq_str_and_check_alphabet(sep)
         return [
-            Seq(part, self.alphabet) for part in str(self).rsplit(sep_str, maxsplit)
+            Seq(part, self.alphabet) for part in str(self).rsplit(str(sep), maxsplit)
         ]
 
     def strip(self, chars=None):
@@ -735,9 +671,7 @@ class Seq:
 
         See also the lstrip and rstrip methods.
         """
-        # If it has one, check the alphabet:
-        strip_str = self._get_seq_str_and_check_alphabet(chars)
-        return Seq(str(self).strip(strip_str), self.alphabet)
+        return Seq(str(self).strip(str(chars)), self.alphabet)
 
     def lstrip(self, chars=None):
         """Return a new Seq object with leading (left) end stripped.
@@ -752,9 +686,7 @@ class Seq:
 
         See also the strip and rstrip methods.
         """
-        # If it has one, check the alphabet:
-        strip_str = self._get_seq_str_and_check_alphabet(chars)
-        return Seq(str(self).lstrip(strip_str), self.alphabet)
+        return Seq(str(self).lstrip(str(chars)), self.alphabet)
 
     def rstrip(self, chars=None):
         """Return a new Seq object with trailing (right) end stripped.
@@ -776,16 +708,13 @@ class Seq:
 
         See also the strip and lstrip methods.
         """
-        # If it has one, check the alphabet:
-        strip_str = self._get_seq_str_and_check_alphabet(chars)
-        return Seq(str(self).rstrip(strip_str), self.alphabet)
+        return Seq(str(self).rstrip(str(chars)), self.alphabet)
 
     def upper(self):
         """Return an upper case copy of the sequence.
 
-        >>> from Bio.Alphabet import generic_protein
         >>> from Bio.Seq import Seq
-        >>> my_seq = Seq("VHLTPeeK*", generic_protein)
+        >>> my_seq = Seq("VHLTPeeK*")
         >>> my_seq
         Seq('VHLTPeeK*')
         >>> my_seq.lower()
@@ -1493,7 +1422,7 @@ class UnknownSeq(Seq):
         >>> UnknownSeq(4, character="N").count("NNN")
         1
         """
-        sub_str = self._get_seq_str_and_check_alphabet(sub)
+        sub_str = str(sub)
         len_self, len_sub_str = self._length, len(sub_str)
         # Handling case where substring not in self
         if set(sub_str) != set(self._character):
@@ -1557,7 +1486,7 @@ class UnknownSeq(Seq):
         >>> UnknownSeq(4, character="N").count_overlap("AA") == UnknownSeq(4, character="N").count("AA")
         True
         """
-        sub_str = self._get_seq_str_and_check_alphabet(sub)
+        sub_str = str(sub)
         len_self, len_sub_str = self._length, len(sub_str)
         # Handling case where substring not in self
         if set(sub_str) != set(self._character):

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1167,11 +1167,9 @@ class Seq:
             # translating strings).
             codon_table = CodonTable.ambiguous_generic_by_id[table_id]
 
-        protein = _translate_str(
-            str(self), codon_table, stop_symbol, to_stop, cds, gap=gap
+        return Seq(
+            _translate_str(str(self), codon_table, stop_symbol, to_stop, cds, gap=gap)
         )
-
-        return Seq(protein, Alphabet.generic_protein)
 
     def ungap(self, gap="-"):
         """Return a copy of the sequence without the gap character(s).

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -632,9 +632,7 @@ class Seq:
         Seq('VMAIVMGR*KGAR')
         Seq('L')
         """
-        return [
-            Seq(part, self.alphabet) for part in str(self).split(str(sep), maxsplit)
-        ]
+        return [Seq(part) for part in str(self).split(str(sep), maxsplit)]
 
     def rsplit(self, sep=None, maxsplit=-1):
         """Do a right split method, like that of a python string.
@@ -654,9 +652,7 @@ class Seq:
 
         See also the split method.
         """
-        return [
-            Seq(part, self.alphabet) for part in str(self).rsplit(str(sep), maxsplit)
-        ]
+        return [Seq(part) for part in str(self).rsplit(str(sep), maxsplit)]
 
     def strip(self, chars=None):
         """Return a new Seq object with leading and trailing ends stripped.
@@ -671,7 +667,7 @@ class Seq:
 
         See also the lstrip and rstrip methods.
         """
-        return Seq(str(self).strip(str(chars)), self.alphabet)
+        return Seq(str(self).strip(str(chars)))
 
     def lstrip(self, chars=None):
         """Return a new Seq object with leading (left) end stripped.
@@ -686,7 +682,7 @@ class Seq:
 
         See also the strip and rstrip methods.
         """
-        return Seq(str(self).lstrip(str(chars)), self.alphabet)
+        return Seq(str(self).lstrip(str(chars)))
 
     def rstrip(self, chars=None):
         """Return a new Seq object with trailing (right) end stripped.
@@ -708,7 +704,7 @@ class Seq:
 
         See also the strip and lstrip methods.
         """
-        return Seq(str(self).rstrip(str(chars)), self.alphabet)
+        return Seq(str(self).rstrip(str(chars)))
 
     def upper(self):
         """Return an upper case copy of the sequence.

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -573,10 +573,8 @@ def parse(handle, format, alphabet=None):
     >>> for record in SeqIO.parse(filename, "fasta"):
     ...    print("ID %s" % record.id)
     ...    print("Sequence length %i" % len(record))
-    ...    print("Sequence alphabet %s" % record.seq.alphabet)
     ID gi|3176602|gb|U78617.1|LOU78617
     Sequence length 309
-    Sequence alphabet SingleLetterAlphabet()
 
     For file formats like FASTA where the alphabet cannot be determined, it
     may be useful to specify the alphabet explicitly:
@@ -677,8 +675,6 @@ def read(handle, format, alphabet=None):
     ID AC007323.5
     >>> print("Sequence length %i" % len(record))
     Sequence length 86436
-    >>> print("Sequence alphabet %s" % record.seq.alphabet)
-    Sequence alphabet DNAAlphabet()
 
     If the handle contains no records, or more than one record,
     an exception is raised.  For example:
@@ -956,7 +952,6 @@ def index_db(
     This indexing function will return a dictionary like object, giving the
     SeqRecord objects as values:
 
-    >>> from Bio.Alphabet import generic_protein
     >>> from Bio import SeqIO
     >>> files = ["GenBank/NC_000932.faa", "GenBank/NC_005816.faa"]
     >>> def get_gi(name):
@@ -965,7 +960,7 @@ def index_db(
     ...     assert i != -1
     ...     return parts[i+1]
     >>> idx_name = ":memory:" #use an in memory SQLite DB for this test
-    >>> records = SeqIO.index_db(idx_name, files, "fasta", generic_protein, get_gi)
+    >>> records = SeqIO.index_db(idx_name, files, "fasta", key_function=get_gi)
     >>> len(records)
     95
     >>> records["7525076"].description

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -693,7 +693,6 @@ class StringMethodTests(unittest.TestCase):
                 # Default to DNA, e.g. complement("A") -> "T" not "U"
                 mapping = str.maketrans("ACGTacgt", "TGCAtgca")
             self.assertEqual(str1.translate(mapping), str(comp))
-            self.assertEqual(comp.alphabet, example1.alphabet)
 
     def test_the_reverse_complement(self):
         """Check obj.reverse_complement() method."""

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -732,7 +732,6 @@ class StringMethodTests(unittest.TestCase):
                 # TODO - Check for or silence the expected warning?
                 continue
             self.assertEqual(str1.replace("T", "U").replace("t", "u"), str(tran))
-            self.assertEqual(tran.alphabet, generic_rna)  # based on limited examples
 
     def test_the_back_transcription(self):
         """Check obj.back_transcribe() method."""
@@ -750,7 +749,6 @@ class StringMethodTests(unittest.TestCase):
                 raise
             str1 = str(example1)
             self.assertEqual(str1.replace("U", "T").replace("u", "t"), str(tran))
-            self.assertEqual(tran.alphabet, generic_dna)  # based on limited examples
 
     def test_the_translate(self):
         """Check obj.translate() method."""

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -713,7 +713,6 @@ class StringMethodTests(unittest.TestCase):
                 # Defaults to DNA, so reverse_complement("A") --> "T" not "U"
                 mapping = str.maketrans("ACGTacgt", "TGCAtgca")
             self.assertEqual(str1.translate(mapping)[::-1], str(comp))
-            self.assertEqual(comp.alphabet, example1.alphabet)
 
     def test_the_transcription(self):
         """Check obj.transcribe() method."""

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -768,10 +768,6 @@ class StringMethodTests(unittest.TestCase):
             # Try with positional vs named argument:
             self.assertEqual(example1.translate(11), example1.translate(table=11))
 
-            # This is based on the limited example not having stop codons:
-            if tran.alphabet not in [extended_protein, protein, generic_protein]:
-                print(tran.alphabet)
-                self.fail()
             # TODO - check the actual translation, and all the optional args
 
     def test_the_translation_of_stops(self):

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -1048,38 +1048,6 @@ class TestTranslating(unittest.TestCase):
                 expected = Seq.translate(nucleotide_seq)
                 self.assertEqual(repr(expected), repr(nucleotide_seq.translate()))
 
-    def test_alphabets_of_translated_seqs(self):
-        def triple_pad(s):
-            """Add N to ensure length is a multiple of three (whole codons)."""
-            while len(s) % 3:
-                s += "N"
-            return s
-
-        self.assertIs(self.test_seqs[0].translate().alphabet, Alphabet.generic_protein)
-        self.assertIs(self.test_seqs[1].translate().alphabet, Alphabet.generic_protein)
-        self.assertIs(self.test_seqs[2].translate().alphabet, Alphabet.generic_protein)
-        self.assertIs(self.test_seqs[3].translate().alphabet, Alphabet.generic_protein)
-        self.assertIs(self.test_seqs[10].translate().alphabet, Alphabet.generic_protein)
-        self.assertIs(self.test_seqs[11].translate().alphabet, Alphabet.generic_protein)
-        self.assertIs(self.test_seqs[12].translate().alphabet, Alphabet.generic_protein)
-
-        self.assertIs(
-            triple_pad(self.test_seqs[13]).translate().alphabet,
-            Alphabet.generic_protein,
-        )
-
-        self.assertIs(self.test_seqs[14].translate().alphabet, Alphabet.generic_protein)
-        self.assertIs(self.test_seqs[15].translate().alphabet, Alphabet.generic_protein)
-
-        self.assertIs(
-            triple_pad(self.test_seqs[16]).translate().alphabet,
-            Alphabet.generic_protein,
-        )
-        self.assertIs(
-            triple_pad(self.test_seqs[17]).translate().alphabet,
-            Alphabet.generic_protein,
-        )
-
     def test_gapped_seq_with_gap_char_given(self):
         seq = Seq.Seq("ATG---AAACTG")
         self.assertEqual("M-KL", seq.translate(gap="-"))
@@ -1108,31 +1076,6 @@ class TestTranslating(unittest.TestCase):
     def test_gapped_seq_no_gap_char_given(self):
         seq = Seq.Seq("ATG---AAACTG")
         self.assertRaises(TranslationError, seq.translate, gap=None)
-
-    def test_alphabet_of_translated_gapped_seq(self):
-        seq = Seq.Seq("ATG---AAACTG", Alphabet.generic_dna)
-        self.assertIs(seq.translate().alphabet, Alphabet.generic_protein)
-
-        seq = Seq.Seq("ATG---AAACTG", Alphabet.generic_dna)
-        self.assertIs(seq.translate().alphabet, Alphabet.generic_protein)
-
-        seq = Seq.Seq("ATG~~~AAACTG", Alphabet.generic_dna)
-        self.assertIs(seq.translate(gap="~").alphabet, Alphabet.generic_protein)
-
-        seq = Seq.Seq("ATG---AAACTG")
-        self.assertIs(seq.translate(gap="-").alphabet, Alphabet.generic_protein)
-
-        seq = Seq.Seq("ATG~~~AAACTG")
-        self.assertIs(seq.translate(gap="~").alphabet, Alphabet.generic_protein)
-
-        seq = Seq.Seq("ATG~~~AAACTGTAG")
-        self.assertIs(seq.translate(gap="~").alphabet, Alphabet.generic_protein)
-
-        seq = Seq.Seq("ATG---AAACTGTGA")
-        self.assertIs(seq.translate(gap="-").alphabet, Alphabet.generic_protein)
-
-        seq = Seq.Seq("ATG---AAACTGTGA")
-        self.assertIs(seq.translate(gap="-").alphabet, Alphabet.generic_protein)
 
     def test_translation_wrong_type(self):
         """Test translation table cannot be CodonTable."""

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -274,14 +274,6 @@ class TestSeqStringMethods(unittest.TestCase):
 
         self.assertEqual(7, len(self.test_chars))
 
-    def test_exception_when_clashing_alphabets(self):
-        """Test by setting up clashing alphabet sequences."""
-        b = Seq.Seq("-", Alphabet.generic_nucleotide)
-        self.assertRaises(TypeError, self.protein[0].strip, b)
-
-        b = Seq.Seq("-", Alphabet.generic_protein)
-        self.assertRaises(TypeError, self.dna[0].strip, b)
-
     def test_stripping_characters(self):
         for a in self.dna + self.rna + self.nuc + self.protein:
             for char in self.test_chars:

--- a/Tests/test_translate.py
+++ b/Tests/test_translate.py
@@ -64,10 +64,8 @@ class TestTranscriptionTranslation(unittest.TestCase):
         s = "TCAAAAAGGTGCATCTAGATG"
         dna = Seq.Seq(s, IUPAC.unambiguous_dna)
         protein = dna.translate(to_stop=True)
-        self.assertIs(protein.alphabet, Alphabet.generic_protein)
         self.assertEqual(str(protein), "SKRCI")
         gapped_protein = dna.translate()
-        self.assertIs(gapped_protein.alphabet, Alphabet.generic_protein)
         self.assertEqual(str(gapped_protein), "SKRCI*M")
         # The table used here has "AGG" as a stop codon:
         p2 = dna.translate(table=2, to_stop=True)
@@ -79,7 +77,6 @@ class TestTranscriptionTranslation(unittest.TestCase):
         r = s.replace("T", "U")
         rna = Seq.Seq(r, IUPAC.unambiguous_rna)
         protein = rna.translate(to_stop=True)
-        self.assertIs(protein.alphabet, Alphabet.generic_protein)
         self.assertEqual(str(protein), "SKRCI")
         gapped_protein = rna.translate()
         self.assertEqual(str(gapped_protein), "SKRCI*M")


### PR DESCRIPTION
Following discussion on #2972 moving recording the molecule type from the Seq object's alphabet to the SeqRecord objects's annotation, this follows updating type checking of the biological methods accordingly in #2977, by dropping the alphabet in many of the Seq object method return values.

(Still more to do, I'll add more to this PR and/or do the rest in a follow on PR)

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
