### PR TITLE
MSA object's .alphabet migration to .molecule_type instead - part one

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -224,6 +224,29 @@ class MultipleSeqAlignment:
         doc="""Dictionary of per-letter-annotation for the sequence.""",
     )
 
+    @property
+    def molecule_type(self):
+        """Consensus molecule type of the alignment, or None. Read only.
+
+        Typically a string DNA, RNA, or protein, or None. This gives the
+        consensus of the record.annotations['molecule_type'] values, or
+        None if they are in conflict. This is a read only property.
+        """
+        values = {_.annotations.get("molecule_type", None) for _ in self}
+        if not values:
+            return None  # no records, no molecule type
+        elif len(values) == 1:
+            # Easy case, perfect consensus
+            return list(values)[0]
+        elif all(_ and "DNA" in _ for _ in values):
+            return "DNA"  # e.g. mix of "DNA" and "gDNA"
+        elif all(_ and "RNA" in _ for _ in values):
+            return "RNA"  # e.g. mix of "RNA" and "mRNA"
+        elif all(_ and "DNA" in _ for _ in values):
+            return "protein"
+        else:
+            return None
+
     def _str_line(self, record, length=50):
         """Return a truncated string representation of a SeqRecord (PRIVATE).
 

--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -470,16 +470,9 @@ def convert(in_file, in_format, out_file, out_format, alphabet=None):
     """
     # TODO - Add optimised versions of important conversions
     # For now just off load the work to SeqIO parse/write
-    with as_handle(in_file) as in_handle:
-        # Don't open the output file until we've checked the input is OK:
-        alignments = parse(in_handle, in_format, None, alphabet)
-
-        # This will check the arguments and issue error messages,
-        # after we have opened the file which is a shame.
-        with as_handle(out_file, "w") as out_handle:
-            count = write(alignments, out_handle, out_format)
-
-    return count
+    # Don't open the output file until we've checked the input is OK:
+    alignments = parse(in_file, in_format, None, alphabet)
+    return write(alignments, out_file, out_format)
 
 
 if __name__ == "__main__":

--- a/Tests/test_Nexus.py
+++ b/Tests/test_Nexus.py
@@ -22,7 +22,6 @@ from Bio.AlignIO.NexusIO import NexusIterator, NexusWriter
 from Bio.SeqRecord import SeqRecord
 from Bio.Nexus import Nexus, Trees
 from Bio.Seq import Seq
-from Bio.Alphabet.IUPAC import ambiguous_dna
 from Bio import SeqIO
 
 
@@ -85,7 +84,7 @@ class NexusTest1(unittest.TestCase):
 
     def test_write_with_dups(self):
         # see issue: biopython/Bio/Nexus/Nexus.py _unique_label() eval error #633
-        records = [SeqRecord(Seq("ATGCTGCTGAT", alphabet=ambiguous_dna), id="foo") for _ in range(4)]
+        records = [SeqRecord(Seq("ATGCTGCTGAT"), id="foo", annotations={"molecule_type": "DNA"}) for _ in range(4)]
         out_file = StringIO()
         self.assertEqual(4, SeqIO.write(records, out_file, "nexus"))
 
@@ -376,8 +375,9 @@ usertype matrix_test stepmatrix=5
 
     def test_write_alignment(self):
         # Default causes no interleave (columns <= 1000)
