### PR TITLE
replaced alphabets with molecule_type in Bio.SearchIO

### DIFF
--- a/Bio/SearchIO/BlastIO/blast_text.py
+++ b/Bio/SearchIO/BlastIO/blast_text.py
@@ -12,7 +12,6 @@ parser (which is now deprecated).
 
 """
 
-from Bio.Alphabet import generic_dna, generic_protein
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 from Bio.SearchIO._legacy import NCBIStandalone
 
@@ -48,11 +47,11 @@ class BlastTextParser:
             qresult.seq_len = rec.query_letters
             qresult.version = rec.version
 
-            # determine alphabet based on program
+            # determine molecule_type based on program
             if qresult.program == "blastn":
-                alphabet = generic_dna
+                molecule_type = "DNA"
             elif qresult.program in ["blastp", "blastx", "tblastn", "tblastx"]:
-                alphabet = generic_protein
+                molecule_type = "protein"
 
             # iterate over the 'alignments' (hits) and the hit table
             for idx, aln in enumerate(rec.alignments):
@@ -71,7 +70,7 @@ class BlastTextParser:
                 hsp_list = []
                 for bhsp in aln.hsps:
                     frag = HSPFragment(hid, qid)
-                    frag.alphabet = alphabet
+                    frag.molecule_type = molecule_type
                     # set alignment length
                     frag.aln_span = bhsp.identities[1]
                     # set frames

--- a/Bio/SearchIO/BlastIO/blast_xml.py
+++ b/Bio/SearchIO/BlastIO/blast_xml.py
@@ -15,7 +15,6 @@ from xml.etree import ElementTree
 from xml.sax.saxutils import XMLGenerator, escape
 
 from Bio import BiopythonParserWarning
-from Bio.Alphabet import generic_dna, generic_protein
 from Bio.SearchIO._index import SearchIndexer
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 
@@ -530,12 +529,12 @@ class BlastXmlParser:
                     setattr(frag, start_type, min(start, end) - 1)
                     setattr(frag, end_type, max(start, end))
 
-            # set alphabet, based on program
+            # set molecule type, based on program
             prog = self._meta.get("program")
             if prog == "blastn":
-                frag.alphabet = generic_dna
+                frag.molecule_type = "DNA"
             elif prog in ["blastp", "blastx", "tblastn", "tblastx"]:
-                frag.alphabet = generic_protein
+                frag.molecule_type = "protein"
 
             hsp = HSP([frag])
             for key, val_info in _ELEM_HSP.items():

--- a/Bio/SearchIO/BlatIO.py
+++ b/Bio/SearchIO/BlatIO.py
@@ -182,7 +182,6 @@ HSP and HSPFragment documentation for more details on these properties.
 import re
 from math import log
 
-from Bio.Alphabet import generic_dna
 from Bio.SearchIO._index import SearchIndexer
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 
@@ -356,8 +355,8 @@ def _create_hsp(hid, qid, psl):
         qseqlist = psl.get("qseqs")
         qseq = "" if not qseqlist else qseqlist[idx]
         frag = HSPFragment(hid, qid, hit=hseq, query=qseq)
-        # set alphabet
-        frag.alphabet = generic_dna
+        # set molecule type
+        frag.molecule_type = "DNA"
         # set coordinates
         frag.query_start = qcoords[0]
         frag.query_end = qcoords[1]

--- a/Bio/SearchIO/ExonerateIO/_base.py
+++ b/Bio/SearchIO/ExonerateIO/_base.py
@@ -291,7 +291,7 @@ def _create_hsp(hid, qid, hspd):
         "model",
         "vulgar_comp",
         "cigar_comp",
-        "alphabet",
+        "molecule_type",
     ):
         if attr in hspd:
             setattr(hsp, attr, hspd[attr])

--- a/Bio/SearchIO/ExonerateIO/exonerate_text.py
+++ b/Bio/SearchIO/ExonerateIO/exonerate_text.py
@@ -9,8 +9,6 @@ import re
 from itertools import chain
 
 
-from Bio.Alphabet import generic_protein
-
 from ._base import (
     _BaseExonerateParser,
     _BaseExonerateIndexer,
@@ -367,14 +365,14 @@ class ExonerateTextParser(_BaseExonerateParser):
         hsp["query"] = [x["query"] for x in seq_blocks]
         hsp["hit"] = [x["hit"] for x in seq_blocks]
         hsp["aln_annotation"] = {}
-        # set the alphabet
+        # set the molecule type
         # currently only limited to models with protein queries
         if (
             "protein2" in qresult["model"]
             or "coding2" in qresult["model"]
             or "2protein" in qresult["model"]
         ):
-            hsp["alphabet"] = generic_protein
+            hsp["molecule_type"] = "protein"
         # get the annotations if they exist
         for annot_type in ("similarity", "query_annotation", "hit_annotation"):
             try:

--- a/Bio/SearchIO/FastaIO.py
+++ b/Bio/SearchIO/FastaIO.py
@@ -107,7 +107,6 @@ The following object attributes are provided:
 
 import re
 
-from Bio.Alphabet import generic_dna, generic_protein
 from Bio.SearchIO._index import SearchIndexer
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 
@@ -207,8 +206,8 @@ def _set_hsp_seqs(hsp, parsed, program):
     # query and hit sequence types must be the same
     assert parsed["query"]["_type"] == parsed["hit"]["_type"]
     type_val = parsed["query"]["_type"]  # hit works fine too
-    alphabet = generic_dna if type_val == "D" else generic_protein
-    setattr(hsp.fragment, "alphabet", alphabet)
+    molecule_type = "DNA" if type_val == "D" else "protein"
+    setattr(hsp.fragment, "molecule_type", molecule_type)
 
     for seq_type in ("hit", "query"):
         # get and set start and end coordinates
@@ -217,10 +216,10 @@ def _set_hsp_seqs(hsp, parsed, program):
 
         setattr(hsp.fragment, seq_type + "_start", min(start, end) - 1)
         setattr(hsp.fragment, seq_type + "_end", max(start, end))
-        # set seq and alphabet
+        # set seq and molecule type
         setattr(hsp.fragment, seq_type, parsed[seq_type]["seq"])
 
-        if alphabet is not generic_protein:
+        if molecule_type != "protein":
             # get strand from coordinate; start <= end is plus
             # start > end is minus
             if start <= end:

--- a/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
+++ b/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
@@ -11,7 +11,6 @@ import warnings
 
 from Bio.SearchIO._utils import read_forward
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
-from Bio.Alphabet import generic_protein
 
 __all__ = ("Hhsuite2TextParser",)
 
@@ -200,7 +199,7 @@ class Hhsuite2TextParser:
             hit_id = block["hit_id"]
 
             frag = HSPFragment(hit_id, query_id)
-            frag.alphabet = generic_protein
+            frag.molecule_type = "protein"
             frag.query_start = block["query_start"] - 1
             frag.query_end = block["query_end"]
             frag.hit_start = block["hit_start"] - 1

--- a/Bio/SearchIO/HmmerIO/hmmer2_text.py
+++ b/Bio/SearchIO/HmmerIO/hmmer2_text.py
@@ -7,7 +7,6 @@
 
 import re
 
-from Bio.Alphabet import generic_protein
 from Bio.SearchIO._utils import read_forward
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 
@@ -201,7 +200,7 @@ class Hmmer2TextParser:
             ) = self.line.split()
 
             frag = HSPFragment(id_, self.qresult.id)
-            frag.alphabet = generic_protein
+            frag.molecule_type = "protein"
             if self._meta["program"] == "hmmpfam":
                 frag.hit_start = int(hmm_f) - 1
                 frag.hit_end = int(hmm_t)

--- a/Bio/SearchIO/HmmerIO/hmmer3_domtab.py
+++ b/Bio/SearchIO/HmmerIO/hmmer3_domtab.py
@@ -7,7 +7,6 @@
 
 from itertools import chain
 
-from Bio.Alphabet import generic_protein
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 
 from .hmmer3_tab import Hmmer3TabParser, Hmmer3TabIndexer
@@ -67,8 +66,8 @@ class Hmmer3DomtabParser(Hmmer3TabParser):
         frag["hit_end"] = int(cols[16])  # hmm to
         frag["query_start"] = int(cols[17]) - 1  # ali from
         frag["query_end"] = int(cols[18])  # ali to
-        # HMMER alphabets are always protein
-        frag["alphabet"] = generic_protein
+        # HMMER results are always protein
+        frag["molecule_type"] = "protein"
 
         # switch hmm<-->ali coordinates if hmm is not hit
         if not self.hmm_as_hit:

--- a/Bio/SearchIO/HmmerIO/hmmer3_tab.py
+++ b/Bio/SearchIO/HmmerIO/hmmer3_tab.py
@@ -7,7 +7,6 @@
 
 from itertools import chain
 
-from Bio.Alphabet import generic_protein
 from Bio.SearchIO._index import SearchIndexer
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 
@@ -68,7 +67,7 @@ class Hmmer3TabParser:
         # strand is always 0, since HMMER now only handles protein
         frag = {}
         frag["hit_strand"] = frag["query_strand"] = 0
-        frag["alphabet"] = generic_protein
+        frag["molecule_type"] = "protein"
 
         return {"qresult": qresult, "hit": hit, "hsp": hsp, "frag": frag}
 

--- a/Bio/SearchIO/HmmerIO/hmmer3_text.py
+++ b/Bio/SearchIO/HmmerIO/hmmer3_text.py
@@ -7,7 +7,6 @@
 
 import re
 
-from Bio.Alphabet import generic_protein
 from Bio.SearchIO._utils import read_forward
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 
@@ -278,8 +277,8 @@ class Hmmer3TextParser:
                     frag.query_description = qdesc
                 if hdesc:
                     frag.hit_description = hdesc
-                # HMMER3 alphabets are always protein alphabets
-                frag.alphabet = generic_protein
+                # HMMER3 results are always protein
+                frag.molecule_type = "protein"
                 # depending on whether the program is hmmsearch, hmmscan, or phmmer
                 # {hmm,ali}{from,to} can either be hit_{from,to} or query_{from,to}
                 # for hmmscan, hit is the hmm profile, query is the sequence

--- a/Bio/SearchIO/InterproscanIO/interproscan_xml.py
+++ b/Bio/SearchIO/InterproscanIO/interproscan_xml.py
@@ -11,7 +11,6 @@
 import re
 from xml.etree import ElementTree
 
-from Bio.Alphabet import generic_protein
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 
 
@@ -139,7 +138,7 @@ class InterproscanXmlParser:
         for hsp_elem in root_hsp_elem:
             # create frag and assign attributes
             frag = HSPFragment(hit_id, query_id)
-            setattr(frag, "alphabet", generic_protein)
+            setattr(frag, "molecule_type", "protein")
             if query_seq is not None:
                 setattr(frag, "query", query_seq)
             for key, (attr, caster) in _ELEM_FRAG.items():

--- a/Bio/SearchIO/_model/hsp.py
+++ b/Bio/SearchIO/_model/hsp.py
@@ -800,7 +800,9 @@ class HSPFragment(_BaseHSP):
         """Return object of index idx."""
         if self.aln is not None:
             obj = self.__class__(
-                hit_id=self.hit_id, query_id=self.query_id, molecule_type=self.molecule_type
+                hit_id=self.hit_id,
+                query_id=self.query_id,
+                molecule_type=self.molecule_type,
             )
             # transfer query and hit attributes
             # let SeqRecord handle feature slicing, then retrieve the sliced

--- a/Tests/test_SearchIO_model.py
+++ b/Tests/test_SearchIO_model.py
@@ -19,7 +19,6 @@ from copy import deepcopy
 from search_tests_common import compare_search_obj
 
 from Bio.Align import MultipleSeqAlignment
-from Bio.Alphabet import single_letter_alphabet, generic_dna
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
@@ -1218,21 +1217,21 @@ class HSPMultipleFragmentCases(unittest.TestCase):
                     self.assertEqual(getattr(fragment, attr_name), new_value)
                     self.assertNotEqual(getattr(fragment, attr_name), value)
 
-    def test_alphabet(self):
-        """Test HSP.alphabet getter."""
-        self.assertTrue(self.hsp.alphabet is single_letter_alphabet)
+    def test_molecule_type(self):
+        """Test HSP.molecule_type getter."""
+        self.assertTrue(self.hsp.molecule_type is None)
 
-    def test_alphabet_set(self):
-        """Test HSP.alphabet setter."""
+    def test_molecule_type_set(self):
+        """Test HSP.molecule_type setter."""
         # test initial values
-        self.assertTrue(self.hsp.alphabet is single_letter_alphabet)
+        self.assertTrue(self.hsp.molecule_type is None)
         for frag in self.hsp.fragments:
-            self.assertTrue(frag.alphabet is single_letter_alphabet)
-        self.hsp.alphabet = generic_dna
+            self.assertTrue(frag.molecule_type is None)
+        self.hsp.molecule_type = "DNA"
         # test values after setting
-        self.assertTrue(self.hsp.alphabet is generic_dna)
+        self.assertTrue(self.hsp.molecule_type == "DNA")
         for frag in self.hsp.fragments:
-            self.assertTrue(frag.alphabet is generic_dna)
+            self.assertTrue(frag.molecule_type == "DNA")
 
     def test_range(self):
         """Test HSP range properties."""
@@ -1278,7 +1277,7 @@ class HSPFragmentWithoutSeqCases(unittest.TestCase):
                 attr_name = "%s_%s" % (seq_type, attr)
                 self.assertTrue(getattr(fragment, attr_name) is None)
         self.assertTrue(fragment.aln is None)
-        self.assertTrue(fragment.alphabet is single_letter_alphabet)
+        self.assertTrue(fragment.molecule_type is None)
         self.assertEqual(fragment.aln_annotation, {})
 
     def test_seqmodel(self):
@@ -1369,31 +1368,32 @@ class HSPFragmentCases(unittest.TestCase):
         self.assertIsInstance(self.fragment.hit, SeqRecord)
         self.assertEqual("<unknown description>", self.fragment.hit.description)
         self.assertEqual("aligned hit sequence", self.fragment.hit.name)
-        self.assertEqual(single_letter_alphabet, self.fragment.hit.seq.alphabet)
+        self.assertEqual(None, self.fragment.hit.annotations["molecule_type"])
         # check query
         self.assertIsInstance(self.fragment.query, SeqRecord)
         self.assertEqual("<unknown description>", self.fragment.query.description)
         self.assertEqual("aligned query sequence", self.fragment.query.name)
-        self.assertEqual(single_letter_alphabet, self.fragment.query.seq.alphabet)
+        self.assertEqual(None, self.fragment.query.annotations["molecule_type"])
         # check alignment
         self.assertIsInstance(self.fragment.aln, MultipleSeqAlignment)
-        self.assertEqual(single_letter_alphabet, self.fragment.aln._alphabet)
+        with self.assertRaises(AttributeError):
+            self.fragment.aln.molecule_type
 
-    def test_alphabet_no_seq(self):
-        """Test HSPFragment alphabet property, query and hit sequences not present."""
-        self.assertTrue(self.fragment.alphabet is single_letter_alphabet)
-        self.fragment.alphabet = generic_dna
-        self.assertTrue(self.fragment.alphabet is generic_dna)
+    def test_molecule_type_no_seq(self):
+        """Test HSPFragment molecule_type property, query and hit sequences not present."""
+        self.assertTrue(self.fragment.molecule_type is None)
+        self.fragment.molecule_type = "DNA"
+        self.assertTrue(self.fragment.molecule_type == "DNA")
 
-    def test_alphabet_with_seq(self):
-        """Test HSPFragment alphabet property, query or hit sequences present."""
-        self.assertTrue(self.fragment.alphabet is single_letter_alphabet)
+    def test_molecule_type_with_seq(self):
+        """Test HSPFragment molecule_type property, query or hit sequences present."""
+        self.assertTrue(self.fragment.molecule_type is None)
         self.fragment._hit = SeqRecord(Seq("AAA"))
         self.fragment._query = SeqRecord(Seq("AAA"))
-        self.fragment.alphabet = generic_dna
-        self.assertTrue(self.fragment.alphabet is generic_dna)
-        self.assertTrue(self.fragment.hit.seq.alphabet is generic_dna)
-        self.assertTrue(self.fragment.query.seq.alphabet is generic_dna)
+        self.fragment.molecule_type = "DNA"
+        self.assertTrue(self.fragment.molecule_type == "DNA")
+        self.assertTrue(self.fragment.hit.annotations["molecule_type"] == "DNA")
+        self.assertTrue(self.fragment.query.annotations["molecule_type"] == "DNA")
 
     def test_seq_unequal_hit_query_len(self):
         """Test HSPFragment sequence setter with unequal hit and query lengths."""


### PR DESCRIPTION
This pull request replaces alphabets with molecule_type in `Bio.SearchIO`.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
