### PR TITLE
Update pre-commit settings for doc8 (Windows line endings)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,11 @@
 # On Windows, git can be setup to convert text files to use
 # DOS/Windows newlines (\r\n) rather than Unix style (\n).
 # This should be harmless for most of our unit tests...
-#
+# Still, it's better when we try to assure unform Unix style
+# when committing:
+
+* text=auto
+
 # However, where testing indexing and get_raw (including the
 # BGZF tests comparing the uncompressed file to the compressed
 # file) it can be important to preserve the line endings in git.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,11 +41,11 @@ repos:
     -   id: rstcheck
         args: [--report=warning]
 -   repo: https://github.com/PyCQA/doc8
-    rev: 0.8.1
+    rev: ''
     hooks:
     -   id: doc8
         additional_dependencies: [pygments]
-        args: [--quiet,--ignore-path=Doc/examples/ec_*.txt]
+        args: [--quiet,--ignore-path=Doc/examples/ec_*.txt, --ignore=D004]
 -   repo: local
     hooks:
     -   id: doi-link-style

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -48,6 +48,7 @@ possible, especially the following contributors:
 - João Rodrigues
 - João Vitor F Cavalcante (first contribution)
 - Marie Crane
+- Markus Piotrowski
 - Michiel de Hoon
 - Peter Cock
 - Sergio Valqui


### PR DESCRIPTION
This PR is related to issue #2580. It adjusts the `pre-commit` settings for the recent update in `doc8` so that line endings will not be checked.

In short: This will allow developers on Windows to change text files and use our `pre-commit` setup without the need to convert line endings to Unix style. 

I also added a line to `.gitattibutes` which ensures that text files will have Unix line endings when being committed. This works repository-wide, in contrast to user `git` settings (e.g. `core.autocrlf true` for Windows users) which may be set wrongly. This should ensure that we have uniform line endings in the project.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
