### PR TITLE
Apply black style to test_Ace.py, version 19.10b0.

### DIFF
--- a/Tests/test_Ace.py
+++ b/Tests/test_Ace.py
@@ -28,7 +28,13 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.wa[0].tag_type, "phrap_params")
         self.assertEqual(record.wa[0].program, "phrap")
         self.assertEqual(record.wa[0].date, "040203:114710")
-        self.assertEqual(record.wa[0].info, ["phrap 304_nuclsu.fasta.screen -new_ace -retain_duplicates", "phrap version 0.990329"])
+        self.assertEqual(
+            record.wa[0].info,
+            [
+                "phrap 304_nuclsu.fasta.screen -new_ace -retain_duplicates",
+                "phrap version 0.990329",
+            ],
+        )
         self.assertEqual(len(record.contigs), 2)
         self.assertEqual(len(record.contigs[0].reads), 2)
         self.assertEqual(record.contigs[0].name, "Contig1")
@@ -38,12 +44,21 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[0].uorc, "U")
         center = len(record.contigs[0].sequence) // 2
         self.assertEqual(record.contigs[0].sequence[:10], "aatacgGGAT")
-        self.assertEqual(record.contigs[0].sequence[center - 5:center + 5], "ACATCATCTG")
+        self.assertEqual(
+            record.contigs[0].sequence[center - 5 : center + 5], "ACATCATCTG"
+        )
         self.assertEqual(record.contigs[0].sequence[-10:], "cATCTAGtac")
         center = len(record.contigs[0].quality) // 2
-        self.assertEqual(record.contigs[0].quality[:10], [0, 0, 0, 0, 0, 0, 22, 23, 25, 28])
-        self.assertEqual(record.contigs[0].quality[center - 5:center + 5], [90, 90, 90, 90, 90, 90, 90, 90, 90, 90])
-        self.assertEqual(record.contigs[0].quality[-10:], [15, 22, 30, 24, 28, 22, 21, 15, 19, 0])
+        self.assertEqual(
+            record.contigs[0].quality[:10], [0, 0, 0, 0, 0, 0, 22, 23, 25, 28]
+        )
+        self.assertEqual(
+            record.contigs[0].quality[center - 5 : center + 5],
+            [90, 90, 90, 90, 90, 90, 90, 90, 90, 90],
+        )
+        self.assertEqual(
+            record.contigs[0].quality[-10:], [15, 22, 30, 24, 28, 22, 21, 15, 19, 0]
+        )
         self.assertEqual(len(record.contigs[0].af), 2)
         self.assertEqual(record.contigs[0].af[1].name, "BL060c3-LR0R.b.ab1")
         self.assertEqual(record.contigs[0].af[1].coru, "U")
@@ -62,7 +77,10 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[0].ct[0].padded_start, 52)
         self.assertEqual(record.contigs[0].ct[0].padded_end, 53)
         self.assertEqual(record.contigs[0].ct[0].date, "555456:555432")
-        self.assertEqual(record.contigs[0].ct[0].info, ["This is the forst line of comment for c1", "and this the second for c1"])
+        self.assertEqual(
+            record.contigs[0].ct[0].info,
+            ["This is the forst line of comment for c1", "and this the second for c1"],
+        )
         self.assertIsNone(record.contigs[0].wa)
         self.assertEqual(len(record.contigs[0].reads), 2)
         self.assertEqual(record.contigs[0].reads[0].rd.name, "BL060c3-LR5.g.ab1")
@@ -71,7 +89,10 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[0].rd.read_tags, 0)
         center = len(record.contigs[0].reads[0].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[0].rd.sequence[:10], "tagcgaggaa")
-        self.assertEqual(record.contigs[0].reads[0].rd.sequence[center - 5:center + 5], "CCGAGGCCAA")
+        self.assertEqual(
+            record.contigs[0].reads[0].rd.sequence[center - 5 : center + 5],
+            "CCGAGGCCAA",
+        )
         self.assertEqual(record.contigs[0].reads[0].rd.sequence[-10:], "gaaccatcag")
         self.assertEqual(record.contigs[0].reads[0].qa.qual_clipping_start, 80)
         self.assertEqual(record.contigs[0].reads[0].qa.qual_clipping_end, 853)
@@ -80,25 +101,33 @@ class AceTestOne(unittest.TestCase):
         self.assertIsNone(record.contigs[0].reads[0].ds)
         self.assertEqual(len(record.contigs[0].reads[0].rt), 4)
         self.assertEqual(record.contigs[0].reads[0].rt[0].name, "BL060c3-LR5.g.ab1")
-        self.assertEqual(record.contigs[0].reads[0].rt[0].tag_type, "matchElsewhereHighQual")
+        self.assertEqual(
+            record.contigs[0].reads[0].rt[0].tag_type, "matchElsewhereHighQual"
+        )
         self.assertEqual(record.contigs[0].reads[0].rt[0].program, "phrap")
         self.assertEqual(record.contigs[0].reads[0].rt[0].padded_start, 590)
         self.assertEqual(record.contigs[0].reads[0].rt[0].padded_end, 607)
         self.assertEqual(record.contigs[0].reads[0].rt[0].date, "040217:110357")
         self.assertEqual(record.contigs[0].reads[0].rt[1].name, "BL060c3-LR5.g.ab1")
-        self.assertEqual(record.contigs[0].reads[0].rt[1].tag_type, "matchElsewhereHighQual")
+        self.assertEqual(
+            record.contigs[0].reads[0].rt[1].tag_type, "matchElsewhereHighQual"
+        )
         self.assertEqual(record.contigs[0].reads[0].rt[1].program, "phrap")
         self.assertEqual(record.contigs[0].reads[0].rt[1].padded_start, 617)
         self.assertEqual(record.contigs[0].reads[0].rt[1].padded_end, 631)
         self.assertEqual(record.contigs[0].reads[0].rt[1].date, "040217:110357")
         self.assertEqual(record.contigs[0].reads[0].rt[2].name, "BL060c3-LR5.g.ab1")
-        self.assertEqual(record.contigs[0].reads[0].rt[2].tag_type, "matchElsewhereHighQual")
+        self.assertEqual(
+            record.contigs[0].reads[0].rt[2].tag_type, "matchElsewhereHighQual"
+        )
         self.assertEqual(record.contigs[0].reads[0].rt[2].program, "phrap")
         self.assertEqual(record.contigs[0].reads[0].rt[2].padded_start, 617)
         self.assertEqual(record.contigs[0].reads[0].rt[2].padded_end, 631)
         self.assertEqual(record.contigs[0].reads[0].rt[2].date, "040217:110357")
         self.assertEqual(record.contigs[0].reads[0].rt[3].name, "BL060c3-LR5.g.ab1")
-        self.assertEqual(record.contigs[0].reads[0].rt[3].tag_type, "matchElsewhereHighQual")
+        self.assertEqual(
+            record.contigs[0].reads[0].rt[3].tag_type, "matchElsewhereHighQual"
+        )
         self.assertEqual(record.contigs[0].reads[0].rt[3].program, "phrap")
         self.assertEqual(record.contigs[0].reads[0].rt[3].padded_start, 617)
         self.assertEqual(record.contigs[0].reads[0].rt[3].padded_end, 631)
@@ -115,7 +144,10 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[1].rd.read_tags, 0)
         center = len(record.contigs[0].reads[1].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[1].rd.sequence[:10], "aatacgGGAT")
-        self.assertEqual(record.contigs[0].reads[1].rd.sequence[center - 5:center + 5], "ACATCATCTG")
+        self.assertEqual(
+            record.contigs[0].reads[1].rd.sequence[center - 5 : center + 5],
+            "ACATCATCTG",
+        )
         self.assertEqual(record.contigs[0].reads[1].rd.sequence[-10:], "cATCTAGtac")
         self.assertEqual(record.contigs[0].reads[1].qa.qual_clipping_start, 7)
         self.assertEqual(record.contigs[0].reads[1].qa.qual_clipping_end, 778)
@@ -133,12 +165,19 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].uorc, "U")
         center = len(record.contigs[1].sequence) // 2
         self.assertEqual(record.contigs[1].sequence[:10], "cacggatgat")
-        self.assertEqual(record.contigs[1].sequence[center - 5:center + 5], "TTTGAATATT")
+        self.assertEqual(
+            record.contigs[1].sequence[center - 5 : center + 5], "TTTGAATATT"
+        )
         self.assertEqual(record.contigs[1].sequence[-10:], "Atccttgtag")
         center = len(record.contigs[1].quality) // 2
         self.assertEqual(record.contigs[1].quality[:10], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-        self.assertEqual(record.contigs[1].quality[center - 5:center + 5], [90, 90, 90, 90, 90, 90, 90, 90, 90, 90])
-        self.assertEqual(record.contigs[1].quality[-10:], [24, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        self.assertEqual(
+            record.contigs[1].quality[center - 5 : center + 5],
+            [90, 90, 90, 90, 90, 90, 90, 90, 90, 90],
+        )
+        self.assertEqual(
+            record.contigs[1].quality[-10:], [24, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        )
         self.assertEqual(len(record.contigs[1].af), 14)
         self.assertEqual(record.contigs[1].af[7].name, "BL060-LR3R.b.ab1")
         self.assertEqual(record.contigs[1].af[7].coru, "C")
@@ -160,12 +199,21 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].ct[0].padded_start, 42)
         self.assertEqual(record.contigs[1].ct[0].padded_end, 43)
         self.assertEqual(record.contigs[1].ct[0].date, "123456:765432")
-        self.assertEqual(record.contigs[1].ct[0].info, ["This is the forst line of comment for c2", "and this the second for c2"])
+        self.assertEqual(
+            record.contigs[1].ct[0].info,
+            ["This is the forst line of comment for c2", "and this the second for c2"],
+        )
         self.assertEqual(len(record.contigs[1].wa), 1)
         self.assertEqual(record.contigs[1].wa[0].tag_type, "phrap_params")
         self.assertEqual(record.contigs[1].wa[0].program, "phrap")
         self.assertEqual(record.contigs[1].wa[0].date, "040203:114710")
-        self.assertEqual(record.contigs[1].wa[0].info, ["phrap 304_nuclsu.fasta.screen -new_ace -retain_duplicates", "phrap version 0.990329"])
+        self.assertEqual(
+            record.contigs[1].wa[0].info,
+            [
+                "phrap 304_nuclsu.fasta.screen -new_ace -retain_duplicates",
+                "phrap version 0.990329",
+            ],
+        )
 
         self.assertEqual(len(record.contigs[1].reads), 14)
 
@@ -176,14 +224,21 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[0].rd.read_tags, 0)
         center = len(record.contigs[1].reads[0].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[0].rd.sequence[:10], "cacggatgat")
-        self.assertEqual(record.contigs[1].reads[0].rd.sequence[center - 5:center + 5], "GTTCTCGTTG")
+        self.assertEqual(
+            record.contigs[1].reads[0].rd.sequence[center - 5 : center + 5],
+            "GTTCTCGTTG",
+        )
         self.assertEqual(record.contigs[1].reads[0].rd.sequence[-10:], "CGTTTACCcg")
         self.assertEqual(record.contigs[1].reads[0].qa.qual_clipping_start, 81)
         self.assertEqual(record.contigs[1].reads[0].qa.qual_clipping_end, 842)
         self.assertEqual(record.contigs[1].reads[0].qa.align_clipping_start, 1)
         self.assertEqual(record.contigs[1].reads[0].qa.align_clipping_end, 862)
-        self.assertEqual(record.contigs[1].reads[0].ds.chromat_file, "BL060-c1-LR12.g.ab1")
-        self.assertEqual(record.contigs[1].reads[0].ds.phd_file, "BL060-c1-LR12.g.ab1.phd.1")
+        self.assertEqual(
+            record.contigs[1].reads[0].ds.chromat_file, "BL060-c1-LR12.g.ab1"
+        )
+        self.assertEqual(
+            record.contigs[1].reads[0].ds.phd_file, "BL060-c1-LR12.g.ab1.phd.1"
+        )
         self.assertEqual(record.contigs[1].reads[0].ds.time, "Tue Feb  3 11:01:16 2004")
         self.assertEqual(record.contigs[1].reads[0].ds.chem, "term")
         self.assertEqual(record.contigs[1].reads[0].ds.dye, "big")
@@ -199,14 +254,21 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[1].rd.read_tags, 0)
         center = len(record.contigs[1].reads[1].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[1].rd.sequence[:10], "ctttctgacC")
