### PR TITLE
remove unnecessary str from Nib reading/writing

### DIFF
--- a/Bio/SeqIO/NibIO.py
+++ b/Bio/SeqIO/NibIO.py
@@ -47,6 +47,7 @@ from .Interfaces import SequenceIterator, SequenceWriter
 
 import struct
 import sys
+import binascii
 
 
 class NibIterator(SequenceIterator):
@@ -100,7 +101,7 @@ class NibIterator(SequenceIterator):
         number = handle.read(4)
         length = int.from_bytes(number, byteorder)
         data = handle.read()
-        indices = data.hex()
+        indices = binascii.hexlify(data)
         if length % 2 == 0:
             if len(indices) != length:
                 raise ValueError("Unexpected file size")
@@ -108,9 +109,9 @@ class NibIterator(SequenceIterator):
             if len(indices) != length + 1:
                 raise ValueError("Unexpected file size")
             indices = indices[:length]
-        if not set(indices).issubset("0123489abc"):
+        if not set(indices).issubset(b"0123489abc"):
             raise ValueError("Unexpected sequence data found in file")
-        table = str.maketrans("0123489abc", "TCAGNtcagn")
+        table = bytes.maketrans(b"0123489abc", b"TCAGNtcagn")
         nucleotides = indices.translate(table)
         sequence = Seq(nucleotides)
         record = SeqRecord(sequence)
@@ -146,17 +147,17 @@ class NibWriter(SequenceWriter):
         """Write a single record to the output file."""
         handle = self.handle
         sequence = record.seq
-        nucleotides = str(sequence)
+        nucleotides = bytes(sequence)
         length = len(sequence)
         handle.write(struct.pack("i", length))
-        table = str.maketrans("TCAGNtcagn", "0123489abc")
+        table = bytes.maketrans(b"TCAGNtcagn", b"0123489abc")
         padding = length % 2
-        suffix = padding * "T"
+        suffix = padding * b"T"
         nucleotides += suffix
-        if not set(nucleotides).issubset("ACGTNacgtn"):
+        if not set(nucleotides).issubset(b"ACGTNacgtn"):
             raise ValueError("Sequence should contain A,C,G,T,N,a,c,g,t,n only")
         indices = nucleotides.translate(table)
-        handle.write(bytes.fromhex(indices))
+        handle.write(binascii.unhexlify(indices))
 
     def write_file(self, records):
         """Write the complete file with the records, and return the number of records."""

--- a/Tests/test_SeqIO_NibIO.py
+++ b/Tests/test_SeqIO_NibIO.py
@@ -12,29 +12,29 @@ class TestNibReaderWriter(unittest.TestCase):
     def test_read_even(self):
         with open("Nib/test_even.fa") as handle:
             record = SeqIO.read(handle, "fasta")
-        sequence = str(record.seq)
+        sequence = record.seq
         with open("Nib/test_even_bigendian.nib", "rb") as handle:
             record = SeqIO.read(handle, "nib")
-        self.assertEqual(sequence, str(record.seq))
+        self.assertEqual(sequence, record.seq)
         with open("Nib/test_even_littleendian.nib", "rb") as handle:
             record = SeqIO.read(handle, "nib")
-        self.assertEqual(sequence, str(record.seq))
+        self.assertEqual(sequence, record.seq)
 
     def test_read_odd(self):
         with open("Nib/test_odd.fa") as handle:
             record = SeqIO.read(handle, "fasta")
-        sequence = str(record.seq)
+        sequence = record.seq
         with open("Nib/test_odd_bigendian.nib", "rb") as handle:
             record = SeqIO.read(handle, "nib")
-        self.assertEqual(sequence, str(record.seq))
+        self.assertEqual(sequence, record.seq)
         with open("Nib/test_odd_littleendian.nib", "rb") as handle:
             record = SeqIO.read(handle, "nib")
-        self.assertEqual(sequence, str(record.seq))
+        self.assertEqual(sequence, record.seq)
 
     def test_write_even(self):
         with open("Nib/test_even.fa") as handle:
             record = SeqIO.read(handle, "fasta")
-        sequence = str(record.seq)
+        sequence = record.seq
         handle = BytesIO()
         n = SeqIO.write(record, handle, "nib")
         self.assertEqual(n, 1)
@@ -42,12 +42,12 @@ class TestNibReaderWriter(unittest.TestCase):
         handle.seek(0)
         record = SeqIO.read(handle, "nib")
         handle.close()
-        self.assertEqual(sequence, str(record.seq))
+        self.assertEqual(sequence, record.seq)
 
     def test_write_odd(self):
         with open("Nib/test_odd.fa") as handle:
             record = SeqIO.read(handle, "fasta")
-        sequence = str(record.seq)
+        sequence = record.seq
         handle = BytesIO()
         n = SeqIO.write(record, handle, "nib")
         self.assertEqual(n, 1)
@@ -55,7 +55,7 @@ class TestNibReaderWriter(unittest.TestCase):
         handle.seek(0)
         record = SeqIO.read(handle, "nib")
         handle.close()
-        self.assertEqual(sequence, str(record.seq))
+        self.assertEqual(sequence, record.seq)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR removes unnecessary calls to `str` from the Nib file reader/writer.