### PR TITLE
better support for unicode strings

### DIFF
--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -1720,6 +1720,7 @@ set_alphabet(Aligner* self, PyObject* alphabet)
             Py_DECREF(self->alphabet);
             self->alphabet = NULL;
         }
+        *(self->mapping) = UNMAPPED;
         return 0;
     }
     else if (PyUnicode_Check(alphabet)) {
@@ -1729,6 +1730,7 @@ set_alphabet(Aligner* self, PyObject* alphabet)
             PyErr_SetString(PyExc_ValueError, "alphabet has zero length");
             return 0;
         }
+        *(self->mapping) = UNMAPPED;
         if (PyUnicode_KIND(alphabet) == PyUnicode_1BYTE_KIND) {
             int i;
             /* don't set self->mapping until we are sure there are no
@@ -1747,11 +1749,7 @@ set_alphabet(Aligner* self, PyObject* alphabet)
                 }
                 mapping[j] = i;
             }
-            if (i < size) {
-                /* alphabet is not an ASCII string; cannot use mapping */
-                *(self->mapping) = UNMAPPED;
-            }
-            else {
+            if (i == size) {
                 /* alphabet is an ASCII string; use mapping for speed */
                 memcpy(self->mapping, mapping, 128);
             }
@@ -1770,6 +1768,7 @@ set_alphabet(Aligner* self, PyObject* alphabet)
             "alphabet should support the sequence protocol (e.g.,\n"
             "strings, lists, and tuples can be valid alphabets).");
         if (!sequence) return -1;
+        *(self->mapping) = UNMAPPED;
         size = PySequence_Fast_GET_SIZE(sequence);
         for (i = 0; i < 128; i++) mapping[i] = MISSING_LETTER;
         for (i = 0; i < size; i++) {
@@ -1793,11 +1792,7 @@ set_alphabet(Aligner* self, PyObject* alphabet)
             }
             mapping[j] = i;
         }
-        if (i < size) {
-            /* alphabet is not an ASCII string; cannot use mapping */
-            *(self->mapping) = UNMAPPED;
-        }
-        else {
+        if (i == size) {
             /* alphabet is an ASCII string; use mapping for speed */
             memcpy(self->mapping, mapping, 128);
         }
@@ -6305,6 +6300,45 @@ convert_objects_to_ints(Py_buffer* view, PyObject* alphabet, PyObject* sequence)
     PyObject *obj1, *obj2;
     int equal;
     view->buf = NULL;
+    if (!alphabet) {
+        if (!PyUnicode_Check(sequence)) {
+            PyErr_SetString(PyExc_ValueError, "alphabet is None; cannot interpret sequence");
+            return 0;
+        }
+        if (PyUnicode_READY(sequence) == -1) return 0;
+        n = PyUnicode_GET_LENGTH(sequence);
+        indices = PyMem_Malloc(n*sizeof(int));
+        if (!indices) {
+            PyErr_NoMemory();
+            return 0;
+        }
+        switch (PyUnicode_KIND(sequence)) {
+            case PyUnicode_1BYTE_KIND: {
+                Py_UCS1* data = PyUnicode_1BYTE_DATA(sequence);
+                for (i = 0; i < n; i++) indices[i] = (int)(data[i]);
+                break;
+            }
+            case PyUnicode_2BYTE_KIND: {
+                Py_UCS2* data = PyUnicode_2BYTE_DATA(sequence);
+                for (i = 0; i < n; i++) indices[i] = (int)(data[i]);
+                break;
+            }
+            case PyUnicode_4BYTE_KIND: {
+                Py_UCS4* data = PyUnicode_4BYTE_DATA(sequence);
+                for (i = 0; i < n; i++) indices[i] = (int)(data[i]);
+                break;
+            }
+            case PyUnicode_WCHAR_KIND:
+            default:
+                PyErr_SetString(PyExc_ValueError, "cannot interpret unicode data");
+                PyMem_Del(indices);
+                return 0;
+        }
+        view->buf = indices;
+        view->itemsize = 1;
+        view->len = n;
+        return 1;
+    }
     sequence = PySequence_Fast(sequence,
                                "argument should support the sequence protocol");
     if (!sequence) return 0;

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2379,6 +2379,7 @@ class TestUnicodeStrings(unittest.TestCase):
         )
         self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((1, 2), (2, 3))))
 
