### PR TITLE
Add test files to .gitattributes as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@ Tests/GenBank/NC_000932.gb binary
 Tests/Quality/example.fastq binary
 Tests/Quality/example_dos.fastq binary
 Tests/Blast/wnts.xml binary
+Tests/MAF/cnksr3.fa binary
 
 # This pickle file has to be using Unix new lines otherwise at
 # least Python 3.4's C pickle parser fails with exception:

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ Tests/Quality/example.fastq binary
 Tests/Quality/example_dos.fastq binary
 Tests/Blast/wnts.xml binary
 Tests/MAF/cnksr3.fa binary
+Tests/MAF/ucsc_mm9_chr10_big.maf binary
 
 # This pickle file has to be using Unix new lines otherwise at
 # least Python 3.4's C pickle parser fails with exception:


### PR DESCRIPTION
- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

Closes #1149 (extra info in #3350). All tests should now pass on a Windows machine on a fresh clone. A workaround on existing local repositories is to remove and re-add the files in question, e.g.:

```bash
git rm --cached MAF/ucsc_mm9_chr10_big.maf MAF/cnksr3.fa
git add MAF/ucsc_mm9_chr10_big.maf MAF/cnksr3.fa
```