### PR TITLE
removed alphabets

### DIFF
--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -10,9 +10,7 @@ import unittest
 import warnings
 
 from Bio import BiopythonWarning
-from Bio import Alphabet
 from Bio import Seq
-from Bio.Alphabet import IUPAC
 from Bio.Data.IUPACData import (
     ambiguous_dna_complement,
     ambiguous_rna_complement,
@@ -23,47 +21,39 @@ from Bio.Data.CodonTable import TranslationError, standard_dna_table
 from Bio.Seq import MutableSeq
 
 test_seqs = [
-    Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna),
-    Seq.Seq("T", IUPAC.ambiguous_dna),
+    Seq.Seq("TCAAAAGGATGCATCATG"),
+    Seq.Seq("T"),
     Seq.Seq("ATGAAACTG"),
     Seq.Seq("ATGAARCTG"),
     Seq.Seq("AWGAARCKG"),  # Note no U or T
     Seq.Seq("".join(ambiguous_rna_values)),
     Seq.Seq("".join(ambiguous_dna_values)),
-    Seq.Seq("".join(ambiguous_rna_values), Alphabet.generic_rna),
-    Seq.Seq("".join(ambiguous_dna_values), Alphabet.generic_dna),
-    Seq.Seq("".join(ambiguous_rna_values), IUPAC.IUPACAmbiguousRNA()),
-    Seq.Seq("".join(ambiguous_dna_values), IUPAC.IUPACAmbiguousDNA()),
-    Seq.Seq("AWGAARCKG", Alphabet.generic_dna),
-    Seq.Seq("AUGAAACUG", Alphabet.generic_rna),
-    Seq.Seq("ATGAAACTG", IUPAC.unambiguous_dna),
-    Seq.Seq("ATGAAA-CTG", Alphabet.generic_dna),
-    Seq.Seq("ATGAAACTGWN", IUPAC.ambiguous_dna),
-    Seq.Seq("AUGAAACUG", Alphabet.generic_rna),
-    Seq.Seq("AUGAAA==CUG", Alphabet.generic_rna),
-    Seq.Seq("AUGAAACUG", IUPAC.unambiguous_rna),
-    Seq.Seq("AUGAAACUGWN", IUPAC.ambiguous_rna),
-    Seq.Seq("ATGAAACTG", Alphabet.generic_nucleotide),
-    Seq.Seq("AUGAAACTG", Alphabet.generic_nucleotide),  # U and T
-    Seq.MutableSeq("ATGAAACTG", Alphabet.generic_dna),
-    Seq.MutableSeq("AUGaaaCUG", IUPAC.unambiguous_rna),
-    Seq.Seq("ACTGTCGTCT", Alphabet.generic_protein),
+    Seq.Seq("AWGAARCKG"),
+    Seq.Seq("AUGAAACUG"),
+    Seq.Seq("ATGAAA-CTG"),
+    Seq.Seq("ATGAAACTGWN"),
+    Seq.Seq("AUGAAA==CUG"),
+    Seq.Seq("AUGAAACUGWN"),
+    Seq.Seq("AUGAAACTG"),  # U and T
+    Seq.MutableSeq("ATGAAACTG"),
+    Seq.MutableSeq("AUGaaaCUG"),
+    Seq.Seq("ACTGTCGTCT"),
 ]
 protein_seqs = [
-    Seq.Seq("ATCGPK", IUPAC.protein),
-    Seq.Seq("T.CGPK", Alphabet.generic_protein),
-    Seq.Seq("T-CGPK", Alphabet.generic_protein),
-    Seq.Seq("MEDG-KRXR*", Alphabet.generic_protein),
-    Seq.MutableSeq("ME-K-DRXR*XU", Alphabet.generic_protein),
-    Seq.Seq("MEDG-KRXR@", Alphabet.generic_protein),
-    Seq.Seq("ME-KR@", Alphabet.generic_protein),
-    Seq.Seq("MEDG.KRXR@", Alphabet.generic_protein),
+    Seq.Seq("ATCGPK"),
+    Seq.Seq("T.CGPK"),
+    Seq.Seq("T-CGPK"),
+    Seq.Seq("MEDG-KRXR*"),
+    Seq.MutableSeq("ME-K-DRXR*XU"),
+    Seq.Seq("MEDG-KRXR@"),
+    Seq.Seq("ME-KR@"),
+    Seq.Seq("MEDG.KRXR@"),
 ]
 
 
 class TestSeq(unittest.TestCase):
     def setUp(self):
-        self.s = Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna)
+        self.s = Seq.Seq("TCAAAAGGATGCATCATG")
 
     def test_as_string(self):
         """Test converting Seq to string."""
