### PR TITLE
add lower and upper to MutableSeq

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2474,6 +2474,76 @@ class MutableSeq:
             suffix = suffix.encode("ASCII")
         return self._data.endswith(suffix, start, end)
 
+    def upper(self, inplace=False):
+        """Return the sequence in upper case.
+
+        An upper-case copy of the sequence is returned if inplace is False,
+        the default value:
+
+        >>> from Bio.Seq import MutableSeq
+        >>> my_seq = MutableSeq("VHLTPeeK*")
+        >>> my_seq
+        MutableSeq('VHLTPeeK*')
+        >>> my_seq.lower()
+        MutableSeq('vhltpeek*')
+        >>> my_seq.upper()
+        MutableSeq('VHLTPEEK*')
+        >>> my_seq
+        MutableSeq('VHLTPeeK*')
+
+        The sequence is modified in-place and returned if inplace is True:
+
+        >>> my_seq.lower(inplace=True)
+        MutableSeq('vhltpeek*')
+        >>> my_seq
+        MutableSeq('vhltpeek*')
+        >>> my_seq.upper(inplace=True)
+        MutableSeq('VHLTPEEK*')
+        >>> my_seq
+        MutableSeq('VHLTPEEK*')
+        """
+        data = self._data.upper()
+        if inplace:
+            self._data[:] = data
+            return self
+        else:
+            return MutableSeq(data)
+
+    def lower(self, inplace=False):
+        """Return the sequence in lower case.
+
+        A lower-case copy of the sequence is returned if inplace is False,
+        the default value:
+
+        >>> from Bio.Seq import MutableSeq
+        >>> my_seq = MutableSeq("VHLTPeeK*")
+        >>> my_seq
+        MutableSeq('VHLTPeeK*')
+        >>> my_seq.lower()
+        MutableSeq('vhltpeek*')
+        >>> my_seq.upper()
+        MutableSeq('VHLTPEEK*')
+        >>> my_seq
+        MutableSeq('VHLTPeeK*')
+
+        The sequence is modified in-place and returned if inplace is True:
+
+        >>> my_seq.lower(inplace=True)
+        MutableSeq('vhltpeek*')
+        >>> my_seq
+        MutableSeq('vhltpeek*')
+        >>> my_seq.upper(inplace=True)
+        MutableSeq('VHLTPEEK*')
+        >>> my_seq
+        MutableSeq('VHLTPEEK*')
+        """
+        data = self._data.lower()
+        if inplace:
+            self._data[:] = data
+            return self
+        else:
+            return MutableSeq(data)
+
     def translate(
         self, table="Standard", stop_symbol="*", to_stop=False, cds=False, gap="-"
     ):

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1845,7 +1845,7 @@ class MutableSeq:
             self._data = bytearray(bytes(data))
         else:
             raise TypeError(
-                "data should be a string, bytearray obejct, Seq object, or a "
+                "data should be a string, bytearray object, Seq object, or a "
                 "MutableSeq object"
             )
 
@@ -2473,6 +2473,230 @@ class MutableSeq:
         elif isinstance(suffix, str):
             suffix = suffix.encode("ASCII")
         return self._data.endswith(suffix, start, end)
