### PR TITLE
let the Swiss-Prot parser fix the file handle mode if it's binary

### DIFF
--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -17,6 +17,8 @@ Functions:
 """
 
 
+import io
+
 from Bio.SeqFeature import (
     SeqFeature,
     FeatureLocation,
@@ -273,11 +275,14 @@ def read(source):
 def _open(source):
     try:
         handle = open(source)
+        return handle
     except TypeError:
         handle = source
-        if handle.read(0) != "":
-            raise ValueError("SwissProt files must be opened in text mode.") from None
-    return handle
+        if handle.read(0) == "":
+            # handle is text; assume the encoding is compatible with ASCII
+            return handle
+        # handle is binary; SwissProt encoding is always ASCII
+        return io.TextIOWrapper(handle, encoding="ASCII")
 
 
 def _read(handle):

--- a/Doc/Tutorial/chapter_uniprot.tex
+++ b/Doc/Tutorial/chapter_uniprot.tex
@@ -28,9 +28,8 @@ To parse a Swiss-Prot record, we first get a handle to a Swiss-Prot record. Ther
 \item Open a Swiss-Prot file over the internet:
 \begin{minted}{pycon}
 >>> from urllib.request import urlopen
->>> from io import TextIOWrapper
 >>> url = "https://raw.githubusercontent.com/biopython/biopython/master/Tests/SwissProt/F2CXE6.txt"
->>> handle = TextIOWrapper(urlopen(url))
+>>> handle = urlopen(url)
 \end{minted}
 to open the file stored on the Internet before calling \verb|read|.
 
@@ -41,7 +40,7 @@ to open the file stored on the Internet before calling \verb|read|.
 >>> handle = ExPASy.get_sprot_raw(myaccessionnumber)
 \end{minted}
 \end{itemize}
-The key point is that for the parser, it doesn't matter how the handle was created, as long as it points to data in the Swiss-Prot format.
+The key point is that for the parser, it doesn't matter how the handle was created, as long as it points to data in the Swiss-Prot format. The parser will automatically decode the data as ASCII (the encoding used by Swiss-Prot) if the handle was opened in binary mode.
 
 We can use \verb+Bio.SeqIO+ as described in Section~\ref{sec:SeqIO_ExPASy_and_SwissProt} to get file format agnostic \verb|SeqRecord| objects.  Alternatively, we can use \verb+Bio.SwissProt+ get \verb|Bio.SwissProt.Record| objects, which are a much closer match to the underlying file format.
 


### PR DESCRIPTION
In the Swiss-Prot parser, fix the file handle if it is in binary mode.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
