### PR TITLE
Apply black styling to remaining non-formatted tests

### DIFF
--- a/Tests/test_Blast_Record.py
+++ b/Tests/test_Blast_Record.py
@@ -14,7 +14,7 @@ class TestHsp(unittest.TestCase):
         # Test empty instance
         self.assertEqual(
             str(HSP()),
-            "Score <unknown> (<unknown> bits), expectation <unknown>, alignment length <unknown>"
+            "Score <unknown> (<unknown> bits), expectation <unknown>, alignment length <unknown>",
         )
 
         # Test instance with non-default attributes
@@ -29,7 +29,7 @@ class TestHsp(unittest.TestCase):
             """Score 1 (2 bits), expectation 3.0e+00, alignment length 4
 Query:    None  None
 
-Sbjct:    None  None"""
+Sbjct:    None  None""",
         )
 
 

--- a/Tests/test_File.py
+++ b/Tests/test_File.py
@@ -31,9 +31,9 @@ class RandomAccess(unittest.TestCase):
 
     def test_gzip(self):
         """Test gzip compressed file."""
-        self.assertRaises(ValueError,
-                          File._open_for_random_access,
-                          "Quality/example.fastq.gz")
+        self.assertRaises(
+            ValueError, File._open_for_random_access, "Quality/example.fastq.gz"
+        )
 
 
 class AsHandleTestCase(unittest.TestCase):
@@ -56,14 +56,20 @@ class AsHandleTestCase(unittest.TestCase):
         p = self._path("test_file.fasta")
         with open(p, "wb") as fp:
             with File.as_handle(fp) as handle:
-                self.assertEqual(fp, handle, "as_handle should "
-                                 "return argument when given a "
-                                 "file-like object")
+                self.assertEqual(
+                    fp,
+                    handle,
+                    "as_handle should "
+                    "return argument when given a "
+                    "file-like object",
+                )
                 self.assertFalse(handle.closed)
 
-            self.assertFalse(handle.closed,
-                             "Exiting as_handle given a file-like object "
-                             "should not close the file")
+            self.assertFalse(
+                handle.closed,
+                "Exiting as_handle given a file-like object "
+                "should not close the file",
+            )
 
     def test_string_path(self):
         """Test as_handle with a string path argument."""
@@ -78,6 +84,7 @@ class AsHandleTestCase(unittest.TestCase):
     def test_path_object(self):
         """Test as_handle with a pathlib.Path object."""
         from pathlib import Path
+
         p = Path(self._path("test_file.fasta"))
         mode = "wb"
         with File.as_handle(p, mode=mode) as handle:
@@ -88,6 +95,7 @@ class AsHandleTestCase(unittest.TestCase):
 
     def test_custom_path_like_object(self):
         """Test as_handle with a custom path-like object."""
+
         class CustomPathLike:
             def __init__(self, path):
                 self.path = path

--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -7556,7 +7556,7 @@ class GenBankTests(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", BiopythonParserWarning)
             record = SeqIO.read(path, "genbank")
-            self.assertEqual(None, record.features[-1].location)
+            self.assertIsNone(record.features[-1].location)
 
     def test_dot_lineage(self):
         """Missing taxonomy lineage."""
@@ -7590,12 +7590,11 @@ class GenBankTests(unittest.TestCase):
         record = SeqIO.read(path, "gb")
         self.assertEqual(record.dbxrefs, ["Project:57779", "BioProject:PRJNA57779"])
         gb = record.format("gb")
-        self.assertTrue(
+        self.assertIn(
             """
 DBLINK      Project: 57779
             BioProject: PRJNA57779
-KEYWORDS    """
-            in gb,
+KEYWORDS    """,
             gb,
         )
         embl = record.format("embl")
@@ -7606,12 +7605,11 @@ KEYWORDS    """
         record = SeqIO.read("GenBank/DS830848.gb", "gb")
         self.assertIn("BioProject:PRJNA16232", record.dbxrefs)
         gb = record.format("gb")
-        self.assertTrue(
+        self.assertIn(
             """
 DBLINK      BioProject: PRJNA16232
             BioSample: SAMN03004382
-KEYWORDS    """
-            in gb,
+KEYWORDS    """,
             gb,
         )
         # Also check EMBL output
@@ -7624,15 +7622,14 @@ KEYWORDS    """
         # TODO: Should we map this to BioProject:PRJNA16232
         self.assertIn("Project:PRJNA16232", record.dbxrefs)
         gb = record.format("gb")
-        self.assertTrue(
+        self.assertIn(
             """
 DBLINK      Project: PRJNA16232
             MD5: 387e72e4f7ae804780d06f875ab3bc41
             ENA: ABJB010000000
             ENA: ABJB000000000
             BioSample: SAMN03004382
-KEYWORDS    """
-            in gb,
+KEYWORDS    """,
             gb,
         )
         embl = record.format("embl")
