### PR TITLE
fix the URL of PDF-Tutorial

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -16,7 +16,7 @@ See also the Seq_ wiki and the chapter in our tutorial:
 
 .. _Seq: http://biopython.org/wiki/Seq
 .. _`HTML Tutorial`: http://biopython.org/DIST/docs/tutorial/Tutorial.html
-.. _`PDF Tutorial`: http://biopython.org/DIST/docs/tutorial/Tutclassorial.pdf
+.. _`PDF Tutorial`: http://biopython.org/DIST/docs/tutorial/Tutorial.pdf
 
 """
 


### PR DESCRIPTION
fix the URL error of `PDF Tutorial`