### PR TITLE
deprecate UnknownSeq

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -310,7 +310,9 @@ class Seq:
         >>> Seq("MELKI") + "LV"
         Seq('MELKILV')
         """
-        if isinstance(self._data, _UndefinedSequenceData) and isinstance(other._data, _UndefinedSequenceData):
+        if isinstance(self._data, _UndefinedSequenceData) and isinstance(
+            other._data, _UndefinedSequenceData
+        ):
             return Seq(None, len(self) + len(other))
         elif isinstance(other, (Seq, MutableSeq)):
             return self.__class__(bytes(self) + bytes(other))

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -310,7 +310,9 @@ class Seq:
         >>> Seq("MELKI") + "LV"
         Seq('MELKILV')
         """
-        if isinstance(other, (Seq, MutableSeq)):
+        if isinstance(self._data, _UndefinedSequenceData) and isinstance(other._data, _UndefinedSequenceData):
+            return Seq(None, len(self) + len(other))
+        elif isinstance(other, (Seq, MutableSeq)):
             return self.__class__(bytes(self) + bytes(other))
         elif isinstance(other, str):
             return self.__class__(bytes(self) + other.encode("ASCII"))
@@ -975,6 +977,10 @@ class Seq:
         "A" has complement "T". The letter "I" has no defined
         meaning under the IUPAC convention, and is unchanged.
         """
+        if isinstance(self._data, _UndefinedSequenceData):
+            # complement of an undefined sequence is an undefined sequence
+            # of the same length
+            return self
         if (b"U" in self._data or b"u" in self._data) and (
             b"T" in self._data or b"t" in self._data
         ):
@@ -1058,6 +1064,10 @@ class Seq:
         >>> Seq("CGAUT").complement_rna()
         Seq('GCUAA')
         """
+        if isinstance(self._data, _UndefinedSequenceData):
+            # complement of an undefined sequence is an undefined sequence
+            # of the same length
+            return self
         return Seq(bytes(self).translate(_rna_complement_table))
 
     def reverse_complement_rna(self):
@@ -1095,7 +1105,13 @@ class Seq:
         >>> my_protein.transcribe()
         Seq('MAIVMGRU')
         """
-        return Seq(bytes(self).replace(b"T", b"U").replace(b"t", b"u"))
+        try:
+            data = bytes(self)
+        except UndefinedSequenceError:
+            # transcribing an undefined sequence yields an undefined sequence
+            # of the same length
+            return self
+        return Seq(data.replace(b"T", b"U").replace(b"t", b"u"))
 
     def back_transcribe(self):
         """Return the DNA sequence from an RNA sequence by creating a new Seq object.
@@ -1120,7 +1136,13 @@ class Seq:
         >>> my_protein.back_transcribe()
         Seq('MAIVMGRT')
         """
-        return Seq(bytes(self).replace(b"U", b"T").replace(b"u", b"t"))
+        try:
+            data = bytes(self)
+        except UndefinedSequenceError:
+            # back-transcribing an undefined sequence yields an undefined
+            # sequence of the same length
+            return self
+        return Seq(data.replace(b"U", b"T").replace(b"u", b"t"))
 
     def translate(
         self, table="Standard", stop_symbol="*", to_stop=False, cds=False, gap="-"
@@ -1207,8 +1229,21 @@ class Seq:
                 "the python string object's translate method. "
                 "Use str(my_seq).translate(...) instead."
             )
+        try:
+            data = str(self)
+        except UndefinedSequenceError:
+            # translating an undefined sequence yields an undefined
+            # sequence with the length divided by 3
+            n = len(self)
+            if n % 3 != 0:
+                warnings.warn(
+                    "Partial codon, len(sequence) not a multiple of three. "
+                    "This may become an error in future.",
+                    BiopythonWarning,
+                )
+            return Seq(None, n // 3)
 
-        return Seq(_translate_str(str(self), table, stop_symbol, to_stop, cds, gap=gap))
+        return Seq(_translate_str(data, table, stop_symbol, to_stop, cds, gap=gap))
 
     def ungap(self, gap="-"):
         """Return a copy of the sequence without the gap character(s).
