### PR TITLE
make pairwise aligner picklable

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1598,7 +1598,9 @@ class PairwiseAligner(_aligners.PairwiseAligner):
     def __setstate__(self, state):
         self.wildcard = state["wildcard"]
         self.target_internal_open_gap_score = state["target_internal_open_gap_score"]
-        self.target_internal_extend_gap_score = state["target_internal_extend_gap_score"]
+        self.target_internal_extend_gap_score = state[
+            "target_internal_extend_gap_score"
+        ]
         self.target_left_open_gap_score = state["target_left_open_gap_score"]
         self.target_left_extend_gap_score = state["target_left_extend_gap_score"]
         self.target_right_open_gap_score = state["target_right_open_gap_score"]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1571,6 +1571,52 @@ class PairwiseAligner(_aligners.PairwiseAligner):
             seqB = bytes(seqB)
         return _aligners.PairwiseAligner.score(self, seqA, seqB)
 
+    def __getstate__(self):
+        state = {
+            "wildcard": self.wildcard,
+            "target_internal_open_gap_score": self.target_internal_open_gap_score,
+            "target_internal_extend_gap_score": self.target_internal_extend_gap_score,
+            "target_left_open_gap_score": self.target_left_open_gap_score,
+            "target_left_extend_gap_score": self.target_left_extend_gap_score,
+            "target_right_open_gap_score": self.target_right_open_gap_score,
+            "target_right_extend_gap_score": self.target_right_extend_gap_score,
+            "query_internal_open_gap_score": self.query_internal_open_gap_score,
+            "query_internal_extend_gap_score": self.query_internal_extend_gap_score,
+            "query_left_open_gap_score": self.query_left_open_gap_score,
+            "query_left_extend_gap_score": self.query_left_extend_gap_score,
+            "query_right_open_gap_score": self.query_right_open_gap_score,
+            "query_right_extend_gap_score": self.query_right_extend_gap_score,
+            "mode": self.mode,
+        }
+        if self.substitution_matrix is None:
+            state["match_score"] = self.match_score
+            state["mismatch_score"] = self.mismatch_score
+        else:
+            state["substitution_matrix"] = self.substitution_matrix
+        return state
+
+    def __setstate__(self, state):
+        self.wildcard = state["wildcard"]
+        self.target_internal_open_gap_score = state["target_internal_open_gap_score"]
+        self.target_internal_extend_gap_score = state["target_internal_extend_gap_score"]
+        self.target_left_open_gap_score = state["target_left_open_gap_score"]
+        self.target_left_extend_gap_score = state["target_left_extend_gap_score"]
+        self.target_right_open_gap_score = state["target_right_open_gap_score"]
+        self.target_right_extend_gap_score = state["target_right_extend_gap_score"]
+        self.query_internal_open_gap_score = state["query_internal_open_gap_score"]
+        self.query_internal_extend_gap_score = state["query_internal_extend_gap_score"]
+        self.query_left_open_gap_score = state["query_left_open_gap_score"]
+        self.query_left_extend_gap_score = state["query_left_extend_gap_score"]
+        self.query_right_open_gap_score = state["query_right_open_gap_score"]
+        self.query_right_extend_gap_score = state["query_right_extend_gap_score"]
+        self.mode = state["mode"]
+        substitution_matrix = state.get("substitution_matrix")
+        if substitution_matrix is None:
+            self.match_score = state["match_score"]
+            self.mismatch_score = state["mismatch_score"]
+        else:
+            self.substitution_matrix = substitution_matrix
+
 
 if __name__ == "__main__":
     from Bio._utils import run_doctest

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2519,6 +2519,7 @@ class TestUnicodeStrings(unittest.TestCase):
         )
         self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((1, 2), (2, 3))))
 
+
 class TestAlignerPickling(unittest.TestCase):
     def test_pickle_aligner_match_mismatch(self):
         import pickle
