### PR TITLE
removed repr where possible

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -307,8 +307,8 @@ class MultipleSeqAlignment:
         )
         # This version is useful for doing eval(repr(alignment)),
         # but it can be VERY long:
-        # return "%s(%s)" \
-        #       % (self.__class__, repr(self._records))
+        # return "%s(%r)" \
+        #       % (self.__class__, self._records)
 
     def format(self, format_spec):
         """Return the alignment as a string in the specified file format [DEPRECATED].

--- a/Bio/AlignIO/ClustalIO.py
+++ b/Bio/AlignIO/ClustalIO.py
@@ -222,13 +222,13 @@ class ClustalIterator(AlignmentIterator):
 
             for i in range(len(ids)):
                 if line[0] == " ":
-                    raise ValueError("Unexpected line:\n%s" % repr(line))
+                    raise ValueError("Unexpected line:\n%r" % line)
                 fields = line.rstrip().split()
 
                 # We expect there to be two fields, there can be an optional
                 # "sequence number" field containing the letter count.
                 if len(fields) < 2 or len(fields) > 3:
-                    raise ValueError("Could not parse line:\n%s" % repr(line))
+                    raise ValueError("Could not parse line:\n%r" % line)
 
                 if fields[0] != ids[i]:
                     raise ValueError(

--- a/Bio/AlignIO/EmbossIO.py
+++ b/Bio/AlignIO/EmbossIO.py
@@ -145,12 +145,12 @@ class EmbossIterator(AlignmentIterator):
                         assert seq.replace("-", "") == "", line
                     elif start - seq_starts[index] != len(seqs[index].replace("-", "")):
                         raise ValueError(
-                            "Found %i chars so far for sequence %i (%s, %s), line says start %i:\n%s"
+                            "Found %i chars so far for sequence %i (%s, %r), line says start %i:\n%s"
                             % (
                                 len(seqs[index].replace("-", "")),
                                 index,
                                 id,
-                                repr(seqs[index]),
+                                seqs[index],
                                 start,
                                 line,
                             )
@@ -160,12 +160,12 @@ class EmbossIterator(AlignmentIterator):
                     # Check the end ...
                     if end != seq_starts[index] + len(seqs[index].replace("-", "")):
                         raise ValueError(
-                            "Found %i chars so far for sequence %i (%s, %s, start=%i), file says end %i:\n%s"
+                            "Found %i chars so far for sequence %i (%s, %r, start=%i), file says end %i:\n%s"
                             % (
                                 len(seqs[index].replace("-", "")),
                                 index,
                                 id,
-                                repr(seqs[index]),
+                                seqs[index],
                                 seq_starts[index],
                                 end,
                                 line,

--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -240,8 +240,7 @@ def write(alignments, handle, format):
     if not isinstance(count, int):
         raise RuntimeError(
             "Internal error - the underlying %s "
-            "writer should have returned the alignment count, not %r"
-            % (format, count)
+            "writer should have returned the alignment count, not %r" % (format, count)
         )
 
     return count

--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -240,8 +240,8 @@ def write(alignments, handle, format):
     if not isinstance(count, int):
         raise RuntimeError(
             "Internal error - the underlying %s "
-            "writer should have returned the alignment count, not %s"
-            % (format, repr(count))
+            "writer should have returned the alignment count, not %r"
+            % (format, count)
         )
 
     return count

--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -332,17 +332,17 @@ def _parse_qblast_ref_page(handle):
     elif not rid:
         # Can this happen?
         raise ValueError(
-            "No RID found in the 'please wait' page. (although RTOE = %s)" % repr(rtoe)
+            "No RID found in the 'please wait' page. (although RTOE = %r)" % rtoe
         )
     elif not rtoe:
         # Can this happen?
         raise ValueError(
-            "No RTOE found in the 'please wait' page. (although RID = %s)" % repr(rid)
+            "No RTOE found in the 'please wait' page. (although RID = %r)" % rid
         )
 
     try:
         return rid, int(rtoe)
     except ValueError:
         raise ValueError(
-            "A non-integer RTOE found in the 'please wait' page, %s" % repr(rtoe)
+            "A non-integer RTOE found in the 'please wait' page, %r" % rtoe
         ) from None

--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -75,8 +75,8 @@ class _XMLparser(ContentHandler):
         # but that white space doesn't belong to child tags like Hsp_midline
         if self._value.strip():
             raise ValueError(
-                "What should we do with %s before the %s tag?"
-                % (repr(self._value), name)
+                "What should we do with %s before the %r tag?"
+                % (self._value, name)
             )
         self._value = ""
 

--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -75,8 +75,7 @@ class _XMLparser(ContentHandler):
         # but that white space doesn't belong to child tags like Hsp_midline
         if self._value.strip():
             raise ValueError(
-                "What should we do with %s before the %r tag?"
-                % (self._value, name)
+                "What should we do with %s before the %r tag?" % (self._value, name)
             )
         self._value = ""
 

--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -86,7 +86,7 @@ class NoneElement:
             attributes = self.attributes
         except AttributeError:
             return "NoneElement"
-        return "NoneElement(attributes=%s)" % repr(attributes)
+        return "NoneElement(attributes=%r)" % attributes
 
 
 class IntegerElement(int):
@@ -110,7 +110,7 @@ class IntegerElement(int):
             attributes = self.attributes
         except AttributeError:
             return text
-        return "IntegerElement(%s, attributes=%s)" % (text, repr(attributes))
+        return "IntegerElement(%s, attributes=%r)" % (text, attributes)
 
 
 class StringElement(str):
@@ -133,7 +133,7 @@ class StringElement(str):
         attributes = self.attributes
         if not attributes:
             return text
-        return "StringElement(%s, attributes=%s)" % (text, repr(attributes))
+        return "StringElement(%s, attributes=%r)" % (text, attributes)
 
 
 class UnicodeElement(str):
@@ -156,7 +156,7 @@ class UnicodeElement(str):
         attributes = self.attributes
         if not attributes:
             return text
-        return "UnicodeElement(%s, attributes=%s)" % (text, repr(attributes))
+        return "UnicodeElement(%s, attributes=%r)" % (text, attributes)
 
 
 class ListElement(list):
@@ -178,7 +178,7 @@ class ListElement(list):
         attributes = self.attributes
         if not attributes:
             return text
-        return "ListElement(%s, attributes=%s)" % (text, repr(attributes))
+        return "ListElement(%s, attributes=%r)" % (text, attributes)
 
     def store(self, value):
         """Append an element to the list, checking tags."""
@@ -211,7 +211,7 @@ class DictionaryElement(dict):
         attributes = self.attributes
         if not attributes:
             return text
-        return "DictElement(%s, attributes=%s)" % (text, repr(attributes))
+        return "DictElement(%s, attributes=%r)" % (text, attributes)
 
     def store(self, value):
         """Add an entry to the dictionary, checking tags."""

--- a/Bio/ExPASy/Prosite.py
+++ b/Bio/ExPASy/Prosite.py
@@ -216,7 +216,7 @@ def __read(handle):
                     m = re.match(r"(\d+)\((\d+)\)", data)
                     if not m:
                         raise Exception(
-                            "Broken data %s in comment line\n%s" % (repr(data), line)
+                            "Broken data %s in comment line\n%r" % (data, line)
                         )
                     hits = tuple(map(int, m.groups()))
                     if qual == "/TOTAL":
@@ -229,7 +229,7 @@ def __read(handle):
                         record.nr_false_pos = hits
                 else:
                     raise ValueError(
-                        "Unknown qual %s in comment line\n%s" % (repr(qual), line)
+                        "Unknown qual %s in comment line\n%r" % (qual, line)
                     )
         elif keyword == "CC":
             # Expect CC lines like this:
@@ -271,7 +271,7 @@ def __read(handle):
                     record.cc_version = data
                 else:
                     raise ValueError(
-                        "Unknown qual %s in comment line\n%s" % (repr(qual), line)
+                        "Unknown qual %s in comment line\n%r" % (qual, line)
                     )
         elif keyword == "DR":
             refs = value.split(";")

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -339,7 +339,7 @@ def _loc(loc_str, expected_seq_length, strand, seq_type=None):
                 pos = _pos(s)
             else:
                 raise ValueError(
-                    "Invalid between location %s" % repr(loc_str)
+                    "Invalid between location %r" % loc_str
                 ) from None
             return SeqFeature.FeatureLocation(pos, pos, strand, ref=ref)
         else:

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -338,9 +338,7 @@ def _loc(loc_str, expected_seq_length, strand, seq_type=None):
             elif int(s) == expected_seq_length and e == "1":
                 pos = _pos(s)
             else:
-                raise ValueError(
-                    "Invalid between location %r" % loc_str
-                ) from None
+                raise ValueError("Invalid between location %r" % loc_str) from None
             return SeqFeature.FeatureLocation(pos, pos, strand, ref=ref)
         else:
             # e.g. "123"

--- a/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
@@ -261,7 +261,7 @@ def draw_arrow(
         x1, x2, y1, y2 = xmax, xmin, ymin, ymax
     else:
         raise ValueError(
-            "Invalid orientation %s, should be 'left' or 'right'" % repr(orientation)
+            "Invalid orientation %r, should be 'left' or 'right'" % orientation
         )
 
     # We define boxheight and boxwidth accordingly, and calculate the shaft

--- a/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
@@ -1418,8 +1418,7 @@ class CircularDrawer(AbstractDrawer):
         startangle, endangle = min(startangle, endangle), max(startangle, endangle)
         if orientation != "left" and orientation != "right":
             raise ValueError(
-                "Invalid orientation %r, should be 'left' or 'right'"
-                % orientation
+                "Invalid orientation %r, should be 'left' or 'right'" % orientation
             )
 
         angle = float(endangle - startangle)  # angle subtended by arc

--- a/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
@@ -1418,8 +1418,8 @@ class CircularDrawer(AbstractDrawer):
         startangle, endangle = min(startangle, endangle), max(startangle, endangle)
         if orientation != "left" and orientation != "right":
             raise ValueError(
-                "Invalid orientation %s, should be 'left' or 'right'"
-                % repr(orientation)
+                "Invalid orientation %r, should be 'left' or 'right'"
+                % orientation
             )
 
         angle = float(endangle - startangle)  # angle subtended by arc

--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -187,9 +187,9 @@ class PDBIO(StructureIO):
                     from Bio import BiopythonWarning
 
                     warnings.warn(
-                        "Missing occupancy in atom %s written as blank"
-                        % repr(atom.get_full_id()),
-                        BiopythonWarning,
+                        "Missing occupancy in atom %r written as blank"
+                        % (atom.get_full_id(), ),
+                        BiopythonWarning
                     )
                 else:
                     raise TypeError(
@@ -228,8 +228,8 @@ class PDBIO(StructureIO):
                     from Bio import BiopythonWarning
 
                     warnings.warn(
-                        "Missing charge in atom %s written as blank"
-                        % repr(atom.get_full_id()),
+                        "Missing charge in atom %r written as blank"
+                        % (atom.get_full_id(), ),
                         BiopythonWarning,
                     )
                 else:
@@ -246,8 +246,8 @@ class PDBIO(StructureIO):
                     from Bio import BiopythonWarning
 
                     warnings.warn(
-                        "Missing radius in atom %s written as blank"
-                        % repr(atom.get_full_id()),
+                        "Missing radius in atom %r written as blank"
+                        % (atom.get_full_id(), ),
                         BiopythonWarning,
                     )
                 else:

--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -229,7 +229,7 @@ class PDBIO(StructureIO):
 
                     warnings.warn(
                         "Missing charge in atom %r written as blank"
-                        % (atom.get_full_id(), ),
+                        % (atom.get_full_id(),),
                         BiopythonWarning,
                     )
                 else:
@@ -247,7 +247,7 @@ class PDBIO(StructureIO):
 
                     warnings.warn(
                         "Missing radius in atom %r written as blank"
-                        % (atom.get_full_id(), ),
+                        % (atom.get_full_id(),),
                         BiopythonWarning,
                     )
                 else:

--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -188,8 +188,8 @@ class PDBIO(StructureIO):
 
                     warnings.warn(
                         "Missing occupancy in atom %r written as blank"
-                        % (atom.get_full_id(), ),
-                        BiopythonWarning
+                        % (atom.get_full_id(),),
+                        BiopythonWarning,
                     )
                 else:
                     raise TypeError(

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -441,7 +441,7 @@ class TreeMixin:
         # Validation -- otherwise izip throws a spooky error below
         for p, t in zip(paths, targets):
             if p is None:
-                raise ValueError("target %s is not in this tree" % repr(t))
+                raise ValueError("target %r is not in this tree" % t)
         mrca = self.root
         for level in zip(*paths):
             ref = level[0]

--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -91,7 +91,7 @@ class Phyloxml(PhyloElement):
             if tree.name == index:
                 return tree
         else:
-            raise KeyError("no phylogeny found with name " + repr(index))
+            raise KeyError("no phylogeny found with name %r" % index)
 
     def __iter__(self):
         """Iterate through the phylogenetic trees in this object."""
@@ -912,7 +912,7 @@ class Events(PhyloElement):
         except AttributeError:
             raise KeyError(key) from None
         if val is None:
-            raise KeyError("%s has not been set in this object" % repr(key))
+            raise KeyError("%r has not been set in this object" % key)
         return val
 
     def __setitem__(self, key, val):

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -119,7 +119,7 @@ def _check_bases(seq_string):
         seq_string = seq_string.replace(c, "")
     # Check only allowed IUPAC letters
     if not set(seq_string).issubset(set("ABCDGHKMNRSTVWY")):
-        raise TypeError("Invalid character found in %s" % repr(seq_string))
+        raise TypeError("Invalid character found in %r" % seq_string)
     return " " + seq_string
 
 
@@ -188,7 +188,7 @@ class FormattedSeq:
 
     def __repr__(self):
         """Represent ``FormattedSeq`` class as a string."""
-        return "FormattedSeq(%s, linear=%s)" % (repr(self[1:]), repr(self.linear))
+        return "FormattedSeq(%r, linear=%r)" % (self[1:], self.linear)
 
     def __eq__(self, other):
         """Implement equality operator for ``FormattedSeq`` object."""
@@ -272,7 +272,7 @@ class RestrictionType(type):
         See below.
         """
         if "-" in name:
-            raise ValueError("Problem with hyphen in %s as enzyme name" % repr(name))
+            raise ValueError("Problem with hyphen in %r as enzyme name" % name)
         # 2011/11/26 - Nobody knows what this call was supposed to accomplish,
         # but all unit tests seem to pass without it.
         # super().__init__(cls, name, bases, dct)
@@ -2341,7 +2341,7 @@ class Analysis(RestrictionBatch, PrintFormat):
 
     def __repr__(self):
         """Represent ``Analysis`` class as a string."""
-        return "Analysis(%s,%s,%s)" % (repr(self.rb), repr(self.sequence), self.linear)
+        return "Analysis(%r,%r,%s)" % (self.rb, self.sequence, self.linear)
 
     def _sub_set(self, wanted):
         """Filter result for keys which are in wanted (PRIVATE).

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -271,17 +271,17 @@ class SeqFeature:
 
     def __repr__(self):
         """Represent the feature as a string for debugging."""
-        answer = "%s(%s" % (self.__class__.__name__, repr(self.location))
+        answer = "%s(%r" % (self.__class__.__name__, self.location)
         if self.type:
-            answer += ", type=%s" % repr(self.type)
+            answer += ", type=%r" % self.type
         if self.location_operator:
-            answer += ", location_operator=%s" % repr(self.location_operator)
+            answer += ", location_operator=%r" % self.location_operator
         if self.id and self.id != "<unknown id>":
-            answer += ", id=%s" % repr(self.id)
+            answer += ", id=%r" % self.id
         if self.ref:
-            answer += ", ref=%s" % repr(self.ref)
+            answer += ", ref=%r" % self.ref
         if self.ref_db:
-            answer += ", ref_db=%s" % repr(self.ref_db)
+            answer += ", ref_db=%r" % self.ref_db
         answer += ")"
         return answer
 
@@ -632,8 +632,8 @@ class Reference:
 
     def __repr__(self):
         """Represent the Reference object as a string for debugging."""
-        # TODO - Update this is __init__ later accpets values
-        return "%s(title=%s, ...)" % (self.__class__.__name__, repr(self.title))
+        # TODO - Update this is __init__ later accepts values
+        return "%s(title=%r, ...)" % (self.__class__.__name__, self.title)
 
     def __eq__(self, other):
         """Check if two Reference objects should be considered equal.
