### PR TITLE
Minor styling fixes to test_Clustalw_tool.py

### DIFF
--- a/Tests/test_Clustalw_tool.py
+++ b/Tests/test_Clustalw_tool.py
@@ -47,11 +47,16 @@ if sys.platform == "win32":
     # One particular case is www.tc.cornell.edu currently provide a
     # clustalw1.83 installer which uses the following long location:
     # C:\Program Files\CTCBioApps\clustalw\v1.83\clustalw1.83.exe
-    likely_dirs = ["ClustalW2", "",
-                   "Clustal", "Clustalw", "Clustalw183", "Clustalw1.83",
-                   r"CTCBioApps\clustalw\v1.83"]
-    likely_exes = ["clustalw2.exe",
-                   "clustalw.exe", "clustalw1.83.exe"]
+    likely_dirs = [
+        "ClustalW2",
+        "",
+        "Clustal",
+        "Clustalw",
+        "Clustalw183",
+        "Clustalw1.83",
+        r"CTCBioApps\clustalw\v1.83",
+    ]
+    likely_exes = ["clustalw2.exe", "clustalw.exe", "clustalw1.83.exe"]
     for folder in likely_dirs:
         if os.path.isdir(os.path.join(prog_files, folder)):
             for filename in likely_exes:
@@ -62,6 +67,7 @@ if sys.platform == "win32":
                 break
 else:
     from subprocess import getoutput
+
     # Note that clustalw 1.83 and clustalw 2.1 don't obey the --version
     # command, but this does cause them to quit cleanly.  Otherwise they prompt
     # the user for input (causing a lock up).
@@ -79,7 +85,8 @@ else:
 
 if not clustalw_exe:
     raise MissingExternalDependencyError(
-        "Install clustalw or clustalw2 if you want to use it from Biopython.")
+        "Install clustalw or clustalw2 if you want to use it from Biopython."
+    )
 
 
 class ClustalWTestCase(unittest.TestCase):
@@ -96,8 +103,9 @@ class ClustalWTestCase(unittest.TestCase):
     def standard_test_procedure(self, cline):
         """Shared test procedure used by all tests."""
         self.assertEqual(str(eval(repr(cline))), str(cline))
-        input_records = SeqIO.to_dict(SeqIO.parse(cline.infile, "fasta"),
-                                      lambda rec: rec.id.replace(":", "_"))  # noqa: E731
+        input_records = SeqIO.to_dict(
+            SeqIO.parse(cline.infile, "fasta"), lambda rec: rec.id.replace(":", "_")
+        )  # noqa: E731
 
         # Determine name of tree file
         if cline.newtree:
@@ -121,10 +129,10 @@ class ClustalWTestCase(unittest.TestCase):
         output_records = SeqIO.to_dict(SeqIO.parse(cline.outfile, "clustal"))
         self.assertEqual(set(input_records.keys()), set(output_records.keys()))
         for record in align:
-            self.assertEqual(str(record.seq),
-                             str(output_records[record.id].seq))
-            self.assertEqual(str(record.seq).replace("-", ""),
-                             str(input_records[record.id].seq))
+            self.assertEqual(str(record.seq), str(output_records[record.id].seq))
+            self.assertEqual(
+                str(record.seq).replace("-", ""), str(input_records[record.id].seq)
+            )
 
         # Check the DND file was created.
         # TODO - Try and parse this with Bio.Nexus?
@@ -147,9 +155,12 @@ class ClustalWTestErrorConditions(ClustalWTestCase):
         try:
             stdout, stderr = cline()
         except ApplicationError as err:
-            self.assertTrue("Cannot open sequence file" in str(err) or
-                            "Cannot open input file" in str(err) or
-                            "Non-zero return code " in str(err), str(err))
+            self.assertTrue(
+                "Cannot open sequence file" in str(err)
+                or "Cannot open input file" in str(err)
+                or "Non-zero return code " in str(err),
+                str(err),
+            )
         else:
             self.fail("expected an ApplicationError")
 
@@ -189,10 +200,12 @@ class ClustalWTestErrorConditions(ClustalWTestCase):
             # Note:
             # Python 2.3 on Windows gave (0, 'Error')
             # Python 2.5 on Windows gives [Errno 0] Error
-            self.assertTrue("invalid format" in str(err) or
-                            "not produced" in str(err) or
-                            "No sequences in file" in str(err) or
-                            "Non-zero return code " in str(err))
+            self.assertTrue(
+                "invalid format" in str(err)
+                or "not produced" in str(err)
+                or "No sequences in file" in str(err)
+                or "Non-zero return code " in str(err)
+            )
         else:
             self.fail("expected an ApplicationError")
 
@@ -213,9 +226,9 @@ class ClustalWTestNormalConditions(ClustalWTestCase):
         """Test a simple fasta input file."""
         input_file = "Fasta/f002"
         output_file = "temp_test.aln"
-        cline = ClustalwCommandline(clustalw_exe,
-                                    infile=input_file,
-                                    outfile=output_file)
+        cline = ClustalwCommandline(
+            clustalw_exe, infile=input_file, outfile=output_file
+        )
 
         self.standard_test_procedure(cline)
 