@@ -7720,9 +7717,9 @@ KEYWORDS    """
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             record = SeqIO.read(path, "genbank")
-            self.assertFalse("structured_comment" in record.annotations)
-            self.assertTrue(
-                "Structured comment not parsed for AYW00820." in str(caught[0].message)
+            self.assertNotIn("structured_comment", record.annotations)
+            self.assertIn(
+                "Structured comment not parsed for AYW00820.", str(caught[0].message)
             )
 
     def test_locus_line_topogoly(self):
@@ -7758,8 +7755,7 @@ KEYWORDS    """
                 str(caught[0].message),
                 'The NCBI states double-quote characters like " should be escaped'
                 ' as "" (two double - quotes), but here it was not: '
-                "%r"
-                % 'One missing ""quotation mark" here',
+                "%r" % 'One missing ""quotation mark" here',
             )
         # Check records parsed as expected
         f1 = record.features[0]

--- a/Tests/test_KEGG_online.py
+++ b/Tests/test_KEGG_online.py
@@ -159,29 +159,33 @@ class KEGGTests(unittest.TestCase):
         with kegg_get("hsa:10458+ece:Z5100", "aaseq") as handle:
             data = SeqIO.parse(handle, "fasta")
             self.assertEqual(len(list(data)), 2)
-        self.assertEqual(handle.url,
-                         "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq")
+        self.assertEqual(
+            handle.url, "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq"
+        )
 
     def test_get_hsa_10458_list_ece_Z5100_as_aaseq(self):
         with kegg_get(["hsa:10458", "ece:Z5100"], "aaseq") as handle:
             data = SeqIO.parse(handle, "fasta")
             self.assertEqual(len(list(data)), 2)
-        self.assertEqual(handle.url,
-                         "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq")
+        self.assertEqual(
+            handle.url, "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq"
+        )
 
     def test_get_hsa_10458_plus_ece_Z5100_as_ntseq(self):
         with kegg_get("hsa:10458+ece:Z5100", "ntseq") as handle:
             data = SeqIO.parse(handle, "fasta")
             self.assertEqual(len(list(data)), 2)
-        self.assertEqual(handle.url,
-                         "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq")
+        self.assertEqual(
+            handle.url, "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq"
+        )
 
     def test_get_hsa_10458_list_ece_Z5100_as_ntseq(self):
         with kegg_get(["hsa:10458", "ece:Z5100"], "ntseq") as handle:
             data = SeqIO.parse(handle, "fasta")
             self.assertEqual(len(list(data)), 2)
-        self.assertEqual(handle.url,
-                         "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq")
+        self.assertEqual(
+            handle.url, "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq"
+        )
 
     def test_get_hsa05130_image(self):
         with kegg_get("hsa05130", "image") as handle:

--- a/Tests/test_UniGene.py
+++ b/Tests/test_UniGene.py
@@ -9,7 +9,6 @@ import unittest
 
 
 class TestUniGene(unittest.TestCase):
-
     def test_parse(self):
 
         # Start of the UniGene file for Equus caballus downloaded from:
@@ -25,8 +24,10 @@ class TestUniGene(unittest.TestCase):
             self.assertEqual(record.symbol, "RPL3")
             self.assertEqual(record.gene_id, "100070291")
             self.assertEqual(record.locuslink, "100070291")
-            self.assertEqual(record.homol, True)
-            self.assertEqual(record.express, ["blood", "cartilage", "trophoblast", "adult"])
+            self.assertTrue(record.homol)
+            self.assertEqual(
+                record.express, ["blood", "cartilage", "trophoblast", "adult"]
+            )
             self.assertEqual(record.restr_expr, ["blood", "adult"])
             self.assertEqual(len(record.protsim), 40)
             self.assertEqual(record.protsim[0].org, "10090")
@@ -700,7 +701,7 @@ class TestUniGene(unittest.TestCase):
             self.assertEqual(record.cytoband, "10p12")
             self.assertEqual(record.gene_id, "100034238")
             self.assertEqual(record.locuslink, "100034238")
-            self.assertEqual(record.homol, True)
+            self.assertTrue(record.homol)
             self.assertEqual(record.express, ["blood", "adult"])
             self.assertEqual(len(record.protsim), 11)
             self.assertEqual(record.protsim[0].org, "10090")
@@ -814,46 +815,52 @@ class TestUniGene(unittest.TestCase):
             # Make sure that there are no more records
             self.assertRaises(StopIteration, next, records)
 
