### PR TITLE
Small rst bug

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -68,7 +68,7 @@ As mentioned above, to simplify your contributions, we provide a `pre-commit
 <https://pre-commit.com/>`_ configuration. Pre-commit is a Python package which
 automatically hooks into git. When you run "git commit" within the biopython
 repository, it will automatically run various fast checks (including flake8 and
-black) before the commit happens. In order to install it, run
+black) before the commit happens. In order to install it, run::
 
     $ pip install pre-commit
 


### PR DESCRIPTION
Small change for proper code formatting in `CONTRIBUTING.rst`.

This PR superseeds PR #3233 which was done as manual patch and where Travis CI has some problems although I just added two colons. Hopefully this passes.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)