### PR TITLE
Apply black styling to test_C*.py

### DIFF
--- a/Tests/test_Chi2.py
+++ b/Tests/test_Chi2.py
@@ -10,7 +10,6 @@ from Bio.Phylo.PAML import chi2
 
 
 class ModTest(unittest.TestCase):
-
     def test_cdf_chi2(self):
         self.assertRaises(ValueError, chi2.cdf_chi2, df=0, stat=3.84)
         self.assertRaises(ValueError, chi2.cdf_chi2, df=1, stat=-3.84)
@@ -19,14 +18,11 @@ class ModTest(unittest.TestCase):
 
     def test_ln_gamma(self):
         self.assertRaises(ValueError, chi2._ln_gamma_function, -1)
-        self.assertAlmostEqual(chi2._ln_gamma_function(10), 12.80183,
-                               places=5)
+        self.assertAlmostEqual(chi2._ln_gamma_function(10), 12.80183, places=5)
 
     def test_incomplete_gamma(self):
-        self.assertRaises(ValueError, chi2._incomplete_gamma, x=0.5,
-                          alpha=-1)
-        self.assertAlmostEqual(chi2._incomplete_gamma(0.5, 0.5), 0.6826895,
-                               places=5)
+        self.assertRaises(ValueError, chi2._incomplete_gamma, x=0.5, alpha=-1)
+        self.assertAlmostEqual(chi2._incomplete_gamma(0.5, 0.5), 0.6826895, places=5)
 
 
 if __name__ == "__main__":

--- a/Tests/test_ColorSpiral.py
+++ b/Tests/test_ColorSpiral.py
@@ -14,12 +14,14 @@ from cmath import rect
 
 # Do we have ReportLab?  Raise error if not present.
 from Bio import MissingPythonDependencyError
+
 try:
     from reportlab.pdfgen.canvas import Canvas
     from reportlab.lib.pagesizes import A4
 except ImportError:
     raise MissingPythonDependencyError(
-        "Install reportlab if you want to use Bio.Graphics.") from None
+        "Install reportlab if you want to use Bio.Graphics."
+    ) from None
 
 
 # Biopython Bio.Graphics.ColorSpiral
@@ -40,12 +42,17 @@ class SpiralTest(unittest.TestCase):
         """Get set of eight colours, no jitter, using ColorSpiral."""
         cs = ColorSpiral(a=4, b=0.33, jitter=0)
         colours = list(cs.get_colors(8))
-        cstr = ["(%.2f, %.2f, %.2f)" % (r, g, b)
-                for r, g, b in colours]
-        expected = \
-            ["(0.64, 0.74, 0.81)", "(0.68, 0.52, 0.76)", "(0.72, 0.41, 0.55)",
-             "(0.68, 0.39, 0.31)", "(0.63, 0.54, 0.22)", "(0.48, 0.59, 0.13)",
-             "(0.24, 0.54, 0.06)", "(0.01, 0.50, -0.00)"]
+        cstr = ["(%.2f, %.2f, %.2f)" % (r, g, b) for r, g, b in colours]
+        expected = [
+            "(0.64, 0.74, 0.81)",
+            "(0.68, 0.52, 0.76)",
+            "(0.72, 0.41, 0.55)",
+            "(0.68, 0.39, 0.31)",
+            "(0.63, 0.54, 0.22)",
+            "(0.48, 0.59, 0.13)",
+            "(0.24, 0.54, 0.06)",
+            "(0.01, 0.50, -0.00)",
+        ]
         self.assertEqual(cstr, expected)
 
     def test_colorspiral(self):
@@ -58,8 +65,9 @@ class SpiralTest(unittest.TestCase):
             h, s, v = colorsys.rgb_to_hsv(r, g, b)
             coords = rect(s * A4[0] * 0.45, h * 2 * pi)
             x, y = self.x_0 + coords.real, self.y_0 + coords.imag
-            self.c.ellipse(x - radius, y - radius, x + radius, y + radius,
-                           stroke=0, fill=1)
+            self.c.ellipse(
+                x - radius, y - radius, x + radius, y + radius, stroke=0, fill=1
+            )
         self.finish()
 
     def finish(self):
@@ -101,12 +109,16 @@ class DictTest(unittest.TestCase):
         """get_color_dict() for classes A-D, no jitter."""
         classes = ["A", "B", "C", "D"]
         colors = get_color_dict(classes, jitter=0)
-        cstr = ["%s: (%.2f, %.2f, %.2f)" % (c, r, g, b)
-                for c, (r, g, b) in sorted(colors.items())]
-        expected = ["A: (0.52, 0.76, 0.69)",
-                    "B: (0.40, 0.31, 0.68)",
-                    "C: (0.59, 0.13, 0.47)",
-                    "D: (0.50, 0.00, 0.00)"]
+        cstr = [
+            "%s: (%.2f, %.2f, %.2f)" % (c, r, g, b)
+            for c, (r, g, b) in sorted(colors.items())
+        ]
+        expected = [
+            "A: (0.52, 0.76, 0.69)",
+            "B: (0.40, 0.31, 0.68)",
+            "C: (0.59, 0.13, 0.47)",
+            "D: (0.50, 0.00, 0.00)",
+        ]
         self.assertEqual(cstr, expected)
 
 

