### PR TITLE
Added method to calculate center of mass of Entities

### DIFF
--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -7,9 +7,10 @@
 
 """Atom class, used in Structure objects."""
 
-import numpy
 import warnings
 import copy
+
+import numpy as np
 
 from Bio.PDB.Entity import DisorderedEntityWrapper
 from Bio.PDB.PDBExceptions import PDBConstructionWarning
@@ -247,7 +248,7 @@ class Atom:
 
         """
         diff = self.coord - other.coord
-        return numpy.sqrt(numpy.dot(diff, diff))
+        return np.sqrt(np.dot(diff, diff))
 
     # set methods
 
@@ -426,7 +427,7 @@ class Atom:
             atom.transform(rotation, translation)
 
         """
-        self.coord = numpy.dot(self.coord, rot) + tran
+        self.coord = np.dot(self.coord, rot) + tran
 
     def get_vector(self):
         """Return coordinates as Vector.
@@ -509,4 +510,4 @@ class DisorderedAtom(DisorderedEntityWrapper):
         See the documentation of Atom.transform for details.
         """
         for child in self:
-            child.coord = numpy.dot(child.coord, rot) + tran
+            child.coord = np.dot(child.coord, rot) + tran

--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -222,7 +222,7 @@ class Atom:
 
     def _assign_atom_mass(self):
         """Return atom weight (PRIVATE)."""
-        # Needed for Bio/Struct/Geometry.py C.O.M. function
+        # Needed for C.O.M. function
         if self.element:
             return IUPACData.atom_weights[self.element.capitalize()]
         else:
@@ -486,10 +486,10 @@ class DisorderedAtom(DisorderedEntityWrapper):
     # This is a separate method from Entity.center_of_mass since DisorderedAtoms
     # will be unpacked by Residue.get_unpacked_list(). Here we allow for a very
     # specific use case that is much simpler than the general implementation.
-    def center_of_mass(self, geometrical=False):
+    def center_of_mass(self, geometric=False):
         """Return the center of mass of the DisorderedAtom as a numpy array.
 
-        If geometrical is True, returns the center of geometry instead.
+        If geometric is True, returns the center of geometry instead.
         """
         children = self.disordered_get_list()
 
@@ -497,7 +497,7 @@ class DisorderedAtom(DisorderedEntityWrapper):
             raise ValueError("{} does not have children".format(self))
 
         coords = np.asarray([a.coord for a in children], dtype=np.float32)
-        if geometrical:
+        if geometric:
             masses = None
         else:
             masses = np.asarray([a.mass for a in children], dtype=np.float32)

--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -497,10 +497,10 @@ class DisorderedAtom(DisorderedEntityWrapper):
     # This is a separate method from Entity.center_of_mass since DisorderedAtoms
     # will be unpacked by Residue.get_unpacked_list(). Here we allow for a very
     # specific use case that is much simpler than the general implementation.
-    def center_of_mass(self, geometric=False):
+    def center_of_mass(self):
         """Return the center of mass of the DisorderedAtom as a numpy array.
 
-        If geometric is True, returns the center of geometry instead.
+        Assumes all child atoms have the same mass (same element).
         """
         children = self.disordered_get_list()
 
@@ -508,12 +508,7 @@ class DisorderedAtom(DisorderedEntityWrapper):
             raise ValueError("{} does not have children".format(self))
 
         coords = np.asarray([a.coord for a in children], dtype=np.float32)
-        if geometric:
-            masses = None
-        else:
-            masses = np.asarray([a.mass for a in children], dtype=np.float32)
-
-        return np.average(coords, axis=0, weights=masses)
+        return np.average(coords, axis=0, weights=None)
 
     def disordered_get_list(self):
         """Return list of atom instances.

--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -483,6 +483,27 @@ class DisorderedAtom(DisorderedEntityWrapper):
         """Return disordered atom identifier."""
         return "<Disordered Atom %s>" % self.get_id()
 
+    # This is a separate method from Entity.center_of_mass since DisorderedAtoms
+    # will be unpacked by Residue.get_unpacked_list(). Here we allow for a very
+    # specific use case that is much simpler than the general implementation.
+    def center_of_mass(self, geometrical=False):
+        """Return the center of mass of the DisorderedAtom as a numpy array.
+
+        If geometrical is True, returns the center of geometry instead.
+        """
+        children = self.disordered_get_list()
+
+        if not children:
+            raise ValueError("{} does not have children".format(self))
+
+        coords = np.asarray([a.coord for a in children], dtype=np.float32)
+        if geometrical:
+            masses = None
+        else:
+            masses = np.asarray([a.mass for a in children], dtype=np.float32)
+
+        return np.average(coords, axis=0, weights=masses)
+
     def disordered_get_list(self):
         """Return list of atom instances.
 

