### PR TITLE
Specify molecule type in Bio.SeqIO.convert

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -1460,7 +1460,7 @@ class ImgtWriter(EmblWriter):
     FEATURE_HEADER = "FH   Key                 Location/Qualifiers\nFH\n"
 
 
-def _genbank_convert_fasta(in_file, out_file, alphabet=None):
+def _genbank_convert_fasta(in_file, out_file):
     """Fast GenBank to FASTA (PRIVATE)."""
     # We don't need to parse the features...
     records = GenBankScanner().parse_records(in_file, do_features=False)
@@ -1468,7 +1468,7 @@ def _genbank_convert_fasta(in_file, out_file, alphabet=None):
     return SeqIO.write(records, out_file, "fasta")
 
 
-def _embl_convert_fasta(in_file, out_file, alphabet=None):
+def _embl_convert_fasta(in_file, out_file):
     """Fast EMBL to FASTA (PRIVATE)."""
     # We don't need to parse the features...
     records = EmblScanner().parse_records(in_file, do_features=False)

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -2033,7 +2033,7 @@ def _fastq_generic2(in_file, out_file, mapping, truncate_char, truncate_msg):
     return count
 
 
-def _fastq_sanger_convert_fastq_sanger(in_file, out_file, alphabet=None):
+def _fastq_sanger_convert_fastq_sanger(in_file, out_file):
     """Fast Sanger FASTQ to Sanger FASTQ conversion (PRIVATE).
 
     Useful for removing line wrapping and the redundant second identifier
@@ -2052,7 +2052,7 @@ def _fastq_sanger_convert_fastq_sanger(in_file, out_file, alphabet=None):
     return _fastq_generic(in_file, out_file, mapping)
 
 
-def _fastq_solexa_convert_fastq_solexa(in_file, out_file, alphabet=None):
+def _fastq_solexa_convert_fastq_solexa(in_file, out_file):
     """Fast Solexa FASTQ to Solexa FASTQ conversion (PRIVATE).
 
     Useful for removing line wrapping and the redundant second identifier
@@ -2070,7 +2070,7 @@ def _fastq_solexa_convert_fastq_solexa(in_file, out_file, alphabet=None):
     return _fastq_generic(in_file, out_file, mapping)
 
 
-def _fastq_illumina_convert_fastq_illumina(in_file, out_file, alphabet=None):
+def _fastq_illumina_convert_fastq_illumina(in_file, out_file):
     """Fast Illumina 1.3+ FASTQ to Illumina 1.3+ FASTQ conversion (PRIVATE).
 
     Useful for removing line wrapping and the redundant second identifier
@@ -2088,7 +2088,7 @@ def _fastq_illumina_convert_fastq_illumina(in_file, out_file, alphabet=None):
     return _fastq_generic(in_file, out_file, mapping)
 
 
-def _fastq_illumina_convert_fastq_sanger(in_file, out_file, alphabet=None):
+def _fastq_illumina_convert_fastq_sanger(in_file, out_file):
     """Fast Illumina 1.3+ FASTQ to Sanger FASTQ conversion (PRIVATE).
 
     Avoids creating SeqRecord and Seq objects in order to speed up this
@@ -2104,7 +2104,7 @@ def _fastq_illumina_convert_fastq_sanger(in_file, out_file, alphabet=None):
     return _fastq_generic(in_file, out_file, mapping)
 
 
-def _fastq_sanger_convert_fastq_illumina(in_file, out_file, alphabet=None):
+def _fastq_sanger_convert_fastq_illumina(in_file, out_file):
     """Fast Sanger FASTQ to Illumina 1.3+ FASTQ conversion (PRIVATE).
 
     Avoids creating SeqRecord and Seq objects in order to speed up this
@@ -2129,7 +2129,7 @@ def _fastq_sanger_convert_fastq_illumina(in_file, out_file, alphabet=None):
     )
 
 
-def _fastq_solexa_convert_fastq_sanger(in_file, out_file, alphabet=None):
+def _fastq_solexa_convert_fastq_sanger(in_file, out_file):
     """Fast Solexa FASTQ to Sanger FASTQ conversion (PRIVATE).
 
     Avoids creating SeqRecord and Seq objects in order to speed up this
@@ -2148,7 +2148,7 @@ def _fastq_solexa_convert_fastq_sanger(in_file, out_file, alphabet=None):
     return _fastq_generic(in_file, out_file, mapping)
 
 
