### PR TITLE
Add unicode support to the pairwise aligner in Bio.Align

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1556,9 +1556,9 @@ class PairwiseAligner(_aligners.PairwiseAligner):
     def align(self, seqA, seqB):
         """Return the alignments of two sequences using PairwiseAligner."""
         if isinstance(seqA, Seq):
-            seqA = str(seqA)
+            seqA = str(seqA).encode()
         if isinstance(seqB, Seq):
-            seqB = str(seqB)
+            seqB = str(seqB).encode()
         score, paths = _aligners.PairwiseAligner.align(self, seqA, seqB)
         alignments = PairwiseAlignments(seqA, seqB, score, paths)
         return alignments
@@ -1566,9 +1566,9 @@ class PairwiseAligner(_aligners.PairwiseAligner):
     def score(self, seqA, seqB):
         """Return the alignments score of two sequences using PairwiseAligner."""
         if isinstance(seqA, Seq):
-            seqA = str(seqA)
+            seqA = str(seqA).encode()
         if isinstance(seqB, Seq):
-            seqB = str(seqB)
+            seqB = str(seqB).encode()
         return _aligners.PairwiseAligner.score(self, seqA, seqB)
 
 

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1011,6 +1011,8 @@ class PairwiseAlignment:
         return self.path >= other.path
 
     def _convert_sequence_string(self, sequence):
+        if isinstance(sequence, (bytes, bytearray)):
+            return sequence.decode()
         if isinstance(sequence, str):
             return sequence
         if isinstance(sequence, Seq):

--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -26,7 +26,7 @@
 #define OVERFLOW_ERROR -1
 #define MEMORY_ERROR -2
 
-#define ANY_LETTER -1
+#define ANY_LETTER (int)'X'
 #define MISSING_LETTER -2
 #define UNMAPPED -3
 
@@ -1807,7 +1807,7 @@ set_alphabet(Aligner* self, PyObject* alphabet)
 static int
 Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
 {
-    int i, j;
+    int i;
     Py_ssize_t n;
     self->alphabet = NULL;
     n = set_alphabet(self, NULL);
@@ -1833,16 +1833,7 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->substitution_matrix.obj = NULL;
     self->substitution_matrix.buf = NULL;
     self->algorithm = Unknown;
-    for (i = 0; i < 128; i++) self->mapping[i] = MISSING_LETTER;
-    i = (int)'A';
-    for (j = 0; j < n; i++, j++) self->mapping[i] = j;
-    i = (int)'a';
-    for (j = 0; j < n; i++, j++) self->mapping[i] = j;
-    /* X represents an undetermined letter. */
-    i = (int)'x';
-    self->mapping[i] = ANY_LETTER;
-    i = (int)'X';
-    self->mapping[i] = ANY_LETTER;
+    for (i = 0; i < 128; i++) self->mapping[i] = i;
     return 0;
 }
 
@@ -5970,7 +5961,7 @@ exit:
 /* ----------------- alignment algorithms ----------------- */
 
 #define MATRIX_SCORE scores[kA*n+kB]
-#define COMPARE_SCORE (kA < 0 || kB < 0) ? 0 : (kA == kB) ? match : mismatch
+#define COMPARE_SCORE (kA == ANY_LETTER || kB == ANY_LETTER) ? 0 : (kA == kB) ? match : mismatch
 
 
 static PyObject*

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2507,7 +2507,7 @@ Negative indices are interpreted as unknown letters, and receive a zero score:
 
 %cont-doctest
 \begin{minted}{pycon}
->>> s2 = numpy.array([2, -5, 13], numpy.int32)
+>>> s2 = numpy.array([2, ord('X'), 13], numpy.int32)
 >>> aligner.gap_score = -3
 >>> alignments = aligner.align(s1, s2)
 >>> print(len(alignments))
@@ -2515,12 +2515,12 @@ Negative indices are interpreted as unknown letters, and receive a zero score:
 >>> print(alignments[0])
 2 10 10 13
 | .. -- ||
