### PR TITLE
removed alphabets from test_translate

### DIFF
--- a/Tests/test_translate.py
+++ b/Tests/test_translate.py
@@ -9,85 +9,83 @@
 import unittest
 
 from Bio import Seq
-from Bio import Alphabet
-from Bio.Alphabet import IUPAC
 
 
 class TestTranscriptionTranslation(unittest.TestCase):
     def test_transcription(self):
         s = "ATA"
-        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        dna = Seq.Seq(s)
         rna = dna.transcribe()
-        self.assertEqual(str(rna), "AUA")
+        self.assertEqual(rna, "AUA")
         s = "GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCATATT"
-        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        dna = Seq.Seq(s)
         rna = dna.transcribe()
         self.assertEqual(
-            str(rna),
+            rna,
             "GAAAAUUCAUUUUCUUUGGACUUUCUCUGAAAUCCGAGUCCUAGGAAAGAUGCGUGAGAUUCUUCAUAUU",
         )
         s = "GAAAAUUCAUUUUCUUUGGACUUUCUCUGAAAUCCGAGUCCUAGGAAAGAUGCGUGAGAUUCUUCAUAUU"
-        rna = Seq.Seq(s, IUPAC.unambiguous_rna)
+        rna = Seq.Seq(s)
         dna = rna.back_transcribe()
         self.assertEqual(
-            str(dna),
+            dna,
             "GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCATATT",
         )
 
     def test_translation(self):
         s = ""
-        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        dna = Seq.Seq(s)
         protein = dna.translate(to_stop=True)
-        self.assertEqual(str(protein), "")
+        self.assertEqual(protein, "")
         s = "TAA"
-        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        dna = Seq.Seq(s)
         protein = dna.translate(to_stop=True)
-        self.assertEqual(str(protein), "")
+        self.assertEqual(protein, "")
         s = "GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCA"
-        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        dna = Seq.Seq(s)
         protein = dna.translate(to_stop=True)
-        self.assertEqual(str(protein), "ENSFSLDFL")
+        self.assertEqual(protein, "ENSFSLDFL")
         s = "GAA"
-        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        dna = Seq.Seq(s)
         protein = dna.translate(15, to_stop=True)
-        self.assertEqual(str(protein), "E")
+        self.assertEqual(protein, "E")
         s = "ATA"
-        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        dna = Seq.Seq(s)
         protein = dna.translate("Vertebrate Mitochondrial", to_stop=True)
-        self.assertEqual(str(protein), "M")
+        self.assertEqual(protein, "M")
         s = "GAAAATTCATTTTCTTTGGACTTTCTCTGAAATCCGAGTCCTAGGAAAGATGCGTGAGATTCTTCATAT"
-        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        dna = Seq.Seq(s)
         protein = dna.translate("SGC8", to_stop=True)
-        self.assertEqual(str(protein), "ENSFSLDFLWNPSPSNDAWDSSY")
+        self.assertEqual(protein, "ENSFSLDFLWNPSPSNDAWDSSY")
 
     def test_dna_rna_translation(self):
         s = "TCAAAAAGGTGCATCTAGATG"
-        dna = Seq.Seq(s, IUPAC.unambiguous_dna)
+        dna = Seq.Seq(s)
         protein = dna.translate(to_stop=True)
-        self.assertEqual(str(protein), "SKRCI")
+        self.assertEqual(protein, "SKRCI")
         gapped_protein = dna.translate()
-        self.assertEqual(str(gapped_protein), "SKRCI*M")
+        self.assertEqual(gapped_protein, "SKRCI*M")
         # The table used here has "AGG" as a stop codon:
         p2 = dna.translate(table=2, to_stop=True)
-        self.assertEqual(str(p2), "SK")
+        self.assertEqual(p2, "SK")
         p2 = dna.translate(table=2)
-        self.assertEqual(str(p2), "SK*CI*M")
+        self.assertEqual(p2, "SK*CI*M")
         p2 = dna.translate(table=2, stop_symbol="+")
-        self.assertEqual(str(p2), "SK+CI+M")
+        self.assertEqual(p2, "SK+CI+M")
         r = s.replace("T", "U")
-        rna = Seq.Seq(r, IUPAC.unambiguous_rna)
+        rna = Seq.Seq(r)
         protein = rna.translate(to_stop=True)
-        self.assertEqual(str(protein), "SKRCI")
+        self.assertEqual(protein, "SKRCI")
         gapped_protein = rna.translate()
-        self.assertEqual(str(gapped_protein), "SKRCI*M")
+        self.assertEqual(gapped_protein, "SKRCI*M")
 
     def test_ambiguous(self):
         s = "RATGATTARAATYTA"
-        dna = Seq.Seq(s, IUPAC.ambiguous_dna)
+        dna = Seq.Seq(s)
         protein = dna.translate("Vertebrate Mitochondrial")
-        self.assertEqual(str(protein), "BD*NL")
+        self.assertEqual(protein, "BD*NL")
         stop_protein = dna.translate("SGC1", to_stop=True)
-        self.assertEqual(str(stop_protein), "BD")
+        self.assertEqual(stop_protein, "BD")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request removes alphabets from `test_translate.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