@@ -81,7 +71,7 @@ class TestSeq(unittest.TestCase):
     def test_truncated_repr(self):
         seq = "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGA"
         expected = "Seq('TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATG...GGA')"
-        self.assertEqual(expected, repr(Seq.Seq(seq, IUPAC.ambiguous_dna)))
+        self.assertEqual(expected, repr(Seq.Seq(seq)))
 
     def test_length(self):
         """Test len method on Seq object."""
@@ -109,36 +99,11 @@ class TestSeq(unittest.TestCase):
         self.assertEqual("CAGGTT", str(self.s[1::3]))
         self.assertEqual("AAACCG", str(self.s[2::3]))
 
-    def test_alphabet_letters(self):
-        """Test nucleotides in DNA Seq."""
-        self.assertEqual("GATC", self.s.alphabet.letters)
-
-    def test_alphabet(self):
-        """Test alphabet of derived Seq object."""
-        t = Seq.Seq("T", IUPAC.unambiguous_dna)
-        u = self.s + t
-        self.assertEqual("IUPACUnambiguousDNA()", str(u.alphabet))
-
-    def test_length_concatenated_unambiguous_seq(self):
-        """Test length of concatenated Seq object with unambiguous DNA."""
-        t = Seq.Seq("T", IUPAC.unambiguous_dna)
-        u = self.s + t
-        self.assertEqual(19, len(u))
-
     def test_concatenation_of_seq(self):
-        t = Seq.Seq("T", IUPAC.unambiguous_dna)
+        t = Seq.Seq("T")
         u = self.s + t
         self.assertEqual(str(self.s) + "T", str(u))
-
-    def test_concatenation_mixed(self):
-        """DNA Seq objects cannot be concatenated with Protein Seq objects."""
-        self.assertEqual(self.s + Seq.Seq("T", IUPAC.protein), "TCAAAAGGATGCATCATGT")
-
-    def test_concatenation_of_ambiguous_and_unambiguous_dna(self):
-        """Concatenate Seq object with ambiguous and unambiguous DNA returns ambiguous Seq."""
-        t = Seq.Seq("T", IUPAC.ambiguous_dna)
-        u = self.s + t
-        self.assertEqual(str(self.s) + "T", u)
+        self.assertEqual(self.s + Seq.Seq("T"), "TCAAAAGGATGCATCATGT")
 
     def test_ungap(self):
         self.assertEqual("ATCCCA", str(Seq.Seq("ATC-CCA").ungap("-")))
@@ -152,31 +117,31 @@ class TestSeq(unittest.TestCase):
 
 class TestSeqStringMethods(unittest.TestCase):
     def setUp(self):
-        self.s = Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna)
+        self.s = Seq.Seq("TCAAAAGGATGCATCATG")
         self.dna = [
-            Seq.Seq("ATCG", IUPAC.ambiguous_dna),
-            Seq.Seq("gtca", Alphabet.generic_dna),
-            Seq.MutableSeq("GGTCA", Alphabet.generic_dna),
-            Seq.Seq("CTG-CA", Alphabet.generic_dna),
+            Seq.Seq("ATCG"),
+            Seq.Seq("gtca"),
+            Seq.MutableSeq("GGTCA"),
+            Seq.Seq("CTG-CA"),
         ]
         self.rna = [
-            Seq.Seq("AUUUCG", IUPAC.ambiguous_rna),
-            Seq.MutableSeq("AUUCG", IUPAC.ambiguous_rna),
-            Seq.Seq("uCAg", Alphabet.generic_rna),
-            Seq.MutableSeq("UC-AG", Alphabet.generic_rna),
-            Seq.Seq("U.CAG", Alphabet.generic_rna),
+            Seq.Seq("AUUUCG"),
+            Seq.MutableSeq("AUUCG"),
+            Seq.Seq("uCAg"),
+            Seq.MutableSeq("UC-AG"),
+            Seq.Seq("U.CAG"),
         ]
