### PR TITLE
remove deprecated argument

### DIFF
--- a/Bio/PDB/ResidueDepth.py
+++ b/Bio/PDB/ResidueDepth.py
@@ -64,7 +64,6 @@ from Bio.PDB.AbstractPropertyMap import AbstractPropertyMap
 from Bio.PDB.Polypeptide import is_aa
 
 from Bio import BiopythonWarning
-from Bio import BiopythonDeprecationWarning
 
 # Table 1: Atom Type to radius
 _atomic_radii = {
@@ -579,18 +578,10 @@ def ca_depth(residue, surface):
 class ResidueDepth(AbstractPropertyMap):
     """Calculate residue and CA depth for all residues."""
 
-    def __init__(self, model, pdb_file=None, msms_exec=None):
+    def __init__(self, model, msms_exec=None):
         """Initialize the class."""
         if msms_exec is None:
             msms_exec = "msms"
-
-        # Issue warning if pdb_file is given
-        if pdb_file is not None:
-            warnings.warn(
-                "ResidueDepth no longer requires a pdb file. This argument will be "
-                "removed in a future release of Biopython.",
-                BiopythonDeprecationWarning,
-            )
 
         depth_dict = {}
         depth_list = []


### PR DESCRIPTION
This PR removes the deprecated argument `pdb_file` from `ResidueDepth.__init__` in `Bio.PDB.ResidueDepth`. This argument was first deprecated in release 1.70 of July 2017. 

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
