### PR TITLE
removed superfluous str

### DIFF
--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -1504,14 +1504,14 @@ class FastqPhredWriter(SequenceWriter):
         assert not self._footer_written
         self._record_written = True
         # TODO - Is an empty sequence allowed in FASTQ format?
-        if record.seq is None:
+        seq = record.seq
+        if seq is None:
             raise ValueError("No sequence for record %s" % record.id)
-        seq_str = str(record.seq)
         qualities_str = _get_sanger_quality_str(record)
-        if len(qualities_str) != len(seq_str):
+        if len(qualities_str) != len(seq):
             raise ValueError(
                 "Record %s has sequence length %i but %i quality scores"
-                % (record.id, len(seq_str), len(qualities_str))
+                % (record.id, len(seq), len(qualities_str))
             )
 
         # FASTQ files can include a description, just like FASTA files
@@ -1526,7 +1526,7 @@ class FastqPhredWriter(SequenceWriter):
         else:
             title = id
 
-        self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str))
+        self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq, qualities_str))
 
 
 def as_fastq(record):
@@ -1760,14 +1760,14 @@ class FastqSolexaWriter(SequenceWriter):
         self._record_written = True
 
         # TODO - Is an empty sequence allowed in FASTQ format?
-        if record.seq is None:
+        seq = record.seq
+        if seq is None:
             raise ValueError("No sequence for record %s" % record.id)
-        seq_str = str(record.seq)
         qualities_str = _get_solexa_quality_str(record)
-        if len(qualities_str) != len(seq_str):
+        if len(qualities_str) != len(seq):
             raise ValueError(
                 "Record %s has sequence length %i but %i quality scores"
-                % (record.id, len(seq_str), len(qualities_str))
+                % (record.id, len(seq), len(qualities_str))
             )
 
         # FASTQ files can include a description, just like FASTA files
@@ -1782,7 +1782,7 @@ class FastqSolexaWriter(SequenceWriter):
         else:
             title = id
 
-        self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str))
+        self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq, qualities_str))
 
 
 def as_fastq_solexa(record):
@@ -1844,14 +1844,14 @@ class FastqIlluminaWriter(SequenceWriter):
         self._record_written = True
 
         # TODO - Is an empty sequence allowed in FASTQ format?
-        if record.seq is None:
+        seq = record.seq
+        if seq is None:
             raise ValueError("No sequence for record %s" % record.id)
-        seq_str = str(record.seq)
         qualities_str = _get_illumina_quality_str(record)
-        if len(qualities_str) != len(seq_str):
+        if len(qualities_str) != len(seq):
             raise ValueError(
                 "Record %s has sequence length %i but %i quality scores"
-                % (record.id, len(seq_str), len(qualities_str))
+                % (record.id, len(seq), len(qualities_str))
             )
 
         # FASTQ files can include a description, just like FASTA files
@@ -1866,7 +1866,7 @@ class FastqIlluminaWriter(SequenceWriter):
         else:
             title = id
 
-        self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str))
+        self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq, qualities_str))
 
 
 def as_fastq_illumina(record):

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -1369,7 +1369,7 @@ class SffWriter(SequenceWriter):
         # Basics
         name = record.id.encode()
         name_len = len(name)
-        seq = str(record.seq).upper().encode()
+        seq = record.seq.upper().encode()
         seq_len = len(seq)
         # Qualities
         try:


### PR DESCRIPTION
This pull request replaces a bunch of `str(seq)` with `seq` where possible.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