-        self.assertEqual(record.contigs[1].reads[1].rd.sequence[center - 5:center + 5], "CTGTGGTTTC")
+        self.assertEqual(
+            record.contigs[1].reads[1].rd.sequence[center - 5 : center + 5],
+            "CTGTGGTTTC",
+        )
         self.assertEqual(record.contigs[1].reads[1].rd.sequence[-10:], "cggagttacg")
         self.assertEqual(record.contigs[1].reads[1].qa.qual_clipping_start, 11)
         self.assertEqual(record.contigs[1].reads[1].qa.qual_clipping_end, 807)
         self.assertEqual(record.contigs[1].reads[1].qa.align_clipping_start, 8)
         self.assertEqual(record.contigs[1].reads[1].qa.align_clipping_end, 880)
-        self.assertEqual(record.contigs[1].reads[1].ds.chromat_file, "BL060-c1-LR11.g.ab1")
-        self.assertEqual(record.contigs[1].reads[1].ds.phd_file, "BL060-c1-LR11.g.ab1.phd.1")
+        self.assertEqual(
+            record.contigs[1].reads[1].ds.chromat_file, "BL060-c1-LR11.g.ab1"
+        )
+        self.assertEqual(
+            record.contigs[1].reads[1].ds.phd_file, "BL060-c1-LR11.g.ab1.phd.1"
+        )
         self.assertEqual(record.contigs[1].reads[1].ds.time, "Tue Feb  3 11:01:16 2004")
         self.assertEqual(record.contigs[1].reads[1].ds.chem, "term")
         self.assertEqual(record.contigs[1].reads[1].ds.dye, "big")
@@ -222,14 +284,21 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[2].rd.read_tags, 0)
         center = len(record.contigs[1].reads[2].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[2].rd.sequence[:10], "cacccaCTTT")
-        self.assertEqual(record.contigs[1].reads[2].rd.sequence[center - 5:center + 5], "ACCAAACATT")
+        self.assertEqual(
+            record.contigs[1].reads[2].rd.sequence[center - 5 : center + 5],
+            "ACCAAACATT",
+        )
         self.assertEqual(record.contigs[1].reads[2].rd.sequence[-10:], "GGTAGCACgc")
         self.assertEqual(record.contigs[1].reads[2].qa.qual_clipping_start, 7)
         self.assertEqual(record.contigs[1].reads[2].qa.qual_clipping_end, 840)
         self.assertEqual(record.contigs[1].reads[2].qa.align_clipping_start, 4)
         self.assertEqual(record.contigs[1].reads[2].qa.align_clipping_end, 864)
-        self.assertEqual(record.contigs[1].reads[2].ds.chromat_file, "BL060-c1-LR9.g.ab1")
-        self.assertEqual(record.contigs[1].reads[2].ds.phd_file, "BL060-c1-LR9.g.ab1.phd.1")
+        self.assertEqual(
+            record.contigs[1].reads[2].ds.chromat_file, "BL060-c1-LR9.g.ab1"
+        )
+        self.assertEqual(
+            record.contigs[1].reads[2].ds.phd_file, "BL060-c1-LR9.g.ab1.phd.1"
+        )
         self.assertEqual(record.contigs[1].reads[2].ds.time, "Tue Feb  3 11:01:16 2004")
         self.assertEqual(record.contigs[1].reads[2].ds.chem, "term")
         self.assertEqual(record.contigs[1].reads[2].ds.dye, "big")
@@ -245,14 +314,21 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[3].rd.read_tags, 0)
         center = len(record.contigs[1].reads[3].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[3].rd.sequence[:10], "ctaattggcc")
-        self.assertEqual(record.contigs[1].reads[3].rd.sequence[center - 5:center + 5], "GGAACCTTTC")
+        self.assertEqual(
+            record.contigs[1].reads[3].rd.sequence[center - 5 : center + 5],
+            "GGAACCTTTC",
+        )
         self.assertEqual(record.contigs[1].reads[3].rd.sequence[-10:], "CAACCTgact")
         self.assertEqual(record.contigs[1].reads[3].qa.qual_clipping_start, 63)
         self.assertEqual(record.contigs[1].reads[3].qa.qual_clipping_end, 857)
         self.assertEqual(record.contigs[1].reads[3].qa.align_clipping_start, 1)
         self.assertEqual(record.contigs[1].reads[3].qa.align_clipping_end, 861)
-        self.assertEqual(record.contigs[1].reads[3].ds.chromat_file, "BL060-c1-LR17R.b.ab1")
-        self.assertEqual(record.contigs[1].reads[3].ds.phd_file, "BL060-c1-LR17R.b.ab1.phd.1")
+        self.assertEqual(
+            record.contigs[1].reads[3].ds.chromat_file, "BL060-c1-LR17R.b.ab1"
+        )
+        self.assertEqual(
+            record.contigs[1].reads[3].ds.phd_file, "BL060-c1-LR17R.b.ab1.phd.1"
+        )
         self.assertEqual(record.contigs[1].reads[3].ds.time, "Tue Feb  3 11:01:16 2004")
         self.assertEqual(record.contigs[1].reads[3].ds.chem, "term")
         self.assertEqual(record.contigs[1].reads[3].ds.dye, "big")
@@ -268,14 +344,21 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[4].rd.read_tags, 0)
         center = len(record.contigs[1].reads[4].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[4].rd.sequence[:10], "tgCTGCGGTT")
-        self.assertEqual(record.contigs[1].reads[4].rd.sequence[center - 5:center + 5], "GGCAGTTTCA")
+        self.assertEqual(
+            record.contigs[1].reads[4].rd.sequence[center - 5 : center + 5],
+            "GGCAGTTTCA",
+        )
         self.assertEqual(record.contigs[1].reads[4].rd.sequence[-10:], "tactcataaa")
         self.assertEqual(record.contigs[1].reads[4].qa.qual_clipping_start, 13)
         self.assertEqual(record.contigs[1].reads[4].qa.qual_clipping_end, 729)
         self.assertEqual(record.contigs[1].reads[4].qa.align_clipping_start, 1)
         self.assertEqual(record.contigs[1].reads[4].qa.align_clipping_end, 877)
-        self.assertEqual(record.contigs[1].reads[4].ds.chromat_file, "BL060-LR8.5.g.ab1")
-        self.assertEqual(record.contigs[1].reads[4].ds.phd_file, "BL060-LR8.5.g.ab1.phd.1")
+        self.assertEqual(
+            record.contigs[1].reads[4].ds.chromat_file, "BL060-LR8.5.g.ab1"
+        )
+        self.assertEqual(
+            record.contigs[1].reads[4].ds.phd_file, "BL060-LR8.5.g.ab1.phd.1"
+        )
         self.assertEqual(record.contigs[1].reads[4].ds.time, "Fri Nov 14 09:46:03 2003")
         self.assertEqual(record.contigs[1].reads[4].ds.chem, "term")
         self.assertEqual(record.contigs[1].reads[4].ds.dye, "big")
@@ -291,14 +374,19 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[5].rd.read_tags, 0)
         center = len(record.contigs[1].reads[5].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[5].rd.sequence[:10], "ctCTTAGGAT")
-        self.assertEqual(record.contigs[1].reads[5].rd.sequence[center - 5:center + 5], "AACTCACATT")
+        self.assertEqual(
+            record.contigs[1].reads[5].rd.sequence[center - 5 : center + 5],
+            "AACTCACATT",
+        )
         self.assertEqual(record.contigs[1].reads[5].rd.sequence[-10:], "*CACCCAAac")
         self.assertEqual(record.contigs[1].reads[5].qa.qual_clipping_start, 65)
         self.assertEqual(record.contigs[1].reads[5].qa.qual_clipping_end, 874)
         self.assertEqual(record.contigs[1].reads[5].qa.align_clipping_start, 1)
         self.assertEqual(record.contigs[1].reads[5].qa.align_clipping_end, 874)
         self.assertEqual(record.contigs[1].reads[5].ds.chromat_file, "BL060-LR3R.b.ab1")
-        self.assertEqual(record.contigs[1].reads[5].ds.phd_file, "BL060-LR3R.b.ab1.phd.1")
+        self.assertEqual(
+            record.contigs[1].reads[5].ds.phd_file, "BL060-LR3R.b.ab1.phd.1"
+        )
         self.assertEqual(record.contigs[1].reads[5].ds.time, "Fri Nov 14 09:46:03 2003")
         self.assertEqual(record.contigs[1].reads[5].ds.chem, "term")
         self.assertEqual(record.contigs[1].reads[5].ds.dye, "big")
