### PR TITLE
use unittest in test_SCOP_Scop.py

### DIFF
--- a/Tests/test_SCOP_Scop.py
+++ b/Tests/test_SCOP_Scop.py
@@ -24,16 +24,11 @@ class ScopTests(unittest.TestCase):
         """
         fields1 = cla_line_1.rstrip().split("\t")
         fields2 = cla_line_2.rstrip().split("\t")
-        print(fields1)
-        print(fields2)
         # compare the first five fields in a Cla line, which should be exactly
         # the same
-        if fields1[:5] != fields2[:5]:
-            return False
+        self.assertEqual(fields1[:5], fields2[:5])
         # compare the hierarchy key-value pairs, which are unordered
-        if set(fields1[5].split(",")) != set(fields2[5].split(",")):
-            return False
-        return True
+        self.assertCountEqual(fields1[5].split(","), fields2[5].split(","))
 
     def testParse(self):
         with open("./SCOP/dir.cla.scop.txt_test") as f:
@@ -49,7 +44,7 @@ class ScopTests(unittest.TestCase):
         scop.write_cla(cla_out)
         lines = zip(cla.rstrip().split("\n"), cla_out.getvalue().rstrip().split("\n"))
         for expected_line, line in lines:
-            self.assertTrue(self._compare_cla_lines(expected_line, line))
+            self._compare_cla_lines(expected_line, line)
 
         des_out = StringIO()
         scop.write_des(des_out)


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)