### PR TITLE
Pairwise aligner: allow alignment scores on the reverse strand

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1722,13 +1722,13 @@ class PairwiseAligner(_aligners.PairwiseAligner):
         alignments = PairwiseAlignments(seqA, seqB, score, paths)
         return alignments
 
-    def score(self, seqA, seqB):
+    def score(self, seqA, seqB, strand="+"):
         """Return the alignments score of two sequences using PairwiseAligner."""
         if isinstance(seqA, (Seq, MutableSeq)):
             seqA = bytes(seqA)
         if isinstance(seqB, (Seq, MutableSeq)):
             seqB = bytes(seqB)
-        return _aligners.PairwiseAligner.score(self, seqA, seqB)
+        return _aligners.PairwiseAligner.score(self, seqA, seqB, strand)
 
     def __getstate__(self):
         state = {

--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -6467,6 +6467,162 @@ exit:
 }
 
 static int
+reverse_complement(Py_buffer* view)
+{
+    Py_ssize_t i;
+    const Py_ssize_t n = view->len;
+    int* indices;
+
+    if (view->obj) {
+        int* rc_indices = PyMem_Malloc(n*sizeof(int));
+        if (!rc_indices) {
+            PyErr_NoMemory();
+            return 0;
+        }
+        indices = view->buf;
+        for (i = 0; i < n; i++) {
+            switch(indices[i]) {
+                case 'A': rc_indices[i] = 'T'; break;
+                case 'C': rc_indices[i] = 'G'; break;
+                case 'G': rc_indices[i] = 'C'; break;
+                case 'T': rc_indices[i] = 'A'; break;
+                case 'M': rc_indices[i] = 'K'; break;
+                case 'R': rc_indices[i] = 'Y'; break;
+                case 'W': rc_indices[i] = 'W'; break;
+                case 'S': rc_indices[i] = 'S'; break;
+                case 'Y': rc_indices[i] = 'R'; break;
+                case 'K': rc_indices[i] = 'M'; break;
+                case 'V': rc_indices[i] = 'B'; break;
+                case 'H': rc_indices[i] = 'D'; break;
+                case 'D': rc_indices[i] = 'H'; break;
+                case 'B': rc_indices[i] = 'V'; break;
+                case 'a': rc_indices[i] = 't'; break;
+                case 'c': rc_indices[i] = 'g'; break;
+                case 'g': rc_indices[i] = 'c'; break;
+                case 't': rc_indices[i] = 'a'; break;
+                case 'm': rc_indices[i] = 'k'; break;
+                case 'r': rc_indices[i] = 'y'; break;
+                case 'w': rc_indices[i] = 'w'; break;
+                case 's': rc_indices[i] = 's'; break;
+                case 'y': rc_indices[i] = 'r'; break;
+                case 'k': rc_indices[i] = 'm'; break;
+                case 'v': rc_indices[i] = 'b'; break;
+                case 'h': rc_indices[i] = 'd'; break;
+                case 'd': rc_indices[i] = 'h'; break;
+                case 'b': rc_indices[i] = 'v'; break;
+                default: rc_indices[i] = indices[i];
+            }
+        }
+        PyBuffer_Release(view);  /* also sets view->obj to NULL */
+        view->buf = rc_indices;
+    }
+    else {
+        int index;
+        indices = view->buf;
+        for (i = 0; i < n/2; i++) {
+            index = indices[n-i-1];
+            switch (indices[i]) {
+                case 'A': indices[n-1-i] = 'T'; break;
+                case 'C': indices[n-1-i] = 'G'; break;
+                case 'G': indices[n-1-i] = 'C'; break;
+                case 'T': indices[n-1-i] = 'A'; break;
+                case 'M': indices[n-1-i] = 'K'; break;
+                case 'R': indices[n-1-i] = 'Y'; break;
+                case 'W': indices[n-1-i] = 'W'; break;
+                case 'S': indices[n-1-i] = 'S'; break;
+                case 'Y': indices[n-1-i] = 'R'; break;
+                case 'K': indices[n-1-i] = 'M'; break;
+                case 'V': indices[n-1-i] = 'B'; break;
+                case 'H': indices[n-1-i] = 'D'; break;
+                case 'D': indices[n-1-i] = 'H'; break;
+                case 'B': indices[n-1-i] = 'V'; break;
+                case 'a': indices[n-1-i] = 't'; break;
+                case 'c': indices[n-1-i] = 'g'; break;
+                case 'g': indices[n-1-i] = 'c'; break;
+                case 't': indices[n-1-i] = 'a'; break;
+                case 'm': indices[n-1-i] = 'k'; break;
+                case 'r': indices[n-1-i] = 'y'; break;
+                case 'w': indices[n-1-i] = 'w'; break;
+                case 's': indices[n-1-i] = 's'; break;
+                case 'y': indices[n-1-i] = 'r'; break;
+                case 'k': indices[n-1-i] = 'm'; break;
+                case 'v': indices[n-1-i] = 'b'; break;
+                case 'h': indices[n-1-i] = 'd'; break;
+                case 'd': indices[n-1-i] = 'h'; break;
+                case 'b': indices[n-1-i] = 'v'; break;
+                default: indices[n-1-i] = indices[i];
+            }
+            switch (index) {
+                case 'A': indices[i] = 'T'; break;
+                case 'C': indices[i] = 'G'; break;
+                case 'G': indices[i] = 'C'; break;
+                case 'T': indices[i] = 'A'; break;
+                case 'M': indices[i] = 'K'; break;
+                case 'R': indices[i] = 'Y'; break;
+                case 'W': indices[i] = 'W'; break;
+                case 'S': indices[i] = 'S'; break;
+                case 'Y': indices[i] = 'R'; break;
+                case 'K': indices[i] = 'M'; break;
+                case 'V': indices[i] = 'B'; break;
+                case 'H': indices[i] = 'D'; break;
+                case 'D': indices[i] = 'H'; break;
+                case 'B': indices[i] = 'V'; break;
+                case 'a': indices[i] = 't'; break;
+                case 'c': indices[i] = 'g'; break;
+                case 'g': indices[i] = 'c'; break;
+                case 't': indices[i] = 'a'; break;
+                case 'm': indices[i] = 'k'; break;
+                case 'r': indices[i] = 'y'; break;
+                case 'w': indices[i] = 'w'; break;
+                case 's': indices[i] = 's'; break;
+                case 'y': indices[i] = 'r'; break;
+                case 'k': indices[i] = 'm'; break;
+                case 'v': indices[i] = 'b'; break;
+                case 'h': indices[i] = 'd'; break;
+                case 'd': indices[i] = 'h'; break;
+                case 'b': indices[i] = 'v'; break;
+                default: indices[i] = index;
+            }
+        }
+        if (i != n-i) {
+            index = indices[i];
+            switch (index) {
+                case 'A': indices[i] = 'T'; break;
+                case 'C': indices[i] = 'G'; break;
+                case 'G': indices[i] = 'C'; break;
+                case 'T': indices[i] = 'A'; break;
+                case 'M': indices[i] = 'K'; break;
+                case 'R': indices[i] = 'Y'; break;
+                case 'W': indices[i] = 'W'; break;
+                case 'S': indices[i] = 'S'; break;
+                case 'Y': indices[i] = 'R'; break;
+                case 'K': indices[i] = 'M'; break;
+                case 'V': indices[i] = 'B'; break;
+                case 'H': indices[i] = 'D'; break;
+                case 'D': indices[i] = 'H'; break;
+                case 'B': indices[i] = 'V'; break;
+                case 'a': indices[i] = 't'; break;
+                case 'c': indices[i] = 'g'; break;
+                case 'g': indices[i] = 'c'; break;
+                case 't': indices[i] = 'a'; break;
+                case 'm': indices[i] = 'k'; break;
+                case 'r': indices[i] = 'y'; break;
+                case 'w': indices[i] = 'w'; break;
+                case 's': indices[i] = 's'; break;
+                case 'y': indices[i] = 'r'; break;
+                case 'k': indices[i] = 'm'; break;
+                case 'v': indices[i] = 'b'; break;
+                case 'h': indices[i] = 'd'; break;
+                case 'd': indices[i] = 'h'; break;
+                case 'b': indices[i] = 'v'; break;
+                default: indices[i] = index;
+            }
+        }
+    }
+    return 1;
+}
+ 
+static int
 sequence_converter(PyObject* argument, void* pointer)
 {
     Py_buffer* view = pointer;
@@ -6636,7 +6792,9 @@ Aligner_score(Aligner* self, PyObject* args, PyObject* keywords)
                                     strand_converter, &strand))
         return NULL;
 
