### PR TITLE
Generator typehints for Structure, Model, Residues, Atoms classes

### DIFF
--- a/Bio/PDB/Chain.py
+++ b/Bio/PDB/Chain.py
@@ -7,10 +7,13 @@
 
 """Chain class, used in Structure objects."""
 
+from Bio.PDB.Atom import Atom
+from Bio.KEGG import Gene
+from Bio.PDB.Residue import Residue
 from Bio.PDB.Entity import Entity
 from Bio.PDB.internal_coords import IC_Chain
 
-from typing import Optional
+from typing import Generator, List, Optional
 
 
 class Chain(Entity):
@@ -20,7 +23,7 @@ class Chain(Entity):
     access atoms from residues.
     """
 
-    def __init__(self, id):
+    def __init__(self, id) -> None:
         """Initialize the class."""
         self.level = "C"
         self.internal_coord = None
@@ -133,7 +136,7 @@ class Chain(Entity):
 
     # Public methods
 
-    def get_unpacked_list(self):
+    def get_unpacked_list(self) -> List[Residue]:
         """Return a list of undisordered residues.
 
         Some Residue objects hide several disordered residues
@@ -166,11 +169,11 @@ class Chain(Entity):
 
     # Public
 
-    def get_residues(self):
+    def get_residues(self) -> Generator[Residue, None, None]:
         """Return residues."""
         yield from self
 
-    def get_atoms(self):
+    def get_atoms(self) -> Generator[Atom, None, None]:
         """Return atoms from residues."""
         for r in self.get_residues():
             yield from r

--- a/Bio/PDB/Model.py
+++ b/Bio/PDB/Model.py
@@ -5,8 +5,13 @@
 
 """Model class, used in Structure objects."""
 
-from Bio.PDB.Entity import Entity
 from Bio.PDB.internal_coords import IC_Chain
+from Bio.PDB.Atom import Atom
+from Bio.PDB.Residue import Residue
+from Bio.PDB.Chain import Chain
+from Bio.PDB.Entity import Entity
+
+from typing import Generator
 
 
 class Model(Entity):
@@ -37,16 +42,16 @@ class Model(Entity):
         """Return model identifier."""
         return "<Model id=%s>" % self.get_id()
 
-    def get_chains(self):
+    def get_chains(self) -> Generator[Chain, None, None]:
         """Return chains."""
         yield from self
 
-    def get_residues(self):
+    def get_residues(self) -> Generator[Residue, None, None]:
         """Return residues."""
         for c in self.get_chains():
             yield from c
 
-    def get_atoms(self):
+    def get_atoms(self) -> Generator[Atom, None, None]:
         """Return atoms."""
         for r in self.get_residues():
             yield from r

--- a/Bio/PDB/NeighborSearch.py
+++ b/Bio/PDB/NeighborSearch.py
@@ -84,7 +84,6 @@ class NeighborSearch:
          - center - Numeric array
          - radius - float
          - level - char (A, R, C, M, S)
-
         """
         if level not in entity_levels:
             raise PDBException("%s: Unknown level" % level)

--- a/Bio/PDB/Residue.py
+++ b/Bio/PDB/Residue.py
@@ -7,6 +7,8 @@
 
 """Residue class, used by Structure objects."""
 
+from Bio.PDB.Atom import Atom
+from typing import Generator
 from Bio.PDB.PDBExceptions import PDBConstructionException
 from Bio.PDB.Entity import Entity, DisorderedEntityWrapper
 
@@ -77,7 +79,7 @@ class Residue(Entity):
         """Return the segment identifier."""
         return self.segid
 
-    def get_atoms(self):
+    def get_atoms(self) -> Generator[Atom, None, None]:
         """Return atoms."""
         yield from self
 

--- a/Bio/PDB/Structure.py
+++ b/Bio/PDB/Structure.py
@@ -7,37 +7,42 @@
 
 """The structure class, representing a macromolecular structure."""
 
+from typing import Generator
 from Bio.PDB.Entity import Entity
 from Bio.PDB.internal_coords import IC_Chain
+from Bio.PDB.Atom import Atom
+from Bio.PDB.Residue import Residue
+from Bio.PDB.Chain import Chain
+from Bio.PDB.Model import Model
 
 
 class Structure(Entity):
     """The Structure class contains a collection of Model instances."""
 
-    def __init__(self, id):
+    def __init__(self, id) -> None:
         """Initialize the class."""
         self.level = "S"
         Entity.__init__(self, id)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return the structure identifier."""
         return "<Structure id=%s>" % self.get_id()
 
-    def get_models(self):
+    def get_models(self) -> Generator[Model, None, None]:
         """Return models."""
         yield from self
 
-    def get_chains(self):
+    def get_chains(self) -> Generator[Chain, None, None]:
         """Return chains from models."""
         for m in self.get_models():
             yield from m
 
-    def get_residues(self):
+    def get_residues(self) -> Generator[Residue, None, None]:
         """Return residues from chains."""
         for c in self.get_chains():
             yield from c
 
-    def get_atoms(self):
+    def get_atoms(self) -> Generator[Atom, None, None]:
         """Return atoms from residue."""
         for r in self.get_residues():
             yield from r


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


Added some generator type-hints for structural classes in Bio.PDB's `Structure, Model, Chain, Residue, Atom`, in particular the getters like "`get_atoms`" etc. 
(It's frequently annoying to not have method hints on the generator or just those for the abstract `Entity`)

To João: `typing` is already present(at least) 7 months ago in Chain.py, added by Rob Miller. 