### PR TITLE
remove str in applications code

### DIFF
--- a/Tests/test_Emboss.py
+++ b/Tests/test_Emboss.py
@@ -187,7 +187,8 @@ class SeqRetTests(unittest.TestCase):
                 msg,
             )
             self.assertEqual(len(old.seq), len(new.seq), msg)
-            if str(old.seq).upper() != str(new.seq).upper():
+            if old.seq.upper() != new.seq.upper():
+                raise Exception
                 if str(old.seq).replace("X", "N") == str(new.seq):
                     self.fail("%s: X -> N (protein forced into nucleotide?)" % msg)
                 else:
@@ -280,7 +281,7 @@ class SeqRetSeqIOTests(SeqRetTests):
                 pass
             else:
                 self.assertEqual(old.id, new.id)
-            self.assertEqual(str(old.seq), str(new.seq))
+            self.assertEqual(old.seq, new.seq)
             if emboss_version < (6, 3, 0) and new.letter_annotations[
                 "phred_quality"
             ] == [1] * len(old):
@@ -459,13 +460,13 @@ class PairwiseAlignmentTests(unittest.TestCase):
                 self.assertIn(str(alignment[0].seq).replace("-", ""), query_seq)
                 self.assertIn(
                     str(alignment[1].seq).replace("-", "").upper(),
-                    str(target.seq).upper(),
+                    target.seq.upper(),
                 )
             else:
                 # Global alignment
-                self.assertEqual(str(query_seq), str(alignment[0].seq).replace("-", ""))
+                self.assertEqual(query_seq, str(alignment[0].seq).replace("-", ""))
                 self.assertEqual(
-                    str(target.seq).upper(),
+                    target.seq.upper(),
                     str(alignment[1].seq).replace("-", "").upper(),
                 )
         return True
@@ -501,8 +502,8 @@ class PairwiseAlignmentTests(unittest.TestCase):
         # Check we can parse the output...
         align = AlignIO.read(cline.outfile, "emboss")
         self.assertEqual(len(align), 2)
-        self.assertEqual(str(align[0].seq), "ACCCGGGCGCGGT")
-        self.assertEqual(str(align[1].seq), "ACCCGAGCGCGGT")
+        self.assertEqual(align[0].seq, "ACCCGGGCGCGGT")
+        self.assertEqual(align[1].seq, "ACCCGAGCGCGGT")
         # Clean up,
         os.remove(cline.outfile)
 
@@ -538,8 +539,8 @@ class PairwiseAlignmentTests(unittest.TestCase):
         # Check we could read its output
         align = AlignIO.read(child.stdout, "emboss")
         self.assertEqual(len(align), 2)
-        self.assertEqual(str(align[0].seq), "ACCCGGGCGCGGT")
-        self.assertEqual(str(align[1].seq), "ACCCGAGCGCGGT")
+        self.assertEqual(align[0].seq, "ACCCGGGCGCGGT")
+        self.assertEqual(align[1].seq, "ACCCGAGCGCGGT")
         # Check no error output:
         self.assertEqual(child.stderr.read(), "")
         self.assertEqual(0, child.wait())
@@ -573,8 +574,8 @@ class PairwiseAlignmentTests(unittest.TestCase):
         # Check we can parse the output...
         align = AlignIO.read(filename, "emboss")
         self.assertEqual(len(align), 2)
-        self.assertEqual(str(align[0].seq), "ACCCGGGCGCGGT")
-        self.assertEqual(str(align[1].seq), "ACCCGAGCGCGGT")
+        self.assertEqual(align[0].seq, "ACCCGGGCGCGGT")
+        self.assertEqual(align[1].seq, "ACCCGAGCGCGGT")
         # Clean up,
         os.remove(filename)
 
@@ -610,8 +611,8 @@ class PairwiseAlignmentTests(unittest.TestCase):
         # Check we could read its output
         align = AlignIO.read(child.stdout, "emboss")
         self.assertEqual(len(align), 2)
-        self.assertEqual(str(align[0].seq), "ACCCGGGCGCGGT")
-        self.assertEqual(str(align[1].seq), "ACCCGAGCGCGGT")
+        self.assertEqual(align[0].seq, "ACCCGGGCGCGGT")
+        self.assertEqual(align[1].seq, "ACCCGAGCGCGGT")
         # Check no error output:
         self.assertEqual(child.stderr.read(), "")
         self.assertEqual(0, child.wait())
@@ -902,7 +903,7 @@ class TranslationTests(unittest.TestCase):
         else:
             self.assertTrue(record.id.startswith("asis"), msg=msg)
 
-        translation = str(record.seq)
+        translation = record.seq
         if table is None:
             table = 1
         self.assertEqual(translation, sequence.translate(table))

