### PR TITLE
removed unused alphabet from test_ProtParam.py

### DIFF
--- a/Tests/test_ProtParam.py
+++ b/Tests/test_ProtParam.py
@@ -9,7 +9,6 @@
 
 import unittest
 from Bio.Seq import Seq
-from Bio.Alphabet import IUPAC
 from Bio.SeqUtils import ProtParam, ProtParamData
 from Bio.SeqUtils import molecular_weight
 


### PR DESCRIPTION
This pull request removes an unused import from `Bio.Alphabet` from `test_ProtParam.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
