### PR TITLE
use a single loop to allow iterators"

### DIFF
--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -183,23 +183,24 @@ class Instances(list):
         """Initialize the class."""
         from Bio.Seq import Seq
 
-        if instances is None:
-            instances = []
-        self.length = None
-        for instance in instances:
-            if self.length is None:
-                self.length = len(instance)
-            elif self.length != len(instance):
-                message = (
-                    "All instances should have the same length (%d found, %d expected)"
-                    % (len(instance), self.length)
-                )
-                raise ValueError(message)
-        for instance in instances:
-            if not isinstance(instance, Seq):
-                sequence = str(instance)
-                instance = Seq(sequence)
-            self.append(instance)
+        length = None
+        if instances is not None:
+            sequences = []
+            for instance in instances:
+                if length is None:
+                    length = len(instance)
+                elif length != len(instance):
+                    message = (
+                        "All instances should have the same length (%d found, %d expected)"
+                        % (len(instance), length)
+                    )
+                    raise ValueError(message)
+                if not isinstance(instance, Seq):
+                    instance = Seq(str(instance))
+                sequences.append(instance)
+            # no errors were raised; store the instances:
+            self.extend(sequences)
+        self.length = length
         self.alphabet = alphabet
 
     def __str__(self):


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR reorganizes the initialization code of the `Instances` class in `Bio.motifs` such that it iterators over `instances` only once. This allows `instances` to be an iterator, not just `list`, `tuple`, etc.

This closes issue #476.