-        self.assertEqual(repr(record.sequence), "[ACC=AB120409.1; NID=g45597282;"
-                                                " PID=g45597283; SEQTYPE=mRNA, "
-                                                "ACC=NM_001082527.1; NID=g146262002; "
-                                                "PID=g146262003; SEQTYPE=mRNA, ACC=AB120410.1; "
-                                                "NID=g45597284; PID=g45597285; SEQTYPE=mRNA, "
-                                                "ACC=AB120411.1; NID=g45597286; PID=g45597287; "
-                                                "SEQTYPE=mRNA, ACC=CD467202.1; NID=g31388470; "
-                                                "CLONE=LeukoS1_2_D11_A023; END=5'; LID=13774; "
-                                                "SEQTYPE=EST; TRACE=891190473, ACC=CD535974.1; "
-                                                "NID=g31578389; CLONE=LeukoN6_2_F07_A028; "
-                                                "END=3'; LID=13844; SEQTYPE=EST; TRACE=891184067, "
-                                                "ACC=CD469544.1; NID=g31390812; CLONE=LeukoS2_4_"
-                                                "D05_A024; END=5'; LID=13776; SEQTYPE=EST; "
-                                                "TRACE=891191700, ACC=CD528742.1; NID=g31567364; "
-                                                "CLONE=LeukoN3_7_F08_A025; END=3'; LID=13842; "
-                                                "SEQTYPE=EST; TRACE=891187302, ACC=CD469487.1; "
-                                                "NID=g31390755; CLONE=LeukoS2_4_D05_A024; END=3'; "
-                                                "LID=13776; SEQTYPE=EST; "
-                                                "TRACE=891191801]")
-        self.assertEqual(repr(record.protsim), "[ORG=10090; PROTGI=156766061; "
-                                               "PROTID=NP_001074708.2; PCT=50.00; ALN=281, "
-                                               "ORG=9606; PROTGI=32490553; PROTID=NP_067073.1; "
-                                               "PCT=62.42; ALN=296, ORG=13616; PROTGI=126346255; "
-                                               "PROTID=XP_001375479.1; PCT=40.43; ALN=281, "
-                                               "ORG=9615; PROTGI=73947540; PROTID=XP_854148.1; "
-                                               "PCT=42.11; ALN=303, ORG=9913; PROTGI=194674905; "
-                                               "PROTID=XP_001788837.1; PCT=61.11; ALN=233, "
-                                               "ORG=9258; PROTGI=149631692; "
-                                               "PROTID=XP_001516158.1; PCT=35.65; ALN=229, "
-                                               "ORG=9796; PROTGI=146262003; "
-                                               "PROTID=NP_001075996.1; PCT=100.00; ALN=279, "
-                                               "ORG=10116; PROTGI=109461031; "
-                                               "PROTID=XP_001065532.1; PCT=52.77; ALN=269, "
-                                               "ORG=9544; PROTGI=100818611; "
-                                               "PROTID=NP_001035767.1; PCT=57.35; ALN=277, "
-                                               "ORG=9823; PROTGI=178057314; "
-                                               "PROTID=NP_001116615.1; PCT=43.01; ALN=278, "
-                                               "ORG=9598; PROTGI=58801536; "
-                                               "PROTID=NP_001009045.1; "
-                                               "PCT=54.51; ALN=276]")
+        self.assertEqual(
+            repr(record.sequence),
+            "[ACC=AB120409.1; NID=g45597282;"
+            " PID=g45597283; SEQTYPE=mRNA, "
+            "ACC=NM_001082527.1; NID=g146262002; "
+            "PID=g146262003; SEQTYPE=mRNA, ACC=AB120410.1; "
+            "NID=g45597284; PID=g45597285; SEQTYPE=mRNA, "
+            "ACC=AB120411.1; NID=g45597286; PID=g45597287; "
+            "SEQTYPE=mRNA, ACC=CD467202.1; NID=g31388470; "
+            "CLONE=LeukoS1_2_D11_A023; END=5'; LID=13774; "
+            "SEQTYPE=EST; TRACE=891190473, ACC=CD535974.1; "
+            "NID=g31578389; CLONE=LeukoN6_2_F07_A028; "
+            "END=3'; LID=13844; SEQTYPE=EST; TRACE=891184067, "
+            "ACC=CD469544.1; NID=g31390812; CLONE=LeukoS2_4_"
+            "D05_A024; END=5'; LID=13776; SEQTYPE=EST; "
+            "TRACE=891191700, ACC=CD528742.1; NID=g31567364; "
+            "CLONE=LeukoN3_7_F08_A025; END=3'; LID=13842; "
+            "SEQTYPE=EST; TRACE=891187302, ACC=CD469487.1; "
+            "NID=g31390755; CLONE=LeukoS2_4_D05_A024; END=3'; "
+            "LID=13776; SEQTYPE=EST; "
+            "TRACE=891191801]",
+        )
+        self.assertEqual(
+            repr(record.protsim),
+            "[ORG=10090; PROTGI=156766061; "
+            "PROTID=NP_001074708.2; PCT=50.00; ALN=281, "
+            "ORG=9606; PROTGI=32490553; PROTID=NP_067073.1; "
+            "PCT=62.42; ALN=296, ORG=13616; PROTGI=126346255; "
+            "PROTID=XP_001375479.1; PCT=40.43; ALN=281, "
+            "ORG=9615; PROTGI=73947540; PROTID=XP_854148.1; "
+            "PCT=42.11; ALN=303, ORG=9913; PROTGI=194674905; "
+            "PROTID=XP_001788837.1; PCT=61.11; ALN=233, "
+            "ORG=9258; PROTGI=149631692; "
+            "PROTID=XP_001516158.1; PCT=35.65; ALN=229, "
+            "ORG=9796; PROTGI=146262003; "
+            "PROTID=NP_001075996.1; PCT=100.00; ALN=279, "
+            "ORG=10116; PROTGI=109461031; "
+            "PROTID=XP_001065532.1; PCT=52.77; ALN=269, "
+            "ORG=9544; PROTGI=100818611; "
+            "PROTID=NP_001035767.1; PCT=57.35; ALN=277, "
+            "ORG=9823; PROTGI=178057314; "
+            "PROTID=NP_001116615.1; PCT=43.01; ALN=278, "
+            "ORG=9598; PROTGI=58801536; "
+            "PROTID=NP_001009045.1; "
+            "PCT=54.51; ALN=276]",
+        )
 
     def test_read(self):
 
