### PR TITLE
Entrez id handling

### DIFF
--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -253,6 +253,13 @@ def elink(**keywds):
     See the online documentation for an explanation of the parameters:
     http://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ELink
 
+    Note that ELink treats the "id" parameter differently than the other tools.
+    If you are querying more than one UID, you should generally pass them as a
+    list of strings or integers. This will provide a "one-to-one" mapping
+    from source database UIDs to destination database UIDs in the result. If
+    multiple source UIDs are passed as a comma-delimited string all destination
+    UIDs will be mixed together in the result.
+
     This example finds articles related to the Biopython application
     note's entry in the PubMed database:
 

--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -36,6 +36,16 @@ which has a ``.name`` attribute giving the filename, the handles from
 ``Bio.Entrez`` all have a ``.url`` attribute instead giving the URL
 used to connect to the NCBI Entrez API.
 
+The ``epost``, ``efetch``, and ``esummary`` tools take an "id" parameter
+which corresponds to one or more database UIDs (or accession.version
+identifiers in the case of sequence databases such as "nuccore" or
+"protein"). The Python value of the "id" keyword passed to these functions
+may be either a single ID as a string or integer or multiple IDs as an
+iterable of strings/integers. You may also pass a single string containing
+multiple IDs delimited by commas. The ``elink`` tool also accepts multiple
+IDs but the argument is handled differently than the other three. See that
+function's docstring for more information.
+
 All the functions that send requests to the NCBI Entrez API will
 automatically respect the NCBI rate limit (of 3 requests per second
 without an API key, or 10 requests per second with an API key) and
@@ -182,28 +192,7 @@ def efetch(db, **keywords):
     cgi = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
     variables = {"db": db}
     variables.update(keywords)
-    post = False
-    try:
-        ids = variables["id"]
-    except KeyError:
-        pass
-    else:
-        try:
-            # ids is a single integer or a string representing a single integer
-            ids = str(int(ids))
-        except TypeError:
-            # ids was not a string; try an iterable:
-            ids = ",".join(map(str, ids))
-        except ValueError:
-            # string with commas or string not representing an integer
-            ids = ",".join(map(str, (id.strip() for id in ids.split(","))))
-
-        variables["id"] = ids
-        if ids.count(",") >= 200:
-            # NCBI prefers an HTTP POST instead of an HTTP GET if there are
-            # more than about 200 IDs
-            post = True
-    request = _build_request(cgi, variables, post=post)
+    request = _build_request(cgi, variables)
     return _open(request)
 
 
@@ -253,12 +242,12 @@ def elink(**keywds):
     See the online documentation for an explanation of the parameters:
     http://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ELink
 
-    Note that ELink treats the "id" parameter differently than the other tools.
-    If you are querying more than one UID, you should generally pass them as a
-    list of strings or integers. This will provide a "one-to-one" mapping
-    from source database UIDs to destination database UIDs in the result. If
-    multiple source UIDs are passed as a comma-delimited string all destination
-    UIDs will be mixed together in the result.
+    Note that ELink treats the "id" parameter differently than the other
+    tools when multiple values are given. You should generally pass multiple
+    UIDs as a list of strings or integers. This will provide a "one-to-one"
+    mapping from source database UIDs to destination database UIDs in the
+    result. If multiple source UIDs are passed as a single comma-delimited
+    string all destination UIDs will be mixed together in the result.
 
     This example finds articles related to the Biopython application
     note's entry in the PubMed database:
@@ -283,7 +272,7 @@ def elink(**keywds):
     cgi = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi"
     variables = {}
     variables.update(keywds)
-    request = _build_request(cgi, variables)
+    request = _build_request(cgi, variables, join_ids=False)
     return _open(request)
 
 
@@ -629,7 +618,7 @@ def _open(request):
 _open.previous = 0
 
 
-def _build_request(cgi, params=None, post=None, ecitmatch=False):
+def _build_request(cgi, params=None, post=None, ecitmatch=False, join_ids=True):
     """Build a Request object for an E-utility.
 
     :param str cgi: base URL for the CGI script to access.
@@ -640,10 +629,11 @@ def _build_request(cgi, params=None, post=None, ecitmatch=False):
         suggested in the E-Utilities documentation.
     :param bool ecitmatch: Don't URL-encode pipe ("|") characters, this is expected by the ecitmatch
         tool.
+    :param bool join_ids: Passed to ``_construct_params``.
     :returns: A request object ready to be passed to ``_open``.
     :rtype: urllib.request.Request
     """
-    params = _construct_params(params)
+    params = _construct_params(params, join_ids=join_ids)
 
     params_str = urlencode(params, doseq=True)
     if ecitmatch:
@@ -653,17 +643,25 @@ def _build_request(cgi, params=None, post=None, ecitmatch=False):
     if post is None and len(params_str) > 1000:
         post = True
 
+    # NCBI prefers an HTTP POST instead of an HTTP GET if there are more than about 200 IDs
+    if post is None and "id" in params:
+        idcount = params["id"].count(",") + 1
+        if idcount >= 200:
+            post = True
+
     if post:
         return Request(cgi, data=params_str.encode("utf8"), method="POST")
     else:
         return Request(cgi + "?" + params_str, method="GET")
 
 
