### PR TITLE
Changed atom has valid element check from PDBIO

### DIFF
--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -161,7 +161,7 @@ class PDBIO(StructureIO):
 
         if atom.element:
             element = atom.element.strip().upper()
-            if element.capitalize() not in atom_weights:
+            if element.capitalize() not in atom_weights and element != "X":
                 raise ValueError("Unrecognised element %r" % atom.element)
             element = element.rjust(2)
         else:

--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -9,9 +9,6 @@
 # To allow saving of chains, residues, etc..
 from Bio.PDB.StructureBuilder import StructureBuilder
 
-# Allowed Elements
-from Bio.Data.IUPACData import atom_weights
-
 
 _ATOM_FORMAT_STRING = (
     "%s%5i %-4s%c%3s %c%4i%c   %8.3f%8.3f%8.3f%s%6.2f      %4s%2s%2s\n"
@@ -161,8 +158,8 @@ class PDBIO(StructureIO):
 
         if atom.element:
             element = atom.element.strip().upper()
-            if element.capitalize() not in atom_weights:
-                raise ValueError("Unrecognised element %r" % atom.element)
+            if len(element) > 2:
+                raise ValueError("Element string is too long: %r" % atom.element)
             element = element.rjust(2)
         else:
             element = "  "

--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -9,6 +9,9 @@
 # To allow saving of chains, residues, etc..
 from Bio.PDB.StructureBuilder import StructureBuilder
 
+# Allowed Elements
+from Bio.Data.IUPACData import atom_weights
+
 
 _ATOM_FORMAT_STRING = (
     "%s%5i %-4s%c%3s %c%4i%c   %8.3f%8.3f%8.3f%s%6.2f      %4s%2s%2s\n"
@@ -158,8 +161,8 @@ class PDBIO(StructureIO):
 
         if atom.element:
             element = atom.element.strip().upper()
-            if len(element) > 2:
-                raise ValueError("Element string is too long: %r" % atom.element)
+            if element.capitalize() not in atom_weights:
+                raise ValueError("Unrecognised element %r" % atom.element)
             element = element.rjust(2)
         else:
             element = "  "

--- a/Tests/test_PDB_PDBIO.py
+++ b/Tests/test_PDB_PDBIO.py
@@ -302,6 +302,40 @@ class WriteTest(unittest.TestCase):
         finally:
             os.remove(filename)
 
+    def test_pdbio_write_x_element(self):
+        """Write a structure with atomic element X with PDBIO."""
+        struct1 = self.structure
+
+        # Change element of one atom
+        atom = next(struct1.get_atoms())
+        atom.element = "X"  # X is assigned in Atom.py as last resort
+
+        self.io.set_structure(struct1)
+
+        filenumber, filename = tempfile.mkstemp()
+        os.close(filenumber)
+
+        try:
+            self.io.save(filename)
+        finally:
+            os.remove(filename)
+
+    def test_pdbio_write_unk_element(self):
+        """PDBIO raises ValueError when writing unrecognised atomic elements."""
+        struct1 = self.structure
+
+        atom = next(struct1.get_atoms())
+        atom.element = "1"
+
+        self.io.set_structure(struct1)
+
+        filenumber, filename = tempfile.mkstemp()
+        os.close(filenumber)
+
+        with self.assertRaises(ValueError):
+            self.io.save(filename)
+        os.remove(filename)
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
Realized PR #3250 introduces a bug in PDBIO when writing structures with unknown elements because "X" is not a valid element (in Bio.Data.IUPACData.atom_weights).

I thought of simply checking if element is "X", but I'd argue that the writer module should enforce the format and not necessarily the content. If users want to overload that particular column with whatever value, they should be able to as long as they comply with the format (2 characters max length).

@peterjc, you introduced the element check back in 2009 (at least according to git log!). Do you remember if there was a particular reason in mind back then? I could find a request in the old mailing list/bug tracker to parse elements, but that's it.

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)