### PR TITLE
fix gap counts in PSL output

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1173,8 +1173,8 @@ class PairwiseAlignment:
             tName = "target"
         else:
             target = target.seq
-        seq1 = str(target)
-        seq2 = str(query)
+        seq1 = bytes(target)
+        seq2 = bytes(query)
         n1 = len(seq1)
         n2 = len(seq2)
         # variable names follow those in the PSL file format specification
@@ -1197,12 +1197,14 @@ class PairwiseAlignment:
             tCount = tEnd - tStart
             qCount = qEnd - qStart
             if tCount == 0:
-                qNumInsert += 1
-                qBaseInsert += qCount
+                if qStart > 0 and qEnd < qSize:
+                    qNumInsert += 1
+                    qBaseInsert += qCount
                 qStart = qEnd
             elif qCount == 0:
-                tNumInsert += 1
-                tBaseInsert += tCount
+                if tStart > 0 and tEnd < tSize:
+                    tNumInsert += 1
+                    tBaseInsert += tCount
                 tStart = tEnd
             else:
                 assert tCount == qCount
@@ -1556,10 +1558,14 @@ class PairwiseAligner(_aligners.PairwiseAligner):
     def align(self, seqA, seqB):
         """Return the alignments of two sequences using PairwiseAligner."""
         if isinstance(seqA, (Seq, MutableSeq)):
-            seqA = bytes(seqA)
+            sA = bytes(seqA)
+        else:
+            sA = seqA
         if isinstance(seqB, (Seq, MutableSeq)):
-            seqB = bytes(seqB)
-        score, paths = _aligners.PairwiseAligner.align(self, seqA, seqB)
+            sB = bytes(seqB)
+        else:
+            sB = seqB
+        score, paths = _aligners.PairwiseAligner.align(self, sA, sB)
         alignments = PairwiseAlignments(seqA, seqB, score, paths)
         return alignments
 

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1173,8 +1173,14 @@ class PairwiseAlignment:
             tName = "target"
         else:
             target = target.seq