@@ -314,14 +402,21 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[6].rd.read_tags, 0)
         center = len(record.contigs[1].reads[6].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[6].rd.sequence[:10], "CCaTGTCCAA")
-        self.assertEqual(record.contigs[1].reads[6].rd.sequence[center - 5:center + 5], "AAGGGTT*CA")
+        self.assertEqual(
+            record.contigs[1].reads[6].rd.sequence[center - 5 : center + 5],
+            "AAGGGTT*CA",
+        )
         self.assertEqual(record.contigs[1].reads[6].rd.sequence[-10:], "ACACTCGCga")
         self.assertEqual(record.contigs[1].reads[6].qa.qual_clipping_start, 73)
         self.assertEqual(record.contigs[1].reads[6].qa.qual_clipping_end, 862)
         self.assertEqual(record.contigs[1].reads[6].qa.align_clipping_start, 1)
         self.assertEqual(record.contigs[1].reads[6].qa.align_clipping_end, 863)
-        self.assertEqual(record.contigs[1].reads[6].ds.chromat_file, "BL060-c1-LR3R.b.ab1")
-        self.assertEqual(record.contigs[1].reads[6].ds.phd_file, "BL060-c1-LR3R.b.ab1.phd.1")
+        self.assertEqual(
+            record.contigs[1].reads[6].ds.chromat_file, "BL060-c1-LR3R.b.ab1"
+        )
+        self.assertEqual(
+            record.contigs[1].reads[6].ds.phd_file, "BL060-c1-LR3R.b.ab1.phd.1"
+        )
         self.assertEqual(record.contigs[1].reads[6].ds.time, "Tue Feb  3 11:01:16 2004")
         self.assertEqual(record.contigs[1].reads[6].ds.chem, "term")
         self.assertEqual(record.contigs[1].reads[6].ds.dye, "big")
@@ -337,14 +432,19 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[7].rd.read_tags, 0)
         center = len(record.contigs[1].reads[7].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[7].rd.sequence[:10], "agaaagagga")
-        self.assertEqual(record.contigs[1].reads[7].rd.sequence[center - 5:center + 5], "nnnannnnnn")
+        self.assertEqual(
+            record.contigs[1].reads[7].rd.sequence[center - 5 : center + 5],
+            "nnnannnnnn",
+        )
         self.assertEqual(record.contigs[1].reads[7].rd.sequence[-10:], "gtctttgctc")
         self.assertEqual(record.contigs[1].reads[7].qa.qual_clipping_start, 548)
         self.assertEqual(record.contigs[1].reads[7].qa.qual_clipping_end, 847)
         self.assertEqual(record.contigs[1].reads[7].qa.align_clipping_start, 442)
         self.assertEqual(record.contigs[1].reads[7].qa.align_clipping_end, 854)
         self.assertEqual(record.contigs[1].reads[7].ds.chromat_file, "BL060-LR3R.b.ab1")
-        self.assertEqual(record.contigs[1].reads[7].ds.phd_file, "BL060-LR3R.b.ab1.phd.1")
+        self.assertEqual(
+            record.contigs[1].reads[7].ds.phd_file, "BL060-LR3R.b.ab1.phd.1"
+        )
         self.assertEqual(record.contigs[1].reads[7].ds.time, "Fri Jan 16 09:01:10 2004")
         self.assertEqual(record.contigs[1].reads[7].ds.chem, "term")
         self.assertEqual(record.contigs[1].reads[7].ds.dye, "big")
@@ -360,14 +460,21 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[8].rd.read_tags, 0)
         center = len(record.contigs[1].reads[8].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[8].rd.sequence[:10], "agTttc*ctc")
-        self.assertEqual(record.contigs[1].reads[8].rd.sequence[center - 5:center + 5], "TCATAAAACT")
+        self.assertEqual(
+            record.contigs[1].reads[8].rd.sequence[center - 5 : center + 5],
+            "TCATAAAACT",
+        )
         self.assertEqual(record.contigs[1].reads[8].rd.sequence[-10:], "xxxxxxxxxx")
         self.assertEqual(record.contigs[1].reads[8].qa.qual_clipping_start, 20)
         self.assertEqual(record.contigs[1].reads[8].qa.qual_clipping_end, 798)
         self.assertEqual(record.contigs[1].reads[8].qa.align_clipping_start, 1)
         self.assertEqual(record.contigs[1].reads[8].qa.align_clipping_end, 798)
-        self.assertEqual(record.contigs[1].reads[8].ds.chromat_file, "BL060-c1-LR7.g.ab1")
-        self.assertEqual(record.contigs[1].reads[8].ds.phd_file, "BL060-c1-LR7.g.ab1.phd.1")
+        self.assertEqual(
+            record.contigs[1].reads[8].ds.chromat_file, "BL060-c1-LR7.g.ab1"
+        )
+        self.assertEqual(
+            record.contigs[1].reads[8].ds.phd_file, "BL060-c1-LR7.g.ab1.phd.1"
+        )
         self.assertEqual(record.contigs[1].reads[8].ds.time, "Tue Feb  3 11:01:16 2004")
         self.assertEqual(record.contigs[1].reads[8].ds.chem, "term")
         self.assertEqual(record.contigs[1].reads[8].ds.dye, "big")
@@ -383,14 +490,19 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[9].rd.read_tags, 0)
         center = len(record.contigs[1].reads[9].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[9].rd.sequence[:10], "ggctaCGCCc")
-        self.assertEqual(record.contigs[1].reads[9].rd.sequence[center - 5:center + 5], "ATTGAGTTTC")
+        self.assertEqual(
+            record.contigs[1].reads[9].rd.sequence[center - 5 : center + 5],
+            "ATTGAGTTTC",
+        )
         self.assertEqual(record.contigs[1].reads[9].rd.sequence[-10:], "tggcgttgcg")
         self.assertEqual(record.contigs[1].reads[9].qa.qual_clipping_start, 14)
         self.assertEqual(record.contigs[1].reads[9].qa.qual_clipping_end, 765)
         self.assertEqual(record.contigs[1].reads[9].qa.align_clipping_start, 4)
         self.assertEqual(record.contigs[1].reads[9].qa.align_clipping_end, 765)
         self.assertEqual(record.contigs[1].reads[9].ds.chromat_file, "BL060-LR7.g.ab1")
-        self.assertEqual(record.contigs[1].reads[9].ds.phd_file, "BL060-LR7.g.ab1.phd.1")
+        self.assertEqual(
+            record.contigs[1].reads[9].ds.phd_file, "BL060-LR7.g.ab1.phd.1"
+        )
         self.assertEqual(record.contigs[1].reads[9].ds.time, "Fri Nov 14 09:46:03 2003")
         self.assertEqual(record.contigs[1].reads[9].ds.chem, "term")
         self.assertEqual(record.contigs[1].reads[9].ds.dye, "big")
@@ -406,15 +518,24 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[10].rd.read_tags, 0)
         center = len(record.contigs[1].reads[10].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[10].rd.sequence[:10], "ggtTCGATTA")
-        self.assertEqual(record.contigs[1].reads[10].rd.sequence[center - 5:center + 5], "ACCAATTGAC")
+        self.assertEqual(
+            record.contigs[1].reads[10].rd.sequence[center - 5 : center + 5],
+            "ACCAATTGAC",
+        )
         self.assertEqual(record.contigs[1].reads[10].rd.sequence[-10:], "ACCACCCatt")
         self.assertEqual(record.contigs[1].reads[10].qa.qual_clipping_start, 12)
         self.assertEqual(record.contigs[1].reads[10].qa.qual_clipping_end, 767)
         self.assertEqual(record.contigs[1].reads[10].qa.align_clipping_start, 1)
         self.assertEqual(record.contigs[1].reads[10].qa.align_clipping_end, 871)
-        self.assertEqual(record.contigs[1].reads[10].ds.chromat_file, "BL060c5-LR5.g.ab1")
-        self.assertEqual(record.contigs[1].reads[10].ds.phd_file, "BL060c5-LR5.g.ab1.phd.1")
-        self.assertEqual(record.contigs[1].reads[10].ds.time, "Fri Nov 14 09:46:03 2003")
+        self.assertEqual(
+            record.contigs[1].reads[10].ds.chromat_file, "BL060c5-LR5.g.ab1"
+        )
+        self.assertEqual(
+            record.contigs[1].reads[10].ds.phd_file, "BL060c5-LR5.g.ab1.phd.1"
+        )
+        self.assertEqual(
+            record.contigs[1].reads[10].ds.time, "Fri Nov 14 09:46:03 2003"
+        )
         self.assertEqual(record.contigs[1].reads[10].ds.chem, "term")
         self.assertEqual(record.contigs[1].reads[10].ds.dye, "big")
         self.assertEqual(record.contigs[1].reads[10].ds.template, "")
@@ -429,7 +550,10 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[11].rd.read_tags, 0)
         center = len(record.contigs[1].reads[11].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[11].rd.sequence[:10], "ggttcatatg")
-        self.assertEqual(record.contigs[1].reads[11].rd.sequence[center - 5:center + 5], "TAAAATCAGT")
+        self.assertEqual(
+            record.contigs[1].reads[11].rd.sequence[center - 5 : center + 5],
+            "TAAAATCAGT",
+        )
         self.assertEqual(record.contigs[1].reads[11].rd.sequence[-10:], "TCTTGCaata")
         self.assertEqual(record.contigs[1].reads[11].qa.qual_clipping_start, 11)
         self.assertEqual(record.contigs[1].reads[11].qa.qual_clipping_end, 757)
@@ -438,7 +562,9 @@ class AceTestOne(unittest.TestCase):
         self.assertIsNone(record.contigs[1].reads[11].ds)
         self.assertEqual(len(record.contigs[1].reads[11].rt), 1)
         self.assertEqual(record.contigs[1].reads[11].rt[0].name, "BL060c2-LR5.g.ab1")
-        self.assertEqual(record.contigs[1].reads[11].rt[0].tag_type, "matchElsewhereHighQual")
+        self.assertEqual(
+            record.contigs[1].reads[11].rt[0].tag_type, "matchElsewhereHighQual"
+        )
         self.assertEqual(record.contigs[1].reads[11].rt[0].program, "phrap")
         self.assertEqual(record.contigs[1].reads[11].rt[0].padded_start, 617)
         self.assertEqual(record.contigs[1].reads[11].rt[0].padded_end, 631)
