### PR TITLE
BioSQL doesn't need to subclass Seq

### DIFF
--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -11,8 +11,7 @@
 
 # NEEDS TO BE SYNCH WITH THE REST OF BIOPYTHON AND BIOPERL
 # In particular, the SeqRecord and BioSQL.BioSeq.DBSeqRecord classes
-# need to be in sync (this is the BioSQL "Database SeqRecord", see
-# also BioSQL.BioSeq.DBSeq which is the "Database Seq" class)
+# need to be in sync (this is the BioSQL "Database SeqRecord").
 
 
 from io import StringIO

--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -32,7 +32,7 @@ class _BioSQLSequenceData:
         You wouldn't normally create a _BioSQLSequenceData object yourself,
         this is done for you when retrieving a DBSeqRecord object from the
         database, which creates a Seq object using a _BioSQLSequenceData
-        instance as the data provider..
+        instance as the data provider.
         """
         self.primary_id = primary_id
         self.adaptor = adaptor
@@ -74,7 +74,7 @@ class _BioSQLSequenceData:
             full = self.adaptor.get_subseq_as_string(
                 self.primary_id, self.start + start, self.start + end
             )
-            return full[:: step].encode("ASCII")
+            return full[::step].encode("ASCII")
 
     def __bytes__(self):
         """Return the full sequence as bytes."""

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -691,7 +691,7 @@ class BioSeqDatabase:
         Example: seq_rec = db.get_Seq_by_id('ROA1_HUMAN')
 
         The name of this method is misleading since it returns a DBSeqRecord
-        rather than a DBSeq ojbect, and presumably was to mirror BioPerl.
+        rather than a Seq ojbect, and presumably was to mirror BioPerl.
         """
         seqid = self.adaptor.fetch_seqid_by_display_id(self.dbid, name)
         return BioSeq.DBSeqRecord(self.adaptor, seqid)
@@ -702,7 +702,7 @@ class BioSeqDatabase:
         Example: seq_rec = db.get_Seq_by_acc('X77802')
 
         The name of this method is misleading since it returns a DBSeqRecord
-        rather than a DBSeq ojbect, and presumably was to mirror BioPerl.
+        rather than a Seq ojbect, and presumably was to mirror BioPerl.
         """
         seqid = self.adaptor.fetch_seqid_by_accession(self.dbid, name)
         return BioSeq.DBSeqRecord(self.adaptor, seqid)
@@ -713,7 +713,7 @@ class BioSeqDatabase:
         Example: seq_rec = db.get_Seq_by_ver('X77802.1')
 
         The name of this method is misleading since it returns a DBSeqRecord
-        rather than a DBSeq ojbect, and presumably was to mirror BioPerl.
+        rather than a Seq ojbect, and presumably was to mirror BioPerl.
         """
         seqid = self.adaptor.fetch_seqid_by_version(self.dbid, name)
         return BioSeq.DBSeqRecord(self.adaptor, seqid)
@@ -724,7 +724,7 @@ class BioSeqDatabase:
         Example: seq_recs = db.get_Seq_by_acc('X77802')
 
         The name of this method is misleading since it returns a list of
-        DBSeqRecord objects rather than a list of DBSeq ojbects, and presumably
+        DBSeqRecord objects rather than a list of Seq ojbects, and presumably
         was to mirror BioPerl.
         """
         seqids = self.adaptor.fetch_seqids_by_accession(self.dbid, name)
@@ -837,7 +837,7 @@ class BioSeqDatabase:
         Rather than db.get_Seq_by_primary_id(my_id) use db[my_id]
 
         The name of this method is misleading since it returns a DBSeqRecord
-        rather than a DBSeq ojbect, and presumably was to mirror BioPerl.
+        rather than a Seq ojbect, and presumably was to mirror BioPerl.
         """
         import warnings
 

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -691,7 +691,7 @@ class BioSeqDatabase:
         Example: seq_rec = db.get_Seq_by_id('ROA1_HUMAN')
 
         The name of this method is misleading since it returns a DBSeqRecord
-        rather than a Seq ojbect, and presumably was to mirror BioPerl.
+        rather than a Seq object, and presumably was to mirror BioPerl.
         """
         seqid = self.adaptor.fetch_seqid_by_display_id(self.dbid, name)
         return BioSeq.DBSeqRecord(self.adaptor, seqid)
@@ -702,7 +702,7 @@ class BioSeqDatabase:
         Example: seq_rec = db.get_Seq_by_acc('X77802')
 
         The name of this method is misleading since it returns a DBSeqRecord
-        rather than a Seq ojbect, and presumably was to mirror BioPerl.
+        rather than a Seq object, and presumably was to mirror BioPerl.
         """
         seqid = self.adaptor.fetch_seqid_by_accession(self.dbid, name)
         return BioSeq.DBSeqRecord(self.adaptor, seqid)
@@ -713,7 +713,7 @@ class BioSeqDatabase:
         Example: seq_rec = db.get_Seq_by_ver('X77802.1')
 
         The name of this method is misleading since it returns a DBSeqRecord
-        rather than a Seq ojbect, and presumably was to mirror BioPerl.
+        rather than a Seq object, and presumably was to mirror BioPerl.
         """
         seqid = self.adaptor.fetch_seqid_by_version(self.dbid, name)
         return BioSeq.DBSeqRecord(self.adaptor, seqid)
@@ -724,7 +724,7 @@ class BioSeqDatabase:
         Example: seq_recs = db.get_Seq_by_acc('X77802')
 
         The name of this method is misleading since it returns a list of
-        DBSeqRecord objects rather than a list of Seq ojbects, and presumably
+        DBSeqRecord objects rather than a list of Seq objects, and presumably
         was to mirror BioPerl.
         """
         seqids = self.adaptor.fetch_seqids_by_accession(self.dbid, name)
