### PR TITLE
Utilized __slots__ in Seq and SeqRecord classes, issue #2854

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -73,6 +73,8 @@ class Seq:
     not applicable to protein sequences).
     """
 
+    __slots__ = ('_data', 'alphabet')
+
     def __init__(self, data):
         """Create a Seq object.
 
@@ -261,7 +263,8 @@ class Seq:
         Seq('ATGATG')
         """
         if not isinstance(other, int):
-            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(
+                f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(str(self) * other)
 
     def __rmul__(self, other):
@@ -272,7 +275,8 @@ class Seq:
         Seq('ATGATG')
         """
         if not isinstance(other, int):
-            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(
+                f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(str(self) * other)
 
     def __imul__(self, other):
@@ -285,7 +289,8 @@ class Seq:
         Seq('ATGATG')
         """
         if not isinstance(other, int):
-            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(
+                f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(str(self) * other)
 
     def tomutable(self):  # Needed?  Or use a function?
@@ -1007,7 +1012,8 @@ class Seq:
             codon_table = CodonTable.ambiguous_generic_by_id[table_id]
 
         return Seq(
-            _translate_str(str(self), codon_table, stop_symbol, to_stop, cds, gap=gap)
+            _translate_str(str(self), codon_table,
+                           stop_symbol, to_stop, cds, gap=gap)
         )
 
     def ungap(self, gap="-"):
@@ -1127,6 +1133,8 @@ class UnknownSeq(Seq):
     UnknownSeq(2, character='K')
     """
 
+    __slots__ = ('_length', '_character')
+
     def __init__(self, length, alphabet=None, character="?"):
         """Create a new UnknownSeq object.
 
@@ -1143,7 +1151,8 @@ class UnknownSeq(Seq):
             # TODO - Block zero length UnknownSeq?  You can just use a Seq!
             raise ValueError("Length must not be negative.")
         if not character or len(character) != 1:
-            raise ValueError("character argument should be a single letter string.")
+            raise ValueError(
+                "character argument should be a single letter string.")
         self._character = character
 
     def __len__(self):
@@ -1202,7 +1211,8 @@ class UnknownSeq(Seq):
         UnknownSeq(6, character='N')
         """
         if not isinstance(other, int):
-            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(
+                f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(len(self) * other, character=self._character)
 
     def __rmul__(self, other):
@@ -1215,7 +1225,8 @@ class UnknownSeq(Seq):
         UnknownSeq(6, character='N')
         """
         if not isinstance(other, int):
-            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(
+                f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(len(self) * other, character=self._character)
 
     def __imul__(self, other):
@@ -1228,7 +1239,8 @@ class UnknownSeq(Seq):
         UnknownSeq(6, character='N')
         """
         if not isinstance(other, int):
-            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(
+                f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(len(self) * other, character=self._character)
 
     def __getitem__(self, index):
@@ -1696,6 +1708,8 @@ class MutableSeq:
     or biological methods as the Seq object.
     """
 
+    __slots__ = ('data')
+
     def __init__(self, data):
         """Initialize the class."""
         if isinstance(data, str):  # TODO - What about unicode?
@@ -1894,7 +1908,8 @@ class MutableSeq:
         MutableSeq('ATGATG')
         """
         if not isinstance(other, int):
-            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(
+                f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(self.data * other)
 
     def __rmul__(self, other):
@@ -1908,7 +1923,8 @@ class MutableSeq:
         MutableSeq('ATGATG')
         """
         if not isinstance(other, int):
-            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(
+                f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(self.data * other)
 
     def __imul__(self, other):
@@ -1921,7 +1937,8 @@ class MutableSeq:
         MutableSeq('ATGATG')
         """
         if not isinstance(other, int):
-            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(
+                f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(self.data * other)
 
     def append(self, c):
@@ -2381,12 +2398,14 @@ def _translate_str(
         )
     if gap is not None:
         if not isinstance(gap, str):
-            raise TypeError("Gap character should be a single character string.")
+            raise TypeError(
+                "Gap character should be a single character string.")
         elif len(gap) > 1:
-            raise ValueError("Gap character should be a single character string.")
+            raise ValueError(
+                "Gap character should be a single character string.")
 
     for i in range(0, n - n % 3, 3):
-        codon = sequence[i : i + 3]
+        codon = sequence[i: i + 3]
         try:
             amino_acids.append(forward_table[codon])
         except (KeyError, CodonTable.TranslationError):

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -263,8 +263,7 @@ class Seq:
         Seq('ATGATG')
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(str(self) * other)
 
     def __rmul__(self, other):
@@ -275,8 +274,7 @@ class Seq:
         Seq('ATGATG')
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(str(self) * other)
 
     def __imul__(self, other):
@@ -289,8 +287,7 @@ class Seq:
         Seq('ATGATG')
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(str(self) * other)
 
     def tomutable(self):  # Needed?  Or use a function?
@@ -1012,8 +1009,7 @@ class Seq:
             codon_table = CodonTable.ambiguous_generic_by_id[table_id]
 
         return Seq(
-            _translate_str(str(self), codon_table,
-                           stop_symbol, to_stop, cds, gap=gap)
+            _translate_str(str(self), codon_table, stop_symbol, to_stop, cds, gap=gap)
         )
 
     def ungap(self, gap="-"):
@@ -1151,8 +1147,7 @@ class UnknownSeq(Seq):
             # TODO - Block zero length UnknownSeq?  You can just use a Seq!
             raise ValueError("Length must not be negative.")
         if not character or len(character) != 1:
-            raise ValueError(
-                "character argument should be a single letter string.")
+            raise ValueError("character argument should be a single letter string.")
         self._character = character
 
     def __len__(self):
@@ -1211,8 +1206,7 @@ class UnknownSeq(Seq):
         UnknownSeq(6, character='N')
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(len(self) * other, character=self._character)
 
     def __rmul__(self, other):
@@ -1225,8 +1219,7 @@ class UnknownSeq(Seq):
         UnknownSeq(6, character='N')
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(len(self) * other, character=self._character)
 
     def __imul__(self, other):
@@ -1239,8 +1232,7 @@ class UnknownSeq(Seq):
         UnknownSeq(6, character='N')
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(len(self) * other, character=self._character)
 
     def __getitem__(self, index):
@@ -1908,8 +1900,7 @@ class MutableSeq:
         MutableSeq('ATGATG')
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(self.data * other)
 
     def __rmul__(self, other):
@@ -1923,8 +1914,7 @@ class MutableSeq:
         MutableSeq('ATGATG')
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(self.data * other)
 
     def __imul__(self, other):
@@ -1937,8 +1927,7 @@ class MutableSeq:
         MutableSeq('ATGATG')
         """
         if not isinstance(other, int):
-            raise TypeError(
-                f"can't multiply {self.__class__.__name__} by non-int type")
+            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(self.data * other)
 
     def append(self, c):
@@ -2398,14 +2387,12 @@ def _translate_str(
         )
     if gap is not None:
         if not isinstance(gap, str):
-            raise TypeError(
-                "Gap character should be a single character string.")
+            raise TypeError("Gap character should be a single character string.")
         elif len(gap) > 1:
-            raise ValueError(
-                "Gap character should be a single character string.")
+            raise ValueError("Gap character should be a single character string.")
 
     for i in range(0, n - n % 3, 3):
-        codon = sequence[i: i + 3]
+        codon = sequence[i : i + 3]
         try:
             amino_acids.append(forward_table[codon])
         except (KeyError, CodonTable.TranslationError):

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -165,7 +165,9 @@ class SeqRecord:
         'dbxrefs',
         'annotations',
         '_per_letter_annotations',
-        'features'
+        'features',
+        '_al_start',
+        '_al_stop'
     )
 
     def __init__(
@@ -240,8 +242,7 @@ class SeqRecord:
                 self._per_letter_annotations = _RestrictedDict(length=0)
             else:
                 try:
-                    self._per_letter_annotations = _RestrictedDict(
-                        length=len(seq))
+                    self._per_letter_annotations = _RestrictedDict(length=len(seq))
                 except TypeError:
                     raise TypeError(
                         "seq argument should be a Seq object or similar"
@@ -330,13 +331,10 @@ class SeqRecord:
     @letter_annotations.setter
     def letter_annotations(self, value):
         if not isinstance(value, dict):
-            raise TypeError(
-                "The per-letter-annotations should be a (restricted) dictionary."
-            )
+            raise TypeError("The per-letter-annotations should be a (restricted) dictionary.")
         # Turn this into a restricted-dictionary (and check the entries)
         try:
-            self._per_letter_annotations = _RestrictedDict(
-                length=len(self.seq))
+            self._per_letter_annotations = _RestrictedDict(length=len(self.seq))
         except AttributeError:
             # e.g. seq is None
             self._per_letter_annotations = _RestrictedDict(length=0)
@@ -353,8 +351,7 @@ class SeqRecord:
         if self._per_letter_annotations:
             if len(self) != len(value):
                 # TODO - Make this a warning? Silently empty the dictionary?
-                raise ValueError(
-                    "You must empty the letter annotations first!")
+                raise ValueError("You must empty the letter annotations first!")
             else:
                 # Leave the existing per letter annotations unchanged:
                 self._seq = value
@@ -362,8 +359,7 @@ class SeqRecord:
             self._seq = value
             # Reset the (empty) letter annotations dict with new length:
             try:
-                self._per_letter_annotations = _RestrictedDict(
-                    length=len(self.seq))
+                self._per_letter_annotations = _RestrictedDict(length=len(self.seq))
             except AttributeError:
                 # e.g. seq is None
                 self._per_letter_annotations = _RestrictedDict(length=0)
@@ -483,8 +479,7 @@ class SeqRecord:
             return self.seq[index]
         elif isinstance(index, slice):
             if self.seq is None:
-                raise ValueError(
-                    "If the sequence is None, we cannot slice it.")
+                raise ValueError("If the sequence is None, we cannot slice it.")
             parent_length = len(self)
             try:
                 from BioSQL.BioSeq import DBSeqRecord
@@ -668,15 +663,13 @@ class SeqRecord:
         if self.description:
             lines.append(f"Description: {self.description}")
         if self.dbxrefs:
-            lines.append("Database cross-references: " +
-                         ", ".join(self.dbxrefs))
+            lines.append("Database cross-references: " + ", ".join(self.dbxrefs))
         lines.append(f"Number of features: {len(self.features)}")
         for a in self.annotations:
             lines.append(f"/{a}={str(self.annotations[a])}")
         if self.letter_annotations:
             lines.append(
-                "Per letter annotation for: " +
-                ", ".join(self.letter_annotations)
+                "Per letter annotation for: " + ", ".join(self.letter_annotations)
             )
         # Don't want to include the entire sequence
         lines.append(repr(self.seq))

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -344,6 +344,7 @@ class SeqRecord:
 
     @property
     def seq(self):
+        """The sequence itself, as a Seq or MutableSeq object."""
         return self._seq
 
     @seq.setter


### PR DESCRIPTION
Added `__slots__` to the Seq and SeqRecord classes. 

In SeqRecord the `seq` and `letter_annotations` attributes were changed into functions with property decorators. 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #2854
