### PR TITLE
No more Bio.Alphabet in SeqIO

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -189,14 +189,11 @@ class FastaIterator(SequenceIterator):
 
     def iterate(self, handle):
         """Parse the file and generate SeqRecord objects."""
-        alphabet = self.alphabet
         title2ids = self.title2ids
         if title2ids:
             for title, sequence in SimpleFastaParser(handle):
                 id, name, descr = title2ids(title)
-                yield SeqRecord(
-                    Seq(sequence, alphabet), id=id, name=name, description=descr
-                )
+                yield SeqRecord(Seq(sequence), id=id, name=name, description=descr)
         else:
             for title, sequence in SimpleFastaParser(handle):
                 try:
@@ -206,10 +203,7 @@ class FastaIterator(SequenceIterator):
                     # Should we use SeqRecord default for no ID?
                     first_word = ""
                 yield SeqRecord(
-                    Seq(sequence, alphabet),
-                    id=first_word,
-                    name=first_word,
-                    description=title,
+                    Seq(sequence), id=first_word, name=first_word, description=title,
                 )
 
 

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -14,7 +14,6 @@ import warnings
 from Bio import BiopythonDeprecationWarning
 
 from Bio import StreamModeError
-from Bio.Alphabet import generic_alphabet
 from Bio.Seq import Seq, MutableSeq
 from Bio.SeqRecord import SeqRecord
 
@@ -26,12 +25,12 @@ class SequenceIterator:
     may wish to redefine the __init__ method as well.
     """
 
-    def __init__(self, source, alphabet=generic_alphabet, mode="t", fmt=None):
+    def __init__(self, source, alphabet=None, mode="t", fmt=None):
         """Create a SequenceIterator object.
 
         Arguments:
         - source - input file stream, or path to input file
-        - alphabet - optional, e.g. Bio.Alphabet.generic_protein
+        - alphabet - no longer used, should be None
 
         This method MAY be overridden by any subclass.
 
@@ -40,7 +39,8 @@ class SequenceIterator:
         - you do not have to require an alphabet.
         - you can add additional optional arguments.
         """
-        self.alphabet = alphabet
+        if alphabet is not None:
+            raise ValueError("The alphabet argument is no longer supported")
         try:
             self.stream = open(source, "r" + mode)
             self.should_close_stream = True

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -11,7 +11,6 @@ import collections
 import warnings
 
 from Bio import BiopythonParserWarning
-from Bio.Alphabet import generic_protein
 from Bio.Data.SCOPData import protein_letters_3to1
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
@@ -92,9 +91,8 @@ def AtomIterator(pdb_id, structure):
         # if len(structure) > 1 :
         #     id = ("Model%s|" % str(model.id)) + id
 
-        record = SeqRecord(
-            Seq("".join(res_out), generic_protein), id=record_id, description=record_id
-        )
+        record = SeqRecord(Seq("".join(res_out)), id=record_id, description=record_id)
+        # TODO: Test PDB files with DNA and RNA too:
         record.annotations["molecule_type"] = "protein"
 
         record.annotations["model"] = model.id
@@ -224,8 +222,9 @@ class PdbSeqresIterator(SequenceIterator):
             raise ValueError("Empty file.")
 
         for chn_id, residues in sorted(chains.items()):
-            record = SeqRecord(Seq("".join(residues), generic_protein))
+            record = SeqRecord(Seq("".join(residues)))
             record.annotations = {"chain": chn_id}
+            # TODO: Test PDB files with DNA and RNA too:
             record.annotations["molecule_type"] = "protein"
             if chn_id in metadata:
                 m = metadata[chn_id][0]
@@ -430,8 +429,9 @@ def CifSeqresIterator(source):
         metadata[chain_id][-1].update(struct_ref)
 
     for chn_id, residues in sorted(chains.items()):
-        record = SeqRecord(Seq("".join(residues), generic_protein))
+        record = SeqRecord(Seq("".join(residues)))
         record.annotations = {"chain": chn_id}
+        # TODO: Test PDB files with DNA and RNA too:
         record.annotations["molecule_type"] = "protein"
         if chn_id in metadata:
             m = metadata[chn_id][0]

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -1386,7 +1386,6 @@ class QualPhredIterator(SequenceIterator):
     def iterate(self, handle):
         """Parse the file and generate SeqRecord objects."""
         title2ids = self.title2ids
-        alphabet = self.alphabet
         # Skip any text before the first record (e.g. blank lines, comments)
         for line in handle:
             if line[0] == ">":
@@ -1424,10 +1423,7 @@ class QualPhredIterator(SequenceIterator):
 
             # Return the record and then continue...
             record = SeqRecord(
-                UnknownSeq(len(qualities), alphabet),
-                id=id,
-                name=name,
-                description=descr,
+                UnknownSeq(len(qualities)), id=id, name=name, description=descr,
             )
             # Dirty trick to speed up this line:
             # record.letter_annotations["phred_quality"] = qualities


### PR DESCRIPTION
This pull request addresses issue #2046, finishing work started on #3121. This does not address ``PdbIO`` assuming protein which was logged as #3125.

This deliberately leaves in place the alphabet arguments to the top level ``SeqIO`` parsing functions. The rational is allow examples like those in #3156.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
