### PR TITLE
replaced alphabet by molecule_type

### DIFF
--- a/Tests/test_SeqIO_Xdna.py
+++ b/Tests/test_SeqIO_Xdna.py
@@ -9,7 +9,7 @@
 import unittest
 from io import BytesIO
 
-from Bio import Alphabet, SeqIO, BiopythonWarning
+from Bio import SeqIO, BiopythonWarning
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation, BeforePosition
 from Bio.SeqRecord import SeqRecord
@@ -24,7 +24,7 @@ class TestXdna(unittest.TestCase):
             "id": "Sample",
             "description": "Sample sequence A",
             "length": 1000,
-            "alphabet": Alphabet.generic_dna,
+            "molecule_type": "DNA",
             "topology": "linear",
             "features": [
                 {
@@ -49,7 +49,7 @@ class TestXdna(unittest.TestCase):
             "id": "Sample",
             "description": "Sample sequence B",
             "length": 1000,
-            "alphabet": Alphabet.generic_dna,
+            "molecule_type": "DNA",
             "topology": "circular",
             "features": [
                 {
@@ -74,7 +74,7 @@ class TestXdna(unittest.TestCase):
             "id": "Sample",
             "description": "Sample Sequence C",
             "length": 1000,
-            "alphabet": Alphabet.generic_protein,
+            "molecule_type": "protein",
             "topology": "linear",
             "features": [
                 {
@@ -103,7 +103,7 @@ class TestXdna(unittest.TestCase):
             self.assertEqual(sample["id"], record.id)
             self.assertEqual(sample["description"], record.description)
             self.assertEqual(sample["length"], len(record))
-            self.assertEqual(sample["alphabet"], record.seq.alphabet)
+            self.assertEqual(sample["molecule_type"], record.annotations["molecule_type"])
             self.assertEqual(sample["topology"], record.annotations["topology"])
 
             self.assertEqual(len(sample["features"]), len(record.features))


### PR DESCRIPTION
This pull request replaces alphabets by molecule_type in `test_SeqIO_Xdna.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
