### PR TITLE
set molecule type where needed

### DIFF
--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -456,7 +456,7 @@ class TestSeqIO(SeqIOTestBaseClass):
         expected_lengths,
         expected_alignment,
         expected_messages,
-        molecule_types={},
+        molecule_types=None,
     ):
         mode = "r" + self.get_mode(t_format)
         with warnings.catch_warnings():
@@ -629,6 +629,8 @@ class TestSeqIO(SeqIOTestBaseClass):
         # They should all have been converted by the parser, but if
         # not reversing the record order might expose an error.  Maybe.
         records.reverse()
+        if molecule_types is None:
+            molecule_types = {}
         self.check_simple_write_read(records, t_format, t_count, expected_messages, molecule_types)
 
     def test_sff1(self):

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -6,6 +6,7 @@
 """Tests for SeqIO module."""
 
 
+import copy
 import gzip
 import sys
 import unittest
@@ -271,7 +272,7 @@ class TestSeqIO(SeqIOTestBaseClass):
                 msg=msg,
             )
 
-    def check_simple_write_read(self, records, t_format, t_count, messages):
+    def check_simple_write_read(self, records, t_format, t_count, messages, molecule_types):
         """Check can write/read given records.
 
         messages is dictionary of error messages keyed by output format.
@@ -283,26 +284,35 @@ class TestSeqIO(SeqIOTestBaseClass):
         else:
             debug = False
         unequal_length = len({len(_) for _ in records}) != 1
-        for format in test_write_read_alignment_formats:
+        for fmt in test_write_read_alignment_formats:
             if (
-                format not in possible_unknown_seq_formats
+                fmt not in possible_unknown_seq_formats
                 and isinstance(records[0].seq, UnknownSeq)
                 and len(records[0].seq) > 100
             ):
                 # Skipping for speed.  Some of the unknown sequences are
                 # rather long, and it seems a bit pointless to record them.
                 continue
+            # Set the molecule type if the source format does not define it
+            # while the destination format does require it, or if the molecule
+            # type defined by the source format is not compatible with the
+            # molecule type required by the destination format.
+            records1 = copy.deepcopy(records)
+            molecule_type = molecule_types.get(fmt)
+            if molecule_type is not None:
+                for record in records1:
+                    record.annotations["molecule_type"] = molecule_type
             # Going to write to a handle...
-            mode = self.get_mode(format)
+            mode = self.get_mode(fmt)
             if mode == "t":
                 handle = StringIO()
             elif mode == "b":
                 handle = BytesIO()
 
-            if unequal_length and format in AlignIO._FormatToWriter:
+            if unequal_length and fmt in AlignIO._FormatToWriter:
                 msg = "Sequences must all be the same length"
-            elif format in messages:
-                msg = messages[format]
+            elif fmt in messages:
+                msg = messages[fmt]
             elif debug:
                 msg = True
             else:
@@ -315,19 +325,19 @@ class TestSeqIO(SeqIOTestBaseClass):
                     with warnings.catch_warnings():
                         # e.g. data loss
                         warnings.simplefilter("ignore", BiopythonWarning)
-                        SeqIO.write(sequences=records, handle=handle, format=format)
+                        SeqIO.write(sequences=records1, handle=handle, format=fmt)
                 except (ValueError, TypeError) as e:
                     if debug:
-                        messages[format] = str(e)
+                        messages[fmt] = str(e)
                     else:
                         self.assertEqual(
-                            str(e), msg, "Wrong error on %s -> %s" % (t_format, format)
+                            str(e), msg, "Wrong error on %s -> %s" % (t_format, fmt)
                         )
                 else:
                     if not debug:
                         raise ValueError(
                             "Expected following error writing to %s:\n%s"
-                            % (format, msg)
+                            % (fmt, msg)
                         )
 
                 # Carry on to the next format:
@@ -337,31 +347,31 @@ class TestSeqIO(SeqIOTestBaseClass):
             with warnings.catch_warnings():
                 # e.g. data loss
                 warnings.simplefilter("ignore", BiopythonWarning)
-                c = SeqIO.write(sequences=records, handle=handle, format=format)
-            self.assertEqual(c, len(records))
+                c = SeqIO.write(sequences=records1, handle=handle, format=fmt)
+            self.assertEqual(c, len(records1))
 
             handle.flush()
             handle.seek(0)
             # Now ready to read back from the handle...
             try:
-                records2 = list(SeqIO.parse(handle=handle, format=format))
+                records2 = list(SeqIO.parse(handle=handle, format=fmt))
             except ValueError as e:
                 # This is BAD.  We can't read our own output.
                 # I want to see the output when called from the test harness,
                 # run_tests.py (which can be funny about new lines on Windows)
                 handle.seek(0)
                 raise ValueError(
-                    "%s\n\n%r\n\n%r" % (str(e), handle.read(), records)
+                    "%s\n\n%r\n\n%r" % (str(e), handle.read(), records1)
                 ) from None
 
             self.assertEqual(len(records2), t_count)
-            for r1, r2 in zip(records, records2):
+            for r1, r2 in zip(records1, records2):
                 # Check the bare minimum (ID and sequence) as
                 # many formats can't store more than that.
                 self.assertEqual(len(r1), len(r2))
 
                 # Check the sequence
-                if format in ["gb", "genbank", "embl", "imgt"]:
+                if fmt in ["gb", "genbank", "embl", "imgt"]:
                     # The GenBank/EMBL parsers will convert to upper case.
                     if isinstance(r1.seq, UnknownSeq) and isinstance(
                         r2.seq, UnknownSeq
@@ -371,32 +381,32 @@ class TestSeqIO(SeqIOTestBaseClass):
                         self.assertEqual(r1.seq._character.upper(), r2.seq._character)
                     else:
                         self.assertEqual(str(r1.seq).upper(), str(r2.seq))
-                elif format == "qual":
+                elif fmt == "qual":
                     self.assertIsInstance(r2.seq, UnknownSeq)
                     self.assertEqual(len(r2), len(r1))
                 else:
                     self.assertEqual(str(r1.seq), str(r2.seq))
                 # Beware of different quirks and limitations in the
                 # valid character sets and the identifier lengths!
-                if format in ["phylip", "phylip-sequential"]:
+                if fmt in ["phylip", "phylip-sequential"]:
                     self.assertEqual(
                         PhylipIO.sanitize_name(r1.id, 10),
                         r2.id,
                         "'%s' vs '%s'" % (r1.id, r2.id),
                     )
-                elif format == "phylip-relaxed":
+                elif fmt == "phylip-relaxed":
                     self.assertEqual(
                         PhylipIO.sanitize_name(r1.id),
                         r2.id,
                         "'%s' vs '%s'" % (r1.id, r2.id),
                     )
-                elif format == "clustal":
+                elif fmt == "clustal":
                     self.assertEqual(
                         r1.id.replace(" ", "_")[:30],
                         r2.id,
                         "'%s' vs '%s'" % (r1.id, r2.id),
                     )
-                elif format == "stockholm":
+                elif fmt == "stockholm":
                     r1_id = r1.id.replace(" ", "_")
                     if "start" in r1.annotations and "end" in r1.annotations:
                         suffix = "/%d-%d" % (
@@ -407,18 +417,18 @@ class TestSeqIO(SeqIOTestBaseClass):
                             r1_id += suffix
 
                     self.assertEqual(r1_id, r2.id, "'%s' vs '%s'" % (r1.id, r2.id))
-                elif format == "maf":
+                elif fmt == "maf":
                     self.assertEqual(
                         r1.id.replace(" ", "_"), r2.id, "'%s' vs '%s'" % (r1.id, r2.id)
                     )
-                elif format in ["fasta", "fasta-2line"]:
+                elif fmt in ["fasta", "fasta-2line"]:
                     self.assertEqual(r1.id.split()[0], r2.id)
-                elif format == "nib":
+                elif fmt == "nib":
                     self.assertEqual(r2.id, "<unknown id>")
                 else:
                     self.assertEqual(r1.id, r2.id, "'%s' vs '%s'" % (r1.id, r2.id))
 
-            if len(records) > 1:
+            if len(records1) > 1:
                 # Try writing just one record (passing a SeqRecord, not a list)
                 if mode == "t":
                     handle = StringIO()
@@ -426,9 +436,9 @@ class TestSeqIO(SeqIOTestBaseClass):
                     handle = BytesIO()
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore", BiopythonWarning)
-                    SeqIO.write(records[0], handle, format)
+                    SeqIO.write(records1[0], handle, fmt)
                     if mode == "t":
-                        self.assertEqual(handle.getvalue(), records[0].format(format))
+                        self.assertEqual(handle.getvalue(), records1[0].format(fmt))
         if debug:
             self.fail(
                 "Update %s test to use this dict:\nmessages = %r" % (t_format, messages)
@@ -446,6 +456,7 @@ class TestSeqIO(SeqIOTestBaseClass):
         expected_lengths,
         expected_alignment,
         expected_messages,
+        molecule_types={},
     ):
         mode = "r" + self.get_mode(t_format)
         with warnings.catch_warnings():
@@ -618,7 +629,7 @@ class TestSeqIO(SeqIOTestBaseClass):
         # They should all have been converted by the parser, but if
         # not reversing the record order might expose an error.  Maybe.
         records.reverse()
-        self.check_simple_write_read(records, t_format, t_count, expected_messages)
+        self.check_simple_write_read(records, t_format, t_count, expected_messages, molecule_types)
 
     def test_sff1(self):
         sequences = [
@@ -664,20 +675,22 @@ class TestSeqIO(SeqIOTestBaseClass):
  D- alignment column 4
  || ...
  V- alignment column 600"""
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|671626|emb|CAA85685.1|).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|671626|emb|CAA85685.1|).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|671626|emb|CAA85685.1|).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|671626|emb|CAA85685.1|).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|671626|emb|CAA85685.1|).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "clustal",
@@ -690,6 +703,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_clustal2(self):
@@ -715,20 +729,22 @@ class TestSeqIO(SeqIOTestBaseClass):
  CCCCCCC alignment column 4
  ||||||| ...
  AAAAAAA alignment column 155"""
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|6273291|gb|AF191665.1|AF191).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|6273291|gb|AF191665.1|AF191).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|6273291|gb|AF191665.1|AF191).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|6273291|gb|AF191665.1|AF191).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|6273291|gb|AF191665.1|AF191).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "clustal",
@@ -741,6 +757,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_clustal3(self):
@@ -766,20 +783,22 @@ class TestSeqIO(SeqIOTestBaseClass):
  V---- alignment column 4
  ||||| ...
  ---SS alignment column 446"""
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|56122354|gb|AAV74328.1|).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|56122354|gb|AAV74328.1|).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|56122354|gb|AAV74328.1|).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|56122354|gb|AAV74328.1|).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|56122354|gb|AAV74328.1|).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "clustal",
@@ -792,6 +811,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_clustal4(self):
@@ -810,21 +830,23 @@ class TestSeqIO(SeqIOTestBaseClass):
  -A alignment column 4
  || ...
  GG alignment column 686"""
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         messages = {
             "phylip": "Repeated name 'AT3G20900.' (originally 'AT3G20900.1-CDS'), possibly due to truncation",
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=AT3G20900.1-SEQ).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=AT3G20900.1-SEQ).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=AT3G20900.1-SEQ).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=AT3G20900.1-SEQ).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=AT3G20900.1-SEQ).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
             "phylip-sequential": "Repeated name 'AT3G20900.' (originally 'AT3G20900.1-CDS'), possibly due to truncation",
         }
         self.perform_test(
@@ -838,6 +860,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta1(self):
@@ -846,18 +869,20 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|5049839|gb|AI730987.1|AI730987"]
         lengths = [655]
         alignment = None
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5049839|gb|AI730987.1|AI730987).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5049839|gb|AI730987.1|AI730987).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5049839|gb|AI730987.1|AI730987).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5049839|gb|AI730987.1|AI730987).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5049839|gb|AI730987.1|AI730987).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -870,6 +895,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta2(self):
@@ -878,18 +904,20 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|4218935|gb|AF074388.1|AF074388"]
         lengths = [2050]
         alignment = None
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4218935|gb|AF074388.1|AF074388).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4218935|gb|AF074388.1|AF074388).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4218935|gb|AF074388.1|AF074388).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4218935|gb|AF074388.1|AF074388).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4218935|gb|AF074388.1|AF074388).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -902,6 +930,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta3(self):
@@ -910,18 +939,20 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|5052071|gb|AF067555.1|AF067555"]
         lengths = [623]
         alignment = None
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5052071|gb|AF067555.1|AF067555).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5052071|gb|AF067555.1|AF067555).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5052071|gb|AF067555.1|AF067555).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5052071|gb|AF067555.1|AF067555).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5052071|gb|AF067555.1|AF067555).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -934,6 +965,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta4(self):
@@ -942,18 +974,20 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|4104054|gb|AH007193.1|SEG_CVIGS"]
         lengths = [1002]
         alignment = None
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4104054|gb|AH007193.1|SEG_CVIGS).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4104054|gb|AH007193.1|SEG_CVIGS).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4104054|gb|AH007193.1|SEG_CVIGS).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4104054|gb|AH007193.1|SEG_CVIGS).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4104054|gb|AH007193.1|SEG_CVIGS).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -966,6 +1000,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta5(self):
@@ -974,18 +1009,20 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|5817701|gb|AF142731.1|AF142731"]
         lengths = [2551]
         alignment = None
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5817701|gb|AF142731.1|AF142731).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5817701|gb|AF142731.1|AF142731).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5817701|gb|AF142731.1|AF142731).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5817701|gb|AF142731.1|AF142731).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5817701|gb|AF142731.1|AF142731).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -998,6 +1035,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta6(self):
@@ -1006,18 +1044,20 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|3176602|gb|U78617.1|LOU78617"]
         lengths = [309]
         alignment = None
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3176602|gb|U78617.1|LOU78617).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3176602|gb|U78617.1|LOU78617).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3176602|gb|U78617.1|LOU78617).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3176602|gb|U78617.1|LOU78617).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3176602|gb|U78617.1|LOU78617).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1030,6 +1070,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta7(self):
@@ -1038,18 +1079,20 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|5690369|gb|AF158246.1|AF158246"]
         lengths = [550]
         alignment = None
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5690369|gb|AF158246.1|AF158246).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5690369|gb|AF158246.1|AF158246).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5690369|gb|AF158246.1|AF158246).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5690369|gb|AF158246.1|AF158246).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|5690369|gb|AF158246.1|AF158246).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1062,6 +1105,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta8(self):
@@ -1070,19 +1114,21 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|3298468|dbj|BAA31520.1|"]
         lengths = [107]
         alignment = None
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1095,6 +1141,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta9(self):
@@ -1103,19 +1150,21 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|3298468|dbj|BAA31520.1|"]
         lengths = [107]
         alignment = None
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1128,6 +1177,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta_2line1(self):
@@ -1136,19 +1186,21 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|3298468|dbj|BAA31520.1|"]
         lengths = [107]
         alignment = None
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3298468|dbj|BAA31520.1|).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta-2line",
@@ -1161,6 +1213,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta10(self):
@@ -1169,19 +1222,21 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|2781234|pdb|1JLY|B"]
         lengths = [304]
         alignment = None
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|2781234|pdb|1JLY|B).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|2781234|pdb|1JLY|B).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|2781234|pdb|1JLY|B).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|2781234|pdb|1JLY|B).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|2781234|pdb|1JLY|B).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1194,6 +1249,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta11(self):
@@ -1202,19 +1258,21 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|4959044|gb|AAD34209.1|AF069992_1"]
         lengths = [600]
         alignment = None
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4959044|gb|AAD34209.1|AF069992_1).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4959044|gb|AAD34209.1|AF069992_1).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4959044|gb|AAD34209.1|AF069992_1).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4959044|gb|AAD34209.1|AF069992_1).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|4959044|gb|AAD34209.1|AF069992_1).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1227,6 +1285,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta12(self):
@@ -1235,19 +1294,21 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|671626|emb|CAA85685.1|"]
         lengths = [473]
         alignment = None
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|671626|emb|CAA85685.1|).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|671626|emb|CAA85685.1|).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|671626|emb|CAA85685.1|).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|671626|emb|CAA85685.1|).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|671626|emb|CAA85685.1|).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1260,6 +1321,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta13(self):
@@ -1269,19 +1331,21 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|3318709|pdb|1A91|"]
         lengths = [79]
         alignment = None
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3318709|pdb|1A91|).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3318709|pdb|1A91|).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3318709|pdb|1A91|).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3318709|pdb|1A91|).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|3318709|pdb|1A91|).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1294,6 +1358,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta14(self):
@@ -1314,18 +1379,21 @@ class TestSeqIO(SeqIOTestBaseClass):
             "gi|1592936|gb|G29385|G29385",
         ]
         lengths = [633, 413, 471]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|1592936|gb|G29385|G29385).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|1592936|gb|G29385|G29385).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|1592936|gb|G29385|G29385).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|1592936|gb|G29385|G29385).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|1592936|gb|G29385|G29385).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
         }
@@ -1340,6 +1408,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta15(self):
@@ -1351,18 +1420,20 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["AK1H_ECOLI/1-378", "AKH_HAEIN/1-382"]
         names = ["AK1H_ECOLI/1-378", "AKH_HAEIN/1-382"]
         lengths = [378, 382]
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+        }
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=AKH_HAEIN/1-382).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=AKH_HAEIN/1-382).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=AKH_HAEIN/1-382).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=AKH_HAEIN/1-382).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=AKH_HAEIN/1-382).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
         }
@@ -1377,6 +1448,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta16(self):
@@ -1386,18 +1458,20 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|45478711|ref|NC_005816.1|"]
         lengths = [9609]
         alignment = None
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478711|ref|NC_005816.1|).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478711|ref|NC_005816.1|).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478711|ref|NC_005816.1|).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478711|ref|NC_005816.1|).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478711|ref|NC_005816.1|).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1410,6 +1484,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta17(self):
@@ -1432,18 +1507,21 @@ class TestSeqIO(SeqIOTestBaseClass):
             "ref|NC_005816.1|:c8360-8088",
         ]
         lengths = [1023, 783, 195, 273]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=ref|NC_005816.1|:c8360-8088).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=ref|NC_005816.1|:c8360-8088).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=ref|NC_005816.1|:c8360-8088).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=ref|NC_005816.1|:c8360-8088).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=ref|NC_005816.1|:c8360-8088).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
         }
@@ -1458,6 +1536,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta18(self):
@@ -1467,6 +1546,13 @@ class TestSeqIO(SeqIOTestBaseClass):
             "MNKQQQTALNMARFIRSQSLILLEKLDALDADEQAAMCER...AESETGT",
             "MADLKKLQVYGPELPRPYADTVKGSRYKNMKELRVQFSGR...LNTLESK",
         ]
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         ids = [
             "gi|45478712|ref|NP_995567.1|",
             "gi|45478713|ref|NP_995568.1|",
@@ -1482,16 +1568,12 @@ class TestSeqIO(SeqIOTestBaseClass):
         lengths = [340, 260, 64, 90]
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478721|ref|NP_995576.1|).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478721|ref|NP_995576.1|).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478721|ref|NP_995576.1|).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478721|ref|NP_995576.1|).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478721|ref|NP_995576.1|).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
         }
@@ -1506,6 +1588,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta19(self):
@@ -1515,6 +1598,13 @@ class TestSeqIO(SeqIOTestBaseClass):
             "MDKFQGYLEFDGARQQSFLYPLFFREYIYVLAYDHGLNRL...NDLVNHE",
             "MAIHLYKTSTPSTRNGAVDSQVKSNPRNNLICGQHHCGKG...ILRRRSK",
         ]
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         ids = [
             "gi|7525080|ref|NP_051037.1|",
             "gi|7525013|ref|NP_051039.1|",
@@ -1530,16 +1620,12 @@ class TestSeqIO(SeqIOTestBaseClass):
         lengths = [123, 353, 504, 274]
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|7525099|ref|NP_051123.1|).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|7525099|ref|NP_051123.1|).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|7525099|ref|NP_051123.1|).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|7525099|ref|NP_051123.1|).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|7525099|ref|NP_051123.1|).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
         }
@@ -1554,6 +1640,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_tab1(self):
@@ -1563,6 +1650,13 @@ class TestSeqIO(SeqIOTestBaseClass):
             "MNKQQQTALNMARFIRSQSLILLEKLDALDADEQAAMCER...AESETGT",
             "MADLKKLQVYGPELPRPYADTVKGSRYKNMKELRVQFSGR...LNTLESK",
         ]
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         ids = [
             "gi|45478712|ref|NP_995567.1|",
             "gi|45478713|ref|NP_995568.1|",
@@ -1578,16 +1672,12 @@ class TestSeqIO(SeqIOTestBaseClass):
         lengths = [340, 260, 64, 90]
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478721|ref|NP_995576.1|).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478721|ref|NP_995576.1|).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478721|ref|NP_995576.1|).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478721|ref|NP_995576.1|).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|45478721|ref|NP_995576.1|).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
         }
@@ -1602,6 +1692,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta20(self):
@@ -1610,19 +1701,21 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["gi|9629357|ref|NC_001802.1|"]
         names = ["gi|9629357|ref|NC_001802.1|"]
         lengths = [9181]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|NC_001802.1|).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|NC_001802.1|).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|NC_001802.1|).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|NC_001802.1|).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|NC_001802.1|).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1635,6 +1728,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta21(self):
@@ -1644,18 +1738,20 @@ class TestSeqIO(SeqIOTestBaseClass):
         names = ["gi|9629357|ref|nc_001802.1|"]
         lengths = [9181]
         alignment = None
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|nc_001802.1|).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|nc_001802.1|).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|nc_001802.1|).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|nc_001802.1|).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|9629357|ref|nc_001802.1|).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1668,6 +1764,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta22(self):
@@ -1676,6 +1773,13 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["test1", "test2", "test3"]
         names = ["test1", "test2", "test3"]
         lengths = [8, 8, 8]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = """\
  AGA alignment column 0
  CGA alignment column 1