@@ -2182,7 +2182,7 @@ class PositionGap:
 
     def __repr__(self):
         """Represent the position gap as a string for debugging."""
-        return "%s(%s)" % (self.__class__.__name__, repr(self.gap_size))
+        return "%s(%r)" % (self.__class__.__name__, self.gap_size)
 
     def __str__(self):
         """Return a representation of the PositionGap object (with python counting)."""

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -1216,12 +1216,12 @@ class EmblWriter(_InsdcWriter):
 
         if ";" in accession:
             raise ValueError(
-                "Cannot have semi-colon in EMBL accession, %s" % repr(str(accession))
+                "Cannot have semi-colon in EMBL accession, '%s'" % accession
             )
         if " " in accession:
             # This is out of practicality... might it be allowed?
             raise ValueError(
-                "Cannot have spaces in EMBL accession, %s" % repr(str(accession))
+                "Cannot have spaces in EMBL accession, '%s'" % accession
             )
 
         topology = self._get_annotation_str(record, "topology", default="")

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -1220,9 +1220,7 @@ class EmblWriter(_InsdcWriter):
             )
         if " " in accession:
             # This is out of practicality... might it be allowed?
-            raise ValueError(
-                "Cannot have spaces in EMBL accession, '%s'" % accession
-            )
+            raise ValueError("Cannot have spaces in EMBL accession, '%s'" % accession)
 
         topology = self._get_annotation_str(record, "topology", default="")
 

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -667,7 +667,7 @@ class SeqRecord:
         ...                 id="NP_418483.1", name="b4059",
         ...                 description="ssDNA-binding protein",
         ...                 dbxrefs=["ASAP:13298", "GI:16131885", "GeneID:948570"])