+
+    def split(self, sep=None, maxsplit=-1):
+        """Split method, like that of a python string.
+
+        This behaves like the python string method of the same name.
+
+        Return a list of the 'words' in the string (as MutableSeq objects),
+        using sep as the delimiter string.  If maxsplit is given, at
+        most maxsplit splits are done.  If maxsplit is omitted, all
+        splits are made.
+
+        Following the python string method, sep will by default be any
+        white space (tabs, spaces, newlines) but this is unlikely to
+        apply to biological sequences.
+
+        e.g.
+
+        >>> from Bio.Seq import MutableSeq
+        >>> my_rna = MutableSeq("GUCAUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAGUUG")
+        >>> my_aa = my_rna.translate()
+        >>> my_aa
+        MutableSeq('VMAIVMGR*KGAR*L')
+        >>> for pep in my_aa.split("*"):
+        ...     pep
+        MutableSeq('VMAIVMGR')
+        MutableSeq('KGAR')
+        MutableSeq('L')
+        >>> for pep in my_aa.split("*", 1):
+        ...     pep
+        MutableSeq('VMAIVMGR')
+        MutableSeq('KGAR*L')
+
+        See also the rsplit method:
+
+        >>> for pep in my_aa.rsplit("*", 1):
+        ...     pep
+        MutableSeq('VMAIVMGR*KGAR')
+        MutableSeq('L')
+        """
+        if isinstance(sep, (Seq, MutableSeq)):
+            sep = bytes(sep)
+        elif isinstance(sep, str):
+            sep = sep.encode("ASCII")
+        return [MutableSeq(part) for part in self._data.split(sep, maxsplit)]
+
+    def rsplit(self, sep=None, maxsplit=-1):
+        """Do a right split method, like that of a python string.
+
+        This behaves like the python string method of the same name.
+
+        Return a list of the 'words' in the string (as MutableSeq objects),
+        using sep as the delimiter string.  If maxsplit is given, at
+        most maxsplit splits are done COUNTING FROM THE RIGHT.
+        If maxsplit is omitted, all splits are made.
+
+        Following the python string method, sep will by default be any
+        white space (tabs, spaces, newlines) but this is unlikely to
+        apply to biological sequences.
+
+        e.g. print(my_seq.rsplit("*",1))
+
+        See also the split method.
+        """
+        if isinstance(sep, (Seq, MutableSeq)):
+            sep = bytes(sep)
+        elif isinstance(sep, str):
+            sep = sep.encode("ASCII")
+        return [MutableSeq(part) for part in self._data.rsplit(sep, maxsplit)]
+
+    def strip(self, chars=None, inplace=False):
+        """Return a MutableSeq object with leading and trailing ends stripped.
+
+        This behaves like the python string method of the same name.
+
+        A copy of the sequence is returned if ``inplace`` is `False` (the
+        default value). If ``inplace`` is `True`, the sequence is stripped
+        in-place and returned:
+
+        >>> seq = MutableSeq("ACGT ")
+        >>> seq.strip()
+        MutableSeq('ACGT')
+        >>> seq
+        MutableSeq('ACGT ')
+        >>> seq.strip(inplace=True)
+        MutableSeq('ACGT')
+        >>> seq
+        MutableSeq('ACGT')
+
+        Optional argument chars defines which characters to remove.  If
+        omitted or None (default) then as for the python string method,
+        this defaults to removing any white space.
+
+        e.g.
+
+        >>> MutableSeq("ACGT ").strip()
+        MutableSeq('ACGT')
+        >>> MutableSeq("ACGT ").strip(" ")
+        MutableSeq('ACGT')
+
+        Just like the Python string, the order of the characters to be
+        removed is not important:
+
+        >>> MutableSeq("ACGTACGT").strip("TGCA")
+        MutableSeq('')
+
+        As with the Python string, an inappropriate argument
+        will give a TypeError:
+
+        >>> MutableSeq("ACGT ").strip(7)
+        Traceback (most recent call last):
+           ...
+        TypeError: argument must be None or a string, Seq, MutableSeq, or bytes-like object
+
+        See also the lstrip and rstrip methods.
+        """
+        if isinstance(chars, (Seq, MutableSeq)):
+            chars = bytes(chars)
+        elif isinstance(chars, str):
+            chars = chars.encode("ASCII")
+        try:
+            data = self._data.strip(chars)
+        except TypeError:
+            raise TypeError(
+                "argument must be None or a string, Seq, MutableSeq, or bytes-like object"
+            ) from None
+        if inplace:
+            self._data[:] = data
+            return self
+        else:
+            return MutableSeq(data)
+
+    def lstrip(self, chars=None, inplace=False):
+        """Return a MutableSeq object with leading (left) end stripped.
+
+        This behaves like the python string method of the same name.
+
+        A copy of the sequence is returned if ``inplace`` is `False` (the
+        default value). If ``inplace`` is `True`, the sequence is stripped
+        in-place and returned:
+
+        >>> seq = MutableSeq(" ACGT ")
+        >>> seq.lstrip()
+        MutableSeq('ACGT ')
+        >>> seq
+        MutableSeq(' ACGT ')
+        >>> seq.lstrip(inplace=True)
+        MutableSeq('ACGT ')
+        >>> seq
+        MutableSeq('ACGT ')
+
+        Optional argument chars defines which characters to remove.  If
+        omitted or None (default) then as for the python string method,
+        this defaults to removing any white space.
+
+        >>> MutableSeq("AAACGTA").lstrip("A")
+        MutableSeq('CGTA')
+
+        See also the strip and rstrip methods.
+        """
+        if isinstance(chars, (Seq, MutableSeq)):
+            chars = bytes(chars)
+        elif isinstance(chars, str):
+            chars = chars.encode("ASCII")
+        try:
+            data = self._data.lstrip(chars)
+        except TypeError:
+            raise TypeError(
+                "argument must be None or a string, Seq, MutableSeq, or bytes-like object"
+            ) from None
+        if inplace:
+            self._data[:] = data
+            return self
+        else:
+            return MutableSeq(data)
+
+    def rstrip(self, chars=None, inplace=False):
+        """Return a MutableSeq object with trailing (right) end stripped.
+
+        This behaves like the python string method of the same name.
+
+        A copy of the sequence is returned if ``inplace`` is `False` (the
+        default value). If ``inplace`` is `True`, the sequence is stripped
+        in-place and returned:
+
+        >>> seq = MutableSeq(" ACGT ")
+        >>> seq.rstrip()
+        MutableSeq(' ACGT')
+        >>> seq
+        MutableSeq(' ACGT ')
+        >>> seq.rstrip(inplace=True)
+        MutableSeq(' ACGT')
+        >>> seq
+        MutableSeq(' ACGT')
+
+        Optional argument chars defines which characters to remove.  If
+        omitted or None (default) then as for the python string method,
+        this defaults to removing any white space.
+
+        e.g. Removing a nucleotide sequence's polyadenylation (poly-A tail):
+
+        >>> from Bio.Seq import MutableSeq
+        >>> my_seq = MutableSeq("CGGTACGCTTATGTCACGTAGAAAAAA")
+        >>> my_seq
+        MutableSeq('CGGTACGCTTATGTCACGTAGAAAAAA')
+        >>> my_seq.rstrip("A")
+        MutableSeq('CGGTACGCTTATGTCACGTAG')
+
+        See also the strip and lstrip methods.
+        """
+        if isinstance(chars, (Seq, MutableSeq)):
+            chars = bytes(chars)
+        elif isinstance(chars, str):
+            chars = chars.encode("ASCII")
+        try:
+            data = self._data.rstrip(chars)
+        except TypeError:
+            raise TypeError(
+                "argument must be None or a string, Seq, MutableSeq, or bytes-like object"
+            ) from None
+        if inplace:
+            self._data[:] = data
+            return self
+        else:
+            return MutableSeq(data)
 
     def upper(self, inplace=False):
         """Return the sequence in upper case.

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -91,13 +91,13 @@ class StringMethodTests(unittest.TestCase):
         self.assertIsInstance(method_name, str)
         for example1 in self._examples:
             if not hasattr(example1, method_name):
-                # e.g. MutableSeq does not support upper
+                # e.g. MutableSeq does not support strip
                 continue
             str1 = str(example1)
 
             for example2 in self._examples:
                 if not hasattr(example2, method_name):
-                    # e.g. MutableSeq does not support upper
+                    # e.g. MutableSeq does not support strip
                     continue
                 str2 = str(example2)
 
@@ -500,16 +500,12 @@ class StringMethodTests(unittest.TestCase):
     def test_str_upper(self):
         """Check matches the python string upper method."""
         for example1 in self._examples:
-            if isinstance(example1, MutableSeq):
-                continue
             str1 = str(example1)
             self.assertEqual(example1.upper(), str1.upper())
 
     def test_str_lower(self):
         """Check matches the python string lower method."""
         for example1 in self._examples:
-            if isinstance(example1, MutableSeq):
-                continue
             str1 = str(example1)
             self.assertEqual(example1.lower(), str1.lower())
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -91,13 +91,13 @@ class StringMethodTests(unittest.TestCase):
         self.assertIsInstance(method_name, str)
         for example1 in self._examples:
             if not hasattr(example1, method_name):
-                # e.g. MutableSeq does not support strip
+                # e.g. MutableSeq does not support transcribe
                 continue
             str1 = str(example1)
 
             for example2 in self._examples:
                 if not hasattr(example2, method_name):
-                    # e.g. MutableSeq does not support strip
+                    # e.g. MutableSeq does not support transcribe
                     continue
                 str2 = str(example2)
 
@@ -464,32 +464,60 @@ class StringMethodTests(unittest.TestCase):
     def test_str_strip(self):
         """Check matches the python string strip method."""
         self._test_method("strip")
-        self.assertEqual(Seq(" ACGT ").strip(), "ACGT")
-        self.assertRaises(TypeError, Seq("ACGT").strip, 7)
+        s = Seq(" ACGT ")
+        m = MutableSeq(" ACGT ")
+        self.assertEqual(s.strip(), "ACGT")
+        self.assertRaises(TypeError, s.strip, 7)
+        self.assertEqual(s, " ACGT ")
+        self.assertEqual(m.strip(), "ACGT")
+        self.assertRaises(TypeError, m.strip, 7)
+        self.assertEqual(m, " ACGT ")
+        self.assertEqual(m.strip(inplace=True), "ACGT")
+        self.assertEqual(m, "ACGT")
+
+    def test_str_lstrip(self):
+        """Check matches the python string lstrip method."""
+        self._test_method("lstrip")
+        s = Seq(" ACGT ")
+        m = MutableSeq(" ACGT ")
+        self.assertEqual(s.lstrip(), "ACGT ")
+        self.assertRaises(TypeError, s.lstrip, 7)
+        self.assertEqual(s, " ACGT ")
+        self.assertEqual(m.lstrip(), "ACGT ")
+        self.assertRaises(TypeError, m.lstrip, 7)
+        self.assertEqual(m, " ACGT ")
+        self.assertEqual(m.lstrip(inplace=True), "ACGT ")
+        self.assertEqual(m, "ACGT ")
 
     def test_str_rstrip(self):
         """Check matches the python string rstrip method."""
         self._test_method("rstrip")
-        self.assertEqual(Seq(" ACGT ").rstrip(), " ACGT")
-        self.assertRaises(TypeError, Seq("ACGT").rstrip, 7)
-
-    def test_str_lstrip(self):
-        """Check matches the python string lstrip method."""
-        self._test_method("rstrip")
-        self.assertEqual(Seq(" ACGT ").lstrip(), "ACGT ")
-        self.assertRaises(TypeError, Seq("ACGT").lstrip, 7)
+        s = Seq(" ACGT ")
+        m = MutableSeq(" ACGT ")
+        self.assertEqual(s.rstrip(), " ACGT")
+        self.assertRaises(TypeError, s.rstrip, 7)
+        self.assertEqual(s, " ACGT ")
+        self.assertEqual(m.rstrip(), " ACGT")
+        self.assertRaises(TypeError, m.rstrip, 7)
+        self.assertEqual(m, " ACGT ")
+        self.assertEqual(m.rstrip(inplace=True), " ACGT")
+        self.assertEqual(m, " ACGT")
 
     def test_str_split(self):
-        """Check matches the python string rstrip method."""
+        """Check matches the python string split method."""
         self._test_method("split")
-        self.assertEqual(Seq("AC7GT").rsplit("7"), "AC7GT".split("7"))
+        self.assertEqual(Seq("AC7GT").split("7"), "AC7GT".split("7"))
         self.assertRaises(TypeError, Seq("AC7GT").split, 7)
+        self.assertEqual(MutableSeq("AC7GT").split("7"), "AC7GT".split("7"))
+        self.assertRaises(TypeError, MutableSeq("AC7GT").split, 7)
 
     def test_str_rsplit(self):
-        """Check matches the python string rstrip method."""
+        """Check matches the python string rsplit method."""
         self._test_method("rsplit")
         self.assertEqual(Seq("AC7GT").rsplit("7"), "AC7GT".rsplit("7"))
         self.assertRaises(TypeError, Seq("AC7GT").rsplit, 7)
+        self.assertEqual(MutableSeq("AC7GT").rsplit("7"), "AC7GT".rsplit("7"))
+        self.assertRaises(TypeError, MutableSeq("AC7GT").rsplit, 7)
 
     def test_str_length(self):
         """Check matches the python string __len__ method."""

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -166,10 +166,9 @@ class TestSeqStringMethods(unittest.TestCase):
         for a in self.dna + self.rna + self.nuc + self.protein:
             self.assertEqual(a.lower(), str(a).lower())
             self.assertEqual(a.upper(), str(a).upper())
-            if isinstance(a, Seq.Seq):
-                self.assertEqual(a.strip(), str(a).strip())
-                self.assertEqual(a.lstrip(), str(a).lstrip())
-                self.assertEqual(a.rstrip(), str(a).rstrip())
+            self.assertEqual(a.strip(), str(a).strip())
+            self.assertEqual(a.lstrip(), str(a).lstrip())
+            self.assertEqual(a.rstrip(), str(a).rstrip())
 
     def test_mutableseq_upper_lower(self):
         seq = Seq.MutableSeq("ACgt")
@@ -276,10 +275,9 @@ class TestSeqStringMethods(unittest.TestCase):
         for a in self.dna + self.rna + self.nuc + self.protein:
             for char in self.test_chars:
                 str_char = str(char)
-                if isinstance(a, Seq.Seq):
-                    self.assertEqual(a.strip(char), str(a).strip(str_char))
-                    self.assertEqual(a.lstrip(char), str(a).lstrip(str_char))
-                    self.assertEqual(a.rstrip(char), str(a).rstrip(str_char))
+                self.assertEqual(a.strip(char), str(a).strip(str_char))
+                self.assertEqual(a.lstrip(char), str(a).lstrip(str_char))
+                self.assertEqual(a.rstrip(char), str(a).rstrip(str_char))
 
     def test_finding_characters(self):
         for a in self.dna + self.rna + self.nuc + self.protein:
@@ -301,14 +299,13 @@ class TestSeqStringMethods(unittest.TestCase):
         for a in self.dna + self.rna + self.nuc + self.protein:
             for char in self.test_chars:
                 str_char = str(char)
-                if isinstance(a, Seq.Seq):
-                    self.assertEqual(a.split(char), str(a).split(str_char))
-                    self.assertEqual(a.rsplit(char), str(a).rsplit(str_char))
+                self.assertEqual(a.split(char), str(a).split(str_char))
+                self.assertEqual(a.rsplit(char), str(a).rsplit(str_char))
 
-                    for max_sep in [0, 1, 2, 999]:
-                        self.assertEqual(
-                            a.split(char, max_sep), str(a).split(str_char, max_sep)
-                        )
+                for max_sep in [0, 1, 2, 999]:
+                    self.assertEqual(
+                        a.split(char, max_sep), str(a).split(str_char, max_sep)
+                    )
 
 
 class TestSeqAddition(unittest.TestCase):
@@ -980,10 +977,7 @@ class TestTranslating(unittest.TestCase):
     def test_translation(self):
         for nucleotide_seq in self.test_seqs:
             nucleotide_seq = nucleotide_seq[: 3 * (len(nucleotide_seq) // 3)]
-            if (
-                isinstance(nucleotide_seq, (Seq.Seq, Seq.MutableSeq))
-                and "X" not in nucleotide_seq
-            ):
+            if "X" not in nucleotide_seq:
                 expected = Seq.translate(nucleotide_seq)
                 self.assertEqual(expected, nucleotide_seq.translate())
 
@@ -1035,7 +1029,7 @@ class TestTranslating(unittest.TestCase):
     def test_translation_to_stop(self):
         for nucleotide_seq in self.test_seqs:
             nucleotide_seq = nucleotide_seq[: 3 * (len(nucleotide_seq) // 3)]
-            if isinstance(nucleotide_seq, Seq.Seq) and "X" not in nucleotide_seq:
+            if "X" not in nucleotide_seq:
                 short = Seq.translate(nucleotide_seq, to_stop=True)
                 self.assertEqual(short, Seq.translate(nucleotide_seq).split("*")[0])
 
@@ -1048,9 +1042,8 @@ class TestTranslating(unittest.TestCase):
             with self.assertRaises(TranslationError):
                 Seq.translate(s)
 
-            if isinstance(s, Seq.Seq):
-                with self.assertRaises(TranslationError):
-                    s.translate()
+            with self.assertRaises(TranslationError):
+                s.translate()
 
     def test_translation_of_invalid_codon(self):
         for codon in ["TA?", "N-N", "AC_", "Ac_"]:

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -164,12 +164,34 @@ class TestSeqStringMethods(unittest.TestCase):
 
     def test_string_methods(self):
         for a in self.dna + self.rna + self.nuc + self.protein:
+            self.assertEqual(a.lower(), str(a).lower())
+            self.assertEqual(a.upper(), str(a).upper())
             if isinstance(a, Seq.Seq):
                 self.assertEqual(a.strip(), str(a).strip())
                 self.assertEqual(a.lstrip(), str(a).lstrip())
                 self.assertEqual(a.rstrip(), str(a).rstrip())
-                self.assertEqual(a.lower(), str(a).lower())
-                self.assertEqual(a.upper(), str(a).upper())
+
+    def test_mutableseq_upper_lower(self):
+        seq = Seq.MutableSeq("ACgt")
+        lseq = seq.lower()
+        self.assertEqual(lseq, "acgt")
+        self.assertEqual(seq, "ACgt")
+        lseq = seq.lower(inplace=False)
+        self.assertEqual(lseq, "acgt")
+        self.assertEqual(seq, "ACgt")
+        lseq = seq.lower(inplace=True)
+        self.assertEqual(lseq, "acgt")
+        self.assertIs(lseq, seq)
+        seq = Seq.MutableSeq("ACgt")
+        useq = seq.upper()
+        self.assertEqual(useq, "ACGT")
+        self.assertEqual(seq, "ACgt")
+        useq = seq.upper(inplace=False)
+        self.assertEqual(useq, "ACGT")
+        self.assertEqual(seq, "ACgt")
+        useq = seq.upper(inplace=True)
+        self.assertEqual(useq, "ACGT")
+        self.assertIs(useq, seq)
 
     def test_hash(self):
         with warnings.catch_warnings(record=True):


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


This PR adds `upper` and `lower` methods to `MutableSeq`. For consistency with `Seq`, the methods create a upper/lower-case copy of the sequence if `inplace` is `False` (the default), but modify the sequence in place and return it if `inplace` is True.