### PR TITLE
Fix Newick and Nexus write for comments and internally named nodes

### DIFF
--- a/Bio/Phylo/NewickIO.py
+++ b/Bio/Phylo/NewickIO.py
@@ -84,7 +84,7 @@ def _format_comment(text):
 
 def _get_comment(clade):
     try:
-        comment = clade.coment
+        comment = clade.comment
     except AttributeError:
         pass
     else:

--- a/Bio/Phylo/NewickIO.py
+++ b/Bio/Phylo/NewickIO.py
@@ -140,6 +140,9 @@ class Parser:
 
         lp_count = 0
         rp_count = 0
+        # Initialize the previous token var to empty str
+        token_prev = ""
+
         for match in tokens:
             token = match.group()
 
@@ -184,12 +187,24 @@ class Parser:
                 break
 
             elif token.startswith(":"):
-                # branch length or confidence
+                # branch length and/or confidence
                 value = float(token[1:])
+                # only confidence
+                # ex. (NodeA:98)
                 if self.values_are_confidence:
                     current_clade.confidence = value
+                # both confidence and branch length
                 else:
-                    current_clade.branch_length = value
+                    # Assign the first token encountered to branch length
+                    # (ex. NodeB:055)
+                    if not current_clade.branch_length:
+                        current_clade.branch_length = value
+                    # if branch_length has been assigned, reassign token_prev
+                    # to confidence and current token to branch_length
+                    # (ex. NodeA:98:0.11)
+                    else:
+                        current_clade.branch_length = value
+                        current_clade.confidence = float(token_prev[1:])
 
             elif token == "\n":
                 pass
@@ -197,6 +212,9 @@ class Parser:
             else:
                 # unquoted node label
                 current_clade.name = token
+
+            # Update token_prev var to store current token
+            token_prev = token
 
         if not lp_count == rp_count:
             raise NewickError("Number of open/close parentheses do not match.")
@@ -364,8 +382,14 @@ class Writer:
                     return (":" + format_branch_length) % (
                         clade.branch_length or 0.0
                     ) + _get_comment(clade)
-                else:
+                # If this is an internal node that is not named, no colon in front
+                elif (not hasattr(clade, "name")):
                     return (format_confidence + ":" + format_branch_length) % (
+                        clade.confidence,
+                        clade.branch_length or 0.0,
+                    ) + _get_comment(clade)
+                else:
+                    return (":" + format_confidence + ":" + format_branch_length) % (
                         clade.confidence,
                         clade.branch_length or 0.0,
                     ) + _get_comment(clade)

--- a/Tests/Nexus/attr_rich_val.nwk
+++ b/Tests/Nexus/attr_rich_val.nwk
@@ -1,0 +1,1 @@
+[&R] (A:0.11[&country="USA"],(B:0.23[&country="USA"],(C:0.16[&country="Canada"],D:0.14[&country="Canada"])E:98:0.46[&country="Canada"])F:99:0.38[&country="USA"]);

--- a/Tests/Nexus/attr_rich_val_no_internal_name.nwk
+++ b/Tests/Nexus/attr_rich_val_no_internal_name.nwk
@@ -1,0 +1,1 @@
+[&R] (A:0.11[&country="USA"],(B:0.23[&country="USA"],(C:0.16[&country="Canada"],D:0.14[&country="Canada"])98:0.46[&country="Canada"])99:0.38[&country="USA"]);


### PR DESCRIPTION
This pull request proposes several changes that fix or enhance writing Newick and Nexus tree output.
* **Bug Fix**: Comments were not written for Newick/Nexus trees (Issue: #3012). Fixed a typo in the function ```Phylo.NewickIO._get_comment```
* **Bug Fix**: The names of internal nodes became concatenated with confidence values. Added case handling in the function ```Phylo.NewickIO.Writer.to_strings```
* **Bug Fix/Feature(?)**: Confidence values were not stored as attributes for internally named nodes. Added case handling in the function ```Phylo.NewickIO.Parser._parse_tree```
* **New Tests**: Validate Newick/Nexus IO, primarily focused on parsing node attributes and writing to files.
  * ```test_Phylo.py::test_newick_write_string```
  * ```test_Phylo.py::test_newick_write_name```
  * ```test_Phylo.py::test_newick_write_comment```
  * ```test_Phylo.py::test_newick_write_branch_length```
  * ```test_Phylo.py::test_newick_write_confidence_value```
  * ```test_Phylo.py::test_newick_write_confidence_value_internal_node_name```
  * ```test_Phylo.py::test_newick_write_confidence_comment```
  * ```test_Phylo.py::test_nexus_write_single_tree```


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
