### PR TITLE
Fix another alphabet relic in Bio/Seq.py

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1804,7 +1804,7 @@ class MutableSeq:
             return self.data[index]
         else:
             # Return the (sub)sequence as another Seq object
-            return MutableSeq(self.data[index], self.alphabet)
+            return MutableSeq(self.data[index])
 
     def __setitem__(self, index, value):
         """Set a subsequence of single letter via value parameter.


### PR DESCRIPTION
This pull request addresses issue #2046.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