-2 -5 -- 13
+2 88 -- 13
 <BLANKLINE>
 >>> print(alignments[1])
 2 10 10 13
 | -- .. ||
-2 -- -5 13
+2 -- 88 13
 <BLANKLINE>
 >>> print(alignments.score)
 9.0

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1847,10 +1847,10 @@ Substitution scores define the value to be added to the total score when two let
 >>> print(score)
 1.0
 \end{minted}
-When using match and mismatch scores, the character \verb+X+ is interpreted as an unknown character and gets a zero score in alignments, irrespective of the value of the match or mismatch score:
+When using match and mismatch scores, the wildcard character ('\verb+?+' by default) is interpreted as an unknown character and gets a zero score in alignments, irrespective of the value of the match or mismatch score:
 %cont-doctest
 \begin{minted}{pycon}
->>> score = aligner.score("ACGT","ACXT")
+>>> score = aligner.score("ACGT","AC?T")
 >>> print(score)
 3.0
 \end{minted}
@@ -2503,11 +2503,14 @@ Internally, the first step when performing an alignment is to replace the two se
 \end{minted}
 Note that the indices should consist of 32-bit integers, as specified in this example by \verb+numpy.int32+.
 
-Negative indices are interpreted as unknown letters, and receive a zero score:
+For an \verb+Aligner+ object with the default wildcard character '\verb+?+', unknown letters can be represented by the corresponding Unicode code point number \verb+ord("?")+, which happens to be 63:
 
 %cont-doctest
 \begin{minted}{pycon}
->>> s2 = numpy.array([2, ord('X'), 13], numpy.int32)
+>>> u = ord("?")
+>>> u
+63
+>>> s2 = numpy.array([2, 63, 13], numpy.int32)
 >>> aligner.gap_score = -3
 >>> alignments = aligner.align(s1, s2)
 >>> print(len(alignments))
@@ -2515,12 +2518,34 @@ Negative indices are interpreted as unknown letters, and receive a zero score:
 >>> print(alignments[0])
 2 10 10 13
 | .. -- ||
-2 88 -- 13
+2 63 -- 13
 <BLANKLINE>
 >>> print(alignments[1])
 2 10 10 13
 | -- .. ||
-2 -- 88 13
+2 -- 63 13
+<BLANKLINE>
+>>> print(alignments.score)
+9.0
+\end{minted}
+Alternatively you can redefine the wildcard character to a value of your liking, for example to 0:
+%cont-doctest
+\begin{minted}{pycon}
+>>> aligner.wildcard = chr(0)
+>>> s2 = numpy.array([2, 0, 13], numpy.int32)
+>>> aligner.gap_score = -3
+>>> alignments = aligner.align(s1, s2)
+>>> print(len(alignments))
+2
+>>> print(alignments[0])
+2 10 10 13
+| .  -- ||
+2 0  -- 13
+<BLANKLINE>
+>>> print(alignments[1])
+2 10 10 13
+| -- .  ||
+2 -- 0  13
 <BLANKLINE>
 >>> print(alignments.score)
 9.0

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1779,6 +1779,7 @@ for the pairwise alignments. To see an overview of the values for all parameters
 \begin{minted}{pycon}
 >>> print(aligner)
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: 0.000000
@@ -1847,9 +1848,10 @@ Substitution scores define the value to be added to the total score when two let
 >>> print(score)
 1.0
 \end{minted}
-When using match and mismatch scores, the wildcard character ('\verb+?+' by default) is interpreted as an unknown character and gets a zero score in alignments, irrespective of the value of the match or mismatch score:
+When using match and mismatch scores, you can specify a wildcard character (+None+ by default) for unknown letters. These will get a zero score in alignments, irrespective of the value of the match or mismatch score:
 %cont-doctest
 \begin{minted}{pycon}
+>>> aligner.wildcard = "?"
 >>> score = aligner.score("ACGT","AC?T")
 >>> print(score)
 3.0