@@ -837,7 +837,7 @@ class BioSeqDatabase:
         Rather than db.get_Seq_by_primary_id(my_id) use db[my_id]
 
         The name of this method is misleading since it returns a DBSeqRecord
-        rather than a Seq ojbect, and presumably was to mirror BioPerl.
+        rather than a Seq object, and presumably was to mirror BioPerl.
         """
         import warnings
 

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -323,7 +323,7 @@ class DBServer:
 
 
 class _CursorWrapper:
-    """A wraper for mysql.connector resolving bytestring representations."""
+    """A wrapper for mysql.connector resolving bytestring representations."""
 
     def __init__(self, real_cursor):
         self.real_cursor = real_cursor

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -447,7 +447,7 @@ class SeqInterfaceTest(unittest.TestCase):
     def test_seq_record(self):
         """Make sure SeqRecords from BioSQL implement the right interface."""
         test_record = self.item
-        self.assertIsInstance(test_record.seq, BioSeq.DBSeq)
+        self.assertIsInstance(test_record.seq, Seq)
         self.assertEqual(test_record.id, "X62281.1", test_record.id)
         self.assertEqual(test_record.name, "ATKIN2")
         self.assertEqual(test_record.description, "A.thaliana kin2 gene")
@@ -467,8 +467,6 @@ class SeqInterfaceTest(unittest.TestCase):
     def test_seq(self):
         """Make sure Seqs from BioSQL implement the right interface."""
         test_seq = self.item.seq
-        data = test_seq.data
-        self.assertEqual(type(data), type(""))
         string_rep = str(test_seq)
         self.assertEqual(string_rep, str(test_seq))  # check __str__ too
         self.assertEqual(type(string_rep), type(""))
@@ -533,7 +531,7 @@ class SeqInterfaceTest(unittest.TestCase):
         """Check that slices of sequences are retrieved properly."""
         test_seq = self.item.seq
         new_seq = test_seq[:10]
-        self.assertIsInstance(new_seq, BioSeq.DBSeq)
+        self.assertIsInstance(new_seq, Seq)
         # simple slicing
         self.assertEqual(test_seq[:5], "ATTTG")
         self.assertEqual(test_seq[0:5], "ATTTG")

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -480,7 +480,7 @@ class SeqInterfaceTest(unittest.TestCase):
         self.assertRaises(TypeError, test_seq.__getitem__, None)
 
     def test_convert(self):
-        """Check can turn a DBSeq object into a Seq or MutableSeq."""
+        """Check can turn a Seq object from BioSQL into a Seq or MutableSeq."""
         test_seq = self.item.seq
 
         other = Seq(test_seq)
@@ -492,7 +492,7 @@ class SeqInterfaceTest(unittest.TestCase):
         self.assertIsInstance(other, MutableSeq)
 
     def test_addition(self):
-        """Check can add DBSeq objects together."""
+        """Check can add Seq objects from BioSQL together."""
         test_seq = self.item.seq
         for other in [
             Seq("ACGT"),
@@ -507,24 +507,21 @@ class SeqInterfaceTest(unittest.TestCase):
             self.assertEqual(test, str(other) + str(test_seq))
 
     def test_multiplication(self):
-        """Check can multiply DBSeq objects by integers."""
+        """Check can multiply Seq objects from BioSQL by integers."""
         test_seq = self.item.seq
         tripled = test_seq * 3
-        # Test DBSeq.__mul__
+        # Test Seq.__mul__
         self.assertIsInstance(tripled, Seq)
-        self.assertNotIsInstance(tripled, BioSeq.DBSeq)
         self.assertEqual(tripled, str(test_seq) * 3)
-        # Test DBSeq.__rmul__
+        # Test Seq.__rmul__
         tripled = 3 * test_seq
         self.assertIsInstance(tripled, Seq)
-        self.assertNotIsInstance(tripled, BioSeq.DBSeq)
         self.assertEqual(tripled, str(test_seq) * 3)
-        # Test DBSeq.__imul__
+        # Test Seq.__imul__
         original = self.item.seq
         tripled = test_seq
         tripled *= 3
         self.assertIsInstance(tripled, Seq)
-        self.assertNotIsInstance(tripled, BioSeq.DBSeq)
         self.assertEqual(tripled, str(original) * 3)
 
     def test_seq_slicing(self):

--- a/Tests/seq_tests_common.py
+++ b/Tests/seq_tests_common.py
@@ -127,7 +127,7 @@ class SeqRecordTestBaseClass(unittest.TestCase):
             self.compare_feature(old_f, new_f)
 
     def compare_sequence(self, old, new):
-        """Compare two Seq or DBSeq objects."""
+        """Compare two Seq objects."""
         self.assertEqual(len(old), len(new))
         self.assertEqual(old, new)
 


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

With the recent changes in `Bio.Seq`, it is no longer necessary for BioSQL to define its own `DBSeq` class as a subclass of the `Seq` class in `Bio.Seq`. A data provider class suffices. This simplifies the code in `BioSQL`, and avoids the `Seq` class in `Bio.Seq` to be aware of the implementation details of its subclass.