### PR TITLE
In Bio.pairwise2, replace substitution matrices

### DIFF
--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -232,10 +232,10 @@ Some examples:
     <BLANKLINE>
 
 - The alignment function can also use known matrices already included in
-  Biopython (``MatrixInfo`` from ``Bio.SubsMat``):
+  Biopython (in ``Bio.Align.substitution_matrices``):
 
-    >>> from Bio.SubsMat import MatrixInfo as matlist
-    >>> matrix = matlist.blosum62
+    >>> from Bio.Align import substitution_matrices
+    >>> matrix = substitution_matrices.load("BLOSUM62")
     >>> for a in pairwise2.align.globaldx("KEVLA", "EVL", matrix):
     ...     print(format_alignment(*a))
     KEVLA

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1520,7 +1520,8 @@ and a gap extension penalty of 0.5 (using \verb|globalds|):
 \begin{minted}{pycon}
 >>> from Bio import pairwise2
 >>> from Bio import SeqIO
->>> from Bio.SubsMat.MatrixInfo import blosum62
+>>> from Bio.Align import substitution_matrices
+>>> blosum62 = substitution_matrices.load("BLOSUM62")
 >>> seq1 = SeqIO.read("alpha.faa", "fasta")
 >>> seq2 = SeqIO.read("beta.faa", "fasta")
 >>> alignments = pairwise2.align.globalds(seq1.seq, seq2.seq, blosum62, -10, -0.5)
@@ -1543,7 +1544,8 @@ where again XX stands for a two letter code for the match and gap functions:
 %doctest
 \begin{minted}{pycon}
 >>> from Bio import pairwise2
->>> from Bio.SubsMat.MatrixInfo import blosum62
+>>> from Bio.Align import substitution_matrices
+>>> blosum62 = substitution_matrices.load("BLOSUM62")
 >>> alignments = pairwise2.align.localds("LSPADKTNVKAA", "PEEKSAV", blosum62, -10, -1)
 >>> print(pairwise2.format_alignment(*alignments[0]))
 3 PADKTNV
@@ -1561,7 +1563,8 @@ aligned parts of the sequences, use the keyword-parameter \verb|full_sequences=T
 %doctest
 \begin{minted}{pycon}
 >>> from Bio import pairwise2
->>> from Bio.SubsMat.MatrixInfo import blosum62
+>>> from Bio.Align import substitution_matrices
+>>> blosum62 = substitution_matrices.load("BLOSUM62")
 >>> alignments = pairwise2.align.localds("LSPADKTNVKAA", "PEEKSAV", blosum62, -10, -1)
 >>> print(pairwise2.format_alignment(*alignments[0], full_sequences=True))
 LSPADKTNVKAA
@@ -1582,7 +1585,8 @@ part has not been extended:
 %doctest
 \begin{minted}{pycon}
 >>> from Bio import pairwise2
->>> from Bio.SubsMat.MatrixInfo import blosum62
+>>> from Bio.Align import substitution_matrices
+>>> blosum62 = substitution_matrices.load("BLOSUM62")
 >>> alignments = pairwise2.align.localds("LSSPADKTNVKKAA", "DDPEEKSAVNN", blosum62, -10, -1)
 >>> print(pairwise2.format_alignment(*alignments[0]))
 4 PADKTNV

--- a/Tests/pairwise2_testCases.py
+++ b/Tests/pairwise2_testCases.py
@@ -17,6 +17,7 @@ import warnings
 
 from Bio import BiopythonWarning
 from Bio import pairwise2
+from Bio.Align import substitution_matrices
 
 
 class TestPairwiseErrorConditions(unittest.TestCase):
@@ -172,7 +173,6 @@ class TestPairwiseLocal(unittest.TestCase):
     """Test some simple local alignments."""
 
     def setUp(self):
-        from Bio.Align import substitution_matrices
         self.blosum62 = substitution_matrices.load("BLOSUM62")
 
     def test_localxs_1(self):

--- a/Tests/pairwise2_testCases.py
+++ b/Tests/pairwise2_testCases.py
@@ -15,7 +15,6 @@ with or without complementing C extensions.
 import unittest
 import warnings
 
-from Bio.SubsMat.MatrixInfo import blosum62
 from Bio import BiopythonWarning
 from Bio import pairwise2
 
@@ -172,6 +171,10 @@ GAACT
 class TestPairwiseLocal(unittest.TestCase):
     """Test some simple local alignments."""
 
+    def setUp(self):
+        from Bio.Align import substitution_matrices
+        self.blosum62 = substitution_matrices.load("BLOSUM62")
+
     def test_localxs_1(self):
         """Test localxx."""
         aligns = sorted(pairwise2.align.localxs("AxBx", "zABz", -0.1, 0))
@@ -212,8 +215,8 @@ zA-Bz
 
     def test_localds_zero_score_segments_symmetric(self):
         """Test if alignment is independent on direction of sequence."""
-        aligns1 = pairwise2.align.localds("CWHISLKM", "CWHGISGLKM", blosum62, -11, -1)
-        aligns2 = pairwise2.align.localds("MKLSIHWC", "MKLGSIGHWC", blosum62, -11, -1)
+        aligns1 = pairwise2.align.localds("CWHISLKM", "CWHGISGLKM", self.blosum62, -11, -1)
+        aligns2 = pairwise2.align.localds("MKLSIHWC", "MKLGSIGHWC", self.blosum62, -11, -1)
         self.assertEqual(len(aligns1), len(aligns2))
 
     def test_localxs_generic(self):
@@ -264,10 +267,10 @@ zA-Bz
 
     def test_blosum62(self):
         """Test localds with blosum62."""
-        self.assertEqual(1, blosum62[("K", "Q")])
-        self.assertEqual(4, blosum62[("A", "A")])
-        self.assertEqual(8, blosum62[("H", "H")])
-        alignments = pairwise2.align.localds("VKAHGKKV", "FQAHCAGV", blosum62, -4, -4)
+        self.assertEqual(1, self.blosum62[("K", "Q")])
+        self.assertEqual(4, self.blosum62[("A", "A")])
+        self.assertEqual(8, self.blosum62[("H", "H")])
+        alignments = pairwise2.align.localds("VKAHGKKV", "FQAHCAGV", self.blosum62, -4, -4)
         for a in alignments:
             self.assertEqual(
                 pairwise2.format_alignment(*a), "2 KAH\n  .||\n2 QAH\n  Score=13\n"


### PR DESCRIPTION
This pull request replaces the substitution matrices in `Bio.pairwise2` from `Bio.SubsMat` by those from `Bio.Align.substitution_matrices`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
