### PR TITLE
Seq bytes

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -97,7 +97,9 @@ class Seq:
         elif isinstance(data, str):
             self._data = bytes(data, encoding="ASCII")
         else:
-            raise TypeError("data should be a string, bytes, bytearray, Seq, or MutableSeq object")
+            raise TypeError(
+                "data should be a string, bytes, bytearray, Seq, or MutableSeq object"
+            )
 
     def __bytes__(self):
         return self._data
@@ -375,7 +377,10 @@ class Seq:
         elif isinstance(sub, str):
             sub = sub.encode("ASCII")
         elif not isinstance(sub, (bytes, bytearray)):
-            raise TypeError("a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'" % type(sub))
+            raise TypeError(
+                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
+                % type(sub)
+            )
         return bytes(self).count(sub, start, end)
 
     def count_overlap(self, sub, start=None, end=None):
@@ -433,7 +438,10 @@ class Seq:
         elif isinstance(sub, str):
             sub = sub.encode("ASCII")
         elif not isinstance(sub, (bytes, bytearray)):
-            raise TypeError("a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'" % type(sub))
+            raise TypeError(
+                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
+                % type(sub)
+            )
         data = bytes(self)
         overlap_count = 0
         while True:
@@ -488,7 +496,10 @@ class Seq:
         elif isinstance(sub, str):
             sub = sub.encode("ASCII")
         elif not isinstance(sub, (bytes, bytearray)):
-            raise TypeError("a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'" % type(sub))
+            raise TypeError(
+                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
+                % type(sub)
+            )
         return bytes(self).find(sub, start, end)
 
     def rfind(self, sub, start=None, end=None):
@@ -518,7 +529,10 @@ class Seq:
         elif isinstance(sub, str):
             sub = sub.encode("ASCII")
         elif not isinstance(sub, (bytes, bytearray)):
-            raise TypeError("a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'" % type(sub))
+            raise TypeError(
+                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
+                % type(sub)
+            )
         return bytes(self).rfind(sub, start, end)
 
     def index(self, sub, start=None, end=None):
@@ -538,7 +552,10 @@ class Seq:
         elif isinstance(sub, str):
             sub = sub.encode("ASCII")
         elif not isinstance(sub, (bytes, bytearray)):
-            raise TypeError("a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'" % type(sub))
+            raise TypeError(
+                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
+                % type(sub)
+            )
         return bytes(self).index(sub, start, end)
 
     def rindex(self, sub, start=None, end=None):
@@ -548,7 +565,10 @@ class Seq:
         elif isinstance(sub, str):
             sub = sub.encode("ASCII")
         elif not isinstance(sub, (bytes, bytearray)):
-            raise TypeError("a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'" % type(sub))
+            raise TypeError(
+                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
+                % type(sub)
+            )
         return bytes(self).rindex(sub, start, end)
 
     def startswith(self, prefix, start=None, end=None):
@@ -575,7 +595,8 @@ class Seq:
         """
         if isinstance(prefix, tuple):
             prefix = tuple(
-                bytes(p) if isinstance(p, (Seq, MutableSeq)) else p.encode("ASCII") for p in prefix
+                bytes(p) if isinstance(p, (Seq, MutableSeq)) else p.encode("ASCII")
+                for p in prefix
             )
         elif isinstance(prefix, (Seq, MutableSeq)):
             prefix = bytes(prefix)
@@ -607,7 +628,8 @@ class Seq:
         """
         if isinstance(suffix, tuple):
             suffix = tuple(
-                bytes(p) if isinstance(p, (Seq, MutableSeq)) else p.encode("ASCII") for p in suffix
+                bytes(p) if isinstance(p, (Seq, MutableSeq)) else p.encode("ASCII")
+                for p in suffix
             )
         elif isinstance(suffix, (Seq, MutableSeq)):
             suffix = bytes(suffix)
@@ -722,7 +744,9 @@ class Seq:
         try:
             data = bytes(self).strip(chars)
         except TypeError:
-            raise TypeError("argument must be None or a string, Seq, MutableSeq, or bytes-like object") from None
+            raise TypeError(
+                "argument must be None or a string, Seq, MutableSeq, or bytes-like object"
+            ) from None
         return Seq(data)
 
     def lstrip(self, chars=None):
@@ -746,7 +770,9 @@ class Seq:
         try:
             data = bytes(self).lstrip(chars)
         except TypeError:
-            raise TypeError("argument should be a string, Seq, MutableSeq, or bytes-like object") from None
+            raise TypeError(
+                "argument must be None or a string, Seq, MutableSeq, or bytes-like object"
+            ) from None
         return Seq(data)
 
     def rstrip(self, chars=None):
@@ -776,7 +802,9 @@ class Seq:
         try:
             data = bytes(self).rstrip(chars)
         except TypeError:
-            raise TypeError("argument should be a string, Seq, MutableSeq, or bytes-like object") from None
+            raise TypeError(
+                "argument must be None or a string, Seq, MutableSeq, or bytes-like object"
+            ) from None
         return Seq(data)
 
     def upper(self):
@@ -1430,7 +1458,9 @@ class UnknownSeq(Seq):
         if isinstance(sub, (Seq, MutableSeq)):
             sub = str(sub)
         elif not isinstance(sub, str):
-            raise TypeError("a Seq, MutableSeq, or string object is required, not '%s'" % type(sub))
+            raise TypeError(
+                "a Seq, MutableSeq, or string object is required, not '%s'" % type(sub)
+            )
         # Handling case where subsequence not in self
         if set(sub) != set(self._character):
             return 0
@@ -2729,7 +2759,9 @@ def complement(sequence):
     # to a string.
     # This worked, but is over five times slower on short sequences!
     sequence = sequence.encode("ASCII")
-    if (b"U" in sequence or b"u" in sequence) and (b"T" in sequence or b"t" in sequence):
+    if (b"U" in sequence or b"u" in sequence) and (
+        b"T" in sequence or b"t" in sequence
+    ):  # ugly but this is what black wants
         raise ValueError("Mixed RNA/DNA found")
     elif b"U" in sequence or b"u" in sequence:
         # TODO - warning or exception in future?

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1656,8 +1656,13 @@ class UnknownSeq(Seq):
         UnknownSeq(2, character='X')
         """
         try:
-            s = translate(self._character * 3,
-                table=table, stop_symbol=stop_symbol, to_stop=to_stop, cds=cds, gap=gap
+            s = translate(
+                self._character * 3,
+                table=table,
+                stop_symbol=stop_symbol,
+                to_stop=to_stop,
+                cds=cds,
+                gap=gap,
             )
         except CodonTable.TranslationError:
             # Preserve historic behaviour, ??? (default character) and XXX -> X
@@ -1819,7 +1824,7 @@ class MutableSeq:
             "a MutableSeq object.",
             BiopythonDeprecationWarning,
         )
-        return array.array('u', self._data.decode("ASCII"))
+        return array.array("u", self._data.decode("ASCII"))
 
     @data.setter
     def data(self, value):

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1509,7 +1509,9 @@ class UnknownSeq(Seq):
         if isinstance(sub, (Seq, MutableSeq)):
             sub = str(sub)
         elif not isinstance(sub, str):
-            raise TypeError("a Seq, MutableSeq, or string object is required, not '%s'" % type(sub))
+            raise TypeError(
+                "a Seq, MutableSeq, or string object is required, not '%s'" % type(sub)
+            )
         # Handling case where subsequence not in self
         if set(sub) != set(self._character):
             return 0

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -89,7 +89,6 @@ class Seq:
         >>> print(my_seq)
         MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF
         """
-        # Enforce string storage
         if isinstance(data, bytes):
             self._data = data
         elif isinstance(data, (bytearray, Seq, MutableSeq)):
@@ -545,7 +544,7 @@ class Seq:
         >>> my_rna.index("T")
         Traceback (most recent call last):
                    ...