-        self.nuc = [Seq.Seq("ATCG", Alphabet.generic_nucleotide)]
+        self.nuc = [Seq.Seq("ATCG")]
         self.protein = [
-            Seq.Seq("ATCGPK", IUPAC.protein),
-            Seq.Seq("atcGPK", Alphabet.generic_protein),
-            Seq.Seq("T.CGPK", Alphabet.generic_protein),
-            Seq.Seq("T-CGPK", Alphabet.generic_protein),
-            Seq.Seq("MEDG-KRXR*", Alphabet.generic_protein),
-            Seq.MutableSeq("ME-K-DRXR*XU", Alphabet.generic_protein),
-            Seq.Seq("MEDG-KRXR@", Alphabet.generic_protein),
-            Seq.Seq("ME-KR@", Alphabet.generic_protein),
-            Seq.Seq("MEDG.KRXR@", Alphabet.generic_protein),
+            Seq.Seq("ATCGPK"),
+            Seq.Seq("atcGPK"),
+            Seq.Seq("T.CGPK"),
+            Seq.Seq("T-CGPK"),
+            Seq.Seq("MEDG-KRXR*"),
+            Seq.MutableSeq("ME-K-DRXR*XU"),
+            Seq.Seq("MEDG-KRXR@"),
+            Seq.Seq("ME-KR@"),
+            Seq.Seq("MEDG.KRXR@"),
         ]
         self.test_chars = ["-", Seq.Seq("-"), Seq.Seq("*"), "-X@"]
 
@@ -195,10 +160,7 @@ class TestSeqStringMethods(unittest.TestCase):
 
     def test_not_equal_comparsion(self):
         """Test __ne__ comparison method."""
-        self.assertNotEqual(
-            Seq.Seq("TCAAA", IUPAC.ambiguous_dna),
-            Seq.Seq("TCAAAA", IUPAC.ambiguous_dna),
-        )
+        self.assertNotEqual(Seq.Seq("TCAAA"), Seq.Seq("TCAAAA"))
 
     def test_less_than_comparison(self):
         """Test __lt__ comparison method."""
@@ -261,16 +223,13 @@ class TestSeqStringMethods(unittest.TestCase):
         self.assertTrue(self.s.endswith(("ATG", "CTA")))
 
     def test_append_nucleotides(self):
-        self.test_chars.append(Seq.Seq("A", IUPAC.ambiguous_dna))
-        self.test_chars.append(Seq.Seq("A", IUPAC.ambiguous_rna))
-        self.test_chars.append(Seq.Seq("A", Alphabet.generic_nucleotide))
-
-        self.assertEqual(7, len(self.test_chars))
+        self.test_chars.append(Seq.Seq("A"))
+        self.assertEqual(5, len(self.test_chars))
 
     def test_append_proteins(self):
-        self.test_chars.append(Seq.Seq("K", Alphabet.generic_protein))
-        self.test_chars.append(Seq.Seq("K-", Alphabet.generic_protein))
-        self.test_chars.append(Seq.Seq("K@", Alphabet.generic_protein))
+        self.test_chars.append(Seq.Seq("K"))
+        self.test_chars.append(Seq.Seq("K-"))
+        self.test_chars.append(Seq.Seq("K@"))
 
         self.assertEqual(7, len(self.test_chars))
 
@@ -327,31 +286,28 @@ class TestSeqStringMethods(unittest.TestCase):
 class TestSeqAddition(unittest.TestCase):
     def setUp(self):
         self.dna = [
-            Seq.Seq("ATCG", IUPAC.ambiguous_dna),
-            Seq.Seq("gtca", Alphabet.generic_dna),
-            Seq.MutableSeq("GGTCA", Alphabet.generic_dna),
-            Seq.Seq("CTG-CA", Alphabet.generic_dna),
+            Seq.Seq("ATCG"),
+            Seq.Seq("gtca"),
+            Seq.MutableSeq("GGTCA"),
+            Seq.Seq("CTG-CA"),
             "TGGTCA",
         ]
         self.rna = [
-            Seq.Seq("AUUUCG", IUPAC.ambiguous_rna),
-            Seq.MutableSeq("AUUCG", IUPAC.ambiguous_rna),
-            Seq.Seq("uCAg", Alphabet.generic_rna),
-            Seq.MutableSeq("UC-AG", Alphabet.generic_rna),
-            Seq.Seq("U.CAG", Alphabet.generic_rna),
+            Seq.Seq("AUUUCG"),
+            Seq.MutableSeq("AUUCG"),
+            Seq.Seq("uCAg"),
+            Seq.MutableSeq("UC-AG"),
+            Seq.Seq("U.CAG"),
             "UGCAU",
         ]
-        self.nuc = [
-            Seq.Seq("ATCG", Alphabet.generic_nucleotide),
-            "UUUTTTACG",
-        ]
+        self.nuc = [Seq.Seq("ATCG"), "UUUTTTACG", ]
         self.protein = [
-            Seq.Seq("ATCGPK", IUPAC.protein),
-            Seq.Seq("atcGPK", Alphabet.generic_protein),
-            Seq.Seq("T.CGPK", Alphabet.generic_protein),
-            Seq.Seq("T-CGPK", Alphabet.generic_protein),
-            Seq.Seq("MEDG-KRXR*", Alphabet.generic_protein),
-            Seq.MutableSeq("ME-K-DRXR*XU", Alphabet.generic_protein),
+            Seq.Seq("ATCGPK"),
+            Seq.Seq("atcGPK"),
+            Seq.Seq("T.CGPK"),
+            Seq.Seq("T-CGPK"),
+            Seq.Seq("MEDG-KRXR*"),
+            Seq.MutableSeq("ME-K-DRXR*XU"),
             "TEDDF",
         ]
 