@@ -1685,19 +1789,14 @@ class TestSeqIO(SeqIOTestBaseClass):
  ||| ...
  GCC alignment column 7"""
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=test3).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=test3).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=test3).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=test3).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=test3).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fasta",
@@ -1710,6 +1809,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fasta23(self):
@@ -3241,19 +3341,21 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["DD231055.1"]
         names = ["DD231055"]
         lengths = [315]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=DD231055.1).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=DD231055.1).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=DD231055.1).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=DD231055.1).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=DD231055.1).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
 
         self.perform_test(
@@ -3267,6 +3369,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_embl7(self):
@@ -3572,6 +3675,13 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["AP001509.1", "AE007476.1"]
         names = ["AP001509.1", "AE007476.1"]
         lengths = [104, 104]
+        molecule_types = {
+            "embl": "RNA",
+            "genbank": "RNA",
+            "imgt": "RNA",
+            "seqxml": "RNA",
+            "nexus": "RNA",
+        }
         alignment = """\
  UA alignment column 0
  UA alignment column 1
@@ -3581,19 +3691,14 @@ class TestSeqIO(SeqIOTestBaseClass):
  || ...
  UU alignment column 103"""
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=AE007476.1).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=AE007476.1).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=AE007476.1).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=AE007476.1).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=AE007476.1).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "stockholm",
@@ -3606,6 +3711,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_stockholm2(self):
@@ -3628,6 +3734,10 @@ class TestSeqIO(SeqIOTestBaseClass):
             "363253|refseq_protein.50.proto_past_mitoc_micro_vira|gi|94986659|ref|YP_594592.1|awsonia_intraceuaris_PHE/MN1-00",
         ]
         lengths = [43, 43, 43, 43]
+        molecule_types = {
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         alignment = """\
  MMMEEE alignment column 0
  TQIVVV alignment column 1