-        seq1 = bytes(target)
-        seq2 = bytes(query)
+        try:
+            seq1 = bytes(target)
+        except TypeError:  # string
+            seq1 = target
+        try:
+            seq2 = bytes(query)
+        except TypeError:  # string
+            seq2 = query
         n1 = len(seq1)
         n2 = len(seq2)
         # variable names follow those in the PSL file format specification

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2692,23 +2692,31 @@ class TestAlignmentFormat(unittest.TestCase):
         alignments = aligner.align("GAACT", "GCT")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertEqual(str(alignment), """\
+        self.assertEqual(
+            str(alignment),
+            """\
 GAACT
 |--||
 G--CT
 """)
-        self.assertEqual(format(alignment, "psl"), """\
+        self.assertEqual(
+            format(alignment, "psl"),
+            """\
 3	0	0	0	0	0	1	2	+	query	3	0	3	target	5	0	5	2	1,2,	0,1,	0,3,
 """)
         alignments = aligner.align("GCT", "GAACT")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertEqual(str(alignment), """\
+        self.assertEqual(
+            str(alignment),
+            """\
 G--CT
 |--||
 GAACT
 """)
-        self.assertEqual(format(alignment, "psl"), """\
+        self.assertEqual(
+            format(alignment, "psl"),
+            """\
 3	0	0	0	1	2	0	0	+	query	5	0	5	target	3	0	3	2	1,2,	0,3,	0,1,
 """)
 
@@ -2720,45 +2728,61 @@ GAACT
         alignments = aligner.align("ACGTAGCATCAGC", "CCCCACGTAGCATCAGC")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertEqual(str(alignment), """\
+        self.assertEqual(
+            str(alignment),
+            """\
 ----ACGTAGCATCAGC
 ----|||||||||||||
 CCCCACGTAGCATCAGC
 """)
-        self.assertEqual(format(alignment, "psl"), """\
+        self.assertEqual(
+            format(alignment, "psl"),
+            """\
 13	0	0	0	0	0	0	0	+	query	17	4	17	target	13	0	13	1	13,	4,	0,
 """)
         alignments = aligner.align("CCCCACGTAGCATCAGC", "ACGTAGCATCAGC")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertEqual(str(alignment), """\
+        self.assertEqual(
+            str(alignment),
+            """\
 CCCCACGTAGCATCAGC
 ----|||||||||||||
 ----ACGTAGCATCAGC
 """)
-        self.assertEqual(format(alignment, "psl"), """\
+        self.assertEqual(
+            format(alignment, "psl"),
+            """\
 13	0	0	0	0	0	0	0	+	query	13	0	13	target	17	4	17	1	13,	0,	4,
 """)
         alignments = aligner.align("ACGTAGCATCAGC", "ACGTAGCATCAGCGGGG")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertEqual(str(alignment), """\
+        self.assertEqual(
+            str(alignment),
+            """\
 ACGTAGCATCAGC----
 |||||||||||||----
 ACGTAGCATCAGCGGGG
 """)
-        self.assertEqual(format(alignment, "psl"), """\
+        self.assertEqual(
+            format(alignment, "psl"),
+            """\
 13	0	0	0	0	0	0	0	+	query	17	0	13	target	13	0	13	1	13,	0,	0,
 """)
         alignments = aligner.align("ACGTAGCATCAGCGGGG", "ACGTAGCATCAGC")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertEqual(str(alignment), """\
+        self.assertEqual(
+            str(alignment),
+            """\
 ACGTAGCATCAGCGGGG
 |||||||||||||----
 ACGTAGCATCAGC----
 """)
-        self.assertEqual(format(alignment, "psl"), """\
+        self.assertEqual(
+            format(alignment, "psl"),
+            """\
 13	0	0	0	0	0	0	0	+	query	13	0	13	target	17	0	13	1	13,	0,	0,
 """)
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2698,12 +2698,14 @@ class TestAlignmentFormat(unittest.TestCase):
 GAACT
 |--||
 G--CT
-""")
+""",
+        )
         self.assertEqual(
             format(alignment, "psl"),
             """\
 3	0	0	0	0	0	1	2	+	query	3	0	3	target	5	0	5	2	1,2,	0,1,	0,3,
-""")
+""",
+        )
         alignments = aligner.align("GCT", "GAACT")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -2713,12 +2715,14 @@ G--CT
 G--CT
 |--||
 GAACT
-""")
+""",
+        )
         self.assertEqual(
             format(alignment, "psl"),
             """\
 3	0	0	0	1	2	0	0	+	query	5	0	5	target	3	0	3	2	1,2,	0,3,	0,1,
-""")
+""",
+        )
 
     def test_alignment_end_gap(self):
         aligner = Align.PairwiseAligner()
@@ -2734,12 +2738,14 @@ GAACT
 ----ACGTAGCATCAGC
 ----|||||||||||||
 CCCCACGTAGCATCAGC
-""")
+""",
+        )
         self.assertEqual(
             format(alignment, "psl"),
             """\
 13	0	0	0	0	0	0	0	+	query	17	4	17	target	13	0	13	1	13,	4,	0,
-""")
+""",
+        )
         alignments = aligner.align("CCCCACGTAGCATCAGC", "ACGTAGCATCAGC")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -2749,12 +2755,14 @@ CCCCACGTAGCATCAGC
 CCCCACGTAGCATCAGC
 ----|||||||||||||
 ----ACGTAGCATCAGC
-""")
+""",
+        )
         self.assertEqual(
             format(alignment, "psl"),
             """\
 13	0	0	0	0	0	0	0	+	query	13	0	13	target	17	4	17	1	13,	0,	4,
-""")
+""",
+        )
         alignments = aligner.align("ACGTAGCATCAGC", "ACGTAGCATCAGCGGGG")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -2764,12 +2772,14 @@ CCCCACGTAGCATCAGC
 ACGTAGCATCAGC----
 |||||||||||||----
 ACGTAGCATCAGCGGGG
-""")
+""",
+        )
         self.assertEqual(
             format(alignment, "psl"),
             """\
 13	0	0	0	0	0	0	0	+	query	17	0	13	target	13	0	13	1	13,	0,	0,
-""")
+""",
+        )
         alignments = aligner.align("ACGTAGCATCAGCGGGG", "ACGTAGCATCAGC")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -2779,17 +2789,16 @@ ACGTAGCATCAGCGGGG
 ACGTAGCATCAGCGGGG
 |||||||||||||----
 ACGTAGCATCAGC----
-""")
+""",
+        )
         self.assertEqual(
             format(alignment, "psl"),
             """\
 13	0	0	0	0	0	0	0	+	query	13	0	13	target	17	0	13	1	13,	0,	0,
