### PR TITLE
SeqIO and AlignIO convert doctests with mol type.

### DIFF
--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -418,6 +418,35 @@ def convert(in_file, in_format, out_file, out_format, molecule_type=None):
     **NOTE** - If you provide an output filename, it will be opened which will
     overwrite any existing file without warning. This may happen if even the
     conversion is aborted (e.g. an invalid out_format name is given).
+
+    Some output formats require the molecule type be specified where this
+    cannot be determined by the parser. For example, converting to FASTA,
+    Clustal, or PHYLIP format to NEXUS:
+
+    >>> from io import StringIO
+    >>> from Bio import AlignIO
+    >>> handle = StringIO()
+    >>> AlignIO.convert("Phylip/horses.phy", "phylip", handle, "nexus", "DNA")
+    1
+    >>> print(handle.getvalue())
+    #NEXUS
+    begin data;
+    dimensions ntax=10 nchar=40;
+    format datatype=dna missing=? gap=-;
+    matrix
+    Mesohippus   AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+    Hypohippus   AAACCCCCCCAAAAAAAAACAAAAAAAAAAAAAAAAAAAA
+    Archaeohip   CAAAAAAAAAAAAAAAACACAAAAAAAAAAAAAAAAAAAA
+    Parahippus   CAAACAACAACAAAAAAAACAAAAAAAAAAAAAAAAAAAA
+    Merychippu   CCAACCACCACCCCACACCCAAAAAAAAAAAAAAAAAAAA
+    'M. secundu' CCAACCACCACCCACACCCCAAAAAAAAAAAAAAAAAAAA
+    Nannipus     CCAACCACAACCCCACACCCAAAAAAAAAAAAAAAAAAAA
+    Neohippari   CCAACCCCCCCCCCACACCCAAAAAAAAAAAAAAAAAAAA
+    Calippus     CCAACCACAACCCACACCCCAAAAAAAAAAAAAAAAAAAA
+    Pliohippus   CCCACCCCCCCCCACACCCCAAAAAAAAAAAAAAAAAAAA
+    ;
+    end;
+    <BLANKLINE>
     """
     if molecule_type:
         if not isinstance(molecule_type, str):

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -1593,10 +1593,8 @@ class Nexus:
             if comment:
                 fh.write("[" + comment + "]\n")
             fh.write("begin data;\n")
-            fh.write(
-                "\tdimensions ntax=%d nchar=%d;\n" % (ntax_adjusted, nchar_adjusted)
-            )
-            fh.write("\tformat datatype=" + self.datatype)
+            fh.write("dimensions ntax=%d nchar=%d;\n" % (ntax_adjusted, nchar_adjusted))
+            fh.write("format datatype=" + self.datatype)
             if self.respectcase:
                 fh.write(" respectcase")
             if self.missing:

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -1050,9 +1050,8 @@ def convert(in_file, in_format, out_file, out_format, molecule_type=None):
     GTTGCTTCTGGCGTGGGTGGGGGGG
     <BLANKLINE>
 
-    Note some formats require a binary handle (bytes) rather than a text mode
-    handle (strings), and may require you to specify the molecule type when it
-    cannot be determined by the parser:
+    Note some formats like SeqXML require you to specify the molecule type
+    when it cannot be determined by the parser:
 
     >>> from Bio import SeqIO
     >>> from io import BytesIO

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -1049,6 +1049,16 @@ def convert(in_file, in_format, out_file, out_format, molecule_type=None):
     >EAS54_6_R1_2_1_443_348
     GTTGCTTCTGGCGTGGGTGGGGGGG
     <BLANKLINE>
+
+    Note some formats require a binary handle (bytes) rather than a text mode
+    handle (strings), and may require you to specify the molecule type when it
+    cannot be determined by the parser:
+
+    >>> from Bio import SeqIO
+    >>> from io import BytesIO
+    >>> handle = BytesIO()
+    >>> SeqIO.convert("Quality/example.fastq", "fastq", handle, "seqxml", "DNA")
+    3
     """
     if molecule_type:
         if not isinstance(molecule_type, str):


### PR DESCRIPTION
Add some explicit examples using molecule type to the doctests following #3154 and #3155.

The tabs in the NEXUS output are unfortunate for use in doctests.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