@@ -862,13 +869,27 @@ class TestUniGene(unittest.TestCase):
         with open("UniGene/Hs.2.data") as handle:
             record = UniGene.read(handle)
         self.assertEqual(record.ID, "Hs.2")
-        self.assertEqual(record.title, "N-acetyltransferase 2 (arylamine N-acetyltransferase)")
+        self.assertEqual(
+            record.title, "N-acetyltransferase 2 (arylamine N-acetyltransferase)"
+        )
         self.assertEqual(record.symbol, "NAT2")
         self.assertEqual(record.cytoband, "8p22")
         self.assertEqual(record.gene_id, "10")
         self.assertEqual(record.locuslink, "10")
-        self.assertEqual(record.homol, True)
-        self.assertEqual(record.express, ["bone", "connective tissue", "intestine", "liver", "liver tumor", "normal", "soft tissue/muscle tissue tumor", "adult"])
+        self.assertTrue(record.homol)
+        self.assertEqual(
+            record.express,
+            [
+                "bone",
+                "connective tissue",
+                "intestine",
+                "liver",
+                "liver tumor",
+                "normal",
+                "soft tissue/muscle tissue tumor",
+                "adult",
+            ],
+        )
         self.assertEqual(record.restr_expr, ["adult"])
         self.assertEqual(record.chromosome, "8")
         self.assertEqual(len(record.sts), 7)
@@ -1164,14 +1185,20 @@ class TestUniGene(unittest.TestCase):
         self.assertEqual(record.sequence[37].lid, "8800")
         self.assertEqual(record.sequence[37].seqtype, "EST")
 
-        self.assertEqual(repr(record.sts), "[ACC=PMC310725P3 UNISTS=272646, ACC=WIAF-2120 "
-                                           "UNISTS=44576, ACC=G59899 UNISTS=137181, ACC=G06461 "
-                                           "UNISTS=17088, ACC=GDB:310612 UNISTS=156422, "
-                                           "ACC=GDB:310613 UNISTS=156423, ACC=GDB:187676 "
-                                           "UNISTS=155563]")
+        self.assertEqual(
+            repr(record.sts),
+            "[ACC=PMC310725P3 UNISTS=272646, ACC=WIAF-2120 "
+            "UNISTS=44576, ACC=G59899 UNISTS=137181, ACC=G06461 "
+            "UNISTS=17088, ACC=GDB:310612 UNISTS=156422, "
+            "ACC=GDB:310613 UNISTS=156423, ACC=GDB:187676 "
+            "UNISTS=155563]",
+        )
 
-        self.assertEqual(repr(record), "<Record> Hs.2 NAT2 N-acetyltransferase 2 "
-                                       "(arylamine N-acetyltransferase)")
+        self.assertEqual(
+            repr(record),
+            "<Record> Hs.2 NAT2 N-acetyltransferase 2 "
+            "(arylamine N-acetyltransferase)",
+        )
 
     def test_read_value_error(self):
 

--- a/Tests/test_codonalign.py
+++ b/Tests/test_codonalign.py
@@ -28,7 +28,10 @@ TEST_ALIGN_FILE2 = [("codonalign/nucl2.fa", "codonalign/pro2.aln"), "parse"]
 TEST_ALIGN_FILE3 = [("codonalign/nucl3.fa", "codonalign/pro3.aln"), "index"]
 TEST_ALIGN_FILE4 = [("codonalign/nucl4.fa", "codonalign/pro4.aln"), "index"]
 TEST_ALIGN_FILE5 = [("codonalign/nucl5.fa", "codonalign/pro5.aln"), "parse"]
-TEST_ALIGN_FILE6 = [("codonalign/egfr_nucl.fa", "codonalign/egfr_pro.aln", "codonalign/egfr_id"), "id"]
+TEST_ALIGN_FILE6 = [
+    ("codonalign/egfr_nucl.fa", "codonalign/egfr_pro.aln", "codonalign/egfr_id"),
+    "id",
+]
 TEST_ALIGN_FILE7 = [("codonalign/drosophilla.fasta", "codonalign/adh.aln"), "index"]
 
 temp_dir = tempfile.mkdtemp()
@@ -42,7 +45,9 @@ class TestCodonSeq(unittest.TestCase):
         self.assertEqual(str(codonseq1.get_codon(0)), "AAA")
         self.assertEqual(str(codonseq1.get_codon(-1)), "CCC")
         self.assertEqual(str(codonseq1.get_codon(slice(1, 3))), "TTT---")
-        self.assertEqual(str(codonseq1.get_codon(slice(None, None, -1))), "CCCGGATTT---TTTAAA")
+        self.assertEqual(
+            str(codonseq1.get_codon(slice(None, None, -1))), "CCCGGATTT---TTTAAA"
+        )
 
         self.assertRaises(ValueError, codonalign.CodonSeq, "AAA-T")
         self.assertIsInstance(codonseq1.toSeq(), Seq)
