### PR TITLE
add SAM output to the pairwise aligner

### DIFF
--- a/Doc/Tutorial.tex
+++ b/Doc/Tutorial.tex
@@ -206,6 +206,9 @@ Teuvo Kohonen: ``Self-organizing maps'', 2nd Edition. Berlin; New York: Springer
 Pierre L'Ecuyer: ``Efficient and Portable Combined Random Number Generators.''
 \textit{Communications of the ACM} {\bf 31} (6): 742--749,774 (1988).
 \url{https://doi.org/10.1145/62959.62969}
+\bibitem{li2009}
+Heng Li, Bob Handsaker, Alec Wysoker, Tim Fennell, Jue Ruan, Nils Homer, Gabor Marth, Goncalo Abecasis, Richard Durbin: ``The Sequence Alignment/Map format and SAMtools.'' \textit{Bioinformatics} {\bf 25} (16): 2078--2079 (2009).
+\url{https://doi:10.1093/bioinformatics/btp352}
 \bibitem{majumdar2005}
 Indraneel Majumdar, S. Sri Krishna, Nick V. Grishin: ``PALSSE: A program to delineate linear secondary structural elements from protein structures.'' \textit{BMC Bioinformatics}, {\bf 6}: 202 (2005).
 \url{https://doi.org/10.1186/1471-2105-6-202}.

--- a/Doc/Tutorial.tex
+++ b/Doc/Tutorial.tex
@@ -208,7 +208,7 @@ Pierre L'Ecuyer: ``Efficient and Portable Combined Random Number Generators.''
 \url{https://doi.org/10.1145/62959.62969}
 \bibitem{li2009}
 Heng Li, Bob Handsaker, Alec Wysoker, Tim Fennell, Jue Ruan, Nils Homer, Gabor Marth, Goncalo Abecasis, Richard Durbin: ``The Sequence Alignment/Map format and SAMtools.'' \textit{Bioinformatics} {\bf 25} (16): 2078--2079 (2009).
-\url{https://doi:10.1093/bioinformatics/btp352}
+\url{https://doi.org/10.1093/bioinformatics/btp352}
 \bibitem{majumdar2005}
 Indraneel Majumdar, S. Sri Krishna, Nick V. Grishin: ``PALSSE: A program to delineate linear secondary structural elements from protein structures.'' \textit{BMC Bioinformatics}, {\bf 6}: 202 (2005).
 \url{https://doi.org/10.1186/1471-2105-6-202}.

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2201,6 +2201,12 @@ or in BED (Browser Extensible Data) format:
 >>> format(alignment, 'bed')
 'target\t0\t5\tquery\t3.0\t+\t0\t5\t0\t2\t2,1,\t0,4,\n'
 \end{minted}
+or in SAM (Sequence Alignment/Map \cite{li2009}) format:
+%cont-doctest
+\begin{minted}{pycon}
+>>> format(alignment, 'sam')
+'query\t0\ttarget\t1\t255\t2M2D1M\t*\t0\t0\tGAT\t*\tAS:i:3\n'
+\end{minted}
 
 Use the \verb+aligned+ property to find the start and end indices of subsequences in the target and query sequence that were aligned to each other.
 Generally, if the alignment between target (t) and query (q) consists of $N$


### PR DESCRIPTION
Adds SAM output to the pairwise aligner in `Bio.Align`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
