### PR TITLE
Discard alphabet when adding Seq objects

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1564,7 +1564,7 @@ class UnknownSeq(Seq):
         XXX
 
         """
-        return UnknownSeq(self._length // 3, Alphabet.generic_protein, "X")
+        return UnknownSeq(self._length // 3, character="X")
 
     def ungap(self, gap="-"):
         """Return a copy of the sequence without the gap character(s).

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -168,14 +168,10 @@ class Seq:
         The new behaviour is to use string-like equality:
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_dna
         >>> seq1 == seq2
         True
         >>> seq1 == "ACGT"
         True
-        >>> seq1 == Seq("ACGT", generic_dna)
-        True
-
         """
         return str(self) == str(other)
 
@@ -255,8 +251,7 @@ class Seq:
         """Add a sequence on the left.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_protein
-        >>> "LV" + Seq("MELKI", generic_protein)
+        >>> "LV" + Seq("MELKI")
         Seq('LVMELKI')
 
         Adding two Seq (like) objects is handled via the __add__ method.
@@ -763,8 +758,7 @@ class Seq:
         Trying to complement a protein sequence gives a meaningless
         sequence:
 
-        >>> from Bio.Alphabet import generic_protein
-        >>> my_protein = Seq("MAIVMGR", generic_protein)
+        >>> my_protein = Seq("MAIVMGR")
         >>> my_protein.complement()
         Seq('KTIBKCY')
 
@@ -803,9 +797,8 @@ class Seq:
 
         You can of course used mixed case sequences,
 
-        >>> from Bio.Alphabet import generic_dna
         >>> from Bio.Seq import Seq
-        >>> my_dna = Seq("CCCCCgatA-G", generic_dna)
+        >>> my_dna = Seq("CCCCCgatA-G")
         >>> my_dna
         Seq('CCCCCgatA-G')
         >>> my_dna.reverse_complement()
@@ -833,9 +826,8 @@ class Seq:
         Trying to reverse complement a protein sequence will give
         a meaningless sequence:
 
-        >>> from Bio.Alphabet import generic_protein
         >>> from Bio.Seq import Seq
-        >>> my_protein = Seq("MAIVMGR", generic_protein)
+        >>> my_protein = Seq("MAIVMGR")
         >>> my_protein.reverse_complement()
         Seq('YCKBITK')
 
@@ -888,9 +880,7 @@ class Seq:
         """Return the RNA sequence from a DNA sequence by creating a new Seq object.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_dna
-        >>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG",
-        ...                  generic_dna)
+        >>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG")
         >>> coding_dna
         Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
         >>> coding_dna.transcribe()
@@ -906,9 +896,8 @@ class Seq:
         biologically plausible rational. Older versions of Biopython
         would throw an exception.
 
-        >>> from Bio.Alphabet import generic_protein
         >>> from Bio.Seq import Seq
-        >>> my_protein = Seq("MAIVMGRT", generic_protein)
+        >>> my_protein = Seq("MAIVMGRT")
         >>> my_protein.transcribe()
         Seq('MAIVMGRU')
         """
@@ -1054,8 +1043,7 @@ class Seq:
         via sequence's alphabet (as was possible up to Biopython 1.77):
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_dna
-        >>> my_dna = Seq("-ATA--TGAAAT-TTGAAAA", generic_dna)
+        >>> my_dna = Seq("-ATA--TGAAAT-TTGAAAA")
         >>> my_dna
         Seq('-ATA--TGAAAT-TTGAAAA')
         >>> my_dna.ungap("-")
@@ -1231,10 +1219,9 @@ class UnknownSeq(Seq):
         """Multiply UnknownSeq by integer.
 
         >>> from Bio.Seq import UnknownSeq
-        >>> from Bio.Alphabet import generic_dna
         >>> UnknownSeq(3) * 2
         UnknownSeq(6, character='?')
-        >>> UnknownSeq(3, generic_dna) * 2
+        >>> UnknownSeq(3, character="N") * 2
         UnknownSeq(6, character='N')
         """
         if not isinstance(other, int):
@@ -1467,8 +1454,7 @@ class UnknownSeq(Seq):
         The reverse complement of an unknown nucleotide equals itself:
 
         >>> from Bio.Seq import UnknownSeq
-        >>> from Bio.Alphabet import generic_dna
-        >>> example = UnknownSeq(6, generic_dna)
+        >>> example = UnknownSeq(6, character="N")
         >>> print(example)
         NNNNNN
         >>> print(example.reverse_complement())
@@ -1674,8 +1660,7 @@ class MutableSeq:
     However, this means you cannot use a MutableSeq object as a dictionary key.
 
     >>> from Bio.Seq import MutableSeq
-    >>> from Bio.Alphabet import generic_dna
-    >>> my_seq = MutableSeq("ACTCGTCGTCG", generic_dna)
+    >>> my_seq = MutableSeq("ACTCGTCGTCG")
     >>> my_seq
     MutableSeq('ACTCGTCGTCG')
     >>> my_seq[5]
