### PR TITLE
Added ability to return GC content as a ratio. [Finish  #564]

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -835,13 +835,13 @@ class MultipleSeqAlignment:
         As an example using a different sort order, you could sort on the
         GC content of each sequence.
 
-        >>> from Bio.SeqUtils import gc_content
+        >>> from Bio.SeqUtils import gc_fraction
         >>> print(align1)
         Alignment with 3 rows and 4 columns
         ACGC Chicken
         ACGT Human
         ACGG Mouse
-        >>> align1.sort(key = lambda record: gc_content(record.seq))
+        >>> align1.sort(key = lambda record: gc_fraction(record.seq))
         >>> print(align1)
         Alignment with 3 rows and 4 columns
         ACGT Human

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -835,13 +835,13 @@ class MultipleSeqAlignment:
         As an example using a different sort order, you could sort on the
         GC content of each sequence.
 
-        >>> from Bio.SeqUtils import GC
+        >>> from Bio.SeqUtils import gc_content
         >>> print(align1)
         Alignment with 3 rows and 4 columns
         ACGC Chicken
         ACGT Human
         ACGG Mouse
-        >>> align1.sort(key = lambda record: GC(record.seq))
+        >>> align1.sort(key = lambda record: gc_content(record.seq))
         >>> print(align1)
         Alignment with 3 rows and 4 columns
         ACGT Human

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -564,7 +564,7 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
         corr = 0.368 * (len(seq) - 1) * math.log(mon)
     if method == 6:
         corr = (
-            (4.29 * SeqUtils.gc_content(seq) - 3.95) * 1e-5 * math.log(mon)
+            (4.29 * SeqUtils.gc_content(seq, "ignore") - 3.95) * 1e-5 * math.log(mon)
         ) + 9.40e-6 * math.log(mon) ** 2
     # Turn black code style off
     # fmt: off
@@ -581,7 +581,7 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
         if Mon > 0:
             R = math.sqrt(mg) / mon
             if R < 0.22:
-                corr = (4.29 * SeqUtils.gc_content(seq) - 3.95) * \
+                corr = (4.29 * SeqUtils.gc_content(seq, "ignore") - 3.95) * \
                     1e-5 * math.log(mon) + 9.40e-6 * math.log(mon) ** 2
                 return corr
             elif R < 6.0:
@@ -590,7 +590,7 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
                             - 8.03e-3 * math.log(mon) ** 2)
                 g = 8.31 * (0.486 - 0.258 * math.log(mon)
                             + 5.25e-3 * math.log(mon) ** 3)
