### PR TITLE
Use assertIn in tests

### DIFF
--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -743,15 +743,14 @@ class DupLoadTest(unittest.TestCase):
             # Good!
             # Note we don't do a specific exception handler because the
             # exception class will depend on which DB back end is in use.
-            self.assertTrue(
-                err.__class__.__name__
-                in [
+            self.assertIn(
+                err.__class__.__name__,
+                [
                     "IntegrityError",
                     "UniqueViolation",
                     "AttributeError",
                     "OperationalError",
                 ],
-                err.__class__.__name__,
             )
             return
         raise Exception("Should have failed! Loaded %i records" % count)
@@ -767,10 +766,9 @@ class DupLoadTest(unittest.TestCase):
             count = self.db.load([record])
         except Exception as err:
             # Good!
-            self.assertTrue(
-                err.__class__.__name__
-                in ["IntegrityError", "UniqueViolation", "AttributeError"],
+            self.assertIn(
                 err.__class__.__name__,
+                ["IntegrityError", "UniqueViolation", "AttributeError"],
             )
             return
         raise Exception("Should have failed! Loaded %i records" % count)
@@ -787,10 +785,9 @@ class DupLoadTest(unittest.TestCase):
             count = self.db.load([record1, record2])
         except Exception as err:
             # Good!
-            self.assertTrue(
-                err.__class__.__name__
-                in ["IntegrityError", "UniqueViolation", "AttributeError"],
+            self.assertIn(
                 err.__class__.__name__,
+                ["IntegrityError", "UniqueViolation", "AttributeError"],
             )
             return
         raise Exception("Should have failed! Loaded %i records" % count)
@@ -1010,10 +1007,9 @@ class InDepthLoadTest(unittest.TestCase):
             count = self.db.load([record])
         except Exception as err:
             # Good!
-            self.assertTrue(
-                err.__class__.__name__
-                in ["IntegrityError", "UniqueViolation", "AttributeError"],
+            self.assertIn(
                 err.__class__.__name__,
+                ["IntegrityError", "UniqueViolation", "AttributeError"],
             )
             return
         raise Exception("Should have failed! Loaded %i records" % count)

--- a/Tests/test_Prank_tool.py
+++ b/Tests/test_Prank_tool.py
@@ -184,8 +184,8 @@ class PrankConversion(unittest.TestCase):
         self.assertEqual(str(eval(repr(cmdline))), str(cmdline))
         message, error = cmdline()
         self.assertIn("PRANK", message)
-        self.assertTrue(
-            ("converting '%s' to '%s'" % (self.input, filename)) in message, message
+        self.assertIn(
+            ("converting '%s' to '%s'" % (self.input, filename)), message, message
         )
         self.assertEqual(error, "")
         self.assertTrue(os.path.isfile(filename))

--- a/Tests/test_SffIO.py
+++ b/Tests/test_SffIO.py
@@ -349,10 +349,11 @@ class TestConcatenated(unittest.TestCase):
             for record in SeqIO.parse("Roche/invalid_greek_E3MFGYR02.sff", "sff"):
                 count += 1
         except ValueError as err:
-            self.assertTrue(
+            self.assertIn(
                 "Additional data at end of SFF file, perhaps "
                 "multiple SFF files concatenated? "
-                "See offset 65296" in str(err),
+                "See offset 65296",
+                str(err),
                 err,
             )
             caught = True
@@ -363,10 +364,11 @@ class TestConcatenated(unittest.TestCase):
         try:
             d = SeqIO.index("Roche/invalid_greek_E3MFGYR02.sff", "sff")
         except ValueError as err:
-            self.assertTrue(
+            self.assertIn(
                 "Additional data at end of SFF file, perhaps "
                 "multiple SFF files concatenated? "
-                "See offset 65296" in str(err),
+                "See offset 65296",
+                str(err),
                 err,
             )
         else:
@@ -379,11 +381,12 @@ class TestConcatenated(unittest.TestCase):
             for record in SeqIO.parse("Roche/invalid_paired_E3MFGYR02.sff", "sff"):
                 count += 1
         except ValueError as err:
-            self.assertTrue(
+            self.assertIn(
                 "Your SFF file is invalid, post index 5 byte "
                 "null padding region ended '.sff' which could "
                 "be the start of a concatenated SFF file? "
-                "See offset 54371" in str(err),
+                "See offset 54371",
+                str(err),
                 err,
             )
             caught = True
@@ -394,11 +397,12 @@ class TestConcatenated(unittest.TestCase):
         try:
             d = SeqIO.index("Roche/invalid_paired_E3MFGYR02.sff", "sff")
         except ValueError as err:
-            self.assertTrue(
+            self.assertIn(
                 "Your SFF file is invalid, post index 5 byte "
                 "null padding region ended '.sff' which could "
                 "be the start of a concatenated SFF file? "
-                "See offset 54371" in str(err),
+                "See offset 54371",
+                str(err),
                 err,
             )
         else:

--- a/Tests/test_TogoWS.py
+++ b/Tests/test_TogoWS.py
@@ -594,9 +594,7 @@ class TogoSearch(unittest.TestCase):
         search_iter = list(TogoWS.search_iter(database, search_term, limit))
         self.assertEqual(count, len(search_iter))
         for match in expected_matches:
-            self.assertTrue(
-                match in search_iter, "Expected %s in results but not" % match
-            )
+            self.assertIn(match, search_iter, "Expected %s in results" % match)
 
 
 class TogoConvert(unittest.TestCase):


### PR DESCRIPTION
Fixes flake8-assertive A501 errors about assertIn (but not the ones about rounding), spin out from #2835.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
