### PR TITLE
removed the alphabet from the to_generic method of Bio.Blast.Record

### DIFF
--- a/Bio/Blast/Record.py
+++ b/Bio/Blast/Record.py
@@ -291,15 +291,12 @@ class MultipleAlignment:
         """Initialize the class."""
         self.alignment = []
 
-    def to_generic(self, alphabet):
+    def to_generic(self):
         """Retrieve generic alignment object for the given alignment.
 
         Instead of the tuples, this returns a MultipleSeqAlignment object
         from Bio.Align, through which you can manipulate and query
         the object.
-
-        alphabet is the specified alphabet for the sequences in the code (for
-        example IUPAC.IUPACProtein).
 
         Thanks to James Casbon for the code.
         """
@@ -320,9 +317,9 @@ class MultipleAlignment:
                 seq_parts[n] += seq
                 n += 1
 
-        generic = MultipleSeqAlignment([], alphabet)
+        generic = MultipleSeqAlignment([])
         for (name, seq) in zip(seq_names, seq_parts):
-            generic.append(SeqRecord(Seq(seq, alphabet), name))
+            generic.append(SeqRecord(Seq(seq), name))
 
         return generic
 

--- a/Tests/test_NCBITextParser.py
+++ b/Tests/test_NCBITextParser.py
@@ -28,14 +28,11 @@ class TestBlastRecord(unittest.TestCase):
 
     def test_conversion(self):
         """Converting a Blast record multiple alignment."""
-        from Bio.Alphabet import IUPAC
-
         path = os.path.join("Blast", "text_2010L_blastp_006.txt")
         with open(path) as handle:
             record = self.parser.parse(handle)
-        generic_align = record.multiple_alignment.to_generic(IUPAC.protein)
+        generic_align = record.multiple_alignment.to_generic()
         test_seq = generic_align[0].seq
-        self.assertEqual(test_seq.alphabet, IUPAC.protein)
         self.assertEqual(str(test_seq[:60]), record.multiple_alignment.alignment[0][2])
 
 


### PR DESCRIPTION
This pull request removes the alphabet from the `to_generic` method of `Bio.Blast.Record`.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