@@ -2548,51 +2549,51 @@ class TestAlignerPickling(unittest.TestCase):
         self.assertIsNone(pickled_aligner.substitution_matrix)
         self.assertAlmostEqual(
             aligner.target_internal_open_gap_score,
-            pickled_aligner.target_internal_open_gap_score
+            pickled_aligner.target_internal_open_gap_score,
         )
         self.assertAlmostEqual(
             aligner.target_internal_extend_gap_score,
-            pickled_aligner.target_internal_extend_gap_score
+            pickled_aligner.target_internal_extend_gap_score,
         )
         self.assertAlmostEqual(
             aligner.target_left_open_gap_score,
-            pickled_aligner.target_left_open_gap_score
+            pickled_aligner.target_left_open_gap_score,
         )
         self.assertAlmostEqual(
             aligner.target_left_extend_gap_score,
-            pickled_aligner.target_left_extend_gap_score
+            pickled_aligner.target_left_extend_gap_score,
         )
         self.assertAlmostEqual(
             aligner.target_right_open_gap_score,
-            pickled_aligner.target_right_open_gap_score
+            pickled_aligner.target_right_open_gap_score,
         )
         self.assertAlmostEqual(
             aligner.target_right_extend_gap_score,
-            pickled_aligner.target_right_extend_gap_score
+            pickled_aligner.target_right_extend_gap_score,
         )
         self.assertAlmostEqual(
             aligner.query_internal_open_gap_score,
-            pickled_aligner.query_internal_open_gap_score
+            pickled_aligner.query_internal_open_gap_score,
         )
         self.assertAlmostEqual(
             aligner.query_internal_extend_gap_score,
-            pickled_aligner.query_internal_extend_gap_score
+            pickled_aligner.query_internal_extend_gap_score,
         )
         self.assertAlmostEqual(
             aligner.query_left_open_gap_score,
-            pickled_aligner.query_left_open_gap_score
+            pickled_aligner.query_left_open_gap_score,
         )
         self.assertAlmostEqual(
             aligner.query_left_extend_gap_score,
-            pickled_aligner.query_left_extend_gap_score
+            pickled_aligner.query_left_extend_gap_score,
         )
         self.assertAlmostEqual(
             aligner.query_right_open_gap_score,
-            pickled_aligner.query_right_open_gap_score
+            pickled_aligner.query_right_open_gap_score,
         )
         self.assertAlmostEqual(
             aligner.query_right_extend_gap_score,
-            pickled_aligner.query_right_extend_gap_score
+            pickled_aligner.query_right_extend_gap_score,
         )
         self.assertEqual(aligner.mode, pickled_aligner.mode)
 
@@ -2602,6 +2603,7 @@ class TestAlignerPickling(unittest.TestCase):
         except ImportError:
             return
         import pickle
+
         aligner = Align.PairwiseAligner()
         aligner.wildcard = "N"
         aligner.substitution_matrix = substitution_matrices.load("BLOSUM80")
