### PR TITLE
removed alphabet from test_GenBank.py

### DIFF
--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -24,7 +24,6 @@ from Bio import BiopythonParserWarning
 from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord
 from Bio.Seq import Seq
-from Bio.Alphabet import generic_dna
 
 # GenBank stuff to test:
 from Bio import GenBank
@@ -6770,7 +6769,7 @@ KEYWORDS    """
             # Make the length match the desired target
             record = original[:]
             # TODO - Implement Seq * int
-            record.seq = Seq("N" * seq_len, original.seq.alphabet)
+            record.seq = Seq("N" * seq_len)
             record.annotations["molecule_type"] = original.annotations["molecule_type"]
             # Set the identifier to the desired name
             record.id = record.name = name
@@ -6805,7 +6804,7 @@ KEYWORDS    """
 
     def test_genbank_date_default(self):
         """Check if default date is handled correctly."""
-        sequence_object = Seq("ATGC", generic_dna)
+        sequence_object = Seq("ATGC")
         # check if default value is inserted correctly
         record = SeqRecord(
             sequence_object,
@@ -6822,7 +6821,7 @@ KEYWORDS    """
 
     def test_genbank_date_correct(self):
         """Check if user provided date is inserted correctly."""
-        sequence_object = Seq("ATGC", generic_dna)
+        sequence_object = Seq("ATGC")
         record = SeqRecord(
             sequence_object,
             id="123456789",
@@ -6839,7 +6838,7 @@ KEYWORDS    """
 
     def test_genbank_date_list(self):
         """Check if date lists are handled correctly."""
-        sequence_object = Seq("ATGC", generic_dna)
+        sequence_object = Seq("ATGC")
         record = SeqRecord(
             sequence_object,
             id="123456789",
@@ -6870,7 +6869,7 @@ KEYWORDS    """
 
     def test_genbank_date_datetime(self):
         """Check if datetime objects are handled correctly."""
-        sequence_object = Seq("ATGC", generic_dna)
+        sequence_object = Seq("ATGC")
         record = SeqRecord(
             sequence_object,
             id="123456789",
@@ -6889,7 +6888,7 @@ KEYWORDS    """
         """Check if invalid dates are treated as default."""
         invalid_dates = ("invalid date", "29-2-1981", "35-1-2018", "1-1-80", "1-9-99")
 
-        sequence_object = Seq("ATGC", generic_dna)
+        sequence_object = Seq("ATGC")
         for invalid_date in invalid_dates:
             record = SeqRecord(
                 sequence_object,
@@ -7171,7 +7170,7 @@ class OutputTests(unittest.TestCase):
         """Writing and reading back accesssion.version variants."""
         for identifier in ["example", "example.1a", "example.1.2", "example.1-2"]:
             old = SeqRecord(
-                Seq("ACGT", generic_dna),
+                Seq("ACGT"),
                 id=identifier,
                 name=identifier,
                 description="mad dots",
@@ -7185,7 +7184,7 @@ class OutputTests(unittest.TestCase):
 
     def test_seqrecord_default_description(self):
         """Read in file using SeqRecord default description."""
-        old = SeqRecord(Seq("ACGT", generic_dna), id="example", name="short", annotations={"molecule_type": "DNA"})
+        old = SeqRecord(Seq("ACGT"), id="example", name="short", annotations={"molecule_type": "DNA"})
         self.assertEqual(old.description, "<unknown description>")
         txt = old.format("gb")
         self.assertIn("DEFINITION  .\n", txt)


### PR DESCRIPTION
This pull request removes alphabets from test_GenBank.py

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
