### PR TITLE
deprecate the ungap method of Seq objects

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1917,6 +1917,10 @@ class Seq(_SeqAbstractBaseClass):
         >>> my_dna.ungap("-")
         Seq('ATATGAAATTTGAAAA')
         """
+        warnings.warn(
+            "myseq.ungap(gap) is deprecated; please use myseq.replace(gap, '') instead.",
+            BiopythonDeprecationWarning,
+        )
         if not gap:
             raise ValueError("Gap character required.")
         elif len(gap) != 1 or not isinstance(gap, str):
@@ -2436,12 +2440,10 @@ class UnknownSeq(Seq):
         >>> my_gap.ungap("-")
         Seq('')
         """
-        # Offload the argument validation
-        s = Seq(self._character).ungap(gap)
-        if s:
-            return UnknownSeq(self._length, character=self._character)
-        else:
+        if self._character == gap:
             return Seq("")
+        else:
+            return UnknownSeq(self._length, character=self._character)
 
     def join(self, other):
         """Return a merge of the sequences in other, spaced by the sequence from self.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1904,7 +1904,7 @@ class Seq(_SeqAbstractBaseClass):
         return self.complement()[::-1]
 
     def ungap(self, gap="-"):
-        """Return a copy of the sequence without the gap character(s).
+        """Return a copy of the sequence without the gap character(s) (OBSOLETE).
 
         The gap character now defaults to the minus sign, and can only
         be specified via the method argument. This is no longer possible
@@ -1916,11 +1916,9 @@ class Seq(_SeqAbstractBaseClass):
         Seq('-ATA--TGAAAT-TTGAAAA')
         >>> my_dna.ungap("-")
         Seq('ATATGAAATTTGAAAA')
+
+        This method is OBSOLETE; please use my_dna.replace(gap, "") instead.
         """
-        warnings.warn(
-            "myseq.ungap(gap) is deprecated; please use myseq.replace(gap, '') instead.",
-            BiopythonDeprecationWarning,
-        )
         if not gap:
             raise ValueError("Gap character required.")
         elif len(gap) != 1 or not isinstance(gap, str):

--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -265,7 +265,7 @@ def _check_corr(
         if aa != gap_char:
             pro_re += aa2re[aa]
 
-    nucl_seq = str(nucl.seq.upper().ungap(gap_char))
+    nucl_seq = str(nucl.seq.upper().replace(gap_char, ""))
     match = re.search(pro_re, nucl_seq)
     if match:
         # mode = 0, direct match
@@ -588,12 +588,12 @@ def _get_codon_rec(
     import re
     from Bio.Seq import Seq
 
-    nucl_seq = nucl.seq.ungap(gap_char)
+    nucl_seq = nucl.seq.replace(gap_char, "")
     span = span_mode[0]
     mode = span_mode[1]
     aa2re = _get_aa_regex(codon_table)
     if mode in (0, 1):
-        if len(pro.seq.ungap(gap_char)) * 3 != (span[1] - span[0]):
+        if len(pro.seq.replace(gap_char, "")) * 3 != (span[1] - span[0]):
             raise ValueError(
                 f"Protein Record {pro.id} and "
                 f"Nucleotide Record {nucl.id} do not match!"
@@ -684,7 +684,7 @@ def _get_codon_rec(
                     aa_num += 1
             else:
                 if (
-                    aa_num < len(pro.seq.ungap("-")) - 1
+                    aa_num < len(pro.seq.replace("-", "")) - 1
                     and rf_table[aa_num + 1] - rf_table[aa_num] - 3 < 0
                 ):
                     max_score -= 1

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -195,7 +195,7 @@ Bio.Seq.MutableSeq(myseq) or Bio.Seq.Seq(mymutableseq), respectively.
 
 Bio.Seq.Seq.ungap()
 -------------------
-Deprecated in release 1.79.
+Declared obsolete in release 1.79.
 Instead of myseq.ungap(), please use myseq.replace("-", "").
 
 Bio.Seq.UnknownSeq

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -193,6 +193,11 @@ Deprecated in release 1.79.
 Instead of myseq.tomutable() or mymutableseq.toseq(), you should now use
 Bio.Seq.MutableSeq(myseq) or Bio.Seq.Seq(mymutableseq), respectively.
 
+Bio.Seq.Seq.ungap()
+-------------------
+Deprecated in release 1.79.
+Instead of myseq.ungap(), please use myseq.replace("-", "").
+
 Bio.Seq.UnknownSeq
 ------------------
 Deprecated in release 1.79.

--- a/Tests/test_MafIO_index.py
+++ b/Tests/test_MafIO_index.py
@@ -526,7 +526,7 @@ if sqlite3:
                 "loxAfr1.scaffold_75566": 54,
             }
             for seq_id, length in correct_lengths.items():
-                self.assertEqual(len(seq_dict[seq_id].ungap("-")), length)
+                self.assertEqual(len(seq_dict[seq_id].replace("-", "")), length)
 
         def test_correct_spliced_sequences_1(self):
             """Checking that spliced sequences are correct.
@@ -564,7 +564,7 @@ if sqlite3:
                 "loxAfr1.scaffold_75566": "GGGAGTATAAACCATTTAGTCTGCGAAATGCCAAATCTTCAGGGGAAAAAGCTG",
             }
             for seq_id, sequence in correct_sequences.items():
-                self.assertEqual(seq_dict[seq_id].ungap("-"), sequence)
+                self.assertEqual(seq_dict[seq_id].replace("-", ""), sequence)
 
         def test_correct_spliced_sequences_2(self):
             """Checking that spliced sequences are correct.
@@ -619,7 +619,7 @@ if sqlite3:
                 "loxAfr1.scaffold_75566": "TTTGGTTAGAATTATGCTTTAATTCAAAACTTCCGGGAGTATAAACCATTTAGTCTGCGAAATGCCAAATCTTCAGGGGAAAAAGCTG",
             }
             for seq_id, sequence in correct_sequences.items():
-                self.assertEqual(seq_dict[seq_id].ungap("-"), sequence)
+                self.assertEqual(seq_dict[seq_id].replace("-", ""), sequence)
 
     class TestSearchBadMAF(unittest.TestCase):
         """Test index searching on an incorrectly-formatted MAF."""

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -122,14 +122,8 @@ class TestSeq(unittest.TestCase):
         self.assertEqual(str(self.s) + "T", u)
         self.assertEqual(self.s + Seq.Seq("T"), "TCAAAAGGATGCATCATGT")
 
-    def test_ungap(self):
-        self.assertEqual("ATCCCA", Seq.Seq("ATC-CCA").ungap("-"))
-
-        with self.assertRaises(ValueError):
-            Seq.Seq("ATC-CCA").ungap("--")
-
-        with self.assertRaises(ValueError):
-            Seq.Seq("ATC-CCA").ungap(gap=None)
+    def test_replace(self):
+        self.assertEqual("ATCCCA", Seq.Seq("ATC-CCA").replace("-", ""))
 
 
 class TestSeqStringMethods(unittest.TestCase):


### PR DESCRIPTION
'- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR deprecates the `ungap` method of `Seq` objects.

The `ungap` method was added for removing gap characters in an alphabet-aware manner. Since alphabets have been removed from Biopython, `replace` can be used instead. Note that `ungap` was not documented in the Biopython tutorial.

For `Bio.codonalign`, the `ungap` method of a `CodonSeq` object is not deprecated. Usage of `ungap` on `Seq` objects in `Bio.codonalign` was replaced by `replace`; this has the added benefit that `MutableSeq` objects can be used in addition to `Seq` objects.