### PR TITLE
Use a format method instead of the format function

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -19,7 +19,6 @@ from Bio.Align import _aligners
 from Bio.Align import substitution_matrices
 from Bio.Seq import Seq, MutableSeq
 from Bio.SeqRecord import SeqRecord, _RestrictedDict
-from Bio import BiopythonDeprecationWarning
 
 # Import errors may occur here if a compiled aligners.c file
 # (_aligners.pyd or _aligners.so) is missing or if the user is

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -13,8 +13,6 @@ class, used in the Bio.AlignIO module.
 
 """
 
-import warnings
-
 from Bio.Align import _aligners
 from Bio.Align import substitution_matrices
 from Bio.Seq import Seq, MutableSeq

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1036,7 +1036,6 @@ class PairwiseAlignment:
         return None
 
     def __format__(self, format_spec):
-        raise Exception("Vervelend hee")
         warnings.warn(
             """\
 The ``__format__`` method is deprecated. Please use ``alignment.format(fmt)``

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -13,10 +13,13 @@ class, used in the Bio.AlignIO module.
 
 """
 
+import warnings
+
 from Bio.Align import _aligners
 from Bio.Align import substitution_matrices
 from Bio.Seq import Seq, MutableSeq
 from Bio.SeqRecord import SeqRecord, _RestrictedDict
+from Bio import BiopythonDeprecationWarning
 
 # Import errors may occur here if a compiled aligners.c file
 # (_aligners.pyd or _aligners.so) is missing or if the user is
@@ -1033,17 +1036,28 @@ class PairwiseAlignment:
         return None
 
     def __format__(self, format_spec):
+        raise Exception("Vervelend hee")
+        warnings.warn(
+            """\
+The ``__format__`` method is deprecated. Please use ``alignment.format(fmt)``
+instead of ``alignment(matrix, fmt)``.
+""",
+            BiopythonDeprecationWarning,
+        )
+        return self.format(format_spec)
+
+    def format(self, fmt=None):
         """Create a human-readable representation of the alignment."""
-        if format_spec == "":
+        if fmt is None:
             return self._format_pretty()
-        elif format_spec == "psl":
+        elif fmt == "psl":
             return self._format_psl()
-        elif format_spec == "bed":
+        elif fmt == "bed":
             return self._format_bed()
-        elif format_spec == "sam":
+        elif fmt == "sam":
             return self._format_sam()
         else:
-            raise ValueError("Unknown format %s" % format_spec)
+            raise ValueError("Unknown format %s" % fmt)
 
     def _format_pretty(self):
         seq1 = self._convert_sequence_string(self.target)
@@ -1408,7 +1422,7 @@ class PairwiseAlignment:
         return line
 
     def __str__(self):
-        return self.__format__("")
+        return self.format()
 
     @property
     def aligned(self):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1036,18 +1036,11 @@ class PairwiseAlignment:
         return None
 
     def __format__(self, format_spec):
-        warnings.warn(
-            """\
-The ``__format__`` method is deprecated. Please use ``alignment.format(fmt)``
-instead of ``alignment(matrix, fmt)``.
-""",
-            BiopythonDeprecationWarning,
-        )
         return self.format(format_spec)
 
-    def format(self, fmt=None):
+    def format(self, fmt=""):
         """Create a human-readable representation of the alignment."""
-        if fmt is None:
+        if fmt == "":
             return self._format_pretty()
         elif fmt == "psl":
             return self._format_psl()

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -419,7 +419,6 @@ class Array(numpy.ndarray):
         return text
 
     def __format__(self, fmt):
-        raise Exception("Vervelend hee")
         warnings.warn(
             """\
 The ``__format__`` method is deprecated. Please use ``matrix.format(fmt)``

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -419,16 +419,9 @@ class Array(numpy.ndarray):
         return text
 
     def __format__(self, fmt):
-        warnings.warn(
-            """\
-The ``__format__`` method is deprecated. Please use ``matrix.format(fmt)``
-instead of ``format(matrix, fmt)``.
-""",
-            BiopythonDeprecationWarning,
-        )
         return self.format(fmt)
 
-    def format(self, fmt=None):
+    def format(self, fmt=""):
         """Return a string representation of the array.
 
         The argument ``fmt`` specifies the number format to be used.
@@ -436,7 +429,7 @@ instead of ``format(matrix, fmt)``.
         numbers, and "%.1f" otherwise.
 
         """
