### PR TITLE
removed alphabets from test_PhyloXML.py

### DIFF
--- a/Tests/test_PhyloXML.py
+++ b/Tests/test_PhyloXML.py
@@ -10,7 +10,6 @@ import tempfile
 import unittest
 from itertools import chain
 
-from Bio import Alphabet
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Align import MultipleSeqAlignment
@@ -675,7 +674,7 @@ class MethodTests(unittest.TestCase):
         )
         srec = pseq.to_seqrecord()
         # TODO: check seqrec-specific traits (see args)
-        #   Seq(letters, alphabet), id, name, description, features
+        #   Seq(letters), id, name, description, features
         pseq2 = PX.Sequence.from_seqrecord(srec)
         # TODO: check the round-tripped attributes again
 
@@ -685,11 +684,10 @@ class MethodTests(unittest.TestCase):
         self.assertIsInstance(aln, MultipleSeqAlignment)
         self.assertEqual(len(aln), 0)
         # Add sequences to the terminals
-        alphabet = Alphabet.generic_dna
         for tip, seqstr in zip(tree.get_terminals(), ("AA--TTA", "AA--TTG", "AACCTTC")):
             tip.sequences.append(
                 PX.Sequence.from_seqrecord(
-                    SeqRecord(Seq(seqstr, alphabet), id=str(tip)), is_aligned=True
+                    SeqRecord(Seq(seqstr), id=str(tip)), is_aligned=True
                 )
             )
         # Check the alignment


### PR DESCRIPTION
This pull request removes alphabets from `test_PhyloXML.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