@@ -55,10 +60,12 @@ class TestCodonAlignment(unittest.TestCase):
         codonseq3 = codonalign.CodonSeq("AAGTAT---TTTGGACCC")
         codonseq4 = codonalign.CodonSeq("AACTTT---TTTGGACGC")
 
-        self.seqrec = [SeqRecord(codonseq1, id="alpha"),
-                       SeqRecord(codonseq2, id="beta"),
-                       SeqRecord(codonseq3, id="gamma"),
-                       SeqRecord(codonseq4, id="delta")]
+        self.seqrec = [
+            SeqRecord(codonseq1, id="alpha"),
+            SeqRecord(codonseq2, id="beta"),
+            SeqRecord(codonseq3, id="gamma"),
+            SeqRecord(codonseq4, id="delta"),
+        ]
 
     def test_align(self):
         codonAlign = codonalign.CodonAlignment(self.seqrec)
@@ -85,13 +92,19 @@ class TestAddition(unittest.TestCase):
 
         self.assertIsInstance(new_aln1, MultipleSeqAlignment)
         for x in range(len(self.codon_aln)):
-            self.assertEqual(str(new_aln1[x].seq), str(self.codon_aln[x].seq) + str(self.multi_aln[x].seq))
+            self.assertEqual(
+                str(new_aln1[x].seq),
+                str(self.codon_aln[x].seq) + str(self.multi_aln[x].seq),
+            )
 
         new_aln2 = self.multi_aln + self.codon_aln
 
         self.assertIsInstance(new_aln2, MultipleSeqAlignment)
         for x in range(len(self.codon_aln)):
-            self.assertEqual(str(new_aln2[x].seq), str(self.multi_aln[x].seq) + str(self.codon_aln[x].seq))
+            self.assertEqual(
+                str(new_aln2[x].seq),
+                str(self.multi_aln[x].seq) + str(self.codon_aln[x].seq),
+            )
 
     def test_addition_CodonAlignment(self):
         """Check addition of CodonAlignment and CodonAlignment."""
@@ -99,13 +112,20 @@ class TestAddition(unittest.TestCase):
 
         self.assertIsInstance(new_aln, codonalign.CodonAlignment)
         for x in range(len(self.codon_aln)):
-            self.assertEqual(str(new_aln[x].seq), str(self.codon_aln[x].seq) + str(self.codon_aln[x].seq))
+            self.assertEqual(
+                str(new_aln[x].seq),
+                str(self.codon_aln[x].seq) + str(self.codon_aln[x].seq),
+            )
 
     def test_ValueError(self):
         """Check that ValueError is thrown for Alignments of different lengths."""
         # original len(self.aln) = 2 , len(aln) = 3
-        aln = MultipleSeqAlignment([self.pro1, self.pro2, SeqRecord(Seq("M--"), id="pro3")])
-        triple_codon = codonalign.build(aln, [self.seq1, self.seq2, SeqRecord(Seq("ATG"), id="pro3")])
+        aln = MultipleSeqAlignment(
+            [self.pro1, self.pro2, SeqRecord(Seq("M--"), id="pro3")]
+        )
+        triple_codon = codonalign.build(
+            aln, [self.seq1, self.seq2, SeqRecord(Seq("ATG"), id="pro3")]
+        )
         with self.assertRaises(ValueError):
             triple_codon + self.multi_aln
         with self.assertRaises(ValueError):
@@ -120,12 +140,14 @@ class TestAddition(unittest.TestCase):
 
 class TestBuildAndIO(unittest.TestCase):
     def setUp(self):
-        self.aln_file = [TEST_ALIGN_FILE1,
-                         TEST_ALIGN_FILE2,
-                         TEST_ALIGN_FILE3,
-                         TEST_ALIGN_FILE4,
-                         TEST_ALIGN_FILE5,
-                         TEST_ALIGN_FILE6]
+        self.aln_file = [
+            TEST_ALIGN_FILE1,
+            TEST_ALIGN_FILE2,
+            TEST_ALIGN_FILE3,
+            TEST_ALIGN_FILE4,
+            TEST_ALIGN_FILE5,
+            TEST_ALIGN_FILE6,
+        ]
         alns = []
         for i in self.aln_file:
             if i[1] == "parse":
@@ -182,23 +204,68 @@ class Test_build(unittest.TestCase):
         self.seqlist1 = [seq1, seq2]
         # Test set 2
         #                      M  K  K  H  E L(F)L  C  Q  G  T  S  N  K  L  T  Q(L)L  G  T  F  E  D  H  F  L  S  L  Q  R  M  F  N  N  C  E  V  V
