### PR TITLE
Do RST checks via pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,9 @@ repos:
     hooks:
     -   id: rstcheck
         args: [--report=warning]
+-   repo: https://github.com/PyCQA/doc8
+    rev: 0.8.1
+    hooks:
+    -   id: doc8
+        additional_dependencies: [pygments]
+        args: [--quiet,--ignore-path=Doc/examples/ec_*.txt]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,8 @@ repos:
     -   id: blacken-docs
         additional_dependencies: [black==19.10b0]
         exclude: ^.github/
+-   repo: https://github.com/myint/rstcheck
+    rev: ''
+    hooks:
+    -   id: rstcheck
+        args: [--report=warning]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,10 @@ repos:
     hooks:
     -   id: check-executables-have-shebangs
         files: \.(py|sh)$
-        exclude: ^Tests/
     -   id: check-json
     -   id: debug-statements
     -   id: end-of-file-fixer
         files: \.py$
-        exclude: ^Tests/
     -   id: mixed-line-ending
 -   repo: https://github.com/psf/black
     rev: 19.10b0

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -93,11 +93,9 @@ skip_install = True
 whitelist_externals =
     black
     doc8
-    rst-lint
     bash
 deps =
     black
-    restructuredtext_lint
     doc8
     pygments
     # doc8 needs docutils, but docutils==0.15 has an import order bug
@@ -106,8 +104,6 @@ deps =
     docutils==0.14
 commands =
     # Now do various checks on our RST files:
-    # Calling via bash to get it to expand the wildcard for us
-    bash -c \'rst-lint --level warning *.rst\'
     # Check sort order (bash call work around for pipe character)
     bash -c \'grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f\'
     # Check copyright date

--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -92,24 +92,15 @@ commands =
 skip_install = True
 whitelist_externals =
     black
-    doc8
     bash
 deps =
     black
-    doc8
-    pygments
-    # doc8 needs docutils, but docutils==0.15 has an import order bug
-    # https://bugs.launchpad.net/doc8/+bug/1837515
-    # https://sourceforge.net/p/docutils/bugs/366/
-    docutils==0.14
 commands =
     # Now do various checks on our RST files:
     # Check sort order (bash call work around for pipe character)
     bash -c \'grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f\'
     # Check copyright date
     bash -c \'grep "1999-`date +'%Y'`" LICENSE.rst\'
-    # Would like to tell doc8 to just check *.rst but does *.txt too:
-    bash -c "doc8 --ignore-path 'Doc/examples/ec_*.txt' 'Doc/doc.rst' *.rst Doc/"
     # Check no __docformat__ lines
     bash -c "if grep --include '*.py' -rn '^__docformat__ ' Bio BioSQL Tests Scripts Doc ; then echo 'Remove __docformat__ line(s), we assume restructuredtext.'; false; fi"
     # Check DOI link style, see https://www.crossref.org/display-guidelines/

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       before_install: echo "Going to run style checks using pre-commit"
       install:
         - pip install pre-commit
-        - pre-commit install
+        - pre-commit install --install-hooks
       script:
         - pre-commit run -a
     - stage: basics


### PR DESCRIPTION
This pull request addresses issue #2580, using ``rstcheck`` and ``doc8`` via ``pre-commit`` instead of via ``tox``.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