@@ -491,19 +447,19 @@ class TestSeqMultiplication(unittest.TestCase):
 
 class TestMutableSeq(unittest.TestCase):
     def setUp(self):
-        self.s = Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna)
-        self.mutable_s = MutableSeq("TCAAAAGGATGCATCATG", IUPAC.ambiguous_dna)
+        self.s = Seq.Seq("TCAAAAGGATGCATCATG")
+        self.mutable_s = MutableSeq("TCAAAAGGATGCATCATG")
 
     def test_mutableseq_creation(self):
         """Test creating MutableSeqs in multiple ways."""
-        mutable_s = MutableSeq("TCAAAAGGATGCATCATG", IUPAC.ambiguous_dna)
+        mutable_s = MutableSeq("TCAAAAGGATGCATCATG")
         self.assertIsInstance(mutable_s, MutableSeq, "Creating MutableSeq")
 
         mutable_s = self.s.tomutable()
         self.assertIsInstance(mutable_s, MutableSeq, "Converting Seq to mutable")
 
         array_seq = MutableSeq(
-            array.array("u", "TCAAAAGGATGCATCATG"), IUPAC.ambiguous_dna
+            array.array("u", "TCAAAAGGATGCATCATG")
         )
         self.assertIsInstance(array_seq, MutableSeq, "Creating MutableSeq using array")
 
@@ -515,7 +471,7 @@ class TestMutableSeq(unittest.TestCase):
         expected = (
             "MutableSeq('TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATG...GGA')"
         )
-        self.assertEqual(expected, repr(MutableSeq(seq, IUPAC.ambiguous_dna)))
+        self.assertEqual(expected, repr(MutableSeq(seq)))
 
     def test_equal_comparison(self):
         """Test __eq__ comparison method."""
@@ -583,7 +539,7 @@ class TestMutableSeq(unittest.TestCase):
     def test_radd_method_incompatible_alphabets(self):
         self.assertEqual(
             "UCAAAAGGATCAAAAGGATGCATCATG",
-            self.mutable_s.__radd__(MutableSeq("UCAAAAGGA", IUPAC.ambiguous_rna)),
+            self.mutable_s.__radd__(MutableSeq("UCAAAAGGA")),
         )
 
     def test_radd_method_using_seq_object(self):
@@ -609,72 +565,58 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_setting_slices(self):
         self.assertEqual(
-            MutableSeq("CAAA", IUPAC.ambiguous_dna),
+            MutableSeq("CAAA"),
             self.mutable_s[1:5],
             "Slice mutable seq",
         )
 
         self.mutable_s[1:3] = "GAT"
         self.assertEqual(
-            MutableSeq("TGATAAAGGATGCATCATG", IUPAC.ambiguous_dna),
+            MutableSeq("TGATAAAGGATGCATCATG"),
             self.mutable_s,
             "Set slice with string and adding extra nucleotide",
         )
 
         self.mutable_s[1:3] = self.mutable_s[5:7]
         self.assertEqual(
-            MutableSeq("TAATAAAGGATGCATCATG", IUPAC.ambiguous_dna),
+            MutableSeq("TAATAAAGGATGCATCATG"),
             self.mutable_s,
             "Set slice with MutableSeq",
         )
 
         self.mutable_s[1:3] = array.array("u", "GAT")
         self.assertEqual(
-            MutableSeq("TGATTAAAGGATGCATCATG", IUPAC.ambiguous_dna),
+            MutableSeq("TGATTAAAGGATGCATCATG"),
             self.mutable_s,
             "Set slice with array",
         )
 
     def test_setting_item(self):
         self.mutable_s[3] = "G"
-        self.assertEqual(
-            MutableSeq("TCAGAAGGATGCATCATG", IUPAC.ambiguous_dna), self.mutable_s
-        )
+        self.assertEqual(MutableSeq("TCAGAAGGATGCATCATG"), self.mutable_s)
 
     def test_deleting_slice(self):
         del self.mutable_s[4:5]
-        self.assertEqual(
-            MutableSeq("TCAAAGGATGCATCATG", IUPAC.ambiguous_dna), self.mutable_s
-        )
+        self.assertEqual(MutableSeq("TCAAAGGATGCATCATG"), self.mutable_s)
 
     def test_deleting_item(self):
         del self.mutable_s[3]
