### PR TITLE
support pickling in Bio.Align.substitution_matrices

### DIFF
--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -235,6 +235,7 @@ class Array(numpy.ndarray):
 
     def __reduce__(self):
         import pickle
+
         values = numpy.array(self)
         state = pickle.dumps(values)
         alphabet = self._alphabet
@@ -245,7 +246,8 @@ class Array(numpy.ndarray):
 
     def __setstate__(self, state):
         import pickle
-        self[:,:] = pickle.loads(state)
+
+        self[:, :] = pickle.loads(state)
 
     def transpose(self, axes=None):
         """Transpose the array."""

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -233,6 +233,20 @@ class Array(numpy.ndarray):
 
         return results[0] if len(results) == 1 else results
 
+    def __reduce__(self):
+        import pickle
+        values = numpy.array(self)
+        state = pickle.dumps(values)
+        alphabet = self._alphabet
+        dims = len(self.shape)
+        dtype = self.dtype
+        arguments = (Array, alphabet, dims, None, dtype)
+        return (Array.__new__, arguments, state)
+
+    def __setstate__(self, state):
+        import pickle
+        self[:,:] = pickle.loads(state)
+
     def transpose(self, axes=None):
         """Transpose the array."""
         other = numpy.ndarray.transpose(self, axes)

--- a/Tests/test_align_substitution_matrices.py
+++ b/Tests/test_align_substitution_matrices.py
@@ -17,12 +17,14 @@ except ImportError:
 
 
 import os
+import pickle
 from collections import Counter
 import unittest
 
 
 import numpy
 from Bio import SeqIO
+from Bio.Align import substitution_matrices
 
 from Bio.Data import IUPACData
 
@@ -32,8 +34,6 @@ protein_alphabet = IUPACData.protein_letters
 
 class Test_basics(unittest.TestCase):
     def test_basics_vector(self):
-        from Bio.Align import substitution_matrices
-
         counts = substitution_matrices.Array("XYZ")
         self.assertEqual(
             str(counts),
@@ -63,8 +63,6 @@ Z  5.5
             counts[8]
 
     def test_basics_matrix(self):
-        from Bio.Align import substitution_matrices
-
         counts = substitution_matrices.Array("XYZ", dims=2)
         self.assertEqual(
             str(counts),
@@ -110,8 +108,6 @@ Z  0.0
         )
 
     def test_read_write(self):
-        from Bio.Align import substitution_matrices
-
         path = os.path.join("Align", "hg38.chrom.sizes")
         sizes = substitution_matrices.read(path, numpy.int64)
         # Note that sum(sizes) below is larger than 2147483647, and won't
@@ -132,8 +128,6 @@ Z  0.0
         self.assertEqual(lines[4], "chr5 181538259")
 
     def test_nucleotide_freq(self):
-        from Bio.Align import substitution_matrices
-
         counts = Counter()
         path = os.path.join("Align", "ecoli.fa")
         records = SeqIO.parse(path, "fasta")
@@ -186,8 +180,6 @@ Z  0.0
         self.assertAlmostEqual(frequencies["T"], 0.2025723472668810)
 
     def test_protein_freq(self):
-        from Bio.Align import substitution_matrices
-
         counts = Counter()
         path = os.path.join("Align", "cow.fa")
         records = SeqIO.parse(path, "fasta")
@@ -271,6 +263,15 @@ Z  0.0
         self.assertAlmostEqual(frequencies["W"], 0.015217055)
         self.assertAlmostEqual(frequencies["Y"], 0.031515526)
 
+    def test_pickling(self):
+        matrix = substitution_matrices.load("BLOSUM62")
+        pickled = pickle.dumps(matrix)
+        loaded = pickle.loads(pickled)
+        self.assertEqual(matrix.alphabet, loaded.alphabet)
+        for c1 in matrix.alphabet:
+            for c2 in matrix.alphabet:
+                self.assertAlmostEqual(matrix[c1, c2], loaded[c1, c2])
+
 
 class TestScoringMatrices(unittest.TestCase):
     @classmethod
@@ -278,7 +279,6 @@ class TestScoringMatrices(unittest.TestCase):
 
         from Bio import SeqIO
         from Bio.Align import PairwiseAligner
-        from Bio.Align import substitution_matrices
 
         observed = substitution_matrices.Array(alphabet=protein_alphabet, dims=2)
         aligner = PairwiseAligner()
@@ -2382,7 +2382,6 @@ class TestScoringMatrices(unittest.TestCase):
         # Proceedings of the National Academy of Sciences USA 89(2):
         # 10915-10919 (1992).
         from Bio.Data.IUPACData import protein_letters as alphabet
-        from Bio.Align import substitution_matrices
 
         m = substitution_matrices.load("BLOSUM62")
         self.assertEqual(alphabet, "ACDEFGHIKLMNPQRSTVWY")


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #3441 by supporting pickling substitution matrices in `Bio.Align.substitution_matrices`