### PR TITLE
TravisCI: save the pre-commit cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ services:
   - mysql
   - postgresql
 language: python
-cache: pip
+cache:
+ - pip
+ - $HOME/.cache/pre-commit
 matrix:
   include:
     - stage: basics


### PR DESCRIPTION
Suggested on #3216, seems to save about 30s on the TravisCI pre-commit runtime.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
