### PR TITLE
removed alphabets

### DIFF
--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -170,7 +170,6 @@ from Bio import BiopythonWarning
 from Bio import BiopythonDeprecationWarning
 
 
-
 # Thermodynamic lookup tables (dictionaries):
 # Enthalpy (dH) and entropy (dS) values for nearest neighbors and initiation
 # process. Calculation of duplex initiation is quite different in several

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -167,6 +167,8 @@ import warnings
 
 from Bio import SeqUtils, Seq
 from Bio import BiopythonWarning
+from Bio import BiopythonDeprecationWarning
+
 
 
 # Thermodynamic lookup tables (dictionaries):
@@ -1107,8 +1109,7 @@ def Tm_staluc(s, dnac=50, saltc=50, rna=0):
     You can also use a Seq object instead of a string,
 
     >>> from Bio.Seq import Seq
-    >>> from Bio.Alphabet import generic_nucleotide
-    >>> s = Seq('CAGTCAGTACGTACGTGTACTGCCGTA', generic_nucleotide)
+    >>> s = Seq('CAGTCAGTACGTACGTGTACTGCCGTA')
     >>> print("%0.2f" % Tm_staluc(s))
     59.87
     >>> print("%0.2f" % Tm_staluc(s, rna=True))
@@ -1120,7 +1121,7 @@ def Tm_staluc(s, dnac=50, saltc=50, rna=0):
 
     warnings.warn(
         "Tm_staluc may be depreciated in the future. Use Tm_NN instead.",
-        PendingDeprecationWarning,
+        BiopythonDeprecationWarning,
     )
     if not rna:
         return Tm_NN(s, dnac1=dnac / 2.0, dnac2=dnac / 2.0, Na=saltc)

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -1119,7 +1119,7 @@ def Tm_staluc(s, dnac=50, saltc=50, rna=0):
     # now superseded by Tm_NN.
 
     warnings.warn(
-        "Tm_staluc may be depreciated in the future. Use Tm_NN instead.",
+        "Tm_staluc is deprecated; please use Tm_NN instead.",
         BiopythonDeprecationWarning,
     )
     if not rna:


### PR DESCRIPTION
This pull request removes alphabets from `Bio/SeqUtils/MeltingTemp.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
