### PR TITLE
Issue 3466

### DIFF
--- a/Bio/KEGG/KGML/KGML_pathway.py
+++ b/Bio/KEGG/KGML/KGML_pathway.py
@@ -79,7 +79,9 @@ class Pathway:
         header = "\n".join(
             [
                 '<?xml version="1.0"?>',
-                "<!DOCTYPE pathway SYSTEM " '"http://www.genome.jp/kegg/xml/' 'KGML_v0.7.2_.dtd">',
+                "<!DOCTYPE pathway SYSTEM "
+                '"http://www.genome.jp/kegg/xml/'
+                'KGML_v0.7.2_.dtd">',
                 "<!-- Created by KGML_Pathway.py %s -->" % time.asctime(),
             ]
         )
@@ -91,14 +93,18 @@ class Pathway:
         """Add an Entry element to the pathway."""
         # We insist that the node ID is an integer
         if not isinstance(entry.id, int):
-            raise TypeError("Node ID must be an integer, got %s (%s)" % (type(entry.id), entry.id))
+            raise TypeError(
+                "Node ID must be an integer, got %s (%s)" % (type(entry.id), entry.id)
+            )
         entry._pathway = self  # Let the entry know about the pathway
         self.entries[entry.id] = entry
 
     def remove_entry(self, entry):
         """Remove an Entry element from the pathway."""
         if not isinstance(entry.id, int):
-            raise TypeError("Node ID must be an integer, got %s (%s)" % (type(entry.id), entry.id))
+            raise TypeError(
+                "Node ID must be an integer, got %s (%s)" % (type(entry.id), entry.id)
+            )
         # We need to remove the entry from any other elements that may
         # contain it, which means removing those elements
         # TODO
@@ -108,7 +114,10 @@ class Pathway:
         """Add a Reaction element to the pathway."""
         # We insist that the node ID is an integer and corresponds to an entry
         if not isinstance(reaction.id, int):
-            raise ValueError("Node ID must be an integer, got %s (%s)" % (type(reaction.id), reaction.id))
+            raise ValueError(
+                "Node ID must be an integer, got %s (%s)"
+                % (type(reaction.id), reaction.id)
+            )
         if reaction.id not in self.entries:
             raise ValueError("Reaction ID %d has no corresponding entry" % reaction.id)
         reaction._pathway = self  # Let the reaction know about the pathway
@@ -117,7 +126,10 @@ class Pathway:
     def remove_reaction(self, reaction):
         """Remove a Reaction element from the pathway."""
         if not isinstance(reaction.id, int):
-            raise TypeError("Node ID must be an integer, got %s (%s)" % (type(reaction.id), reaction.id))
+            raise TypeError(
+                "Node ID must be an integer, got %s (%s)"
+                % (type(reaction.id), reaction.id)
+            )
         # We need to remove the reaction from any other elements that may
         # contain it, which means removing those elements
         # TODO