@@ -224,11 +237,13 @@ class ClustalWTestNormalConditions(ClustalWTestCase):
         input_file = "Registry/seqs.fasta"
         output_file = "temp_test.aln"
         newtree_file = "temp_test.dnd"
-        cline = ClustalwCommandline(clustalw_exe,
-                                    infile=input_file,
-                                    outfile=output_file,
-                                    newtree=newtree_file,
-                                    align=True)
+        cline = ClustalwCommandline(
+            clustalw_exe,
+            infile=input_file,
+            outfile=output_file,
+            newtree=newtree_file,
+            align=True,
+        )
 
         self.standard_test_procedure(cline)
         cline.newtree = "temp with space.dnd"
@@ -248,9 +263,9 @@ class ClustalWTestNormalConditions(ClustalWTestCase):
         del records
         output_file = "temp_cw_prot.aln"
 
-        cline = ClustalwCommandline(clustalw_exe,
-                                    infile=input_file,
-                                    outfile=output_file)
+        cline = ClustalwCommandline(
+            clustalw_exe, infile=input_file, outfile=output_file
+        )
 
         self.add_file_to_clean(input_file)
         self.standard_test_procedure(cline)
@@ -262,9 +277,9 @@ class ClustalWTestNormalConditions(ClustalWTestCase):
             SeqIO.write(SeqIO.parse("Phylip/hennigian.phy", "phylip"), handle, "fasta")
         output_file = "temp with space.aln"
 
-        cline = ClustalwCommandline(clustalw_exe,
-                                    infile=input_file,
-                                    outfile=output_file)
+        cline = ClustalwCommandline(
+            clustalw_exe, infile=input_file, outfile=output_file
+        )
 
         self.add_file_to_clean(input_file)
         self.standard_test_procedure(cline)
@@ -273,9 +288,9 @@ class ClustalWTestNormalConditions(ClustalWTestCase):
         """Test an output filename containing spaces."""
         input_file = "GFF/multi.fna"
         output_file = "temp with space.aln"
-        cline = ClustalwCommandline(clustalw_exe,
-                                    infile=input_file,
-                                    outfile=output_file)
+        cline = ClustalwCommandline(
+            clustalw_exe, infile=input_file, outfile=output_file
+        )
 
         self.standard_test_procedure(cline)
 
@@ -289,10 +304,12 @@ class ClustalWTestVersionTwoSpecific(ClustalWTestCase):
             input_file = "Fasta/f002"
             output_file = "temp_test.aln"
             statistics_file = "temp_stats.txt"
-            cline = ClustalwCommandline(clustalw_exe,
-                                        infile=input_file,
-                                        outfile=output_file,
-                                        stats=statistics_file)
+            cline = ClustalwCommandline(
+                clustalw_exe,
+                infile=input_file,
+                outfile=output_file,
+                stats=statistics_file,
+            )
 
             self.add_file_to_clean(statistics_file)
             self.standard_test_procedure(cline)

--- a/Tests/test_Clustalw_tool.py
+++ b/Tests/test_Clustalw_tool.py
@@ -95,7 +95,7 @@ class ClustalWTestCase(unittest.TestCase):
 
     def standard_test_procedure(self, cline):
         """Shared test procedure used by all tests."""
-        self.assertTrue(str(eval(repr(cline))) == str(cline))
+        self.assertEqual(str(eval(repr(cline))), str(cline))
         input_records = SeqIO.to_dict(SeqIO.parse(cline.infile, "fasta"),
                                       lambda rec: rec.id.replace(":", "_"))  # noqa: E731
 
@@ -112,14 +112,14 @@ class ClustalWTestCase(unittest.TestCase):
 
         output, error = cline()
         self.assertTrue(output.strip().startswith("CLUSTAL"))
-        self.assertTrue(error.strip() == "")
+        self.assertEqual(error.strip(), "")
 
         # Check the output...
         align = AlignIO.read(cline.outfile, "clustal")
         # The length of the alignment will depend on the version of clustalw
         # (clustalw 2.1 and clustalw 1.83 are certainly different).
         output_records = SeqIO.to_dict(SeqIO.parse(cline.outfile, "clustal"))
-        self.assertTrue(set(input_records.keys()) == set(output_records.keys()))
+        self.assertEqual(set(input_records.keys()), set(output_records.keys()))
         for record in align:
             self.assertEqual(str(record.seq),
                              str(output_records[record.id].seq))
@@ -157,7 +157,7 @@ class ClustalWTestErrorConditions(ClustalWTestCase):
         """Test an input file containing a single sequence."""
         input_file = "Fasta/f001"
         self.assertTrue(os.path.isfile(input_file))
-        self.assertTrue(len(list(SeqIO.parse(input_file, "fasta"))) == 1)
+        self.assertEqual(len(list(SeqIO.parse(input_file, "fasta"))), 1)
         cline = ClustalwCommandline(clustalw_exe, infile=input_file)
 
         try:


### PR DESCRIPTION
This pull request addresses issues #2552 and #2835 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
