### PR TITLE
Apply black styling to test_pairwise*.py

### DIFF
--- a/Tests/test_pairwise2.py
+++ b/Tests/test_pairwise2.py
@@ -1,4 +1,3 @@
-
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
@@ -21,9 +20,7 @@ from Bio import pairwise2
 if pairwise2.rint == pairwise2._python_rint:
     from Bio import MissingExternalDependencyError
 
-    raise MissingExternalDependencyError(
-        "Missing or non-compiled file: 'cpairwise2'"
-    )
+    raise MissingExternalDependencyError("Missing or non-compiled file: 'cpairwise2'")
 
 
 if __name__ == "__main__":

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -1,4 +1,3 @@
-
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Very little changed, looks like another one that was black formatted but had edits along the way.