### PR TITLE
clean up __getitem__ for UnknownSeq

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1319,36 +1319,12 @@ class UnknownSeq(Seq):
         NNN
         """
         if isinstance(index, int):
-            # TODO - Check the bounds without wasting memory
-            return str(self)[index]
-        old_length = self._length
-        step = index.step
-        if step is None or step == 1:
-            # This calculates the length you'd get from ("N"*old_length)[index]
-            start = index.start
-            end = index.stop
-            if start is None:
-                start = 0
-            elif start < 0:
-                start = max(0, old_length + start)
-            elif start > old_length:
-                start = old_length
-            if end is None:
-                end = old_length
-            elif end < 0:
-                end = max(0, old_length + end)
-            elif end > old_length:
-                end = old_length
-            new_length = max(0, end - start)
-        elif step == 0:
-            raise ValueError("slice step cannot be zero")
-        else:
-            # TODO - handle step efficiently
-            new_length = len(("X" * old_length)[index])
-        # assert new_length == len(("X"*old_length)[index]), \
-        #       (index, start, end, step, old_length,
-        #        new_length, len(("X"*old_length)[index]))
-        return UnknownSeq(new_length, character=self._character)
+            if index >= -self._length and index < self._length:
+                return self._character
+            raise IndexError("sequence index out of range")
+        start, stop, stride = index.indices(self._length)
+        length = len(range(start, stop, stride))
+        return UnknownSeq(length, character=self._character)
 
     def count(self, sub, start=0, end=sys.maxsize):
         """Return a non-overlapping count, like that of a python string.


### PR DESCRIPTION
This PR cleans up the `__getitem__` method for `UnknownSeq` objects.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
