### PR TITLE
Seq baseclass

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -923,22 +923,19 @@ class _SeqAbstractBaseClass(ABC):
         Seq('VMAIVMGR*KGAR*L')
         >>> for pep in my_aa.split("*"):
         ...     pep
-        ...
         Seq('VMAIVMGR')
         Seq('KGAR')
         Seq('L')
         >>> for pep in my_aa.split("*", 1):
         ...     pep
-        ...
         Seq('VMAIVMGR')
         Seq('KGAR*L')
 
         See also the rsplit method, which splits the sequence starting from the
-        end::
+        end:
 
         >>> for pep in my_aa.rsplit("*", 1):
         ...     pep
-        ...
         Seq('VMAIVMGR*KGAR')
         Seq('L')
         """

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -283,78 +283,23 @@ class SequenceDataAbstractBaseClass(ABC):
         return bytes(self).translate(table)
 
 
-class Seq:
-    """Read-only sequence object (essentially a string with biological methods).
+class _SeqAbstractBaseClass(ABC):
+    """Abstract base class for the Seq and MutableSeq classes (PRIVATE)
 
-    Like normal python strings, our basic sequence object is immutable.
-    This prevents you from doing my_seq[5] = "A" for example, but does allow
-    Seq objects to be used as dictionary keys.
-
-    The Seq object provides a number of string like methods (such as count,
-    find, split and strip).
-
-    The Seq object also provides some biological methods, such as complement,
-    reverse_complement, transcribe, back_transcribe and translate (which are
-    not applicable to protein sequences).
+    Most users will not need to use this class. It is used internally as an
+    abstract base class for Seq and MutableSeq, as most of their methods are
+    identical.
     """
 
-    def __init__(self, data, length=None):
-        """Create a Seq object.
-
-        Arguments:
-         - data - Sequence, required (string)
-         - length - Sequence length, used only if data is None (integer)
-
-        You will typically use Bio.SeqIO to read in sequences from files as
-        SeqRecord objects, whose sequence will be exposed as a Seq object via
-        the seq property.
-
-        However, you can also create a Seq object directly:
-
-        >>> from Bio.Seq import Seq
-        >>> my_seq = Seq("MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF")
-        >>> my_seq
-        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF')
-        >>> print(my_seq)
-        MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF
-
-        To create a Seq object with for a sequence of known length but
-        unknown sequence contents, use None for the data argument and pass
-        the sequence length for the length argument. Trying to access the
-        sequence contents of a Seq object created in this way will raise
-        an UndefinedSequenceError:
-
-        >>> my_undefined_seq = Seq(None, 20)
-        >>> my_undefined_seq
-        Seq(None, length=20)
-        >>> len(my_undefined_seq)
-        20
-        >>> print(my_undefined_seq)
-        Traceback (most recent call last):
-        ...
-        Bio.Seq.UndefinedSequenceError: Sequence content is undefined
-        """
-        if length is None:
-            if isinstance(data, (bytes, SequenceDataAbstractBaseClass)):
-                self._data = data
-            elif isinstance(data, (bytearray, Seq, MutableSeq)):
-                self._data = bytes(data)
-            elif isinstance(data, str):
-                self._data = bytes(data, encoding="ASCII")
-            else:
-                raise TypeError(
-                    "data should be a string, bytes, bytearray, Seq, or MutableSeq object"
-                )
-        else:
-            if data is not None:
-                raise ValueError("length should be None if data is None")
-            self._data = _UndefinedSequenceData(length)
+    @abstractmethod
+    def __init__(self):
+        pass
 
     def __bytes__(self):
         return bytes(self._data)
 
     def __repr__(self):
-        """Return (truncated) representation of the sequence for debugging."""
+        """Return (truncated) representation of the sequence."""
         data = self._data
         if isinstance(data, _UndefinedSequenceData):
             return f"Seq(None, length={len(self)})"
@@ -370,58 +315,41 @@ class Seq:
             return f"{self.__class__.__name__}('{data}')"
 
     def __str__(self):
-        """Return the full sequence as a python string, use str(my_seq).
-
-        Note that Biopython 1.44 and earlier would give a truncated
-        version of repr(my_seq) for str(my_seq).  If you are writing code
-        which need to be backwards compatible with really old Biopython,
-        you should continue to use my_seq.tostring() as follows::
-
-            try:
-                # The old way, removed in Biopython 1.73
-                as_string = seq_obj.tostring()
-            except AttributeError:
-                # The new way, needs Biopython 1.45 or later.
-                # Don't use this on Biopython 1.44 or older as truncates
-                as_string = str(seq_obj)
-
-        """
+        """Return the full sequence as a python string."""
         return self._data.decode("ASCII")
 
-    def __hash__(self):
-        """Hash of the sequence as a string for comparison.
-
-        See Seq object comparison documentation (method ``__eq__`` in
-        particular) as this has changed in Biopython 1.65. Older versions
-        would hash on object identity.
-        """
-        return hash(self._data)
-
     def __eq__(self, other):
-        """Compare the sequence to another sequence or a string (README).
+        """Compare the sequence to another sequence or a string.
 
-        Historically comparing Seq objects has done Python object comparison.
-        After considerable discussion (keeping in mind constraints of the
-        Python language, hashes and dictionary support), Biopython now uses
-        simple string comparison (with a warning about the change).
+        Sequences are equal to each other if their sequence contents is
+        identical:
 
-        If you still need to support releases prior to Biopython 1.65, please
-        just do explicit comparisons:
-
-        >>> from Bio.Seq import Seq
+        >>> from Bio.Seq import Seq, MutableSeq
         >>> seq1 = Seq("ACGT")
         >>> seq2 = Seq("ACGT")
-        >>> id(seq1) == id(seq2)
-        False
-        >>> str(seq1) == str(seq2)
-        True
-
-        The new behaviour is to use string-like equality:
-
-        >>> from Bio.Seq import Seq
+        >>> mutable_seq = MutableSeq("ACGT")
         >>> seq1 == seq2
         True
+        >>> seq1 == mutable_seq
+        True
         >>> seq1 == "ACGT"
+        True
+
+        Note that the sequence objects are not identical to each other:
+
+        >>> id(seq1) == id(seq2)
+        False
+        >>> seq1 is seq2
+        False
+
+        Sequences can also be compared to strings, ``bytes``, and ``bytearray``
+        objects:
+
+        >>> seq1 == "ACGT"
+        True
+        >>> seq1 == b"ACGT"
+        True
+        >>> seq1 == bytearray(b"ACGT")
         True
         """
         if isinstance(other, (Seq, MutableSeq)):
@@ -468,21 +396,32 @@ class Seq:
             return self._data >= other
 
     def __len__(self):
-        """Return the length of the sequence, use len(my_seq)."""
+        """Return the length of the sequence."""
         return len(self._data)
 
     def __getitem__(self, index):
-        """Return a subsequence of single letter, use my_seq[index].
+        """Return a subsequence of single letter or as a sequence object.
 
-        >>> my_seq = Seq('ACTCGACGTCG')
-        >>> my_seq[5]
+        If the index is an integer, a single letter is returned as a Python
+        string:
+
+        >>> seq = Seq('ACTCGACGTCG')
+        >>> seq[5]
         'A'
+
+        Otherwise, a new sequence object of the same class is returned:
+
+        >>> seq[5:8]
+        Seq('ACG')
+        >>> mutable_seq = MutableSeq('ACTCGACGTCG')
+        >>> mutable_seq[5:8]
+        MutableSeq('ACG')
         """
         if isinstance(index, int):
             # Return a single letter as a string
             return chr(self._data[index])
         else:
-            # Return the (sub)sequence as another Seq object
+            # Return the (sub)sequence as another Seq/MutableSeq object
             return self.__class__(self._data[index])
 
     def __add__(self, other):
@@ -555,22 +494,6 @@ class Seq:
         if not isinstance(other, int):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(self._data * other)
-
-    def tomutable(self):
-        """Return the full sequence as a MutableSeq object.
-
-        >>> from Bio.Seq import Seq
-        >>> my_seq = Seq("MKQHKAMIVALIVICITAVVAAL")
-        >>> my_seq
-        Seq('MKQHKAMIVALIVICITAVVAAL')
-        >>> my_seq.tomutable()
-        MutableSeq('MKQHKAMIVALIVICITAVVAAL')
-        """
-        warnings.warn(
-            "myseq.tomutable() is deprecated; please use MutableSeq(myseq) instead.",
-            BiopythonDeprecationWarning,
-        )
-        return MutableSeq(self)
 
     def count(self, sub, start=None, end=None):
         """Return a non-overlapping count, like that of a python string.
@@ -956,10 +879,24 @@ class Seq:
             sep = sep.encode("ASCII")
         return [Seq(part) for part in self._data.rsplit(sep, maxsplit)]
 
-    def strip(self, chars=None):
-        """Return a new Seq object with leading and trailing ends stripped.
+    def strip(self, chars=None, inplace=False):
+        """Return a sequence object with leading and trailing ends stripped.
 
         This behaves like the python string method of the same name.
+
+        A copy of the sequence is returned if ``inplace`` is `False` (the
+        default value). If ``inplace`` is `True`, the sequence is stripped
+        in-place and returned:
+
+        >>> seq = MutableSeq("ACGT ")
+        >>> seq.strip()
+        MutableSeq('ACGT')
+        >>> seq
+        MutableSeq('ACGT ')
+        >>> seq.strip(inplace=True)
+        MutableSeq('ACGT')
+        >>> seq
+        MutableSeq('ACGT')
 
         Optional argument chars defines which characters to remove.  If
         omitted or None (default) then as for the python string method,
@@ -967,21 +904,21 @@ class Seq:
 
         e.g.
 
-        >>> Seq("ACGT ").strip()
-        Seq('ACGT')
-        >>> Seq("ACGT ").strip(" ")
-        Seq('ACGT')
+        >>> MutableSeq("ACGT ").strip()
+        MutableSeq('ACGT')
+        >>> MutableSeq("ACGT ").strip(" ")
+        MutableSeq('ACGT')
 
         Just like the Python string, the order of the characters to be
         removed is not important:
 
-        >>> Seq("ACGTACGT").strip("TGCA")
-        Seq('')
+        >>> MutableSeq("ACGTACGT").strip("TGCA")
+        MutableSeq('')
 
         As with the Python string, an inappropriate argument
         will give a TypeError:
 
-        >>> Seq("ACGT ").strip(7)
+        >>> MutableSeq("ACGT ").strip(7)
         Traceback (most recent call last):
            ...
         TypeError: argument must be None or a string, Seq, MutableSeq, or bytes-like object
@@ -998,19 +935,41 @@ class Seq:
             raise TypeError(
                 "argument must be None or a string, Seq, MutableSeq, or bytes-like object"
             ) from None
-        return Seq(data)
+        if inplace:
+            if not isinstance(self._data, bytearray):
+                raise TypeError("Sequence is immutable")
+            self._data[:] = data
+            return self
+        elif isinstance(self, UnknownSeq):
+            return Seq(data)
+        else:
+            return self.__class__(data)
 
-    def lstrip(self, chars=None):
-        """Return a new Seq object with leading (left) end stripped.
+    def lstrip(self, chars=None, inplace=False):
+        """Return a MutableSeq object with leading (left) end stripped.
 
         This behaves like the python string method of the same name.
+
+        A copy of the sequence is returned if ``inplace`` is `False` (the
+        default value). If ``inplace`` is `True`, the sequence is stripped
+        in-place and returned:
+
+        >>> seq = MutableSeq(" ACGT ")
+        >>> seq.lstrip()
+        MutableSeq('ACGT ')
+        >>> seq
+        MutableSeq(' ACGT ')
+        >>> seq.lstrip(inplace=True)
+        MutableSeq('ACGT ')
+        >>> seq
+        MutableSeq('ACGT ')
 
         Optional argument chars defines which characters to remove.  If
         omitted or None (default) then as for the python string method,
         this defaults to removing any white space.
 
-        >>> Seq("AAACGTA").lstrip("A")
-        Seq('CGTA')
+        >>> MutableSeq("AAACGTA").lstrip("A")
+        MutableSeq('CGTA')
 
         See also the strip and rstrip methods.
         """
