### PR TITLE
Recognize negative residues in REMARK 465

### DIFF
--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -150,7 +150,7 @@ def _parse_remark_465(line):
         (\d+\s[\sA-Z][\sA-Z][A-Z] |   # Either model number + residue name
             [A-Z]{1,3})               # Or only residue name with 1 (RNA) to 3 letters
         \s ([A-Za-z0-9])              # A single character chain
-        \s+(\d+[A-Za-z]?)$            # Residue number: A digit followed by an optional
+        \s+([-]?\d+[A-Za-z]?)$        # Residue number: A digit followed by an optional
                                       # insertion code (Hetero-flags make no sense in
                                       # context with missing res)
         """,

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -150,7 +150,7 @@ def _parse_remark_465(line):
         (\d+\s[\sA-Z][\sA-Z][A-Z] |   # Either model number + residue name
             [A-Z]{1,3})               # Or only residue name with 1 (RNA) to 3 letters
         \s ([A-Za-z0-9])              # A single character chain
-        \s+([-]?\d+[A-Za-z]?)$        # Residue number: A digit followed by an optional
+        \s+(-?\d+[A-Za-z]?)$        # Residue number: A digit followed by an optional
                                       # insertion code (Hetero-flags make no sense in
                                       # context with missing res)
         """,

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -150,7 +150,7 @@ def _parse_remark_465(line):
         (\d+\s[\sA-Z][\sA-Z][A-Z] |   # Either model number + residue name
             [A-Z]{1,3})               # Or only residue name with 1 (RNA) to 3 letters
         \s ([A-Za-z0-9])              # A single character chain
-        \s+(-?\d+[A-Za-z]?)$        # Residue number: A digit followed by an optional
+        \s+(-?\d+[A-Za-z]?)$          # Residue number: A digit followed by an optional
                                       # insertion code (Hetero-flags make no sense in
                                       # context with missing res)
         """,

--- a/Tests/test_PDB_parse_pdb_header.py
+++ b/Tests/test_PDB_parse_pdb_header.py
@@ -97,6 +97,18 @@ class ParseReal(unittest.TestCase):
             },
         )
 
+        info = _parse_remark_465("U R    -9") # Based on PDB id: 7c7a
+        self.assertEqual(
+            info,
+            {
+                "model": None,
+                "res_name": "U",
+                "chain": "R",
+                "ssseq": -9,
+                "insertion": None,
+            },
+        )
+
         info = _parse_remark_465("2 GLU B   276B")
         self.assertEqual(
             info,

--- a/Tests/test_PDB_parse_pdb_header.py
+++ b/Tests/test_PDB_parse_pdb_header.py
@@ -97,7 +97,7 @@ class ParseReal(unittest.TestCase):
             },
         )
 
-        info = _parse_remark_465("U R    -9") # Based on PDB id: 7c7a
+        info = _parse_remark_465("U R    -9")  # Based on PDB id: 7c7a
         self.assertEqual(
             info,
             {


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #3306.
Adjusts the regular expression to allow negative sign so residues with negative numbers are not skipped over.
Adds a test for negative residue numbers.

These were small changes and so I didn't run ``pre-commit`` locally.
