### PR TITLE
removed alphabets

### DIFF
--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -37,7 +37,6 @@ except ImportError:
 
 from Bio import BiopythonWarning
 from Bio.Seq import Seq
-from Bio.Alphabet import generic_protein
 from Bio.PDB import (
     PDBParser,
     PPBuilder,
@@ -201,7 +200,6 @@ class ParseTest(unittest.TestCase):
         # Check the sequence
         s = pp.get_sequence()
         self.assertIsInstance(s, Seq)
-        self.assertEqual(s.alphabet, generic_protein)
         self.assertEqual(
             "RCGSQGGGSTCPGLRCCSIWGWCGDSEPYCGRTCENKCWSGER"
             "SDHRCGAAVGNPPCGQDRCCSVHGWCGGGNDYCSGGNCQYRC",
@@ -220,7 +218,6 @@ class ParseTest(unittest.TestCase):
         # Check the sequence
         s = pp.get_sequence()
         self.assertIsInstance(s, Seq)
-        self.assertEqual(s.alphabet, generic_protein)
         self.assertEqual(
             "RCGSQGGGSTCPGLRCCSIWGWCGDSEPYCGRTCENKCWSGER"
             "SDHRCGAAVGNPPCGQDRCCSVHGWCGGGNDYCSGGNCQYRC",
@@ -765,7 +762,6 @@ class ParseReal(unittest.TestCase):
             # Check the sequence
             s = pp.get_sequence()
             self.assertIsInstance(s, Seq)
-            self.assertEqual(s.alphabet, generic_protein)
             # Here non-standard MSE are shown as M
             self.assertEqual(
                 "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQ"
@@ -784,7 +780,6 @@ class ParseReal(unittest.TestCase):
             self.assertEqual(pp[-1].get_id()[1], 184)
             s = pp.get_sequence()
             self.assertIsInstance(s, Seq)
-            self.assertEqual(s.alphabet, generic_protein)
             self.assertEqual("DIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNW", str(s))
             # Second fragment
             pp = polypeptides[1]
@@ -792,7 +787,6 @@ class ParseReal(unittest.TestCase):
             self.assertEqual(pp[-1].get_id()[1], 213)
             s = pp.get_sequence()
             self.assertIsInstance(s, Seq)
-            self.assertEqual(s.alphabet, generic_protein)
             self.assertEqual("TETLLVQNANPDCKTILKALGPGATLEE", str(s))
             # Third fragment
             pp = polypeptides[2]
@@ -800,7 +794,6 @@ class ParseReal(unittest.TestCase):
             self.assertEqual(pp[-1].get_id()[1], 220)
             s = pp.get_sequence()
             self.assertIsInstance(s, Seq)
-            self.assertEqual(s.alphabet, generic_protein)
             self.assertEqual("TACQG", str(s))
 
     def test_strict(self):

--- a/Tests/test_PDB_MMCIFParser.py
+++ b/Tests/test_PDB_MMCIFParser.py
@@ -29,7 +29,6 @@ except ImportError:
 
 
 from Bio.Seq import Seq
-from Bio.Alphabet import generic_protein
 from Bio.PDB.PDBExceptions import PDBConstructionException, PDBConstructionWarning
 
 from Bio.PDB import PPBuilder, CaPPBuilder
@@ -81,13 +80,12 @@ class ParseReal(unittest.TestCase):
             self.assertEqual(s, f_s)  # enough to test this
 
             self.assertIsInstance(s, Seq)
-            self.assertEqual(s.alphabet, generic_protein)
 
             # Here non-standard MSE are shown as M
             self.assertEqual(
                 "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQ"
                 "NANPDCKTILKALGPGATLEEMMTACQG",
-                str(s),
+                s,
             )
 
             # ==========================================================
@@ -103,8 +101,7 @@ class ParseReal(unittest.TestCase):
             self.assertEqual(pp[-1].get_id()[1], 184)
             s = pp.get_sequence()
             self.assertIsInstance(s, Seq)
-            self.assertEqual(s.alphabet, generic_protein)
-            self.assertEqual("DIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNW", str(s))
+            self.assertEqual("DIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNW", s)
 
             # Second fragment
             pp = polypeptides[1]
@@ -112,8 +109,7 @@ class ParseReal(unittest.TestCase):
             self.assertEqual(pp[-1].get_id()[1], 213)
             s = pp.get_sequence()
             self.assertIsInstance(s, Seq)
-            self.assertEqual(s.alphabet, generic_protein)
-            self.assertEqual("TETLLVQNANPDCKTILKALGPGATLEE", str(s))
+            self.assertEqual("TETLLVQNANPDCKTILKALGPGATLEE", s)
 
             # Third fragment
             pp = polypeptides[2]
@@ -121,8 +117,7 @@ class ParseReal(unittest.TestCase):
             self.assertEqual(pp[-1].get_id()[1], 220)
             s = pp.get_sequence()
             self.assertIsInstance(s, Seq)
-            self.assertEqual(s.alphabet, generic_protein)
-            self.assertEqual("TACQG", str(s))
+            self.assertEqual("TACQG", s)
 
         s_atoms = list(structure.get_atoms())
         f_atoms = list(f_structure.get_atoms())
@@ -210,10 +205,9 @@ class ParseReal(unittest.TestCase):
             # Check the sequence
             s = pp.get_sequence()
             self.assertIsInstance(s, Seq)
-            self.assertEqual(s.alphabet, generic_protein)
             # Here non-standard MSE are shown as M
             self.assertEqual(
-                "MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR", str(s)
+                "MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR", s
             )
             # ==========================================================
             # Now try strict version with only standard amino acids
@@ -226,9 +220,8 @@ class ParseReal(unittest.TestCase):
             # Check the sequence
             s = pp.get_sequence()
             self.assertIsInstance(s, Seq)
-            self.assertEqual(s.alphabet, generic_protein)
             self.assertEqual(
-                "MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR", str(s)
+                "MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR", s
             )
 
         # This structure contains several models with multiple lengths.
@@ -259,8 +252,7 @@ class ParseReal(unittest.TestCase):
             )
             s = pp.get_sequence()
             self.assertIsInstance(s, Seq)
-            self.assertEqual(s.alphabet, generic_protein)
-            self.assertEqual(refseq, str(s))
+            self.assertEqual(refseq, s)
 
     def test_filehandle(self):
         """Test if the parser can handle file handle as well as filename."""


### PR DESCRIPTION
This pull request removes alphabets from test_PDB.py and test_PDB_MMCIFParser.py.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
