### PR TITLE
Fix PairwiseAligner compiler warnings on switch statements

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1693,8 +1693,6 @@ class PairwiseAligner(_aligners.PairwiseAligner):
 
     """
 
-    __slots__ = ()  # To prevent confusion, don't allow users to create new attributes.
-
     def __init__(self, **kwargs):
         """Initialize a new PairwiseAligner with the keyword arguments as attributes.
 
@@ -1704,6 +1702,14 @@ class PairwiseAligner(_aligners.PairwiseAligner):
         for name, value in kwargs.items():
             setattr(self, name, value)
 
+    def __setattr__(self, key, value):
+        if key not in dir(_aligners.PairwiseAligner):
+            # To prevent confusion, don't allow users to create new attributes.
+            # On CPython, __slots__ can be used for this, but currently
+            # __slots__ does not behave the same way on PyPy at least.
+            raise AttributeError("PairwiseAligner object has no attribute '%s'" % key)
+        _aligners.PairwiseAligner.__setattr__(self, key, value)
+ 
     def align(self, seqA, seqB):
         """Return the alignments of two sequences using PairwiseAligner."""
         if isinstance(seqA, (Seq, MutableSeq)):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1707,7 +1707,7 @@ class PairwiseAligner(_aligners.PairwiseAligner):
             # To prevent confusion, don't allow users to create new attributes.
             # On CPython, __slots__ can be used for this, but currently
             # __slots__ does not behave the same way on PyPy at least.
-            raise AttributeError("PairwiseAligner object has no attribute '%s'" % key)
+            raise AttributeError("'PairwiseAligner' object has no attribute '%s'" % key)
         _aligners.PairwiseAligner.__setattr__(self, key, value)
 
     def align(self, seqA, seqB):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1709,7 +1709,7 @@ class PairwiseAligner(_aligners.PairwiseAligner):
             # __slots__ does not behave the same way on PyPy at least.
             raise AttributeError("PairwiseAligner object has no attribute '%s'" % key)
         _aligners.PairwiseAligner.__setattr__(self, key, value)
- 
+
     def align(self, seqA, seqB):
         """Return the alignments of two sequences using PairwiseAligner."""
         if isinstance(seqA, (Seq, MutableSeq)):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1693,23 +1693,16 @@ class PairwiseAligner(_aligners.PairwiseAligner):
 
     """
 
+    __slots__ = ()  # To prevent confusion, don't allow users to create new attributes.
+
     def __init__(self, **kwargs):
         """Initialize a new PairwiseAligner with the keyword arguments as attributes.
 
-        This function subclasses `_aligners.PairwiseAligner` and loops over all
-        the keyword arguments that are given in the constructor to set them
-        as attributes on the object. This will call the `__setattr__` method to
-        do that.
+        Loops over the keyword arguments and sets them as attributes on the object.
         """
         super().__init__()
         for name, value in kwargs.items():
             setattr(self, name, value)
-
-    def __setattr__(self, key, value):
-        if key not in dir(_aligners.PairwiseAligner):
-            # To prevent confusion, don't allow users to create new attributes
-            raise AttributeError("PairwiseAligner object has no attribute '%s'" % key)
-        _aligners.PairwiseAligner.__setattr__(self, key, value)
 
     def align(self, seqA, seqB):
         """Return the alignments of two sequences using PairwiseAligner."""

--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -4298,6 +4298,9 @@ static PyGetSetDef Aligner_getset[] = {
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
             break; \
+        default: \
+            PyErr_SetString(PyExc_RuntimeError, "strand was neither '+' nor '-'"); \
+            return NULL; \
     } \
 \
     /* Needleman-Wunsch algorithm */ \
@@ -4572,6 +4575,7 @@ static PyGetSetDef Aligner_getset[] = {
             right_gap_open_B = self->query_right_open_gap_score; \
             right_gap_extend_A = self->target_right_extend_gap_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
+            break; \
         case '-': \
             left_gap_open_A = self->target_right_open_gap_score; \
             left_gap_open_B = self->query_right_open_gap_score; \
@@ -4581,6 +4585,10 @@ static PyGetSetDef Aligner_getset[] = {
             right_gap_open_B = self->query_left_open_gap_score; \
             right_gap_extend_A = self->target_left_extend_gap_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
+            break; \
+        default: \
+            PyErr_SetString(PyExc_RuntimeError, "strand was neither '+' nor '-'"); \
+            return NULL; \
     } \
 \
     /* Gotoh algorithm with three states */ \

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -177,10 +177,18 @@ Pairwise sequence aligner with parameters
 
     def test_aligner_nonexisting_property(self):
         aligner = Align.PairwiseAligner()
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(AttributeError) as cm:
             aligner.no_such_property
-        with self.assertRaises(AttributeError):
+        self.assertEqual(
+            str(cm.exception),
+            "'PairwiseAligner' object has no attribute 'no_such_property'",
+        )
+        with self.assertRaises(AttributeError) as cm:
             aligner.no_such_property = 1
+        self.assertEqual(
+            str(cm.exception),
+            "'PairwiseAligner' object has no attribute 'no_such_property'",
+        )
 
 
 class TestPairwiseGlobal(unittest.TestCase):


### PR DESCRIPTION
use `__slots__` on `PairwiseAligner`, instead of reinventing the wheel.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