@@ -1890,10 +1875,7 @@ class MutableSeq:
         matching native Python list multiplication.
 
         >>> from Bio.Seq import MutableSeq
-        >>> from Bio.Alphabet import generic_dna
         >>> MutableSeq('ATG') * 2
-        MutableSeq('ATGATG')
-        >>> MutableSeq('ATG', generic_dna) * 2
         MutableSeq('ATGATG')
         """
         if not isinstance(other, int):
@@ -1907,10 +1889,7 @@ class MutableSeq:
         matching native Python list multiplication.
 
         >>> from Bio.Seq import MutableSeq
-        >>> from Bio.Alphabet import generic_dna
         >>> 2 * MutableSeq('ATG')
-        MutableSeq('ATGATG')
-        >>> 2 * MutableSeq('ATG', generic_dna)
         MutableSeq('ATGATG')
         """
         if not isinstance(other, int):
@@ -1921,8 +1900,7 @@ class MutableSeq:
         """Multiply MutableSeq in-place.
 
         >>> from Bio.Seq import MutableSeq
-        >>> from Bio.Alphabet import generic_dna
-        >>> seq = MutableSeq('ATG', generic_dna)
+        >>> seq = MutableSeq('ATG')
         >>> seq *= 2
         >>> seq
         MutableSeq('ATGATG')

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1207,40 +1207,35 @@ class UnknownSeq(Seq):
         """Add another sequence or string to this sequence.
 
         Adding two UnknownSeq objects returns another UnknownSeq object
-        provided the character is the same and the alphabets are compatible.
+        provided the character is the same.
 
         >>> from Bio.Seq import UnknownSeq
-        >>> from Bio.Alphabet import generic_protein
-        >>> UnknownSeq(10, generic_protein) + UnknownSeq(5, generic_protein)
+        >>> UnknownSeq(10, character='X') + UnknownSeq(5, character='X')
         UnknownSeq(15, character='X')
 
         If the characters differ, an UnknownSeq object cannot be used, so a
         Seq object is returned:
 
         >>> from Bio.Seq import UnknownSeq
-        >>> from Bio.Alphabet import generic_protein
-        >>> UnknownSeq(10, generic_protein) + UnknownSeq(5, generic_protein,
-        ...                                              character="x")
+        >>> UnknownSeq(10, character='X') + UnknownSeq(5, character="x")
         Seq('XXXXXXXXXXxxxxx')
 
-        If adding a string to an UnknownSeq, a new Seq is returned with the
-        same alphabet:
+        If adding a string to an UnknownSeq, a new Seq is returned:
 
         >>> from Bio.Seq import UnknownSeq
-        >>> from Bio.Alphabet import generic_protein
-        >>> UnknownSeq(5, generic_protein) + "LV"
+        >>> UnknownSeq(5, character='X') + "LV"
         Seq('XXXXXLV')
         """
         if isinstance(other, UnknownSeq) and other._character == self._character:
-            return UnknownSeq(len(self) + len(other), self.alphabet, self._character)
+            return UnknownSeq(len(self) + len(other), character=self._character)
         # Offload to the base class...
-        return Seq(str(self), self.alphabet) + other
+        return Seq(str(self)) + other
 
     def __radd__(self, other):
         """Add a sequence on the left."""
         # If other is an UnknownSeq, then __add__ would be called.
         # Offload to the base class...
-        return other + Seq(str(self), self.alphabet)
+        return other + Seq(str(self))
 
     def __mul__(self, other):
         """Multiply UnknownSeq by integer.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -236,37 +236,13 @@ class Seq:
     def __add__(self, other):
         """Add another sequence or string to this sequence.
 
-        If adding a string to a Seq, the alphabet is preserved:
-
         >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import generic_protein
-        >>> Seq("MELKI", generic_protein) + "LV"
+        >>> Seq("MELKI") + "LV"
         Seq('MELKILV')
-
-        When adding two Seq (like) objects, if they share the
-        same alphabet it is preserved, but otherwise discarded.
-        This means you can add RNA and DNA, or nucleotide and
-        protein if you really want to. This is a change as of
-        Biopython 1.78, this previously raised a TypeError:
-
-        >>> from Bio.Alphabet import generic_dna, generic_rna
-        >>> Seq("ACGT", generic_dna) + Seq("ACGU", generic_rna)
-        Seq('ACGTACGU')
-
-        >>> from Bio.Alphabet import generic_dna, generic_protein
-        >>> Seq("ACGT", generic_dna) + Seq("MELKI", generic_protein)
-        Seq('ACGTMELKI')
         """
-        if hasattr(other, "alphabet"):
-            if other.alphabet == self.alphabet:
-                # Perfect match, preserve the alphabet
-                return self.__class__(str(self) + str(other), self.alphabet)
-            else:
-                # Discard the alphabet
-                return self.__class__(str(self) + str(other))
-        elif isinstance(other, str):
-            # other is a plain string - use the current alphabet
-            return self.__class__(str(self) + other, self.alphabet)
+        if isinstance(other, (str, Seq, MutableSeq)):
+            # Discard any alphabet
+            return self.__class__(str(self) + str(other))
 
         from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
 