+
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)
     unittest.main(testRunner=runner)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2285,6 +2285,100 @@ Pairwise sequence aligner with parameters
         )
 
 
+class TestUnicodeStrings(unittest.TestCase):
+    def test_needlemanwunsch_simple1(self):
+        seq1 = "ĞĀĀČŦ"
+        seq2 = "ĞĀŦ"
+        aligner = Align.PairwiseAligner()
+        aligner.mode = "global"
+        aligner.alphabet = None
+        self.assertEqual(aligner.algorithm, "Needleman-Wunsch")
+        score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, 3.0)
+        alignments = aligner.align(seq1, seq2)
+        self.assertEqual(len(alignments), 2)
+        alignment = alignments[0]
+        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertEqual(
+            str(alignment),
+            """\
+ĞĀĀČŦ
+||--|
+ĞĀ--Ŧ
+""",
+        )
+        self.assertEqual(alignment.aligned, (((0, 2), (4, 5)), ((0, 2), (2, 3))))
+        alignment = alignments[1]
+        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertEqual(
+            str(alignment),
+            """\
+ĞĀĀČŦ
+|-|-|
+Ğ-Ā-Ŧ
+""",
+        )
+        self.assertEqual(
+            alignment.aligned, (((0, 1), (2, 3), (4, 5)), ((0, 1), (1, 2), (2, 3)))
+        )
+
+    def test_align_affine1_score(self):
+        aligner = Align.PairwiseAligner()
+        aligner.mode = "global"
+        aligner.alphabet = None
+        aligner.match_score = 0
+        aligner.mismatch_score = -1
+        aligner.open_gap_score = -5
+        aligner.extend_gap_score = -1
+        self.assertEqual(aligner.algorithm, "Gotoh global alignment algorithm")
+        score = aligner.score("いい", "あいいう")
+        self.assertAlmostEqual(score, -7.0)
+
+    def test_smithwaterman(self):
+        aligner = Align.PairwiseAligner()
+        aligner.mode = "local"
+        aligner.alphabet = None
+        aligner.gap_score = -0.1
+        self.assertEqual(aligner.algorithm, "Smith-Waterman")
+        score = aligner.score("ℵℷℶℷ", "ℸℵℶℸ")
+        self.assertAlmostEqual(score, 1.9)
+        alignments = aligner.align("ℵℷℶℷ", "ℸℵℶℸ")
+        self.assertEqual(len(alignments), 1)
+        alignment = alignments[0]
+        self.assertAlmostEqual(alignment.score, 1.9)
+        self.assertEqual(
+            str(alignment),
+            """\
+ ℵℷℶℷ
+ |-| 
+ℸℵ-ℶℸ
+""",  # noqa: W291
+        )
+        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((1, 2), (2, 3))))
+
+    def test_gotoh_local(self):
+        aligner = Align.PairwiseAligner()
+        aligner.alphabet = None
+        aligner.mode = "local"
+        aligner.open_gap_score = -0.1
+        aligner.extend_gap_score = 0.0
+        self.assertEqual(aligner.algorithm, "Gotoh local alignment algorithm")
+        score = aligner.score("生物科物", "学生科学")
+        self.assertAlmostEqual(score, 1.9)
+        alignments = aligner.align("生物科物", "学生科学")
+        self.assertEqual(len(alignments), 1)
+        alignment = alignments[0]
+        self.assertAlmostEqual(alignment.score, 1.9)
+        self.assertEqual(
+            str(alignment),
+            """\
+ 生物科物
+ |-| 
+学生-科学
+""",  # noqa: W291
+        )
+        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((1, 2), (2, 3))))
+
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)
     unittest.main(testRunner=runner)


### PR DESCRIPTION
Allow the pairwise aligner to act directly on unicode strings if the alphabet is `None`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)