### PR TITLE
removed the alphabet from one section in the cookbook

### DIFF
--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -132,7 +132,7 @@ this is with the string object's join method.
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
 >>> from Bio.SeqRecord import SeqRecord
->>> shuffled_rec = SeqRecord(Seq("".join(nuc_list), original_rec.seq.alphabet),
+>>> shuffled_rec = SeqRecord(Seq("".join(nuc_list)),
 ...                          id="Shuffled", description="Based on %s" % original_rec.id)
 ...
 \end{minted}
@@ -146,50 +146,51 @@ This first version just uses a big for loop and writes out the records one by on
 Section~\ref{sec:Bio.SeqIO-and-StringIO}):
 
 \begin{minted}{python}
-import random
-from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
-from Bio import SeqIO
+>>> import random
+>>> from Bio.Seq import Seq
+>>> from Bio.SeqRecord import SeqRecord
+>>> from Bio import SeqIO
 
-original_rec = SeqIO.read("NC_005816.gb", "genbank")
+>>> original_rec = SeqIO.read("NC_005816.gb", "genbank")
 
-with open("shuffled.fasta", "w") as output_handle:
-    for i in range(30):
-        nuc_list = list(original_rec.seq)
-        random.shuffle(nuc_list)
-        shuffled_rec = SeqRecord(
-            Seq("".join(nuc_list), original_rec.seq.alphabet),
-            id="Shuffled%i" % (i + 1),
-            description="Based on %s" % original_rec.id,
-        )
-        out_handle.write(shuffled_rec.format("fasta"))
+>>> with open("shuffled.fasta", "w") as output_handle:
+...     for i in range(30):
+...         nuc_list = list(original_rec.seq)
+...         random.shuffle(nuc_list)
+...         shuffled_rec = SeqRecord(
+...             Seq("".join(nuc_list)),
+...             id="Shuffled%i" % (i + 1),
+...             description="Based on %s" % original_rec.id,
+...         )
+...         output_handle.write(shuffled_rec.format("fasta"))
+...
 \end{minted}
 
 Personally I prefer the following version using a function to shuffle the record
 and a generator expression instead of the for loop:
 
 \begin{minted}{python}
-import random
-from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
-from Bio import SeqIO
+>>> import random
+>>> from Bio.Seq import Seq
+>>> from Bio.SeqRecord import SeqRecord
+>>> from Bio import SeqIO
 
+>>> def make_shuffle_record(record, new_id):
+...     nuc_list = list(record.seq)
+...     random.shuffle(nuc_list)
+...     return SeqRecord(
+...         Seq("".join(nuc_list)),
+...         id=new_id,
+...         description="Based on %s" % original_rec.id,
+...     )
+...
 
-def make_shuffle_record(record, new_id):
-    nuc_list = list(record.seq)
-    random.shuffle(nuc_list)
-    return SeqRecord(
-        Seq("".join(nuc_list), record.seq.alphabet),
-        id=new_id,
-        description="Based on %s" % original_rec.id,
-    )
-
-
-original_rec = SeqIO.read("NC_005816.gb", "genbank")
-shuffled_recs = (
-    make_shuffle_record(original_rec, "Shuffled%i" % (i + 1)) for i in range(30)
-)
-SeqIO.write(shuffled_recs, "shuffled.fasta", "fasta")
+>>> original_rec = SeqIO.read("NC_005816.gb", "genbank")
+>>> shuffled_recs = (
+...     make_shuffle_record(original_rec, "Shuffled%i" % (i + 1)) for i in range(30)
+... )
+...
+>>> SeqIO.write(shuffled_recs, "shuffled.fasta", "fasta")
 \end{minted}
 
 \subsection{Translating a FASTA file of CDS entries}

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -146,51 +146,49 @@ This first version just uses a big for loop and writes out the records one by on
 Section~\ref{sec:Bio.SeqIO-and-StringIO}):
 
 \begin{minted}{python}
->>> import random
->>> from Bio.Seq import Seq
->>> from Bio.SeqRecord import SeqRecord
->>> from Bio import SeqIO
+import random
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
+from Bio import SeqIO
 
->>> original_rec = SeqIO.read("NC_005816.gb", "genbank")
+original_rec = SeqIO.read("NC_005816.gb", "genbank")
 
->>> with open("shuffled.fasta", "w") as output_handle:
-...     for i in range(30):
-...         nuc_list = list(original_rec.seq)
-...         random.shuffle(nuc_list)
-...         shuffled_rec = SeqRecord(
-...             Seq("".join(nuc_list)),
-...             id="Shuffled%i" % (i + 1),
-...             description="Based on %s" % original_rec.id,
-...         )
-...         output_handle.write(shuffled_rec.format("fasta"))
-...
+with open("shuffled.fasta", "w") as output_handle:
+    for i in range(30):
+        nuc_list = list(original_rec.seq)
+        random.shuffle(nuc_list)
+        shuffled_rec = SeqRecord(
+            Seq("".join(nuc_list)),
+            id="Shuffled%i" % (i + 1),
+            description="Based on %s" % original_rec.id,
+        )
+        output_handle.write(shuffled_rec.format("fasta"))
 \end{minted}
 
 Personally I prefer the following version using a function to shuffle the record
 and a generator expression instead of the for loop:
 
 \begin{minted}{python}
->>> import random
->>> from Bio.Seq import Seq
->>> from Bio.SeqRecord import SeqRecord
->>> from Bio import SeqIO
+import random
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
+from Bio import SeqIO
 
->>> def make_shuffle_record(record, new_id):
-...     nuc_list = list(record.seq)
-...     random.shuffle(nuc_list)
-...     return SeqRecord(
-...         Seq("".join(nuc_list)),
-...         id=new_id,
-...         description="Based on %s" % original_rec.id,
-...     )
-...
+def make_shuffle_record(record, new_id):
+    nuc_list = list(record.seq)
+    random.shuffle(nuc_list)
+    return SeqRecord(
+        Seq("".join(nuc_list)),
+        id=new_id,
+        description="Based on %s" % original_rec.id,
+    )
 
->>> original_rec = SeqIO.read("NC_005816.gb", "genbank")
->>> shuffled_recs = (
-...     make_shuffle_record(original_rec, "Shuffled%i" % (i + 1)) for i in range(30)
-... )
-...
->>> SeqIO.write(shuffled_recs, "shuffled.fasta", "fasta")
+original_rec = SeqIO.read("NC_005816.gb", "genbank")
+shuffled_recs = (
+    make_shuffle_record(original_rec, "Shuffled%i" % (i + 1)) for i in range(30)
+)
+
+SeqIO.write(shuffled_recs, "shuffled.fasta", "fasta")
 \end{minted}
 
 \subsection{Translating a FASTA file of CDS entries}


### PR DESCRIPTION
This pull request removes the alphabet from one section in the cookbook, and fixes a typo.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
