### PR TITLE
remove alphabets in the UnknownSeq documentation

### DIFF
--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -690,14 +690,11 @@ UnknownSeq(20, character='?')
 20
 \end{minted}
 
-You can of course specify an alphabet, meaning for nucleotide sequences
-the letter defaults to ``N'' and for proteins ``X'', rather than just ``?''.
-
+For DNA or RNA sequences, unknown nucleotides are commonly denoted by the letter ``N'', while for proteins ``X'' is commonly used for unknown amino acids. When creating an `UnknownSeq`, you can specify the character to be used instead of ``?'' to represent unknown letters. For example
 %cont-doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import UnknownSeq
->>> from Bio.Alphabet import generic_dna
->>> unk_dna = UnknownSeq(20, alphabet=generic_dna)
+>>> unk_dna = UnknownSeq(20, character="N")
 >>> unk_dna
 UnknownSeq(20, character='N')
 >>> print(unk_dna)


### PR DESCRIPTION
This pull request removes alphabets from the description of `UnknownSeq` objects in the tutorial.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