--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -310,13 +310,9 @@ class Entity:
 
         entities = deque([self])  # start with [self] to avoid auto-unpacking
         while True:
-
             e = entities.popleft()
             if e.level in maybe_disordered:
                 entities += e.get_unpacked_list()
-            elif e.level == "A":
-                entities.append(e)
-                continue
             else:
                 entities += e.child_list
 

--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -295,10 +295,10 @@ class Entity:
         for o in self.get_list():
             o.transform(rot, tran)
 
-    def center_of_mass(self, geometrical=False):
+    def center_of_mass(self, geometric=False):
         """Return the center of mass of the Entity as a numpy array.
 
-        If geometrical is True, returns the center of geometry instead.
+        If geometric is True, returns the center of geometry instead.
         """
         # Recursively iterate through children until we get all atom coordinates
 
@@ -325,7 +325,7 @@ class Entity:
                 break  # nothing else to unpack
 
         coords = np.asarray([a.coord for a in entities], dtype=np.float32)
-        if geometrical:
+        if geometric:
             masses = None
         else:
             masses = np.asarray([a.mass for a in entities], dtype=np.float32)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -17,6 +17,9 @@ tested on PyPy3.6.1 v7.1.1.
 Element assignment in Bio.PDB.Atom now returns "X" when the element cannot be
 unambiguously guessed from the atom name, in accordance with PDB structures.
 
+Bio.PDB entities now have a ``center_of_mass()`` method that calculates either
+centers of gravity or geometry.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 

--- a/Tests/test_PDB_Disordered.py
+++ b/Tests/test_PDB_Disordered.py
@@ -10,6 +10,9 @@
 import os
 import tempfile
 import unittest
+import warnings
+
+import numpy as np
 
 from Bio.PDB import PDBParser, PDBIO
 
@@ -17,16 +20,18 @@ from Bio.PDB import PDBParser, PDBIO
 class TestDisordered(unittest.TestCase):
     """Tests for operations on DisorderedEntities."""
 
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = parser = PDBParser(QUIET=1)
+        cls.structure = parser.get_structure("x", "PDB/disordered.pdb")
+
     def unpack_all_atoms(self, structure):
         """Return a list of all atoms in the structure."""
         return [a for r in structure.get_residues() for a in r.get_unpacked_list()]
 
     def test_copy_disordered_atom(self):
         """Copies disordered atoms and all their children."""
-        parser = PDBParser(QUIET=1)
-        s = parser.get_structure("x", "PDB/disordered.pdb")
-
-        resi27 = s[0]["A"][27]
+        resi27 = self.structure[0]["A"][27]
         resi27_copy = resi27.copy()
 
         self.assertNotEqual(id(resi27), id(resi27_copy))  # did we really copy
@@ -40,9 +45,7 @@ class TestDisordered(unittest.TestCase):
 
     def test_copy_entire_chain(self):
         """Copy propagates throughout SMCRA object."""
-        parser = PDBParser(QUIET=1)
-        s = parser.get_structure("x", "PDB/disordered.pdb")
-
+        s = self.structure
         s_copy = s.copy()
 
         self.assertNotEqual(id(s), id(s_copy))  # did we really copy
@@ -58,9 +61,7 @@ class TestDisordered(unittest.TestCase):
         """Transform propagates through disordered atoms."""
         # This test relates to issue #455 where applying a transformation
         # to a copied structure did not work for disordered atoms.
-        parser = PDBParser(QUIET=1)
-        s = parser.get_structure("x", "PDB/disordered.pdb")
-
+        s = self.structure
         s_copy = s.copy()
 
         mtx = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
@@ -76,10 +77,9 @@ class TestDisordered(unittest.TestCase):
 
     def test_copy_and_write_disordered(self):
         """Extract, save, and parse again disordered atoms."""
-        parser = PDBParser(QUIET=1)
         writer = PDBIO()
 
-        s = parser.get_structure("x", "PDB/disordered.pdb")
+        s = self.structure
 
         # Extract the chain object
         chain = s[0]["A"]
