### PR TITLE
Fixed bug at PDBIO.set_structure()

### DIFF
--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -78,21 +78,21 @@ class StructureIO:
                 else:
                     sb.init_chain("A")
                     if pdb_object.level == "R":
+                        parent_id = pdb_object.parent.id
                         try:
-                            parent_id = pdb_object.parent.id
                             sb.structure[0]["A"].id = parent_id
                         except Exception:
                             pass
-                        sb.structure[0]["A"].add(pdb_object.copy())
+                        sb.structure[0][parent_id].add(pdb_object.copy())
                     else:
                         # Atom
                         sb.init_residue("DUM", " ", 1, " ")
+                        parent_id = pdb_object.parent.parent.id
                         try:
-                            parent_id = pdb_object.parent.parent.id
                             sb.structure[0]["A"].id = parent_id
                         except Exception:
                             pass
-                        sb.structure[0]["A"].child_list[0].add(pdb_object.copy())
+                        sb.structure[0][parent_id].child_list[0].add(pdb_object.copy())
 
             # Return structure
             structure = sb.structure


### PR DESCRIPTION
It always tries to access a chain object whose id is "A". However, if one tries to save a Residue/Atom whose chain id is not "A", it raises a KeyError exception because the recently created chain (line 79) had its id updated to pdb_object.parent.id at line 83 (when pdb_object is a residue) or 92 (when pdb_object is an atom).

This pull request addresses issue #2995 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [ ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ ] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