-        self.assertEqual(
-            MutableSeq("TCAAAGGATGCATCATG", IUPAC.ambiguous_dna), self.mutable_s
-        )
+        self.assertEqual(MutableSeq("TCAAAGGATGCATCATG"), self.mutable_s)
 
     def test_appending(self):
         self.mutable_s.append("C")
-        self.assertEqual(
-            MutableSeq("TCAAAAGGATGCATCATGC", IUPAC.ambiguous_dna), self.mutable_s
-        )
+        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGC"), self.mutable_s)
 
     def test_inserting(self):
         self.mutable_s.insert(4, "G")
-        self.assertEqual(
-            MutableSeq("TCAAGAAGGATGCATCATG", IUPAC.ambiguous_dna), self.mutable_s
-        )
+        self.assertEqual(MutableSeq("TCAAGAAGGATGCATCATG"), self.mutable_s)
 
     def test_popping_last_item(self):
         self.assertEqual("G", self.mutable_s.pop())
 
     def test_remove_items(self):
         self.mutable_s.remove("G")
-        self.assertEqual(
-            MutableSeq("TCAAAAGATGCATCATG", IUPAC.ambiguous_dna),
-            self.mutable_s,
-            "Remove first G",
-        )
+        self.assertEqual(MutableSeq("TCAAAAGATGCATCATG"), self.mutable_s, "Remove first G")
 
         self.assertRaises(ValueError, self.mutable_s.remove, "Z")
 
@@ -689,22 +631,18 @@ class TestMutableSeq(unittest.TestCase):
     def test_reverse(self):
         """Test using reverse method."""
         self.mutable_s.reverse()
-        self.assertEqual(
-            MutableSeq("GTACTACGTAGGAAAACT", IUPAC.ambiguous_dna), self.mutable_s
-        )
+        self.assertEqual(MutableSeq("GTACTACGTAGGAAAACT"), self.mutable_s)
 
     def test_reverse_with_stride(self):
         """Test reverse using -1 stride."""
-        self.assertEqual(
-            MutableSeq("GTACTACGTAGGAAAACT", IUPAC.ambiguous_dna), self.mutable_s[::-1]
-        )
+        self.assertEqual(MutableSeq("GTACTACGTAGGAAAACT"), self.mutable_s[::-1])
 
     def test_complement(self):
         self.mutable_s.complement()
         self.assertEqual("AGTTTTCCTACGTAGTAC", str(self.mutable_s))
 
     def test_complement_rna(self):
-        seq = Seq.MutableSeq("AUGaaaCUG", IUPAC.unambiguous_rna)
+        seq = Seq.MutableSeq("AUGaaaCUG")
         seq.complement()
         self.assertEqual("UACuuuGAC", str(seq))
 
@@ -729,40 +667,26 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_extend_method(self):
         self.mutable_s.extend("GAT")
-        self.assertEqual(
-            MutableSeq("TCAAAAGGATGCATCATGGAT", IUPAC.ambiguous_dna), self.mutable_s
-        )
+        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGGAT"), self.mutable_s)
 
     def test_extend_with_mutable_seq(self):
-        self.mutable_s.extend(MutableSeq("TTT", IUPAC.ambiguous_dna))
-        self.assertEqual(
-            MutableSeq("TCAAAAGGATGCATCATGTTT", IUPAC.ambiguous_dna), self.mutable_s
-        )
+        self.mutable_s.extend(MutableSeq("TTT"))
+        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGTTT"), self.mutable_s)
 
     def test_delete_stride_slice(self):
         del self.mutable_s[4 : 6 - 1]
-        self.assertEqual(
-            MutableSeq("TCAAAGGATGCATCATG", IUPAC.ambiguous_dna), self.mutable_s
-        )
+        self.assertEqual(MutableSeq("TCAAAGGATGCATCATG"), self.mutable_s)
 
     def test_extract_third_nucleotide(self):
         """Test extracting every third nucleotide (slicing with stride 3)."""
-        self.assertEqual(
-            MutableSeq("TAGTAA", IUPAC.ambiguous_dna), self.mutable_s[0::3]
-        )
-        self.assertEqual(
-            MutableSeq("CAGGTT", IUPAC.ambiguous_dna), self.mutable_s[1::3]
-        )
-        self.assertEqual(
-            MutableSeq("AAACCG", IUPAC.ambiguous_dna), self.mutable_s[2::3]
-        )
+        self.assertEqual(MutableSeq("TAGTAA"), self.mutable_s[0::3])
+        self.assertEqual(MutableSeq("CAGGTT"), self.mutable_s[1::3])
+        self.assertEqual(MutableSeq("AAACCG"), self.mutable_s[2::3])
 
     def test_set_wobble_codon_to_n(self):
         """Test setting wobble codon to N (set slice with stride 3)."""
         self.mutable_s[2::3] = "N" * len(self.mutable_s[2::3])
