### PR TITLE
Apply black styling to test_align*.py

### DIFF
--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -163,7 +163,6 @@ TGAATATCAAAGAATCTATTGATTTAGTGTACCAGA
 
 
 class TestBasics(unittest.TestCase):
-
     def test_empty_alignment(self):
         """Very simple tests on an empty alignment."""
         alignment = MultipleSeqAlignment([])
@@ -186,7 +185,9 @@ class TestBasics(unittest.TestCase):
         self.assertEqual(alignment[1].id, "lower")
         self.assertEqual(alignment[2].id, "upper")
         for (col, letter) in enumerate(letters):
-            self.assertEqual(alignment[:, col], letter + letter.lower() + letter.upper())
+            self.assertEqual(
+                alignment[:, col], letter + letter.lower() + letter.upper()
+            )
         # Check row extractions:
         self.assertEqual(alignment[0].id, "mixed")
         self.assertEqual(alignment[-1].id, "upper")
@@ -197,7 +198,6 @@ class TestBasics(unittest.TestCase):
 
 
 class TestReading(unittest.TestCase):
-
     def test_read_clustal1(self):
         """Parse an alignment file and get an alignment object."""
         path = os.path.join(os.getcwd(), "Clustalw", "opuntia.aln")
@@ -217,30 +217,56 @@ class TestReading(unittest.TestCase):
         self.assertEqual(len(alignment), 7)
         seq_record = alignment[0]
         self.assertEqual(seq_record.description, "gi|6273285|gb|AF191659.1|AF191")
-        self.assertEqual(seq_record.seq, Seq("TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATA----------ATATATTTCAAATTTCCTTATATACCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCCATTGATTTAGTGTACCAGA"))
+        self.assertEqual(
+            seq_record.seq,
+            Seq(
+                "TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATA----------ATATATTTCAAATTTCCTTATATACCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCCATTGATTTAGTGTACCAGA"
+            ),
+        )
         seq_record = alignment[1]
         self.assertEqual(seq_record.description, "gi|6273284|gb|AF191658.1|AF191")
-        self.assertEqual(seq_record.seq, "TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATATA--------ATATATTTCAAATTTCCTTATATACCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA")
+        self.assertEqual(
+            seq_record.seq,
+            "TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATATA--------ATATATTTCAAATTTCCTTATATACCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA",
+        )
         seq_record = alignment[2]
         self.assertEqual(seq_record.description, "gi|6273287|gb|AF191661.1|AF191")
-        self.assertEqual(seq_record.seq, "TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATA----------ATATATTTCAAATTTCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA")
+        self.assertEqual(
+            seq_record.seq,
+            "TATACATTAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATA----------ATATATTTCAAATTTCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA",
+        )
         seq_record = alignment[3]
         self.assertEqual(seq_record.description, "gi|6273286|gb|AF191660.1|AF191")
-        self.assertEqual(seq_record.seq, "TATACATAAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATA----------ATATATTTATAATTTCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA")
+        self.assertEqual(
+            seq_record.seq,
+            "TATACATAAAAGAAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATA----------ATATATTTATAATTTCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA",
+        )
         seq_record = alignment[4]
         self.assertEqual(seq_record.description, "gi|6273290|gb|AF191664.1|AF191")
-        self.assertEqual(seq_record.seq, "TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATATATA------ATATATTTCAAATTCCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA")
+        self.assertEqual(
+            seq_record.seq,
+            "TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATATATA------ATATATTTCAAATTCCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA",
+        )
         seq_record = alignment[5]
         self.assertEqual(seq_record.description, "gi|6273289|gb|AF191663.1|AF191")
-        self.assertEqual(seq_record.seq, "TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATATATA------ATATATTTCAAATTCCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTATACCAGA")
+        self.assertEqual(
+            seq_record.seq,
+            "TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATATATA------ATATATTTCAAATTCCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTATACCAGA",
+        )
         seq_record = alignment[6]
         self.assertEqual(seq_record.description, "gi|6273291|gb|AF191665.1|AF191")
