### PR TITLE
Fix cif header resolution

### DIFF
--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -109,10 +109,11 @@ class MMCIFParser:
         self._update_header_entry(
             "resolution", ["_refine.ls_d_res_high", "_refine_hist.d_res_high"]
         )
-        try:
-            self.header["resolution"] = float(self.header["resolution"])
-        except ValueError:
-            self.header["resolution"] = None
+        if self.header["resolution"] is not None:
+            try:
+                self.header["resolution"] = float(self.header["resolution"])
+            except ValueError:
+                self.header["resolution"] = None
 
         return self.header
 

--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -92,7 +92,7 @@ class MMCIFParser:
             "idcode": "",
             "deposition_date": "",
             "structure_method": "",
-            "resolution": 0.0,
+            "resolution": None,
         }
 
         self._update_header_entry(
@@ -109,7 +109,10 @@ class MMCIFParser:
         self._update_header_entry(
             "resolution", ["_refine.ls_d_res_high", "_refine_hist.d_res_high"]
         )
-        self.header["resolution"] = float(self.header["resolution"])
+        try:
+            self.header["resolution"] = float(self.header["resolution"])
+        except ValueError:
+            self.header["resolution"] = None
 
         return self.header
 

--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -107,7 +107,12 @@ class MMCIFParser:
         )
         self._update_header_entry("structure_method", ["_exptl.method"])
         self._update_header_entry(
-            "resolution", ["_refine.ls_d_res_high", "_refine_hist.d_res_high"]
+            "resolution",
+            [
+                "_refine.ls_d_res_high",
+                "_refine_hist.d_res_high",
+                "_em_3d_reconstruction.resolution",
+            ],
         )
         if self.header["resolution"] is not None:
             try:

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -186,7 +186,7 @@ def _parse_pdb_header_list(header):
         "deposition_date": "1909-01-08",
         "release_date": "1909-01-08",
         "structure_method": "unknown",
-        "resolution": 0.0,
+        "resolution": None,
         "structure_reference": "unknown",
         "journal_reference": "unknown",
         "author": "",
@@ -322,6 +322,7 @@ def _parse_pdb_header_list(header):
             # print(key)
             pass
     if pdbh_dict["structure_method"] == "unknown":
-        if pdbh_dict["resolution"] > 0.0:
+        res = pdbh_dict["resolution"]
+        if res is not None and res > 0.0:
             pdbh_dict["structure_method"] = "x-ray diffraction"
     return pdbh_dict

--- a/Tests/PDB/1SSU_mod.cif
+++ b/Tests/PDB/1SSU_mod.cif
@@ -1,5 +1,8 @@
 data_1SSU
 #
+_refine.ls_d_res_high                            . 
+_refine.ls_d_res_low                             ? 
+#
 loop_
 _atom_site.group_PDB
 _atom_site.id

--- a/Tests/test_PDB_MMCIFParser.py
+++ b/Tests/test_PDB_MMCIFParser.py
@@ -315,6 +315,7 @@ class ParseReal(unittest.TestCase):
         """Test if the parser populates header data."""
         parser = MMCIFParser(QUIET=1)
 
+        # test default values
         structure = parser.get_structure("example", "PDB/a_structure.cif")
         self.assertEqual("", structure.header["idcode"])
         self.assertEqual("", structure.header["head"])
@@ -322,12 +323,17 @@ class ParseReal(unittest.TestCase):
         self.assertEqual("", structure.header["structure_method"])
         self.assertEqual(None, structure.header["resolution"])
 
+        # test extracting fields
         structure = parser.get_structure("example", "PDB/1A8O.cif")
         self.assertEqual("1A8O", structure.header["idcode"])
         self.assertEqual("Viral protein", structure.header["head"])
         self.assertEqual("", structure.header["deposition_date"])
         self.assertEqual("X-RAY DIFFRACTION", structure.header["structure_method"])
         self.assertEqual(1.7, structure.header["resolution"])
+
+        # test not confused by '.'
+        structure = parser.get_structure("example", "PDB/1SSU_mod.cif")
+        self.assertEqual(None, structure.header["resolution"])
 
 
 class CIFtoPDB(unittest.TestCase):

--- a/Tests/test_PDB_MMCIFParser.py
+++ b/Tests/test_PDB_MMCIFParser.py
@@ -320,7 +320,7 @@ class ParseReal(unittest.TestCase):
         self.assertEqual("", structure.header["head"])
         self.assertEqual("", structure.header["deposition_date"])
         self.assertEqual("", structure.header["structure_method"])
-        self.assertEqual(0.0, structure.header["resolution"])
+        self.assertEqual(None, structure.header["resolution"])
 
         structure = parser.get_structure("example", "PDB/1A8O.cif")
         self.assertEqual("1A8O", structure.header["idcode"])


### PR DESCRIPTION

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This addresses #3195 by handling '.' as a `None` value for resolution and adding `_em_3d_reconstruction.resolution` as a source for a resolution value from mmCIF files as suggested by @ChrisMoth.  This also changes the default `resolution` value to `None` which is perhaps better than '0.0' although the latter can be directly sorted.

#3195 also suggests being able to parse all the current PDB and mmCIF files without exception.  This week's PDB files pass this test, but I still find the following exceptions for the mmCIF set:

    6gux PDBConstructionException: Atom H3A defined twice in residue <Residue DD9 het=H_DD9 resseq=308 icode= >
    5o61 PDBConstructionException: Blank altlocs in duplicate residue ILE (' ', 105, ' ')
    1ejg PDBConstructionException: Blank altlocs in duplicate residue SER (' ', 22, ' ')
    6gob PDBConstructionException: Atom CL2 defined twice in residue <Residue F6Q het=H_F6Q resseq=205 icode= >
    6goh PDBConstructionException: Atom CL2 defined twice in residue <Residue F7T het=H_F7T resseq=206 icode= >

`6gux`, `1ejg`, `6gob` and `6goh` PDB files all pass loading with `Permissive=True`, while `5o61` and `4udf` are not currently present in PDB files.  Have not investigated further, seems like these should be raised in another issue to get them to load.