### PR TITLE
fix docstrings

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -276,9 +276,6 @@ class Seq:
     def __imul__(self, other):
         """Multiply Seq in-place.
 
-        Note although Seq is immutable, the in-place method is
-        included to match the behaviour for regular Python strings.
-
         >>> from Bio.Seq import Seq
         >>> seq = Seq('ATG')
         >>> seq *= 2
@@ -1223,9 +1220,6 @@ class UnknownSeq(Seq):
 
     def __imul__(self, other):
         """Multiply UnknownSeq in-place.
-
-        Note although UnknownSeq is immutable, the in-place method is
-        included to match the behaviour for regular Python strings.
 
         >>> from Bio.Seq import UnknownSeq
         >>> seq = UnknownSeq(3, character="N")


### PR DESCRIPTION
The current docstring for the `__imul__` method on `Seq` and `UnknownSeq` classes is not quite correct:

`Note although Seq is immutable, the in-place method is included to match the behaviour for regular Python strings.`

But the `__imul__` method does not change an immutable object; the `Seq` object is still immutable.
Also, in Python this method does not just exist for strings. Other immutable objects have the same method, for example tuples:
```python
>>> x = (1,2,3)
>>> x *= 3
>>> x
(1, 2, 3, 1, 2, 3, 1, 2, 3)
```

Use `id` to confirm that the immutable object was not modified:
```python
>>> from Bio.Seq import Seq
>>> s = Seq("ABCD")
>>> id(s)
140294467491056
>>> s *= 3
>>> id(s)
140294487886096
```
i.e. a new `Seq` object is created, and `s` points to this new object.


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
