### PR TITLE
Remove str from SeqIO code

### DIFF
--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -598,7 +598,7 @@ class SeqXmlWriter(SequenceWriter):
         if isinstance(record.seq, UnknownSeq):
             raise TypeError("Sequence type is UnknownSeq but SeqXML requires sequence")
 
-        seq = str(record.seq)
+        seq = bytes(record.seq)
 
         if not len(seq) > 0:
             raise ValueError("The sequence length should be greater than 0")

--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -286,7 +286,7 @@ class XdnaWriter(SequenceWriter):
         )
 
         # Actual sequence and comment
-        self.handle.write(str(record.seq).encode("ASCII"))
+        self.handle.write(bytes(record.seq))
         self.handle.write(comment.encode("ASCII"))
 
         self.handle.write(pack(">B", 0))  # Annotation section marker

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -94,7 +94,7 @@ class SeqIOTestBaseClass(unittest.TestCase):
                 err_msg = "'%s...' vs '%s...'" % (old.seq[:100], new.seq[:100])
             if msg is not None:
                 err_msg = "%s: %s" % (msg, err_msg)
-            self.assertEqual(str(old.seq), str(new.seq), msg=err_msg)
+            self.assertEqual(old.seq, new.seq, msg=err_msg)
 
     def compare_records(self, old_list, new_list, *args, **kwargs):
         """Check if two lists of SeqRecords are equal."""
@@ -252,7 +252,7 @@ class TestSeqIO(SeqIOTestBaseClass):
         self.assertEqual(record_one.name, record_two.name, msg=msg)
         self.assertEqual(record_one.description, record_two.description, msg=msg)
         self.assertEqual(len(record_one), len(record_two), msg=msg)
-        self.assertEqual(str(record_one.seq), str(record_two.seq), msg=msg)
+        self.assertEqual(record_one.seq, record_two.seq, msg=msg)
         # TODO - check features and annotation (see code for BioSQL tests)
         for key in set(record_one.letter_annotations).intersection(
             record_two.letter_annotations
@@ -365,12 +365,12 @@ class TestSeqIO(SeqIOTestBaseClass):
                 # Check the sequence
                 if fmt in ["gb", "genbank", "embl", "imgt"]:
                     # The GenBank/EMBL parsers will convert to upper case.
-                    self.assertEqual(str(r1.seq).upper(), str(r2.seq))
+                    self.assertEqual(r1.seq.upper(), r2.seq)
                 elif fmt == "qual":
                     self.assertIsInstance(r2.seq, UnknownSeq)
                     self.assertEqual(len(r2), len(r1))
                 else:
-                    self.assertEqual(str(r1.seq), str(r2.seq))
+                    self.assertEqual(r1.seq, r2.seq)
                 # Beware of different quirks and limitations in the
                 # valid character sets and the identifier lengths!
                 if fmt in ["phylip", "phylip-sequential"]:
@@ -574,7 +574,7 @@ class TestSeqIO(SeqIOTestBaseClass):
                         length = None
                         seq = record.seq
                     else:
-                        seq = str(record.seq)
+                        seq = record.seq
                         length = len(seq)
                         if length > 50:
                             seq = str(seq[:40]) + "..." + str(seq[-7:])

--- a/Tests/test_SeqIO_AbiIO.py
+++ b/Tests/test_SeqIO_AbiIO.py
@@ -249,7 +249,7 @@ class TestAbi(unittest.TestCase):
                     basename(test_data[trace]["path"][-1]).replace(".ab1", ""),
                     record.name,
                 )
-                self.assertEqual(test_data[trace]["seq"], str(record.seq))
+                self.assertEqual(test_data[trace]["seq"], record.seq)
                 self.assertEqual(
                     test_data[trace]["qual"], record.letter_annotations["phred_quality"]
                 )
@@ -275,10 +275,10 @@ class TestAbi(unittest.TestCase):
         for trace in test_data:
             record = SeqIO.read(test_data[trace]["handle"], "abi-trim")
             if trace != "data_empty" and trace != "test_fsa":
-                self.assertNotEqual(str(record.seq), test_data[trace]["seq"])
+                self.assertNotEqual(record.seq, test_data[trace]["seq"])
                 self.assertIn(str(record.seq), test_data[trace]["seq"])
             else:
-                self.assertEqual(str(record.seq), test_data[trace]["seq"])
+                self.assertEqual(record.seq, test_data[trace]["seq"])
 
     def test_no_smpl1(self):
         """Test parsing of ABIF file without the normally expected SMPL1 tag."""

--- a/Tests/test_SeqIO_FastaIO.py
+++ b/Tests/test_SeqIO_FastaIO.py
@@ -95,13 +95,13 @@ class TitleFunctions(unittest.TestCase):
         self.assertEqual(record.id, idn, msg=msg)
         self.assertEqual(record.name, name, msg=msg)
         self.assertEqual(record.description, descr, msg=msg)
-        self.assertEqual(str(record.seq), seq, msg=msg)
+        self.assertEqual(record.seq, seq, msg=msg)
         # Now check using Bio.SeqIO (default settings)
         record = SeqIO.read(filename, "fasta")
         self.assertEqual(record.id, title.split()[0], msg=msg)
         self.assertEqual(record.name, title.split()[0], msg=msg)
         self.assertEqual(record.description, title, msg=msg)
-        self.assertEqual(str(record.seq), seq, msg=msg)
+        self.assertEqual(record.seq, seq, msg=msg)
         # Uncomment this for testing the methods are calling the right files:
         # print("{%s done}" % filename)
 
@@ -116,7 +116,7 @@ class TitleFunctions(unittest.TestCase):
             self.assertEqual(new.id, idn, msg=msg)
             self.assertEqual(new.name, name, msg=msg)
             self.assertEqual(new.description, descr, msg=msg)
-            self.assertEqual(str(new.seq), str(old.seq), msg=msg)
+            self.assertEqual(new.seq, old.seq, msg=msg)
         # Uncomment this for testing the methods are calling the right files:
         # print("{%s done}" % filename)
 
@@ -125,7 +125,7 @@ class TitleFunctions(unittest.TestCase):
         handle = StringIO(">\nACGT")
         record = SeqIO.read(handle, "fasta")
         handle.close()
-        self.assertEqual(str(record.seq), "ACGT")
+        self.assertEqual(record.seq, "ACGT")
         self.assertEqual("", record.id)
         self.assertEqual("", record.name)
         self.assertEqual("", record.description)

--- a/Tests/test_SeqIO_PdbIO.py
+++ b/Tests/test_SeqIO_PdbIO.py
@@ -63,7 +63,7 @@ def SeqresTestGenerator(extension, parser):
             for chain, chn_id in zip(chains, "ABCDE"):
                 self.assertEqual(chain.id, "2BEG:" + chn_id)
                 self.assertEqual(chain.annotations["chain"], chn_id)
-                self.assertEqual(str(chain.seq), actual_seq)
+                self.assertEqual(chain.seq, actual_seq)
 
         def test_seqres_read(self):
             """Read a single-chain structure by sequence entries.
@@ -75,7 +75,7 @@ def SeqresTestGenerator(extension, parser):
             self.assertEqual(chain.id, "1A8O:A")
             self.assertEqual(chain.annotations["chain"], "A")
             self.assertEqual(
-                str(chain.seq),
+                chain.seq,
                 "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQNANPD"
                 "CKTILKALGPGATLEEMMTACQG",
             )
@@ -120,7 +120,7 @@ def AtomTestGenerator(extension, parser):
                 self.assertEqual(chain.id, "2BEG:" + chn_id)
                 self.assertEqual(chain.annotations["chain"], chn_id)
                 self.assertEqual(chain.annotations["model"], 0)
-                self.assertEqual(str(chain.seq), actual_seq)
+                self.assertEqual(chain.seq, actual_seq)
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", PDBConstructionWarning)
@@ -133,7 +133,7 @@ def AtomTestGenerator(extension, parser):
                 "XXXXXXXXNEIRDRHKDIQQLERSLLELHEMFTDMSTLVASQGEMIDRIE"
                 "FSVEQSHNYV"
             )
-            self.assertEqual(str(chains[1].seq), actual_seq)
+            self.assertEqual(chains[1].seq, actual_seq)
 
         def test_atom_read(self):
             """Read a single-chain structure by ATOM entries.
@@ -146,7 +146,7 @@ def AtomTestGenerator(extension, parser):
             self.assertEqual(chain.annotations["chain"], "A")
             self.assertEqual(chain.annotations["model"], 0)
             self.assertEqual(
-                str(chain.seq),
+                chain.seq,
                 "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQNANPDCKTIL"
                 "KALGPGATLEEMMTACQG",
             )
