### PR TITLE
Fix writing to NeXML from Bio.Phylo.write

### DIFF
--- a/Bio/Phylo/NeXMLIO.py
+++ b/Bio/Phylo/NeXMLIO.py
@@ -284,7 +284,12 @@ class Writer:
         # use xml.dom.minodom for pretty printing
         rough_string = ElementTree.tostring(root_node, "utf-8")
         reparsed = minidom.parseString(rough_string)
-        handle.write(reparsed.toprettyxml(indent="  ").encode("utf8"))
+        try:
+            # XML handles ought to be in binary mode
+            handle.write(reparsed.toprettyxml(indent="  ").encode("utf8"))
+        except TypeError:
+            # Fall back for text mode
+            handle.write(reparsed.toprettyxml(indent="  "))
 
         return count
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Fixed the problem in #3206 by restoring the behaviour in Biopython 1.76 (with improved test coverage), but does not address the underlying issue that ``Bio.Phylo`` ought to open XML files in binary mode (for both reading and writing).