### PR TITLE
remove unnecessary str from Blast code

### DIFF
--- a/Bio/Blast/Record.py
+++ b/Bio/Blast/Record.py
@@ -247,17 +247,14 @@ class HSP:
             )
             lines.append("               %s" % self.match)
             lines.append(
-                "Sbjct:%8s %s %s"
-                % (self.sbjct_start, self.sbjct, self.sbjct_end)
+                "Sbjct:%8s %s %s" % (self.sbjct_start, self.sbjct, self.sbjct_end)
             )
         else:
             lines.append(
                 "Query:%8s %s...%s %s"
                 % (self.query_start, self.query[:45], self.query[-3:], self.query_end,)
             )
-            lines.append(
-                "               %s...%s" % (self.match[:45], self.match[-3:])
-            )
+            lines.append("               %s...%s" % (self.match[:45], self.match[-3:]))
             lines.append(
                 "Sbjct:%8s %s...%s %s"
                 % (self.sbjct_start, self.sbjct[:45], self.sbjct[-3:], self.sbjct_end)

--- a/Bio/Blast/Record.py
+++ b/Bio/Blast/Record.py
@@ -243,35 +243,24 @@ class HSP:
             return "\n".join(lines)
         if self.align_length < 50:
             lines.append(
-                "Query:%s %s %s"
-                % (str(self.query_start).rjust(8), str(self.query), str(self.query_end))
+                "Query:%8s %s %s" % (self.query_start, self.query, self.query_end)
             )
-            lines.append("               %s" % (str(self.match)))
+            lines.append("               %s" % self.match)
             lines.append(
-                "Sbjct:%s %s %s"
-                % (str(self.sbjct_start).rjust(8), str(self.sbjct), str(self.sbjct_end))
+                "Sbjct:%8s %s %s"
+                % (self.sbjct_start, self.sbjct, self.sbjct_end)
             )
         else:
             lines.append(
-                "Query:%s %s...%s %s"
-                % (
-                    str(self.query_start).rjust(8),
-                    str(self.query)[:45],
-                    str(self.query)[-3:],
-                    str(self.query_end),
-                )
+                "Query:%8s %s...%s %s"
+                % (self.query_start, self.query[:45], self.query[-3:], self.query_end,)
             )
             lines.append(
-                "               %s...%s" % (str(self.match)[:45], str(self.match)[-3:])
+                "               %s...%s" % (self.match[:45], self.match[-3:])
             )
             lines.append(
-                "Sbjct:%s %s...%s %s"
-                % (
-                    str(self.sbjct_start).rjust(8),
-                    str(self.sbjct)[:45],
-                    str(self.sbjct)[-3:],
-                    str(self.sbjct_end),
-                )
+                "Sbjct:%8s %s...%s %s"
+                % (self.sbjct_start, self.sbjct[:45], self.sbjct[-3:], self.sbjct_end)
             )
         return "\n".join(lines)
 

--- a/Bio/SearchIO/_legacy/NCBIStandalone.py
+++ b/Bio/SearchIO/_legacy/NCBIStandalone.py
@@ -891,7 +891,7 @@ class _HeaderConsumer:
         if line.startswith("Reference: "):
             self._header.reference = line[11:]
         else:
-            self._header.reference = self._header.reference + line
+            self._header.reference += line
 
     def query_info(self, line):
         if line.startswith("Query= "):
@@ -917,7 +917,7 @@ class _HeaderConsumer:
         elif not line.endswith("total letters"):
             if self._header.database:
                 # Need to include a space when merging multi line datase descr
-                self._header.database = self._header.database + " " + line.strip()
+                self._header.database += " " + line.strip()
             else:
                 self._header.database = line.strip()
         else:
@@ -1307,7 +1307,7 @@ class _HSPConsumer:
             seq += " " * (self._query_len - len(seq))
             if len(seq) < self._query_len:
                 raise ValueError("Match is longer than the query in line\n%s" % line)
-        self._hsp.match = self._hsp.match + seq
+        self._hsp.match += seq
 
     # To match how we do the query, cache the regular expression.
     # Note that the colon is not always present.

--- a/Tests/test_NCBITextParser.py
+++ b/Tests/test_NCBITextParser.py
@@ -35,7 +35,7 @@ class TestBlastRecord(unittest.TestCase):
             record = self.parser.parse(handle)
         generic_align = record.multiple_alignment.to_generic()
         test_seq = generic_align[0].seq
-        self.assertEqual(str(test_seq[:60]), record.multiple_alignment.alignment[0][2])
+        self.assertEqual(test_seq[:60], record.multiple_alignment.alignment[0][2])
 
 
 class TestNCBITextParser(unittest.TestCase):

--- a/Tests/test_NCBI_BLAST_tools.py
+++ b/Tests/test_NCBI_BLAST_tools.py
@@ -385,7 +385,7 @@ class CheckCompleteArgList(unittest.TestCase):
             shell=(sys.platform != "win32"),
         )
         stdoutdata, stderrdata = child.communicate()
-        self.assertEqual(stderrdata, "", "%s\n%s" % (str(cline), stderrdata))
+        self.assertEqual(stderrdata, "", "%s\n%s" % (cline, stderrdata))
         names_in_tool = set()
         while stdoutdata:
             index = stdoutdata.find("[")


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR removes unnecessary calls to `str` from Blast code, + minor cleanup.