-    // if (strand == '-') reverse_complement(&bB);
+    if (strand == '-') {
+        if (!reverse_complement(&bB)) goto error;
+    }
 
     sA = bA.buf;
     nA = bA.len / bA.itemsize;
@@ -6698,6 +6856,7 @@ Aligner_score(Aligner* self, PyObject* args, PyObject* keywords)
             break;
     }
 
+error:
     sequence_converter(NULL, &bA);
     sequence_converter(NULL, &bB);
 

--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -6666,6 +6666,7 @@ sequence_converter(PyObject* argument, void* pointer)
             }
             indices = convert_1bytes_to_ints(aligner->mapping, n, view->buf);
             if (!indices) return 0;
+            PyBuffer_Release(view);
             view->itemsize = 1;
             view->len = n;
             view->buf = indices;

--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -4278,13 +4278,27 @@ static PyGetSetDef Aligner_getset[] = {
     int kB; \
     const double gap_extend_A = self->target_internal_extend_gap_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
-    const double left_gap_extend_A = self->target_left_extend_gap_score; \
-    const double right_gap_extend_A = self->target_right_extend_gap_score; \
-    const double left_gap_extend_B = self->query_left_extend_gap_score; \
-    const double right_gap_extend_B = self->query_right_extend_gap_score; \
     double score; \
     double temp; \
     double* row; \
+    double left_gap_extend_A; \
+    double right_gap_extend_A; \
+    double left_gap_extend_B; \
+    double right_gap_extend_B; \
+    switch (strand) { \
+        case '+': \
+            left_gap_extend_A = self->target_left_extend_gap_score; \
+            right_gap_extend_A = self->target_right_extend_gap_score; \
+            left_gap_extend_B = self->query_left_extend_gap_score; \
+            right_gap_extend_B = self->query_right_extend_gap_score; \
+            break; \
+        case '-': \
+            left_gap_extend_A = self->target_right_extend_gap_score; \
+            right_gap_extend_A = self->target_left_extend_gap_score; \
+            left_gap_extend_B = self->query_right_extend_gap_score; \
+            right_gap_extend_B = self->query_left_extend_gap_score; \
+            break; \
+    } \
 \
     /* Needleman-Wunsch algorithm */ \
     row = PyMem_Malloc((nB+1)*sizeof(double)); \
@@ -4532,14 +4546,14 @@ static PyGetSetDef Aligner_getset[] = {
     const double gap_open_B = self->query_internal_open_gap_score; \
     const double gap_extend_A = self->target_internal_extend_gap_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
-    const double left_gap_open_A = self->target_left_open_gap_score; \
-    const double left_gap_open_B = self->query_left_open_gap_score; \
-    const double left_gap_extend_A = self->target_left_extend_gap_score; \
-    const double left_gap_extend_B = self->query_left_extend_gap_score; \
-    const double right_gap_open_A = self->target_right_open_gap_score; \
-    const double right_gap_open_B = self->query_right_open_gap_score; \
-    const double right_gap_extend_A = self->target_right_extend_gap_score; \
-    const double right_gap_extend_B = self->query_right_extend_gap_score; \
+    double left_gap_open_A; \
+    double left_gap_open_B; \
+    double left_gap_extend_A; \
+    double left_gap_extend_B; \
+    double right_gap_open_A; \
+    double right_gap_open_B; \
+    double right_gap_extend_A; \
+    double right_gap_extend_B; \
     double* M_row = NULL; \
     double* Ix_row = NULL; \
     double* Iy_row = NULL; \
@@ -4548,6 +4562,26 @@ static PyGetSetDef Aligner_getset[] = {
     double M_temp; \
     double Ix_temp; \
     double Iy_temp; \
+    switch (strand) { \
+        case '+': \
+            left_gap_open_A = self->target_left_open_gap_score; \
+            left_gap_open_B = self->query_left_open_gap_score; \
+            left_gap_extend_A = self->target_left_extend_gap_score; \
+            left_gap_extend_B = self->query_left_extend_gap_score; \
+            right_gap_open_A = self->target_right_open_gap_score; \
+            right_gap_open_B = self->query_right_open_gap_score; \
+            right_gap_extend_A = self->target_right_extend_gap_score; \
+            right_gap_extend_B = self->query_right_extend_gap_score; \
+        case '-': \
+            left_gap_open_A = self->target_right_open_gap_score; \
+            left_gap_open_B = self->query_right_open_gap_score; \
+            left_gap_extend_A = self->target_right_extend_gap_score; \
+            left_gap_extend_B = self->query_right_extend_gap_score; \
+            right_gap_open_A = self->target_left_open_gap_score; \
+            right_gap_open_B = self->query_left_open_gap_score; \
+            right_gap_extend_A = self->target_left_extend_gap_score; \
+            right_gap_extend_B = self->query_left_extend_gap_score; \
+    } \
 \
     /* Gotoh algorithm with three states */ \
     M_row = PyMem_Malloc((nB+1)*sizeof(double)); \
@@ -5116,9 +5150,9 @@ exit: \
     return PyErr_NoMemory(); \
 
 
-#define WATERMANSMITHBEYER_GLOBAL_SCORE(align_score) \
+#define WATERMANSMITHBEYER_ENTER_SCORE \
     int i; \
-    int j; \
+    int j = 0; \
     int k; \
     int kA; \
     int kB; \
@@ -5126,9 +5160,10 @@ exit: \
     double** Ix = NULL; \
     double** Iy = NULL; \
     double score = 0.0; \
-    double gapscore; \
+    double gapscore = 0.0; \
     double temp; \
     int ok = 1; \
+    PyObject* result = NULL; \
 \
     /* Waterman-Smith-Beyer algorithm */ \
     M = PyMem_Malloc((nA+1)*sizeof(double*)); \
@@ -5145,7 +5180,9 @@ exit: \
         Iy[i] = PyMem_Malloc((nB+1)*sizeof(double)); \
         if (!Iy[i]) goto exit; \
     } \
-\
+
+
+#define WATERMANSMITHBEYER_GLOBAL_SCORE(align_score, query_gap_start) \
     /* The top row of the score matrix is a special case, \
      *  as there are no previously aligned characters. \
      */ \
@@ -5153,7 +5190,7 @@ exit: \
     Ix[0][0] = -DBL_MAX; \
     Iy[0][0] = -DBL_MAX; \
     for (i = 1; i <= nA; i++) { \
-        ok = _call_query_gap_function(self, 0, i, &score); \
+        ok = _call_query_gap_function(self, query_gap_start, i, &score); \
         if (!ok) goto exit; \
         M[i][0] = -DBL_MAX; \
         Ix[i][0] = score; \
@@ -5174,7 +5211,7 @@ exit: \
             M[i][j] = score + (align_score); \
             score = -DBL_MAX; \
             for (k = 1; k <= i; k++) { \
-                ok = _call_query_gap_function(self, j, k, &gapscore); \
+                ok = _call_query_gap_function(self, query_gap_start, k, &gapscore); \
                 if (!ok) goto exit; \
                 SELECT_SCORE_WATERMAN_SMITH_BEYER(M[i-k][j], Iy[i-k][j]); \
             } \
@@ -5190,62 +5227,11 @@ exit: \
     } \
     SELECT_SCORE_GLOBAL(M[nA][nB], Ix[nA][nB], Iy[nA][nB]); \
 \
-exit: \
-    if (M) { \
-        /* If M is NULL, then Ix is also NULL. */ \
-        if (Ix) { \
-            /* If Ix is NULL, then Iy is also NULL. */ \
-            if (Iy) { \
-                /* If Iy is NULL, then M[i], Ix[i], and Iy[i] are also NULL. */  \
-                for (i = 0; i <= nA; i++) { \
-                    if (!M[i]) break; \
-                    PyMem_Free(M[i]);  \
-                    if (!Ix[i]) break; \
-                    PyMem_Free(Ix[i]); \
-                    if (!Iy[i]) break; \
-                    PyMem_Free(Iy[i]); \
-                } \
-                PyMem_Free(Iy); \
-            } \
-            PyMem_Free(Ix); \
-        } \
-        PyMem_Free(M); \
-    } \
-    if (!ok) return NULL; \
-    return PyFloat_FromDouble(score); \
+    result = PyFloat_FromDouble(score); \
 
 
-#define WATERMANSMITHBEYER_LOCAL_SCORE(align_score) \
-    int i; \
-    int j; \
-    int gap; \
-    int kA; \
-    int kB; \
-    double** M = NULL; \
-    double** Ix = NULL; \
-    double** Iy = NULL; \
-    double score = 0.0; \
-    double gapscore = 0.0; \
-    double temp; \
-    int ok = 1; \
+#define WATERMANSMITHBEYER_LOCAL_SCORE(align_score, query_gap_start) \
     double maximum = 0.0; \
-    PyObject* result = NULL; \
- \
-    /* Waterman-Smith-Beyer algorithm */ \
-    M = PyMem_Malloc((nA+1)*sizeof(double*)); \
-    if (!M) goto exit; \
-    Ix = PyMem_Malloc((nA+1)*sizeof(double*)); \
-    if (!Ix) goto exit; \
-    Iy = PyMem_Malloc((nA+1)*sizeof(double*)); \
-    if (!Iy) goto exit; \
-    for (i = 0; i <= nA; i++) { \
-        M[i] = PyMem_Malloc((nB+1)*sizeof(double)); \
-        if (!M[i]) goto exit; \
-        Ix[i] = PyMem_Malloc((nB+1)*sizeof(double)); \
-        if (!Ix[i]) goto exit; \
-        Iy[i] = PyMem_Malloc((nB+1)*sizeof(double)); \
-        if (!Iy[i]) goto exit; \
-    } \
     /* The top row of the score matrix is a special case, \
      *  as there are no previously aligned characters. \
      */ \
@@ -5277,18 +5263,18 @@ exit: \
                 continue; \
             } \
             score = 0.0; \
-            for (gap = 1; gap <= i; gap++) { \
-                ok = _call_query_gap_function(self, j, gap, &gapscore); \
-                SELECT_SCORE_WATERMAN_SMITH_BEYER(M[i-gap][j], Iy[i-gap][j]); \
+            for (k = 1; k <= i; k++) { \
+                ok = _call_query_gap_function(self, query_gap_start, k, &gapscore); \
+                SELECT_SCORE_WATERMAN_SMITH_BEYER(M[i-k][j], Iy[i-k][j]); \
                 if (!ok) goto exit; \
             } \
             if (score > maximum) maximum = score; \
             Ix[i][j] = score; \
             score = 0.0; \
-            for (gap = 1; gap <= j; gap++) { \
-                ok = _call_target_gap_function(self, i, gap, &gapscore); \
+            for (k = 1; k <= j; k++) { \
+                ok = _call_target_gap_function(self, i, k, &gapscore); \
                 if (!ok) goto exit; \
-                SELECT_SCORE_WATERMAN_SMITH_BEYER(M[i][j-gap], Ix[i][j-gap]); \
+                SELECT_SCORE_WATERMAN_SMITH_BEYER(M[i][j-k], Ix[i][j-k]); \
             } \
             if (score > maximum) maximum = score; \
             Iy[i][j] = score; \
@@ -5297,6 +5283,9 @@ exit: \
     SELECT_SCORE_GLOBAL(M[nA][nB], Ix[nA][nB], Iy[nA][nB]); \
     if (score > maximum) maximum = score; \
     result = PyFloat_FromDouble(maximum); \
+
+
+#define WATERMANSMITHBEYER_EXIT_SCORE \
 exit: \
     if (M) { \
         /* If M is NULL, then Ix is also NULL. */ \
@@ -5981,7 +5970,8 @@ exit:
 static PyObject*
 Aligner_needlemanwunsch_score_compare(Aligner* self,
                                       const int* sA, Py_ssize_t nA,
-                                      const int* sB, Py_ssize_t nB)
+                                      const int* sB, Py_ssize_t nB,
+                                      unsigned char strand)
 {
     const double match = self->match;
     const double mismatch = self->mismatch;
@@ -5992,7 +5982,8 @@ Aligner_needlemanwunsch_score_compare(Aligner* self,
 static PyObject*
 Aligner_needlemanwunsch_score_matrix(Aligner* self,
                                      const int* sA, Py_ssize_t nA,
-                                     const int* sB, Py_ssize_t nB)
+                                     const int* sB, Py_ssize_t nB,
+                                     unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
     const double* scores = self->substitution_matrix.buf;
@@ -6013,7 +6004,8 @@ Aligner_smithwaterman_score_compare(Aligner* self,
 static PyObject*
 Aligner_smithwaterman_score_matrix(Aligner* self,
                                    const int* sA, Py_ssize_t nA,
-                                   const int* sB, Py_ssize_t nB)
+                                   const int* sB, Py_ssize_t nB,
+                                   unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
     const double* scores = self->substitution_matrix.buf;
@@ -6065,7 +6057,8 @@ Aligner_smithwaterman_align_matrix(Aligner* self,
 static PyObject*
 Aligner_gotoh_global_score_compare(Aligner* self,
                                    const int* sA, Py_ssize_t nA,
-                                   const int* sB, Py_ssize_t nB)
+                                   const int* sB, Py_ssize_t nB,
+                                   unsigned char strand)
 {
     const double match = self->match;
     const double mismatch = self->mismatch;
@@ -6076,7 +6069,8 @@ Aligner_gotoh_global_score_compare(Aligner* self,
 static PyObject*
 Aligner_gotoh_global_score_matrix(Aligner* self,
                                   const int* sA, Py_ssize_t nA,
-                                  const int* sB, Py_ssize_t nB)
+                                  const int* sB, Py_ssize_t nB,
+                                  unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
     const double* scores = self->substitution_matrix.buf;
@@ -6189,43 +6183,89 @@ _call_target_gap_function(Aligner* aligner, int i, int j, double* score)
 static PyObject*
 Aligner_watermansmithbeyer_global_score_compare(Aligner* self,
                                                 const int* sA, Py_ssize_t nA,
-                                                const int* sB, Py_ssize_t nB)
+                                                const int* sB, Py_ssize_t nB,
+                                                unsigned char strand)
 {
     const double match = self->match;
     const double mismatch = self->mismatch;
     const int wildcard = self->wildcard;
-    WATERMANSMITHBEYER_GLOBAL_SCORE(COMPARE_SCORE);
+    WATERMANSMITHBEYER_ENTER_SCORE
+    switch (strand) {
+        case '+': {
+            WATERMANSMITHBEYER_GLOBAL_SCORE(COMPARE_SCORE, j);
+            break;
+        }
+        case '-': {
+            WATERMANSMITHBEYER_GLOBAL_SCORE(COMPARE_SCORE, nB-j);
+            break;
+	}
+    }
+    WATERMANSMITHBEYER_EXIT_SCORE
 }
 
 static PyObject*
 Aligner_watermansmithbeyer_global_score_matrix(Aligner* self,
                                                const int* sA, Py_ssize_t nA,
-                                               const int* sB, Py_ssize_t nB)
+                                               const int* sB, Py_ssize_t nB,
+                                               unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
     const double* scores = self->substitution_matrix.buf;
-    WATERMANSMITHBEYER_GLOBAL_SCORE(MATRIX_SCORE);
+    WATERMANSMITHBEYER_ENTER_SCORE
+    switch (strand) {
+        case '+':
+            WATERMANSMITHBEYER_GLOBAL_SCORE(MATRIX_SCORE, j);
+            break;
+        case '-':
+            WATERMANSMITHBEYER_GLOBAL_SCORE(MATRIX_SCORE, nB-j);
+            break;
+    }
+    WATERMANSMITHBEYER_EXIT_SCORE
 }
 
 static PyObject*
 Aligner_watermansmithbeyer_local_score_compare(Aligner* self,
                                                const int* sA, Py_ssize_t nA,
-                                               const int* sB, Py_ssize_t nB)
+                                               const int* sB, Py_ssize_t nB,
+                                               unsigned char strand)
 {
     const double match = self->match;
     const double mismatch = self->mismatch;
     const int wildcard = self->wildcard;
-    WATERMANSMITHBEYER_LOCAL_SCORE(COMPARE_SCORE);
+    WATERMANSMITHBEYER_ENTER_SCORE
+    switch (strand) {
+        case '+': {
+            WATERMANSMITHBEYER_LOCAL_SCORE(COMPARE_SCORE, j);
+            break;
+        }
+        case '-': {
+            WATERMANSMITHBEYER_LOCAL_SCORE(COMPARE_SCORE, nB-j);
+            break;
+        }
+    }
+    WATERMANSMITHBEYER_EXIT_SCORE
 }
 
 static PyObject*
 Aligner_watermansmithbeyer_local_score_matrix(Aligner* self,
                                               const int* sA, Py_ssize_t nA,
-                                              const int* sB, Py_ssize_t nB)
+                                              const int* sB, Py_ssize_t nB,
+                                              unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
     const double* scores = self->substitution_matrix.buf;
-    WATERMANSMITHBEYER_LOCAL_SCORE(MATRIX_SCORE);
+    WATERMANSMITHBEYER_ENTER_SCORE
+    switch (strand) {
+        case '+': {
+            WATERMANSMITHBEYER_LOCAL_SCORE(MATRIX_SCORE, j);
+            break;
+        }
+        case '-': {
+            WATERMANSMITHBEYER_LOCAL_SCORE(MATRIX_SCORE, nB-j);
+            break;
+        }
+    }
+    WATERMANSMITHBEYER_EXIT_SCORE
 }
 
 static PyObject*
@@ -6549,6 +6589,26 @@ sequence_converter(PyObject* argument, void* pointer)
     return 0;
 }
  
+static int
+strand_converter(PyObject* argument, void* pointer)
+{
+    if (!PyUnicode_Check(argument)) goto error;
+    if (PyUnicode_READY(argument) == -1) return 0;
+    if (PyUnicode_GET_LENGTH(argument) == 1) {
+        const Py_UCS4 ch = PyUnicode_READ_CHAR(argument, 0);
+        if (ch < 128) {
+            const char c = ch;
+            if (ch == '+' || ch == '-') {
+                *((char*)pointer) = c;
+                return 1;
+            }
+        }
+    }
+error:
+    PyErr_SetString(PyExc_ValueError, "strand must be '+' or '-'");
+    return 0;
+}
+
 static const char Aligner_score__doc__[] = "calculates the alignment score";
 
 static PyObject*
@@ -6562,17 +6622,21 @@ Aligner_score(Aligner* self, PyObject* args, PyObject* keywords)
     Py_buffer bB = {0};
     const Mode mode = self->mode;
     const Algorithm algorithm = _get_algorithm(self);
+    char strand = '+';
     PyObject* result = NULL;
     PyObject* substitution_matrix = self->substitution_matrix.obj;
 
-    static char *kwlist[] = {"sequenceA", "sequenceB", NULL};
+    static char *kwlist[] = {"sequenceA", "sequenceB", "strand", NULL};
 
     bA.obj = (PyObject*)self;
     bB.obj = (PyObject*)self;
-    if(!PyArg_ParseTupleAndKeywords(args, keywords, "O&O&", kwlist,
+    if(!PyArg_ParseTupleAndKeywords(args, keywords, "O&O&O&", kwlist,
                                     sequence_converter, &bA,
-                                    sequence_converter, &bB))
+                                    sequence_converter, &bB,
+                                    strand_converter, &strand))
         return NULL;
+
+    // if (strand == '-') reverse_complement(&bB);
 
     sA = bA.buf;
     nA = bA.len / bA.itemsize;
@@ -6584,13 +6648,13 @@ Aligner_score(Aligner* self, PyObject* args, PyObject* keywords)
             switch (mode) {
                 case Global:
                     if (substitution_matrix)
-                        result = Aligner_needlemanwunsch_score_matrix(self, sA, nA, sB, nB);
+                        result = Aligner_needlemanwunsch_score_matrix(self, sA, nA, sB, nB, strand);
                     else
-                        result = Aligner_needlemanwunsch_score_compare(self, sA, nA, sB, nB);
+                        result = Aligner_needlemanwunsch_score_compare(self, sA, nA, sB, nB, strand);
                     break;
                 case Local:
                     if (substitution_matrix)
-                        result = Aligner_smithwaterman_score_matrix(self, sA, nA, sB, nB);
+                        result = Aligner_smithwaterman_score_matrix(self, sA, nA, sB, nB, strand);
                     else
                         result = Aligner_smithwaterman_score_compare(self, sA, nA, sB, nB);
                     break;
@@ -6600,9 +6664,9 @@ Aligner_score(Aligner* self, PyObject* args, PyObject* keywords)
             switch (mode) {
                 case Global:
                     if (substitution_matrix)
-                        result = Aligner_gotoh_global_score_matrix(self, sA, nA, sB, nB);
+                        result = Aligner_gotoh_global_score_matrix(self, sA, nA, sB, nB, strand);
                     else
-                        result = Aligner_gotoh_global_score_compare(self, sA, nA, sB, nB);
+                        result = Aligner_gotoh_global_score_compare(self, sA, nA, sB, nB, strand);
                     break;
                 case Local:
                     if (substitution_matrix)
@@ -6616,15 +6680,15 @@ Aligner_score(Aligner* self, PyObject* args, PyObject* keywords)
             switch (mode) {
                 case Global:
                     if (substitution_matrix)
-                        result = Aligner_watermansmithbeyer_global_score_matrix(self, sA, nA, sB, nB);
+                        result = Aligner_watermansmithbeyer_global_score_matrix(self, sA, nA, sB, nB, strand);
                     else
-                        result = Aligner_watermansmithbeyer_global_score_compare(self, sA, nA, sB, nB);
+                        result = Aligner_watermansmithbeyer_global_score_compare(self, sA, nA, sB, nB, strand);
                     break;
                 case Local:
                     if (substitution_matrix)
-                        result = Aligner_watermansmithbeyer_local_score_matrix(self, sA, nA, sB, nB);
+                        result = Aligner_watermansmithbeyer_local_score_matrix(self, sA, nA, sB, nB, strand);
                     else
-                        result = Aligner_watermansmithbeyer_local_score_compare(self, sA, nA, sB, nB);
+                        result = Aligner_watermansmithbeyer_local_score_compare(self, sA, nA, sB, nB, strand);
                     break;
             }
             break;

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2015,6 +2015,37 @@ For convenience, \verb+PairwiseAligner+ objects have additional attributes that 
 \label{table:align-meta-attributes}
 \end{table}
 
+\subsubsection{Aligning to the reverse strand}
+\label{sec:pairwise-general-gapscores}
+
+By default, the pairwise aligner aligns the forward strand of the query to the forward strand of the target. To calculate the alignment score for \verb+seq2+ to the reverse strand of \verb+seq1+, use \verb+strand='-'+:
+%doctest
+\begin{minted}{pycon}
+>>> from Bio import Align
+>>> from Bio.Seq import reverse_complement
+>>> seq1 = "AAAACCC"
+>>> seq2 = "AACC"
+>>> aligner = Align.PairwiseAligner()
+>>> aligner.score(seq1, seq2)
+4.0
+>>> aligner.score(seq1, seq2, strand="+")
+4.0
+>>> aligner.score(seq1, reverse_complement(seq2), strand="-")
+4.0
+\end{minted}
+Note that the score for aligning \verb+seq2+ to the reverse strand of \verb+seq1+ may be different from the score for aligning the reverse complement of \verb+seq2+ to the forward strand of \verb+seq1+ if the left and right gap scores are different:
+%cont-doctest
+\begin{minted}{pycon}
+>>> aligner.internal_gap_score = -1
+>>> aligner.left_gap_score = -0.5
+>>> aligner.right_gap_score = -0.2
+>>> aligner.score(seq1, seq2)
+2.8
+>>> aligner.score(seq1, reverse_complement(seq2), strand="-")
+3.1
+\end{minted}
+
+
 \subsubsection{General gap scores}
 \label{sec:pairwise-general-gapscores}
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -10,7 +10,7 @@ import os
 import unittest
 
 from Bio import Align, SeqIO
-from Bio.Seq import Seq
+from Bio.Seq import Seq, reverse_complement
 
 
 class TestAlignerProperties(unittest.TestCase):
@@ -214,6 +214,8 @@ Pairwise sequence aligner with parameters
         self.assertEqual(aligner.algorithm, "Needleman-Wunsch")
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
+        score = aligner.score(seq1, reverse_complement(seq2), "-")
+        self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -242,6 +244,8 @@ G-A-T
         )
 
     def test_align_affine1_score(self):
+        seq1 = "CC"
+        seq2 = "ACCT"
         aligner = Align.PairwiseAligner()
         aligner.mode = "global"
         aligner.match_score = 0
@@ -271,7 +275,9 @@ Pairwise sequence aligner with parameters
   mode: global
 """,
         )
-        score = aligner.score("CC", "ACCT")
+        score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, -7.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, -7.0)
 
 
@@ -375,6 +381,8 @@ class TestUnknownCharacter(unittest.TestCase):
         aligner.wildcard = "?"
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -392,6 +400,8 @@ GA?T
         aligner.wildcard = "X"
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -407,6 +417,8 @@ GAXT
         self.assertEqual(alignment.aligned, (((0, 4),), ((0, 4),)))
         aligner.wildcard = None
         score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, 2.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
@@ -430,6 +442,8 @@ GAXT
         aligner.wildcard = "?"
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 4.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -449,6 +463,8 @@ GA-A?T
         seq2 = "GAAXT"
         aligner.wildcard = "X"
         score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, 4.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
@@ -501,6 +517,8 @@ Pairwise sequence aligner with parameters
         seq1 = "AA"
         seq2 = "A"
         score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, 1.9)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 2)
@@ -561,6 +579,8 @@ Pairwise sequence aligner with parameters
         seq2 = "GA"
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 2.9)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 2.9)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -618,6 +638,8 @@ Pairwise sequence aligner with parameters
         seq2 = "GAT"
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 2.9)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 2.9)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -664,6 +686,8 @@ Pairwise sequence aligner with parameters
         seq1 = "GCT"
         seq2 = "GATA"
         score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, 1.7)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.7)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 2)
@@ -724,6 +748,8 @@ Pairwise sequence aligner with parameters
         seq2 = "GT"
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 1.3)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 1.3)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -769,6 +795,8 @@ Pairwise sequence aligner with parameters
         seq1 = "GACT"
         seq2 = "GT"
         score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, 0.6)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 0.6)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 2)
@@ -829,6 +857,8 @@ Pairwise sequence aligner with parameters
         seq2 = "GT"
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, -1.2)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, -1.2)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -879,6 +909,8 @@ Pairwise sequence aligner with parameters
         seq1 = "GACT"
         seq2 = "GT"
         score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, 1.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 3)
@@ -958,6 +990,8 @@ Pairwise sequence aligner with parameters
         )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 1.7)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 1.7)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -1017,6 +1051,8 @@ Pairwise sequence aligner with parameters
         seq2 = "GTCT"
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 1.8)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 1.8)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -1070,6 +1106,8 @@ Pairwise sequence aligner with parameters
 """,
         )
         score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, 1.9)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 3)
@@ -1185,6 +1223,8 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
         self.assertEqual(lines[14], "  mode: local")
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -1247,6 +1287,8 @@ AT-T
         self.assertEqual(lines[14], "  mode: local")
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -1297,6 +1339,8 @@ ATT
         self.assertEqual(lines[13], "  query_right_extend_gap_score: 0.000000")
         self.assertEqual(lines[14], "  mode: local")
         score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, 3.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
@@ -1351,6 +1395,8 @@ ATAT
         self.assertEqual(lines[13], "  query_right_extend_gap_score: 0.000000")
         self.assertEqual(lines[14], "  mode: local")
         score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, 3.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 2)
