### PR TITLE
Calculating substitutions matrices from alignments without SubsMat

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -937,7 +937,7 @@ class MultipleSeqAlignment:
     def substitutions(self):
         """Return an Array with the number of substitutions of letters in the alignment.
 
-        As an example, consider a multiple sequence alignment of three DNA sequences::
+        As an example, consider a multiple sequence alignment of three DNA sequences:
 
         >>> from Bio.Seq import Seq
         >>> from Bio.SeqRecord import SeqRecord

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -953,6 +953,7 @@ class MultipleSeqAlignment:
         A--A seq2
         ACGT seq3
         TTTC seq4
+        <BLANKLINE>
         >>> m = alignment.substitutions
         >>> print(m)
             A   C   G   T

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -953,7 +953,7 @@ class MultipleSeqAlignment:
         A--A seq2
         ACGT seq3
         TTTC seq4
-        <BLANKLINE>
+
         >>> m = alignment.substitutions
         >>> print(m)
             A   C   G   T

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -19,6 +19,7 @@ import warnings
 from Bio import Alphabet
 from Bio import BiopythonDeprecationWarning
 from Bio.Align import _aligners
+from Bio.Align import substitution_matrices
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord, _RestrictedDict
 
@@ -931,6 +932,81 @@ class MultipleSeqAlignment:
             self._records.sort(key=lambda r: r.id, reverse=reverse)
         else:
             self._records.sort(key=key, reverse=reverse)
+
+    @property
+    def substitutions(self):
+        """Return an Array with the number of substitutions of letters in the alignment.
+
+        As an example, consider a multiple sequence alignment of three DNA sequences::
+
+        >>> from Bio.Seq import Seq
+        >>> from Bio.SeqRecord import SeqRecord
+        >>> from Bio.Align import MultipleSeqAlignment
+        >>> seq1 = SeqRecord(Seq("ACGT"), id="seq1")
+        >>> seq2 = SeqRecord(Seq("A--A"), id="seq2")
+        >>> seq3 = SeqRecord(Seq("ACGT"), id="seq3")
+        >>> seq4 = SeqRecord(Seq("TTTC"), id="seq4")
+        >>> alignment = MultipleSeqAlignment([seq1, seq2, seq3, seq4])
+        >>> print(alignment)
+        Alignment with 4 rows and 4 columns
+        ACGT seq1
+        A--A seq2
+        ACGT seq3
+        TTTC seq4
+        >>> m = alignment.substitutions
+        >>> print(m)
+            A   C   G   T
+        A 3.0 0.5 0.0 2.5
+        C 0.5 1.0 0.0 2.0
+        G 0.0 0.0 1.0 1.0
+        T 2.5 2.0 1.0 1.0
+        <BLANKLINE>
+
+        Note that the matrix is symmetric, with counts divided equally on both
+        sides of the diagonal. For example, the total number of substitutions
+        between A and T in the alignment is 3.5 + 3.5 = 7.
+
+        Any weights associated with the sequences are taken into account when
+        calculating the substitution matrix.  For example, given the following
+        multiple sequence alignment::
+
+            GTATC  0.5
+            AT--C  0.8
+            CTGTC  1.0
+
+        For the first column we have::
+
+            ('A', 'G') : 0.5 * 0.8 = 0.4
+            ('C', 'G') : 0.5 * 1.0 = 0.5
+            ('A', 'C') : 0.8 * 1.0 = 0.8
+
+        """
+        letters = set.union(*[set(record.seq) for record in self])
+        try:
+            letters.remove("-")
+        except KeyError:
+            pass
+        letters = "".join(sorted(letters))
+        m = substitution_matrices.Array(letters, dims=2)
+        for rec_num1, alignment1 in enumerate(self):
+            seq1 = alignment1.seq
+            weight1 = alignment1.annotations.get("weight", 1.0)
+            for rec_num2, alignment2 in enumerate(self):
+                if rec_num1 == rec_num2:
+                    break
+                seq2 = alignment2.seq
+                weight2 = alignment2.annotations.get("weight", 1.0)
+                for residue1, residue2 in zip(seq1, seq2):
+                    if residue1 == "-":
+                        continue
+                    if residue2 == "-":
+                        continue
+                    m[(residue1, residue2)] += weight1 * weight2
+
+        m += m.transpose()
+        m /= 2.0
+
+        return m
 
 
 class PairwiseAlignment:

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -315,11 +315,21 @@ class Array(numpy.ndarray):
 
     def select(self, alphabet):
         """Subset the array by selecting the letters from the specified alphabet."""
-        indices = [self._convert_key(key) for key in alphabet]
+        ii = []
+        jj = []
+        for i, key in enumerate(alphabet):
+            try:
+                j = self._alphabet.index(key)
+            except ValueError:
+                continue
+            ii.append(i)
+            jj.append(j)
         dims = len(self.shape)
-        indices = numpy.ix_(*[indices]*dims)
-        data = numpy.array(self)[indices]
-        return Array(alphabet, data=data)
+        a = Array(alphabet, dims=dims)
+        ii = numpy.ix_(*[ii]*dims)
+        jj = numpy.ix_(*[jj]*dims)
+        a[ii] = numpy.ndarray.__getitem__(self, jj)
+        return a
 
     def _format_1D(self, fmt):
         _alphabet = self._alphabet

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -313,6 +313,14 @@ class Array(numpy.ndarray):
         for key in F:
             self[key] = F[key]
 
+    def select(self, alphabet):
+        """Subset the array by selecting the letters from the specified alphabet."""
+        indices = [self._convert_key(key) for key in alphabet]
+        dims = len(self.shape)
+        indices = numpy.ix_(*[indices]*dims)
+        data = numpy.array(self)[indices]
+        return Array(alphabet, data=data)
+
     def _format_1D(self, fmt):
         _alphabet = self._alphabet
         n = len(_alphabet)

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -326,8 +326,8 @@ class Array(numpy.ndarray):
             jj.append(j)
         dims = len(self.shape)
         a = Array(alphabet, dims=dims)
-        ii = numpy.ix_(*[ii]*dims)
-        jj = numpy.ix_(*[jj]*dims)
+        ii = numpy.ix_(*[ii] * dims)
+        jj = numpy.ix_(*[jj] * dims)
         a[ii] = numpy.ndarray.__getitem__(self, jj)
         return a
 

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -899,7 +899,7 @@ T 1.0  0.5 12.0
 As the ordering of pairs is arbitrary, counts are divided equally above and below the diagonal. For example, the 9 alignments of \verb+A+ to \verb+C+ are stored as 4.5 at position \verb+['A', 'C']+ and 4.5  at position \verb+['C', 'A']+. This arrangement helps to make the math easier when calculating a substitution matrix from these counts, as described in Section~\ref{sec:subs_mat_ex}.
 
 Note that \verb+alignment.substitutions+ contains entries for the letters appearing in the alignment only. You can use the \verb+select+ method to add entries for missing letters, for example
-%cont-doctest
+%% %cont-doctest
 \begin{minted}{pycon}
 >>> m = alignment.substitutions.select("ATCG")
 >>> print(m)

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -889,6 +889,8 @@ Array([[ 2. ,  4.5,  1. ],
        [ 4.5, 10. ,  0.5],
        [ 1. ,  0.5, 12. ]],
          alphabet='ACT')
+\end{minted}
+\begin{minted}{pycon}
 >>> print(alignment.substitutions)
     A    C    T
 A 2.0  4.5  1.0

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -858,6 +858,61 @@ the array by column (as in Fortran) rather than its default of by row (as in C):
 Note that this leaves the original Biopython alignment object and the NumPy array
 in memory as separate objects - editing one will not update the other!
 
+\section{Getting information on the alignment}
+
+\subsection{Substitutions}
+
+The \verb+substitutions+ property of an alignment reports how often letters in the alignment are substituted for each other. This is calculated by taking all pairs of rows in the alignment, counting the number of times two letters are aligned to each other, and summing this over all pairs. For example,
+
+%doctest
+\begin{minted}{pycon}
+>>> from Bio.Seq import Seq
+>>> from Bio.SeqRecord import SeqRecord
+>>> from Bio.Align import MultipleSeqAlignment
+>>> alignment = MultipleSeqAlignment(
+...     [
+...         SeqRecord(Seq("ACTCCTA"), id='seq1'),
+...         SeqRecord(Seq("AAT-CTA"), id='seq2'),
+...         SeqRecord(Seq("CCTACT-"), id='seq3'),
+...         SeqRecord(Seq("TCTCCTC"), id='seq4'),
+...     ]
+... )
+...
+>>> print(alignment)
+Alignment with 4 rows and 7 columns
+ACTCCTA seq1
+AAT-CTA seq2
+CCTACT- seq3
+TCTCCTC seq4
+<BLANKLINE>
+>>> alignment.substitutions
+Array([[ 2. ,  4.5,  1. ],
+       [ 4.5, 10. ,  0.5],
+       [ 1. ,  0.5, 12. ]],
+         alphabet='ACT')
+>>> print(alignment.substitutions)
+    A    C    T
+A 2.0  4.5  1.0
+C 4.5 10.0  0.5
+T 1.0  0.5 12.0
+<BLANKLINE>
+\end{minted}
+As the ordering of pairs is arbitrary, counts are divided equally above and below the diagonal. For example, the 9 alignments of \verb+A+ to \verb+C+ are stored as 4.5 at position \verb+['A', 'C']+ and 4.5  at position \verb+['C', 'A']+. This arrangement helps to make the math easier when calculating a substitution matrix from these counts, as described in Section~\ref{sec:subs_mat_ex}.
+
+Note that \verb+alignment.substitutions+ contains entries for the letters appearing in the alignment only. You can use the \verb+select+ method to add entries for missing letters, for example
+%cont-doctest
+\begin{minted}{pycon}
+>>> m = alignment.substitutions.select("ATCG")
+>>> print(m)
+    A    T    C   G
+A 2.0  1.0  4.5 0.0
+T 1.0 12.0  0.5 0.0
+C 4.5  0.5 10.0 0.0
+G 0.0  0.0  0.0 0.0
+<BLANKLINE>
+\end{minted}
+This also allows you to change the order of letters in the alphabet.
+
 \section{Alignment Tools}
 \label{sec:alignment-tools}
 

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -884,14 +884,10 @@ ACTCCTA seq1
 AAT-CTA seq2
 CCTACT- seq3
 TCTCCTC seq4
->>> alignment.substitutions
-Array([[ 2. ,  4.5,  1. ],
-       [ 4.5, 10. ,  0.5],
-       [ 1. ,  0.5, 12. ]],
-         alphabet='ACT')
+>>> substitutions = alignment.substitutions
 \end{minted}
 \begin{minted}{pycon}
->>> print(alignment.substitutions)
+>>> print(substitutions)
     A    C    T
 A 2.0  4.5  1.0
 C 4.5 10.0  0.5
@@ -903,7 +899,7 @@ As the ordering of pairs is arbitrary, counts are divided equally above and belo
 Note that \verb+alignment.substitutions+ contains entries for the letters appearing in the alignment only. You can use the \verb+select+ method to add entries for missing letters, for example
 %% %cont-doctest
 \begin{minted}{pycon}
->>> m = alignment.substitutions.select("ATCG")
+>>> m = substitutions.select("ATCG")
 >>> print(m)
     A    T    C   G
 A 2.0  1.0  4.5 0.0

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -884,7 +884,6 @@ ACTCCTA seq1
 AAT-CTA seq2
 CCTACT- seq3
 TCTCCTC seq4
-<BLANKLINE>
 >>> alignment.substitutions
 Array([[ 2. ,  4.5,  1. ],
        [ 4.5, 10. ,  0.5],

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -885,8 +885,6 @@ AAT-CTA seq2
 CCTACT- seq3
 TCTCCTC seq4
 >>> substitutions = alignment.substitutions
-\end{minted}
-\begin{minted}{pycon}
 >>> print(substitutions)
     A    C    T
 A 2.0  4.5  1.0
@@ -897,7 +895,7 @@ T 1.0  0.5 12.0
 As the ordering of pairs is arbitrary, counts are divided equally above and below the diagonal. For example, the 9 alignments of \verb+A+ to \verb+C+ are stored as 4.5 at position \verb+['A', 'C']+ and 4.5  at position \verb+['C', 'A']+. This arrangement helps to make the math easier when calculating a substitution matrix from these counts, as described in Section~\ref{sec:subs_mat_ex}.
 
 Note that \verb+alignment.substitutions+ contains entries for the letters appearing in the alignment only. You can use the \verb+select+ method to add entries for missing letters, for example
-%% %cont-doctest
+%cont-doctest
 \begin{minted}{pycon}
 >>> m = substitutions.select("ATCG")
 >>> print(m)

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2653,9 +2653,42 @@ array([0., 5., 0., 0.])
 {'A': 0.0, 'C': 5.0, 'G': 0.0, 'T': 0.0}
 \end{minted}
 
-While the alphabet of a \verb+Array+ is usually a string, you may also use a tuple of (immutable) objects. This is used for example for a \hyperlink{codonmatrix}{codon substitution matrix}, where the keys are not individual nucleotides or amino acids but instead three-nucleotide codons.
+While the alphabet of an \verb+Array+ is usually a string, you may also use a tuple of (immutable) objects. This is used for example for a \hyperlink{codonmatrix}{codon substitution matrix}, where the keys are not individual nucleotides or amino acids but instead three-nucleotide codons.
 
-\subsection*{Calculating a substitution matrix from a sequence alignment}
+While the \verb+alphabet+ property of an \verb+Array+ is immutable, you can create a new \verb+Array+ object by selecting the letters you are interested in from the alphabet. For example,
+%cont-doctest
+\begin{minted}{pycon}
+>>> a = Array("ABCD", dims=2, data=numpy.arange(16).reshape(4,4))
+>>> print(a)
+     A    B    C    D
+A  0.0  1.0  2.0  3.0
+B  4.0  5.0  6.0  7.0
+C  8.0  9.0 10.0 11.0
+D 12.0 13.0 14.0 15.0
+<BLANKLINE>
+>>> b = a.select("CAD")
+>>> print(b)
+     C    A    D
+C 10.0  8.0 11.0
+A  2.0  0.0  3.0
+D 14.0 12.0 15.0
+<BLANKLINE>
+\end{minted}
+Note that this also allows you to reorder the alphabet.
+
+Data for letters that are not found in the alphabet are set to zero:
+%cont-doctest
+\begin{minted}{pycon}
+>>> c = a.select("DEC")
+>>> print(c)
+     D   E    C
+D 15.0 0.0 14.0
+E  0.0 0.0  0.0
+C 11.0 0.0 10.0
+<BLANKLINE>
+\end{minted}
+
+\subsection*{Calculating a substitution matrix from a pairwise sequence alignment}
 
 As \verb+Array+ is a subclass of a numpy array, you can apply mathematical operations on an \verb+Array+ object in much the same way. Here, we illustrate this by calculating a scoring matrix from the alignment of the 16S ribosomal RNA gene sequences of {\it Escherichia coli} and {\it Bacillus subtilis}. First, we create a \verb+PairwiseAligner+ and initialize it with the default scores used by \verb+blastn+:
 

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1622,174 +1622,112 @@ Biopython provides a ton of common substitution matrices, and also provides func
 \subsection{Creating your own substitution matrix from an alignment}
 \label{sec:subs_mat_ex}
 
-A very cool thing that you can do easily with the substitution matrix
-classes is to create your own substitution matrix from an
-alignment. In practice, this is normally done with protein
-alignments. In this example, we'll first get a Biopython alignment
-object and then get a summary object to calculate info about the
-alignment. The file containing \href{examples/protein.aln}{protein.aln}
-(also available online
+You can create your own substitution matrix from an alignment.  In this
+example, we'll first read an protein sequence alignment from the Clustalw file
+\href{examples/protein.aln}{protein.aln} (also available online
 \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/protein.aln}{here})
-contains the Clustalw alignment output.
 
 %doctest ../Tests/Clustalw
 \begin{minted}{pycon}
 >>> from Bio import AlignIO
->>> from Bio import Alphabet
->>> from Bio.Alphabet import IUPAC
->>> from Bio.Align import AlignInfo
 >>> filename = "protein.aln"
->>> alpha = Alphabet.Gapped(IUPAC.protein)
->>> c_align = AlignIO.read(filename, "clustal", alphabet=alpha)
->>> summary_align = AlignInfo.SummaryInfo(c_align)
+>>> alignment = AlignIO.read(filename, "clustal")
 \end{minted}
 
-Sections~\ref{sec:align_clustal} and~\ref{sec:summary_info} contain
-more information on doing this.
+Section~\ref{sec:align_clustal} contains more information on doing this.
 
-Now that we've got our \verb|summary_align| object, we want to use it
-to find out the number of times different residues substitute for each
-other. To make the example more readable, we'll focus on only amino
-acids with polar charged side chains. Luckily, this can be done easily
-when generating a replacement dictionary, by passing in all of the
-characters that should be ignored. Thus we'll create a dictionary of
-replacements for only charged polar amino acids using:
+The `substitutions` property of the alignment stores the number of times
+different residues substitute for each other:
+%cont-doctest
+\begin{minted}{pycon}
+>>> observed_frequencies = alignment.substitutions
+\end{minted}
+
+To make the example more readable, we'll select only amino acids with polar charged side chains:
 
 %cont-doctest
 \begin{minted}{pycon}
->>> replace_info = summary_align.replacement_dictionary(["G", "A", "V", "L", "I",
-...                                                      "M", "P", "F", "W", "S",
-...                                                      "T", "N", "Q", "Y", "C"])
+>>> observed_frequencies = observed_frequencies.select("DEHKR")
+>>> print(observed_frequencies)
+       D      E      H      K      R
+D 2360.0  255.5    7.5    0.5   25.0
+E  255.5 3305.0   16.5   27.0    2.0
+H    7.5   16.5 1235.0   16.0    8.5
+K    0.5   27.0   16.0 3218.0  116.5
+R   25.0    2.0    8.5  116.5 2079.0
+<BLANKLINE>
 \end{minted}
+Rows and columns for other amino acids were removed from the matrix.
 
-This information about amino acid replacements is represented as a
-python dictionary which will look something like (the order can vary):
-
-\begin{minted}{python}
-{
-    ("R", "R"): 2079.0,
-    ("R", "H"): 17.0,
-    ("R", "K"): 103.0,
-    ("R", "E"): 2.0,
-    ("R", "D"): 2.0,
-    ("H", "R"): 0,
-    ("D", "H"): 15.0,
-    ("K", "K"): 3218.0,
-    ("K", "H"): 24.0,
-    ("H", "K"): 8.0,
-    ("E", "H"): 15.0,
-    ("H", "H"): 1235.0,
-    ("H", "E"): 18.0,
-    ("H", "D"): 0,
-    ("K", "D"): 0,
-    ("K", "E"): 9.0,
-    ("D", "R"): 48.0,
-    ("E", "R"): 2.0,
-    ("D", "K"): 1.0,
-    ("E", "K"): 45.0,
-    ("K", "R"): 130.0,
-    ("E", "D"): 241.0,
-    ("E", "E"): 3305.0,
-    ("D", "E"): 270.0,
-    ("D", "D"): 2360.0,
-}
-\end{minted}
-
-This information gives us our accepted number of replacements, or how
-often we expect different things to substitute for each other. It
-turns out, amazingly enough, that this is all of the information we
-need to go ahead and create a substitution matrix. First, we use the
-replacement dictionary information to create an Accepted Replacement
-Matrix (ARM):
-
+Next, we normalize the matrix:
 %cont-doctest
 \begin{minted}{pycon}
->>> from Bio import SubsMat
->>> my_arm = SubsMat.SeqMat(replace_info)
+>>> import numpy
+>>> observed_frequencies /= numpy.sum(observed_frequencies)
 \end{minted}
 
-With this accepted replacement matrix, we can go right ahead and
-create our log odds matrix (i.~e.~a standard type Substitution Matrix):
-
+Summing over rows or columns gives the relative frequency of occurrence of
+each residue:
 %cont-doctest
 \begin{minted}{pycon}
->>> my_lom = SubsMat.make_log_odds_matrix(my_arm)
+>>> residue_frequencies = numpy.sum(observed_frequencies, 0)
+>>> print(format(residue_frequencies, "%.4f"))
+D 0.2015
+E 0.2743
+H 0.0976
+K 0.2569
+R 0.1697
+<BLANKLINE>
+>>> numpy.sum(residue_frequencies)
+1.0
 \end{minted}
 
-The log odds matrix you create is customizable with the following
-optional arguments:
-
-\begin{itemize}
-  \item \verb|exp_freq_table| -- You can pass a table of expected
-  frequencies for each alphabet. If supplied, this will be used
-  instead of the passed accepted replacement matrix when calculate
-  expected replacments.
-
-  \item \verb|logbase| - The base of the logarithm taken to create the
-  log odd matrix. Defaults to base 10.
-
-  \item \verb|factor| - The factor to multiply each matrix entry
-  by. This defaults to 10, which normally makes the matrix numbers
-  easy to work with.
-
-  \item \verb|round_digit| - The digit to round to in the matrix. This
-  defaults to 0 (i.~e.~no digits).
-
-\end{itemize}
-
-Once you've got your log odds matrix, you can display it prettily
-using the function \verb|format|. Doing this on our created matrix
-gives:
-
+The expected frequency of residue pairs is then
 %cont-doctest
 \begin{minted}{pycon}
->>> print(my_lom.format())
-D   2
-E  -1   1
-H  -5  -4   3
-K -10  -5  -4   1
-R  -4  -8  -4  -2   2
-   D   E   H   K   R
+>>> expected_frequencies = numpy.multiply.outer(residue_frequencies, residue_frequencies)
+>>> print(format(expected_frequencies, "%.4f"))
+       D      E      H      K      R
+D 0.0406 0.0553 0.0197 0.0518 0.0342
+E 0.0553 0.0752 0.0268 0.0705 0.0465
+H 0.0197 0.0268 0.0095 0.0251 0.0166
+K 0.0518 0.0705 0.0251 0.0660 0.0436
+R 0.0342 0.0465 0.0166 0.0436 0.0288
+<BLANKLINE>
 \end{minted}
 
-Very nice. Now we've got our very own substitution matrix to play with!
-
-% alternative using Array objects
+We can now calculate the log-odds matrix by dividing the observed frequencies by the expected freqencies and taking the logarithm:
+%cont-doctest
 \begin{minted}{pycon}
-from Bio import AlignIO
-from Bio import Alphabet
-from Bio.Alphabet import IUPAC
-from Bio.Align import AlignInfo
-from Bio import SubsMat
-from Bio.SubsMat import FreqTable
-from Bio.Align.substitution_matrices import Array
-import numpy
+>>> m = log(observed_frequencies/expected_frequencies)
+>>> print(m)
+      D    E    H     K    R
+D   2.1 -1.5 -5.1 -10.4 -4.2
+E  -1.5  1.7 -4.4  -5.1 -8.3
+H  -5.1 -4.4  3.3  -4.4 -4.7
+K -10.4 -5.1 -4.4   1.9 -2.3
+R  -4.2 -8.3 -4.7  -2.3  2.5
+<BLANKLINE>
+\end{minted}
 
-
-filename = "protein.aln"
-alpha = Alphabet.Gapped(IUPAC.protein)
-c_align = AlignIO.read(filename, "clustal", alphabet=alpha)
-summary_align = AlignInfo.SummaryInfo(c_align)
-
-replace_info = summary_align.replacement_dictionary([])
-
-my_arm = Array(data=replace_info)
-my_arm += numpy.transpose(my_arm)
-my_arm /= 2.0
-
-my_arm = my_arm.select("DEHKR")
-
-obs_freq_mat = my_arm / numpy.sum(my_arm)
-
-exp_freq_table = numpy.sum(obs_freq_mat, 0)
-
-exp_freq_mat = numpy.multiply.outer(exp_freq_table, exp_freq_table)
-
-subs_mat = obs_freq_mat / exp_freq_mat
-
-lo_mat = numpy.log2(subs_mat)
-
-print(format(lo_mat, "%d"))
+This matrix can be used as the substitution matrix when performing alignments. For example,
+%cont-doctest
+\begin{minted}{pycon}
+>>> from Bio.Align import PairwiseAligner
+>>> aligner = PairwiseAligner()
+>>> aligner.substitution_matrix = m
+>>> aligner.gap_score = -3.0
+>>> alignments = aligner.align("DEHEK", "DHHKK")
+>>> print(alignments[0])
+DEHEK
+|.|.|
+DHHKK
+<BLANKLINE>
+>>> print("%.2f" % alignments.score)
+-2.18
+>>> score = lo_mat['D','D'] + lo_mat['E','H'] + lo_mat['H','H'] + lo_mat['E','K'] + lo_mat['K','K']
+>>> print("%.2f" % score)
+-2.18
 \end{minted}
 
 

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1754,6 +1754,45 @@ R  -4  -8  -4  -2   2
 
 Very nice. Now we've got our very own substitution matrix to play with!
 
+% alternative using Array objects
+\begin{minted}{pycon}
+from Bio import AlignIO
+from Bio import Alphabet
+from Bio.Alphabet import IUPAC
+from Bio.Align import AlignInfo
+from Bio import SubsMat
+from Bio.SubsMat import FreqTable
+from Bio.Align.substitution_matrices import Array
+import numpy
+
+
+filename = "protein.aln"
+alpha = Alphabet.Gapped(IUPAC.protein)
+c_align = AlignIO.read(filename, "clustal", alphabet=alpha)
+summary_align = AlignInfo.SummaryInfo(c_align)
+
+replace_info = summary_align.replacement_dictionary([])
+
+my_arm = Array(data=replace_info)
+my_arm += numpy.transpose(my_arm)
+my_arm /= 2.0
+
+my_arm = my_arm.select("DEHKR")
+
+obs_freq_mat = my_arm / numpy.sum(my_arm)
+
+exp_freq_table = numpy.sum(obs_freq_mat, 0)
+
+exp_freq_mat = numpy.multiply.outer(exp_freq_table, exp_freq_table)
+
+subs_mat = obs_freq_mat / exp_freq_mat
+
+lo_mat = numpy.log2(subs_mat)
+
+print(format(lo_mat, "%d"))
+\end{minted}
+
+
 \section{BioSQL -- storing sequences in a relational database}
 \label{sec:BioSQL}
 \href{https://www.biosql.org/}{BioSQL} is a joint effort between the

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1619,11 +1619,11 @@ Biopython provides a ton of common substitution matrices, and also provides func
 
 \subsection{Using common substitution matrices}
 
-\subsection{Creating your own substitution matrix from an alignment}
+\subsection{Calculating a substitution matrix from a multiple sequence alignment}
 \label{sec:subs_mat_ex}
 
 You can create your own substitution matrix from an alignment.  In this
-example, we'll first read an protein sequence alignment from the Clustalw file
+example, we'll first read a protein sequence alignment from the Clustalw file
 \href{examples/protein.aln}{protein.aln} (also available online
 \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/protein.aln}{here})
 
@@ -1725,7 +1725,7 @@ DHHKK
 <BLANKLINE>
 >>> print("%.2f" % alignments.score)
 -2.18
->>> score = lo_mat['D','D'] + lo_mat['E','H'] + lo_mat['H','H'] + lo_mat['E','K'] + lo_mat['K','K']
+>>> score = m['D','D'] + m['E','H'] + m['H','H'] + m['E','K'] + m['K','K']
 >>> print("%.2f" % score)
 -2.18
 \end{minted}

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1700,7 +1700,7 @@ Here, \verb+residue_frequencies[:, None]+ creates a 2D array consisting of a sin
 We can now calculate the log-odds matrix by dividing the observed frequencies by the expected freqencies and taking the logarithm:
 %cont-doctest
 \begin{minted}{pycon}
->>> m = log(observed_frequencies/expected_frequencies)
+>>> m = numpy.log2(observed_frequencies/expected_frequencies)
 >>> print(m)
       D    E    H     K    R
 D   2.1 -1.5 -5.1 -10.4 -4.2

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1636,7 +1636,7 @@ example, we'll first read a protein sequence alignment from the Clustalw file
 
 Section~\ref{sec:align_clustal} contains more information on doing this.
 
-The `substitutions` property of the alignment stores the number of times
+The \verb+substitutions+ property of the alignment stores the number of times
 different residues substitute for each other:
 %cont-doctest
 \begin{minted}{pycon}
@@ -1685,7 +1685,7 @@ R 0.1697
 The expected frequency of residue pairs is then
 %cont-doctest
 \begin{minted}{pycon}
->>> expected_frequencies = numpy.multiply.outer(residue_frequencies, residue_frequencies)
+>>> expected_frequencies = numpy.dot(residue_frequencies[:, None], residue_frequencies[None, :])
 >>> print(format(expected_frequencies, "%.4f"))
        D      E      H      K      R
 D 0.0406 0.0553 0.0197 0.0518 0.0342
@@ -1695,6 +1695,7 @@ K 0.0518 0.0705 0.0251 0.0660 0.0436
 R 0.0342 0.0465 0.0166 0.0436 0.0288
 <BLANKLINE>
 \end{minted}
+Here, \verb+residue_frequencies[:, None]+ creates a 2D array consisting of a single column with the values of \verb+residue_frequencies+, and \verb+residue_frequencies[None, :]+ a 2D array with these values as a single row. Taking their dot product (inner product) creates a matrix of expected frequencies where each entry consists of two \verb+residue_frequencies+ values multiplied with each other. For example, \verb+expected_frequencies['D', 'E']+ is equal to \verb+residue_frequencies['D'] * residue_frequencies['E']+.
 
 We can now calculate the log-odds matrix by dividing the observed frequencies by the expected freqencies and taking the logarithm:
 %cont-doctest


### PR DESCRIPTION
This pull request replaces the cookbook example on substitution matrices by one that does not rely on SubsMat.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