@@ -166,7 +166,7 @@ class TestPdbAtom(AtomTestGenerator("pdb", "pdb-atom")):
 
         self.assertEqual(len(chains), 1)
         self.assertEqual(
-            str(chains[0].seq), "MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR"
+            chains[0].seq, "MKPVTLYDVAEYAGVSYQTVSRVVNQASHVSAKTREKVEAAMAELNYIPNR"
         )
 
     def test_atom_read_noheader(self):
@@ -177,12 +177,12 @@ class TestPdbAtom(AtomTestGenerator("pdb", "pdb-atom")):
             chain = SeqIO.read("PDB/a_structure.pdb", "pdb-atom")
         self.assertEqual(chain.id, "????:A")
         self.assertEqual(chain.annotations["chain"], "A")
-        self.assertEqual(str(chain.seq), "E")
+        self.assertEqual(chain.seq, "E")
 
     def test_atom_with_insertion(self):
         """Read a PDB with residue insertion code."""
         chain = SeqIO.read("PDB/2n0n_M1.pdb", "pdb-atom")
-        self.assertEqual(str(chain.seq), "HAEGKFTSEF")
+        self.assertEqual(chain.seq, "HAEGKFTSEF")
 
 
 class TestCifAtom(AtomTestGenerator("cif", "cif-atom")):
@@ -197,7 +197,7 @@ class TestCifAtom(AtomTestGenerator("cif", "cif-atom")):
         self.assertEqual(chain.id, "????:A")
         self.assertEqual(chain.annotations["chain"], "A")
         self.assertEqual(
-            str(chain.seq),
+            chain.seq,
             "MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLLVQNANPDCKTILKALGPGATLEEMMTACQG",
         )
 

--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -168,7 +168,7 @@ class TestReferenceSffConversions(unittest.TestCase):
             self.assertEqual(old.id, new.id)
             self.assertEqual(old.name, new.name)
             if fmt != "qual":
-                self.assertEqual(str(old.seq), str(new.seq))
+                self.assertEqual(old.seq, new.seq)
             elif fmt != "fasta":
                 self.assertEqual(
                     old.letter_annotations["phred_quality"],
@@ -867,7 +867,7 @@ class MappingTests(unittest.TestCase):
             self.assertLessEqual(len(w), 1, w)
         out_handle.seek(0)
         record = SeqIO.read(out_handle, "fastq-solexa")
-        self.assertEqual(str(record.seq), seq)
+        self.assertEqual(record.seq, seq)
         self.assertEqual(record.letter_annotations["solexa_quality"], expected_sol)
 
     def test_solexa_to_sanger(self):
@@ -885,7 +885,7 @@ class MappingTests(unittest.TestCase):
         SeqIO.write(SeqIO.parse(in_handle, "fastq-solexa"), out_handle, "fastq-sanger")
         out_handle.seek(0)
         record = SeqIO.read(out_handle, "fastq-sanger")
-        self.assertEqual(str(record.seq), seq)
+        self.assertEqual(record.seq, seq)
         self.assertEqual(record.letter_annotations["phred_quality"], expected_phred)
 
     def test_sanger_to_illumina(self):
@@ -903,7 +903,7 @@ class MappingTests(unittest.TestCase):
             self.assertLessEqual(len(w), 1, w)
         out_handle.seek(0)
         record = SeqIO.read(out_handle, "fastq-illumina")
-        self.assertEqual(str(record.seq), seq)
+        self.assertEqual(record.seq, seq)
         self.assertEqual(record.letter_annotations["phred_quality"], expected_phred)
 
     def test_illumina_to_sanger(self):
@@ -918,7 +918,7 @@ class MappingTests(unittest.TestCase):
         )
         out_handle.seek(0)
         record = SeqIO.read(out_handle, "fastq-sanger")
-        self.assertEqual(str(record.seq), seq)
+        self.assertEqual(record.seq, seq)
         self.assertEqual(record.letter_annotations["phred_quality"], expected_phred)
 
 
@@ -928,7 +928,7 @@ class TestSFF(unittest.TestCase):
     def test_overlapping_clip(self):
         record = next(SeqIO.parse("Roche/greek.sff", "sff"))
         self.assertEqual(len(record), 395)