-        seq3 = SeqRecord(Seq("ATGAAAAAGCACGAGTTACTTTGCCAAGGGACAAGTAACAAGCTCACCCAGTTGGGCACTTTTGAAGACCACTTTCTGAGCCTACAGAGGATGTTCAACAACTGTGAGGTGGTCCTTGGGAATTTGGAAATTACCTACATGCAGAGTAGTTACAACCTTTCTTTTCTCAAGACCATCCAGGAGGTTGCCGGCTATGTACTCATTGCCCTC"), id="pro1")
+        seq3 = SeqRecord(
+            Seq(
+                "ATGAAAAAGCACGAGTTACTTTGCCAAGGGACAAGTAACAAGCTCACCCAGTTGGGCACTTTTGAAGACCACTTTCTGAGCCTACAGAGGATGTTCAACAACTGTGAGGTGGTCCTTGGGAATTTGGAAATTACCTACATGCAGAGTAGTTACAACCTTTCTTTTCTCAAGACCATCCAGGAGGTTGCCGGCTATGTACTCATTGCCCTC"
+            ),
+            id="pro1",
+        )
         # seq4 =SeqRecord(Seq('ATGAAAAAGCACGAGTT CTTTGCCAAGGGACAAGTAACAAGCTCACCCAGTTGGGCACTTTTGAAGACCACTTTCTGAGCCTACAGAGGATGTTCAACAA TGTGAGGTGGTCCTTGGGAATTTGGAAATTACCTACATGCAGAGTAGTTACAACCTTTCTTTTCTCAAGACCATCCAGGAGGTTGCCGGCTATGTACTCATTGCCCTC'), id='pro2')
-        seq4 = SeqRecord(Seq("ATGAAAAAGCACGAGTTCTTTGCCAAGGGACAAGTAACAAGCTCACCCAGTTGGGCACTTTTGAAGACCACTTTCTGAGCCTACAGAGGATGTTCAACAATGTGAGGTGGTCCTTGGGAATTTGGAAATTACCTACATGCAGAGTAGTTACAACCTTTCTTTTCTCAAGACCATCCAGGAGGTTGCCGGCTATGTACTCATTGCCCTC"), id="pro2")
+        seq4 = SeqRecord(
+            Seq(
+                "ATGAAAAAGCACGAGTTCTTTGCCAAGGGACAAGTAACAAGCTCACCCAGTTGGGCACTTTTGAAGACCACTTTCTGAGCCTACAGAGGATGTTCAACAATGTGAGGTGGTCCTTGGGAATTTGGAAATTACCTACATGCAGAGTAGTTACAACCTTTCTTTTCTCAAGACCATCCAGGAGGTTGCCGGCTATGTACTCATTGCCCTC"
+            ),
+            id="pro2",
+        )
         # seq5 =SeqRecord(Seq('ATGAAAAAGCACGAGTT CTTTGCCAAGGGACAAGTAACAAGCTCACCC  TTGGGCACTTTTGAAGACCACTTTCTGAGCCTACAGAGGATGTTCAACAACTGTGAGGTGGTCCTTGGGAATTTGGAAATTACCTACATGCAGAGTAGTTACAACCTTTCTTTTCTCAAGACCATCCAGGAGGTTGCCGGCTATGTACTCATTGCCCTC'), id='pro3')
-        seq5 = SeqRecord(Seq("ATGAAAAAGCACGAGTTACTTTGCCAAGGGACAAGTAACAAGCTCACCCTTGGGCACTTTTGAAGACCACTTTCTGAGCCTACAGAGGATGTTCAACAACTGTGAGGTGGTCCTTGGGAATTTGGAAATTACCTACATGCAGAGTAGTTACAACCTTTCTTTTCTCAAGACCATCCAGGAGGTTGCCGGCTATGTACTCATTGCCCTC"), id="pro3")
-        pro3 = SeqRecord(Seq("MKKHELLCQGTSNKLTQLGTFEDHFLSLQRMFNNCEVVLGNLEITYMQSSYNLSFLKTIQEVAGYVLIAL"), id="pro1")
-        pro4 = SeqRecord(Seq("MKKHEFLCQGTSNKLTQLGTFEDHFLSLQRMFNNCEVVLGNLEITYMQSSYNLSFLKTIQEVAGYVLIAL"), id="pro2")
-        pro5 = SeqRecord(Seq("MKKHELLCQGTSNKLTLLGTFEDHFLSLQRMFNNCEVVLGNLEITYMQSSYNLSFLKTIQEVAGYVLIAL"), id="pro3")
+        seq5 = SeqRecord(
+            Seq(
+                "ATGAAAAAGCACGAGTTACTTTGCCAAGGGACAAGTAACAAGCTCACCCTTGGGCACTTTTGAAGACCACTTTCTGAGCCTACAGAGGATGTTCAACAACTGTGAGGTGGTCCTTGGGAATTTGGAAATTACCTACATGCAGAGTAGTTACAACCTTTCTTTTCTCAAGACCATCCAGGAGGTTGCCGGCTATGTACTCATTGCCCTC"
+            ),
+            id="pro3",
+        )
+        pro3 = SeqRecord(
+            Seq(
+                "MKKHELLCQGTSNKLTQLGTFEDHFLSLQRMFNNCEVVLGNLEITYMQSSYNLSFLKTIQEVAGYVLIAL"
+            ),
+            id="pro1",
+        )
+        pro4 = SeqRecord(
+            Seq(
+                "MKKHEFLCQGTSNKLTQLGTFEDHFLSLQRMFNNCEVVLGNLEITYMQSSYNLSFLKTIQEVAGYVLIAL"
+            ),
+            id="pro2",
+        )
+        pro5 = SeqRecord(
+            Seq(
+                "MKKHELLCQGTSNKLTLLGTFEDHFLSLQRMFNNCEVVLGNLEITYMQSSYNLSFLKTIQEVAGYVLIAL"
+            ),
+            id="pro3",
+        )
         aln2 = MultipleSeqAlignment([pro3, pro4, pro5])
         self.aln2 = aln2
         self.seqlist2 = [seq3, seq4, seq5]
 
         # Test set 3
         # use Yeast mitochondrial codon table
