### PR TITLE
deprecating the format method

### DIFF
--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -16,6 +16,9 @@ import copy
 import itertools
 import random
 import re
+import warnings
+
+from Bio import BiopythonDeprecationWarning
 
 
 # General tree-traversal algorithms

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -955,8 +955,7 @@ class Tree(TreeElement, TreeMixin):
     def __format__(self, format_spec):
         """Serialize the tree as a string in the specified file format.
 
-        This method supports the ``format`` built-in function added in Python
-        2.6/3.0.
+        This method supports Python's ``format`` built-in function.
 
         :param format_spec: a lower-case string supported by ``Bio.Phylo.write``
             as an output file format.
@@ -978,6 +977,12 @@ class Tree(TreeElement, TreeMixin):
 
         This duplicates the __format__ magic method for pre-2.6 Pythons.
         """
+        warnings.warn(
+            "Tree.format has been deprecated, and we intend to remove it in "
+            "a future release of Biopython. Instead of tree.format(format), "
+            "please use format(tree, format_spec) or an f-string.",
+            BiopythonDeprecationWarning,
+        )
         return self.__format__(format)
 
     # Pretty-printer for the entire tree hierarchy

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -859,3 +859,8 @@ Biopython still using this class.
 Bio.FSSP
 -----------
 Deprecated in release 1.77.
+
+Bio.Phylo.BaseTree.Tree
+-----------------------
+The format method was deprecated in Release 1.79 in favor of the __format__
+method, which supports Python's built-in format function.


### PR DESCRIPTION
This PR deprecates the `format` method on Tree objects in Bio.Phylo.BaseTree, in favor of the (already existing) `__format__` method, which supports Python's built-in `format` function.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