@@ -2627,55 +2629,55 @@ class TestAlignerPickling(unittest.TestCase):
             (aligner.substitution_matrix == pickled_aligner.substitution_matrix).all())
         self.assertEqual(
             aligner.substitution_matrix.alphabet,
-            pickled_aligner.substitution_matrix.alphabet
+            pickled_aligner.substitution_matrix.alphabet,
         )
         self.assertAlmostEqual(
             aligner.target_internal_open_gap_score,
-            pickled_aligner.target_internal_open_gap_score
+            pickled_aligner.target_internal_open_gap_score,
         )
         self.assertAlmostEqual(
             aligner.target_internal_extend_gap_score,
-            pickled_aligner.target_internal_extend_gap_score
+            pickled_aligner.target_internal_extend_gap_score,
         )
         self.assertAlmostEqual(
             aligner.target_left_open_gap_score,
-            pickled_aligner.target_left_open_gap_score
+            pickled_aligner.target_left_open_gap_score,
         )
         self.assertAlmostEqual(
             aligner.target_left_extend_gap_score,
-            pickled_aligner.target_left_extend_gap_score
+            pickled_aligner.target_left_extend_gap_score,
         )
         self.assertAlmostEqual(
             aligner.target_right_open_gap_score,
-            pickled_aligner.target_right_open_gap_score
+            pickled_aligner.target_right_open_gap_score,
         )
         self.assertAlmostEqual(
             aligner.target_right_extend_gap_score,
-            pickled_aligner.target_right_extend_gap_score
+            pickled_aligner.target_right_extend_gap_score,
         )
         self.assertAlmostEqual(
             aligner.query_internal_open_gap_score,
-            pickled_aligner.query_internal_open_gap_score
+            pickled_aligner.query_internal_open_gap_score,
         )
         self.assertAlmostEqual(
             aligner.query_internal_extend_gap_score,
-            pickled_aligner.query_internal_extend_gap_score
+            pickled_aligner.query_internal_extend_gap_score,
         )
         self.assertAlmostEqual(
             aligner.query_left_open_gap_score,
-            pickled_aligner.query_left_open_gap_score
+            pickled_aligner.query_left_open_gap_score,
         )
         self.assertAlmostEqual(
             aligner.query_left_extend_gap_score,
-            pickled_aligner.query_left_extend_gap_score
+            pickled_aligner.query_left_extend_gap_score,
         )
         self.assertAlmostEqual(
             aligner.query_right_open_gap_score,
-            pickled_aligner.query_right_open_gap_score
+            pickled_aligner.query_right_open_gap_score,
         )
         self.assertAlmostEqual(
             aligner.query_right_extend_gap_score,
-            pickled_aligner.query_right_extend_gap_score
+            pickled_aligner.query_right_extend_gap_score,
         )
         self.assertEqual(aligner.mode, pickled_aligner.mode)
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2626,7 +2626,8 @@ class TestAlignerPickling(unittest.TestCase):
         self.assertIsNone(pickled_aligner.match_score)
         self.assertIsNone(pickled_aligner.mismatch_score)
         self.assertTrue(
-            (aligner.substitution_matrix == pickled_aligner.substitution_matrix).all())
+            (aligner.substitution_matrix == pickled_aligner.substitution_matrix).all()
+        )
         self.assertEqual(
             aligner.substitution_matrix.alphabet,
             pickled_aligner.substitution_matrix.alphabet,

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2519,6 +2519,90 @@ class TestUnicodeStrings(unittest.TestCase):
         )
         self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((1, 2), (2, 3))))
 