-        self.assertEqual(seq_record.seq, "TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATATATATATATAATATATTTCAAATTCCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA")
+        self.assertEqual(
+            seq_record.seq,
+            "TATACATTAAAGGAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATATATATATATAATATATTTCAAATTCCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA",
+        )
         self.assertEqual(alignment.get_alignment_length(), 156)
         align_info = AlignInfo.SummaryInfo(alignment)
         consensus = align_info.dumb_consensus()
         self.assertIsInstance(consensus, Seq)
-        self.assertEqual(consensus, "TATACATTAAAGXAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATATATATATATAATATATTTCAAATTXCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA")
+        self.assertEqual(
+            consensus,
+            "TATACATTAAAGXAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATATATATATATAATATATTTCAAATTXCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA",
+        )
         dictionary = align_info.replacement_dictionary(skip_chars=None, letters="ACGT")
         self.assertEqual(len(dictionary), 16)
         self.assertAlmostEqual(dictionary[("A", "A")], 1395.0, places=1)
@@ -260,7 +286,9 @@ class TestReading(unittest.TestCase):
         self.assertAlmostEqual(dictionary[("T", "G")], 0, places=1)
         self.assertAlmostEqual(dictionary[("T", "T")], 874.0, places=1)
         matrix = align_info.pos_specific_score_matrix(consensus, ["N", "-"])
-        self.assertEqual(str(matrix), """\
+        self.assertEqual(
+            str(matrix),
+            """\
     A   C   G   T
 T  0.0 0.0 0.0 7.0
 A  7.0 0.0 0.0 0.0
@@ -418,10 +446,13 @@ C  0.0 7.0 0.0 0.0
 A  7.0 0.0 0.0 0.0
 G  0.0 0.0 7.0 0.0
 A  7.0 0.0 0.0 0.0
-""")
+""",
+        )
 
         matrix = align_info.pos_specific_score_matrix(chars_to_ignore=["N", "-"])
-        self.assertEqual(str(matrix), """\
+        self.assertEqual(
+            str(matrix),
+            """\
     A   C   G   T
 T  0.0 0.0 0.0 7.0
 A  7.0 0.0 0.0 0.0
@@ -579,11 +610,14 @@ C  0.0 7.0 0.0 0.0
 A  7.0 0.0 0.0 0.0
 G  0.0 0.0 7.0 0.0
 A  7.0 0.0 0.0 0.0
-""")
+""",
+        )
 
         second_seq = alignment[1].seq
         matrix = align_info.pos_specific_score_matrix(second_seq, ["N", "-"])
-        self.assertEqual(str(matrix), """\
+        self.assertEqual(
+            str(matrix),
+            """\
     A   C   G   T
 T  0.0 0.0 0.0 7.0
 A  7.0 0.0 0.0 0.0
@@ -741,12 +775,16 @@ C  0.0 7.0 0.0 0.0
 A  7.0 0.0 0.0 0.0
 G  0.0 0.0 7.0 0.0
 A  7.0 0.0 0.0 0.0
-""")
+""",
+        )
         e_freq_table = {"G": 0.25, "C": 0.25, "A": 0.25, "T": 0.25}
-        value = align_info.information_content(5, 50, chars_to_ignore=["N"], e_freq_table=e_freq_table)
+        value = align_info.information_content(
+            5, 50, chars_to_ignore=["N"], e_freq_table=e_freq_table
+        )
         self.assertAlmostEqual(value, 88.42, places=2)
-        value = align_info.information_content(e_freq_table=e_freq_table,
-                                               chars_to_ignore=["N"])
+        value = align_info.information_content(
+            e_freq_table=e_freq_table, chars_to_ignore=["N"]
+        )
         self.assertAlmostEqual(value, 287.55, places=2)
         self.assertEqual(align_info.get_column(1), "AAAAAAA")
         self.assertAlmostEqual(align_info.ic_vector[1], 2.00, places=2)
@@ -754,7 +792,9 @@ A  7.0 0.0 0.0 0.0
         self.assertAlmostEqual(align_info.ic_vector[7], 1.41, places=2)
         handle = StringIO()
         AlignInfo.print_info_content(align_info, fout=handle)