-        records = [SeqRecord(Seq("ATGCTGCTGA" * 90, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
-        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+        records = [SeqRecord(Seq("ATGCTGCTGA" * 90), id=_id, annotations={"molecule_type": "DNA"}) for _id in ["foo", "bar", "baz"]]
+        a = MultipleSeqAlignment(records)
+        self.assertEqual(a.molecule_type, "DNA")
 
         handle = StringIO()
         NexusWriter(handle).write_alignment(a)
@@ -386,8 +386,8 @@ usertype matrix_test stepmatrix=5
         self.assertIn("ATGCTGCTGA" * 90, data)
 
         # Default causes interleave (columns > 1000)
-        records = [SeqRecord(Seq("ATGCTGCTGA" * 110, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
-        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+        records = [SeqRecord(Seq("ATGCTGCTGA" * 110), id=_id, annotations={"molecule_type": "DNA"}) for _id in ["foo", "bar", "baz"]]
+        a = MultipleSeqAlignment(records)
         handle = StringIO()
         NexusWriter(handle).write_alignment(a)
         handle.seek(0)
@@ -396,8 +396,8 @@ usertype matrix_test stepmatrix=5
         self.assertIn("ATGCTGCTGA" * 7, data)
 
         # Override interleave: True
-        records = [SeqRecord(Seq("ATGCTGCTGA" * 9, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
-        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+        records = [SeqRecord(Seq("ATGCTGCTGA" * 9), id=_id, annotations={"molecule_type": "DNA"}) for _id in ["foo", "bar", "baz"]]
+        a = MultipleSeqAlignment(records)
         handle = StringIO()
         NexusWriter(handle).write_alignment(a, interleave=True)
         handle.seek(0)
@@ -406,8 +406,8 @@ usertype matrix_test stepmatrix=5
         self.assertIn("ATGCTGCTGA" * 7, data)
 
         # Override interleave: False
-        records = [SeqRecord(Seq("ATGCTGCTGA" * 110, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
-        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+        records = [SeqRecord(Seq("ATGCTGCTGA" * 110), id=_id, annotations={"molecule_type": "DNA"}) for _id in ["foo", "bar", "baz"]]
+        a = MultipleSeqAlignment(records)
         handle = StringIO()
         NexusWriter(handle).write_alignment(a, interleave=False)
         handle.seek(0)
@@ -687,10 +687,10 @@ class TestSelf(unittest.TestCase):
         self.assertEqual([], list(NexusIterator(StringIO())))
 
     def test_multiple_output(self):
-        records = [SeqRecord(Seq("ATGCTGCTGAT", alphabet=ambiguous_dna), id="foo"),
-                   SeqRecord(Seq("ATGCTGCAGAT", alphabet=ambiguous_dna), id="bar"),
-                   SeqRecord(Seq("ATGCTGCGGAT", alphabet=ambiguous_dna), id="baz")]
-        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+        records = [SeqRecord(Seq("ATGCTGCTGAT"), id="foo", annotations={"molecule_type": "DNA"}),
+                   SeqRecord(Seq("ATGCTGCAGAT"), id="bar", annotations={"molecule_type": "DNA"}),
+                   SeqRecord(Seq("ATGCTGCGGAT"), id="baz", annotations={"molecule_type": "DNA"})]
+        a = MultipleSeqAlignment(records)
 
         handle = StringIO()
         NexusWriter(handle).write_file([a])

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -24,7 +24,7 @@ from Bio.Seq import Seq, UnknownSeq
 from Bio import Alphabet
 from Bio.Align import MultipleSeqAlignment
 from Bio import StreamModeError
-
+from Bio.Nexus.Nexus import NexusError
 
 # TODO - Check that desired warnings are issued. Used to do that by capturing
 # warnings to stdout and verifying via the print-and-compare check. However,
@@ -372,7 +372,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             # Now ready to read back from the handle...
             try:
                 records2 = list(SeqIO.parse(handle=handle, format=format))
-            except ValueError as e:
+            except (ValueError, NexusError) as e:
                 # This is BAD.  We can't read our own output.
                 # I want to see the output when called from the test harness,
                 # run_tests.py (which can be funny about new lines on Windows)
@@ -2580,6 +2580,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=NM_006141.1).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=NM_006141.1).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=NM_006141.1).",
+            "nexus": "NM_006141.1 contains T, but RNA alignment",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=NM_006141.1).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=NM_006141.1).",
             "sff": "Missing SFF flow information",
@@ -2641,6 +2642,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=AL109817.1).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=AL109817.1).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=AL109817.1).",
+            "nexus": "AL109817.1 contains T, but RNA alignment",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=AL109817.1).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=AL109817.1).",
             "sff": "Missing SFF flow information",
@@ -3259,6 +3261,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=X56734.1).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=X56734.1).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=X56734.1).",
+            "nexus": "X56734.1 contains T, but RNA alignment",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=X56734.1).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=X56734.1).",
             "sff": "Missing SFF flow information",
@@ -3550,6 +3553,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
+            "nexus": "A04195 contains T, but RNA alignment",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "sff": "Missing SFF flow information",
@@ -3578,6 +3582,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
+            "nexus": "A04195 contains T, but RNA alignment",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "sff": "Missing SFF flow information",


### PR DESCRIPTION
This pull request addresses in part issue #2046, and #3010.

The proposal here is to replace the ``MultipleSeqAlignment`` object's ``.alphabet`` attribute with a ``.molecule_type`` property (implemented as the consensus of the annotation of the records in the alignment). The Nexus output is updated to use this a a proof of concept.

A future update can change the ``__init__`` to allow setting the molecule type instead of passing an alphabet object (likewise for the ``Bio.AlignIO`` and ``Bio.SeqIO`` functions).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