@@ -3646,10 +3756,8 @@ class TestSeqIO(SeqIOTestBaseClass):
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=363253|refseq_protein.50.proto_past_mitoc_micro_vira|gi|94986659|ref|YP_594592.1|awsonia_intraceuaris_PHE/MN1-00).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=363253|refseq_protein.50.proto_past_mitoc_micro_vira|gi|94986659|ref|YP_594592.1|awsonia_intraceuaris_PHE/MN1-00).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "stockholm",
@@ -3662,6 +3770,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_phylip1(self):
@@ -3669,6 +3778,13 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["Archaeopt", "Hesperorni", "Baluchithe", "B.subtilis"]
         names = ["Archaeopt", "Hesperorni", "Baluchithe", "B.subtilis"]
         lengths = [13, 13, 13, 13]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = """\
  CCTTCG alignment column 0
  GGAAAG alignment column 1
@@ -3678,20 +3794,18 @@ class TestSeqIO(SeqIOTestBaseClass):
  |||||| ...
  CTTTTC alignment column 12"""
         messages = {
+            "embl": "Cannot have spaces in EMBL accession, 'B. virgini'",
+            "genbank": "Invalid whitespace in 'B. virgini' for LOCUS line",
+            "imgt": "Cannot have spaces in EMBL accession, 'B. virgini'",
             "phylip-relaxed": "Whitespace not allowed in identifier: B. virgini",
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=B.subtilis).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=B.subtilis).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=B.subtilis).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=B.subtilis).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=B.subtilis).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -3704,6 +3818,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_phylip2(self):
@@ -3716,6 +3831,13 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["Archaeopt", "Hesperorni", "Baluchithe", "B.subtilis"]
         names = ["Archaeopt", "Hesperorni", "Baluchithe", "B.subtilis"]
         lengths = [39, 39, 39, 39]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = """\
  CCTTCG alignment column 0
  GGAAAG alignment column 1
@@ -3725,20 +3847,18 @@ class TestSeqIO(SeqIOTestBaseClass):
  |||||| ...
  CTTTTC alignment column 38"""
         messages = {
+            "embl": "Cannot have spaces in EMBL accession, 'B. virgini'",
+            "genbank": "Invalid whitespace in 'B. virgini' for LOCUS line",
+            "imgt": "Cannot have spaces in EMBL accession, 'B. virgini'",
             "phylip-relaxed": "Whitespace not allowed in identifier: B. virgini",
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=B.subtilis).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=B.subtilis).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=B.subtilis).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=B.subtilis).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=B.subtilis).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -3751,6 +3871,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_phylip3(self):
@@ -3763,6 +3884,13 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["A", "B", "C", "J"]
         names = ["A", "B", "C", "J"]
         lengths = [40, 40, 40, 40]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = """\
  CCCCCAAAAA alignment column 0
  AAAAACCCCC alignment column 1
@@ -3772,19 +3900,14 @@ class TestSeqIO(SeqIOTestBaseClass):
  |||||||||| ...
  AAAAAAAAAA alignment column 39"""
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=J).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=J).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=J).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=J).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=J).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -3797,6 +3920,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_phylip4(self):
@@ -3809,6 +3933,13 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["Mesohippus", "Hypohippus", "Archaeohip", "Pliohippus"]
         names = ["Mesohippus", "Hypohippus", "Archaeohip", "Pliohippus"]
         lengths = [40, 40, 40, 40]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = """\
  AACCCCCCCC alignment column 0
  AAAACCCCCC alignment column 1
@@ -3818,20 +3949,18 @@ class TestSeqIO(SeqIOTestBaseClass):
  |||||||||| ...
  AAAAAAAAAA alignment column 39"""
         messages = {
+            "embl": "Cannot have spaces in EMBL accession, 'M. secundu'",
+            "genbank": "Invalid whitespace in 'M. secundu' for LOCUS line",
+            "imgt": "Cannot have spaces in EMBL accession, 'M. secundu'",
             "phylip-relaxed": "Whitespace not allowed in identifier: M. secundu",
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=Pliohippus).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=Pliohippus).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=Pliohippus).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=Pliohippus).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=Pliohippus).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -3844,6 +3973,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_phylip5(self):
@@ -3856,6 +3986,13 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["A", "B", "C", "J"]
         names = ["A", "B", "C", "J"]
         lengths = [40, 40, 40, 40]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = """\
  CAAAACAAAC alignment column 0
  AACAACCACC alignment column 1
@@ -3865,19 +4002,14 @@ class TestSeqIO(SeqIOTestBaseClass):
  |||||||||| ...
  AAAAAAAAAA alignment column 39"""
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=J).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=J).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=J).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=J).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=J).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -3890,6 +4022,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_phylip6(self):
@@ -3901,6 +4034,13 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["CYS1_DICDI", "ALEU_HORVU", "CATH_HUMAN"]
         names = ["CYS1_DICDI", "ALEU_HORVU", "CATH_HUMAN"]
         lengths = [384, 384, 384]
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         alignment = """\
  -M- alignment column 0
  -A- alignment column 1
@@ -3910,19 +4050,14 @@ class TestSeqIO(SeqIOTestBaseClass):
  ||| ...
  -AV alignment column 383"""
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=CATH_HUMAN).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=CATH_HUMAN).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=CATH_HUMAN).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=CATH_HUMAN).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=CATH_HUMAN).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -3935,6 +4070,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_phylip7(self):
@@ -3947,6 +4083,13 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["IXI_234", "IXI_235", "IXI_236", "IXI_237"]
         names = ["IXI_234", "IXI_235", "IXI_236", "IXI_237"]
         lengths = [131, 131, 131, 131]
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         alignment = """\
  TTTT alignment column 0
  SSSS alignment column 1
@@ -3956,19 +4099,14 @@ class TestSeqIO(SeqIOTestBaseClass):
  |||| ...
  EEEE alignment column 130"""
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_237).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_237).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_237).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_237).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_237).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "phylip",
@@ -3981,6 +4119,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_emboss1(self):
@@ -3993,6 +4132,13 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["IXI_234", "IXI_235", "IXI_236", "IXI_237"]
         names = ["<unknown name>", "<unknown name>", "<unknown name>", "<unknown name>"]
         lengths = [131, 131, 131, 131]
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         alignment = """\
  TTTT alignment column 0
  SSSS alignment column 1
@@ -4002,19 +4148,14 @@ class TestSeqIO(SeqIOTestBaseClass):
  |||| ...
  EEEE alignment column 130"""
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_237).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_237).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_237).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_237).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_237).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "emboss",
@@ -4027,6 +4168,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_emboss2(self):
@@ -4039,18 +4181,20 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["ref_rec", "gi|94968718|receiver", "ref_rec", "gi|94970041|receiver"]
         names = ["<unknown name>", "<unknown name>", "<unknown name>", "<unknown name>"]
         lengths = [124, 124, 119, 125]
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+        }
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|94970041|receiver).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|94970041|receiver).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|94970041|receiver).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|94970041|receiver).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=gi|94970041|receiver).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
         }