@@ -302,7 +314,9 @@ class Entry:
         """
         if self._pathway is not None:
             if element.id not in self._pathway.entries:
-                raise ValueError("Component %s is not an entry in the pathway" % element.id)
+                raise ValueError(
+                    "Component %s is not an entry in the pathway" % element.id
+                )
         self.components.add(element)
 
     def remove_component(self, value):
@@ -327,7 +341,9 @@ class Entry:
     def _delname(self):
         self._names = []
 
-    name = property(_getname, _setname, _delname, "List of KEGG identifiers for the Entry.")
+    name = property(
+        _getname, _setname, _delname, "List of KEGG identifiers for the Entry."
+    )
 
     # Reactions may be given as a space-separated list of KEGG identifiers
     def _getreaction(self):
@@ -510,7 +526,9 @@ class Graphics:
     def _delwidth(self):
         del self._width
 
-    width = property(_getwidth, _setwidth, _delwidth, "The width of the graphics element.")
+    width = property(
+        _getwidth, _setwidth, _delwidth, "The width of the graphics element."
+    )
 
     def _getheight(self):
         return self._height
@@ -521,7 +539,9 @@ class Graphics:
     def _delheight(self):
         del self._height
 
-    height = property(_getheight, _setheight, _delheight, "The height of the graphics element.")
+    height = property(
+        _getheight, _setheight, _delheight, "The height of the graphics element."
+    )
 
     # We make sure that the polyline co-ordinates are integers, too
     def _getcoords(self):
@@ -598,7 +618,9 @@ class Graphics:
             if getattr(self, attr) is not None:
                 graphics.attrib[n] = str(getattr(self, attr))
         if self.type == "line":  # Need to write polycoords
-            graphics.attrib["coords"] = ",".join([str(e) for e in chain.from_iterable(self.coords)])
+            graphics.attrib["coords"] = ",".join(
+                [str(e) for e in chain.from_iterable(self.coords)]
+            )
         return graphics
 
     @property
@@ -669,14 +691,19 @@ class Reaction:
         """Add a substrate, identified by its node ID, to the reaction."""
         if self._pathway is not None:
             if int(substrate_id) not in self._pathway.entries:
-                raise ValueError("Couldn't add substrate, no node ID %d in Pathway" % int(substrate_id))
+                raise ValueError(
+                    "Couldn't add substrate, no node ID %d in Pathway"
+                    % int(substrate_id)
+                )
         self._substrates.add(substrate_id)
 
     def add_product(self, product_id):
         """Add a product, identified by its node ID, to the reaction."""
         if self._pathway is not None:
             if int(product_id) not in self._pathway.entries:
-                raise ValueError("Couldn't add product, no node ID %d in Pathway" % product_id)
+                raise ValueError(
+                    "Couldn't add product, no node ID %d in Pathway" % product_id
+                )
         self._products.add(int(product_id))
 
     # The node ID is also the node ID of the Entry that corresponds to the
@@ -703,7 +730,9 @@ class Reaction:
     def _delnames(self):
         del self.names
 
-    name = property(_getnames, _setnames, _delnames, "List of KEGG identifiers for the reaction.")
+    name = property(
+        _getnames, _setnames, _delnames, "List of KEGG identifiers for the reaction."
+    )
 
     # products and substrates are read-only properties, returning lists
     # of Entry objects

--- a/Bio/KEGG/KGML/KGML_pathway.py
+++ b/Bio/KEGG/KGML/KGML_pathway.py
@@ -7,7 +7,7 @@
 
 """Classes to represent a KGML Pathway Map.
 
