### PR TITLE
remove unnecessary str from PDB code

### DIFF
--- a/Tests/test_PDB_Polypeptide.py
+++ b/Tests/test_PDB_Polypeptide.py
@@ -9,7 +9,7 @@
 # Please see the LICENSE file that should have been included as part of this
 # package.
 
-"""Unit tests for the Bio.PDB.Polypetide module."""
+"""Unit tests for the Bio.PDB.Polypeptide module."""
 
 import unittest
 
@@ -18,7 +18,7 @@ from Bio.Seq import Seq
 
 
 class PolypeptideTests(unittest.TestCase):
-    """Test Polypetide module."""
+    """Test Polypeptide module."""
 
     @classmethod
     def setUpClass(self):
@@ -66,8 +66,7 @@ class PolypeptideTests(unittest.TestCase):
         self.assertIsInstance(s, Seq)
         # Here non-standard MSE are shown as M
         self.assertEqual(
-            "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQNANPDCKTILKALGPGATLEEMMTACQG",
-            s,
+            "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQNANPDCKTILKALGPGATLEEMMTACQG", s,
         )
 
     def test_ppbuilder_torsion(self):
@@ -165,8 +164,7 @@ class PolypeptideTests(unittest.TestCase):
         self.assertIsInstance(s, Seq)
         # Here non-standard MSE are shown as M
         self.assertEqual(
-            "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQNANPDCKTILKALGPGATLEEMMTACQG",
-            s,
+            "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQNANPDCKTILKALGPGATLEEMMTACQG", s,
         )
 
     def test_cappbuilder_tau(self):

--- a/Tests/test_PDB_Polypetide.py
+++ b/Tests/test_PDB_Polypetide.py
@@ -46,9 +46,9 @@ class PolypeptideTests(unittest.TestCase):
         pp1_seq = pp[1].get_sequence()
         pp2_seq = pp[2].get_sequence()
         self.assertIsInstance(pp0_seq, Seq)
-        self.assertEqual(str(pp0_seq), "DIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNW")
-        self.assertEqual(str(pp1_seq), "TETLLVQNANPDCKTILKALGPGATLEE")
-        self.assertEqual(str(pp2_seq), "TACQG")
+        self.assertEqual(pp0_seq, "DIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNW")
+        self.assertEqual(pp1_seq, "TETLLVQNANPDCKTILKALGPGATLEE")
+        self.assertEqual(pp2_seq, "TACQG")
 
     def test_ppbuilder_real_nonstd(self):
         """Test PPBuilder on real PDB file allowing non-standard amino acids."""
@@ -67,7 +67,7 @@ class PolypeptideTests(unittest.TestCase):
         # Here non-standard MSE are shown as M
         self.assertEqual(
             "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQNANPDCKTILKALGPGATLEEMMTACQG",
-            str(s),
+            s,
         )
 
     def test_ppbuilder_torsion(self):
@@ -107,9 +107,9 @@ class PolypeptideTests(unittest.TestCase):
         pp0_seq = pp[0].get_sequence()
         pp1_seq = pp[1].get_sequence()
         pp2_seq = pp[2].get_sequence()
-        self.assertEqual(str(pp0_seq), "DIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNW")
-        self.assertEqual(str(pp1_seq), "TETLLVQNANPDCKTILKALGPGATLEE")
-        self.assertEqual(str(pp2_seq), "TACQG")
+        self.assertEqual(pp0_seq, "DIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNW")
+        self.assertEqual(pp1_seq, "TETLLVQNANPDCKTILKALGPGATLEE")
+        self.assertEqual(pp2_seq, "TACQG")
         self.assertEqual(
             [ca.serial_number for ca in pp[0].get_ca_list()],
             [
@@ -166,7 +166,7 @@ class PolypeptideTests(unittest.TestCase):
         # Here non-standard MSE are shown as M
         self.assertEqual(
             "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQNANPDCKTILKALGPGATLEEMMTACQG",
-            str(s),
+            s,
         )
 
     def test_cappbuilder_tau(self):


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR removes a bunch of unnecessary calls to `str` from the PDB code.