@@ -4065,6 +4209,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_emboss3(self):
@@ -4075,6 +4220,13 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["IXI_234", "IXI_235"]
         names = ["<unknown name>", "<unknown name>"]
         lengths = [131, 131]
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         alignment = """\
  TT alignment column 0
  SS alignment column 1
@@ -4084,19 +4236,14 @@ class TestSeqIO(SeqIOTestBaseClass):
  || ...
  EE alignment column 130"""
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_235).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_235).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_235).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_235).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=IXI_235).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "emboss",
@@ -4109,6 +4256,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_phd1(self):
@@ -4301,18 +4449,20 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["A_U455", "B_HXB2R", "C_UG268A", "SYK_SYK"]
         names = ["A_U455", "B_HXB2R", "C_UG268A", "SYK_SYK"]
         lengths = [303, 306, 267, 330]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+        }
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=SYK_SYK).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=SYK_SYK).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=SYK_SYK).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=SYK_SYK).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=SYK_SYK).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
         }
@@ -4327,6 +4477,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_ig2(self):
@@ -4339,6 +4490,13 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["most-likely", "U455", "HXB2R", "SYK"]
         names = ["most-likely", "U455", "HXB2R", "SYK"]
         lengths = [298, 298, 298, 298]
+        molecule_types = {
+            "embl": "mRNA",
+            "genbank": "mRNA",
+            "imgt": "mRNA",
+            "seqxml": "protein",
+            "nexus": "protein",
+        }
         alignment = """\
  MMMMMMMMMMMMMMMM alignment column 0
  EEEEEEETEEEENEEE alignment column 1
@@ -4348,19 +4506,14 @@ class TestSeqIO(SeqIOTestBaseClass):
  |||||||||||||||| ...
  HHHHHHH-AAAAL-R- alignment column 297"""
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=SYK).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=SYK).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=SYK).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=SYK).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=SYK).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "ig",
@@ -4373,6 +4526,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_ig3(self):
@@ -4386,18 +4540,20 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["VPU_CONSENSUS", "A_U455", "B_SF2", "CPZANT"]
         names = ["VPU_CONSENSUS", "A_U455", "B_SF2", "CPZANT"]
         lengths = [294, 294, 294, 294]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+        }
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=CPZANT).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=CPZANT).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=CPZANT).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=CPZANT).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=CPZANT).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
         }