-        if fmt is None:
+        if fmt == "":
             if numpy.issubdtype(self.dtype, numpy.integer):
                 fmt = "%i"
             else:

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -10,7 +10,6 @@
 import os
 import string
 import numpy
-import warnings
 
 
 class Array(numpy.ndarray):

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -12,8 +12,6 @@ import string
 import numpy
 import warnings
 
-from Bio import BiopythonDeprecationWarning
-
 
 class Array(numpy.ndarray):
     """numpy array subclass indexed by integers and by letters."""

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -10,6 +10,9 @@
 import os
 import string
 import numpy
+import warnings
+
+from Bio import BiopythonDeprecationWarning
 
 
 class Array(numpy.ndarray):
@@ -416,7 +419,18 @@ class Array(numpy.ndarray):
         return text
 
     def __format__(self, fmt):
-        if fmt == "":
+        raise Exception("Vervelend hee")
+        warnings.warn(
+            """\
+The ``__format__`` method is deprecated. Please use ``matrix.format(fmt)``
+instead of ``format(matrix, fmt)``.
+""",
+            BiopythonDeprecationWarning,
+        )
+        return self.format(fmt)
+
+    def format(self, fmt=None):
+        if fmt is None:
             if numpy.issubdtype(self.dtype, numpy.integer):
                 fmt = "%i"
             else:
@@ -430,7 +444,7 @@ class Array(numpy.ndarray):
             raise RuntimeError("Array has unexpected rank %d" % n)
 
     def __str__(self):
-        return self.__format__("")
+        return self.format()
 
     def __repr__(self):
         text = numpy.ndarray.__repr__(self)

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -429,6 +429,13 @@ instead of ``format(matrix, fmt)``.
         return self.format(fmt)
 
     def format(self, fmt=None):
+        """Return a string representation of the array.
+
+        The argument ``fmt`` specifies the number format to be used.
+        By default, the number format is "%i" if the array contains integer
+        numbers, and "%.1f" otherwise.
+
+        """
         if fmt is None:
             if numpy.issubdtype(self.dtype, numpy.integer):
                 fmt = "%i"

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -974,18 +974,23 @@ class Tree(TreeElement, TreeMixin):
             # Follow python convention and default to using __str__
             return str(self)
 
-    def format(self, format):
+    def format(self, fmt=None, format=None):
         """Serialize the tree as a string in the specified file format.
 
-        This duplicates the __format__ magic method for pre-2.6 Pythons.
+        :param fmt: a lower-case string supported by ``Bio.Phylo.write``
+            as an output file format.
+
         """
-        warnings.warn(
-            "Tree.format has been deprecated, and we intend to remove it in "
-            "a future release of Biopython. Instead of tree.format(format), "
-            "please use format(tree, format_spec) or an f-string.",
-            BiopythonDeprecationWarning,
-        )
-        return self.__format__(format)
+        if format is not None:
+            if fmt is not None:
+                raise ValueError("The ``format`` argument has been renamed to ``fmt``.")
+            raise Exception("Vervelend hee")
+            warnings.warn(
+                "The ``format`` argument has been renamed to ``fmt``.",
+                BiopythonDeprecationWarning,
+            )
+            fmt = format
+        return self.__format__(fmt)
 
     # Pretty-printer for the entire tree hierarchy
 

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -984,7 +984,6 @@ class Tree(TreeElement, TreeMixin):
         if format is not None:
             if fmt is not None:
                 raise ValueError("The ``format`` argument has been renamed to ``fmt``.")
