### PR TITLE
make index, rindex consistent for Seq and MutableSeq

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2287,7 +2287,7 @@ class MutableSeq:
             else:
                 return overlap_count
 
-    def index(self, item):
+    def index(self, sub, start=None, end=None):
         """Return first occurrence position of a single entry (i.e. letter).
 
         >>> my_seq = MutableSeq("ACTCGACGTCG")
@@ -2298,15 +2298,28 @@ class MutableSeq:
         >>> my_seq.index(Seq("T"))
         2
         """
-        if isinstance(item, MutableSeq):
-            item = item._data
-        elif isinstance(item, Seq):
-            item = bytes(item)
-        elif isinstance(item, str):
-            item = item.encode("ASCII")
+        if isinstance(sub, MutableSeq):
+            sub = sub._data
+        elif isinstance(sub, Seq):
+            sub = bytes(sub)
+        elif isinstance(sub, str):
+            sub = sub.encode("ASCII")
         else:
             raise TypeError("expected a string, Seq or MutableSeq")
-        return self._data.index(item)
+        return self._data.index(sub, start, end)
+
+    def rindex(self, sub, start=None, end=None):
+        """Like rfind() but raise ValueError when the substring is not found."""
+        if isinstance(sub, (Seq, MutableSeq)):
+            sub = bytes(sub)
+        elif isinstance(sub, str):
+            sub = sub.encode("ASCII")
+        elif not isinstance(sub, (bytes, bytearray)):
+            raise TypeError(
+                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
+                % type(sub)
+            )
+        return self._data.rindex(sub, start, end)
 
     def reverse(self):
         """Modify the mutable sequence to reverse itself.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2287,6 +2287,72 @@ class MutableSeq:
             else:
                 return overlap_count
 
+    def find(self, sub, start=None, end=None):
+        """Find method, like that of a python string.
+
+        This behaves like the python string method of the same name.
+
+        Returns an integer, the index of the first occurrence of substring
+        argument sub in the (sub)sequence given by [start:end].
+
+        Arguments:
+         - sub - a string or another Seq or MutableSeq object to look for
+         - start - optional integer, slice start
+         - end - optional integer, slice end
+
+        Returns -1 if the subsequence is NOT found.
+
+        e.g. Locating the first typical start codon, AUG, in an RNA sequence:
+
+        >>> from Bio.Seq import MutableSeq
+        >>> my_rna = MutableSeq("GUCAUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAGUUG")
+        >>> my_rna.find("AUG")
+        3
+        """
+        if isinstance(sub, (Seq, MutableSeq)):
+            sub = bytes(sub)
+        elif isinstance(sub, str):
+            sub = sub.encode("ASCII")
+        elif not isinstance(sub, (bytes, bytearray)):
+            raise TypeError(
+                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
+                % type(sub)
+            )
+        return self._data.find(sub, start, end)
+
+    def rfind(self, sub, start=None, end=None):
+        """Find from right method, like that of a python string.
+
+        This behaves like the python string method of the same name.
+
+        Returns an integer, the index of the last (right most) occurrence of
+        substring argument sub in the (sub)sequence given by [start:end].
+
+        Arguments:
+         - sub - a string or another Seq or MutablSeq object to look for
+         - start - optional integer, slice start
+         - end - optional integer, slice end
+
+        Returns -1 if the subsequence is NOT found.
+
+        e.g. Locating the last typical start codon, AUG, in an RNA sequence:
+
+        >>> from Bio.Seq import MutableSeq
+        >>> my_rna = MutableSeq("GUCAUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAGUUG")
+        >>> my_rna.rfind("AUG")
+        15
+        """
+        if isinstance(sub, (Seq, MutableSeq)):
+            sub = bytes(sub)
+        elif isinstance(sub, str):
+            sub = sub.encode("ASCII")
+        elif not isinstance(sub, (bytes, bytearray)):
+            raise TypeError(
+                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
+                % type(sub)
+            )
+        return self._data.rfind(sub, start, end)
+
     def index(self, sub, start=None, end=None):
         """Return first occurrence position of a single entry (i.e. letter).
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2287,6 +2287,24 @@ class MutableSeq:
             else:
                 return overlap_count
 
