### PR TITLE
removed unnecessary str from test_Uniprot.py

### DIFF
--- a/Tests/test_Uniprot.py
+++ b/Tests/test_Uniprot.py
@@ -457,7 +457,7 @@ class TestUniprot(SeqRecordTestBaseClass):
         self.assertEqual(old.id, new.id)
         self.assertEqual(old.name, new.name)
         self.assertEqual(len(old), len(new))
-        self.assertEqual(str(old.seq), str(new.seq))
+        self.assertEqual(old.seq, new.seq)
         for key in set(old.annotations).intersection(new.annotations):
             if key in ["date"]:
                 # TODO - Why is this a list vs str?
@@ -564,7 +564,7 @@ class TestUniprot(SeqRecordTestBaseClass):
         for txt, xml, fas, id in zip(txt_list, xml_list, fas_list, ids):
             self.assertEqual(txt.id, id)
             self.assertIn(txt.id, fas.id.split("|"))
-            self.assertEqual(str(txt.seq), str(fas.seq))
+            self.assertEqual(txt.seq, fas.seq)
             self.compare_txt_xml(txt, xml)
 
     def test_multi_ex_index(self):


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR removed an unnecessary call to `str` from `test_Uniprot.py`.