### PR TITLE
Removing Seq object's alphabet attribute

### DIFF
--- a/Bio/Alphabet/Reduced.py
+++ b/Bio/Alphabet/Reduced.py
@@ -27,14 +27,13 @@ These alphabets have been used with Bio.utils.reduce_sequence, which has been
 removed from Biopython. You can use this is alphabets and tables like this:
 
     >>> from Bio.Seq import Seq
-    >>> from Bio import Alphabet
     >>> from Bio.Alphabet import Reduced
-    >>> my_protein = Seq('MAGSKEWKRFCELTINEA', Alphabet.ProteinAlphabet())
+    >>> my_protein = Seq('MAGSKEWKRFCELTINEA')
 
 Now, we convert this sequence into a sequence which only recognizes polar (P)
 or hydrophobic (H) residues:
 
-    >>> new_protein = Seq('', Alphabet.Reduced.HPModel())
+    >>> new_protein = Seq('')
     >>> for aa in my_protein:
     ...     new_protein += Alphabet.Reduced.hp_model_tab[aa]
     >>> new_protein

--- a/Bio/Alphabet/__init__.py
+++ b/Bio/Alphabet/__init__.py
@@ -490,21 +490,6 @@ def _check_type_compatible(alphabets):
 def _verify_alphabet(sequence):
     """Check all letters in sequence are in the alphabet (PRIVATE).
 
-        >>> from Bio.Seq import Seq
-        >>> from Bio.Alphabet import IUPAC
-        >>> my_seq = Seq("MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF",
-        ...              IUPAC.protein)
-        >>> _verify_alphabet(my_seq)
-        True
-
-        This example has an X, which is not in the IUPAC protein alphabet
-        (you should be using the IUPAC extended protein alphabet):
-
-        >>> bad_seq = Seq("MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVFX",
-        ...                IUPAC.protein)
-        >>> _verify_alphabet(bad_seq)
-        False
-
     This replaces Bio.utils.verify_alphabet() since we are deprecating
     that. Potentially this could be added to the Alphabet object, and
     I would like it to be an option when creating a Seq object... but

--- a/Bio/motifs/meme.py
+++ b/Bio/motifs/meme.py
@@ -162,7 +162,7 @@ def __read_motifs(record, xml_tree, sequence_id_name_map):
                 for letter_ref in site_tree.find("site").findall("letter_ref")
             ]
             sequence = "".join(letters)
-            instance = Instance(sequence, record.alphabet)
+            instance = Instance(sequence)
             instance.motif_name = motif_tree.get("name")
             instance.sequence_id = site_tree.get("sequence_id")
             instance.sequence_name = sequence_id_name_map[instance.sequence_id]

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -322,7 +322,7 @@ class SeqFeatureExtractionWritingReading(unittest.TestCase):
         self.assertIsInstance(new, Seq)  # Not MutableSeq!
         self.assertEqual(str(new), answer_str)
 
-        new = feature.extract(UnknownSeq(len(parent_seq), parent_seq.alphabet))
+        new = feature.extract(UnknownSeq(len(parent_seq), character="N"))
         self.assertIsInstance(new, UnknownSeq)
         self.assertEqual(len(new), len(answer_str))
 

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -2252,7 +2252,7 @@ class MotifTestPWM(unittest.TestCase):
         counts = self.m.counts
         pwm = counts.normalize(pseudocounts=0.25)
         pssm = pwm.log_odds()
-        result = pssm.calculate(Seq("ACGTGTGCGTAGTGCGTN", self.m.alphabet))
+        result = pssm.calculate(Seq("ACGTGTGCGTAGTGCGTN"))
         self.assertEqual(7, len(result))
         self.assertAlmostEqual(result[0], -29.18363571, places=5)
         self.assertAlmostEqual(result[1], -38.3365097, places=5)


### PR DESCRIPTION
This pull request addresses issue #2046 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