@@ -1268,7 +1303,7 @@ class Seq:
 
 
 class UnknownSeq(Seq):
-    """Read-only sequence object of known length but unknown contents.
+    """Read-only sequence object of known length but unknown contents (DEPRECATED).
 
     If you have an unknown sequence, you can represent this with a normal
     Seq object, for example:
@@ -1339,6 +1374,10 @@ class UnknownSeq(Seq):
          - character - single letter string, default "?". Typically "N"
            for nucleotides, "X" for proteins, and "?" otherwise.
         """
+        warnings.warn(
+            "UnknownSeq(length) is deprecated; please use Seq(None, length) instead.",
+            BiopythonDeprecationWarning,
+        )
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
         self._length = int(length)

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -62,8 +62,8 @@ class SequenceDataAbstractBaseClass(ABC):
     defined in this module, and _TwoBitSequenceData in Bio.SeqIO.TwoBitIO.
     Instances of these classes can be used instead of a ``bytes`` object as the
     data argument when creating a Seq object, and provide the sequence content
-    only when requested via ``__getitem``. This allows lazy parsers to load and
-    parse sequence data from a file only for the requested sequence regions,
+    only when requested via ``__getitem__``. This allows lazy parsers to load
+    and parse sequence data from a file only for the requested sequence regions,
     and _UndefinedSequenceData instances to raise an exception when undefined
     sequence data are requested.
 

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -171,7 +171,7 @@ class SeqRecord:
         """Create a SeqRecord.
 
         Arguments:
-         - seq         - Sequence, required (Seq, MutableSeq or UnknownSeq)
+         - seq         - Sequence, required (Seq or MutableSeq)
          - id          - Sequence identifier, recommended (string)
          - name        - Sequence name, optional (string)
          - description - Sequence description, optional (string)
@@ -189,9 +189,6 @@ class SeqRecord:
         Note that while an id is optional, we strongly recommend you supply a
         unique id string for each record.  This is especially important
         if you wish to write your sequences to a file.
-
-        If you don't have the actual sequence, but you do know its length,
-        then using the UnknownSeq object from Bio.Seq is appropriate.
 
         You can create a 'blank' SeqRecord object, and then populate the
         attributes later.

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -188,6 +188,15 @@ Deprecated in release 1.79.
 Instead of myseq.tomutable() or mymutableseq.toseq(), you should now use
 Bio.Seq.MutableSeq(myseq) or Bio.Seq.Seq(mymutableseq), respectively.
 
+Bio.Seq.UnknownSeq
+------------------
+Deprecated in release 1.79.
+Instead of ``UnknownSeq(length)``, please use ``Seq(None, length=length)``.
+Note that the sequence contents of a ``Seq`` object constructed in this way
+is considered to be unknown, and any attempt to access the sequence contents
+(for example, by calling ``print`` on the object) will result in an
+``UndefinedSequenceError``.
+
 Iterator .next() methods
 ------------------------
 The .next() method defined for any Biopython iterator is deprecated as of

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -585,6 +585,32 @@ As an extension to this, using sequence objects as keys in a Python dictionary
 is equivalent to using the sequence as a plain string for the key.
 See also Section~\ref{sec:seq-to-string}.
 
+\section{Sequences with unknown sequence contents}
+
+In some cases, the length of a sequence may be known but not the actual letters constituting it. For example, GenBank and EMBL files may represent a genomic DNA sequence only by its config information, without specifying the sequence contents explicitly. Such sequences can be represented by creating a \verb|Seq| object with the argument \verb|None|, followed by the sequence length:
+
+%doctest
+\begin{minted}{pycon}
+>>> from Bio.Seq import Seq
+>>> unknown_seq = Seq(None, 10)
+\end{minted}
+
+The \verb|Seq| object thus created has a well-defined length. Any attempt to access the sequence contents, however, will raise an \verb|UndefinedSequenceError|:
+
+%cont-doctest
+\begin{minted}{pycon}
+>>> unknown_seq
+Seq(None, length=10)
+>>> len(unknown_seq)
+10
+>>> print(unknown_seq)
+Traceback (most recent call last):
+...
+Bio.Seq.UndefinedSequenceError: Sequence content is undefined
+>>>
+\end{minted}
+
+
 \section{MutableSeq objects}
 \label{sec:mutable-seq}
 
