### PR TITLE
Changed QualityIO so that it uses iter explicitly on the handle, so t…

### DIFF
--- a/Bio/AlignIO/MafIO.py
+++ b/Bio/AlignIO/MafIO.py
@@ -140,10 +140,8 @@ def MafIterator(handle, seq_count=None):
 
     while True:
         # allows parsing of the last bundle without duplicating code
-        try:
-            line = next(handle)
-        except StopIteration:
-            line = ""
+        line = handle.readline()
+
         try:
             # Will be in binary mode if called via the indexing code
             # (which needs the raw offsets for cross platform indexing)

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -194,9 +194,8 @@ class FastaIterator(SequenceIterator):
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
         super().__init__(source, fmt="Fasta")
-        try:
-            line = next(self.stream)
-        except StopIteration:
+        line = self.stream.readline()
+        if not line:
             line = None
         else:
             if not line.startswith(">"):

--- a/Bio/SeqIO/PirIO.py
+++ b/Bio/SeqIO/PirIO.py
@@ -144,16 +144,22 @@ class PirIterator(SequenceIterator):
         line = self._line
         if line is None:
             raise StopIteration
-        stream = self.stream
+
         pir_type = line[1:3]
         if pir_type not in _pir_mol_type or line[3] != ";":
             raise ValueError(
                 "Records should start with '>XX;' where XX is a valid sequence type"
             )
+
         identifier = line[4:].strip()
-        description = next(stream).strip()
+        description = self.stream.readline()
+        if description == "":
+            raise StopIteration
+        else:
+            description = description.strip()
+
         lines = []
-        for line in stream:
+        for line in self.stream:
             if line[0] == ">":
                 self._line = line
                 break

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -933,9 +933,9 @@ def FastqGeneralIterator(source: _TextIOSource) -> Iterator[tuple[str, str, str]
     with as_handle(source) as handle:
         if handle.read(0) != "":
             raise StreamModeError("Fastq files must be opened in text mode") from None
-        try:
-            line = next(handle)
-        except StopIteration:
+
+        line = handle.readline()
+        if line == "":
             return  # Premature end of file, or just empty?
 
         while True:
@@ -1031,15 +1031,11 @@ class FastqIteratorAbstractBaseClass(SequenceIterator[str]):
 
     def __next__(self) -> SeqRecord:
         """Parse the file and generate SeqRecord objects."""
+
         line = self.line
         if line is None:
-            try:
-                line = next(self.stream)
-            except StopIteration:  # empty file?
-                self.line = None
-            else:
-                self.line = line
-        if line is None:
+            line = self.stream.readline()
+        if not line:
             raise StopIteration
         if line[0] != "@":
             raise ValueError("Records in Fastq files should start with '@' character")

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -301,7 +301,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Sebastian Bassi <https://about.me/bassi>
 - Sergei Lebedev <https://github.com/superbobry>
 - Sergio Valqui <https://github.com/svalqui>
-- Seth Sims <seth.sims at gmail>
+- Seth Sims <https://github.com/xzy3>
 - She Zhang <https://github.com/shz66>
 - Shoichiro Kawauchi <https://github.com/lacrosse91>
 - Shuichiro MAKIGAKI <https://github.com/shuichiro-makigaki>


### PR DESCRIPTION
…hat tempfile.NamedTemporaryFile can be used easily.

3.7.0 (default, Aug 15 2018, 09:03:42)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
CPython
Linux-3.10.0-1127.e17.x86_64-x86_64-with-centos-7.8.2003-Core
Bio.__version__ 1.77

This line:
https://github.com/biopython/biopython/blob/380932dfd17945a9af9e413d9560111eeed7cb9e/Bio/SeqIO/QualityIO.py#L923

has broken reading from `tempfile.NamedTemporaryFile` unless you do this`SeqIO.parse(tmp_fd.file, 'fastq')`. NamedTemporaryFile returns https://github.com/python/cpython/blob/1bf9cc509326bc42cd8cb1650eb9bf64550d817e/Lib/tempfile.py#L457
which is for some reason seems to not be its own iterator. I don't see any recent changes to the `tempfile` module to cause this. 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
