### PR TITLE
Solve flake8-bugbear v20.11.1 warnings

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -45,12 +45,12 @@ ignore =
 # ========================
 per-file-ignores =
     Bio/*:F401,F841,D105,B009,B010,B011,C812,C815
-    Tests/*:F401,F841,D101,D102,D103,W504,B009,B010,B011,C812
+    Tests/*:F401,F841,D101,D102,D103,W504,B009,B010,B011,B015,C812
 
     # Due to a bug in flake8, we need the following lines for running the
     # pre-commit hook. If you made edits above, please change also here!
     /Bio/*:F401,F841,D105,B009,B010,B011,C812,C815
-    /Tests/*:F401,F841,D101,D102,D103,W504,B009,B010,B011,C812
+    /Tests/*:F401,F841,D101,D102,D103,W504,B009,B010,B011,B015,C812
 
 #Explanation of the codes being ignored in Bio/ and Tests/:
 #
@@ -77,6 +77,8 @@ per-file-ignores =
 #             it is not any safer than normal property access
 #        B011 do not call assert False since python -O removes these calls;
 #             instead callers should raise AssertionError()
+#        B015 Pointless comparison. This comparison does nothing ...
+#             (Intended to trigger exceptions in our tests)
 #        C812 missing trailing comma
 
 # =======================

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -475,37 +475,37 @@ class SeqRecordMethodsMore(unittest.TestCase):
 
     def test_lt_exception(self):
         def lt():
-            SeqRecord(Seq("A")) < SeqRecord(Seq("A"))
+            return SeqRecord(Seq("A")) < SeqRecord(Seq("A"))
 
         self.assertRaises(NotImplementedError, lt)
 
     def test_le_exception(self):
         def le():
-            SeqRecord(Seq("A")) <= SeqRecord(Seq("A"))
+            return SeqRecord(Seq("A")) <= SeqRecord(Seq("A"))
 
         self.assertRaises(NotImplementedError, le)
 
     def test_eq_exception(self):
         def equality():
-            SeqRecord(Seq("A")) == SeqRecord(Seq("A"))
+            return SeqRecord(Seq("A")) == SeqRecord(Seq("A"))
 
         self.assertRaises(NotImplementedError, equality)
 
     def test_ne_exception(self):
         def notequality():
-            SeqRecord(Seq("A")) != SeqRecord(Seq("A"))
+            return SeqRecord(Seq("A")) != SeqRecord(Seq("A"))
 
         self.assertRaises(NotImplementedError, notequality)
 
     def test_gt_exception(self):
         def gt():
-            SeqRecord(Seq("A")) > SeqRecord(Seq("A"))
+            return SeqRecord(Seq("A")) > SeqRecord(Seq("A"))
 
         self.assertRaises(NotImplementedError, gt)
 
     def test_ge_exception(self):
         def ge():
-            SeqRecord(Seq("A")) >= SeqRecord(Seq("A"))
+            return SeqRecord(Seq("A")) >= SeqRecord(Seq("A"))
 
         self.assertRaises(NotImplementedError, ge)
 


### PR DESCRIPTION
The recent release of flake8-bugbear v20.11.1 triggered new B015 warnings from apparently pointless expressions in the tests which were there to tigger exceptions.


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