+class TestAlignerPickling(unittest.TestCase):
+    def test_pickle_aligner_match_mismatch(self):
+        import pickle
+        aligner = Align.PairwiseAligner()
+        aligner.wildcard = "X"
+        aligner.match_score = 3
+        aligner.mismatch_score = -2
+        aligner.target_internal_open_gap_score = -2.5
+        aligner.target_internal_extend_gap_score = -3.5
+        aligner.target_left_open_gap_score = -2.5
+        aligner.target_left_extend_gap_score = -3.5
+        aligner.target_right_open_gap_score = -4
+        aligner.target_right_extend_gap_score = -4
+        aligner.query_internal_open_gap_score = -0.1
+        aligner.query_internal_extend_gap_score = -2
+        aligner.query_left_open_gap_score = -9
+        aligner.query_left_extend_gap_score = +1
+        aligner.query_right_open_gap_score = -1
+        aligner.query_right_extend_gap_score = -2
+        aligner.mode = "local"
+        state = pickle.dumps(aligner)
+        pickled_aligner = pickle.loads(state)
+        self.assertEqual(aligner.wildcard, pickled_aligner.wildcard)
+        self.assertAlmostEqual(aligner.match_score, pickled_aligner.match_score)
+        self.assertAlmostEqual(aligner.mismatch_score, pickled_aligner.mismatch_score)
+        self.assertIsNone(pickled_aligner.substitution_matrix)
+        self.assertAlmostEqual(aligner.target_internal_open_gap_score, pickled_aligner.target_internal_open_gap_score)
+        self.assertAlmostEqual(aligner.target_internal_extend_gap_score, pickled_aligner.target_internal_extend_gap_score)
+        self.assertAlmostEqual(aligner.target_left_open_gap_score, pickled_aligner.target_left_open_gap_score)
+        self.assertAlmostEqual(aligner.target_left_extend_gap_score, pickled_aligner.target_left_extend_gap_score)
+        self.assertAlmostEqual(aligner.target_right_open_gap_score, pickled_aligner.target_right_open_gap_score)
+        self.assertAlmostEqual(aligner.target_right_extend_gap_score, pickled_aligner.target_right_extend_gap_score)
+        self.assertAlmostEqual(aligner.query_internal_open_gap_score, pickled_aligner.query_internal_open_gap_score)
+        self.assertAlmostEqual(aligner.query_internal_extend_gap_score, pickled_aligner.query_internal_extend_gap_score)
+        self.assertAlmostEqual(aligner.query_left_open_gap_score, pickled_aligner.query_left_open_gap_score)
+        self.assertAlmostEqual(aligner.query_left_extend_gap_score, pickled_aligner.query_left_extend_gap_score)
+        self.assertAlmostEqual(aligner.query_right_open_gap_score, pickled_aligner.query_right_open_gap_score)
+        self.assertAlmostEqual(aligner.query_right_extend_gap_score, pickled_aligner.query_right_extend_gap_score)
+        self.assertEqual(aligner.mode, pickled_aligner.mode)
+
+    def test_pickle_aligner_substitution_matrix(self):
+        try:
+            from Bio.Align import substitution_matrices
+        except ImportError:
+            return
+        import pickle
+        aligner = Align.PairwiseAligner()
+        aligner.wildcard = "N"
+        aligner.substitution_matrix = substitution_matrices.load("BLOSUM80")
+        aligner.target_internal_open_gap_score = -5
+        aligner.target_internal_extend_gap_score = -3
+        aligner.target_left_open_gap_score = -2
+        aligner.target_left_extend_gap_score = -3
+        aligner.target_right_open_gap_score = -4.5
+        aligner.target_right_extend_gap_score = -4.3
+        aligner.query_internal_open_gap_score = -2
+        aligner.query_internal_extend_gap_score = -2.5
+        aligner.query_left_open_gap_score = -9.1
+        aligner.query_left_extend_gap_score = +1.7
+        aligner.query_right_open_gap_score = -1.9
+        aligner.query_right_extend_gap_score = -2.0
+        aligner.mode = "global"
+        state = pickle.dumps(aligner)
+        pickled_aligner = pickle.loads(state)
+        self.assertEqual(aligner.wildcard, pickled_aligner.wildcard)
+        self.assertIsNone(pickled_aligner.match_score)
+        self.assertIsNone(pickled_aligner.mismatch_score)
+        self.assertTrue((aligner.substitution_matrix == pickled_aligner.substitution_matrix).all())
+        self.assertEqual(aligner.substitution_matrix.alphabet, pickled_aligner.substitution_matrix.alphabet)
+        self.assertAlmostEqual(aligner.target_internal_open_gap_score, pickled_aligner.target_internal_open_gap_score)
+        self.assertAlmostEqual(aligner.target_internal_extend_gap_score, pickled_aligner.target_internal_extend_gap_score)
+        self.assertAlmostEqual(aligner.target_left_open_gap_score, pickled_aligner.target_left_open_gap_score)
+        self.assertAlmostEqual(aligner.target_left_extend_gap_score, pickled_aligner.target_left_extend_gap_score)
+        self.assertAlmostEqual(aligner.target_right_open_gap_score, pickled_aligner.target_right_open_gap_score)
+        self.assertAlmostEqual(aligner.target_right_extend_gap_score, pickled_aligner.target_right_extend_gap_score)
+        self.assertAlmostEqual(aligner.query_internal_open_gap_score, pickled_aligner.query_internal_open_gap_score)
+        self.assertAlmostEqual(aligner.query_internal_extend_gap_score, pickled_aligner.query_internal_extend_gap_score)
+        self.assertAlmostEqual(aligner.query_left_open_gap_score, pickled_aligner.query_left_open_gap_score)
+        self.assertAlmostEqual(aligner.query_left_extend_gap_score, pickled_aligner.query_left_extend_gap_score)
+        self.assertAlmostEqual(aligner.query_right_open_gap_score, pickled_aligner.query_right_open_gap_score)
+        self.assertAlmostEqual(aligner.query_right_extend_gap_score, pickled_aligner.query_right_extend_gap_score)
+        self.assertEqual(aligner.mode, pickled_aligner.mode)
+
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2522,6 +2522,7 @@ class TestUnicodeStrings(unittest.TestCase):
 class TestAlignerPickling(unittest.TestCase):
     def test_pickle_aligner_match_mismatch(self):
         import pickle