@@ -2503,12 +2505,12 @@ Internally, the first step when performing an alignment is to replace the two se
 \end{minted}
 Note that the indices should consist of 32-bit integers, as specified in this example by \verb+numpy.int32+.
 
-For an \verb+Aligner+ object with the default wildcard character '\verb+?+', unknown letters can be represented by the corresponding Unicode code point number \verb+ord("?")+, which happens to be 63:
+Unknown letters can again be included by defining a wildcard character, and using the corresponding Unicode code point number as the index:
 
 %cont-doctest
 \begin{minted}{pycon}
->>> u = ord("?")
->>> u
+>>> aligner.wildcard = "?"
+>>> ord(aligner.wildcard)
 63
 >>> s2 = numpy.array([2, 63, 13], numpy.int32)
 >>> aligner.gap_score = -3
@@ -2524,28 +2526,6 @@ For an \verb+Aligner+ object with the default wildcard character '\verb+?+', unk
 2 10 10 13
 | -- .. ||
 2 -- 63 13
-<BLANKLINE>
->>> print(alignments.score)
-9.0
-\end{minted}
-Alternatively you can redefine the wildcard character to a value of your liking, for example to 0:
-%cont-doctest
-\begin{minted}{pycon}
->>> aligner.wildcard = chr(0)
->>> s2 = numpy.array([2, 0, 13], numpy.int32)
->>> aligner.gap_score = -3
->>> alignments = aligner.align(s1, s2)
->>> print(len(alignments))
-2
->>> print(alignments[0])
-2 10 10 13
-| .  -- ||
-2 0  -- 13
-<BLANKLINE>
->>> print(alignments[1])
-2 10 10 13
-| -- .  ||
-2 -- 0  13
 <BLANKLINE>
 >>> print(alignments.score)
 9.0

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -48,6 +48,7 @@ class TestAlignerProperties(unittest.TestCase):
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 3.000000
   mismatch_score: -2.000000
   target_internal_open_gap_score: 0.000000
@@ -90,6 +91,7 @@ Pairwise sequence aligner with parameters
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -5.000000
@@ -145,6 +147,7 @@ Pairwise sequence aligner with parameters
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -3.000000
@@ -189,6 +192,7 @@ class TestPairwiseGlobal(unittest.TestCase):
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: 0.000000
@@ -248,6 +252,7 @@ G-A-T
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 0.000000
   mismatch_score: -1.000000
   target_internal_open_gap_score: -5.000000
@@ -279,6 +284,7 @@ class TestPairwiseLocal(unittest.TestCase):
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.100000
@@ -322,6 +328,7 @@ zA-Bz
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.100000
@@ -364,6 +371,7 @@ class TestUnknownCharacter(unittest.TestCase):
         aligner.mode = "global"
         aligner.gap_score = -1.0
         aligner.mismatch_score = -1.0
