### PR TITLE
remove unnecessary str from Clustal code

### DIFF
--- a/Tests/test_ClustalOmega_tool.py
+++ b/Tests/test_ClustalOmega_tool.py
@@ -76,7 +76,7 @@ class ClustalOmegaTestCase(unittest.TestCase):
             len(set(input_records.keys())), len(set(output_records.keys()))
         )
         for record in align:
-            self.assertEqual(str(record.seq), str(output_records[record.id].seq))
+            self.assertEqual(record.seq, output_records[record.id].seq)
 
         # TODO - Try and parse this with Bio.Nexus?
         if cline.guidetree_out:
@@ -99,11 +99,12 @@ class ClustalOmegaTestErrorConditions(ClustalOmegaTestCase):
         try:
             stdout, stderr = cline()
         except ApplicationError as err:
+            message = str(err)
             self.assertTrue(
-                "Cannot open sequence file" in str(err)
-                or "Cannot open input file" in str(err)
-                or "Non-zero return code" in str(err),
-                str(err),
+                "Cannot open sequence file" in message
+                or "Cannot open input file" in message
+                or "Non-zero return code" in message,
+                message,
             )
         else:
             self.fail("Should have failed, returned:\n%s\n%s" % (stdout, stderr))

--- a/Tests/test_Clustalw_tool.py
+++ b/Tests/test_Clustalw_tool.py
@@ -129,9 +129,9 @@ class ClustalWTestCase(unittest.TestCase):
         output_records = SeqIO.to_dict(SeqIO.parse(cline.outfile, "clustal"))
         self.assertEqual(set(input_records.keys()), set(output_records.keys()))
         for record in align:
-            self.assertEqual(str(record.seq), str(output_records[record.id].seq))
+            self.assertEqual(record.seq, output_records[record.id].seq)
             self.assertEqual(
-                str(record.seq).replace("-", ""), str(input_records[record.id].seq)
+                str(record.seq).replace("-", ""), input_records[record.id].seq
             )
 
         # Check the DND file was created.
@@ -155,11 +155,12 @@ class ClustalWTestErrorConditions(ClustalWTestCase):
         try:
             stdout, stderr = cline()
         except ApplicationError as err:
+            message = str(err)
             self.assertTrue(
-                "Cannot open sequence file" in str(err)
-                or "Cannot open input file" in str(err)
-                or "Non-zero return code " in str(err),
-                str(err),
+                "Cannot open sequence file" in message
+                or "Cannot open input file" in message
+                or "Non-zero return code " in message,
+                message,
             )
         else:
             self.fail("expected an ApplicationError")


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


This PR removes unnecessary calls to `str` in Clustal code.