### PR TITLE
Drop alphabets in SeqIO indexing & SFF

### DIFF
--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -642,7 +642,7 @@ _valid_UAN_read_name = re.compile(r"^[a-zA-Z0-9]{14}$")
 
 
 def _sff_read_seq_record(
-    handle, number_of_flows_per_read, flow_chars, key_sequence, alphabet, trim=False
+    handle, number_of_flows_per_read, flow_chars, key_sequence, trim=False
 ):
     """Parse the next read in the file, return data as a SeqRecord (PRIVATE)."""
     # Now on to the reads...
@@ -774,7 +774,7 @@ def _sff_read_seq_record(
         annotations["coords"] = _get_read_xy(name)
     annotations["molecule_type"] = "DNA"
     record = SeqRecord(
-        Seq(seq, alphabet), id=name, name=name, description="", annotations=annotations
+        Seq(seq), id=name, name=name, description="", annotations=annotations
     )
     # Dirty trick to speed up this line:
     # record.letter_annotations["phred_quality"] = quals
@@ -1047,12 +1047,7 @@ class SffIterator(SequenceIterator):
                 # the index_offset so we can skip extra handle.tell() calls:
                 index_offset = 0
             yield _sff_read_seq_record(
-                handle,
-                number_of_flows_per_read,
-                flow_chars,
-                key_sequence,
-                alphabet,
-                trim,
+                handle, number_of_flows_per_read, flow_chars, key_sequence, trim,
             )
         _check_eof(handle, index_offset, index_length)
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -793,9 +793,7 @@ def index(filename, format, alphabet=None, key_function=None):
     Arguments:
      - filename - string giving name of file to be indexed
      - format   - lower case string describing the file format
-     - alphabet - optional Alphabet object, useful when the sequence type
-       cannot be automatically inferred from the file itself
-       (e.g. format="fasta" or "tab")
+     - alphabet - no longer used, leave as None
      - key_function - Optional callback function which when given a
        SeqRecord identifier string should return a unique key for the
        dictionary.
@@ -905,8 +903,6 @@ def index(filename, format, alphabet=None, key_function=None):
         raise ValueError("Format required (lower case string)")
     if not format.islower():
         raise ValueError("Format string '%s' should be lower case" % format)
-    if alphabet is not None and not isinstance(alphabet, (Alphabet, AlphabetEncoder)):
-        raise ValueError("Invalid alphabet, %r" % alphabet)
 
     # Map the file format to a sequence iterator:
     from ._index import _FormatToRandomAccess  # Lazy import
@@ -923,7 +919,7 @@ def index(filename, format, alphabet=None, key_function=None):
         key_function,
     )
     return _IndexedSeqFileDict(
-        proxy_class(filename, format, alphabet), key_function, repr, "SeqRecord"
+        proxy_class(filename, format), key_function, repr, "SeqRecord"
     )
 
 