-        self.assertEqual(handle.getvalue(), """\
+        self.assertEqual(
+            handle.getvalue(),
+            """\
 0 T 2.000
 1 A 2.000
 2 T 2.000
@@ -911,7 +951,8 @@ A  7.0 0.0 0.0 0.0
 153 A 2.000
 154 G 2.000
 155 A 2.000
-""")
+""",
+        )
 
     def test_read_fasta(self):
         path = os.path.join(os.curdir, "Quality", "example.fasta")
@@ -931,11 +972,14 @@ A  7.0 0.0 0.0 0.0
         consensus = align_info.dumb_consensus(ambiguous="N", threshold=0.6)
         self.assertIsInstance(consensus, Seq)
         self.assertEqual(consensus, "NTNGCNTNNNNNGNNGGNTGGNTCN")
-        self.assertEqual(str(alignment), """\
+        self.assertEqual(
+            str(alignment),
+            """\
 Alignment with 3 rows and 25 columns
 CCCTTCTTGTCTTCAGCGTTTCTCC EAS54_6_R1_2_1_413_324
 TTGGCAGGCCAAGGCCGATGGATCA EAS54_6_R1_2_1_540_792
-GTTGCTTCTGGCGTGGGTGGGGGGG EAS54_6_R1_2_1_443_348""")
+GTTGCTTCTGGCGTGGGTGGGGGGG EAS54_6_R1_2_1_443_348""",
+        )
 
     def test_format_conversion(self):
         """Parse the alignment file and get an alignment object."""

--- a/Tests/test_align_substitution_matrices.py
+++ b/Tests/test_align_substitution_matrices.py
@@ -6,11 +6,14 @@
 
 try:
     import numpy
+
     del numpy
 except ImportError:
     from Bio import MissingExternalDependencyError
+
     raise MissingExternalDependencyError(
-        "Install NumPy if you want to use Bio.Align.substitution_matrices.") from None
+        "Install NumPy if you want to use Bio.Align.substitution_matrices."
+    ) from None
 
 
 import os
@@ -22,28 +25,35 @@ import numpy
 from Bio import SeqIO
 
 from Bio.Data import IUPACData
+
 nucleotide_alphabet = IUPACData.unambiguous_dna_letters
 protein_alphabet = IUPACData.protein_letters
 
 
 class Test_basics(unittest.TestCase):
-
     def test_basics_vector(self):
         from Bio.Align import substitution_matrices
+
         counts = substitution_matrices.Array("XYZ")
-        self.assertEqual(str(counts), """\
+        self.assertEqual(
+            str(counts),
+            """\
 X 0.0
 Y 0.0
 Z 0.0
-""")
+""",
+        )
         self.assertEqual(counts.alphabet, "XYZ")
         counts["X"] = -9
         counts[2] = 5.5
-        self.assertEqual(str(counts), """\
+        self.assertEqual(
+            str(counts),
+            """\
 X -9.0
 Y  0.0
 Z  5.5
-""")
+""",
+        )
         self.assertAlmostEqual(counts[0], -9)
         with self.assertRaises(IndexError):
             counts["U"]
@@ -54,40 +64,54 @@ Z  5.5
 
     def test_basics_matrix(self):
         from Bio.Align import substitution_matrices
+
         counts = substitution_matrices.Array("XYZ", dims=2)
-        self.assertEqual(str(counts), """\
+        self.assertEqual(
+            str(counts),
+            """\
     X   Y   Z
 X 0.0 0.0 0.0
 Y 0.0 0.0 0.0
 Z 0.0 0.0 0.0
-""")
+""",
+        )
         counts["X", "Z"] = 12.0
         counts[2, 1] = 3.0
         counts["Y", 0] = -2.0
         counts[0, "Y"] = 5.0
-        self.assertEqual(str(counts), """\
+        self.assertEqual(
+            str(counts),
+            """\
      X   Y    Z
 X  0.0 5.0 12.0
 Y -2.0 0.0  0.0
 Z  0.0 3.0  0.0
-""")
+""",
+        )
         with self.assertRaises(IndexError):
             counts["U", 1]
         with self.assertRaises(IndexError):
             counts["X", 5]