-        self.assertEqual(
-            MutableSeq("TCNAANGGNTGNATNATN", IUPAC.ambiguous_dna), self.mutable_s
-        )
+        self.assertEqual(MutableSeq("TCNAANGGNTGNATNATN"), self.mutable_s)
 
 
 class TestUnknownSeq(unittest.TestCase):
@@ -771,8 +695,8 @@ class TestUnknownSeq(unittest.TestCase):
 
     def test_construction(self):
         self.assertEqual("??????", str(Seq.UnknownSeq(6)))
-        self.assertEqual("NNNNNN", str(Seq.UnknownSeq(6, Alphabet.generic_dna)))
-        self.assertEqual("XXXXXX", str(Seq.UnknownSeq(6, Alphabet.generic_protein)))
+        self.assertEqual("NNNNNN", str(Seq.UnknownSeq(6, character="N")))
+        self.assertEqual("XXXXXX", str(Seq.UnknownSeq(6, character="X")))
         self.assertEqual("??????", str(Seq.UnknownSeq(6, character="?")))
 
         with self.assertRaises(ValueError):
@@ -788,10 +712,10 @@ class TestUnknownSeq(unittest.TestCase):
         self.assertEqual("UnknownSeq(6, character='?')", repr(self.s))
 
     def test_add_method(self):
-        seq1 = Seq.UnknownSeq(3, Alphabet.generic_dna)
+        seq1 = Seq.UnknownSeq(3, character="N")
         self.assertEqual("??????NNN", str(self.s + seq1))
 
-        seq2 = Seq.UnknownSeq(3, Alphabet.generic_dna)
+        seq2 = Seq.UnknownSeq(3, character="N")
         self.assertEqual("NNNNNN", str(seq1 + seq2))
 
     def test_getitem_method(self):
@@ -828,21 +752,21 @@ class TestUnknownSeq(unittest.TestCase):
         self.assertEqual("??????", self.s.back_transcribe())
 
     def test_upper(self):
-        seq = Seq.UnknownSeq(6, Alphabet.generic_dna)
+        seq = Seq.UnknownSeq(6, character="N")
         self.assertEqual("NNNNNN", str(seq.upper()))
 
     def test_lower(self):
-        seq = Seq.UnknownSeq(6, Alphabet.generic_dna)
+        seq = Seq.UnknownSeq(6, character="N")
         self.assertEqual("nnnnnn", str(seq.lower()))
 
     def test_translation(self):
         self.assertEqual("XX", str(self.s.translate()))
 
     def test_ungap(self):
-        seq = Seq.UnknownSeq(7, alphabet=Alphabet.generic_dna)
+        seq = Seq.UnknownSeq(7, character="N")
         self.assertEqual("NNNNNNN", str(seq.ungap("-")))
 
-        seq = Seq.UnknownSeq(20, alphabet=Alphabet.generic_dna, character="-")
+        seq = Seq.UnknownSeq(20, character="-")
         self.assertEqual("", seq.ungap("-"))
 
 
@@ -856,16 +780,14 @@ class TestAmbiguousComplements(unittest.TestCase):
 class TestComplement(unittest.TestCase):
     def test_complement_ambiguous_dna_values(self):
         for ambig_char, values in sorted(ambiguous_dna_values.items()):
-            compl_values = str(
-                Seq.Seq(values, alphabet=IUPAC.ambiguous_dna).complement()
-            )
+            compl_values = str(Seq.Seq(values).complement())
             ambig_values = ambiguous_dna_values[ambiguous_dna_complement[ambig_char]]
             self.assertEqual(set(compl_values), set(ambig_values))
 
     def test_complement_ambiguous_rna_values(self):
         for ambig_char, values in sorted(ambiguous_rna_values.items()):
             compl_values = str(
-                # Will default to DNA if niether T or U found...
+                # Will default to DNA if neither T or U found...
                 Seq.Seq(values).complement().transcribe()
             )
             ambig_values = ambiguous_rna_values[ambiguous_rna_complement[ambig_char]]
@@ -892,12 +814,10 @@ class TestComplement(unittest.TestCase):
 class TestReverseComplement(unittest.TestCase):
     def test_reverse_complement(self):
         test_seqs_copy = copy.copy(test_seqs)
-        test_seqs_copy.pop(21)
+        test_seqs_copy.pop(13)
 
         for nucleotide_seq in test_seqs_copy:
