### PR TITLE
use the underlying binary handle if a text handle is inadvertently passed

### DIFF
--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -167,11 +167,15 @@ class SequenceWriter:
                     handle = target
                 except AttributeError:
                     # for example, io.StringIO does not have a binary stream
-                    raise StreamModeError("File must be opened in binary mode.") from None
+                    raise StreamModeError(
+                        "File must be opened in binary mode."
+                    ) from None
                 try:
                     handle.write(b"")
                 except TypeError:
-                    raise StreamModeError("File must be opened in binary mode.") from None
+                    raise StreamModeError(
+                        "File must be opened in binary mode."
+                    ) from None
             except AttributeError:
                 # target is a path
                 handle = open(target, mode)

--- a/Tests/test_SeqIO_AbiIO.py
+++ b/Tests/test_SeqIO_AbiIO.py
@@ -220,12 +220,17 @@ def open_files(test_array):
 
 def open_files_wrong_mode(test_array):
     for trace in test_array:
-        test_array[trace]["handle"] = open(join(*test_array[trace]["path"]))
+        test_array[trace]["texthandle"] = open(join(*test_array[trace]["path"]))
 
 
 def close_files(test_array):
     for trace in test_array:
         test_array[trace]["handle"].close()
+
+
+def close_files_wrong_mode(test_array):
+    for trace in test_array:
+        test_array[trace]["texthandle"].close()
 
 
 class TestAbi(unittest.TestCase):
@@ -512,15 +517,20 @@ class TestAbiNonAscii(unittest.TestCase):
 
 class TestAbiWrongMode(unittest.TestCase):
     def setUp(self):
+        open_files(test_data)
         open_files_wrong_mode(test_data)
 
     def tearDown(self):
         close_files(test_data)
+        close_files_wrong_mode(test_data)
 
     def test_file_mode(self):
-        """Test if exception is raised if file is not opened in 'rb' mode."""
+        """Test if file is read correctly even if inadvertently opened in text mode."""
         for trace in test_data:
-            self.assertRaises(ValueError, SeqIO.read, test_data[trace]["handle"], "abi")
+            record1 = SeqIO.read(test_data[trace]["handle"], "abi")
+            record2 = SeqIO.read(test_data[trace]["texthandle"], "abi")
+            self.assertEqual(record1.seq, record2.seq)
+            self.assertEqual(vars(record1), vars(record2))
 
 
 class TestAbiFake(unittest.TestCase):


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Currently `SeqIO.read` and `SeqIO.write` will raise a `StreamModeError` if the file handle is in text mode while it should be in binary mode. However it is trivial to obtain the binary file handle from a text file handle, so we may as well do that and use the binary file handle. This PR modifies `SeqIO.Interfaces` to use the underlying binary handle if a text handle is inadvertently passed.