@@ -452,22 +578,33 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[12].rd.read_tags, 0)
         center = len(record.contigs[1].reads[12].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[12].rd.sequence[:10], "cACTCGCGTA")
-        self.assertEqual(record.contigs[1].reads[12].rd.sequence[center - 5:center + 5], "CTCGTAAAAT")
+        self.assertEqual(
+            record.contigs[1].reads[12].rd.sequence[center - 5 : center + 5],
+            "CTCGTAAAAT",
+        )
         self.assertEqual(record.contigs[1].reads[12].rd.sequence[-10:], "aacccctgca")
         self.assertEqual(record.contigs[1].reads[12].qa.qual_clipping_start, 94)
         self.assertEqual(record.contigs[1].reads[12].qa.qual_clipping_end, 835)
         self.assertEqual(record.contigs[1].reads[12].qa.align_clipping_start, 1)
         self.assertEqual(record.contigs[1].reads[12].qa.align_clipping_end, 847)
-        self.assertEqual(record.contigs[1].reads[12].ds.chromat_file, "BL060c5-LR0R.b.ab1")
-        self.assertEqual(record.contigs[1].reads[12].ds.phd_file, "BL060c5-LR0R.b.ab1.phd.1")
-        self.assertEqual(record.contigs[1].reads[12].ds.time, "Wed Nov 12 08:16:30 2003")
+        self.assertEqual(
+            record.contigs[1].reads[12].ds.chromat_file, "BL060c5-LR0R.b.ab1"
+        )
+        self.assertEqual(
+            record.contigs[1].reads[12].ds.phd_file, "BL060c5-LR0R.b.ab1.phd.1"
+        )
+        self.assertEqual(
+            record.contigs[1].reads[12].ds.time, "Wed Nov 12 08:16:30 2003"
+        )
         self.assertEqual(record.contigs[1].reads[12].ds.chem, "term")
         self.assertEqual(record.contigs[1].reads[12].ds.dye, "big")
         self.assertEqual(record.contigs[1].reads[12].ds.template, "")
         self.assertEqual(record.contigs[1].reads[12].ds.direction, "")
         self.assertEqual(len(record.contigs[1].reads[12].rt), 1)
         self.assertEqual(record.contigs[1].reads[12].rt[0].name, "BL060c5-LR0R.b.ab1")
-        self.assertEqual(record.contigs[1].reads[12].rt[0].tag_type, "matchElsewhereHighQual")
+        self.assertEqual(
+            record.contigs[1].reads[12].rt[0].tag_type, "matchElsewhereHighQual"
+        )
         self.assertEqual(record.contigs[1].reads[12].rt[0].program, "phrap")
         self.assertEqual(record.contigs[1].reads[12].rt[0].padded_start, 617)
         self.assertEqual(record.contigs[1].reads[12].rt[0].padded_end, 631)
@@ -481,15 +618,24 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(record.contigs[1].reads[13].rd.read_tags, 0)
         center = len(record.contigs[1].reads[13].rd.sequence) // 2
         self.assertEqual(record.contigs[1].reads[13].rd.sequence[:10], "cgCGTa*tTG")
-        self.assertEqual(record.contigs[1].reads[13].rd.sequence[center - 5:center + 5], "GTAAAATATT")
+        self.assertEqual(
+            record.contigs[1].reads[13].rd.sequence[center - 5 : center + 5],
+            "GTAAAATATT",
+        )
         self.assertEqual(record.contigs[1].reads[13].rd.sequence[-10:], "Atccttgtag")
         self.assertEqual(record.contigs[1].reads[13].qa.qual_clipping_start, 33)
         self.assertEqual(record.contigs[1].reads[13].qa.qual_clipping_end, 831)
         self.assertEqual(record.contigs[1].reads[13].qa.align_clipping_start, 1)
         self.assertEqual(record.contigs[1].reads[13].qa.align_clipping_end, 852)
-        self.assertEqual(record.contigs[1].reads[13].ds.chromat_file, "BL060c2-LR0R.b.ab1")
-        self.assertEqual(record.contigs[1].reads[13].ds.phd_file, "BL060c2-LR0R.b.ab1.phd.1")
-        self.assertEqual(record.contigs[1].reads[13].ds.time, "Wed Nov 12 08:16:29 2003")
+        self.assertEqual(
+            record.contigs[1].reads[13].ds.chromat_file, "BL060c2-LR0R.b.ab1"
+        )
+        self.assertEqual(
+            record.contigs[1].reads[13].ds.phd_file, "BL060c2-LR0R.b.ab1.phd.1"
+        )
+        self.assertEqual(
+            record.contigs[1].reads[13].ds.time, "Wed Nov 12 08:16:29 2003"
+        )
         self.assertEqual(record.contigs[1].reads[13].ds.chem, "term")
         self.assertEqual(record.contigs[1].reads[13].ds.dye, "big")
         self.assertEqual(record.contigs[1].reads[13].ds.template, "")
@@ -515,11 +661,14 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.uorc, "U")
         center = len(contig.sequence) // 2
         self.assertEqual(contig.sequence[:10], "aatacgGGAT")
-        self.assertEqual(contig.sequence[center - 5:center + 5], "ACATCATCTG")
+        self.assertEqual(contig.sequence[center - 5 : center + 5], "ACATCATCTG")
         self.assertEqual(contig.sequence[-10:], "cATCTAGtac")
         center = len(contig.quality) // 2
         self.assertEqual(contig.quality[:10], [0, 0, 0, 0, 0, 0, 22, 23, 25, 28])
-        self.assertEqual(contig.quality[center - 5:center + 5], [90, 90, 90, 90, 90, 90, 90, 90, 90, 90])
+        self.assertEqual(
+            contig.quality[center - 5 : center + 5],
+            [90, 90, 90, 90, 90, 90, 90, 90, 90, 90],
+        )
         self.assertEqual(contig.quality[-10:], [15, 22, 30, 24, 28, 22, 21, 15, 19, 0])
         self.assertEqual(len(contig.af), 2)
         self.assertEqual(contig.af[1].name, "BL060c3-LR0R.b.ab1")
@@ -541,7 +690,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[0].rd.read_tags, 0)
         center = len(contig.reads[0].rd.sequence) // 2
         self.assertEqual(contig.reads[0].rd.sequence[:10], "tagcgaggaa")
-        self.assertEqual(contig.reads[0].rd.sequence[center - 5:center + 5], "CCGAGGCCAA")
+        self.assertEqual(
+            contig.reads[0].rd.sequence[center - 5 : center + 5], "CCGAGGCCAA"
+        )
         self.assertEqual(contig.reads[0].rd.sequence[-10:], "gaaccatcag")
         self.assertEqual(contig.reads[0].qa.qual_clipping_start, 80)
         self.assertEqual(contig.reads[0].qa.qual_clipping_end, 853)
@@ -574,7 +725,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[1].rd.read_tags, 0)
         center = len(contig.reads[1].rd.sequence) // 2
         self.assertEqual(contig.reads[1].rd.sequence[:10], "aatacgGGAT")
-        self.assertEqual(contig.reads[1].rd.sequence[center - 5:center + 5], "ACATCATCTG")
+        self.assertEqual(
+            contig.reads[1].rd.sequence[center - 5 : center + 5], "ACATCATCTG"
+        )
         self.assertEqual(contig.reads[1].rd.sequence[-10:], "cATCTAGtac")
         self.assertEqual(contig.reads[1].qa.qual_clipping_start, 7)
         self.assertEqual(contig.reads[1].qa.qual_clipping_end, 778)
@@ -594,11 +747,14 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.uorc, "U")
         center = len(contig.sequence) // 2
         self.assertEqual(contig.sequence[:10], "cacggatgat")
-        self.assertEqual(contig.sequence[center - 5:center + 5], "TTTGAATATT")
+        self.assertEqual(contig.sequence[center - 5 : center + 5], "TTTGAATATT")
         self.assertEqual(contig.sequence[-10:], "Atccttgtag")
         center = len(contig.quality) // 2
         self.assertEqual(contig.quality[:10], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-        self.assertEqual(contig.quality[center - 5:center + 5], [90, 90, 90, 90, 90, 90, 90, 90, 90, 90])
+        self.assertEqual(
+            contig.quality[center - 5 : center + 5],
+            [90, 90, 90, 90, 90, 90, 90, 90, 90, 90],
+        )
         self.assertEqual(contig.quality[-10:], [24, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         self.assertEqual(len(contig.af), 14)
         self.assertEqual(contig.af[7].name, "BL060-LR3R.b.ab1")
@@ -621,14 +777,23 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.ct[0].padded_start, 42)
         self.assertEqual(contig.ct[0].padded_end, 43)
         self.assertEqual(contig.ct[0].date, "123456:765432")
-        self.assertEqual(contig.ct[0].info, ["This is the forst line of comment for c2", "and this the second for c2"])
+        self.assertEqual(
+            contig.ct[0].info,
+            ["This is the forst line of comment for c2", "and this the second for c2"],
+        )
         self.assertEqual(contig.ct[1].name, "unrelated_Contig")
         self.assertEqual(contig.ct[1].tag_type, "repeat")
         self.assertEqual(contig.ct[1].program, "phrap")
         self.assertEqual(contig.ct[1].padded_start, 1142)
         self.assertEqual(contig.ct[1].padded_end, 143)
         self.assertEqual(contig.ct[1].date, "122226:722232")
-        self.assertEqual(contig.ct[1].info, ["This is the forst line of comment for the unrelated ct tag", "and this the second"])
+        self.assertEqual(
+            contig.ct[1].info,
+            [
+                "This is the forst line of comment for the unrelated ct tag",
+                "and this the second",
+            ],
+        )
 
         self.assertEqual(contig.ct[2].name, "Contig1")
         self.assertEqual(contig.ct[2].tag_type, "repeat")
@@ -636,13 +801,22 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.ct[2].padded_start, 52)
         self.assertEqual(contig.ct[2].padded_end, 53)
         self.assertEqual(contig.ct[2].date, "555456:555432")
-        self.assertEqual(contig.ct[2].info, ["This is the forst line of comment for c1", "and this the second for c1"])
+        self.assertEqual(
+            contig.ct[2].info,
+            ["This is the forst line of comment for c1", "and this the second for c1"],
+        )
 
         self.assertEqual(len(contig.wa), 1)
         self.assertEqual(contig.wa[0].tag_type, "phrap_params")
         self.assertEqual(contig.wa[0].program, "phrap")
         self.assertEqual(contig.wa[0].date, "040203:114710")
-        self.assertEqual(contig.wa[0].info, ["phrap 304_nuclsu.fasta.screen -new_ace -retain_duplicates", "phrap version 0.990329"])
+        self.assertEqual(
+            contig.wa[0].info,
+            [
+                "phrap 304_nuclsu.fasta.screen -new_ace -retain_duplicates",
+                "phrap version 0.990329",
+            ],
+        )
 
         self.assertEqual(len(contig.reads), 14)
 
@@ -653,7 +827,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[0].rd.read_tags, 0)
         center = len(contig.reads[0].rd.sequence) // 2
         self.assertEqual(contig.reads[0].rd.sequence[:10], "cacggatgat")