@@ -657,6 +683,10 @@ Seq('AGCCCGTGGGAAAGTCGCCGGGTAATGCACCG')
 You can also get a string from a \verb|MutableSeq| object just like from a \verb|Seq| object (Section~\ref{sec:seq-to-string}).
 
 \section{UnknownSeq objects}
+
+\textbf{Note that \verb|UnknownSeq| is deprecated. To represent a sequence of
+known length but unknown sequence contents, please use \verb|Seq(None, length)|.}}
+
 The \verb|UnknownSeq| object is a subclass of the basic \verb|Seq| object
 and its purpose is to represent a
 sequence where we know the length, but not the actual letters making it up.

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -11,8 +11,10 @@ and confirms they are consistent using our different parsers.
 
 import os
 import unittest
+import warnings
 from io import StringIO
 
+from Bio import BiopythonDeprecationWarning
 from Bio import SeqIO
 from Bio.Data.CodonTable import TranslationError
 from Bio.Seq import (
@@ -282,9 +284,11 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
         self.assertIsInstance(new, Seq)  # Not MutableSeq!
         self.assertEqual(new, answer_str)
 
-        new = feature.extract(UnknownSeq(len(parent_seq), character="N"))
-        self.assertIsInstance(new, UnknownSeq)
+        new = feature.extract(Seq(None, len(parent_seq)))
+        self.assertIsInstance(new, Seq)
         self.assertEqual(len(new), len(answer_str))
+        if len(answer_str) > 0:
+            self.assertRaises(UndefinedSequenceError, str, new)
 
         if _get_location_string(feature, 1326) != location_str:
             # This is to avoid issues with the N^1 between feature which only

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -8,7 +8,7 @@
 import warnings
 import unittest
 
-from Bio import BiopythonWarning
+from Bio import BiopythonWarning, BiopythonDeprecationWarning
 from Bio import SeqIO
 from Bio.Data.IUPACData import ambiguous_dna_values, ambiguous_rna_values
 from Bio.Seq import (
@@ -80,13 +80,17 @@ class StringMethodTests(unittest.TestCase):
         Seq("ACGUGGGGU"),
         Seq("GG"),
         Seq("A"),
-        UnknownSeq(1),
-        UnknownSeq(1, character="n"),
-        UnknownSeq(1, character="N"),
-        UnknownSeq(12, character="N"),
-        UnknownSeq(12, character="X"),
-        UnknownSeq(12),
     ]
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", BiopythonDeprecationWarning)
+        _examples.extend([
+            UnknownSeq(1),
+            UnknownSeq(1, character="n"),
+            UnknownSeq(1, character="N"),
+            UnknownSeq(12, character="N"),
+            UnknownSeq(12, character="X"),
+            UnknownSeq(12),
+        ])
     for seq in _examples[:]:
         if not isinstance(seq, UnknownSeq):
             _examples.append(MutableSeq(seq))
@@ -246,11 +250,13 @@ class StringMethodTests(unittest.TestCase):
             ("X", 1, 7, 0),
         ]
 
-        for char, start, end, exp in char_start_end_exp:
-            self.assertEqual(
-                UnknownSeq(12, character=char).count_overlap("GG", start, end), exp
-            )
-        self.assertEqual(UnknownSeq(12, character="X").count_overlap("GG", 1, 7), 0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonDeprecationWarning)
+            for char, start, end, exp in char_start_end_exp:
+                self.assertEqual(
+                    UnknownSeq(12, character=char).count_overlap("GG", start, end), exp
+                )
+            self.assertEqual(UnknownSeq(12, character="X").count_overlap("GG", 1, 7), 0)
 
         # Testing UnknownSeq() with some more cases including unusual edge cases
         substr_start_end_exp = [
@@ -270,11 +276,13 @@ class StringMethodTests(unittest.TestCase):
             ("GGG", 1, 2, 0),
         ]
 
