### PR TITLE
removed alphabets from Bio/Data/CodonTable.py

### DIFF
--- a/Bio/Data/CodonTable.py
+++ b/Bio/Data/CodonTable.py
@@ -13,8 +13,6 @@ using Scripts/update_ncbi_codon_table.py
 Last updated at Version 4.4 (May 2019)
 """
 
-from Bio import Alphabet
-from Bio.Alphabet import IUPAC
 from Bio.Data import IUPACData
 
 
@@ -51,9 +49,6 @@ class TranslationError(Exception):
 class CodonTable:
     """A codon-table, or genetic code."""
 
-    nucleotide_alphabet = Alphabet.generic_nucleotide
-    protein_alphabet = Alphabet.generic_protein
-
     forward_table = {}  # only includes codons which actually code
     back_table = {}  # for back translations
     start_codons = []
@@ -62,8 +57,8 @@ class CodonTable:
     # Not always called from derived classes!
     def __init__(
         self,
-        nucleotide_alphabet=nucleotide_alphabet,
-        protein_alphabet=protein_alphabet,
+        nucleotide_alphabet=None,
+        protein_alphabet=None,
         forward_table=forward_table,
         back_table=back_table,
         start_codons=start_codons,
@@ -115,10 +110,8 @@ class CodonTable:
 
         # Use the main four letters (and the conventional ordering)
         # even for ambiguous tables
-        letters = self.nucleotide_alphabet.letters
-        if isinstance(self.nucleotide_alphabet, Alphabet.DNAAlphabet) or (
-            letters is not None and "T" in letters
-        ):
+        letters = self.nucleotide_alphabet
+        if letters is not None and "T" in letters:
             letters = "TCAG"
         else:
             # Should be either RNA or generic nucleotides,
@@ -172,8 +165,8 @@ def make_back_table(table, default_stop_codon):
 class NCBICodonTable(CodonTable):
     """Codon table for generic nucleotide sequences."""
 
-    nucleotide_alphabet = Alphabet.generic_nucleotide
-    protein_alphabet = IUPAC.protein
+    nucleotide_alphabet = None
+    protein_alphabet = IUPACData.protein_letters
 
     def __init__(self, id, names, table, start_codons, stop_codons):
         """Initialize the class."""
@@ -196,13 +189,13 @@ class NCBICodonTable(CodonTable):
 class NCBICodonTableDNA(NCBICodonTable):
     """Codon table for unambiguous DNA sequences."""
 
-    nucleotide_alphabet = IUPAC.unambiguous_dna
+    nucleotide_alphabet = IUPACData.unambiguous_dna_letters
 
 
 class NCBICodonTableRNA(NCBICodonTable):
     """Codon table for unambiguous RNA sequences."""
 
-    nucleotide_alphabet = IUPAC.unambiguous_rna
+    nucleotide_alphabet = IUPACData.unambiguous_rna_letters
 
 
 # ########  Deal with ambiguous forward translations
@@ -517,9 +510,9 @@ def register_ncbi_table(name, alt_name, id, table, start_codons, stop_codons):
     dna = NCBICodonTableDNA(id, names + [alt_name], table, start_codons, stop_codons)
     ambig_dna = AmbiguousCodonTable(
         dna,
-        IUPAC.ambiguous_dna,
+        IUPACData.ambiguous_dna_letters,
         IUPACData.ambiguous_dna_values,
-        IUPAC.extended_protein,
+        IUPACData.extended_protein_letters,
         IUPACData.extended_protein_values,
     )
 
@@ -559,9 +552,9 @@ def register_ncbi_table(name, alt_name, id, table, start_codons, stop_codons):
     _merged_values["T"] = "U"
     ambig_generic = AmbiguousCodonTable(
         generic,
-        Alphabet.NucleotideAlphabet(),
+        None,
         _merged_values,
-        IUPAC.extended_protein,
+        IUPACData.extended_protein_letters,
         IUPACData.extended_protein_values,
     )
 
@@ -571,9 +564,9 @@ def register_ncbi_table(name, alt_name, id, table, start_codons, stop_codons):
 
     ambig_rna = AmbiguousCodonTable(
         rna,
-        IUPAC.ambiguous_rna,
+        IUPACData.ambiguous_rna_letters,
         IUPACData.ambiguous_rna_values,
-        IUPAC.extended_protein,
+        IUPACData.extended_protein_letters,
         IUPACData.extended_protein_values,
     )
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2400,8 +2400,8 @@ def _translate_str(
     amino_acids = []
     forward_table = table.forward_table
     stop_codons = table.stop_codons
-    if table.nucleotide_alphabet.letters is not None:
-        valid_letters = set(table.nucleotide_alphabet.letters.upper())
+    if table.nucleotide_alphabet is not None:
+        valid_letters = set(table.nucleotide_alphabet.upper())
     else:
         # Assume the worst case, ambiguous DNA or RNA:
         valid_letters = set(


### PR DESCRIPTION
This pull request removes alphabets from `Bio/Data/CodonTable.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
