### PR TITLE
Remove str GenBank

### DIFF
--- a/Scripts/GenBank/check_output_simple.py
+++ b/Scripts/GenBank/check_output_simple.py
@@ -52,7 +52,7 @@ with open(sys.argv[1]) as handle:
             else:
                 print("References*")
                 for reference in cur_record.annotations[annotation_key]:
-                    print(str(reference))
-        print("Feaures")
+                    print(reference)
+        print("Features")
         for feature in cur_record.features:
             print(feature)

--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -7508,8 +7508,7 @@ class GenBankTests(unittest.TestCase):
             "MPYKTQGCLGKGATPTPSSRGI*",
         )
         self.assertEqual(
-            seq_features[2].extract(seq_record).seq.translate(),
-            "MPRLEGVGVAPFPRQPWVL*",
+            seq_features[2].extract(seq_record).seq.translate(), "MPRLEGVGVAPFPRQPWVL*",
         )
 
     def test_fuzzy_origin_wrap(self):

--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -7496,19 +7496,19 @@ class GenBankTests(unittest.TestCase):
                 seq_record = SeqIO.read(handle, "genbank")
         seq_features = seq_record.features
         self.assertEqual(
-            str(seq_features[1].extract(seq_record).seq.lower()),
+            seq_features[1].extract(seq_record).seq.lower(),
             "atgccctataaaacccagggctgccttggaaaaggcgcaaccccaaccccctcgagccgcggcatataa",
         )
         self.assertEqual(
-            str(seq_features[2].extract(seq_record).seq.lower()),
+            seq_features[2].extract(seq_record).seq.lower(),
             "atgccgcggctcgagggggttggggttgcgccttttccaaggcagccctgggttttatag",
         )
         self.assertEqual(
-            str(seq_features[1].extract(seq_record).seq.translate()),
+            seq_features[1].extract(seq_record).seq.translate(),
             "MPYKTQGCLGKGATPTPSSRGI*",
         )
         self.assertEqual(
-            str(seq_features[2].extract(seq_record).seq.translate()),
+            seq_features[2].extract(seq_record).seq.translate(),
             "MPRLEGVGVAPFPRQPWVL*",
         )
 


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR removes a couple of unnecessary calls to `str` from the GenBank code.