### PR TITLE
use PSL convention for qStart, tStart, qEnd, tEnd

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1192,36 +1192,36 @@ class PairwiseAlignment:
         qStarts = []
         tStarts = []
         strand = "+"
-        start1, start2 = self.path[0]
-        tStart = start1
-        qStart = start2
-        for end1, end2 in self.path[1:]:
-            count1 = end1 - start1
-            count2 = end2 - start2
-            if count1 == 0:
+        tStart, qStart = self.path[0]
+        for tEnd, qEnd in self.path[1:]:
+            tCount = tEnd - tStart
+            qCount = qEnd - qStart
+            if tCount == 0:
                 qNumInsert += 1
-                qBaseInsert += count2
-                start2 = end2
-            elif count2 == 0:
+                qBaseInsert += qCount
+                qStart = qEnd
+            elif qCount == 0:
                 tNumInsert += 1
-                tBaseInsert += count1
-                start1 = end1
+                tBaseInsert += tCount
+                tStart = tEnd
             else:
-                assert count1 == count2
-                tStarts.append(start1)
-                qStarts.append(start2)
-                blockSizes.append(count1)
-                for c1, c2 in zip(seq1[start1:end1], seq2[start2:end2]):
+                assert tCount == qCount
+                tStarts.append(tStart)
+                qStarts.append(qStart)
+                blockSizes.append(tCount)
+                for c1, c2 in zip(seq1[tStart:tEnd], seq2[qStart:qEnd]):
                     if c1 == "N" or c2 == "N":
                         nCount += 1
                     elif c1 == c2:
                         matches += 1
                     else:
                         misMatches += 1
-                start1 = end1
-                start2 = end2
-        tEnd = end1
-        qEnd = end2
+                tStart = tEnd
+                qStart = qEnd
+        tStart = tStarts[0]  # start of alignment in target
+        qStart = qStarts[0]  # start of alignment in query
+        tEnd = tStarts[-1] + blockSizes[-1]  # end of alignment in target
+        qEnd = qStarts[-1] + blockSizes[-1]  # end of alignment in query
         blockcount = len(blockSizes)
         blockSizes = ",".join(map(str, blockSizes)) + ","
         qStarts = ",".join(map(str, qStarts)) + ","


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR modifies the PSL formatter to be consistent with the PSL specification definition of qStart, qEnd, tStart, tEnd.