### PR TITLE
fix: fix typo in code formatting comments for nodes and branches

### DIFF
--- a/Bio/Phylo/NewickIO.py
+++ b/Bio/Phylo/NewickIO.py
@@ -84,7 +84,7 @@ def _format_comment(text):
 
 def _get_comment(clade):
     try:
-        comment = clade.coment
+        comment = clade.comment
     except AttributeError:
         pass
     else:


### PR DESCRIPTION
- [X ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #3361 by fixing a typo in the line that retrieves the comment from the node. 

comments are now correctly printed to the nexus output:
```python
from io import StringIO
from Bio import Phylo

t = Phylo.read(StringIO("((A,B),C);"), 'newick')

for ni,n in enumerate(t.get_terminals()):
    n.comment = f"&node_number={ni}"

out = StringIO()
Phylo.write(t, out, "nexus")
print(out.getvalue())
```
returns
```
#NEXUS
Begin Taxa;
 Dimensions NTax=3;
 TaxLabels A B C;
End;
Begin Trees;
 Tree tree1=((A:0.00000[&node_number=0],B:0.00000[&node_number=1]):0.00000,C:0.00000[&node_number=2]):0.00000;
End;
```
as expected. 