-        seq6 = SeqRecord(Seq("ATGGCAAGGGACCACCCAGTTGGGCACTGATATGATCGGGTGTATTTGCAGAGTAGTAACCTTTCTTTTCTCAAGACCATCCAG"), id="pro6")
-        seq7 = SeqRecord(Seq("ATGGCAAGGCACCATCCAGTTGAGCACTGATATGATCGGGTGTATTTGCAGAGTAGTAACGTGTCTCTGCTCAAGACCATCCAG"), id="pro7")
-        seq8 = SeqRecord(Seq("ATGGCAGGGGACCACCCAGTTGGGCACTGATATGATCGTGTGTATCTGCAGAGTAGTAACCACTCTTTTCTCATGACCATCCAG"), id="pro8")
+        seq6 = SeqRecord(
+            Seq(
+                "ATGGCAAGGGACCACCCAGTTGGGCACTGATATGATCGGGTGTATTTGCAGAGTAGTAACCTTTCTTTTCTCAAGACCATCCAG"
+            ),
+            id="pro6",
+        )
+        seq7 = SeqRecord(
+            Seq(
+                "ATGGCAAGGCACCATCCAGTTGAGCACTGATATGATCGGGTGTATTTGCAGAGTAGTAACGTGTCTCTGCTCAAGACCATCCAG"
+            ),
+            id="pro7",
+        )
+        seq8 = SeqRecord(
+            Seq(
+                "ATGGCAGGGGACCACCCAGTTGGGCACTGATATGATCGTGTGTATCTGCAGAGTAGTAACCACTCTTTTCTCATGACCATCCAG"
+            ),
+            id="pro8",
+        )
         pro6 = SeqRecord(Seq("MARDHPVGHWYDRVYLQSSNTSFTKTIQ"), id="pro6")
         pro7 = SeqRecord(Seq("MARHHPVEHWYDRVYLQSSNVSTTKTIQ"), id="pro7")
         pro8 = SeqRecord(Seq("MAGDHPVGHWYDRVYTQSSNHSFTMTIQ"), id="pro8")
@@ -210,7 +277,9 @@ class Test_build(unittest.TestCase):
     def test_build(self):
         codon_aln1 = codonalign.build(self.aln1, self.seqlist1)
         codon_aln2 = codonalign.build(self.aln2, self.seqlist2)
-        codon_aln3 = codonalign.build(self.aln3, self.seqlist3, codon_table=self.codontable3)
+        codon_aln3 = codonalign.build(
+            self.aln3, self.seqlist3, codon_table=self.codontable3
+        )
 
 
 class Test_dn_ds(unittest.TestCase):
@@ -226,6 +295,7 @@ class Test_dn_ds(unittest.TestCase):
 
     def test_dn_ds(self):
         from Bio.codonalign.codonseq import cal_dn_ds
+
         codon_seq1 = self.aln[0]
         codon_seq2 = self.aln[1]
         dN, dS = cal_dn_ds(codon_seq1, codon_seq2, method="NG86")
@@ -243,6 +313,7 @@ class Test_dn_ds(unittest.TestCase):
 
         # This should be present:
         from scipy.linalg import expm
+
         dN, dS = cal_dn_ds(codon_seq1, codon_seq2, method="YN00")
         self.assertAlmostEqual(dN, 0.0198, places=4)
         self.assertAlmostEqual(dS, 0.0222, places=4)
@@ -250,6 +321,7 @@ class Test_dn_ds(unittest.TestCase):
         try:
             # New in scipy v0.11
             from scipy.optimize import minimize
+
             dN, dS = cal_dn_ds(codon_seq1, codon_seq2, method="ML")
             self.assertAlmostEqual(dN, 0.0194, places=4)
             self.assertAlmostEqual(dS, 0.0217, places=4)
@@ -259,8 +331,52 @@ class Test_dn_ds(unittest.TestCase):
 
     def test_dn_ds_matrix(self):
         # NG86 method with default codon table