-        s = str(record.seq.lower())
+        s = record.seq.lower()
         # Apply overlapping clipping
         record.annotations["clip_qual_left"] = 51
         record.annotations["clip_qual_right"] = 44
@@ -951,7 +951,7 @@ class TestSFF(unittest.TestCase):
         self.assertEqual(record.annotations["clip_adapter_left"], 50)
         self.assertEqual(record.annotations["clip_adapter_right"], 75)
         self.assertEqual(len(record), 395)
-        self.assertEqual(s, str(record.seq.lower()))
+        self.assertEqual(s, record.seq.lower())
         # And check with trimming applied...
         h.seek(0)
         with warnings.catch_warnings(record=True) as w:

--- a/Tests/test_SeqIO_SeqXML.py
+++ b/Tests/test_SeqIO_SeqXML.py
@@ -53,10 +53,10 @@ class TestDetailedRead(unittest.TestCase):
 
     def test_full_characters_set_read(self):
         """Read full characters set for each type."""
-        self.assertEqual(str(self.records["dna"][1].seq), "ACGTMRWSYKVHDBXN.-")
-        self.assertEqual(str(self.records["rna"][1].seq), "ACGUMRWSYKVHDBXN.-")
+        self.assertEqual(self.records["dna"][1].seq, "ACGTMRWSYKVHDBXN.-")
+        self.assertEqual(self.records["rna"][1].seq, "ACGUMRWSYKVHDBXN.-")
         self.assertEqual(
-            str(self.records["protein"][1].seq), "ABCDEFGHIJKLMNOPQRSTUVWXYZ.-*"
+            self.records["protein"][1].seq, "ABCDEFGHIJKLMNOPQRSTUVWXYZ.-*"
         )
 
     def test_duplicated_property(self):

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -131,7 +131,7 @@ class SeqIOFeatureTestBaseClass(SeqIOTestBaseClass):
             err_msg = "'%s...' vs '%s...'" % (old.seq[:100], new.seq[:100])
         if msg:
             err_msg = "%s; %s" % (msg, err_msg)
-        self.assertEqual(str(old.seq).upper(), str(new.seq).upper(), msg=err_msg)
+        self.assertEqual(old.seq.upper(), new.seq.upper(), msg=err_msg)
         if old.features and new.features:
             self.assertEqual(len(old.features), len(new.features), msg=msg)
             for old_feature, new_feature in zip(old.features, new.features):
@@ -251,7 +251,7 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
 
         new = feature.extract(parent_seq)
         self.assertIsInstance(new, Seq)
-        self.assertEqual(str(new), answer_str)
+        self.assertEqual(new, answer_str)
 
         new = feature.extract(str(parent_seq))
         self.assertIsInstance(new, str)
@@ -259,7 +259,7 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
 
         new = feature.extract(MutableSeq(parent_seq))
         self.assertIsInstance(new, Seq)  # Not MutableSeq!
-        self.assertEqual(str(new), answer_str)
+        self.assertEqual(new, answer_str)
 
         new = feature.extract(UnknownSeq(len(parent_seq), character="N"))
         self.assertIsInstance(new, UnknownSeq)
@@ -1071,9 +1071,9 @@ class NC_000932(SeqIOFeatureTestBaseClass):
                 msg = "%s\n%r, %r, %r\n%s" % (e, r.id, nuc, self.table, f)
                 self.fail(msg)
             if pro[-1] == "*":
-                self.assertEqual(str(pro)[:-1], str(r.seq))
+                self.assertEqual(pro[:-1], r.seq)
             else:
-                self.assertEqual(str(pro), str(r.seq))
+                self.assertEqual(pro, r.seq)
 
 
 class NC_005816(NC_000932):
@@ -1117,8 +1117,8 @@ class NC_005816(NC_000932):
                 faa.format("fasta"),
             )
             self.assertTrue(
-                str(translation) == str(faa.seq)
-                or str(translation) != str(faa.seq) + "*"
+                translation == faa.seq
+                or translation != faa.seq + "*"
             )
 
     def test_Genome(self):
@@ -1149,8 +1149,7 @@ class NC_005816(NC_000932):
         for fa_record, f in zip(fa_records, features):
             # TODO - check the FASTA ID line against the co-ordinates?
             f_seq = f.extract(gb_record.seq)