-""")
+""",
+        )
 
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)
     unittest.main(testRunner=runner)
-
-
-

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2683,6 +2683,89 @@ class TestAlignerPickling(unittest.TestCase):
         self.assertEqual(aligner.mode, pickled_aligner.mode)
 
 
+class TestAlignmentFormat(unittest.TestCase):
+    def test_alignment_simple(self):
+        aligner = Align.PairwiseAligner()
+        aligner.extend_gap_score = -1
+        aligner.open_gap_score = -3
+        aligner.mismatch = -10
+        alignments = aligner.align("GAACT", "GCT")
+        self.assertEqual(len(alignments), 1)
+        alignment = alignments[0]
+        self.assertEqual(str(alignment), """\
+GAACT
+|--||
+G--CT
+""")
+        self.assertEqual(format(alignment, "psl"), """\
+3	0	0	0	0	0	1	2	+	query	3	0	3	target	5	0	5	2	1,2,	0,1,	0,3,
+""")
+        alignments = aligner.align("GCT", "GAACT")
+        self.assertEqual(len(alignments), 1)
+        alignment = alignments[0]
+        self.assertEqual(str(alignment), """\
+G--CT
+|--||
+GAACT
+""")
+        self.assertEqual(format(alignment, "psl"), """\
+3	0	0	0	1	2	0	0	+	query	5	0	5	target	3	0	3	2	1,2,	0,3,	0,1,
+""")
+
+    def test_alignment_end_gap(self):
+        aligner = Align.PairwiseAligner()
+        aligner.gap_score = -1
+        aligner.end_gap_score = 0
+        aligner.mismatch = -10
+        alignments = aligner.align("ACGTAGCATCAGC", "CCCCACGTAGCATCAGC")
+        self.assertEqual(len(alignments), 1)
+        alignment = alignments[0]
+        self.assertEqual(str(alignment), """\
+----ACGTAGCATCAGC
+----|||||||||||||
+CCCCACGTAGCATCAGC
+""")
+        self.assertEqual(format(alignment, "psl"), """\
+13	0	0	0	0	0	0	0	+	query	17	4	17	target	13	0	13	1	13,	4,	0,
+""")
+        alignments = aligner.align("CCCCACGTAGCATCAGC", "ACGTAGCATCAGC")
+        self.assertEqual(len(alignments), 1)
+        alignment = alignments[0]
+        self.assertEqual(str(alignment), """\
+CCCCACGTAGCATCAGC
+----|||||||||||||
+----ACGTAGCATCAGC
+""")
+        self.assertEqual(format(alignment, "psl"), """\
+13	0	0	0	0	0	0	0	+	query	13	0	13	target	17	4	17	1	13,	0,	4,
+""")
+        alignments = aligner.align("ACGTAGCATCAGC", "ACGTAGCATCAGCGGGG")
+        self.assertEqual(len(alignments), 1)
+        alignment = alignments[0]
+        self.assertEqual(str(alignment), """\
+ACGTAGCATCAGC----
+|||||||||||||----
+ACGTAGCATCAGCGGGG
+""")
+        self.assertEqual(format(alignment, "psl"), """\
+13	0	0	0	0	0	0	0	+	query	17	0	13	target	13	0	13	1	13,	0,	0,
+""")
+        alignments = aligner.align("ACGTAGCATCAGCGGGG", "ACGTAGCATCAGC")
+        self.assertEqual(len(alignments), 1)
+        alignment = alignments[0]
+        self.assertEqual(str(alignment), """\
+ACGTAGCATCAGCGGGG
+|||||||||||||----
+ACGTAGCATCAGC----
+""")
+        self.assertEqual(format(alignment, "psl"), """\
+13	0	0	0	0	0	0	0	+	query	13	0	13	target	17	0	13	1	13,	0,	0,
+""")
+
+
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)
     unittest.main(testRunner=runner)
+
+
+


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR fixes the `qNumInsert`, `qBaseInsert`, `tNumInsert`, `tBaseInsert` fields in PSL output if the alignment starts or ends with a gap.
