### PR TITLE
Don't record alphabet in SnapGeneIO

### DIFF
--- a/Bio/SeqIO/SnapGeneIO.py
+++ b/Bio/SeqIO/SnapGeneIO.py
@@ -16,7 +16,6 @@ from re import sub
 from struct import unpack
 from xml.dom.minidom import parseString
 
-from Bio import Alphabet
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation
 from Bio.SeqRecord import SeqRecord
@@ -62,7 +61,7 @@ def _parse_dna_packet(length, data, record):
         raise ValueError("The file contains more than one DNA packet")
 
     flags, sequence = unpack(">B%ds" % (length - 1), data)
-    record.seq = Seq(sequence.decode("ASCII"), alphabet=Alphabet.generic_dna)
+    record.seq = Seq(sequence.decode("ASCII"))
     record.annotations["molecule_type"] = "DNA"
     if flags & 0x01:
         record.annotations["topology"] = "circular"


### PR DESCRIPTION
This pull request is a subset of #3126, part of the general removal of ``Bio.Alphabet`` work (#2046).

As it stands it does not remove this line which was suggested during the review of #3126:

```python
record.annotations["molecule_type"] = "DNA"
```

All the comments in the code are DNA centric, as is the SnapGene public facing documentation.

@gouttegd is there _anything_ to suggest SnapGene binary files might contain RNA (or even protein)?

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