-        for substr, start, end, exp in substr_start_end_exp:
-            self.assertEqual(
-                UnknownSeq(7, character="N").count_overlap(substr, start, end), exp
-            )
-        self.assertEqual(UnknownSeq(7, character="N").count_overlap("GG", 1), 0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonDeprecationWarning)
+            for substr, start, end, exp in substr_start_end_exp:
+                self.assertEqual(
+                    UnknownSeq(7, character="N").count_overlap(substr, start, end), exp
+                )
+            self.assertEqual(UnknownSeq(7, character="N").count_overlap("GG", 1), 0)
 
     def test_str_count_overlap_NN(self):
         """Check our count_overlap method using NN."""
@@ -351,11 +359,13 @@ class StringMethodTests(unittest.TestCase):
             ("X", 1, 7, 0),
         ]
 
-        for char, start, end, exp in char_start_end_exp:
-            self.assertEqual(
-                UnknownSeq(12, character=char).count_overlap("NN", start, end), exp
-            )
-        self.assertEqual(UnknownSeq(12, character="X").count_overlap("NN", 1, 7), 0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonDeprecationWarning)
+            for char, start, end, exp in char_start_end_exp:
+                self.assertEqual(
+                    UnknownSeq(12, character=char).count_overlap("NN", start, end), exp
+                )
+            self.assertEqual(UnknownSeq(12, character="X").count_overlap("NN", 1, 7), 0)
 
         # Testing UnknownSeq() with some more cases including unusual edge cases
         substr_start_end_exp = [
@@ -375,11 +385,13 @@ class StringMethodTests(unittest.TestCase):
             ("NNN", 1, 2, 0),
         ]
 
-        for substr, start, end, exp in substr_start_end_exp:
-            self.assertEqual(
-                UnknownSeq(7, character="N").count_overlap(substr, start, end), exp
-            )
-        self.assertEqual(UnknownSeq(7, character="N").count_overlap("NN", 1), 5)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonDeprecationWarning)
+            for substr, start, end, exp in substr_start_end_exp:
+                self.assertEqual(
+                    UnknownSeq(7, character="N").count_overlap(substr, start, end), exp
+                )
+            self.assertEqual(UnknownSeq(7, character="N").count_overlap("NN", 1), 5)
 
     def test_str_find(self):
         """Check matches the python string find method."""
@@ -424,9 +436,15 @@ class StringMethodTests(unittest.TestCase):
 
         # Now check with a tuple of sub sequences
         for example1 in self._examples:
-            subs = tuple(
-                example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
-            )
+            if isinstance(example1, UnknownSeq) and len(example1) > 1:
+                with self.assertWarns(BiopythonDeprecationWarning):
+                    subs = tuple(
+                        example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
+                )
+            else:
+                subs = tuple(
+                    example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
+                )
             subs_str = tuple(str(s) for s in subs)
 
             self.assertEqual(
@@ -451,9 +469,15 @@ class StringMethodTests(unittest.TestCase):
 
         # Now check with a tuple of sub sequences
         for example1 in self._examples:
-            subs = tuple(
-                example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
-            )
+            if isinstance(example1, UnknownSeq) and len(example1) > 1:
+                with self.assertWarns(BiopythonDeprecationWarning):
+                    subs = tuple(
+                        example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
+                    )
+            else:
+                subs = tuple(
+                    example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
+                )
             subs_str = tuple(str(s) for s in subs)
 
             self.assertEqual(str(example1).endswith(subs_str), example1.endswith(subs))
@@ -535,13 +559,23 @@ class StringMethodTests(unittest.TestCase):
         """Check matches the python string upper method."""
         for example1 in self._examples:
             str1 = str(example1)
-            self.assertEqual(example1.upper(), str1.upper())
+            if isinstance(example1, UnknownSeq):
+                with self.assertWarns(BiopythonDeprecationWarning):
+                    example1 = example1.upper()
+            else:
+                example1 = example1.upper()
+            self.assertEqual(example1, str1.upper())
 
     def test_str_lower(self):
         """Check matches the python string lower method."""
         for example1 in self._examples:
             str1 = str(example1)
-            self.assertEqual(example1.lower(), str1.lower())
+            if isinstance(example1, UnknownSeq):
+                with self.assertWarns(BiopythonDeprecationWarning):
+                    example1 = example1.lower()
+            else:
+                example1 = example1.lower()
+            self.assertEqual(example1, str1.lower())
 
     def test_str_encode(self):
         """Check matches the python string encode method."""
@@ -605,19 +639,35 @@ class StringMethodTests(unittest.TestCase):
             for i in self._start_end_values:
                 if i is not None and abs(i) < len(example1):
                     self.assertEqual(example1[i], str1[i])
-                self.assertEqual(example1[:i], str1[:i])
-                self.assertEqual(example1[i:], str1[i:])
-                for j in self._start_end_values:
-                    self.assertEqual(example1[i:j], str1[i:j])
-                    for step in range(-3, 4):
-                        if step == 0:
-                            with self.assertRaises(ValueError) as cm:
-                                example1[i:j:step]
-                            self.assertEqual(
-                                str(cm.exception), "slice step cannot be zero"
-                            )
-                        else:
-                            self.assertEqual(example1[i:j:step], str1[i:j:step])
+                if isinstance(example1, UnknownSeq):
+                    with self.assertWarns(BiopythonDeprecationWarning):
+                        self.assertEqual(example1[:i], str1[:i])
+                        self.assertEqual(example1[i:], str1[i:])
+                        for j in self._start_end_values:
+                            self.assertEqual(example1[i:j], str1[i:j])
+                            for step in range(-3, 4):
+                                if step == 0:
+                                    with self.assertRaises(ValueError) as cm:
+                                        example1[i:j:step]
+                                    self.assertEqual(
+                                        str(cm.exception), "slice step cannot be zero"
+                                    )
+                                else:
+                                    self.assertEqual(example1[i:j:step], str1[i:j:step])
+                else:
+                    self.assertEqual(example1[:i], str1[:i])
+                    self.assertEqual(example1[i:], str1[i:])
+                    for j in self._start_end_values:
+                        self.assertEqual(example1[i:j], str1[i:j])
+                        for step in range(-3, 4):
+                            if step == 0:
+                                with self.assertRaises(ValueError) as cm:
+                                    example1[i:j:step]
+                                self.assertEqual(
+                                    str(cm.exception), "slice step cannot be zero"
+                                )
+                            else:
+                                self.assertEqual(example1[i:j:step], str1[i:j:step])
 
     def test_tomutable(self):
         """Check creating a MutableSeq object."""
@@ -639,7 +689,11 @@ class StringMethodTests(unittest.TestCase):
         for example1 in self._examples:
             if isinstance(example1, MutableSeq):
                 continue
-            comp = example1.complement()
+            if isinstance(example1, UnknownSeq):
+                with self.assertWarns(BiopythonDeprecationWarning):
+                    comp = example1.complement()
+            else:
+                comp = example1.complement()
             str1 = str(example1)
             if "U" in str1 or "u" in str1:
                 mapping = str.maketrans("ACGUacgu", "UGCAugca")
@@ -654,7 +708,11 @@ class StringMethodTests(unittest.TestCase):
         for example1 in self._examples:
             if isinstance(example1, MutableSeq):
                 continue
-            comp = example1.reverse_complement()
+            if isinstance(example1, UnknownSeq):
+                with self.assertWarns(BiopythonDeprecationWarning):
+                    comp = example1.reverse_complement()
+            else:
+                comp = example1.reverse_complement()
             str1 = str(example1)
             if "U" in str1 or "u" in str1:
                 mapping = str.maketrans("ACGUacgu", "UGCAugca")
@@ -669,7 +727,11 @@ class StringMethodTests(unittest.TestCase):
         for example1 in self._examples:
             if isinstance(example1, MutableSeq):
                 continue
-            tran = example1.transcribe()
+            if isinstance(example1, UnknownSeq):
+                with self.assertWarns(BiopythonDeprecationWarning):
+                    tran = example1.transcribe()
+            else:
+                tran = example1.transcribe()
             str1 = str(example1)
             if len(str1) % 3 != 0:
                 # TODO - Check for or silence the expected warning?
@@ -682,7 +744,11 @@ class StringMethodTests(unittest.TestCase):
         for example1 in self._examples:
             if isinstance(example1, MutableSeq):
                 continue
-            tran = example1.back_transcribe()
+            if isinstance(example1, UnknownSeq):
+                with self.assertWarns(BiopythonDeprecationWarning):
+                    tran = example1.back_transcribe()
+            else:
+                tran = example1.back_transcribe()
             str1 = str(example1)
             self.assertEqual(str1.replace("U", "T").replace("u", "t"), tran)
 
@@ -693,9 +759,15 @@ class StringMethodTests(unittest.TestCase):
             if len(example1) % 3 != 0:
                 # TODO - Check for or silence the expected warning?
                 continue
-            tran = example1.translate()
-            # Try with positional vs named argument:
-            self.assertEqual(example1.translate(11), example1.translate(table=11))
+            if isinstance(example1, UnknownSeq):
+                with self.assertWarns(BiopythonDeprecationWarning):
+                    tran = example1.translate()
+                    # Try with positional vs named argument:
+                    self.assertEqual(example1.translate(11), example1.translate(table=11))
+            else:
+                tran = example1.translate()
+                # Try with positional vs named argument:
+                self.assertEqual(example1.translate(11), example1.translate(table=11))
 
             # TODO - check the actual translation, and all the optional args
 
@@ -829,7 +901,9 @@ class StringMethodTests(unittest.TestCase):
         """Checks that a TypeError is thrown for all non-iterable types."""
         # No iterable types which contain non-accepted types either.
 
-        spacer = UnknownSeq(5, character="-")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonDeprecationWarning)
+            spacer = UnknownSeq(5, character="-")
         self.assertRaises(TypeError, spacer.join, 5)
         self.assertRaises(TypeError, spacer.join, ["ATG", "ATG", 5, "ATG"])
         spacer = Seq(None, length=5)