-        self.assertEqual(str(counts["Y"]), """\
+        self.assertEqual(
+            str(counts["Y"]),
+            """\
 X -2.0
 Y  0.0
 Z  0.0
-""")
-        self.assertEqual(str(counts[:, "Z"]), """\
+""",
+        )
+        self.assertEqual(
+            str(counts[:, "Z"]),
+            """\
 X 12.0
 Y  0.0
 Z  0.0
-""")
+""",
+        )
 
     def test_read_write(self):
         from Bio.Align import substitution_matrices
+
         path = os.path.join("Align", "hg38.chrom.sizes")
         sizes = substitution_matrices.read(path, numpy.int64)
         # Note that sum(sizes) below is larger than 2147483647, and won't
@@ -109,6 +133,7 @@ Z  0.0
 
     def test_nucleotide_freq(self):
         from Bio.Align import substitution_matrices
+
         counts = Counter()
         path = os.path.join("Align", "ecoli.fa")
         records = SeqIO.parse(path, "fasta")
@@ -120,7 +145,7 @@ Z  0.0
         path = os.path.join("Align", "ecoli.txt")
         frequencies = substitution_matrices.read(path)
         self.assertEqual(frequencies.alphabet, nucleotide_alphabet)
-        self.assertEqual(frequencies.shape, (len(nucleotide_alphabet), ))
+        self.assertEqual(frequencies.shape, (len(nucleotide_alphabet),))
         for letter in letters:
             self.assertAlmostEqual(frequencies[letter], counts[letter])
         with open(path) as handle:
@@ -145,7 +170,7 @@ Z  0.0
         path = os.path.join("Align", "bsubtilis.txt")
         frequencies = substitution_matrices.read(path)
         self.assertEqual(frequencies.alphabet, nucleotide_alphabet)
-        self.assertEqual(frequencies.shape, (len(nucleotide_alphabet), ))
+        self.assertEqual(frequencies.shape, (len(nucleotide_alphabet),))
         for letter in letters:
             self.assertAlmostEqual(frequencies[letter], counts[letter])
         with open(path) as handle:
@@ -162,6 +187,7 @@ Z  0.0
 
     def test_protein_freq(self):
         from Bio.Align import substitution_matrices
+
         counts = Counter()
         path = os.path.join("Align", "cow.fa")
         records = SeqIO.parse(path, "fasta")
@@ -173,7 +199,7 @@ Z  0.0
         path = os.path.join("Align", "cow.txt")
         frequencies = substitution_matrices.read(path)
         self.assertEqual(frequencies.alphabet, protein_alphabet)
-        self.assertEqual(frequencies.shape, (len(protein_alphabet), ))
+        self.assertEqual(frequencies.shape, (len(protein_alphabet),))
         for letter in letters:
             self.assertAlmostEqual(frequencies[letter], counts[letter])
         with open(path) as handle:
@@ -214,7 +240,7 @@ Z  0.0
         path = os.path.join("Align", "pig.txt")
         frequencies = substitution_matrices.read(path)
         self.assertEqual(frequencies.alphabet, protein_alphabet)
-        self.assertEqual(frequencies.shape, (len(protein_alphabet), ))
+        self.assertEqual(frequencies.shape, (len(protein_alphabet),))
         for letter in letters:
             self.assertAlmostEqual(frequencies[letter], counts[letter])
         with open(path) as handle:
@@ -247,7 +273,6 @@ Z  0.0
 
 
 class TestScoringMatrices(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
 
@@ -2358,12 +2383,13 @@ class TestScoringMatrices(unittest.TestCase):
         # 10915-10919 (1992).
         from Bio.Data.IUPACData import protein_letters as alphabet
         from Bio.Align import substitution_matrices
+
         m = substitution_matrices.load("BLOSUM62")
         self.assertEqual(alphabet, "ACDEFGHIKLMNPQRSTVWY")
         match_score = round(numpy.mean([m[c, c] for c in alphabet]))
-        mismatch_score = round(numpy.mean([m[c1, c2]
-                               for c1 in alphabet for c2 in alphabet
-                               if c1 != c2]))
+        mismatch_score = round(
+            numpy.mean([m[c1, c2] for c1 in alphabet for c2 in alphabet if c1 != c2])
+        )
         self.assertAlmostEqual(match_score, 6.0)
         self.assertAlmostEqual(mismatch_score, -1.0)
 


### PR DESCRIPTION
This pull request addresses issue #2552 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
