### PR TITLE
Drop alphabet argument and support in assorted SeqIO parsers

### DIFF
--- a/Bio/SeqIO/IgIO.py
+++ b/Bio/SeqIO/IgIO.py
@@ -23,11 +23,10 @@ from .Interfaces import SequenceIterator
 class IgIterator(SequenceIterator):
     """Parser for IntelliGenetics files."""
 
-    def __init__(self, source, alphabet=single_letter_alphabet):
+    def __init__(self, source):
         """Iterate over IntelliGenetics records (as SeqRecord objects).
 
         source - file-like object opened in text mode, or a path to a file
-        alphabet - optional alphabet
 
         The optional free format file header lines (which start with two
         semi-colons) are ignored.
@@ -62,7 +61,7 @@ class IgIterator(SequenceIterator):
         SYK_SYK length 330
 
         """
-        super().__init__(source, alphabet=alphabet, mode="t", fmt="IntelliGenetics")
+        super().__init__(source, mode="t", fmt="IntelliGenetics")
 
     def parse(self, handle):
         """Start parsing the file, and return a SeqRecord generator."""
@@ -114,10 +113,12 @@ class IgIterator(SequenceIterator):
                 )
 
             # Return the record and then continue...
-            alphabet = self.alphabet
-            record = SeqRecord(Seq(seq_str, alphabet), id=title, name=title)
-            record.annotations["comment"] = "\n".join(comment_lines)
-            yield record
+            yield SeqRecord(
+                Seq(seq_str),
+                id=title,
+                name=title,
+                annotations={"comment": "\n".join(comment_lines)},
+            )
 
         # We should be at the end of the file now
         assert not line

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -37,7 +37,6 @@ from Bio import BiopythonWarning
 
 from Bio.Seq import UnknownSeq
 from Bio.GenBank.Scanner import GenBankScanner, EmblScanner, _ImgtScanner
-from Bio import Alphabet
 from Bio import SeqIO
 from Bio import SeqFeature
 from .Interfaces import SequenceIterator, SequenceWriter
@@ -177,7 +176,7 @@ class ImgtIterator(SequenceIterator):
 class GenBankCdsFeatureIterator(SequenceIterator):
     """Parser for GenBank files, creating a SeqRecord for each CDS feature."""
 
-    def __init__(self, source, alphabet=Alphabet.generic_protein):
+    def __init__(self, source):
         """Break up a Genbank file into SeqRecord objects for each CDS feature.
 
         Argument source is a file-like object opened in text mode or a path to a file.
@@ -186,19 +185,17 @@ class GenBankCdsFeatureIterator(SequenceIterator):
         many CDS features.  These are returned as with the stated amino acid
         translation sequence (if given).
         """
-        super().__init__(source, alphabet=alphabet, mode="t", fmt="GenBank")
+        super().__init__(source, mode="t", fmt="GenBank")
 
     def parse(self, handle):
         """Start parsing the file, and return a SeqRecord generator."""
-        alphabet = self.alphabet
-        records = GenBankScanner(debug=0).parse_cds_features(handle, alphabet)
-        return records
+        return GenBankScanner(debug=0).parse_cds_features(handle)
 
 
 class EmblCdsFeatureIterator(SequenceIterator):
     """Parser for EMBL files, creating a SeqRecord for each CDS feature."""
 
-    def __init__(self, source, alphabet=Alphabet.generic_protein):
+    def __init__(self, source):
         """Break up a EMBL file into SeqRecord objects for each CDS feature.
 
         Argument source is a file-like object opened in text mode or a path to a file.
@@ -207,13 +204,11 @@ class EmblCdsFeatureIterator(SequenceIterator):
         many CDS features.  These are returned as with the stated amino acid
         translation sequence (if given).
         """
-        super().__init__(source, alphabet=alphabet, mode="t", fmt="EMBL")
+        super().__init__(source, mode="t", fmt="EMBL")
 
     def parse(self, handle):
         """Start parsing the file, and return a SeqRecord generator."""
-        alphabet = self.alphabet
-        records = EmblScanner(debug=0).parse_cds_features(handle, alphabet)
-        return records
+        return EmblScanner(debug=0).parse_cds_features(handle)
 
 
 def _insdc_feature_position_string(pos, offset=0):