+
         aligner = Align.PairwiseAligner()
         aligner.wildcard = "X"
         aligner.match_score = 3
@@ -2545,18 +2546,54 @@ class TestAlignerPickling(unittest.TestCase):
         self.assertAlmostEqual(aligner.match_score, pickled_aligner.match_score)
         self.assertAlmostEqual(aligner.mismatch_score, pickled_aligner.mismatch_score)
         self.assertIsNone(pickled_aligner.substitution_matrix)
-        self.assertAlmostEqual(aligner.target_internal_open_gap_score, pickled_aligner.target_internal_open_gap_score)
-        self.assertAlmostEqual(aligner.target_internal_extend_gap_score, pickled_aligner.target_internal_extend_gap_score)
-        self.assertAlmostEqual(aligner.target_left_open_gap_score, pickled_aligner.target_left_open_gap_score)
-        self.assertAlmostEqual(aligner.target_left_extend_gap_score, pickled_aligner.target_left_extend_gap_score)
-        self.assertAlmostEqual(aligner.target_right_open_gap_score, pickled_aligner.target_right_open_gap_score)
-        self.assertAlmostEqual(aligner.target_right_extend_gap_score, pickled_aligner.target_right_extend_gap_score)
-        self.assertAlmostEqual(aligner.query_internal_open_gap_score, pickled_aligner.query_internal_open_gap_score)
-        self.assertAlmostEqual(aligner.query_internal_extend_gap_score, pickled_aligner.query_internal_extend_gap_score)
-        self.assertAlmostEqual(aligner.query_left_open_gap_score, pickled_aligner.query_left_open_gap_score)
-        self.assertAlmostEqual(aligner.query_left_extend_gap_score, pickled_aligner.query_left_extend_gap_score)
-        self.assertAlmostEqual(aligner.query_right_open_gap_score, pickled_aligner.query_right_open_gap_score)
-        self.assertAlmostEqual(aligner.query_right_extend_gap_score, pickled_aligner.query_right_extend_gap_score)
+        self.assertAlmostEqual(
+            aligner.target_internal_open_gap_score,
+            pickled_aligner.target_internal_open_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.target_internal_extend_gap_score,
+            pickled_aligner.target_internal_extend_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.target_left_open_gap_score,
+            pickled_aligner.target_left_open_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.target_left_extend_gap_score,
+            pickled_aligner.target_left_extend_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.target_right_open_gap_score,
+            pickled_aligner.target_right_open_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.target_right_extend_gap_score,
+            pickled_aligner.target_right_extend_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.query_internal_open_gap_score,
+            pickled_aligner.query_internal_open_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.query_internal_extend_gap_score,
+            pickled_aligner.query_internal_extend_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.query_left_open_gap_score,
+            pickled_aligner.query_left_open_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.query_left_extend_gap_score,
+            pickled_aligner.query_left_extend_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.query_right_open_gap_score,
+            pickled_aligner.query_right_open_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.query_right_extend_gap_score,
+            pickled_aligner.query_right_extend_gap_score
+        )
         self.assertEqual(aligner.mode, pickled_aligner.mode)
 
     def test_pickle_aligner_substitution_matrix(self):
