### PR TITLE
Add ignore rule for Windows-only pyd files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ dist
 *.pyc
 *.pyo
 *.py-e
+*.pyd
 
 #Ignore all Jython class files (present if using Jython)
 *.class


### PR DESCRIPTION
Running install on Windows machines generates a few `pyd` files from the compiled C extensions.

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
