### PR TITLE
remove unnecessary calls to str in SearchIO code

### DIFF
--- a/Bio/SearchIO/ExonerateIO/_base.py
+++ b/Bio/SearchIO/ExonerateIO/_base.py
@@ -201,10 +201,10 @@ def _split_fragment(frag):
         # coordinates for the split strand
         qstart, hstart = qpos, hpos
         qpos += (
-            len(split) - sum(str(split.query.seq).count(x) for x in ("-", "<", ">"))
+            len(split) - sum(split.query.seq.count(x) for x in ("-", "<", ">"))
         ) * qstep
         hpos += (
-            len(split) - sum(str(split.hit.seq).count(x) for x in ("-", "<", ">"))
+            len(split) - sum(split.hit.seq.count(x) for x in ("-", "<", ">"))
         ) * hstep
 
         split.hit_start = min(hstart, hpos)
@@ -215,7 +215,7 @@ def _split_fragment(frag):
         # account for frameshift length
         abs_slice = slice(abs_pos + s_start, abs_pos + s_stop)
         if len(frag.aln_annotation) == 2:
-            seqs = (str(frag[abs_slice].query.seq), str(frag[abs_slice].hit.seq))
+            seqs = (frag[abs_slice].query.seq, frag[abs_slice].hit.seq)
         elif len(frag.aln_annotation) == 3:
             seqs = (
                 frag[abs_slice].aln_annotation["query_annotation"],

--- a/Bio/SearchIO/InterproscanIO/interproscan_xml.py
+++ b/Bio/SearchIO/InterproscanIO/interproscan_xml.py
@@ -122,7 +122,7 @@ class InterproscanXmlParser:
                 if value is not None:
                     setattr(hit, attr, caster(value))
             # format specific attributes
-            hit.attributes["Hit type"] = str(hit_type)
+            hit.attributes["Hit type"] = hit_type
             signature_lib = signature.find(self.NS + "signature-library-release")
             hit.attributes["Target"] = str(signature_lib.attrib.get("library"))
             hit.attributes["Target version"] = str(signature_lib.attrib.get("version"))

--- a/Bio/SearchIO/_model/hit.py
+++ b/Bio/SearchIO/_model/hit.py
@@ -235,7 +235,7 @@ class Hit(_BaseSearchObject):
                 # append the hsp row
                 lines.append(
                     pattern
-                    % (str(idx), evalue, bitscore, aln_span, query_range, hit_range)
+                    % (idx, evalue, bitscore, aln_span, query_range, hit_range)
                 )
 
         return "\n".join(lines)

--- a/Bio/SearchIO/_model/hit.py
+++ b/Bio/SearchIO/_model/hit.py
@@ -234,8 +234,7 @@ class Hit(_BaseSearchObject):
                 hit_range = hit_range[:19] + "~]" if len(hit_range) > 21 else hit_range
                 # append the hsp row
                 lines.append(
-                    pattern
-                    % (idx, evalue, bitscore, aln_span, query_range, hit_range)
+                    pattern % (idx, evalue, bitscore, aln_span, query_range, hit_range)
                 )
 
         return "\n".join(lines)

--- a/Bio/SearchIO/_model/hsp.py
+++ b/Bio/SearchIO/_model/hsp.py
@@ -839,11 +839,11 @@ class HSPFragment(_BaseHSP):
         # sequences
         if self.query is not None and self.hit is not None:
             try:
-                qseq = str(self.query.seq)
+                qseq = self.query.seq
             except AttributeError:  # query is None
                 qseq = "?"
             try:
-                hseq = str(self.hit.seq)
+                hseq = self.hit.seq
             except AttributeError:  # hit is None
                 hseq = "?"
 

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -291,12 +291,12 @@ class QueryResult(_BaseSearchObject):
                     hid_line = "%s  %s" % (hit.id, hit.description)
                     if len(hid_line) > 58:
                         hid_line = hid_line[:55] + "..."
-                    lines.append(pattern % (idx, str(len(hit)), hid_line))
+                    lines.append(pattern % (idx, len(hit), hid_line))
                 elif idx > len(self.hits) - 4:
                     hid_line = "%s  %s" % (hit.id, hit.description)
                     if len(hid_line) > 58:
                         hid_line = hid_line[:55] + "..."
-                    lines.append(pattern % (idx, str(len(hit)), hid_line))
+                    lines.append(pattern % (idx, len(hit), hid_line))
                 elif idx == 30:
                     lines.append("%14s" % "~~~")
 

--- a/Tests/search_tests_common.py
+++ b/Tests/search_tests_common.py
@@ -152,11 +152,7 @@ def compare_attrs(obj_a, obj_b, attrs):
         if attr in ("_hit", "_query") and (val_a is not None and val_b is not None):
             # compare seq directly if it's a contiguous hsp
             if isinstance(val_a, SeqRecord) and isinstance(val_b, SeqRecord):
-                assert val_a.seq == val_b.seq, "%s: %r vs %r" % (
-                    attr,
-                    val_a,
-                    val_b,
-                )
+                assert val_a.seq == val_b.seq, "%s: %r vs %r" % (attr, val_a, val_b,)
             elif isinstance(val_a, list) and isinstance(val_b, list):
                 for seq_a, seq_b in zip(val_a, val_b):
                     assert seq_a.seq == seq_b.seq, "%s: %r vs %r" % (

--- a/Tests/search_tests_common.py
+++ b/Tests/search_tests_common.py
@@ -152,14 +152,14 @@ def compare_attrs(obj_a, obj_b, attrs):
         if attr in ("_hit", "_query") and (val_a is not None and val_b is not None):
             # compare seq directly if it's a contiguous hsp
             if isinstance(val_a, SeqRecord) and isinstance(val_b, SeqRecord):
-                assert str(val_a.seq) == str(val_b.seq), "%s: %r vs %r" % (
+                assert val_a.seq == val_b.seq, "%s: %r vs %r" % (
                     attr,
                     val_a,
                     val_b,
                 )
             elif isinstance(val_a, list) and isinstance(val_b, list):
                 for seq_a, seq_b in zip(val_a, val_b):
-                    assert str(seq_a.seq) == str(seq_b.seq), "%s: %r vs %r" % (
+                    assert seq_a.seq == seq_b.seq, "%s: %r vs %r" % (
                         attr,
                         seq_a,
                         seq_b,

--- a/Tests/test_SearchIO_blast_tab.py
+++ b/Tests/test_SearchIO_blast_tab.py
@@ -740,12 +740,8 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(1872, hsp.hit_end)
         self.assertEqual(1e-05, hsp.evalue)
         self.assertEqual(34.7, hsp.bitscore)
-        self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq
-        )
-        self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq
-        )
+        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq)
+        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq)
         self.assertEqual(78, hsp.bitscore_raw)
         self.assertEqual(15, hsp.ident_num)
         self.assertEqual(26, hsp.pos_num)
@@ -779,8 +775,7 @@ class BlastTabCases(unittest.TestCase):
             hsp.query.seq,
         )
         self.assertEqual(
-            "GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL",
-            hsp.hit.seq,
+            "GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL", hsp.hit.seq,
         )
         self.assertEqual(70.0, hsp.bitscore_raw)
         self.assertEqual(20, hsp.ident_num)
@@ -952,12 +947,8 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(1872, hsp.hit_end)
         self.assertEqual(1e-05, hsp.evalue)
         self.assertEqual(34.7, hsp.bitscore)
-        self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq
-        )
-        self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq
-        )
+        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq)
+        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq)
 
         hit = qresult[-1]
         self.assertEqual("gi|115975252|ref|XM_001180111.1|", hit.id)
@@ -982,8 +973,7 @@ class BlastTabCases(unittest.TestCase):
             hsp.query.seq,
         )
         self.assertEqual(
-            "GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL",
-            hsp.hit.seq,
+            "GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL", hsp.hit.seq,
         )
 
         # check if we've finished iteration over qresults

--- a/Tests/test_SearchIO_blast_tab.py
+++ b/Tests/test_SearchIO_blast_tab.py
@@ -741,10 +741,10 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(1e-05, hsp.evalue)
         self.assertEqual(34.7, hsp.bitscore)
         self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq
         )
         self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq
         )
         self.assertEqual(78, hsp.bitscore_raw)
         self.assertEqual(15, hsp.ident_num)
@@ -776,11 +776,11 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(31.6, hsp.bitscore)
         self.assertEqual(
             "GLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(70.0, hsp.bitscore_raw)
         self.assertEqual(20, hsp.ident_num)
@@ -830,11 +830,11 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(199, hsp.bitscore)
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(506.0, hsp.bitscore_raw)
         self.assertEqual(94, hsp.ident_num)
@@ -859,11 +859,11 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(32.7, hsp.bitscore)
         self.assertEqual(
             "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(73.0, hsp.bitscore_raw)
         self.assertEqual(21, hsp.ident_num)
@@ -953,10 +953,10 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(1e-05, hsp.evalue)
         self.assertEqual(34.7, hsp.bitscore)
         self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq
         )
         self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq
         )
 
         hit = qresult[-1]
@@ -979,11 +979,11 @@ class BlastTabCases(unittest.TestCase):
         self.assertEqual(31.6, hsp.bitscore)
         self.assertEqual(
             "GLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
 
         # check if we've finished iteration over qresults

--- a/Tests/test_SearchIO_blast_text.py
+++ b/Tests/test_SearchIO_blast_text.py
@@ -105,24 +105,24 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(490, hsp.query_end)
         self.assertEqual(490, hsp.hit_end)
         self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.query.seq)[:40]
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.hit.seq)[:40]
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq)[-40:]
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq)[-40:]
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.hit.seq[-40:]
         )
         # first qresult, second hit
         hit = qresult[1]
@@ -151,24 +151,24 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(490, hsp.query_end)
         self.assertEqual(570, hsp.hit_end)
         self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.query.seq)[:40]
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.hit.seq)[:40]
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq)[-40:]
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq)[-40:]
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.hit.seq[-40:]
         )
 
     def test_text_2226_blastn_003(self):
@@ -217,24 +217,24 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(2926, hsp.hit_end)
         self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.query.seq)[:40]
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.hit.seq)[:40]
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", str(hsp.query.seq)[-40:]
+            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq)[-40:]
+            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:]
         )
         # first qresult, second hit
         hit = qresult[1]
@@ -263,24 +263,24 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(3738, hsp.hit_end)
         self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.query.seq)[:40]
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.hit.seq)[:40]
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", str(hsp.query.seq)[-40:]
+            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq)[-40:]
+            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:]
         )
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
@@ -300,24 +300,24 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(58, hsp.query_end)
         self.assertEqual(2876, hsp.hit_end)
         self.assertEqual(
-            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", str(hsp.query.seq)[:40]
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.query.seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", str(hsp.hit.seq)[:40]
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", str(hsp.query.seq)[-40:]
+            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.hit.seq)[-40:]
+            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", hsp.hit.seq[-40:]
         )
 
     def test_text_2226_blastn_004(self):
@@ -376,24 +376,24 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(490, hsp.query_end)
         self.assertEqual(490, hsp.hit_end)
         self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.query.seq)[:40]
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.hit.seq)[:40]
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq)[-40:]
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq)[-40:]
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.hit.seq[-40:]
         )
         # second qresult, second hit
         hit = qresult[1]
@@ -422,24 +422,24 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(490, hsp.query_end)
         self.assertEqual(570, hsp.hit_end)
         self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.query.seq)[:40]
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", str(hsp.hit.seq)[:40]
+            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.query.seq)[-40:]
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", str(hsp.hit.seq)[-40:]
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.hit.seq[-40:]
         )
 
         # test third qresult
@@ -481,24 +481,24 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(3738, hsp.hit_end)
         self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.query.seq)[:40]
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.hit.seq)[:40]
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", str(hsp.query.seq)[-40:]
+            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq)[-40:]
+            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:]
         )
         # third qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -518,24 +518,24 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(58, hsp.query_end)
         self.assertEqual(2876, hsp.hit_end)
         self.assertEqual(
-            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", str(hsp.query.seq)[:40]
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.query.seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", str(hsp.hit.seq)[:40]
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", str(hsp.query.seq)[-40:]
+            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.hit.seq)[-40:]
+            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", hsp.hit.seq[-40:]
         )
         # third qresult, second hit
         hit = qresult[1]
@@ -564,24 +564,24 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(2926, hsp.hit_end)
         self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.query.seq)[:40]
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", str(hsp.hit.seq)[:40]
+            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", str(hsp.query.seq)[-40:]
+            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", str(hsp.hit.seq)[-40:]
+            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:]
         )
 
 
@@ -649,24 +649,24 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(102, hsp.query_end)
         self.assertEqual(102, hsp.hit_end)
         self.assertEqual(
-            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", str(hsp.query.seq)[:40]
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", str(hsp.hit.seq)[:40]
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.query.seq)[-40:]
+            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.hit.seq)[-40:]
+            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.hit.seq[-40:]
         )
         # first qresult, second hit
         hit = qresult[1]
@@ -695,24 +695,24 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(102, hsp.query_end)
         self.assertEqual(100, hsp.hit_end)
         self.assertEqual(
-            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", str(hsp.query.seq)[:40]
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "MKK    LFFILLL+GCGV ++KSQGED      + TKEG",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", str(hsp.hit.seq)[:40]
+            "MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.query.seq)[-40:]
+            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "DITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", str(hsp.hit.seq)[-40:]
+            "DITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", hsp.hit.seq[-40:]
         )
 
     def test_text_2226_blastp_003(self):
@@ -755,24 +755,24 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(101, hsp.hit_end)
         self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:]
         )
         # first qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -792,24 +792,24 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(345, hsp.hit_end)
         self.assertEqual(
-            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40]
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+            "FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "VKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+            "VKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", hsp.hit.seq[-40:]
         )
         # first qresult, second hit
         hit = qresult[1]
@@ -837,24 +837,24 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(101, hsp.hit_end)
         self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:]
         )
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
@@ -874,24 +874,24 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(345, hsp.hit_end)
         self.assertEqual(
-            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40]
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+            "GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", hsp.hit.seq[-40:]
         )
 
     def test_text_2226_blastp_004(self):
@@ -950,24 +950,24 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(102, hsp.query_end)
         self.assertEqual(100, hsp.hit_end)
         self.assertEqual(
-            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", str(hsp.query.seq)[:40]
+            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "MKK    LFFILLL+GCGV ++KSQGED      + TKEG",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", str(hsp.hit.seq)[:40]
+            "MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", str(hsp.query.seq)[-40:]
+            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "DITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", str(hsp.hit.seq)[-40:]
+            "DITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", hsp.hit.seq[-40:]
         )
         # second qresult, second hit
         hit = qresult[1]
@@ -996,24 +996,24 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(101, hsp.query_end)
         self.assertEqual(104, hsp.hit_end)
         self.assertEqual(
-            "MKKFIALLFFILL----LSGCGVNSQKSQGEDVSPDSNIE", str(hsp.query.seq)[:40]
+            "MKKFIALLFFILL----LSGCGVNSQKSQGEDVSPDSNIE", hsp.query.seq[:40]
         )
         self.assertEqual(
             "MKK IA  F ILL    L+ CG   Q  +G   S ++  +",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "MKKTIAASFLILLFSVVLAACGTAEQSKKGSG-SSENQAQ", str(hsp.hit.seq)[:40]
+            "MKKTIAASFLILLFSVVLAACGTAEQSKKGSG-SSENQAQ", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "LDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERA", str(hsp.query.seq)[-40:]
+            "LDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             " + +++ +  L+KF+  DKV+ITY  ND+GQ  +K+IE+A",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "FEFSDDFSDVLNKFSENDKVSITYFTNDKGQKEIKEIEKA", str(hsp.hit.seq)[-40:]
+            "FEFSDDFSDVLNKFSENDKVSITYFTNDKGQKEIKEIEKA", hsp.hit.seq[-40:]
         )
 
         # test third qresult
@@ -1049,24 +1049,24 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(101, hsp.hit_end)
         self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:]
         )
         # third qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -1086,24 +1086,24 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(345, hsp.hit_end)
         self.assertEqual(
-            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40]
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+            "FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "VKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+            "VKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", hsp.hit.seq[-40:]
         )
         # third qresult, second hit
         hit = qresult[1]
@@ -1131,24 +1131,24 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(101, hsp.hit_end)
         self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:]
         )
         # third qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
@@ -1168,24 +1168,24 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(345, hsp.hit_end)
         self.assertEqual(
-            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40]
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+            "GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", hsp.hit.seq[-40:]
         )
 
 
@@ -1253,24 +1253,24 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(488, hsp.query_end)
         self.assertEqual(140, hsp.hit_end)
         self.assertEqual(
-            "MAGHLAsdfafspppgggdgsagLEPGWVDPRTWLSFQgp", str(hsp.query.seq)[:40]
+            "MAGHLAsdfafspppgggdgsagLEPGWVDPRTWLSFQgp", hsp.query.seq[:40]
         )
         self.assertEqual(
             "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", str(hsp.hit.seq)[:40]
+            "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", str(hsp.query.seq)[-40:]
+            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", str(hsp.hit.seq)[-40:]
+            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.hit.seq[-40:]
         )
         # first qresult, second hit
         hit = qresult[1]
@@ -1296,24 +1296,24 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(488, hsp.query_end)
         self.assertEqual(140, hsp.hit_end)
         self.assertEqual(
-            "MAGHLAsdfafspppgggdgsagLEPGWVDPRTWLSFQgp", str(hsp.query.seq)[:40]
+            "MAGHLAsdfafspppgggdgsagLEPGWVDPRTWLSFQgp", hsp.query.seq[:40]
         )
         self.assertEqual(
             "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", str(hsp.hit.seq)[:40]
+            "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", str(hsp.query.seq)[-40:]
+            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "NSEG SS PC  RP+AVKLEKVEP+PEESQDMKALQKELE",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "NSEGASSGPCTARPSAVKLEKVEPSPEESQDMKALQKELE", str(hsp.hit.seq)[-40:]
+            "NSEGASSGPCTARPSAVKLEKVEPSPEESQDMKALQKELE", hsp.hit.seq[-40:]
         )
 
     def test_text_2226_blastx_003(self):
@@ -1362,24 +1362,24 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(300, hsp.query_end)
         self.assertEqual(119, hsp.hit_end)
         self.assertEqual(
-            "LRRSFALVAQAGVQWLDLGppqpppPGFK*FSCLSHPSSW", str(hsp.query.seq)[:40]
+            "LRRSFALVAQAGVQWLDLGppqpppPGFK*FSCLSHPSSW", hsp.query.seq[:40]
         )
         self.assertEqual(
             "LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", str(hsp.hit.seq)[:40]
+            "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq)[-40:]
+            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "VE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "VEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", str(hsp.hit.seq)[-40:]
+            "VEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", hsp.hit.seq[-40:]
         )
         # first qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -1399,24 +1399,24 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(459, hsp.query_end)
         self.assertEqual(98, hsp.hit_end)
         self.assertEqual(
-            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", str(hsp.query.seq)[:40]
+            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", hsp.query.seq[:40]
         )
         self.assertEqual(
             "V   RVQ ++L S QPP P FK FS LSL SSW+ R  PP",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", str(hsp.hit.seq)[:40]
+            "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", str(hsp.query.seq)[-40:]
+            "WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "W+ R  PPH AN     F F +   F  V QAG++ +  G",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "WEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", str(hsp.hit.seq)[-40:]
+            "WEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", hsp.hit.seq[-40:]
         )
         # first qresult, second hit
         hit = qresult[1]
@@ -1444,24 +1444,24 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(279, hsp.query_end)
         self.assertEqual(117, hsp.hit_end)
         self.assertEqual(
-            "VAQAGVQWLDLGppqpppPGFK*FSCLSHPSSWDYRHMPP", str(hsp.query.seq)[:40]
+            "VAQAGVQWLDLGppqpppPGFK*FSCLSHPSSWDYRHMPP", hsp.query.seq[:40]
         )
         self.assertEqual(
             "++ AGVQW +LG PQPP P FK FSCLS PSSWDYRH+PP",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", str(hsp.hit.seq)[:40]
+            "ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq)[-40:]
+            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "VET F +VGQAGLE P SG+LP  ASQS  ITGVSH A P",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "VETKFPYVGQAGLELPTSGDLPTSASQSAKITGVSHRAWP", str(hsp.hit.seq)[-40:]
+            "VETKFPYVGQAGLELPTSGDLPTSASQSAKITGVSHRAWP", hsp.hit.seq[-40:]
         )
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
@@ -1481,24 +1481,24 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(465, hsp.query_end)
         self.assertEqual(91, hsp.hit_end)
         self.assertEqual(
-            "VSVGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCP", str(hsp.query.seq)[:40]
+            "VSVGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCP", hsp.query.seq[:40]
         )
         self.assertEqual(
             "+++  A VQ  +L S QPP+PEFK FS LSL SSWD R  ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", str(hsp.hit.seq)[:40]
+            "LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", str(hsp.query.seq)[-40:]
+            "SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "SL SSWD R  PP  AN     F F +   F  V QAG++",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "SLPSSWDYRHVPPRLAN-----FVFLVETKFPYVGQAGLE", str(hsp.hit.seq)[-40:]
+            "SLPSSWDYRHVPPRLAN-----FVFLVETKFPYVGQAGLE", hsp.hit.seq[-40:]
         )
 
     def test_text_2226_blastx_004(self):
@@ -1557,24 +1557,24 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(300, hsp.query_end)
         self.assertEqual(119, hsp.hit_end)
         self.assertEqual(
-            "LRRSFALVAQAGVQWLDLGppqpppPGFK*FSCLSHPSSW", str(hsp.query.seq)[:40]
+            "LRRSFALVAQAGVQWLDLGppqpppPGFK*FSCLSHPSSW", hsp.query.seq[:40]
         )
         self.assertEqual(
             "LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", str(hsp.hit.seq)[:40]
+            "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq)[-40:]
+            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "VE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "VEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", str(hsp.hit.seq)[-40:]
+            "VEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", hsp.hit.seq[-40:]
         )
         # second qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -1594,24 +1594,24 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(459, hsp.query_end)
         self.assertEqual(98, hsp.hit_end)
         self.assertEqual(
-            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", str(hsp.query.seq)[:40]
+            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", hsp.query.seq[:40]
         )
         self.assertEqual(
             "V   RVQ ++L S QPP P FK FS LSL SSW+ R  PP",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", str(hsp.hit.seq)[:40]
+            "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", str(hsp.query.seq)[-40:]
+            "WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "W+ R  PPH AN     F F +   F  V QAG++ +  G",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "WEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", str(hsp.hit.seq)[-40:]
+            "WEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", hsp.hit.seq[-40:]
         )
         # second qresult, second hit
         hit = qresult[1]
@@ -1639,24 +1639,24 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(279, hsp.query_end)
         self.assertEqual(117, hsp.hit_end)
         self.assertEqual(
-            "VAQAGVQWLDLGppqpppPGFK*FSCLSHPSSWDYRHMPP", str(hsp.query.seq)[:40]
+            "VAQAGVQWLDLGppqpppPGFK*FSCLSHPSSWDYRHMPP", hsp.query.seq[:40]
         )
         self.assertEqual(
             "++ AGVQW +LG PQPP P FK FSCLS PSSWDYRH+PP",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", str(hsp.hit.seq)[:40]
+            "ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", str(hsp.query.seq)[-40:]
+            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "VET F +VGQAGLE P SG+LP  ASQS  ITGVSH A P",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "VETKFPYVGQAGLELPTSGDLPTSASQSAKITGVSHRAWP", str(hsp.hit.seq)[-40:]
+            "VETKFPYVGQAGLELPTSGDLPTSASQSAKITGVSHRAWP", hsp.hit.seq[-40:]
         )
         # second qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
@@ -1676,24 +1676,24 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(465, hsp.query_end)
         self.assertEqual(91, hsp.hit_end)
         self.assertEqual(
-            "VSVGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCP", str(hsp.query.seq)[:40]
+            "VSVGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCP", hsp.query.seq[:40]
         )
         self.assertEqual(
             "+++  A VQ  +L S QPP+PEFK FS LSL SSWD R  ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", str(hsp.hit.seq)[:40]
+            "LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", str(hsp.query.seq)[-40:]
+            "SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "SL SSWD R  PP  AN     F F +   F  V QAG++",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "SLPSSWDYRHVPPRLAN-----FVFLVETKFPYVGQAGLE", str(hsp.hit.seq)[-40:]
+            "SLPSSWDYRHVPPRLAN-----FVFLVETKFPYVGQAGLE", hsp.hit.seq[-40:]
         )
 
 
@@ -1761,24 +1761,24 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(73, hsp.query_end)
         self.assertEqual(1872, hsp.hit_end)
         self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTS", str(hsp.query.seq)[:40]
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "P +   TK+GT +GL   HTI   + +  +SL++ E++  ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", str(hsp.hit.seq)[:40]
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)[-40:]
+            "NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "ATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)[-40:]
+            "ATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq[-40:]
         )
         # first qresult, second hit
         hit = qresult[1]
@@ -1807,24 +1807,24 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(94, hsp.query_end)
         self.assertEqual(1318, hsp.hit_end)
         self.assertEqual(
-            "VSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEES", str(hsp.query.seq)[:40]
+            "VSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEES", hsp.query.seq[:40]
         )
         self.assertEqual(
             "+  DS +   +G   GL D H + + + + P S+D  +E ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "IGNDSYLALSKG---GLVDEHVLILPIGHYPSSIDAPQEV", str(hsp.hit.seq)[:40]
+            "IGNDSYLALSKG---GLVDEHVLILPIGHYPSSIDAPQEV", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "DITEESTSDLDK--------FNSGDKVTITYEKNDEGQLL", str(hsp.query.seq)[-40:]
+            "DITEESTSDLDK--------FNSGDKVTITYEKNDEGQLL", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "D  +E   ++DK        F+S ++  + +E+N   Q L",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "DAPQEVIEEIDKFKVALRKYFSSKNQTCVMFERNFRSQHL", str(hsp.hit.seq)[-40:]
+            "DAPQEVIEEIDKFKVALRKYFSSKNQTCVMFERNFRSQHL", hsp.hit.seq[-40:]
         )
 
     def test_text_2226_tblastn_003(self):
@@ -1870,24 +1870,24 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(369, hsp.hit_end)
         self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:]
         )
         # first qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -1907,24 +1907,24 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(1101, hsp.hit_end)
         self.assertEqual(
-            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40]
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+            "GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", hsp.hit.seq[-40:]
         )
         # first qresult, second hit
         hit = qresult[1]
@@ -1953,24 +1953,24 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(388, hsp.hit_end)
         self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "FGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "FGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+            "FGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", hsp.hit.seq[-40:]
         )
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
@@ -1990,24 +1990,24 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(754, hsp.hit_end)
         self.assertEqual(
-            "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK-", str(hsp.query.seq)[:40]
+            "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK-", hsp.query.seq[:40]
         )
         self.assertEqual(
             "+ +Y       P G I L+G  +TS      GK  F+ + ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", str(hsp.hit.seq)[:40]
+            "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+            "GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "GK  F+ +     T  +  +F QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+            "GKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", hsp.hit.seq[-40:]
         )
 
     def test_text_2226_tblastn_004(self):
@@ -2066,24 +2066,24 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(73, hsp.query_end)
         self.assertEqual(1872, hsp.hit_end)
         self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTS", str(hsp.query.seq)[:40]
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "P +   TK+GT +GL   HTI   + +  +SL++ E++  ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", str(hsp.hit.seq)[:40]
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)[-40:]
+            "NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "ATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)[-40:]
+            "ATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq[-40:]
         )
         # second qresult, second hit
         hit = qresult[1]
@@ -2112,24 +2112,24 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(94, hsp.query_end)
         self.assertEqual(1233, hsp.hit_end)
         self.assertEqual(
-            "GLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSG-----", str(hsp.query.seq)[:40]
+            "GLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSG-----", hsp.query.seq[:40]
         )
         self.assertEqual(
             "GL   HT+ + V +    LD+TEE  ++LD+F S      ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYY", str(hsp.hit.seq)[:40]
+            "GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYY", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "DITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL", str(hsp.query.seq)[-40:]
+            "DITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "D+TEE  ++LD+F S          K  + YE+N   Q L",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "DLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL", str(hsp.hit.seq)[-40:]
+            "DLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL", hsp.hit.seq[-40:]
         )
 
         # test third qresult
@@ -2168,24 +2168,24 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(388, hsp.hit_end)
         self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "FGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "FGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+            "FGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", hsp.hit.seq[-40:]
         )
         # third qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -2205,24 +2205,24 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(754, hsp.hit_end)
         self.assertEqual(
-            "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK-", str(hsp.query.seq)[:40]
+            "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK-", hsp.query.seq[:40]
         )
         self.assertEqual(
             "+ +Y       P G I L+G  +TS      GK  F+ + ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", str(hsp.hit.seq)[:40]
+            "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+            "GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "GK  F+ +     T  +  +F QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+            "GKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", hsp.hit.seq[-40:]
         )
         # third qresult, second hit
         hit = qresult[1]
@@ -2251,24 +2251,24 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(371, hsp.hit_end)
         self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "KRIREGYLVK+GSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "KRIREGYLVKRGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", str(hsp.hit.seq)[:40]
+            "KRIREGYLVKRGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.query.seq)[-40:]
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "FGKRMFV KITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "FGKRMFVFKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", str(hsp.hit.seq)[-40:]
+            "FGKRMFVFKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:]
         )
         # third qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
@@ -2288,24 +2288,24 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(1103, hsp.hit_end)
         self.assertEqual(
-            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", str(hsp.query.seq)[:40]
+            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40]
         )
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       ",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", str(hsp.hit.seq)[:40]
+            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "QDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", str(hsp.query.seq)[-40:]
+            "QDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "    +   + +I T  +  +F QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "VRKSEEENLFEIITADEVHYFLQAATPKERTEWIKAIQVA", str(hsp.hit.seq)[-40:]
+            "VRKSEEENLFEIITADEVHYFLQAATPKERTEWIKAIQVA", hsp.hit.seq[-40:]
         )
 
 
@@ -2373,24 +2373,24 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(489, hsp.query_end)
         self.assertEqual(489, hsp.hit_end)
         self.assertEqual(
-            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", str(hsp.query.seq)[:40]
+            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", str(hsp.hit.seq)[:40]
+            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", str(hsp.query.seq)[-40:]
+            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", str(hsp.hit.seq)[-40:]
+            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.hit.seq[-40:]
         )
         # first qresult, second hit
         hit = qresult[1]
@@ -2419,24 +2419,24 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(489, hsp.query_end)
         self.assertEqual(570, hsp.hit_end)
         self.assertEqual(
-            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", str(hsp.query.seq)[:40]
+            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", str(hsp.hit.seq)[:40]
+            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", str(hsp.query.seq)[-40:]
+            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "TQREPPLSPVPTAPMP*SWRRWNQL RSPRT*KPCRRS*N",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "TQREPPLSPVPTAPMP*SWRRWNQLQRSPRT*KPCRRS*N", str(hsp.hit.seq)[-40:]
+            "TQREPPLSPVPTAPMP*SWRRWNQLQRSPRT*KPCRRS*N", hsp.hit.seq[-40:]
         )
 
     def test_text_2226_tblastx_003(self):
@@ -2484,24 +2484,24 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(459, hsp.query_end)
         self.assertEqual(943, hsp.hit_end)
         self.assertEqual(
-            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", str(hsp.query.seq)[:40]
+            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", hsp.query.seq[:40]
         )
         self.assertEqual(
             "V  A V+ H+LSSLQPP P FK FS LSL SSWD R  PP",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "VTQAGVKWHNLSSLQPPPPGFKQFSCLSLPSSWDYRRGPP", str(hsp.hit.seq)[:40]
+            "VTQAGVKWHNLSSLQPPPPGFKQFSCLSLPSSWDYRRGPP", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "WLDLGppqpppPGFK*FSCLSHPSSWDYRHMPPCLINFVF", str(hsp.query.seq)[-40:]
+            "WLDLGppqpppPGFK*FSCLSHPSSWDYRHMPPCLINFVF", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "W DLG  Q PPPGF  FSCLS PSSWDYR   P   NF++",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "WRDLGSLQAPPPGFTPFSCLSLPSSWDYRRPLPRPANFLY", str(hsp.hit.seq)[-40:]
+            "WRDLGSLQAPPPGFTPFSCLSLPSSWDYRRPLPRPANFLY", hsp.hit.seq[-40:]
         )
         # first qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -2521,24 +2521,24 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(148, hsp.query_end)
         self.assertEqual(630, hsp.hit_end)
         self.assertEqual(
-            "FCIFSRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEP", str(hsp.query.seq)[:40]
+            "FCIFSRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEP", hsp.query.seq[:40]
         )
         self.assertEqual(
             "FCIFSRDGV  CW GWSRTPDL+*S  LGLPKCWDYR EP",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "FCIFSRDGVSSCWPGWSRTPDLK*STHLGLPKCWDYRREP", str(hsp.hit.seq)[:40]
+            "FCIFSRDGVSSCWPGWSRTPDLK*STHLGLPKCWDYRREP", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", str(hsp.query.seq)[-40:]
+            "SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "SRDGV  CW GWSRTPDL+*S  LGLPKCWDYR EPPRPA",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "SRDGVSSCWPGWSRTPDLK*STHLGLPKCWDYRREPPRPA", str(hsp.hit.seq)[-40:]
+            "SRDGVSSCWPGWSRTPDLK*STHLGLPKCWDYRREPPRPA", hsp.hit.seq[-40:]
         )
         # first qresult, second hit
         hit = qresult[1]
@@ -2567,24 +2567,24 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(298, hsp.query_end)
         self.assertEqual(3026, hsp.hit_end)
         self.assertEqual(
-            "ETEFRSCCPGWSAMA*SWPTTASTSWIQVILLPQSPE*LG", str(hsp.query.seq)[:40]
+            "ETEFRSCCPGWSAMA*SWPTTASTSWIQVILLPQSPE*LG", hsp.query.seq[:40]
         )
         self.assertEqual(
             "E EFRSCCPGWSAMA SW    S SW+QVIL PQ PE*LG",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "EMEFRSCCPGWSAMAQSWLIATSVSWVQVILWPQPPE*LG", str(hsp.hit.seq)[:40]
+            "EMEFRSCCPGWSAMAQSWLIATSVSWVQVILWPQPPE*LG", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", str(hsp.query.seq)[-40:]
+            "SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "SRDGV PCWSGWSRTPDLR*SACLGLPKCWDYR EPP PA",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "SRDGVSPCWSGWSRTPDLR*SACLGLPKCWDYRREPPCPA", str(hsp.hit.seq)[-40:]
+            "SRDGVSPCWSGWSRTPDLR*SACLGLPKCWDYRREPPCPA", hsp.hit.seq[-40:]
         )
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
@@ -2604,24 +2604,24 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(299, hsp.query_end)
         self.assertEqual(3027, hsp.hit_end)
         self.assertEqual(
-            "AGRGGSHL*SQHFGRPRQADYLRSGVRDQPDQHGKTPSLL", str(hsp.query.seq)[:40]
+            "AGRGGSHL*SQHFGRPRQADYLRSGVRDQPDQHGKTPSLL", hsp.query.seq[:40]
         )
         self.assertEqual(
             "AG GGS L*SQHFGRPRQAD+LRSGVRDQPDQHG+TPSLL",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "AGHGGSRL*SQHFGRPRQADHLRSGVRDQPDQHGETPSLL", str(hsp.hit.seq)[:40]
+            "AGHGGSRL*SQHFGRPRQADHLRSGVRDQPDQHGETPSLL", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "PSYSGD*GRRIT*IQEVEAVVGQDQAIALQPGQQERNSVS", str(hsp.query.seq)[-40:]
+            "PSYSGD*GRRIT*IQEVEAVVGQDQAIALQPGQQERNSVS", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "PSYSG *G+RIT* QE E  + QD AIALQPGQQERNS+S",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "PSYSGG*GQRIT*TQETEVAMSQDCAIALQPGQQERNSIS", str(hsp.hit.seq)[-40:]
+            "PSYSGG*GQRIT*TQETEVAMSQDCAIALQPGQQERNSIS", hsp.hit.seq[-40:]
         )
 
     def test_text_2226_tblastx_004(self):
@@ -2680,24 +2680,24 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(349, hsp.query_end)
         self.assertEqual(349, hsp.hit_end)
         self.assertEqual(
-            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", str(hsp.query.seq)[:40]
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", hsp.query.seq[:40]
         )
         self.assertEqual(
             "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", str(hsp.hit.seq)[:40]
+            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", str(hsp.query.seq)[-40:]
+            "WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", str(hsp.hit.seq)[-40:]
+            "WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", hsp.hit.seq[-40:]
         )
         # second qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
@@ -2717,24 +2717,24 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(349, hsp.query_end)
         self.assertEqual(349, hsp.hit_end)
         self.assertEqual(
-            "LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", str(hsp.query.seq)[:40]
+            "LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", hsp.query.seq[:40]
         )
         self.assertEqual(
             "LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", str(hsp.hit.seq)[:40]
+            "LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", str(hsp.query.seq)[-40:]
+            "WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", str(hsp.hit.seq)[-40:]
+            "WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", hsp.hit.seq[-40:]
         )
         # second qresult, second hit
         hit = qresult[1]
@@ -2763,24 +2763,24 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(348, hsp.query_end)
         self.assertEqual(342, hsp.hit_end)
         self.assertEqual(
-            "TIRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRN", str(hsp.query.seq)[:40]
+            "TIRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRN", hsp.query.seq[:40]
         )
         self.assertEqual(
             "TI+HASDKSI+ILK + + EEL RHPDF  P VLAC SRN",
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "TIKHASDKSIDILKTIQNIEELVRHPDFVTPLVLACSSRN", str(hsp.hit.seq)[:40]
+            "TIKHASDKSIDILKTIQNIEELVRHPDFVTPLVLACSSRN", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "LAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK", str(hsp.query.seq)[-40:]
+            "LAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK", hsp.query.seq[-40:]
         )
         self.assertEqual(
             "+AMQCLQGL++VPSIP SR+ E+LD FIEAT LAMEIQLK",
             hsp.aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "IAMQCLQGLASVPSIPESRIPEVLDGFIEATQLAMEIQLK", str(hsp.hit.seq)[-40:]
+            "IAMQCLQGLASVPSIPESRIPEVLDGFIEATQLAMEIQLK", hsp.hit.seq[-40:]
         )
         # second qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
@@ -2799,9 +2799,9 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(62, hsp.hit_start)
         self.assertEqual(110, hsp.query_end)
         self.assertEqual(104, hsp.hit_end)
-        self.assertEqual("FRIEKKKFNHSPC*", str(hsp.query.seq))
+        self.assertEqual("FRIEKKKFNHSPC*", hsp.query.seq)
         self.assertEqual("FRI KKKFNH  C*", hsp.aln_annotation["similarity"])
-        self.assertEqual("FRI*KKKFNH*TC*", str(hsp.hit.seq))
+        self.assertEqual("FRI*KKKFNH*TC*", hsp.hit.seq)
 
     def test_text_2230_blastp_001(self):
         """Test parsing blastp output (text_2230_blastp_001.txt)."""

--- a/Tests/test_SearchIO_blast_text.py
+++ b/Tests/test_SearchIO_blast_text.py
@@ -250,14 +250,14 @@ class BlastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40])
-        self.assertEqual("AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:])
+        self.assertEqual(
+            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:])
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(53, hsp.aln_span)
@@ -594,7 +594,9 @@ class BlastpCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.hit.seq[:40])
-        self.assertEqual("DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:])
+        self.assertEqual(
+            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
             hsp.aln_annotation["similarity"][-40:],

--- a/Tests/test_SearchIO_blast_text.py
+++ b/Tests/test_SearchIO_blast_text.py
@@ -104,26 +104,18 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(490, hsp.query_end)
         self.assertEqual(490, hsp.hit_end)
-        self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.query.seq[:40]
-        )
+        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.query.seq[:40])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40])
+        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.hit.seq[-40:])
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|XR_141831.1|", hit.id)
@@ -150,26 +142,18 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(80, hsp.hit_start)
         self.assertEqual(490, hsp.query_end)
         self.assertEqual(570, hsp.hit_end)
-        self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.query.seq[:40]
-        )
+        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.query.seq[:40])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40])
+        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.hit.seq[-40:])
 
     def test_text_2226_blastn_003(self):
         """Test parsing blastn output (text_2226_blastn_003.txt)."""
@@ -216,26 +200,18 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(2864, hsp.hit_start)
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(2926, hsp.hit_end)
-        self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.query.seq[:40]
-        )
+        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.query.seq[:40])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:]
-        )
+        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40])
+        self.assertEqual("AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:])
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|NM_001040441.1|", hit.id)
@@ -262,26 +238,18 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(3676, hsp.hit_start)
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(3738, hsp.hit_end)
-        self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.query.seq[:40]
-        )
+        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.query.seq[:40])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:]
-        )
+        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40])
+        self.assertEqual("AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:])
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(53, hsp.aln_span)
@@ -299,26 +267,18 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(2823, hsp.hit_start)
         self.assertEqual(58, hsp.query_end)
         self.assertEqual(2876, hsp.hit_end)
-        self.assertEqual(
-            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.query.seq[:40]
-        )
+        self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.query.seq[:40])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", hsp.query.seq[-40:]
-        )
+        self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.hit.seq[:40])
+        self.assertEqual("GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", hsp.query.seq[-40:])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("GCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", hsp.hit.seq[-40:])
 
     def test_text_2226_blastn_004(self):
         """Test parsing blastn output (text_2226_blastn_004.txt)."""
@@ -375,26 +335,18 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(490, hsp.query_end)
         self.assertEqual(490, hsp.hit_end)
-        self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.query.seq[:40]
-        )
+        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.query.seq[:40])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40])
+        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.hit.seq[-40:])
         # second qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|377833530|ref|XR_141831.1|", hit.id)
@@ -421,26 +373,18 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(80, hsp.hit_start)
         self.assertEqual(490, hsp.query_end)
         self.assertEqual(570, hsp.hit_end)
-        self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.query.seq[:40]
-        )
+        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.query.seq[:40])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40])
+        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.hit.seq[-40:])
 
         # test third qresult
         qresult = qresults[2]
@@ -480,26 +424,18 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(3676, hsp.hit_start)
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(3738, hsp.hit_end)
-        self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.query.seq[:40]
-        )
+        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.query.seq[:40])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:]
-        )
+        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40])
+        self.assertEqual("AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:])
         # third qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(53, hsp.aln_span)
@@ -517,26 +453,18 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(2823, hsp.hit_start)
         self.assertEqual(58, hsp.query_end)
         self.assertEqual(2876, hsp.hit_end)
-        self.assertEqual(
-            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.query.seq[:40]
-        )
+        self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.query.seq[:40])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", hsp.query.seq[-40:]
-        )
+        self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.hit.seq[:40])
+        self.assertEqual("GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", hsp.query.seq[-40:])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("GCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", hsp.hit.seq[-40:])
         # third qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|332237160|ref|XM_003267724.1|", hit.id)
@@ -563,26 +491,18 @@ class BlastnCases(BaseBlastCases):
         self.assertEqual(2864, hsp.hit_start)
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(2926, hsp.hit_end)
-        self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.query.seq[:40]
-        )
+        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.query.seq[:40])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:]
-        )
+        self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40])
+        self.assertEqual("AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:])
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:])
 
 
 class BlastpCases(BaseBlastCases):
@@ -665,9 +585,7 @@ class BlastpCases(BaseBlastCases):
             "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.hit.seq[-40:])
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|YP_003922001.1|", hit.id)
@@ -694,26 +612,18 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(102, hsp.query_end)
         self.assertEqual(100, hsp.hit_end)
-        self.assertEqual(
-            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.query.seq[:40]
-        )
+        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.query.seq[:40])
         self.assertEqual(
             "MKK    LFFILLL+GCGV ++KSQGED      + TKEG",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:]
-        )
+        self.assertEqual("MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", hsp.hit.seq[:40])
+        self.assertEqual("DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:])
         self.assertEqual(
             "DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "DITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("DITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", hsp.hit.seq[-40:])
 
     def test_text_2226_blastp_003(self):
         """Test parsing blastp output (text_2226_blastp_003.txt)."""
@@ -754,26 +664,18 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(3, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(101, hsp.hit_end)
-        self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
-        )
+        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
+        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:])
         # first qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(100, hsp.aln_span)
@@ -791,26 +693,18 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(245, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(345, hsp.hit_end)
-        self.assertEqual(
-            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40])
+        self.assertEqual("FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
         self.assertEqual(
             "  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "VKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("VKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", hsp.hit.seq[-40:])
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|XP_003502426.1|", hit.id)
@@ -836,26 +730,18 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(3, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(101, hsp.hit_end)
-        self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
-        )
+        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
+        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:])
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(100, hsp.aln_span)
@@ -873,26 +759,18 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(245, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(345, hsp.hit_end)
-        self.assertEqual(
-            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40])
+        self.assertEqual("GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
         self.assertEqual(
             "GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", hsp.hit.seq[-40:])
 
     def test_text_2226_blastp_004(self):
         """Test parsing blastp output (text_2226_blastp_004.txt)."""
@@ -949,26 +827,18 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(102, hsp.query_end)
         self.assertEqual(100, hsp.hit_end)
-        self.assertEqual(
-            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.query.seq[:40]
-        )
+        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.query.seq[:40])
         self.assertEqual(
             "MKK    LFFILLL+GCGV ++KSQGED      + TKEG",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:]
-        )
+        self.assertEqual("MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", hsp.hit.seq[:40])
+        self.assertEqual("DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:])
         self.assertEqual(
             "DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "DITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("DITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN", hsp.hit.seq[-40:])
         # second qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|375363999|ref|YP_005132038.1|", hit.id)
@@ -995,26 +865,18 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(101, hsp.query_end)
         self.assertEqual(104, hsp.hit_end)
-        self.assertEqual(
-            "MKKFIALLFFILL----LSGCGVNSQKSQGEDVSPDSNIE", hsp.query.seq[:40]
-        )
+        self.assertEqual("MKKFIALLFFILL----LSGCGVNSQKSQGEDVSPDSNIE", hsp.query.seq[:40])
         self.assertEqual(
             "MKK IA  F ILL    L+ CG   Q  +G   S ++  +",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "MKKTIAASFLILLFSVVLAACGTAEQSKKGSG-SSENQAQ", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "LDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("MKKTIAASFLILLFSVVLAACGTAEQSKKGSG-SSENQAQ", hsp.hit.seq[:40])
+        self.assertEqual("LDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERA", hsp.query.seq[-40:])
         self.assertEqual(
             " + +++ +  L+KF+  DKV+ITY  ND+GQ  +K+IE+A",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "FEFSDDFSDVLNKFSENDKVSITYFTNDKGQKEIKEIEKA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("FEFSDDFSDVLNKFSENDKVSITYFTNDKGQKEIKEIEKA", hsp.hit.seq[-40:])
 
         # test third qresult
         qresult = qresults[2]
@@ -1048,26 +910,18 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(3, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(101, hsp.hit_end)
-        self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
-        )
+        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
+        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:])
         # third qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(100, hsp.aln_span)
@@ -1085,26 +939,18 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(245, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(345, hsp.hit_end)
-        self.assertEqual(
-            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40])
+        self.assertEqual("FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
         self.assertEqual(
             "  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "VKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("VKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA", hsp.hit.seq[-40:])
         # third qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|354480464|ref|XP_003502426.1|", hit.id)
@@ -1130,26 +976,18 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(3, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(101, hsp.hit_end)
-        self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
-        )
+        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
+        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:])
         # third qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(100, hsp.aln_span)
@@ -1167,26 +1005,18 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(245, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(345, hsp.hit_end)
-        self.assertEqual(
-            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40])
+        self.assertEqual("GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
         self.assertEqual(
             "GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", hsp.hit.seq[-40:])
 
 
 class BlastxCases(BaseBlastCases):
@@ -1252,26 +1082,18 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(488, hsp.query_end)
         self.assertEqual(140, hsp.hit_end)
-        self.assertEqual(
-            "MAGHLAsdfafspppgggdgsagLEPGWVDPRTWLSFQgp", hsp.query.seq[:40]
-        )
+        self.assertEqual("MAGHLAsdfafspppgggdgsagLEPGWVDPRTWLSFQgp", hsp.query.seq[:40])
         self.assertEqual(
             "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.query.seq[-40:]
-        )
+        self.assertEqual("MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", hsp.hit.seq[:40])
+        self.assertEqual("NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.query.seq[-40:])
         self.assertEqual(
             "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.hit.seq[-40:])
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|NP_001009178.1|", hit.id)
@@ -1295,26 +1117,18 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(488, hsp.query_end)
         self.assertEqual(140, hsp.hit_end)
-        self.assertEqual(
-            "MAGHLAsdfafspppgggdgsagLEPGWVDPRTWLSFQgp", hsp.query.seq[:40]
-        )
+        self.assertEqual("MAGHLAsdfafspppgggdgsagLEPGWVDPRTWLSFQgp", hsp.query.seq[:40])
         self.assertEqual(
             "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.query.seq[-40:]
-        )
+        self.assertEqual("MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", hsp.hit.seq[:40])
+        self.assertEqual("NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.query.seq[-40:])
         self.assertEqual(
             "NSEG SS PC  RP+AVKLEKVEP+PEESQDMKALQKELE",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "NSEGASSGPCTARPSAVKLEKVEPSPEESQDMKALQKELE", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("NSEGASSGPCTARPSAVKLEKVEPSPEESQDMKALQKELE", hsp.hit.seq[-40:])
 
     def test_text_2226_blastx_003(self):
         """Test parsing blastx output (text_2226_blastx_003.txt)."""
@@ -1361,26 +1175,18 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(24, hsp.hit_start)
         self.assertEqual(300, hsp.query_end)
         self.assertEqual(119, hsp.hit_end)
-        self.assertEqual(
-            "LRRSFALVAQAGVQWLDLGppqpppPGFK*FSCLSHPSSW", hsp.query.seq[:40]
-        )
+        self.assertEqual("LRRSFALVAQAGVQWLDLGppqpppPGFK*FSCLSHPSSW", hsp.query.seq[:40])
         self.assertEqual(
             "LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:]
-        )
+        self.assertEqual("LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", hsp.hit.seq[:40])
+        self.assertEqual("VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:])
         self.assertEqual(
             "VE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "VEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("VEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", hsp.hit.seq[-40:])
         # first qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(72, hsp.aln_span)
@@ -1398,26 +1204,18 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(31, hsp.hit_start)
         self.assertEqual(459, hsp.query_end)
         self.assertEqual(98, hsp.hit_end)
-        self.assertEqual(
-            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", hsp.query.seq[:40]
-        )
+        self.assertEqual("VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", hsp.query.seq[:40])
         self.assertEqual(
             "V   RVQ ++L S QPP P FK FS LSL SSW+ R  PP",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", hsp.query.seq[-40:]
-        )
+        self.assertEqual("VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", hsp.hit.seq[:40])
+        self.assertEqual("WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", hsp.query.seq[-40:])
         self.assertEqual(
             "W+ R  PPH AN     F F +   F  V QAG++ +  G",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "WEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("WEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", hsp.hit.seq[-40:])
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|NP_001243358.1|", hit.id)
@@ -1443,26 +1241,18 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(29, hsp.hit_start)
         self.assertEqual(279, hsp.query_end)
         self.assertEqual(117, hsp.hit_end)
-        self.assertEqual(
-            "VAQAGVQWLDLGppqpppPGFK*FSCLSHPSSWDYRHMPP", hsp.query.seq[:40]
-        )
+        self.assertEqual("VAQAGVQWLDLGppqpppPGFK*FSCLSHPSSWDYRHMPP", hsp.query.seq[:40])
         self.assertEqual(
             "++ AGVQW +LG PQPP P FK FSCLS PSSWDYRH+PP",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:]
-        )
+        self.assertEqual("ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", hsp.hit.seq[:40])
+        self.assertEqual("VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:])
         self.assertEqual(
             "VET F +VGQAGLE P SG+LP  ASQS  ITGVSH A P",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "VETKFPYVGQAGLELPTSGDLPTSASQSAKITGVSHRAWP", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("VETKFPYVGQAGLELPTSGDLPTSASQSAKITGVSHRAWP", hsp.hit.seq[-40:])
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(69, hsp.aln_span)
@@ -1480,26 +1270,18 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(27, hsp.hit_start)
         self.assertEqual(465, hsp.query_end)
         self.assertEqual(91, hsp.hit_end)
-        self.assertEqual(
-            "VSVGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCP", hsp.query.seq[:40]
-        )
+        self.assertEqual("VSVGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCP", hsp.query.seq[:40])
         self.assertEqual(
             "+++  A VQ  +L S QPP+PEFK FS LSL SSWD R  ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", hsp.query.seq[-40:]
-        )
+        self.assertEqual("LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", hsp.hit.seq[:40])
+        self.assertEqual("SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", hsp.query.seq[-40:])
         self.assertEqual(
             "SL SSWD R  PP  AN     F F +   F  V QAG++",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "SLPSSWDYRHVPPRLAN-----FVFLVETKFPYVGQAGLE", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("SLPSSWDYRHVPPRLAN-----FVFLVETKFPYVGQAGLE", hsp.hit.seq[-40:])
 
     def test_text_2226_blastx_004(self):
         """Test parsing blastx output (text_2226_blastx_004.txt)."""
@@ -1556,26 +1338,18 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(24, hsp.hit_start)
         self.assertEqual(300, hsp.query_end)
         self.assertEqual(119, hsp.hit_end)
-        self.assertEqual(
-            "LRRSFALVAQAGVQWLDLGppqpppPGFK*FSCLSHPSSW", hsp.query.seq[:40]
-        )
+        self.assertEqual("LRRSFALVAQAGVQWLDLGppqpppPGFK*FSCLSHPSSW", hsp.query.seq[:40])
         self.assertEqual(
             "LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:]
-        )
+        self.assertEqual("LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", hsp.hit.seq[:40])
+        self.assertEqual("VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:])
         self.assertEqual(
             "VE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "VEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("VEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP", hsp.hit.seq[-40:])
         # second qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(72, hsp.aln_span)
@@ -1593,26 +1367,18 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(31, hsp.hit_start)
         self.assertEqual(459, hsp.query_end)
         self.assertEqual(98, hsp.hit_end)
-        self.assertEqual(
-            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", hsp.query.seq[:40]
-        )
+        self.assertEqual("VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", hsp.query.seq[:40])
         self.assertEqual(
             "V   RVQ ++L S QPP P FK FS LSL SSW+ R  PP",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", hsp.query.seq[-40:]
-        )
+        self.assertEqual("VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", hsp.hit.seq[:40])
+        self.assertEqual("WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", hsp.query.seq[-40:])
         self.assertEqual(
             "W+ R  PPH AN     F F +   F  V QAG++ +  G",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "WEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("WEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG", hsp.hit.seq[-40:])
         # second qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|374093214|ref|NP_001243358.1|", hit.id)
@@ -1638,26 +1404,18 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(29, hsp.hit_start)
         self.assertEqual(279, hsp.query_end)
         self.assertEqual(117, hsp.hit_end)
-        self.assertEqual(
-            "VAQAGVQWLDLGppqpppPGFK*FSCLSHPSSWDYRHMPP", hsp.query.seq[:40]
-        )
+        self.assertEqual("VAQAGVQWLDLGppqpppPGFK*FSCLSHPSSWDYRHMPP", hsp.query.seq[:40])
         self.assertEqual(
             "++ AGVQW +LG PQPP P FK FSCLS PSSWDYRH+PP",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:]
-        )
+        self.assertEqual("ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", hsp.hit.seq[:40])
+        self.assertEqual("VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:])
         self.assertEqual(
             "VET F +VGQAGLE P SG+LP  ASQS  ITGVSH A P",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "VETKFPYVGQAGLELPTSGDLPTSASQSAKITGVSHRAWP", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("VETKFPYVGQAGLELPTSGDLPTSASQSAKITGVSHRAWP", hsp.hit.seq[-40:])
         # second qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(69, hsp.aln_span)
@@ -1675,26 +1433,18 @@ class BlastxCases(BaseBlastCases):
         self.assertEqual(27, hsp.hit_start)
         self.assertEqual(465, hsp.query_end)
         self.assertEqual(91, hsp.hit_end)
-        self.assertEqual(
-            "VSVGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCP", hsp.query.seq[:40]
-        )
+        self.assertEqual("VSVGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCP", hsp.query.seq[:40])
         self.assertEqual(
             "+++  A VQ  +L S QPP+PEFK FS LSL SSWD R  ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", hsp.query.seq[-40:]
-        )
+        self.assertEqual("LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", hsp.hit.seq[:40])
+        self.assertEqual("SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", hsp.query.seq[-40:])
         self.assertEqual(
             "SL SSWD R  PP  AN     F F +   F  V QAG++",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "SLPSSWDYRHVPPRLAN-----FVFLVETKFPYVGQAGLE", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("SLPSSWDYRHVPPRLAN-----FVFLVETKFPYVGQAGLE", hsp.hit.seq[-40:])
 
 
 class TblastnCases(BaseBlastCases):
@@ -1760,26 +1510,18 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(1743, hsp.hit_start)
         self.assertEqual(73, hsp.query_end)
         self.assertEqual(1872, hsp.hit_end)
-        self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTS", hsp.query.seq[:40]
-        )
+        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTS", hsp.query.seq[:40])
         self.assertEqual(
             "P +   TK+GT +GL   HTI   + +  +SL++ E++  ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq[-40:]
-        )
+        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", hsp.hit.seq[:40])
+        self.assertEqual("NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq[-40:])
         self.assertEqual(
             "   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "ATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("ATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq[-40:])
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|XM_003382561.1|", hit.id)
@@ -1806,26 +1548,18 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(1105, hsp.hit_start)
         self.assertEqual(94, hsp.query_end)
         self.assertEqual(1318, hsp.hit_end)
-        self.assertEqual(
-            "VSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEES", hsp.query.seq[:40]
-        )
+        self.assertEqual("VSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEES", hsp.query.seq[:40])
         self.assertEqual(
             "+  DS +   +G   GL D H + + + + P S+D  +E ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "IGNDSYLALSKG---GLVDEHVLILPIGHYPSSIDAPQEV", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "DITEESTSDLDK--------FNSGDKVTITYEKNDEGQLL", hsp.query.seq[-40:]
-        )
+        self.assertEqual("IGNDSYLALSKG---GLVDEHVLILPIGHYPSSIDAPQEV", hsp.hit.seq[:40])
+        self.assertEqual("DITEESTSDLDK--------FNSGDKVTITYEKNDEGQLL", hsp.query.seq[-40:])
         self.assertEqual(
             "D  +E   ++DK        F+S ++  + +E+N   Q L",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "DAPQEVIEEIDKFKVALRKYFSSKNQTCVMFERNFRSQHL", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("DAPQEVIEEIDKFKVALRKYFSSKNQTCVMFERNFRSQHL", hsp.hit.seq[-40:])
 
     def test_text_2226_tblastn_003(self):
         """Test parsing tblastn output (text_2226_tblastn_003.txt)."""
@@ -1869,26 +1603,18 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(75, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(369, hsp.hit_end)
-        self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
-        )
+        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
+        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:])
         # first qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(100, hsp.aln_span)
@@ -1906,26 +1632,18 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(801, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(1101, hsp.hit_end)
-        self.assertEqual(
-            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40])
+        self.assertEqual("GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
         self.assertEqual(
             "GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("GKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA", hsp.hit.seq[-40:])
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|XM_003360601.2|", hit.id)
@@ -1952,26 +1670,18 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(94, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(388, hsp.hit_end)
-        self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
-        )
+        self.assertEqual("KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
+        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
         self.assertEqual(
             "FGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "FGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("FGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", hsp.hit.seq[-40:])
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(71, hsp.aln_span)
@@ -1989,26 +1699,18 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(541, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(754, hsp.hit_end)
-        self.assertEqual(
-            "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK-", hsp.query.seq[:40]
-        )
+        self.assertEqual("IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK-", hsp.query.seq[:40])
         self.assertEqual(
             "+ +Y       P G I L+G  +TS      GK  F+ + ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", hsp.hit.seq[:40])
+        self.assertEqual("GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
         self.assertEqual(
             "GK  F+ +     T  +  +F QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "GKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("GKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", hsp.hit.seq[-40:])
 
     def test_text_2226_tblastn_004(self):
         """Test parsing tblastn output (text_2226_tblastn_004.txt)."""
@@ -2065,26 +1767,18 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(1743, hsp.hit_start)
         self.assertEqual(73, hsp.query_end)
         self.assertEqual(1872, hsp.hit_end)
-        self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTS", hsp.query.seq[:40]
-        )
+        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTS", hsp.query.seq[:40])
         self.assertEqual(
             "P +   TK+GT +GL   HTI   + +  +SL++ E++  ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq[-40:]
-        )
+        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", hsp.hit.seq[:40])
+        self.assertEqual("NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq[-40:])
         self.assertEqual(
             "   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "ATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("ATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq[-40:])
         # second qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|72012412|ref|XM_777959.1|", hit.id)
@@ -2111,26 +1805,18 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(1056, hsp.hit_start)
         self.assertEqual(94, hsp.query_end)
         self.assertEqual(1233, hsp.hit_end)
-        self.assertEqual(
-            "GLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSG-----", hsp.query.seq[:40]
-        )
+        self.assertEqual("GLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSG-----", hsp.query.seq[:40])
         self.assertEqual(
             "GL   HT+ + V +    LD+TEE  ++LD+F S      ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYY", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "DITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL", hsp.query.seq[-40:]
-        )
+        self.assertEqual("GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYY", hsp.hit.seq[:40])
+        self.assertEqual("DITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL", hsp.query.seq[-40:])
         self.assertEqual(
             "D+TEE  ++LD+F S          K  + YE+N   Q L",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "DLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("DLTEEVQTELDQFKSALRKYYLSKGKTCVIYERNFRTQHL", hsp.hit.seq[-40:])
 
         # test third qresult
         qresult = qresults[2]
@@ -2167,26 +1853,18 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(94, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(388, hsp.hit_end)
-        self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
-        )
+        self.assertEqual("KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
+        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
         self.assertEqual(
             "FGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "FGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("FGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK", hsp.hit.seq[-40:])
         # third qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(71, hsp.aln_span)
@@ -2204,26 +1882,18 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(541, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(754, hsp.hit_end)
-        self.assertEqual(
-            "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK-", hsp.query.seq[:40]
-        )
+        self.assertEqual("IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK-", hsp.query.seq[:40])
         self.assertEqual(
             "+ +Y       P G I L+G  +TS      GK  F+ + ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", hsp.hit.seq[:40])
+        self.assertEqual("GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
         self.assertEqual(
             "GK  F+ +     T  +  +F QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "GKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("GKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA", hsp.hit.seq[-40:])
         # third qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|301779869|ref|XM_002925302.1|", hit.id)
@@ -2250,26 +1920,18 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(77, hsp.hit_start)
         self.assertEqual(98, hsp.query_end)
         self.assertEqual(371, hsp.hit_end)
-        self.assertEqual(
-            "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "KRIREGYLVK+GSVFNTWKPMWVVLLEDGIEFYKKKSDNS",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "KRIREGYLVKRGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
-        )
+        self.assertEqual("KRIREGYLVKRGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
+        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
         self.assertEqual(
             "FGKRMFV KITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "FGKRMFVFKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("FGKRMFVFKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.hit.seq[-40:])
         # third qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(100, hsp.aln_span)
@@ -2287,26 +1949,18 @@ class TblastnCases(BaseBlastCases):
         self.assertEqual(803, hsp.hit_start)
         self.assertEqual(96, hsp.query_end)
         self.assertEqual(1103, hsp.hit_end)
-        self.assertEqual(
-            "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40]
-        )
+        self.assertEqual("IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNS", hsp.query.seq[:40])
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       ",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "QDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40])
+        self.assertEqual("QDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
         self.assertEqual(
             "    +   + +I T  +  +F QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "VRKSEEENLFEIITADEVHYFLQAATPKERTEWIKAIQVA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("VRKSEEENLFEIITADEVHYFLQAATPKERTEWIKAIQVA", hsp.hit.seq[-40:])
 
 
 class TblastxCases(BaseBlastCases):
@@ -2372,26 +2026,18 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(489, hsp.query_end)
         self.assertEqual(489, hsp.hit_end)
-        self.assertEqual(
-            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.query.seq[:40]
-        )
+        self.assertEqual("EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.query.seq[:40])
         self.assertEqual(
             "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.query.seq[-40:]
-        )
+        self.assertEqual("EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.hit.seq[:40])
+        self.assertEqual("TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.query.seq[-40:])
         self.assertEqual(
             "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.hit.seq[-40:])
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|XR_141831.1|", hit.id)
@@ -2418,26 +2064,18 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(81, hsp.hit_start)
         self.assertEqual(489, hsp.query_end)
         self.assertEqual(570, hsp.hit_end)
-        self.assertEqual(
-            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.query.seq[:40]
-        )
+        self.assertEqual("EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.query.seq[:40])
         self.assertEqual(
             "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.query.seq[-40:]
-        )
+        self.assertEqual("EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.hit.seq[:40])
+        self.assertEqual("TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.query.seq[-40:])
         self.assertEqual(
             "TQREPPLSPVPTAPMP*SWRRWNQL RSPRT*KPCRRS*N",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "TQREPPLSPVPTAPMP*SWRRWNQLQRSPRT*KPCRRS*N", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("TQREPPLSPVPTAPMP*SWRRWNQLQRSPRT*KPCRRS*N", hsp.hit.seq[-40:])
 
     def test_text_2226_tblastx_003(self):
         """Test parsing tblastx output (text_2226_tblastx_003.txt)."""
@@ -2483,26 +2121,18 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(622, hsp.hit_start)
         self.assertEqual(459, hsp.query_end)
         self.assertEqual(943, hsp.hit_end)
-        self.assertEqual(
-            "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", hsp.query.seq[:40]
-        )
+        self.assertEqual("VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPP", hsp.query.seq[:40])
         self.assertEqual(
             "V  A V+ H+LSSLQPP P FK FS LSL SSWD R  PP",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "VTQAGVKWHNLSSLQPPPPGFKQFSCLSLPSSWDYRRGPP", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "WLDLGppqpppPGFK*FSCLSHPSSWDYRHMPPCLINFVF", hsp.query.seq[-40:]
-        )
+        self.assertEqual("VTQAGVKWHNLSSLQPPPPGFKQFSCLSLPSSWDYRRGPP", hsp.hit.seq[:40])
+        self.assertEqual("WLDLGppqpppPGFK*FSCLSHPSSWDYRHMPPCLINFVF", hsp.query.seq[-40:])
         self.assertEqual(
             "W DLG  Q PPPGF  FSCLS PSSWDYR   P   NF++",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "WRDLGSLQAPPPGFTPFSCLSLPSSWDYRRPLPRPANFLY", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("WRDLGSLQAPPPGFTPFSCLSLPSSWDYRRPLPRPANFLY", hsp.hit.seq[-40:])
         # first qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(44, hsp.aln_span)
@@ -2520,26 +2150,18 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(498, hsp.hit_start)
         self.assertEqual(148, hsp.query_end)
         self.assertEqual(630, hsp.hit_end)
-        self.assertEqual(
-            "FCIFSRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEP", hsp.query.seq[:40]
-        )
+        self.assertEqual("FCIFSRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEP", hsp.query.seq[:40])
         self.assertEqual(
             "FCIFSRDGV  CW GWSRTPDL+*S  LGLPKCWDYR EP",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "FCIFSRDGVSSCWPGWSRTPDLK*STHLGLPKCWDYRREP", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("FCIFSRDGVSSCWPGWSRTPDLK*STHLGLPKCWDYRREP", hsp.hit.seq[:40])
+        self.assertEqual("SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", hsp.query.seq[-40:])
         self.assertEqual(
             "SRDGV  CW GWSRTPDL+*S  LGLPKCWDYR EPPRPA",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "SRDGVSSCWPGWSRTPDLK*STHLGLPKCWDYRREPPRPA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("SRDGVSSCWPGWSRTPDLK*STHLGLPKCWDYRREPPRPA", hsp.hit.seq[-40:])
         # first qresult, second hit
         hit = qresult[1]
         self.assertEqual("ref|XM_003255417.1|", hit.id)
@@ -2566,26 +2188,18 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(2744, hsp.hit_start)
         self.assertEqual(298, hsp.query_end)
         self.assertEqual(3026, hsp.hit_end)
-        self.assertEqual(
-            "ETEFRSCCPGWSAMA*SWPTTASTSWIQVILLPQSPE*LG", hsp.query.seq[:40]
-        )
+        self.assertEqual("ETEFRSCCPGWSAMA*SWPTTASTSWIQVILLPQSPE*LG", hsp.query.seq[:40])
         self.assertEqual(
             "E EFRSCCPGWSAMA SW    S SW+QVIL PQ PE*LG",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "EMEFRSCCPGWSAMAQSWLIATSVSWVQVILWPQPPE*LG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", hsp.query.seq[-40:]
-        )
+        self.assertEqual("EMEFRSCCPGWSAMAQSWLIATSVSWVQVILWPQPPE*LG", hsp.hit.seq[:40])
+        self.assertEqual("SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", hsp.query.seq[-40:])
         self.assertEqual(
             "SRDGV PCWSGWSRTPDLR*SACLGLPKCWDYR EPP PA",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "SRDGVSPCWSGWSRTPDLR*SACLGLPKCWDYRREPPCPA", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("SRDGVSPCWSGWSRTPDLR*SACLGLPKCWDYRREPPCPA", hsp.hit.seq[-40:])
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(94, hsp.aln_span)
@@ -2603,26 +2217,18 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(2745, hsp.hit_start)
         self.assertEqual(299, hsp.query_end)
         self.assertEqual(3027, hsp.hit_end)
-        self.assertEqual(
-            "AGRGGSHL*SQHFGRPRQADYLRSGVRDQPDQHGKTPSLL", hsp.query.seq[:40]
-        )
+        self.assertEqual("AGRGGSHL*SQHFGRPRQADYLRSGVRDQPDQHGKTPSLL", hsp.query.seq[:40])
         self.assertEqual(
             "AG GGS L*SQHFGRPRQAD+LRSGVRDQPDQHG+TPSLL",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "AGHGGSRL*SQHFGRPRQADHLRSGVRDQPDQHGETPSLL", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "PSYSGD*GRRIT*IQEVEAVVGQDQAIALQPGQQERNSVS", hsp.query.seq[-40:]
-        )
+        self.assertEqual("AGHGGSRL*SQHFGRPRQADHLRSGVRDQPDQHGETPSLL", hsp.hit.seq[:40])
+        self.assertEqual("PSYSGD*GRRIT*IQEVEAVVGQDQAIALQPGQQERNSVS", hsp.query.seq[-40:])
         self.assertEqual(
             "PSYSG *G+RIT* QE E  + QD AIALQPGQQERNS+S",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "PSYSGG*GQRIT*TQETEVAMSQDCAIALQPGQQERNSIS", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("PSYSGG*GQRIT*TQETEVAMSQDCAIALQPGQQERNSIS", hsp.hit.seq[-40:])
 
     def test_text_2226_tblastx_004(self):
         """Test parsing tblastx output (text_2226_tblastx_004.txt)."""
@@ -2679,26 +2285,18 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(1, hsp.hit_start)
         self.assertEqual(349, hsp.query_end)
         self.assertEqual(349, hsp.hit_end)
-        self.assertEqual(
-            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", hsp.query.seq[:40]
-        )
+        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", hsp.query.seq[:40])
         self.assertEqual(
             "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", hsp.query.seq[-40:]
-        )
+        self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", hsp.hit.seq[:40])
+        self.assertEqual("WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", hsp.query.seq[-40:])
         self.assertEqual(
             "WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", hsp.hit.seq[-40:])
         # second qresult, first hit, second hsp
         hsp = qresult[0].hsps[1]
         self.assertEqual(116, hsp.aln_span)
@@ -2716,26 +2314,18 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(1, hsp.hit_start)
         self.assertEqual(349, hsp.query_end)
         self.assertEqual(349, hsp.hit_end)
-        self.assertEqual(
-            "LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", hsp.query.seq[:40]
-        )
+        self.assertEqual("LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", hsp.query.seq[:40])
         self.assertEqual(
             "LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", hsp.query.seq[-40:]
-        )
+        self.assertEqual("LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", hsp.hit.seq[:40])
+        self.assertEqual("WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", hsp.query.seq[-40:])
         self.assertEqual(
             "WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", hsp.hit.seq[-40:])
         # second qresult, second hit
         hit = qresult[1]
         self.assertEqual("gi|365982352|ref|XM_003667962.1|", hit.id)
@@ -2762,26 +2352,18 @@ class TblastxCases(BaseBlastCases):
         self.assertEqual(87, hsp.hit_start)
         self.assertEqual(348, hsp.query_end)
         self.assertEqual(342, hsp.hit_end)
-        self.assertEqual(
-            "TIRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRN", hsp.query.seq[:40]
-        )
+        self.assertEqual("TIRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRN", hsp.query.seq[:40])
         self.assertEqual(
             "TI+HASDKSI+ILK + + EEL RHPDF  P VLAC SRN",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "TIKHASDKSIDILKTIQNIEELVRHPDFVTPLVLACSSRN", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "LAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK", hsp.query.seq[-40:]
-        )
+        self.assertEqual("TIKHASDKSIDILKTIQNIEELVRHPDFVTPLVLACSSRN", hsp.hit.seq[:40])
+        self.assertEqual("LAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK", hsp.query.seq[-40:])
         self.assertEqual(
             "+AMQCLQGL++VPSIP SR+ E+LD FIEAT LAMEIQLK",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual(
-            "IAMQCLQGLASVPSIPESRIPEVLDGFIEATQLAMEIQLK", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("IAMQCLQGLASVPSIPESRIPEVLDGFIEATQLAMEIQLK", hsp.hit.seq[-40:])
         # second qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(14, hsp.aln_span)

--- a/Tests/test_SearchIO_blast_text.py
+++ b/Tests/test_SearchIO_blast_text.py
@@ -110,7 +110,9 @@ class BlastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40])
-        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
@@ -148,7 +150,9 @@ class BlastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40])
-        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
@@ -206,7 +210,9 @@ class BlastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40])
-        self.assertEqual("AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:])
+        self.assertEqual(
+            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
@@ -249,7 +255,9 @@ class BlastnCases(BaseBlastCases):
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
         )
-        self.assertEqual("AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:])
+        self.assertEqual(
+            "AACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA", hsp.hit.seq[-40:]
+        )
         # first qresult, second hit, second hsp
         hsp = qresult[1].hsps[1]
         self.assertEqual(53, hsp.aln_span)
@@ -273,7 +281,9 @@ class BlastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.hit.seq[:40])
-        self.assertEqual("GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", hsp.query.seq[-40:])
+        self.assertEqual(
+            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
@@ -341,7 +351,9 @@ class BlastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40])
-        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
@@ -379,7 +391,9 @@ class BlastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGG", hsp.hit.seq[:40])
-        self.assertEqual("AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "AGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
@@ -430,7 +444,9 @@ class BlastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40])
-        self.assertEqual("AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:])
+        self.assertEqual(
+            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
@@ -459,7 +475,9 @@ class BlastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGT", hsp.hit.seq[:40])
-        self.assertEqual("GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", hsp.query.seq[-40:])
+        self.assertEqual(
+            "GCCTGGGCAACAAGAGCGAAACTCCGTCTCaaaaaaaaaa", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
@@ -497,7 +515,9 @@ class BlastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCG", hsp.hit.seq[:40])
-        self.assertEqual("AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:])
+        self.assertEqual(
+            "AACAAGAGCGAAACTCCGTCTCaaaaaaaaaaaaaaaaaa", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp.aln_annotation["similarity"][-40:],
@@ -568,19 +588,13 @@ class BlastpCases(BaseBlastCases):
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(102, hsp.query_end)
         self.assertEqual(102, hsp.hit_end)
-        self.assertEqual(
-            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.query.seq[:40]
-        )
+        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.query.seq[:40])
         self.assertEqual(
             "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG",
             hsp.aln_annotation["similarity"][:40],
         )
-        self.assertEqual(
-            "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:]
-        )
+        self.assertEqual("MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEG", hsp.hit.seq[:40])
+        self.assertEqual("DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:])
         self.assertEqual(
             "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
             hsp.aln_annotation["similarity"][-40:],
@@ -618,7 +632,9 @@ class BlastpCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", hsp.hit.seq[:40])
-        self.assertEqual("DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:])
+        self.assertEqual(
+            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN",
             hsp.aln_annotation["similarity"][-40:],
@@ -670,7 +686,9 @@ class BlastpCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
@@ -699,7 +717,9 @@ class BlastpCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40])
-        self.assertEqual("FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
@@ -736,7 +756,9 @@ class BlastpCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
@@ -765,7 +787,9 @@ class BlastpCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40])
-        self.assertEqual("GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
@@ -833,7 +857,9 @@ class BlastpCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEG", hsp.hit.seq[:40])
-        self.assertEqual("DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:])
+        self.assertEqual(
+            "DITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN",
             hsp.aln_annotation["similarity"][-40:],
@@ -871,7 +897,9 @@ class BlastpCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("MKKTIAASFLILLFSVVLAACGTAEQSKKGSG-SSENQAQ", hsp.hit.seq[:40])
-        self.assertEqual("LDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "LDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             " + +++ +  L+KF+  DKV+ITY  ND+GQ  +K+IE+A",
             hsp.aln_annotation["similarity"][-40:],
@@ -916,7 +944,9 @@ class BlastpCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
@@ -945,7 +975,9 @@ class BlastpCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40])
-        self.assertEqual("FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "FGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
@@ -982,7 +1014,9 @@ class BlastpCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
@@ -1011,7 +1045,9 @@ class BlastpCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40])
-        self.assertEqual("GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
@@ -1088,7 +1124,9 @@ class BlastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", hsp.hit.seq[:40])
-        self.assertEqual("NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.query.seq[-40:])
+        self.assertEqual(
+            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE",
             hsp.aln_annotation["similarity"][-40:],
@@ -1123,7 +1161,9 @@ class BlastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("MAGHLASDFAFSPPPGGGDGSAGLEPGWVDPRTWLSFQGP", hsp.hit.seq[:40])
-        self.assertEqual("NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.query.seq[-40:])
+        self.assertEqual(
+            "NSEGTSSEPCADRPNAVKLEKVEPTPEESQDMKALQKELE", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "NSEG SS PC  RP+AVKLEKVEP+PEESQDMKALQKELE",
             hsp.aln_annotation["similarity"][-40:],
@@ -1181,7 +1221,9 @@ class BlastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", hsp.hit.seq[:40])
-        self.assertEqual("VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:])
+        self.assertEqual(
+            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "VE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
             hsp.aln_annotation["similarity"][-40:],
@@ -1210,7 +1252,9 @@ class BlastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", hsp.hit.seq[:40])
-        self.assertEqual("WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", hsp.query.seq[-40:])
+        self.assertEqual(
+            "WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "W+ R  PPH AN     F F +   F  V QAG++ +  G",
             hsp.aln_annotation["similarity"][-40:],
@@ -1247,7 +1291,9 @@ class BlastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", hsp.hit.seq[:40])
-        self.assertEqual("VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:])
+        self.assertEqual(
+            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "VET F +VGQAGLE P SG+LP  ASQS  ITGVSH A P",
             hsp.aln_annotation["similarity"][-40:],
@@ -1276,7 +1322,9 @@ class BlastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", hsp.hit.seq[:40])
-        self.assertEqual("SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", hsp.query.seq[-40:])
+        self.assertEqual(
+            "SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "SL SSWD R  PP  AN     F F +   F  V QAG++",
             hsp.aln_annotation["similarity"][-40:],
@@ -1344,7 +1392,9 @@ class BlastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSW", hsp.hit.seq[:40])
-        self.assertEqual("VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:])
+        self.assertEqual(
+            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "VE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
             hsp.aln_annotation["similarity"][-40:],
@@ -1373,7 +1423,9 @@ class BlastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPP", hsp.hit.seq[:40])
-        self.assertEqual("WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", hsp.query.seq[-40:])
+        self.assertEqual(
+            "WDCRCPPPHPANffffffffFLRRSFALVAQAGVQWLDLG", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "W+ R  PPH AN     F F +   F  V QAG++ +  G",
             hsp.aln_annotation["similarity"][-40:],
@@ -1410,7 +1462,9 @@ class BlastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("ISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHVPP", hsp.hit.seq[:40])
-        self.assertEqual("VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:])
+        self.assertEqual(
+            "VETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "VET F +VGQAGLE P SG+LP  ASQS  ITGVSH A P",
             hsp.aln_annotation["similarity"][-40:],
@@ -1439,7 +1493,9 @@ class BlastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("LTISSAGVQWRNLGSPQPPSPEFKRFSCLSLPSSWDYRHV", hsp.hit.seq[:40])
-        self.assertEqual("SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", hsp.query.seq[-40:])
+        self.assertEqual(
+            "SLQSSWDCRCPPPHPANffffffffFLRRSFALVAQAGVQ", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "SL SSWD R  PP  AN     F F +   F  V QAG++",
             hsp.aln_annotation["similarity"][-40:],
@@ -1516,7 +1572,9 @@ class TblastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", hsp.hit.seq[:40])
-        self.assertEqual("NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq[-40:])
+        self.assertEqual(
+            "NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
             hsp.aln_annotation["similarity"][-40:],
@@ -1554,7 +1612,9 @@ class TblastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("IGNDSYLALSKG---GLVDEHVLILPIGHYPSSIDAPQEV", hsp.hit.seq[:40])
-        self.assertEqual("DITEESTSDLDK--------FNSGDKVTITYEKNDEGQLL", hsp.query.seq[-40:])
+        self.assertEqual(
+            "DITEESTSDLDK--------FNSGDKVTITYEKNDEGQLL", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "D  +E   ++DK        F+S ++  + +E+N   Q L",
             hsp.aln_annotation["similarity"][-40:],
@@ -1609,7 +1669,9 @@ class TblastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
@@ -1638,7 +1700,9 @@ class TblastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40])
-        self.assertEqual("GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
@@ -1676,7 +1740,9 @@ class TblastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "FGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
@@ -1705,7 +1771,9 @@ class TblastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", hsp.hit.seq[:40])
-        self.assertEqual("GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "GK  F+ +     T  +  +F QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
@@ -1773,7 +1841,9 @@ class TblastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*K", hsp.hit.seq[:40])
-        self.assertEqual("NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq[-40:])
+        self.assertEqual(
+            "NIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
             hsp.aln_annotation["similarity"][-40:],
@@ -1811,7 +1881,9 @@ class TblastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("GLVPDHTLILPVGHYQSMLDLTEEVQTELDQFKSALRKYY", hsp.hit.seq[:40])
-        self.assertEqual("DITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL", hsp.query.seq[-40:])
+        self.assertEqual(
+            "DITEESTSDLDKFNSG--------DKVTITYEKNDEGQLL", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "D+TEE  ++LD+F S          K  + YE+N   Q L",
             hsp.aln_annotation["similarity"][-40:],
@@ -1859,7 +1931,9 @@ class TblastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "FGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
@@ -1888,7 +1962,9 @@ class TblastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWER", hsp.hit.seq[:40])
-        self.assertEqual("GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "GKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "GK  F+ +     T  +  +F QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
@@ -1926,7 +2002,9 @@ class TblastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("KRIREGYLVKRGSVFNTWKPMWVVLLEDGIEFYKKKSDNS", hsp.hit.seq[:40])
-        self.assertEqual("FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:])
+        self.assertEqual(
+            "FGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "FGKRMFV KITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
             hsp.aln_annotation["similarity"][-40:],
@@ -1955,7 +2033,9 @@ class TblastnCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGED", hsp.hit.seq[:40])
-        self.assertEqual("QDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "QDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "    +   + +I T  +  +F QAA  +ER  W++ I+ A",
             hsp.aln_annotation["similarity"][-40:],
@@ -2032,7 +2112,9 @@ class TblastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.hit.seq[:40])
-        self.assertEqual("TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.query.seq[-40:])
+        self.assertEqual(
+            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N",
             hsp.aln_annotation["similarity"][-40:],
@@ -2070,7 +2152,9 @@ class TblastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("EVKPSLGEPSFHQAPGSGCPPSPWLDTWLQTSPSHPHQVG", hsp.hit.seq[:40])
-        self.assertEqual("TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.query.seq[-40:])
+        self.assertEqual(
+            "TQREPPLSPVPTAPMP*SWRRWNQLPRSPRT*KPCRRS*N", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "TQREPPLSPVPTAPMP*SWRRWNQL RSPRT*KPCRRS*N",
             hsp.aln_annotation["similarity"][-40:],
@@ -2127,7 +2211,9 @@ class TblastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("VTQAGVKWHNLSSLQPPPPGFKQFSCLSLPSSWDYRRGPP", hsp.hit.seq[:40])
-        self.assertEqual("WLDLGppqpppPGFK*FSCLSHPSSWDYRHMPPCLINFVF", hsp.query.seq[-40:])
+        self.assertEqual(
+            "WLDLGppqpppPGFK*FSCLSHPSSWDYRHMPPCLINFVF", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "W DLG  Q PPPGF  FSCLS PSSWDYR   P   NF++",
             hsp.aln_annotation["similarity"][-40:],
@@ -2156,7 +2242,9 @@ class TblastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("FCIFSRDGVSSCWPGWSRTPDLK*STHLGLPKCWDYRREP", hsp.hit.seq[:40])
-        self.assertEqual("SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "SRDGV  CW GWSRTPDL+*S  LGLPKCWDYR EPPRPA",
             hsp.aln_annotation["similarity"][-40:],
@@ -2194,7 +2282,9 @@ class TblastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("EMEFRSCCPGWSAMAQSWLIATSVSWVQVILWPQPPE*LG", hsp.hit.seq[:40])
-        self.assertEqual("SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", hsp.query.seq[-40:])
+        self.assertEqual(
+            "SRDGVLPCWSGWSRTPDLR*SACLGLPKCWDYRCEPPRPA", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "SRDGV PCWSGWSRTPDLR*SACLGLPKCWDYR EPP PA",
             hsp.aln_annotation["similarity"][-40:],
@@ -2223,7 +2313,9 @@ class TblastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("AGHGGSRL*SQHFGRPRQADHLRSGVRDQPDQHGETPSLL", hsp.hit.seq[:40])
-        self.assertEqual("PSYSGD*GRRIT*IQEVEAVVGQDQAIALQPGQQERNSVS", hsp.query.seq[-40:])
+        self.assertEqual(
+            "PSYSGD*GRRIT*IQEVEAVVGQDQAIALQPGQQERNSVS", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "PSYSG *G+RIT* QE E  + QD AIALQPGQQERNS+S",
             hsp.aln_annotation["similarity"][-40:],
@@ -2291,7 +2383,9 @@ class TblastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINP", hsp.hit.seq[:40])
-        self.assertEqual("WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", hsp.query.seq[-40:])
+        self.assertEqual(
+            "WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "WQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
             hsp.aln_annotation["similarity"][-40:],
@@ -2320,7 +2414,9 @@ class TblastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("LLIESPSRDE*PQ*RHPKFQTAGFEE*MERLTVPVGIALP", hsp.hit.seq[:40])
-        self.assertEqual("WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", hsp.query.seq[-40:])
+        self.assertEqual(
+            "WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "WIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP",
             hsp.aln_annotation["similarity"][-40:],
@@ -2358,7 +2454,9 @@ class TblastxCases(BaseBlastCases):
             hsp.aln_annotation["similarity"][:40],
         )
         self.assertEqual("TIKHASDKSIDILKTIQNIEELVRHPDFVTPLVLACSSRN", hsp.hit.seq[:40])
-        self.assertEqual("LAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK", hsp.query.seq[-40:])
+        self.assertEqual(
+            "LAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK", hsp.query.seq[-40:]
+        )
         self.assertEqual(
             "+AMQCLQGL++VPSIP SR+ E+LD FIEAT LAMEIQLK",
             hsp.aln_annotation["similarity"][-40:],

--- a/Tests/test_SearchIO_blast_xml.py
+++ b/Tests/test_SearchIO_blast_xml.py
@@ -1030,9 +1030,7 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(23, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(42, hsp.aln_span)
-        self.assertEqual(
-            "TQIAICPNNHEVHIYEKSGAKWNKVHELKEHNGQVTGIDWAP", hsp.query.seq
-        )
+        self.assertEqual("TQIAICPNNHEVHIYEKSGAKWNKVHELKEHNGQVTGIDWAP", hsp.query.seq)
         self.assertEqual("TILASCSYDGKVMIWKEENGRWSQIAVHAVHSASVNSVQWAP", hsp.hit.seq)
         self.assertEqual(
             "T +A C  + +V I+++   +W+++     H+  V  + WAP",
@@ -2813,12 +2811,8 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(26, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(43, hsp.aln_span)
-        self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq
-        )
-        self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq
-        )
+        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq)
+        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq)
         self.assertEqual(
             "P +   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
             hsp.aln_annotation["similarity"],
@@ -3043,12 +3037,8 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(26, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(43, hsp.aln_span)
-        self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq
-        )
-        self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq
-        )
+        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq)
+        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq)
         self.assertEqual(
             "P +   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
             hsp.aln_annotation["similarity"],
@@ -3276,12 +3266,8 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(26, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(43, hsp.aln_span)
-        self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq
-        )
-        self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq
-        )
+        self.assertEqual("PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq)
+        self.assertEqual("PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq)
         self.assertEqual(
             "P +   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
             hsp.aln_annotation["similarity"],

--- a/Tests/test_SearchIO_blast_xml.py
+++ b/Tests/test_SearchIO_blast_xml.py
@@ -87,8 +87,8 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(19, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(19, hsp.aln_span)
-        self.assertEqual("CAGGCCAGCGACTTCTGGG", str(hsp.query.seq))
-        self.assertEqual("CAGGCCAGCGACTTCTGGG", str(hsp.hit.seq))
+        self.assertEqual("CAGGCCAGCGACTTCTGGG", hsp.query.seq)
+        self.assertEqual("CAGGCCAGCGACTTCTGGG", hsp.hit.seq)
         self.assertEqual("|||||||||||||||||||", hsp.aln_annotation["similarity"])
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
@@ -117,8 +117,8 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(20, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(21, hsp.aln_span)
-        self.assertEqual("TGAAAGGAAATNAAAATGGAA", str(hsp.query.seq))
-        self.assertEqual("TGAAAGGAAATCAAAATGGAA", str(hsp.hit.seq))
+        self.assertEqual("TGAAAGGAAATNAAAATGGAA", hsp.query.seq)
+        self.assertEqual("TGAAAGGAAATCAAAATGGAA", hsp.hit.seq)
         self.assertEqual("||||||||||| |||||||||", hsp.aln_annotation["similarity"])
         self.assertRaises(IndexError, hit.__getitem__, 1)
 
@@ -210,11 +210,11 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(490, hsp.aln_span)
         self.assertEqual(
             "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
@@ -264,11 +264,11 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(62, hsp.aln_span)
         self.assertEqual(
             "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
@@ -290,10 +290,10 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(53, hsp.aln_span)
         self.assertEqual(
-            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.query.seq)
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", hsp.query.seq
         )
         self.assertEqual(
-            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.hit.seq)
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", hsp.hit.seq
         )
         self.assertEqual(
             "|||||||||||||||||||||||||||||||||||||||||||||||||||||",
@@ -327,11 +327,11 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(66, hsp.aln_span)
         self.assertEqual(
             "TCAAGCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "TCACGCCATTGCACTCCAGCCTGGGCAACAAGAGTGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "||| |||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||",
@@ -452,11 +452,11 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(490, hsp.aln_span)
         self.assertEqual(
             "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
@@ -514,11 +514,11 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(62, hsp.aln_span)
         self.assertEqual(
             "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
@@ -540,10 +540,10 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(53, hsp.aln_span)
         self.assertEqual(
-            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.query.seq)
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", hsp.query.seq
         )
         self.assertEqual(
-            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", str(hsp.hit.seq)
+            "CCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAA", hsp.hit.seq
         )
         self.assertEqual(
             "|||||||||||||||||||||||||||||||||||||||||||||||||||||",
@@ -577,11 +577,11 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(66, hsp.aln_span)
         self.assertEqual(
             "TCAAGCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "TCACGCCATTGCACTCCAGCCTGGGCAACAAGAGTGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "||| |||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||",
@@ -677,11 +677,11 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(490, hsp.aln_span)
         self.assertEqual(
             "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "GAGGTGAAACCGTCCCTAGGTGAGCCGTCTTTCCACCAGGCCCCCGGCTCGGGGTGCCCACCTTCCCCATGGCTGGACACCTGGCTTCAGACTTCGCCTTCTCACCCCCACCAGGTGGGGGTGATGGGTCAGCAGGGCTGGAGCCGGGCTGGGTGGATCCTCGAACCTGGCTAAGCTTCCAAGGGCCTCCAGGTGGGCCTGGAATCGGACCAGGCTCAGAGGTATTGGGGATCTCCCCATGTCCGCCCGCATACGAGTTCTGCGGAGGGATGGCATACTGTGGACCTCAGGTTGGACTGGGCCTAGTCCCCCAAGTTGGCGTGGAGACTTTGCAGCCTGAGGGCCAGGCAGGAGCACGAGTGGAAAGCAACTCAGAGGGAACCTCCTCTGAGCCCTGTGCCGACCGCCCCAATGCCGTGAAGTTGGAGAAGGTGGAACCAACTCCCGAGGAGTCCCAGGACATGAAAGCCCTGCAGAAGGAGCTAGAACA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
@@ -732,11 +732,11 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(62, hsp.aln_span)
         self.assertEqual(
             "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "GCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
@@ -769,11 +769,11 @@ class BlastnXmlCases(unittest.TestCase):
         self.assertEqual(66, hsp.aln_span)
         self.assertEqual(
             "TCAAGCCATTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "TCATGCCACTGCACTCCAGCCTGGGCAACAAGAGCGAAACTCCGTCTCAAAAAAAAAAAAAAAAAA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "||| |||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||",
@@ -890,11 +890,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(103, hsp.aln_span)
         self.assertEqual(
             "MRLCLIIIYHRGTCMGGISIWQXXXXXXXXXXXFGTKKLGSIGSDLGASIKGFKKAMSDDEPKQDKTSQDADFTAKTIADKQADTNQEQAKTEDAKRHDKEQV",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "MRLCLIIIYHRGTCMGGISIWQLLIIAVIVVLLFGTKKLGSIGSDLGASIKGFKKAMSDDEPKQDKTSQDADFTAKTIADKQADTNQEQAKTEDAKRHDKEQV",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "MRLCLIIIYHRGTCMGGISIWQLLIIAVIVVLLFGTKKLGSIGSDLGASIKGFKKAMSDDEPKQDKTSQDADFTAKTIADKQADTNQEQAKTEDAKRHDKEQV",
@@ -927,10 +927,10 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(4, hsp.gap_num)
         self.assertEqual(51, hsp.aln_span)
         self.assertEqual(
-            "KAMSDDEPKQD---KTSQDADFTAKTIADKQADTNQEQAKTEDAKRHDKEQ", str(hsp.query.seq)
+            "KAMSDDEPKQD---KTSQDADFTAKTIADKQADTNQEQAKTEDAKRHDKEQ", hsp.query.seq
         )
         self.assertEqual(
-            "KKEADDKAKKDLEAKTKKEADEKAKKEADEKA-KKEAEAKTKEAEAKTKKE", str(hsp.hit.seq)
+            "KKEADDKAKKDLEAKTKKEADEKAKKEADEKA-KKEAEAKTKEAEAKTKKE", hsp.hit.seq
         )
         self.assertEqual(
             "K  +DD+ K+D   KT ++AD  AK  AD++A   + +AKT++A+   K++",
@@ -995,10 +995,10 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(2, hsp.gap_num)
         self.assertEqual(50, hsp.aln_span)
         self.assertEqual(
-            "AWNKDRTQIAICPNNHEVHIYE--KSGAKWNKVHELKEHNGQVTGIDWAP", str(hsp.query.seq)
+            "AWNKDRTQIAICPNNHEVHIYE--KSGAKWNKVHELKEHNGQVTGIDWAP", hsp.query.seq
         )
         self.assertEqual(
-            "AWSNDGYYLATCSRDKSVWIWETDESGEEYECISVLQEHSQDVKHVIWHP", str(hsp.hit.seq)
+            "AWSNDGYYLATCSRDKSVWIWETDESGEEYECISVLQEHSQDVKHVIWHP", hsp.hit.seq
         )
         self.assertEqual(
             "AW+ D   +A C  +  V I+E  +SG ++  +  L+EH+  V  + W P",
@@ -1031,9 +1031,9 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(42, hsp.aln_span)
         self.assertEqual(
-            "TQIAICPNNHEVHIYEKSGAKWNKVHELKEHNGQVTGIDWAP", str(hsp.query.seq)
+            "TQIAICPNNHEVHIYEKSGAKWNKVHELKEHNGQVTGIDWAP", hsp.query.seq
         )
-        self.assertEqual("TILASCSYDGKVMIWKEENGRWSQIAVHAVHSASVNSVQWAP", str(hsp.hit.seq))
+        self.assertEqual("TILASCSYDGKVMIWKEENGRWSQIAVHAVHSASVNSVQWAP", hsp.hit.seq)
         self.assertEqual(
             "T +A C  + +V I+++   +W+++     H+  V  + WAP",
             hsp.aln_annotation["similarity"],
@@ -1197,11 +1197,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(107, hsp.aln_span)
         self.assertEqual(
             "GGHVNPAVTFGAFVGGNITLLRGIVYIIAQLLGSTVACLLLKFVTNDMAVGVFSLSAGVGVTNALVFEIVMTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "GGHVNPAVTFGAFVGGNITLLRGIVYIIAQLLGSTVACLLLKFVTNDMAVGVFSLSAGVGVTNALVFEIVMTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "GGHVNPAVTFGAFVGGNITLLRGIVYIIAQLLGSTVACLLLKFVTNDMAVGVFSLSAGVGVTNALVFEIVMTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI",
@@ -1235,11 +1235,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(107, hsp.aln_span)
         self.assertEqual(
             "GGHVNPAVTFGAFVGGNITLLRGIVYIIAQLLGSTVACLLLKFVTNDMAVGVFSLSAGVGVTNALVFEIVMTFGLVYTVYATAIDPKKGSLGTIAPIAIGFIVGANI",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "GGHVNPAVTFGAFVGGNITLFRGILYIIAQLLGSTVACFLLEFATGGMSTGAFALSAGVSVWNAFVFEIVMTFGLVYTVYATAIDPKKGDLGVIAPIAIGFIVGANI",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "GGHVNPAVTFGAFVGGNITL RGI+YIIAQLLGSTVAC LL+F T  M+ G F+LSAGV V NA VFEIVMTFGLVYTVYATAIDPKKG LG IAPIAIGFIVGANI",
@@ -1334,11 +1334,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(102, hsp.aln_span)
         self.assertEqual(
             "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEGTYVGLADTHTIEVTVDHEPVSFDITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "MKK    LFFILLL+GCGV ++KSQGED      + TKEGTYVGLADTHTIEVTVD+EPVS DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN",
@@ -1382,11 +1382,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.aln_span)
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
@@ -1409,11 +1409,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(100, hsp.aln_span)
         self.assertEqual(
             "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNSPKGMIPLKGSTLTS--PCQDFGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGEDPLGAVHLRGCVVTSVESSHDVKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       P G + L+G  +TS     D  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
@@ -1442,11 +1442,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.aln_span)
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
@@ -1569,11 +1569,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(102, hsp.aln_span)
         self.assertEqual(
             "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "MKKIFGCLFFILLLAGCGVTNEKSQGEDAG--EKLVTKEGTYVGLADTHTIEVTVDHEPVSFDITEESADDVKNLNNGEKVTVKYQKNSKGQLVLKDIEPAN",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "MKK    LFFILLL+GCGV ++KSQGED      + TKEGTYVGLADTHTIEVTVD+EPVS DITEES  D+   N+G+KVT+ Y+KN +GQL+LKDIE AN",
@@ -1645,11 +1645,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.aln_span)
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
@@ -1672,11 +1672,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(100, hsp.aln_span)
         self.assertEqual(
             "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNSPKGMIPLKGSTLTS--PCQDFGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGEDPLGAVHLRGCVVTSVESSHDVKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       P G + L+G  +TS     D  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
@@ -1705,11 +1705,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.aln_span)
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
@@ -1831,11 +1831,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(102, hsp.aln_span)
         self.assertEqual(
             "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "MKKFIALLFFILLLSGCGVNSQKSQGEDVSPDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLDKFNSGDKVTITYEKNDEGQLLLKDIERAN",
@@ -1879,11 +1879,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.aln_span)
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
@@ -1906,11 +1906,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(100, hsp.aln_span)
         self.assertEqual(
             "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNSPKGMIPLKGSTLTS--PCQDFGK--RMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGEDPLGAVHLRGCVVTSVESSHDVKKSDEENLFEIITADEVHYYLQAATSKERTEWIKAIQVA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       P G + L+G  +TS     D  K     + +I T  +  ++ QAA  +ER  W++ I+ A",
@@ -1939,11 +1939,11 @@ class BlastpXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.aln_span)
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
@@ -2012,11 +2012,11 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(133, hsp.aln_span)
         self.assertEqual(
             "DLQLLIKAVNLFPAGTNSRWEVIANYMNIHSSSGVKRTAKDVIGKAKSLQKLDPHQKDDINKKAFDKFKKEHGVVPQADNATPSERFXGPYTDFTPXTTEXQKLXEQALNTYPVNTXERWXXIAVAVPGRXKE",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "DLQLLIKAVNLFPAGTNSRWEVIANYMNIHSSSGVKRTAKDVIGKAKSLQKLDPHQKDDINKKAFDKFKKEHGVVPQADNATPSERFEGPYTDFTPWTTEEQKLLEQALKTYPVNTPERWEKIAEAVPGRTKK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "DLQLLIKAVNLFPAGTNSRWEVIANYMNIHSSSGVKRTAKDVIGKAKSLQKLDPHQKDDINKKAFDKFKKEHGVVPQADNATPSERF GPYTDFTP TTE QKL EQAL TYPVNT ERW  IA AVPGR K+",
@@ -2047,11 +2047,11 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(3, hsp.gap_num)
         self.assertEqual(
             "AGTNSRWEVIANYMNI--HSSSGVKRT-AKDVIGKAKSLQKLDPHQKDDINKKAFDKFKKEHGVVPQ",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "SSSNSSSKASASSSNVGASSSSGTKKSDSKSSNESSKSKRDKEDHKEGSINRSKDEKVSKEHRVVKE",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "+ +NS  +  A+  N+   SSSG K++ +K     +KS +  + H++  IN+   +K  KEH VV +",
@@ -2120,8 +2120,8 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(25, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(26, hsp.aln_span)
-        self.assertEqual("HMLVSKIKPCMCKYEQIQTVKLRMAH", str(hsp.query.seq))
-        self.assertEqual("HMLVSKIKPCMCKYELIRTVKLRMAH", str(hsp.hit.seq))
+        self.assertEqual("HMLVSKIKPCMCKYEQIQTVKLRMAH", hsp.query.seq)
+        self.assertEqual("HMLVSKIKPCMCKYELIRTVKLRMAH", hsp.hit.seq)
         self.assertEqual("HMLVSKIKPCMCKYE I+TVKLRMAH", hsp.aln_annotation["similarity"])
 
     def test_xml_2226_blastx_001(self):
@@ -2206,11 +2206,11 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(95, hsp.aln_span)
         self.assertEqual(
             "LRRSFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLANFLFLVEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW+YRH+PP L NF+FLVE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
@@ -2233,11 +2233,11 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(72, hsp.aln_span)
         self.assertEqual(
             "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPPHPANXXXXXXXXFLRRSFALVAQAGVQWLDLG",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "V   RVQ ++L S QPP P FK FS LSL SSW+ R  PPH AN     F F +   F  V QAG++ +  G",
@@ -2268,11 +2268,11 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(91, hsp.aln_span)
         self.assertEqual(
             "SFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQ",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "SFQESLRAGMQWCDLSSLQPPPPGFKRFSHLSLPNSWNYRHLPSCPTNFCIFVETGFHHVGQACLELLTSGGLLASASQSAGITGVSHHAR",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "SF    +AG+QW DL   QPPPPGFK FS LS P+SW+YRH+P C  NF   VETGF+HVGQA LE   SG L A ASQS GITGVSHHA+",
@@ -2387,11 +2387,11 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(95, hsp.aln_span)
         self.assertEqual(
             "LRRSFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLANFLFLVEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW+YRH+PP L NF+FLVE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
@@ -2414,11 +2414,11 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(72, hsp.aln_span)
         self.assertEqual(
             "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPPHPANXXXXXXXXFLRRSFALVAQAGVQWLDLG",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "V   RVQ ++L S QPP P FK FS LSL SSW+ R  PPH AN     F F +   F  V QAG++ +  G",
@@ -2449,11 +2449,11 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(91, hsp.aln_span)
         self.assertEqual(
             "SFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQ",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "SFQESLRAGMQWCDLSSLQPPPPGFKRFSHLSLPNSWNYRHLPSCPTNFCIFVETGFHHVGQACLELLTSGGLLASASQSAGITGVSHHAR",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "SF    +AG+QW DL   QPPPPGFK FS LS P+SW+YRH+P C  NF   VETGF+HVGQA LE   SG L A ASQS GITGVSHHA+",
@@ -2545,11 +2545,11 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(95, hsp.aln_span)
         self.assertEqual(
             "LRRSFALVAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQP",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "LRRSFALVAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLANFLFLVEMGFLHVGQAGLELVTSGDPPTLTSQSAGIIGVSHCAQP",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "LRRSFALVAQ  VQW +LG PQPPPPGFK FSCLS  SSW+YRH+PP L NF+FLVE GF HVGQAGLE   SG+ P   SQS GI GVSH AQP",
@@ -2572,11 +2572,11 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(72, hsp.aln_span)
         self.assertEqual(
             "VGPARVQ*HDLSSLQPPAPEFK*FSHLSLQSSWDCRCPPPHPANXXXXXXXXFLRRSFALVAQAGVQWLDLG",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "VAQTRVQWYNLGSPQPPPPGFKRFSCLSLLSSWEYRHVPPHLAN-----FLFLVEMGFLHVGQAGLELVTSG",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "V   RVQ ++L S QPP P FK FS LSL SSW+ R  PPH AN     F F +   F  V QAG++ +  G",
@@ -2607,11 +2607,11 @@ class BlastxXmlCases(unittest.TestCase):
         self.assertEqual(91, hsp.aln_span)
         self.assertEqual(
             "VAQAGVQWLDLGXXXXXXPGFK*FSCLSHPSSWDYRHMPPCLINFVFLVETGFYHVGQAGLEPPISGNLPAWASQSVGITGVSHHAQPLCE",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "VPHAGVQWHNLSSLQPPPSRFKPFSYLSLLSSWDQRRPPPCLVTFVFLIETGFRHVGQAGLKLLTSGDPSASASQSAGIRGVSHCTWPECQ",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "V  AGVQW +L   QPPP  FK FS LS  SSWD R  PPCL+ FVFL+ETGF HVGQAGL+   SG+  A ASQS GI GVSH   P C+",
@@ -2680,11 +2680,11 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(252, hsp.aln_span)
         self.assertEqual(
             "LKDKVVVVTGGSKGLGRAMAVRFGQEQSKVVVNYRSNXXXXXXXXXXXXXXXXGGQAIIVRGDVTKEEDVVNLVETAVKEFGSLDVMINNAGVENPVPSH---ELSLENWNQVIDTNLTGAFLGSREAIKYFVENDIKG-NVINMSSVHEMIPWPLFVHYAASKGGMKLMTETLALEYAPKGIRVNNIGPGAIDTPINAEKFADPEQRADVESMIPMGYIGKPEEIASVAAFLASSQASYVTGITLFADGGM",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "LQGKVVAITGCSTGIGRAIAIGAAKNGANVVLHHLGDSTASDIAQVQEECKQAGAKTVVVPGDIAEAKTANEIVSAAVSSFSRIDVLISNAGI---CPFHSFLDLPHPLWKRVQDVNLNGSFYVVQAVANQMAKQEPKGGSIVAVSSISALMGGGEQCHYTPTKAGIKSLMESCAIALGPMGIRCNSVLPGTIETNINKEDLSNPEKRADQIRRVPLGRLGKPEDLVGPTLFFASDLSNYCTGASVLVDGGM",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "L+ KVV +TG S G+GRA+A+   +  + VV+++  +   +   + + E  +AG + ++V GD+ + +    +V  AV  F  +DV+I+NAG+    P H   +L    W +V D NL G+F   +       + + KG +++ +SS+  ++      HY  +K G+K + E+ A+   P GIR N++ PG I+T IN E  ++PE+RAD    +P+G +GKPE++     F AS  ++Y TG ++  DGGM",
@@ -2717,11 +2717,11 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(228, hsp.aln_span)
         self.assertEqual(
             "LKDKVVVVTGGSKGLGRAMAVRFGQEQSKVVVNYRSNXXXXXXXXXXXXXXGGQAIIVRGDVTKEEDVVNLVETAVKEFGSLDVMINNAGV-----------ENPVPS-HELSLE-----NWNQVIDTNLTGAFLGSREAIKYFVENDIKGNVINMSSVHEMIPW-PLFVHYAASKGGMKLMTETLALEYAPKGIRVNNIGPGAIDTPI----------NAEKFADPE",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "LDGKVALVTGAGRGIGAAIAVALGQPGAKVVVNYANSREAAEKVVDEIKSNAQSAISIQADVGDPDAVTKLMDQAVEHFGYLDIVSSNAGIVSFGHVKDVTPDVCVPSPYESPVEL*PQQEFDRVFRVNTRGQFFVAREAYRHLREG---GRIILTSSNTASVKGVPRHAVYSGSKGAIDTFVRCLAIDCGDKKITVNAVAPGAIKTDMFLSVSREYIPNGETFTDEQ",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "L  KV +VTG  +G+G A+AV  GQ  +KVVVNY ++ E A +V  EI+     AI ++ DV   + V  L++ AV+ FG LD++ +NAG+           +  VPS +E  +E      +++V   N  G F  +REA ++  E    G +I  SS    +   P    Y+ SKG +      LA++   K I VN + PGAI T +          N E F D +",
@@ -2814,10 +2814,10 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(43, hsp.aln_span)
         self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq
         )
         self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq
         )
         self.assertEqual(
             "P +   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
@@ -2864,11 +2864,11 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.aln_span)
         self.assertEqual(
             "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
@@ -2891,11 +2891,11 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(71, hsp.aln_span)
         self.assertEqual(
             "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "+ +Y       P G I L+G  +TS      GK  F+ +     T  +  +F QAA  +ER  W++ I+ A",
@@ -2926,10 +2926,10 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(9, hsp.gap_num)
         self.assertEqual(52, hsp.aln_span)
         self.assertEqual(
-            "GSVFNTWKPMWVVLL---------EDGIEFYKKKSDNSPKGMIPLKGSTLTS", str(hsp.query.seq)
+            "GSVFNTWKPMWVVLL---------EDGIEFYKKKSDNSPKGMIPLKGSTLTS", hsp.query.seq
         )
         self.assertEqual(
-            "GSCFPTWDLIFIEVLNPFLKEKLWEADNEEISKFVDLTLKGLVDLYPSHFTS", str(hsp.hit.seq)
+            "GSCFPTWDLIFIEVLNPFLKEKLWEADNEEISKFVDLTLKGLVDLYPSHFTS", hsp.hit.seq
         )
         self.assertEqual(
             "GS F TW  +++ +L         E   E   K  D + KG++ L  S  TS",
@@ -3044,10 +3044,10 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(43, hsp.aln_span)
         self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq
         )
         self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq
         )
         self.assertEqual(
             "P +   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
@@ -3121,11 +3121,11 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.aln_span)
         self.assertEqual(
             "KRIREGYLVKKGSMFNTWKPMWVILLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDGWVRDIKKAIK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGS+FNTWKPMWV+LLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERD WVRDIKKAIK",
@@ -3148,11 +3148,11 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(71, hsp.aln_span)
         self.assertEqual(
             "IEFYKKKSDNSPKGMIPLKGSTLTS-PCQDFGKRMFVLK---ITTTKQQDHFFQAAFLEERDAWVRDIKKA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "LHYYDPAGGEDPLGAIHLRGCVVTSVESNTDGKNGFLWERAXXITADEVHYFLQAANPKERTEWIKAIQVA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "+ +Y       P G I L+G  +TS      GK  F+ +     T  +  +F QAA  +ER  W++ I+ A",
@@ -3183,10 +3183,10 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(9, hsp.gap_num)
         self.assertEqual(52, hsp.aln_span)
         self.assertEqual(
-            "GSVFNTWKPMWVVLL---------EDGIEFYKKKSDNSPKGMIPLKGSTLTS", str(hsp.query.seq)
+            "GSVFNTWKPMWVVLL---------EDGIEFYKKKSDNSPKGMIPLKGSTLTS", hsp.query.seq
         )
         self.assertEqual(
-            "GSCFPTWDLIFIEVLNPFLKEKLWEADNEEISKFVDLTLKGLVDLYPSHFTS", str(hsp.hit.seq)
+            "GSCFPTWDLIFIEVLNPFLKEKLWEADNEEISKFVDLTLKGLVDLYPSHFTS", hsp.hit.seq
         )
         self.assertEqual(
             "GS F TW  +++ +L         E   E   K  D + KG++ L  S  TS",
@@ -3277,10 +3277,10 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(43, hsp.aln_span)
         self.assertEqual(
-            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", str(hsp.query.seq)
+            "PDSNIETKEGTYVGLADTHTIEVTVDNEPVSLDITEESTSDLD", hsp.query.seq
         )
         self.assertEqual(
-            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", str(hsp.hit.seq)
+            "PKTATGTKKGTIIGLLSIHTILFILTSHALSLEVKEQT*KDID", hsp.hit.seq
         )
         self.assertEqual(
             "P +   TK+GT +GL   HTI   + +  +SL++ E++  D+D",
@@ -3327,11 +3327,11 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.aln_span)
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
@@ -3354,11 +3354,11 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(100, hsp.aln_span)
         self.assertEqual(
             "IREGYLVKKGSVFNTWKPMWVVLLEDG--IEFYKKKSDNSPKGMIPLKGSTLTSPCQDF-GKRM---FVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "IKQGCLLKQGHRRKNWKVRKFILREDPAYLHYYDPAGGEDPLGAIHLRGCVVTSVESNHDGKKSDDENLFEIITADEVHYYLQAAAPKERTEWIKAIQVA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "I++G L+K+G     WK    +L ED   + +Y       P G I L+G  +TS   +  GK+     + +I T  +  ++ QAA  +ER  W++ I+ A",
@@ -3389,11 +3389,11 @@ class TblastnXmlCases(unittest.TestCase):
         self.assertEqual(98, hsp.aln_span)
         self.assertEqual(
             "KRIREGYLVKKGSVFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGSMFNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFVFKITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KRIREGYLVKKGS+FNTWKPMWVVLLEDGIEFYKKKSDNSPKGMIPLKGSTLTSPCQDFGKRMFV KITTTKQQDHFFQAAFLEERDAWVRDIKKAIK",
@@ -3466,11 +3466,11 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(118, hsp.aln_span)
         self.assertEqual(
             "ECXFIMLYIFPARIWST*VICPPEQWL*RRKLSSGQKLLRRCGKTGYIKNNAGLK*PMRFCQGILH*CI*SKSGPIQRMWLKAPFWPFLFLLRALHTFPLFLSKWTK*RVS*VEGHSD",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "ECCFIMLYIFPARIWST*VICPPEQWL*RRKLSSGQKLLRRCGKTGYIKNNAGLK*PMRFCQGILH*CI*SKSGPIQRMWLKAPFWPFLFLLRALHTFPLFLSKWTK*RVS*VEGHSD",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "EC FIMLYIFPARIWST*VICPPEQWL*RRKLSSGQKLLRRCGKTGYIKNNAGLK*PMRFCQGILH*CI*SKSGPIQRMWLKAPFWPFLFLLRALHTFPLFLSKWTK*RVS*VEGHSD",
@@ -3500,8 +3500,8 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(19, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(28, hsp.aln_span)
-        self.assertEqual("PLTKAHRLFQTSIVFYVTCFTASSQQLL", str(hsp.query.seq))
-        self.assertEqual("PLNKYHTIFQISLCFYLFCYNMAQKQLL", str(hsp.hit.seq))
+        self.assertEqual("PLTKAHRLFQTSIVFYVTCFTASSQQLL", hsp.query.seq)
+        self.assertEqual("PLNKYHTIFQISLCFYLFCYNMAQKQLL", hsp.hit.seq)
         self.assertEqual(
             "PL K H +FQ S+ FY+ C+  + +QLL", hsp.aln_annotation["similarity"]
         )
@@ -3592,11 +3592,11 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(116, hsp.aln_span)
         self.assertEqual(
             "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
@@ -3617,8 +3617,8 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(9, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(11, hsp.aln_span)
-        self.assertEqual("KFWMPSLRLLI", str(hsp.query.seq))
-        self.assertEqual("KKWVPPVKLLI", str(hsp.hit.seq))
+        self.assertEqual("KFWMPSLRLLI", hsp.query.seq)
+        self.assertEqual("KKWVPPVKLLI", hsp.hit.seq)
         self.assertEqual("K W+P ++LLI", hsp.aln_annotation["similarity"])
 
         hit = qresult[-1]
@@ -3646,11 +3646,11 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(84, hsp.aln_span)
         self.assertEqual(
             "IRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "IRNASDKSIEILKVVHSYEELSRHPDFIVPLVMSCASKNAKLTTISMQCFQKLATVPCIPVDKLSDVLDAFIEANQLAMDIKLK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "IR+ASDKSIEILK VHS+EEL RHPDF +P V++C S+NAK+TT++MQC Q L+TVP IP  +LS++LDAFIEA  LAM+I+LK",
@@ -3766,11 +3766,11 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(116, hsp.aln_span)
         self.assertEqual(
             "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
@@ -3791,8 +3791,8 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(9, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(11, hsp.aln_span)
-        self.assertEqual("KFWMPSLRLLI", str(hsp.query.seq))
-        self.assertEqual("KKWVPPVKLLI", str(hsp.hit.seq))
+        self.assertEqual("KFWMPSLRLLI", hsp.query.seq)
+        self.assertEqual("KKWVPPVKLLI", hsp.hit.seq)
         self.assertEqual("K W+P ++LLI", hsp.aln_annotation["similarity"])
 
         hit = qresult[-1]
@@ -3820,11 +3820,11 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(84, hsp.aln_span)
         self.assertEqual(
             "IRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "IRNASDKSIEILKVVHSYEELSRHPDFIVPLVMSCASKNAKLTTISMQCFQKLATVPCIPVDKLSDVLDAFIEANQLAMDIKLK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "IR+ASDKSIEILK VHS+EEL RHPDF +P V++C S+NAK+TT++MQC Q L+TVP IP  +LS++LDAFIEA  LAM+I+LK",
@@ -3928,11 +3928,11 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(116, hsp.aln_span)
         self.assertEqual(
             "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "WP*TLEGLTPCKGNLKQNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K",
@@ -3953,8 +3953,8 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(14, hsp.pos_num)
         self.assertEqual(0, hsp.gap_num)
         self.assertEqual(14, hsp.aln_span)
-        self.assertEqual("MAMNTGGFDSMQRQ", str(hsp.query.seq))
-        self.assertEqual("MAMNTGGFDSMQRQ", str(hsp.hit.seq))
+        self.assertEqual("MAMNTGGFDSMQRQ", hsp.query.seq)
+        self.assertEqual("MAMNTGGFDSMQRQ", hsp.hit.seq)
         self.assertEqual("MAMNTGGFDSMQRQ", hsp.aln_annotation["similarity"])
 
         hit = qresult[-1]
@@ -3983,11 +3983,11 @@ class TblastxXmlCases(unittest.TestCase):
         self.assertEqual(84, hsp.aln_span)
         self.assertEqual(
             "IRHASDKSIEILKRVHSFEELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "IRNASDKSIEILKVVHSYEELSRHPDFIVPLVMSCASKNAKLTTISMQCFQKLATVPCIPVDKLSDVLDAFIEANQLAMDIKLK",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "IR+ASDKSIEILK VHS+EEL RHPDF +P V++C S+NAK+TT++MQC Q L+TVP IP  +LS++LDAFIEA  LAM+I+LK",

--- a/Tests/test_SearchIO_blat_psl.py
+++ b/Tests/test_SearchIO_blat_psl.py
@@ -1081,90 +1081,90 @@ class BlatPslxCases(BlatPslCases):
         qresult = self.qresults[0]
         # first qresult, first hit, first hsp
         hsp = qresult[0].hsps[0]
-        self.assertEqual("aggtaaactgccttca", str(hsp.query_all[0].seq))
-        self.assertEqual("aggtaaactgccttca", str(hsp.hit_all[0].seq))
+        self.assertEqual("aggtaaactgccttca", hsp.query_all[0].seq)
+        self.assertEqual("aggtaaactgccttca", hsp.hit_all[0].seq)
         # first qresult, second hit, first hsp
         hsp = qresult[1].hsps[0]
-        self.assertEqual("atgagcttccaaggtaaactgccttcaagattc", str(hsp.query_all[0].seq))
-        self.assertEqual("atgagcttccaaggtaaactgccttcaagattc", str(hsp.hit_all[0].seq))
+        self.assertEqual("atgagcttccaaggtaaactgccttcaagattc", hsp.query_all[0].seq)
+        self.assertEqual("atgagcttccaaggtaaactgccttcaagattc", hsp.hit_all[0].seq)
         # first qresult, third hit, first hsp
         hsp = qresult[2].hsps[0]
-        self.assertEqual("aaggcagtttaccttgg", str(hsp.query_all[0].seq))
-        self.assertEqual("aaggcagtttaccttgg", str(hsp.hit_all[0].seq))
+        self.assertEqual("aaggcagtttaccttgg", hsp.query_all[0].seq)
+        self.assertEqual("aaggcagtttaccttgg", hsp.hit_all[0].seq)
 
         # test second qresult
         qresult = self.qresults[1]
         # second qresult, first hit, first hsp
         hsp = qresult[0].hsps[0]
         self.assertEqual(
-            "acaaaggggctgggcgtggtggctcacacctgtaatcccaa", str(hsp.query_all[0].seq)
+            "acaaaggggctgggcgtggtggctcacacctgtaatcccaa", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "acaaaggggctgggcgcagtggctcacgcctgtaatcccaa", str(hsp.hit_all[0].seq)
+            "acaaaggggctgggcgcagtggctcacgcctgtaatcccaa", hsp.hit_all[0].seq
         )
         # second qresult, second hit, first hsp
         hsp = qresult[1].hsps[0]
         self.assertEqual(
-            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", str(hsp.query_all[0].seq)
+            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", str(hsp.hit_all[0].seq)
+            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.hit_all[0].seq
         )
         # second qresult, third hit, first hsp
         hsp = qresult[2].hsps[0]
         self.assertEqual(
-            "aaaggggctgggcgtggtggctcacacctgtaatcc", str(hsp.query_all[0].seq)
+            "aaaggggctgggcgtggtggctcacacctgtaatcc", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "aaaggggctgggcgtggtagctcatgcctgtaatcc", str(hsp.hit_all[0].seq)
+            "aaaggggctgggcgtggtagctcatgcctgtaatcc", hsp.hit_all[0].seq
         )
         # second qresult, third hit, second hsp
         hsp = qresult[2].hsps[1]
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctt", str(hsp.query_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccctt", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "tgggattacaggcgggagccaccacgcccagcccctt", str(hsp.hit_all[0].seq)
+            "tgggattacaggcgggagccaccacgcccagcccctt", hsp.hit_all[0].seq
         )
         # second qresult, fourth hit, first hsp
         hsp = qresult[3].hsps[0]
-        self.assertEqual("aaaaat", str(hsp.query_all[0].seq))
-        self.assertEqual("aaaaat", str(hsp.hit_all[0].seq))
+        self.assertEqual("aaaaat", hsp.query_all[0].seq)
+        self.assertEqual("aaaaat", hsp.hit_all[0].seq)
         self.assertEqual(
-            "aaaggggctgggcgtggtggctcacacctgtaatccca", str(hsp.query_all[1].seq)
+            "aaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[1].seq
         )
         self.assertEqual(
-            "aaaggggctgggcgtggtggctcacgcctgtaatccca", str(hsp.hit_all[1].seq)
+            "aaaggggctgggcgtggtggctcacgcctgtaatccca", hsp.hit_all[1].seq
         )
         # second qresult, fourth hit, second hsp
         hsp = qresult[3].hsps[1]
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccct", str(hsp.query_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccct", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "tgggattacaggcgtgagccaccacgcccagcccct", str(hsp.hit_all[0].seq)
+            "tgggattacaggcgtgagccaccacgcccagcccct", hsp.hit_all[0].seq
         )
         # second qresult, fifth hit, first hsp
         hsp = qresult[4].hsps[0]
-        self.assertEqual("caaaggggctgggcgtggtggctca", str(hsp.query_all[0].seq))
-        self.assertEqual("caaaggggctgggcgtagtggctga", str(hsp.hit_all[0].seq))
-        self.assertEqual("cacctgtaatc", str(hsp.query_all[1].seq))
-        self.assertEqual("cacctgtaatc", str(hsp.hit_all[1].seq))
+        self.assertEqual("caaaggggctgggcgtggtggctca", hsp.query_all[0].seq)
+        self.assertEqual("caaaggggctgggcgtagtggctga", hsp.hit_all[0].seq)
+        self.assertEqual("cacctgtaatc", hsp.query_all[1].seq)
+        self.assertEqual("cacctgtaatc", hsp.hit_all[1].seq)
         # second qresult, fifth hit, second hsp
         hsp = qresult[4].hsps[1]
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", str(hsp.query_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", str(hsp.hit_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.hit_all[0].seq
         )
         # second qresult, fifth hit, third hsp
         hsp = qresult[4].hsps[2]
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", str(hsp.query_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "tgggatgacaggggtgaggcaccacgcccagcccctttg", str(hsp.hit_all[0].seq)
+            "tgggatgacaggggtgaggcaccacgcccagcccctttg", hsp.hit_all[0].seq
         )
 
     def test_pslx_34_002(self, testf="pslx_34_002.pslx"):
@@ -1179,16 +1179,16 @@ class BlatPslxCases(BlatPslCases):
         qresult = self.qresults[0]
         # first qresult, first hit, first hsp
         hsp = qresult[0].hsps[0]
-        self.assertEqual("aggtaaactgccttca", str(hsp.query_all[0].seq))
-        self.assertEqual("aggtaaactgccttca", str(hsp.hit_all[0].seq))
+        self.assertEqual("aggtaaactgccttca", hsp.query_all[0].seq)
+        self.assertEqual("aggtaaactgccttca", hsp.hit_all[0].seq)
         # first qresult, second hit, first hsp
         hsp = qresult[1].hsps[0]
-        self.assertEqual("atgagcttccaaggtaaactgccttcaagattc", str(hsp.query_all[0].seq))
-        self.assertEqual("atgagcttccaaggtaaactgccttcaagattc", str(hsp.hit_all[0].seq))
+        self.assertEqual("atgagcttccaaggtaaactgccttcaagattc", hsp.query_all[0].seq)
+        self.assertEqual("atgagcttccaaggtaaactgccttcaagattc", hsp.hit_all[0].seq)
         # first qresult, third hit, first hsp
         hsp = qresult[2].hsps[0]
-        self.assertEqual("aaggcagtttaccttgg", str(hsp.query_all[0].seq))
-        self.assertEqual("aaggcagtttaccttgg", str(hsp.hit_all[0].seq))
+        self.assertEqual("aaggcagtttaccttgg", hsp.query_all[0].seq)
+        self.assertEqual("aaggcagtttaccttgg", hsp.hit_all[0].seq)
 
     def test_pslx_34_004(self, testf="pslx_34_004.pslx"):
         """Test parsing blat output (pslx_34_004.pslx)."""
@@ -1199,74 +1199,74 @@ class BlatPslxCases(BlatPslCases):
         # first qresult, first hit, first hsp
         hsp = qresult[0].hsps[0]
         self.assertEqual(
-            "acaaaggggctgggcgtggtggctcacacctgtaatcccaa", str(hsp.query_all[0].seq)
+            "acaaaggggctgggcgtggtggctcacacctgtaatcccaa", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "acaaaggggctgggcgcagtggctcacgcctgtaatcccaa", str(hsp.hit_all[0].seq)
+            "acaaaggggctgggcgcagtggctcacgcctgtaatcccaa", hsp.hit_all[0].seq
         )
         # first qresult, second hit, first hsp
         hsp = qresult[1].hsps[0]
         self.assertEqual(
-            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", str(hsp.query_all[0].seq)
+            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", str(hsp.hit_all[0].seq)
+            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.hit_all[0].seq
         )
         # first qresult, third hit, first hsp
         hsp = qresult[2].hsps[0]
         self.assertEqual(
-            "aaaggggctgggcgtggtggctcacacctgtaatcc", str(hsp.query_all[0].seq)
+            "aaaggggctgggcgtggtggctcacacctgtaatcc", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "aaaggggctgggcgtggtagctcatgcctgtaatcc", str(hsp.hit_all[0].seq)
+            "aaaggggctgggcgtggtagctcatgcctgtaatcc", hsp.hit_all[0].seq
         )
         # first qresult, third hit, second hsp
         hsp = qresult[2].hsps[1]
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctt", str(hsp.query_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccctt", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "tgggattacaggcgggagccaccacgcccagcccctt", str(hsp.hit_all[0].seq)
+            "tgggattacaggcgggagccaccacgcccagcccctt", hsp.hit_all[0].seq
         )
         # first qresult, fourth hit, first hsp
         hsp = qresult[3].hsps[0]
-        self.assertEqual("aaaaat", str(hsp.query_all[0].seq))
-        self.assertEqual("aaaaat", str(hsp.hit_all[0].seq))
+        self.assertEqual("aaaaat", hsp.query_all[0].seq)
+        self.assertEqual("aaaaat", hsp.hit_all[0].seq)
         self.assertEqual(
-            "aaaggggctgggcgtggtggctcacacctgtaatccca", str(hsp.query_all[1].seq)
+            "aaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[1].seq
         )
         self.assertEqual(
-            "aaaggggctgggcgtggtggctcacgcctgtaatccca", str(hsp.hit_all[1].seq)
+            "aaaggggctgggcgtggtggctcacgcctgtaatccca", hsp.hit_all[1].seq
         )
         # first qresult, fourth hit, second hsp
         hsp = qresult[3].hsps[1]
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccct", str(hsp.query_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccct", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "tgggattacaggcgtgagccaccacgcccagcccct", str(hsp.hit_all[0].seq)
+            "tgggattacaggcgtgagccaccacgcccagcccct", hsp.hit_all[0].seq
         )
         # first qresult, fifth hit, first hsp
         hsp = qresult[4].hsps[0]
-        self.assertEqual("caaaggggctgggcgtggtggctca", str(hsp.query_all[0].seq))
-        self.assertEqual("caaaggggctgggcgtagtggctga", str(hsp.hit_all[0].seq))
-        self.assertEqual("cacctgtaatc", str(hsp.query_all[1].seq))
-        self.assertEqual("cacctgtaatc", str(hsp.hit_all[1].seq))
+        self.assertEqual("caaaggggctgggcgtggtggctca", hsp.query_all[0].seq)
+        self.assertEqual("caaaggggctgggcgtagtggctga", hsp.hit_all[0].seq)
+        self.assertEqual("cacctgtaatc", hsp.query_all[1].seq)
+        self.assertEqual("cacctgtaatc", hsp.hit_all[1].seq)
         # first qresult, fifth hit, second hsp
         hsp = qresult[4].hsps[1]
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", str(hsp.query_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", str(hsp.hit_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.hit_all[0].seq
         )
         # first qresult, fifth hit, third hsp
         hsp = qresult[4].hsps[2]
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", str(hsp.query_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "tgggatgacaggggtgaggcaccacgcccagcccctttg", str(hsp.hit_all[0].seq)
+            "tgggatgacaggggtgaggcaccacgcccagcccctttg", hsp.hit_all[0].seq
         )
 
     def test_pslx_34_005(self, testf="pslx_34_005.pslx"):
@@ -1277,90 +1277,90 @@ class BlatPslxCases(BlatPslCases):
         qresult = self.qresults[0]
         # first qresult, first hit, first hsp
         hsp = qresult[0].hsps[0]
-        self.assertEqual("aggtaaactgccttca", str(hsp.query_all[0].seq))
-        self.assertEqual("aggtaaactgccttca", str(hsp.hit_all[0].seq))
+        self.assertEqual("aggtaaactgccttca", hsp.query_all[0].seq)
+        self.assertEqual("aggtaaactgccttca", hsp.hit_all[0].seq)
         # first qresult, second hit, first hsp
         hsp = qresult[1].hsps[0]
-        self.assertEqual("atgagcttccaaggtaaactgccttcaagattc", str(hsp.query_all[0].seq))
-        self.assertEqual("atgagcttccaaggtaaactgccttcaagattc", str(hsp.hit_all[0].seq))
+        self.assertEqual("atgagcttccaaggtaaactgccttcaagattc", hsp.query_all[0].seq)
+        self.assertEqual("atgagcttccaaggtaaactgccttcaagattc", hsp.hit_all[0].seq)
         # first qresult, third hit, first hsp
         hsp = qresult[2].hsps[0]
-        self.assertEqual("aaggcagtttaccttgg", str(hsp.query_all[0].seq))
-        self.assertEqual("aaggcagtttaccttgg", str(hsp.hit_all[0].seq))
+        self.assertEqual("aaggcagtttaccttgg", hsp.query_all[0].seq)
+        self.assertEqual("aaggcagtttaccttgg", hsp.hit_all[0].seq)
 
         # test second qresult
         qresult = self.qresults[1]
         # second qresult, first hit, first hsp
         hsp = qresult[0].hsps[0]
         self.assertEqual(
-            "acaaaggggctgggcgtggtggctcacacctgtaatcccaa", str(hsp.query_all[0].seq)
+            "acaaaggggctgggcgtggtggctcacacctgtaatcccaa", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "acaaaggggctgggcgcagtggctcacgcctgtaatcccaa", str(hsp.hit_all[0].seq)
+            "acaaaggggctgggcgcagtggctcacgcctgtaatcccaa", hsp.hit_all[0].seq
         )
         # second qresult, second hit, first hsp
         hsp = qresult[1].hsps[0]
         self.assertEqual(
-            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", str(hsp.query_all[0].seq)
+            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", str(hsp.hit_all[0].seq)
+            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.hit_all[0].seq
         )
         # second qresult, third hit, first hsp
         hsp = qresult[2].hsps[0]
         self.assertEqual(
-            "aaaggggctgggcgtggtggctcacacctgtaatcc", str(hsp.query_all[0].seq)
+            "aaaggggctgggcgtggtggctcacacctgtaatcc", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "aaaggggctgggcgtggtagctcatgcctgtaatcc", str(hsp.hit_all[0].seq)
+            "aaaggggctgggcgtggtagctcatgcctgtaatcc", hsp.hit_all[0].seq
         )
         # second qresult, third hit, second hsp
         hsp = qresult[2].hsps[1]
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctt", str(hsp.query_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccctt", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "tgggattacaggcgggagccaccacgcccagcccctt", str(hsp.hit_all[0].seq)
+            "tgggattacaggcgggagccaccacgcccagcccctt", hsp.hit_all[0].seq
         )
         # second qresult, fourth hit, first hsp
         hsp = qresult[3].hsps[0]
-        self.assertEqual("aaaaat", str(hsp.query_all[0].seq))
-        self.assertEqual("aaaaat", str(hsp.hit_all[0].seq))
+        self.assertEqual("aaaaat", hsp.query_all[0].seq)
+        self.assertEqual("aaaaat", hsp.hit_all[0].seq)
         self.assertEqual(
-            "aaaggggctgggcgtggtggctcacacctgtaatccca", str(hsp.query_all[1].seq)
+            "aaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[1].seq
         )
         self.assertEqual(
-            "aaaggggctgggcgtggtggctcacgcctgtaatccca", str(hsp.hit_all[1].seq)
+            "aaaggggctgggcgtggtggctcacgcctgtaatccca", hsp.hit_all[1].seq
         )
         # second qresult, fourth hit, second hsp
         hsp = qresult[3].hsps[1]
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccct", str(hsp.query_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccct", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "tgggattacaggcgtgagccaccacgcccagcccct", str(hsp.hit_all[0].seq)
+            "tgggattacaggcgtgagccaccacgcccagcccct", hsp.hit_all[0].seq
         )
         # second qresult, fifth hit, first hsp
         hsp = qresult[4].hsps[0]
-        self.assertEqual("caaaggggctgggcgtggtggctca", str(hsp.query_all[0].seq))
-        self.assertEqual("caaaggggctgggcgtagtggctga", str(hsp.hit_all[0].seq))
-        self.assertEqual("cacctgtaatc", str(hsp.query_all[1].seq))
-        self.assertEqual("cacctgtaatc", str(hsp.hit_all[1].seq))
+        self.assertEqual("caaaggggctgggcgtggtggctca", hsp.query_all[0].seq)
+        self.assertEqual("caaaggggctgggcgtagtggctga", hsp.hit_all[0].seq)
+        self.assertEqual("cacctgtaatc", hsp.query_all[1].seq)
+        self.assertEqual("cacctgtaatc", hsp.hit_all[1].seq)
         # second qresult, fifth hit, second hsp
         hsp = qresult[4].hsps[1]
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", str(hsp.query_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", str(hsp.hit_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.hit_all[0].seq
         )
         # second qresult, fifth hit, third hsp
         hsp = qresult[4].hsps[2]
         self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", str(hsp.query_all[0].seq)
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
         )
         self.assertEqual(
-            "tgggatgacaggggtgaggcaccacgcccagcccctttg", str(hsp.hit_all[0].seq)
+            "tgggatgacaggggtgaggcaccacgcccagcccctttg", hsp.hit_all[0].seq
         )
 
     def test_pslx_35_002(self, testf="pslx_35_002.pslx"):
@@ -1372,20 +1372,20 @@ class BlatPslxCases(BlatPslCases):
         hsp = qresult[-1].hsps[0]
 
         self.assertEqual(
-            "MEGQRWLPLEANPEVTNQFLKQLGLHPNWQFVDVY", str(hsp.query_all[0].seq)[:35]
+            "MEGQRWLPLEANPEVTNQFLKQLGLHPNWQFVDVY", hsp.query_all[0].seq[:35]
         )
         self.assertEqual(
-            "ETSAHEGQTEAPSIDEKVDLHFIALVHVDGHLYEL", str(hsp.query_all[0].seq)[-35:]
+            "ETSAHEGQTEAPSIDEKVDLHFIALVHVDGHLYEL", hsp.query_all[0].seq[-35:]
         )
-        self.assertEqual("DAIEVCKKFMERDPDELRFNAIALSAA", str(hsp.query_all[1].seq))
+        self.assertEqual("DAIEVCKKFMERDPDELRFNAIALSAA", hsp.query_all[1].seq)
 
         self.assertEqual(
-            "MESQRWLPLEANPEVTNQFLKQLGLHPNWQCVDVY", str(hsp.hit_all[0].seq)[:35]
+            "MESQRWLPLEANPEVTNQFLKQLGLHPNWQCVDVY", hsp.hit_all[0].seq[:35]
         )
         self.assertEqual(
-            "ETSAHEGQTEAPNIDEKVDLHFIALVHVDGHLYEL", str(hsp.hit_all[0].seq)[-35:]
+            "ETSAHEGQTEAPNIDEKVDLHFIALVHVDGHLYEL", hsp.hit_all[0].seq[-35:]
         )
-        self.assertEqual("DAIEVCKKFMERDPDELRFNAIALSAA", str(hsp.hit_all[1].seq))
+        self.assertEqual("DAIEVCKKFMERDPDELRFNAIALSAA", hsp.hit_all[1].seq)
 
 
 if __name__ == "__main__":

--- a/Tests/test_SearchIO_blat_psl.py
+++ b/Tests/test_SearchIO_blat_psl.py
@@ -1319,9 +1319,7 @@ class BlatPslxCases(BlatPslCases):
         )
         self.assertEqual("DAIEVCKKFMERDPDELRFNAIALSAA", hsp.query_all[1].seq)
 
-        self.assertEqual(
-            "MESQRWLPLEANPEVTNQFLKQLGLHPNWQCVDVY", hsp.hit_all[0].seq[:35]
-        )
+        self.assertEqual("MESQRWLPLEANPEVTNQFLKQLGLHPNWQCVDVY", hsp.hit_all[0].seq[:35])
         self.assertEqual(
             "ETSAHEGQTEAPNIDEKVDLHFIALVHVDGHLYEL", hsp.hit_all[0].seq[-35:]
         )

--- a/Tests/test_SearchIO_blat_psl.py
+++ b/Tests/test_SearchIO_blat_psl.py
@@ -1104,46 +1104,26 @@ class BlatPslxCases(BlatPslCases):
         )
         # second qresult, second hit, first hsp
         hsp = qresult[1].hsps[0]
-        self.assertEqual(
-            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.hit_all[0].seq
-        )
+        self.assertEqual("cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[0].seq)
+        self.assertEqual("cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.hit_all[0].seq)
         # second qresult, third hit, first hsp
         hsp = qresult[2].hsps[0]
-        self.assertEqual(
-            "aaaggggctgggcgtggtggctcacacctgtaatcc", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "aaaggggctgggcgtggtagctcatgcctgtaatcc", hsp.hit_all[0].seq
-        )
+        self.assertEqual("aaaggggctgggcgtggtggctcacacctgtaatcc", hsp.query_all[0].seq)
+        self.assertEqual("aaaggggctgggcgtggtagctcatgcctgtaatcc", hsp.hit_all[0].seq)
         # second qresult, third hit, second hsp
         hsp = qresult[2].hsps[1]
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctt", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "tgggattacaggcgggagccaccacgcccagcccctt", hsp.hit_all[0].seq
-        )
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctt", hsp.query_all[0].seq)
+        self.assertEqual("tgggattacaggcgggagccaccacgcccagcccctt", hsp.hit_all[0].seq)
         # second qresult, fourth hit, first hsp
         hsp = qresult[3].hsps[0]
         self.assertEqual("aaaaat", hsp.query_all[0].seq)
         self.assertEqual("aaaaat", hsp.hit_all[0].seq)
-        self.assertEqual(
-            "aaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[1].seq
-        )
-        self.assertEqual(
-            "aaaggggctgggcgtggtggctcacgcctgtaatccca", hsp.hit_all[1].seq
-        )
+        self.assertEqual("aaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[1].seq)
+        self.assertEqual("aaaggggctgggcgtggtggctcacgcctgtaatccca", hsp.hit_all[1].seq)
         # second qresult, fourth hit, second hsp
         hsp = qresult[3].hsps[1]
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccct", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "tgggattacaggcgtgagccaccacgcccagcccct", hsp.hit_all[0].seq
-        )
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccct", hsp.query_all[0].seq)
+        self.assertEqual("tgggattacaggcgtgagccaccacgcccagcccct", hsp.hit_all[0].seq)
         # second qresult, fifth hit, first hsp
         hsp = qresult[4].hsps[0]
         self.assertEqual("caaaggggctgggcgtggtggctca", hsp.query_all[0].seq)
@@ -1152,20 +1132,12 @@ class BlatPslxCases(BlatPslCases):
         self.assertEqual("cacctgtaatc", hsp.hit_all[1].seq)
         # second qresult, fifth hit, second hsp
         hsp = qresult[4].hsps[1]
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.hit_all[0].seq
-        )
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq)
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.hit_all[0].seq)
         # second qresult, fifth hit, third hsp
         hsp = qresult[4].hsps[2]
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "tgggatgacaggggtgaggcaccacgcccagcccctttg", hsp.hit_all[0].seq
-        )
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq)
+        self.assertEqual("tgggatgacaggggtgaggcaccacgcccagcccctttg", hsp.hit_all[0].seq)
 
     def test_pslx_34_002(self, testf="pslx_34_002.pslx"):
         """Test parsing blat output (pslx_34_002.pslx)."""
@@ -1214,38 +1186,22 @@ class BlatPslxCases(BlatPslCases):
         )
         # first qresult, third hit, first hsp
         hsp = qresult[2].hsps[0]
-        self.assertEqual(
-            "aaaggggctgggcgtggtggctcacacctgtaatcc", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "aaaggggctgggcgtggtagctcatgcctgtaatcc", hsp.hit_all[0].seq
-        )
+        self.assertEqual("aaaggggctgggcgtggtggctcacacctgtaatcc", hsp.query_all[0].seq)
+        self.assertEqual("aaaggggctgggcgtggtagctcatgcctgtaatcc", hsp.hit_all[0].seq)
         # first qresult, third hit, second hsp
         hsp = qresult[2].hsps[1]
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctt", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "tgggattacaggcgggagccaccacgcccagcccctt", hsp.hit_all[0].seq
-        )
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctt", hsp.query_all[0].seq)
+        self.assertEqual("tgggattacaggcgggagccaccacgcccagcccctt", hsp.hit_all[0].seq)
         # first qresult, fourth hit, first hsp
         hsp = qresult[3].hsps[0]
         self.assertEqual("aaaaat", hsp.query_all[0].seq)
         self.assertEqual("aaaaat", hsp.hit_all[0].seq)
-        self.assertEqual(
-            "aaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[1].seq
-        )
-        self.assertEqual(
-            "aaaggggctgggcgtggtggctcacgcctgtaatccca", hsp.hit_all[1].seq
-        )
+        self.assertEqual("aaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[1].seq)
+        self.assertEqual("aaaggggctgggcgtggtggctcacgcctgtaatccca", hsp.hit_all[1].seq)
         # first qresult, fourth hit, second hsp
         hsp = qresult[3].hsps[1]
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccct", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "tgggattacaggcgtgagccaccacgcccagcccct", hsp.hit_all[0].seq
-        )
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccct", hsp.query_all[0].seq)
+        self.assertEqual("tgggattacaggcgtgagccaccacgcccagcccct", hsp.hit_all[0].seq)
         # first qresult, fifth hit, first hsp
         hsp = qresult[4].hsps[0]
         self.assertEqual("caaaggggctgggcgtggtggctca", hsp.query_all[0].seq)
@@ -1254,20 +1210,12 @@ class BlatPslxCases(BlatPslCases):
         self.assertEqual("cacctgtaatc", hsp.hit_all[1].seq)
         # first qresult, fifth hit, second hsp
         hsp = qresult[4].hsps[1]
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.hit_all[0].seq
-        )
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq)
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.hit_all[0].seq)
         # first qresult, fifth hit, third hsp
         hsp = qresult[4].hsps[2]
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "tgggatgacaggggtgaggcaccacgcccagcccctttg", hsp.hit_all[0].seq
-        )
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq)
+        self.assertEqual("tgggatgacaggggtgaggcaccacgcccagcccctttg", hsp.hit_all[0].seq)
 
     def test_pslx_34_005(self, testf="pslx_34_005.pslx"):
         """Test parsing blat output (pslx_34_005.pslx)."""
@@ -1308,38 +1256,22 @@ class BlatPslxCases(BlatPslCases):
         )
         # second qresult, third hit, first hsp
         hsp = qresult[2].hsps[0]
-        self.assertEqual(
-            "aaaggggctgggcgtggtggctcacacctgtaatcc", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "aaaggggctgggcgtggtagctcatgcctgtaatcc", hsp.hit_all[0].seq
-        )
+        self.assertEqual("aaaggggctgggcgtggtggctcacacctgtaatcc", hsp.query_all[0].seq)
+        self.assertEqual("aaaggggctgggcgtggtagctcatgcctgtaatcc", hsp.hit_all[0].seq)
         # second qresult, third hit, second hsp
         hsp = qresult[2].hsps[1]
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctt", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "tgggattacaggcgggagccaccacgcccagcccctt", hsp.hit_all[0].seq
-        )
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctt", hsp.query_all[0].seq)
+        self.assertEqual("tgggattacaggcgggagccaccacgcccagcccctt", hsp.hit_all[0].seq)
         # second qresult, fourth hit, first hsp
         hsp = qresult[3].hsps[0]
         self.assertEqual("aaaaat", hsp.query_all[0].seq)
         self.assertEqual("aaaaat", hsp.hit_all[0].seq)
-        self.assertEqual(
-            "aaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[1].seq
-        )
-        self.assertEqual(
-            "aaaggggctgggcgtggtggctcacgcctgtaatccca", hsp.hit_all[1].seq
-        )
+        self.assertEqual("aaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[1].seq)
+        self.assertEqual("aaaggggctgggcgtggtggctcacgcctgtaatccca", hsp.hit_all[1].seq)
         # second qresult, fourth hit, second hsp
         hsp = qresult[3].hsps[1]
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccct", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "tgggattacaggcgtgagccaccacgcccagcccct", hsp.hit_all[0].seq
-        )
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccct", hsp.query_all[0].seq)
+        self.assertEqual("tgggattacaggcgtgagccaccacgcccagcccct", hsp.hit_all[0].seq)
         # second qresult, fifth hit, first hsp
         hsp = qresult[4].hsps[0]
         self.assertEqual("caaaggggctgggcgtggtggctca", hsp.query_all[0].seq)
@@ -1348,20 +1280,12 @@ class BlatPslxCases(BlatPslCases):
         self.assertEqual("cacctgtaatc", hsp.hit_all[1].seq)
         # second qresult, fifth hit, second hsp
         hsp = qresult[4].hsps[1]
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.hit_all[0].seq
-        )
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq)
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.hit_all[0].seq)
         # second qresult, fifth hit, third hsp
         hsp = qresult[4].hsps[2]
-        self.assertEqual(
-            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
-        )
-        self.assertEqual(
-            "tgggatgacaggggtgaggcaccacgcccagcccctttg", hsp.hit_all[0].seq
-        )
+        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq)
+        self.assertEqual("tgggatgacaggggtgaggcaccacgcccagcccctttg", hsp.hit_all[0].seq)
 
     def test_pslx_35_002(self, testf="pslx_35_002.pslx"):
         """Test parsing blat output (pslx_35_002.pslx)."""
@@ -1371,20 +1295,12 @@ class BlatPslxCases(BlatPslCases):
         qresult = self.qresults[0]
         hsp = qresult[-1].hsps[0]
 
-        self.assertEqual(
-            "MEGQRWLPLEANPEVTNQFLKQLGLHPNWQFVDVY", hsp.query_all[0].seq[:35]
-        )
-        self.assertEqual(
-            "ETSAHEGQTEAPSIDEKVDLHFIALVHVDGHLYEL", hsp.query_all[0].seq[-35:]
-        )
+        self.assertEqual("MEGQRWLPLEANPEVTNQFLKQLGLHPNWQFVDVY", hsp.query_all[0].seq[:35])
+        self.assertEqual("ETSAHEGQTEAPSIDEKVDLHFIALVHVDGHLYEL", hsp.query_all[0].seq[-35:])
         self.assertEqual("DAIEVCKKFMERDPDELRFNAIALSAA", hsp.query_all[1].seq)
 
-        self.assertEqual(
-            "MESQRWLPLEANPEVTNQFLKQLGLHPNWQCVDVY", hsp.hit_all[0].seq[:35]
-        )
-        self.assertEqual(
-            "ETSAHEGQTEAPNIDEKVDLHFIALVHVDGHLYEL", hsp.hit_all[0].seq[-35:]
-        )
+        self.assertEqual("MESQRWLPLEANPEVTNQFLKQLGLHPNWQCVDVY", hsp.hit_all[0].seq[:35])
+        self.assertEqual("ETSAHEGQTEAPNIDEKVDLHFIALVHVDGHLYEL", hsp.hit_all[0].seq[-35:])
         self.assertEqual("DAIEVCKKFMERDPDELRFNAIALSAA", hsp.hit_all[1].seq)
 
 

--- a/Tests/test_SearchIO_blat_psl.py
+++ b/Tests/test_SearchIO_blat_psl.py
@@ -1104,8 +1104,12 @@ class BlatPslxCases(BlatPslCases):
         )
         # second qresult, second hit, first hsp
         hsp = qresult[1].hsps[0]
-        self.assertEqual("cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[0].seq)
-        self.assertEqual("cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.hit_all[0].seq)
+        self.assertEqual(
+            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.query_all[0].seq
+        )
+        self.assertEqual(
+            "cacaaaggggctgggcgtggtggctcacacctgtaatccca", hsp.hit_all[0].seq
+        )
         # second qresult, third hit, first hsp
         hsp = qresult[2].hsps[0]
         self.assertEqual("aaaggggctgggcgtggtggctcacacctgtaatcc", hsp.query_all[0].seq)
@@ -1132,11 +1136,15 @@ class BlatPslxCases(BlatPslCases):
         self.assertEqual("cacctgtaatc", hsp.hit_all[1].seq)
         # second qresult, fifth hit, second hsp
         hsp = qresult[4].hsps[1]
-        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq)
+        self.assertEqual(
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
+        )
         self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.hit_all[0].seq)
         # second qresult, fifth hit, third hsp
         hsp = qresult[4].hsps[2]
-        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq)
+        self.assertEqual(
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
+        )
         self.assertEqual("tgggatgacaggggtgaggcaccacgcccagcccctttg", hsp.hit_all[0].seq)
 
     def test_pslx_34_002(self, testf="pslx_34_002.pslx"):
@@ -1210,11 +1218,15 @@ class BlatPslxCases(BlatPslCases):
         self.assertEqual("cacctgtaatc", hsp.hit_all[1].seq)
         # first qresult, fifth hit, second hsp
         hsp = qresult[4].hsps[1]
-        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq)
+        self.assertEqual(
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
+        )
         self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.hit_all[0].seq)
         # first qresult, fifth hit, third hsp
         hsp = qresult[4].hsps[2]
-        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq)
+        self.assertEqual(
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
+        )
         self.assertEqual("tgggatgacaggggtgaggcaccacgcccagcccctttg", hsp.hit_all[0].seq)
 
     def test_pslx_34_005(self, testf="pslx_34_005.pslx"):
@@ -1280,11 +1292,15 @@ class BlatPslxCases(BlatPslCases):
         self.assertEqual("cacctgtaatc", hsp.hit_all[1].seq)
         # second qresult, fifth hit, second hsp
         hsp = qresult[4].hsps[1]
-        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq)
+        self.assertEqual(
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
+        )
         self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.hit_all[0].seq)
         # second qresult, fifth hit, third hsp
         hsp = qresult[4].hsps[2]
-        self.assertEqual("tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq)
+        self.assertEqual(
+            "tgggattacaggtgtgagccaccacgcccagcccctttg", hsp.query_all[0].seq
+        )
         self.assertEqual("tgggatgacaggggtgaggcaccacgcccagcccctttg", hsp.hit_all[0].seq)
 
     def test_pslx_35_002(self, testf="pslx_35_002.pslx"):
@@ -1295,12 +1311,20 @@ class BlatPslxCases(BlatPslCases):
         qresult = self.qresults[0]
         hsp = qresult[-1].hsps[0]
 
-        self.assertEqual("MEGQRWLPLEANPEVTNQFLKQLGLHPNWQFVDVY", hsp.query_all[0].seq[:35])
-        self.assertEqual("ETSAHEGQTEAPSIDEKVDLHFIALVHVDGHLYEL", hsp.query_all[0].seq[-35:])
+        self.assertEqual(
+            "MEGQRWLPLEANPEVTNQFLKQLGLHPNWQFVDVY", hsp.query_all[0].seq[:35]
+        )
+        self.assertEqual(
+            "ETSAHEGQTEAPSIDEKVDLHFIALVHVDGHLYEL", hsp.query_all[0].seq[-35:]
+        )
         self.assertEqual("DAIEVCKKFMERDPDELRFNAIALSAA", hsp.query_all[1].seq)
 
-        self.assertEqual("MESQRWLPLEANPEVTNQFLKQLGLHPNWQCVDVY", hsp.hit_all[0].seq[:35])
-        self.assertEqual("ETSAHEGQTEAPNIDEKVDLHFIALVHVDGHLYEL", hsp.hit_all[0].seq[-35:])
+        self.assertEqual(
+            "MESQRWLPLEANPEVTNQFLKQLGLHPNWQCVDVY", hsp.hit_all[0].seq[:35]
+        )
+        self.assertEqual(
+            "ETSAHEGQTEAPNIDEKVDLHFIALVHVDGHLYEL", hsp.hit_all[0].seq[-35:]
+        )
         self.assertEqual("DAIEVCKKFMERDPDELRFNAIALSAA", hsp.hit_all[1].seq)
 
 

--- a/Tests/test_SearchIO_exonerate.py
+++ b/Tests/test_SearchIO_exonerate.py
@@ -117,24 +117,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.hit_all[0].seq[-40:]
         )
 
         # second hit
@@ -163,24 +163,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ACCTAAGAGGAAGGTGGGCAGACCAGGCAGAAAA-AGGAT", str(hsp.query_all[0].seq)[:40]
+            "ACCTAAGAGGAAGGTGGGCAGACCAGGCAGAAAA-AGGAT", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||| |||| |||||   ||| | |  ||| |||  | |||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ACCGAAGAAGAAGGGTAGCAAAACTAGCAAAAAGCAAGAT", str(hsp.hit_all[0].seq)[:40]
+            "ACCGAAGAAGAAGGGTAGCAAAACTAGCAAAAAGCAAGAT", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "AAGTTATGTGGAACA--TAGGCTCATGGAACGCTCCCAGT", str(hsp.query_all[0].seq)[-40:]
+            "AAGTTATGTGGAACA--TAGGCTCATGGAACGCTCCCAGT", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "| ||   | | ||||  ||   |||   || | ||| |||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "ATGT--GGGGAAACAATTACCTTCACCAAATGATCCAAGT", str(hsp.hit_all[0].seq)[-40:]
+            "ATGT--GGGGAAACAATTACCTTCACCAAATGATCCAAGT", hsp.hit_all[0].seq[-40:]
         )
 
         # third hit
@@ -209,24 +209,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ATGTTGCTAAATAAAGATGGAACACCTAAGAGGAAGGTG-", str(hsp.query_all[0].seq)[:40]
+            "ATGTTGCTAAATAAAGATGGAACACCTAAGAGGAAGGTG-", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||| || || || | |||||   |   |||| ||    | ",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGATGATATATTA-GATGGGG-ATG-AAGATGAGCCAGA", str(hsp.hit_all[0].seq)[:40]
+            "ATGATGATATATTA-GATGGGG-ATG-AAGATGAGCCAGA", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "G-TATAGAAGTACAGCCGCACACTCAAGAGAATGAGAAAG", str(hsp.query_all[0].seq)[-40:]
+            "G-TATAGAAGTACAGCCGCACACTCAAGAGAATGAGAAAG", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "| |  |||||   | | | | |   | ||| | |||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GTTGAAGAAGCCAAACGGAAGAAAGACGAGGA-GAGAAAG", str(hsp.hit_all[0].seq)[-40:]
+            "GTTGAAGAAGCCAAACGGAAGAAAGACGAGGA-GAGAAAG", hsp.hit_all[0].seq[-40:]
         )
 
     def test_exn_22_m_cdna2genome(self):
@@ -275,24 +275,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.hit_all[0].seq[-40:]
         )
 
         # first hit, second hsp
@@ -313,24 +313,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", str(hsp.query_all[0].seq)[:40]
+            "CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", str(hsp.hit_all[0].seq)[:40]
+            "CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", str(hsp.query_all[0].seq)[-40:]
+            "CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", str(hsp.hit_all[0].seq)[-40:]
+            "CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", hsp.hit_all[0].seq[-40:]
         )
 
         # second hit
@@ -377,45 +377,45 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(5, len(hsp.hit_all))
         # first block
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||  ||  | ||||   | ||||||  |||| | | | ",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGGTGAACCT-CTTCAAGACGGTCAG--AATA-A-TCAA", str(hsp.hit_all[0].seq)[:40]
+            "ATGGTGAACCT-CTTCAAGACGGTCAG--AATA-A-TCAA", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "AGCAAATATATTTAGCAGGTGACATGAAGAAGCAAATGTT", str(hsp.query_all[0].seq)[-40:]
+            "AGCAAATATATTTAGCAGGTGACATGAAGAAGCAAATGTT", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||  |||| | | | ||||    ||||||||||||| | |",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "AG--AATA-A-TCAACAGG----ATGAAGAAGCAAAAGAT", str(hsp.hit_all[0].seq)[-40:]
+            "AG--AATA-A-TCAACAGG----ATGAAGAAGCAAAAGAT", hsp.hit_all[0].seq[-40:]
         )
         # last block
         self.assertEqual(
-            "TATTAGCCTTCC--TCGATGATCTGCA--A-GAACAACAG", str(hsp.query_all[-1].seq)[:40]
+            "TATTAGCCTTCC--TCGATGATCTGCA--A-GAACAACAG", hsp.query_all[-1].seq[:40]
         )
         self.assertEqual(
             "|  |||| || |  ||||| | || ||  | ||| | |  ",
             hsp[-1].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "TCATAGCGTTACGTTCGAT-ACCTTCACTACGAAGATCCA", str(hsp.hit_all[-1].seq)[:40]
+            "TCATAGCGTTACGTTCGAT-ACCTTCACTACGAAGATCCA", hsp.hit_all[-1].seq[:40]
         )
         self.assertEqual(
-            "AAGTATAGAAGTACAGCCGCACACTCAAGAGAATGAGAAA", str(hsp.query_all[-1].seq)[-40:]
+            "AAGTATAGAAGTACAGCCGCACACTCAAGAGAATGAGAAA", hsp.query_all[-1].seq[-40:]
         )
         self.assertEqual(
             "   |||||||||||||     ||  ||| | ||  | |||",
             hsp[-1].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "TTCTATAGAAGTACAGTTATTCAAACAAAAAAAAAAAAAA", str(hsp.hit_all[-1].seq)[-40:]
+            "TTCTATAGAAGTACAGTTATTCAAACAAAAAAAAAAAAAA", hsp.hit_all[-1].seq[-40:]
         )
 
     def test_exn_22_m_coding2coding(self):
@@ -464,24 +464,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.query_all[0].seq)[:40]
+            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.hit_all[0].seq)[:40]
+            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.query_all[0].seq)[-40:]
+            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.hit_all[0].seq)[-40:]
+            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", hsp.hit_all[0].seq[-40:]
         )
 
         # first hit, second hsp
@@ -502,24 +502,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.hit_all[0].seq[-40:]
         )
 
         # second hit
@@ -548,24 +548,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "TGCTACCACATTCTCGAAGAGATCTCCTCCCTACCAAAAT", str(hsp.query_all[0].seq)[:40]
+            "TGCTACCACATTCTCGAAGAGATCTCCTCCCTACCAAAAT", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||+!  .!.|||   !!:...||+:!::!:!  ||+||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "TGTTCGGAAATTTGGGATAGAATAACAACACATCCGAAAT", str(hsp.hit_all[0].seq)[:40]
+            "TGTTCGGAAATTTGGGATAGAATAACAACACATCCGAAAT", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "CAAAGCTCGCGACTTACAGAGTGCTCTGGTTAGACAGCTC", str(hsp.query_all[0].seq)[-40:]
+            "CAAAGCTCGCGACTTACAGAGTGCTCTGGTTAGACAGCTC", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "!!!.||+...|||:!:||+   |||+||  !!::!!.:!:",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "CAATGCAGAAGACGTTCAATTAGCTTTGAATAAGCATATG", str(hsp.hit_all[0].seq)[-40:]
+            "CAATGCAGAAGACGTTCAATTAGCTTTGAATAAGCATATG", hsp.hit_all[0].seq[-40:]
         )
 
     def test_exn_22_m_coding2genome(self):
@@ -614,24 +614,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.query_all[0].seq)[:40]
+            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.hit_all[0].seq)[:40]
+            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.query_all[0].seq)[-40:]
+            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.hit_all[0].seq)[-40:]
+            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", hsp.hit_all[0].seq[-40:]
         )
 
         # first hit, second hsp
@@ -652,24 +652,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.hit_all[0].seq[-40:]
         )
 
         # second hit
@@ -698,24 +698,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "TGCTACCACATTCTCGAAGAGATCTCCTCCCTACCAAAAT", str(hsp.query_all[0].seq)[:40]
+            "TGCTACCACATTCTCGAAGAGATCTCCTCCCTACCAAAAT", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||+!  .!.|||   !!:...||+:!::!:!  ||+||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "TGTTCGGAAATTTGGGATAGAATAACAACACATCCGAAAT", str(hsp.hit_all[0].seq)[:40]
+            "TGTTCGGAAATTTGGGATAGAATAACAACACATCCGAAAT", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "CAAAGCTCGCGACTTACAGAGTGCTCTGGTTAGACAGCTC", str(hsp.query_all[0].seq)[-40:]
+            "CAAAGCTCGCGACTTACAGAGTGCTCTGGTTAGACAGCTC", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "!!!.||+...|||:!:||+   |||+||  !!::!!.:!:",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "CAATGCAGAAGACGTTCAATTAGCTTTGAATAAGCATATG", str(hsp.hit_all[0].seq)[-40:]
+            "CAATGCAGAAGACGTTCAATTAGCTTTGAATAAGCATATG", hsp.hit_all[0].seq[-40:]
         )
 
     def test_exn_22_m_dna2protein(self):
@@ -751,11 +751,11 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(344, hsp[0].hit_end)
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
-        self.assertEqual("NSPFXKGPLASVQNPVYHKQPLNPAPNAETH", str(hsp[0].query.seq)[:40])
+        self.assertEqual("NSPFXKGPLASVQNPVYHKQPLNPAPNAETH", hsp[0].query.seq[:40])
         self.assertEqual(
             ["|||", "...", " !!", " !!", "! !"], hsp[0].aln_annotation["similarity"][:5]
         )
-        self.assertEqual("NQSVPKRPAGSVQNPVYHNQPLNPAPSRDPH", str(hsp[0].hit.seq)[:40])
+        self.assertEqual("NQSVPKRPAGSVQNPVYHNQPLNPAPSRDPH", hsp[0].hit.seq[:40])
 
     def test_exn_22_m_est2genome(self):
         """Test parsing exonerate output (exn_22_m_est2genome.exn)."""
@@ -803,24 +803,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.hit_all[0].seq[-40:]
         )
 
         # second hit
@@ -857,31 +857,31 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(4, len(hsp.hit_all))
         # first block
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||  ||  | ||||   | ||||||  |||| | | | ",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGGTGAACCT-CTTCAAGACGGTCAG--AATA-A-TCAA", str(hsp.hit_all[0].seq)[:40]
+            "ATGGTGAACCT-CTTCAAGACGGTCAG--AATA-A-TCAA", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "AGCAAATATATTTAGCAGGTGACATGAAGAAGCAAATGTT", str(hsp.query_all[0].seq)[-40:]
+            "AGCAAATATATTTAGCAGGTGACATGAAGAAGCAAATGTT", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||  |||| | | | ||||    ||||||||||||| | |",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "AG--AATA-A-TCAACAGG----ATGAAGAAGCAAAAGAT", str(hsp.hit_all[0].seq)[-40:]
+            "AG--AATA-A-TCAACAGG----ATGAAGAAGCAAAAGAT", hsp.hit_all[0].seq[-40:]
         )
         # last block
-        self.assertEqual("AGCTAAGAATTCTGATGATG-----AAAGAA", str(hsp.query_all[-1].seq))
+        self.assertEqual("AGCTAAGAATTCTGATGATG-----AAAGAA", hsp.query_all[-1].seq)
         self.assertEqual(
             "|   |||||||||||| |||     ||||||", hsp[-1].aln_annotation["similarity"]
         )
-        self.assertEqual("ATGGAAGAATTCTGATAATGCTGTAAAAGAA", str(hsp.hit_all[-1].seq))
+        self.assertEqual("ATGGAAGAATTCTGATAATGCTGTAAAAGAA", hsp.hit_all[-1].seq)
 
         # second hit, second hsp
         hsp = qresult[1].hsps[1]
@@ -904,45 +904,45 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(3, len(hsp.hit_all))
         # first block
         self.assertEqual(
-            "AGCAAATATATTTA-GCAGGTGACATGAAGAAGCAAATGT", str(hsp.query_all[0].seq)[:40]
+            "AGCAAATATATTTA-GCAGGTGACATGAAGAAGCAAATGT", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "| |||| |||   | ||||   | | || |||| | |  |",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ACCAAAGATAACAAGGCAG--AAAAAGAGGAAGAAGAAAT", str(hsp.hit_all[0].seq)[:40]
+            "ACCAAAGATAACAAGGCAG--AAAAAGAGGAAGAAGAAAT", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "AG-GACTGCCCAGAATAGGGCAGCTCAACGAGCGTTCCGA", str(hsp.query_all[0].seq)[-40:]
+            "AG-GACTGCCCAGAATAGGGCAGCTCAACGAGCGTTCCGA", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "|| |||  ||||||  ||   |||  || ||   ||| ||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "AGTGAC--CCCAGAGGAGCCAAGCAAAAAGA---TTCGGA", str(hsp.hit_all[0].seq)[-40:]
+            "AGTGAC--CCCAGAGGAGCCAAGCAAAAAGA---TTCGGA", hsp.hit_all[0].seq[-40:]
         )
         # last block
         self.assertEqual(
-            "AATAAGACTACCACGGACTTTTTACTATGTTCTTTAAAAA", str(hsp.query_all[-1].seq)[:40]
+            "AATAAGACTACCACGGACTTTTTACTATGTTCTTTAAAAA", hsp.query_all[-1].seq[:40]
         )
         self.assertEqual(
             "|||||||  | ||| |    |||| | |  | | ||    ",
             hsp[-1].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "AATAAGAGCAACACAG----TTTA-TCTTATATGTA----", str(hsp.hit_all[-1].seq)[:40]
+            "AATAAGAGCAACACAG----TTTA-TCTTATATGTA----", hsp.hit_all[-1].seq[:40]
         )
         self.assertEqual(
-            "CTGCAAGAACAACAGAAAAGGGAAAACGAAAAAGGAACAA", str(hsp.query_all[-1].seq)[-40:]
+            "CTGCAAGAACAACAGAAAAGGGAAAACGAAAAAGGAACAA", hsp.query_all[-1].seq[-40:]
         )
         self.assertEqual(
             "|  | | || |  | || ||  ||||||||  ||  ||||",
             hsp[-1].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "CCACTAAAAAATTATAAGAGCCAAAACGAAGTAGATACAA", str(hsp.hit_all[-1].seq)[-40:]
+            "CCACTAAAAAATTATAAGAGCCAAAACGAAGTAGATACAA", hsp.hit_all[-1].seq[-40:]
         )
 
     def test_exn_22_m_genome2genome(self):
@@ -991,24 +991,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ATCCCTTATCTCTTTATCTTGTTGCCTGGTTCTCTTTTCC", str(hsp.query_all[0].seq)[:40]
+            "ATCCCTTATCTCTTTATCTTGTTGCCTGGTTCTCTTTTCC", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATCCCTTATCTCTTTATCTTGTTGCCTGGTTCTCTTTTCC", str(hsp.hit_all[0].seq)[:40]
+            "ATCCCTTATCTCTTTATCTTGTTGCCTGGTTCTCTTTTCC", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "ACGGCAATACCTGGCATGTGATTGTCGGAAAGAACTTTGG", str(hsp.query_all[0].seq)[-40:]
+            "ACGGCAATACCTGGCATGTGATTGTCGGAAAGAACTTTGG", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "ACGGCAATACCTGGCATGTGATTGTCGGAAAGAACTTTGG", str(hsp.hit_all[0].seq)[-40:]
+            "ACGGCAATACCTGGCATGTGATTGTCGGAAAGAACTTTGG", hsp.hit_all[0].seq[-40:]
         )
 
         # first hit, second hsp
@@ -1029,24 +1029,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "CCAAAGTTCTTTCCGACAATCACATGCCAGGTATTGCCGT", str(hsp.query_all[0].seq)[:40]
+            "CCAAAGTTCTTTCCGACAATCACATGCCAGGTATTGCCGT", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "CCAAAGTTCTTTCCGACAATCACATGCCAGGTATTGCCGT", str(hsp.hit_all[0].seq)[:40]
+            "CCAAAGTTCTTTCCGACAATCACATGCCAGGTATTGCCGT", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "GGAAAAGAGAACCAGGCAACAAGATAAAGAGATAAGGGAT", str(hsp.query_all[0].seq)[-40:]
+            "GGAAAAGAGAACCAGGCAACAAGATAAAGAGATAAGGGAT", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GGAAAAGAGAACCAGGCAACAAGATAAAGAGATAAGGGAT", str(hsp.hit_all[0].seq)[-40:]
+            "GGAAAAGAGAACCAGGCAACAAGATAAAGAGATAAGGGAT", hsp.hit_all[0].seq[-40:]
         )
 
         # second hit
@@ -1092,31 +1092,31 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(5, len(hsp.query_all))
         self.assertEqual(5, len(hsp.hit_all))
         # first block
-        self.assertEqual("CCCTTTAAATGGAGATTACAAACTAGCGA", str(hsp.query_all[0].seq))
+        self.assertEqual("CCCTTTAAATGGAGATTACAAACTAGCGA", hsp.query_all[0].seq)
         self.assertEqual(
             "||  | ||| | |||  ||||| |  | |", hsp[0].aln_annotation["similarity"]
         )
-        self.assertEqual("CCGCTGAAAGGAAGAGAACAAAGTTACAA", str(hsp.hit_all[0].seq))
+        self.assertEqual("CCGCTGAAAGGAAGAGAACAAAGTTACAA", hsp.hit_all[0].seq)
         # last block
         self.assertEqual(
-            "TTTTCTTTACTAAC-TCGAGGAAGAGTGAGGTTTTCTTCC", str(hsp.query_all[-1].seq)[:40]
+            "TTTTCTTTACTAAC-TCGAGGAAGAGTGAGGTTTTCTTCC", hsp.query_all[-1].seq[:40]
         )
         self.assertEqual(
             "| ||    || | | |  |||||| |||| | | |  |||",
             hsp[-1].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "TCTTGAAGACCAGCATGTAGGAAG-GTGATGATATGCTCC", str(hsp.hit_all[-1].seq)[:40]
+            "TCTTGAAGACCAGCATGTAGGAAG-GTGATGATATGCTCC", hsp.hit_all[-1].seq[:40]
         )
         self.assertEqual(
-            "TTTGTGTGTGTACATTTGAATATATATATTTAC-TAACAA", str(hsp.query_all[-1].seq)[-40:]
+            "TTTGTGTGTGTACATTTGAATATATATATTTAC-TAACAA", hsp.query_all[-1].seq[-40:]
         )
         self.assertEqual(
             " |||  ||| |   |||||||||||||   | | ||||||",
             hsp[-1].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "ATTGATTGTTTTGTTTTGAATATATATTGATGCTTAACAA", str(hsp.hit_all[-1].seq)[-40:]
+            "ATTGATTGTTTTGTTTTGAATATATATTGATGCTTAACAA", hsp.hit_all[-1].seq[-40:]
         )
 
         # third hit
@@ -1163,34 +1163,34 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(5, len(hsp.hit_all))
         # first block
         self.assertEqual(
-            "ATCCCTTATCTCTTTATCTTGTTGCCTGGTTCTCTTTTCC", str(hsp.query_all[0].seq)[:40]
+            "ATCCCTTATCTCTTTATCTTGTTGCCTGGTTCTCTTTTCC", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||       |||  |||||   ||||  ",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATCCCTTATCTCTTCTAAAGATTGTGTGGTT---TTTT--", str(hsp.hit_all[0].seq)[:40]
+            "ATCCCTTATCTCTTCTAAAGATTGTGTGGTT---TTTT--", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "AAATGGAGATTACAA---ACTAGCGAA-ACTGCAGAAAAG", str(hsp.query_all[0].seq)[-40:]
+            "AAATGGAGATTACAA---ACTAGCGAA-ACTGCAGAAAAG", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "  ||     || |||    || || ||  || || | |||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GCATATTTTTTCCAACCTTCTTGCCAATTCTTCA-ACAAG", str(hsp.hit_all[0].seq)[-40:]
+            "GCATATTTTTTCCAACCTTCTTGCCAATTCTTCA-ACAAG", hsp.hit_all[0].seq[-40:]
         )
         # last block
         self.assertEqual(
-            "TAAAGATGCTCTGGACAAGTACCAGTTGGAAAGAGA", str(hsp.query_all[-1].seq)
+            "TAAAGATGCTCTGGACAAGTACCAGTTGGAAAGAGA", hsp.query_all[-1].seq
         )
         self.assertEqual(
             " ||||||  |||  || | |  ||||||||||||||", hsp[-1].aln_annotation["similarity"]
         )
         self.assertEqual(
-            "AAAAGATTTTCT--ACGACTTGCAGTTGGAAAGAGA", str(hsp.hit_all[-1].seq)
+            "AAAAGATTTTCT--ACGACTTGCAGTTGGAAAGAGA", hsp.hit_all[-1].seq
         )
 
     def test_exn_22_m_ungapped(self):
@@ -1239,24 +1239,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.hit_all[0].seq[-40:]
         )
 
         # second hit
@@ -1285,24 +1285,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "TTGACTCTGAAGCTAAGAGTAGGAGGACTGCCCAGAATAG", str(hsp.query_all[0].seq)[:40]
+            "TTGACTCTGAAGCTAAGAGTAGGAGGACTGCCCAGAATAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "| ||  ||||| |||||   | |||||||||||| ||| |",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "TGGATCCTGAAACTAAGCAGAAGAGGACTGCCCAAAATCG", str(hsp.hit_all[0].seq)[:40]
+            "TGGATCCTGAAACTAAGCAGAAGAGGACTGCCCAAAATCG", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "CCAAAATGAAGAGTTTGCAAGAGAGGGTAGAGTTACTAGA", str(hsp.query_all[0].seq)[-40:]
+            "CCAAAATGAAGAGTTTGCAAGAGAGGGTAGAGTTACTAGA", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "  || ||||||   ||| |  ||| |||| |     ||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GGAAGATGAAGGAATTGGAGAAGAAGGTACAAAGTTTAGA", str(hsp.hit_all[0].seq)[-40:]
+            "GGAAGATGAAGGAATTGGAGAAGAAGGTACAAAGTTTAGA", hsp.hit_all[0].seq[-40:]
         )
 
         # second hit, second hsp
@@ -1323,24 +1323,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "CCAAAATATTCATCGTTGGACATAGATGATTTATGCAGCG", str(hsp.query_all[0].seq)[:40]
+            "CCAAAATATTCATCGTTGGACATAGATGATTTATGCAGCG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "|| ||||| |||    | ||  | |||| ||||||   ||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "CCGAAATACTCAGATATTGATGTCGATGGTTTATGTTCCG", str(hsp.hit_all[0].seq)[:40]
+            "CCGAAATACTCAGATATTGATGTCGATGGTTTATGTTCCG", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "ATTTATGCAGCGAATTAATAATCAAGGCAAAATGTACAGA", str(hsp.query_all[0].seq)[-40:]
+            "ATTTATGCAGCGAATTAATAATCAAGGCAAAATGTACAGA", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             " ||||||   |||  ||||    |||||||||||| ||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GTTTATGTTCCGAGCTAATGGCAAAGGCAAAATGTTCAGA", str(hsp.hit_all[0].seq)[-40:]
+            "GTTTATGTTCCGAGCTAATGGCAAAGGCAAAATGTTCAGA", hsp.hit_all[0].seq[-40:]
         )
 
     def test_exn_22_m_ungapped_trans(self):
@@ -1389,24 +1389,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.query_all[0].seq)[:40]
+            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", str(hsp.hit_all[0].seq)[:40]
+            "ACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGAGC", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.query_all[0].seq)[-40:]
+            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", str(hsp.hit_all[0].seq)[-40:]
+            "GCTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCA", hsp.hit_all[0].seq[-40:]
         )
 
         # first hit, second hsp
@@ -1427,24 +1427,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.hit_all[0].seq[-40:]
         )
 
         # first hit, third hsp
@@ -1465,24 +1465,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", str(hsp.query_all[0].seq)[:40]
+            "CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", str(hsp.hit_all[0].seq)[:40]
+            "CTACAGGAGCTGTCTAACCAGAGCACTCTGTAAGTCGCGA", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", str(hsp.query_all[0].seq)[-40:]
+            "CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", str(hsp.hit_all[0].seq)[-40:]
+            "CTAAATATATTTGCTGACCTTTCCGAAGGATATTGCCCAT", hsp.hit_all[0].seq[-40:]
         )
 
     def test_exn_22_m_ner(self):
@@ -1529,24 +1529,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.hit_all[0].seq[-40:]
         )
 
         # first hit, second hsp
@@ -1589,15 +1589,15 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(24, len(hsp.query_all))
         self.assertEqual(24, len(hsp.hit_all))
         # first block
-        self.assertEqual("TGAGA", str(hsp.query_all[0].seq))
+        self.assertEqual("TGAGA", hsp.query_all[0].seq)
         self.assertEqual("|||||", hsp[0].aln_annotation["similarity"])
-        self.assertEqual("TGAGA", str(hsp.hit_all[0].seq))
+        self.assertEqual("TGAGA", hsp.hit_all[0].seq)
         # last block
-        self.assertEqual("GACTGCAAAATAGTAGTCAAAGCTC", str(hsp.query_all[-1].seq))
+        self.assertEqual("GACTGCAAAATAGTAGTCAAAGCTC", hsp.query_all[-1].seq)
         self.assertEqual(
             "||| | ||||||||||||| | |||", hsp[-1].aln_annotation["similarity"]
         )
-        self.assertEqual("GACGGTAAAATAGTAGTCACACCTC", str(hsp.hit_all[-1].seq))
+        self.assertEqual("GACGGTAAAATAGTAGTCACACCTC", hsp.hit_all[-1].seq)
 
         # second hit
         hit = qresult[1]
@@ -1647,13 +1647,13 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(33, len(hsp.query_all))
         self.assertEqual(33, len(hsp.hit_all))
         # first block
-        self.assertEqual("CAGAAAA", str(hsp.query_all[0].seq))
+        self.assertEqual("CAGAAAA", hsp.query_all[0].seq)
         self.assertEqual("| |||||", hsp[0].aln_annotation["similarity"])
-        self.assertEqual("CTGAAAA", str(hsp.hit_all[0].seq))
+        self.assertEqual("CTGAAAA", hsp.hit_all[0].seq)
         # last block
-        self.assertEqual("TGGTTAGACAGCTCCTGTAG", str(hsp.query_all[-1].seq))
+        self.assertEqual("TGGTTAGACAGCTCCTGTAG", hsp.query_all[-1].seq)
         self.assertEqual("|| |  ||||||||||||||", hsp[-1].aln_annotation["similarity"])
-        self.assertEqual("TGATAGGACAGCTCCTGTAG", str(hsp.hit_all[-1].seq))
+        self.assertEqual("TGATAGGACAGCTCCTGTAG", hsp.hit_all[-1].seq)
 
     def test_exn_22_q_multiple(self):
         """Test parsing exonerate output (exn_22_q_multiple.exn)."""
@@ -1695,24 +1695,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ATGAGCGGTGAATTAGCAAATTACAAAAGACTTGAGAAAG", str(hsp.query_all[0].seq)[:40]
+            "ATGAGCGGTGAATTAGCAAATTACAAAAGACTTGAGAAAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGAGCGGTGAATTAGCAAATTACAAAAGACTTGAGAAAG", str(hsp.hit_all[0].seq)[:40]
+            "ATGAGCGGTGAATTAGCAAATTACAAAAGACTTGAGAAAG", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "CAGAAGAGCAGCCATCCACCCCTACTTCCAAGAATCATAA", str(hsp.query_all[0].seq)[-40:]
+            "CAGAAGAGCAGCCATCCACCCCTACTTCCAAGAATCATAA", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "CAGAAGAGCAGCCATCCACCCCTACTTCCAAGAATCATAA", str(hsp.hit_all[0].seq)[-40:]
+            "CAGAAGAGCAGCCATCCACCCCTACTTCCAAGAATCATAA", hsp.hit_all[0].seq[-40:]
         )
 
         # first qresult, second hit
@@ -1736,24 +1736,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "GAGCGGTGAATTAGCAAATTACAAAAGACTTGAGAAAGTC", str(hsp.query_all[0].seq)[:40]
+            "GAGCGGTGAATTAGCAAATTACAAAAGACTTGAGAAAGTC", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||  |  || | || |||  |  ||  | || ||  | ",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "GAGC--TCTATGAACAGATTTAAGCAG-TTAGAAAAGCTT", str(hsp.hit_all[0].seq)[:40]
+            "GAGC--TCTATGAACAGATTTAAGCAG-TTAGAAAAGCTT", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "C-AGAAGAGCAGCCATCCACCCCTACTTCCAAGAATCATA", str(hsp.query_all[0].seq)[-40:]
+            "C-AGAAGAGCAGCCATCCACCCCTACTTCCAAGAATCATA", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "| || ||      ||| ||||| |  ||   ||| |  ||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "CAAGCAGGCTCTGCAT-CACCCTTGGTTTGCAGAGTACTA", str(hsp.hit_all[0].seq)[-40:]
+            "CAAGCAGGCTCTGCAT-CACCCTTGGTTTGCAGAGTACTA", hsp.hit_all[0].seq[-40:]
         )
 
         # first qresult, third hit
@@ -1778,31 +1778,31 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(2, len(hsp.hit_all))
         # first block
         self.assertEqual(
-            "AGAAAGTCGGTGAAGGTACATACGGTGTTGTTTATAAAGC", str(hsp.query_all[0].seq)[:40]
+            "AGAAAGTCGGTGAAGGTACATACGGTGTTGTTTATAAAGC", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||| ||||| ||||| || |  ||||||||    | ",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "AGAAAGTTGGTGAGGGTACTTATGCGGTTGTTTA-CTTGG", str(hsp.hit_all[0].seq)[:40]
+            "AGAAAGTTGGTGAGGGTACTTATGCGGTTGTTTA-CTTGG", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "CGATCAGATTTTCAAG--ATATTCAGAGTATTGGGAACGC", str(hsp.query_all[0].seq)[-40:]
+            "CGATCAGATTTTCAAG--ATATTCAGAGTATTGGGAACGC", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "|||||| |  |  |||  |  ||||| |  || || || |",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "CGATCAAA--TGGAAGTAACGTTCAGGGCCTTAGGGACAC", str(hsp.hit_all[0].seq)[-40:]
+            "CGATCAAA--TGGAAGTAACGTTCAGGGCCTTAGGGACAC", hsp.hit_all[0].seq[-40:]
         )
         # last block
-        self.assertEqual("CGAATGAAGCTA-TATGGCCAGATATTGTCT", str(hsp.query_all[-1].seq))
+        self.assertEqual("CGAATGAAGCTA-TATGGCCAGATATTGTCT", hsp.query_all[-1].seq)
         self.assertEqual(
             "| ||   || ||  ||||||||||||| |||", hsp[-1].aln_annotation["similarity"]
         )
-        self.assertEqual("CAAACCGAGATAGAATGGCCAGATATTCTCT", str(hsp.hit_all[-1].seq))
+        self.assertEqual("CAAACCGAGATAGAATGGCCAGATATTCTCT", hsp.hit_all[-1].seq)
 
         # test second qresult
         qresult = qresults[1]
@@ -1831,24 +1831,24 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.query_all))
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.hit_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.query_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", str(hsp.hit_all[0].seq)[-40:]
+            "TCGCGACTTACAGAGTGCTCTGGTTAGACAGCTCCTGTAG", hsp.hit_all[0].seq[-40:]
         )
 
         # second qresult, second hit
@@ -1880,31 +1880,31 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(4, len(hsp.hit_all))
         # first block
         self.assertEqual(
-            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", str(hsp.query_all[0].seq)[:40]
+            "ATGGGCAATATCCTTCGGAAAGGTCAGCAAATATATTTAG", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "||||  ||  | ||||   | ||||||  |||| | | | ",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ATGGTGAACCT-CTTCAAGACGGTCAG--AATA-A-TCAA", str(hsp.hit_all[0].seq)[:40]
+            "ATGGTGAACCT-CTTCAAGACGGTCAG--AATA-A-TCAA", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "AGCAAATATATTTAGCAGGTGACATGAAGAAGCAAATGTT", str(hsp.query_all[0].seq)[-40:]
+            "AGCAAATATATTTAGCAGGTGACATGAAGAAGCAAATGTT", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "||  |||| | | | ||||    ||||||||||||| | |",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "AG--AATA-A-TCAACAGG----ATGAAGAAGCAAAAGAT", str(hsp.hit_all[0].seq)[-40:]
+            "AG--AATA-A-TCAACAGG----ATGAAGAAGCAAAAGAT", hsp.hit_all[0].seq[-40:]
         )
         # last block
-        self.assertEqual("AGCTAAGAATTCTGATGATG-----AAAGAA", str(hsp.query_all[-1].seq))
+        self.assertEqual("AGCTAAGAATTCTGATGATG-----AAAGAA", hsp.query_all[-1].seq)
         self.assertEqual(
             "|   |||||||||||| |||     ||||||", hsp[-1].aln_annotation["similarity"]
         )
-        self.assertEqual("ATGGAAGAATTCTGATAATGCTGTAAAAGAA", str(hsp.hit_all[-1].seq))
+        self.assertEqual("ATGGAAGAATTCTGATAATGCTGTAAAAGAA", hsp.hit_all[-1].seq)
 
         # second qresult, second hit, second hsp
         # second hit, second hsp
@@ -1926,45 +1926,45 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(3, len(hsp.hit_all))
         # first block
         self.assertEqual(
-            "AGCAAATATATTTA-GCAGGTGACATGAAGAAGCAAATGT", str(hsp.query_all[0].seq)[:40]
+            "AGCAAATATATTTA-GCAGGTGACATGAAGAAGCAAATGT", hsp.query_all[0].seq[:40]
         )
         self.assertEqual(
             "| |||| |||   | ||||   | | || |||| | |  |",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ACCAAAGATAACAAGGCAG--AAAAAGAGGAAGAAGAAAT", str(hsp.hit_all[0].seq)[:40]
+            "ACCAAAGATAACAAGGCAG--AAAAAGAGGAAGAAGAAAT", hsp.hit_all[0].seq[:40]
         )
         self.assertEqual(
-            "AG-GACTGCCCAGAATAGGGCAGCTCAACGAGCGTTCCGA", str(hsp.query_all[0].seq)[-40:]
+            "AG-GACTGCCCAGAATAGGGCAGCTCAACGAGCGTTCCGA", hsp.query_all[0].seq[-40:]
         )
         self.assertEqual(
             "|| |||  ||||||  ||   |||  || ||   ||| ||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "AGTGAC--CCCAGAGGAGCCAAGCAAAAAGA---TTCGGA", str(hsp.hit_all[0].seq)[-40:]
+            "AGTGAC--CCCAGAGGAGCCAAGCAAAAAGA---TTCGGA", hsp.hit_all[0].seq[-40:]
         )
         # last block
         self.assertEqual(
-            "AATAAGACTACCACGGACTTTTTACTATGTTCTTTAAAAA", str(hsp.query_all[-1].seq)[:40]
+            "AATAAGACTACCACGGACTTTTTACTATGTTCTTTAAAAA", hsp.query_all[-1].seq[:40]
         )
         self.assertEqual(
             "|||||||  | ||| |    |||| | |  | | ||    ",
             hsp[-1].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "AATAAGAGCAACACAG----TTTA-TCTTATATGTA----", str(hsp.hit_all[-1].seq)[:40]
+            "AATAAGAGCAACACAG----TTTA-TCTTATATGTA----", hsp.hit_all[-1].seq[:40]
         )
         self.assertEqual(
-            "CTGCAAGAACAACAGAAAAGGGAAAACGAAAAAGGAACAA", str(hsp.query_all[-1].seq)[-40:]
+            "CTGCAAGAACAACAGAAAAGGGAAAACGAAAAAGGAACAA", hsp.query_all[-1].seq[-40:]
         )
         self.assertEqual(
             "|  | | || |  | || ||  ||||||||  ||  ||||",
             hsp[-1].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "CCACTAAAAAATTATAAGAGCCAAAACGAAGTAGATACAA", str(hsp.hit_all[-1].seq)[-40:]
+            "CCACTAAAAAATTATAAGAGCCAAAACGAAGTAGATACAA", hsp.hit_all[-1].seq[-40:]
         )
 
     def test_exn_22_m_coding2coding_fshifts(self):
@@ -2019,29 +2019,29 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(4, len(hsp.aln_annotation_all))
         # first block
         self.assertEqual(
-            "ACTGTGAACACAAGTATAGAAGTACAGCCGCACACTCAAG", str(hsp[0].query.seq)[:40]
+            "ACTGTGAACACAAGTATAGAAGTACAGCCGCACACTCAAG", hsp[0].query.seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "ACTGTGAACACAAGTATAGAAGTACAGCCGCACACTCAAG", str(hsp[0].hit.seq)[:40]
+            "ACTGTGAACACAAGTATAGAAGTACAGCCGCACACTCAAG", hsp[0].hit.seq[:40]
         )
         self.assertEqual(
-            "TATGTGGAACATAGGCTCATGGAACGCTCCCAGTTTAACC", str(hsp[0].query.seq)[-40:]
+            "TATGTGGAACATAGGCTCATGGAACGCTCCCAGTTTAACC", hsp[0].query.seq[-40:]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[0].aln_annotation["similarity"][-40:],
         )
         self.assertEqual(
-            "TATGTGGAACATAGGCTCATGGAACGCTCCCAGTTTAACC", str(hsp[0].hit.seq)[-40:]
+            "TATGTGGAACATAGGCTCATGGAACGCTCCCAGTTTAACC", hsp[0].hit.seq[-40:]
         )
         # last block
-        self.assertEqual("GACGAAAGTATTAATGGTAGT", str(hsp[-1].query.seq))
+        self.assertEqual("GACGAAAGTATTAATGGTAGT", hsp[-1].query.seq)
         self.assertEqual("|||||||||||||||||||||", hsp[-1].aln_annotation["similarity"])
-        self.assertEqual("GACGAAAGTATTAATGGTAGT", str(hsp[-1].hit.seq))
+        self.assertEqual("GACGAAAGTATTAATGGTAGT", hsp[-1].hit.seq)
 
         # first hit, second hsp
         hsp = qresult[0][1]
@@ -2063,25 +2063,25 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(2, len(hsp.aln_annotation_all))
         # first block
         self.assertEqual(
-            "TACCATTAATACTTTCGTCATGGT<-><->AACGGCATGT", str(hsp[0].query.seq)[:40]
+            "TACCATTAATACTTTCGTCATGGT<-><->AACGGCATGT", hsp[0].query.seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||+ !       ...  !:!!|",
             hsp[0].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "TACCATTAATACTTTCGTCACCGATGGTAACGGCACCTGT", str(hsp[0].hit.seq)[:40]
+            "TACCATTAATACTTTCGTCACCGATGGTAACGGCACCTGT", hsp[0].hit.seq[:40]
         )
         # last block
         self.assertEqual(
-            "TGGTTAAACTGGGAGCGTTCCATGAGCCTATGTTCCACAT", str(hsp[-1].query.seq)[:40]
+            "TGGTTAAACTGGGAGCGTTCCATGAGCCTATGTTCCACAT", hsp[-1].query.seq[:40]
         )
         self.assertEqual(
             "||||||||||||||||||||||||||||||||||||||||",
             hsp[-1].aln_annotation["similarity"][:40],
         )
         self.assertEqual(
-            "TGGTTAAACTGGGAGCGTTCCATGAGCCTATGTTCCACAT", str(hsp[-1].hit.seq)[:40]
+            "TGGTTAAACTGGGAGCGTTCCATGAGCCTATGTTCCACAT", hsp[-1].hit.seq[:40]
         )
 
     def test_exn_22_m_protein2dna_fshifts(self):
@@ -2133,20 +2133,20 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(2, len(hsp.aln_annotation_all))
         # first block
         self.assertEqual(
-            "HTKTIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYS", str(hsp[0].query.seq)[:40]
+            "HTKTIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYS", hsp[0].query.seq[:40]
         )
         self.assertEqual(
-            "HTKTIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYS", str(hsp[0].hit.seq)[:40]
+            "HTKTIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYS", hsp[0].hit.seq[:40]
         )
         self.assertEqual(
-            "TIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYSSLD", str(hsp[0].query.seq)[-40:]
+            "TIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYSSLD", hsp[0].query.seq[-40:]
         )
         self.assertEqual(
-            "TIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYSSLD", str(hsp[0].hit.seq)[-40:]
+            "TIRTQSEAIEHISSAISNGKASCYHILEEISSLPKYSSLD", hsp[0].hit.seq[-40:]
         )
         # last block
-        self.assertEqual("IDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", str(hsp[-1].query.seq))
-        self.assertEqual("IDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", str(hsp[-1].hit.seq))
+        self.assertEqual("IDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", hsp[-1].query.seq)
+        self.assertEqual("IDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", hsp[-1].hit.seq)
 
         # first hit, second hsp
         hsp = qresult[0][1]
@@ -2167,16 +2167,16 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(1, len(hsp.hit_all))
         self.assertEqual(1, len(hsp.aln_annotation_all))
         self.assertEqual(
-            "KGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKRIDSEAK", str(hsp[0].query.seq)[:40]
+            "KGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKRIDSEAK", hsp[0].query.seq[:40]
         )
         self.assertEqual(
-            "KGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKRIDSEAK", str(hsp[0].hit.seq)[:40]
+            "KGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKRIDSEAK", hsp[0].hit.seq[:40]
         )
         self.assertEqual(
-            "RKVGRPGRKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKS", str(hsp[0].query.seq)[-40:]
+            "RKVGRPGRKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKS", hsp[0].query.seq[-40:]
         )
         self.assertEqual(
-            "RKVGRPGRKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKS", str(hsp[0].hit.seq)[-40:]
+            "RKVGRPGRKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKS", hsp[0].hit.seq[-40:]
         )
 
     def test_exn_22_m_protein2genome(self):
@@ -2218,16 +2218,16 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(409, hsp.query_end)
         self.assertEqual(1319275, hsp.hit_end)
         self.assertEqual(
-            "MGNILRKGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKR", str(hsp[0].query.seq)[:40]
+            "MGNILRKGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKR", hsp[0].query.seq[:40]
         )
         self.assertEqual(
-            "MGNILRKGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKR", str(hsp[0].hit.seq)[:40]
+            "MGNILRKGQQIYLAGDMKKQMLLNKDGTPKRKVGRPGRKR", hsp[0].hit.seq[:40]
         )
         self.assertEqual(
-            "SSLDIDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", str(hsp[0].query.seq)[-40:]
+            "SSLDIDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", hsp[0].query.seq[-40:]
         )
         self.assertEqual(
-            "SSLDIDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", str(hsp[0].hit.seq)[-40:]
+            "SSLDIDDLCSELIIKAKCTDDCKIVVKARDLQSALVRQLL", hsp[0].hit.seq[-40:]
         )
 
         # last hit
@@ -2244,19 +2244,19 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual([0, 0], hsp.query_strand_all)
         self.assertEqual([-1, -1], hsp.hit_strand_all)
         self.assertEqual(
-            "RKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKSLQERX", str(hsp[0].query.seq)
+            "RKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKSLQERX", hsp[0].query.seq
         )
-        self.assertEqual("NENVPDDSKAKKKAQNRAAQKAFRERKEARMKELQDKX", str(hsp[0].hit.seq))
+        self.assertEqual("NENVPDDSKAKKKAQNRAAQKAFRERKEARMKELQDKX", hsp[0].hit.seq)
         self.assertEqual("!.!", hsp.aln_annotation_all[0]["similarity"][0])
         self.assertEqual(":!", hsp.aln_annotation_all[0]["similarity"][-1])
         self.assertEqual("AAT", hsp.aln_annotation_all[0]["hit_annotation"][0])
         self.assertEqual("TT", hsp.aln_annotation_all[0]["hit_annotation"][-1])
         self.assertEqual(
             "XELLEQKDAQNKTTTDFLLCSLKSLLSEITKYRAKNSDDERILAFLDDLQE",
-            str(hsp[-1].query.seq),
+            hsp[-1].query.seq,
         )
         self.assertEqual(
-            "XNKILNRDPQFMSNSSFHQCVSLDSINTIEKDEEKNSDDDAGLQAATDARE", str(hsp[-1].hit.seq)
+            "XNKILNRDPQFMSNSSFHQCVSLDSINTIEKDEEKNSDDDAGLQAATDARE", hsp[-1].hit.seq
         )
         self.assertEqual("!", hsp.aln_annotation_all[-1]["similarity"][0])
         self.assertEqual("|||", hsp.aln_annotation_all[-1]["similarity"][-1])

--- a/Tests/test_SearchIO_exonerate.py
+++ b/Tests/test_SearchIO_exonerate.py
@@ -1183,15 +1183,11 @@ class ExonerateTextCases(unittest.TestCase):
             "GCATATTTTTTCCAACCTTCTTGCCAATTCTTCA-ACAAG", hsp.hit_all[0].seq[-40:]
         )
         # last block
-        self.assertEqual(
-            "TAAAGATGCTCTGGACAAGTACCAGTTGGAAAGAGA", hsp.query_all[-1].seq
-        )
+        self.assertEqual("TAAAGATGCTCTGGACAAGTACCAGTTGGAAAGAGA", hsp.query_all[-1].seq)
         self.assertEqual(
             " ||||||  |||  || | |  ||||||||||||||", hsp[-1].aln_annotation["similarity"]
         )
-        self.assertEqual(
-            "AAAAGATTTTCT--ACGACTTGCAGTTGGAAAGAGA", hsp.hit_all[-1].seq
-        )
+        self.assertEqual("AAAAGATTTTCT--ACGACTTGCAGTTGGAAAGAGA", hsp.hit_all[-1].seq)
 
     def test_exn_22_m_ungapped(self):
         """Test parsing exonerate output (exn_22_m_ungapped.exn)."""
@@ -2243,17 +2239,14 @@ class ExonerateTextCases(unittest.TestCase):
         self.assertEqual(122, hsp.score)
         self.assertEqual([0, 0], hsp.query_strand_all)
         self.assertEqual([-1, -1], hsp.hit_strand_all)
-        self.assertEqual(
-            "RKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKSLQERX", hsp[0].query.seq
-        )
+        self.assertEqual("RKRIDSEAKSRRTAQNRAAQRAFRDRKEAKMKSLQERX", hsp[0].query.seq)
         self.assertEqual("NENVPDDSKAKKKAQNRAAQKAFRERKEARMKELQDKX", hsp[0].hit.seq)
         self.assertEqual("!.!", hsp.aln_annotation_all[0]["similarity"][0])
         self.assertEqual(":!", hsp.aln_annotation_all[0]["similarity"][-1])
         self.assertEqual("AAT", hsp.aln_annotation_all[0]["hit_annotation"][0])
         self.assertEqual("TT", hsp.aln_annotation_all[0]["hit_annotation"][-1])
         self.assertEqual(
-            "XELLEQKDAQNKTTTDFLLCSLKSLLSEITKYRAKNSDDERILAFLDDLQE",
-            hsp[-1].query.seq,
+            "XELLEQKDAQNKTTTDFLLCSLKSLLSEITKYRAKNSDDERILAFLDDLQE", hsp[-1].query.seq,
         )
         self.assertEqual(
             "XNKILNRDPQFMSNSSFHQCVSLDSINTIEKDEEKNSDDDAGLQAATDARE", hsp[-1].hit.seq

--- a/Tests/test_SearchIO_fasta_m10.py
+++ b/Tests/test_SearchIO_fasta_m10.py
@@ -330,8 +330,7 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(86, hsp.query_start)
         self.assertEqual(141, hsp.query_end)
         self.assertEqual(
-            "ISISNNKDQYEELQKEQGERDLKTVDQLVRIAAAGGGLRLSASTKTVDQLVRIAA",
-            hsp.query.seq,
+            "ISISNNKDQYEELQKEQGERDLKTVDQLVRIAAAGGGLRLSASTKTVDQLVRIAA", hsp.query.seq,
         )
         self.assertEqual(17, hsp.hit_start)
         self.assertEqual(69, hsp.hit_end)
@@ -632,14 +631,10 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(43, hsp.aln_span)
         self.assertEqual(196, hsp.query_start)
         self.assertEqual(238, hsp.query_end)
-        self.assertEqual(
-            "SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDVEMEDYSTYC", hsp.query.seq
-        )
+        self.assertEqual("SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDVEMEDYSTYC", hsp.query.seq)
         self.assertEqual(51, hsp.hit_start)
         self.assertEqual(94, hsp.hit_end)
-        self.assertEqual(
-            "SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDMLISSHGEYC", hsp.hit.seq
-        )
+        self.assertEqual("SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDMLISSHGEYC", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
 
@@ -997,14 +992,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(45, hsp.aln_span)
         self.assertEqual(26, hsp.query_start)
         self.assertEqual(66, hsp.query_end)
-        self.assertEqual(
-            "EIRKRAAECGKTVSGFLRAAA-----LGKKVNSLTDDRVLKEVMR", hsp.query.seq
-        )
+        self.assertEqual("EIRKRAAECGKTVSGFLRAAA-----LGKKVNSLTDDRVLKEVMR", hsp.query.seq)
         self.assertEqual(42, hsp.hit_start)
         self.assertEqual(87, hsp.hit_end)
-        self.assertEqual(
-            "ELVKLIADMGISVRALLRKNVEPYEELGLEEDKFTDDQLIDFMLQ", hsp.hit.seq
-        )
+        self.assertEqual("ELVKLIADMGISVRALLRKNVEPYEELGLEEDKFTDDQLIDFMLQ", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
             {"similarity": ":. :  :. : .: ..::  .-----:: . ...:::...  ..."},
@@ -1182,14 +1173,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(43, hsp.aln_span)
         self.assertEqual(196, hsp.query_start)
         self.assertEqual(238, hsp.query_end)
-        self.assertEqual(
-            "SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDVEMEDYSTYC", hsp.query.seq
-        )
+        self.assertEqual("SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDVEMEDYSTYC", hsp.query.seq)
         self.assertEqual(51, hsp.hit_start)
         self.assertEqual(94, hsp.hit_end)
-        self.assertEqual(
-            "SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDMLISSHGEYC", hsp.hit.seq
-        )
+        self.assertEqual("SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDMLISSHGEYC", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
             {"similarity": ":...: . . :  ::.: : .:: -. . . .:. . ... ::"},
@@ -1964,9 +1951,7 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(42, hsp.aln_span)
         self.assertEqual(33, hsp.query_start)
         self.assertEqual(75, hsp.query_end)
-        self.assertEqual(
-            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", hsp.query.seq
-        )
+        self.assertEqual("CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", hsp.query.seq)
         self.assertEqual(11, hsp.hit_start)
         self.assertEqual(52, hsp.hit_end)
         self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", hsp.hit.seq)
@@ -1992,9 +1977,7 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(42, hsp.aln_span)
         self.assertEqual(33, hsp.query_start)
         self.assertEqual(75, hsp.query_end)
-        self.assertEqual(
-            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", hsp.query.seq
-        )
+        self.assertEqual("CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", hsp.query.seq)
         self.assertEqual(11, hsp.hit_start)
         self.assertEqual(52, hsp.hit_end)
         self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", hsp.hit.seq)
@@ -2021,9 +2004,7 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(42, hsp.aln_span)
         self.assertEqual(33, hsp.query_start)
         self.assertEqual(75, hsp.query_end)
-        self.assertEqual(
-            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", hsp.query.seq
-        )
+        self.assertEqual("CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", hsp.query.seq)
         self.assertEqual(11, hsp.hit_start)
         self.assertEqual(52, hsp.hit_end)
         self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", hsp.hit.seq)
@@ -2074,9 +2055,7 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(42, hsp.aln_span)
         self.assertEqual(33, hsp.query_start)
         self.assertEqual(75, hsp.query_end)
-        self.assertEqual(
-            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", hsp.query.seq
-        )
+        self.assertEqual("CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", hsp.query.seq)
         self.assertEqual(11, hsp.hit_start)
         self.assertEqual(52, hsp.hit_end)
         self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", hsp.hit.seq)

--- a/Tests/test_SearchIO_fasta_m10.py
+++ b/Tests/test_SearchIO_fasta_m10.py
@@ -72,13 +72,13 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(89, hsp.query_end)
         self.assertEqual(
             "SGSNTRRRAISRPVR--LTAEEDQEIRKRAAECG-KTVSGFLRAAALGKKVNSLTDDRVLKEVMRLGALQKKLFIDGKRVGDREYAEV",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(15, hsp.hit_start)
         self.assertEqual(103, hsp.hit_end)
         self.assertEqual(
             "SQRSTRRKPENQPTRVILFNKPYDVLPQFTDEAGRKTLKEFIPVQGVYAAGRLDRDSEGLLVLTNNGALQARLTQPGKRTGKIYYVQV",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
@@ -106,12 +106,12 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(26, hsp.query_start)
         self.assertEqual(74, hsp.query_end)
         self.assertEqual(
-            "EIRKRAAECGKTVSGFLRAAA-LGKKV----NSLTDDRVLKEVMRLGALQKKL", str(hsp.query.seq)
+            "EIRKRAAECGKTVSGFLRAAA-LGKKV----NSLTDDRVLKEVMRLGALQKKL", hsp.query.seq
         )
         self.assertEqual(166, hsp.hit_start)
         self.assertEqual(219, hsp.hit_end)
         self.assertEqual(
-            "EIKPRGTSKGEAIAAFMQEAPFIGRTPVFLGDDLTDESGFAVVNRLGGMSVKI", str(hsp.hit.seq)
+            "EIKPRGTSKGEAIAAFMQEAPFIGRTPVFLGDDLTDESGFAVVNRLGGMSVKI", hsp.hit.seq
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
@@ -152,13 +152,13 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(117, hsp.query_end)
         self.assertEqual(
             "SEFFSKIESDLKKKKSKGDVFFDLIIPNG-----GKKDRYVYTSFNGEKFSSYTLNKVTKTDEYNDLSELSASFFKKNFDKINVNLLSKATS",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(295, hsp.hit_start)
         self.assertEqual(384, hsp.hit_end)
         self.assertEqual(
             "TELNSELAKAMKVDAQRG-AFVSQVLPNSSAAKAGIKAGDVITSLNGKPISSFAALRA-QVGTMPVGSKLTLGLLRDG-KQVNVNLELQQSS",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
@@ -187,13 +187,13 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(123, hsp.query_end)
         self.assertEqual(
             "FFDLIIPNGGKKDRYVYTSFNGEKFSSYTLNKVTKTDEYNDLSELSASFFKKNFDKINVNLLSKATSFALKKG",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(116, hsp.hit_start)
         self.assertEqual(185, hsp.hit_end)
         self.assertEqual(
             "LFDLFLKNDAMHDPMVNESYC-ETFGWVSKENLARMKE---LTYKANDVLKKLFDDAGLILVDFKLEFGLYKG",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
@@ -235,13 +235,13 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(246, hsp.query_end)
         self.assertEqual(
             "VDIKK-ETIESELHSKLPKSIDKIHEDIKKQLSCSLI--MKKID-VEMEDYSTYCFSALRAIE",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(13, hsp.hit_start)
         self.assertEqual(76, hsp.hit_end)
         self.assertEqual(
             "IDPKKIEQIARQVHESMPKGIREFGEDVEKKIRQTLQAQLTRLDLVSREEFDVQTQVLLRTRE",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
@@ -270,13 +270,13 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(281, hsp.query_end)
         self.assertEqual(
             "QYIMTTSNGDRVRAKIYKRGSIQFQGKYLQIASLINDFMCSILNMKEIVEQKNKEFNVDI---KKETI-ESELHSKLPKSIDKIHEDIKKQLSCSLIMKKIDV-EMEDYSTYCFSALRA-IEGFIYQILNDVCNPSSSKNLGEYFTENKPKYIIREI",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(9, hsp.hit_start)
         self.assertEqual(155, hsp.hit_end)
         self.assertEqual(
             "EFIRLLSDHDQFEKDQISELTVAANALKLEVAK--NNY-----NMKYSFDTQTERRMIELIREQKDLIPEKYLHQSGIKKL-KLHED---EFSSLLVDAERQVLEGSSFVLCCGEKINSTISELLSKKITDLTHPTESFTLSEYFSYDVYEEIFKKV",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
@@ -331,12 +331,12 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(141, hsp.query_end)
         self.assertEqual(
             "ISISNNKDQYEELQKEQGERDLKTVDQLVRIAAAGGGLRLSASTKTVDQLVRIAA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(17, hsp.hit_start)
         self.assertEqual(69, hsp.hit_end)
         self.assertEqual(
-            "VRLTAEEDQ--EIRKRAAECG-KTVSGFLRAAALGKKVNSLTDDRVLKEVMRLGA", str(hsp.hit.seq)
+            "VRLTAEEDQ--EIRKRAAECG-KTVSGFLRAAALGKKVNSLTDDRVLKEVMRLGA", hsp.hit.seq
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
@@ -402,10 +402,10 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(22, hsp.aln_span)
         self.assertEqual(42, hsp.query_start)
         self.assertEqual(63, hsp.query_end)
-        self.assertEqual("DDAEHLFRTLSSR-LDALQDGN", str(hsp.query.seq))
+        self.assertEqual("DDAEHLFRTLSSR-LDALQDGN", hsp.query.seq)
         self.assertEqual(101, hsp.hit_start)
         self.assertEqual(123, hsp.hit_end)
-        self.assertEqual("DDRANLFEFLSEEGITITEDNN", str(hsp.hit.seq))
+        self.assertEqual("DDRANLFEFLSEEGITITEDNN", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
 
@@ -446,13 +446,13 @@ class Fasta34Cases(unittest.TestCase):
         self.assertEqual(109, hsp.query_end)
         self.assertEqual(
             "VFGSFEQPKGEHLSGQVSEQ--RDTAFADQNEQVIRHLKQEIEHLNTLLLSKDSHIDSLKQAM",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(65, hsp.hit_start)
         self.assertEqual(124, hsp.hit_end)
         self.assertEqual(
             "VYTSFN---GEKFSSYTLNKVTKTDEYNDLSELSASFFKKNFDKINVNLLSKATSF-ALKKGI",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
@@ -509,13 +509,13 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(103, hsp.query_end)
         self.assertEqual(
             "SGSNT-RRRAISRPVRLTAEED---QEIRKRAAECGKTVSGFLRAAALGKKVNSLTDDRVLKEVM-----RLGALQKKLFIDGKRVGDREYAEVLIAITEYHRALLSR",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(95, hsp.hit_start)
         self.assertEqual(195, hsp.hit_end)
         self.assertEqual(
             "AGSGAPRRRGSGLASRISEQSEALLQEAAKHAAEFGRS------EVDTEHLLLALADSDVVKTILGQFKIKVDDLKRQIESEAKR-GDKPF-EGEIGVSPRVKDALSR",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
@@ -544,13 +544,13 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(94, hsp.query_end)
         self.assertEqual(
             "AAECGKTVSGFLRAAALGKKVNSLTDDRVLKEV-MRLGALQKKLFIDGKRVGDREYAEVLIAIT",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(190, hsp.hit_start)
         self.assertEqual(248, hsp.hit_end)
         self.assertEqual(
             "ASRQGCTVGG--KMDSVQDKASDKDKERVMKNINIMWNALSKNRLFDG----NKELKEFIMTLT",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
@@ -590,10 +590,10 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(38, hsp.aln_span)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(38, hsp.query_end)
-        self.assertEqual("MKKDKKYQIEAIKNKDKTLFIVYATDIYSPSEFFSKIE", str(hsp.query.seq))
+        self.assertEqual("MKKDKKYQIEAIKNKDKTLFIVYATDIYSPSEFFSKIE", hsp.query.seq)
         self.assertEqual(43, hsp.hit_start)
         self.assertEqual(81, hsp.hit_end)
-        self.assertEqual("IKKDLGVSFLKLKNREKTLIVDALKKKYPVAELLSVLQ", str(hsp.hit.seq))
+        self.assertEqual("IKKDLGVSFLKLKNREKTLIVDALKKKYPVAELLSVLQ", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
 
@@ -633,12 +633,12 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(196, hsp.query_start)
         self.assertEqual(238, hsp.query_end)
         self.assertEqual(
-            "SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDVEMEDYSTYC", str(hsp.query.seq)
+            "SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDVEMEDYSTYC", hsp.query.seq
         )
         self.assertEqual(51, hsp.hit_start)
         self.assertEqual(94, hsp.hit_end)
         self.assertEqual(
-            "SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDMLISSHGEYC", str(hsp.hit.seq)
+            "SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDMLISSHGEYC", hsp.hit.seq
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
@@ -696,13 +696,13 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(105, hsp.query_end)
         self.assertEqual(
             "AAAAAAGATAAAAAATATCAAATAGAAGCAATAAAAAATAAAGATAAAACTTTATTTATTGTCTATGCTACTGATATTTATAGCCCGAGCGAATTTTTCTCA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(312, hsp.hit_start)
         self.assertEqual(414, hsp.hit_end)
         self.assertEqual(
             "AGAGAAAATAAAACAAGTAATAAAATATTAATGGAAAAAATAAATTCTTGTTTATTTAGACCTGATTCTAATCACTTTTCTTGCCCGGAGTCATTTTTGACA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(1, hsp.query_strand)
         self.assertEqual(
@@ -782,13 +782,13 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(114, hsp.query_end)
         self.assertEqual(
             "IKNKDKTLFIVYAT-DIYSPSEFFSKIESDLKKKKSKGDV--FFDLIIPNGGKKD--RYVYTSFNGEKFSSYTLNKVTKTDEYNDL--SELSASFFKKNFDKINVNLLSK",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(38, hsp.hit_start)
         self.assertEqual(148, hsp.hit_end)
         self.assertEqual(
             "IKDELPVAFCSWASLDLECEVKYINDVTSLYAKDWMSGERKWFIDWIAPFGHNMELYKYMRKKYPYELFRAIRLDESSKTGKIAEFHGGGIDKKLASKIFRQYHHELMSE",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({}, hsp.aln_annotation)
@@ -852,13 +852,13 @@ class Fasta35Cases(unittest.TestCase):
         self.assertEqual(131, hsp.query_end)
         self.assertEqual(
             "GCAACGCTTCAAGAACTGGAATTAGGAACCGTGACAACGATTAATGAGGAGATTTATGAAGAGGGTTCTTCGATTTTAGGCCAATCGGAAGGAATTATGTAGCAAGTCCATCAGAAAATGGAAGAAGTCAT",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(359, hsp.hit_start)
         self.assertEqual(490, hsp.hit_end)
         self.assertEqual(
             "GCAACGCTTCAAGAACTGGAATTAGGAACCGTGACAACGATTAATGAGGAGATTTATGAAGAGGGTTCTTCGATTTTAGGCCAATCGGAAGGAATTATGTAGCAAGTCCATCAGAAAATGGAAGTAGTCAT",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(-1, hsp.query_strand)
         self.assertEqual(
@@ -919,13 +919,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(103, hsp.query_end)
         self.assertEqual(
             "SGSNT-RRRAISRPVRLTAEED---QEIRKRAAECGKTVSGFLRAAALGKKVNSLTDDRVLKEVM-----RLGALQKKLFIDGKRVGDREYAEVLIAITEYHRALLSR",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(95, hsp.hit_start)
         self.assertEqual(195, hsp.hit_end)
         self.assertEqual(
             "AGSGAPRRRGSGLASRISEQSEALLQEAAKHAAEFGRS------EVDTEHLLLALADSDVVKTILGQFKIKVDDLKRQIESEAKR-GDKPF-EGEIGVSPRVKDALSR",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
@@ -959,13 +959,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(94, hsp.query_end)
         self.assertEqual(
             "AAECGKTVSGFLRAAALGKKVNSLTDDRVLKEV-MRLGALQKKLFIDGKRVGDREYAEVLIAIT",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(190, hsp.hit_start)
         self.assertEqual(248, hsp.hit_end)
         self.assertEqual(
             "ASRQGCTVGG--KMDSVQDKASDKDKERVMKNINIMWNALSKNRLFDG----NKELKEFIMTLT",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
@@ -998,12 +998,12 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(26, hsp.query_start)
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(
-            "EIRKRAAECGKTVSGFLRAAA-----LGKKVNSLTDDRVLKEVMR", str(hsp.query.seq)
+            "EIRKRAAECGKTVSGFLRAAA-----LGKKVNSLTDDRVLKEVMR", hsp.query.seq
         )
         self.assertEqual(42, hsp.hit_start)
         self.assertEqual(87, hsp.hit_end)
         self.assertEqual(
-            "ELVKLIADMGISVRALLRKNVEPYEELGLEEDKFTDDQLIDFMLQ", str(hsp.hit.seq)
+            "ELVKLIADMGISVRALLRKNVEPYEELGLEEDKFTDDQLIDFMLQ", hsp.hit.seq
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
@@ -1046,10 +1046,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(38, hsp.aln_span)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(38, hsp.query_end)
-        self.assertEqual("MKKDKKYQIEAIKNKDKTLFIVYATDIYSPSEFFSKIE", str(hsp.query.seq))
+        self.assertEqual("MKKDKKYQIEAIKNKDKTLFIVYATDIYSPSEFFSKIE", hsp.query.seq)
         self.assertEqual(43, hsp.hit_start)
         self.assertEqual(81, hsp.hit_end)
-        self.assertEqual("IKKDLGVSFLKLKNREKTLIVDALKKKYPVAELLSVLQ", str(hsp.hit.seq))
+        self.assertEqual("IKKDLGVSFLKLKNREKTLIVDALKKKYPVAELLSVLQ", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
             {"similarity": ".:::   ..  .::..:::..      :  .:..: .."}, hsp.aln_annotation
@@ -1077,10 +1077,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(11, hsp.aln_span)
         self.assertEqual(50, hsp.query_start)
         self.assertEqual(61, hsp.query_end)
-        self.assertEqual("FFDLIIPNGGK", str(hsp.query.seq))
+        self.assertEqual("FFDLIIPNGGK", hsp.query.seq)
         self.assertEqual(407, hsp.hit_start)
         self.assertEqual(418, hsp.hit_end)
-        self.assertEqual("FFDLVIENPGK", str(hsp.hit.seq))
+        self.assertEqual("FFDLVIENPGK", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual({"similarity": "::::.: : ::"}, hsp.aln_annotation)
         # second qresult, third hit
@@ -1106,10 +1106,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(40, hsp.aln_span)
         self.assertEqual(15, hsp.query_start)
         self.assertEqual(53, hsp.query_end)
-        self.assertEqual("DKTLFIVYATDIYSPSE-FFSKIESDLKKKKSKGD-VFFD", str(hsp.query.seq))
+        self.assertEqual("DKTLFIVYATDIYSPSE-FFSKIESDLKKKKSKGD-VFFD", hsp.query.seq)
         self.assertEqual(44, hsp.hit_start)
         self.assertEqual(84, hsp.hit_end)
-        self.assertEqual("ESVVFILMAGFAMSVCYLFFSVLEKVINARKSKDESIYHD", str(hsp.hit.seq))
+        self.assertEqual("ESVVFILMAGFAMSVCYLFFSVLEKVINARKSKDESIYHD", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
             {"similarity": "....::..:   .:   -::: .:. .. .::: .-.. :"},
@@ -1138,10 +1138,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(30, hsp.aln_span)
         self.assertEqual(96, hsp.query_start)
         self.assertEqual(126, hsp.query_end)
-        self.assertEqual("ASFFKKNFDKINVNLLSKATSFALKKGIPI", str(hsp.query.seq))
+        self.assertEqual("ASFFKKNFDKINVNLLSKATSFALKKGIPI", hsp.query.seq)
         self.assertEqual(6, hsp.hit_start)
         self.assertEqual(36, hsp.hit_end)
-        self.assertEqual("ASFSKEEQDKVAVDKVAADVAWQERMNKPV", str(hsp.hit.seq))
+        self.assertEqual("ASFSKEEQDKVAVDKVAADVAWQERMNKPV", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
             {"similarity": "::: :.. ::. :. ..  ...  . . :."}, hsp.aln_annotation
@@ -1183,12 +1183,12 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(196, hsp.query_start)
         self.assertEqual(238, hsp.query_end)
         self.assertEqual(
-            "SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDVEMEDYSTYC", str(hsp.query.seq)
+            "SELHSKLPKSIDKIHEDIKKQLSC-SLIMKKIDVEMEDYSTYC", hsp.query.seq
         )
         self.assertEqual(51, hsp.hit_start)
         self.assertEqual(94, hsp.hit_end)
         self.assertEqual(
-            "SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDMLISSHGEYC", str(hsp.hit.seq)
+            "SRINSDVARRIPGIHRDPKDRLSSLKQVEEALDMLISSHGEYC", hsp.hit.seq
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
@@ -1220,13 +1220,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(101, hsp.query_end)
         self.assertEqual(
             "ISGTYKGIDFLIKLMPSGGNTTIGRASGQNNTYFDEIALIIKENCLY--SDTKNFEYTIPKFSD",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(221, hsp.hit_start)
         self.assertEqual(281, hsp.hit_end)
         self.assertEqual(
             "IDGVITAFD-LRTGMNISKDKVVAQIQGMDPVW---ISAAVPESIAYLLKDTSQFEISVPAYPD",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
@@ -1299,13 +1299,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(514, hsp.query_end)
         self.assertEqual(
             "LQHRHPHQQQQQQQQQQQQQQQQQQQQQQQQQQQH---HHHHHHHLLQDAYMQQYQHATQQQQML",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(122, hsp.hit_start)
         self.assertEqual(317, hsp.hit_end)
         self.assertEqual(
             "IPHQLPHALRHRPAQEAAHASQLHPAQPGCGQPLHGLWRLHHHPVYLYAWILRLRGHGMQSGGLL",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
@@ -1336,13 +1336,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(599, hsp.query_end)
         self.assertEqual(
             "GPEIL---LGQ-GPPQQPPQQHRVLQQLQQGDWRLQQLH-------LQHRHPHQQQQQQQQQQQQQQQQQQQQQQQQQQQH-----HHHHHH-HLLQDAYMQQYQHATQQQQMLQQQF-LMHSVYQPQPSASQYPTMMPQYQQAFFQQQMLAQHQPSQQQASPEYLTSPQEFSPALVSYTSSLPA-QVGTIMDSSYSANRS",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(14, hsp.hit_start)
         self.assertEqual(595, hsp.hit_end)
         self.assertEqual(
             "GPELLRALLQQNGCGTQPLRVPTVLPG*AMAVLHAGRLHVPAHRAWLPHQLPHALRHGPAQEAAHASQLHPAQPGRG*PLHGLRWLHHHPLH/PLCMDTLSLGPQDAIWRASLPHWAVKLPCGLWWSWPLSGTWWCVSP*ATSA------LGRTMP*WASLSPGSWHWPALHPPSLVGPGTSLKACSVHAGSTTTHSSQKS",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
@@ -1395,13 +1395,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(348, hsp.query_end)
         self.assertEqual(
             "MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGDDEASATVSKTETSQVAPA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(1044, hsp.hit_end)
         self.assertEqual(
             "MNGTEGPNFYVPFSNKTGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVFGGFTTTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLVGWSRYIPEGMQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIVIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTLPAFFAKSSSIYNPVIYIMMNKQFRNCMLTTLCCGKNPLGDDEASTTGSKTETSQVAPA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
@@ -1435,13 +1435,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(348, hsp.query_end)
         self.assertEqual(
             "MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGDDEASATVSKTETSQVAPA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(1044, hsp.hit_end)
         self.assertEqual(
             "MNGTEGPNFYVPFSNKTGVVRSPFEAPQYYLAEPWQFSMLAAYMFLLIMLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVFGGFTTTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLVGWSRYIPEGMQCSCGIDYYTPHEETNNESFVIYMFVVHFIIPLIVIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWLPYAGVAFYIFTHQGSDFGPIFMTIPAFFAKTSAVYNPVIYIMMNKQFRNCMVTTLCCGKNPLGDDEASTTVSKTETSQVAPA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # fourth qresult, third hit
@@ -1475,13 +1475,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(336, hsp.query_end)
         self.assertEqual(
             "VPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGDDEASAT",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(978, hsp.hit_end)
         self.assertEqual(
             "VPFSNKTGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVANLFMVFGGFTTTLYTSMHGYFVFGATGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGLAFTWVMALACAAPPLAGWSRYIPEGMQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIVIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVVAFLICWLPYASVAFYIFTHQGSNFGPVFMTIPAFFAKSSSIYNPVIYIMMNKQFRNCMLTTLCCGKNPLGDDEASTT",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         self.assertEqual(
@@ -1504,10 +1504,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(31, hsp.aln_span)
         self.assertEqual(234, hsp.query_start)
         self.assertEqual(265, hsp.query_end)
-        self.assertEqual("AQQQESATTQKAEKEVTRMVIIMVIAFLICW", str(hsp.query.seq))
+        self.assertEqual("AQQQESATTQKAEKEVTRMVIIMVIAFLICW", hsp.query.seq)
         self.assertEqual(674, hsp.hit_start)
         self.assertEqual(767, hsp.hit_end)
-        self.assertEqual("SQQIRNATTMMMTMRVTSFSAFWVVADSCCW", str(hsp.hit.seq))
+        self.assertEqual("SQQIRNATTMMMTMRVTSFSAFWVVADSCCW", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         # fourth qresult, fourth hit
         hit = qresult[3]
@@ -1531,13 +1531,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(348, hsp.query_end)
         self.assertEqual(
             "MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGDDEAS-ATVSKTE-----TSQVAPA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(41, hsp.hit_start)
         self.assertEqual(1103, hsp.hit_end)
         self.assertEqual(
             "MNGTEGPNFYIPMSNKTGVVRSPFEYPQYYLAEPWQYSILCAYMFLLILLGFPINFMTLYVTIQHKKLRTPLNYILLNLAFANHFMVLCGFTVTMYSSMNGYFILGATGCYVEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFSENHAVMGVAFTWIMALSCAVPPLLGWSRYIPEGMQCSCGVDYYTLKPEVNNESFVIYMFVVHFTIPLIIIFFCYGRLVCTVKEAAAQQQESATTQKAEKEVTRMVIIMVVFFLICWVPYASVAFFIFSNQGSEFGPIFMTVPAFFAKSSSIYNPVIYIMLNKQFRNCMITTLCCGKNPFGEDDASSAATSKTEASSVSSSQVSPA",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # fourth qresult, fifth hit
@@ -1565,13 +1565,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(346, hsp.query_end)
         self.assertEqual(
             "MNGTEGPNFYVPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSRYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKEAAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQFRNCMLTTICCGKNPLGD-DEASATVSKTETSQVA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(22, hsp.hit_start)
         self.assertEqual(1063, hsp.hit_end)
         self.assertEqual(
             "MNGTEGPNFYIPMSNATGVVRSPFEYPQYYLAEPWAFSALSAYMFFLIIAGFPINFLTLYVTIEHKKLRTPLNYILLNLAVADLFMVFGGFTTTMYTSMHGYFVFGPTGCNIEGFFATLGGEIALWCLVVLAIERWMVVCKPVTNFRFGESHAIMGVMVTWTMALACALPPLFGWSRYIPEGLQCSCGIDYYTRAPGINNESFVIYMFTCHFSIPLAVISFCYGRLVCTVKEAAAQQQESETTQRAEREVTRMVVIMVISFLVCWVPYASVAWYIFTHQGSTFGPIFMTIPSFFAKSSALYNPMIYICMNKQFRHCMITTLCCGKNPFEEEDGASATSSKTEASSVS",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # fourth qresult, sixth hit
@@ -1599,13 +1599,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(121, hsp.query_end)
         self.assertEqual(
             "VPFSNATGVVRSPFEYPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVLGGFTSTLYTSLHGYFVFGPTGCNLEGFFATLGG",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(333, hsp.hit_end)
         self.assertEqual(
             "VPFSNKTGVVRSPFEHPQYYLAEPWQFSMLAAYMFLLIVLGFPINFLTLYVTVQHKKLRTPLNYILLNLAVADLFMVFGGFTTTLYTSLHGYFVFGPTGCNLEGFFATLGG",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # fourth qresult, sixth hit, second hsp
@@ -1624,13 +1624,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(312, hsp.query_end)
         self.assertEqual(
             "RYIPEGLQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIIIFFCYGQLVFTVKE------------------------------------AAAQQQESATTQKAEKEVTRMVIIMVIAFLICWVPYASVAFYIFTHQGSNFGPIFMTIPAFFAKSAAIYNPVIYIMMNKQ",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(2854, hsp.hit_start)
         self.assertEqual(3368, hsp.hit_end)
         self.assertEqual(
             r"RYIPEGMQCSCGIDYYTLKPEVNNESFVIYMFVVHFTIPMIVIFFCYGQLVFTVKEVRSCVGHWGHAH*VNGAQLHSQSCHSLDT*PCVPA\AAAQQQESATTQKAEKEVTRMVIIMVIAFLICWLPYAGVAFYIFTHQGSNFGPIFMTLPAFFAKSSSIYNPVIYIMMNKQ",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # fourth qresult, sixth hit, third hsp
@@ -1649,13 +1649,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(189, hsp.query_end)
         self.assertEqual(
             "LGGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGVAFTWVMALACAAPPLAGWSR--YIPEGLQCSCGI",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(1403, hsp.hit_start)
         self.assertEqual(1619, hsp.hit_end)
         self.assertEqual(
             "LAGEIALWSLVVLAIERYVVVCKPMSNFRFGENHAIMGLALTWVMALACAAPPLVGWSR*WH*TEG-KCL*GL",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # fourth qresult, sixth hit, fourth hsp
@@ -1672,10 +1672,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(30, hsp.aln_span)
         self.assertEqual(306, hsp.query_start)
         self.assertEqual(336, hsp.query_end)
-        self.assertEqual("IMMNKQFRNCMLTTICCGKNPLGDDEASAT", str(hsp.query.seq))
+        self.assertEqual("IMMNKQFRNCMLTTICCGKNPLGDDEASAT", hsp.query.seq)
         self.assertEqual(4206, hsp.hit_start)
         self.assertEqual(4296, hsp.hit_end)
-        self.assertEqual("MLLAFQFRNCMLTTLCCGKNPLGDDEASTT", str(hsp.hit.seq))
+        self.assertEqual("MLLAFQFRNCMLTTLCCGKNPLGDDEASTT", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
 
     def test_output009(self):
@@ -1731,10 +1731,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(22, hsp.aln_span)
         self.assertEqual(7, hsp.query_start)
         self.assertEqual(29, hsp.query_end)
-        self.assertEqual("TGATGTTCTGTTTCTAAAACAG", str(hsp.query.seq))
+        self.assertEqual("TGATGTTCTGTTTCTAAAACAG", hsp.query.seq)
         self.assertEqual(3483, hsp.hit_start)
         self.assertEqual(3505, hsp.hit_end)
-        self.assertEqual("TGATTTTTTTTGTCTAAAACAG", str(hsp.hit.seq))
+        self.assertEqual("TGATTTTTTTTGTCTAAAACAG", hsp.hit.seq)
         self.assertEqual(-1, hsp.query_strand)
 
         # test third qresult
@@ -1767,10 +1767,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(14, hsp.aln_span)
         self.assertEqual(2, hsp.query_start)
         self.assertEqual(16, hsp.query_end)
-        self.assertEqual("AGAAGGAAAAAAAA", str(hsp.query.seq))
+        self.assertEqual("AGAAGGAAAAAAAA", hsp.query.seq)
         self.assertEqual(572, hsp.hit_start)
         self.assertEqual(586, hsp.hit_end)
-        self.assertEqual("AGAACTAAAAAAAA", str(hsp.hit.seq))
+        self.assertEqual("AGAACTAAAAAAAA", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
         # third qresult, second hit
         hit = qresult[1]
@@ -1794,10 +1794,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(14, hsp.aln_span)
         self.assertEqual(2, hsp.query_start)
         self.assertEqual(16, hsp.query_end)
-        self.assertEqual("AGAAGGAAAAAAAA", str(hsp.query.seq))
+        self.assertEqual("AGAAGGAAAAAAAA", hsp.query.seq)
         self.assertEqual(84, hsp.hit_start)
         self.assertEqual(98, hsp.hit_end)
-        self.assertEqual("AGAAGGTATAAAAA", str(hsp.hit.seq))
+        self.assertEqual("AGAAGGTATAAAAA", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
         # third qresult, third hit
         hit = qresult[2]
@@ -1821,10 +1821,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(14, hsp.aln_span)
         self.assertEqual(1, hsp.query_start)
         self.assertEqual(15, hsp.query_end)
-        self.assertEqual("TTTTTTTCCTTCTT", str(hsp.query.seq))
+        self.assertEqual("TTTTTTTCCTTCTT", hsp.query.seq)
         self.assertEqual(633, hsp.hit_start)
         self.assertEqual(647, hsp.hit_end)
-        self.assertEqual("TTTTTTTACATCTT", str(hsp.hit.seq))
+        self.assertEqual("TTTTTTTACATCTT", hsp.hit.seq)
         self.assertEqual(-1, hsp.query_strand)
         # third qresult, fourth hit
         hit = qresult[3]
@@ -1845,10 +1845,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(14, hsp.aln_span)
         self.assertEqual(1, hsp.query_start)
         self.assertEqual(15, hsp.query_end)
-        self.assertEqual("AAGAAGGAAAAAAA", str(hsp.query.seq))
+        self.assertEqual("AAGAAGGAAAAAAA", hsp.query.seq)
         self.assertEqual(3547, hsp.hit_start)
         self.assertEqual(3561, hsp.hit_end)
-        self.assertEqual("AATAAGTAAAAAAA", str(hsp.hit.seq))
+        self.assertEqual("AATAAGTAAAAAAA", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
         # third qresult, fifth hit
         hit = qresult[4]
@@ -1872,10 +1872,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(14, hsp.aln_span)
         self.assertEqual(1, hsp.query_start)
         self.assertEqual(15, hsp.query_end)
-        self.assertEqual("TTTTTTTCCTTCTT", str(hsp.query.seq))
+        self.assertEqual("TTTTTTTCCTTCTT", hsp.query.seq)
         self.assertEqual(983, hsp.hit_start)
         self.assertEqual(997, hsp.hit_end)
-        self.assertEqual("TTTTTTTACATCTT", str(hsp.hit.seq))
+        self.assertEqual("TTTTTTTACATCTT", hsp.hit.seq)
         self.assertEqual(-1, hsp.query_strand)
         # third qresult, fifth hit, second hsp
         hsp = qresult[4].hsps[1]
@@ -1890,10 +1890,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(14, hsp.aln_span)
         self.assertEqual(1, hsp.query_start)
         self.assertEqual(15, hsp.query_end)
-        self.assertEqual("AAGAAGGAAAAAAA", str(hsp.query.seq))
+        self.assertEqual("AAGAAGGAAAAAAA", hsp.query.seq)
         self.assertEqual(19, hsp.hit_start)
         self.assertEqual(33, hsp.hit_end)
-        self.assertEqual("AAGAAGGTAAAAGA", str(hsp.hit.seq))
+        self.assertEqual("AAGAAGGTAAAAGA", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
 
     def test_output010(self):
@@ -1965,11 +1965,11 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(33, hsp.query_start)
         self.assertEqual(75, hsp.query_end)
         self.assertEqual(
-            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", str(hsp.query.seq)
+            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", hsp.query.seq
         )
         self.assertEqual(11, hsp.hit_start)
         self.assertEqual(52, hsp.hit_end)
-        self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", str(hsp.hit.seq))
+        self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
         # first qresult, second hit
         hit = qresult[1]
@@ -1993,11 +1993,11 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(33, hsp.query_start)
         self.assertEqual(75, hsp.query_end)
         self.assertEqual(
-            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", str(hsp.query.seq)
+            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", hsp.query.seq
         )
         self.assertEqual(11, hsp.hit_start)
         self.assertEqual(52, hsp.hit_end)
-        self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", str(hsp.hit.seq))
+        self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
         # first qresult, third hit
         hit = qresult[2]
@@ -2022,11 +2022,11 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(33, hsp.query_start)
         self.assertEqual(75, hsp.query_end)
         self.assertEqual(
-            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", str(hsp.query.seq)
+            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", hsp.query.seq
         )
         self.assertEqual(11, hsp.hit_start)
         self.assertEqual(52, hsp.hit_end)
-        self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", str(hsp.hit.seq))
+        self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
         # first qresult, fourth hit
         hit = qresult[3]
@@ -2047,10 +2047,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(25, hsp.aln_span)
         self.assertEqual(12, hsp.query_start)
         self.assertEqual(37, hsp.query_end)
-        self.assertEqual("TTAGAAACAGAACATCATCTTCAAC", str(hsp.query.seq))
+        self.assertEqual("TTAGAAACAGAACATCATCTTCAAC", hsp.query.seq)
         self.assertEqual(415, hsp.hit_start)
         self.assertEqual(440, hsp.hit_end)
-        self.assertEqual("TGACAAACTCAACACCATCTTCAAC", str(hsp.hit.seq))
+        self.assertEqual("TGACAAACTCAACACCATCTTCAAC", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
         # first qresult, fifth hit
         hit = qresult[4]
@@ -2075,11 +2075,11 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(33, hsp.query_start)
         self.assertEqual(75, hsp.query_end)
         self.assertEqual(
-            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", str(hsp.query.seq)
+            "CAACATCCAGAGGACTGTCATCCTTGTCCCTGTGGGTGAGGG", hsp.query.seq
         )
         self.assertEqual(11, hsp.hit_start)
         self.assertEqual(52, hsp.hit_end)
-        self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", str(hsp.hit.seq))
+        self.assertEqual("CAAGAGCGAGAGGACCATCAT-CATGTCCCTCTGGGACAAGG", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
 
     def test_output012(self):
@@ -2126,10 +2126,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(15, hsp.aln_span)
         self.assertEqual(1, hsp.query_start)
         self.assertEqual(16, hsp.query_end)
-        self.assertEqual("AAGAAGGAAAAAAAA", str(hsp.query.seq))
+        self.assertEqual("AAGAAGGAAAAAAAA", hsp.query.seq)
         self.assertEqual(529, hsp.hit_start)
         self.assertEqual(544, hsp.hit_end)
-        self.assertEqual("AAGAATAAAAAAAAA", str(hsp.hit.seq))
+        self.assertEqual("AAGAATAAAAAAAAA", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
         # first qresult, second hit
         hit = qresult[1]
@@ -2152,10 +2152,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(15, hsp.aln_span)
         self.assertEqual(1, hsp.query_start)
         self.assertEqual(16, hsp.query_end)
-        self.assertEqual("AAGAAGGAAAAAAAA", str(hsp.query.seq))
+        self.assertEqual("AAGAAGGAAAAAAAA", hsp.query.seq)
         self.assertEqual(531, hsp.hit_start)
         self.assertEqual(546, hsp.hit_end)
-        self.assertEqual("AAGAAAAAAAAAAAA", str(hsp.hit.seq))
+        self.assertEqual("AAGAAAAAAAAAAAA", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
         # first qresult, third hit
         hit = qresult[2]
@@ -2176,10 +2176,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(16, hsp.aln_span)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(16, hsp.query_end)
-        self.assertEqual("GAAGAAGGAAAAAAAA", str(hsp.query.seq))
+        self.assertEqual("GAAGAAGGAAAAAAAA", hsp.query.seq)
         self.assertEqual(1781, hsp.hit_start)
         self.assertEqual(1797, hsp.hit_end)
-        self.assertEqual("GAAGAAAAAAAAAAAA", str(hsp.hit.seq))
+        self.assertEqual("GAAGAAAAAAAAAAAA", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
         # first qresult, fourth hit
         hit = qresult[3]
@@ -2203,10 +2203,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(15, hsp.aln_span)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(15, hsp.query_end)
-        self.assertEqual("GAAGAAGGAAAAAAA", str(hsp.query.seq))
+        self.assertEqual("GAAGAAGGAAAAAAA", hsp.query.seq)
         self.assertEqual(131, hsp.hit_start)
         self.assertEqual(146, hsp.hit_end)
-        self.assertEqual("GAAGAAGGTAAAACA", str(hsp.hit.seq))
+        self.assertEqual("GAAGAAGGTAAAACA", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
         # first qresult, fifth hit
         hit = qresult[4]
@@ -2230,10 +2230,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(15, hsp.aln_span)
         self.assertEqual(1, hsp.query_start)
         self.assertEqual(16, hsp.query_end)
-        self.assertEqual("TTTTTTTTCCTTCTT", str(hsp.query.seq))
+        self.assertEqual("TTTTTTTTCCTTCTT", hsp.query.seq)
         self.assertEqual(589, hsp.hit_start)
         self.assertEqual(604, hsp.hit_end)
-        self.assertEqual("TTTTTTTTACATCTT", str(hsp.hit.seq))
+        self.assertEqual("TTTTTTTTACATCTT", hsp.hit.seq)
         self.assertEqual(-1, hsp.query_strand)
         # first qresult, sixth hit
         hit = qresult[5]
@@ -2256,10 +2256,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(15, hsp.aln_span)
         self.assertEqual(1, hsp.query_start)
         self.assertEqual(16, hsp.query_end)
-        self.assertEqual("AAGAAGGAAAAAAAA", str(hsp.query.seq))
+        self.assertEqual("AAGAAGGAAAAAAAA", hsp.query.seq)
         self.assertEqual(642, hsp.hit_start)
         self.assertEqual(657, hsp.hit_end)
-        self.assertEqual("AAAAAAGAAAAAAAA", str(hsp.hit.seq))
+        self.assertEqual("AAAAAAGAAAAAAAA", hsp.hit.seq)
         self.assertEqual(1, hsp.query_strand)
         # first qresult, seventh hit
         hit = qresult[6]
@@ -2282,10 +2282,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(15, hsp.aln_span)
         self.assertEqual(1, hsp.query_start)
         self.assertEqual(16, hsp.query_end)
-        self.assertEqual("TTTTTTTTCCTTCTT", str(hsp.query.seq))
+        self.assertEqual("TTTTTTTTCCTTCTT", hsp.query.seq)
         self.assertEqual(6, hsp.hit_start)
         self.assertEqual(21, hsp.hit_end)
-        self.assertEqual("TTTTTTTTTTTTCTT", str(hsp.hit.seq))
+        self.assertEqual("TTTTTTTTTTTTCTT", hsp.hit.seq)
         self.assertEqual(-1, hsp.query_strand)
         # first qresult, seventh hit, second hsp
         hsp = qresult[6].hsps[1]
@@ -2300,10 +2300,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(15, hsp.aln_span)
         self.assertEqual(1, hsp.query_start)
         self.assertEqual(16, hsp.query_end)
-        self.assertEqual("TTTTTTTTCCTTCTT", str(hsp.query.seq))
+        self.assertEqual("TTTTTTTTCCTTCTT", hsp.query.seq)
         self.assertEqual(45, hsp.hit_start)
         self.assertEqual(60, hsp.hit_end)
-        self.assertEqual("TTTTTTTTTTTTCTT", str(hsp.hit.seq))
+        self.assertEqual("TTTTTTTTTTTTCTT", hsp.hit.seq)
         self.assertEqual(-1, hsp.query_strand)
         # first qresult, seventh hit, third hsp
         hsp = qresult[6].hsps[2]
@@ -2318,10 +2318,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(15, hsp.aln_span)
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(15, hsp.query_end)
-        self.assertEqual("TTTTTTTCCTTCTTC", str(hsp.query.seq))
+        self.assertEqual("TTTTTTTCCTTCTTC", hsp.query.seq)
         self.assertEqual(644, hsp.hit_start)
         self.assertEqual(659, hsp.hit_end)
-        self.assertEqual("TTTTTTTCCTCCTCC", str(hsp.hit.seq))
+        self.assertEqual("TTTTTTTCCTCCTCC", hsp.hit.seq)
         self.assertEqual(-1, hsp.query_strand)
         # first qresult, eighth hit
         hit = qresult[7]
@@ -2345,10 +2345,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(15, hsp.aln_span)
         self.assertEqual(1, hsp.query_start)
         self.assertEqual(16, hsp.query_end)
-        self.assertEqual("TTTTTTTTCCTTCTT", str(hsp.query.seq))
+        self.assertEqual("TTTTTTTTCCTTCTT", hsp.query.seq)
         self.assertEqual(662, hsp.hit_start)
         self.assertEqual(677, hsp.hit_end)
-        self.assertEqual("TTTTTTTTACATCTT", str(hsp.hit.seq))
+        self.assertEqual("TTTTTTTTACATCTT", hsp.hit.seq)
         self.assertEqual(-1, hsp.query_strand)
 
     def test_output013(self):
@@ -2405,13 +2405,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(
             "PNGSVPPIY-----VPPGYAPQVIEDNGVRRVVVVPQAPEFHPGSHTVLHRSPHPPLPGFIPVPTMMPPPP",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(10704, hsp.hit_start)
         self.assertEqual(10775, hsp.hit_end)
         self.assertEqual(
             "PEKKVPPAVPKKPEAPPAKVPEAPKEVVPEKKIAVPKKPEVPPAKVPEVPKKPVIEEKPVIPVPKKVESPP",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
 
@@ -2449,13 +2449,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(79, hsp.query_end)
         self.assertEqual(
             "LSNIVKPVASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVG-EETNITLNDLKPAMDY",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(22430, hsp.hit_start)
         self.assertEqual(22499, hsp.hit_end)
         self.assertEqual(
             "VSNI-RPAASDISPHTLTLTWDTP------EDDGGSLITSYVVEMFDVS---DGKWQTLTTTCRRPPYPVKGLNPSATY",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # third qresult, second hit
@@ -2481,10 +2481,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(37, hsp.aln_span)
         self.assertEqual(43, hsp.query_start)
         self.assertEqual(80, hsp.query_end)
-        self.assertEqual("YEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH", str(hsp.query.seq))
+        self.assertEqual("YEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH", hsp.query.seq)
         self.assertEqual(542, hsp.hit_start)
         self.assertEqual(579, hsp.hit_end)
-        self.assertEqual("YELVYWAAEEEGQQRKVTFDPTSSYTLEDLKPDTLYH", str(hsp.hit.seq))
+        self.assertEqual("YELVYWAAEEEGQQRKVTFDPTSSYTLEDLKPDTLYH", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         # third qresult, third hit
         hit = qresult[2]
@@ -2509,10 +2509,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(37, hsp.aln_span)
         self.assertEqual(43, hsp.query_start)
         self.assertEqual(80, hsp.query_end)
-        self.assertEqual("YEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH", str(hsp.query.seq))
+        self.assertEqual("YEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH", hsp.query.seq)
         self.assertEqual(542, hsp.hit_start)
         self.assertEqual(579, hsp.hit_end)
-        self.assertEqual("YELVYWAAEEEGQQRKVTFDPTSSYTLEDLKPDTLYH", str(hsp.hit.seq))
+        self.assertEqual("YELVYWAAEEEGQQRKVTFDPTSSYTLEDLKPDTLYH", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         # third qresult, fourth hit
         hit = qresult[3]
@@ -2538,13 +2538,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(79, hsp.query_end)
         self.assertEqual(
             "ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(615, hsp.hit_start)
         self.assertEqual(673, hsp.hit_end)
         self.assertEqual(
             "ASSISYHSIKLKWGHQSS-------KKSI-----LNHTLQMQNKSGSFNTVYSGMDTSFTLSKLKELTPY",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
 
@@ -2615,13 +2615,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(
             "PPIY----VPPGYA---PQVIEDNGVRRVVVVPQAPEFH---PGSHTVLHRSPHPPLPGFIPVPTMMPPPP",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(128, hsp.hit_start)
         self.assertEqual(195, hsp.hit_end)
         self.assertEqual(
             "PPLLQQTATPPQGAQIVPPVCALHHPQQQLALMAAMQHHHPLPPPHA-LHHAPLPPPP---PLPLNPGPPP",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, second hit
@@ -2646,13 +2646,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(66, hsp.query_end)
         self.assertEqual(
             "PNGSVPPIY--VPPGYAPQVIEDNGVRRVVVVPQAPEFHPGSHTVLHRSPHPPLPGFIPVPTMMPPPP",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(10780, hsp.hit_start)
         self.assertEqual(10848, hsp.hit_end)
         self.assertEqual(
             "PEKKVPPKKPEAPPAKVPEVPKEVVTEKKVAVPKKPEVPPAKVPEVPKKPVIEEKPAIPVVEKVASPP",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
 
@@ -2701,10 +2701,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(23, hsp.aln_span)
         self.assertEqual(56, hsp.query_start)
         self.assertEqual(79, hsp.query_end)
-        self.assertEqual("YKSVYVGEETNITLNDLKPAMDY", str(hsp.query.seq))
+        self.assertEqual("YKSVYVGEETNITLNDLKPAMDY", hsp.query.seq)
         self.assertEqual(424, hsp.hit_start)
         self.assertEqual(447, hsp.hit_end)
-        self.assertEqual("FRPVYTGIDTNYKVVDLTPNCDY", str(hsp.hit.seq))
+        self.assertEqual("FRPVYTGIDTNYKVVDLTPNCDY", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         # first qresult, second hit
         hit = qresult[1]
@@ -2731,13 +2731,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(79, hsp.query_end)
         self.assertEqual(
             "VASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(325, hsp.hit_start)
         self.assertEqual(385, hsp.hit_end)
         self.assertEqual(
             "VVTETTATSVTLTWD------SGNTEPVS---FYG--IQYRAAGTDGPFQEVDGVASTRYSIGGLSPFSEY",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, second hit, second hsp
@@ -2754,10 +2754,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(37, hsp.aln_span)
         self.assertEqual(43, hsp.query_start)
         self.assertEqual(80, hsp.query_end)
-        self.assertEqual("YEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH", str(hsp.query.seq))
+        self.assertEqual("YEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH", hsp.query.seq)
         self.assertEqual(542, hsp.hit_start)
         self.assertEqual(579, hsp.hit_end)
-        self.assertEqual("YELVYWAAEDEGQQHKVTFDPTSSYTLEDLKPDTLYH", str(hsp.hit.seq))
+        self.assertEqual("YELVYWAAEDEGQQHKVTFDPTSSYTLEDLKPDTLYH", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         # first qresult, third hit
         hit = qresult[2]
@@ -2784,13 +2784,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(80, hsp.query_end)
         self.assertEqual(
             "PVASDIQARTVVLTWSPPSSL-INGETDESS-----VP---ELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(497, hsp.hit_start)
         self.assertEqual(579, hsp.hit_end)
         self.assertEqual(
             "PPSPTIQVKTQQGVPAQPADFQANAESDTRIQLSWLLPPQERIVKYELVYWAAEDEGQQHKVTFDPTSSYTLEDLKPDTLYH",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, third hit, second hsp
@@ -2809,13 +2809,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(79, hsp.query_end)
         self.assertEqual(
             "VASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(325, hsp.hit_start)
         self.assertEqual(385, hsp.hit_end)
         self.assertEqual(
             "VVTETTATSVTLTWD------SGNTEPVS---FYG--IQYRAAGTDGPFQEVDGVASTRYSIGGLSPFSEY",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, fourth hit
@@ -2841,10 +2841,10 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(37, hsp.aln_span)
         self.assertEqual(43, hsp.query_start)
         self.assertEqual(80, hsp.query_end)
-        self.assertEqual("YEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH", str(hsp.query.seq))
+        self.assertEqual("YEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH", hsp.query.seq)
         self.assertEqual(542, hsp.hit_start)
         self.assertEqual(579, hsp.hit_end)
-        self.assertEqual("YELVYWAAEDEGQQHKVTFDPTSSYTLEDLKPDTVYH", str(hsp.hit.seq))
+        self.assertEqual("YELVYWAAEDEGQQHKVTFDPTSSYTLEDLKPDTVYH", hsp.hit.seq)
         self.assertEqual(0, hsp.query_strand)
         # first qresult, fifth hit
         hit = qresult[4]
@@ -2870,13 +2870,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(79, hsp.query_end)
         self.assertEqual(
             "ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(4760, hsp.hit_start)
         self.assertEqual(4823, hsp.hit_end)
         self.assertEqual(
             "ASDVHAEGCTLTWKPP------EDDGGQPIDKYVVEKMDEATGRWVPAGETD-GPQTSLQVEGLTPGHKY",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit
@@ -2904,13 +2904,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(79, hsp.query_end)
         self.assertEqual(
             "ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(2241, hsp.hit_start)
         self.assertEqual(2302, hsp.hit_end)
         self.assertEqual(
             "ANAVDSQSIRINWQPPTE-PNGN--------VLGYNIFYTTEGESGNNQQTVGPDDTTYVIEGLRPATQY",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit, second hsp
@@ -2929,13 +2929,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(79, hsp.query_end)
         self.assertEqual(
             "VASDIQA-RTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(2818, hsp.hit_start)
         self.assertEqual(2881, hsp.hit_end)
         self.assertEqual(
             "VTADGQAPDTVVVTWQSPAET-NGD--------LLGYYIYYQVVGSTETSQAETGPDETTYSISGLRPATEY",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit, third hsp
@@ -2954,13 +2954,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(79, hsp.query_end)
         self.assertEqual(
             "VASDIQA-RTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(3300, hsp.hit_start)
         self.assertEqual(3363, hsp.hit_end)
         self.assertEqual(
             "VTAEGQAPDTITVTWQSPAET-NGD--------LLGYYIYYQVVGSTEDVRAEAGPEETTYSISGLRPATEY",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit, fourth hsp
@@ -2979,13 +2979,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(80, hsp.query_end)
         self.assertEqual(
             "IQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDYH",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(3686, hsp.hit_start)
         self.assertEqual(3747, hsp.hit_end)
         self.assertEqual(
             "IDSTTIELQWMPPSP------DEQN-GVIKGYKILYKKVGEEGENEEDAGLLDLMYTLSDLEKWTEYN",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit, fifth hsp
@@ -3004,13 +3004,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(79, hsp.query_end)
         self.assertEqual(
             "ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(3398, hsp.hit_start)
         self.assertEqual(3459, hsp.hit_end)
         self.assertEqual(
             "ASSLGSEAIEVSWQPPPQS-NGE--------ILGYRLHYQIVGEESASTQEVEGYETFYLLRGLRPVTEY",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit, sixth hsp
@@ -3029,13 +3029,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(79, hsp.query_end)
         self.assertEqual(
             "ASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEETNITLNDLKPAMDY",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(2145, hsp.hit_start)
         self.assertEqual(2206, hsp.hit_end)
         self.assertEqual(
             "ATPVDPRTVRVEWQPPQQ-PNGE--------IQGYNIYYRTTESDEDALQQAGAQDIFLTLTGLSPFTEY",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, sixth hit, seventh hsp
@@ -3054,13 +3054,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(79, hsp.query_end)
         self.assertEqual(
             "IQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGE-ETNITLNDLKPAMDY",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(3497, hsp.hit_start)
         self.assertEqual(3555, hsp.hit_end)
         self.assertEqual(
             "VEPTTITVDWQPPLE-INGV--------LLGYKVIYMPENA-AEFSTVELGPAELSTMLLDLEPATTY",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, seventh hit
@@ -3085,13 +3085,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(73, hsp.query_end)
         self.assertEqual(
             "VASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYV-GEETNITL-NDL",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(775, hsp.hit_start)
         self.assertEqual(835, hsp.hit_end)
         self.assertEqual(
             "VASGRTNQSIMVQWQPPP-----ETEHNGV--LRGYILRYRLAGLPGEYQQRNITSPEVNYCLVTDL",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, eighth hit
@@ -3118,13 +3118,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(80, hsp.query_end)
         self.assertEqual(
             "IVKPVASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYVGEE-TNITLNDLKPAMDYH",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(674, hsp.hit_start)
         self.assertEqual(740, hsp.hit_end)
         self.assertEqual(
             "LASPNSS--HSHAVVLSWVRP---FDGNS-----PILY-YIVELSENNSPWKVHLSNVGPEMTGITVSGLTPARTYQ",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
         # first qresult, eighth hit, second hsp
@@ -3143,13 +3143,13 @@ class Fasta36Cases(unittest.TestCase):
         self.assertEqual(73, hsp.query_end)
         self.assertEqual(
             "VASDIQARTVVLTWSPPSSLINGETDESSVPELYGYEVLISSTGKDGKYKSVYV-GEETNITL-NDL",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(775, hsp.hit_start)
         self.assertEqual(835, hsp.hit_end)
         self.assertEqual(
             "VASGRTNQSIMVQWQPPP-----ETEHNGV--LRGYILRYRLAGLPGEYQQRNITSPEVNYCLVTDL",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(0, hsp.query_strand)
 

--- a/Tests/test_SearchIO_hhsuite2_text.py
+++ b/Tests/test_SearchIO_hhsuite2_text.py
@@ -67,13 +67,13 @@ class HhsuiteCases(unittest.TestCase):
             "ERCGEQGSNMECPNNLCCSQYGYCGMGGDYCGKGCQNGACWTSKRCGSQAGGATCTNNQCCSQYGYCGFGAEYC"
             "GAGCQGGPCRADIKCGSQAGGKLCPNNLCCSQWGFCGLGSEFCGGGCQSGACSTDKPCGKDAGGRVCTNNYCCS"
             "KWGSCGIGPGYCGAGCQSGGCDG",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "ERCGEQGSNMECPNNLCCSQYGYCGMGGDYCGKGCQNGACWTSKRCGSQAGGATCTNNQCCSQYGYCGFGAEYC"
             "GAGCQGGPCRADIKCGSQAGGKLCPNNLCCSQWGFCGLGSEFCGGGCQSGACSTDKPCGKDAGGRVCTNNYCCS"
             "KWGSCGIGPGYCGAGCQSGGCDG",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
 
         # Check last hit
@@ -106,12 +106,12 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(
             "XCXXXXCCXXXXXCXXXXXXCXXXCXXXXCXXXXXCXXX--XXXCXXXXCCXXXXXCXXXXXXCXXXCXXXXCXXXXXCX"
             "XX--XXXCXXXXCCXXXXXCXXXXXXCXXX",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "TCTNNQCCSQYGYCGFGAEYCGAGCQGGPCRADIKCGSQAGGKLCPNNLCCSQWGFCGLGSEFCGGGCQSGACSTDKPCG"
             "KDAGGRVCTNNYCCSKWGSCGIGPGYCGAG",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
 
     def test_2uvo_onlyheader(self):
@@ -166,8 +166,8 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(24, hsp.hit_end)
         self.assertEqual(38, hsp.query_start)
         self.assertEqual(39, hsp.query_end)
-        self.assertEqual("T", str(hsp.hit.seq))
-        self.assertEqual("X", str(hsp.query.seq))
+        self.assertEqual("T", hsp.hit.seq)
+        self.assertEqual("X", hsp.query.seq)
 
         # Check last hit
         hit = qresult[num_hits - 1]
@@ -196,8 +196,8 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(1, hsp.hit_end)
         self.assertEqual(3, hsp.query_start)
         self.assertEqual(4, hsp.query_end)
-        self.assertEqual("D", str(hsp.hit.seq))
-        self.assertEqual("X", str(hsp.query.seq))
+        self.assertEqual("D", hsp.hit.seq)
+        self.assertEqual("X", hsp.query.seq)
 
     def test_4y9h_nossm(self):
         """Parsing 4y9h_hhsearch_server_NOssm.hhr file."""
@@ -241,13 +241,13 @@ class HhsuiteCases(unittest.TestCase):
             "GRPEWIWLALGTALMGLGTLYFLVKGMGVSDPDAKKFYAITTLVPAIAFTMYLSMLLGYGLTMVPFGGEQNPIYWARYAD"
             "WLFTTPLLLLDLALLVDADQGTILALVGADGIMIGTGLVGALTKVYSYRFVWWAISTAAMLYILYVLFFGFTSKAESMRP"
             "EVASTFKVLRNVTVVLWSAYPVVWLIGSEGAGIVPLNIETLLFMVLDVSAKVGFGLILLRSRAIFG",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "GRPEWIWLALGTALMGLGTLYFLVKGMGVSDPDAKKFYAITTLVPAIAFTMYLSMLLGYGLTMVPFGGEQNPIYWARYAD"
             "WLFTTPLLLLDLALLVDADQGTILALVGADGIMIGTGLVGALTKVYSYRFVWWAISTAAMLYILYVLFFGFTSKAESMRP"
             "EVASTFKVLRNVTVVLWSAYPVVWLIGSEGAGIVPLNIETLLFMVLDVSAKVGFGLILLRSRAIFG",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
 
         # Check last hit
@@ -278,10 +278,10 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(7, hsp.query_start)
         self.assertEqual(59, hsp.query_end)
         self.assertEqual(
-            "FWLVTAALLASTVFFFVERDRVS-AKWKTSLTVSGLVTGIAFWHYMYMRGVW", str(hsp.hit.seq)
+            "FWLVTAALLASTVFFFVERDRVS-AKWKTSLTVSGLVTGIAFWHYMYMRGVW", hsp.hit.seq
         )
         self.assertEqual(
-            "LALGTALMGLGTLYFLVKGMGVSDPDAKKFYAITTLVPAIAFTMYLSMLLGY", str(hsp.query.seq)
+            "LALGTALMGLGTLYFLVKGMGVSDPDAKKFYAITTLVPAIAFTMYLSMLLGY", hsp.query.seq
         )
 
     def test_q9bsu1(self):
@@ -328,7 +328,7 @@ class HhsuiteCases(unittest.TestCase):
             "MYIYSGNSLQDTKAPMMPLSCFLGNVYAESVDVLRDGTGPAGLRLRLLAAGCGPGLLADAKMRVFERSVYFGDSCQDVLS"
             "MLGSPHKVFYKSEDKMKIHSPSPHKQVPSKCNDYFFNYFTLGVDILFDANTHKVKKFVLHTNYPGHYNFNIYHRCEFKIP"
             "LAIKKENADGQTE--TCTTYSKWDNIQELLGHPVEKPVVLHRSSSPNNTNPFGSTFCFGLQRMIFEVMQNNHIASVTLY",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "EQWE----FALGMPLAQAISILQKHCRIIKNVQVLYSEQMPLSHDLILNLTQDGIKLLFDACNQRLKVIEVYDLTKVKLK"
@@ -336,7 +336,7 @@ class HhsuiteCases(unittest.TestCase):
             "MYIYSGNNLQETKAPAMPLACFLGNVYAECVEVLRDGAGPLGLKLRLLTAGCGPGVLADTKVRAVERSIYFGDSCQDVLS"
             "ALGSPHKVFYKSEDKMKIHSPSPHKQVPSKCNDYFFNYYILGVDILFDSTTHLVKKFVLHTNFPGHYNFNIYHRCDFKIP"
             "LIIKKDGADAHSEDCILTTYSKWDQIQELLGHPMEKPVVLHRSSSANNTNPFGSTFCFGLQRMIFEVMQNNHIASVTLY",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
 
         # Check last hit
@@ -364,8 +364,8 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(48, hsp.hit_end)
         self.assertEqual(61, hsp.query_start)
         self.assertEqual(85, hsp.query_end)
-        self.assertEqual("APNVIFDYDA-EGRIVGIELLDAR", str(hsp.hit.seq))
-        self.assertEqual("QDGIKLMFDAFNQRLKVIEVCDLT", str(hsp.query.seq))
+        self.assertEqual("APNVIFDYDA-EGRIVGIELLDAR", hsp.hit.seq)
+        self.assertEqual("QDGIKLMFDAFNQRLKVIEVCDLT", hsp.query.seq)
 
     def test_4p79(self):
         """Parsing 4p79_hhsearch_server_NOssm.hhr file."""
@@ -407,13 +407,13 @@ class HhsuiteCases(unittest.TestCase):
             "GSEFMSVAVETFGFFMSALGLLMLGLTLSNSYWRVSTVHGNVITTNTIFENLWYSCATDSLGVSNCWDFPSMLALSGYVQ"
             "GCRALMITAILLGFLGLFLGMVGLRATNVGNMDLSKKAKLLAIAGTLHILAGACGMVAISWYAVNITTDFFNPLYAGTKY"
             "ELGPALYLGWSASLLSILGGICVFSTAAASSKEEPATR",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "GSEFMSVAVETFGFFMSALGLLMLGLTLSNSYWRVSTVHGNVITTNTIFENLWYSCATDSLGVSNCWDFPSMLALSGYVQ"
             "GCRALMITAILLGFLGLFLGMVGLRATNVGNMDLSKKAKLLAIAGTLHILAGACGMVAISWYAVNITTDFFNPLYAGTKY"
             "ELGPALYLGWSASLLSILGGICVFSTAAASSKEEPATR",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
 
         # Check last hit
@@ -445,8 +445,8 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(42, hsp.hit_end)
         self.assertEqual(5, hsp.query_start)
         self.assertEqual(37, hsp.query_end)
-        self.assertEqual("RTSVVVSTLLGLVMALLIHFVVLSSGAFNWLRAP", str(hsp.hit.seq))
-        self.assertEqual("SVAVETFGFFMSALGLLMLGLTLSNS--YWRVST", str(hsp.query.seq))
+        self.assertEqual("RTSVVVSTLLGLVMALLIHFVVLSSGAFNWLRAP", hsp.hit.seq)
+        self.assertEqual("SVAVETFGFFMSALGLLMLGLTLSNS--YWRVST", hsp.query.seq)
 
     def test_9590198(self):
         """Parsing hhpred_9590198.hhr file."""
@@ -493,7 +493,7 @@ class HhsuiteCases(unittest.TestCase):
             "RALGAPARLYYKADDKMRIHRPTARRR-PPPASDYLFNYFTLGLDVLFDARTNQVKKFVLHTNYPGHYNFNMYHRCEFEL"
             "TVQPD-KSEAHSLVESGGGVAVTAYSKWEVVSRAL-RVCERPVVLNRASSTNTTNPFGSTFCYGYQDIIFEVMSNNYIAS"
             "ITLY",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "GMPLAQAVAILQKHCRIIKNVQVLYSEQSPLSHDLILNLTQDGIKLMFDAFNQRLKVIEVCDLTKVKLKYCGVHFNSQAI"
@@ -502,7 +502,7 @@ class HhsuiteCases(unittest.TestCase):
             "SMLGSPHKVFYKSEDKMKIHSPSPHKQVPSKCNDYFFNYFTLGVDILFDANTHKVKKFVLHTNYPGHYNFNIYHRCEFKI"
             "PLAIKKENADG------QTETCTTYSKWDNIQELLGHPVEKPVVLHRSSSPNNTNPFGSTFCFGLQRMIFEVMQNNHIAS"
             "VTLY",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
 
         # Check last hit
@@ -535,12 +535,12 @@ class HhsuiteCases(unittest.TestCase):
         self.assertEqual(
             "FTLGMPLAQAVAILQKHCRIIKNVQVLYSEQSPLSHDLILNLTQDGIKLMFDAFNQRLKVIEVCDLTKVKLKYCGVH-FN"
             "SQAIAPTIEQIDQSFGA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "IQFGMDRTLVWQLAGADQSCSDQVERIICYNNPDH-------YGPQGHFFFNA-ADKLIHKRQMELFPAPKPTMRLATYN"
             "KTQTGMTEAQFWAAVPS",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
 
 

--- a/Tests/test_SearchIO_hmmer2_text.py
+++ b/Tests/test_SearchIO_hmmer2_text.py
@@ -296,29 +296,21 @@ class HmmpfamTests(unittest.TestCase):
         self.assertEqual(108, hsp.query_start)
         self.assertEqual(271, hsp.query_end)
         self.assertEqual("..", hsp.query_endtype)
-        self.assertEqual(
-            "ENHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQG--", hsp.query.seq[:40]
-        )
+        self.assertEqual("ENHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQG--", hsp.query.seq[:40])
         self.assertEqual(
             "+++++  L+++++e++k+ewP++Wp+ + +l  l++++  ",
             str(hsp.aln_annotation["similarity"])[:40],
         )
-        self.assertEqual(
-            "WVSMSHITA-ENCkLLEILCLLL----NEQELQLGAAECL", hsp.query.seq[-40:]
-        )
+        self.assertEqual("WVSMSHITA-ENCkLLEILCLLL----NEQELQLGAAECL", hsp.query.seq[-40:])
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(178, hsp.hit_end)
         self.assertEqual("[]", hsp.hit_endtype)
-        self.assertEqual(
-            "pkflrnKLalalaelakqewPsnWpsffpdlvsllsssss", hsp.hit.seq[:40]
-        )
+        self.assertEqual("pkflrnKLalalaelakqewPsnWpsffpdlvsllsssss", hsp.hit.seq[:40])
         self.assertEqual(
             "W+++++i + ++++ll++l+ lL    +  +l++ A+eCL",
             str(hsp.aln_annotation["similarity"])[-40:],
         )
-        self.assertEqual(
-            "Wipiglianvnpi.llnllfslLsgpesdpdlreaAveCL", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("Wipiglianvnpi.llnllfslLsgpesdpdlreaAveCL", hsp.hit.seq[-40:])
 
         # fourth qresult, second from last hit
         hit = res[-2]
@@ -479,12 +471,8 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(337, hsp.query_end)
         self.assertEqual("[]", hsp.query_endtype)
-        self.assertEqual(
-            "lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", hsp.query.seq[:40]
-        )
-        self.assertEqual(
-            "IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", hsp.query.seq[-40:]
-        )
+        self.assertEqual("lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", hsp.query.seq[:40])
+        self.assertEqual("IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", hsp.query.seq[-40:])
         self.assertEqual(337, len(hsp.query.seq))
         self.assertEqual(
             "+P+++DWRe kg  VtpVK+QG qCGSCWAFSa g lEg+",
@@ -497,12 +485,8 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual(113, hsp.hit_start)
         self.assertEqual(332, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
-        self.assertEqual(
-            "IPKTVDWRE-KG-CVTPVKNQG-QCGSCWAFSASGCLEGQ", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "LVKNSWGKEWGMDGYIKIAKDRN----NHCGLATAASYPI", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("IPKTVDWRE-KG-CVTPVKNQG-QCGSCWAFSASGCLEGQ", hsp.hit.seq[:40])
+        self.assertEqual("LVKNSWGKEWGMDGYIKIAKDRN----NHCGLATAASYPI", hsp.hit.seq[-40:])
         self.assertEqual(337, len(hsp.hit.seq))
 
         # last hit
@@ -526,12 +510,8 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual(0, hsp.query_start)
         self.assertEqual(337, hsp.query_end)
         self.assertEqual("[]", hsp.query_endtype)
-        self.assertEqual(
-            "lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", hsp.query.seq[:40]
-        )
-        self.assertEqual(
-            "IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", hsp.query.seq[-40:]
-        )
+        self.assertEqual("lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", hsp.query.seq[:40])
+        self.assertEqual("IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", hsp.query.seq[-40:])
         self.assertEqual(337, len(hsp.query.seq))
         self.assertEqual(
             "+Pe +DWR+ kg aVtpVK+QG +CGSCWAFSav ++Eg+",
@@ -544,12 +524,8 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual(133, hsp.hit_start)
         self.assertEqual(343, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
-        self.assertEqual(
-            "IPEYVDWRQ-KG-AVTPVKNQG-SCGSCWAFSAVVTIEGI", hsp.hit.seq[:40]
-        )
-        self.assertEqual(
-            "LIKNSWGTGWGENGYIRIKRGTGNS-YGVCGLYTSSFYPV", hsp.hit.seq[-40:]
-        )
+        self.assertEqual("IPEYVDWRQ-KG-AVTPVKNQG-SCGSCWAFSAVVTIEGI", hsp.hit.seq[:40])
+        self.assertEqual("LIKNSWGTGWGENGYIRIKRGTGNS-YGVCGLYTSSFYPV", hsp.hit.seq[-40:])
         self.assertEqual(337, len(hsp.hit.seq))
 
 

--- a/Tests/test_SearchIO_hmmer2_text.py
+++ b/Tests/test_SearchIO_hmmer2_text.py
@@ -301,7 +301,9 @@ class HmmpfamTests(unittest.TestCase):
             "+++++  L+++++e++k+ewP++Wp+ + +l  l++++  ",
             str(hsp.aln_annotation["similarity"])[:40],
         )
-        self.assertEqual("WVSMSHITA-ENCkLLEILCLLL----NEQELQLGAAECL", hsp.query.seq[-40:])
+        self.assertEqual(
+            "WVSMSHITA-ENCkLLEILCLLL----NEQELQLGAAECL", hsp.query.seq[-40:]
+        )
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(178, hsp.hit_end)
         self.assertEqual("[]", hsp.hit_endtype)
@@ -472,7 +474,9 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual(337, hsp.query_end)
         self.assertEqual("[]", hsp.query_endtype)
         self.assertEqual("lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", hsp.query.seq[:40])
-        self.assertEqual("IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", hsp.query.seq[-40:])
+        self.assertEqual(
+            "IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", hsp.query.seq[-40:]
+        )
         self.assertEqual(337, len(hsp.query.seq))
         self.assertEqual(
             "+P+++DWRe kg  VtpVK+QG qCGSCWAFSa g lEg+",
@@ -511,7 +515,9 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual(337, hsp.query_end)
         self.assertEqual("[]", hsp.query_endtype)
         self.assertEqual("lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", hsp.query.seq[:40])
-        self.assertEqual("IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", hsp.query.seq[-40:])
+        self.assertEqual(
+            "IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", hsp.query.seq[-40:]
+        )
         self.assertEqual(337, len(hsp.query.seq))
         self.assertEqual(
             "+Pe +DWR+ kg aVtpVK+QG +CGSCWAFSav ++Eg+",

--- a/Tests/test_SearchIO_hmmer2_text.py
+++ b/Tests/test_SearchIO_hmmer2_text.py
@@ -47,7 +47,7 @@ class HmmpfamTests(unittest.TestCase):
         self.assertAlmostEqual(2.2e-17, hsp.evalue)
         self.assertEqual(
             "lfVgNLppdvteedLkdlFskfGpivsikivrDiiekpketgkskGfaFVeFeseedAekAlealnG.kelggrklrv",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "lf+g+L + +t+e Lk++F+k G iv++ +++D     + t++s+Gf+F+++  ++  + A +    +++++gr+++ ",
@@ -55,7 +55,7 @@ class HmmpfamTests(unittest.TestCase):
         )
         self.assertEqual(
             "LFIGGLDYRTTDENLKAHFEKWGNIVDVVVMKD-----PRTKRSRGFGFITYSHSSMIDEAQK--SRpHKIDGRVVEP",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
 
         hsp = hit[1]
@@ -70,7 +70,7 @@ class HmmpfamTests(unittest.TestCase):
         self.assertAlmostEqual(1.1e-18, hsp.evalue)
         self.assertEqual(
             "lfVgNLppdvteedLkdlFskfGpivsikivrDiiekpketgkskGfaFVeFeseedAekAlealnGkelggrklrv",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "lfVg L  d +e+ ++d+F++fG iv+i+iv+D     ketgk +GfaFVeF++++ ++k +     ++l+g+ + v",
@@ -78,7 +78,7 @@ class HmmpfamTests(unittest.TestCase):
         )
         self.assertEqual(
             "LFVGALKDDHDEQSIRDYFQHFGNIVDINIVID-----KETGKKRGFAFVEFDDYDPVDKVVL-QKQHQLNGKMVDV",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
 
     def test_hmmpfam_22(self):
@@ -119,7 +119,7 @@ class HmmpfamTests(unittest.TestCase):
             "ededlekedfyqkkGvFilPsqlFwdfikeaeknkldedigtdldkifseledqialgypaSeedfkGlfpdld"
             "fnsnkLgskaqarnetLtelidlfselelgtPmHNG.dfeelgikDlfGDaYEYLLgkFAeneGKsGGeFYTPq"
             "eVSkLiaeiLtigqpsegdfsIYDPAcGSGSLllqaskflgehdgkrnaisyYGQEsn",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             " ++EL+++  av+   R              L+F K++ dk      +i+         p +   + +++y   "
@@ -133,7 +133,7 @@ class HmmpfamTests(unittest.TestCase):
             "KKSNVLI-NYYDAY-L----KPLFYEVLNTPEDER--KENIRT-NPYYKDIPYL---N-G-------GLFRSNN"
             "V--PNELSFTIKDNEIIGEVINFLERYKFTLSTSEGsEEVELNP-DILGYVYEKLINILAEKGQKGLGAYYTPD"
             "EITSYIAKNT-IEPIVVE----------------RFKEIIK--NWKINDINF----ST",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
 
     def test_hmmpfam_23(self):
@@ -166,11 +166,11 @@ class HmmpfamTests(unittest.TestCase):
         self.assertEqual("..", hsp.query_endtype)
         self.assertAlmostEqual(1.3, hsp.bitscore)
         self.assertAlmostEqual(3, hsp.evalue)
-        self.assertEqual("lPwelgLaevhqtLvengLRdrVsLia", str(hsp.hit.seq))
+        self.assertEqual("lPwelgLaevhqtLvengLRdrVsLia", hsp.hit.seq)
         self.assertEqual(
             "+P  l++ +vh  L++ gLR + s+ +", str(hsp.aln_annotation["similarity"])
         )
-        self.assertEqual("IPPLLAVGAVHHHLINKGLRQEASILV", str(hsp.query.seq))
+        self.assertEqual("IPPLLAVGAVHHHLINKGLRQEASILV", hsp.query.seq)
 
         hsp = hit[1]
         self.assertEqual(2, hsp.domain_index)
@@ -233,7 +233,7 @@ class HmmpfamTests(unittest.TestCase):
         self.assertEqual(len(hsp.query.seq), len(hsp.aln_annotation["similarity"]))
         self.assertEqual(
             "msEEqLKAFiAKvqaDtsLqEqLKaEGADvvaiAKAaGFtitteDLnahiqakeLsdeeLEgvaGg",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "        F+                           G  +t   Ln                   ",
@@ -241,7 +241,7 @@ class HmmpfamTests(unittest.TestCase):
         )
         self.assertEqual(
             "-------CFL---------------------------GCLVTNWVLNRS-----------------",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
 
     def test_hmmpfam_23_break_in_end_of_seq(self):
@@ -297,27 +297,27 @@ class HmmpfamTests(unittest.TestCase):
         self.assertEqual(271, hsp.query_end)
         self.assertEqual("..", hsp.query_endtype)
         self.assertEqual(
-            "ENHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQG--", str(hsp.query.seq)[:40]
+            "ENHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQG--", hsp.query.seq[:40]
         )
         self.assertEqual(
             "+++++  L+++++e++k+ewP++Wp+ + +l  l++++  ",
             str(hsp.aln_annotation["similarity"])[:40],
         )
         self.assertEqual(
-            "WVSMSHITA-ENCkLLEILCLLL----NEQELQLGAAECL", str(hsp.query.seq)[-40:]
+            "WVSMSHITA-ENCkLLEILCLLL----NEQELQLGAAECL", hsp.query.seq[-40:]
         )
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(178, hsp.hit_end)
         self.assertEqual("[]", hsp.hit_endtype)
         self.assertEqual(
-            "pkflrnKLalalaelakqewPsnWpsffpdlvsllsssss", str(hsp.hit.seq)[:40]
+            "pkflrnKLalalaelakqewPsnWpsffpdlvsllsssss", hsp.hit.seq[:40]
         )
         self.assertEqual(
             "W+++++i + ++++ll++l+ lL    +  +l++ A+eCL",
             str(hsp.aln_annotation["similarity"])[-40:],
         )
         self.assertEqual(
-            "Wipiglianvnpi.llnllfslLsgpesdpdlreaAveCL", str(hsp.hit.seq)[-40:]
+            "Wipiglianvnpi.llnllfslLsgpesdpdlreaAveCL", hsp.hit.seq[-40:]
         )
 
         # fourth qresult, second from last hit
@@ -337,11 +337,11 @@ class HmmpfamTests(unittest.TestCase):
         self.assertEqual(20, hsp.query_start)
         self.assertEqual(47, hsp.query_end)
         self.assertEqual("..", hsp.query_endtype)
-        self.assertEqual("MDPNSTQRYRLEALKFCEEFKE-KCPIC", str(hsp.query.seq))
+        self.assertEqual("MDPNSTQRYRLEALKFCEEFKE-KCPIC", hsp.query.seq)
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(28, hsp.hit_end)
         self.assertEqual("[.", hsp.hit_endtype)
-        self.assertEqual("galesekaelkkaieeleeeesscCPvC", str(hsp.hit.seq))
+        self.assertEqual("galesekaelkkaieeleeeesscCPvC", hsp.hit.seq)
 
         # fourth qresult, second from last hit, last hsp
         hsp = hit[-1]
@@ -351,11 +351,11 @@ class HmmpfamTests(unittest.TestCase):
         self.assertEqual(789, hsp.query_start)
         self.assertEqual(811, hsp.query_end)
         self.assertEqual("..", hsp.query_endtype)
-        self.assertEqual("EMLAKMAEPFTKALDMLDAEKS", str(hsp.query.seq))
+        self.assertEqual("EMLAKMAEPFTKALDMLDAEKS", hsp.query.seq)
         self.assertEqual(0, hsp.hit_start)
         self.assertEqual(22, hsp.hit_end)
         self.assertEqual("[.", hsp.hit_endtype)
-        self.assertEqual("galesekaelkkaieeleeees", str(hsp.hit.seq))
+        self.assertEqual("galesekaelkkaieeleeees", hsp.hit.seq)
 
 
 class HmmsearchTests(unittest.TestCase):
@@ -480,10 +480,10 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual(337, hsp.query_end)
         self.assertEqual("[]", hsp.query_endtype)
         self.assertEqual(
-            "lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", str(hsp.query.seq)[:40]
+            "lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", hsp.query.seq[:40]
         )
         self.assertEqual(
-            "IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", str(hsp.query.seq)[-40:]
+            "IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", hsp.query.seq[-40:]
         )
         self.assertEqual(337, len(hsp.query.seq))
         self.assertEqual(
@@ -498,10 +498,10 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual(332, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
         self.assertEqual(
-            "IPKTVDWRE-KG-CVTPVKNQG-QCGSCWAFSASGCLEGQ", str(hsp.hit.seq)[:40]
+            "IPKTVDWRE-KG-CVTPVKNQG-QCGSCWAFSASGCLEGQ", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "LVKNSWGKEWGMDGYIKIAKDRN----NHCGLATAASYPI", str(hsp.hit.seq)[-40:]
+            "LVKNSWGKEWGMDGYIKIAKDRN----NHCGLATAASYPI", hsp.hit.seq[-40:]
         )
         self.assertEqual(337, len(hsp.hit.seq))
 
@@ -527,10 +527,10 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual(337, hsp.query_end)
         self.assertEqual("[]", hsp.query_endtype)
         self.assertEqual(
-            "lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", str(hsp.query.seq)[:40]
+            "lPesfDWReWkggaVtpVKdQGiqCGSCWAFSavgalEgr", hsp.query.seq[:40]
         )
         self.assertEqual(
-            "IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", str(hsp.query.seq)[-40:]
+            "IVKNSWGtdWGEnGYfriaRgknksgkneCGIaseasypi", hsp.query.seq[-40:]
         )
         self.assertEqual(337, len(hsp.query.seq))
         self.assertEqual(
@@ -545,10 +545,10 @@ class HmmsearchTests(unittest.TestCase):
         self.assertEqual(343, hsp.hit_end)
         self.assertEqual("..", hsp.hit_endtype)
         self.assertEqual(
-            "IPEYVDWRQ-KG-AVTPVKNQG-SCGSCWAFSAVVTIEGI", str(hsp.hit.seq)[:40]
+            "IPEYVDWRQ-KG-AVTPVKNQG-SCGSCWAFSAVVTIEGI", hsp.hit.seq[:40]
         )
         self.assertEqual(
-            "LIKNSWGTGWGENGYIRIKRGTGNS-YGVCGLYTSSFYPV", str(hsp.hit.seq)[-40:]
+            "LIKNSWGTGWGENGYIRIKRGTGNS-YGVCGLYTSSFYPV", hsp.hit.seq[-40:]
         )
         self.assertEqual(337, len(hsp.hit.seq))
 

--- a/Tests/test_SearchIO_hmmer3_text.py
+++ b/Tests/test_SearchIO_hmmer3_text.py
@@ -87,11 +87,11 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(0.97, hsp.acc_avg)
         self.assertEqual(
             "eldleeleefakefkqrrikLgltqadvgsalgalyGkefsqttIcrFEalqLslknmckLkpllekWLeeae",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KALQKELEQFAKLLKQKRITLGYTQADVGLTLGVLFGKVFSQTTICRFEALQLSLKNMCKLRPLLEKWVEEAD",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "67899******************************************************************96",
@@ -129,11 +129,11 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(0.77, hsp.acc_avg)
         self.assertEqual(
             "adlaavleelnkakkeevdlvvlGcPhlsleeleelaellkgrkkkvsvelvvttsravlsk",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "QARKRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEK--DVVRVWFCNRRQKGKR",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "345666667778888899************************99..9999999988876554",
@@ -207,11 +207,11 @@ class HmmscanCases(unittest.TestCase):
         )
         self.assertEqual(
             "qkalvkaswekvkanaeeigaeilkrlfkaypdtkklFkkfgdls.aedlksspkfkahakkvlaaldeavknldnddnlkaalkklgarHakrg.vdpanfklfgeal",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "EWQLVLNVWGKVEADIPGHGQEVLIRLFKGHPETLEKFDKFKHLKsEDEMKASEDLKKHGATVLTALGGILKK---KGHHEAEIKPLAQSHATKHkIPVKYLEFISECI",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "5789*********************************************************************...6899***********************999998",
@@ -263,11 +263,11 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(0.94, hsp.acc_avg)
         self.assertEqual(
             "kPvisvspsptvtsggnvtLtCsaeggpppptisWy.....ietppelqgsegssssestLtissvtsedsgtYtCva",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KPTLSAQPSPVVNSGGNVILQCDSQVA--FDGFSLCkegedEHPQCLNSQPHARGSSRAIFSVGPVSPSRRWWYRCYA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "8************************99..78888888****************************************9",
@@ -303,11 +303,11 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(0.71, hsp.acc_avg)
         self.assertEqual(
             "kpvlvapp.svvtegenvtLtCsapgnptprvqwykdg.vels......qsqnq........lfipnvsaedsgtYtCra....rnseggktstsveltv",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KPTLSAQPsPVVNSGGNVILQCDSQVA-FDGFSLCKEGeDEHPqclnsqP---HargssraiFSVGPVSPSRRWWYRCYAydsnSPYEWSLPSDLLELLV",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "799998885779*************85.899***9988655554443320...134455543444669************88443344588888888766",
@@ -360,11 +360,11 @@ class HmmscanCases(unittest.TestCase):
         )
         self.assertEqual(
             "kflrnklaealaelflqeypnqWpsffddllsllssspsglelllriLkvlpeEiadfsrskleqerrnelkdllrsqvqkilelllqileqsvskk...............sselveatLkclsswvswidiglivnsp..llsllfqlLndpelreaAvecL",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "NHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQGETQTELVMFILLRLAEDVVTF--QTLPPQRRRDIQQTLTQNMERIFSFLLNTLQENVNKYqqvktdtsqeskaqaNCRVGVAALNTLAGYIDWVSMSHITAENckLLEILCLLLNEQELQLGAAECL",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "89******************************************************99..79*********************************99*****************************************8889*********************8",
@@ -389,8 +389,8 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.86, hsp.acc_avg)
         self.assertEqual("HHCTTS-CHHCHCS.HHHHHCHHCCSCC", hsp.aln_annotation["CS"])
-        self.assertEqual("swvswidiglivnspllsllfqlLndpe", str(hsp.hit.seq))
-        self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", str(hsp.query.seq))
+        self.assertEqual("swvswidiglivnspllsllfqlLndpe", hsp.hit.seq)
+        self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", hsp.query.seq)
         self.assertEqual("899*********98.8888899998776", hsp.aln_annotation["PP"])
 
         hit = qresult[-1]
@@ -427,11 +427,11 @@ class HmmscanCases(unittest.TestCase):
         )
         self.assertEqual(
             "qLnqlekqkPgflsallqilanksldlevRqlAalyLknlItkhWkseeaqrqqqlpeeekelIrnnllnll",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "FCEEFKEKCPICVPCGLRLA-EKTQVAIVRHFGLQILEHVVKFRWN--------GMSRLEKVYLKNSVMELI",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "56788886699*********.6555899******************........999999****99999887",
@@ -456,8 +456,8 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.85, hsp.acc_avg)
         self.assertEqual("HCS-HHHHHHHHHHHHHHH", hsp.aln_annotation["CS"])
-        self.assertEqual("qqlpeeekelIrnnllnll", str(hsp.hit.seq))
-        self.assertEqual("QTLPPQRRRDIQQTLTQNM", str(hsp.query.seq))
+        self.assertEqual("qqlpeeekelIrnnllnll", hsp.hit.seq)
+        self.assertEqual("QTLPPQRRRDIQQTLTQNM", hsp.query.seq)
         self.assertEqual("6899*******99998865", hsp.aln_annotation["PP"])
 
         # test fifth result
@@ -505,11 +505,11 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(0.97, hsp.acc_avg)
         self.assertEqual(
             "eldleeleefakefkqrrikLgltqadvgsalgalyGkefsqttIcrFEalqLslknmckLkpllekWLeeae",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KALQKELEQFAKLLKQKRITLGYTQADVGLTLGVLFGKVFSQTTICRFEALQLSLKNMCKLRPLLEKWVEEAD",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "67899******************************************************************96",
@@ -550,11 +550,11 @@ class HmmscanCases(unittest.TestCase):
         )
         self.assertEqual(
             "rrkRttftkeqleeLeelFeknrypsaeereeLAkklgLterqVkvWFqNrRakekk",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQKGKR",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "79****************************************************997",
@@ -589,9 +589,9 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(184, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.96, hsp.acc_avg)
-        self.assertEqual("aLGarLralReraGLtqeevAerlg......vSastlsrlE", str(hsp.hit.seq))
+        self.assertEqual("aLGarLralReraGLtqeevAerlg......vSastlsrlE", hsp.hit.seq)
         self.assertEqual(
-            "QFAKLLKQKRITLGYTQADVGLTLGvlfgkvFSQTTICRFE", str(hsp.query.seq)
+            "QFAKLLKQKRITLGYTQADVGLTLGvlfgkvFSQTTICRFE", hsp.query.seq
         )
         self.assertEqual(
             "6999***********************************99", hsp.aln_annotation["PP"]
@@ -614,8 +614,8 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(270, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.86, hsp.acc_avg)
-        self.assertEqual("rgrpsaavlaalaralgldpaera", str(hsp.hit.seq))
-        self.assertEqual("CPKPSLQQITHIANQLGLEKDVVR", str(hsp.query.seq))
+        self.assertEqual("rgrpsaavlaalaralgldpaera", hsp.hit.seq)
+        self.assertEqual("CPKPSLQQITHIANQLGLEKDVVR", hsp.query.seq)
         self.assertEqual("678**************9988765", hsp.aln_annotation["PP"])
 
         hit = qresult[3]
@@ -646,8 +646,8 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(277, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.91, hsp.acc_avg)
-        self.assertEqual("hnPYPskevkeelakqTglsrkqidnWFiNaRr", str(hsp.hit.seq))
-        self.assertEqual("KCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQ", str(hsp.query.seq))
+        self.assertEqual("hnPYPskevkeelakqTglsrkqidnWFiNaRr", hsp.hit.seq)
+        self.assertEqual("KCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQ", hsp.query.seq)
         self.assertEqual("56779*************************996", hsp.aln_annotation["PP"])
 
         hit = qresult[4]
@@ -680,11 +680,11 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(0.77, hsp.acc_avg)
         self.assertEqual(
             "adlaavleelnkakkeevdlvvlGcPhlsleeleelaellkgrkkkvsvelvvttsravlsk",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "QARKRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEK--DVVRVWFCNRRQKGKR",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "345666667778888899************************99..9999999988876554",
@@ -768,11 +768,11 @@ class HmmscanCases(unittest.TestCase):
         )
         self.assertEqual(
             "qkalvkaswekvkanaeeigaeilkrlfkaypdtkklFkkfgdls.aedlksspkfkahakkvlaaldeavknldnddnlkaalkklgarHakrg.vdpanfklfgeal",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "EWQLVLNVWGKVEADIPGHGQEVLIRLFKGHPETLEKFDKFKHLKsEDEMKASEDLKKHGATVLTALGGILKK---KGHHEAEIKPLAQSHATKHkIPVKYLEFISECI",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "5789*********************************************************************...6899***********************999998",
@@ -834,11 +834,11 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(0.94, hsp.acc_avg)
         self.assertEqual(
             "kPvisvspsptvtsggnvtLtCsaeggpppptisWy.....ietppelqgsegssssestLtissvtsedsgtYtCva",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KPTLSAQPSPVVNSGGNVILQCDSQVA--FDGFSLCkegedEHPQCLNSQPHARGSSRAIFSVGPVSPSRRWWYRCYA",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "8************************99..78888888****************************************9",
@@ -874,11 +874,11 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(0.71, hsp.acc_avg)
         self.assertEqual(
             "kpvlvapp.svvtegenvtLtCsapgnptprvqwykdg.vels......qsqnq........lfipnvsaedsgtYtCra....rnseggktstsveltv",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KPTLSAQPsPVVNSGGNVILQCDSQVA-FDGFSLCKEGeDEHPqclnsqP---HargssraiFSVGPVSPSRRWWYRCYAydsnSPYEWSLPSDLLELLV",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "799998885779*************85.899***9988655554443320...134455543444669************88443344588888888766",
@@ -941,11 +941,11 @@ class HmmscanCases(unittest.TestCase):
         )
         self.assertEqual(
             "kflrnklaealaelflqeypnqWpsffddllsllssspsglelllriLkvlpeEiadfsrskleqerrnelkdllrsqvqkilelllqileqsvskk...............sselveatLkclsswvswidiglivnsp..llsllfqlLndpelreaAvecL",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "NHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQGETQTELVMFILLRLAEDVVTF--QTLPPQRRRDIQQTLTQNMERIFSFLLNTLQENVNKYqqvktdtsqeskaqaNCRVGVAALNTLAGYIDWVSMSHITAENckLLEILCLLLNEQELQLGAAECL",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "89******************************************************99..79*********************************99*****************************************8889*********************8",
@@ -970,8 +970,8 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.86, hsp.acc_avg)
         self.assertEqual("HHCTTS-CHHCHCS.HHHHHCHHCCSCC", hsp.aln_annotation["CS"])
-        self.assertEqual("swvswidiglivnspllsllfqlLndpe", str(hsp.hit.seq))
-        self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", str(hsp.query.seq))
+        self.assertEqual("swvswidiglivnspllsllfqlLndpe", hsp.hit.seq)
+        self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", hsp.query.seq)
         self.assertEqual("899*********98.8888899998776", hsp.aln_annotation["PP"])
 
         hit = qresult[-1]
@@ -1008,11 +1008,11 @@ class HmmscanCases(unittest.TestCase):
         )
         self.assertEqual(
             "qLnqlekqkPgflsallqilanksldlevRqlAalyLknlItkhWkseeaqrqqqlpeeekelIrnnllnll",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "FCEEFKEKCPICVPCGLRLA-EKTQVAIVRHFGLQILEHVVKFRWN--------GMSRLEKVYLKNSVMELI",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "56788886699*********.6555899******************........999999****99999887",
@@ -1037,8 +1037,8 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.85, hsp.acc_avg)
         self.assertEqual("HCS-HHHHHHHHHHHHHHH", hsp.aln_annotation["CS"])
-        self.assertEqual("qqlpeeekelIrnnllnll", str(hsp.hit.seq))
-        self.assertEqual("QTLPPQRRRDIQQTLTQNM", str(hsp.query.seq))
+        self.assertEqual("qqlpeeekelIrnnllnll", hsp.hit.seq)
+        self.assertEqual("QTLPPQRRRDIQQTLTQNM", hsp.query.seq)
         self.assertEqual("6899*******99998865", hsp.aln_annotation["PP"])
 
         # test if we've properly finished iteration
@@ -1096,11 +1096,11 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(0.97, hsp.acc_avg)
         self.assertEqual(
             "eldleeleefakefkqrrikLgltqadvgsalgalyGkefsqttIcrFEalqLslknmckLkpllekWLeeae",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KALQKELEQFAKLLKQKRITLGYTQADVGLTLGVLFGKVFSQTTICRFEALQLSLKNMCKLRPLLEKWVEEAD",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "67899******************************************************************96",
@@ -1141,11 +1141,11 @@ class HmmscanCases(unittest.TestCase):
         )
         self.assertEqual(
             "rrkRttftkeqleeLeelFeknrypsaeereeLAkklgLterqVkvWFqNrRakekk",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "KRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQKGKR",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "79****************************************************997",
@@ -1180,9 +1180,9 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(184, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.96, hsp.acc_avg)
-        self.assertEqual("aLGarLralReraGLtqeevAerlg......vSastlsrlE", str(hsp.hit.seq))
+        self.assertEqual("aLGarLralReraGLtqeevAerlg......vSastlsrlE", hsp.hit.seq)
         self.assertEqual(
-            "QFAKLLKQKRITLGYTQADVGLTLGvlfgkvFSQTTICRFE", str(hsp.query.seq)
+            "QFAKLLKQKRITLGYTQADVGLTLGvlfgkvFSQTTICRFE", hsp.query.seq
         )
         self.assertEqual(
             "6999***********************************99", hsp.aln_annotation["PP"]
@@ -1205,8 +1205,8 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(270, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.86, hsp.acc_avg)
-        self.assertEqual("rgrpsaavlaalaralgldpaera", str(hsp.hit.seq))
-        self.assertEqual("CPKPSLQQITHIANQLGLEKDVVR", str(hsp.query.seq))
+        self.assertEqual("rgrpsaavlaalaralgldpaera", hsp.hit.seq)
+        self.assertEqual("CPKPSLQQITHIANQLGLEKDVVR", hsp.query.seq)
         self.assertEqual("678**************9988765", hsp.aln_annotation["PP"])
 
         hit = qresult[3]
@@ -1237,8 +1237,8 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(277, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.91, hsp.acc_avg)
-        self.assertEqual("hnPYPskevkeelakqTglsrkqidnWFiNaRr", str(hsp.hit.seq))
-        self.assertEqual("KCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQ", str(hsp.query.seq))
+        self.assertEqual("hnPYPskevkeelakqTglsrkqidnWFiNaRr", hsp.hit.seq)
+        self.assertEqual("KCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQ", hsp.query.seq)
         self.assertEqual("56779*************************996", hsp.aln_annotation["PP"])
 
         hit = qresult[4]
@@ -1271,11 +1271,11 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(0.77, hsp.acc_avg)
         self.assertEqual(
             "adlaavleelnkakkeevdlvvlGcPhlsleeleelaellkgrkkkvsvelvvttsravlsk",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "QARKRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEK--DVVRVWFCNRRQKGKR",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "345666667778888899************************99..9999999988876554",
@@ -1526,11 +1526,11 @@ class HmmscanCases(unittest.TestCase):
         )
         self.assertEqual(
             "kflrnklaealaelflqeypnqWpsffddllsllssspsglelllriLkvlpeEiadfsrskleqerrnelkdllrsqvqkilelllqileqsvskk...............sselveatLkclsswvswidiglivnsp..llsllfqlLndpelreaAvecL",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "NHIKDALSRIVVEMIKREWPQHWPDMLIELDTLSKQGETQTELVMFILLRLAEDVVTF--QTLPPQRRRDIQQTLTQNMERIFSFLLNTLQENVNKYqqvktdtsqeskaqaNCRVGVAALNTLAGYIDWVSMSHITAENckLLEILCLLLNEQELQLGAAECL",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "89******************************************************99..79*********************************99*****************************************8889*********************8",
@@ -1555,8 +1555,8 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.86, hsp.acc_avg)
         self.assertEqual("HHCTTS-CHHCHCS.HHHHHCHHCCSCC", hsp.aln_annotation["CS"])
-        self.assertEqual("swvswidiglivnspllsllfqlLndpe", str(hsp.hit.seq))
-        self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", str(hsp.query.seq))
+        self.assertEqual("swvswidiglivnspllsllfqlLndpe", hsp.hit.seq)
+        self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", hsp.query.seq)
         self.assertEqual("899*********98.8888899998776", hsp.aln_annotation["PP"])
 
         hit = qresult[-1]
@@ -1593,11 +1593,11 @@ class HmmscanCases(unittest.TestCase):
         )
         self.assertEqual(
             "qLnqlekqkPgflsallqilanksldlevRqlAalyLknlItkhWkseeaqrqqqlpeeekelIrnnllnll",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "FCEEFKEKCPICVPCGLRLA-EKTQVAIVRHFGLQILEHVVKFRWN--------GMSRLEKVYLKNSVMELI",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "56788886699*********.6555899******************........999999****99999887",
@@ -1622,8 +1622,8 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.85, hsp.acc_avg)
         self.assertEqual("HCS-HHHHHHHHHHHHHHH", hsp.aln_annotation["CS"])
-        self.assertEqual("qqlpeeekelIrnnllnll", str(hsp.hit.seq))
-        self.assertEqual("QTLPPQRRRDIQQTLTQNM", str(hsp.query.seq))
+        self.assertEqual("qqlpeeekelIrnnllnll", hsp.hit.seq)
+        self.assertEqual("QTLPPQRRRDIQQTLTQNM", hsp.query.seq)
         self.assertEqual("6899*******99998865", hsp.aln_annotation["PP"])
 
         # test if we've properly finished iteration
@@ -1776,11 +1776,11 @@ class HmmersearchCases(unittest.TestCase):
         )
         self.assertEqual(
             "yelleklGsGsfGkVykakk...kktgkkvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "FELLKVLGQGSYGKVFLVRKvtgSDAGQLYAMKVLKKATLKVRDRVRSKMERDILAEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHGLGIIYRDLKPENILLDEEGHIKITDFGLSKEATDHDKRAYSFCGTIEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGSLPFQGK---DRKETMALILKAKLGMPQFLS----AEAQSLLRALFKRNPCNRLGagvdgVEEIKRHPFF",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
@@ -1862,11 +1862,11 @@ class HmmersearchCases(unittest.TestCase):
         )
         self.assertEqual(
             "yelleklGsGsfGkVykakk...kktgkkvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "FELLKVLGQGSYGKVFLVRKvtgSDAGQLYAMKVLKKATLKVRDRVRSKMERDILAEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHGLGIIYRDLKPENILLDEEGHIKITDFGLSKEATDHDKRAYSFCGTIEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGSLPFQGK---DRKETMALILKAKLGMPQFLS----AEAQSLLRALFKRNPCNRLGagvdgVEEIKRHPFF",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
@@ -1896,11 +1896,11 @@ class HmmersearchCases(unittest.TestCase):
         )
         self.assertEqual(
             "yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "YEIKEDIGVGSYSVCKRCVHKATDAEYAVKIIDKSKRDPSE------EIEILLRYgQHPNIITLKDVYDDGKYVYLVMELMRGGELLDRILRQRCFSEREASDVLYTIARTMDYLHSQGVVHRDLKPSNILYMDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDVWSLGILLYTMLAGFTPFANGPDDTPEEILARIGSGKYALSGGNWDSISDAAKDVVSKMLHVDPQQRLTAVQVLKHPWI",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "7899***********************************98......9*******99**************************************************************************98544444888**********************************.***************************************************************************************7",
@@ -1944,11 +1944,11 @@ class HmmersearchCases(unittest.TestCase):
         )
         self.assertEqual(
             "yelleklGsGsfGkVykakkkktgk...kvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "FELLKVLGQGSFGKVFLVKKISGSDarqLYAMKVLKKATLKVRDRVRTKMERDILVEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHSLGIIYRDLKPENILLDEEGHIKLTDFGLSKESIDHEKKAYSFCGTVEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGTLPFQGK---DRKETMTMILKAKLGMPQFLS----PEAQSLLRMLFKRNPANRLGagpdgVEEIKRHSFF",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "67899**********8888876655455****************999999****************************************************************************************************9***********************.******************************...999999999999988888866....9******************9888888999999886",
@@ -1978,11 +1978,11 @@ class HmmersearchCases(unittest.TestCase):
         )
         self.assertEqual(
             "yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "YEVKEDIGVGSYSVCKRCIHKATNMEFAVKIIDKSKRDPTE------EIEILLRYgQHPNIITLKDVYDDGKYVYVVTELMKGGELLDKILRQKFFSEREASAVLFTITKTVEYLHAQGVVHRDLKPSNILYVDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDIWSLGVLLYTMLTGYTPFANGPDDTPEEILARIGSGKFSLSGGYWNSVSDTAKDLVSKMLHVDPHQRLTAALVLRHPWI",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "7899***********************************88......9*******99**********************************9***************************************98554444888**********************************.***************************************************************************************7",
@@ -2170,11 +2170,11 @@ class HmmersearchCases(unittest.TestCase):
         )
         self.assertEqual(
             "yelleklGsGsfGkVykakk...kktgkkvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "FELLKVLGQGSYGKVFLVRKvtgSDAGQLYAMKVLKKATLKVRDRVRSKMERDILAEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHGLGIIYRDLKPENILLDEEGHIKITDFGLSKEATDHDKRAYSFCGTIEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGSLPFQGK---DRKETMALILKAKLGMPQFLS----AEAQSLLRALFKRNPCNRLGagvdgVEEIKRHPFF",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
@@ -2204,11 +2204,11 @@ class HmmersearchCases(unittest.TestCase):
         )
         self.assertEqual(
             "yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "YEIKEDIGVGSYSVCKRCVHKATDAEYAVKIIDKSKRDPSE------EIEILLRYgQHPNIITLKDVYDDGKYVYLVMELMRGGELLDRILRQRCFSEREASDVLYTIARTMDYLHSQGVVHRDLKPSNILYMDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDVWSLGILLYTMLAGFTPFANGPDDTPEEILARIGSGKYALSGGNWDSISDAAKDVVSKMLHVDPQQRLTAVQVLKHPWI",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "7899***********************************98......9*******99**************************************************************************98544444888**********************************.***************************************************************************************7",
@@ -2252,11 +2252,11 @@ class HmmersearchCases(unittest.TestCase):
         )
         self.assertEqual(
             "yelleklGsGsfGkVykakkkktgk...kvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "FELLKVLGQGSFGKVFLVKKISGSDarqLYAMKVLKKATLKVRDRVRTKMERDILVEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHSLGIIYRDLKPENILLDEEGHIKLTDFGLSKESIDHEKKAYSFCGTVEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGTLPFQGK---DRKETMTMILKAKLGMPQFLS----PEAQSLLRMLFKRNPANRLGagpdgVEEIKRHSFF",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "67899**********8888876655455****************999999****************************************************************************************************9***********************.******************************...999999999999988888866....9******************9888888999999886",
@@ -2286,11 +2286,11 @@ class HmmersearchCases(unittest.TestCase):
         )
         self.assertEqual(
             "yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "YEVKEDIGVGSYSVCKRCIHKATNMEFAVKIIDKSKRDPTE------EIEILLRYgQHPNIITLKDVYDDGKYVYVVTELMKGGELLDKILRQKFFSEREASAVLFTITKTVEYLHAQGVVHRDLKPSNILYVDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDIWSLGVLLYTMLTGYTPFANGPDDTPEEILARIGSGKFSLSGGYWNSVSDTAKDLVSKMLHVDPHQRLTAALVLRHPWI",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "7899***********************************88......9*******99**********************************9***************************************98554444888**********************************.***************************************************************************************7",
@@ -2368,11 +2368,11 @@ class HmmersearchCases(unittest.TestCase):
         )
         self.assertEqual(
             "yelleklGsGsfGkVykakk...kktgkkvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "FELLKVLGQGSYGKVFLVRKvtgSDAGQLYAMKVLKKATLKVRDRVRSKMERDILAEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHGLGIIYRDLKPENILLDEEGHIKITDFGLSKEATDHDKRAYSFCGTIEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGSLPFQGK---DRKETMALILKAKLGMPQFLS----AEAQSLLRALFKRNPCNRLGagvdgVEEIKRHPFF",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
@@ -2402,11 +2402,11 @@ class HmmersearchCases(unittest.TestCase):
         )
         self.assertEqual(
             "yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "YEIKEDIGVGSYSVCKRCVHKATDAEYAVKIIDKSKRDPSE------EIEILLRYgQHPNIITLKDVYDDGKYVYLVMELMRGGELLDRILRQRCFSEREASDVLYTIARTMDYLHSQGVVHRDLKPSNILYMDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDVWSLGILLYTMLAGFTPFANGPDDTPEEILARIGSGKYALSGGNWDSISDAAKDVVSKMLHVDPQQRLTAVQVLKHPWI",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "7899***********************************98......9*******99**************************************************************************98544444888**********************************.***************************************************************************************7",
@@ -2450,11 +2450,11 @@ class HmmersearchCases(unittest.TestCase):
         )
         self.assertEqual(
             "yelleklGsGsfGkVykakkkktgk...kvAvKilkkeeekskkektavrElkilkklsHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgevkiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRlt.....aeeilkhpwl",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "FELLKVLGQGSFGKVFLVKKISGSDarqLYAMKVLKKATLKVRDRVRTKMERDILVEVNHPFIVKLHYAFQTEGKLYLILDFLRGGDLFTRLSKEVMFTEEDVKFYLAELALALDHLHSLGIIYRDLKPENILLDEEGHIKLTDFGLSKESIDHEKKAYSFCGTVEYMAPEVVN-RRGHTQSADWWSFGVLMFEMLTGTLPFQGK---DRKETMTMILKAKLGMPQFLS----PEAQSLLRMLFKRNPANRLGagpdgVEEIKRHSFF",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "67899**********8888876655455****************999999****************************************************************************************************9***********************.******************************...999999999999988888866....9******************9888888999999886",
@@ -2484,11 +2484,11 @@ class HmmersearchCases(unittest.TestCase):
         )
         self.assertEqual(
             "yelleklGsGsfGkVykakkkktgkkvAvKilkkeeekskkektavrElkilkkl.sHpnivkllevfetkdelylvleyveggdlfdllkkegklseeeikkialqilegleylHsngiiHrDLKpeNiLldkkgev....kiaDFGlakkleksseklttlvgtreYmAPEvllkakeytkkvDvWslGvilyelltgklpfsgeseedqleliekilkkkleedepkssskseelkdlikkllekdpakRltaeeilkhpwl",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
         self.assertEqual(
             "YEVKEDIGVGSYSVCKRCIHKATNMEFAVKIIDKSKRDPTE------EIEILLRYgQHPNIITLKDVYDDGKYVYVVTELMKGGELLDKILRQKFFSEREASAVLFTITKTVEYLHAQGVVHRDLKPSNILYVDESGNpesiRICDFGFAKQLRAENGLLMTPCYTANFVAPEVLK-RQGYDAACDIWSLGVLLYTMLTGYTPFANGPDDTPEEILARIGSGKFSLSGGYWNSVSDTAKDLVSKMLHVDPHQRLTAALVLRHPWI",
-            str(hsp.hit.seq),
+            hsp.hit.seq,
         )
         self.assertEqual(
             "7899***********************************88......9*******99**********************************9***************************************98554444888**********************************.***************************************************************************************7",
@@ -2554,11 +2554,11 @@ class PhmmerCases(unittest.TestCase):
         self.assertEqual(1.00, hsp.acc_avg)
         self.assertEqual(
             "mafsaedvlkeydrrrrmealllslyypndrklldykewspprvqvecpkapvewnnppsekglivghfsgikykgekaqasevdvnkm",
-            str(hsp.query.seq)[:89],
+            hsp.query.seq[:89],
         )
         self.assertEqual(
             "MAFSAEDVLKEYDRRRRMEALLLSLYYPNDRKLLDYKEWSPPRVQVECPKAPVEWNNPPSEKGLIVGHFSGIKYKGEKAQASEVDVNKM",
-            str(hsp.hit.seq)[:89],
+            hsp.hit.seq[:89],
         )
         self.assertEqual(
             "89***************************************************************************************",
@@ -2609,8 +2609,8 @@ class PhmmerCases(unittest.TestCase):
         self.assertEqual(127, hsp.env_end)
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.84, hsp.acc_avg)
-        self.assertEqual("cpqswygspqlereivckmsgaphypnyyp", str(hsp.query.seq))
-        self.assertEqual("YPDCSYGMSQLERSIVVACEGSPYVPVHFD", str(hsp.hit.seq))
+        self.assertEqual("cpqswygspqlereivckmsgaphypnyyp", hsp.query.seq)
+        self.assertEqual("YPDCSYGMSQLERSIVVACEGSPYVPVHFD", hsp.hit.seq)
         self.assertEqual("68889******************9887764", hsp.aln_annotation["PP"])
 
 

--- a/Tests/test_SearchIO_hmmer3_text.py
+++ b/Tests/test_SearchIO_hmmer3_text.py
@@ -549,12 +549,10 @@ class HmmscanCases(unittest.TestCase):
             hsp.aln_annotation["CS"],
         )
         self.assertEqual(
-            "rrkRttftkeqleeLeelFeknrypsaeereeLAkklgLterqVkvWFqNrRakekk",
-            hsp.hit.seq,
+            "rrkRttftkeqleeLeelFeknrypsaeereeLAkklgLterqVkvWFqNrRakekk", hsp.hit.seq,
         )
         self.assertEqual(
-            "KRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQKGKR",
-            hsp.query.seq,
+            "KRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQKGKR", hsp.query.seq,
         )
         self.assertEqual(
             "79****************************************************997",
@@ -590,9 +588,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.96, hsp.acc_avg)
         self.assertEqual("aLGarLralReraGLtqeevAerlg......vSastlsrlE", hsp.hit.seq)
-        self.assertEqual(
-            "QFAKLLKQKRITLGYTQADVGLTLGvlfgkvFSQTTICRFE", hsp.query.seq
-        )
+        self.assertEqual("QFAKLLKQKRITLGYTQADVGLTLGvlfgkvFSQTTICRFE", hsp.query.seq)
         self.assertEqual(
             "6999***********************************99", hsp.aln_annotation["PP"]
         )
@@ -1140,12 +1136,10 @@ class HmmscanCases(unittest.TestCase):
             hsp.aln_annotation["CS"],
         )
         self.assertEqual(
-            "rrkRttftkeqleeLeelFeknrypsaeereeLAkklgLterqVkvWFqNrRakekk",
-            hsp.hit.seq,
+            "rrkRttftkeqleeLeelFeknrypsaeereeLAkklgLterqVkvWFqNrRakekk", hsp.hit.seq
         )
         self.assertEqual(
-            "KRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQKGKR",
-            hsp.query.seq,
+            "KRKRTSIENRVRWSLETMFLKCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQKGKR", hsp.query.seq
         )
         self.assertEqual(
             "79****************************************************997",
@@ -1181,9 +1175,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("..", hsp.env_endtype)
         self.assertEqual(0.96, hsp.acc_avg)
         self.assertEqual("aLGarLralReraGLtqeevAerlg......vSastlsrlE", hsp.hit.seq)
-        self.assertEqual(
-            "QFAKLLKQKRITLGYTQADVGLTLGvlfgkvFSQTTICRFE", hsp.query.seq
-        )
+        self.assertEqual("QFAKLLKQKRITLGYTQADVGLTLGvlfgkvFSQTTICRFE", hsp.query.seq)
         self.assertEqual(
             "6999***********************************99", hsp.aln_annotation["PP"]
         )

--- a/Tests/test_SearchIO_interproscan_xml.py
+++ b/Tests/test_SearchIO_interproscan_xml.py
@@ -67,7 +67,7 @@ class InterproscanXmlCases(unittest.TestCase):
             "MDPMDIVGKSKEDASLPKATMTKIIKEMLPPDVRVARDAQDLLIECCVEFINLVSSESNDVCNKEDKRTIAPEH"
             "VLKALQVLGFGEYIEEVYAAYEQHKYETMDTQRSVKWNPGAQMTEEEAAAEQQRMFAEARARMNGGVSVPQPEH"
             "PETDQRSPQS",
-            str(hsp.query.seq),
+            hsp.query.seq,
         )
 
         # parse last hit

--- a/Tests/test_SearchIO_model.py
+++ b/Tests/test_SearchIO_model.py
@@ -559,7 +559,7 @@ class QueryResultCases(unittest.TestCase):
         self.assertEqual([hit11, hit21, hit31], list(self.qresult.hits))
         # filter func: no '-' in hsp query sequence
         # this would filter out hsp113 and hsp211, effectively removing hit21
-        filter_func = lambda hsp: "-" not in str(hsp.fragments[0].query)  # noqa: E731
+        filter_func = lambda hsp: "-" not in hsp.fragments[0].query  # noqa: E731
         filtered = self.qresult.hsp_filter(filter_func)
         self.assertIn("hit1", filtered)
         self.assertNotIn("hit2", filtered)
@@ -613,26 +613,26 @@ class QueryResultCases(unittest.TestCase):
             for hsp in hit.hsps:
                 self.assertFalse(hasattr(hsp, "mock"))
         # check hsps in hit1
-        self.assertEqual("TGCGCAT", str(mapped["hit1"][0][0].hit.seq))
-        self.assertEqual("TGCGCAT", str(mapped["hit1"][0][0].query.seq))
-        self.assertEqual("TG", str(mapped["hit1"][1][0].hit.seq))
-        self.assertEqual("AT", str(mapped["hit1"][1][0].query.seq))
-        self.assertEqual("TTCG", str(mapped["hit1"][2][0].hit.seq))
-        self.assertEqual("T-CG", str(mapped["hit1"][2][0].query.seq))
-        self.assertEqual("TTCG", str(mapped["hit1"][2][1].hit.seq))
-        self.assertEqual("T-CG", str(mapped["hit1"][2][1].query.seq))
-        self.assertEqual("T", str(mapped["hit1"][3][0].hit.seq))
-        self.assertEqual("T", str(mapped["hit1"][3][0].query.seq))
-        self.assertEqual("TCG", str(mapped["hit1"][3][1].hit.seq))
-        self.assertEqual("TGG", str(mapped["hit1"][3][1].query.seq))
+        self.assertEqual("TGCGCAT", mapped["hit1"][0][0].hit.seq)
+        self.assertEqual("TGCGCAT", mapped["hit1"][0][0].query.seq)
+        self.assertEqual("TG", mapped["hit1"][1][0].hit.seq)
+        self.assertEqual("AT", mapped["hit1"][1][0].query.seq)
+        self.assertEqual("TTCG", mapped["hit1"][2][0].hit.seq)
+        self.assertEqual("T-CG", mapped["hit1"][2][0].query.seq)
+        self.assertEqual("TTCG", mapped["hit1"][2][1].hit.seq)
+        self.assertEqual("T-CG", mapped["hit1"][2][1].query.seq)
+        self.assertEqual("T", mapped["hit1"][3][0].hit.seq)
+        self.assertEqual("T", mapped["hit1"][3][0].query.seq)
+        self.assertEqual("TCG", mapped["hit1"][3][1].hit.seq)
+        self.assertEqual("TGG", mapped["hit1"][3][1].query.seq)
         # check hsps in hit2
-        self.assertEqual("GGCCC", str(mapped["hit2"][0][0].hit.seq))
-        self.assertEqual("GGCC-", str(mapped["hit2"][0][0].query.seq))
+        self.assertEqual("GGCCC", mapped["hit2"][0][0].hit.seq)
+        self.assertEqual("GGCC-", mapped["hit2"][0][0].query.seq)
         # check hsps in hit3
-        self.assertEqual("ATG", str(mapped["hit3"][0][0].hit.seq))
-        self.assertEqual("TTG", str(mapped["hit3"][0][0].query.seq))
-        self.assertEqual("TATAT", str(mapped["hit3"][1][0].hit.seq))
-        self.assertEqual("TATAT", str(mapped["hit3"][1][0].query.seq))
+        self.assertEqual("ATG", mapped["hit3"][0][0].hit.seq)
+        self.assertEqual("TTG", mapped["hit3"][0][0].query.seq)
+        self.assertEqual("TATAT", mapped["hit3"][1][0].hit.seq)
+        self.assertEqual("TATAT", mapped["hit3"][1][0].query.seq)
         # and make sure the attributes are transferred
         self.assertEqual(1102, mapped.seq_len)
         self.assertEqual("refseq_rna", mapped.target)
@@ -1007,14 +1007,14 @@ class HitCases(unittest.TestCase):
         for hsp in mapped:
             self.assertFalse(hasattr(hsp, "mock"))
         # check hsps in hit1
-        self.assertEqual("TGCGCAT", str(mapped[0][0].hit.seq))
-        self.assertEqual("TGCGCAT", str(mapped[0][0].query.seq))
-        self.assertEqual("TG", str(mapped[1][0].hit.seq))
-        self.assertEqual("AT", str(mapped[1][0].query.seq))
-        self.assertEqual("TTCG", str(mapped[2][0].hit.seq))
-        self.assertEqual("T-CG", str(mapped[2][0].query.seq))
-        self.assertEqual("TTCG", str(mapped[2][1].hit.seq))
-        self.assertEqual("T-CG", str(mapped[2][1].query.seq))
+        self.assertEqual("TGCGCAT", mapped[0][0].hit.seq)
+        self.assertEqual("TGCGCAT", mapped[0][0].query.seq)
+        self.assertEqual("TG", mapped[1][0].hit.seq)
+        self.assertEqual("AT", mapped[1][0].query.seq)
+        self.assertEqual("TTCG", mapped[2][0].hit.seq)
+        self.assertEqual("T-CG", mapped[2][0].query.seq)
+        self.assertEqual("TTCG", mapped[2][1].hit.seq)
+        self.assertEqual("T-CG", mapped[2][1].query.seq)
         # and make sure the attributes are transferred
         self.assertEqual(5e-10, mapped.evalue)
         self.assertEqual("test", mapped.name)
@@ -1082,16 +1082,16 @@ class HSPSingleFragmentCases(unittest.TestCase):
 
     def test_seq(self):
         """Test HSP sequence properties."""
-        self.assertEqual("ATCAGT", str(self.hsp.hit.seq))
-        self.assertEqual("AT-ACT", str(self.hsp.query.seq))
+        self.assertEqual("ATCAGT", self.hsp.hit.seq)
+        self.assertEqual("AT-ACT", self.hsp.query.seq)
 
     def test_alignment(self):
         """Test HSP.alignment property."""
         aln = self.hsp.aln
         self.assertIsInstance(aln, MultipleSeqAlignment)
         self.assertEqual(2, len(aln))
-        self.assertTrue("ATCAGT", str(aln[0].seq))
-        self.assertTrue("AT-ACT", str(aln[1].seq))
+        self.assertTrue("ATCAGT", aln[0].seq)
+        self.assertTrue("AT-ACT", aln[1].seq)
 
     def test_aln_span(self):
         """Test HSP.aln_span property."""
@@ -1188,8 +1188,8 @@ class HSPMultipleFragmentCases(unittest.TestCase):
 
     def test_seqs(self):
         """Test HSP sequence properties."""
-        self.assertEqual(["ATCAGT", "GGG"], [str(x.seq) for x in self.hsp.hit_all])
-        self.assertEqual(["AT-ACT", "CCC"], [str(x.seq) for x in self.hsp.query_all])
+        self.assertEqual(["ATCAGT", "GGG"], [x.seq for x in self.hsp.hit_all])
+        self.assertEqual(["AT-ACT", "CCC"], [x.seq for x in self.hsp.query_all])
 
     def test_id_desc_set(self):
         """Test HSP query and hit id and description setters."""
@@ -1316,13 +1316,13 @@ class HSPFragmentWithoutSeqCases(unittest.TestCase):
         """Test HSPFragment.__getitem__, only query."""
         # getitem should work if only query is present
         self.fragment.query = "AATCG"
-        self.assertEqual("ATCG", str(self.fragment[1:].query.seq))
+        self.assertEqual("ATCG", self.fragment[1:].query.seq)
 
     def test_getitem_only_hit(self):
         """Test HSPFragment.__getitem__, only hit."""
         # getitem should work if only query is present
         self.fragment.hit = "CATGC"
-        self.assertEqual("ATGC", str(self.fragment[1:].hit.seq))
+        self.assertEqual("ATGC", self.fragment[1:].hit.seq)
 
     def test_iter(self):
         """Test HSP.__iter__, no alignments."""
@@ -1424,8 +1424,8 @@ class HSPFragmentCases(unittest.TestCase):
         sliced_fragment = self.fragment[:5]
         self.assertIsInstance(sliced_fragment, HSPFragment)
         self.assertEqual(5, len(sliced_fragment))
-        self.assertEqual("ATGCT", str(sliced_fragment.hit.seq))
-        self.assertEqual("ATG--", str(sliced_fragment.query.seq))
+        self.assertEqual("ATGCT", sliced_fragment.hit.seq)
+        self.assertEqual("ATG--", sliced_fragment.query.seq)
 
     def test_getitem_attrs(self):
         """Test HSPFragment.__getitem__, with attributes."""


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR removes unnecessary calls to `str` from SearchIO-related code.