### PR TITLE
Apply black style to test_cellosaurus.py, version 19.10b0.

### DIFF
--- a/Tests/test_cellosaurus.py
+++ b/Tests/test_cellosaurus.py
@@ -22,17 +22,17 @@ class TestCellosaurus(unittest.TestCase):
         self.assertEqual(record["DR"][1], ("ECACC", "94050311"))
         self.assertEqual(record["DR"][2], ("IHW", "IHW9326"))
         self.assertEqual(record["DR"][3], ("IMGT/HLA", "10074"))
-        self.assertEqual(record["WW"][0], "http://bioinformatics."
-                                          "hsanmartino.it"
-                                          "/ecbr/cl326.html")
-        self.assertEqual(record["CC"][0],
-                         "Part of: 12th International "
-                         "Histocompatibility Workshop "
-                         "(12IHW) cell line panel.")
-        self.assertEqual(record["CC"][1],
-                         "Transformant: EBV.")
-        self.assertEqual(record["OX"][0],
-                         "NCBI_TaxID=9606; ! Homo sapiens")
+        self.assertEqual(
+            record["WW"][0], "http://bioinformatics.hsanmartino.it/ecbr/cl326.html",
+        )
+        self.assertEqual(
+            record["CC"][0],
+            "Part of: 12th International "
+            "Histocompatibility Workshop "
+            "(12IHW) cell line panel.",
+        )
+        self.assertEqual(record["CC"][1], "Transformant: EBV.")
+        self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens")
         self.assertEqual(record["SX"], "Female")
         self.assertEqual(record["CA"], "Transformed cell line")
 
@@ -63,19 +63,23 @@ class TestCellosaurus(unittest.TestCase):
             self.assertEqual(record["ST"][7], "TH01: 7")
             self.assertEqual(record["ST"][8], "TPOX: 8,11")
             self.assertEqual(record["ST"][9], "vWA: 14,16")
-            self.assertEqual(record["DI"][0], "NCIt; C3965; Xeroderma pigmentosum,"
-                                              " complementation group A")
+            self.assertEqual(
+                record["DI"][0],
+                "NCIt; C3965; Xeroderma pigmentosum, complementation group A",
+            )
             self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens")
             self.assertEqual(record["SX"], "Female")
             self.assertEqual(record["CA"], "Finite cell line")
             record = next(records)
             self.assertEqual(record["ID"], "1-5c-4")
             self.assertEqual(record["AC"], "CVCL_2260")
-            self.assertEqual(record["SY"],
-                             "Clone 1-5c-4; Clone 1-5c-4 WKD of "
-                             "Chang Conjunctiva; "
-                             "Wong-Kilbourne derivative of "
-                             "Chang conjunctiva; ChWK")
+            self.assertEqual(
+                record["SY"],
+                "Clone 1-5c-4; Clone 1-5c-4 WKD of "
+                "Chang Conjunctiva; "
+                "Wong-Kilbourne derivative of "
+                "Chang conjunctiva; ChWK",
+            )
             self.assertEqual(len(record["DR"]), 10)
             self.assertEqual(record["DR"][0], ("CLO", "CLO_0002500"))
             self.assertEqual(record["DR"][1], ("CLO", "CLO_0002501"))
@@ -90,13 +94,18 @@ class TestCellosaurus(unittest.TestCase):
             self.assertEqual(record["RX"][0], "PubMed=566722;")
             self.assertEqual(record["RX"][1], "PubMed=19630270;")
             self.assertEqual(record["RX"][2], "PubMed=20143388;")
-            self.assertEqual(record["WW"][0], "http://iclac.org/"
-                                              "wp-content/uploads/"
-                                              "Cross-Contaminations-v7_2.pdf")
-            self.assertEqual(record["CC"][0],
-                             "Problematic cell line: Contaminated. "
-                             "Shown to be a HeLa derivative "
-                             "(PubMed 566722, PubMed 20143388).")
+            self.assertEqual(
+                record["WW"][0],
+                "http://iclac.org/"
+                "wp-content/uploads/"
+                "Cross-Contaminations-v7_2.pdf",
+            )
+            self.assertEqual(
+                record["CC"][0],
+                "Problematic cell line: Contaminated. "
+                "Shown to be a HeLa derivative "
+                "(PubMed 566722, PubMed 20143388).",
+            )
             self.assertEqual(record["CC"][1], "Omics: Transcriptome analysis.")
             self.assertEqual(record["ST"][0], "Source(s): ATCC; KCLB")
             self.assertEqual(record["ST"][1], "Amelogenin: X")
@@ -110,8 +119,7 @@ class TestCellosaurus(unittest.TestCase):
             self.assertEqual(record["ST"][9], "TH01: 7")
             self.assertEqual(record["ST"][10], "TPOX: 8,12")
             self.assertEqual(record["ST"][11], "vWA: 16,18")
-            self.assertEqual(record["DI"][0], "NCIt; C4029; Cervical "
-                                              "adenocarcinoma")
+            self.assertEqual(record["DI"][0], "NCIt; C4029; Cervical adenocarcinoma")
             self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens")
             self.assertEqual(record["HI"][0], "CVCL_0030 ! HeLa")
             self.assertEqual(record["SX"], "Female")

--- a/Tests/test_cellosaurus.py
+++ b/Tests/test_cellosaurus.py
@@ -27,9 +27,8 @@ class TestCellosaurus(unittest.TestCase):
         )
         self.assertEqual(
             record["CC"][0],
-            "Part of: 12th International "
-            "Histocompatibility Workshop "
-            "(12IHW) cell line panel.",
+            "Part of: 12th International Histocompatibility Workshop (12IHW) "
+            "cell line panel.",
         )
         self.assertEqual(record["CC"][1], "Transformant: EBV.")
         self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens")
@@ -75,10 +74,8 @@ class TestCellosaurus(unittest.TestCase):
             self.assertEqual(record["AC"], "CVCL_2260")
             self.assertEqual(
                 record["SY"],
-                "Clone 1-5c-4; Clone 1-5c-4 WKD of "
-                "Chang Conjunctiva; "
-                "Wong-Kilbourne derivative of "
-                "Chang conjunctiva; ChWK",
+                "Clone 1-5c-4; Clone 1-5c-4 WKD of Chang Conjunctiva; "
+                "Wong-Kilbourne derivative of Chang conjunctiva; ChWK",
             )
             self.assertEqual(len(record["DR"]), 10)
             self.assertEqual(record["DR"][0], ("CLO", "CLO_0002500"))
@@ -96,15 +93,12 @@ class TestCellosaurus(unittest.TestCase):
             self.assertEqual(record["RX"][2], "PubMed=20143388;")
             self.assertEqual(
                 record["WW"][0],
-                "http://iclac.org/"
-                "wp-content/uploads/"
-                "Cross-Contaminations-v7_2.pdf",
+                "http://iclac.org/wp-content/uploads/Cross-Contaminations-v7_2.pdf",
             )
             self.assertEqual(
                 record["CC"][0],
                 "Problematic cell line: Contaminated. "
-                "Shown to be a HeLa derivative "
-                "(PubMed 566722, PubMed 20143388).",
+                "Shown to be a HeLa derivative (PubMed 566722, PubMed 20143388).",
             )
             self.assertEqual(record["CC"][1], "Omics: Transcriptome analysis.")
             self.assertEqual(record["ST"][0], "Source(s): ATCC; KCLB")


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black formatting to test_cellosaurus.py, small change should be fine to merge.