### PR TITLE
removed alphabets from test_AlignIO_convert.py

### DIFF
--- a/Tests/test_AlignIO_convert.py
+++ b/Tests/test_AlignIO_convert.py
@@ -8,16 +8,15 @@ import unittest
 from io import StringIO
 
 from Bio import AlignIO
-from Bio.Alphabet import generic_protein, generic_nucleotide, generic_dna
 
 
 class ConvertTests(unittest.TestCase):
 
-    def check_convert(self, in_filename, in_format, out_format, alphabet=None):
+    def check_convert(self, in_filename, in_format, out_format):
         # Write it out using parse/write
         msg = "Failed converting %s from %s to %s" % (in_filename, in_format, out_format)
         handle = StringIO()
-        aligns = list(AlignIO.parse(in_filename, in_format, None, alphabet))
+        aligns = list(AlignIO.parse(in_filename, in_format, None))
         try:
             count = AlignIO.write(aligns, handle, out_format)
         except ValueError:
@@ -25,7 +24,7 @@ class ConvertTests(unittest.TestCase):
         # Write it out using convert passing filename and handle
         handle2 = StringIO()
         try:
-            count2 = AlignIO.convert(in_filename, in_format, handle2, out_format, alphabet)
+            count2 = AlignIO.convert(in_filename, in_format, handle2, out_format)
         except ValueError:
             count2 = 0
         self.assertEqual(count, count2, msg=msg)
@@ -34,7 +33,7 @@ class ConvertTests(unittest.TestCase):
         handle2 = StringIO()
         try:
             with open(in_filename) as handle1:
-                count2 = AlignIO.convert(handle1, in_format, handle2, out_format, alphabet)
+                count2 = AlignIO.convert(handle1, in_format, handle2, out_format)
         except ValueError:
             count2 = 0
         self.assertEqual(count, count2, msg=msg)
@@ -42,20 +41,20 @@ class ConvertTests(unittest.TestCase):
         # TODO - convert passing an output filename?
 
     def test_convert(self):
-        tests = [("Clustalw/hedgehog.aln", "clustal", None),
-                 ("Nexus/test_Nexus_input.nex", "nexus", None),
-                 ("Stockholm/simple.sth", "stockholm", None),
-                 ("GFF/multi.fna", "fasta", generic_nucleotide),
-                 ("Quality/example.fastq", "fastq", None),
-                 ("Quality/example.fastq", "fastq-sanger", generic_dna),
-                 ("Fasta/output001.m10", "fasta-m10", None),
-                 ("IntelliGenetics/VIF_mase-pro.txt", "ig", generic_protein),
-                 ("NBRF/clustalw.pir", "pir", None),
+        tests = [("Clustalw/hedgehog.aln", "clustal"),
+                 ("Nexus/test_Nexus_input.nex", "nexus"),
+                 ("Stockholm/simple.sth", "stockholm"),
+                 ("GFF/multi.fna", "fasta"),
+                 ("Quality/example.fastq", "fastq"),
+                 ("Quality/example.fastq", "fastq-sanger"),
+                 ("Fasta/output001.m10", "fasta-m10"),
+                 ("IntelliGenetics/VIF_mase-pro.txt", "ig"),
+                 ("NBRF/clustalw.pir", "pir"),
                  ]
         output_formats = ["fasta"] + sorted(AlignIO._FormatToWriter)
-        for filename, in_format, alphabet in tests:
+        for filename, in_format in tests:
             for out_format in output_formats:
-                self.check_convert(filename, in_format, out_format, alphabet)
+                self.check_convert(filename, in_format, out_format)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request removes alphabets from `test_AlignIO_convert.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
