### PR TITLE
TravisCI: Use pre-commit for running flake8 etc

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -87,26 +87,6 @@ commands =
     cover: bash -c \'cd Tests && coverage run run_tests.py --offline && coverage xml\'
     cover: codecov --file Tests/coverage.xml -X pycov -X gcov
 
-[testenv:flake8]
-# Doing this separately from and in parallel with black etc
-# This does not need to install Biopython or any of its dependencies
-skip_install = True
-whitelist_externals =
-    flake8
-deps =
-    flake8
-    flake8-docstrings
-    flake8-blind-except
-    flake8-rst-docstrings
-    flake8-comprehensions
-    flake8-bugbear
-    flake8-implicit-str-concat
-    flake8-quotes
-    # pydocstyle v4 had false positives with D413, need v5
-    pydocstyle>=5.0.0
-commands =
-    flake8
-
 [testenv:style]
 # This does not need to install Biopython or any of its dependencies
 skip_install = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,17 @@ matrix:
   include:
     - stage: basics
       python: 3.7
-      env: TOXENV=flake8
+      env: SKIP=black
       services:
       addons:
         apt:
           packages:
-      before_install: echo "Going to run basic checks"
+      before_install: echo "Going to run style checks using pre-commit"
+      install:
+        - pip install pre-commit
+        - pre-commit install
+      script:
+        - pre-commit run -a
     - stage: basics
       python: 3.7
       env: TOXENV=style,sdist,bdist_wheel


### PR DESCRIPTION
Even with this applied, we still have some style checks via Tox which have not yet been implemented in the pre-commit hook.

Also, I am deliberately still running black separately from pre-commit in order to balance the run time of the two TravisCI jobs in the the basics stage.

This pull request addresses issue #2580

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