-            if not isinstance(
-                nucleotide_seq.alphabet, Alphabet.ProteinAlphabet
-            ) and isinstance(nucleotide_seq, Seq.Seq):
+            if isinstance(nucleotide_seq, Seq.Seq):
                 expected = Seq.reverse_complement(nucleotide_seq)
                 self.assertEqual(
                     repr(expected), repr(nucleotide_seq.reverse_complement())
@@ -935,42 +855,22 @@ class TestDoubleReverseComplement(unittest.TestCase):
         for sequence in [
             Seq.Seq("".join(sorted_amb_rna)),
             Seq.Seq("".join(sorted_amb_dna)),
-            Seq.Seq("".join(sorted_amb_rna), Alphabet.generic_rna),
-            Seq.Seq("".join(sorted_amb_dna), Alphabet.generic_dna),
-            Seq.Seq(
-                "".join(sorted_amb_rna).replace("X", ""), IUPAC.IUPACAmbiguousRNA()
-            ),
-            Seq.Seq(
-                "".join(sorted_amb_dna).replace("X", ""), IUPAC.IUPACAmbiguousDNA()
-            ),
+            Seq.Seq("".join(sorted_amb_rna).replace("X", "")),
+            Seq.Seq("".join(sorted_amb_dna).replace("X", "")),
             Seq.Seq("AWGAARCKG"),
         ]:  # Note no U or T
             reversed_sequence = sequence.reverse_complement()
             self.assertEqual(str(sequence), str(reversed_sequence.reverse_complement()))
 
 
-class TestSequenceAlphabets(unittest.TestCase):
-    def test_sequence_alphabets(self):
-        """Sanity test on the test sequence alphabets.
-
-        See also enhancement bug 2597.
-        """
-        for nucleotide_seq in test_seqs:
-            if "U" in str(nucleotide_seq).upper():
-                self.assertNotIsInstance(nucleotide_seq.alphabet, Alphabet.DNAAlphabet)
-            if "T" in str(nucleotide_seq).upper():
-                self.assertNotIsInstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet)
-
-
 class TestTranscription(unittest.TestCase):
     def test_transcription_dna_into_rna(self):
         for nucleotide_seq in test_seqs:
-            if isinstance(nucleotide_seq.alphabet, Alphabet.DNAAlphabet):
-                expected = Seq.transcribe(nucleotide_seq)
-                self.assertEqual(
-                    str(nucleotide_seq).replace("t", "u").replace("T", "U"),
-                    str(expected),
-                )
+            expected = Seq.transcribe(nucleotide_seq)
+            self.assertEqual(
+                str(nucleotide_seq).replace("t", "u").replace("T", "U"),
+                str(expected),
+            )
 
     def test_transcription_dna_string_into_rna(self):
         seq = "ATGAAACTG"
@@ -978,9 +878,7 @@ class TestTranscription(unittest.TestCase):
 
     def test_seq_object_transcription_method(self):
         for nucleotide_seq in test_seqs:
-            if isinstance(nucleotide_seq.alphabet, Alphabet.DNAAlphabet) and isinstance(
-                nucleotide_seq, Seq.Seq
-            ):
+            if isinstance(nucleotide_seq, Seq.Seq):
                 self.assertEqual(
                     repr(Seq.transcribe(nucleotide_seq)),
                     repr(nucleotide_seq.transcribe()),
@@ -988,12 +886,11 @@ class TestTranscription(unittest.TestCase):
 
     def test_back_transcribe_rna_into_dna(self):
         for nucleotide_seq in test_seqs:
-            if isinstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet):
-                expected = Seq.back_transcribe(nucleotide_seq)
-                self.assertEqual(
-                    str(nucleotide_seq).replace("u", "t").replace("U", "T"),
-                    str(expected),
-                )
+            expected = Seq.back_transcribe(nucleotide_seq)
+            self.assertEqual(
+                str(nucleotide_seq).replace("u", "t").replace("U", "T"),
+                str(expected),
+            )
 
     def test_back_transcribe_rna_string_into_dna(self):
         seq = "AUGAAACUG"
@@ -1001,9 +898,7 @@ class TestTranscription(unittest.TestCase):
 
     def test_seq_object_back_transcription_method(self):
         for nucleotide_seq in test_seqs:
-            if isinstance(nucleotide_seq.alphabet, Alphabet.RNAAlphabet) and isinstance(
-                nucleotide_seq, Seq.Seq
-            ):
+            if isinstance(nucleotide_seq, Seq.Seq):
                 expected = Seq.back_transcribe(nucleotide_seq)
                 self.assertEqual(repr(nucleotide_seq.back_transcribe()), repr(expected))
 
