### PR TITLE
deprecating Bio.SubsMat

### DIFF
--- a/Bio/SubsMat/__init__.py
+++ b/Bio/SubsMat/__init__.py
@@ -132,8 +132,6 @@ warnings.warn(
 )
 
 
-
-
 log = math.log
 # Matrix types
 NOTYPE = 0

--- a/Bio/SubsMat/__init__.py
+++ b/Bio/SubsMat/__init__.py
@@ -119,6 +119,7 @@ import math
 
 # BioPython imports
 from Bio.SubsMat import FreqTable
+from Bio import BiopythonDeprecationWarning
 
 import warnings
 

--- a/Bio/SubsMat/__init__.py
+++ b/Bio/SubsMat/__init__.py
@@ -121,7 +121,16 @@ import math
 from Bio.SubsMat import FreqTable
 
 import warnings
-from Bio import BiopythonDeprecationWarning
+
+warnings.warn(
+    "Bio.SubsMat has been deprecated, and we intend to remove it in a future "
+    "release of Biopython. As an alternative, please consider using "
+    "Bio.Align.substitution_matrices as a replacement, and contact the "
+    "Biopython developers if you still need the Bio.SubsMat module.",
+    BiopythonDeprecationWarning,
+)
+
+
 
 
 log = math.log

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -800,6 +800,8 @@ Bio.SubsMat
 -----------
 The methods letter_sum and all_letters_sum were removed from the SeqMat class
 in Bio.SubsMat in Release 1.57.
+The Bio.SubsMat module was deprecated in Release 1.78. As an alternative,
+please consider using Bio.Align.substitution_matrices.
 
 Bio.Align
 ---------

--- a/Doc/Tutorial/chapter_advanced.tex
+++ b/Doc/Tutorial/chapter_advanced.tex
@@ -33,6 +33,8 @@ into \verb|SeqRecord| objects.
 
 \section{Substitution Matrices}
 
+\textbf{Please note that Bio.SubsMat was deprecated in Release 1.78.} As an alternative, please consider using \verb|Bio.Align.substitution_matrices| (described in section~\ref{sec:substitution_matrices}).
+
 \subsection{SubsMat}
 
 This module provides a class and a few routines for generating substitution matrices, similar to BLOSUM or PAM matrices, but based on user-provided data. Additionally, you may select a matrix from MatrixInfo.py, a collection of established substitution matrices.


### PR DESCRIPTION
This pull request deprecates `Bio.SubsMat`, which currently is not being maintained, with `Bio.Align.substitution_matrices` as a replacement.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