-        ValueError: subsection not found...
+        ValueError: ...
         """
         if isinstance(sub, (Seq, MutableSeq)):
             sub = bytes(sub)

--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -120,6 +120,10 @@ class DBSeq(Seq):
             self.primary_id, self.start, self.start + self._length
         )
 
+    def __bytes__(self):
+        """Return the full sequence as bytes."""
+        return str(self).encode("ASCII")
+
     def __str__(self):
         """Return the full sequence as a python string."""
         return self.adaptor.get_subseq_as_string(

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -469,7 +469,6 @@ class TestMutableSeq(unittest.TestCase):
         self.s = Seq.Seq(sequence)
         self.mutable_s = Seq.MutableSeq(sequence)
 
-
     def test_mutableseq_construction(self):
         """Test MutableSeq object initialization."""
         sequence = bytes(self.s)

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -18,7 +18,6 @@ from Bio.Data.IUPACData import (
     ambiguous_rna_values,
 )
 from Bio.Data.CodonTable import TranslationError, standard_dna_table
-from Bio.Seq import MutableSeq
 
 test_seqs = [
     Seq.Seq("TCAAAAGGATGCATCATG"),
@@ -59,10 +58,26 @@ class TestSeq(unittest.TestCase):
         """Test converting Seq to string."""
         self.assertEqual("TCAAAAGGATGCATCATG", str(self.s))
 
-    def test_construction_using_a_seq_object(self):
-        """Test using a Seq object to initialize another Seq object."""
-        s = Seq.Seq(self.s)
+    def test_seq_construction(self):
+        """Test Seq object initialization."""
+        sequence = bytes(self.s)
+        s = Seq.Seq(sequence)
+        self.assertIsInstance(s, Seq.Seq, "Creating MutableSeq using bytes")
         self.assertEqual(s, self.s)
+        s = Seq.Seq(bytearray(sequence))
+        self.assertIsInstance(s, Seq.Seq, "Creating MutableSeq using bytearray")
+        self.assertEqual(s, self.s)
+        s = Seq.Seq(sequence.decode("ASCII"))
+        self.assertIsInstance(s, Seq.Seq, "Creating MutableSeq using str")
+        self.assertEqual(s, self.s)
+        s = Seq.Seq(self.s)
+        self.assertIsInstance(s, Seq.Seq, "Creating MutableSeq using Seq")
+        self.assertEqual(s, self.s)
+        s = Seq.Seq(Seq.MutableSeq(sequence))
+        self.assertIsInstance(s, Seq.Seq, "Creating MutableSeq using MutableSeq")
+        self.assertEqual(s, self.s)
+        self.assertRaises(UnicodeEncodeError, Seq.Seq, "ÄþÇÐ")  # All are Latin-1 characters
+        self.assertRaises(UnicodeEncodeError, Seq.Seq, "あいうえお")  # These are not
 
     def test_repr(self):
         """Test representation of Seq object."""
@@ -450,19 +465,35 @@ class TestSeqMultiplication(unittest.TestCase):
 
 class TestMutableSeq(unittest.TestCase):
     def setUp(self):
-        self.s = Seq.Seq("TCAAAAGGATGCATCATG")
-        self.mutable_s = MutableSeq("TCAAAAGGATGCATCATG")
+        sequence = b"TCAAAAGGATGCATCATG"
+        self.s = Seq.Seq(sequence)
+        self.mutable_s = Seq.MutableSeq(sequence)
 
-    def test_mutableseq_creation(self):
-        """Test creating MutableSeqs in multiple ways."""
-        mutable_s = MutableSeq("TCAAAAGGATGCATCATG")
-        self.assertIsInstance(mutable_s, MutableSeq, "Creating MutableSeq")
 
-        mutable_s = MutableSeq(self.s)
-        self.assertIsInstance(mutable_s, MutableSeq, "Converting Seq to mutable")
-
-        array_seq = MutableSeq(array.array("u", "TCAAAAGGATGCATCATG"))
-        self.assertIsInstance(array_seq, MutableSeq, "Creating MutableSeq using array")
+    def test_mutableseq_construction(self):
+        """Test MutableSeq object initialization."""
+        sequence = bytes(self.s)
+        mutable_s = Seq.MutableSeq(sequence)
+        self.assertIsInstance(mutable_s, Seq.MutableSeq, "Initializing MutableSeq from bytes")
+        self.assertEqual(mutable_s, self.s)
+        mutable_s = Seq.MutableSeq(bytearray(sequence))
+        self.assertIsInstance(mutable_s, Seq.MutableSeq, "Initializing MutableSeq from bytearray")
+        self.assertEqual(mutable_s, self.s)
+        mutable_s = Seq.MutableSeq(sequence.decode("ASCII"))
+        self.assertIsInstance(mutable_s, Seq.MutableSeq, "Initializing MutableSeq from str")
+        self.assertEqual(mutable_s, self.s)
+        mutable_s = Seq.MutableSeq(self.s)
+        self.assertIsInstance(mutable_s, Seq.MutableSeq, "Initializing MutableSeq from Seq")
+        self.assertEqual(mutable_s, self.s)
+        mutable_s = Seq.MutableSeq(Seq.MutableSeq(sequence))
+        self.assertEqual(mutable_s, self.s)
+        self.assertIsInstance(mutable_s, Seq.MutableSeq, "Initializing MutableSeq from MutableSeq")
+        # Deprecated:
+        mutable_s = Seq.MutableSeq(array.array("u", sequence.decode("ASCII")))
+        self.assertIsInstance(mutable_s, Seq.MutableSeq, "Creating MutableSeq using array")
+        self.assertEqual(mutable_s, self.s)
+        self.assertRaises(UnicodeEncodeError, Seq.MutableSeq, "ÄþÇÐ")  # All are Latin-1 characters
+        self.assertRaises(UnicodeEncodeError, Seq.MutableSeq, "あいうえお")  # These are not
 
     def test_repr(self):
         self.assertEqual("MutableSeq('TCAAAAGGATGCATCATG')", repr(self.mutable_s))
@@ -472,7 +503,7 @@ class TestMutableSeq(unittest.TestCase):
         expected = (
             "MutableSeq('TCAAAAGGATGCATCATGTCAAAAGGATGCATCATGTCAAAAGGATGCATCATG...GGA')"
         )
-        self.assertEqual(expected, repr(MutableSeq(seq)))
+        self.assertEqual(expected, repr(Seq.MutableSeq(seq)))
 
     def test_equal_comparison(self):
         """Test __eq__ comparison method."""
@@ -540,7 +571,7 @@ class TestMutableSeq(unittest.TestCase):
     def test_radd_method_using_mutalbeseq_object(self):
         self.assertEqual(
             "UCAAAAGGATCAAAAGGATGCATCATG",
-            self.mutable_s.__radd__(MutableSeq("UCAAAAGGA")),
+            self.mutable_s.__radd__(Seq.MutableSeq("UCAAAAGGA")),
         )
 
     def test_radd_method_using_seq_object(self):
@@ -566,42 +597,42 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_setting_slices(self):
         self.assertEqual(
-            MutableSeq("CAAA"), self.mutable_s[1:5], "Slice mutable seq",
+            Seq.MutableSeq("CAAA"), self.mutable_s[1:5], "Slice mutable seq",
         )
 
         self.mutable_s[1:3] = "GAT"
         self.assertEqual(
-            MutableSeq("TGATAAAGGATGCATCATG"),
+            Seq.MutableSeq("TGATAAAGGATGCATCATG"),
             self.mutable_s,
             "Set slice with string and adding extra nucleotide",
         )
 
         self.mutable_s[1:3] = self.mutable_s[5:7]
         self.assertEqual(
-            MutableSeq("TAATAAAGGATGCATCATG"),
+            Seq.MutableSeq("TAATAAAGGATGCATCATG"),
             self.mutable_s,
             "Set slice with MutableSeq",
         )
 
     def test_setting_item(self):
         self.mutable_s[3] = "G"
-        self.assertEqual(MutableSeq("TCAGAAGGATGCATCATG"), self.mutable_s)
+        self.assertEqual(Seq.MutableSeq("TCAGAAGGATGCATCATG"), self.mutable_s)
 
     def test_deleting_slice(self):
         del self.mutable_s[4:5]
-        self.assertEqual(MutableSeq("TCAAAGGATGCATCATG"), self.mutable_s)
+        self.assertEqual(Seq.MutableSeq("TCAAAGGATGCATCATG"), self.mutable_s)
 
     def test_deleting_item(self):
         del self.mutable_s[3]
-        self.assertEqual(MutableSeq("TCAAAGGATGCATCATG"), self.mutable_s)
+        self.assertEqual(Seq.MutableSeq("TCAAAGGATGCATCATG"), self.mutable_s)
 
     def test_appending(self):
         self.mutable_s.append("C")
-        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGC"), self.mutable_s)
+        self.assertEqual(Seq.MutableSeq("TCAAAAGGATGCATCATGC"), self.mutable_s)
 
     def test_inserting(self):
         self.mutable_s.insert(4, "G")
-        self.assertEqual(MutableSeq("TCAAGAAGGATGCATCATG"), self.mutable_s)
+        self.assertEqual(Seq.MutableSeq("TCAAGAAGGATGCATCATG"), self.mutable_s)
 
     def test_popping_last_item(self):
         self.assertEqual("G", self.mutable_s.pop())
@@ -609,7 +640,7 @@ class TestMutableSeq(unittest.TestCase):
     def test_remove_items(self):
         self.mutable_s.remove("G")
         self.assertEqual(
-            MutableSeq("TCAAAAGATGCATCATG"), self.mutable_s, "Remove first G"
+            Seq.MutableSeq("TCAAAAGATGCATCATG"), self.mutable_s, "Remove first G"
         )
 
         self.assertRaises(ValueError, self.mutable_s.remove, "Z")
@@ -625,11 +656,11 @@ class TestMutableSeq(unittest.TestCase):
     def test_reverse(self):
         """Test using reverse method."""
         self.mutable_s.reverse()
-        self.assertEqual(MutableSeq("GTACTACGTAGGAAAACT"), self.mutable_s)
+        self.assertEqual(Seq.MutableSeq("GTACTACGTAGGAAAACT"), self.mutable_s)
 
     def test_reverse_with_stride(self):
         """Test reverse using -1 stride."""
-        self.assertEqual(MutableSeq("GTACTACGTAGGAAAACT"), self.mutable_s[::-1])
+        self.assertEqual(Seq.MutableSeq("GTACTACGTAGGAAAACT"), self.mutable_s[::-1])
 
     def test_complement(self):
         self.mutable_s.complement()
@@ -661,33 +692,33 @@ class TestMutableSeq(unittest.TestCase):
 
     def test_extend_method(self):
         self.mutable_s.extend("GAT")
-        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGGAT"), self.mutable_s)
+        self.assertEqual(Seq.MutableSeq("TCAAAAGGATGCATCATGGAT"), self.mutable_s)
 
     def test_extend_with_mutable_seq(self):
-        self.mutable_s.extend(MutableSeq("TTT"))
-        self.assertEqual(MutableSeq("TCAAAAGGATGCATCATGTTT"), self.mutable_s)
+        self.mutable_s.extend(Seq.MutableSeq("TTT"))
+        self.assertEqual(Seq.MutableSeq("TCAAAAGGATGCATCATGTTT"), self.mutable_s)
 
     def test_delete_stride_slice(self):
         del self.mutable_s[4 : 6 - 1]
-        self.assertEqual(MutableSeq("TCAAAGGATGCATCATG"), self.mutable_s)
+        self.assertEqual(Seq.MutableSeq("TCAAAGGATGCATCATG"), self.mutable_s)
 
     def test_extract_third_nucleotide(self):
         """Test extracting every third nucleotide (slicing with stride 3)."""
-        self.assertEqual(MutableSeq("TAGTAA"), self.mutable_s[0::3])
-        self.assertEqual(MutableSeq("CAGGTT"), self.mutable_s[1::3])
-        self.assertEqual(MutableSeq("AAACCG"), self.mutable_s[2::3])
+        self.assertEqual(Seq.MutableSeq("TAGTAA"), self.mutable_s[0::3])
+        self.assertEqual(Seq.MutableSeq("CAGGTT"), self.mutable_s[1::3])
+        self.assertEqual(Seq.MutableSeq("AAACCG"), self.mutable_s[2::3])
 
     def test_set_wobble_codon_to_n(self):
         """Test setting wobble codon to N (set slice with stride 3)."""
         self.mutable_s[2::3] = "N" * len(self.mutable_s[2::3])
-        self.assertEqual(MutableSeq("TCNAANGGNTGNATNATN"), self.mutable_s)
+        self.assertEqual(Seq.MutableSeq("TCNAANGGNTGNATNATN"), self.mutable_s)
 
 
 class TestUnknownSeq(unittest.TestCase):
     def setUp(self):
         self.s = Seq.UnknownSeq(6)
 
-    def test_construction(self):
+    def test_unknownseq_construction(self):
         self.assertEqual("??????", str(Seq.UnknownSeq(6)))
         self.assertEqual("NNNNNN", str(Seq.UnknownSeq(6, character="N")))
         self.assertEqual("XXXXXX", str(Seq.UnknownSeq(6, character="X")))

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -76,7 +76,9 @@ class TestSeq(unittest.TestCase):
         s = Seq.Seq(Seq.MutableSeq(sequence))
         self.assertIsInstance(s, Seq.Seq, "Creating MutableSeq using MutableSeq")
         self.assertEqual(s, self.s)
-        self.assertRaises(UnicodeEncodeError, Seq.Seq, "ÄþÇÐ")  # All are Latin-1 characters
+        self.assertRaises(
+            UnicodeEncodeError, Seq.Seq, "ÄþÇÐ"
+        )  # All are Latin-1 characters
         self.assertRaises(UnicodeEncodeError, Seq.Seq, "あいうえお")  # These are not
 
     def test_repr(self):
@@ -473,25 +475,39 @@ class TestMutableSeq(unittest.TestCase):
         """Test MutableSeq object initialization."""
         sequence = bytes(self.s)
         mutable_s = Seq.MutableSeq(sequence)
-        self.assertIsInstance(mutable_s, Seq.MutableSeq, "Initializing MutableSeq from bytes")
+        self.assertIsInstance(
+            mutable_s, Seq.MutableSeq, "Initializing MutableSeq from bytes"
+        )
         self.assertEqual(mutable_s, self.s)
         mutable_s = Seq.MutableSeq(bytearray(sequence))
-        self.assertIsInstance(mutable_s, Seq.MutableSeq, "Initializing MutableSeq from bytearray")
+        self.assertIsInstance(
+            mutable_s, Seq.MutableSeq, "Initializing MutableSeq from bytearray"
+        )
         self.assertEqual(mutable_s, self.s)
         mutable_s = Seq.MutableSeq(sequence.decode("ASCII"))
-        self.assertIsInstance(mutable_s, Seq.MutableSeq, "Initializing MutableSeq from str")
+        self.assertIsInstance(
+            mutable_s, Seq.MutableSeq, "Initializing MutableSeq from str"
+        )
         self.assertEqual(mutable_s, self.s)
         mutable_s = Seq.MutableSeq(self.s)
-        self.assertIsInstance(mutable_s, Seq.MutableSeq, "Initializing MutableSeq from Seq")
+        self.assertIsInstance(
+            mutable_s, Seq.MutableSeq, "Initializing MutableSeq from Seq"
+        )
         self.assertEqual(mutable_s, self.s)
         mutable_s = Seq.MutableSeq(Seq.MutableSeq(sequence))
         self.assertEqual(mutable_s, self.s)
-        self.assertIsInstance(mutable_s, Seq.MutableSeq, "Initializing MutableSeq from MutableSeq")
+        self.assertIsInstance(
+            mutable_s, Seq.MutableSeq, "Initializing MutableSeq from MutableSeq"
+        )
         # Deprecated:
         mutable_s = Seq.MutableSeq(array.array("u", sequence.decode("ASCII")))
-        self.assertIsInstance(mutable_s, Seq.MutableSeq, "Creating MutableSeq using array")
+        self.assertIsInstance(
+            mutable_s, Seq.MutableSeq, "Creating MutableSeq using array"
+        )
         self.assertEqual(mutable_s, self.s)
-        self.assertRaises(UnicodeEncodeError, Seq.MutableSeq, "ÄþÇÐ")  # All are Latin-1 characters
+        self.assertRaises(
+            UnicodeEncodeError, Seq.MutableSeq, "ÄþÇÐ"
+        )  # All are Latin-1 characters
         self.assertRaises(UnicodeEncodeError, Seq.MutableSeq, "あいうえお")  # These are not
 
     def test_repr(self):

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -583,9 +583,13 @@ class TestMutableSeq(unittest.TestCase):
             "Set slice with MutableSeq",
         )
 
-        self.mutable_s[1:3] = array.array("u", "GAT")
+        self.mutable_s[1:3] = b"GAT"
         self.assertEqual(
-            MutableSeq("TGATTAAAGGATGCATCATG"), self.mutable_s, "Set slice with array",
+            MutableSeq("TGATTAAAGGATGCATCATG"), self.mutable_s, "Set slice with bytes",
+        )
+        self.mutable_s[1:3] = bytearray(b"CTT")
+        self.assertEqual(
+            MutableSeq("TCTTTTAAAGGATGCATCATG"), self.mutable_s, "Set slice with bytearray",
         )
 
     def test_setting_item(self):

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -583,15 +583,6 @@ class TestMutableSeq(unittest.TestCase):
             "Set slice with MutableSeq",
         )
 
-        self.mutable_s[1:3] = b"GAT"
-        self.assertEqual(
-            MutableSeq("TGATTAAAGGATGCATCATG"), self.mutable_s, "Set slice with bytes",
-        )
-        self.mutable_s[1:3] = bytearray(b"CTT")
-        self.assertEqual(
-            MutableSeq("TCTTTTAAAGGATGCATCATG"), self.mutable_s, "Set slice with bytearray",
-        )
-
     def test_setting_item(self):
         self.mutable_s[3] = "G"
         self.assertEqual(MutableSeq("TCAGAAGGATGCATCATG"), self.mutable_s)


### PR DESCRIPTION
This PR addresses issue #3318 by storing sequence data as `bytes` and `bytearray` in the private `_data` attribute of `Seq` and `MutableSeq` objects, respectively. This was missed in the python2 -> python3 transition: With python2 the `_data` attribute was a `str` object, and a python2 `str` object corresponds to a python3 `bytes` object. A python3 `str` object instead corresponds to a python2 `unicode` object, which doesn't make sense for sequence data.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)