### PR TITLE
str in test_Prank_tool.py 

### DIFF
--- a/Tests/test_Prank_tool.py
+++ b/Tests/test_Prank_tool.py
@@ -198,7 +198,7 @@ class PrankConversion(unittest.TestCase):
         self.assertEqual(len(old), len(new))
         for old_r, new_r in zip(old, new):
             self.assertEqual(old_r.id, new_r.id)
-            self.assertEqual(str(old_r.seq), str(new_r.seq))
+            self.assertEqual(old_r.seq, new_r.seq)
         os.remove(filename)
 
     def test_convert_to_fasta(self):


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR removes an unnecessary call to `str` in `test_Prank_tool.py`.