### PR TITLE
Remove alphabets from Bio.SeqFeature

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -54,8 +54,9 @@ Classes:
 
 
 from collections import OrderedDict
+import functools
 
-from Bio.Seq import Seq, MutableSeq, reverse_complement
+from Bio.Seq import MutableSeq, reverse_complement
 
 
 class SeqFeature:
@@ -1527,7 +1528,7 @@ class CompoundLocation:
         """
         # This copes with mixed strand features & all on reverse:
         parts = [loc.extract(parent_sequence) for loc in self.parts]
-        f_seq = Seq("").join(parts)
+        f_seq = functools.reduce(lambda x, y: x+y, parts)
         return f_seq
 
 

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1528,7 +1528,7 @@ class CompoundLocation:
         """
         # This copes with mixed strand features & all on reverse:
         parts = [loc.extract(parent_sequence) for loc in self.parts]
-        f_seq = functools.reduce(lambda x, y: x+y, parts)
+        f_seq = functools.reduce(lambda x, y: x + y, parts)
         return f_seq
 
 

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -55,7 +55,7 @@ Classes:
 
 from collections import OrderedDict
 
-from Bio.Seq import MutableSeq, reverse_complement
+from Bio.Seq import Seq, MutableSeq, reverse_complement
 
 
 class SeqFeature:
@@ -1527,7 +1527,7 @@ class CompoundLocation:
         """
         # This copes with mixed strand features & all on reverse:
         parts = [loc.extract(parent_sequence) for loc in self.parts]
-        f_seq = "".join(parts)
+        f_seq = Seq("").join(parts)
         return f_seq
 
 

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -339,9 +339,8 @@ class SeqFeature:
         here reverse strand features are not permitted.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_protein
         >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
-        >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL", generic_protein)
+        >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL")
         >>> f = SeqFeature(FeatureLocation(8, 15), type="domain")
         >>> f.extract(seq)
         Seq('VALIVIC')
@@ -351,7 +350,7 @@ class SeqFeature:
 
         >>> from Bio.Seq import Seq
         >>> from Bio.SeqFeature import SeqFeature
-        >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL", generic_protein)
+        >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL")
         >>> f = SeqFeature(None, type="domain")
         >>> f.extract(seq)
         Traceback (most recent call last):
@@ -392,9 +391,7 @@ class SeqFeature:
         as Seq.translate, refer to that documentation for further information.
 
         Arguments:
-         - parent_sequence - This method will translate DNA or RNA sequences,
-           and those with a nucleotide or generic alphabet. Trying to
-           translate a protein sequence raises an exception.
+         - parent_sequence - A DNA or RNA sequence.
          - table - Which codon table to use if there is no transl_table
            qualifier for this feature. This can be either a name
            (string), an NCBI identifier (integer), or a CodonTable
@@ -408,9 +405,8 @@ class SeqFeature:
            Will override a codon_start qualifier
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_dna
         >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
-        >>> seq = Seq("GGTTACACTTACCGATAATGTCTCTGATGA", generic_dna)
+        >>> seq = Seq("GGTTACACTTACCGATAATGTCTCTGATGA")
         >>> f = SeqFeature(FeatureLocation(0, 30), type="CDS")
         >>> f.qualifiers['transl_table'] = [11]
 
@@ -483,9 +479,8 @@ class SeqFeature:
         """Return the length of the region where the feature is located.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_protein
         >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
-        >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL", generic_protein)
+        >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL")
         >>> f = SeqFeature(FeatureLocation(8, 15), type="domain")
         >>> len(f)
         7
@@ -1104,9 +1099,8 @@ class FeatureLocation:
         a MutableSeq as the parent sequence will return a Seq object.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_protein
         >>> from Bio.SeqFeature import FeatureLocation
-        >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL", generic_protein)
+        >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL")
         >>> feature_loc = FeatureLocation(8, 15)
         >>> feature_loc.extract(seq)
         Seq('VALIVIC')
@@ -1522,9 +1516,8 @@ class CompoundLocation:
         a MutableSeq as the parent sequence will return a Seq object.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_protein
         >>> from Bio.SeqFeature import FeatureLocation, CompoundLocation
-        >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL", generic_protein)
+        >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL")
         >>> fl1 = FeatureLocation(2, 8)
         >>> fl2 = FeatureLocation(10, 15)
         >>> fl3 = CompoundLocation([fl1,fl2])
@@ -1534,10 +1527,7 @@ class CompoundLocation:
         """
         # This copes with mixed strand features & all on reverse:
         parts = [loc.extract(parent_sequence) for loc in self.parts]
-        # We use addition rather than a join to avoid alphabet issues:
-        f_seq = parts[0]
-        for part in parts[1:]:
-            f_seq += part
+        f_seq = "".join(parts)
         return f_seq
 
 


### PR DESCRIPTION
This pull request removes alphabets from the `Bio.SeqFeature` doctests.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