--- a/Tests/test_Compass.py
+++ b/Tests/test_Compass.py
@@ -17,7 +17,8 @@ class CompassTest(unittest.TestCase):
         file_dir = os.path.join("Compass")
         self.test_files = [
             os.path.join(file_dir, "comtest1"),
-            os.path.join(file_dir, "comtest2")]
+            os.path.join(file_dir, "comtest2"),
+        ]
 
     def testCompassScanAndConsume(self):
         with open(self.test_files[0]) as handle:

--- a/Tests/test_Consensus.py
+++ b/Tests/test_Consensus.py
@@ -116,11 +116,17 @@ class ConsensusTest(unittest.TestCase):
 
     def test_get_support(self):
         support_tree = Consensus.get_support(self.trees[0], self.trees)
-        clade = support_tree.common_ancestor([support_tree.find_any(name="Beta"), support_tree.find_any(name="Gamma")])
+        clade = support_tree.common_ancestor(
+            [support_tree.find_any(name="Beta"), support_tree.find_any(name="Gamma")]
+        )
         self.assertEqual(clade.confidence, 2 * 100.0 / 3)
-        clade = support_tree.common_ancestor([support_tree.find_any(name="Alpha"), support_tree.find_any(name="Beta")])
+        clade = support_tree.common_ancestor(
+            [support_tree.find_any(name="Alpha"), support_tree.find_any(name="Beta")]
+        )
         self.assertEqual(clade.confidence, 3 * 100.0 / 3)
-        clade = support_tree.common_ancestor([support_tree.find_any(name="Delta"), support_tree.find_any(name="Epsilon")])
+        clade = support_tree.common_ancestor(
+            [support_tree.find_any(name="Delta"), support_tree.find_any(name="Epsilon")]
+        )
         self.assertEqual(clade.confidence, 2 * 100.0 / 3)
 
 
@@ -146,7 +152,9 @@ class BootstrapTest(unittest.TestCase):
     def test_bootstrap_consensus(self):
         calculator = DistanceCalculator("blosum62")
         constructor = DistanceTreeConstructor(calculator, "nj")
-        tree = Consensus.bootstrap_consensus(self.msa, 100, constructor, Consensus.majority_consensus)
+        tree = Consensus.bootstrap_consensus(
+            self.msa, 100, constructor, Consensus.majority_consensus
+        )
         self.assertIsInstance(tree, BaseTree.Tree)
         Phylo.write(tree, os.path.join(temp_dir, "bootstrap_consensus.tre"), "newick")
 

--- a/Tests/test_Crystal.py
+++ b/Tests/test_Crystal.py
@@ -11,6 +11,7 @@ import copy
 import warnings
 
 from Bio import BiopythonDeprecationWarning
+
 with warnings.catch_warnings():
     warnings.simplefilter("ignore", BiopythonDeprecationWarning)
     # modules to be tested
@@ -18,7 +19,6 @@ with warnings.catch_warnings():
 
 
 class ChainTestCase(unittest.TestCase):
-
     def setUp(self):
         self.a = "C A A C T A G G T C A C U A G G T C A G"
         self.b = "C T G A C C T A G T G A C C T A G T T G"
@@ -421,14 +421,16 @@ class ChainTestCase(unittest.TestCase):
 
 
 class CrystalTestCase(unittest.TestCase):
-
     def setUp(self):
 
-        self.crystal = Crystal({"a": "T T G A C T C T C T T A A",
-                                "b": Chain("G A G A G T C A"),
-                                "c": "T T G A C T C T C T T A A",
-                                "d": Chain("G A G A G T C A")
-                                })
+        self.crystal = Crystal(
+            {
+                "a": "T T G A C T C T C T T A A",
+                "b": Chain("G A G A G T C A"),
+                "c": "T T G A C T C T C T T A A",
+                "d": Chain("G A G A G T C A"),
+            }
+        )
 
     def testLen(self):
         self.assertEqual(len(self.crystal), len(self.crystal.data))
@@ -458,16 +460,13 @@ class CrystalTestCase(unittest.TestCase):
         self.assertEqual(len(target.data), 0)
 
     def testKeys(self):
-        self.assertEqual(list(self.crystal.keys()),
-                         list(self.crystal.data.keys()))
+        self.assertEqual(list(self.crystal.keys()), list(self.crystal.data.keys()))
 
     def testValues(self):
-        self.assertEqual(list(self.crystal.values()),
-                         list(self.crystal.data.values()))
+        self.assertEqual(list(self.crystal.values()), list(self.crystal.data.values()))
 
     def testItems(self):
-        self.assertEqual(list(self.crystal.items()),
-                         list(self.crystal.data.items()))
+        self.assertEqual(list(self.crystal.items()), list(self.crystal.data.items()))
 
     def testHasKey(self):
         self.assertIn("b", self.crystal)
@@ -476,7 +475,6 @@ class CrystalTestCase(unittest.TestCase):
 
 
 class HeteroTestCase(unittest.TestCase):
-
     def testInit(self):
         self.assertRaises(CrystalError, Hetero, "abcd")
         self.assertRaises(CrystalError, Hetero, "")


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Not changing test_Cluster.py as #3089 is already doing that.