@@ -1145,7 +1140,6 @@ class EmblWriter(_InsdcWriter):
         data = self._get_seq_string(record).lower()
         seq_len = len(data)
 
-        # Get the base alphabet (underneath any Gapped or StopCodon encoding)
         molecule_type = record.annotations.get("molecule_type")
         if molecule_type is not None and "DNA" in molecule_type:
             # TODO - What if we have RNA?

--- a/Bio/SeqIO/NibIO.py
+++ b/Bio/SeqIO/NibIO.py
@@ -52,12 +52,11 @@ import sys
 class NibIterator(SequenceIterator):
     """Parser for nib files."""
 
-    def __init__(self, source, alphabet=None):
+    def __init__(self, source):
         """Iterate over a nib file and yield a SeqRecord.
 
             - source - a file-like object or a path to a file in the nib file
               format as defined by UCSC; the file must be opened in binary mode.
-            - alphabet - always ignored.
 
         Note that a nib file always contains only one sequence record.
         The sequence of the resulting SeqRecord object should match the sequence
@@ -79,8 +78,6 @@ class NibIterator(SequenceIterator):
         nAGAAGagccgcNGgCActtGAnTAtCGTCgcCacCaGncGncTtGNtGG 50
 
         """
-        if alphabet is not None:
-            raise ValueError("Alphabets are ignored.")
         super().__init__(source, mode="b", fmt="Nib")
 
     def parse(self, handle):

--- a/Bio/SeqIO/PirIO.py
+++ b/Bio/SeqIO/PirIO.py
@@ -87,28 +87,21 @@ Sequence codes and their meanings:
 
 """
 
-
-from Bio.Alphabet import (
-    single_letter_alphabet,
-    generic_protein,
-    generic_dna,
-    generic_rna,
-)
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from .Interfaces import SequenceIterator, SequenceWriter
 
 
-_pir_alphabets = {
-    "P1": generic_protein,
-    "F1": generic_protein,
-    "D1": generic_dna,
-    "DL": generic_dna,
-    "DC": generic_dna,
-    "RL": generic_rna,
-    "RC": generic_rna,
-    "N3": generic_rna,
-    "XX": single_letter_alphabet,
+_pir_mol_type = {
+    "P1": "protein",
+    "F1": "protein",
+    "D1": "DNA",
+    "DL": "DNA",
+    "DC": "DNA",
+    "RL": "RNA",
+    "RC": "RNA",
+    "N3": "RNA",
+    "XX": None,
 }
 
 
@@ -151,7 +144,7 @@ class PirIterator(SequenceIterator):
 
         while True:
             pir_type = line[1:3]
-            if pir_type not in _pir_alphabets or line[3] != ";":
+            if pir_type not in _pir_mol_type or line[3] != ";":
                 raise ValueError(
                     "Records should start with '>XX;' where XX is a valid sequence type"
                 )
@@ -176,18 +169,11 @@ class PirIterator(SequenceIterator):
 
             # Return the record and then continue...
             record = SeqRecord(
-                Seq(seq[:-1], _pir_alphabets[pir_type]),
-                id=identifier,
-                name=identifier,
-                description=description,
+                Seq(seq[:-1]), id=identifier, name=identifier, description=description,
             )
             record.annotations["PIR-type"] = pir_type
-            if pir_type in ("P1", "F1"):
-                record.annotations["molecule_type"] = "protein"
-            elif pir_type in ("D1", "DL", "DC"):
-                record.annotations["molecule_type"] = "DNA"
-            elif pir_type in ("RL", "RC", "N3"):
-                record.annotations["molecule_type"] = "RNA"
+            if _pir_mol_type[pir_type]:
+                record.annotations["molecule_type"] = _pir_mol_type[pir_type]
             yield record
 
             if line is None:
@@ -273,9 +259,9 @@ class PirWriter(SequenceWriter):
             else:
                 code = "XX"
 
-        if code not in _pir_alphabets:
+        if code not in _pir_mol_type:
             raise TypeError(
-                "Sequence code must be one of " + _pir_alphabets.keys() + "."
+                "Sequence code must be one of " + _pir_mol_type.keys() + "."
             )
         assert "\n" not in title
         assert "\r" not in description


### PR DESCRIPTION
This pull request addresses issue #2046, and is a slightly cleared up version of the straightforward bits on #3121.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
