### PR TITLE
use unittest in test_SeqIO_SeqXML

### DIFF
--- a/Tests/test_SeqIO_SeqXML.py
+++ b/Tests/test_SeqIO_SeqXML.py
@@ -206,7 +206,11 @@ class TestReadAndWrite(unittest.TestCase):
         text = output.decode("UTF-8")
         self.assertIn("Homo sapiens (Human)", text)
         self.assertIn("9606", text)
-        self.assertIn('<species name="Homo sapiens (Human)" ncbiTaxID="9606"></species>', text, msg="Missing expected <species> tag: %r" % text)
+        self.assertIn(
+            '<species name="Homo sapiens (Human)" ncbiTaxID="9606"></species>',
+            text,
+            msg="Missing expected <species> tag: %r" % text
+        )
 
 
 class TestReadCorruptFiles(unittest.TestCase):

--- a/Tests/test_SeqIO_SeqXML.py
+++ b/Tests/test_SeqIO_SeqXML.py
@@ -206,11 +206,7 @@ class TestReadAndWrite(unittest.TestCase):
         text = output.decode("UTF-8")
         self.assertIn("Homo sapiens (Human)", text)
         self.assertIn("9606", text)
-        if (
-            '<species name="Homo sapiens (Human)" ncbiTaxID="9606"></species>'
-            not in text
-        ):
-            raise ValueError("Missing expected <species> tag: %r" % text)
+        self.assertIn('<species name="Homo sapiens (Human)" ncbiTaxID="9606"></species>', text, msg="Missing expected <species> tag: %r" % text)
 
 
 class TestReadCorruptFiles(unittest.TestCase):

--- a/Tests/test_SeqIO_SeqXML.py
+++ b/Tests/test_SeqIO_SeqXML.py
@@ -209,7 +209,7 @@ class TestReadAndWrite(unittest.TestCase):
         self.assertIn(
             '<species name="Homo sapiens (Human)" ncbiTaxID="9606"></species>',
             text,
-            msg="Missing expected <species> tag: %r" % text
+            msg="Missing expected <species> tag: %r" % text,
         )
 
 


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Minor fix in `test_SeqIO_SeqXML.py`.