-The KGML definition is as of release KGML v0.7.1
+The KGML definition is as of release KGML v0.7.2
 (http://www.kegg.jp/kegg/xml/docs/)
 
 Classes:
@@ -33,7 +33,7 @@ class Pathway:
     """Represents a KGML pathway from KEGG.
 
     Specifies graph information for the pathway map, as described in
-    release KGML v0.7.1 (http://www.kegg.jp/kegg/xml/docs/)
+    release KGML v0.7.2 (http://www.kegg.jp/kegg/xml/docs/)
 
     Attributes:
      - name - KEGGID of the pathway map
@@ -79,9 +79,7 @@ class Pathway:
         header = "\n".join(
             [
                 '<?xml version="1.0"?>',
-                "<!DOCTYPE pathway SYSTEM "
-                '"http://www.genome.jp/kegg/xml/'
-                'KGML_v0.7.1_.dtd">',
+                "<!DOCTYPE pathway SYSTEM " '"http://www.genome.jp/kegg/xml/' 'KGML_v0.7.2_.dtd">',
                 "<!-- Created by KGML_Pathway.py %s -->" % time.asctime(),
             ]
         )
@@ -93,18 +91,14 @@ class Pathway:
         """Add an Entry element to the pathway."""
         # We insist that the node ID is an integer
         if not isinstance(entry.id, int):
-            raise TypeError(
-                "Node ID must be an integer, got %s (%s)" % (type(entry.id), entry.id)
-            )
+            raise TypeError("Node ID must be an integer, got %s (%s)" % (type(entry.id), entry.id))
         entry._pathway = self  # Let the entry know about the pathway
         self.entries[entry.id] = entry
 
     def remove_entry(self, entry):
         """Remove an Entry element from the pathway."""
         if not isinstance(entry.id, int):
-            raise TypeError(
-                "Node ID must be an integer, got %s (%s)" % (type(entry.id), entry.id)
-            )
+            raise TypeError("Node ID must be an integer, got %s (%s)" % (type(entry.id), entry.id))
         # We need to remove the entry from any other elements that may
         # contain it, which means removing those elements
         # TODO
@@ -114,10 +108,7 @@ class Pathway:
         """Add a Reaction element to the pathway."""
         # We insist that the node ID is an integer and corresponds to an entry
         if not isinstance(reaction.id, int):
-            raise ValueError(
-                "Node ID must be an integer, got %s (%s)"
-                % (type(reaction.id), reaction.id)
-            )
+            raise ValueError("Node ID must be an integer, got %s (%s)" % (type(reaction.id), reaction.id))
         if reaction.id not in self.entries:
             raise ValueError("Reaction ID %d has no corresponding entry" % reaction.id)
         reaction._pathway = self  # Let the reaction know about the pathway
@@ -126,10 +117,7 @@ class Pathway:
     def remove_reaction(self, reaction):
         """Remove a Reaction element from the pathway."""
         if not isinstance(reaction.id, int):
-            raise TypeError(
-                "Node ID must be an integer, got %s (%s)"
-                % (type(reaction.id), reaction.id)
-            )
+            raise TypeError("Node ID must be an integer, got %s (%s)" % (type(reaction.id), reaction.id))
         # We need to remove the reaction from any other elements that may
         # contain it, which means removing those elements
         # TODO
@@ -262,7 +250,7 @@ class Entry:
     """Represent an Entry from KGML.
 
     Each Entry element is a node in the pathway graph, as described in
-    release KGML v0.7.1 (http://www.kegg.jp/kegg/xml/docs/)
+    release KGML v0.7.2 (http://www.kegg.jp/kegg/xml/docs/)
 
     Attributes:
      - id - The ID of the entry in the pathway map (integer)
@@ -314,9 +302,7 @@ class Entry:
         """
         if self._pathway is not None:
             if element.id not in self._pathway.entries:
-                raise ValueError(
-                    "Component %s is not an entry in the pathway" % element.id
-                )
+                raise ValueError("Component %s is not an entry in the pathway" % element.id)
         self.components.add(element)
 
     def remove_component(self, value):
@@ -341,9 +327,7 @@ class Entry:
     def _delname(self):
         self._names = []
 
-    name = property(
-        _getname, _setname, _delname, "List of KEGG identifiers for the Entry."
-    )
+    name = property(_getname, _setname, _delname, "List of KEGG identifiers for the Entry.")
 
     # Reactions may be given as a space-separated list of KEGG identifiers
     def _getreaction(self):
@@ -422,7 +406,7 @@ class Component:
     """An Entry subelement used to represents a complex node.
 
     A subelement of the Entry element, used when the Entry is a complex
-    node, as described in release KGML v0.7.1
+    node, as described in release KGML v0.7.2
     (http://www.kegg.jp/kegg/xml/docs/)
 
     The Component acts as a collection (with type 'group', and typically
@@ -460,7 +444,7 @@ class Graphics:
     """An Entry subelement used to represents the visual representation.
 
     A subelement of Entry, specifying its visual representation, as
-    described in release KGML v0.7.1 (http://www.kegg.jp/kegg/xml/docs/)
+    described in release KGML v0.7.2 (http://www.kegg.jp/kegg/xml/docs/)
 
     Attributes:
      - name         Label for the graphics object
@@ -526,9 +510,7 @@ class Graphics:
     def _delwidth(self):
         del self._width
 
-    width = property(
-        _getwidth, _setwidth, _delwidth, "The width of the graphics element."
-    )
+    width = property(_getwidth, _setwidth, _delwidth, "The width of the graphics element.")
 
     def _getheight(self):
         return self._height
@@ -539,9 +521,7 @@ class Graphics:
     def _delheight(self):
         del self._height
 
-    height = property(
-        _getheight, _setheight, _delheight, "The height of the graphics element."
-    )
+    height = property(_getheight, _setheight, _delheight, "The height of the graphics element.")
 
     # We make sure that the polyline co-ordinates are integers, too
     def _getcoords(self):
@@ -618,9 +598,7 @@ class Graphics:
             if getattr(self, attr) is not None:
                 graphics.attrib[n] = str(getattr(self, attr))
         if self.type == "line":  # Need to write polycoords
-            graphics.attrib["coords"] = ",".join(
-                [str(e) for e in chain.from_iterable(self.coords)]
-            )
+            graphics.attrib["coords"] = ",".join([str(e) for e in chain.from_iterable(self.coords)])
         return graphics
 
     @property
@@ -691,19 +669,14 @@ class Reaction:
         """Add a substrate, identified by its node ID, to the reaction."""
         if self._pathway is not None:
             if int(substrate_id) not in self._pathway.entries:
-                raise ValueError(
-                    "Couldn't add substrate, no node ID %d in Pathway"
-                    % int(substrate_id)
-                )
+                raise ValueError("Couldn't add substrate, no node ID %d in Pathway" % int(substrate_id))
         self._substrates.add(substrate_id)
 
     def add_product(self, product_id):
         """Add a product, identified by its node ID, to the reaction."""
         if self._pathway is not None:
             if int(product_id) not in self._pathway.entries:
-                raise ValueError(
-                    "Couldn't add product, no node ID %d in Pathway" % product_id
-                )
+                raise ValueError("Couldn't add product, no node ID %d in Pathway" % product_id)
         self._products.add(int(product_id))
 
     # The node ID is also the node ID of the Entry that corresponds to the
@@ -730,9 +703,7 @@ class Reaction:
     def _delnames(self):
         del self.names
 
-    name = property(
-        _getnames, _setnames, _delnames, "List of KEGG identifiers for the reaction."
-    )
+    name = property(_getnames, _setnames, _delnames, "List of KEGG identifiers for the reaction.")
 
     # products and substrates are read-only properties, returning lists
     # of Entry objects
@@ -780,7 +751,7 @@ class Relation:
     """A relationship between to products, KOs, or protein and compound.
 
     This describes a relationship between two products, KOs, or protein
-    and compound, as described in release KGML v0.7.1
+    and compound, as described in release KGML v0.7.2
     (http://www.kegg.jp/kegg/xml/docs/)
 
     Attributes:
@@ -854,6 +825,6 @@ class Relation:
         }
         for (name, value) in self.subtypes:
             subtype = ET.Element("subtype")
-            subtype.attrib[name] = str(value)
+            subtype.attrib = {"name": name, "value": str(value)}
             relation.append(subtype)
         return relation

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -32,6 +32,9 @@ string like methods (fixing a regression in Biopython 1.78).
 A parser for twoBit (.2bit) sequence data was added to ``Bio.SeqIO``. This is
 a lazy parser that allows fast access to genome-size DNA sequence files.
 
+The KEGG ``KGML_Pathway`` KGML output was fixed to produce output that complies
+with KGML v0.7.2.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
@@ -40,6 +43,7 @@ possible, especially the following contributors:
 - Markus Piotrowski
 - Suyash Gupta
 - Vini Salazar (first contribution)
+- Leighton Pritchard
 
 4 September 2020: Biopython 1.78
 ================================

--- a/Tests/test_KEGG_online.py
+++ b/Tests/test_KEGG_online.py
@@ -8,6 +8,7 @@
 """Tests for online functionality of the KEGG module."""
 
 # Builtins
+import io
 import unittest
 
 from Bio.KEGG.KGML import KGML_parser
@@ -250,6 +251,17 @@ class KGMLPathwayTests(unittest.TestCase):
         with kegg_get("ko03070", "kgml") as handle:
             pathway = KGML_parser.read(handle)
         self.assertEqual(pathway.name, "path:ko03070")
+
+    def test_parser_roundtrip(self):
+        """Download a KEGG pathway, write local KGML and check roundtrip."""
+        with kegg_get("ko00680", "kgml") as remote_handle:
+            pathway = KGML_parser.read(remote_handle)
+
+        with io.StringIO(pathway.get_KGML()) as local_handle:
+            roundtrip = KGML_parser.read(local_handle)
+
+        self.assertEqual(pathway.name, roundtrip.name)
+        self.assertEqual(len(pathway.relations), len(roundtrip.relations))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The KGML version had incremented to 0.7.2 (see
https://www.genome.jp/kegg/xml/) but the KGML parser had not been
kept up to date.

These changes update mentions of KGML v0.7.1 to v0.7.2, and fix
the parser so that it produces KGML compliant with the DTD for
relation subtype entities.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3466

The KEGG `KGML_Pathway` KGML output is fixed to produce output that complies
with KGML v0.7.2.