-        >>> print(repr(rec))
+        >>> rec
         SeqRecord(seq=Seq('MASRGVNKVILVGNLGQDPEVRYMPNGGAVANITLATSESWRDKATGEMKEQTE...IPF'), id='NP_418483.1', name='b4059', description='ssDNA-binding protein', dbxrefs=['ASAP:13298', 'GI:16131885', 'GeneID:948570'])
 
         At the python prompt you can also use this shorthand:

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -667,7 +667,7 @@ class SeqRecord:
         ...                 id="NP_418483.1", name="b4059",
         ...                 description="ssDNA-binding protein",
         ...                 dbxrefs=["ASAP:13298", "GI:16131885", "GeneID:948570"])
-        >>> rec
+        >>> print(repr(rec))
         SeqRecord(seq=Seq('MASRGVNKVILVGNLGQDPEVRYMPNGGAVANITLATSESWRDKATGEMKEQTE...IPF'), id='NP_418483.1', name='b4059', description='ssDNA-binding protein', dbxrefs=['ASAP:13298', 'GI:16131885', 'GeneID:948570'])
 
         At the python prompt you can also use this shorthand:

--- a/Bio/Wise/__init__.py
+++ b/Bio/Wise/__init__.py
@@ -72,7 +72,7 @@ def align(
 ):
     """Run an alignment. Returns a filehandle."""
     if not pair or len(pair) != 2:
-        raise ValueError("Expected pair of filename, not %s" % repr(pair))
+        raise ValueError("Expected pair of filename, not %r" % pair)
 
     output_file = tempfile.NamedTemporaryFile(mode="r")
     input_files = (

--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -270,8 +270,8 @@ class CodonSeq(Seq):
                 gap = self.alphabet.gap_char
             elif gap != self.alphabet.gap_char:
                 raise ValueError(
-                    "Gap %s does not match %s from alphabet"
-                    % (repr(gap), repr(self.alphabet.alphabet.gap_char))
+                    "Gap %r does not match %r from alphabet"
+                    % (gap, self.alphabet.alphabet.gap_char)
                 )
             alpha = _ungap(self.alphabet)
         elif not gap:
@@ -279,7 +279,7 @@ class CodonSeq(Seq):
         else:
             alpha = self.alphabet  # modify!
         if len(gap) != 1 or not isinstance(gap, str):
-            raise ValueError("Unexpected gap character, %s" % repr(gap))
+            raise ValueError("Unexpected gap character, %r" % gap)
         return CodonSeq(str(self._data).replace(gap, ""), alpha, rf_table=self.rf_table)
 
     @classmethod

--- a/Bio/phenotype/__init__.py
+++ b/Bio/phenotype/__init__.py
@@ -140,8 +140,8 @@ def write(plates, handle, format):
         if not isinstance(count, int):
             raise TypeError(
                 "Internal error - the underlying %s "
-                "writer should have returned the record count, not %s"
-                % (format, repr(count))
+                "writer should have returned the record count, not %r"
+                % (format, count)
             )
 
     return count

--- a/Bio/phenotype/__init__.py
+++ b/Bio/phenotype/__init__.py
@@ -140,8 +140,7 @@ def write(plates, handle, format):
         if not isinstance(count, int):
             raise TypeError(
                 "Internal error - the underlying %s "
-                "writer should have returned the record count, not %r"
-                % (format, count)
+                "writer should have returned the record count, not %r" % (format, count)
             )
 
     return count

--- a/Scripts/query_pubmed.py
+++ b/Scripts/query_pubmed.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
         print_usage()
         sys.exit(0)
 
-    print("Doing a PubMed search for %s..." % repr(query))
+    print("Doing a PubMed search for %r..." % query)
 
     if count_only:
         handle = Entrez.esearch(db="pubmed", term=query)

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -579,7 +579,7 @@ class SeqInterfaceTest(unittest.TestCase):
             self.assertEqual(cds_feature.qualifiers["codon_start"], ["1"])
         except KeyError:
             raise KeyError(
-                "Missing expected entries, have %s" % repr(cds_feature.qualifiers)
+                "Missing expected entries, have %r" % cds_feature.qualifiers
             ) from None
 
         self.assertIn("db_xref", cds_feature.qualifiers)
@@ -1122,9 +1122,7 @@ class AutoSeqIOTests(unittest.TestCase):
             if "accessions" in record.annotations:
                 # Only expect FIRST accession to work!
                 key = record.annotations["accessions"][0]
-                assert key, "Blank accession in annotation %s" % repr(
-                    record.annotations
-                )
+                assert key, "Blank accession in annotation %r" % record.annotations
                 if key != record.id:
                     # print(" - Retrieving by accession '%s'," % key)
                     db_rec = db.lookup(accession=key)

--- a/Tests/seq_tests_common.py
+++ b/Tests/seq_tests_common.py
@@ -134,8 +134,7 @@ def compare_feature(old_f, new_f):
             elif isinstance(new_f.qualifiers[key], list):
                 # Maybe a string turning into a list of strings?
                 assert [old_f.qualifiers[key]] == new_f.qualifiers[key], \
-                    "%s -> %s" % (repr(old_f.qualifiers[key]),
-                                  repr(new_f.qualifiers[key]))
+                    "%r -> %r" % (old_f.qualifiers[key], new_f.qualifiers[key])
             else:
                 raise ValueError("Problem with feature's '%s' qualifier" % key)
         else:
@@ -181,9 +180,9 @@ def compare_sequence(old, new):
         for j in indices:
             expected = s[i:j]
             assert expected == str(old[i:j]), \
-                "Slice %s vs %s" % (repr(expected), repr(old[i:j]))
+                "Slice %r vs %r" % (expected, old[i:j])
             assert expected == str(new[i:j]), \
-                "Slice %s vs %s" % (repr(expected), repr(new[i:j]))
+                "Slice %r vs %r" % (expected, new[i:j])
             # Slicing with step of 1 should make no difference.
             # Slicing with step 3 might be useful for codons.
             for step in [1, 3]:
@@ -273,7 +272,7 @@ def compare_record(old, new):
             new_comment = new_comment.replace("\n", " ").replace("  ", " ")
             assert old_comment == new_comment, \
                 ("Comment annotation changed by load/retrieve\n"
-                 "Was:%s\nNow:%s" % (repr(old_comment), repr(new_comment)))
+                 "Was:%r\nNow:%r" % (old_comment, new_comment))
         elif key in ["taxonomy", "organism", "source"]:
             # If there is a taxon id recorded, these fields get overwritten
             # by data from the taxon/taxon_name tables.  There is no

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -378,7 +378,7 @@ class TestSeqIO(SeqIOTestBaseClass):
                 # run_tests.py (which can be funny about new lines on Windows)
                 handle.seek(0)
                 raise ValueError(
-                    "%s\n\n%s\n\n%s" % (str(e), repr(handle.read()), repr(records))
+                    "%s\n\n%r\n\n%r" % (str(e), handle.read(), records)
                 ) from None
 
             self.assertEqual(len(records2), t_count)
