### PR TITLE
Adds module-level documentation for kdtrees C module

### DIFF
--- a/Bio/PDB/kdtrees.c
+++ b/Bio/PDB/kdtrees.c
@@ -1400,10 +1400,16 @@ static PyTypeObject KDTreeType = {
 /* -- Initialization -------------------------------------------------------- */
 /* ========================================================================== */
 
+PyDoc_STRVAR(module_doc,
+"KDTree implementation for fast neighbor searches in 3D structures.\n\
+This module implements three objects: KDTree, Point, and Neighbor. \n\
+Refer to their docstrings for more documentation on usage and implementation."
+);
+
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "kdtrees",
-        NULL,
+        module_doc,
         -1,
         NULL,
         NULL,

--- a/Bio/PDB/kdtrees.c
+++ b/Bio/PDB/kdtrees.c
@@ -1401,9 +1401,9 @@ static PyTypeObject KDTreeType = {
 /* ========================================================================== */
 
 PyDoc_STRVAR(module_doc,
-"KDTree implementation for fast neighbor searches in 3D structures.\n\
-This module implements three objects: KDTree, Point, and Neighbor. \n\
-Refer to their docstrings for more documentation on usage and implementation."
+"KDTree implementation for fast neighbor searches in 3D structures.\n\n\
+This module implements three objects: KDTree, Point, and Neighbor. Refer \
+to their docstrings for more documentation on usage and implementation."
 );
 
 static struct PyModuleDef moduledef = {


### PR DESCRIPTION
- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

```
In [1]: from Bio.PDB import kdtrees

In [2]: help(kdtrees)
Help on module Bio.PDB.kdtrees in Bio.PDB:

NAME
    Bio.PDB.kdtrees

DESCRIPTION
    KDTree implementation for fast neighbor searches in 3D structures.
    This module implements three objects: KDTree, Point, and Neighbor.
    Refer to their docstrings for more documentation on usage and implementation.

FILE
    d:\miniconda3\envs\biopy-dev\lib\site-packages\biopython-1.78.dev0-py3.7-win-amd64.egg\bio\pdb\kdtrees.cp37-win_amd64.pyd

In [3]:
```

@peterjc - not sure about the sphinx docs, are these docstrings picked up automatically as long as they are available in Python-land?

Resolves issue #2756 