### PR TITLE
In PSL output, use bytes when checking for wildcard

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1176,13 +1176,14 @@ class PairwiseAlignment:
         try:
             seq1 = bytes(target)
         except TypeError:  # string
-            seq1 = target
+            seq1 = bytes(target, "ASCII")
         try:
             seq2 = bytes(query)
         except TypeError:  # string
-            seq2 = query
+            seq2 = bytes(query, "ASCII")
         n1 = len(seq1)
         n2 = len(seq2)
+        wildcard = ord("N")
         # variable names follow those in the PSL file format specification
         matches = 0
         misMatches = 0
@@ -1218,7 +1219,7 @@ class PairwiseAlignment:
                 qStarts.append(qStart)
                 blockSizes.append(tCount)
                 for c1, c2 in zip(seq1[tStart:tEnd], seq2[qStart:qEnd]):
-                    if c1 == "N" or c2 == "N":
+                    if c1 == wildcard or c2 == wildcard:
                         nCount += 1
                     elif c1 == c2:
                         matches += 1

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2817,7 +2817,7 @@ ACGTAGCATCAGC----
 TTTTTNACGCTCGAGCAGCTACG-----
 ------|||.||||||.||||||-----
 ------ACGATCGAGCNGCTACGCCCNC
-            """,
+""",
         )
         self.assertEqual(
             format(alignment, "psl"),

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2811,11 +2811,14 @@ ACGTAGCATCAGC----
         alignments = aligner.align(target, query)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertEqual(str(alignment), """\
+        self.assertEqual(
+            str(alignment),
+            """\
 TTTTTNACGCTCGAGCAGCTACG-----
 ------|||.||||||.||||||-----
 ------ACGATCGAGCNGCTACGCCCNC
-""")
+            """,
+        )
         self.assertEqual(
             format(alignment, "psl"),
             """\
@@ -2826,11 +2829,14 @@ TTTTTNACGCTCGAGCAGCTACG-----
         alignments = aligner.align(Seq(target), Seq(query))
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertEqual(str(alignment), """\
+        self.assertEqual(
+            str(alignment),
+            """\
 TTTTTNACGCTCGAGCAGCTACG-----
 ------|||.||||||.||||||-----
 ------ACGATCGAGCNGCTACGCCCNC
-""")
+""",
+            )
         self.assertEqual(
             format(alignment, "psl"),
             """\

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -10,6 +10,7 @@ import os
 import unittest
 
 from Bio import Align, SeqIO
+from Bio.Seq import Seq
 
 
 class TestAlignerProperties(unittest.TestCase):
@@ -2795,6 +2796,45 @@ ACGTAGCATCAGC----
             format(alignment, "psl"),
             """\
 13	0	0	0	0	0	0	0	+	query	13	0	13	target	17	0	13	1	13,	0,	0,
+""",
+        )
+
+    def test_alignment_wildcard(self):
+        aligner = Align.PairwiseAligner()
+        aligner.gap_score = -10
+        aligner.end_gap_score = 0
+        aligner.mismatch = -2
+        aligner.wildcard = "N"
+        target = "TTTTTNACGCTCGAGCAGCTACG"
+        query = "ACGATCGAGCNGCTACGCCCNC"
+        # use strings for target and query
+        alignments = aligner.align(target, query)
+        self.assertEqual(len(alignments), 1)
+        alignment = alignments[0]
+        self.assertEqual(str(alignment), """\
+TTTTTNACGCTCGAGCAGCTACG-----
+------|||.||||||.||||||-----
+------ACGATCGAGCNGCTACGCCCNC
+""")
+        self.assertEqual(
+            format(alignment, "psl"),
+            """\
+15	1	0	1	0	0	0	0	+	query	22	0	17	target	23	6	23	1	17,	0,	6,
+""",
+        )
+        # use Seq objects for target and query
+        alignments = aligner.align(Seq(target), Seq(query))
+        self.assertEqual(len(alignments), 1)
+        alignment = alignments[0]
+        self.assertEqual(str(alignment), """\
+TTTTTNACGCTCGAGCAGCTACG-----
+------|||.||||||.||||||-----
+------ACGATCGAGCNGCTACGCCCNC
+""")
+        self.assertEqual(
+            format(alignment, "psl"),
+            """\
+15	1	0	1	0	0	0	0	+	query	22	0	17	target	23	6	23	1	17,	0,	6,
 """,
         )
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2836,7 +2836,7 @@ TTTTTNACGCTCGAGCAGCTACG-----
 ------|||.||||||.||||||-----
 ------ACGATCGAGCNGCTACGCCCNC
 """,
-            )
+        )
         self.assertEqual(
             format(alignment, "psl"),
             """\


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR makes sure that we are comparing `bytes` to `bytes` when counting the occurrence of wildcard characters in the alignment.