@@ -1024,12 +983,34 @@ class Seq:
             raise TypeError(
                 "argument must be None or a string, Seq, MutableSeq, or bytes-like object"
             ) from None
-        return Seq(data)
+        if inplace:
+            if not isinstance(self._data, bytearray):
+                raise TypeError("Sequence is immutable")
+            self._data[:] = data
+            return self
+        elif isinstance(self, UnknownSeq):
+            return Seq(data)
+        else:
+            return self.__class__(data)
 
-    def rstrip(self, chars=None):
-        """Return a new Seq object with trailing (right) end stripped.
+    def rstrip(self, chars=None, inplace=False):
+        """Return a MutableSeq object with trailing (right) end stripped.
 
         This behaves like the python string method of the same name.
+
+        A copy of the sequence is returned if ``inplace`` is `False` (the
+        default value). If ``inplace`` is `True`, the sequence is stripped
+        in-place and returned:
+
+        >>> seq = MutableSeq(" ACGT ")
+        >>> seq.rstrip()
+        MutableSeq(' ACGT')
+        >>> seq
+        MutableSeq(' ACGT ')
+        >>> seq.rstrip(inplace=True)
+        MutableSeq(' ACGT')
+        >>> seq
+        MutableSeq(' ACGT')
 
         Optional argument chars defines which characters to remove.  If
         omitted or None (default) then as for the python string method,
@@ -1037,12 +1018,12 @@ class Seq:
 
         e.g. Removing a nucleotide sequence's polyadenylation (poly-A tail):
 
-        >>> from Bio.Seq import Seq
-        >>> my_seq = Seq("CGGTACGCTTATGTCACGTAGAAAAAA")
+        >>> from Bio.Seq import MutableSeq
+        >>> my_seq = MutableSeq("CGGTACGCTTATGTCACGTAGAAAAAA")
         >>> my_seq
-        Seq('CGGTACGCTTATGTCACGTAGAAAAAA')
+        MutableSeq('CGGTACGCTTATGTCACGTAGAAAAAA')
         >>> my_seq.rstrip("A")
-        Seq('CGGTACGCTTATGTCACGTAG')
+        MutableSeq('CGGTACGCTTATGTCACGTAG')
 
         See also the strip and lstrip methods.
         """
@@ -1056,35 +1037,445 @@ class Seq:
             raise TypeError(
                 "argument must be None or a string, Seq, MutableSeq, or bytes-like object"
             ) from None
-        return Seq(data)
+        if inplace:
+            if not isinstance(self._data, bytearray):
+                raise TypeError("Sequence is immutable")
+            self._data[:] = data
+            return self
+        elif isinstance(self, UnknownSeq):
+            return Seq(data)
+        else:
+            return self.__class__(data)
 
-    def upper(self):
-        """Return an upper case copy of the sequence.
+    def upper(self, inplace=False):
+        """Return the sequence in upper case.
 
-        >>> from Bio.Seq import Seq
-        >>> my_seq = Seq("VHLTPeeK*")
+        An upper-case copy of the sequence is returned if inplace is False,
+        the default value:
+
+        >>> from Bio.Seq import MutableSeq
+        >>> my_seq = MutableSeq("VHLTPeeK*")
         >>> my_seq
-        Seq('VHLTPeeK*')
+        MutableSeq('VHLTPeeK*')
         >>> my_seq.lower()
-        Seq('vhltpeek*')
+        MutableSeq('vhltpeek*')
         >>> my_seq.upper()
-        Seq('VHLTPEEK*')
-        """
-        return Seq(self._data.upper())
+        MutableSeq('VHLTPEEK*')
+        >>> my_seq
+        MutableSeq('VHLTPeeK*')
 