@@ -942,9 +938,7 @@ def index_db(
        (optional if reloading an existing index, but must match)
      - format   - lower case string describing the file format
        (optional if reloading an existing index, but must match)
-     - alphabet - optional Alphabet object, useful when the sequence type
-       cannot be automatically inferred from the file itself
-       (e.g. format="fasta" or "tab")
+     - alphabet - no longer used, leave as None.
      - key_function - Optional callback function which when given a
        SeqRecord identifier string should return a unique
        key for the dictionary.
@@ -991,22 +985,22 @@ def index_db(
         raise TypeError("Need a string for the file format (lower case)")
     if format and not format.islower():
         raise ValueError("Format string '%s' should be lower case" % format)
-    if alphabet is not None and not isinstance(alphabet, (Alphabet, AlphabetEncoder)):
-        raise ValueError("Invalid alphabet, %r" % alphabet)
 
     # Map the file format to a sequence iterator:
     from ._index import _FormatToRandomAccess  # Lazy import
     from Bio.File import _SQLiteManySeqFilesDict
 
-    repr = (
-        "SeqIO.index_db(%r, filenames=%r, format=%r, alphabet=%r, key_function=%r)"
-        % (index_filename, filenames, format, alphabet, key_function)
+    repr = "SeqIO.index_db(%r, filenames=%r, format=%r, key_function=%r)" % (
+        index_filename,
+        filenames,
+        format,
+        key_function,
     )
 
     def proxy_factory(format, filename=None):
         """Given a filename returns proxy object, else boolean if format OK."""
         if filename:
-            return _FormatToRandomAccess[format](filename, format, alphabet)
+            return _FormatToRandomAccess[format](filename, format)
         else:
             return format in _FormatToRandomAccess
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -903,6 +903,8 @@ def index(filename, format, alphabet=None, key_function=None):
         raise ValueError("Format required (lower case string)")
     if not format.islower():
         raise ValueError("Format string '%s' should be lower case" % format)
+    if alphabet is not None:
+        raise ValueError("The alphabet argument is no longer supported")
 
     # Map the file format to a sequence iterator:
     from ._index import _FormatToRandomAccess  # Lazy import
@@ -985,6 +987,8 @@ def index_db(
         raise TypeError("Need a string for the file format (lower case)")
     if format and not format.islower():
         raise ValueError("Format string '%s' should be lower case" % format)
+    if alphabet is not None:
+        raise ValueError("The alphabet argument is no longer supported")
 
     # Map the file format to a sequence iterator:
     from ._index import _FormatToRandomAccess  # Lazy import

--- a/Bio/SeqIO/_index.py
+++ b/Bio/SeqIO/_index.py
@@ -32,37 +32,24 @@ from io import BytesIO
 from io import StringIO
 
 from Bio import SeqIO
-from Bio import Alphabet
 from Bio.File import _IndexedSeqFileProxy, _open_for_random_access
 
 
 class SeqFileRandomAccess(_IndexedSeqFileProxy):
     """Base class for defining random access to sequence files."""
 
-    def __init__(self, filename, format, alphabet):
+    def __init__(self, filename, format):
         """Initialize the class."""
         self._handle = _open_for_random_access(filename)
-        self._alphabet = alphabet
         self._format = format
         # Load the parser class/function once an avoid the dict lookup in each
         # __getitem__ call:
         i = SeqIO._FormatToIterator[format]
-        # The following alphabet code is a bit nasty... duplicates logic in
-        # Bio.SeqIO.parse()
-        if alphabet is None:
 
-            def _parse(handle):
-                """Dynamically generated parser function (PRIVATE)."""
-                return next(i(handle))
-
-        else:
-            # TODO - Detect alphabet support ONCE at __init__
-            def _parse(handle):
-                """Dynamically generated parser function (PRIVATE)."""
-                try:
-                    return next(i(handle, alphabet=alphabet))
-                except TypeError:
-                    return next(SeqIO._force_alphabet(i(handle), alphabet))
+        # TODO - can we simplify this now?
+        def _parse(handle):
+            """Dynamically generated parser function (PRIVATE)."""
+            return next(i(handle))
 
         self._parse = _parse
 
@@ -82,9 +69,9 @@ class SeqFileRandomAccess(_IndexedSeqFileProxy):
 class SffRandomAccess(SeqFileRandomAccess):
     """Random access to a Standard Flowgram Format (SFF) file."""
 
-    def __init__(self, filename, format, alphabet):
+    def __init__(self, filename, format):
         """Initialize the class."""
-        SeqFileRandomAccess.__init__(self, filename, format, alphabet)
+        SeqFileRandomAccess.__init__(self, filename, format)
         (
             header_length,
             index_offset,
@@ -97,8 +84,6 @@ class SffRandomAccess(SeqFileRandomAccess):
 
     def __iter__(self):
         """Load any index block in the file, or build it the slow way (PRIVATE)."""
-        if self._alphabet is None:
-            self._alphabet = Alphabet.generic_dna
         handle = self._handle
         handle.seek(0)
         # Alread did this in __init__ but need handle in right place
@@ -163,11 +148,7 @@ class SffRandomAccess(SeqFileRandomAccess):
         handle = self._handle
         handle.seek(offset)
         return SeqIO.SffIO._sff_read_seq_record(
-            handle,
-            self._flows_per_read,
-            self._flow_chars,
-            self._key_sequence,
-            self._alphabet,
+            handle, self._flows_per_read, self._flow_chars, self._key_sequence,
         )
 
     def get_raw(self, offset):
@@ -189,7 +170,6 @@ class SffTrimedRandomAccess(SffRandomAccess):
             self._flows_per_read,
             self._flow_chars,
             self._key_sequence,
-            self._alphabet,
             trim=True,
         )
 
@@ -202,9 +182,9 @@ class SffTrimedRandomAccess(SffRandomAccess):
 class SequentialSeqFileRandomAccess(SeqFileRandomAccess):
     """Random access to a simple sequential sequence file."""
 
-    def __init__(self, filename, format, alphabet):
+    def __init__(self, filename, format):
         """Initialize the class."""
-        SeqFileRandomAccess.__init__(self, filename, format, alphabet)
+        SeqFileRandomAccess.__init__(self, filename, format)
         marker = {
             "ace": b"CO ",
             "embl": b"ID ",
@@ -520,9 +500,9 @@ class UniprotRandomAccess(SequentialSeqFileRandomAccess):
 class IntelliGeneticsRandomAccess(SeqFileRandomAccess):
     """Random access to a IntelliGenetics file."""
 
-    def __init__(self, filename, format, alphabet):
+    def __init__(self, filename, format):
         """Initialize the class."""
-        SeqFileRandomAccess.__init__(self, filename, format, alphabet)
+        SeqFileRandomAccess.__init__(self, filename, format)
         self._marker_re = re.compile(b"^;")
 
     def __iter__(self):

--- a/Bio/SeqIO/_index.py
+++ b/Bio/SeqIO/_index.py
@@ -44,19 +44,12 @@ class SeqFileRandomAccess(_IndexedSeqFileProxy):
         self._format = format
         # Load the parser class/function once an avoid the dict lookup in each
         # __getitem__ call:
-        i = SeqIO._FormatToIterator[format]
-
-        # TODO - can we simplify this now?
-        def _parse(handle):
-            """Dynamically generated parser function (PRIVATE)."""
-            return next(i(handle))
-
-        self._parse = _parse
+        self._iterator = SeqIO._FormatToIterator[format]
 
     def get(self, offset):
         """Return SeqRecord."""
         # Should be overridden for binary file formats etc:
-        return self._parse(StringIO(self.get_raw(offset).decode()))
+        return next(self._iterator(StringIO(self.get_raw(offset).decode())))
 
 
 ####################

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -110,7 +110,7 @@ if sqlite3:
         def test_old_contents(self):
             """Check actual filenames in existing indexes."""
             filenames, flag = raw_filenames("Roche/triple_sff.idx")
-            self.assertEqual(flag, None)
+            self.assertIsNone(flag)
             self.assertEqual(
                 filenames, ["E3MFGYR02_no_manifest.sff", "greek.sff", "paired.sff"]
             )
@@ -419,7 +419,7 @@ class IndexDictTests(SeqIOTestBaseClass):
         assert chr(0) not in keys, "Bad example in test"
         with self.assertRaises(KeyError, msg=msg):
             rec = rec_dict[chr(0)]
-        self.assertEqual(rec_dict.get(chr(0)), None, msg=msg)
+        self.assertIsNone(rec_dict.get(chr(0)), msg=msg)
         self.assertEqual(rec_dict.get(chr(0), chr(1)), chr(1), msg=msg)
         with self.assertRaises(AttributeError, msg=msg):
             rec_dict.iteritems
@@ -565,9 +565,7 @@ class IndexDictTests(SeqIOTestBaseClass):
             rec_dict._con.close()  # hack for PyPy
 
             # Now reload without passing filenames and format
-            rec_dict = SeqIO.index_db(
-                index_tmp, key_function=self.add_prefix
-            )
+            rec_dict = SeqIO.index_db(index_tmp, key_function=self.add_prefix)
             self.check_dict_methods(rec_dict, key_list, id_list, msg=msg)
             rec_dict.close()
             rec_dict._con.close()  # hack for PyPy
@@ -671,6 +669,27 @@ class IndexDictTests(SeqIOTestBaseClass):
             self.assertEqual(True, compare_record(rec1, rec2))
         rec_dict.close()
         del rec_dict
+
+    if sqlite3:
+
+        def test_alpha_fails_db(self):
+            """Reject alphabet argument in Bio.SeqIO.index_db()."""
+            # In historic usage, alphabet=... would be a Bio.Alphabet object.
+            self.assertRaises(
+                ValueError,
+                SeqIO.index_db,
+                ":memory:",
+                ["Fasta/dups.fasta"],
+                "fasta",
+                alphabet="XXX",
+            )
+
+    def test_alpha_fails(self):
+        """Reject alphabet argument in Bio.SeqIO.index()."""
+        # In historic usage, alphabet=... would be a Bio.Alphabet object.
+        self.assertRaises(
+            ValueError, SeqIO.index, "Fasta/dups.fasta", "fasta", alphabet="XXX"
+        )
 
     if sqlite3:
 

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -638,7 +638,6 @@ class IndexDictTests(SeqIOTestBaseClass):
                     rec_dict._proxy._flows_per_read,
                     rec_dict._proxy._flow_chars,
                     rec_dict._proxy._key_sequence,
-                    alphabet=None,
                     trim=False,
                 )
             elif fmt == "sff-trim":
@@ -647,7 +646,6 @@ class IndexDictTests(SeqIOTestBaseClass):
                     rec_dict._proxy._flows_per_read,
                     rec_dict._proxy._flow_chars,
                     rec_dict._proxy._key_sequence,
-                    alphabet=None,
                     trim=True,
                 )
             elif fmt == "uniprot-xml":


### PR DESCRIPTION
This pull request addresses issue #2046 - it means the alphabet argument to the SeqIO indexing functions are now ignored, likewise for the internals of the SFF parser.

Question: Should the argument trigger a deprecation warning if not None? Could make it raise a ValueError if not None, or simply remove the optional argument but that is more of an API break. My choice to keep the argument (for now) and just ignore it is intended to ease backward compatibility.

Cross reference discussion about if molecule type should be an optional argument at parse/input (not doing that here), or perhaps an optional argument for writing/output, or set manually in between.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
