### PR TITLE
remove unnecessary str from Togo

### DIFF
--- a/Tests/test_TogoWS.py
+++ b/Tests/test_TogoWS.py
@@ -620,7 +620,7 @@ class TogoConvert(unittest.TestCase):
         old = SeqIO.read(filename, "gb")
         with open(filename) as handle:
             new = SeqIO.read(TogoWS.convert(handle, "genbank", "fasta"), "fasta")
-        self.assertEqual(str(old.seq), str(new.seq))
+        self.assertEqual(old.seq, new.seq)
 
 
 #    def test_genbank_to_embl(self):


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


This PR removes unnecessary calls to `str` in `test_TogoWS.py`.