### PR TITLE
Fix Seq.__repr__

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -104,7 +104,7 @@ class Seq:
             # Shows the last three letters as it is often useful to see if
             # there is a stop codon at the end of a sequence.
             # Note total length is 54+3+3=60
-            return f"{self.__class__.__name__}('{str(self)[:54]}...{str(self)[-3:]}')"
+            return f"{self.__class__.__name__}('{str(self[:54])}...{str(self[-3:])}')"
         else:
             return f"{self.__class__.__name__}({self._data!r})"
 


### PR DESCRIPTION
This pull request fixes `Seq.__repr__`, which currently converts the whole sequence to a string, twice, even if only the ends are needed.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
