### PR TITLE
removes unnecessary str from Bio/ExPASy/ScanProsite.py 

### DIFF
--- a/Bio/ExPASy/ScanProsite.py
+++ b/Bio/ExPASy/ScanProsite.py
@@ -130,7 +130,6 @@ class ContentHandler(handler.ContentHandler):
     def endElement(self, name):
         """Define the end of the search record."""
         assert name == self.element.pop()
-        name = str(name)
         if self.element == ["matchset", "match"]:
             match = self.record[-1]
             if name in ContentHandler.integers:


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR removes an unnecessary call to `str` from `Bio/ExPASy/ScanProsite.py`.