### PR TITLE
Make gap an explicit argument in AlignInfo

### DIFF
--- a/Doc/examples/clustal_run.py
+++ b/Doc/examples/clustal_run.py
@@ -16,8 +16,6 @@ and parse the results into an object that can be dealt with easily.
 import sys
 import subprocess
 
-# biopython
-from Bio.Alphabet import Gapped, IUPAC
 from Bio.Align.Applications import ClustalwCommandline
 from Bio import AlignIO
 from Bio.Align import AlignInfo
@@ -32,7 +30,7 @@ return_code = subprocess.call(str(cline), shell=(sys.platform != "win32"))
 assert return_code == 0, "Calling ClustalW failed"
 
 # Parse the output
-alignment = AlignIO.read("test.aln", "clustal", alphabet=Gapped(IUPAC.unambiguous_dna))
+alignment = AlignIO.read("test.aln", "clustal")
 
 print(alignment)
 
@@ -57,7 +55,7 @@ print(my_pssm)
 expect_freq = {"A": 0.3, "G": 0.2, "T": 0.3, "C": 0.2}
 
 info_content = summary_align.information_content(
-    5, 30, chars_to_ignore=["N"], e_freq_table=expect_freq
+    5, 30, chars_to_ignore=["N", "-"], e_freq_table=expect_freq
 )
 
 print("relative info content: %f" % info_content)

--- a/Doc/examples/clustal_run.py
+++ b/Doc/examples/clustal_run.py
@@ -55,7 +55,7 @@ print(my_pssm)
 expect_freq = {"A": 0.3, "G": 0.2, "T": 0.3, "C": 0.2}
 
 info_content = summary_align.information_content(
-    5, 30, chars_to_ignore=["N", "-"], e_freq_table=expect_freq
+    5, 30, chars_to_ignore=["N"], e_freq_table=expect_freq
 )
 
 print("relative info content: %f" % info_content)

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -243,7 +243,7 @@ class TestReading(unittest.TestCase):
         consensus = align_info.dumb_consensus()
         self.assertIsInstance(consensus, Seq)
         self.assertEqual(consensus, "TATACATTAAAGXAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATATATATATATAATATATTTCAAATTXCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA")
-        dictionary = align_info.replacement_dictionary(["N", "-"])
+        dictionary = align_info.replacement_dictionary(["N"])
         self.assertEqual(len(dictionary), 16)
         self.assertAlmostEqual(dictionary[("A", "A")], 1395.0, places=1)
         self.assertAlmostEqual(dictionary[("A", "C")], 3.0, places=1)
@@ -261,7 +261,7 @@ class TestReading(unittest.TestCase):
         self.assertAlmostEqual(dictionary[("T", "C")], 12.0, places=1)
         self.assertAlmostEqual(dictionary[("T", "G")], 0, places=1)
         self.assertAlmostEqual(dictionary[("T", "T")], 874.0, places=1)
-        matrix = align_info.pos_specific_score_matrix(consensus, ["N", "-"])
+        matrix = align_info.pos_specific_score_matrix(consensus, ["N"])
         self.assertEqual(str(matrix), """\
     A   C   G   T
 T  0.0 0.0 0.0 7.0


### PR DESCRIPTION
Have to explicitly ignore the gap char now for AlignInfo

This pull request addresses issue #2046 work, see also #2945.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
