### PR TITLE
Bug fix in DisorderedAtom object copying

### DIFF
--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -564,3 +564,13 @@ class DisorderedAtom(DisorderedEntityWrapper):
         """
         for child in self:
             child.coord = np.dot(child.coord, rot) + tran
+
+    def copy(self):
+        """Create a copy of the DisorderedAtom. DisorderedEntityWrapper.copy()
+        does not work well with DisorderedAtom objects, so we need to define it
+        explicitly"""
+        shallow = copy.copy(self)
+        shallow.detach_parent()
+        shallow.set_coord(copy.copy(self.get_coord()))
+        shallow.xtra = self.xtra.copy()
+        return shallow

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -126,6 +126,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Hye-Shik Chang <perky at domain fallin.lv>
 - Iddo Friedberg <https://github.com/idoerg>
 - Ilya Flyamer <https://github.com/Phlya>
+- Ioannis Riziotis <https://github.com/iriziotis>
 - Ivan Antonov <https://github.com/vanya-antonov>
 - Jacek Śmietański <https://github.com/dadoskawina>
 - Jack Twilley <https://github.com/mathuin>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -141,6 +141,7 @@ possible, especially the following contributors:
 - Suyash Gupta
 - Vini Salazar (first contribution)
 - Leighton Pritchard
+- Ioannis Riziotis
 
 4 September 2020: Biopython 1.78
 ================================


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
Implemented an explicit copy() method to DisorderedAtom to overload the DisorderedEntityWrapper.copy() method that caused problems when inserting copies of DisorderedAtom instances in a SMCRA structure. It should be a fix for issue #3223. Hope this helps, it works nicely for my purposes.
