### PR TITLE
remove remaining unicode stuff

### DIFF
--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -138,29 +138,6 @@ class StringElement(str):
         return "StringElement(%s, attributes=%r)" % (text, attributes)
 
 
-class UnicodeElement(str):
-    """NCBI Entrez XML element mapped to a unicode string."""
-
-    def __new__(cls, value, tag, attributes, key=None):
-        """Create a UnicodeElement."""
-        self = str.__new__(cls, value)
-        self.tag = tag
-        if key is None:
-            self.key = tag
-        else:
-            self.key = key
-        self.attributes = attributes
-        return self
-
-    def __repr__(self):
-        """Return a string representation of the object."""
-        text = str.__repr__(self)
-        attributes = self.attributes
-        if not attributes:
-            return text
-        return "UnicodeElement(%s, attributes=%r)" % (text, attributes)
-
-
 class ListElement(list):
     """NCBI Entrez XML element mapped to a list."""
 
@@ -284,8 +261,8 @@ class DataHandler:
 
     from Bio import Entrez
 
-    global_dtd_dir = os.path.join(str(Entrez.__path__[0]), "DTDs")
-    global_xsd_dir = os.path.join(str(Entrez.__path__[0]), "XSDs")
+    global_dtd_dir = os.path.join(Entrez.__path__[0], "DTDs")
+    global_xsd_dir = os.path.join(Entrez.__path__[0], "XSDs")
     local_dtd_dir = ""
     local_xsd_dir = ""
 
@@ -496,8 +473,8 @@ class DataHandler:
         """Handle start of an XML element."""
         if tag in self.items:
             assert tag == "Item"
-            name = str(attrs["Name"])  # convert from Unicode
-            itemtype = str(attrs["Type"])  # convert from Unicode
+            name = attrs["Name"]
+            itemtype = attrs["Type"]
             del attrs["Type"]
             if itemtype == "Structure":
                 del attrs["Name"]
@@ -653,15 +630,11 @@ class DataHandler:
         self.attributes = None
         if tag in self.items:
             assert tag == "Item"
-            key = str(attributes["Name"])  # convert from Unicode
+            key = attributes["Name"]
             del attributes["Name"]
         else:
             key = tag
-        # Convert Unicode strings to plain strings if possible
-        try:
-            value = StringElement(value, tag, attributes, key)
-        except UnicodeEncodeError:
-            value = UnicodeElement(value, tag, attributes, key)
+        value = StringElement(value, tag, attributes, key)
         if element is None:
             self.record = element
         else:
@@ -707,7 +680,7 @@ class DataHandler:
         attributes = self.attributes
         self.attributes = None
         assert tag == "Item"
-        key = str(attributes["Name"])  # convert from Unicode
+        key = attributes["Name"]
         del attributes["Name"]
         if self.data:
             value = int("".join(self.data))

--- a/Bio/Phylo/PhyloXMLIO.py
+++ b/Bio/Phylo/PhyloXMLIO.py
@@ -665,7 +665,7 @@ class Parser:
 
 
 def _serialize(value):
-    """Convert a Python primitive to a phyloXML-compatible Unicode string (PRIVATE)."""
+    """Convert a Python primitive to a phyloXML-compatible string (PRIVATE)."""
     if isinstance(value, float):
         return str(value).upper()
     elif isinstance(value, bool):

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -150,8 +150,8 @@ CCCTTTTGGGTTTNTTNTTGGTAAANNNTTCCCGGGTGGGGGNGGTNNNGAAA
 >>> record_dict.close()
 
 Here the original file and what Biopython would output differ in the line
-wrapping. Also note that the get_raw method will return a bytes string,
-hence the use of decode to turn it into a (unicode) string.
+wrapping. Also note that the get_raw method will return a bytes object,
+hence the use of decode to turn it into a string.
 
 Also note that the get_raw method will preserve the newline endings. This
 example FASTQ file uses Unix style endings (b"\n" only),

--- a/Bio/SeqUtils/CheckSum.py
+++ b/Bio/SeqUtils/CheckSum.py
@@ -29,7 +29,7 @@ def crc32(seq):
         # Assume it's a Seq object
         return _crc32(str(seq).encode())
     except AttributeError:
-        # Assume it's a string/unicode
+        # Assume it's a string
         return _crc32(seq.encode())
 
 

--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -407,23 +407,7 @@ def _retrieve_annotations(adaptor, primary_id, taxon_id):
     annotations.update(_retrieve_reference(adaptor, primary_id))
     annotations.update(_retrieve_taxon(adaptor, primary_id, taxon_id))
     annotations.update(_retrieve_comment(adaptor, primary_id))
-    # Convert values into strings in cases of unicode from the database.
-    # BioSQL could eventually be expanded to be unicode aware.
-    str_anns = {}
-    for key, val in annotations.items():
-        if isinstance(val, list):
-            val = [_make_unicode_into_string(x) for x in val]
-        elif isinstance(val, str):
-            val = str(val)
-        str_anns[key] = val
-    return str_anns
-
-
-def _make_unicode_into_string(text):
-    if isinstance(text, str):
-        return str(text)
-    else:
-        return text
+    return annotations
 
 
 def _retrieve_alphabet(adaptor, primary_id):

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -596,7 +596,7 @@ class Adaptor:
         #             from biosequence where bioentry_id = %s""",
         #    (start+1, length, seqid))[0]
         return self.execute_one(
-            """SELECT SUBSTR(seq, %s, %s) FROM biosequence WHERE bioentry_id = %s""",
+            "SELECT SUBSTR(seq, %s, %s) FROM biosequence WHERE bioentry_id = %s",
             (start + 1, length, seqid),
         )[0]
 

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -596,8 +596,7 @@ class Adaptor:
         #             from biosequence where bioentry_id = %s""",
         #    (start+1, length, seqid))[0]
         return self.execute_one(
-            """select SUBSTR(seq, %s, %s)
-                     from biosequence where bioentry_id = %s""",
+            """SELECT SUBSTR(seq, %s, %s) FROM biosequence WHERE bioentry_id = %s""",
             (start + 1, length, seqid),
         )[0]
 

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -595,16 +595,11 @@ class Adaptor:
         #    """select SUBSTRING(seq FROM %s FOR %s)
         #             from biosequence where bioentry_id = %s""",
         #    (start+1, length, seqid))[0]
-        #
-        # Convert to a string on returning for databases that give back
-        # unicode. Shouldn't need unicode for sequences so this seems safe.
-        return str(
-            self.execute_one(
+        return self.execute_one(
                 """select SUBSTR(seq, %s, %s)
                      from biosequence where bioentry_id = %s""",
                 (start + 1, length, seqid),
             )[0]
-        )
 
     def execute_and_fetch_col0(self, sql, args=None):
         """Return a list of values from the first column in the row."""
@@ -630,7 +625,7 @@ class MysqlConnectorAdaptor(Adaptor):
 
     @staticmethod
     def _bytearray_to_str(s):
-        """If s is bytes or bytearray, convert to a unicode string (PRIVATE)."""
+        """If s is bytes or bytearray, convert to a string (PRIVATE)."""
         if isinstance(s, (bytes, bytearray)):
             return s.decode()
         return s

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -596,10 +596,10 @@ class Adaptor:
         #             from biosequence where bioentry_id = %s""",
         #    (start+1, length, seqid))[0]
         return self.execute_one(
-                """select SUBSTR(seq, %s, %s)
+            """select SUBSTR(seq, %s, %s)
                      from biosequence where bioentry_id = %s""",
-                (start + 1, length, seqid),
-            )[0]
+            (start + 1, length, seqid),
+        )[0]
 
     def execute_and_fetch_col0(self, sql, args=None):
         """Return a list of values from the first column in the row."""

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -799,7 +799,7 @@ class StringMethodTests(unittest.TestCase):
 
     def test_init_typeerror(self):
         """Check Seq __init__ gives TypeError exceptions."""
-        # Only expect it to take strings and unicode - not Seq objects!
+        # Only expect it to take strings - not Seq objects!
         self.assertRaises(TypeError, Seq, 1066)
         self.assertRaises(TypeError, Seq, Seq("ACGT"))
 


### PR DESCRIPTION
This PR removes some remaining unicode stuff that is no longer needed since we dropped python2.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
