### PR TITLE
Dual licence Bio.Phylo.Applications and rest of Bio.Phylo

### DIFF
--- a/Bio/Phylo/Applications/_Fasttree.py
+++ b/Bio/Phylo/Applications/_Fasttree.py
@@ -2,9 +2,10 @@
 # Based on code in _Phyml.py by Eric Talevich.
 # All rights reserved.
 #
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 """Command-line wrapper for tree inference program Fasttree."""
 
 

--- a/Bio/Phylo/Applications/_Phyml.py
+++ b/Bio/Phylo/Applications/_Phyml.py
@@ -1,8 +1,9 @@
 # Copyright 2011 by Eric Talevich.  All rights reserved.
 #
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 """Command-line wrapper for the tree inference program PhyML."""
 
 from Bio.Application import _Option, _Switch, AbstractCommandline

--- a/Bio/Phylo/Applications/_Raxml.py
+++ b/Bio/Phylo/Applications/_Raxml.py
@@ -1,8 +1,9 @@
 # Copyright 2012 by Eric Talevich.  All rights reserved.
 #
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 """Command-line wrapper for the tree inference program RAxML.
 
 Derived from the help page for RAxML version 7.3 by Alexandros Stamatakis, but

--- a/Bio/Phylo/Applications/__init__.py
+++ b/Bio/Phylo/Applications/__init__.py
@@ -1,7 +1,10 @@
 # Copyright 2011 by Eric Talevich.  All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license.  Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
+
 """Phylogenetics command line tool wrappers."""
 
 from ._Phyml import PhymlCommandline

--- a/Bio/Phylo/NeXMLIO.py
+++ b/Bio/Phylo/NeXMLIO.py
@@ -2,9 +2,11 @@
 # Based on Bio.Nexus, copyright 2005-2008 by Frank Kauff & Cymon J. Cox
 # and Bio.Phylo.Newick, copyright 2009 by Eric Talevich.
 # All rights reserved.
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """I/O function wrappers for the NeXML file format.
 

--- a/Bio/Phylo/PhyloXMLIO.py
+++ b/Bio/Phylo/PhyloXMLIO.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2009 by Eric Talevich (eric.talevich@gmail.com)
-# This code is part of the Biopython distribution and governed by its
-# license. Please see the LICENSE file that should have been included
-# as part of this package.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
 
 """PhyloXML reader/parser, writer, and associated functions.
 


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Addresses #898, continuing work in #2320. As noted there, we did not have explicit agreement from Jingping Li (@Jingping) for a change in ``Bio/Phylo/Applications/_Raxml.py`` made on #73. On reviewing that I think I can reasonably claim the copyright as I suggested the change, but recorded the commit with their authorship to reflect their contribution in identifying the problem and testing the solution. This is recorded in the commit doing the dual licensing.