@@ -4412,6 +4568,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_pir1(self):
@@ -4606,6 +4763,13 @@ class TestSeqIO(SeqIOTestBaseClass):
             "EAS54_6_R1_2_1_443_348",
         ]
         lengths = [25, 25, 25]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = """\
  CTG alignment column 0
  CTT alignment column 1
@@ -4616,19 +4780,14 @@ class TestSeqIO(SeqIOTestBaseClass):
  CAG alignment column 24"""
         messages = {
             "phylip": "Repeated name 'EAS54_6_R1' (originally 'EAS54_6_R1_2_1_540_792'), possibly due to truncation",
-            "embl": "missing molecule_type in annotations",
             "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=EAS54_6_R1_2_1_443_348).",
             "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=EAS54_6_R1_2_1_443_348).",
             "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=EAS54_6_R1_2_1_443_348).",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
             "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=EAS54_6_R1_2_1_443_348).",
             "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=EAS54_6_R1_2_1_443_348).",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
             "phylip-sequential": "Repeated name 'EAS54_6_R1' (originally 'EAS54_6_R1_2_1_540_792'), possibly due to truncation",
         }
         self.perform_test(
@@ -4642,6 +4801,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_qual1(self):
@@ -4704,6 +4864,13 @@ class TestSeqIO(SeqIOTestBaseClass):
             "EAS54_6_R1_2_1_443_348",
         ]
         lengths = [25, 25, 25]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = """\
  CTG alignment column 0
  CTT alignment column 1
@@ -4714,14 +4881,9 @@ class TestSeqIO(SeqIOTestBaseClass):
  CAG alignment column 24"""
         messages = {
             "phylip": "Repeated name 'EAS54_6_R1' (originally 'EAS54_6_R1_2_1_540_792'), possibly due to truncation",
-            "embl": "missing molecule_type in annotations",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
             "phylip-sequential": "Repeated name 'EAS54_6_R1' (originally 'EAS54_6_R1_2_1_540_792'), possibly due to truncation",
         }
         self.perform_test(
@@ -4735,6 +4897,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fastq2(self):
@@ -4754,6 +4917,13 @@ class TestSeqIO(SeqIOTestBaseClass):
             "EAS54_6_R1_2_1_443_348",
         ]
         lengths = [25, 25, 25]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = """\
  CTG alignment column 0
  CTT alignment column 1
@@ -4764,14 +4934,9 @@ class TestSeqIO(SeqIOTestBaseClass):
  CAG alignment column 24"""
         messages = {
             "phylip": "Repeated name 'EAS54_6_R1' (originally 'EAS54_6_R1_2_1_540_792'), possibly due to truncation",
-            "embl": "missing molecule_type in annotations",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
             "phylip-sequential": "Repeated name 'EAS54_6_R1' (originally 'EAS54_6_R1_2_1_540_792'), possibly due to truncation",
         }
         self.perform_test(
@@ -4785,6 +4950,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fastq3(self):
@@ -4807,6 +4973,13 @@ class TestSeqIO(SeqIOTestBaseClass):
             "071113_EAS56_0053:1:3:990:501",
         ]
         lengths = [36, 36, 36, 36]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = """\
  TATT alignment column 0
  TCGG alignment column 1
@@ -4817,14 +4990,9 @@ class TestSeqIO(SeqIOTestBaseClass):
  AGTA alignment column 35"""
         messages = {
             "phylip": "Repeated name '071113_EAS' (originally '071113_EAS56_0053:1:1:153:10'), possibly due to truncation",
-            "embl": "missing molecule_type in annotations",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
             "phylip-sequential": "Repeated name '071113_EAS' (originally '071113_EAS56_0053:1:1:153:10'), possibly due to truncation",
         }
         self.perform_test(
@@ -4838,6 +5006,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fastq4(self):
@@ -4845,14 +5014,16 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["Test"]
         names = ["Test"]
         lengths = [41]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fastq",
@@ -4865,6 +5036,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fastq5(self):
@@ -4872,14 +5044,16 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["Test"]
         names = ["Test"]
         lengths = [94]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fastq",
@@ -4892,6 +5066,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fastq_illumina1(self):
@@ -4899,14 +5074,16 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["Test"]
         names = ["Test"]
         lengths = [41]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fastq-illumina",
@@ -4919,6 +5096,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fastq_solexa1(self):
@@ -4926,14 +5104,16 @@ class TestSeqIO(SeqIOTestBaseClass):
         ids = ["slxa_0001_1_0001_01"]
         names = ["slxa_0001_1_0001_01"]
         lengths = [46]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = None
         messages = {
-            "embl": "missing molecule_type in annotations",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
-            "nexus": "Need the molecule type to be defined",
         }
         self.perform_test(
             "fastq-solexa",
@@ -4946,6 +5126,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_fastq_solexa2(self):
@@ -4968,6 +5149,13 @@ class TestSeqIO(SeqIOTestBaseClass):
             "SLXA-B3_649_FC8437_R1_1_1_183_714",
         ]
         lengths = [25, 25, 25, 25]
+        molecule_types = {
+            "embl": "DNA",
+            "genbank": "DNA",
+            "imgt": "DNA",
+            "seqxml": "DNA",
+            "nexus": "DNA",
+        }
         alignment = """\
  GGGGG alignment column 0
  AGAGT alignment column 1
@@ -4978,14 +5166,9 @@ class TestSeqIO(SeqIOTestBaseClass):
  AAGGA alignment column 24"""
         messages = {
             "phylip": "Repeated name 'SLXA-B3_64' (originally 'SLXA-B3_649_FC8437_R1_1_1_362_549'), possibly due to truncation",
-            "embl": "missing molecule_type in annotations",
-            "genbank": "missing molecule_type in annotations",
-            "imgt": "missing molecule_type in annotations",
             "nib": "More than one sequence found",
-            "seqxml": "molecule_type is not defined",
             "sff": "Missing SFF flow information",
             "xdna": "More than one sequence found",
-            "nexus": "Need the molecule type to be defined",
             "phylip-sequential": "Repeated name 'SLXA-B3_64' (originally 'SLXA-B3_649_FC8437_R1_1_1_362_549'), possibly due to truncation",
         }
         self.perform_test(
@@ -4999,6 +5182,7 @@ class TestSeqIO(SeqIOTestBaseClass):
             lengths,
             alignment,
             messages,
+            molecule_types,
         )
 
     def test_seqxml1(self):


### PR DESCRIPTION
This pull request sets the molecule type in `test_SeqIO.py` where needed to let the tests run.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
