### PR TITLE
fix three typos

### DIFF
--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -472,7 +472,7 @@ class StringMethodTests(unittest.TestCase):
 
     def test_str_split(self):
         """Check matches the python string rstrip method."""
-        # Calling (r)split should return a list of Seq-like objects, we'll
+        # Calling split should return a list of Seq-like objects, we'll
         # just apply str() to each of them so it matches the string method
         self._test_method(
             "split", pre_comp_function=lambda x: [str(y) for y in x]  # noqa: E731
@@ -480,7 +480,7 @@ class StringMethodTests(unittest.TestCase):
 
     def test_str_rsplit(self):
         """Check matches the python string rstrip method."""
-        # Calling (r)split should return a list of Seq-like objects, we'll
+        # Calling rsplit should return a list of Seq-like objects, we'll
         # just apply str() to each of them so it matches the string method
         self._test_method(
             "rsplit", pre_comp_function=lambda x: [str(y) for y in x]  # noqa: E731
@@ -488,7 +488,7 @@ class StringMethodTests(unittest.TestCase):
 
     def test_str_lsplit(self):
         """Check matches the python string rstrip method."""
-        # Calling (r)split should return a list of Seq-like objects, we'll
+        # Calling lsplit should return a list of Seq-like objects, we'll
         # just apply str() to each of them so it matches the string method
         self._test_method(
             "lsplit", pre_comp_function=lambda x: [str(y) for y in x]  # noqa: E731

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -475,7 +475,7 @@ class StringMethodTests(unittest.TestCase):
         # Calling (r)split should return a list of Seq-like objects, we'll
         # just apply str() to each of them so it matches the string method
         self._test_method(
-            "rstrip", pre_comp_function=lambda x: [str(y) for y in x]  # noqa: E731
+            "split", pre_comp_function=lambda x: [str(y) for y in x]  # noqa: E731
         )
 
     def test_str_rsplit(self):
@@ -483,7 +483,7 @@ class StringMethodTests(unittest.TestCase):
         # Calling (r)split should return a list of Seq-like objects, we'll
         # just apply str() to each of them so it matches the string method
         self._test_method(
-            "rstrip", pre_comp_function=lambda x: [str(y) for y in x]  # noqa: E731
+            "rsplit", pre_comp_function=lambda x: [str(y) for y in x]  # noqa: E731
         )
 
     def test_str_lsplit(self):
@@ -491,7 +491,7 @@ class StringMethodTests(unittest.TestCase):
         # Calling (r)split should return a list of Seq-like objects, we'll
         # just apply str() to each of them so it matches the string method
         self._test_method(
-            "rstrip", pre_comp_function=lambda x: [str(y) for y in x]  # noqa: E731
+            "lsplit", pre_comp_function=lambda x: [str(y) for y in x]  # noqa: E731
         )
 
     def test_str_length(self):


### PR DESCRIPTION
This pull request fixes three typos in `test_Seq_objs.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
