### PR TITLE
Call black directly (not via flake8)

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -102,8 +102,8 @@ deps =
     flake8-comprehensions
     flake8-bugbear
     flake8-implicit-str-concat
-    flake8-black
     flake8-quotes
+    black
     restructuredtext_lint
     doc8
     pygments
@@ -116,6 +116,8 @@ deps =
 commands =
     # PEP-8 and PEP-257 style checks:
     flake8
+    # Black style check
+    black --check .
     # Now do various checks on our RST files:
     # Calling via bash to get it to expand the wildcard for us
     bash -c \'rst-lint --level warning *.rst\'

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -114,10 +114,7 @@ deps =
     # pydocstyle v4 had false positives with D413, need v5
     pydocstyle>=5.0.0
 commands =
-    # PEP-8 and PEP-257 style checks:
-    flake8
-    # Black style check
-    black --check .
+    # Leave flake8 till last as it is the slowest
     # Now do various checks on our RST files:
     # Calling via bash to get it to expand the wildcard for us
     bash -c \'rst-lint --level warning *.rst\'
@@ -133,6 +130,10 @@ commands =
     bash -c "if grep --include '*.py' --include '*.rst' --include '*.tex' -rni 'doi:' Bio BioSQL Scripts Doc ; then echo 'Please use https://doi.org/... not the doi: or DOI: style.'; false; fi"
     bash -c "if grep --include '*.py' --include '*.rst' --include '*.tex' -rn 'dx\.doi\.org' Bio BioSQL Tests Scripts Doc ; then echo 'Please use https://doi.org/... not the dx.doi.org style.'; false; fi"
     bash -c "if grep --include '*.py' --include '*.rst' --include '*.tex' -rn 'http://doi\.org' Bio BioSQL Tests Scripts Doc ; then echo 'Please use https://doi.org/... not http://doi.org/...'; false; fi"
+    # Black style check:
+    black --check .
+    # Python style and code checks:
+    flake8
 
 [testenv:sdist]
 # This does not need to install Biopython or any of its dependencies

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -141,7 +141,7 @@ commands =
     bash -c "if grep --include '*.py' --include '*.rst' --include '*.tex' -rn 'dx\.doi\.org' Bio BioSQL Tests Scripts Doc ; then echo 'Please use https://doi.org/... not the dx.doi.org style.'; false; fi"
     bash -c "if grep --include '*.py' --include '*.rst' --include '*.tex' -rn 'http://doi\.org' Bio BioSQL Tests Scripts Doc ; then echo 'Please use https://doi.org/... not http://doi.org/...'; false; fi"
     # Black style check:
-    black --check .
+    black --diff .
 
 [testenv:sdist]
 # This does not need to install Biopython or any of its dependencies

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -31,6 +31,7 @@ minversion = 2.0
 skipsdist = True
 envlist =
     style
+    flake8
     sdist
     bdist_wheel
     api
@@ -86,15 +87,12 @@ commands =
     cover: bash -c \'cd Tests && coverage run run_tests.py --offline && coverage xml\'
     cover: codecov --file Tests/coverage.xml -X pycov -X gcov
 
-[testenv:style]
+[testenv:flake8]
+# Doing this separately from and in parallel with black etc
 # This does not need to install Biopython or any of its dependencies
 skip_install = True
 whitelist_externals =
     flake8
-    black
-    doc8
-    rst-lint
-    bash
 deps =
     flake8
     flake8-docstrings
@@ -104,6 +102,20 @@ deps =
     flake8-bugbear
     flake8-implicit-str-concat
     flake8-quotes
+    # pydocstyle v4 had false positives with D413, need v5
+    pydocstyle>=5.0.0
+commands =
+    flake8
+
+[testenv:style]
+# This does not need to install Biopython or any of its dependencies
+skip_install = True
+whitelist_externals =
+    black
+    doc8
+    rst-lint
+    bash
+deps =
     black
     restructuredtext_lint
     doc8
@@ -112,10 +124,7 @@ deps =
     # https://bugs.launchpad.net/doc8/+bug/1837515
     # https://sourceforge.net/p/docutils/bugs/366/
     docutils==0.14
-    # pydocstyle v4 had false positives with D413, need v5
-    pydocstyle>=5.0.0
 commands =
-    # Leave flake8 till last as it is the slowest
     # Now do various checks on our RST files:
     # Calling via bash to get it to expand the wildcard for us
     bash -c \'rst-lint --level warning *.rst\'
@@ -133,8 +142,6 @@ commands =
     bash -c "if grep --include '*.py' --include '*.rst' --include '*.tex' -rn 'http://doi\.org' Bio BioSQL Tests Scripts Doc ; then echo 'Please use https://doi.org/... not http://doi.org/...'; false; fi"
     # Black style check:
     black --check .
-    # Python style and code checks:
-    flake8
 
 [testenv:sdist]
 # This does not need to install Biopython or any of its dependencies

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -91,6 +91,7 @@ commands =
 skip_install = True
 whitelist_externals =
     flake8
+    black
     doc8
     rst-lint
     bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
   include:
     - stage: basics
       python: 3.7
-      env: TOXENV=style
+      env: TOXENV=flake8
       services:
       addons:
         apt:
@@ -31,7 +31,7 @@ matrix:
       before_install: echo "Going to run basic checks"
     - stage: basics
       python: 3.7
-      env: TOXENV=sdist,bdist_wheel
+      env: TOXENV=style,sdist,bdist_wheel
       services:
       addons:
         apt:


### PR DESCRIPTION
Now that the entire code base uses black this is practical - the flake8 configuration gave a convenient way to manage the gradual adoption.

However, right now my flake8-black plugin has more overhead than it should and slows this down: https://github.com/peterjc/flake8-black/issues/26

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