-        dn_correct = [0, 0.02090783050583131, 0, 0.6115239249238438, 0.6102203266798018, 0, 0.6140350835631757, 0.6040168621204747, 0.041180350405913294, 0, 0.6141532531400524, 0.6018263135601294, 0.06701051445629494, 0.061470360954086874, 0, 0.6187088340904762, 0.6068687248870475, 0.07386903034833081, 0.07357890927918581, 0.05179847072570129, 0]
-        ds_correct = [0, 0.01783718763890243, 0, 2.9382055377913687, 3.0375115405379267, 0, 2.008913071877126, 2.0182088023715616, 0.5638033197005285, 0, 2.771425931736778, 2.7353083173058295, 0.6374483799734671, 0.723542095485497, 0, -1, -1, 0.953865978141643, 1.182154857347706, 0.843182957978177, 0]
+        dn_correct = [
+            0,
+            0.02090783050583131,
+            0,
+            0.6115239249238438,
+            0.6102203266798018,
+            0,
+            0.6140350835631757,
+            0.6040168621204747,
+            0.041180350405913294,
+            0,
+            0.6141532531400524,
+            0.6018263135601294,
+            0.06701051445629494,
+            0.061470360954086874,
+            0,
+            0.6187088340904762,
+            0.6068687248870475,
+            0.07386903034833081,
+            0.07357890927918581,
+            0.05179847072570129,
+            0,
+        ]
+        ds_correct = [
+            0,
+            0.01783718763890243,
+            0,
+            2.9382055377913687,
+            3.0375115405379267,
+            0,
+            2.008913071877126,
+            2.0182088023715616,
+            0.5638033197005285,
+            0,
+            2.771425931736778,
+            2.7353083173058295,
+            0.6374483799734671,
+            0.723542095485497,
+            0,
+            -1,
+            -1,
+            0.953865978141643,
+            1.182154857347706,
+            0.843182957978177,
+            0,
+        ]
         dn, ds = self.aln.get_dn_ds_matrix()
         dn_list = []
         for i in dn.matrix:
@@ -273,9 +389,55 @@ class Test_dn_ds(unittest.TestCase):
         for ds_cal, ds_corr in zip(ds_list, ds_correct):
             self.assertAlmostEqual(ds_cal, ds_corr, places=4)
         # YN00 method with user specified codon table
-        dn_correct = [0, 0.019701773284646867, 0, 0.6109649819852769, 0.6099903856901369, 0, 0.6114499930666559, 0.6028068208599121, 0.045158286242251426, 0, 0.6151835071687592, 0.6053227393422296, 0.07034397741651377, 0.06956967795096626, 0, 0.6103850655769698, 0.5988716898831496, 0.07905930042150053, 0.08203052937107111, 0.05659346894088538, 0]
-        ds_correct = [0, 0.01881718550096053, 0, 1.814457265482046, 1.8417575124882066, 0, 1.5627041719628896, 1.563930819079887, 0.4748890153032888, 0, 1.6754828466084355, 1.6531212012501901, 0.5130923627791538, 0.5599667707191436, 0, 2.0796114236540943, 2.1452591651827304, 0.7243066372971764, 0.8536617406770075, 0.6509203399899367, 0]
-        dn, ds = self.aln.get_dn_ds_matrix(method="LWL85", codon_table=CodonTable.unambiguous_dna_by_id[3])
+        dn_correct = [
+            0,
+            0.019701773284646867,
+            0,
+            0.6109649819852769,
+            0.6099903856901369,
+            0,
+            0.6114499930666559,
+            0.6028068208599121,
+            0.045158286242251426,
+            0,
+            0.6151835071687592,
+            0.6053227393422296,
+            0.07034397741651377,
+            0.06956967795096626,
+            0,
+            0.6103850655769698,
+            0.5988716898831496,
+            0.07905930042150053,
+            0.08203052937107111,
+            0.05659346894088538,
+            0,
+        ]
+        ds_correct = [
+            0,
+            0.01881718550096053,
+            0,
+            1.814457265482046,
+            1.8417575124882066,
+            0,
+            1.5627041719628896,
+            1.563930819079887,
+            0.4748890153032888,
+            0,
+            1.6754828466084355,
+            1.6531212012501901,
+            0.5130923627791538,
+            0.5599667707191436,
+            0,
+            2.0796114236540943,
+            2.1452591651827304,
+            0.7243066372971764,
+            0.8536617406770075,
+            0.6509203399899367,
+            0,
+        ]
+        dn, ds = self.aln.get_dn_ds_matrix(
+            method="LWL85", codon_table=CodonTable.unambiguous_dna_by_id[3]
+        )
         dn_list = []
         for i in dn.matrix:
             dn_list.extend(i)
@@ -294,13 +456,18 @@ except ImportError:
     numpy = None
 
 if numpy:
+
     class Test_MK(unittest.TestCase):
         def test_mk(self):
             p = SeqIO.index(TEST_ALIGN_FILE7[0][0], "fasta")
             pro_aln = AlignIO.read(TEST_ALIGN_FILE7[0][1], "clustal")
             codon_aln = codonalign.build(pro_aln, p)
             p.close()  # Close indexed FASTA file
-            self.assertAlmostEqual(codonalign.mktest([codon_aln[1:12], codon_aln[12:16], codon_aln[16:]]), 0.0021, places=4)
+            self.assertAlmostEqual(
+                codonalign.mktest([codon_aln[1:12], codon_aln[12:16], codon_aln[16:]]),
+                0.0021,
+                places=4,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request addresses issue #2552 and #2835 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X]  I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X]  I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X]  I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Since most of these are very minor changes I decided to do all of them in a single PR, but if preferred I can close this and do a separate one for each.
