### PR TITLE
Tell Sphinx/AutoDoc to ignore Bio.Alphabet

### DIFF
--- a/Doc/api/conf.py
+++ b/Doc/api/conf.py
@@ -92,7 +92,7 @@ autodoc_default_options = {
 }
 
 # To avoid import errors.
-autodoc_mock_imports = ["MySQLdb", "Bio.Restriction.Restriction"]
+autodoc_mock_imports = ["MySQLdb", "Bio.Restriction.Restriction", "Bio.Alphabet"]
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
This pull request hopefully fixes the API documentation after #3173 was merged.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
