### PR TITLE
remove unnecessary calls to str from Nexus code

### DIFF
--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -1064,9 +1064,7 @@ class Nexus:
                             if p == -1:
                                 break
                             iupac_seq = Seq(
-                                iupac_seq[:p]
-                                + refseq[p]
-                                + iupac_seq[p + 1 :],
+                                iupac_seq[:p] + refseq[p] + iupac_seq[p + 1 :]
                             )
 
                 # Check for invalid characters

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -1060,17 +1060,17 @@ class Nexus:
                 else:
                     if self.matchchar:
                         while True:
-                            p = str(iupac_seq).find(self.matchchar)
+                            p = iupac_seq.find(self.matchchar)
                             if p == -1:
                                 break
                             iupac_seq = Seq(
-                                str(iupac_seq)[:p]
+                                iupac_seq[:p]
                                 + refseq[p]
-                                + str(iupac_seq)[p + 1 :],
+                                + iupac_seq[p + 1 :],
                             )
 
                 # Check for invalid characters
-                for i, c in enumerate(str(iupac_seq)):
+                for i, c in enumerate(iupac_seq):
                     if (
                         c not in self.valid_characters
                         and c != self.gap


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR removes unnecessary calls to `str` from the Nexus modules.