### PR TITLE
fix bug single nucleotide TwoBit

### DIFF
--- a/Bio/SeqIO/TwoBitIO.py
+++ b/Bio/SeqIO/TwoBitIO.py
@@ -104,13 +104,17 @@ class _TwoBitSequenceData(SequenceDataAbstractBaseClass):
         super().__init__()
 
     def __getitem__(self, key):
+        length = self.length
         if isinstance(key, slice):
-            length = self.length
             start, end, step = key.indices(length)
             size = len(range(start, end, step))
             if size == 0:
                 return b""
         else:
+            if key < 0:
+                key += length
+                if key < 0:
+                    raise IndexError("index out of range")
             start = key
             end = key + 1
             step = 1
@@ -129,7 +133,10 @@ class _TwoBitSequenceData(SequenceDataAbstractBaseClass):
         sequence = _twoBitIO.convert(
             data, start, end, step, self.nBlocks, self.maskBlocks
         )
-        return sequence
+        if isinstance(key, slice):
+            return sequence
+        else:  # single nucleotide
+            return ord(sequence)
 
     def __len__(self):
         return self.length

--- a/Tests/test_SeqIO_TwoBitIO.py
+++ b/Tests/test_SeqIO_TwoBitIO.py
@@ -296,6 +296,16 @@ class TestBaseClassMethods(unittest.TestCase):
     def tearDown(self):
         self.stream.close()
 
+    def test_getitem(self):
+        self.assertEqual(self.seq1_twobit, self.seq1_fasta)
+        self.assertEqual(self.seq2_twobit, self.seq2_fasta)
+        self.assertEqual(self.seq1_twobit[:], self.seq1_fasta[:])
+        self.assertEqual(self.seq2_twobit[:], self.seq2_fasta[:])
+        self.assertEqual(self.seq1_twobit[30], self.seq1_fasta[30])
+        self.assertEqual(self.seq2_twobit[30], self.seq2_fasta[30])
+        self.assertEqual(self.seq1_twobit[-30], self.seq1_fasta[-30])
+        self.assertEqual(self.seq2_twobit[-30], self.seq2_fasta[-30])
+
     def test_bytes(self):
         b = bytes(self.seq1_twobit)
         self.assertIsInstance(b, bytes)


### PR DESCRIPTION
This PR fixes a bug in the `_TwoBitSequenceData` class, where `__getitem__` returned a `bytes` object also for single nucleotides (i.e., when the key is an integer). For consistency with Python's `bytes` objects, `__getitem__` should return an integer if the key is an integer and not a slice.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


