### PR TITLE
str in codonalign

### DIFF
--- a/Bio/codonalign/codonalignment.py
+++ b/Bio/codonalign/codonalignment.py
@@ -115,7 +115,7 @@ class CodonAlignment(MultipleSeqAlignment):
                 BiopythonWarning,
             )
             merged = (
-                SeqRecord(seq=CodonSeq(str(left.seq) + str(right.seq)))
+                SeqRecord(seq=CodonSeq(left.seq + right.seq))
                 for left, right in zip(self, other)
             )
             return CodonAlignment(merged)

--- a/Tests/test_codonalign.py
+++ b/Tests/test_codonalign.py
@@ -111,8 +111,7 @@ class TestAddition(unittest.TestCase):
         self.assertIsInstance(new_aln, codonalign.CodonAlignment)
         for x in range(len(self.codon_aln)):
             self.assertEqual(
-                new_aln[x].seq,
-                self.codon_aln[x].seq + self.codon_aln[x].seq
+                new_aln[x].seq, self.codon_aln[x].seq + self.codon_aln[x].seq
             )
 
     def test_ValueError(self):

--- a/Tests/test_codonalign.py
+++ b/Tests/test_codonalign.py
@@ -93,8 +93,7 @@ class TestAddition(unittest.TestCase):
         self.assertIsInstance(new_aln1, MultipleSeqAlignment)
         for x in range(len(self.codon_aln)):
             self.assertEqual(
-                str(new_aln1[x].seq),
-                str(self.codon_aln[x].seq) + str(self.multi_aln[x].seq),
+                new_aln1[x].seq, self.codon_aln[x].seq + self.multi_aln[x].seq
             )
 
         new_aln2 = self.multi_aln + self.codon_aln
@@ -102,8 +101,7 @@ class TestAddition(unittest.TestCase):
         self.assertIsInstance(new_aln2, MultipleSeqAlignment)
         for x in range(len(self.codon_aln)):
             self.assertEqual(
-                str(new_aln2[x].seq),
-                str(self.multi_aln[x].seq) + str(self.codon_aln[x].seq),
+                new_aln2[x].seq, self.multi_aln[x].seq + self.codon_aln[x].seq
             )
 
     def test_addition_CodonAlignment(self):
@@ -113,8 +111,8 @@ class TestAddition(unittest.TestCase):
         self.assertIsInstance(new_aln, codonalign.CodonAlignment)
         for x in range(len(self.codon_aln)):
             self.assertEqual(
-                str(new_aln[x].seq),
-                str(self.codon_aln[x].seq) + str(self.codon_aln[x].seq),
+                new_aln[x].seq,
+                self.codon_aln[x].seq + self.codon_aln[x].seq
             )
 
     def test_ValueError(self):


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR removes unnecessary calls to `str` from `codonalign`.