@@ -1416,6 +1462,8 @@ AT-T
         self.assertEqual(lines[14], "  mode: local")
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -1468,6 +1516,8 @@ ATT
         self.assertEqual(lines[13], "  query_right_extend_gap_score: 0.000000")
         self.assertEqual(lines[14], "  mode: local")
         score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, 3.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
@@ -1703,6 +1753,8 @@ Pairwise sequence aligner with parameters
         )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 2)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 2)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -1755,6 +1807,8 @@ Pairwise sequence aligner with parameters
             aligner.algorithm, "Waterman-Smith-Beyer global alignment algorithm"
         )
         score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, -10)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, -10)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 2)
@@ -1821,6 +1875,8 @@ Pairwise sequence aligner with parameters
         )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 2.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -1849,6 +1905,8 @@ Pairwise sequence aligner with parameters
             % (gap_score, gap_score),
         )
         score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, -8.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, -8.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 4)
@@ -1935,6 +1993,8 @@ Pairwise sequence aligner with parameters
         )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 13)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 13)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -1998,6 +2058,8 @@ Pairwise sequence aligner with parameters
             aligner.algorithm, "Waterman-Smith-Beyer local alignment algorithm"
         )
         score = aligner.score(seq1, seq2)
+        self.assertAlmostEqual(score, 13)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 13)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 2)
@@ -2064,6 +2126,8 @@ Pairwise sequence aligner with parameters
         )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 2.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -2105,6 +2169,8 @@ Pairwise sequence aligner with parameters
         alignments = aligner.align(seq1, seq2)
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 2.0)
+        score = aligner.score(seq1, reverse_complement(seq2), strand="-")
+        self.assertAlmostEqual(score, 2.0)
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -2144,11 +2210,15 @@ TTGGAA
         with self.assertRaises(RuntimeError):
             aligner.score(seq1, seq2)
         with self.assertRaises(RuntimeError):
