### PR TITLE
removed alphabets from Bio.Sequencing.Phd

### DIFF
--- a/Bio/Sequencing/Phd.py
+++ b/Bio/Sequencing/Phd.py
@@ -16,7 +16,6 @@ internally.  This will give SeqRecord objects for each contig sequence.
 """
 
 from Bio import Seq
-from Bio.Alphabet import generic_dna
 
 
 CKEYWORDS = [
@@ -191,7 +190,7 @@ def _read(handle):
     else:
         raise ValueError("Failed to find END_SEQUENCE line")
 
-    record.seq = Seq.Seq("".join(n[0] for n in record.sites), generic_dna)
+    record.seq = Seq.Seq("".join(n[0] for n in record.sites))
     if record.comments["trim"] is not None:
         first, last = record.comments["trim"][:2]
         record.seq_trimmed = record.seq[first:last]


### PR DESCRIPTION
This pull request removes alphabets from Bio.Sequencing.Phd.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