+        aligner.wildcard = "?"
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
@@ -396,12 +404,30 @@ GAXT
 """,
         )
         self.assertEqual(alignment.aligned, (((0, 4),), ((0, 4),)))
+        aligner.wildcard = None
+        score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, 2.0)
+        alignments = aligner.align(seq1, seq2)
+        self.assertEqual(len(alignments), 1)
+        alignment = alignments[0]
+        self.assertAlmostEqual(alignment.score, 2.0)
+        self.assertEqual(
+            str(alignment),
+            """\
+GACT
+||.|
+GAXT
+""",
+        )
+        self.assertEqual(alignment.aligned, (((0, 4),), ((0, 4),)))
+
 
     def test_needlemanwunsch_simple2(self):
         seq1 = "GA?AT"
         seq2 = "GAA?T"
         aligner = Align.PairwiseAligner()
         aligner.mode = "global"
+        aligner.wildcard = "?"
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
@@ -454,6 +480,7 @@ class TestPairwiseOpenPenalty(unittest.TestCase):
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 2.000000
   mismatch_score: -1.000000
   target_internal_open_gap_score: -0.100000
@@ -512,6 +539,7 @@ A-
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.500000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.100000
@@ -568,6 +596,7 @@ GA-
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: 0.000000
@@ -614,6 +643,7 @@ GA--T
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: -2.000000
   target_internal_open_gap_score: -0.100000
@@ -672,6 +702,7 @@ class TestPairwiseExtendPenalty(unittest.TestCase):
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.200000
@@ -717,6 +748,7 @@ G--T
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.200000
@@ -775,6 +807,7 @@ class TestPairwisePenalizeExtendWhenOpening(unittest.TestCase):
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -1.700000
@@ -824,6 +857,7 @@ class TestPairwisePenalizeEndgaps(unittest.TestCase):
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.200000
@@ -904,6 +938,7 @@ class TestPairwiseSeparateGapPenalties(unittest.TestCase):
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.300000
@@ -960,6 +995,7 @@ GTCT
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.300000
@@ -1015,6 +1051,7 @@ class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.100000
@@ -1458,6 +1495,7 @@ class TestPairwiseOneCharacter(unittest.TestCase):
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.300000
@@ -1501,6 +1539,7 @@ abcde
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.300000
@@ -1555,6 +1594,7 @@ abcce
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.300000
@@ -1600,6 +1640,7 @@ abcde
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.300000
@@ -1648,6 +1689,7 @@ class TestPerSiteGapPenalties(unittest.TestCase):
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: -1.000000
   target_gap_function: %s
@@ -1700,6 +1742,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: -1.000000
   target_gap_function: %s
@@ -1762,6 +1805,7 @@ AAB------------BBAAAACCCCAAAABBBAA--
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: -10.000000
   target_gap_function: %s
@@ -1795,6 +1839,7 @@ TTG--GAA
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: -10.000000
   target_gap_function: %s
@@ -1879,6 +1924,7 @@ TTG--GAA
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: -1.000000
   target_gap_function: %s
@@ -1939,6 +1985,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: -1.000000
   target_gap_function: %s
@@ -2001,6 +2048,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: -10.000000
   target_gap_function: %s
@@ -2045,6 +2093,7 @@ TTGGAA
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: -10.000000
   target_gap_function: %s
@@ -2357,6 +2406,7 @@ class TestKeywordArgumentsConstructor(unittest.TestCase):
             str(aligner),
             """\
 Pairwise sequence aligner with parameters
+  wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.200000

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -388,7 +388,7 @@ GA?T
         )
         self.assertEqual(alignment.aligned, (((0, 4),), ((0, 4),)))
         seq2 = "GAXT"
