### PR TITLE
TravisCI/Tox - pin black==19.10b0

### DIFF
--- a/.travis-tox.ini
+++ b/.travis-tox.ini
@@ -94,7 +94,7 @@ whitelist_externals =
     black
     bash
 deps =
-    black
+    black==19.10b0
 commands =
     # Now do various checks on our RST files:
     # Check sort order (bash call work around for pipe character)


### PR DESCRIPTION
This matches the pre-commit pin, and importably avoids a tab bug in black 20.8b0 and 20.8b1.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3236.