@@ -570,32 +570,30 @@ class TestSeqIO(SeqIOTestBaseClass):
                     accs = record.annotations["accessions"]
                     # Check for blanks, or entries with leading/trailing spaces
                     for acc in accs:
-                        self.assertTrue(
-                            acc, "Bad accession in annotations: %s" % repr(acc)
-                        )
+                        self.assertTrue(acc, "Bad accession in annotations: %r" % acc)
                         self.assertEqual(
                             acc,
                             acc.strip(),
-                            "Bad accession in annotations: %s" % repr(acc),
+                            "Bad accession in annotations: %r" % acc,
                         )
                     self.assertEqual(
                         len(set(accs)),
                         len(accs),
-                        "Repeated accession in annotations: %s" % repr(accs),
+                        "Repeated accession in annotations: %r" % accs,
                     )
                 for ref in record.dbxrefs:
                     self.assertTrue(
-                        ref, "Bad cross reference in dbxrefs: %s" % repr(ref)
+                        ref, "Bad cross reference in dbxrefs: %r" % ref
                     )
                     self.assertEqual(
                         ref,
                         ref.strip(),
-                        "Bad cross reference in dbxrefs: %s" % repr(ref),
+                        "Bad cross reference in dbxrefs: %r" % ref,
                     )
                 self.assertEqual(
                     len(set(record.dbxrefs)),
                     len(record.dbxrefs),
-                    "Repeated cross reference in dbxrefs: %s" % repr(record.dbxrefs),
+                    "Repeated cross reference in dbxrefs: %r" % record.dbxrefs,
                 )
 
                 # Check the lists obtained by the different methods agree