-        corr = (a + b * math.log(mg) + (SeqUtils.gc_content(seq))
+        corr = (a + b * math.log(mg) + (SeqUtils.gc_content(seq, "ignore"))
                 * (c + d * math.log(mg)) + (1 / (2.0 * (len(seq) - 1)))
                 * (e + f * math.log(mg) + g * math.log(mg) ** 2)) * 1e-5
     # Turn black code style on
@@ -780,7 +780,7 @@ def Tm_GC(
         )
 
     # Ambiguous bases: add 0.5, 0.67 or 0.33% depending on G+C probability:
-    percent_gc = SeqUtils.gc_content(seq, "count") * 100
+    percent_gc = SeqUtils.gc_content(seq, "weighted") * 100
 
     # gc_content counts X as 0.5
     if mismatch:
@@ -1012,7 +1012,7 @@ def Tm_NN(
     delta_s += nn_table["init"][d_s]
 
     # Type: Duplex with no (allA/T) or at least one (oneG/C) GC pair
-    if SeqUtils.gc_content(seq) == 0:
+    if SeqUtils.gc_content(seq, "ignore") == 0:
         delta_h += nn_table["init_allA/T"][d_h]
         delta_s += nn_table["init_allA/T"][d_s]
     else:

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -773,19 +773,21 @@ def Tm_GC(
     seq = str(seq)
     if check:
         seq = _check(seq, "Tm_GC")
-    percent_gc = SeqUtils.gc_content(seq) * 100
-    # Ambiguous bases: add 0.5, 0.67 or 0.33% depending on G+C probability:
-    tmp = (
-        sum(map(seq.count, ("K", "M", "N", "R", "Y"))) * 50.0 / len(seq)
-        + sum(map(seq.count, ("B", "V"))) * 66.67 / len(seq)
-        + sum(map(seq.count, ("D", "H"))) * 33.33 / len(seq)
-    )
+
+    tmp = any([(x in seq) for x in "KMNRYBVDH"])
+
     if strict and tmp:
         raise ValueError(
             "ambiguous bases B, D, H, K, M, N, R, V, Y not allowed when 'strict=True'"
         )
-    else:
-        percent_gc += tmp
+
+    # Ambiguous bases: add 0.5, 0.67 or 0.33% depending on G+C probability:
+    percent_gc = SeqUtils.gc_content(seq, "count") * 100
+
+    # gc_content counts X as 0.5
+    if mismatch:
+        percent_gc -= seq.count("X") * 50.0 / len(seq)
+
     if userset:
         A, B, C, D = userset
     else:

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -564,7 +564,7 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
         corr = 0.368 * (len(seq) - 1) * math.log(mon)
     if method == 6:
         corr = (
-            (4.29 * SeqUtils.GC(seq) / 100 - 3.95) * 1e-5 * math.log(mon)
+            (4.29 * SeqUtils.gc_content(seq) - 3.95) * 1e-5 * math.log(mon)
         ) + 9.40e-6 * math.log(mon) ** 2
     # Turn black code style off
     # fmt: off
@@ -581,7 +581,7 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
         if Mon > 0:
             R = math.sqrt(mg) / mon
             if R < 0.22:
-                corr = (4.29 * SeqUtils.GC(seq) / 100 - 3.95) * \
+                corr = (4.29 * SeqUtils.gc_content(seq) - 3.95) * \
                     1e-5 * math.log(mon) + 9.40e-6 * math.log(mon) ** 2
                 return corr
             elif R < 6.0:
@@ -590,7 +590,7 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
                             - 8.03e-3 * math.log(mon) ** 2)
                 g = 8.31 * (0.486 - 0.258 * math.log(mon)
                             + 5.25e-3 * math.log(mon) ** 3)
-        corr = (a + b * math.log(mg) + (SeqUtils.GC(seq) / 100)
+        corr = (a + b * math.log(mg) + (SeqUtils.gc_content(seq))
                 * (c + d * math.log(mg)) + (1 / (2.0 * (len(seq) - 1)))
                 * (e + f * math.log(mg) + g * math.log(mg) ** 2)) * 1e-5
     # Turn black code style on
@@ -773,7 +773,7 @@ def Tm_GC(
     seq = str(seq)
     if check:
         seq = _check(seq, "Tm_GC")
-    percent_gc = SeqUtils.GC(seq)
+    percent_gc = SeqUtils.gc_content(seq) * 100
     # Ambiguous bases: add 0.5, 0.67 or 0.33% depending on G+C probability:
     tmp = (
         sum(map(seq.count, ("K", "M", "N", "R", "Y"))) * 50.0 / len(seq)
@@ -1012,7 +1012,7 @@ def Tm_NN(
     delta_s += nn_table["init"][d_s]
 
     # Type: Duplex with no (allA/T) or at least one (oneG/C) GC pair
-    if SeqUtils.GC(seq) == 0:
+    if SeqUtils.gc_content(seq) == 0:
         delta_h += nn_table["init_allA/T"][d_h]
         delta_s += nn_table["init_allA/T"][d_s]
     else:

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -564,7 +564,7 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
         corr = 0.368 * (len(seq) - 1) * math.log(mon)
     if method == 6:
         corr = (
-            (4.29 * SeqUtils.gc_content(seq, "ignore") - 3.95) * 1e-5 * math.log(mon)
+            (4.29 * SeqUtils.gc_fraction(seq, "ignore") - 3.95) * 1e-5 * math.log(mon)
         ) + 9.40e-6 * math.log(mon) ** 2
     # Turn black code style off
     # fmt: off
@@ -581,7 +581,7 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
         if Mon > 0:
             R = math.sqrt(mg) / mon
             if R < 0.22:
-                corr = (4.29 * SeqUtils.gc_content(seq, "ignore") - 3.95) * \
+                corr = (4.29 * SeqUtils.gc_fraction(seq, "ignore") - 3.95) * \
                     1e-5 * math.log(mon) + 9.40e-6 * math.log(mon) ** 2
                 return corr
             elif R < 6.0:
@@ -590,7 +590,7 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
                             - 8.03e-3 * math.log(mon) ** 2)
                 g = 8.31 * (0.486 - 0.258 * math.log(mon)
                             + 5.25e-3 * math.log(mon) ** 3)
-        corr = (a + b * math.log(mg) + (SeqUtils.gc_content(seq, "ignore"))
+        corr = (a + b * math.log(mg) + (SeqUtils.gc_fraction(seq, "ignore"))
                 * (c + d * math.log(mg)) + (1 / (2.0 * (len(seq) - 1)))
                 * (e + f * math.log(mg) + g * math.log(mg) ** 2)) * 1e-5
     # Turn black code style on
@@ -780,9 +780,9 @@ def Tm_GC(
         )
 
     # Ambiguous bases: add 0.5, 0.67 or 0.33% depending on G+C probability:
-    percent_gc = SeqUtils.gc_content(seq, "weighted") * 100
+    percent_gc = SeqUtils.gc_fraction(seq, "weighted") * 100
 
-    # gc_content counts X as 0.5
+    # gc_fraction counts X as 0.5
     if mismatch:
         percent_gc -= seq.count("X") * 50.0 / len(seq)
 
@@ -1012,7 +1012,7 @@ def Tm_NN(
     delta_s += nn_table["init"][d_s]
 
     # Type: Duplex with no (allA/T) or at least one (oneG/C) GC pair
-    if SeqUtils.gc_content(seq, "ignore") == 0:
+    if SeqUtils.gc_fraction(seq, "ignore") == 0:
         delta_h += nn_table["init_allA/T"][d_h]
         delta_s += nn_table["init_allA/T"][d_s]
     else:

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -774,9 +774,7 @@ def Tm_GC(
     if check:
         seq = _check(seq, "Tm_GC")
 
-    tmp = any([(x in seq) for x in "KMNRYBVDH"])
-
-    if strict and tmp:
+    if strict and any(x in seq for x in "KMNRYBVDH"):
         raise ValueError(
             "ambiguous bases B, D, H, K, M, N, R, V, Y not allowed when 'strict=True'"
         )

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -23,8 +23,8 @@ from Bio.Data import IUPACData
 # {{{
 
 
-def GC(seq):
-    """Calculate G+C content, return percentage (as float between 0 and 100).
+def GC(seq, percentage=True):
+    """Calculates G+C content, returns the percentage (float between 0 and 100). Returns G+C ratio if percentage=False.
 
     Copes mixed case sequences, and with the ambiguous nucleotide S (G or C)
     when counting the G and C content.  The percentage is calculated against
@@ -33,12 +33,18 @@ def GC(seq):
     >>> from Bio.SeqUtils import GC
     >>> GC("ACTGN")
     40.0
+    >>> GC("ACTGN", False)
+    .400
 
     Note that this will return zero for an empty sequence.
     """
     gc = sum(seq.count(x) for x in ["G", "C", "g", "c", "S", "s"])
     try:
-        return gc * 100.0 / len(seq)
+        gc = sum(seq.count(x) for x in ['G', 'C', 'g', 'c', 'S', 's'])
+        if percentage==True:
+            return gc * 100.0 / len(seq)
+        else:
+            return gc / len(seq)
     except ZeroDivisionError:
         return 0.0
 

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -93,8 +93,8 @@ def gc_content(seq: str, ignore_ambiguous: bool = True):
         l = gc + sum(count[x] for x in ["A", "T", "W", "a", "t", "w"])
     else:
         gc = sum(
-            (count[aa] + count[aa.lower()]) * perc
-            for aa, perc in ambiguous_gc_values.items()
+            (count[x] + count[x.lower()]) * perc
+            for x, perc in ambiguous_gc_values.items()
         )
         l = len(seq)
 

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -506,8 +506,10 @@ def molecular_weight(
 
 def six_frame_translations(seq, genetic_code=1):
     """Return pretty string showing the 6 frame translations and GC content.
+
     Nice looking 6 frame translation with GC content - code from xbbtools
     similar to DNA Striders six-frame translation
+
     >>> from Bio.SeqUtils import six_frame_translations
     >>> print(six_frame_translations("AUGGCCAUUGUAAUGGGCCGCUGA"))
     GC_Frame: a:5 t:0 g:8 c:5
@@ -525,6 +527,7 @@ def six_frame_translations(seq, genetic_code=1):
       P  W  Q  L  P  G  S
     <BLANKLINE>
     <BLANKLINE>
+
     """  # noqa for pep8 W291 trailing whitespace
     from Bio.Seq import reverse_complement, reverse_complement_rna, translate
 

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -12,7 +12,6 @@
 
 import re
 import warnings
-from collections import Counter
 from math import pi, sin, cos
 
 from Bio.Seq import Seq, complement, complement_rna
@@ -110,25 +109,23 @@ def gc_content(seq, ambiguous="ignore"):
     if ambiguous not in ("count", "remove", "ignore"):
         raise ValueError(f"ambiguous value '{ambiguous}' not recognized")
 
-    count = Counter(seq)
-
-    if ambiguous == "count":
-        gc = sum(
-            (count[x] + count[x.lower()]) * perc
-            for x, perc in _ambiguous_gc_values.items()
-        )
-    else:
-        gc = sum(count[x] + count[x.lower()] for x in "GCS")
+    gc = sum(seq.count(x) for x in "CGScgs")
 
     if ambiguous == "remove":
-        l = sum(count[x] + count[x.lower()] for x in "ACTGSW")
+        l = gc + sum(seq.count(x) for x in "ATWatw")
     else:
         l = len(seq)
 
-    try:
-        return gc / l
-    except ZeroDivisionError:
+    if ambiguous == "count":
+        gc += sum(
+            (seq.count(x) + seq.count(x.lower())) * _ambiguous_gc_values[x]
+            for x in "BDHKMNRVXY"
+        )
+
+    if l == 0:
         return 0
+
+    return gc / l
 
 
 def GC(seq):

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -25,22 +25,22 @@ from Bio import BiopythonDeprecationWarning
 # {{{
 
 _ambiguous_gc_values = {
-    "A": 0.0,
+    "A": 0,
     "C": 1.0,
-    "T": 0.0,
+    "T": 0,
     "G": 1.0,
     "S": 1.0,
-    "V": 0.6667,
-    "B": 0.6667,
+    "V": 2 / 3,
+    "B": 2 / 3,
     "M": 0.5,
     "R": 0.5,
     "Y": 0.5,
     "K": 0.5,
     "X": 0.5,
     "N": 0.5,
-    "H": 0.3333,
-    "D": 0.3333,
-    "W": 0.0,
+    "H": 1 / 3,
+    "D": 1 / 3,
+    "W": 0,
 }
 
 
@@ -58,7 +58,7 @@ def gc_content(seq: str, ambiguous: str = "ignore"):
     and X will be counted as 0.5, D will be counted as 0.33 etc. See
     Bio.SeqUtils._ambiguous_gc_values for a full list.
 
-    If ambiguous equals "remove", will only only count GCS towards the
+    If ambiguous equals "remove", will only count GCS towards the
     percentage, but will also not count ambiguous characters towards the length
     of the sequence. Equivalent to gc_content(seq.replace('N','')) but replacing
     all ambiguous nucleotides.
@@ -108,7 +108,7 @@ def gc_content(seq: str, ambiguous: str = "ignore"):
     Note that this will return zero for an empty sequence.
     """
     if ambiguous not in ("count", "remove", "ignore"):
-        raise ValueError(f"ambiguous value {ambiguous} not recognized")
+        raise ValueError(f"ambiguous value '{ambiguous}' not recognized")
 
     count = Counter(seq)
 
@@ -137,7 +137,8 @@ def GC(seq):
     Use Bio.SeqUtils.gc_content instead.
     """
     warnings.warn(
-        "GC is deprecated; please use gc_content instead.", BiopythonDeprecationWarning,
+        "GC is deprecated; please use gc_content instead.",
+        BiopythonDeprecationWarning,
     )
 
     gc = sum(seq.count(x) for x in ["G", "C", "g", "c", "S", "s"])

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -43,7 +43,7 @@ _ambiguous_gc_values = {
 }
 
 
-def gc_content(seq, ambiguous="remove"):
+def gc_fraction(seq, ambiguous="remove"):
     """Calculate G+C percentage in seq (float between 0 and 1).
 
     Copes with mixed case sequences. Ambiguous Nucleotides in this context are
@@ -51,7 +51,7 @@ def gc_content(seq, ambiguous="remove"):
 
     If ambiguous equals "remove" (default), will only count GCS towards the
     percentage, but will also only count ACTGSW towards the length of the sequence.
-    Equivalent to gc_content(seq.replace('N','')) but replacing all nucleotides
+    Equivalent to gc_fraction(seq.replace('N','')) but replacing all nucleotides
     that are ambiguous between GC or AT (VBMRYKXNHD).
 
     If ambiguous equals "ignore", it will treat only unambiguous
@@ -65,47 +65,47 @@ def gc_content(seq, ambiguous="remove"):
     Will raise a ValueError for any other value of the ambiguous parameter.
 
 
-    >>> from Bio.SeqUtils import gc_content
+    >>> from Bio.SeqUtils import gc_fraction
     >>> seq = "ACTG"
-    >>> print(f"GC content of {seq} : {gc_content(seq):.2f}")
+    >>> print(f"GC content of {seq} : {gc_fraction(seq):.2f}")
     GC content of ACTG : 0.50
 
     S and W are not considered ambiguous.
 
     >>> seq = "ACTGSSSS"
-    >>> gc = gc_content(seq, "remove")
+    >>> gc = gc_fraction(seq, "remove")
     >>> print(f"GC content of {seq} : {gc:.2f}")
     GC content of ACTGSSSS : 0.75
-    >>> gc = gc_content(seq, "ignore")
+    >>> gc = gc_fraction(seq, "ignore")
     >>> print(f"GC content of {seq} : {gc:.2f}")
     GC content of ACTGSSSS : 0.75
-    >>> gc = gc_content(seq, "weighted")
+    >>> gc = gc_fraction(seq, "weighted")
     >>> print(f"GC content with ambiguous counting: {gc:.2f}")
     GC content with ambiguous counting: 0.75
 
     Some examples with ambiguous nucleotides.
 
     >>> seq = "ACTGN"
-    >>> gc = gc_content(seq, "ignore")
+    >>> gc = gc_fraction(seq, "ignore")
     >>> print(f"GC content of {seq} : {gc:.2f}")
     GC content of ACTGN : 0.40
-    >>> gc = gc_content(seq, "weighted")
+    >>> gc = gc_fraction(seq, "weighted")
     >>> print(f"GC content with ambiguous counting: {gc:.2f}")
     GC content with ambiguous counting: 0.50
-    >>> gc = gc_content(seq, "remove")
+    >>> gc = gc_fraction(seq, "remove")
     >>> print(f"GC content with ambiguous removing: {gc:.2f}")
     GC content with ambiguous removing: 0.50
 
     Ambiguous nucleotides are also removed from the length of the sequence.
 
     >>> seq = "GDVV"
-    >>> gc = gc_content(seq, "ignore")
+    >>> gc = gc_fraction(seq, "ignore")
     >>> print(f"GC content of {seq} : {gc:.2f}")
     GC content of GDVV : 0.25
-    >>> gc = gc_content(seq, "weighted")
+    >>> gc = gc_fraction(seq, "weighted")
     >>> print(f"GC content with ambiguous counting: {gc:.4f}")
     GC content with ambiguous counting: 0.6667
-    >>> gc = gc_content(seq, "remove")
+    >>> gc = gc_fraction(seq, "remove")
     >>> print(f"GC content with ambiguous removing: {gc:.2f}")
     GC content with ambiguous removing: 1.00
 
@@ -137,10 +137,10 @@ def gc_content(seq, ambiguous="remove"):
 def GC(seq):
     """Calculate G+C content (DEPRECATED).
 
-    Use Bio.SeqUtils.gc_content instead.
+    Use Bio.SeqUtils.gc_fraction instead.
     """
     warnings.warn(
-        "GC is deprecated; please use gc_content instead.",
+        "GC is deprecated; please use gc_fraction instead.",
         BiopythonDeprecationWarning,
     )
 

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -24,24 +24,26 @@ from Bio.Data import IUPACData
 
 
 def GC(seq, percentage=True):
-    """Calculates G+C content, returns the percentage (float between 0 and 100). Returns G+C ratio if percentage=False.
+    """Calculate G+C content, returns the percentage (float between 0 and 100).
+
+    Returns G+C ratio if percentage=False (float between 0 and 1).
 
     Copes mixed case sequences, and with the ambiguous nucleotide S (G or C)
-    when counting the G and C content.  The percentage is calculated against
-    the full length, e.g.:
+    when counting the G and C content.  The percentage or ratio is calculated
+    against the full length, e.g.:
 
     >>> from Bio.SeqUtils import GC
-    >>> GC("ACTGN")
-    40.0
-    >>> GC("ACTGN", False)
-    .400
+    >>> seq = "ACTGN"
+    >>> print(f"GC as a percentage: {GC(seq):.2f}")
+    GC as a percentage: 40.00
+    >>> print(f"GC as a ratio: {GC(seq, False):.2f}")
+    GC as a ratio: 0.40
 
     Note that this will return zero for an empty sequence.
     """
     gc = sum(seq.count(x) for x in ["G", "C", "g", "c", "S", "s"])
     try:
-        gc = sum(seq.count(x) for x in ['G', 'C', 'g', 'c', 'S', 's'])
-        if percentage==True:
+        if percentage:
             return gc * 100.0 / len(seq)
         else:
             return gc / len(seq)

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -44,7 +44,7 @@ _ambiguous_gc_values = {
 }
 
 
-def gc_content(seq: str, ambiguous: str = "ignore"):
+def gc_content(seq, ambiguous="ignore"):
     """Calculate G+C percentage in seq (float between 0 and 1).
 
     Copes with mixed case sequences. Ambiguous Nucleotides in this context are

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -506,10 +506,8 @@ def molecular_weight(
 
 def six_frame_translations(seq, genetic_code=1):
     """Return pretty string showing the 6 frame translations and GC content.
-
     Nice looking 6 frame translation with GC content - code from xbbtools
     similar to DNA Striders six-frame translation
-
     >>> from Bio.SeqUtils import six_frame_translations
     >>> print(six_frame_translations("AUGGCCAUUGUAAUGGGCCGCUGA"))
     GC_Frame: a:5 t:0 g:8 c:5
@@ -527,11 +525,13 @@ def six_frame_translations(seq, genetic_code=1):
       P  W  Q  L  P  G  S
     <BLANKLINE>
     <BLANKLINE>
-
     """  # noqa for pep8 W291 trailing whitespace
-    from Bio.Seq import reverse_complement, translate
+    from Bio.Seq import reverse_complement, reverse_complement_rna, translate
 
-    anti = reverse_complement(seq)
+    if "u" in seq.lower():
+        anti = reverse_complement_rna(seq)
+    else:
+        anti = reverse_complement(seq, inplace=False)  # TODO: remove inplace=False
     comp = anti[::-1]
     length = len(seq)
     frames = {}
@@ -545,9 +545,9 @@ def six_frame_translations(seq, genetic_code=1):
         short = f"{seq[:10]} ... {seq[-10:]}"
     else:
         short = seq
-    header = "GC_Frame: "
+    header = "GC_Frame:"
     for nt in ["a", "t", "g", "c"]:
-        header += "%s:%d " % (nt, seq.count(nt.upper()))
+        header += " %s:%d" % (nt, seq.count(nt.upper()))
 
     header += "\nSequence: %s, %d nt, %0.2f %%GC\n\n\n" % (
         short.lower(),
@@ -560,12 +560,12 @@ def six_frame_translations(seq, genetic_code=1):
         subseq = seq[i : i + 60]
         csubseq = comp[i : i + 60]
         p = i // 3
-        res += f"{i+1}/{int(i / 3 + 1)}\n"
+        res += "%d/%d\n" % (i + 1, i / 3 + 1)
         res += "  " + "  ".join(frames[3][p : p + 20]) + "\n"
         res += " " + "  ".join(frames[2][p : p + 20]) + "\n"
         res += "  ".join(frames[1][p : p + 20]) + "\n"
         # seq
-        res += subseq.lower() + f"{int(GC(subseq)):5d} %\n"
+        res += subseq.lower() + "%5d %%\n" % int(GC(subseq))
         res += csubseq.lower() + "\n"
         # - frames
         res += "  ".join(frames[-2][p : p + 20]) + "\n"

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -498,12 +498,9 @@ def six_frame_translations(seq, genetic_code=1):
     <BLANKLINE>
 
     """  # noqa for pep8 W291 trailing whitespace
-    from Bio.Seq import reverse_complement, reverse_complement_rna, translate
+    from Bio.Seq import reverse_complement, translate
 
-    if "u" in seq.lower():
-        anti = reverse_complement_rna(seq)
-    else:
-        anti = reverse_complement(seq, inplace=False)  # TODO: remove inplace=False
+    anti = reverse_complement(seq)
     comp = anti[::-1]
     length = len(seq)
     frames = {}
@@ -517,9 +514,9 @@ def six_frame_translations(seq, genetic_code=1):
         short = f"{seq[:10]} ... {seq[-10:]}"
     else:
         short = seq
-    header = "GC_Frame:"
+    header = "GC_Frame: "
     for nt in ["a", "t", "g", "c"]:
-        header += " %s:%d" % (nt, seq.count(nt.upper()))
+        header += "%s:%d " % (nt, seq.count(nt.upper()))
 
     header += "\nSequence: %s, %d nt, %0.2f %%GC\n\n\n" % (
         short.lower(),
@@ -532,12 +529,12 @@ def six_frame_translations(seq, genetic_code=1):
         subseq = seq[i : i + 60]
         csubseq = comp[i : i + 60]
         p = i // 3
-        res += "%d/%d\n" % (i + 1, i / 3 + 1)
+        res += f"{i+1}/{int(i / 3 + 1)}\n"
         res += "  " + "  ".join(frames[3][p : p + 20]) + "\n"
         res += " " + "  ".join(frames[2][p : p + 20]) + "\n"
         res += "  ".join(frames[1][p : p + 20]) + "\n"
         # seq
-        res += subseq.lower() + "%5d %%\n" % int(GC(subseq))
+        res += subseq.lower() + f"{int(GC(subseq)):5d} %\n"
         res += csubseq.lower() + "\n"
         # - frames
         res += "  ".join(frames[-2][p : p + 20]) + "\n"

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -47,15 +47,23 @@ _ambiguous_gc_values = {
 def gc_content(seq: str, ambiguous: str = "ignore"):
     """Calculate G+C percentage in seq (float between 0 and 1).
 
-    Copes with mixed case sequences.
+    Copes with mixed case sequences. Ambiguous Nucleotides in this context are
+    those different from ATCGSW.
 
-    If ignore_ambiguous=True, it will work as if all ambiguous nucleotides were
-    removed from the sequence (e.g: seq.replace('N','')). Amibiguous Nucleotides
-    in thei context are those different from ATCGSW.
+    If ambiguous equals "ignore" (default) , it will treat only unambiguous
+    nucleotides (GCS) as counting towards the GC percentage.
 
-    If False will use a "mean" value for the ambigous characters, for example,
-    G and C will be counted as 1, N and X will be counted as 0.5, D will be
-    counted as 0.33 etc. See Bio.SeqUtils.ambiguous_gc_values for a full list.
+    If ambiguous equals "count", will use a "mean" value when counting the
+    ambiguous characters, for example, G and C will still be counted as 1, N
+    and X will be counted as 0.5, D will be counted as 0.33 etc. See
+    Bio.SeqUtils._ambiguous_gc_values for a full list.
+
+    If ambiguous equals "remove", will only only count GCS towards the
+    percentage, but will also not count ambiguous characters towards the length
+    of the sequence. Equivalent to gc_content(seq.replace('N','')) but replacing
+    all ambiguous nucleotides.
+
+    Will raise a ValueError for any other value of the ambiguous parameter.
 
 
     >>> from Bio.SeqUtils import gc_content

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -58,10 +58,10 @@ def gc_content(seq: str, ambiguous: str = "ignore"):
     and X will be counted as 0.5, D will be counted as 0.33 etc. See
     Bio.SeqUtils._ambiguous_gc_values for a full list.
 
-    If ambiguous equals "remove", will only count GCS towards the
-    percentage, but will also not count ambiguous characters towards the length
-    of the sequence. Equivalent to gc_content(seq.replace('N','')) but replacing
-    all ambiguous nucleotides.
+    If ambiguous equals "remove", will only count GCS towards the percentage,
+    but will also only count ACTGSW towards the length of the sequence.
+    Equivalent to gc_content(seq.replace('N','')) but replacing all nucleotides
+    that are ambiguous between GC or AT (VBMRYKXNHD).
 
     Will raise a ValueError for any other value of the ambiguous parameter.
 

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -593,8 +593,8 @@ The method 'print_index' of the CodonAdaptationIndex class in
 Bio.SeqUtils.CodonUsage was deprecated in Release 1.80. Instead of
 self.print_index(), please use print(self).
 
-Function 'GC' in Bio.SeqUtils was declared obsolete in Release 1.80.
-Instead use function 'gc_content'.
+Function 'GC' in Bio.SeqUtils was deprecated in Release 1.80. Instead use
+function 'gc_content'.
 
 Bio.GFF (for accessing a MySQL database created with BioPerl, etc)
 ------------------------------------------------------------------

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -594,7 +594,7 @@ Bio.SeqUtils.CodonUsage was deprecated in Release 1.80. Instead of
 self.print_index(), please use print(self).
 
 Function 'GC' in Bio.SeqUtils was deprecated in Release 1.80. Instead use
-function 'gc_content'.
+function 'gc_fraction'.
 
 Bio.GFF (for accessing a MySQL database created with BioPerl, etc)
 ------------------------------------------------------------------

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -593,6 +593,9 @@ The method 'print_index' of the CodonAdaptationIndex class in
 Bio.SeqUtils.CodonUsage was deprecated in Release 1.80. Instead of
 self.print_index(), please use print(self).
 
+Function 'GC' in Bio.SeqUtils was declared obsolete in Release 1.80.
+Instead use function 'gc_content'.
+
 Bio.GFF (for accessing a MySQL database created with BioPerl, etc)
 ------------------------------------------------------------------
 The whole of the old ``Bio.GFF`` module was deprecated in Release 1.53, and

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1131,10 +1131,10 @@ of all the GC percentages.  Again, you could do this with a for loop, but I pref
 
 \begin{minted}{python}
 from Bio import SeqIO
-from Bio.SeqUtils import gc_content
+from Bio.SeqUtils import gc_fraction
 
 gc_values = sorted(
-    100 * gc_content(rec.seq) for rec in SeqIO.parse("ls_orchid.fasta", "fasta")
+    100 * gc_fraction(rec.seq) for rec in SeqIO.parse("ls_orchid.fasta", "fasta")
 )
 \end{minted}
 

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1131,9 +1131,11 @@ of all the GC percentages.  Again, you could do this with a for loop, but I pref
 
 \begin{minted}{python}
 from Bio import SeqIO
-from Bio.SeqUtils import GC
+from Bio.SeqUtils import gc_content
 
-gc_values = sorted(GC(rec.seq) for rec in SeqIO.parse("ls_orchid.fasta", "fasta"))
+gc_values = sorted(
+    100 * gc_content(rec.seq) for rec in SeqIO.parse("ls_orchid.fasta", "fasta")
+)
 \end{minted}
 
 Having read in each sequence and calculated the GC\%, we then sorted them into ascending

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -75,13 +75,13 @@ While you could use the above snippet of code to calculate a GC\%, note that  th
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
->>> from Bio.SeqUtils import GC
+>>> from Bio.SeqUtils import gc_content
 >>> my_seq = Seq("GATCGATGGGCCTATATAGGATCGAAAATCGC")
->>> GC(my_seq)
-46.875
+>>> gc_content(my_seq)
+0.46875
 \end{minted}
 
-\noindent Note that using the \verb|Bio.SeqUtils.GC()| function should automatically cope with mixed case sequences and the ambiguous nucleotide S which means G or C.
+\noindent Note that using the \verb|Bio.SeqUtils.gc_content()| function should automatically cope with mixed case sequences and the ambiguous nucleotide S which means G or C.
 
 Also note that just like a normal Python string, the \verb|Seq| object is in some ways ``read-only''.  If you need to edit your sequence, for example simulating a point mutation, look at the Section~\ref{sec:mutable-seq} below which talks about the \verb|MutableSeq| object.
 

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -75,13 +75,13 @@ While you could use the above snippet of code to calculate a GC\%, note that  th
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
->>> from Bio.SeqUtils import gc_content
+>>> from Bio.SeqUtils import gc_fraction
 >>> my_seq = Seq("GATCGATGGGCCTATATAGGATCGAAAATCGC")
->>> gc_content(my_seq)
+>>> gc_fraction(my_seq)
 0.46875
 \end{minted}
 
-\noindent Note that using the \verb|Bio.SeqUtils.gc_content()| function should automatically cope with mixed case sequences and the ambiguous nucleotide S which means G or C.
+\noindent Note that using the \verb|Bio.SeqUtils.gc_fraction()| function should automatically cope with mixed case sequences and the ambiguous nucleotide S which means G or C.
 
 Also note that just like a normal Python string, the \verb|Seq| object is in some ways ``read-only''.  If you need to edit your sequence, for example simulating a point mutation, look at the Section~\ref{sec:mutable-seq} below which talks about the \verb|MutableSeq| object.
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -59,7 +59,7 @@ from which the enzyme object was created, and a `uri` property with a canonical
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite.
 
-Add new ``gc_content`` function in ``SeqUtils`` and marks ``GC`` for future
+Add new ``gc_fraction`` function in ``SeqUtils`` and marks ``GC`` for future
 deprecation.
 
 Many thanks to the Biopython developers and community for making this release

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -59,7 +59,8 @@ from which the enzyme object was created, and a `uri` property with a canonical
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite.
 
-Add new ``gc_content`` function in ``SeqUtils`` and marks ``GC`` for future deprecation. 
+Add new ``gc_content`` function in ``SeqUtils`` and marks ``GC`` for future
+deprecation.
 
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -59,6 +59,8 @@ from which the enzyme object was created, and a `uri` property with a canonical
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite.
 
+Add new ``gc_content`` function in ``SeqUtils`` and marks ``GC`` for future deprecation. 
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
@@ -66,6 +68,7 @@ possible, especially the following contributors:
 - Arup Ghosh (first contribution)
 - Aziz Khan
 - Alex Morehead
+- Caio Fontes
 - Chenghao Zhu
 - Christian Brueffer
 - Damien Goutte-Gattat

--- a/Scripts/xbbtools/xbb_translations.py
+++ b/Scripts/xbbtools/xbb_translations.py
@@ -15,7 +15,7 @@
 import time
 
 from Bio.Seq import Seq, reverse_complement, translate
-from Bio.SeqUtils import gc_content
+from Bio.SeqUtils import gc_fraction
 
 
 class xbb_translations:
@@ -93,7 +93,7 @@ class xbb_translations:
 
     def gc(self, seq):
         """Calculate GC content in percent (0-100)."""
-        return 100 * gc_content(seq)
+        return 100 * gc_fraction(seq)
 
     def gcframe(self, seq, translation_table=1, direction="both"):
         """Print a pretty print translation in several frames."""

--- a/Scripts/xbbtools/xbb_translations.py
+++ b/Scripts/xbbtools/xbb_translations.py
@@ -15,7 +15,7 @@
 import time
 
 from Bio.Seq import Seq, reverse_complement, translate
-from Bio.SeqUtils import GC
+from Bio.SeqUtils import gc_content
 
 
 class xbb_translations:
@@ -93,7 +93,7 @@ class xbb_translations:
 
     def gc(self, seq):
         """Calculate GC content in percent (0-100)."""
-        return GC(seq)
+        return 100 * gc_content(seq)
 
     def gcframe(self, seq, translation_table=1, direction="both"):
         """Print a pretty print translation in several frames."""

--- a/Tests/test_Align_Alignment.py
+++ b/Tests/test_Align_Alignment.py
@@ -20,7 +20,7 @@ except ImportError:
 from Bio import Align, SeqIO
 from Bio.Seq import Seq, reverse_complement
 from Bio.SeqRecord import SeqRecord
-from Bio.SeqUtils import gc_content
+from Bio.SeqUtils import gc_fraction
 
 
 class TestPairwiseAlignment(unittest.TestCase):
@@ -993,7 +993,7 @@ ACCT
 ACTT
 """,
         )
-        alignment.sort(key=gc_content)
+        alignment.sort(key=gc_fraction)
         self.assertEqual(
             str(alignment),
             """\
@@ -1002,7 +1002,7 @@ ACTT
 ACCT
 """,
         )
-        alignment.sort(key=gc_content, reverse=True)
+        alignment.sort(key=gc_fraction, reverse=True)
         self.assertEqual(
             str(alignment),
             """\
@@ -1613,7 +1613,7 @@ AAAGAAAGAATATATATA--------ATATATTTCAAATTTCCTTATATACCCAAATATA""",
             tuple(sequence.id for sequence in alignment.sequences),
             ("seq7", "seq6", "seq5", "seq4", "seq3", "seq2", "seq1"),
         )
-        alignment.sort(key=lambda record: gc_content(record.seq))
+        alignment.sort(key=lambda record: gc_fraction(record.seq))
         self.assertEqual(
             "\n".join(row for row in alignment),  # str(alignment),
             """\
@@ -1629,7 +1629,7 @@ AAAGAAAGAATATATA----------ATATATTTCAAATTTCCTTATATACCCAAATATA""",
             tuple(sequence.id for sequence in alignment.sequences),
             ("seq3", "seq7", "seq4", "seq5", "seq1", "seq6", "seq2"),
         )
-        alignment.sort(key=lambda record: gc_content(record.seq), reverse=True)
+        alignment.sort(key=lambda record: gc_fraction(record.seq), reverse=True)
         self.assertEqual(
             "\n".join(row for row in alignment),  # str(alignment),
             """\

--- a/Tests/test_Align_Alignment.py
+++ b/Tests/test_Align_Alignment.py
@@ -20,7 +20,7 @@ except ImportError:
 from Bio import Align, SeqIO
 from Bio.Seq import Seq, reverse_complement
 from Bio.SeqRecord import SeqRecord
-from Bio.SeqUtils import GC
+from Bio.SeqUtils import gc_content
 
 
 class TestPairwiseAlignment(unittest.TestCase):
@@ -993,7 +993,7 @@ ACCT
 ACTT
 """,
         )
-        alignment.sort(key=GC)
+        alignment.sort(key=gc_content)
         self.assertEqual(
             str(alignment),
             """\
@@ -1002,7 +1002,7 @@ ACTT
 ACCT
 """,
         )
-        alignment.sort(key=GC, reverse=True)
+        alignment.sort(key=gc_content, reverse=True)
         self.assertEqual(
             str(alignment),
             """\
@@ -1613,7 +1613,7 @@ AAAGAAAGAATATATATA--------ATATATTTCAAATTTCCTTATATACCCAAATATA""",
             tuple(sequence.id for sequence in alignment.sequences),
             ("seq7", "seq6", "seq5", "seq4", "seq3", "seq2", "seq1"),
         )
-        alignment.sort(key=lambda record: GC(record.seq))
+        alignment.sort(key=lambda record: gc_content(record.seq))
         self.assertEqual(
             "\n".join(row for row in alignment),  # str(alignment),
             """\
@@ -1629,7 +1629,7 @@ AAAGAAAGAATATATA----------ATATATTTCAAATTTCCTTATATACCCAAATATA""",
             tuple(sequence.id for sequence in alignment.sequences),
             ("seq3", "seq7", "seq4", "seq5", "seq1", "seq6", "seq2"),
         )
-        alignment.sort(key=lambda record: GC(record.seq), reverse=True)
+        alignment.sort(key=lambda record: gc_content(record.seq), reverse=True)
         self.assertEqual(
             "\n".join(row for row in alignment),  # str(alignment),
             """\

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -342,31 +342,31 @@ TTT	0.886
 
     def test_gc_content(self):
         """Tests gc_content function."""
-        self.assertEqual(gc_content(""), 0)
-        self.assertEqual(gc_content("", "count"), 0)
-        self.assertEqual(gc_content("", "remove"), 0)
+        self.assertAlmostEqual(gc_content(""), 0, places=3)
+        self.assertAlmostEqual(gc_content("", "count"), 0, places=3)
+        self.assertAlmostEqual(gc_content("", "remove"), 0, places=3)
 
         seq = "ACGGGCTACCGTATAGGCAAGAGATGATGCCC"
-        self.assertEqual(gc_content(seq), 0.5625)
-        self.assertEqual(gc_content(seq, "count"), 0.5625)
-        self.assertEqual(gc_content(seq, "remove"), 0.5625)
+        self.assertAlmostEqual(gc_content(seq), 0.5625, places=3)
+        self.assertAlmostEqual(gc_content(seq, "count"), 0.5625, places=3)
+        self.assertAlmostEqual(gc_content(seq, "remove"), 0.5625, places=3)
 
         seq = "ACTGSSSS"
-        self.assertEqual(gc_content(seq), 0.75)
-        self.assertEqual(gc_content(seq, "count"), 0.75)
-        self.assertEqual(gc_content(seq, "remove"), 0.75)
+        self.assertAlmostEqual(gc_content(seq), 0.75, places=3)
+        self.assertAlmostEqual(gc_content(seq, "count"), 0.75, places=3)
+        self.assertAlmostEqual(gc_content(seq, "remove"), 0.75, places=3)
 
         # Test ambiguous nucleotide behaviour
 
         seq = "CCTGNN"
-        self.assertEqual(gc_content(seq), 0.5)
+        self.assertAlmostEqual(gc_content(seq), 0.5, places=3)
         self.assertAlmostEqual(gc_content(seq, "count"), 0.667, places=3)
-        self.assertEqual(gc_content(seq, "remove"), 0.75)
+        self.assertAlmostEqual(gc_content(seq, "remove"), 0.75, places=3)
 
         seq = "GDVV"
-        self.assertEqual(gc_content(seq), 0.25)
+        self.assertAlmostEqual(gc_content(seq), 0.25, places=3)
         self.assertAlmostEqual(gc_content(seq, "count"), 0.6667, places=3)
-        self.assertEqual(gc_content(seq, "remove"), 1.00)
+        self.assertAlmostEqual(gc_content(seq, "remove"), 1.00, places=3)
 
         with self.assertRaises(ValueError):
             gc_content(seq, "other string")

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -342,30 +342,30 @@ TTT	0.886
 
     def test_gc_content(self):
         """Tests gc_content function."""
-        self.assertAlmostEqual(gc_content(""), 0, places=3)
-        self.assertAlmostEqual(gc_content("", "count"), 0, places=3)
+        self.assertAlmostEqual(gc_content("", "ignore"), 0, places=3)
+        self.assertAlmostEqual(gc_content("", "weighted"), 0, places=3)
         self.assertAlmostEqual(gc_content("", "remove"), 0, places=3)
 
         seq = "ACGGGCTACCGTATAGGCAAGAGATGATGCCC"
-        self.assertAlmostEqual(gc_content(seq), 0.5625, places=3)
-        self.assertAlmostEqual(gc_content(seq, "count"), 0.5625, places=3)
+        self.assertAlmostEqual(gc_content(seq, "ignore"), 0.5625, places=3)
+        self.assertAlmostEqual(gc_content(seq, "weighted"), 0.5625, places=3)
         self.assertAlmostEqual(gc_content(seq, "remove"), 0.5625, places=3)
 
         seq = "ACTGSSSS"
-        self.assertAlmostEqual(gc_content(seq), 0.75, places=3)
-        self.assertAlmostEqual(gc_content(seq, "count"), 0.75, places=3)
+        self.assertAlmostEqual(gc_content(seq, "ignore"), 0.75, places=3)
+        self.assertAlmostEqual(gc_content(seq, "weighted"), 0.75, places=3)
         self.assertAlmostEqual(gc_content(seq, "remove"), 0.75, places=3)
 
         # Test ambiguous nucleotide behaviour
 
         seq = "CCTGNN"
-        self.assertAlmostEqual(gc_content(seq), 0.5, places=3)
-        self.assertAlmostEqual(gc_content(seq, "count"), 0.667, places=3)
+        self.assertAlmostEqual(gc_content(seq, "ignore"), 0.5, places=3)
+        self.assertAlmostEqual(gc_content(seq, "weighted"), 0.667, places=3)
         self.assertAlmostEqual(gc_content(seq, "remove"), 0.75, places=3)
 
         seq = "GDVV"
-        self.assertAlmostEqual(gc_content(seq), 0.25, places=3)
-        self.assertAlmostEqual(gc_content(seq, "count"), 0.6667, places=3)
+        self.assertAlmostEqual(gc_content(seq, "ignore"), 0.25, places=3)
+        self.assertAlmostEqual(gc_content(seq, "weighted"), 0.6667, places=3)
         self.assertAlmostEqual(gc_content(seq, "remove"), 1.00, places=3)
 
         with self.assertRaises(ValueError):

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -11,7 +11,7 @@ from Bio import SeqIO
 from Bio.Seq import MutableSeq
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.SeqUtils import GC
+from Bio.SeqUtils import gc_content
 from Bio.SeqUtils import GC_skew
 from Bio.SeqUtils import seq1
 from Bio.SeqUtils import seq3
@@ -340,13 +340,22 @@ TTT	0.886
             ),
         )
 
-    def test_GC(self):
-        s = "ACGGGCTACCGTATAGGCAAGAGATGATGCCC"
-        seq = Seq(s)
-        record = SeqRecord(seq)
-        self.assertEqual(GC(s), 56.25)
-        self.assertEqual(GC(seq), 56.25)
-        self.assertEqual(GC(record), 56.25)
+    def test_gc_content(self):
+        seq = "ACGGGCTACCGTATAGGCAAGAGATGATGCCC"
+        self.assertEqual(gc_content(seq), 0.5625)
+
+        seq = "ACTGSSSS"
+        self.assertEqual(gc_content(seq), 0.75)
+
+        # Test ambiguous nucleotide behaviour
+
+        seq = "CCTGNN"
+        self.assertEqual(gc_content(seq), 0.75)
+        self.assertAlmostEqual(gc_content(seq, False), 0.667, places=3)
+
+        seq = "GDVV"
+        self.assertEqual(gc_content(seq), 1.00)
+        self.assertEqual(gc_content(seq, False), 0.6675)
 
     def test_GC_skew(self):
         s = "A" * 50

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -365,7 +365,7 @@ TTT	0.886
 
         seq = "GDVV"
         self.assertEqual(gc_content(seq), 0.25)
-        self.assertEqual(gc_content(seq, "count"), 0.666675)
+        self.assertAlmostEqual(gc_content(seq, "count"), 0.6667, places=3)
         self.assertEqual(gc_content(seq, "remove"), 1.00)
 
         with self.assertRaises(ValueError):

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -11,7 +11,7 @@ from Bio import SeqIO
 from Bio.Seq import MutableSeq
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.SeqUtils import gc_content
+from Bio.SeqUtils import gc_fraction
 from Bio.SeqUtils import GC_skew
 from Bio.SeqUtils import seq1
 from Bio.SeqUtils import seq3
@@ -340,36 +340,36 @@ TTT	0.886
             ),
         )
 
-    def test_gc_content(self):
-        """Tests gc_content function."""
-        self.assertAlmostEqual(gc_content("", "ignore"), 0, places=3)
-        self.assertAlmostEqual(gc_content("", "weighted"), 0, places=3)
-        self.assertAlmostEqual(gc_content("", "remove"), 0, places=3)
+    def test_gc_fraction(self):
+        """Tests gc_fraction function."""
+        self.assertAlmostEqual(gc_fraction("", "ignore"), 0, places=3)
+        self.assertAlmostEqual(gc_fraction("", "weighted"), 0, places=3)
+        self.assertAlmostEqual(gc_fraction("", "remove"), 0, places=3)
 
         seq = "ACGGGCTACCGTATAGGCAAGAGATGATGCCC"
-        self.assertAlmostEqual(gc_content(seq, "ignore"), 0.5625, places=3)
-        self.assertAlmostEqual(gc_content(seq, "weighted"), 0.5625, places=3)
-        self.assertAlmostEqual(gc_content(seq, "remove"), 0.5625, places=3)
+        self.assertAlmostEqual(gc_fraction(seq, "ignore"), 0.5625, places=3)
+        self.assertAlmostEqual(gc_fraction(seq, "weighted"), 0.5625, places=3)
+        self.assertAlmostEqual(gc_fraction(seq, "remove"), 0.5625, places=3)
 
         seq = "ACTGSSSS"
-        self.assertAlmostEqual(gc_content(seq, "ignore"), 0.75, places=3)
-        self.assertAlmostEqual(gc_content(seq, "weighted"), 0.75, places=3)
-        self.assertAlmostEqual(gc_content(seq, "remove"), 0.75, places=3)
+        self.assertAlmostEqual(gc_fraction(seq, "ignore"), 0.75, places=3)
+        self.assertAlmostEqual(gc_fraction(seq, "weighted"), 0.75, places=3)
+        self.assertAlmostEqual(gc_fraction(seq, "remove"), 0.75, places=3)
 
         # Test ambiguous nucleotide behaviour
 
         seq = "CCTGNN"
-        self.assertAlmostEqual(gc_content(seq, "ignore"), 0.5, places=3)
-        self.assertAlmostEqual(gc_content(seq, "weighted"), 0.667, places=3)
-        self.assertAlmostEqual(gc_content(seq, "remove"), 0.75, places=3)
+        self.assertAlmostEqual(gc_fraction(seq, "ignore"), 0.5, places=3)
+        self.assertAlmostEqual(gc_fraction(seq, "weighted"), 0.667, places=3)
+        self.assertAlmostEqual(gc_fraction(seq, "remove"), 0.75, places=3)
 
         seq = "GDVV"
-        self.assertAlmostEqual(gc_content(seq, "ignore"), 0.25, places=3)
-        self.assertAlmostEqual(gc_content(seq, "weighted"), 0.6667, places=3)
-        self.assertAlmostEqual(gc_content(seq, "remove"), 1.00, places=3)
+        self.assertAlmostEqual(gc_fraction(seq, "ignore"), 0.25, places=3)
+        self.assertAlmostEqual(gc_fraction(seq, "weighted"), 0.6667, places=3)
+        self.assertAlmostEqual(gc_fraction(seq, "remove"), 1.00, places=3)
 
         with self.assertRaises(ValueError):
-            gc_content(seq, "other string")
+            gc_fraction(seq, "other string")
 
     def test_GC_skew(self):
         s = "A" * 50

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -341,21 +341,35 @@ TTT	0.886
         )
 
     def test_gc_content(self):
+        """Tests gc_content function."""
+        self.assertEqual(gc_content(""), 0)
+        self.assertEqual(gc_content("", "count"), 0)
+        self.assertEqual(gc_content("", "remove"), 0)
+
         seq = "ACGGGCTACCGTATAGGCAAGAGATGATGCCC"
         self.assertEqual(gc_content(seq), 0.5625)
+        self.assertEqual(gc_content(seq, "count"), 0.5625)
+        self.assertEqual(gc_content(seq, "remove"), 0.5625)
 
         seq = "ACTGSSSS"
         self.assertEqual(gc_content(seq), 0.75)
+        self.assertEqual(gc_content(seq, "count"), 0.75)
+        self.assertEqual(gc_content(seq, "remove"), 0.75)
 
         # Test ambiguous nucleotide behaviour
 
         seq = "CCTGNN"
-        self.assertEqual(gc_content(seq), 0.75)
-        self.assertAlmostEqual(gc_content(seq, False), 0.667, places=3)
+        self.assertEqual(gc_content(seq), 0.5)
+        self.assertAlmostEqual(gc_content(seq, "count"), 0.667, places=3)
+        self.assertEqual(gc_content(seq, "remove"), 0.75)
 
         seq = "GDVV"
-        self.assertEqual(gc_content(seq), 1.00)
-        self.assertEqual(gc_content(seq, False), 0.6675)
+        self.assertEqual(gc_content(seq), 0.25)
+        self.assertEqual(gc_content(seq, "count"), 0.666675)
+        self.assertEqual(gc_content(seq, "remove"), 1.00)
+
+        with self.assertRaises(ValueError):
+            gc_content(seq, "other string")
 
     def test_GC_skew(self):
         s = "A" * 50


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Finishes the work in #564.

Adds the option to return the GC ratio as well as the percentage, fixing the docstring problems in the original PR. Did not add the suggested `float()` conversion since the update to python3 resolved the issue of `int / int` division.