@@ -288,16 +264,9 @@ class Seq:
 
         Adding two Seq (like) objects is handled via the __add__ method.
         """
-        if hasattr(other, "alphabet"):
-            if other.alphabet == self.alphabet:
-                # Perfect match, preserve the alphabet
-                return self.__class__(str(other) + str(self), self.alphabet)
-            else:
-                # Discard the alphabet
-                return self.__class__(str(other) + str(self))
-        elif isinstance(other, str):
-            # other is a plain string - use the current alphabet
-            return self.__class__(other + str(self), self.alphabet)
+        if isinstance(other, (str, Seq, MutableSeq)):
+            # Discard any alphabet
+            return self.__class__(str(other) + str(self))
         else:
             raise TypeError
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1608,11 +1608,11 @@ class UnknownSeq(Seq):
         Seq('')
         """
         # Offload the argument validation
-        s = Seq(self._character, self.alphabet).ungap(gap)
+        s = Seq(self._character).ungap(gap)
         if s:
-            return UnknownSeq(self._length, s.alphabet, self._character)
+            return UnknownSeq(self._length, character=self._character)
         else:
-            return Seq("", s.alphabet)
+            return Seq("")
 
     def join(self, other):
         """Return a merge of the sequences in other, spaced by the sequence from self.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1116,8 +1116,8 @@ class UnknownSeq(Seq):
     >>> print(unk_five)
     ?????
 
-    You can add unknown sequence together. Provided the characters
-    are compatible, and get another memory saving UnknownSeq:
+    You can add unknown sequence together. Provided the characters are the
+    same, you get another memory saving UnknownSeq:
 
     >>> unk_four = UnknownSeq(4)
     >>> unk_four
@@ -1125,8 +1125,7 @@ class UnknownSeq(Seq):
     >>> unk_four + unk_five
     UnknownSeq(9, character='?')
 
-    If the characters don't match up, the addition gives an
-    ordinary Seq object:
+    If the characters are different, addition gives an ordinary Seq object:
 
     >>> unk_nnnn = UnknownSeq(4, character="N")
     >>> unk_nnnn

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1869,20 +1869,12 @@ class MutableSeq:
 
         Returns a new MutableSeq object.
         """
-        a = self.alphabet
-        if hasattr(other, "alphabet"):
-            if a != other.alphabet:
-                # Drop alphabet unless agree
-                a = Alphabet.generic_alphabet
-            if isinstance(other, MutableSeq):
-                # See test_GAQueens.py for an historic usage of a non-string
-                # alphabet!  Adding the arrays should support this.
-                return self.__class__(self.data + other.data, a)
-            else:
-                return self.__class__(str(self) + str(other), a)
-        elif isinstance(other, str):
-            # other is a plain string - use the current alphabet
-            return self.__class__(str(self) + str(other), a)
+        if isinstance(other, MutableSeq):
+            # See test_GAQueens.py for an historic usage of a non-string
+            # alphabet!  Adding the arrays should support this.
+            return self.__class__(self.data + other.data)
+        elif isinstance(other, (str, Seq)):
+            return self.__class__(str(self) + str(other))
         else:
             raise TypeError
 
@@ -1890,23 +1882,15 @@ class MutableSeq:
         """Add a sequence on the left.
 
         >>> from Bio.Seq import MutableSeq
-        >>> from Bio.Alphabet import generic_protein
-        >>> "LV" + MutableSeq("MELKI", generic_protein)
+        >>> "LV" + MutableSeq("MELKI")
         MutableSeq('LVMELKI')
         """
-        a = self.alphabet
-        if hasattr(other, "alphabet"):
-            if a != other.alphabet:
-                a = Alphabet.generic_alphabet
-            if isinstance(other, MutableSeq):
-                # See test_GAQueens.py for an historic usage of a non-string
-                # alphabet!  Adding the arrays should support this.
-                return self.__class__(other.data + self.data, a)
-            else:
-                return self.__class__(str(other) + str(self), a)
-        elif isinstance(other, str):
-            # other is a plain string - use the current alphabet
-            return self.__class__(str(other) + str(self), self.alphabet)
+        if isinstance(other, MutableSeq):
+            # See test_GAQueens.py for an historic usage of a non-string
+            # alphabet!  Adding the arrays should support this.
+            return self.__class__(other.data + self.data)
+        elif isinstance(other, (str, Seq)):
+            return self.__class__(str(other) + str(self))
         else:
             raise TypeError
 


### PR DESCRIPTION
This pull request addresses in part issue #2046, and recent discussion on #3151 with the ``DBSeq`` which subclasses ``Seq``

This discards alphabets when adding Seq objects, plus a few other remaining cases, and removes alphabet usage within the ``Bio.Seq`` doctests.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
