### PR TITLE
Added keyword to specify msms executable on class instantiation

### DIFF
--- a/Bio/PDB/ResidueDepth.py
+++ b/Bio/PDB/ResidueDepth.py
@@ -600,7 +600,6 @@ class ResidueDepth(AbstractPropertyMap):
 
     def __init__(self, model, pdb_file=None, msms_exec=None):
         """Initialize the class."""
-
         if msms_exec is None:
             msms_exec = "msms"
 

--- a/Bio/PDB/ResidueDepth.py
+++ b/Bio/PDB/ResidueDepth.py
@@ -598,8 +598,12 @@ def ca_depth(residue, surface):
 class ResidueDepth(AbstractPropertyMap):
     """Calculate residue and CA depth for all residues."""
 
-    def __init__(self, model, pdb_file=None):
+    def __init__(self, model, pdb_file=None, msms_exec=None):
         """Initialize the class."""
+
+        if msms_exec is None:
+            msms_exec = "msms"
+
         # Issue warning if pdb_file is given
         if pdb_file is not None:
             warnings.warn(
@@ -614,7 +618,7 @@ class ResidueDepth(AbstractPropertyMap):
         # get_residue
         residue_list = Selection.unfold_entities(model, "R")
         # make surface from PDB file using MSMS
-        surface = get_surface(model)
+        surface = get_surface(model, MSMS=msms_exec)
         # calculate rdepth for each residue
         for residue in residue_list:
             if not is_aa(residue):


### PR DESCRIPTION
This pull request closes issue #2983.

Tested on Win10 with MSMS 2.6.1:

```python
import pathlib
from Bio.PDB import PDBParser, ResidueDepth

parser = PDBParser(QUIET=1)
struct = parser.get_structure('x', 'Tests/PDB/2XHE.pdb')

msms = '...'  # path to your executable

rd = ResidueDepth(s, msms_exec=msms)
```

Does not break compatibility with existing code/function calls.

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