@@ -1011,26 +906,17 @@ class TestTranscription(unittest.TestCase):
 class TestTranslating(unittest.TestCase):
     def setUp(self):
         self.test_seqs = [
-            Seq.Seq("TCAAAAGGATGCATCATG", IUPAC.unambiguous_dna),
+            Seq.Seq("TCAAAAGGATGCATCATG"),
             Seq.Seq("ATGAAACTG"),
             Seq.Seq("ATGAARCTG"),
             Seq.Seq("AWGAARCKG"),  # Note no U or T
             Seq.Seq("".join(ambiguous_rna_values)),
             Seq.Seq("".join(ambiguous_dna_values)),
-            Seq.Seq("".join(ambiguous_rna_values), Alphabet.generic_rna),
-            Seq.Seq("".join(ambiguous_dna_values), Alphabet.generic_dna),
-            Seq.Seq("".join(ambiguous_rna_values), IUPAC.IUPACAmbiguousRNA()),
-            Seq.Seq("".join(ambiguous_dna_values), IUPAC.IUPACAmbiguousDNA()),
-            Seq.Seq("AWGAARCKG", Alphabet.generic_dna),
-            Seq.Seq("AUGAAACUG", Alphabet.generic_rna),
-            Seq.Seq("ATGAAACTG", IUPAC.unambiguous_dna),
-            Seq.Seq("ATGAAACTGWN", IUPAC.ambiguous_dna),
-            Seq.Seq("AUGAAACUG", Alphabet.generic_rna),
-            Seq.Seq("AUGAAACUG", IUPAC.unambiguous_rna),
-            Seq.Seq("AUGAAACUGWN", IUPAC.ambiguous_rna),
-            Seq.Seq("ATGAAACTG", Alphabet.generic_nucleotide),
-            Seq.MutableSeq("ATGAAACTG", Alphabet.generic_dna),
-            Seq.MutableSeq("AUGaaaCUG", IUPAC.unambiguous_rna),
+            Seq.Seq("AUGAAACUG"),
+            Seq.Seq("ATGAAACTGWN"),
+            Seq.Seq("AUGAAACUGWN"),
+            Seq.MutableSeq("ATGAAACTG"),
+            Seq.MutableSeq("AUGaaaCUG"),
         ]
 
     def test_translation(self):
@@ -1049,20 +935,15 @@ class TestTranslating(unittest.TestCase):
         self.assertEqual("V-AIVMGR*KGAR*", seq.translate(gap="-"))
         self.assertRaises(TranslationError, seq.translate, gap=None)
 
-        seq = Seq.Seq("ATG---AAACTG", Alphabet.generic_dna)
-        self.assertEqual("M-KL", seq.translate(gap="-"))
-
-        seq = Seq.Seq("ATG~~~AAACTG", Alphabet.generic_dna)
+        seq = Seq.Seq("ATG~~~AAACTG")
         self.assertRaises(TranslationError, seq.translate, gap="-")
 
-        seq = Seq.Seq("ATG---AAACTGTAG", Alphabet.generic_dna)
+        seq = Seq.Seq("ATG---AAACTGTAG")
         self.assertEqual("M-KL*", seq.translate(gap="-"))
-
-        seq = Seq.Seq("ATG---AAACTGTAG", Alphabet.generic_dna)
         self.assertEqual("M-KL@", seq.translate(gap="-", stop_symbol="@"))
         self.assertRaises(TranslationError, seq.translate, gap="~")
 
-        seq = Seq.Seq("ATG~~~AAACTGTAG", Alphabet.generic_dna)
+        seq = Seq.Seq("ATG~~~AAACTGTAG")
         self.assertRaises(TranslationError, seq.translate, gap="-")
 
     def test_gapped_seq_no_gap_char_given(self):
@@ -1187,13 +1068,7 @@ class TestStopCodons(unittest.TestCase):
         self.misc_stops = "TAATAGTGAAGAAGG"
 
     def test_stops(self):
-        for nucleotide_seq in [
-            self.misc_stops,
-            Seq.Seq(self.misc_stops),
-            Seq.Seq(self.misc_stops, Alphabet.generic_nucleotide),
-            Seq.Seq(self.misc_stops, Alphabet.DNAAlphabet()),
-            Seq.Seq(self.misc_stops, IUPAC.unambiguous_dna),
-        ]:
+        for nucleotide_seq in [self.misc_stops, Seq.Seq(self.misc_stops)]:
             self.assertEqual("***RR", str(Seq.translate(nucleotide_seq)))
             self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table=1)))
             self.assertEqual("***RR", str(Seq.translate(nucleotide_seq, table="SGC0")))


### PR DESCRIPTION
This pull request removes alphabets form `test_seq.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