@@ -92,7 +92,7 @@ class TestDisordered(unittest.TestCase):
             writer.save(filename)
 
             # Parse again
-            s2 = parser.get_structure("x_copy", filename)
+            s2 = self.parser.get_structure("x_copy", filename)
 
             # Do we have the same stuff?
             atoms1 = self.unpack_all_atoms(s)
@@ -103,6 +103,37 @@ class TestDisordered(unittest.TestCase):
 
         finally:
             os.remove(filename)
+
+    # DisorderedAtom.center_of_mass
+    def test_structure_w_disordered_com(self):
+        """Calculate center of mass of structure including DisorderedAtoms."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            s = self.parser.get_structure("b", "PDB/disordered.pdb")
+
+        com = s.center_of_mass()
+
+        self.assertTrue(np.allclose(com, [54.545, 19.868, 31.212], atol=1e-3))
+
+    def test_disordered_cog(self):
+        """Calculate DisorderedAtom center of geometry."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            s = self.parser.get_structure("b", "PDB/disordered.pdb")
+
+        arg27 = s[0]["A"][27]
+
+        # Detach all children but NH1
+        for atom in list(arg27):
+            if atom.name != "NH1":
+                arg27.detach_child(atom.name)
+
+        res_cog = arg27.center_of_mass()
+        self.assertTrue(np.allclose(res_cog, [59.555, 21.033, 25.954], atol=1e-3))
+
+        # Now compare to DisorderedAtom.center_of_mass
+        da_cog = arg27["NH1"].center_of_mass()
+        self.assertTrue(np.allclose(res_cog, da_cog, atol=1e-3))
 
 
 if __name__ == "__main__":

--- a/Tests/test_PDB_Disordered.py
+++ b/Tests/test_PDB_Disordered.py
@@ -15,6 +15,7 @@ import warnings
 import numpy as np
 
 from Bio.PDB import PDBParser, PDBIO
+from Bio.PDB.Atom import DisorderedAtom
 
 
 class TestDisordered(unittest.TestCase):
@@ -134,6 +135,12 @@ class TestDisordered(unittest.TestCase):
         # Now compare to DisorderedAtom.center_of_mass
         da_cog = arg27["NH1"].center_of_mass()
         self.assertTrue(np.allclose(res_cog, da_cog, atol=1e-3))
+
+    def test_empty_disordered(self):
+        """Raise ValueError on center of mass calculation of empty DisorderedAtom."""
+        da = DisorderedAtom("dummy")
+        with self.assertRaises(ValueError):
+            da.center_of_mass()
 
 
 if __name__ == "__main__":

--- a/Tests/test_PDB_SMCRA.py
+++ b/Tests/test_PDB_SMCRA.py
@@ -485,16 +485,6 @@ class CenterOfMassTests(unittest.TestCase):
 
         self.assertTrue(numpy.allclose(com, [19.870, 25.455, 28.753], atol=1e-3))
 
-    def test_structure_w_disordered_com(self):
-        """Calculate DisorderedAtom center of mass."""
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", PDBConstructionWarning)
-            s = self.parser.get_structure("b", "PDB/disordered.pdb")
-
-        com = s.center_of_mass()
-
-        self.assertTrue(numpy.allclose(com, [54.545, 19.868, 31.212], atol=1e-3))
-
     def test_structure_cog(self):
         """Calculate Structure center of geometry."""
         cog = self.structure.center_of_mass(geometric=True)
@@ -502,7 +492,7 @@ class CenterOfMassTests(unittest.TestCase):
         self.assertTrue(numpy.allclose(cog, [19.882, 25.842, 28.333], atol=1e-3))
 
     def test_chain_cog(self):
