### PR TITLE
Make MMCIF2Dict more robust

### DIFF
--- a/Tests/test_PDB_MMCIF2Dict.py
+++ b/Tests/test_PDB_MMCIF2Dict.py
@@ -234,7 +234,10 @@ class MMCIF2dictTests(unittest.TestCase):
         self.assertRaises(ValueError, list, mmcif._splitline("foo 'bar"))
         self.assertRaises(ValueError, list, mmcif._splitline("foo 'ba'r  "))
         self.assertRaises(ValueError, list, mmcif._splitline("foo \"bar'"))
-        self.assertRaises(ValueError, list, mmcif._splitline("foo b'ar'"))
+
+        # quotes are allowed if not followed by whitespace
+        self.assertEqual(list(mmcif._splitline("foo b'ar'")), ["foo", "b'ar'"])
+        self.assertEqual(list(mmcif._splitline("foo 'b'ar'")), ["foo", "b'ar"])
 
     def test_verbatim_block(self):
         """Verbatim blocks parsed correctly.
@@ -256,6 +259,29 @@ class MMCIF2dictTests(unittest.TestCase):
         self.assertEqual(
             mmcif_dict["_test_value"], ["First line\n    Second line\nThird line"]
         )
+
+    def test_token_after_multiline(self):
+        """Multi-line string followed by token on the same line."""
+        stream = io.StringIO("data_test _key1\n"
+                             ";foo bar\n"
+                             "; _key2 'value 2'\n")
+        mmcif_dict = MMCIF2Dict(stream)
+        self.assertEqual(mmcif_dict, {
+            "data_": "test",
+            "_key1": ["foo bar"],
+            "_key2": ["value 2"],
+        })
+
+        stream = io.StringIO("data_test _key1\n"
+                             ";foo bar\n"
+                             ";# missing space here")
+        with self.assertRaisesRegex(ValueError, "Missing whitespace"):
+            mmcif_dict = MMCIF2Dict(stream)
+
+    def test_truncated_multiline(self):
+        stream = io.StringIO("data_test\n_key1\n;foo bar\n")
+        with self.assertRaisesRegex(ValueError, "Missing closing semicolon"):
+            mmcif_dict = MMCIF2Dict(stream)
 
     def test_inline_comments(self):
         """Comments may begin outside of column 1 if preceded by whitespace."""


### PR DESCRIPTION
- Allow quotes in _UnquotedString_
- Allow tokens after closing `;` of _SemiColonTextField_
- Raise `ValueError` for truncated _SemiColonTextField_

See https://www.iucr.org/resources/cif/spec/version1.1/cifsyntax

All changes have unit tests.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