+    def __contains__(self, item):
+        """Implement the 'in' keyword, like a python string.
+
+        e.g.
+
+        >>> from Bio.Seq import MutableSeq
+        >>> my_dna = MutableSeq("ATATGAAATTTGAAAA")
+        >>> "AAA" in my_dna
+        True
+        >>> MutableSeq("AAA") in my_dna
+        True
+        """
+        if isinstance(item, (Seq, MutableSeq)):
+            item = bytes(item)
+        elif isinstance(item, str):
+            item = item.encode("ASCII")
+        return item in self._data
+
     def find(self, sub, start=None, end=None):
         """Find method, like that of a python string.
 
@@ -2386,6 +2404,72 @@ class MutableSeq:
                 % type(sub)
             )
         return self._data.rindex(sub, start, end)
+
+    def startswith(self, prefix, start=None, end=None):
+        """Return True if the MutableSeq starts with the given prefix, False otherwise.
+
+        This behaves like the python string method of the same name.
+
+        Return True if the sequence starts with the specified prefix
+        (a string or another Seq object), False otherwise.
+        With optional start, test sequence beginning at that position.
+        With optional end, stop comparing sequence at that position.
+        prefix can also be a tuple of strings to try.  e.g.
+
+        >>> from Bio.Seq import MutableSeq
+        >>> my_rna = MutableSeq("GUCAUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAGUUG")
+        >>> my_rna.startswith("GUC")
+        True
+        >>> my_rna.startswith("AUG")
+        False
+        >>> my_rna.startswith("AUG", 3)
+        True
+        >>> my_rna.startswith(("UCC", "UCA", "UCG"), 1)
+        True
+        """
+        if isinstance(prefix, tuple):
+            prefix = tuple(
+                bytes(p) if isinstance(p, (Seq, MutableSeq)) else p.encode("ASCII")
+                for p in prefix
+            )
+        elif isinstance(prefix, (Seq, MutableSeq)):
+            prefix = bytes(prefix)
+        elif isinstance(prefix, str):
+            prefix = prefix.encode("ASCII")
+        return self._data.startswith(prefix, start, end)
+
+    def endswith(self, suffix, start=None, end=None):
+        """Return True if the MutableSeq ends with the given suffix, False otherwise.
+
+        This behaves like the python string method of the same name.
+
+        Return True if the sequence ends with the specified suffix
+        (a string or another Seq object), False otherwise.
+        With optional start, test sequence beginning at that position.
+        With optional end, stop comparing sequence at that position.
+        suffix can also be a tuple of strings to try.  e.g.
+
+        >>> from Bio.Seq import MutableSeq
+        >>> my_rna = MutableSeq("GUCAUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAGUUG")
+        >>> my_rna.endswith("UUG")
+        True
+        >>> my_rna.endswith("AUG")
+        False
+        >>> my_rna.endswith("AUG", 0, 18)
+        True
+        >>> my_rna.endswith(("UCC", "UCA", "UUG"))
+        True
+        """
+        if isinstance(suffix, tuple):
+            suffix = tuple(
+                bytes(p) if isinstance(p, (Seq, MutableSeq)) else p.encode("ASCII")
+                for p in suffix
+            )
+        elif isinstance(suffix, (Seq, MutableSeq)):
+            suffix = bytes(suffix)
+        elif isinstance(suffix, str):
+            suffix = suffix.encode("ASCII")
+        return self._data.endswith(suffix, start, end)
 
     def reverse(self):
         """Modify the mutable sequence to reverse itself.

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -524,9 +524,8 @@ class TestSeqIO(SeqIOTestBaseClass):
                 # Check returned expected object type
                 self.assertIsInstance(record, SeqRecord)
                 if t_format in possible_unknown_seq_formats:
-                    if (not isinstance(record.seq, Seq)) and (
-                        not isinstance(record.seq, UnknownSeq)
-                    ):
+                    if not isinstance(record.seq, Seq):
+                        # UnknownSeq is a subclass of Seq
                         self.failureException("Expected a Seq or UnknownSeq object")
                 else:
                     self.assertIsInstance(record.seq, Seq)

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -99,13 +99,6 @@ class StringMethodTests(unittest.TestCase):
                 if not hasattr(example2, method_name):
                     # e.g. MutableSeq does not support find
                     continue
-                if (
-                    method_name in ("index", "rindex")
-                    and isinstance(example1, MutableSeq)
-                    and len(example2) > 1
-                ):
-                    # MutableSeq index only supports single entries
-                    continue
                 str2 = str(example2)
 
                 try:
@@ -399,6 +392,9 @@ class StringMethodTests(unittest.TestCase):
         self.assertEqual(Seq("AC7GT").index("7"), 2)
         self.assertRaises(TypeError, Seq("AC7GT").index, 7)
         self.assertRaises(TypeError, Seq("ACGT").index, None)
+        self.assertEqual(MutableSeq("AC7GT").index("7"), 2)
+        self.assertRaises(TypeError, MutableSeq("AC7GT").index, 7)
+        self.assertRaises(TypeError, MutableSeq("ACGT").index, None)
 
     def test_str_rindex(self):
         """Check matches the python string rindex method."""
@@ -406,6 +402,9 @@ class StringMethodTests(unittest.TestCase):
         self.assertEqual(Seq("AC7GT").rindex("7"), 2)
         self.assertRaises(TypeError, Seq("AC7GT").rindex, 7)
         self.assertRaises(TypeError, Seq("ACGT").rindex, None)
+        self.assertEqual(MutableSeq("AC7GT").rindex("7"), 2)
+        self.assertRaises(TypeError, MutableSeq("AC7GT").rindex, 7)
+        self.assertRaises(TypeError, MutableSeq("ACGT").rindex, None)
 
     def test_str_startswith(self):
         """Check matches the python string startswith method."""

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -91,13 +91,13 @@ class StringMethodTests(unittest.TestCase):
         self.assertIsInstance(method_name, str)
         for example1 in self._examples:
             if not hasattr(example1, method_name):
-                # e.g. MutableSeq does not support find
+                # e.g. MutableSeq does not support translate
                 continue
             str1 = str(example1)
 
             for example2 in self._examples:
                 if not hasattr(example2, method_name):
-                    # e.g. MutableSeq does not support find
+                    # e.g. MutableSeq does not support translate
                     continue
                 str2 = str(example2)
 
@@ -408,12 +408,10 @@ class StringMethodTests(unittest.TestCase):
         self._test_method("startswith", start_end=True)
         self.assertTrue("ABCDE".startswith(("ABE", "OBE", "ABC")))
         self.assertRaises(TypeError, Seq("ACGT").startswith, None)
+        self.assertRaises(TypeError, MutableSeq("ACGT").startswith, None)
 
         # Now check with a tuple of sub sequences
         for example1 in self._examples:
-            if not hasattr(example1, "startswith"):
-                # e.g. MutableSeq does not support this
-                continue
             subs = tuple(
                 example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
             )
@@ -441,9 +439,6 @@ class StringMethodTests(unittest.TestCase):
 
         # Now check with a tuple of sub sequences
         for example1 in self._examples:
-            if not hasattr(example1, "endswith"):
-                # e.g. MutableSeq does not support this
-                continue
             subs = tuple(
                 example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
             )

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -82,7 +82,7 @@ class StringMethodTests(unittest.TestCase):
         UnknownSeq(12),
     ]
     for seq in _examples[:]:
-        if isinstance(seq, Seq):
+        if not isinstance(seq, MutableSeq):
             _examples.append(MutableSeq(seq))
     _start_end_values = [0, 1, 2, 1000, -1, -2, -999, None]
 
@@ -121,9 +121,6 @@ class StringMethodTests(unittest.TestCase):
                 self.assertEqual(i, j, "%r.%s(%r)" % (example1, method_name, example2))
 
                 if start_end:
-                    if isinstance(example1, MutableSeq):
-                        # Does not support start/end arguments
-                        continue
                     for start in self._start_end_values:
                         try:
                             i = getattr(example1, method_name)(str2, start)
@@ -518,8 +515,6 @@ class StringMethodTests(unittest.TestCase):
     def test_str_encode(self):
         """Check matches the python string encode method."""
         for example1 in self._examples:
-            if isinstance(example1, MutableSeq):
-                continue
             str1 = str(example1)
             self.assertEqual(bytes(example1), str1.encode("ascii"))
 

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -572,7 +572,7 @@ class TestMutableSeq(unittest.TestCase):
             self.mutable_s.__radd__(self.mutable_s),
         )
 
-    def test_radd_method_using_mutalbeseq_object(self):
+    def test_radd_method_using_mutableseq_object(self):
         self.assertEqual(
             "UCAAAAGGATCAAAAGGATGCATCATG",
             self.mutable_s.__radd__(Seq.MutableSeq("UCAAAAGGA")),
@@ -586,6 +586,17 @@ class TestMutableSeq(unittest.TestCase):
     def test_radd_method_wrong_type(self):
         with self.assertRaises(TypeError):
             self.mutable_s.__radd__(1234)
+
+    def test_contains_method(self):
+        self.assertIn("AAAA", self.mutable_s)
+
+    def test_startswith(self):
+        self.assertTrue(self.mutable_s.startswith("TCA"))
+        self.assertTrue(self.mutable_s.startswith(("CAA", "CTA"), 1))
+
+    def test_endswith(self):
+        self.assertTrue(self.mutable_s.endswith("ATG"))
+        self.assertTrue(self.mutable_s.endswith(("ATG", "CTA")))
 
     def test_as_string(self):
         self.assertEqual("TCAAAAGGATGCATCATG", self.mutable_s)

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -263,23 +263,17 @@ class TestSeqStringMethods(unittest.TestCase):
         for a in self.dna + self.rna + self.nuc + self.protein:
             for char in self.test_chars:
                 str_char = str(char)
-                if isinstance(a, Seq.Seq):
-                    self.assertEqual(a.find(char), str(a).find(str_char))
-                    self.assertEqual(a.find(char, 2, -2), str(a).find(str_char, 2, -2))
-                    self.assertEqual(a.rfind(char), str(a).rfind(str_char))
-                    self.assertEqual(
-                        a.rfind(char, 2, -2), str(a).rfind(str_char, 2, -2)
-                    )
+                self.assertEqual(a.find(char), str(a).find(str_char))
+                self.assertEqual(a.find(char, 2, -2), str(a).find(str_char, 2, -2))
+                self.assertEqual(a.rfind(char), str(a).rfind(str_char))
+                self.assertEqual(a.rfind(char, 2, -2), str(a).rfind(str_char, 2, -2))
 
     def test_counting_characters(self):
         for a in self.dna + self.rna + self.nuc + self.protein:
             for char in self.test_chars:
                 str_char = str(char)
-                if isinstance(a, Seq.Seq):
-                    self.assertEqual(a.count(char), str(a).count(str_char))
-                    self.assertEqual(
-                        a.count(char, 2, -2), str(a).count(str_char, 2, -2)
-                    )
+                self.assertEqual(a.count(char), str(a).count(str_char))
+                self.assertEqual(a.count(char, 2, -2), str(a).count(str_char, 2, -2))
 
     def test_splits(self):
         for a in self.dna + self.rna + self.nuc + self.protein:


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


This PR makes `index` and `rindex` consistent for `Seq` and `MutableSeq`.