### PR TITLE
Use records' molecule type in Nexus output, not alphabet

### DIFF
--- a/Bio/AlignIO/NexusIO.py
+++ b/Bio/AlignIO/NexusIO.py
@@ -125,13 +125,19 @@ class NexusWriter(AlignmentWriter):
         columns = alignment.get_alignment_length()
         if columns == 0:
             raise ValueError("Non-empty sequences are required")
+        datatype = self._classify_mol_type_for_nexus(alignment)
         minimal_record = (
             "#NEXUS\nbegin data; dimensions ntax=0 nchar=0; format datatype=%s; end;"
-            % self._classify_alphabet_for_nexus(alignment._alphabet)
+            % datatype
         )
         n = Nexus.Nexus(minimal_record)
         n.alphabet = alignment._alphabet
         for record in alignment:
+            # Sanity test sequences (should this be even stricter?)
+            if datatype == "dna" and "U" in record.seq:
+                raise ValueError(f"{record.id} contains U, but DNA alignment")
+            elif datatype == "rna" and "T" in record.seq:
+                raise ValueError(f"{record.id} contains T, but RNA alignment")
             n.add_sequence(record.id, str(record.seq))
 
         # Note: MrBayes may choke on large alignments if not interleaved
@@ -139,26 +145,23 @@ class NexusWriter(AlignmentWriter):
             interleave = columns > 1000
         n.write_nexus_data(self.handle, interleave=interleave)
 