-            raise Exception("Vervelend hee")
             warnings.warn(
                 "The ``format`` argument has been renamed to ``fmt``.",
                 BiopythonDeprecationWarning,

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -20,8 +20,6 @@ import warnings
 from urllib.parse import urlencode
 from urllib.request import urlopen, Request
 
-from Bio import BiopythonDeprecationWarning
-
 
 def create(instances, alphabet="ACGT"):
     """Create a Motif object."""
@@ -548,6 +546,19 @@ class Motif:
          - transfac : TRANSFAC like files
 
         """
+        raise Exception("Vervelend hee")
+        return self.format(format_spec)
+
+    def format(self, format_spec):
+        """Return a string representation of the Motif in the given format.
+
+        Currently supported formats:
+         - clusterbuster: Cluster Buster position frequency matrix format
+         - pfm : JASPAR single Position Frequency Matrix
+         - jaspar : JASPAR multiple Position Frequency Matrix
+         - transfac : TRANSFAC like files
+
+        """
         if format_spec in ("pfm", "jaspar"):
             from Bio.motifs import jaspar
 
@@ -565,20 +576,6 @@ class Motif:
             return clusterbuster.write(motifs)
         else:
             raise ValueError("Unknown format type %s" % format_spec)
-
-    def format(self, format_spec):
-        """Return a string representation of the Motif in the given format [DEPRECATED].
-
-        This method is deprecated; instead of motif.format(format_spec),
-        please use format(motif, format_spec).
-        """
-        warnings.warn(
-            "Motif.format has been deprecated, and we intend to remove it in a "
-            "future release of Biopython. Instead of motif.format(format_spec), "
-            "please use format(motif, format_spec).",
-            BiopythonDeprecationWarning,
-        )
-        return self.__format__(format_spec)
 
 
 def write(motifs, fmt):

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -546,7 +546,6 @@ class Motif:
          - transfac : TRANSFAC like files
 
         """
-        raise Exception("Vervelend hee")
         return self.format(format_spec)
 
     def format(self, format_spec):

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -96,7 +96,7 @@ release 1.74. Also affects ``Bio.motifs.read`` and ``Bio.motifs.parse`` for the
 ``mast`` format.
 The ``format`` method of the ``Motif`` class in ``Bio.motifs`` was deprecated
 in release 1.77, in favor of a ``__format__`` method that can be used from the
-``format`` built-in function.
+``format`` built-in function. This decision was reversed in release 1.79.
 
 Bio.Restriction.RanaConfig
 --------------------------
@@ -863,7 +863,11 @@ Bio.Align
 The methods get_column and add_sequence of the MultipleSeqAlignment class were
 deprecated in Release 1.57 and removed in Release 1.69.
 The format method of the MultipleSeqAlignment class and the PairwiseAlignment
-class were deprecated in Release 1.76, and removed in Release 1.79.
+class were deprecated in Release 1.76. This decision was reversed in
+Release 1.79. Instead, the __format__ method of the PairwiseAlignment class was
+deprecated in Release 1.79.
+The __format__ method of the Array class in Bio.Align.substitution_matrices was
+deprecated in Release 1.79.
 
 Bio.Align.Generic
 -----------------
@@ -906,11 +910,6 @@ Biopython still using this class.
 Bio.FSSP
 -----------
 Deprecated in release 1.77.
-
-Bio.Phylo.BaseTree.Tree
------------------------
-The format method was deprecated in Release 1.79 in favor of the __format__
-method, which supports Python's built-in format function.
 
 Bio.Phylo._utils
 ----------------

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -860,14 +860,14 @@ please consider using Bio.Align.substitution_matrices.
 
 Bio.Align
 ---------
-The methods get_column and add_sequence of the MultipleSeqAlignment class were
-deprecated in Release 1.57 and removed in Release 1.69.
-The format method of the MultipleSeqAlignment class and the PairwiseAlignment
-class were deprecated in Release 1.76. This decision was reversed in
-Release 1.79. Instead, the __format__ method of the PairwiseAlignment class was
-deprecated in Release 1.79.
-The __format__ method of the Array class in Bio.Align.substitution_matrices was
-deprecated in Release 1.79.
+The methods ``get_column`` and ``add_sequence`` of the MultipleSeqAlignment
+class were deprecated in Release 1.57 and removed in Release 1.69.
+The ``format`` method of the MultipleSeqAlignment class and the
+PairwiseAlignment class were deprecated in Release 1.76. This decision was
+reversed in Release 1.79. Instead, the ``__format__`` method of the
+PairwiseAlignment class was deprecated in Release 1.79.
+The ``__format__`` method of the Array class in Bio.Align.substitution_matrices
+was deprecated in Release 1.79.
 
 Bio.Align.Generic
 -----------------

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2223,19 +2223,19 @@ You can also represent the alignment as a string in PSL (Pattern Space Layout, a
 
 %cont-doctest
 \begin{minted}{pycon}
->>> format(alignment, 'psl')
+>>> alignment.format('psl')
 '3\t0\t0\t0\t0\t0\t1\t2\t+\tquery\t3\t0\t3\ttarget\t5\t0\t5\t2\t2,1,\t0,2,\t0,4,\n'
 \end{minted}
 or in BED (Browser Extensible Data) format:
 %cont-doctest
 \begin{minted}{pycon}
->>> format(alignment, 'bed')
+>>> alignment.format('bed')
 'target\t0\t5\tquery\t3.0\t+\t0\t5\t0\t2\t2,1,\t0,4,\n'
 \end{minted}
 or in SAM (Sequence Alignment/Map \cite{li2009}) format:
 %cont-doctest
 \begin{minted}{pycon}
->>> format(alignment, 'sam')
+>>> alignment.format('sam')
 'query\t0\ttarget\t1\t255\t2M2D1M\t*\t0\t0\tGAT\t*\tAS:i:3\n'
 \end{minted}
 
@@ -2849,7 +2849,7 @@ We normalize against the total number to find the probability of each substituti
 >>> import numpy
 >>> probabilities = frequency / numpy.sum(frequency)
 >>> probabilities = (probabilities + probabilities.transpose()) / 2.0
->>> print(format(probabilities, "%.4f"))
+>>> print(probabilities.format("%.4f"))
        A      C      G      T
 A 0.2026 0.0112 0.0224 0.0142
 C 0.0112 0.1848 0.0162 0.0215
@@ -2862,7 +2862,7 @@ The background probability is the probability of finding an A, C, G, or T nucleo
 %cont-doctest
 \begin{minted}{pycon}
 >>> background = numpy.sum(probabilities, 0)
->>> print(format(background, "%.4f"))
+>>> print(background.format("%.4f"))
 A 0.2505
 C 0.2337
 G 0.3165
@@ -2874,7 +2874,7 @@ The number of substitutions expected at random is simply the product of the back
 %cont-doctest
 \begin{minted}{pycon}
 >>> expected = numpy.dot(background[:,None], background[None, :])
->>> print(format(expected, "%.4f"))
+>>> print(expected.format("%.4f"))
        A      C      G      T
 A 0.0627 0.0585 0.0793 0.0499
 C 0.0585 0.0546 0.0740 0.0466
@@ -3020,7 +3020,7 @@ To save an Array object, create a string first:
 
 %cont-doctest
 \begin{minted}{pycon}
->>> text = format(matrix)
+>>> text = str(matrix)
 >>> print(text)  #doctest: +ELLIPSIS
 #  Matrix made by matblas from blosum62.iij
 #  * column uses minimum score

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1669,7 +1669,7 @@ each residue:
 %cont-doctest
 \begin{minted}{pycon}
 >>> residue_frequencies = numpy.sum(observed_frequencies, 0)
->>> print(format(residue_frequencies, "%.4f"))
+>>> print(residue_frequencies.format("%.4f"))
 D 0.2015
 E 0.2743
 H 0.0976
@@ -1684,7 +1684,7 @@ The expected frequency of residue pairs is then
 %cont-doctest
 \begin{minted}{pycon}
 >>> expected_frequencies = numpy.dot(residue_frequencies[:, None], residue_frequencies[None, :])
->>> print(format(expected_frequencies, "%.4f"))
+>>> print(expected_frequencies.format("%.4f"))
        D      E      H      K      R
 D 0.0406 0.0553 0.0197 0.0518 0.0342
 E 0.0553 0.0752 0.0268 0.0705 0.0465

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -872,7 +872,7 @@ Speaking of exporting, let's look at export functions in general.
 We can use the \verb+format+ built-in function to write the motif in the simple JASPAR \verb+pfm+ format:
 %the tabs in the output confuse doctest; don't test
 \begin{minted}{pycon}
->>> print(format(arnt, "pfm"))
+>>> print(arnt.format("pfm"))
   4.00  19.00   0.00   0.00   0.00   0.00
  16.00   0.00  20.00   0.00   0.00   0.00
   0.00   1.00   0.00  20.00   0.00  20.00
@@ -880,7 +880,7 @@ We can use the \verb+format+ built-in function to write the motif in the simple 
 \end{minted}
 Similarly, we can use \verb+format+ to write the motif in the JASPAR \verb+jaspar+ format:
 \begin{minted}{pycon}
->>> print(format(arnt, "jaspar"))
+>>> print(arnt.format("jaspar"))
 >MA0004.1  Arnt
 A [  4.00  19.00   0.00   0.00   0.00   0.00]
 C [ 16.00   0.00  20.00   0.00   0.00   0.00]
@@ -892,7 +892,7 @@ To write the motif in a TRANSFAC-like matrix format, use
 
 %cont-doctest
 \begin{minted}{pycon}
->>> print(format(m, "transfac"))
+>>> print(m.format("transfac"))
 P0      A      C      G      T
 01      3      0      0      4      W
 02      7      0      0      0      A

--- a/Tests/test_align_substitution_matrices.py
+++ b/Tests/test_align_substitution_matrices.py
@@ -119,7 +119,7 @@ Z  0.0
         self.assertEqual(sizes["chr4"], 190214555)
         self.assertEqual(sizes["chr5"], 181538259)
         self.assertEqual(sum(sizes), 3209286105)
-        text = format(sizes)
+        text = str(sizes)
         lines = text.split("\n")
         self.assertEqual(lines[0], "chr1 248956422")
         self.assertEqual(lines[1], "chr2 242193529")
@@ -144,7 +144,7 @@ Z  0.0
             self.assertAlmostEqual(frequencies[letter], counts[letter])
         with open(path) as handle:
             text = handle.read()
-        self.assertEqual(format(frequencies, "%d"), text)
+        self.assertEqual(frequencies.format("%d"), text)
         total = sum(frequencies)
         self.assertAlmostEqual(total, sum(counts.values()))
         frequencies /= total
@@ -169,7 +169,7 @@ Z  0.0
             self.assertAlmostEqual(frequencies[letter], counts[letter])
         with open(path) as handle:
             text = handle.read()
-        self.assertEqual(format(frequencies, "%d"), text)
+        self.assertEqual(frequencies.format("%d"), text)
         total = sum(frequencies)
         self.assertAlmostEqual(total, sum(counts.values()))
         frequencies /= total
@@ -196,7 +196,7 @@ Z  0.0
             self.assertAlmostEqual(frequencies[letter], counts[letter])
         with open(path) as handle:
             text = handle.read()
-        self.assertEqual(format(frequencies, "%d"), text)
+        self.assertEqual(frequencies.format("%d"), text)
         total = sum(frequencies)
         self.assertAlmostEqual(total, sum(counts.values()))
         frequencies /= total
@@ -237,7 +237,7 @@ Z  0.0
             self.assertAlmostEqual(frequencies[letter], counts[letter])
         with open(path) as handle:
             text = handle.read()
-        self.assertEqual(format(frequencies, "%d"), text)
+        self.assertEqual(frequencies.format("%d"), text)
         total = sum(frequencies)
         self.assertAlmostEqual(total, sum(counts.values()))
         frequencies /= total

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -496,17 +496,17 @@ class MotifTestsBasic(unittest.TestCase):
     def test_TFoutput(self):
         """Ensure that we can write proper TransFac output files."""
         with open(self.TFout, "w") as output_handle:
-            output_handle.write(format(self.m, "transfac"))
+            output_handle.write(self.m.format("transfac"))
 
     def test_format(self):
         self.m.name = "Foo"
-        s1 = format(self.m, "pfm")
+        s1 = self.m.format("pfm")
         expected_pfm = """  1.00   0.00   1.00   0.00  1.00
   0.00   0.00   0.00   0.00  0.00
   0.00   0.00   0.00   0.00  0.00
   0.00   1.00   0.00   1.00  0.00
 """
-        s2 = format(self.m, "jaspar")
+        s2 = self.m.format("jaspar")
         expected_jaspar = """>None Foo
 A [  1.00   0.00   1.00   0.00   1.00]
 C [  0.00   0.00   0.00   0.00   0.00]
@@ -514,7 +514,7 @@ G [  0.00   0.00   0.00   0.00   0.00]
 T [  0.00   1.00   0.00   1.00   0.00]
 """
         self.assertEqual(s2, expected_jaspar)
-        s3 = format(self.m, "transfac")
+        s3 = self.m.format("transfac")
         expected_transfac = """P0      A      C      G      T
 01      1      0      0      0      A
 02      0      0      0      1      T
@@ -525,7 +525,7 @@ XX
 //
 """
         self.assertEqual(s3, expected_transfac)
-        self.assertRaises(ValueError, format, self.m, "foo_bar")
+        self.assertRaises(ValueError, self.m.format, "foo_bar")
 
     def test_reverse_complement(self):
         """Test if motifs can be reverse-complemented."""
@@ -534,7 +534,7 @@ XX
         m = self.m
         m.background = background
         m.pseudocounts = pseudocounts
-        received_forward = format(self.m, "transfac")
+        received_forward = self.m.format("transfac")
         expected_forward = """\
 P0      A      C      G      T
 01      1      0      0      0      A
@@ -555,7 +555,7 @@ T:   0.17   0.50   0.17   0.50   0.17
 """
         self.assertEqual(str(m.pwm), expected_forward_pwm)
         m = m.reverse_complement()
-        received_reverse = format(m, "transfac")
+        received_reverse = m.format("transfac")
         expected_reverse = """\
 P0      A      C      G      T
 01      0      0      0      1      T
@@ -580,11 +580,11 @@ T:   0.50   0.17   0.50   0.17   0.50
         m = motifs.Motif(counts=counts)
         m.background = background
         m.pseudocounts = pseudocounts
-        received_forward = format(m, "transfac")
+        received_forward = m.format("transfac")
         self.assertEqual(received_forward, expected_forward)
         self.assertEqual(str(m.pwm), expected_forward_pwm)
         m = m.reverse_complement()
-        received_reverse = format(m, "transfac")
+        received_reverse = m.format("transfac")
         self.assertEqual(received_reverse, expected_reverse)
         self.assertEqual(str(m.pwm), expected_reverse_pwm)
 
@@ -2196,8 +2196,8 @@ class TestTransfac(unittest.TestCase):
 
     def test_permissive_transfac_parser(self):
         """Parse the TRANSFAC-like file motifs/MA0056.1.transfac."""
-        # The test file MA0056.1.transfac was provided by the JASPAR database
-        # in a TRANSFAC-like format
+        # The test file MA0056.1.transfac was obtained from the JASPAR database
+        # in a TRANSFAC-like format.
         # Khan, A. et al. JASPAR 2018: update of the open-access database of
         # transcription factor binding profiles and its web framework.
         # Nucleic Acids Res. 2018; 46:D260-D266,

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2785,19 +2785,19 @@ ACGATCAGCGAGCATNGAGC-ACTACGACAGCGAGTGACCACTATTCGCGATCAGGAGCAGATACTTTACGAGCATCGGC
 """,
         )
         self.assertEqual(
-            format(alignment, "psl"),
+            alignment.format("psl"),
             """\
 34	2	0	1	1	1	3	26	+	query	38	0	38	target	79	10	73	5	10,3,12,7,5,	0,11,14,26,33,	10,20,34,60,68,
 """,
         )
         self.assertEqual(
-            format(alignment, "bed"),
+            alignment.format("bed"),
             """\
 target	10	73	query	19.0	+	10	73	0	5	10,3,12,7,5,	0,10,24,50,58,
 """,
         )
         self.assertEqual(
-            format(alignment, "sam"),
+            alignment.format("sam"),
             """\
 query	0	target	11	255	10M1I3M11D12M14D7M1D5M	*	0	0	AGCATCGAGCGACTTGAGTACTATTCATACTTTCGAGC	*	AS:i:19
 """,
@@ -2821,19 +2821,19 @@ CCCCACGTAGCATCAGC
 """,
         )
         self.assertEqual(
-            format(alignment, "psl"),
+            alignment.format("psl"),
             """\
 13	0	0	0	0	0	0	0	+	query	17	4	17	target	13	0	13	1	13,	4,	0,
 """,
         )
         self.assertEqual(
-            format(alignment, "bed"),
+            alignment.format("bed"),
             """\
 target	0	13	query	13.0	+	0	13	0	1	13,	0,
 """,
         )
         self.assertEqual(
-            format(alignment, "sam"),
+            alignment.format("sam"),
             """\
 query	0	target	1	255	4S13M	*	0	0	CCCCACGTAGCATCAGC	*	AS:i:13
 """,
@@ -2851,19 +2851,19 @@ CCCCACGTAGCATCAGC
 """,
         )
         self.assertEqual(
-            format(alignment, "psl"),
+            alignment.format("psl"),
             """\
 13	0	0	0	0	0	0	0	+	query	13	0	13	target	17	4	17	1	13,	0,	4,
 """,
         )
         self.assertEqual(
-            format(alignment, "bed"),
+            alignment.format("bed"),
             """\
 target	4	17	query	13.0	+	4	17	0	1	13,	0,
 """,
         )
         self.assertEqual(
-            format(alignment, "sam"),
+            alignment.format("sam"),
             """\
 query	0	target	5	255	13M	*	0	0	ACGTAGCATCAGC	*	AS:i:13
 """,
@@ -2880,19 +2880,19 @@ ACGTAGCATCAGCGGGG
 """,
         )
         self.assertEqual(
-            format(alignment, "psl"),
+            alignment.format("psl"),
             """\
 13	0	0	0	0	0	0	0	+	query	17	0	13	target	13	0	13	1	13,	0,	0,
 """,
         )
         self.assertEqual(
-            format(alignment, "bed"),
+            alignment.format("bed"),
             """\
 target	0	13	query	13.0	+	0	13	0	1	13,	0,
 """,
         )
         self.assertEqual(
-            format(alignment, "sam"),
+            alignment.format("sam"),
             """\
 query	0	target	1	255	13M4S	*	0	0	ACGTAGCATCAGCGGGG	*	AS:i:13
 """,
@@ -2910,19 +2910,19 @@ ACGTAGCATCAGC----
 """,
         )
         self.assertEqual(
-            format(alignment, "psl"),
+            alignment.format("psl"),
             """\
 13	0	0	0	0	0	0	0	+	query	13	0	13	target	17	0	13	1	13,	0,	0,
 """,
         )
         self.assertEqual(
-            format(alignment, "bed"),
+            alignment.format("bed"),
             """\
 target	0	13	query	13.0	+	0	13	0	1	13,	0,
 """,
         )
         self.assertEqual(
-            format(alignment, "sam"),
+            alignment.format("sam"),
             """\
 query	0	target	1	255	13M	*	0	0	ACGTAGCATCAGC	*	AS:i:13
 """,
@@ -2949,19 +2949,19 @@ TTTTTNACGCTCGAGCAGCTACG-----
 """,
         )
         self.assertEqual(
-            format(alignment, "psl"),
+            alignment.format("psl"),
             """\
 15	1	0	1	0	0	0	0	+	query	22	0	17	target	23	6	23	1	17,	0,	6,
 """,
         )
         self.assertEqual(
-            format(alignment, "bed"),
+            alignment.format("bed"),
             """\
 target	6	23	query	13.0	+	6	23	0	1	17,	0,
 """,
         )
         self.assertEqual(
-            format(alignment, "sam"),
+            alignment.format("sam"),
             """\
 query	0	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
 """,
@@ -2979,19 +2979,19 @@ TTTTTNACGCTCGAGCAGCTACG-----
 """,
         )
         self.assertEqual(
-            format(alignment, "psl"),
+            alignment.format("psl"),
             """\
 15	1	0	1	0	0	0	0	+	query	22	0	17	target	23	6	23	1	17,	0,	6,
 """,
         )
         self.assertEqual(
-            format(alignment, "bed"),
+            alignment.format("bed"),
             """\
 target	6	23	query	13.0	+	6	23	0	1	17,	0,
 """,
         )
         self.assertEqual(
-            format(alignment, "sam"),
+            alignment.format("sam"),
             """\
 query	0	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
 """,


### PR DESCRIPTION
In PRs #2495 and #3267 we deprecated the `format` method in `Bio.motifs` and `Bio.Phylo.BaseTree` and instead asked users to call the `format` Python built-in function, which calls the `__format__` method. This works in most cases, but is not a general solution. In particular, the `format` function is hard-coded to take two arguments only, so it is not possible to modify the exact file format by (optional or required) keyword arguments. An example is the PSL sequence alignment format, for which we would like to specify the wildcard character (`'N'`, `'X'`, or `'?'`, but could be anything in principle) and whether repeat regions were masked as lower characters. This is impossible via the current approach relying on `__format__`.

This PR reverses the deprecation of `format`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

