### PR TITLE
Fix GenBank example from sliced record.

### DIFF
--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -355,8 +355,9 @@ class SeqRecord:
           adjusted accordingly). If you want to preserve any truncated
           features (e.g. GenBank/EMBL source features), you must
           explicitly add them to the new SeqRecord yourself.
-        * The annotations dictionary and the dbxrefs list are not used
-          for the new SeqRecord, as in general they may not apply to the
+        * With the exception of any molecule type, the annotations
+          dictionary and the dbxrefs list are not used for the new
+          SeqRecord, as in general they may not apply to the
           subsequence. If you want to preserve them, you must explicitly
           copy them to the new SeqRecord yourself.
 
@@ -488,6 +489,10 @@ class SeqRecord:
             # answer.annotations = dict(self.annotations.items())
             # answer.dbxrefs = self.dbxrefs[:]
             # TODO - Review this in light of adding SeqRecord objects?
+
+            if "molecule_type" in self.annotations:
+                # This will still apply, and we need it for GenBank/EMBL etc output
+                answer.annotations["molecule_type"] = self.annotations["molecule_type"]
 
             # TODO - Cope with strides by generating ambiguous locations?
             start, stop, step = index.indices(parent_length)

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -790,6 +790,14 @@ any relevant information as appropriate.
 []
 \end{minted}
 
+If you plan to output the sub-record in GenBank or EMBL format, you will need
+to retain the molecule type information:
+
+%cont-doctest
+\begin{minted}{pycon}
+>>> sub_record.annotations['molecule_type'] = record.annotations['molecule_type']
+\end{minted}
+
 The same point could be made about the record \texttt{id}, \texttt{name}
 and \texttt{description}, but for practicality these are preserved:
 
@@ -808,10 +816,14 @@ and \texttt{description}, but for practicality these are preserved:
 Let's fix this and then view the sub-record as a reduced GenBank file using
 the \texttt{format} method described above in Section~\ref{sec:SeqRecord-format}:
 
+%cont-doctest
 \begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
->>> sub_record.description = "Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, partial."
->>> print(sub_record.format("genbank"))
-...
+>>> sub_record.description = "Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, partial"
+>>> print(sub_record.format("genbank")[:200] + "...")
+LOCUS       NC_005816                500 bp    DNA              UNK 01-JAN-1980
+DEFINITION  Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, partial.
+ACCESSION   NC_005816
+VERSION     NC_0058...
 \end{minted}
 
 See Sections~\ref{sec:FASTQ-slicing-off-primer}

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -776,27 +776,19 @@ qualifiers:
 
 \noindent Notice that their locations have been adjusted to reflect the new parent sequence!
 
-While Biopython has done something sensible and hopefully intuitive with the features
-(and any per-letter annotation), for the other annotation it is impossible to know if
-this still applies to the sub-sequence or not. To avoid guessing, the \texttt{annotations}
-and \texttt{dbxrefs} are omitted from the sub-record, and it is up to you to transfer
-any relevant information as appropriate.
+While Biopython has done something sensible and hopefully intuitive with the
+features (and any per-letter annotation), for the other annotation it is
+impossible to know if this still applies to the sub-sequence or not. To avoid
+guessing, with the exception of the molecule type, the \texttt{.annotations}
+and \texttt{.dbxrefs} are omitted from the sub-record, and it is up to you to
+transfer any relevant information as appropriate.
 
 %cont-doctest
 \begin{minted}{pycon}
 >>> sub_record.annotations
-{}
+{'molecule_type': 'DNA'}
 >>> sub_record.dbxrefs
 []
-\end{minted}
-
-\noindent
-If you plan to output the sub-record in GenBank or EMBL format, you will need
-to retain the molecule type information:
-
-%cont-doctest
-\begin{minted}{pycon}
->>> sub_record.annotations['molecule_type'] = record.annotations['molecule_type']
 \end{minted}
 
 \noindent
@@ -934,8 +926,9 @@ SeqRecord(seq=Seq('GATACGCAGTCATATTTTTTACACAATTCTCTAATCCCGACAAGGTCGTAGGTC...GGA'
 9609
 \end{minted}
 
-Note that this isn't perfect in that some annotation like the database cross references
-and one of the features (the source feature) have been lost:
+Note that this isn't perfect in that some annotation like the database cross
+references, all the annotations except molecule type, and one of the features
+(the source feature) have been lost:
 
 %cont-doctest
 \begin{minted}{pycon}
@@ -944,7 +937,7 @@ and one of the features (the source feature) have been lost:
 >>> shifted.dbxrefs
 []
 >>> shifted.annotations.keys()
-dict_keys([])
+dict_keys(['molecule_type'])
 \end{minted}
 
 This is because the \verb|SeqRecord| slicing step is cautious in what annotation

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -790,12 +790,23 @@ any relevant information as appropriate.
 []
 \end{minted}
 
+\noindent
 If you plan to output the sub-record in GenBank or EMBL format, you will need
 to retain the molecule type information:
 
 %cont-doctest
 \begin{minted}{pycon}
 >>> sub_record.annotations['molecule_type'] = record.annotations['molecule_type']
+\end{minted}
+
+\noindent
+You may wish to preserve other entries like the organism? Beware of copying
+the entire annotations dictionary as in this case your partial sequence is no
+longer circular DNA - it is now linear:
+
+%cont-doctest
+\begin{minted}{pycon}
+>>> sub_record.annotations['topology'] = 'linear'
 \end{minted}
 
 The same point could be made about the record \texttt{id}, \texttt{name}
@@ -820,7 +831,7 @@ the \texttt{format} method described above in Section~\ref{sec:SeqRecord-format}
 \begin{minted}[breaklines=true,breaksymbolleft=]{pycon}
 >>> sub_record.description = "Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, partial"
 >>> print(sub_record.format("genbank")[:200] + "...")
-LOCUS       NC_005816                500 bp    DNA              UNK 01-JAN-1980
+LOCUS       NC_005816                500 bp    DNA     linear   UNK 01-JAN-1980
 DEFINITION  Yersinia pestis biovar Microtus str. 91001 plasmid pPCP1, partial.
 ACCESSION   NC_005816
 VERSION     NC_0058...


### PR DESCRIPTION
Need to preserve the molecule type (since the sequence alphabet was dropped from the Seq object).

Also fixes the unwanted second dot on the description in the DEFINITION line.

Makes the example tested as a doctest.

Closes #3384.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
