### PR TITLE
Don't record alphabet in SeqIO FASTA and QUAL parsers

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -1,4 +1,4 @@
-# Copyright 2006-2017 by Peter Cock.  All rights reserved.
+# Copyright 2006-2017,2020 by Peter Cock.  All rights reserved.
 #
 # This file is part of the Biopython distribution and governed by your
 # choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
@@ -15,7 +15,6 @@ You are expected to use this module via the Bio.SeqIO functions.
 """
 
 
-from Bio.Alphabet import single_letter_alphabet
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from .Interfaces import SequenceIterator, SequenceWriter
@@ -138,12 +137,12 @@ def FastaTwoLineParser(handle):
 class FastaIterator(SequenceIterator):
     """Parser for Fasta files."""
 
-    def __init__(self, source, alphabet=single_letter_alphabet, title2ids=None):
+    def __init__(self, source, alphabet=None, title2ids=None):
         """Iterate over Fasta records as SeqRecord objects.
 
         Arguments:
          - source - input stream opened in text mode, or a path to a file
-         - alphabet - optional alphabet
+         - alphabet - optional alphabet, not used. Leave as None.
          - title2ids - A function that, when given the title of the FASTA
            file (without the beginning >), will return the id, name and
            description (in that order) for the record as a tuple of strings.
@@ -178,8 +177,10 @@ class FastaIterator(SequenceIterator):
         DELTA
 
         """
+        if alphabet is not None:
+            raise ValueError("The alphabet argument is no longer supported")
         self.title2ids = title2ids
-        super().__init__(source, alphabet=alphabet, mode="t", fmt="Fasta")
+        super().__init__(source, mode="t", fmt="Fasta")
 
     def parse(self, handle):
         """Start parsing the file, and return a SeqRecord generator."""
@@ -215,12 +216,11 @@ class FastaIterator(SequenceIterator):
 class FastaTwoLineIterator(SequenceIterator):
     """Parser for Fasta files with exactly two lines per record."""
 
-    def __init__(self, source, alphabet=single_letter_alphabet):
+    def __init__(self, source):
         """Iterate over two-line Fasta records (as SeqRecord objects).
 
         Arguments:
          - source - input stream opened in text mode, or a path to a file
-         - alphabet - optional alphabet
 
         This uses a strict interpretation of the FASTA as requiring
         exactly two lines per record (no line wrapping).
@@ -228,7 +228,7 @@ class FastaTwoLineIterator(SequenceIterator):
         Only the default title to ID/name/description parsing offered
         by the relaxed FASTA parser is offered.
         """
-        super().__init__(source, alphabet=alphabet, mode="t", fmt="FASTA")
+        super().__init__(source, mode="t", fmt="FASTA")
 
     def parse(self, handle):
         """Start parsing the file, and return a SeqRecord generator."""
@@ -237,7 +237,6 @@ class FastaTwoLineIterator(SequenceIterator):
 
     def iterate(self, handle):
         """Parse the file and generate SeqRecord objects."""
-        alphabet = self.alphabet
         for title, sequence in FastaTwoLineParser(handle):
             try:
                 first_word = title.split(None, 1)[0]
@@ -246,10 +245,7 @@ class FastaTwoLineIterator(SequenceIterator):
                 # Should we use SeqRecord default for no ID?
                 first_word = ""
             yield SeqRecord(
-                Seq(sequence, alphabet),
-                id=first_word,
-                name=first_word,
-                description=title,
+                Seq(sequence), id=first_word, name=first_word, description=title,
             )
 
 

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -358,7 +358,6 @@ are approximately equal.
 
 """
 
-from Bio.Alphabet import single_letter_alphabet
 from Bio.File import as_handle
 from Bio.Seq import Seq, UnknownSeq
 from Bio.SeqRecord import SeqRecord
@@ -1318,7 +1317,7 @@ def FastqIlluminaIterator(source, alphabet=None, title2ids=None):
 class QualPhredIterator(SequenceIterator):
     """Parser for QUAL files with PHRED quality scores but no sequence."""
 
-    def __init__(self, source, alphabet=single_letter_alphabet, title2ids=None):
+    def __init__(self, source, alphabet=None, title2ids=None):
         """For QUAL files which include PHRED quality scores, but no sequence.
 
         For example, consider this short QUAL file::
@@ -1354,22 +1353,11 @@ class QualPhredIterator(SequenceIterator):
         EAS54_6_R1_2_1_443_348 ?????????????????????????
 
         Becase QUAL files don't contain the sequence string itself, the seq
-        property is set to an UnknownSeq object.  As no alphabet was given, this
-        has defaulted to a generic single letter alphabet and the character "?"
-        used.
+        property is set to an UnknownSeq object.  Although the sequence is
+        almost certainly DNA we can't be sure, so the character "?" is used
+        rather than "N".
 
-        By specifying a nucleotide alphabet, "N" is used instead:
-
-        >>> from Bio import SeqIO
-        >>> from Bio.Alphabet import generic_dna
-        >>> with open("Quality/example.qual") as handle:
-        ...     for record in SeqIO.parse(handle, "qual", alphabet=generic_dna):
-        ...         print("%s %s" % (record.id, record.seq))
-        EAS54_6_R1_2_1_413_324 NNNNNNNNNNNNNNNNNNNNNNNNN
-        EAS54_6_R1_2_1_540_792 NNNNNNNNNNNNNNNNNNNNNNNNN
-        EAS54_6_R1_2_1_443_348 NNNNNNNNNNNNNNNNNNNNNNNNN
-
-        However, the quality scores themselves are available as a list of integers
+        The quality scores themselves are available as a list of integers
         in each record's per-letter-annotation:
 
         >>> print(record.letter_annotations["phred_quality"])
@@ -1385,8 +1373,10 @@ class QualPhredIterator(SequenceIterator):
         scores but will replace them with the lowest possible PHRED score of zero.
         This will trigger a warning, previously it raised a ValueError exception.
         """
+        if alphabet is not None:
+            raise ValueError("The alphabet argument is no longer supported")
         self.title2ids = title2ids
-        super().__init__(source, alphabet=alphabet, mode="t", fmt="QUAL")
+        super().__init__(source, mode="t", fmt="QUAL")
 
     def parse(self, handle):
         """Start parsing the file, and return a SeqRecord generator."""

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -576,20 +576,6 @@ def parse(handle, format, alphabet=None):
     ID gi|3176602|gb|U78617.1|LOU78617
     Sequence length 309
 
-    For file formats like FASTA where the alphabet cannot be determined, it
-    may be useful to specify the alphabet explicitly:
-
-    >>> from Bio import SeqIO
-    >>> from Bio.Alphabet import generic_dna
-    >>> filename = "Fasta/sweetpea.nu"
-    >>> for record in SeqIO.parse(filename, "fasta", generic_dna):
-    ...    print("ID %s" % record.id)
-    ...    print("Sequence length %i" % len(record))
-    ...    print("Sequence alphabet %s" % record.seq.alphabet)
-    ID gi|3176602|gb|U78617.1|LOU78617
-    Sequence length 309
-    Sequence alphabet DNAAlphabet()
-
     If you have a string 'data' containing the file contents, you must
     first turn this into a handle in order to parse it:
 


### PR DESCRIPTION
This pull request addresses issue #2046, continuing the work in #3126.

The change to the QUAL parser might break some existing usage but I see no good way round it - and this lets us tackle the ``UnknownSeq`` object's ``__init__`` arguments now.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
