### PR TITLE
Changed BgzfTests to use mkstemp as per issue #1850

### DIFF
--- a/Tests/test_bgzf.py
+++ b/Tests/test_bgzf.py
@@ -11,6 +11,7 @@ See also the doctests in bgzf.py which are called via run_tests.py
 import unittest
 import gzip
 import os
+import tempfile
 from random import shuffle
 
 from Bio import bgzf
@@ -18,9 +19,8 @@ from Bio import bgzf
 
 class BgzfTests(unittest.TestCase):
     def setUp(self):
-        self.temp_file = "temp.bgzf"
-        if os.path.isfile(self.temp_file):
-            os.remove(self.temp_file)
+        fd, self.temp_file = tempfile.mkstemp()
+        os.close(fd)
 
     def tearDown(self):
         if os.path.isfile(self.temp_file):


### PR DESCRIPTION
This pull request addresses issue #1850 by using tempfile to generate a unique temporary filename. This was tested on Ubuntu 20.04 and Windows 10 using Python 3.8.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
