### PR TITLE
remove unnecessary calls to str from SeqRecord tests

### DIFF
--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -88,10 +88,10 @@ class SeqRecordCreation(unittest.TestCase):
         except ValueError as e:
             self.assertEqual(str(e), "You must empty the letter annotations first!")
         # Check we can replace IF the length is the same
-        self.assertEqual(str(rec.seq), "ACGT")
+        self.assertEqual(rec.seq, "ACGT")
         self.assertEqual(rec.letter_annotations, {"example": [1, 2, 3, 4]})
         rec.seq = Seq("NNNN")
-        self.assertEqual(str(rec.seq), "NNNN")
+        self.assertEqual(rec.seq, "NNNN")
         self.assertEqual(rec.letter_annotations, {"example": [1, 2, 3, 4]})
 
     def test_valid_id(self):
@@ -202,12 +202,10 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX')"""
         self.assertEqual(expected, rec.format("fasta"))
 
     def test_upper(self):
-        self.assertEqual(
-            "ABCDEFGHIJKLMNOPQRSTUVWZYX", str(self.record.lower().upper().seq)
-        )
+        self.assertEqual("ABCDEFGHIJKLMNOPQRSTUVWZYX", self.record.lower().upper().seq)
 
     def test_lower(self):
-        self.assertEqual("abcdefghijklmnopqrstuvwzyx", str(self.record.lower().seq))
+        self.assertEqual("abcdefghijklmnopqrstuvwzyx", self.record.lower().seq)
 
     def test_slicing(self):
         self.assertEqual("B", self.record[1])
@@ -233,11 +231,11 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX')"""
         rec = self.record
         self.assertEqual(len(rec), 26)
         left = rec[:10]
-        self.assertEqual(str(left.seq), str(rec.seq[:10]))
+        self.assertEqual(left.seq, rec.seq[:10])
         right = rec[-10:]
-        self.assertEqual(str(right.seq), str(rec.seq[-10:]))
+        self.assertEqual(right.seq, rec.seq[-10:])
         mid = rec[12:22]
-        self.assertEqual(str(mid.seq), str(rec.seq[12:22]))
+        self.assertEqual(mid.seq, rec.seq[12:22])
         for sub in [left, right, mid]:
             self.assertEqual(len(sub), 10)
             self.assertEqual(sub.id, "TestID")
@@ -248,8 +246,8 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX')"""
             self.assertEqual(sub.annotations, {})  # May change this...
             self.assertEqual(len(sub.features), 1)
             # By construction, each feature matches the full sliced region:
-            self.assertEqual(str(sub.features[0].extract(sub.seq)), str(sub.seq))
-            self.assertEqual(sub.features[0].extract(str(sub.seq)), str(sub.seq))
+            self.assertEqual(sub.features[0].extract(sub.seq), sub.seq)
+            self.assertEqual(sub.features[0].extract(sub.seq), sub.seq)
 
     def test_slice_zero(self):
         """Zero slice."""
@@ -276,7 +274,7 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX')"""
         for other in [Seq("BIO"), "BIO"]:
             rec = self.record + other  # will use SeqRecord's __add__ method
             self.assertEqual(len(rec), 26 + 3)
-            self.assertEqual(str(rec.seq), str(self.record.seq) + "BIO")
+            self.assertEqual(rec.seq, str(self.record.seq) + "BIO")
             self.assertEqual(rec.id, "TestID")
             self.assertEqual(rec.name, "TestName")
             self.assertEqual(rec.description, "TestDescr")
@@ -294,7 +292,7 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX')"""
         other.dbxrefs = ["dummy"]
         rec = self.record + other
         self.assertEqual(len(rec), len(self.record) + len(other))
-        self.assertEqual(str(rec.seq), str(self.record.seq) + str(other.seq))
+        self.assertEqual(rec.seq, self.record.seq + other.seq)
         self.assertEqual(rec.id, "<unknown id>")
         self.assertEqual(rec.name, "<unknown name>")
         self.assertEqual(rec.description, "<unknown description>")
@@ -319,7 +317,7 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX')"""
         for other in [Seq("BIO"), "BIO"]:
             rec = other + self.record  # will use SeqRecord's __radd__ method
             self.assertEqual(len(rec), 26 + 3)
-            self.assertEqual(str(rec.seq), "BIO" + str(self.record.seq))
+            self.assertEqual(rec.seq, "BIO" + self.record.seq)
             self.assertEqual(rec.id, "TestID")
             self.assertEqual(rec.name, "TestName")
             self.assertEqual(rec.description, "TestDescr")
@@ -335,7 +333,7 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX')"""
         """Simple slice and add."""
         for cut in range(27):
             rec = self.record[:cut] + self.record[cut:]
-            self.assertEqual(str(rec.seq), str(self.record.seq))
+            self.assertEqual(rec.seq, self.record.seq)
             self.assertEqual(len(rec), 26)
             self.assertEqual(rec.id, "TestID")
             self.assertEqual(rec.name, "TestName")
@@ -349,9 +347,7 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX')"""
         """Simple slice and add to shift."""
         for cut in range(27):
             rec = self.record[cut:] + self.record[:cut]
-            self.assertEqual(
-                str(rec.seq), str(self.record.seq[cut:] + self.record.seq[:cut])
-            )
+            self.assertEqual(rec.seq, self.record.seq[cut:] + self.record.seq[:cut])
             self.assertEqual(len(rec), 26)
             self.assertEqual(rec.id, "TestID")
             self.assertEqual(rec.name, "TestName")
@@ -388,7 +384,7 @@ class SeqRecordMethodsMore(unittest.TestCase):
             letter_annotations=True,
         )
 
-        self.assertEqual("CAGT", str(rc.seq))
+        self.assertEqual("CAGT", rc.seq)
         self.assertEqual("TestID", rc.id)
         self.assertEqual("TestID", s.reverse_complement(id="TestID").id)
 
@@ -434,7 +430,7 @@ class SeqRecordMethodsMore(unittest.TestCase):
 
     def test_reverse_complement_mutable_seq(self):
         s = SeqRecord(MutableSeq("ACTG"))
-        self.assertEqual("CAGT", str(s.reverse_complement().seq))
+        self.assertEqual("CAGT", s.reverse_complement().seq)
 
     def test_translate(self):
         s = SeqRecord(


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR removes unnecessary calls to `str` from `test_SeqRecord.py`.