### PR TITLE
use an abstract base class for sequence content providers in Bio.Seq

### DIFF
--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -18,12 +18,12 @@ Note: Currently we do not support recording per-letter-annotations
 (like quality scores) in BioSQL.
 """
 
-from Bio.Seq import Seq
+from Bio.Seq import Seq, SequenceDataAbstractBaseClass
 from Bio.SeqRecord import SeqRecord, _RestrictedDict
 from Bio import SeqFeature
 
 
-class _BioSQLSequenceData:
+class _BioSQLSequenceData(SequenceDataAbstractBaseClass):
     """Retrieves sequence data from a BioSQL database (PRIVATE).."""
 
     def __init__(self, primary_id, adaptor, start=0, length=0):
@@ -38,6 +38,7 @@ class _BioSQLSequenceData:
         self.adaptor = adaptor
         self._length = length
         self.start = start
+        super().__init__()
 
     def __len__(self):
         """Return the length of the sequence."""


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


In `Bio.Seq`, use an abstract base class for sequence content providers (currently: `_UndefinedSequenceData`, `_BioSQLSequenceData`, and `_TwoBitSequenceData`).