-        aligner.wildcard = 'X'
+        aligner.wildcard = "X"
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
@@ -420,7 +420,6 @@ GAXT
 """,
         )
         self.assertEqual(alignment.aligned, (((0, 4),), ((0, 4),)))
-
 
     def test_needlemanwunsch_simple2(self):
         seq1 = "GA?AT"

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2193,14 +2193,15 @@ class TestArgumentErrors(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, message):
             aligner.score("AAA", "")
         message = "^sequence contains letters not in the alphabet$"
+        aligner.alphabet = "ABCD"
         with self.assertRaisesRegex(ValueError, message):
-            aligner.score("AAA", "AA&")
+            aligner.score("AAA", "AAE")
 
     def test_aligner_array_errors(self):
         aligner = Align.PairwiseAligner()
         self.assertEqual(aligner.alphabet, "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         s1 = "GGG"
-        s2 = array.array("i", [6, 0, 6])
+        s2 = array.array("i", [ord("G"), ord("A"), ord("G")])
         score = aligner.score(s1, s2)
         self.assertAlmostEqual(score, 2.0)
         s2 = array.array("f", [1.0, 0.0, 1.0])
@@ -2209,7 +2210,7 @@ class TestArgumentErrors(unittest.TestCase):
             aligner.score(s1, s2)
         s1 = array.array("i", [1, 5, 6])
         s2 = array.array("i", [1, 8, 6])
-        s2a = array.array("i", [1, 8, -6])
+        s2a = array.array("i", [1, 8, ord('X')])
         s2b = array.array("i", [1, 28, 6])
         aligner.match = 3.0
         aligner.mismatch = -2.0
@@ -2230,7 +2231,7 @@ class TestArgumentErrors(unittest.TestCase):
             return
         aligner = Align.PairwiseAligner()
         s1 = "GGG"
-        s2 = numpy.array([6, 0, 6], numpy.int32)  # interpreted as GAG
+        s2 = numpy.array([ord("G"), ord("A"), ord("G")], numpy.int32)
         score = aligner.score(s1, s2)
         self.assertAlmostEqual(score, 2.0)
         s2 = numpy.array([1.0, 0.0, 1.0])
@@ -2243,8 +2244,9 @@ class TestArgumentErrors(unittest.TestCase):
             aligner.score(s1, s2)
         s1 = numpy.array([1, 5, 6], numpy.int32)
         s2 = numpy.array([1, 8, 6], numpy.int32)
-        s2a = numpy.array([1, 8, -6], numpy.int32)
+        s2a = numpy.array([1, 8, ord('X')], numpy.int32)
         s2b = numpy.array([1, 28, 6], numpy.int32)
+        s2c = numpy.array([1, 8, -6], numpy.int32)
         aligner.match = 3.0
         aligner.mismatch = -2.0
         aligner.gap_score = -10.0
@@ -2253,8 +2255,6 @@ class TestArgumentErrors(unittest.TestCase):
         # the following two are valid as we are using match/mismatch scores
         # instead of a substitution matrix:
         score = aligner.score(s1, s2a)
-        # negative number is interpreted as an unknown character, and
-        # gets a zero score:
         self.assertAlmostEqual(score, 1.0)
         score = aligner.score(s1, s2b)
         self.assertAlmostEqual(score, 4.0)
@@ -2266,7 +2266,7 @@ class TestArgumentErrors(unittest.TestCase):
         self.assertAlmostEqual(score, 10.0)
         message = "^sequence item 2 is negative \\(-6\\)$"
         with self.assertRaisesRegex(ValueError, message):
-            aligner.score(s1, s2a)
+            aligner.score(s1, s2c)
         message = "^sequence item 1 is out of bound \\(28, should be < 10\\)$"
         with self.assertRaisesRegex(ValueError, message):
             aligner.score(s1, s2b)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2186,8 +2186,8 @@ Gly Ala Ala Cys Thr
 class TestArgumentErrors(unittest.TestCase):
     def test_aligner_string_errors(self):
         aligner = Align.PairwiseAligner()
-        message = "^sequence has unexpected format$"
-        with self.assertRaisesRegex(ValueError, message):
+        message = "^argument should support the sequence protocol$"
+        with self.assertRaisesRegex(TypeError, message):
             aligner.score("AAA", 3)
         message = "^sequence has zero length$"
         with self.assertRaisesRegex(ValueError, message):
@@ -2199,7 +2199,6 @@ class TestArgumentErrors(unittest.TestCase):
 
     def test_aligner_array_errors(self):
         aligner = Align.PairwiseAligner()
-        self.assertEqual(aligner.alphabet, "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         s1 = "GGG"
         s2 = array.array("i", [ord("G"), ord("A"), ord("G")])
         score = aligner.score(s1, s2)


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #3254 

This PR adds full unicode support to the pairwise aligner in `Bio.Align`:
```python
>>> from Bio import Align
>>> aligner = Align.PairwiseAligner()
>>> alignments = aligner.align("mɛɾɪtʰəreniən", "mɛɾɪtʰeniən")
>>> print(alignments[0])
mɛɾɪtʰəreniən
||||||--|||||
mɛɾɪtʰ--eniən
```

This PR also allows the user to set the wildcard character.
