### PR TITLE
Clarify flake8 configuration comments

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -52,9 +52,8 @@ per-file-ignores =
     /Bio/*:F401,F841,D105,B009,B010,B011,C812,C815
     /Tests/*:F401,F841,D101,D102,D103,W504,B009,B010,B011,C812,BLK100
 
-# =============================
-# per-file-ignores error codes:
-# =============================
+#Explanation of the codes being ignored in Bio/ and Tests/:
+#
 #Bio/*:F401 module imported but unused TODO? (107 occurrences)
 #      F841 local variable is assigned to but never used TODO? (55 occurrences)
 #      D105 missing docstring magic method (121 occurrences)


### PR DESCRIPTION
This pull request addresses a point raised in discussion on #2827,

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
