### PR TITLE
remove unnecessary str from Bio.phenotype

### DIFF
--- a/Bio/phenotype/phen_micro.py
+++ b/Bio/phenotype/phen_micro.py
@@ -527,7 +527,7 @@ class PlateRecord:
                 self.__class__.__name__,
                 ", ".join(
                     [
-                        "%s['%s']" % (str(self[x].__class__.__name__), self[x].id)
+                        "%s['%s']" % (self[x].__class__.__name__, self[x].id)
                         for x in sorted(self._wells.keys())[:3]
                     ]
                 ),
@@ -542,7 +542,7 @@ class PlateRecord:
                 self.__class__.__name__,
                 ", ".join(
                     [
-                        "%s['%s']" % (str(self[x].__class__.__name__), self[x].id)
+                        "%s['%s']" % (self[x].__class__.__name__, self[x].id)
                         for x in sorted(self._wells.keys())
                     ]
                 ),

--- a/Tests/test_phenotype.py
+++ b/Tests/test_phenotype.py
@@ -75,7 +75,7 @@ class TestPhenoMicro(unittest.TestCase):
             # I want to see the output when called from the test harness,
             # run_tests.py (which can be funny about new lines on Windows)
             handle.seek(0)
-            self.fail("%s\n\n%r\n\n%r" % (str(e), handle.read(), records))
+            self.fail("%s\n\n%r\n\n%r" % (e, handle.read(), records))
 
         self.assertEqual(p1, records[0])
 


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Removes unnecessary calls to `str` from `Bio.phenotype`