-def _fastq_sanger_convert_fastq_solexa(in_file, out_file, alphabet=None):
+def _fastq_sanger_convert_fastq_solexa(in_file, out_file):
     """Fast Sanger FASTQ to Solexa FASTQ conversion (PRIVATE).
 
     Avoids creating SeqRecord and Seq objects in order to speed up this
@@ -2173,7 +2173,7 @@ def _fastq_sanger_convert_fastq_solexa(in_file, out_file, alphabet=None):
     )
 
 
-def _fastq_solexa_convert_fastq_illumina(in_file, out_file, alphabet=None):
+def _fastq_solexa_convert_fastq_illumina(in_file, out_file):
     """Fast Solexa FASTQ to Illumina 1.3+ FASTQ conversion (PRIVATE).
 
     Avoids creating SeqRecord and Seq objects in order to speed up this
@@ -2192,7 +2192,7 @@ def _fastq_solexa_convert_fastq_illumina(in_file, out_file, alphabet=None):
     return _fastq_generic(in_file, out_file, mapping)
 
 
-def _fastq_illumina_convert_fastq_solexa(in_file, out_file, alphabet=None):
+def _fastq_illumina_convert_fastq_solexa(in_file, out_file):
     """Fast Illumina 1.3+ FASTQ to Solexa FASTQ conversion (PRIVATE).
 
     Avoids creating SeqRecord and Seq objects in order to speed up this
@@ -2208,7 +2208,7 @@ def _fastq_illumina_convert_fastq_solexa(in_file, out_file, alphabet=None):
     return _fastq_generic(in_file, out_file, mapping)
 
 
-def _fastq_convert_fasta(in_file, out_file, alphabet=None):
+def _fastq_convert_fasta(in_file, out_file):
     """Fast FASTQ to FASTA conversion (PRIVATE).
 
     Avoids dealing with the FASTQ quality encoding, and creating SeqRecord and
@@ -2229,7 +2229,7 @@ def _fastq_convert_fasta(in_file, out_file, alphabet=None):
     return count
 
 
-def _fastq_convert_tab(in_file, out_file, alphabet=None):
+def _fastq_convert_tab(in_file, out_file):
     """Fast FASTQ to simple tabbed conversion (PRIVATE).
 
     Avoids dealing with the FASTQ quality encoding, and creating SeqRecord and
@@ -2282,13 +2282,13 @@ def _fastq_convert_qual(in_file, out_file, mapping):
     return count
 
 
-def _fastq_sanger_convert_qual(in_file, out_file, alphabet=None):
+def _fastq_sanger_convert_qual(in_file, out_file):
     """Fast Sanger FASTQ to QUAL conversion (PRIVATE)."""
     mapping = {chr(q + 33): str(q) for q in range(0, 93 + 1)}
     return _fastq_convert_qual(in_file, out_file, mapping)
 
 
-def _fastq_solexa_convert_qual(in_file, out_file, alphabet=None):
+def _fastq_solexa_convert_qual(in_file, out_file):
     """Fast Solexa FASTQ to QUAL conversion (PRIVATE)."""
     mapping = {
         chr(q + 64): str(int(round(phred_quality_from_solexa(q))))
@@ -2297,7 +2297,7 @@ def _fastq_solexa_convert_qual(in_file, out_file, alphabet=None):
     return _fastq_convert_qual(in_file, out_file, mapping)
 
 
-def _fastq_illumina_convert_qual(in_file, out_file, alphabet=None):
+def _fastq_illumina_convert_qual(in_file, out_file):
     """Fast Illumina 1.3+ FASTQ to QUAL conversion (PRIVATE)."""
     mapping = {chr(q + 64): str(q) for q in range(0, 62 + 1)}
     return _fastq_convert_qual(in_file, out_file, mapping)

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -1048,7 +1048,7 @@ _converter = {
 }
 
 
-def convert(in_file, in_format, out_file, out_format, mol_type=None):
+def convert(in_file, in_format, out_file, out_format, molecule_type=None):
     """Convert between two sequence file formats, return number of records.
 
     Arguments:
@@ -1056,7 +1056,8 @@ def convert(in_file, in_format, out_file, out_format, mol_type=None):
      - in_format - input file format, lower case string
      - out_file - an output handle or filename
      - out_format - output file format, lower case string
-     - mol_type - optional molecule type to apply: "DNA", "RNA" or "protein".
+     - molecule_type - optional molecule type to apply, string containing
+       "DNA", "RNA" or "protein".
 
     **NOTE** - If you provide an output filename, it will be opened which will
     overwrite any existing file without warning.
