### PR TITLE
summing Seq

### DIFF
--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -190,16 +190,6 @@ You may often have many sequences to add together, which can be done with a for 
 Seq('ACGTAACCGGTT')
 \end{minted}
 
-Or, a more elegant approach is to the use built in \verb|sum| function with its optional start value argument (which otherwise defaults to zero):
-
-%doctest
-\begin{minted}{pycon}
->>> from Bio.Seq import Seq
->>> list_of_seqs = [Seq("ACGT"), Seq("AACC"), Seq("GGTT")]
->>> sum(list_of_seqs, Seq(""))
-Seq('ACGTAACCGGTT')
-\end{minted}
-
 Like Python strings, Biopython \verb|Seq| also has a \verb|.join| method:
 
 %doctest


### PR DESCRIPTION
I don't think we should advertise summing `Seq` objects. The `sum` docstring says
```
    This function is intended specifically for use with numeric values and may
    reject non-numeric types.
```
and it refuses to act on `str` objects:
```
>>> sum(["ACGT","TCGA"], "")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: sum() can't sum strings [use ''.join(seq) instead]
```

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
