### PR TITLE
Remove more alphabet references in docs, comments, etc

### DIFF
--- a/Bio/File.py
+++ b/Bio/File.py
@@ -466,7 +466,6 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
             "INSERT INTO meta_data (key, value) VALUES (?,?);",
             ("filenames_relative_to_index", "True"),
         )
-        # TODO - Record the alphabet?
         # TODO - Record the file size and modified date?
         con.execute("CREATE TABLE file_data (file_number INTEGER, name TEXT);")
         con.execute(

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -128,7 +128,7 @@ class Seq:
         return self._data
 
     def __hash__(self):
-        """Hash of the sequence as a string (ignoring alphabet) for comparison.
+        """Hash of the sequence as a string for comparison.
 
         See Seq object comparison documentation (method ``__eq__`` in
         particular) as this has changed in Biopython 1.65. Older versions
@@ -1030,7 +1030,7 @@ class Seq:
 
         The gap character now defaults to the minus sign, and can only
         be specified via the method argument. This is no longer possible
-        via sequence's alphabet (as was possible up to Biopython 1.77):
+        via the sequence's alphabet (as was possible up to Biopython 1.77):
 
         >>> from Bio.Seq import Seq
         >>> my_dna = Seq("-ATA--TGAAAT-TTGAAAA")
@@ -1551,7 +1551,7 @@ class UnknownSeq(Seq):
 
         The gap character now defaults to the minus sign, and can only
         be specified via the method argument. This is no longer possible
-        via sequence's alphabet (as was possible up to Biopython 1.77):
+        via the sequence's alphabet (as was possible up to Biopython 1.77):
 
         >>> from Bio.Seq import UnknownSeq
         >>> my_dna = UnknownSeq(20, character='N')
@@ -1633,7 +1633,7 @@ class UnknownSeq(Seq):
 
 
 class MutableSeq:
-    """An editable sequence object (with an alphabet).
+    """An editable sequence object.
 
     Unlike normal python strings and our basic sequence object (the Seq class)
     which are immutable, the MutableSeq lets you edit the sequence in place.

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -1464,7 +1464,6 @@ def _genbank_convert_fasta(in_file, out_file):
     """Fast GenBank to FASTA (PRIVATE)."""
     # We don't need to parse the features...
     records = GenBankScanner().parse_records(in_file, do_features=False)
-    # For FASTA output we can ignore the alphabet too
     return SeqIO.write(records, out_file, "fasta")
 
 
@@ -1472,7 +1471,6 @@ def _embl_convert_fasta(in_file, out_file):
     """Fast EMBL to FASTA (PRIVATE)."""
     # We don't need to parse the features...
     records = EmblScanner().parse_records(in_file, do_features=False)
-    # For FASTA output we can ignore the alphabet too
     return SeqIO.write(records, out_file, "fasta")
 
 

--- a/Bio/SeqIO/PirIO.py
+++ b/Bio/SeqIO/PirIO.py
@@ -200,7 +200,8 @@ class PirWriter(SequenceWriter):
            record.description is used.
          - code - Optional sequence code must be one of P1, F1,
            D1, DL, DC, RL, RC, N3 and XX. By default None is used,
-           which means auto detection based on record alphabet.
+           which means auto detection based on the molecule type
+           in the record annotation.
 
         You can either use::
 

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1452,7 +1452,6 @@ You can adjust how \verb|dumb_consensus| works by passing optional parameters:
 
 \item[the ambiguous character] This is the ambiguity character to use. The default is 'N'.
 
-\item[the consensus alphabet] This is the alphabet to use for the consensus sequence. If an alphabet is not specified than we will try to guess the alphabet based on the alphabets of the sequences in the alignment.
 \end{description}
 
 \subsection{Position Specific Score Matrices}

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -490,7 +490,7 @@ class TestMutableSeq(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.mutable_s < 1
 
-    def test_less_than_comparison_without_alphabet(self):
+    def test_less_than_comparison_with_str(self):
         self.assertLessEqual(self.mutable_s[:-1], "TCAAAAGGATGCATCATG")
 
     def test_less_than_or_equal_comparison(self):
@@ -501,7 +501,7 @@ class TestMutableSeq(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.mutable_s <= 1
 
-    def test_less_than_or_equal_comparison_without_alphabet(self):
+    def test_less_than_or_equal_comparison_with_str(self):
         self.assertLessEqual(self.mutable_s[:-1], "TCAAAAGGATGCATCATG")
 
     def test_greater_than_comparison(self):
@@ -512,7 +512,7 @@ class TestMutableSeq(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.mutable_s > 1
 
-    def test_greater_than_comparison_without_alphabet(self):
+    def test_greater_than_comparison_with_str(self):
         self.assertGreater(self.mutable_s, "TCAAAAGGATGCATCAT")
 
     def test_greater_than_or_equal_comparison(self):
@@ -523,7 +523,7 @@ class TestMutableSeq(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.mutable_s >= 1
 
-    def test_greater_than_or_equal_comparison_without_alphabet(self):
+    def test_greater_than_or_equal_comparison_with_str(self):
         self.assertGreaterEqual(self.mutable_s, "TCAAAAGGATGCATCATG")
 
     def test_add_method(self):
@@ -537,7 +537,7 @@ class TestMutableSeq(unittest.TestCase):
             self.mutable_s.__radd__(self.mutable_s),
         )
 
-    def test_radd_method_incompatible_alphabets(self):
+    def test_radd_method_using_mutalbeseq_object(self):
         self.assertEqual(
             "UCAAAAGGATCAAAAGGATGCATCATG",
             self.mutable_s.__radd__(MutableSeq("UCAAAAGGA")),
@@ -795,7 +795,7 @@ class TestComplement(unittest.TestCase):
             ambig_values = ambiguous_rna_values[ambiguous_rna_complement[ambig_char]]
             self.assertEqual(set(compl_values), set(ambig_values))
 
-    def test_complement_incompatible_alphabets(self):
+    def test_complement_incompatible_letters(self):
         seq = Seq.Seq("CAGGTU")
         with self.assertRaises(ValueError):
             seq.complement()


### PR DESCRIPTION
This pull request addresses issue #2046.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
