### PR TITLE
Changed header delineator from space to pipe

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -312,7 +312,7 @@ class FastaWriter(SequenceWriter):
                 # The description includes the id at the start
                 title = description
             elif description:
-                title = "%s %s" % (id, description)
+                title = "%s|%s" % (id, description)
             else:
                 title = id
 
@@ -389,7 +389,7 @@ def as_fasta(record):
         # The description includes the id at the start
         title = description
     elif description:
-        title = "%s %s" % (id, description)
+        title = "%s|%s" % (id, description)
     else:
         title = id
     assert "\n" not in title
@@ -417,7 +417,7 @@ def as_fasta_2line(record):
         # The description includes the id at the start
         title = description
     elif description:
-        title = "%s %s" % (id, description)
+        title = "%s|%s" % (id, description)
     else:
         title = id
     assert "\n" not in title


### PR DESCRIPTION
There are common utilities for processing FASTA files that only use the string in the header preceding a space, so for this reason pipes are preferred in FASTA header strings

This pull request addresses issue #...

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X ] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
