### PR TITLE
TravisCI workaround, avoid SciPy 1.5.0 due to minimize change

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -72,7 +72,7 @@ deps =
     py37: mysqlclient
     py38: rdflib
     pypy3: mysqlclient
-    py37: scipy
+    py37: scipy<1.5.0
     py38: networkx
     py37: matplotlib
 commands =


### PR DESCRIPTION
This pull request addresses issue #2993.

Workaround for test failure in ``test_codonalign.Test_dn_ds`` most likely due to scipy.optimize.minimize now using bounds strictly. 


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
