### PR TITLE
use assertEqual

### DIFF
--- a/Tests/test_PDB_MMCIF2Dict.py
+++ b/Tests/test_PDB_MMCIF2Dict.py
@@ -311,12 +311,12 @@ class MMCIF2dictTests(unittest.TestCase):
         mmcif_dict2 = MMCIF2Dict(
             io.StringIO(textwrap.dedent(test_data.replace("loop_", "LOOP_")))
         )
-        self.assertDictEqual(mmcif_dict, mmcif_dict2)
+        self.assertEqual(mmcif_dict, mmcif_dict2)
 
         mmcif_dict2 = MMCIF2Dict(
             io.StringIO(textwrap.dedent(test_data.replace("loop_", "looP_")))
         )
-        self.assertDictEqual(mmcif_dict, mmcif_dict2)
+        self.assertEqual(mmcif_dict, mmcif_dict2)
 
         mmcif_dict2 = MMCIF2Dict(
             io.StringIO(textwrap.dedent(test_data.replace("_loop", "_LOOP")))

--- a/Tests/test_PDB_MMCIFParser.py
+++ b/Tests/test_PDB_MMCIFParser.py
@@ -125,10 +125,10 @@ class ParseReal(unittest.TestCase):
         for atoms in [s_atoms, f_atoms]:
             self.assertEqual(len(atoms), 644)
             atom_names = ["N", "CA", "C", "O", "CB"]
-            self.assertSequenceEqual([a.get_name() for a in atoms[:5]], atom_names)
-            self.assertSequenceEqual([a.get_id() for a in atoms[:5]], atom_names)
-            self.assertSequenceEqual([a.get_fullname() for a in atoms[:5]], atom_names)
-            self.assertSequenceEqual(
+            self.assertEqual([a.get_name() for a in atoms[:5]], atom_names)
+            self.assertEqual([a.get_id() for a in atoms[:5]], atom_names)
+            self.assertEqual([a.get_fullname() for a in atoms[:5]], atom_names)
+            self.assertEqual(
                 [a.get_occupancy() for a in atoms[:5]], [1.0, 1.0, 1.0, 1.0, 1.0]
             )
             self.assertIsInstance(atoms[0].get_coord(), numpy.ndarray)
@@ -156,10 +156,10 @@ class ParseReal(unittest.TestCase):
 
         for atoms in [s_atoms, f_atoms]:
             atom_names = ["N", "CA", "C", "O", "CB"]
-            self.assertSequenceEqual([a.get_name() for a in atoms[:5]], atom_names)
-            self.assertSequenceEqual([a.get_id() for a in atoms[:5]], atom_names)
-            self.assertSequenceEqual([a.get_fullname() for a in atoms[:5]], atom_names)
-            self.assertSequenceEqual(
+            self.assertEqual([a.get_name() for a in atoms[:5]], atom_names)
+            self.assertEqual([a.get_id() for a in atoms[:5]], atom_names)
+            self.assertEqual([a.get_fullname() for a in atoms[:5]], atom_names)
+            self.assertEqual(
                 [a.get_occupancy() for a in atoms[:5]], [1.0, 1.0, 1.0, 1.0, 1.0]
             )
             self.assertIsInstance(atoms[0].get_coord(), numpy.ndarray)
@@ -358,11 +358,11 @@ class CIFtoPDB(unittest.TestCase):
         pdb_atom_names = [a.name for a in pdb_struct.get_atoms()]
         cif_atom_names = [a.name for a in cif_struct.get_atoms()]
         self.assertEqual(len(pdb_atom_names), len(cif_atom_names))
-        self.assertSequenceEqual(pdb_atom_names, cif_atom_names)
+        self.assertEqual(pdb_atom_names, cif_atom_names)
 
         pdb_atom_elems = [a.element for a in pdb_struct.get_atoms()]
         cif_atom_elems = [a.element for a in cif_struct.get_atoms()]
-        self.assertSequenceEqual(pdb_atom_elems, cif_atom_elems)
+        self.assertEqual(pdb_atom_elems, cif_atom_elems)
 
     def test_conversion_not_preserve_numbering(self):
         """Convert mmCIF to PDB and renumber atom serials."""

--- a/Tests/test_PDB_MMCIFParser.py
+++ b/Tests/test_PDB_MMCIFParser.py
@@ -357,7 +357,6 @@ class CIFtoPDB(unittest.TestCase):
 
         pdb_atom_names = [a.name for a in pdb_struct.get_atoms()]
         cif_atom_names = [a.name for a in cif_struct.get_atoms()]
-        self.assertEqual(len(pdb_atom_names), len(cif_atom_names))
         self.assertEqual(pdb_atom_names, cif_atom_names)
 
         pdb_atom_elems = [a.element for a in pdb_struct.get_atoms()]

--- a/Tests/test_PDB_ResidueDepth.py
+++ b/Tests/test_PDB_ResidueDepth.py
@@ -111,7 +111,7 @@ class ResidueDepth_tests(unittest.TestCase):
         biopy_radii = []
         for atom in model.get_atoms():
             biopy_radii.append(_get_atom_radius(atom, rtype="united"))
-        self.assertListEqual(msms_radii, biopy_radii)
+        self.assertEqual(msms_radii, biopy_radii)
 
 
 if __name__ == "__main__":

--- a/Tests/test_Pathway.py
+++ b/Tests/test_Pathway.py
@@ -81,8 +81,8 @@ class GraphTestCase(unittest.TestCase):
             repr(a),
             "<Graph: ('a': ('b', 'label1'))('b': ('a', 'label2'),('c', 'label1'))('c': )>",
         )
-        self.assertListEqual(a.edges("label1"), [("a", "b"), ("b", "c")])
-        self.assertListEqual(a.labels(), ["label1", "label2"])
+        self.assertEqual(a.edges("label1"), [("a", "b"), ("b", "c")])
+        self.assertEqual(a.labels(), ["label1", "label2"])
 
 
 class MultiGraphTestCase(unittest.TestCase):
@@ -167,8 +167,8 @@ class MultiGraphTestCase(unittest.TestCase):
         self.assertEqual(
             str(a), "<MultiGraph: 3 node(s), 3 edge(s), 2 unique label(s)>"
         )
-        self.assertListEqual(a.edges("label1"), [("a", "b"), ("b", "c")])
-        self.assertListEqual(a.labels(), ["label1", "label2"])
+        self.assertEqual(a.edges("label1"), [("a", "b"), ("b", "c")])
+        self.assertEqual(a.labels(), ["label1", "label2"])
 
 
 class ReactionTestCase(unittest.TestCase):

--- a/Tests/test_SearchIO_hmmer3_text.py
+++ b/Tests/test_SearchIO_hmmer3_text.py
@@ -1689,10 +1689,10 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(len(qresults), 2)
 
         # Test whether proper query id is read
-        self.assertListEqual([x.id for x in qresults], ["infile_sto", "infile_sto2"])
+        self.assertEqual([x.id for x in qresults], ["infile_sto", "infile_sto2"])
 
         # Test if proper number of hits is read
-        self.assertListEqual([len(x.hits) for x in qresults], [10, 10])
+        self.assertEqual([len(x.hits) for x in qresults], [10, 10])
 
     def test_31b2_hmmscan_001(self):
         """Test parsing hmmscan 3.1b2 (text_31b2_hmmscan_001)."""


### PR DESCRIPTION
In the unit tests, use `assertEqual` where possible instead of `assertMultiLineEqual`, `assertSequenceEqual`, `assertListEqual`, `assertTupleEqual`, `assertSetEqual`, `assertDictEqual`, as the Python documentation states that it is not necessary to invoke these methods directly.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)