### PR TITLE
Accept Seq, MutableSeq objects in Seq, MutableSeq initializers ...

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1715,6 +1715,8 @@ class MutableSeq:
             self._data = data
         elif isinstance(data, str):  # TODO - What about unicode?
             self._data = array.array("u", data)
+        elif isinstance(data, UnknownSeq):
+            self._data = array.array("u", str(data))
         elif isinstance(data, (Seq, MutableSeq)):
             self._data = array.array("u", data._data)
         else:

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1715,10 +1715,11 @@ class MutableSeq:
             self._data = data
         elif isinstance(data, str):  # TODO - What about unicode?
             self._data = array.array("u", data)
-        elif isinstance(data, UnknownSeq):
-            self._data = array.array("u", str(data))
-        elif isinstance(data, (Seq, MutableSeq)):
+        elif isinstance(data, MutableSeq):
             self._data = array.array("u", data._data)
+        else:
+            # Make no assumptions about the Seq subclass internal storage
+            self._data = array.array("u", str(data))
         else:
             raise TypeError(
                 "data should be a string, array of characters, Seq object, or "

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -93,10 +93,13 @@ class Seq:
         MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF
         """
         # Enforce string storage
-        if not isinstance(data, str):
+        if isinstance(data, str):
+            pass
+        elif isinstance(data, (Seq, MutableSeq)):
+            data = str(data)
+        else:
             raise TypeError(
-                "The sequence data given to a Seq object should "
-                "be a string (not another Seq object etc)"
+                "data should be a string, Seq object, or MutableSeq object"
             )
         self._data = data
 
@@ -291,7 +294,7 @@ class Seq:
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(str(self) * other)
 
-    def tomutable(self):  # Needed?  Or use a function?
+    def tomutable(self):
         """Return the full sequence as a MutableSeq object.
 
         >>> from Bio.Seq import Seq
@@ -301,7 +304,11 @@ class Seq:
         >>> my_seq.tomutable()
         MutableSeq('MKQHKAMIVALIVICITAVVAAL')
         """
-        return MutableSeq(str(self))
+        warnings.warn(
+            "myseq.tomutable() is deprecated; please use MutableSeq(myseq) instead.",
+            BiopythonDeprecationWarning,
+        )
+        return MutableSeq(self)
 
     def count(self, sub, start=0, end=sys.maxsize):
         """Return a non-overlapping count, like that of a python string.
@@ -1700,16 +1707,23 @@ class MutableSeq:
     """
 
     def __init__(self, data):
-        """Initialize the class."""
-        if isinstance(data, str):  # TODO - What about unicode?
+        """Create a MutableSeq object."""
+        if isinstance(data, array.array):
+            if data.typecode != "u":
+                raise ValueError(
+                    "data should be a string, array of characters, Seq object, "
+                    "or MutableSeq object"
+                )
+            self._data = data
+        elif isinstance(data, str):  # TODO - What about unicode?
             self._data = array.array("u", data)
-        elif isinstance(data, (Seq, int, float)):
-            raise TypeError(
-                "The sequence data given to a MutableSeq object "
-                "should be a string or an array (not a Seq object etc)"
-            )
+        elif isinstance(data, (Seq, MutableSeq)):
+            self._data = array.array("u", str(data))
         else:
-            self._data = data  # assumes the input is an array
+            raise TypeError(
+                "data should be a string, array of characters, Seq object, or "
+                "MutableSeq object"
+            )
 
     @property
     def data(self):
@@ -2227,7 +2241,11 @@ class MutableSeq:
         >>> my_mseq.toseq()
         Seq('MKQHKAMIVALIVICITAVVAAL')
         """
-        return Seq("".join(self._data))
+        warnings.warn(
+            "myseq.toseq() is deprecated; please use Seq(myseq) instead.",
+            BiopythonDeprecationWarning,
+        )
+        return Seq(self)
 
     def join(self, other):
         """Return a merge of the sequences in other, spaced by the sequence from self.
@@ -2242,7 +2260,7 @@ class MutableSeq:
         are not Seq or String objects
         """
         # returns Seq object instead of MutableSeq
-        return self.toseq().join(other)
+        return Seq(self).join(other)
 
 
 # The transcribe, backward_transcribe, and translate functions are
@@ -2265,7 +2283,7 @@ def transcribe(dna):
     if isinstance(dna, Seq):
         return dna.transcribe()
     elif isinstance(dna, MutableSeq):
-        return dna.toseq().transcribe()
+        return Seq(dna).transcribe()
     else:
         return dna.replace("T", "U").replace("t", "u")
 
@@ -2285,7 +2303,7 @@ def back_transcribe(rna):
     if isinstance(rna, Seq):
         return rna.back_transcribe()
     elif isinstance(rna, MutableSeq):
-        return rna.toseq().back_transcribe()
+        return Seq(rna).back_transcribe()
     else:
         return rna.replace("U", "T").replace("u", "t")
 
@@ -2537,7 +2555,7 @@ def translate(
         return sequence.translate(table, stop_symbol, to_stop, cds)
     elif isinstance(sequence, MutableSeq):
         # Return a Seq object
-        return sequence.toseq().translate(table, stop_symbol, to_stop, cds)
+        return Seq(sequence).translate(table, stop_symbol, to_stop, cds)
     else:
         # Assume its a string, return a string
         try:
@@ -2602,7 +2620,7 @@ def complement(sequence):
         # Return a Seq
         # Don't use the MutableSeq reverse_complement method as it is
         # 'in place'.
-        return sequence.toseq().complement()
+        return Seq(sequence).complement()
 
     # Assume its a string.
     # In order to avoid some code duplication, the old code would turn the
@@ -2634,7 +2652,7 @@ def complement_rna(sequence):
         return sequence.complement_rna()
     elif isinstance(sequence, MutableSeq):
         # Return a Seq
-        return sequence.toseq().complement_rna()
+        return Seq(sequence).complement_rna()
     return sequence.translate(_rna_complement_table)
 
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1716,7 +1716,7 @@ class MutableSeq:
         elif isinstance(data, str):  # TODO - What about unicode?
             self._data = array.array("u", data)
         elif isinstance(data, (Seq, MutableSeq)):
-            self._data = array.array("u", str(data))
+            self._data = array.array("u", data._data)
         else:
             raise TypeError(
                 "data should be a string, array of characters, Seq object, or "

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1716,8 +1716,8 @@ class MutableSeq:
         elif isinstance(data, str):  # TODO - What about unicode?
             self._data = array.array("u", data)
         elif isinstance(data, MutableSeq):
-            self._data = array.array("u", data._data)
-        else:
+            self._data = data._data[:]  # Take a copy
+        elif isinstance(data, Seq):
             # Make no assumptions about the Seq subclass internal storage
             self._data = array.array("u", str(data))
         else:

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -98,9 +98,7 @@ class Seq:
         elif isinstance(data, (Seq, MutableSeq)):
             data = str(data)
         else:
-            raise TypeError(
-                "data should be a string, Seq object, or MutableSeq object"
-            )
+            raise TypeError("data should be a string, Seq object, or MutableSeq object")
         self._data = data
 
     def __repr__(self):

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -56,7 +56,7 @@ Classes:
 from collections import OrderedDict
 import functools
 
-from Bio.Seq import MutableSeq, reverse_complement
+from Bio.Seq import Seq, MutableSeq, reverse_complement
 
 
 class SeqFeature:
@@ -1137,7 +1137,7 @@ class FeatureLocation:
         if isinstance(parent_sequence, MutableSeq):
             # This avoids complications with reverse complements
             # (the MutableSeq reverse complement acts in situ)
-            parent_sequence = parent_sequence.toseq()
+            parent_sequence = Seq(parent_sequence)
         f_seq = parent_sequence[self.nofuzzy_start : self.nofuzzy_end]
         if self.strand == -1:
             try:

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -1194,21 +1194,21 @@ class SeqRecord:
         >>> print("%s %s" % (rc.id, rc.seq))
         Test ACGA
         """
-        from Bio.Seq import MutableSeq  # Lazy to avoid circular imports
+        from Bio.Seq import Seq, MutableSeq  # Lazy to avoid circular imports
 
         if "protein" in self.annotations.get("molecule_type", ""):
             raise ValueError("Proteins do not have complements!")
         if "RNA" in self.annotations.get("molecule_type", ""):
             if isinstance(self.seq, MutableSeq):
                 # Does not currently have reverse_complement_rna method:
-                answer = SeqRecord(self.seq.toseq().reverse_complement_rna())
+                answer = SeqRecord(Seq(self.seq).reverse_complement_rna())
             else:
                 answer = SeqRecord(self.seq.reverse_complement_rna())
         else:
             # Default to DNA
             if isinstance(self.seq, MutableSeq):
                 # Currently the MutableSeq reverse complement is in situ
-                answer = SeqRecord(self.seq.toseq().reverse_complement())
+                answer = SeqRecord(Seq(self.seq).reverse_complement())
             else:
                 answer = SeqRecord(self.seq.reverse_complement())
         if isinstance(id, str):

--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -109,11 +109,12 @@ class DBSeq(Seq):
         my_seq.tostring().
         """
         import warnings
+        from Bio import BiopythonDeprecationWarning
 
         warnings.warn(
             "This method is obsolete; please use str(my_seq) "
             "instead of my_seq.tostring().",
-            PendingDeprecationWarning,
+            BiopythonDeprecationWarning,
         )
         return self.adaptor.get_subseq_as_string(
             self.primary_id, self.start, self.start + self._length
@@ -129,8 +130,16 @@ class DBSeq(Seq):
 
     def toseq(self):
         """Return the full sequence as a Seq object."""
+        import warnings
+        from Bio import BiopythonDeprecationWarning
+
+        warnings.warn(
+            "This method is obsolete; please use Seq(my_seq) "
+            "instead of my_seq.toseq().",
+            BiopythonDeprecationWarning,
+        )
         # Note - the method name copies that of the MutableSeq object
-        return Seq(str(self))
+        return Seq(self)
 
     def __add__(self, other):
         """Add another sequence or string to this sequence.
@@ -138,7 +147,7 @@ class DBSeq(Seq):
         The sequence is first converted to a Seq object before the addition.
         The returned object is a Seq object, not a DBSeq object.
         """
-        return self.toseq() + other
+        return Seq(self) + other
 
     def __radd__(self, other):
         """Add another sequence or string to the left.
@@ -146,7 +155,7 @@ class DBSeq(Seq):
         The sequence is first converted to a Seq object before the addition.
         The returned object is a Seq object, not a DBSeq object.
         """
-        return other + self.toseq()
+        return other + Seq(self)
 
     def __mul__(self, other):
         """Multiply sequence by an integer.
@@ -154,7 +163,7 @@ class DBSeq(Seq):
         The sequence is first converted to a Seq object before multiplication.
         The returned object is a Seq object, not a DBSeq object.
         """
-        return self.toseq() * other
+        return Seq(self) * other
 
     def __rmul__(self, other):
         """Multiply integer by a sequence.
@@ -162,7 +171,7 @@ class DBSeq(Seq):
         The sequence is first converted to a Seq object before multiplication.
         The returned object is a Seq object, not a DBSeq object.
         """
-        return other * self.toseq()
+        return other * Seq(self)
 
     def __imul__(self, other):
         """Multiply sequence by integer in-place.
@@ -170,7 +179,7 @@ class DBSeq(Seq):
         The sequence is first converted to a Seq object before multiplication.
         The returned object is a Seq object, not a DBSeq object.
         """
-        return self.toseq() * other
+        return Seq(self) * other
 
 
 def _retrieve_seq_len(adaptor, primary_id):

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -181,6 +181,12 @@ Deprecated in release 1.64, and removed in release 1.73.
 You should now use str(Bio.Seq.Seq) or str(Bio.Seq.MutableSeq) instead of
 the tostring() methods.
 
+Bio.Seq.Seq.tomutable() and Bio.Seq.MutableSeq.toseq()
+------------------------------------------------------
+Deprecated in release 1.79.
+Instead of myseq.tomutable() or mymutableseq.toseq(), you should now use
+Bio.Seq.MutableSeq(myseq) or Bio.Seq.Seq(mymutableseq), respectively.
+
 Iterator .next() methods
 ------------------------
 The .next() method defined for any Biopython iterator is deprecated as of

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -609,7 +609,8 @@ However, you can convert it into a mutable sequence (a \verb|MutableSeq| object)
 
 %cont-doctest
 \begin{minted}{pycon}
->>> mutable_seq = my_seq.tomutable()
+>>> from Bio.Seq import MutableSeq
+>>> mutable_seq = MutableSeq(my_seq)
 >>> mutable_seq
 MutableSeq('GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA')
 \end{minted}
@@ -647,7 +648,8 @@ Once you have finished editing your a \verb|MutableSeq| object, it's easy to get
 
 %cont-doctest
 \begin{minted}{pycon}
->>> new_seq = mutable_seq.toseq()
+>>> from Bio.Seq import Seq
+>>> new_seq = Seq(mutable_seq)
 >>> new_seq
 Seq('AGCCCGTGGGAAAGTCGCCGGGTAATGCACCG')
 \end{minted}

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -497,11 +497,11 @@ class SeqInterfaceTest(unittest.TestCase):
         """Check can turn a DBSeq object into a Seq or MutableSeq."""
         test_seq = self.item.seq
 
-        other = test_seq.toseq()
+        other = Seq(test_seq)
         self.assertEqual(str(test_seq), str(other))
         self.assertIsInstance(other, Seq)
 
-        other = test_seq.tomutable()
+        other = MutableSeq(test_seq)
         self.assertEqual(str(test_seq), str(other))
         self.assertIsInstance(other, MutableSeq)
 

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -313,7 +313,7 @@ class SeqFeatureExtractionWritingReading(unittest.TestCase):
         self.assertIsInstance(new, str)
         self.assertEqual(new, answer_str)
 
-        new = feature.extract(parent_seq.tomutable())
+        new = feature.extract(MutableSeq(parent_seq))
         self.assertIsInstance(new, Seq)  # Not MutableSeq!
         self.assertEqual(str(new), answer_str)
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -83,7 +83,7 @@ class StringMethodTests(unittest.TestCase):
     ]
     for seq in _examples[:]:
         if isinstance(seq, Seq):
-            _examples.append(seq.tomutable())
+            _examples.append(MutableSeq(seq))
     _start_end_values = [0, 1, 2, 1000, -1, -2, -999, None]
 
     def _test_method(self, method_name, pre_comp_function=None, start_end=False):
@@ -596,22 +596,16 @@ class StringMethodTests(unittest.TestCase):
                             self.assertEqual(str(example1[i:j:step]), str1[i:j:step])
 
     def test_tomutable(self):
-        """Check obj.tomutable() method."""
+        """Check creating a MutableSeq object."""
         for example1 in self._examples:
-            if isinstance(example1, MutableSeq):
-                continue
-            mut = example1.tomutable()
+            mut = MutableSeq(example1)
             self.assertIsInstance(mut, MutableSeq)
             self.assertEqual(str(mut), str(example1))
 
     def test_toseq(self):
-        """Check obj.toseq() method."""
+        """Check creating a Seq object."""
         for example1 in self._examples:
-            try:
-                seq = example1.toseq()
-            except AttributeError:
-                self.assertIsInstance(example1, Seq)
-                continue
+            seq = Seq(example1)
             self.assertIsInstance(seq, Seq)
             self.assertEqual(str(seq), str(example1))
 
@@ -799,14 +793,15 @@ class StringMethodTests(unittest.TestCase):
 
     def test_init_typeerror(self):
         """Check Seq __init__ gives TypeError exceptions."""
-        # Only expect it to take strings - not Seq objects!
-        self.assertRaises(TypeError, Seq, 1066)
-        self.assertRaises(TypeError, Seq, Seq("ACGT"))
+        self.assertRaises(TypeError, Seq, ("A", "C", "G", "T"))
+        self.assertRaises(TypeError, Seq, ["A", "C", "G", "T"])
+        self.assertRaises(TypeError, Seq, 1)
+        self.assertRaises(TypeError, Seq, 1.0)
 
     def test_MutableSeq_init_typeerror(self):
         """Check MutableSeq __init__ gives TypeError exceptions."""
-        self.assertRaises(TypeError, MutableSeq, (Seq("A")))
-        self.assertRaises(TypeError, MutableSeq, (UnknownSeq(1)))
+        self.assertRaises(TypeError, MutableSeq, ("A", "C", "G", "T"))
+        self.assertRaises(TypeError, MutableSeq, ["A", "C", "G", "T"])
         self.assertRaises(TypeError, MutableSeq, 1)
         self.assertRaises(TypeError, MutableSeq, 1.0)
 

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -61,8 +61,8 @@ class TestSeq(unittest.TestCase):
 
     def test_construction_using_a_seq_object(self):
         """Test using a Seq object to initialize another Seq object."""
-        with self.assertRaises(TypeError):
-            Seq.Seq(self.s)
+        s = Seq.Seq(self.s)
+        self.assertEqual(s, self.s)
 
     def test_repr(self):
         """Test representation of Seq object."""
@@ -458,7 +458,7 @@ class TestMutableSeq(unittest.TestCase):
         mutable_s = MutableSeq("TCAAAAGGATGCATCATG")
         self.assertIsInstance(mutable_s, MutableSeq, "Creating MutableSeq")
 
-        mutable_s = self.s.tomutable()
+        mutable_s = MutableSeq(self.s)
         self.assertIsInstance(mutable_s, MutableSeq, "Converting Seq to mutable")
 
         array_seq = MutableSeq(array.array("u", "TCAAAAGGATGCATCATG"))
@@ -559,7 +559,7 @@ class TestMutableSeq(unittest.TestCase):
         self.assertEqual(18, len(self.mutable_s))
 
     def test_converting_to_immutable(self):
-        self.assertIsInstance(self.mutable_s.toseq(), Seq.Seq)
+        self.assertIsInstance(Seq.Seq(self.mutable_s), Seq.Seq)
 
     def test_first_nucleotide(self):
         self.assertEqual("T", self.mutable_s[0])


### PR DESCRIPTION
In the `__init__` method of `Seq` and `MutableSeq`, allow the argument to be `Seq` or `MutableSeq` so we can get rid of the `toseq`, `tomutable` methods.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
