### PR TITLE
Record molecule type in AlignIO FASTA parser

### DIFF
--- a/Bio/AlignIO/FastaIO.py
+++ b/Bio/AlignIO/FastaIO.py
@@ -168,8 +168,10 @@ handle.name: {handle.name}
         if alphabet == single_letter_alphabet and "sq_type" in query_tags:
             if query_tags["sq_type"] == "D":
                 record.seq.alphabet = generic_dna
+                record.annotations["molecule_type"] = "DNA"
             elif query_tags["sq_type"] == "p":
                 record.seq.alphabet = generic_protein
+                record.annotations["molecule_type"] = "protein"
 
         # Match
         # =====

--- a/Bio/AlignIO/FastaIO.py
+++ b/Bio/AlignIO/FastaIO.py
@@ -168,9 +168,12 @@ handle.name: {handle.name}
         if alphabet == single_letter_alphabet and "sq_type" in query_tags:
             if query_tags["sq_type"] == "D":
                 record.seq.alphabet = generic_dna
-                record.annotations["molecule_type"] = "DNA"
             elif query_tags["sq_type"] == "p":
                 record.seq.alphabet = generic_protein
+        if "sq_type" in query_tags:
+            if query_tags["sq_type"] == "D":
+                record.annotations["molecule_type"] = "DNA"
+            elif query_tags["sq_type"] == "p":
                 record.annotations["molecule_type"] = "protein"
 
         # Match


### PR DESCRIPTION
This pull request addresses issue #2046, will need more work to move the AlignIO code over to using molecule type rather than the Seq object's alphabet.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