@@ -872,18 +946,20 @@ class StringMethodTests(unittest.TestCase):
 
     def test_join_UnknownSeq(self):
         """Checks if UnknownSeq join correctly concatenates sequence with the spacer."""
-        spacer1 = UnknownSeq(5, character="-")
-        spacer2 = UnknownSeq(0, character="-")
-        spacers = [spacer1, spacer2]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonDeprecationWarning)
+            spacer1 = UnknownSeq(5, character="-")
+            spacer2 = UnknownSeq(0, character="-")
+            spacers = [spacer1, spacer2]
 
-        self.assertEqual(
-            "-" * 15,
-            spacer1.join([UnknownSeq(5, character="-"), UnknownSeq(5, character="-")]),
-        )
-        self.assertEqual(
-            "N" * 5 + "-" * 10,
-            spacer1.join([Seq("NNNNN"), UnknownSeq(5, character="-")]),
-        )
+            self.assertEqual(
+                "-" * 15,
+                spacer1.join([UnknownSeq(5, character="-"), UnknownSeq(5, character="-")]),
+            )
+            self.assertEqual(
+                "N" * 5 + "-" * 10,
+                spacer1.join([Seq("NNNNN"), UnknownSeq(5, character="-")]),
+            )
 
         example_strings = ["ATG", "ATG", "ATG", "ATG"]
         example_strings_seqs = ["ATG", "ATG", Seq("ATG"), "ATG"]
@@ -940,8 +1016,10 @@ class StringMethodTests(unittest.TestCase):
         seqlist = [record.seq for record in SeqIO.parse(filename, "fasta")]
         seqlist_as_strings = [str(_) for _ in seqlist]
 
-        spacer = UnknownSeq(0, character="-")
-        spacer1 = UnknownSeq(5, character="-")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonDeprecationWarning)
+            spacer = UnknownSeq(0, character="-")
+            spacer1 = UnknownSeq(5, character="-")
         # seq objects with spacer
         seq_concatenated = spacer.join(seqlist)
         # seq objects with empty spacer
@@ -1016,10 +1094,12 @@ class StringMethodTests(unittest.TestCase):
         self.assertEqual(MutableSeq("None"), "None")
         self.assertNotEqual(MutableSeq("None"), None)
 
