### PR TITLE
removed alphabets from Bio/FSSP/FSSPTools.py

### DIFF
--- a/Bio/FSSP/FSSPTools.py
+++ b/Bio/FSSP/FSSPTools.py
@@ -15,7 +15,6 @@ new_sum, new_align = filter(sum, align, 'zscore', 4, 7.5)
 from Bio import FSSP
 import copy
 from Bio.Align import MultipleSeqAlignment
-from Bio.Alphabet import generic_protein
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
@@ -49,13 +48,10 @@ def mult_align(sum_dict, align_dict):
         for j in align_dict.abs(i).pos_align_dict:
             # loop within a position
             mult_align_dict[j] += align_dict.abs(i).pos_align_dict[j].aa
-    fssp_align = MultipleSeqAlignment([], alphabet=generic_protein)
+    fssp_align = MultipleSeqAlignment([])
     for i in sorted(mult_align_dict):
         fssp_align.append(
-            SeqRecord(
-                Seq(mult_align_dict[i], generic_protein),
-                sum_dict[i].pdb2 + sum_dict[i].chain2,
-            )
+            SeqRecord(Seq(mult_align_dict[i]), sum_dict[i].pdb2 + sum_dict[i].chain2)
         )
     return fssp_align
 


### PR DESCRIPTION
This pull request removes alphabets from `Bio/FSSP/FSSPTools.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
