### PR TITLE
Drop more alphabet usage in Seq object methods

### DIFF
--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -1420,7 +1420,11 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                 "molecule_type", molecule_type
             )
         if not sequence and self._expected_size:
-            self.data.seq = UnknownSeq(self._expected_size, seq_alphabet)
+            self.data.seq = UnknownSeq(
+                self._expected_size,
+                seq_alphabet,
+                character="X" if molecule_type == "protein" else "N",
+            )
         else:
             self.data.seq = Seq(sequence, seq_alphabet)
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -310,7 +310,7 @@ class Seq:
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(str(self) * other, self.alphabet)
+        return self.__class__(str(self) * other)
 
     def __rmul__(self, other):
         """Multiply integer by Seq.
@@ -321,7 +321,7 @@ class Seq:
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(str(self) * other, self.alphabet)
+        return self.__class__(str(self) * other)
 
     def __imul__(self, other):
         """Multiply Seq in-place.
@@ -337,7 +337,7 @@ class Seq:
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(str(self) * other, self.alphabet)
+        return self.__class__(str(self) * other)
 
     def tomutable(self):  # Needed?  Or use a function?
         """Return the full sequence as a MutableSeq object.
@@ -348,10 +348,8 @@ class Seq:
         Seq('MKQHKAMIVALIVICITAVVAAL')
         >>> my_seq.tomutable()
         MutableSeq('MKQHKAMIVALIVICITAVVAAL')
-
-        Any alphabet is preserved.
         """
-        return MutableSeq(str(self), self.alphabet)
+        return MutableSeq(str(self))
 
     def count(self, sub, start=0, end=sys.maxsize):
         """Return a non-overlapping count, like that of a python string.
@@ -1985,7 +1983,7 @@ class MutableSeq:
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(self.data * other, self.alphabet)
+        return self.__class__(self.data * other)
 
     def __rmul__(self, other):
         """Multiply integer by MutableSeq.
@@ -2002,7 +2000,7 @@ class MutableSeq:
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(self.data * other, self.alphabet)
+        return self.__class__(self.data * other)
 
     def __imul__(self, other):
         """Multiply MutableSeq in-place.
@@ -2016,7 +2014,7 @@ class MutableSeq:
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(self.data * other, self.alphabet)
+        return self.__class__(self.data * other)
 
     def append(self, c):
         """Add a subsequence to the mutable sequence object.
@@ -2287,18 +2285,14 @@ class MutableSeq:
     def toseq(self):
         """Return the full sequence as a new immutable Seq object.
 
-        >>> from Bio.Alphabet import generic_protein
         >>> from Bio.Seq import Seq
-        >>> my_mseq = MutableSeq("MKQHKAMIVALIVICITAVVAAL",
-        ...                      generic_protein)
+        >>> my_mseq = MutableSeq("MKQHKAMIVALIVICITAVVAAL")
         >>> my_mseq
         MutableSeq('MKQHKAMIVALIVICITAVVAAL')
         >>> my_mseq.toseq()
         Seq('MKQHKAMIVALIVICITAVVAAL')
-
-        Note that the alphabet is preserved.
         """
