### PR TITLE
default phyml test to single threaded

### DIFF
--- a/Tests/test_phyml_tool.py
+++ b/Tests/test_phyml_tool.py
@@ -43,7 +43,7 @@ class AppTests(unittest.TestCase):
 
     def test_phyml(self):
         """Run PhyML using the wrapper."""
-        # Configure phyml to run in single threaded mode by default
+        # Stabilize phyml tests by running in single threaded mode by default
         if not os.getenv("PHYMLCPUS"):
             os.putenv("PHYMLCPUS", "1")
         cmd = PhymlCommandline(phyml_exe, input=EX_PHYLIP, datatype="aa")

--- a/Tests/test_phyml_tool.py
+++ b/Tests/test_phyml_tool.py
@@ -43,6 +43,7 @@ class AppTests(unittest.TestCase):
 
     def test_phyml(self):
         """Run PhyML using the wrapper."""
+        # Configure phyml to run in single threaded mode by default
         if not os.getenv("PHYMLCPUS"):
             os.putenv("PHYMLCPUS", "1")
         cmd = PhymlCommandline(phyml_exe, input=EX_PHYLIP, datatype="aa")

--- a/Tests/test_phyml_tool.py
+++ b/Tests/test_phyml_tool.py
@@ -43,8 +43,8 @@ class AppTests(unittest.TestCase):
 
     def test_phyml(self):
         """Run PhyML using the wrapper."""
-        if not os.getenv('PHYMLCPUS'):
-            os.putenv('PHYMLCPUS', '1')
+        if not os.getenv("PHYMLCPUS"):
+            os.putenv("PHYMLCPUS", "1")
         cmd = PhymlCommandline(phyml_exe, input=EX_PHYLIP, datatype="aa")
         # Smoke test
         try:

--- a/Tests/test_phyml_tool.py
+++ b/Tests/test_phyml_tool.py
@@ -43,6 +43,8 @@ class AppTests(unittest.TestCase):
 
     def test_phyml(self):
         """Run PhyML using the wrapper."""
+        if not os.getenv('PHYMLCPUS'):
+            os.putenv('PHYMLCPUS', '1')
         cmd = PhymlCommandline(phyml_exe, input=EX_PHYLIP, datatype="aa")
         # Smoke test
         try:

--- a/Tests/test_phyml_tool.py
+++ b/Tests/test_phyml_tool.py
@@ -43,7 +43,8 @@ class AppTests(unittest.TestCase):
 
     def test_phyml(self):
         """Run PhyML using the wrapper."""
-        # Stabilize phyml tests by running in single threaded mode by default
+        # Stabilize phyml tests by running in single threaded mode by default.
+        # Note: PHYMLCPUS environment is specific to Debian and derivatives.
         if not os.getenv("PHYMLCPUS"):
             os.putenv("PHYMLCPUS", "1")
         cmd = PhymlCommandline(phyml_exe, input=EX_PHYLIP, datatype="aa")


### PR DESCRIPTION
By default the phyml test runs a MPI variant of the program that makes
the assumption of having access to an X server.  Since it may not be
the case on build servers, this outputs the message "No protocol
specified" in standard error, triggering a failure of the test.

This patch sets the variable PHYMLCPUS, if it is not in use, in order
to run phyml tests with the single threaded variant.  It is still
possible to override by setting with the environment variable if one
wishes to test explicitly the parallel case in the future.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)