### PR TITLE
Fix to MMCIFIO to avoid conflicts when passing set_dic after set_structure.

### DIFF
--- a/Bio/PDB/mmcifio.py
+++ b/Bio/PDB/mmcifio.py
@@ -72,6 +72,9 @@ class MMCIFIO(StructureIO):
     def set_dict(self, dic):
         """Set the mmCIF dictionary to be written out."""
         self.dic = dic
+        # Remove self.structure if it has been set
+        if hasattr(self, "structure"):
+            delattr(self, "structure")
 
     def save(self, filepath, select=_select, preserve_atom_numbering=False):
         """Save the structure to a file.


### PR DESCRIPTION
`MMCIFIO` checks if either `set_structure` or `set_dic` are set, in this order, before deciding what to save. Thus, the following code fails to work as expected:

```python
from Bio.PDB import MMCIFIO
from Bio.PDB.MMCIF2Dict import MMCIF2Dict

parser = MMCIFIO()
fname = '1ctf.cif'

s = parser.get_structure('s1', fname)
d = MMCIF2Dict(fname)

io = MMCIFIO()
io.set_structure(s)
io.save('out.cif')  # works as expected

io.set_dic(d)
io.save('out2.cif')  # saves the structure, not the dictionary.
``` 

This PR addresses that by explictly deleting the `self.structure` attribute when calling `set_dic`. The opposite doesn't matter since 'structure' is checked first in `save()`.

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