-        return Seq("".join(self.data), self.alphabet)
+        return Seq("".join(self.data))
 
     def join(self, other):
         """Return a merge of the sequences in other, spaced by the sequence from self.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -181,7 +181,7 @@ class Seq:
 
     def __lt__(self, other):
         """Implement the less-than operand."""
-        if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
+        if isinstance(other, (str, Seq, MutableSeq)):
             return str(self) < str(other)
         raise TypeError(
             f"'<' not supported between instances of '{type(self).__name__}'"
@@ -190,7 +190,7 @@ class Seq:
 
     def __le__(self, other):
         """Implement the less-than or equal operand."""
-        if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
+        if isinstance(other, (str, Seq, MutableSeq)):
             return str(self) <= str(other)
         raise TypeError(
             f"'<=' not supported between instances of '{type(self).__name__}'"
@@ -199,7 +199,7 @@ class Seq:
 
     def __gt__(self, other):
         """Implement the greater-than operand."""
-        if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
+        if isinstance(other, (str, Seq, MutableSeq)):
             return str(self) > str(other)
         raise TypeError(
             f"'>' not supported between instances of '{type(self).__name__}'"
@@ -208,7 +208,7 @@ class Seq:
 
     def __ge__(self, other):
         """Implement the greater-than or equal operand."""
-        if isinstance(other, (str, Seq, MutableSeq, UnknownSeq)):
+        if isinstance(other, (str, Seq, MutableSeq)):
             return str(self) >= str(other)
         raise TypeError(
             f"'>=' not supported between instances of '{type(self).__name__}'"
@@ -1133,7 +1133,7 @@ class Seq:
         from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
 
         a = self.alphabet
-        if isinstance(other, (Seq, MutableSeq, UnknownSeq)):
+        if isinstance(other, (Seq, MutableSeq)):
             if a == other.alphabet:
                 return self.__class__(str(self).join(str(other)), a)
             else:

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1108,7 +1108,7 @@ class Seq:
             raise ValueError("Gap character required.")
         elif len(gap) != 1 or not isinstance(gap, str):
             raise ValueError(f"Unexpected gap character, {gap!r}")
-        return Seq(str(self).replace(gap, ""), self.alphabet)
+        return Seq(str(self).replace(gap, ""))
 
     def join(self, other):
         """Return a merge of the sequences in other, spaced by the sequence from self.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1130,28 +1130,20 @@ class Seq:
         >>> Seq('NNNNN').join("ACGT")
         Seq('ANNNNNCNNNNNGNNNNNT')
         """
+        if isinstance(other, (str, Seq, MutableSeq)):
+            return self.__class__(str(self).join(str(other)))
+
         from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
 
-        a = self.alphabet
-        if isinstance(other, (Seq, MutableSeq)):
-            if a == other.alphabet:
-                return self.__class__(str(self).join(str(other)), a)
-            else:
-                # Drop the alphabet
-                return self.__class__(str(self).join(str(other)))
         if isinstance(other, SeqRecord):
             raise TypeError("Iterable cannot be a SeqRecord")
+
         for c in other:
             if isinstance(c, SeqRecord):
                 raise TypeError("Iterable cannot contain SeqRecords")
-            elif hasattr(c, "alphabet"):
-                if a != c.alphabet:
-                    # Drop the alphabet
-                    a = Alphabet.generic_alphabet
-            elif not isinstance(c, str):
+            elif not isinstance(c, (str, Seq, MutableSeq)):
                 raise TypeError("Input must be an iterable of Seqs or Strings")
-        temp_data = str(self).join([str(_) for _ in other])
-        return self.__class__(temp_data, a)
+        return self.__class__(str(self).join([str(_) for _ in other]))
 
 
 class UnknownSeq(Seq):

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1295,7 +1295,7 @@ class UnknownSeq(Seq):
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(len(self) * other, self.alphabet)
+        return self.__class__(len(self) * other, self.alphabet, self._character)
 
     def __rmul__(self, other):
         """Multiply integer by UnknownSeq.
@@ -1309,7 +1309,7 @@ class UnknownSeq(Seq):
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(len(self) * other, self.alphabet)
+        return self.__class__(len(self) * other, self.alphabet, self._character)
 
     def __imul__(self, other):
         """Multiply UnknownSeq in-place.
@@ -1326,7 +1326,7 @@ class UnknownSeq(Seq):
         """
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(len(self) * other, self.alphabet)
+        return self.__class__(len(self) * other, self.alphabet, self._character)
 
     def __getitem__(self, index):
         """Get a subsequence from the UnknownSeq object.
@@ -1554,7 +1554,7 @@ class UnknownSeq(Seq):
         """
         # Offload the alphabet stuff
         s = Seq(self._character, self.alphabet).transcribe()
-        return UnknownSeq(self._length, s.alphabet, self._character)
+        return UnknownSeq(self._length, s.alphabet, character=str(s))
 
     def back_transcribe(self):
         """Return an unknown DNA sequence from an unknown RNA sequence.
@@ -1572,7 +1572,7 @@ class UnknownSeq(Seq):
         """
         # Offload the alphabet stuff
         s = Seq(self._character, self.alphabet).back_transcribe()