-        self.assertEqual(contig.reads[0].rd.sequence[center - 5:center + 5], "GTTCTCGTTG")
+        self.assertEqual(
+            contig.reads[0].rd.sequence[center - 5 : center + 5], "GTTCTCGTTG"
+        )
         self.assertEqual(contig.reads[0].rd.sequence[-10:], "CGTTTACCcg")
         self.assertEqual(contig.reads[0].qa.qual_clipping_start, 81)
         self.assertEqual(contig.reads[0].qa.qual_clipping_end, 842)
@@ -676,7 +852,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[1].rd.read_tags, 0)
         center = len(contig.reads[1].rd.sequence) // 2
         self.assertEqual(contig.reads[1].rd.sequence[:10], "ctttctgacC")
-        self.assertEqual(contig.reads[1].rd.sequence[center - 5:center + 5], "CTGTGGTTTC")
+        self.assertEqual(
+            contig.reads[1].rd.sequence[center - 5 : center + 5], "CTGTGGTTTC"
+        )
         self.assertEqual(contig.reads[1].rd.sequence[-10:], "cggagttacg")
         self.assertEqual(contig.reads[1].qa.qual_clipping_start, 11)
         self.assertEqual(contig.reads[1].qa.qual_clipping_end, 807)
@@ -705,7 +883,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[2].rd.read_tags, 0)
         center = len(contig.reads[2].rd.sequence) // 2
         self.assertEqual(contig.reads[2].rd.sequence[:10], "cacccaCTTT")
-        self.assertEqual(contig.reads[2].rd.sequence[center - 5:center + 5], "ACCAAACATT")
+        self.assertEqual(
+            contig.reads[2].rd.sequence[center - 5 : center + 5], "ACCAAACATT"
+        )
         self.assertEqual(contig.reads[2].rd.sequence[-10:], "GGTAGCACgc")
         self.assertEqual(contig.reads[2].qa.qual_clipping_start, 7)
         self.assertEqual(contig.reads[2].qa.qual_clipping_end, 840)
@@ -728,7 +908,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[3].rd.read_tags, 0)
         center = len(contig.reads[3].rd.sequence) // 2
         self.assertEqual(contig.reads[3].rd.sequence[:10], "ctaattggcc")
-        self.assertEqual(contig.reads[3].rd.sequence[center - 5:center + 5], "GGAACCTTTC")
+        self.assertEqual(
+            contig.reads[3].rd.sequence[center - 5 : center + 5], "GGAACCTTTC"
+        )
         self.assertEqual(contig.reads[3].rd.sequence[-10:], "CAACCTgact")
         self.assertEqual(contig.reads[3].qa.qual_clipping_start, 63)
         self.assertEqual(contig.reads[3].qa.qual_clipping_end, 857)
@@ -757,7 +939,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[4].rd.read_tags, 0)
         center = len(contig.reads[4].rd.sequence) // 2
         self.assertEqual(contig.reads[4].rd.sequence[:10], "tgCTGCGGTT")
-        self.assertEqual(contig.reads[4].rd.sequence[center - 5:center + 5], "GGCAGTTTCA")
+        self.assertEqual(
+            contig.reads[4].rd.sequence[center - 5 : center + 5], "GGCAGTTTCA"
+        )
         self.assertEqual(contig.reads[4].rd.sequence[-10:], "tactcataaa")
         self.assertEqual(contig.reads[4].qa.qual_clipping_start, 13)
         self.assertEqual(contig.reads[4].qa.qual_clipping_end, 729)
@@ -780,7 +964,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[5].rd.read_tags, 0)
         center = len(contig.reads[5].rd.sequence) // 2
         self.assertEqual(contig.reads[5].rd.sequence[:10], "ctCTTAGGAT")
-        self.assertEqual(contig.reads[5].rd.sequence[center - 5:center + 5], "AACTCACATT")
+        self.assertEqual(
+            contig.reads[5].rd.sequence[center - 5 : center + 5], "AACTCACATT"
+        )
         self.assertEqual(contig.reads[5].rd.sequence[-10:], "*CACCCAAac")
         self.assertEqual(contig.reads[5].qa.qual_clipping_start, 65)
         self.assertEqual(contig.reads[5].qa.qual_clipping_end, 874)
@@ -803,7 +989,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[6].rd.read_tags, 0)
         center = len(contig.reads[6].rd.sequence) // 2
         self.assertEqual(contig.reads[6].rd.sequence[:10], "CCaTGTCCAA")
-        self.assertEqual(contig.reads[6].rd.sequence[center - 5:center + 5], "AAGGGTT*CA")
+        self.assertEqual(
+            contig.reads[6].rd.sequence[center - 5 : center + 5], "AAGGGTT*CA"
+        )
         self.assertEqual(contig.reads[6].rd.sequence[-10:], "ACACTCGCga")
         self.assertEqual(contig.reads[6].qa.qual_clipping_start, 73)
         self.assertEqual(contig.reads[6].qa.qual_clipping_end, 862)
@@ -826,7 +1014,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[7].rd.read_tags, 0)
         center = len(contig.reads[7].rd.sequence) // 2
         self.assertEqual(contig.reads[7].rd.sequence[:10], "agaaagagga")
-        self.assertEqual(contig.reads[7].rd.sequence[center - 5:center + 5], "nnnannnnnn")
+        self.assertEqual(
+            contig.reads[7].rd.sequence[center - 5 : center + 5], "nnnannnnnn"
+        )
         self.assertEqual(contig.reads[7].rd.sequence[-10:], "gtctttgctc")
         self.assertEqual(contig.reads[7].qa.qual_clipping_start, 548)
         self.assertEqual(contig.reads[7].qa.qual_clipping_end, 847)
@@ -849,7 +1039,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[8].rd.read_tags, 0)
         center = len(contig.reads[8].rd.sequence) // 2
         self.assertEqual(contig.reads[8].rd.sequence[:10], "agTttc*ctc")
-        self.assertEqual(contig.reads[8].rd.sequence[center - 5:center + 5], "TCATAAAACT")
+        self.assertEqual(
+            contig.reads[8].rd.sequence[center - 5 : center + 5], "TCATAAAACT"
+        )
         self.assertEqual(contig.reads[8].rd.sequence[-10:], "xxxxxxxxxx")
         self.assertEqual(contig.reads[8].qa.qual_clipping_start, 20)
         self.assertEqual(contig.reads[8].qa.qual_clipping_end, 798)
@@ -872,7 +1064,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[9].rd.read_tags, 0)
         center = len(contig.reads[9].rd.sequence) // 2
         self.assertEqual(contig.reads[9].rd.sequence[:10], "ggctaCGCCc")
-        self.assertEqual(contig.reads[9].rd.sequence[center - 5:center + 5], "ATTGAGTTTC")
+        self.assertEqual(
+            contig.reads[9].rd.sequence[center - 5 : center + 5], "ATTGAGTTTC"
+        )
         self.assertEqual(contig.reads[9].rd.sequence[-10:], "tggcgttgcg")
         self.assertEqual(contig.reads[9].qa.qual_clipping_start, 14)
         self.assertEqual(contig.reads[9].qa.qual_clipping_end, 765)
@@ -895,7 +1089,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[10].rd.read_tags, 0)
         center = len(contig.reads[10].rd.sequence) // 2
         self.assertEqual(contig.reads[10].rd.sequence[:10], "ggtTCGATTA")
-        self.assertEqual(contig.reads[10].rd.sequence[center - 5:center + 5], "ACCAATTGAC")
+        self.assertEqual(
+            contig.reads[10].rd.sequence[center - 5 : center + 5], "ACCAATTGAC"
+        )
         self.assertEqual(contig.reads[10].rd.sequence[-10:], "ACCACCCatt")
         self.assertEqual(contig.reads[10].qa.qual_clipping_start, 12)
         self.assertEqual(contig.reads[10].qa.qual_clipping_end, 767)
@@ -918,7 +1114,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[11].rd.read_tags, 0)
         center = len(contig.reads[11].rd.sequence) // 2
         self.assertEqual(contig.reads[11].rd.sequence[:10], "ggttcatatg")
-        self.assertEqual(contig.reads[11].rd.sequence[center - 5:center + 5], "TAAAATCAGT")
+        self.assertEqual(
+            contig.reads[11].rd.sequence[center - 5 : center + 5], "TAAAATCAGT"
+        )
         self.assertEqual(contig.reads[11].rd.sequence[-10:], "TCTTGCaata")
         self.assertEqual(contig.reads[11].qa.qual_clipping_start, 11)
         self.assertEqual(contig.reads[11].qa.qual_clipping_end, 757)
@@ -941,7 +1139,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[12].rd.read_tags, 0)
         center = len(contig.reads[12].rd.sequence) // 2
         self.assertEqual(contig.reads[12].rd.sequence[:10], "cACTCGCGTA")
-        self.assertEqual(contig.reads[12].rd.sequence[center - 5:center + 5], "CTCGTAAAAT")
+        self.assertEqual(
+            contig.reads[12].rd.sequence[center - 5 : center + 5], "CTCGTAAAAT"
+        )
         self.assertEqual(contig.reads[12].rd.sequence[-10:], "aacccctgca")
         self.assertEqual(contig.reads[12].qa.qual_clipping_start, 94)
         self.assertEqual(contig.reads[12].qa.qual_clipping_end, 835)
@@ -964,7 +1164,9 @@ class AceTestOne(unittest.TestCase):
         self.assertEqual(contig.reads[13].rd.read_tags, 0)
         center = len(contig.reads[13].rd.sequence) // 2
         self.assertEqual(contig.reads[13].rd.sequence[:10], "cgCGTa*tTG")
-        self.assertEqual(contig.reads[13].rd.sequence[center - 5:center + 5], "GTAAAATATT")
+        self.assertEqual(
+            contig.reads[13].rd.sequence[center - 5 : center + 5], "GTAAAATATT"
+        )
         self.assertEqual(contig.reads[13].rd.sequence[-10:], "Atccttgtag")
         self.assertEqual(contig.reads[13].qa.qual_clipping_start, 33)
         self.assertEqual(contig.reads[13].qa.qual_clipping_end, 831)