@@ -651,7 +649,7 @@ class TestSeqIO(SeqIOTestBaseClass):
                 self.assertIn(
                     t_format,
                     no_alpha_formats,
-                    "Got %s from %s file" % (repr(base_alpha), t_format),
+                    "Got %r from %s file" % (base_alpha, t_format),
                 )
                 good = protein_alphas + dna_alphas + rna_alphas + nucleotide_alphas
             for given_alpha in good:

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -61,7 +61,7 @@ def compare_record(old, new, expect_minor_diffs=False):
         # Jython didn't like us comparing the string of very long
         # UnknownSeq object (out of heap memory error)
         if old.seq._character.upper() != new.seq._character:
-            raise ValueError("%s vs %s" % (repr(old.seq), repr(new.seq)))
+            raise ValueError("%r vs %r" % (old.seq, new.seq))
     elif str(old.seq).upper() != str(new.seq).upper():
         if len(old.seq) < 200:
             raise ValueError("'%s' vs '%s'" % (old.seq, new.seq))
@@ -75,7 +75,7 @@ def compare_record(old, new, expect_minor_diffs=False):
         old.description.split()
     ).intersection(new.description.split()):
         raise ValueError(
-            "%s versus %s" % (repr(old.description), repr(new.description))
+            "%r versus %r" % (old.description, new.description)
         )
     # This only checks common annotation
     # Would a white list be easier?
@@ -144,38 +144,36 @@ def compare_records(old_list, new_list, expect_minor_diffs=False):
 def compare_feature(old, new):
     """Check two SeqFeatures agree."""
     if old.type != new.type:
-        raise ValueError("Type %s versus %s" % (repr(old.type), repr(new.type)))
+        raise ValueError("Type %r versus %r" % (old.type, new.type))
     if (
         old.location.nofuzzy_start != new.location.nofuzzy_start
         or old.location.nofuzzy_end != new.location.nofuzzy_end
     ):
         raise ValueError(
-            "%s versus %s:\n%s\nvs:\n%s"
-            % (old.location, new.location, repr(old), repr(new))
+            "%s versus %s:\n%r\nvs:\n%r"
+            % (old.location, new.location, old, new)
         )
     if old.strand is not None and old.strand != new.strand:
-        raise ValueError("Different strand:\n%s\nvs:\n%s" % (repr(old), repr(new)))
+        raise ValueError("Different strand:\n%r\nvs:\n%r" % (old, new))
     if old.ref != new.ref:
-        raise ValueError("Different ref:\n%s\nvs:\n%s" % (repr(old), repr(new)))
+        raise ValueError("Different ref:\n%r\nvs:\n%r" % (old, new))
     if old.ref_db != new.ref_db:
-        raise ValueError("Different ref_db:\n%s\nvs:\n%s" % (repr(old), repr(new)))
+        raise ValueError("Different ref_db:\n%r\nvs:\n%r" % (old, new))
     if old.location_operator != new.location_operator:
-        raise ValueError(
-            "Different location_operator:\n%s\nvs:\n%s" % (repr(old), repr(new))
-        )
+        raise ValueError("Different location_operator:\n%r\nvs:\n%r" % (old, new))
     if old.location.start != new.location.start or str(old.location.start) != str(
         new.location.start
     ):
         raise ValueError(
-            "Start %s versus %s:\n%s\nvs:\n%s"
-            % (old.location.start, new.location.start, repr(old), repr(new))
+            "Start %s versus %s:\n%r\nvs:\n%r"
+            % (old.location.start, new.location.start, old, new)
         )
     if old.location.end != new.location.end or str(old.location.end) != str(
         new.location.end
     ):
         raise ValueError(
-            "End %s versus %s:\n%s\nvs:\n%s"
-            % (old.location.end, new.location.end, repr(old), repr(new))
+            "End %s versus %s:\n%r\nvs:\n%r"
+            % (old.location.end, new.location.end, old, new)
         )
     # This only checks key shared qualifiers
     # Would a white list be easier?

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -124,8 +124,8 @@ class StringMethodTests(unittest.TestCase):
                     j = ValueError
                 if i != j:
                     raise ValueError(
-                        "%s.%s(%s) = %r, not %r"
-                        % (repr(example1), method_name, repr(str2), i, j)
+                        "%r.%s(%r) = %r, not %r"
+                        % (example1, method_name, str2, i, j)
                     )
 
                 try:
@@ -138,8 +138,8 @@ class StringMethodTests(unittest.TestCase):
                     j = ValueError
                 if i != j:
                     raise ValueError(
-                        "%s.%s(%s) = %r, not %r"
-                        % (repr(example1), method_name, repr(example2), i, j)
+                        "%r.%s(%r) = %r, not %r"
+                        % (example1, method_name, example2, i, j)
                     )
 
                 if start_end:
@@ -161,8 +161,8 @@ class StringMethodTests(unittest.TestCase):
                             j = ValueError
                         if i != j:
                             raise ValueError(
-                                "%s.%s(%s, %i) = %r, not %r"
-                                % (repr(example1), method_name, repr(str2), start, i, j)
+                                "%r.%s(%r, %i) = %r, not %r"
+                                % (example1, method_name, str2, start, i, j)
                             )
 
                         for end in self._start_end_values:
@@ -180,11 +180,11 @@ class StringMethodTests(unittest.TestCase):
                                 j = ValueError
                             if i != j:
                                 raise ValueError(
-                                    "%s.%s(%s, %i, %i) = %r, not %r"
+                                    "%r.%s(%r, %i, %i) = %r, not %r"
                                     % (
-                                        repr(example1),
+                                        example1,
                                         method_name,
-                                        repr(str2),
+                                        str2,
                                         start,
                                         end,
                                         i,

--- a/Tests/test_phenotype.py
+++ b/Tests/test_phenotype.py
@@ -76,7 +76,7 @@ class TestPhenoMicro(unittest.TestCase):
             # run_tests.py (which can be funny about new lines on Windows)
             handle.seek(0)
             raise ValueError(
-                "%s\n\n%s\n\n%s" % (str(e), repr(handle.read()), repr(records))
+                "%s\n\n%r\n\n%r" % (str(e), handle.read(), records)
             ) from None
 
         self.assertEqual(p1, records[0])


### PR DESCRIPTION
This pull request replaces `"%s" % repr(obj)` by `"%r" % obj` where possible.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