-        return UnknownSeq(self._length, s.alphabet, self._character)
+        return UnknownSeq(self._length, s.alphabet, character=str(s))
 
     def upper(self):
         """Return an upper case copy of the sequence.

--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -130,7 +130,7 @@ class DBSeq(Seq):
     def toseq(self):
         """Return the full sequence as a Seq object."""
         # Note - the method name copies that of the MutableSeq object
-        return Seq(str(self), self.alphabet)
+        return Seq(str(self))
 
     def __add__(self, other):
         """Add another sequence or string to this sequence.

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -497,12 +497,10 @@ class SeqInterfaceTest(unittest.TestCase):
 
         other = test_seq.toseq()
         self.assertEqual(str(test_seq), str(other))
-        self.assertEqual(test_seq.alphabet, other.alphabet)
         self.assertIsInstance(other, Seq)
 
         other = test_seq.tomutable()
         self.assertEqual(str(test_seq), str(other))
-        self.assertEqual(test_seq.alphabet, other.alphabet)
         self.assertIsInstance(other, MutableSeq)
 
     def test_addition(self):
@@ -529,13 +527,11 @@ class SeqInterfaceTest(unittest.TestCase):
         self.assertIsInstance(tripled, Seq)
         self.assertNotIsInstance(tripled, BioSeq.DBSeq)
         self.assertEqual(tripled, str(test_seq) * 3)
-        self.assertEqual(tripled.alphabet, alphabet)
         # Test DBSeq.__rmul__
         tripled = 3 * test_seq
         self.assertIsInstance(tripled, Seq)
         self.assertNotIsInstance(tripled, BioSeq.DBSeq)
         self.assertEqual(tripled, str(test_seq) * 3)
-        self.assertEqual(tripled.alphabet, alphabet)
         # Test DBSeq.__imul__
         original = self.item.seq
         tripled = test_seq
@@ -543,7 +539,6 @@ class SeqInterfaceTest(unittest.TestCase):
         self.assertIsInstance(tripled, Seq)
         self.assertNotIsInstance(tripled, BioSeq.DBSeq)
         self.assertEqual(tripled, str(original) * 3)
-        self.assertEqual(tripled.alphabet, alphabet)
 
     def test_seq_slicing(self):
         """Check that slices of sequences are retrieved properly."""

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -971,7 +971,6 @@ class StringMethodTests(unittest.TestCase):
         str_concatenated = spacer1.join(example_strings)
 
         self.assertEqual(str(str_concatenated), "".join(example_strings))
-        self.assertEqual(str_concatenated.alphabet, spacer1.alphabet)
 
         for spacer in spacers:
             seq_concatenated = spacer.join(example_strings_seqs)
@@ -1072,7 +1071,6 @@ class StringMethodTests(unittest.TestCase):
         str_concatenated = spacer1.join(example_strings)
 
         self.assertEqual(str(str_concatenated), "".join(example_strings))
-        self.assertEqual(str_concatenated.alphabet, spacer1.alphabet)
 
         for spacer in spacers:
             seq_concatenated = spacer.join(example_strings_seqs)

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1019,7 +1019,6 @@ class StringMethodTests(unittest.TestCase):
         str_concatenated = spacer1.join(example_strings)
 
         self.assertEqual(str(str_concatenated), "".join(example_strings))
-        self.assertEqual(str_concatenated.alphabet, spacer1.alphabet)
 
         for spacer in spacers:
             seq_concatenated = spacer.join(example_strings_seqs)

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -661,7 +661,6 @@ class StringMethodTests(unittest.TestCase):
             mut = example1.tomutable()
             self.assertIsInstance(mut, MutableSeq)
             self.assertEqual(str(mut), str(example1))
-            self.assertEqual(mut.alphabet, example1.alphabet)
 
     def test_toseq(self):
         """Check obj.toseq() method."""
@@ -673,7 +672,6 @@ class StringMethodTests(unittest.TestCase):
                 continue
             self.assertIsInstance(seq, Seq)
             self.assertEqual(str(seq), str(example1))
-            self.assertEqual(seq.alphabet, example1.alphabet)
 
     def test_the_complement(self):
         """Check obj.complement() method."""


### PR DESCRIPTION
This pull request addresses in part issue #2046, continuing the work in #2988 - more need to do a bit more here but first AlignIO needs some updating for using molecule type via the records.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