@@ -1023,12 +1225,21 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(record.contigs[0].uorc, "U")
         center = len(record.contigs[0].sequence) // 2
         self.assertEqual(record.contigs[0].sequence[:10], "AGTTTTAGTT")
-        self.assertEqual(record.contigs[0].sequence[center - 5:center + 5], "TGTGCGCGCA")
+        self.assertEqual(
+            record.contigs[0].sequence[center - 5 : center + 5], "TGTGCGCGCA"
+        )
         self.assertEqual(record.contigs[0].sequence[-10:], "ATATCACATT")
         center = len(record.contigs[0].quality) // 2
-        self.assertEqual(record.contigs[0].quality[:10], [61, 66, 67, 70, 71, 73, 73, 77, 77, 87])
-        self.assertEqual(record.contigs[0].quality[center - 5:center + 5], [97, 97, 97, 97, 97, 97, 97, 97, 97, 97])
-        self.assertEqual(record.contigs[0].quality[-10:], [56, 51, 49, 41, 38, 39, 45, 44, 49, 46])
+        self.assertEqual(
+            record.contigs[0].quality[:10], [61, 66, 67, 70, 71, 73, 73, 77, 77, 87]
+        )
+        self.assertEqual(
+            record.contigs[0].quality[center - 5 : center + 5],
+            [97, 97, 97, 97, 97, 97, 97, 97, 97, 97],
+        )
+        self.assertEqual(
+            record.contigs[0].quality[-10:], [56, 51, 49, 41, 38, 39, 45, 44, 49, 46]
+        )
         self.assertEqual(len(record.contigs[0].af), 6)
         self.assertEqual(len(record.contigs[0].bs), 0)
         self.assertEqual(record.contigs[0].af[3].name, "R5")
@@ -1048,7 +1259,10 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[0].rd.read_tags, 0)
         center = len(record.contigs[0].reads[0].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[0].rd.sequence[:10], "NNNNNNNNNN")
-        self.assertEqual(record.contigs[0].reads[0].rd.sequence[center - 5:center + 5], "ATGTGCGCTC")
+        self.assertEqual(
+            record.contigs[0].reads[0].rd.sequence[center - 5 : center + 5],
+            "ATGTGCGCTC",
+        )
         self.assertEqual(record.contigs[0].reads[0].rd.sequence[-10:], "CAGCTCACCA")
         self.assertEqual(record.contigs[0].reads[0].qa.qual_clipping_start, 55)
         self.assertEqual(record.contigs[0].reads[0].qa.qual_clipping_end, 916)
@@ -1070,7 +1284,10 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[1].rd.read_tags, 0)
         center = len(record.contigs[0].reads[1].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[1].rd.sequence[:10], "AGCCGGTACC")
-        self.assertEqual(record.contigs[0].reads[1].rd.sequence[center - 5:center + 5], "GGGATGGCAC")
+        self.assertEqual(
+            record.contigs[0].reads[1].rd.sequence[center - 5 : center + 5],
+            "GGGATGGCAC",
+        )
         self.assertEqual(record.contigs[0].reads[1].rd.sequence[-10:], "GGGCTGGGAG")
         self.assertEqual(record.contigs[0].reads[1].qa.qual_clipping_start, 12)
         self.assertEqual(record.contigs[0].reads[1].qa.qual_clipping_end, 863)
@@ -1092,7 +1309,10 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[2].rd.read_tags, 0)
         center = len(record.contigs[0].reads[2].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[2].rd.sequence[:10], "NNNNNNNNNN")
-        self.assertEqual(record.contigs[0].reads[2].rd.sequence[center - 5:center + 5], "GGATGCCTGG")
+        self.assertEqual(
+            record.contigs[0].reads[2].rd.sequence[center - 5 : center + 5],
+            "GGATGCCTGG",
+        )
         self.assertEqual(record.contigs[0].reads[2].rd.sequence[-10:], "GGTTGAGGCC")
         self.assertEqual(record.contigs[0].reads[2].qa.qual_clipping_start, 55)
         self.assertEqual(record.contigs[0].reads[2].qa.qual_clipping_end, 1000)
@@ -1114,7 +1334,10 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[3].rd.read_tags, 0)
         center = len(record.contigs[0].reads[3].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[3].rd.sequence[:10], "NNNNNNNNNN")
-        self.assertEqual(record.contigs[0].reads[3].rd.sequence[center - 5:center + 5], "CCTCCCTACA")
+        self.assertEqual(
+            record.contigs[0].reads[3].rd.sequence[center - 5 : center + 5],
+            "CCTCCCTACA",
+        )
         self.assertEqual(record.contigs[0].reads[3].rd.sequence[-10:], "GCCCCCGGNN")
         self.assertEqual(record.contigs[0].reads[3].qa.qual_clipping_start, 293)
         self.assertEqual(record.contigs[0].reads[3].qa.qual_clipping_end, 874)
@@ -1136,7 +1359,10 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[4].rd.read_tags, 0)
         center = len(record.contigs[0].reads[4].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[4].rd.sequence[:10], "CACTCAGCTC")
-        self.assertEqual(record.contigs[0].reads[4].rd.sequence[center - 5:center + 5], "TCCAAAGGGT")
+        self.assertEqual(
+            record.contigs[0].reads[4].rd.sequence[center - 5 : center + 5],
+            "TCCAAAGGGT",
+        )
         self.assertEqual(record.contigs[0].reads[4].rd.sequence[-10:], "AGCTGAATCG")
         self.assertEqual(record.contigs[0].reads[4].qa.qual_clipping_start, 1)
         self.assertEqual(record.contigs[0].reads[4].qa.qual_clipping_end, 799)
@@ -1158,7 +1384,10 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[5].rd.read_tags, 0)
         center = len(record.contigs[0].reads[5].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[5].rd.sequence[:10], "CCGGCAGTGA")
-        self.assertEqual(record.contigs[0].reads[5].rd.sequence[center - 5:center + 5], "AAAAAAAACC")
+        self.assertEqual(
+            record.contigs[0].reads[5].rd.sequence[center - 5 : center + 5],
+            "AAAAAAAACC",
+        )
         self.assertEqual(record.contigs[0].reads[5].rd.sequence[-10:], "NNNNNNNNNN")
         self.assertEqual(record.contigs[0].reads[5].qa.qual_clipping_start, 24)
         self.assertEqual(record.contigs[0].reads[5].qa.qual_clipping_end, 706)
@@ -1189,11 +1418,14 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(contig.uorc, "U")
         center = len(contig.sequence) // 2
         self.assertEqual(contig.sequence[:10], "AGTTTTAGTT")
-        self.assertEqual(contig.sequence[center - 5:center + 5], "TGTGCGCGCA")
+        self.assertEqual(contig.sequence[center - 5 : center + 5], "TGTGCGCGCA")
         self.assertEqual(contig.sequence[-10:], "ATATCACATT")
         center = len(contig.quality) // 2
         self.assertEqual(contig.quality[:10], [61, 66, 67, 70, 71, 73, 73, 77, 77, 87])
-        self.assertEqual(contig.quality[center - 5:center + 5], [97, 97, 97, 97, 97, 97, 97, 97, 97, 97])
+        self.assertEqual(
+            contig.quality[center - 5 : center + 5],
+            [97, 97, 97, 97, 97, 97, 97, 97, 97, 97],
+        )
         self.assertEqual(contig.quality[-10:], [56, 51, 49, 41, 38, 39, 45, 44, 49, 46])
         self.assertEqual(len(contig.af), 6)
         self.assertEqual(len(contig.bs), 0)
@@ -1214,7 +1446,9 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(contig.reads[0].rd.read_tags, 0)
         center = len(contig.reads[0].rd.sequence) // 2
         self.assertEqual(contig.reads[0].rd.sequence[:10], "NNNNNNNNNN")
-        self.assertEqual(contig.reads[0].rd.sequence[center - 5:center + 5], "ATGTGCGCTC")
+        self.assertEqual(
+            contig.reads[0].rd.sequence[center - 5 : center + 5], "ATGTGCGCTC"
+        )
         self.assertEqual(contig.reads[0].rd.sequence[-10:], "CAGCTCACCA")
         self.assertEqual(contig.reads[0].qa.qual_clipping_start, 55)
         self.assertEqual(contig.reads[0].qa.qual_clipping_end, 916)
@@ -1236,7 +1470,9 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(contig.reads[1].rd.read_tags, 0)
         center = len(contig.reads[1].rd.sequence) // 2
         self.assertEqual(contig.reads[1].rd.sequence[:10], "AGCCGGTACC")
-        self.assertEqual(contig.reads[1].rd.sequence[center - 5:center + 5], "GGGATGGCAC")
+        self.assertEqual(
+            contig.reads[1].rd.sequence[center - 5 : center + 5], "GGGATGGCAC"
+        )
         self.assertEqual(contig.reads[1].rd.sequence[-10:], "GGGCTGGGAG")
         self.assertEqual(contig.reads[1].qa.qual_clipping_start, 12)
         self.assertEqual(contig.reads[1].qa.qual_clipping_end, 863)
@@ -1258,7 +1494,9 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(contig.reads[2].rd.read_tags, 0)
         center = len(contig.reads[2].rd.sequence) // 2
         self.assertEqual(contig.reads[2].rd.sequence[:10], "NNNNNNNNNN")
-        self.assertEqual(contig.reads[2].rd.sequence[center - 5:center + 5], "GGATGCCTGG")
+        self.assertEqual(
+            contig.reads[2].rd.sequence[center - 5 : center + 5], "GGATGCCTGG"
+        )
         self.assertEqual(contig.reads[2].rd.sequence[-10:], "GGTTGAGGCC")
         self.assertEqual(contig.reads[2].qa.qual_clipping_start, 55)
         self.assertEqual(contig.reads[2].qa.qual_clipping_end, 1000)
@@ -1280,7 +1518,9 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(contig.reads[3].rd.read_tags, 0)
         center = len(contig.reads[3].rd.sequence) // 2
         self.assertEqual(contig.reads[3].rd.sequence[:10], "NNNNNNNNNN")