-    def _classify_alphabet_for_nexus(self, alphabet):
-        """Return 'protein', 'dna', or 'rna' based on the alphabet (PRIVATE).
+    def _classify_mol_type_for_nexus(self, alignment):
+        """Return 'protein', 'dna', or 'rna' based on records' molecule type (PRIVATE).
+
+        All the records must have a molecule_type annotation, and they must
+        agree.
 
         Raises an exception if this is not possible.
         """
-        # Get the base alphabet (underneath any Gapped or StopCodon encoding)
-        a = Alphabet._get_base_alphabet(alphabet)
-
-        if not isinstance(a, Alphabet.Alphabet):
-            raise TypeError("Invalid alphabet")
-        elif isinstance(a, Alphabet.ProteinAlphabet):
+        values = {_.annotations.get("molecule_type", None) for _ in alignment}
+        if all(_ and "DNA" in _ for _ in values):
+            return "dna"  # could have been a mix of "DNA" and "gDNA"
+        elif all(_ and "RNA" in _ for _ in values):
+            return "rna"  # could have been a mix of "RNA" and "mRNA"
+        elif all(_ and "protein" in _ for _ in values):
             return "protein"
-        elif isinstance(a, Alphabet.DNAAlphabet):
-            return "dna"
-        elif isinstance(a, Alphabet.RNAAlphabet):
-            return "rna"
         else:
-            # Must be something like NucleotideAlphabet or
-            # just the generic Alphabet (default for fasta files)
-            raise ValueError("Need a DNA, RNA or Protein alphabet")
+            raise ValueError("Need the molecule type to be defined")
 
 
 if __name__ == "__main__":

--- a/Tests/test_Nexus.py
+++ b/Tests/test_Nexus.py
@@ -22,7 +22,6 @@ from Bio.AlignIO.NexusIO import NexusIterator, NexusWriter
 from Bio.SeqRecord import SeqRecord
 from Bio.Nexus import Nexus, Trees
 from Bio.Seq import Seq
-from Bio.Alphabet.IUPAC import ambiguous_dna
 from Bio import SeqIO
 
 
@@ -85,7 +84,7 @@ class NexusTest1(unittest.TestCase):
 
     def test_write_with_dups(self):
         # see issue: biopython/Bio/Nexus/Nexus.py _unique_label() eval error #633
-        records = [SeqRecord(Seq("ATGCTGCTGAT", alphabet=ambiguous_dna), id="foo") for _ in range(4)]
+        records = [SeqRecord(Seq("ATGCTGCTGAT"), id="foo", annotations={"molecule_type": "DNA"}) for _ in range(4)]
         out_file = StringIO()
         self.assertEqual(4, SeqIO.write(records, out_file, "nexus"))
 
@@ -376,8 +375,8 @@ usertype matrix_test stepmatrix=5
 
     def test_write_alignment(self):
         # Default causes no interleave (columns <= 1000)
-        records = [SeqRecord(Seq("ATGCTGCTGA" * 90, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
-        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+        records = [SeqRecord(Seq("ATGCTGCTGA" * 90), id=_id, annotations={"molecule_type": "DNA"}) for _id in ["foo", "bar", "baz"]]
+        a = MultipleSeqAlignment(records)
 
         handle = StringIO()
         NexusWriter(handle).write_alignment(a)
@@ -386,8 +385,8 @@ usertype matrix_test stepmatrix=5
         self.assertIn("ATGCTGCTGA" * 90, data)
 
         # Default causes interleave (columns > 1000)
-        records = [SeqRecord(Seq("ATGCTGCTGA" * 110, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
-        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+        records = [SeqRecord(Seq("ATGCTGCTGA" * 110), id=_id, annotations={"molecule_type": "DNA"}) for _id in ["foo", "bar", "baz"]]
+        a = MultipleSeqAlignment(records)
         handle = StringIO()
         NexusWriter(handle).write_alignment(a)
         handle.seek(0)
@@ -396,8 +395,8 @@ usertype matrix_test stepmatrix=5
         self.assertIn("ATGCTGCTGA" * 7, data)
 
         # Override interleave: True
-        records = [SeqRecord(Seq("ATGCTGCTGA" * 9, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
-        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+        records = [SeqRecord(Seq("ATGCTGCTGA" * 9), id=_id, annotations={"molecule_type": "DNA"}) for _id in ["foo", "bar", "baz"]]
+        a = MultipleSeqAlignment(records)
         handle = StringIO()
         NexusWriter(handle).write_alignment(a, interleave=True)
         handle.seek(0)
@@ -406,8 +405,8 @@ usertype matrix_test stepmatrix=5
         self.assertIn("ATGCTGCTGA" * 7, data)
 
         # Override interleave: False
-        records = [SeqRecord(Seq("ATGCTGCTGA" * 110, alphabet=ambiguous_dna), id=_id) for _id in ["foo", "bar", "baz"]]
-        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+        records = [SeqRecord(Seq("ATGCTGCTGA" * 110), id=_id, annotations={"molecule_type": "DNA"}) for _id in ["foo", "bar", "baz"]]
+        a = MultipleSeqAlignment(records)
         handle = StringIO()
         NexusWriter(handle).write_alignment(a, interleave=False)
         handle.seek(0)
@@ -687,10 +686,10 @@ class TestSelf(unittest.TestCase):
         self.assertEqual([], list(NexusIterator(StringIO())))
 
     def test_multiple_output(self):
-        records = [SeqRecord(Seq("ATGCTGCTGAT", alphabet=ambiguous_dna), id="foo"),
-                   SeqRecord(Seq("ATGCTGCAGAT", alphabet=ambiguous_dna), id="bar"),
-                   SeqRecord(Seq("ATGCTGCGGAT", alphabet=ambiguous_dna), id="baz")]
-        a = MultipleSeqAlignment(records, alphabet=ambiguous_dna)
+        records = [SeqRecord(Seq("ATGCTGCTGAT"), id="foo", annotations={"molecule_type": "DNA"}),
+                   SeqRecord(Seq("ATGCTGCAGAT"), id="bar", annotations={"molecule_type": "DNA"}),
+                   SeqRecord(Seq("ATGCTGCGGAT"), id="baz", annotations={"molecule_type": "DNA"})]
+        a = MultipleSeqAlignment(records)
 
         handle = StringIO()
         NexusWriter(handle).write_file([a])

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -745,7 +745,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "clustal",
@@ -796,7 +796,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "clustal",
@@ -847,7 +847,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "clustal",
@@ -892,7 +892,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
             "phylip-sequential": "Repeated name 'AT3G20900.' (originally 'AT3G20900.1-CDS'), possibly due to truncation",
         }
         self.perform_test(
@@ -925,7 +925,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5049839|gb|AI730987.1|AI730987).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -957,7 +957,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4218935|gb|AF074388.1|AF074388).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -989,7 +989,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5052071|gb|AF067555.1|AF067555).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1021,7 +1021,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4104054|gb|AH007193.1|SEG_CVIGS).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1053,7 +1053,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5817701|gb|AF142731.1|AF142731).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1085,7 +1085,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3176602|gb|U78617.1|LOU78617).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1117,7 +1117,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5690369|gb|AF158246.1|AF158246).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1150,7 +1150,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1183,7 +1183,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1216,7 +1216,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta-2line",
@@ -1249,7 +1249,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|2781234|pdb|1JLY|B).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1282,7 +1282,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4959044|gb|AAD34209.1|AF069992_1).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1315,7 +1315,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|671626|emb|CAA85685.1|).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1349,7 +1349,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3318709|pdb|1A91|).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1465,7 +1465,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478711|ref|NC_005816.1|).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1690,7 +1690,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|NC_001802.1|).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1723,7 +1723,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|nc_001802.1|).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1765,7 +1765,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -2578,6 +2578,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=NM_006141.1).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=NM_006141.1).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=NM_006141.1).",
+            "nexus": "NM_006141.1 contains T, but RNA alignment",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=NM_006141.1).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=NM_006141.1).",
             "sff": "Missing SFF flow information",
@@ -2639,6 +2640,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=AL109817.1).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=AL109817.1).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=AL109817.1).",
+            "nexus": "AL109817.1 contains T, but RNA alignment",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=AL109817.1).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=AL109817.1).",
             "sff": "Missing SFF flow information",
@@ -3257,6 +3259,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=X56734.1).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=X56734.1).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=X56734.1).",
+            "nexus": "X56734.1 contains T, but RNA alignment",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=X56734.1).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=X56734.1).",
             "sff": "Missing SFF flow information",
@@ -3318,7 +3321,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=DD231055.1).",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
 
         self.perform_test(
@@ -3522,7 +3525,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=Test).",
             "seqxml": "unknown molecule_type 'unspecified'",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "embl",
@@ -3548,6 +3551,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
+            "nexus": "A04195 contains T, but RNA alignment",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "sff": "Missing SFF flow information",
@@ -3576,6 +3580,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
+            "nexus": "A04195 contains T, but RNA alignment",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=A04195).",
             "sff": "Missing SFF flow information",
@@ -3656,7 +3661,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "stockholm",
@@ -3712,7 +3717,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "stockholm",
@@ -3754,7 +3759,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -3801,7 +3806,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -3847,7 +3852,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -3894,7 +3899,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -3940,7 +3945,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -3985,7 +3990,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -4031,7 +4036,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -4077,7 +4082,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "emboss",
@@ -4159,7 +4164,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "emboss",
@@ -4423,7 +4428,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "ig",
@@ -4691,7 +4696,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
             "phylip-sequential": "Repeated name 'EAS54_6_R1' (originally 'EAS54_6_R1_2_1_540_792'), possibly due to truncation",
         }
         self.perform_test(
@@ -4734,7 +4739,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "Sequence type is UnknownSeq but SeqXML requires sequence",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
             "phylip-sequential": "Repeated name 'EAS54_6_R1' (originally 'EAS54_6_R1_2_1_540_792'), possibly due to truncation",
         }
         self.perform_test(
@@ -4784,7 +4789,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
             "phylip-sequential": "Repeated name 'EAS54_6_R1' (originally 'EAS54_6_R1_2_1_540_792'), possibly due to truncation",
         }
         self.perform_test(
@@ -4834,7 +4839,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
             "phylip-sequential": "Repeated name 'EAS54_6_R1' (originally 'EAS54_6_R1_2_1_540_792'), possibly due to truncation",
         }
         self.perform_test(
@@ -4887,7 +4892,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
             "phylip-sequential": "Repeated name '071113_EAS' (originally '071113_EAS56_0053:1:1:153:10'), possibly due to truncation",
         }
         self.perform_test(
@@ -4915,7 +4920,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "imgt": "missing molecule_type in annotations",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fastq",
@@ -4942,7 +4947,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "imgt": "missing molecule_type in annotations",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fastq",
@@ -4969,7 +4974,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "imgt": "missing molecule_type in annotations",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fastq-illumina",
@@ -4996,7 +5001,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "imgt": "missing molecule_type in annotations",
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fastq-solexa",
@@ -5048,7 +5053,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need a DNA, RNA or Protein alphabet",
+            "nexus": "Need the molecule type to be defined",
             "phylip-sequential": "Repeated name 'SLXA-B3_64' (originally 'SLXA-B3_649_FC8437_R1_1_1_362_549'), possibly due to truncation",
         }
         self.perform_test(


### PR DESCRIPTION
This extracts the Nexus output work from #3011 without changing the main MSA object at all. i.e. Does not attempt to record the molecule type at the MSA level, nor how to specify this in the ``Bio.AlignIO`` interface.

Also now check for mismatches between molecule type and sequence, e.g. GenBank records for mRNA which use T and not U in the sequence. See #3010.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