-    def lower(self):
-        """Return a lower case copy of the sequence.
+        The sequence is modified in-place and returned if inplace is True:
+
+        >>> my_seq.lower(inplace=True)
+        MutableSeq('vhltpeek*')
+        >>> my_seq
+        MutableSeq('vhltpeek*')
+        >>> my_seq.upper(inplace=True)
+        MutableSeq('VHLTPEEK*')
+        >>> my_seq
+        MutableSeq('VHLTPEEK*')
+        """
+        data = self._data.upper()
+        if inplace:
+            if not isinstance(self._data, bytearray):
+                raise TypeError("Sequence is immutable")
+            self._data[:] = data
+            return self
+        else:
+            return self.__class__(data)
+
+    def lower(self, inplace=False):
+        """Return the sequence in lower case.
+
+        A lower-case copy of the sequence is returned if inplace is False,
+        the default value:
+
+        >>> from Bio.Seq import MutableSeq
+        >>> my_seq = MutableSeq("VHLTPeeK*")
+        >>> my_seq
+        MutableSeq('VHLTPeeK*')
+        >>> my_seq.lower()
+        MutableSeq('vhltpeek*')
+        >>> my_seq.upper()
+        MutableSeq('VHLTPEEK*')
+        >>> my_seq
+        MutableSeq('VHLTPeeK*')
+
+        The sequence is modified in-place and returned if inplace is True:
+
+        >>> my_seq.lower(inplace=True)
+        MutableSeq('vhltpeek*')
+        >>> my_seq
+        MutableSeq('vhltpeek*')
+        >>> my_seq.upper(inplace=True)
+        MutableSeq('VHLTPEEK*')
+        >>> my_seq
+        MutableSeq('VHLTPEEK*')
+        """
+        data = self._data.lower()
+        if inplace:
+            if not isinstance(self._data, bytearray):
+                raise TypeError("Sequence is immutable")
+            self._data[:] = data
+            return self
+        else:
+            return self.__class__(data)
+
+    def translate(
+        self, table="Standard", stop_symbol="*", to_stop=False, cds=False, gap="-"
+    ):
+        """Turn a nucleotide sequence into a protein sequence by creating a new MutableSeq object.
+
+        This method will translate DNA or RNA sequences. It should not
+        be used on protein sequences as any result will be biologically
+        meaningless.
+
+        Arguments:
+         - table - Which codon table to use?  This can be either a name
+           (string), an NCBI identifier (integer), or a CodonTable
+           object (useful for non-standard genetic codes).  This
+           defaults to the "Standard" table.
+         - stop_symbol - Single character string, what to use for
+           terminators.  This defaults to the asterisk, "*".
+         - to_stop - Boolean, defaults to False meaning do a full
+           translation continuing on past any stop codons (translated as the
+           specified stop_symbol).  If True, translation is terminated at
+           the first in frame stop codon (and the stop_symbol is not
+           appended to the returned protein sequence).
+         - cds - Boolean, indicates this is a complete CDS.  If True,
+           this checks the sequence starts with a valid alternative start
+           codon (which will be translated as methionine, M), that the
+           sequence length is a multiple of three, and that there is a
+           single in frame stop codon at the end (this will be excluded
+           from the protein sequence, regardless of the to_stop option).
+           If these tests fail, an exception is raised.
+         - gap - Single character string to denote symbol used for gaps.
+           Defaults to the minus sign.
+
+        e.g. Using the standard table:
+
+        >>> coding_dna = MutableSeq("GTGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG")
+        >>> coding_dna.translate()
+        MutableSeq('VAIVMGR*KGAR*')
+        >>> coding_dna.translate(stop_symbol="@")
+        MutableSeq('VAIVMGR@KGAR@')
+        >>> coding_dna.translate(to_stop=True)
+        MutableSeq('VAIVMGR')
+
+        Now using NCBI table 2, where TGA is not a stop codon:
+
+        >>> coding_dna.translate(table=2)
+        MutableSeq('VAIVMGRWKGAR*')
+        >>> coding_dna.translate(table=2, to_stop=True)
+        MutableSeq('VAIVMGRWKGAR')
+
+        In fact, GTG is an alternative start codon under NCBI table 2, meaning
+        this sequence could be a complete CDS:
+
+        >>> coding_dna.translate(table=2, cds=True)
+        MutableSeq('MAIVMGRWKGAR')
+
+        It isn't a valid CDS under NCBI table 1, due to both the start codon
+        and also the in frame stop codons:
+
+        >>> coding_dna.translate(table=1, cds=True)
+        Traceback (most recent call last):
+            ...
+        Bio.Data.CodonTable.TranslationError: First codon 'GTG' is not a start codon
+
+        If the sequence has no in-frame stop codon, then the to_stop argument
+        has no effect:
+
+        >>> coding_dna2 = MutableSeq("TTGGCCATTGTAATGGGCCGC")
+        >>> coding_dna2.translate()
+        MutableSeq('LAIVMGR')
+        >>> coding_dna2.translate(to_stop=True)
+        MutableSeq('LAIVMGR')
+
+        NOTE - Ambiguous codons like "TAN" or "NNN" could be an amino acid
+        or a stop codon.  These are translated as "X".  Any invalid codon
+        (e.g. "TA?" or "T-A") will throw a TranslationError.
+
+        NOTE - This does NOT behave like the python string's translate
+        method.  For that use str(my_seq).translate(...) instead
+        """
+        if isinstance(table, str) and len(table) == 256:
+            raise ValueError(
+                "The MutableSeq object translate method DOES NOT "
+                "take a 256 character string mapping table like "
+                "the python string object's translate method. "
+                "Use str(my_seq).translate(...) instead."
+            )
+
+        try:
+            data = str(self)
+        except UndefinedSequenceError:
+            # translating an undefined sequence yields an undefined
+            # sequence with the length divided by 3
+            n = len(self)
+            if n % 3 != 0:
+                warnings.warn(
+                    "Partial codon, len(sequence) not a multiple of three. "
+                    "This may become an error in future.",
+                    BiopythonWarning,
+                )
+            return Seq(None, n // 3)
+
+        return self.__class__(
+            _translate_str(str(self), table, stop_symbol, to_stop, cds, gap=gap)
+        )
+
+    def complement_rna(self, inplace=False):
+        """Return the complement as an RNA sequence.
+
+        >>> Seq("CGA").complement_rna()
+        Seq('GCU')
+
+        Any T in the sequence is treated as a U:
+
+        >>> Seq("CGAUT").complement_rna()
+        Seq('GCUAA')
+
+        In contrast, ``complement`` returns a DNA sequence by default:
+
+        >>> Seq("CGA").complement()
+        Seq('GCT')
+        """
+        try:
+            data = self._data.translate(_rna_complement_table)
+        except UndefinedSequenceError:
+            # complement of an undefined sequence is an undefined sequence
+            # of the same length
+            return self
+        if inplace:
+            if not isinstance(self._data, bytearray):
+                raise TypeError("Sequence is immutable")
+            self._data[:] = data
+            return self
+        return self.__class__(data)
+
+    def reverse_complement_rna(self, inplace=False):
+        """Return the reverse complement as an RNA sequence.
 
         >>> from Bio.Seq import Seq
-        >>> my_seq = Seq("CGGTACGCTTATGTCACGTAGAAAAAA")
-        >>> my_seq
-        Seq('CGGTACGCTTATGTCACGTAGAAAAAA')
-        >>> my_seq.lower()
-        Seq('cggtacgcttatgtcacgtagaaaaaa')
-
-        See also the upper method.
+        >>> Seq("ACG").reverse_complement_rna()
+        Seq('CGU')
         """
-        return Seq(self._data.lower())
+        try:
+            data = self._data.translate(_rna_complement_table)
+        except UndefinedSequenceError:
+            # reverse complement of an undefined sequence is an undefined sequence
+            # of the same length
+            return self
+        data = self._data.translate(_rna_complement_table)
+        if inplace:
+            if not isinstance(self._data, bytearray):
+                raise TypeError("Sequence is immutable")
+            self._data[::-1] = data
+            return self
+        return self.__class__(data[::-1])
+
+    def transcribe(self, inplace=False):
+        """Transcribe a DNA sequence into RNA and return the RNA sequence as a new Seq object.
+
+        >>> from Bio.Seq import Seq
+        >>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG")
+        >>> coding_dna
+        Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
+        >>> coding_dna.transcribe()
+        Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG')
+
+        Trying to transcribe an RNA sequence should have no effect.
+        If you have a nucleotide sequence which might be DNA or RNA
+        (or even a mixture), calling the transcribe method will ensure
+        any T becomes U.
+
+        Trying to transcribe a protein sequence will replace any
+        T for Threonine with U for Selenocysteine, which has no
+        biologically plausible rational. Older versions of Biopython
+        would throw an exception.
+
+        >>> from Bio.Seq import Seq
+        >>> my_protein = Seq("MAIVMGRT")
+        >>> my_protein.transcribe()
+        Seq('MAIVMGRU')
+        """
+        try:
+            data = self._data.replace(b"T", b"U").replace(b"t", b"u")
+        except UndefinedSequenceError:
+            # transcribing an undefined sequence yields an undefined sequence
+            # of the same length
+            return self
+        if inplace:
+            if not isinstance(self._data, bytearray):
+                raise TypeError("Sequence is immutable")
+            self._data[:] = data
+            return self
+        return self.__class__(data)
+
+    def back_transcribe(self, inplace=False):
+        """Return the DNA sequence from an RNA sequence by creating a new Seq object.
+
+        >>> from Bio.Seq import Seq
+        >>> messenger_rna = Seq("AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG")
+        >>> messenger_rna
+        Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG')
+        >>> messenger_rna.back_transcribe()
+        Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
+
+        Trying to back-transcribe DNA has no effect, If you have a nucleotide
+        sequence which might be DNA or RNA (or even a mixture), calling the
+        back-transcribe method will ensure any T becomes U.
+
+        Trying to back-transcribe a protein sequence will replace any U for
+        Selenocysteine with T for Threonine, which is biologically meaningless.
+        Older versions of Biopython would raise an exception here:
+
+        >>> from Bio.Seq import Seq
+        >>> my_protein = Seq("MAIVMGRU")
+        >>> my_protein.back_transcribe()
+        Seq('MAIVMGRT')
+        """
+        try:
+            data = self._data.replace(b"U", b"T").replace(b"u", b"t")
+        except UndefinedSequenceError:
+            # back-transcribing an undefined sequence yields an undefined
+            # sequence of the same length
+            return self
+        if inplace:
+            if not isinstance(self._data, bytearray):
+                raise TypeError("Sequence is immutable")
+            self._data[:] = data
+            return self
+        return self.__class__(data)
+
+    def join(self, other):
+        """Return a merge of the sequences in other, spaced by the sequence from self.
+
+        Accepts either a Seq or string (and iterates over the letters), or an
+        iterable containing Seq or string objects. These arguments will be
+        concatenated with the calling sequence as the spacer:
+
+        >>> concatenated = Seq('NNNNN').join([Seq("AAA"), Seq("TTT"), Seq("PPP")])
+        >>> concatenated
+        Seq('AAANNNNNTTTNNNNNPPP')
+
+        Joining the letters of a single sequence:
+
+        >>> Seq('NNNNN').join(Seq("ACGT"))
+        Seq('ANNNNNCNNNNNGNNNNNT')
+        >>> Seq('NNNNN').join("ACGT")
+        Seq('ANNNNNCNNNNNGNNNNNT')
+        """
+        if isinstance(other, (Seq, MutableSeq)):
+            return self.__class__(str(self).join(str(other)))
+        elif isinstance(other, str):
+            return self.__class__(str(self).join(other))
+
+        from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
+
+        if isinstance(other, SeqRecord):
+            raise TypeError("Iterable cannot be a SeqRecord")
+
+        for c in other:
+            if isinstance(c, SeqRecord):
+                raise TypeError("Iterable cannot contain SeqRecords")
+            elif not isinstance(c, (str, Seq, MutableSeq)):
+                raise TypeError("Input must be an iterable of Seqs or Strings")
+        return self.__class__(str(self).join([str(_) for _ in other]))
+
+
+class Seq(_SeqAbstractBaseClass):
+    """Read-only sequence object (essentially a string with biological methods).
+
+    Like normal python strings, our basic sequence object is immutable.
+    This prevents you from doing my_seq[5] = "A" for example, but does allow
+    Seq objects to be used as dictionary keys.
+
+    The Seq object provides a number of string like methods (such as count,
+    find, split and strip).
+
+    The Seq object also provides some biological methods, such as complement,
+    reverse_complement, transcribe, back_transcribe and translate (which are
+    not applicable to protein sequences).
+    """
+
+    def __init__(self, data, length=None):
+        """Create a Seq object.
+
+        Arguments:
+         - data - Sequence, required (string)
+         - length - Sequence length, used only if data is None (integer)
+
+        You will typically use Bio.SeqIO to read in sequences from files as
+        SeqRecord objects, whose sequence will be exposed as a Seq object via
+        the seq property.
+
+        However, you can also create a Seq object directly:
+
+        >>> from Bio.Seq import Seq
+        >>> my_seq = Seq("MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF")
+        >>> my_seq
+        Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF')
+        >>> print(my_seq)
+        MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF
+
+        To create a Seq object with for a sequence of known length but
+        unknown sequence contents, use None for the data argument and pass
+        the sequence length for the length argument. Trying to access the
+        sequence contents of a Seq object created in this way will raise
+        an UndefinedSequenceError:
+
+        >>> my_undefined_seq = Seq(None, 20)
+        >>> my_undefined_seq
+        Seq(None, length=20)
+        >>> len(my_undefined_seq)
+        20
+        >>> print(my_undefined_seq)
+        Traceback (most recent call last):
+        ...
+        Bio.Seq.UndefinedSequenceError: Sequence content is undefined
+        """
+        if length is None:
+            if isinstance(data, (bytes, SequenceDataAbstractBaseClass)):
+                self._data = data
+            elif isinstance(data, (bytearray, Seq, MutableSeq)):
+                self._data = bytes(data)
+            elif isinstance(data, str):
+                self._data = bytes(data, encoding="ASCII")
+            else:
+                raise TypeError(
+                    "data should be a string, bytes, bytearray, Seq, or MutableSeq object"
+                )
+        else:
+            if data is not None:
+                raise ValueError("length should be None if data is None")
+            self._data = _UndefinedSequenceData(length)
+
+    def __hash__(self):
+        """Hash of the sequence as a string for comparison.
+
+        See Seq object comparison documentation (method ``__eq__`` in
+        particular) as this has changed in Biopython 1.65. Older versions
+        would hash on object identity.
+        """
+        return hash(self._data)
+
+    def tomutable(self):
+        """Return the full sequence as a MutableSeq object.
+
+        >>> from Bio.Seq import Seq
+        >>> my_seq = Seq("MKQHKAMIVALIVICITAVVAAL")
+        >>> my_seq
+        Seq('MKQHKAMIVALIVICITAVVAAL')
+        >>> my_seq.tomutable()
+        MutableSeq('MKQHKAMIVALIVICITAVVAAL')
+        """
+        warnings.warn(
+            "myseq.tomutable() is deprecated; please use MutableSeq(myseq) instead.",
+            BiopythonDeprecationWarning,
+        )
+        return MutableSeq(self)
 
     def encode(self, encoding="utf-8", errors="strict"):
         """Return an encoded version of the sequence as a bytes object.
@@ -1239,202 +1630,6 @@ class Seq:
         # Use -1 stride/step to reverse the complement
         return self.complement()[::-1]
 
-    def complement_rna(self):
-        """Complement of an RNA sequence.
-
-        >>> Seq("CGA").complement()  # defaults to DNA
-        Seq('GCT')
-        >>> Seq("CGA").complement_rna()
-        Seq('GCU')
-
-        Any T in the sequence is treated as a U:
-
-        >>> Seq("CGAUT").complement_rna()
-        Seq('GCUAA')
-        """
-        if isinstance(self._data, _UndefinedSequenceData):
-            # complement of an undefined sequence is an undefined sequence
-            # of the same length
-            return self
-        return Seq(self._data.translate(_rna_complement_table))
-
-    def reverse_complement_rna(self):
-        """Reverse complement of an RNA sequence.
-
-        >>> from Bio.Seq import Seq
-        >>> Seq("ACG").reverse_complement_rna()
-        Seq('CGU')
-        """
-        # Use -1 stride/step to reverse the complement
-        return self.complement_rna()[::-1]
-
-    def transcribe(self):
-        """Return the RNA sequence from a DNA sequence by creating a new Seq object.
-
-        >>> from Bio.Seq import Seq
-        >>> coding_dna = Seq("ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG")
-        >>> coding_dna
-        Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
-        >>> coding_dna.transcribe()
-        Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG')
-
-        Trying to transcribe an RNA sequence should have no effect.
-        If you have a nucleotide sequence which might be DNA or RNA
-        (or even a mixture), calling the transcribe method will ensure
-        any T becomes U.
-
-        Trying to transcribe a protein sequence will replace any
-        T for Threonine with U for Selenocysteine, which has no
-        biologically plausible rational. Older versions of Biopython
-        would throw an exception.
-
-        >>> from Bio.Seq import Seq
-        >>> my_protein = Seq("MAIVMGRT")
-        >>> my_protein.transcribe()
-        Seq('MAIVMGRU')
-        """
-        try:
-            data = self._data.replace(b"T", b"U").replace(b"t", b"u")
-        except UndefinedSequenceError:
-            # transcribing an undefined sequence yields an undefined sequence
-            # of the same length
-            return self
-        return Seq(data)
-
-    def back_transcribe(self):
-        """Return the DNA sequence from an RNA sequence by creating a new Seq object.
-
-        >>> from Bio.Seq import Seq
-        >>> messenger_rna = Seq("AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG")
-        >>> messenger_rna
-        Seq('AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG')
-        >>> messenger_rna.back_transcribe()
-        Seq('ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG')
-
-        Trying to back-transcribe DNA has no effect, If you have a nucleotide
-        sequence which might be DNA or RNA (or even a mixture), calling the
-        back-transcribe method will ensure any T becomes U.
-
-        Trying to back-transcribe a protein sequence will replace any U for
-        Selenocysteine with T for Threonine, which is biologically meaningless.
-        Older versions of Biopython would raise an exception here:
-
-        >>> from Bio.Seq import Seq
-        >>> my_protein = Seq("MAIVMGRU")
-        >>> my_protein.back_transcribe()
-        Seq('MAIVMGRT')
-        """
-        try:
-            data = self._data.replace(b"U", b"T").replace(b"u", b"t")
-        except UndefinedSequenceError:
-            # back-transcribing an undefined sequence yields an undefined
-            # sequence of the same length
-            return self
-        return Seq(data)
-
-    def translate(
-        self, table="Standard", stop_symbol="*", to_stop=False, cds=False, gap="-"
-    ):
-        """Turn a nucleotide sequence into a protein sequence by creating a new Seq object.
-
-        This method will translate DNA or RNA sequences. It should not
-        be used on protein sequences as any result will be biologically
-        meaningless.
-
-        Arguments:
-         - table - Which codon table to use?  This can be either a name
-           (string), an NCBI identifier (integer), or a CodonTable
-           object (useful for non-standard genetic codes).  This
-           defaults to the "Standard" table.
-         - stop_symbol - Single character string, what to use for
-           terminators.  This defaults to the asterisk, "*".
-         - to_stop - Boolean, defaults to False meaning do a full
-           translation continuing on past any stop codons (translated as the
-           specified stop_symbol).  If True, translation is terminated at
-           the first in frame stop codon (and the stop_symbol is not
-           appended to the returned protein sequence).
-         - cds - Boolean, indicates this is a complete CDS.  If True,
-           this checks the sequence starts with a valid alternative start
-           codon (which will be translated as methionine, M), that the
-           sequence length is a multiple of three, and that there is a
-           single in frame stop codon at the end (this will be excluded
-           from the protein sequence, regardless of the to_stop option).
-           If these tests fail, an exception is raised.
-         - gap - Single character string to denote symbol used for gaps.
-           Defaults to the minus sign.
-
-        e.g. Using the standard table:
-
-        >>> coding_dna = Seq("GTGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG")
-        >>> coding_dna.translate()
-        Seq('VAIVMGR*KGAR*')
-        >>> coding_dna.translate(stop_symbol="@")
-        Seq('VAIVMGR@KGAR@')
-        >>> coding_dna.translate(to_stop=True)
-        Seq('VAIVMGR')
-
-        Now using NCBI table 2, where TGA is not a stop codon:
-
-        >>> coding_dna.translate(table=2)
-        Seq('VAIVMGRWKGAR*')
-        >>> coding_dna.translate(table=2, to_stop=True)
-        Seq('VAIVMGRWKGAR')
-
-        In fact, GTG is an alternative start codon under NCBI table 2, meaning
-        this sequence could be a complete CDS:
-
-        >>> coding_dna.translate(table=2, cds=True)
-        Seq('MAIVMGRWKGAR')
-
-        It isn't a valid CDS under NCBI table 1, due to both the start codon
-        and also the in frame stop codons:
-
-        >>> coding_dna.translate(table=1, cds=True)
-        Traceback (most recent call last):
-            ...
-        Bio.Data.CodonTable.TranslationError: First codon 'GTG' is not a start codon
-
-        If the sequence has no in-frame stop codon, then the to_stop argument
-        has no effect:
-
-        >>> coding_dna2 = Seq("TTGGCCATTGTAATGGGCCGC")
-        >>> coding_dna2.translate()
-        Seq('LAIVMGR')
-        >>> coding_dna2.translate(to_stop=True)
-        Seq('LAIVMGR')
-
-        NOTE - Ambiguous codons like "TAN" or "NNN" could be an amino acid
-        or a stop codon.  These are translated as "X".  Any invalid codon
-        (e.g. "TA?" or "T-A") will throw a TranslationError.
-
-        NOTE - This does NOT behave like the python string's translate
-        method.  For that use str(my_seq).translate(...) instead
-        """
-        if isinstance(table, str) and len(table) == 256:
-            raise ValueError(
-                "The Seq object translate method DOES NOT take "
-                "a 256 character string mapping table like "
-                "the python string object's translate method. "
-                "Use str(my_seq).translate(...) instead."
-            )
-        try:
-            data = str(self)
-        except UndefinedSequenceError:
-            # translating an undefined sequence yields an undefined
-            # sequence with the length divided by 3
-            n = len(self)
-            if n % 3 != 0:
-                warnings.warn(
-                    "Partial codon, len(sequence) not a multiple of three. "
-                    "This may become an error in future.",
-                    BiopythonWarning,
-                )
-            return Seq(None, n // 3)
-
-        return self.__class__(
-            _translate_str(data, table, stop_symbol, to_stop, cds, gap=gap)
-        )
-
     def ungap(self, gap="-"):
         """Return a copy of the sequence without the gap character(s).
 
@@ -1455,41 +1650,6 @@ class Seq:
             raise ValueError(f"Unexpected gap character, {gap!r}")
         gap = gap.encode("ASCII")
         return Seq(self._data.replace(gap, b""))
-
-    def join(self, other):
-        """Return a merge of the sequences in other, spaced by the sequence from self.
-
-        Accepts either a Seq or string (and iterates over the letters), or an
-        iterable containing Seq or string objects. These arguments will be
-        concatenated with the calling sequence as the spacer:
-
-        >>> concatenated = Seq('NNNNN').join([Seq("AAA"), Seq("TTT"), Seq("PPP")])
-        >>> concatenated
-        Seq('AAANNNNNTTTNNNNNPPP')
-
-        Joining the letters of a single sequence:
-
-        >>> Seq('NNNNN').join(Seq("ACGT"))
-        Seq('ANNNNNCNNNNNGNNNNNT')
-        >>> Seq('NNNNN').join("ACGT")
-        Seq('ANNNNNCNNNNNGNNNNNT')
-        """
-        if isinstance(other, (Seq, MutableSeq)):
-            return self.__class__(str(self).join(str(other)))
-        elif isinstance(other, str):
-            return self.__class__(str(self).join(other))
-
-        from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
-
-        if isinstance(other, SeqRecord):
-            raise TypeError("Iterable cannot be a SeqRecord")
-
-        for c in other:
-            if isinstance(c, SeqRecord):
-                raise TypeError("Iterable cannot contain SeqRecords")
-            elif not isinstance(c, (str, Seq, MutableSeq)):
-                raise TypeError("Input must be an iterable of Seqs or Strings")
-        return self.__class__(str(self).join([str(_) for _ in other]))
 
 
 class UnknownSeq(Seq):
@@ -2063,7 +2223,7 @@ class UnknownSeq(Seq):
         return Seq(temp_data)
 
 
-class MutableSeq:
+class MutableSeq(_SeqAbstractBaseClass):
     """An editable sequence object.
 
     Unlike normal python strings and our basic sequence object (the Seq class)
@@ -2144,121 +2304,6 @@ class MutableSeq:
         )
         self.__init__(value)
 
-    def __bytes__(self):
-        return bytes(self._data)
-
-    def __repr__(self):
-        """Return (truncated) representation of the sequence for debugging."""
-        data = self._data
-        if len(data) > 60:
-            # Shows the last three letters as it is often useful to see if
-            # there is a stop codon at the end of a sequence.
-            # Note total length is 54+3+3=60
-            start = data[:54].decode("ASCII")
-            end = data[-3:].decode("ASCII")
-            return f"{self.__class__.__name__}('{start}...{end}')"
-        else:
-            data = data.decode("ASCII")
-            return f"{self.__class__.__name__}('{data}')"
-
-    def __str__(self):
-        """Return the full sequence as a python string.
-
-        Note that Biopython 1.44 and earlier would give a truncated
-        version of repr(my_seq) for str(my_seq).  If you are writing code
-        which needs to be backwards compatible with old Biopython, you
-        should continue to use my_seq.tostring() rather than str(my_seq).
-        """
-        return self._data.decode("ASCII")
-
-    def __eq__(self, other):
-        """Compare the sequence to another sequence or a string.
-
-        Historically comparing DNA to RNA, or Nucleotide to Protein would
-        raise an exception. This was later downgraded to a warning, but since
-        Biopython 1.78 the alphabet is ignored for comparisons.
-
-        If you need to support older Biopython versions, please just do
-        explicit comparisons:
-
-        >>> seq1 = MutableSeq("ACGT")
-        >>> seq2 = MutableSeq("ACGT")
-        >>> id(seq1) == id(seq2)
-        False
-        >>> str(seq1) == str(seq2)
-        True
-
-        Biopython now does:
-
-        >>> seq1 == seq2
-        True
-        >>> seq1 == Seq("ACGT")
-        True
-        >>> seq1 == "ACGT"
-        True
-
-        """
-        if isinstance(other, (Seq, MutableSeq)):
-            return self._data == other._data
-        elif isinstance(other, str):
-            return self._data == other.encode("ASCII")
-        else:
-            return self._data == other
-
-    def __lt__(self, other):
-        """Implement the less-than operand."""
-        if isinstance(other, (Seq, MutableSeq)):
-            return self._data < other._data
-        elif isinstance(other, str):
-            return self._data < other.encode("ASCII")
-        else:
-            return self._data < other
-
-    def __le__(self, other):
-        """Implement the less-than or equal operand."""
-        if isinstance(other, (Seq, MutableSeq)):
-            return self._data <= other._data
-        elif isinstance(other, str):
-            return self._data <= other.encode("ASCII")
-        else:
-            return self._data <= other
-
-    def __gt__(self, other):
-        """Implement the greater-than operand."""
-        if isinstance(other, (Seq, MutableSeq)):
-            return self._data > other._data
-        elif isinstance(other, str):
-            return self._data > other.encode("ASCII")
-        else:
-            return self._data > other
-
-    def __ge__(self, other):
-        """Implement the greater-than or equal operand."""
-        if isinstance(other, (Seq, MutableSeq)):
-            return self._data >= other._data
-        elif isinstance(other, str):
-            return self._data >= other.encode("ASCII")
-        else:
-            return self._data >= other
-
-    def __len__(self):
-        """Return the length of the sequence, use len(my_seq)."""
-        return len(self._data)
-
-    def __getitem__(self, index):
-        """Return a subsequence of single letter, use my_seq[index].
-
-        >>> my_seq = MutableSeq('ACTCGACGTCG')
-        >>> my_seq[5]
-        'A'
-        """
-        if isinstance(index, int):
-            # Return a single letter as a string
-            return chr(self._data[index])
-        else:
-            # Return the (sub)sequence as another Seq object
-            return self.__class__(self._data[index])
-
     def __setitem__(self, index, value):
         """Set a subsequence of single letter via value parameter.
 
@@ -2291,79 +2336,6 @@ class MutableSeq:
         """
         # Could be deleting a single letter, or a slice
         del self._data[index]
-
-    def __add__(self, other):
-        """Add another sequence or string to this sequence.
-
-        Returns a new MutableSeq object.
-        """
-        if isinstance(other, (Seq, MutableSeq)):
-            return self.__class__(self._data + other._data)
-        elif isinstance(other, str):
-            return self.__class__(self._data + other.encode("ASCII"))
-
-        from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
-
-        if isinstance(other, SeqRecord):
-            # Get the SeqRecord's __radd__ to handle this
-            return NotImplemented
-        else:
-            raise TypeError
-
-    def __radd__(self, other):
-        """Add a sequence on the left.
-
-        >>> from Bio.Seq import MutableSeq
-        >>> "LV" + MutableSeq("MELKI")
-        MutableSeq('LVMELKI')
-        """
-        if isinstance(other, (Seq, MutableSeq)):
-            return self.__class__(other._data + self._data)
-        elif isinstance(other, str):
-            return self.__class__(other.encode("ASCII") + self._data)
-        else:
-            raise TypeError
-
-    def __mul__(self, other):
-        """Multiply MutableSeq by integer.
-
-        Note this is not in-place and returns a new object,
-        matching native Python list multiplication.
-
-        >>> from Bio.Seq import MutableSeq
-        >>> MutableSeq('ATG') * 2
-        MutableSeq('ATGATG')
-        """
-        if not isinstance(other, int):
-            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(self._data * other)
-
-    def __rmul__(self, other):
-        """Multiply integer by MutableSeq.
-
-        Note this is not in-place and returns a new object,
-        matching native Python list multiplication.
-
-        >>> from Bio.Seq import MutableSeq
-        >>> 2 * MutableSeq('ATG')
-        MutableSeq('ATGATG')
-        """
-        if not isinstance(other, int):
-            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(self._data * other)
-
-    def __imul__(self, other):
-        """Multiply MutableSeq in-place.
-
-        >>> from Bio.Seq import MutableSeq
-        >>> seq = MutableSeq('ATG')
-        >>> seq *= 2
-        >>> seq
-        MutableSeq('ATGATG')
-        """
-        if not isinstance(other, int):
-            raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(self._data * other)
 
     def append(self, c):
         """Add a subsequence to the mutable sequence object.
@@ -2429,704 +2401,6 @@ class MutableSeq:
             self._data.remove(codepoint)
         except ValueError:
             raise ValueError("value not found in MutableSeq") from None
-
-    def count(self, sub, start=None, end=None):
-        """Return a non-overlapping count, like that of a python string.
-
-        This behaves like the python string method of the same name,
-        which does a non-overlapping count!
-
-        For an overlapping search use the newer count_overlap() method.
-
-        Returns an integer, the number of occurrences of substring
-        argument sub in the (sub)sequence given by [start:end].
-        Optional arguments start and end are interpreted as in slice
-        notation.
-
-        Arguments:
-         - sub - a string or another Seq object to look for
-         - start - optional integer, slice start
-         - end - optional integer, slice end
-
-        e.g.
-
-        >>> from Bio.Seq import MutableSeq
-        >>> my_mseq = MutableSeq("AAAATGA")
-        >>> print(my_mseq.count("A"))
-        5
-        >>> print(my_mseq.count("ATG"))
-        1
-        >>> print(my_mseq.count(Seq("AT")))
-        1
-        >>> print(my_mseq.count("AT", 2, -1))
-        1
-
-        HOWEVER, please note because that python strings, Seq objects and
-        MutableSeq objects do a non-overlapping search, this may not give
-        the answer you expect:
-
-        >>> "AAAA".count("AA")
-        2
-        >>> print(MutableSeq("AAAA").count("AA"))
-        2
-
-        An overlapping search would give the answer as three!
-        """
-        if isinstance(sub, MutableSeq):
-            sub = sub._data
-        elif isinstance(sub, Seq):
-            sub = bytes(sub)
-        elif isinstance(sub, str):
-            sub = sub.encode("ASCII")
-        elif not isinstance(sub, (bytes, bytearray)):
-            raise TypeError(
-                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
-                % type(sub)
-            )
-        return self._data.count(sub, start, end)
-
-    def count_overlap(self, sub, start=None, end=None):
-        """Return an overlapping count.
-
-        For a non-overlapping search use the count() method.
-
-        Returns an integer, the number of occurrences of substring
-        argument sub in the (sub)sequence given by [start:end].
-        Optional arguments start and end are interpreted as in slice
-        notation.
-
-        Arguments:
-         - sub - a string or another Seq object to look for
-         - start - optional integer, slice start
-         - end - optional integer, slice end
-
-        e.g.
-
-        >>> from Bio.Seq import MutableSeq
-        >>> print(MutableSeq("AAAA").count_overlap("AA"))
-        3
-        >>> print(MutableSeq("ATATATATA").count_overlap("ATA"))
-        4
-        >>> print(MutableSeq("ATATATATA").count_overlap("ATA", 3, -1))
-        1
-
-        Where substrings do not overlap, should behave the same as
-        the count() method:
-
-        >>> from Bio.Seq import MutableSeq
-        >>> my_mseq = MutableSeq("AAAATGA")
-        >>> print(my_mseq.count_overlap("A"))
-        5
-        >>> my_mseq.count_overlap("A") == my_mseq.count("A")
-        True
-        >>> print(my_mseq.count_overlap("ATG"))
-        1
-        >>> my_mseq.count_overlap("ATG") == my_mseq.count("ATG")
-        True
-        >>> print(my_mseq.count_overlap(Seq("AT")))
-        1
-        >>> my_mseq.count_overlap(Seq("AT")) == my_mseq.count(Seq("AT"))
-        True
-        >>> print(my_mseq.count_overlap("AT", 2, -1))
-        1
-        >>> my_mseq.count_overlap("AT", 2, -1) == my_mseq.count("AT", 2, -1)
-        True
-
-        HOWEVER, do not use this method for such cases because the
-        count() method is much for efficient.
-        """
-        if isinstance(sub, MutableSeq):
-            sub = sub._data
-        elif isinstance(sub, Seq):
-            sub = bytes(sub)
-        elif isinstance(sub, str):
-            sub = sub.encode("ASCII")
-        elif not isinstance(sub, (bytes, bytearray)):
-            raise TypeError(
-                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
-                % type(sub)
-            )
-        data = self._data
-        overlap_count = 0
-        while True:
-            start = data.find(sub, start, end) + 1
-            if start != 0:
-                overlap_count += 1
-            else:
-                return overlap_count
-
-    def __contains__(self, item):
-        """Implement the 'in' keyword, like a python string.
-
-        e.g.
-
-        >>> from Bio.Seq import MutableSeq
-        >>> my_dna = MutableSeq("ATATGAAATTTGAAAA")
-        >>> "AAA" in my_dna
-        True
-        >>> MutableSeq("AAA") in my_dna
-        True
-        """
-        if isinstance(item, (Seq, MutableSeq)):
-            item = bytes(item)
-        elif isinstance(item, str):
-            item = item.encode("ASCII")
-        return item in self._data
-
-    def find(self, sub, start=None, end=None):
-        """Find method, like that of a python string.
-
-        This behaves like the python string method of the same name.
-
-        Returns an integer, the index of the first occurrence of substring
-        argument sub in the (sub)sequence given by [start:end].
-
-        Arguments:
-         - sub - a string or another Seq or MutableSeq object to look for
-         - start - optional integer, slice start
-         - end - optional integer, slice end
-
-        Returns -1 if the subsequence is NOT found.
-
-        e.g. Locating the first typical start codon, AUG, in an RNA sequence:
-
-        >>> from Bio.Seq import MutableSeq
-        >>> my_rna = MutableSeq("GUCAUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAGUUG")
-        >>> my_rna.find("AUG")
-        3
-        """
-        if isinstance(sub, (Seq, MutableSeq)):
-            sub = bytes(sub)
-        elif isinstance(sub, str):
-            sub = sub.encode("ASCII")
-        elif not isinstance(sub, (bytes, bytearray)):
-            raise TypeError(
-                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
-                % type(sub)
-            )
-        return self._data.find(sub, start, end)
-
-    def rfind(self, sub, start=None, end=None):
-        """Find from right method, like that of a python string.
-
-        This behaves like the python string method of the same name.
-
-        Returns an integer, the index of the last (right most) occurrence of
-        substring argument sub in the (sub)sequence given by [start:end].
-
-        Arguments:
-         - sub - a string or another Seq or MutablSeq object to look for
-         - start - optional integer, slice start
-         - end - optional integer, slice end
-
-        Returns -1 if the subsequence is NOT found.
-
-        e.g. Locating the last typical start codon, AUG, in an RNA sequence:
-
-        >>> from Bio.Seq import MutableSeq
-        >>> my_rna = MutableSeq("GUCAUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAGUUG")
-        >>> my_rna.rfind("AUG")
-        15
-        """
-        if isinstance(sub, (Seq, MutableSeq)):
-            sub = bytes(sub)
-        elif isinstance(sub, str):
-            sub = sub.encode("ASCII")
-        elif not isinstance(sub, (bytes, bytearray)):
-            raise TypeError(
-                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
-                % type(sub)
-            )
-        return self._data.rfind(sub, start, end)
-
-    def index(self, sub, start=None, end=None):
-        """Return first occurrence position of a single entry (i.e. letter).
-
-        >>> my_seq = MutableSeq("ACTCGACGTCG")
-        >>> my_seq.index("A")
-        0
-        >>> my_seq.index("T")
-        2
-        >>> my_seq.index(Seq("T"))
-        2
-        """
-        if isinstance(sub, MutableSeq):
-            sub = sub._data
-        elif isinstance(sub, Seq):
-            sub = bytes(sub)
-        elif isinstance(sub, str):
-            sub = sub.encode("ASCII")
-        elif not isinstance(sub, (bytes, bytearray)):
-            raise TypeError(
-                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
-                % type(sub)
-            )
-        return self._data.index(sub, start, end)
-
-    def rindex(self, sub, start=None, end=None):
-        """Like rfind() but raise ValueError when the substring is not found."""
-        if isinstance(sub, MutableSeq):
-            sub = sub._data
-        elif isinstance(sub, Seq):
-            sub = bytes(sub)
-        elif isinstance(sub, str):
-            sub = sub.encode("ASCII")
-        elif not isinstance(sub, (bytes, bytearray)):
-            raise TypeError(
-                "a Seq, MutableSeq, str, bytes, or bytearray object is required, not '%s'"
-                % type(sub)
-            )
-        return self._data.rindex(sub, start, end)
-
-    def startswith(self, prefix, start=None, end=None):
-        """Return True if the MutableSeq starts with the given prefix, False otherwise.
-
-        This behaves like the python string method of the same name.
-
-        Return True if the sequence starts with the specified prefix
-        (a string or another Seq object), False otherwise.
-        With optional start, test sequence beginning at that position.
-        With optional end, stop comparing sequence at that position.
-        prefix can also be a tuple of strings to try.  e.g.
-
-        >>> from Bio.Seq import MutableSeq
-        >>> my_rna = MutableSeq("GUCAUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAGUUG")
-        >>> my_rna.startswith("GUC")
-        True
-        >>> my_rna.startswith("AUG")
-        False
-        >>> my_rna.startswith("AUG", 3)
-        True
-        >>> my_rna.startswith(("UCC", "UCA", "UCG"), 1)
-        True
-        """
-        if isinstance(prefix, tuple):
-            prefix = tuple(
-                bytes(p) if isinstance(p, (Seq, MutableSeq)) else p.encode("ASCII")
-                for p in prefix
-            )
-        elif isinstance(prefix, (Seq, MutableSeq)):
-            prefix = bytes(prefix)
-        elif isinstance(prefix, str):
-            prefix = prefix.encode("ASCII")
-        return self._data.startswith(prefix, start, end)
-
-    def endswith(self, suffix, start=None, end=None):
-        """Return True if the MutableSeq ends with the given suffix, False otherwise.
-
-        This behaves like the python string method of the same name.
-
-        Return True if the sequence ends with the specified suffix
-        (a string or another Seq object), False otherwise.
-        With optional start, test sequence beginning at that position.
-        With optional end, stop comparing sequence at that position.
-        suffix can also be a tuple of strings to try.  e.g.
-
-        >>> from Bio.Seq import MutableSeq
-        >>> my_rna = MutableSeq("GUCAUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAGUUG")
-        >>> my_rna.endswith("UUG")
-        True
-        >>> my_rna.endswith("AUG")
-        False
-        >>> my_rna.endswith("AUG", 0, 18)
-        True
-        >>> my_rna.endswith(("UCC", "UCA", "UUG"))
-        True
-        """
-        if isinstance(suffix, tuple):
-            suffix = tuple(
-                bytes(p) if isinstance(p, (Seq, MutableSeq)) else p.encode("ASCII")
-                for p in suffix
-            )
-        elif isinstance(suffix, (Seq, MutableSeq)):
-            suffix = bytes(suffix)
-        elif isinstance(suffix, str):
-            suffix = suffix.encode("ASCII")
-        return self._data.endswith(suffix, start, end)
-
-    def split(self, sep=None, maxsplit=-1):
-        """Split method, like that of a python string.
-
-        This behaves like the python string method of the same name.
-
-        Return a list of the 'words' in the string (as MutableSeq objects),
-        using sep as the delimiter string.  If maxsplit is given, at
-        most maxsplit splits are done.  If maxsplit is omitted, all
-        splits are made.
-
-        Following the python string method, sep will by default be any
-        white space (tabs, spaces, newlines) but this is unlikely to
-        apply to biological sequences.
-
-        e.g.
-
-        >>> from Bio.Seq import MutableSeq
-        >>> my_rna = MutableSeq("GUCAUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAGUUG")
-        >>> my_aa = my_rna.translate()
-        >>> my_aa
-        MutableSeq('VMAIVMGR*KGAR*L')
-        >>> for pep in my_aa.split("*"):
-        ...     pep
-        MutableSeq('VMAIVMGR')
-        MutableSeq('KGAR')
-        MutableSeq('L')
-        >>> for pep in my_aa.split("*", 1):
-        ...     pep
-        MutableSeq('VMAIVMGR')
-        MutableSeq('KGAR*L')
-
-        See also the rsplit method:
-
-        >>> for pep in my_aa.rsplit("*", 1):
-        ...     pep
-        MutableSeq('VMAIVMGR*KGAR')
-        MutableSeq('L')
-        """
-        if isinstance(sep, (Seq, MutableSeq)):
-            sep = bytes(sep)
-        elif isinstance(sep, str):
-            sep = sep.encode("ASCII")
-        return [self.__class__(part) for part in self._data.split(sep, maxsplit)]
-
-    def rsplit(self, sep=None, maxsplit=-1):
-        """Do a right split method, like that of a python string.
-
-        This behaves like the python string method of the same name.
-
-        Return a list of the 'words' in the string (as MutableSeq objects),
-        using sep as the delimiter string.  If maxsplit is given, at
-        most maxsplit splits are done COUNTING FROM THE RIGHT.
-        If maxsplit is omitted, all splits are made.
-
-        Following the python string method, sep will by default be any
-        white space (tabs, spaces, newlines) but this is unlikely to
-        apply to biological sequences.
-
-        e.g. print(my_seq.rsplit("*",1))
-
-        See also the split method.
-        """
-        if isinstance(sep, (Seq, MutableSeq)):
-            sep = bytes(sep)
-        elif isinstance(sep, str):
-            sep = sep.encode("ASCII")
-        return [self.__class__(part) for part in self._data.rsplit(sep, maxsplit)]
-
-    def strip(self, chars=None, inplace=False):
-        """Return a MutableSeq object with leading and trailing ends stripped.
-
-        This behaves like the python string method of the same name.
-
-        A copy of the sequence is returned if ``inplace`` is `False` (the
-        default value). If ``inplace`` is `True`, the sequence is stripped
-        in-place and returned:
-
-        >>> seq = MutableSeq("ACGT ")
-        >>> seq.strip()
-        MutableSeq('ACGT')
-        >>> seq
-        MutableSeq('ACGT ')
-        >>> seq.strip(inplace=True)
-        MutableSeq('ACGT')
-        >>> seq
-        MutableSeq('ACGT')
-
-        Optional argument chars defines which characters to remove.  If
-        omitted or None (default) then as for the python string method,
-        this defaults to removing any white space.
-
-        e.g.
-
-        >>> MutableSeq("ACGT ").strip()
-        MutableSeq('ACGT')
-        >>> MutableSeq("ACGT ").strip(" ")
-        MutableSeq('ACGT')
-
-        Just like the Python string, the order of the characters to be
-        removed is not important:
-
-        >>> MutableSeq("ACGTACGT").strip("TGCA")
-        MutableSeq('')
-
-        As with the Python string, an inappropriate argument
-        will give a TypeError:
-
-        >>> MutableSeq("ACGT ").strip(7)
-        Traceback (most recent call last):
-           ...
-        TypeError: argument must be None or a string, Seq, MutableSeq, or bytes-like object
-
-        See also the lstrip and rstrip methods.
-        """
-        if isinstance(chars, (Seq, MutableSeq)):
-            chars = bytes(chars)
-        elif isinstance(chars, str):
-            chars = chars.encode("ASCII")
-        try:
-            data = self._data.strip(chars)
-        except TypeError:
-            raise TypeError(
-                "argument must be None or a string, Seq, MutableSeq, or bytes-like object"
-            ) from None
-        if inplace:
-            self._data[:] = data
-            return self
-        else:
-            return MutableSeq(data)
-
-    def lstrip(self, chars=None, inplace=False):
-        """Return a MutableSeq object with leading (left) end stripped.
-
-        This behaves like the python string method of the same name.
-
-        A copy of the sequence is returned if ``inplace`` is `False` (the
-        default value). If ``inplace`` is `True`, the sequence is stripped
-        in-place and returned:
-
-        >>> seq = MutableSeq(" ACGT ")
-        >>> seq.lstrip()
-        MutableSeq('ACGT ')
-        >>> seq
-        MutableSeq(' ACGT ')
-        >>> seq.lstrip(inplace=True)
-        MutableSeq('ACGT ')
-        >>> seq
-        MutableSeq('ACGT ')
-
-        Optional argument chars defines which characters to remove.  If
-        omitted or None (default) then as for the python string method,
-        this defaults to removing any white space.
-
-        >>> MutableSeq("AAACGTA").lstrip("A")
-        MutableSeq('CGTA')
-
-        See also the strip and rstrip methods.
-        """
-        if isinstance(chars, (Seq, MutableSeq)):
-            chars = bytes(chars)
-        elif isinstance(chars, str):
-            chars = chars.encode("ASCII")
-        try:
-            data = self._data.lstrip(chars)
-        except TypeError:
-            raise TypeError(
-                "argument must be None or a string, Seq, MutableSeq, or bytes-like object"
-            ) from None
-        if inplace:
-            self._data[:] = data
-            return self
-        else:
-            return MutableSeq(data)
-
-    def rstrip(self, chars=None, inplace=False):
-        """Return a MutableSeq object with trailing (right) end stripped.
-
-        This behaves like the python string method of the same name.
-
-        A copy of the sequence is returned if ``inplace`` is `False` (the
-        default value). If ``inplace`` is `True`, the sequence is stripped
-        in-place and returned:
-
-        >>> seq = MutableSeq(" ACGT ")
-        >>> seq.rstrip()
-        MutableSeq(' ACGT')
-        >>> seq
-        MutableSeq(' ACGT ')
-        >>> seq.rstrip(inplace=True)
-        MutableSeq(' ACGT')
-        >>> seq
-        MutableSeq(' ACGT')
-
-        Optional argument chars defines which characters to remove.  If
-        omitted or None (default) then as for the python string method,
-        this defaults to removing any white space.
-
-        e.g. Removing a nucleotide sequence's polyadenylation (poly-A tail):
-
-        >>> from Bio.Seq import MutableSeq
-        >>> my_seq = MutableSeq("CGGTACGCTTATGTCACGTAGAAAAAA")
-        >>> my_seq
-        MutableSeq('CGGTACGCTTATGTCACGTAGAAAAAA')
-        >>> my_seq.rstrip("A")
-        MutableSeq('CGGTACGCTTATGTCACGTAG')
-
-        See also the strip and lstrip methods.
-        """
-        if isinstance(chars, (Seq, MutableSeq)):
-            chars = bytes(chars)
-        elif isinstance(chars, str):
-            chars = chars.encode("ASCII")
-        try:
-            data = self._data.rstrip(chars)
-        except TypeError:
-            raise TypeError(
-                "argument must be None or a string, Seq, MutableSeq, or bytes-like object"
-            ) from None
-        if inplace:
-            self._data[:] = data
-            return self
-        else:
-            return MutableSeq(data)
-
-    def upper(self, inplace=False):
-        """Return the sequence in upper case.
-
-        An upper-case copy of the sequence is returned if inplace is False,
-        the default value:
-
-        >>> from Bio.Seq import MutableSeq
-        >>> my_seq = MutableSeq("VHLTPeeK*")
-        >>> my_seq
-        MutableSeq('VHLTPeeK*')
-        >>> my_seq.lower()
-        MutableSeq('vhltpeek*')
-        >>> my_seq.upper()
-        MutableSeq('VHLTPEEK*')
-        >>> my_seq
-        MutableSeq('VHLTPeeK*')
-
-        The sequence is modified in-place and returned if inplace is True:
-
-        >>> my_seq.lower(inplace=True)
-        MutableSeq('vhltpeek*')
-        >>> my_seq
-        MutableSeq('vhltpeek*')
-        >>> my_seq.upper(inplace=True)
-        MutableSeq('VHLTPEEK*')
-        >>> my_seq
-        MutableSeq('VHLTPEEK*')
-        """
-        data = self._data.upper()
-        if inplace:
-            self._data[:] = data
-            return self
-        else:
-            return MutableSeq(data)
-
-    def lower(self, inplace=False):
-        """Return the sequence in lower case.
-
-        A lower-case copy of the sequence is returned if inplace is False,
-        the default value:
-
-        >>> from Bio.Seq import MutableSeq
-        >>> my_seq = MutableSeq("VHLTPeeK*")
-        >>> my_seq
-        MutableSeq('VHLTPeeK*')
-        >>> my_seq.lower()
-        MutableSeq('vhltpeek*')
-        >>> my_seq.upper()
-        MutableSeq('VHLTPEEK*')
-        >>> my_seq
-        MutableSeq('VHLTPeeK*')
-
-        The sequence is modified in-place and returned if inplace is True:
-
-        >>> my_seq.lower(inplace=True)
-        MutableSeq('vhltpeek*')
-        >>> my_seq
-        MutableSeq('vhltpeek*')
-        >>> my_seq.upper(inplace=True)
-        MutableSeq('VHLTPEEK*')
-        >>> my_seq
-        MutableSeq('VHLTPEEK*')
-        """
-        data = self._data.lower()
-        if inplace:
-            self._data[:] = data
-            return self
-        else:
-            return MutableSeq(data)
-
-    def translate(
-        self, table="Standard", stop_symbol="*", to_stop=False, cds=False, gap="-"
-    ):
-        """Turn a nucleotide sequence into a protein sequence by creating a new MutableSeq object.
-
-        This method will translate DNA or RNA sequences. It should not
-        be used on protein sequences as any result will be biologically
-        meaningless.
-
-        Arguments:
-         - table - Which codon table to use?  This can be either a name
-           (string), an NCBI identifier (integer), or a CodonTable
-           object (useful for non-standard genetic codes).  This
-           defaults to the "Standard" table.
-         - stop_symbol - Single character string, what to use for
-           terminators.  This defaults to the asterisk, "*".
-         - to_stop - Boolean, defaults to False meaning do a full
-           translation continuing on past any stop codons (translated as the
-           specified stop_symbol).  If True, translation is terminated at
-           the first in frame stop codon (and the stop_symbol is not
-           appended to the returned protein sequence).
-         - cds - Boolean, indicates this is a complete CDS.  If True,
-           this checks the sequence starts with a valid alternative start
-           codon (which will be translated as methionine, M), that the
-           sequence length is a multiple of three, and that there is a
-           single in frame stop codon at the end (this will be excluded
-           from the protein sequence, regardless of the to_stop option).
-           If these tests fail, an exception is raised.
-         - gap - Single character string to denote symbol used for gaps.
-           Defaults to the minus sign.
-
-        e.g. Using the standard table:
-
-        >>> coding_dna = MutableSeq("GTGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG")
-        >>> coding_dna.translate()
-        MutableSeq('VAIVMGR*KGAR*')
-        >>> coding_dna.translate(stop_symbol="@")
-        MutableSeq('VAIVMGR@KGAR@')
-        >>> coding_dna.translate(to_stop=True)
-        MutableSeq('VAIVMGR')
-
-        Now using NCBI table 2, where TGA is not a stop codon:
-
-        >>> coding_dna.translate(table=2)
-        MutableSeq('VAIVMGRWKGAR*')
-        >>> coding_dna.translate(table=2, to_stop=True)
-        MutableSeq('VAIVMGRWKGAR')
-
-        In fact, GTG is an alternative start codon under NCBI table 2, meaning
-        this sequence could be a complete CDS:
-
-        >>> coding_dna.translate(table=2, cds=True)
-        MutableSeq('MAIVMGRWKGAR')
-
-        It isn't a valid CDS under NCBI table 1, due to both the start codon
-        and also the in frame stop codons:
-
-        >>> coding_dna.translate(table=1, cds=True)
-        Traceback (most recent call last):
-            ...
-        Bio.Data.CodonTable.TranslationError: First codon 'GTG' is not a start codon
-
-        If the sequence has no in-frame stop codon, then the to_stop argument
-        has no effect:
-
-        >>> coding_dna2 = MutableSeq("TTGGCCATTGTAATGGGCCGC")
-        >>> coding_dna2.translate()
-        MutableSeq('LAIVMGR')
-        >>> coding_dna2.translate(to_stop=True)
-        MutableSeq('LAIVMGR')
-
-        NOTE - Ambiguous codons like "TAN" or "NNN" could be an amino acid
-        or a stop codon.  These are translated as "X".  Any invalid codon
-        (e.g. "TA?" or "T-A") will throw a TranslationError.
-
-        NOTE - This does NOT behave like the python string's translate
-        method.  For that use str(my_seq).translate(...) instead
-        """
-        if isinstance(table, str) and len(table) == 256:
-            raise ValueError(
-                "The MutableSeq object translate method DOES NOT "
-                "take a 256 character string mapping table like "
-                "the python string object's translate method. "
-                "Use str(my_seq).translate(...) instead."
-            )
-
-        return self.__class__(
-            _translate_str(str(self), table, stop_symbol, to_stop, cds, gap=gap)
-        )
 
     def reverse(self):
         """Modify the mutable sequence to reverse itself.
@@ -3198,21 +2472,6 @@ class MutableSeq:
             BiopythonDeprecationWarning,
         )
         return Seq(self)
-
-    def join(self, other):
-        """Return a merge of the sequences in other, spaced by the sequence from self.
-
-        Accepts all Seq objects and Strings as objects to be concatenated with the spacer
-
-        >>> concatenated = MutableSeq('NNNNN').join([Seq("AAA"), Seq("TTT"), Seq("PPP")])
-        >>> concatenated
-        Seq('AAANNNNNTTTNNNNNPPP')
-
-        Throws error if other is not an iterable and if objects inside of the iterable
-        are not Seq or String objects
-        """
-        # returns Seq object instead of MutableSeq
-        return Seq(self).join(other)
 
 
 class UndefinedSequenceError(ValueError):

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -284,7 +284,7 @@ class SequenceDataAbstractBaseClass(ABC):
 
 
 class _SeqAbstractBaseClass(ABC):
-    """Abstract base class for the Seq and MutableSeq classes (PRIVATE)
+    """Abstract base class for the Seq and MutableSeq classes (PRIVATE).
 
     Most users will not need to use this class. It is used internally as an
     abstract base class for Seq and MutableSeq, as most of their methods are
@@ -923,11 +923,13 @@ class _SeqAbstractBaseClass(ABC):
         Seq('VMAIVMGR*KGAR*L')
         >>> for pep in my_aa.split("*"):
         ...     pep
+        ...
         Seq('VMAIVMGR')
         Seq('KGAR')
         Seq('L')
         >>> for pep in my_aa.split("*", 1):
         ...     pep
+        ...
         Seq('VMAIVMGR')
         Seq('KGAR*L')
 
@@ -936,6 +938,7 @@ class _SeqAbstractBaseClass(ABC):
 
         >>> for pep in my_aa.rsplit("*", 1):
         ...     pep
+        ...
         Seq('VMAIVMGR*KGAR')
         Seq('L')
         """
@@ -1607,7 +1610,9 @@ class _SeqAbstractBaseClass(ABC):
             if isinstance(c, SeqRecord):
                 raise TypeError("Iterable cannot contain SeqRecords")
             elif not isinstance(c, (str, Seq, MutableSeq)):
-                raise TypeError("Input must be an iterable of Seq objects, MutableSeq objects, or strings")
+                raise TypeError(
+                    "Input must be an iterable of Seq objects, MutableSeq objects, or strings"
+                )
         return self.__class__(str(self).join([str(_) for _ in other]))
 
     def replace(self, old, new, inplace=False):

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -353,7 +353,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> seq1 == bytearray(b"ACGT")
         True
         """
-        if isinstance(other, (Seq, MutableSeq)):
+        if isinstance(other, _SeqAbstractBaseClass):
             return self._data == other._data
         elif isinstance(other, str):
             return self._data == other.encode("ASCII")
@@ -362,7 +362,7 @@ class _SeqAbstractBaseClass(ABC):
 
     def __lt__(self, other):
         """Implement the less-than operand."""
-        if isinstance(other, (Seq, MutableSeq)):
+        if isinstance(other, _SeqAbstractBaseClass):
             return self._data < other._data
         elif isinstance(other, str):
             return self._data < other.encode("ASCII")
@@ -371,7 +371,7 @@ class _SeqAbstractBaseClass(ABC):
 
     def __le__(self, other):
         """Implement the less-than or equal operand."""
-        if isinstance(other, (Seq, MutableSeq)):
+        if isinstance(other, _SeqAbstractBaseClass):
             return self._data <= other._data
         elif isinstance(other, str):
             return self._data <= other.encode("ASCII")
@@ -380,7 +380,7 @@ class _SeqAbstractBaseClass(ABC):
 
     def __gt__(self, other):
         """Implement the greater-than operand."""
-        if isinstance(other, (Seq, MutableSeq)):
+        if isinstance(other, _SeqAbstractBaseClass):
             return self._data > other._data
         elif isinstance(other, str):
             return self._data > other.encode("ASCII")
@@ -389,7 +389,7 @@ class _SeqAbstractBaseClass(ABC):
 
     def __ge__(self, other):
         """Implement the greater-than or equal operand."""
-        if isinstance(other, (Seq, MutableSeq)):
+        if isinstance(other, _SeqAbstractBaseClass):
             return self._data >= other._data
         elif isinstance(other, str):
             return self._data >= other.encode("ASCII")
@@ -434,7 +434,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> MutableSeq("MELKI") + "LV"
         MutableSeq('MELKILV')
         """
-        if isinstance(other, (Seq, MutableSeq)):
+        if isinstance(other, _SeqAbstractBaseClass):
             return self.__class__(self._data + other._data)
         elif isinstance(other, str):
             return self.__class__(self._data + other.encode("ASCII"))
@@ -656,7 +656,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> MutableSeq("AAA") in my_dna
         True
         """
-        if isinstance(item, (Seq, MutableSeq)):
+        if isinstance(item, _SeqAbstractBaseClass):
             item = bytes(item)
         elif isinstance(item, str):
             item = item.encode("ASCII")
@@ -689,7 +689,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> my_rna.find("AUG", 4)
         15
         """
-        if isinstance(sub, (Seq, MutableSeq)):
+        if isinstance(sub, _SeqAbstractBaseClass):
             sub = bytes(sub)
         elif isinstance(sub, str):
             sub = sub.encode("ASCII")
@@ -727,7 +727,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> my_rna.rfind("AUG", end=15)
         3
         """
-        if isinstance(sub, (Seq, MutableSeq)):
+        if isinstance(sub, _SeqAbstractBaseClass):
             sub = bytes(sub)
         elif isinstance(sub, str):
             sub = sub.encode("ASCII")
@@ -862,10 +862,10 @@ class _SeqAbstractBaseClass(ABC):
         """
         if isinstance(prefix, tuple):
             prefix = tuple(
-                bytes(p) if isinstance(p, (Seq, MutableSeq)) else p.encode("ASCII")
+                bytes(p) if isinstance(p, _SeqAbstractBaseClass) else p.encode("ASCII")
                 for p in prefix
             )
-        elif isinstance(prefix, (Seq, MutableSeq)):
+        elif isinstance(prefix, _SeqAbstractBaseClass):
             prefix = bytes(prefix)
         elif isinstance(prefix, str):
             prefix = prefix.encode("ASCII")
@@ -893,10 +893,10 @@ class _SeqAbstractBaseClass(ABC):
         """
         if isinstance(suffix, tuple):
             suffix = tuple(
-                bytes(p) if isinstance(p, (Seq, MutableSeq)) else p.encode("ASCII")
+                bytes(p) if isinstance(p, _SeqAbstractBaseClass) else p.encode("ASCII")
                 for p in suffix
             )
-        elif isinstance(suffix, (Seq, MutableSeq)):
+        elif isinstance(suffix, _SeqAbstractBaseClass):
             suffix = bytes(suffix)
         elif isinstance(suffix, str):
             suffix = suffix.encode("ASCII")
@@ -939,7 +939,7 @@ class _SeqAbstractBaseClass(ABC):
         Seq('VMAIVMGR*KGAR')
         Seq('L')
         """
-        if isinstance(sep, (Seq, MutableSeq)):
+        if isinstance(sep, _SeqAbstractBaseClass):
             sep = bytes(sep)
         elif isinstance(sep, str):
             sep = sep.encode("ASCII")
@@ -982,7 +982,7 @@ class _SeqAbstractBaseClass(ABC):
         Seq('VMAIVMGR')
         Seq('KGAR*L')
         """
-        if isinstance(sep, (Seq, MutableSeq)):
+        if isinstance(sep, _SeqAbstractBaseClass):
             sep = bytes(sep)
         elif isinstance(sep, str):
             sep = sep.encode("ASCII")
@@ -1024,7 +1024,7 @@ class _SeqAbstractBaseClass(ABC):
 
         See also the lstrip and rstrip methods.
         """
-        if isinstance(chars, (Seq, MutableSeq)):
+        if isinstance(chars, _SeqAbstractBaseClass):
             chars = bytes(chars)
         elif isinstance(chars, str):
             chars = chars.encode("ASCII")
@@ -1081,7 +1081,7 @@ class _SeqAbstractBaseClass(ABC):
 
         See also the strip and rstrip methods.
         """
-        if isinstance(chars, (Seq, MutableSeq)):
+        if isinstance(chars, _SeqAbstractBaseClass):
             chars = bytes(chars)
         elif isinstance(chars, str):
             chars = chars.encode("ASCII")
@@ -1138,7 +1138,7 @@ class _SeqAbstractBaseClass(ABC):
 
         See also the strip and lstrip methods.
         """
-        if isinstance(chars, (Seq, MutableSeq)):
+        if isinstance(chars, _SeqAbstractBaseClass):
             chars = bytes(chars)
         elif isinstance(chars, str):
             chars = chars.encode("ASCII")
@@ -1593,7 +1593,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> Seq('NNNNN').join("ACGT")
         Seq('ANNNNNCNNNNNGNNNNNT')
         """
-        if isinstance(other, (Seq, MutableSeq)):
+        if isinstance(other, _SeqAbstractBaseClass):
             return self.__class__(str(self).join(str(other)))
         elif isinstance(other, str):
             return self.__class__(str(self).join(other))
@@ -1606,7 +1606,7 @@ class _SeqAbstractBaseClass(ABC):
         for c in other:
             if isinstance(c, SeqRecord):
                 raise TypeError("Iterable cannot contain SeqRecords")
-            elif not isinstance(c, (str, Seq, MutableSeq)):
+            elif not isinstance(c, (str, _SeqAbstractBaseClass)):
                 raise TypeError(
                     "Input must be an iterable of Seq objects, MutableSeq objects, or strings"
                 )
@@ -1641,11 +1641,11 @@ class _SeqAbstractBaseClass(ABC):
         As ``Seq`` objects are immutable, a ``TypeError`` is raised if
         ``replace`` is called on a ``Seq`` object with ``inplace=True``.
         """
-        if isinstance(old, (Seq, MutableSeq)):
+        if isinstance(old, _SeqAbstractBaseClass):
             old = bytes(old)
         elif isinstance(old, str):
             old = old.encode("ASCII")
-        if isinstance(new, (Seq, MutableSeq)):
+        if isinstance(new, _SeqAbstractBaseClass):
             new = bytes(new)
         elif isinstance(new, str):
             new = new.encode("ASCII")
@@ -1712,7 +1712,7 @@ class Seq(_SeqAbstractBaseClass):
         if length is None:
             if isinstance(data, (bytes, SequenceDataAbstractBaseClass)):
                 self._data = data
-            elif isinstance(data, (bytearray, Seq, MutableSeq)):
+            elif isinstance(data, (bytearray, _SeqAbstractBaseClass)):
                 self._data = bytes(data)
             elif isinstance(data, str):
                 self._data = bytes(data, encoding="ASCII")
@@ -2162,7 +2162,7 @@ class UnknownSeq(Seq):
         >>> UnknownSeq(4, character="N").count("NNN")
         1
         """
-        if isinstance(sub, (Seq, MutableSeq)):
+        if isinstance(sub, _SeqAbstractBaseClass):
             sub = str(sub)
         elif not isinstance(sub, str):
             raise TypeError(
@@ -2213,7 +2213,7 @@ class UnknownSeq(Seq):
         >>> UnknownSeq(4, character="N").count_overlap("AA") == UnknownSeq(4, character="N").count("AA")
         True
         """
-        if isinstance(sub, (Seq, MutableSeq)):
+        if isinstance(sub, _SeqAbstractBaseClass):
             sub = str(sub)
         elif not isinstance(sub, str):
             raise TypeError(
@@ -2473,7 +2473,7 @@ class UnknownSeq(Seq):
         """
         from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
 
-        if isinstance(other, (str, Seq, MutableSeq)):
+        if isinstance(other, (str, _SeqAbstractBaseClass)):
             if isinstance(other, UnknownSeq) and self._character == other._character:
                 # Special case, can return an UnknownSeq
                 return self.__class__(
@@ -2486,7 +2486,7 @@ class UnknownSeq(Seq):
         for c in other:
             if isinstance(c, SeqRecord):
                 raise TypeError("Iterable cannot contain SeqRecords")
-            elif not isinstance(c, (str, Seq, MutableSeq)):
+            elif not isinstance(c, (str, _SeqAbstractBaseClass)):
                 raise TypeError("Input must be an iterable of Seqs or Strings")
         temp_data = str(self).join([str(_) for _ in other])
         if temp_data.count(self._character) == len(temp_data):

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -7,7 +7,7 @@
 #
 # This module is for reading and writing FASTA format files as SeqRecord
 # objects.  The code is partly inspired  by earlier Biopython modules,
-# Bio.Fasta.* and the now deprecated Bio.SeqIO.FASTA
+# Bio.Fasta.* and the now removed module Bio.SeqIO.FASTA
 
 """Bio.SeqIO support for the "fasta" (aka FastA or Pearson) file format.
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -583,6 +583,21 @@ class StringMethodTests(unittest.TestCase):
                 example1 = example1.lower()
             self.assertEqual(example1, str1.lower())
 
+    def test_str_replace(self):
+        """Check matches the python string replace method."""
+        s = Seq("AAGTACGT")
+        m = MutableSeq("AAGTACGT")
+        t = s.replace("AC", "XYZ")
+        self.assertEqual(s, "AAGTACGT")
+        self.assertEqual(t, "AAGTXYZGT")
+        self.assertRaises(TypeError, s.replace, "AC", "XYZ", True)
+        t = m.replace("AC", "XYZ")
+        self.assertEqual(m, "AAGTACGT")
+        self.assertEqual(t, "AAGTXYZGT")
+        t = m.replace("AC", "XYZ", inplace=True)
+        self.assertEqual(m, "AAGTXYZGT")
+        self.assertEqual(t, "AAGTXYZGT")
+
     def test_str_encode(self):
         """Check matches the python string encode method."""
         for example1 in self._examples:

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -702,9 +702,42 @@ class TestMutableSeq(unittest.TestCase):
         self.assertEqual("AGTTTTCCTACGTAGTAC", self.mutable_s)
 
     def test_complement_rna(self):
-        seq = Seq.MutableSeq("AUGaaaCUG")
-        seq.complement()
-        self.assertEqual("UACuuuGAC", seq)
+        m = self.mutable_s.complement_rna()
+        self.assertEqual(self.mutable_s, "TCAAAAGGATGCATCATG")
+        self.assertIsInstance(m, Seq.MutableSeq)
+        self.assertEqual(m, "AGUUUUCCUACGUAGUAC")
+        m = self.mutable_s.complement_rna(inplace=True)
+        self.assertEqual(self.mutable_s, "AGUUUUCCUACGUAGUAC")
+        self.assertIsInstance(m, Seq.MutableSeq)
+        self.assertEqual(m, "AGUUUUCCUACGUAGUAC")
+
+    def test_reverse_complement_rna(self):
+        m = self.mutable_s.reverse_complement_rna()
+        self.assertEqual(self.mutable_s, "TCAAAAGGATGCATCATG")
+        self.assertIsInstance(m, Seq.MutableSeq)
+        self.assertEqual(m, "CAUGAUGCAUCCUUUUGA")
+        m = self.mutable_s.reverse_complement_rna(inplace=True)
+        self.assertEqual(self.mutable_s, "CAUGAUGCAUCCUUUUGA")
+        self.assertIsInstance(m, Seq.MutableSeq)
+        self.assertEqual(m, "CAUGAUGCAUCCUUUUGA")
+
+    def test_transcribe(self):
+        r = self.mutable_s.transcribe()
+        self.assertEqual(self.mutable_s, "TCAAAAGGATGCATCATG")
+        self.assertIsInstance(r, Seq.MutableSeq)
+        self.assertEqual(r, "UCAAAAGGAUGCAUCAUG")
+        r = self.mutable_s.transcribe(inplace=True)
+        self.assertEqual(self.mutable_s, "UCAAAAGGAUGCAUCAUG")
+        self.assertIsInstance(r, Seq.MutableSeq)
+        self.assertEqual(r, "UCAAAAGGAUGCAUCAUG")
+        d = self.mutable_s.back_transcribe()
+        self.assertEqual(self.mutable_s, "UCAAAAGGAUGCAUCAUG")
+        self.assertIsInstance(d, Seq.MutableSeq)
+        self.assertEqual(d, "TCAAAAGGATGCATCATG")
+        d = self.mutable_s.back_transcribe(inplace=True)
+        self.assertEqual(self.mutable_s, "TCAAAAGGATGCATCATG")
+        self.assertIsInstance(d, Seq.MutableSeq)
+        self.assertEqual(d, "TCAAAAGGATGCATCATG")
 
     def test_complement_mixed_aphabets(self):
         seq = Seq.MutableSeq("AUGaaaCTG")

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -240,11 +240,6 @@ class TestSeqStringMethods(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.s + {}
 
-    def test_radd_method(self):
-        self.assertEqual(
-            "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG", self.s.__radd__(self.s)
-        )
-
     def test_radd_method_using_wrong_object(self):
         with self.assertRaises(TypeError):
             self.s.__radd__({})
@@ -585,23 +580,6 @@ class TestMutableSeq(unittest.TestCase):
         """Test adding wrong type to MutableSeq."""
         with self.assertRaises(TypeError):
             self.mutable_s + 1234
-
-    def test_radd_method(self):
-        self.assertEqual(
-            "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG",
-            self.mutable_s.__radd__(self.mutable_s),
-        )
-
-    def test_radd_method_using_mutableseq_object(self):
-        self.assertEqual(
-            "UCAAAAGGATCAAAAGGATGCATCATG",
-            self.mutable_s.__radd__(Seq.MutableSeq("UCAAAAGGA")),
-        )
-
-    def test_radd_method_using_seq_object(self):
-        self.assertEqual(
-            "TCAAAAGGATGCATCATGTCAAAAGGATGCATCATG", self.mutable_s.__radd__(self.s)
-        )
 
     def test_radd_method_wrong_type(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Use an abstract base class for the `Seq` and `MutableSeq` classes, as most of their methods are identical.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