-        self.assertEqual(contig.reads[3].rd.sequence[center - 5:center + 5], "CCTCCCTACA")
+        self.assertEqual(
+            contig.reads[3].rd.sequence[center - 5 : center + 5], "CCTCCCTACA"
+        )
         self.assertEqual(contig.reads[3].rd.sequence[-10:], "GCCCCCGGNN")
         self.assertEqual(contig.reads[3].qa.qual_clipping_start, 293)
         self.assertEqual(contig.reads[3].qa.qual_clipping_end, 874)
@@ -1302,7 +1542,9 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(contig.reads[4].rd.read_tags, 0)
         center = len(contig.reads[4].rd.sequence) // 2
         self.assertEqual(contig.reads[4].rd.sequence[:10], "CACTCAGCTC")
-        self.assertEqual(contig.reads[4].rd.sequence[center - 5:center + 5], "TCCAAAGGGT")
+        self.assertEqual(
+            contig.reads[4].rd.sequence[center - 5 : center + 5], "TCCAAAGGGT"
+        )
         self.assertEqual(contig.reads[4].rd.sequence[-10:], "AGCTGAATCG")
         self.assertEqual(contig.reads[4].qa.qual_clipping_start, 1)
         self.assertEqual(contig.reads[4].qa.qual_clipping_end, 799)
@@ -1324,7 +1566,9 @@ class AceTestTwo(unittest.TestCase):
         self.assertEqual(contig.reads[5].rd.read_tags, 0)
         center = len(contig.reads[5].rd.sequence) // 2
         self.assertEqual(contig.reads[5].rd.sequence[:10], "CCGGCAGTGA")
-        self.assertEqual(contig.reads[5].rd.sequence[center - 5:center + 5], "AAAAAAAACC")
+        self.assertEqual(
+            contig.reads[5].rd.sequence[center - 5 : center + 5], "AAAAAAAACC"
+        )
         self.assertEqual(contig.reads[5].rd.sequence[-10:], "NNNNNNNNNN")
         self.assertEqual(contig.reads[5].qa.qual_clipping_start, 24)
         self.assertEqual(contig.reads[5].qa.qual_clipping_end, 706)
@@ -1366,7 +1610,13 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(record.wa[0].tag_type, "phrap_params")
         self.assertEqual(record.wa[0].program, "phrap")
         self.assertEqual(record.wa[0].date, "990621:161947")
-        self.assertEqual(record.wa[0].info, ["/usr/local/genome/bin/phrap standard.fasta.screen -new_ace -view", "phrap version 0.990319"])
+        self.assertEqual(
+            record.wa[0].info,
+            [
+                "/usr/local/genome/bin/phrap standard.fasta.screen -new_ace -view",
+                "phrap version 0.990319",
+            ],
+        )
         self.assertEqual(len(record.contigs), 1)
 
         self.assertEqual(len(record.contigs[0].reads), 8)
@@ -1377,12 +1627,19 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(record.contigs[0].uorc, "U")
         center = len(record.contigs[0].sequence) // 2
         self.assertEqual(record.contigs[0].sequence[:10], "agccccgggc")
-        self.assertEqual(record.contigs[0].sequence[center - 5:center + 5], "CTTCCCCAGG")
+        self.assertEqual(
+            record.contigs[0].sequence[center - 5 : center + 5], "CTTCCCCAGG"
+        )
         self.assertEqual(record.contigs[0].sequence[-10:], "gttgggtttg")
         center = len(record.contigs[0].quality) // 2
         self.assertEqual(record.contigs[0].quality[:10], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-        self.assertEqual(record.contigs[0].quality[center - 5:center + 5], [90, 90, 90, 90, 90, 90, 90, 90, 89, 89])
-        self.assertEqual(record.contigs[0].quality[-10:], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        self.assertEqual(
+            record.contigs[0].quality[center - 5 : center + 5],
+            [90, 90, 90, 90, 90, 90, 90, 90, 89, 89],
+        )
+        self.assertEqual(
+            record.contigs[0].quality[-10:], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        )
         self.assertEqual(len(record.contigs[0].af), 8)
         self.assertEqual(len(record.contigs[0].bs), 156)
         self.assertEqual(record.contigs[0].af[4].name, "K26-291s")
@@ -1411,19 +1668,31 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(record.contigs[0].ct[1].padded_start, 996)
         self.assertEqual(record.contigs[0].ct[1].padded_end, 1007)
         self.assertEqual(record.contigs[0].ct[1].date, "971218:180623")
-        self.assertEqual(record.contigs[0].ct[1].info, ["This is line 1 of a comment", "There may be any number of lines"])
+        self.assertEqual(
+            record.contigs[0].ct[1].info,
+            ["This is line 1 of a comment", "There may be any number of lines"],
+        )
         self.assertEqual(record.contigs[0].ct[2].name, "Contig1")
         self.assertEqual(record.contigs[0].ct[2].tag_type, "oligo")
         self.assertEqual(record.contigs[0].ct[2].program, "consed")
         self.assertEqual(record.contigs[0].ct[2].padded_start, 963)
         self.assertEqual(record.contigs[0].ct[2].padded_end, 987)
         self.assertEqual(record.contigs[0].ct[2].date, "971218:180623")
-        self.assertEqual(record.contigs[0].ct[2].info, ["standard.1 acataagacattctaaatttttact 50 U", "seq from clone"])
+        self.assertEqual(
+            record.contigs[0].ct[2].info,
+            ["standard.1 acataagacattctaaatttttact 50 U", "seq from clone"],
+        )
         self.assertEqual(len(record.contigs[0].wa), 1)
         self.assertEqual(record.contigs[0].wa[0].tag_type, "phrap_params")
         self.assertEqual(record.contigs[0].wa[0].program, "phrap")
         self.assertEqual(record.contigs[0].wa[0].date, "990621:161947")
-        self.assertEqual(record.contigs[0].wa[0].info, ["/usr/local/genome/bin/phrap standard.fasta.screen -new_ace -view", "phrap version 0.990319"])
+        self.assertEqual(
+            record.contigs[0].wa[0].info,
+            [
+                "/usr/local/genome/bin/phrap standard.fasta.screen -new_ace -view",
+                "phrap version 0.990319",
+            ],
+        )
 
         self.assertEqual(len(record.contigs[0].reads), 8)
 
@@ -1433,7 +1702,10 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[0].rd.read_tags, 0)
         center = len(record.contigs[0].reads[0].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[0].rd.sequence[:10], "tcccCgtgag")
-        self.assertEqual(record.contigs[0].reads[0].rd.sequence[center - 5:center + 5], "CTCCTGcctg")
+        self.assertEqual(
+            record.contigs[0].reads[0].rd.sequence[center - 5 : center + 5],
+            "CTCCTGcctg",
+        )
         self.assertEqual(record.contigs[0].reads[0].rd.sequence[-10:], "ggcccccctc")
         self.assertEqual(record.contigs[0].reads[0].qa.qual_clipping_start, 19)
         self.assertEqual(record.contigs[0].reads[0].qa.qual_clipping_end, 349)
@@ -1455,7 +1727,10 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[1].rd.read_tags, 0)
         center = len(record.contigs[0].reads[1].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[1].rd.sequence[:10], "ccgtcctgag")
-        self.assertEqual(record.contigs[0].reads[1].rd.sequence[center - 5:center + 5], "cacagcccT*")
+        self.assertEqual(
+            record.contigs[0].reads[1].rd.sequence[center - 5 : center + 5],
+            "cacagcccT*",
+        )
         self.assertEqual(record.contigs[0].reads[1].rd.sequence[-10:], "Ttttgtttta")
         self.assertEqual(record.contigs[0].reads[1].qa.qual_clipping_start, 12)
         self.assertEqual(record.contigs[0].reads[1].qa.qual_clipping_end, 353)
@@ -1477,7 +1752,10 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[2].rd.read_tags, 0)
         center = len(record.contigs[0].reads[2].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[2].rd.sequence[:10], "aatattaccg")
-        self.assertEqual(record.contigs[0].reads[2].rd.sequence[center - 5:center + 5], "CAGATGGGTT")
+        self.assertEqual(
+            record.contigs[0].reads[2].rd.sequence[center - 5 : center + 5],
+            "CAGATGGGTT",
+        )
         self.assertEqual(record.contigs[0].reads[2].rd.sequence[-10:], "ctattcaggg")
         self.assertEqual(record.contigs[0].reads[2].qa.qual_clipping_start, 20)
         self.assertEqual(record.contigs[0].reads[2].qa.qual_clipping_end, 415)
@@ -1499,7 +1777,10 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[3].rd.read_tags, 0)
         center = len(record.contigs[0].reads[3].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[3].rd.sequence[:10], "ctgcgtatcg")
-        self.assertEqual(record.contigs[0].reads[3].rd.sequence[center - 5:center + 5], "AGGATTGCTT")
+        self.assertEqual(
+            record.contigs[0].reads[3].rd.sequence[center - 5 : center + 5],
+            "AGGATTGCTT",
+        )
         self.assertEqual(record.contigs[0].reads[3].rd.sequence[-10:], "aaccctgggt")
         self.assertEqual(record.contigs[0].reads[3].qa.qual_clipping_start, 18)
         self.assertEqual(record.contigs[0].reads[3].qa.qual_clipping_end, 368)
@@ -1521,7 +1802,10 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[4].rd.read_tags, 0)
         center = len(record.contigs[0].reads[4].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[4].rd.sequence[:10], "gaggatcgct")
-        self.assertEqual(record.contigs[0].reads[4].rd.sequence[center - 5:center + 5], "GTgcgaggat")
+        self.assertEqual(
+            record.contigs[0].reads[4].rd.sequence[center - 5 : center + 5],
+            "GTgcgaggat",
+        )
         self.assertEqual(record.contigs[0].reads[4].rd.sequence[-10:], "caggcagatg")
         self.assertEqual(record.contigs[0].reads[4].qa.qual_clipping_start, 11)
         self.assertEqual(record.contigs[0].reads[4].qa.qual_clipping_end, 373)
@@ -1543,7 +1827,10 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[5].rd.read_tags, 0)
         center = len(record.contigs[0].reads[5].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[5].rd.sequence[:10], "ggggatccg*")
-        self.assertEqual(record.contigs[0].reads[5].rd.sequence[center - 5:center + 5], "GCaAgacCCt")
+        self.assertEqual(
+            record.contigs[0].reads[5].rd.sequence[center - 5 : center + 5],
+            "GCaAgacCCt",
+        )
         self.assertEqual(record.contigs[0].reads[5].rd.sequence[-10:], "gttgggtttg")
 
         self.assertEqual(record.contigs[0].reads[5].qa.qual_clipping_start, 25)
