### PR TITLE
removed alphabets from Bio.Nexus

### DIFF
--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -422,9 +422,7 @@ def combine(matrices):
         for t in combined_only:
             combined.matrix[t] += Seq(combined.missing * m.nchar)
         for t in m_only:
-            combined.matrix[t] = Seq(
-                combined.missing * combined.nchar
-            ) + Seq(
+            combined.matrix[t] = Seq(combined.missing * combined.nchar) + Seq(
                 str(m.matrix[t])
                 .replace(m.gap, combined.gap)
                 .replace(m.missing, combined.missing),

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -2050,10 +2050,7 @@ class Nexus:
         sitesm = list(zip(*[str(self.matrix[t]) for t in self.taxlabels]))
         sitesm[pos:pos] = [["-"] * len(self.taxlabels)] * n
         mapped = ["".join(x) for x in zip(*sitesm)]
-        listed = [
-            (taxon, Seq(mapped[i]))
-            for i, taxon in enumerate(self.taxlabels)
-        ]
+        listed = [(taxon, Seq(mapped[i])) for i, taxon in enumerate(self.taxlabels)]
         self.matrix = dict(listed)
         self.nchar += n
         # now adjust character sets


### PR DESCRIPTION
This pull request removes alphabets from `Bio.Nexus`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