-        """Calculate Chain center of geometry."""
+        """Calculate center of geometry of individual chains."""
         expected = {
             "A": [20.271, 30.191, 23.563],
             "B": [19.272, 21.163, 33.711],
@@ -513,40 +503,11 @@ class CenterOfMassTests(unittest.TestCase):
             cog = chain.center_of_mass(geometric=True)
             self.assertTrue(numpy.allclose(cog, expected[chain.id], atol=1e-3))
 
-    def test_disordered_cog(self):
-        """Calculate DisorderedAtom center of geometry."""
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", PDBConstructionWarning)
-            s = self.parser.get_structure("b", "PDB/disordered.pdb")
-
-        arg27 = s[0]["A"][27]
-
-        # Detach all children but NH1
-        for atom in list(arg27):
-            if atom.name != "NH1":
-                arg27.detach_child(atom.name)
-
-        res_cog = arg27.center_of_mass(geometric=True)
-        self.assertTrue(numpy.allclose(res_cog, [59.555, 21.033, 25.954], atol=1e-3))
-
-        # Now compare to DisorderedAtom.center_of_mass
-        da_cog = arg27["NH1"].center_of_mass(geometric=True)
-        self.assertTrue(numpy.allclose(res_cog, da_cog, atol=1e-3))
-
-    def test_com_fails_on_atom(self):
-        """Atom.center_of_mass fails."""
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", PDBConstructionWarning)
-            s = self.parser.get_structure("b", "PDB/disordered.pdb")
-
-        with self.assertRaises(AttributeError):
-            s[0]["A"][27]["CA"].center_of_mass()
-
     def test_com_empty_structure(self):
-        """Center of mass of empty structure raises error."""
+        """Center of mass of empty structure raises ValueError."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", PDBConstructionWarning)
-            s = self.parser.get_structure("b", "PDB/disordered.pdb")
+            s = self.parser.get_structure("b", "PDB/disordered.pdb")  # smaller
 
         for child in list(s):
             s.detach_child(child.id)

--- a/Tests/test_PDB_SMCRA.py
+++ b/Tests/test_PDB_SMCRA.py
@@ -476,6 +476,16 @@ class CenterOfMassTests(unittest.TestCase):
 
         self.assertTrue(numpy.allclose(com, [19.870, 25.455, 28.753], atol=1e-3))
 
+    def test_structure_w_disordered_com(self):
+        """Calculate DisorderedAtom center of mass."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PDBConstructionWarning)
+            s = self.parser.get_structure("b", "PDB/disordered.pdb")
+
+        com = s.center_of_mass()
+
+        self.assertTrue(numpy.allclose(com, [54.545, 19.868, 31.212], atol=1e-3))
+
     def test_structure_cog(self):
         """Calculate Structure center of geometry."""
         cog = self.structure.center_of_mass(geometric=True)
@@ -511,7 +521,7 @@ class CenterOfMassTests(unittest.TestCase):
         self.assertTrue(numpy.allclose(res_cog, [59.555, 21.033, 25.954], atol=1e-3))
 
         # Now compare to DisorderedAtom.center_of_mass
-        da_cog = arg27["NH1"].center_of_mass()
+        da_cog = arg27["NH1"].center_of_mass(geometric=True)
         self.assertTrue(numpy.allclose(res_cog, da_cog, atol=1e-3))
 
     def test_com_fails_on_atom(self):

--- a/Tests/test_PDB_SMCRA.py
+++ b/Tests/test_PDB_SMCRA.py
@@ -478,7 +478,7 @@ class CenterOfMassTests(unittest.TestCase):
 
     def test_structure_cog(self):
         """Calculate Structure center of geometry."""
-        cog = self.structure.center_of_mass(geometrical=True)
+        cog = self.structure.center_of_mass(geometric=True)
 
         self.assertTrue(numpy.allclose(cog, [19.882, 25.842, 28.333], atol=1e-3))
 
@@ -491,7 +491,7 @@ class CenterOfMassTests(unittest.TestCase):
         }
 
         for chain in self.structure[0].get_chains():  # one model only
-            cog = chain.center_of_mass(geometrical=True)
+            cog = chain.center_of_mass(geometric=True)
             self.assertTrue(numpy.allclose(cog, expected[chain.id], atol=1e-3))
 
     def test_disordered_cog(self):
@@ -507,7 +507,7 @@ class CenterOfMassTests(unittest.TestCase):
             if atom.name != "NH1":
                 arg27.detach_child(atom.name)
 
-        res_cog = arg27.center_of_mass(geometrical=True)
+        res_cog = arg27.center_of_mass(geometric=True)
         self.assertTrue(numpy.allclose(res_cog, [59.555, 21.033, 25.954], atol=1e-3))
 
         # Now compare to DisorderedAtom.center_of_mass


### PR DESCRIPTION
- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Simplified calculation of centers of mass for all entity types. Added a specific method for DisorderedAtoms to keep the logic in Entity simpler.

I wrote a small script to calculate the centers of mass independently for the tests. Possible reviewers: @peterjc, @jgreener64, and @rob-miller.  I'll add an entry to `NEWS.rst` and my name to `CONTRIB.rst` after reviews and CI pass.