### PR TITLE
Removed partial codon warning when testing amino acid sequences

### DIFF
--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -978,16 +978,6 @@ class TestTranslating(unittest.TestCase):
         seq = "GTGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG"
         self.assertEqual("VAIVMGRWKGAR", Seq.translate(seq, table=2, to_stop=True))
 
-    def test_translation_on_proteins(self):
-        """Check translation fails on a protein."""
-        for s in protein_seqs:
-            with self.assertRaises(TranslationError):
-                Seq.translate(s)
-
-            if isinstance(s, Seq.Seq):
-                with self.assertRaises(TranslationError):
-                    s.translate()
-
     def test_translation_of_invalid_codon(self):
         for codon in ["TA?", "N-N", "AC_", "Ac_"]:
             with self.assertRaises(TranslationError):

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -43,11 +43,11 @@ protein_seqs = [
     Seq.Seq("ATCGPK"),
     Seq.Seq("T.CGPK"),
     Seq.Seq("T-CGPK"),
-    Seq.Seq("MEDG-KRXR*"),
+    Seq.Seq("MEDG-KRX*"),
     Seq.MutableSeq("ME-K-DRXR*XU"),
-    Seq.Seq("MEDG-KRXR@"),
+    Seq.Seq("MEDG-KRX@"),
     Seq.Seq("ME-KR@"),
-    Seq.Seq("MEDG.KRXR@"),
+    Seq.Seq("MEDG.KRX@"),
 ]
 
 


### PR DESCRIPTION
Only changed the testing amino acid sequences so the warning isn't triggered. Amino acid sequences don't need to be divisible by 3, only codon sequences.

Trimmed three testing protein_seqs by one amino acid to prevent irrelevant partial codon warning from appearing when testing TranslationError of amino acid Seq() object.


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
