### PR TITLE
Fix numpy deprecation warning

### DIFF
--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -833,14 +833,14 @@ have the same number of rows.
 
 \subsection{Alignments as arrays}
 Depending on what you are doing, it can be more useful to turn the alignment
-object into an array of letters -- and you can do this with NumPy:
+object into an array of letters (length one strings) -- and you can do this with NumPy:
 
 %doctest examples lib:numpy
 \begin{minted}{pycon}
 >>> import numpy as np
 >>> from Bio import AlignIO
 >>> alignment = AlignIO.read("PF05371_seed.sth", "stockholm")
->>> align_array = np.array([list(rec) for rec in alignment], np.character)
+>>> align_array = np.array([list(rec) for rec in alignment], "S1")
 >>> print("Array shape %i by %i" % align_array.shape)
 Array shape 7 by 52
 \end{minted}
@@ -849,7 +849,7 @@ If you will be working heavily with the columns, you can tell NumPy to store
 the array by column (as in Fortran) rather than its default of by row (as in C):
 
 \begin{minted}{pycon}
->>> align_array = np.array([list(rec) for rec in alignment], np.character, order="F")
+>>> align_array = np.array([list(rec) for rec in alignment], "S1", order="F")
 \end{minted}
 
 Note that this leaves the original Biopython alignment object and the NumPy array

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -840,7 +840,7 @@ object into an array of letters (length one strings) -- and you can do this with
 >>> import numpy as np
 >>> from Bio import AlignIO
 >>> alignment = AlignIO.read("PF05371_seed.sth", "stockholm")
->>> align_array = np.array([list(rec) for rec in alignment], "S1")
+>>> align_array = np.array([list(rec) for rec in alignment], "U")
 >>> print("Array shape %i by %i" % align_array.shape)
 Array shape 7 by 52
 \end{minted}
@@ -849,7 +849,7 @@ If you will be working heavily with the columns, you can tell NumPy to store
 the array by column (as in Fortran) rather than its default of by row (as in C):
 
 \begin{minted}{pycon}
->>> align_array = np.array([list(rec) for rec in alignment], "S1", order="F")
+>>> align_array = np.array([list(rec) for rec in alignment], "U", order="F")
 \end{minted}
 
 Note that this leaves the original Biopython alignment object and the NumPy array


### PR DESCRIPTION
Using np.character was treated as dtype='S1', although I wonder if we should explicitly use unicode?

``
DeprecationWarning: Converting `np.character` to a dtype is deprecated. The current result is `np.dtype(np.str_)` which is not strictly correct. Note that `np.character` is generally deprecated and 'S1' should be used.
``

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