-def _construct_params(params):
+def _construct_params(params, join_ids=True):
     """Construct/format parameter dict for an Entrez request.
 
     :param params: User-supplied parameters.
     :type params: dict or None
+    :param bool join_ids: If True and the "id" key of ``params`` is a list
+        containing multiple UIDs, join them into a single comma-delimited string.
     :returns: Parameters with defaults added and keys with None values removed.
     :rtype: dict
     """
@@ -700,7 +698,30 @@ def _construct_params(params):
             UserWarning,
         )
 
+    # Format "id" parameter properly
+    if join_ids and "id" in params:
+        params["id"] = _format_ids(params["id"])
+
     return params
+
+
+def _format_ids(ids):
+    """Convert one or more UIDs to a single comma-delimited string.
+
+    Input may be a single ID as an integer or string, an iterable of strings/ints,
+    or a string of IDs already separated by commas.
+    """
+    if isinstance(ids, int):
+        # Single integer, just convert to str
+        return str(ids)
+
+    if isinstance(ids, str):
+        # String which represents one or more IDs joined by commas
+        # Remove any whitespace around commas if they are present
+        return ",".join(id.strip() for id in ids.split(","))
+
+    # Not a string or integer, assume iterable
+    return ",".join(map(str, ids))
 
 
 def _has_api_key(request):

--- a/Tests/test_Entrez_online.py
+++ b/Tests/test_Entrez_online.py
@@ -141,21 +141,48 @@ class EntrezOnlineCase(unittest.TestCase):
         handle.close()
 
     def test_elink(self):
-        """Test Entrez.elink with multiple ids, both comma separated and as list."""
-        # Commas: Link from protein to gene
-        handle = Entrez.elink(
-            db="gene", dbfrom="protein", id="15718680,157427902,119703751"
-        )
-        handle.close()
+        """Test Entrez.elink with multiple ids, both comma separated and as list.
 
-        # Multiple ID entries: Find one-to-one links from protein to gene
-        handle = Entrez.elink(
-            db="gene", dbfrom="protein", id=["15718680", "157427902", "119703751"]
-        )
-        handle.close()
+        This is tricky because the ELink tool treats the "id" parameter
+        differently than the others (see docstring of the elink() function).
+        """
+        params = {"db": "gene", "dbfrom": "protein"}
+        ids = ["15718680", "157427902", "119703751"]
+
+        # Pass list argument - one-to-one
+        with Entrez.elink(id=ids, **params) as handle:
+            result1 = Entrez.read(handle)
+
+        self.assertEqual(len(result1), len(ids))
+
+        id_map = {}  # Dictionary mapping each gene ID to some number of protein IDs
+
+        for linkset in result1:
+            (from_id,) = linkset["IdList"]
+            (linksetdb,) = linkset["LinkSetDb"]
+            to_ids = [link["Id"] for link in linksetdb["Link"]]
+            # Failure here could indicate we used an invalid ID
+            self.assertGreater(len(to_ids), 0)
+            id_map[from_id] = to_ids
+
+        self.assertCountEqual(id_map.keys(), ids)
+
+        # Pass string argument - single LinkSet
+        with Entrez.elink(id=",".join(ids), **params) as handle:
+            result2 = Entrez.read(handle)
+
+        (linkset,) = result2
+        self.assertCountEqual(linkset["IdList"], ids)
+
+        # Check we got the same set of IDs as in the last request
+        (linksetdb,) = linkset["LinkSetDb"]
+        to_ids = [link["Id"] for link in linksetdb["Link"]]
+        prev_to_ids = set().union(*id_map.values())
+        self.assertCountEqual(to_ids, prev_to_ids)
 
     def test_epost(self):
         """Test Entrez.epost with multiple ids, both comma separated and as list."""
+        # TODO - check results
         handle = Entrez.epost("nuccore", id="186972394,160418")
         handle.close()
         handle = Entrez.epost("nuccore", id=["160418", "160351"])


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

`Entrez.efetch()` has special handling logic for the `id` keyword where it accepts one or more IDs as `int`/`str` and converts them to a single comma-delimited string for the `id` request parameter. The ESummary, EPost, and ELink tools also take this parameter in the same format, so the corresponding functions should process this keyword in the same way.

I moved this conversion logic into its own function `format_ids()` so that it can be tested independently, and call it in `_construct_params()` so it is run for all calls to `_open()` which include this parameter. The tests for URL construction also use the output of `_construct_params()` so we can check the behavior there as well.

`efetch()` also checked whether there were more than 200 IDs in the list so it could default to making a POST request as recommended by the E-Utils documentation. I moved this behavior to `_open()` so that it runs with the other tools when the `'id'` parameter is present (documentation for ESummary, EPost, and ELink also makes the same recommendation).

There is one change to existing behavior which may possibly be an issue - the test `test_construct_cgi_elink_1` checks the encoded `elink` URL with a list used for the `id` parameter. With the existing behavior, the `_encode_options()` function just passes the list directly to `urllib.parse.urlencode()` with `doseq=True`. This results in a URL where the `id` parameter appears multiple times with different values, like `id=123&id=456&id=789`, instead of `id=123%2C456%2C789` as it would be with the new behavior. The test contains asserts for the first format that would fail for the new format. I am pretty sure this is a mistake because the ELink documentation explicitly states that the value of `id` should be a comma-delimited list, and when I manually make a request in the first format only the first ID is included in the result set. 