--- a/Tests/test_Emboss.py
+++ b/Tests/test_Emboss.py
@@ -459,15 +459,13 @@ class PairwiseAlignmentTests(unittest.TestCase):
                 # Local alignment
                 self.assertIn(str(alignment[0].seq).replace("-", ""), query_seq)
                 self.assertIn(
-                    str(alignment[1].seq).replace("-", "").upper(),
-                    target.seq.upper(),
+                    str(alignment[1].seq).replace("-", "").upper(), target.seq.upper(),
                 )
             else:
                 # Global alignment
                 self.assertEqual(query_seq, str(alignment[0].seq).replace("-", ""))
                 self.assertEqual(
-                    target.seq.upper(),
-                    str(alignment[1].seq).replace("-", "").upper(),
+                    target.seq.upper(), str(alignment[1].seq).replace("-", "").upper(),
                 )
         return True
 

--- a/Tests/test_HMMGeneral.py
+++ b/Tests/test_HMMGeneral.py
@@ -298,7 +298,7 @@ class HiddenMarkovModelTest(unittest.TestCase):
         max_prob = math.log(max_prob)
         seq = viterbi[0]
         prob = viterbi[1]
-        self.assertEqual(str(seq), seq_first_state + seq_second_state)
+        self.assertEqual(seq, seq_first_state + seq_second_state)
         self.assertAlmostEqual(prob, max_prob, 11)
 
     def test_non_ergodic(self):
@@ -339,7 +339,7 @@ class HiddenMarkovModelTest(unittest.TestCase):
         prob = viterbi[1]
 
         # the most probable path must be from state 1 to state 2
-        self.assertEqual(str(seq), "12")
+        self.assertEqual(seq, "12")
 
         # The probability of that path is the probability of starting in
         # state 1, then emitting an A, then transitioning 1 -> 2, then

--- a/Tests/test_Muscle_tool.py
+++ b/Tests/test_Muscle_tool.py
@@ -192,7 +192,7 @@ class SimpleAlignTest(unittest.TestCase):
         self.assertEqual(len(records),len(align))
         for old, new in zip(records, align):
             self.assertEqual(old.id, new.id)
-            self.assertEqual(str(new.seq).replace("-",""), str(old.seq))
+            self.assertEqual(str(new.seq).replace("-",""), old.seq)
     """
 
     def test_simple_msf(self):
@@ -225,7 +225,7 @@ class SimpleAlignTest(unittest.TestCase):
         self.assertEqual(len(records), len(align))
         for old, new in zip(records, align):
             self.assertEqual(old.id, new.id)
-            self.assertEqual(str(new.seq).replace("-", ""), str(old.seq))
+            self.assertEqual(str(new.seq).replace("-", ""), old.seq)
 
     def test_simple_clustal(self):
         """Simple muscle call using Clustal output with a MUSCLE header."""
@@ -258,7 +258,7 @@ class SimpleAlignTest(unittest.TestCase):
         self.assertEqual(len(records), len(align))
         for old, new in zip(records, align):
             self.assertEqual(old.id, new.id)
-            self.assertEqual(str(new.seq).replace("-", ""), str(old.seq))
+            self.assertEqual(str(new.seq).replace("-", ""), old.seq)
 
     def test_simple_clustal_strict(self):
         """Simple muscle call using strict Clustal output."""
@@ -290,7 +290,7 @@ class SimpleAlignTest(unittest.TestCase):
         self.assertEqual(len(records), len(align))
         for old, new in zip(records, align):
             self.assertEqual(old.id, new.id)
-            self.assertEqual(str(new.seq).replace("-", ""), str(old.seq))
+            self.assertEqual(str(new.seq).replace("-", ""), old.seq)
         return_code = child.wait()
         self.assertEqual(return_code, 0)
         child.stdout.close()
@@ -335,7 +335,7 @@ class SimpleAlignTest(unittest.TestCase):
         self.assertEqual(len(records), len(align))
         for old, new in zip(records, align):
             self.assertEqual(old.id, new.id)
-            self.assertEqual(str(new.seq).replace("-", ""), str(old.seq))
+            self.assertEqual(str(new.seq).replace("-", ""), old.seq)
         # See if quiet worked:
         self.assertEqual("", child.stderr.read().strip())
         return_code = child.wait()
@@ -371,7 +371,7 @@ class SimpleAlignTest(unittest.TestCase):
         self.assertEqual(len(records), len(align))
         for old, new in zip(records, align):
             self.assertEqual(old.id, new.id)
-            self.assertEqual(str(new.seq).replace("-", ""), str(old.seq))
+            self.assertEqual(str(new.seq).replace("-", ""), old.seq)
         self.assertEqual(0, child.wait())
         child.stdout.close()
         child.stderr.close()


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR removes unnecessary calls to `str` from applications code.