### PR TITLE
take advantage of the fact that Seq stores its sequence data as a bytes object

### DIFF
--- a/Bio/motifs/_pwm.c
+++ b/Bio/motifs/_pwm.c
@@ -6,6 +6,7 @@
  * package.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <math.h>
 
@@ -157,16 +158,15 @@ py_calculate(PyObject* self, PyObject* args, PyObject* keywords)
     static char* kwlist[] = {"sequence", "matrix", "scores", NULL};
     Py_ssize_t m;
     Py_ssize_t n;
-    int s;
+    Py_ssize_t s;
     PyObject* result = NULL;
     Py_buffer scores;
     Py_buffer matrix;
 
     matrix.obj = NULL;
     scores.obj = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, keywords, "s#O&O&", kwlist,
-                                     &sequence,
-                                     &s,
+    if (!PyArg_ParseTupleAndKeywords(args, keywords, "y#O&O&", kwlist,
+                                     &sequence, &s,
                                      matrix_converter, &matrix,
                                      scores_converter, &scores)) return NULL;
     m = matrix.shape[0];
@@ -177,8 +177,10 @@ py_calculate(PyObject* self, PyObject* args, PyObject* keywords)
         result = Py_None;
     }
     else {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "size of scores array is inconsistent");
+        PyErr_Format(PyExc_RuntimeError,
+                    "size of scores array is inconsistent "
+                    "(sequence length is %zd, "
+                    "motif length is %zd, scores length is %zd", s, m, n);
     }
 
     matrix_converter(NULL, &matrix);

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -352,11 +352,17 @@ class PositionSpecificScoringMatrix(GenericPositionMatrix):
             try:
                 sequence = bytes(sequence, "ASCII")
             except TypeError:
-                raise ValueError("sequence should be a Seq, MutableSeq, string, or bytes-like object") from None
+                raise ValueError(
+                    "sequence should be a Seq, MutableSeq, string, or bytes-like object"
+                ) from None
             except UnicodeEncodeError:
-                raise ValueError("sequence should contain ASCII characters only") from None
-        except:
-            raise ValueError("sequence should be a Seq, MutableSeq, string, or bytes-like object") from None
+                raise ValueError(
+                    "sequence should contain ASCII characters only"
+                ) from None
+        except Exception:
+            raise ValueError(
+                "sequence should be a Seq, MutableSeq, string, or bytes-like object"
+            ) from None
 
         n = len(sequence)
         m = self.length

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -27,19 +27,6 @@ from Bio.Seq import Seq
 from . import _pwm
 
 
-def _calculate(score_dict, sequence, m):
-    """Calculate scores using C code (PRIVATE)."""
-    n = len(sequence)
-    # Create the numpy arrays here; the C module then does not rely on numpy
-    # Use a float32 for the scores array to save space
-    scores = np.empty(n - m + 1, np.float32)
-    logodds = np.array(
-        [[score_dict[letter][i] for letter in "ACGT"] for i in range(m)], float
-    )
-    _pwm.calculate(sequence, logodds, scores)
-    return scores
-
-
 class GenericPositionMatrix(dict):
     """Base class for the support of position matrix operations."""
 
@@ -347,7 +334,7 @@ class PositionSpecificScoringMatrix(GenericPositionMatrix):
          - the search is performed only on one strand
          - if the sequence and the motif have the same length, a single
            number is returned
-         - otherwise, the result is a one-dimensional list or numpy array
+         - otherwise, the result is a one-dimensional numpy array
 
         """
         # TODO - Code itself tolerates ambiguous bases (as NaN).
@@ -359,9 +346,27 @@ class PositionSpecificScoringMatrix(GenericPositionMatrix):
         # NOTE: The C code handles mixed case input as this could be large
         # (e.g. contig or chromosome), so requiring it be all upper or lower
         # case would impose an overhead to allocate the extra memory.
-        sequence = str(sequence)
+        try:
+            sequence = bytes(sequence)
+        except TypeError:  # str
+            try:
+                sequence = bytes(sequence, "ASCII")
+            except TypeError:
+                raise ValueError("sequence should be a Seq, MutableSeq, string, or bytes-like object") from None
+            except UnicodeEncodeError:
+                raise ValueError("sequence should contain ASCII characters only") from None
+        except:
+            raise ValueError("sequence should be a Seq, MutableSeq, string, or bytes-like object") from None
+
+        n = len(sequence)
         m = self.length
-        scores = _calculate(self, sequence, m)
+        # Create the numpy arrays here; the C module then does not rely on numpy
+        # Use a float32 for the scores array to save space
+        scores = np.empty(n - m + 1, np.float32)
+        logodds = np.array(
+            [[self[letter][i] for letter in "ACGT"] for i in range(m)], float
+        )
+        _pwm.calculate(sequence, logodds, scores)
 
         if len(scores) == 1:
             return scores[0]


### PR DESCRIPTION
This PR modifies `Bio.motifs` to take advantage of the fact that Seq now stores its sequence data as a bytes object.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