-        self.assertEqual(UnknownSeq(1, character="6"), "6")
-        self.assertNotEqual(UnknownSeq(1, character="6"), 6)
-        self.assertEqual(UnknownSeq(0), "")
-        self.assertNotEqual(UnknownSeq(0), None)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonDeprecationWarning)
+            self.assertEqual(UnknownSeq(1, character="6"), "6")
+            self.assertNotEqual(UnknownSeq(1, character="6"), 6)
+            self.assertEqual(UnknownSeq(0), "")
+            self.assertNotEqual(UnknownSeq(0), None)
 
     # TODO - Addition...
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -481,7 +481,8 @@ class StringMethodTests(unittest.TestCase):
                     )
             else:
                 subs = tuple(
-                    example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
+                    example1[start : start + 2]
+                    for start in range(0, len(example1) - 2, 3)
                 )
             subs_str = tuple(str(s) for s in subs)
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -83,14 +83,16 @@ class StringMethodTests(unittest.TestCase):
     ]
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", BiopythonDeprecationWarning)
-        _examples.extend([
-            UnknownSeq(1),
-            UnknownSeq(1, character="n"),
-            UnknownSeq(1, character="N"),
-            UnknownSeq(12, character="N"),
-            UnknownSeq(12, character="X"),
-            UnknownSeq(12),
-        ])
+        _examples.extend(
+            [
+                UnknownSeq(1),
+                UnknownSeq(1, character="n"),
+                UnknownSeq(1, character="N"),
+                UnknownSeq(12, character="N"),
+                UnknownSeq(12, character="X"),
+                UnknownSeq(12),
+            ]
+        )
     for seq in _examples[:]:
         if not isinstance(seq, UnknownSeq):
             _examples.append(MutableSeq(seq))
@@ -439,11 +441,13 @@ class StringMethodTests(unittest.TestCase):
             if isinstance(example1, UnknownSeq) and len(example1) > 1:
                 with self.assertWarns(BiopythonDeprecationWarning):
                     subs = tuple(
-                        example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
-                )
+                        example1[start : start + 2]
+                        for start in range(0, len(example1) - 2, 3)
+                    )
             else:
                 subs = tuple(
-                    example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
+                    example1[start : start + 2]
+                    for start in range(0, len(example1) - 2, 3)
                 )
             subs_str = tuple(str(s) for s in subs)
 
@@ -472,7 +476,8 @@ class StringMethodTests(unittest.TestCase):
             if isinstance(example1, UnknownSeq) and len(example1) > 1:
                 with self.assertWarns(BiopythonDeprecationWarning):
                     subs = tuple(
-                        example1[start : start + 2] for start in range(0, len(example1) - 2, 3)
+                        example1[start : start + 2]
+                        for start in range(0, len(example1) - 2, 3)
                     )
             else:
                 subs = tuple(
@@ -763,7 +768,9 @@ class StringMethodTests(unittest.TestCase):
                 with self.assertWarns(BiopythonDeprecationWarning):
                     tran = example1.translate()
                     # Try with positional vs named argument:
-                    self.assertEqual(example1.translate(11), example1.translate(table=11))
+                    self.assertEqual(
+                        example1.translate(11), example1.translate(table=11)
+                    )
             else:
                 tran = example1.translate()
                 # Try with positional vs named argument:
@@ -954,7 +961,9 @@ class StringMethodTests(unittest.TestCase):
 
             self.assertEqual(
                 "-" * 15,
-                spacer1.join([UnknownSeq(5, character="-"), UnknownSeq(5, character="-")]),
+                spacer1.join(
+                    [UnknownSeq(5, character="-"), UnknownSeq(5, character="-")]
+                ),
             )
             self.assertEqual(
                 "N" * 5 + "-" * 10,

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -755,6 +755,9 @@ class TestUnknownSeq(unittest.TestCase):
         self.s = Seq.UnknownSeq(6)
         self.u = Seq.Seq(None, length=6)
 
+    def tearDown(self):
+        warnings.simplefilter("default", BiopythonDeprecationWarning)
+
     def test_unknownseq_construction(self):
         self.assertEqual("??????", Seq.UnknownSeq(6))
         self.assertEqual("NNNNNN", Seq.UnknownSeq(6, character="N"))


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


This PR deprecates `UnknownSeq`, replacing it with `Seq(None, length)`.