### PR TITLE
Minimal CircleCI Linux testing integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,69 @@
+# This is a special configuration file to run tests on Circle-CI via
+# GitHub notifications when changes are committed.
+#
+# This file is not intended for end users of Biopython.
+#
+# This uses a CircleCI provided Python image, see
+# https://circleci.com/developer/images/image/cimg/python
+
+version: 2.1
+orbs:
+  codecov: codecov/codecov@1.0.2
+jobs:
+  build:
+    docker:
+      - image: cimg/python:3.7
+    steps:
+      - checkout
+      - run:
+          name: Combine precommit config and python versions for caching
+          command: |
+            cat .pre-commit-config.yaml > pre-commit-deps.txt
+            python -VV >> pre-commit-deps.txt
+      - restore_cache:
+          keys:
+          - v1-precommit-deps-{{ checksum "pre-commit-deps.txt" }}
+      - run:
+          name: Style install
+          command: |
+            python --version
+            pip install pre-commit
+            pre-commit install
+            pre-commit install-hooks
+      - save_cache:
+          paths:
+            - ~/.cache/pre-commit
+            - ./venv
+          key: v1-precommit-deps-{{ checksum "pre-commit-deps.txt" }}
+      - run:
+          name: Style checks
+          command: |
+            pre-commit run -a
+      - run:
+          name: Dependencies
+          command: |
+            python --version
+            pip install coverage codecov numpy scipy mmtf-python mysqlclient mysql-connector-python rdflib networkx matplotlib reportlab
+            echo "Python dependencies installed"
+      - run:
+          name: Installation
+          command: |
+            python setup.py sdist --formats=gztar
+            echo "Built tar-ball, will now use that to test manifest..."
+            tar -zxvf dist/biopython-*.tar.gz
+            cd biopython-*/
+            python setup.py bdist_wheel
+            echo "Built wheel and installing it..."
+            python -m pip install dist/biopython-*.whl
+            echo "Biopython should now be installed"
+      - run:
+          name: Test
+          command: |
+            # Use the unzipped tar-ball where built wheel
+            cd biopython-*/Tests/
+            rm -rf coverage.xml
+            coverage run run_tests.py --offline
+            echo "Tests run"
+            coverage xml
+      - codecov/upload:
+          file: biopython-*/Tests/coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,12 +36,12 @@ repos:
         additional_dependencies: [black==19.10b0]
         exclude: ^.github/
 -   repo: https://github.com/myint/rstcheck
-    rev: ''
+    rev: 3f92957478422df87bd730abde66f089cc1ee19b
     hooks:
     -   id: rstcheck
         args: [--report=warning]
 -   repo: https://github.com/PyCQA/doc8
-    rev: ''
+    rev: 0.8.1
     hooks:
     -   id: doc8
         additional_dependencies: [pygments]


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Seeks to address #3340, see also #3358 (GitHub actions).

Implements a minimal CircleCI configuration covering a single version of Python, no command line dependencies (e.g. blast - using a conda image might be better for this?), running the pre-commit style checks (including black) and our test suite (with coverage tracking).

Does not cache the (optional) Biopython pip dependencies (numpy, scipy, etc), since we don't have a requirements file or similar to give an easy way to key the cache. Does cache the pre-commit dependencies.

Does not run Sphinx/apidocs and update the API documentation (currently done on TravisCI).

Will require adding this repository to CircleCI, and the ``$CODECOV_TOKEN`` environment variable. Proof of principle here: https://app.circleci.com/pipelines/github/peterjc/biopython