### PR TITLE
Added methods to remove children of disordered Entities

### DIFF
--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -469,6 +469,13 @@ class DisorderedEntityWrapper:
         """
         raise NotImplementedError
 
+    def disordered_remove(self, child):
+        """Remove disordered entry.
+
+        This is implemented by DisorderedAtom and DisorderedResidue.
+        """
+        raise NotImplementedError
+
     def is_disordered(self):
         """Return 2, indicating that this Entity is a collection of Entities."""
         return 2

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -20,6 +20,9 @@ unambiguously guessed from the atom name, in accordance with PDB structures.
 Bio.PDB entities now have a ``center_of_mass()`` method that calculates either
 centers of gravity or geometry.
 
+New method ``disordered_remove()`` implemented in Bio.PDB DisorderedAtom and
+DisorderedResidue to remove children.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 


### PR DESCRIPTION
- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Disordered entities like DisorderedAtom and DisorderedResidues allow adding children to them but not removing. Removing is useful when editing structures. This PR adds methods to allow that to happen and simplifies, for instance, removing altlocs from a structure:

```python
s = ...  # structure
for atom in s.get_atoms():
    if atom.is_disordered():
        altlocs = list(atom.child_dict)
        altlocs.remove(atom.selected_child)
        for a in altlocs:
            atom.disordered_remove(a)
```

The methods do not remove the disordered entity completely even if it is empty. I thought that would be better left to the user to do it explicitly from the parent. They do change the `__repr__` of the disordered entity to signal that they are empty.