### PR TITLE
remove alphabets from test_SeqUtils.py

### DIFF
--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -11,7 +11,6 @@ import os
 import unittest
 
 from Bio import SeqIO
-from Bio.Alphabet import single_letter_alphabet
 from Bio.Seq import Seq, MutableSeq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqUtils import GC, seq1, seq3, GC_skew
@@ -115,11 +114,7 @@ class SeqUtilsTests(unittest.TestCase):
         exp_simple_LCC,
         exp_window_LCC,
     ):
-        for s in [
-            seq_str,
-            Seq(seq_str, single_letter_alphabet),
-            MutableSeq(seq_str, single_letter_alphabet),
-        ]:
+        for s in [seq_str, Seq(seq_str), MutableSeq(seq_str)]:
             self.assertEqual(exp_crc32, crc32(s))
             self.assertEqual(exp_crc64, crc64(s))
             self.assertEqual(exp_gcg, gcg(s))


### PR DESCRIPTION
This pull request removes alphabets from `test_SeqUtils.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