-            self.assertEqual(len(fa_record.seq), len(f_seq))
-            self.assertEqual(str(fa_record.seq), str(f_seq))
+            self.assertEqual(fa_record.seq, f_seq)
             self.assertEqual(len(f_seq), len(f))
 
 

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -1116,10 +1116,7 @@ class NC_005816(NC_000932):
                 t.format("fasta"),
                 faa.format("fasta"),
             )
-            self.assertTrue(
-                translation == faa.seq
-                or translation != faa.seq + "*"
-            )
+            self.assertTrue(translation == faa.seq or translation != faa.seq + "*")
 
     def test_Genome(self):
         """Checking GenBank sequence vs FASTA fna file."""

--- a/Tests/test_SeqIO_write.py
+++ b/Tests/test_SeqIO_write.py
@@ -263,7 +263,7 @@ class WriterTests(SeqIOTestBaseClass):
                 )
             else:
                 self.assertEqual(record.id, new_record.id, msg=msg)
-            self.assertEqual(str(record.seq), str(new_record.seq), msg=msg)
+            self.assertEqual(record.seq, new_record.seq, msg=msg)
         handle.close()
 
     def check_write_fails(self, records, fmt, descr, err_type, err_msg=""):

--- a/Tests/test_SffIO.py
+++ b/Tests/test_SffIO.py
@@ -275,7 +275,7 @@ class TestAlternativeIndexes(unittest.TestCase):
         self.assertEqual(len(self.sff), len(new_sff))
         for old, new in zip(self.sff, new_sff):
             self.assertEqual(old.id, new.id)
-            self.assertEqual(str(old.seq), str(new.seq))
+            self.assertEqual(old.seq, new.seq)
 
     def test_alt_index_at_end(self):
         with open("Roche/E3MFGYR02_alt_index_at_end.sff", "rb") as handle:
@@ -405,7 +405,7 @@ class TestSelf(unittest.TestCase):
             sff, sff_trim, fasta_no_trim, qual_no_trim, fasta_trim, qual_trim
         ):
             self.assertEqual(len({s.id, f.id, q.id}), 1)  # All values are the same
-            self.assertEqual(str(s.seq), str(f.seq))
+            self.assertEqual(s.seq, f.seq)
             self.assertEqual(
                 s.letter_annotations["phred_quality"],
                 q.letter_annotations["phred_quality"],
@@ -413,7 +413,7 @@ class TestSelf(unittest.TestCase):
             self.assertEqual(
                 len({s.id, sT.id, fT.id, qT.id}), 1
             )  # All values are the same
-            self.assertEqual(str(sT.seq), str(fT.seq))
+            self.assertEqual(sT.seq, fT.seq)
             self.assertEqual(
                 sT.letter_annotations["phred_quality"],
                 qT.letter_annotations["phred_quality"],
@@ -506,7 +506,7 @@ if False:
     with open("Roche/E3MFGYR02_alt_index_at_start.sff", "rb") as handle:
         records2 = list(SffIterator(handle))
     for old, new in zip(records, records2):
-        assert str(old.seq) == str(new.seq)
+        assert old.seq == new.seq
     with open("Roche/E3MFGYR02_alt_index_at_start.sff", "rb") as handle:
         i = list(_sff_do_slow_index(handle))
 
@@ -540,7 +540,7 @@ if False:
     with open("Roche/E3MFGYR02_alt_index_in_middle.sff", "rb") as handle:
         records2 = list(SffIterator(handle))
     for old, new in zip(records, records2):
-        assert str(old.seq) == str(new.seq)
+        assert old.seq == new.seq
     with open("Roche/E3MFGYR02_alt_index_in_middle.sff", "rb") as handle:
         j = list(_sff_do_slow_index(handle))
 
@@ -567,7 +567,7 @@ if False:
     with open("Roche/E3MFGYR02_alt_index_at_end.sff", "rb") as handle:
         records2 = list(SffIterator(handle))
     for old, new in zip(records, records2):
-        assert str(old.seq) == str(new.seq)
+        assert old.seq == new.seq
     with unittest.TestCase.assertRaises(None, ValueError):
         with open("Roche/E3MFGYR02_alt_index_at_end.sff", "rb") as handle:
             print(ReadRocheXmlManifest(handle))


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


This PR removes unnecessary calls to `str` from `SeqIO`