### PR TITLE
Pin numpydoc==1.0.0 for building API docs

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -161,7 +161,7 @@ deps =
     reportlab
     scipy
     sphinx>=1.8.0
-    numpydoc
+    numpydoc==1.0.0
     pygments
     sphinx_rtd_theme
 commands =


### PR DESCRIPTION
Work around for #3024, something broke in numpydoc v1.1.0 in the ``mangle_signature`` function when it calls new function ``_clean_text_signature`` with something from ``Bio.Restriction`` (appears to be a signature string without matching brackets).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