+            aligner.score(seq1, reverse_complement(seq2), strand="-")
+        with self.assertRaises(RuntimeError):
             alignments = aligner.align(seq1, seq2)
             alignments = list(alignments)
         aligner.mode = "local"
         with self.assertRaises(RuntimeError):
             aligner.score(seq1, seq2)
+        with self.assertRaises(RuntimeError):
+            aligner.score(seq1, reverse_complement(seq2), strand="-")
         with self.assertRaises(RuntimeError):
             alignments = aligner.align(seq1, seq2)
             alignments = list(alignments)
@@ -2158,11 +2228,15 @@ TTGGAA
         with self.assertRaises(RuntimeError):
             aligner.score(seq1, seq2)
         with self.assertRaises(RuntimeError):
+            aligner.score(seq1, reverse_complement(seq2), strand="-")
+        with self.assertRaises(RuntimeError):
             alignments = aligner.align(seq1, seq2)
             alignments = list(alignments)
         aligner.mode = "local"
         with self.assertRaises(RuntimeError):
             aligner.score(seq1, seq2)
+        with self.assertRaises(RuntimeError):
+            aligner.score(seq1, reverse_complement(seq2), strand="-")
         with self.assertRaises(RuntimeError):
             alignments = aligner.align(seq1, seq2)
             alignments = list(alignments)
@@ -2275,9 +2349,13 @@ class TestArgumentErrors(unittest.TestCase):
         message = "^argument should support the sequence protocol$"
         with self.assertRaisesRegex(TypeError, message):
             aligner.score("AAA", 3)
+        with self.assertRaisesRegex(TypeError, message):
+            aligner.score("AAA", 3, strand="-")
         message = "^sequence has zero length$"
         with self.assertRaisesRegex(ValueError, message):
             aligner.score("AAA", "")
+        with self.assertRaisesRegex(ValueError, message):
+            aligner.score("AAA", "", strand="-")
         message = "^sequence contains letters not in the alphabet$"
         aligner.alphabet = "ABCD"
         with self.assertRaisesRegex(ValueError, message):


### PR DESCRIPTION
This PR adds an optional `strand` argument to `aligner.score(...)` to calculate the alignment score of the query against the reverse strand of the target.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
