### PR TITLE
remove alphabet from clustal example

### DIFF
--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -345,8 +345,9 @@ class SummaryInfo:
             raise TypeError("chars_to_ignore should be a list.")
 
         # if we have a gap char, add it to stuff to ignore
-        if isinstance(self.alignment._alphabet, Alphabet.Gapped):
-            chars_to_ignore.append(self.alignment._alphabet.gap_char)
+        gap_char = self._get_gap_char()
+        if gap_char:
+            chars_to_ignore.append(gap_char)
 
         for char in chars_to_ignore:
             all_letters = all_letters.replace(char, "")

--- a/Doc/examples/clustal_run.py
+++ b/Doc/examples/clustal_run.py
@@ -17,7 +17,6 @@ import sys
 import subprocess
 
 # biopython
-from Bio.Alphabet import Gapped, IUPAC
 from Bio.Align.Applications import ClustalwCommandline
 from Bio import AlignIO
 from Bio.Align import AlignInfo
@@ -32,7 +31,7 @@ return_code = subprocess.call(str(cline), shell=(sys.platform != "win32"))
 assert return_code == 0, "Calling ClustalW failed"
 
 # Parse the output
-alignment = AlignIO.read("test.aln", "clustal", alphabet=Gapped(IUPAC.unambiguous_dna))
+alignment = AlignIO.read("test.aln", "clustal")
 
 print(alignment)
 
@@ -51,7 +50,6 @@ consensus = summary_align.dumb_consensus()
 print("consensus %s" % consensus)
 
 my_pssm = summary_align.pos_specific_score_matrix(consensus, chars_to_ignore=["N"])
-
 print(my_pssm)
 
 expect_freq = {"A": 0.3, "G": 0.2, "T": 0.3, "C": 0.2}


### PR DESCRIPTION
This pull request removes the alphabet from the `clustal_run.py` example.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