@@ -2586,22 +2623,61 @@ class TestAlignerPickling(unittest.TestCase):
         self.assertEqual(aligner.wildcard, pickled_aligner.wildcard)
         self.assertIsNone(pickled_aligner.match_score)
         self.assertIsNone(pickled_aligner.mismatch_score)
-        self.assertTrue((aligner.substitution_matrix == pickled_aligner.substitution_matrix).all())
-        self.assertEqual(aligner.substitution_matrix.alphabet, pickled_aligner.substitution_matrix.alphabet)
-        self.assertAlmostEqual(aligner.target_internal_open_gap_score, pickled_aligner.target_internal_open_gap_score)
-        self.assertAlmostEqual(aligner.target_internal_extend_gap_score, pickled_aligner.target_internal_extend_gap_score)
-        self.assertAlmostEqual(aligner.target_left_open_gap_score, pickled_aligner.target_left_open_gap_score)
-        self.assertAlmostEqual(aligner.target_left_extend_gap_score, pickled_aligner.target_left_extend_gap_score)
-        self.assertAlmostEqual(aligner.target_right_open_gap_score, pickled_aligner.target_right_open_gap_score)
-        self.assertAlmostEqual(aligner.target_right_extend_gap_score, pickled_aligner.target_right_extend_gap_score)
-        self.assertAlmostEqual(aligner.query_internal_open_gap_score, pickled_aligner.query_internal_open_gap_score)
-        self.assertAlmostEqual(aligner.query_internal_extend_gap_score, pickled_aligner.query_internal_extend_gap_score)
-        self.assertAlmostEqual(aligner.query_left_open_gap_score, pickled_aligner.query_left_open_gap_score)
-        self.assertAlmostEqual(aligner.query_left_extend_gap_score, pickled_aligner.query_left_extend_gap_score)
-        self.assertAlmostEqual(aligner.query_right_open_gap_score, pickled_aligner.query_right_open_gap_score)
-        self.assertAlmostEqual(aligner.query_right_extend_gap_score, pickled_aligner.query_right_extend_gap_score)
+        self.assertTrue(
+            (aligner.substitution_matrix == pickled_aligner.substitution_matrix).all())
+        self.assertEqual(
+            aligner.substitution_matrix.alphabet,
+            pickled_aligner.substitution_matrix.alphabet
+        )
+        self.assertAlmostEqual(
+            aligner.target_internal_open_gap_score,
+            pickled_aligner.target_internal_open_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.target_internal_extend_gap_score,
+            pickled_aligner.target_internal_extend_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.target_left_open_gap_score,
+            pickled_aligner.target_left_open_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.target_left_extend_gap_score,
+            pickled_aligner.target_left_extend_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.target_right_open_gap_score,
+            pickled_aligner.target_right_open_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.target_right_extend_gap_score,
+            pickled_aligner.target_right_extend_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.query_internal_open_gap_score,
+            pickled_aligner.query_internal_open_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.query_internal_extend_gap_score,
+            pickled_aligner.query_internal_extend_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.query_left_open_gap_score,
+            pickled_aligner.query_left_open_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.query_left_extend_gap_score,
+            pickled_aligner.query_left_extend_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.query_right_open_gap_score,
+            pickled_aligner.query_right_open_gap_score
+        )
+        self.assertAlmostEqual(
+            aligner.query_right_extend_gap_score,
+            pickled_aligner.query_right_extend_gap_score
+        )
         self.assertEqual(aligner.mode, pickled_aligner.mode)
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Make `PairwiseAligner` in `Bio.Align` pickleable by adding `__setstate__`, `__getstate__` methods.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