@@ -1566,7 +1853,10 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[6].rd.read_tags, 0)
         center = len(record.contigs[0].reads[6].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[6].rd.sequence[:10], "agccccgggc")
-        self.assertEqual(record.contigs[0].reads[6].rd.sequence[center - 5:center + 5], "ggatcACATA")
+        self.assertEqual(
+            record.contigs[0].reads[6].rd.sequence[center - 5 : center + 5],
+            "ggatcACATA",
+        )
         self.assertEqual(record.contigs[0].reads[6].rd.sequence[-10:], "aatagtaaca")
         self.assertEqual(record.contigs[0].reads[6].qa.qual_clipping_start, 249)
         self.assertEqual(record.contigs[0].reads[6].qa.qual_clipping_end, 584)
@@ -1588,7 +1878,10 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(record.contigs[0].reads[7].rd.read_tags, 0)
         center = len(record.contigs[0].reads[7].rd.sequence) // 2
         self.assertEqual(record.contigs[0].reads[7].rd.sequence[:10], "gaataattgg")
-        self.assertEqual(record.contigs[0].reads[7].rd.sequence[center - 5:center + 5], "TggCCCATCT")
+        self.assertEqual(
+            record.contigs[0].reads[7].rd.sequence[center - 5 : center + 5],
+            "TggCCCATCT",
+        )
         self.assertEqual(record.contigs[0].reads[7].rd.sequence[-10:], "gaaccacacg")
         self.assertEqual(record.contigs[0].reads[7].qa.qual_clipping_start, 240)
         self.assertEqual(record.contigs[0].reads[7].qa.qual_clipping_end, 584)
@@ -1619,11 +1912,14 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(contig.uorc, "U")
         center = len(contig.sequence) // 2
         self.assertEqual(contig.sequence[:10], "agccccgggc")
-        self.assertEqual(contig.sequence[center - 5:center + 5], "CTTCCCCAGG")
+        self.assertEqual(contig.sequence[center - 5 : center + 5], "CTTCCCCAGG")
         self.assertEqual(contig.sequence[-10:], "gttgggtttg")
         center = len(contig.quality) // 2
         self.assertEqual(contig.quality[:10], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
-        self.assertEqual(contig.quality[center - 5:center + 5], [90, 90, 90, 90, 90, 90, 90, 90, 89, 89])
+        self.assertEqual(
+            contig.quality[center - 5 : center + 5],
+            [90, 90, 90, 90, 90, 90, 90, 90, 89, 89],
+        )
         self.assertEqual(contig.quality[-10:], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         self.assertEqual(len(contig.af), 8)
         self.assertEqual(len(contig.bs), 156)
@@ -1653,19 +1949,31 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(contig.ct[1].padded_start, 996)
         self.assertEqual(contig.ct[1].padded_end, 1007)
         self.assertEqual(contig.ct[1].date, "971218:180623")
-        self.assertEqual(contig.ct[1].info, ["This is line 1 of a comment", "There may be any number of lines"])
+        self.assertEqual(
+            contig.ct[1].info,
+            ["This is line 1 of a comment", "There may be any number of lines"],
+        )
         self.assertEqual(contig.ct[2].name, "Contig1")
         self.assertEqual(contig.ct[2].tag_type, "oligo")
         self.assertEqual(contig.ct[2].program, "consed")
         self.assertEqual(contig.ct[2].padded_start, 963)
         self.assertEqual(contig.ct[2].padded_end, 987)
         self.assertEqual(contig.ct[2].date, "971218:180623")
-        self.assertEqual(contig.ct[2].info, ["standard.1 acataagacattctaaatttttact 50 U", "seq from clone"])
+        self.assertEqual(
+            contig.ct[2].info,
+            ["standard.1 acataagacattctaaatttttact 50 U", "seq from clone"],
+        )
         self.assertEqual(len(contig.wa), 1)
         self.assertEqual(contig.wa[0].tag_type, "phrap_params")
         self.assertEqual(contig.wa[0].program, "phrap")
         self.assertEqual(contig.wa[0].date, "990621:161947")
-        self.assertEqual(contig.wa[0].info, ["/usr/local/genome/bin/phrap standard.fasta.screen -new_ace -view", "phrap version 0.990319"])
+        self.assertEqual(
+            contig.wa[0].info,
+            [
+                "/usr/local/genome/bin/phrap standard.fasta.screen -new_ace -view",
+                "phrap version 0.990319",
+            ],
+        )
 
         self.assertEqual(len(contig.reads), 8)
 
@@ -1675,7 +1983,9 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(contig.reads[0].rd.read_tags, 0)
         center = len(contig.reads[0].rd.sequence) // 2
         self.assertEqual(contig.reads[0].rd.sequence[:10], "tcccCgtgag")
-        self.assertEqual(contig.reads[0].rd.sequence[center - 5:center + 5], "CTCCTGcctg")
+        self.assertEqual(
+            contig.reads[0].rd.sequence[center - 5 : center + 5], "CTCCTGcctg"
+        )
         self.assertEqual(contig.reads[0].rd.sequence[-10:], "ggcccccctc")
         self.assertEqual(contig.reads[0].qa.qual_clipping_start, 19)
         self.assertEqual(contig.reads[0].qa.qual_clipping_end, 349)
@@ -1697,7 +2007,9 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(contig.reads[1].rd.read_tags, 0)
         center = len(contig.reads[1].rd.sequence) // 2
         self.assertEqual(contig.reads[1].rd.sequence[:10], "ccgtcctgag")
-        self.assertEqual(contig.reads[1].rd.sequence[center - 5:center + 5], "cacagcccT*")
+        self.assertEqual(
+            contig.reads[1].rd.sequence[center - 5 : center + 5], "cacagcccT*"
+        )
         self.assertEqual(contig.reads[1].rd.sequence[-10:], "Ttttgtttta")
         self.assertEqual(contig.reads[1].qa.qual_clipping_start, 12)
         self.assertEqual(contig.reads[1].qa.qual_clipping_end, 353)
@@ -1719,7 +2031,9 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(contig.reads[2].rd.read_tags, 0)
         center = len(contig.reads[2].rd.sequence) // 2
         self.assertEqual(contig.reads[2].rd.sequence[:10], "aatattaccg")
-        self.assertEqual(contig.reads[2].rd.sequence[center - 5:center + 5], "CAGATGGGTT")
+        self.assertEqual(
+            contig.reads[2].rd.sequence[center - 5 : center + 5], "CAGATGGGTT"
+        )
         self.assertEqual(contig.reads[2].rd.sequence[-10:], "ctattcaggg")
         self.assertEqual(contig.reads[2].qa.qual_clipping_start, 20)
         self.assertEqual(contig.reads[2].qa.qual_clipping_end, 415)
@@ -1741,7 +2055,9 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(contig.reads[3].rd.read_tags, 0)
         center = len(contig.reads[3].rd.sequence) // 2
         self.assertEqual(contig.reads[3].rd.sequence[:10], "ctgcgtatcg")
-        self.assertEqual(contig.reads[3].rd.sequence[center - 5:center + 5], "AGGATTGCTT")
+        self.assertEqual(
+            contig.reads[3].rd.sequence[center - 5 : center + 5], "AGGATTGCTT"
+        )
         self.assertEqual(contig.reads[3].rd.sequence[-10:], "aaccctgggt")
         self.assertEqual(contig.reads[3].qa.qual_clipping_start, 18)
         self.assertEqual(contig.reads[3].qa.qual_clipping_end, 368)
@@ -1763,7 +2079,9 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(contig.reads[4].rd.read_tags, 0)
         center = len(contig.reads[4].rd.sequence) // 2
         self.assertEqual(contig.reads[4].rd.sequence[:10], "gaggatcgct")
-        self.assertEqual(contig.reads[4].rd.sequence[center - 5:center + 5], "GTgcgaggat")
+        self.assertEqual(
+            contig.reads[4].rd.sequence[center - 5 : center + 5], "GTgcgaggat"
+        )
         self.assertEqual(contig.reads[4].rd.sequence[-10:], "caggcagatg")
         self.assertEqual(contig.reads[4].qa.qual_clipping_start, 11)
         self.assertEqual(contig.reads[4].qa.qual_clipping_end, 373)
@@ -1785,7 +2103,9 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(contig.reads[5].rd.read_tags, 0)
         center = len(contig.reads[5].rd.sequence) // 2
         self.assertEqual(contig.reads[5].rd.sequence[:10], "ggggatccg*")
-        self.assertEqual(contig.reads[5].rd.sequence[center - 5:center + 5], "GCaAgacCCt")
+        self.assertEqual(
+            contig.reads[5].rd.sequence[center - 5 : center + 5], "GCaAgacCCt"
+        )
         self.assertEqual(contig.reads[5].rd.sequence[-10:], "gttgggtttg")
 
         self.assertEqual(contig.reads[5].qa.qual_clipping_start, 25)
@@ -1808,7 +2128,9 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(contig.reads[6].rd.read_tags, 0)
         center = len(contig.reads[6].rd.sequence) // 2
         self.assertEqual(contig.reads[6].rd.sequence[:10], "agccccgggc")
-        self.assertEqual(contig.reads[6].rd.sequence[center - 5:center + 5], "ggatcACATA")
+        self.assertEqual(
+            contig.reads[6].rd.sequence[center - 5 : center + 5], "ggatcACATA"
+        )
         self.assertEqual(contig.reads[6].rd.sequence[-10:], "aatagtaaca")
         self.assertEqual(contig.reads[6].qa.qual_clipping_start, 249)
         self.assertEqual(contig.reads[6].qa.qual_clipping_end, 584)
@@ -1830,7 +2152,9 @@ class AceTestThree(unittest.TestCase):
         self.assertEqual(contig.reads[7].rd.read_tags, 0)
         center = len(contig.reads[7].rd.sequence) // 2
         self.assertEqual(contig.reads[7].rd.sequence[:10], "gaataattgg")
-        self.assertEqual(contig.reads[7].rd.sequence[center - 5:center + 5], "TggCCCATCT")
+        self.assertEqual(
+            contig.reads[7].rd.sequence[center - 5 : center + 5], "TggCCCATCT"
+        )
         self.assertEqual(contig.reads[7].rd.sequence[-10:], "gaaccacacg")
         self.assertEqual(contig.reads[7].qa.qual_clipping_start, 240)
         self.assertEqual(contig.reads[7].qa.qual_clipping_end, 584)


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR applies black format to test_Ace.py, is a big change it would be good to have it reviewed.