@@ -1091,24 +1092,28 @@ def convert(in_file, in_format, out_file, out_format, mol_type=None):
     GTTGCTTCTGGCGTGGGTGGGGGGG
     <BLANKLINE>
     """
-    if mol_type:
-        if not isinstance(mol_type, str):
-            raise TypeError("Molecule type should be a string, not %r" % mol_type)
-        elif "DNA" in mol_type or "RNA" in mol_type or "protein" in mol_type:
+    if molecule_type:
+        if not isinstance(molecule_type, str):
+            raise TypeError("Molecule type should be a string, not %r" % molecule_type)
+        elif (
+            "DNA" in molecule_type
+            or "RNA" in molecule_type
+            or "protein" in molecule_type
+        ):
             pass
         else:
-            raise ValueError("Unexpected molecule type, %r" % mol_type)
+            raise ValueError("Unexpected molecule type, %r" % molecule_type)
     f = _converter.get((in_format, out_format))
     if f:
         count = f(in_file, out_file)
     else:
         records = parse(in_file, in_format)
-        if mol_type:
+        if molecule_type:
             # Edit the records on the fly to set molecule type
 
             def over_ride(record):
                 """Over-ride molecule in-place."""
-                record.annotations["molecule_type"] = mol_type
+                record.annotations["molecule_type"] = molecule_type
                 return record
 
             records = (over_ride(_) for _ in records)

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -1048,7 +1048,7 @@ _converter = {
 }
 
 
-def convert(in_file, in_format, out_file, out_format, alphabet=None):
+def convert(in_file, in_format, out_file, out_format, mol_type=None):
     """Convert between two sequence file formats, return number of records.
 
     Arguments:
@@ -1056,7 +1056,7 @@ def convert(in_file, in_format, out_file, out_format, alphabet=None):
      - in_format - input file format, lower case string
      - out_file - an output handle or filename
      - out_format - output file format, lower case string
-     - alphabet - optional alphabet to assume
+     - mol_type - optional molecule type to apply: "DNA", "RNA" or "protein".
 
     **NOTE** - If you provide an output filename, it will be opened which will
     overwrite any existing file without warning.
@@ -1091,11 +1091,27 @@ def convert(in_file, in_format, out_file, out_format, alphabet=None):
     GTTGCTTCTGGCGTGGGTGGGGGGG
     <BLANKLINE>
     """
+    if mol_type:
+        if not isinstance(mol_type, str):
+            raise TypeError("Molecule type should be a string, not %r" % mol_type)
+        elif "DNA" in mol_type or "RNA" in mol_type or "protein" in mol_type:
+            pass
+        else:
+            raise ValueError("Unexpected molecule type, %r" % mol_type)
     f = _converter.get((in_format, out_format))
     if f:
-        count = f(in_file, out_file, alphabet)
+        count = f(in_file, out_file)
     else:
-        records = parse(in_file, in_format, alphabet)
+        records = parse(in_file, in_format)
+        if mol_type:
+            # Edit the records on the fly to set molecule type
+
+            def over_ride(record):
+                """Over-ride molecule in-place."""
+                record.annotations["molecule_type"] = mol_type
+                return record
+
+            records = (over_ride(_) for _ in records)
         count = write(records, out_file, out_format)
     return count
 

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -5710,6 +5710,27 @@ class TestSeqIO(SeqIOTestBaseClass):
                 with self.assertRaisesRegex(ValueError, "Empty file."):
                     list(SeqIO.parse(handle, t_format))
 
+    def test_pdb_to_seqxml_with_mol_type(self):
+        """Setting molecule type for PDB to SeqXML."""
+        handle = BytesIO()
+        self.assertEqual(
+            1, SeqIO.convert("PDB/1A8O.pdb", "pdb-seqres", handle, "seqxml", "protein")
+        )
+        self.assertIn(
+            b'<property name="molecule_type" value="protein">', handle.getvalue()
+        )
+
+    def test_clustal_to_nexus_with_mol_type(self):
+        """Setting molecule type for Clustal to NEXUS."""
+        handle = StringIO()
+        self.assertEqual(
+            20,
+            SeqIO.convert(
+                "Clustalw/protein.aln", "clustal", handle, "nexus", "protein"
+            ),
+        )
+        self.assertIn(" datatype=protein ", handle.getvalue())
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
Transition ``Bio.SeqIO.convert`` from taking an alphabet argument (used with parsing) to a molecule argument (used before writing). To be followed with essentially the same change in ``Bio.AlignIO.convert`` for alignments.

Also simplified the argument signature of the format specific optimised conversion functions since none of them needed the alphabet/molecule type.

This pull request addresses issue #2046.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
