### PR TITLE
Avoid class instance as default value; add __repr__

### DIFF
--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -509,7 +509,7 @@ class FeatureParser:
     Please use Bio.SeqIO.parse(...) or Bio.SeqIO.read(...) instead.
     """
 
-    def __init__(self, debug_level=0, use_fuzziness=1, feature_cleaner=_cleaner):
+    def __init__(self, debug_level=0, use_fuzziness=1, feature_cleaner=None):
         """Initialize a GenBank parser and Feature consumer.
 
         Arguments:
@@ -527,7 +527,10 @@ class FeatureParser:
         """
         self._scanner = GenBankScanner(debug_level)
         self.use_fuzziness = use_fuzziness
-        self._cleaner = feature_cleaner
+        if feature_cleaner:
+            self._cleaner = feature_cleaner
+        else:
+            self._cleaner = _cleaner  # default
 
     def parse(self, handle):
         """Parse the specified handle."""

--- a/Bio/GenBank/utils.py
+++ b/Bio/GenBank/utils.py
@@ -16,16 +16,18 @@ class FeatureValueCleaner:
          /translation="MED
          YDPWNLRFQSKYKSRDA"
 
-    you'll end up with a value with \012s and spaces in it like::
-
-        "MED\012 YDPWEL..."
-
-    which you probably don't want.
+    you'll otherwise end up with white space in it.
 
     This cleaning needs to be done on a case by case basis since it is
     impossible to interpret whether you should be concatenating everything
     (as in translations), or combining things with spaces (as might be
     the case with /notes).
+
+    >>> cleaner = FeatureValueCleaner(["translation"])
+    >>> cleaner
+    FeatureValueCleaner(['translation'])
+    >>> cleaner.clean_value("translation", "MED\nYDPWNLRFQSKYKSRDA")
+    'MEDYDPWNLRFQSKYKSRDA'
     """
 
     keys_to_process = ["translation"]
@@ -33,6 +35,10 @@ class FeatureValueCleaner:
     def __init__(self, to_process=keys_to_process):
         """Initialize with the keys we should deal with."""
         self._to_process = to_process
+
+    def __repr__(self):
+        """Return a string representation of the class."""
+        return f"{self.__class__.__name__}({self._to_process!r})"
 
     def clean_value(self, key_name, value):
         """Clean the specified value and return it.
@@ -54,3 +60,9 @@ class FeatureValueCleaner:
         """Concatenate a translation value to one long protein string (PRIVATE)."""
         translation_parts = value.split()
         return "".join(translation_parts)
+
+
+if __name__ == "__main__":
+    from Bio._utils import run_doctest
+
+    run_doctest()


### PR DESCRIPTION
This pull request addresses needless changes in the API documentation from having a class instance default value, and the class itself having the default dynamic ``__repr__``.

i.e. Less changes on https://github.com/biopython/docs/commits/gh-pages/dev/api

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
