### PR TITLE
Actually remove add_sequence method

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1572,8 +1572,8 @@ class PairwiseAlignment:
         >>> alignment1 = alignments1[0]
         >>> print(alignment1)
         AAAAAAAACCCCCCCAAAAAAAAAAAGGGGGGAAAAAAAA
-                |||||||-----------||||||
-                CCCCCCC-----------GGGGGG
+                |||||||-----------||||||        
+                CCCCCCC-----------GGGGGG        
         <BLANKLINE>
         >>> sequence = "CCCCGGGG"
         >>> alignments2 = aligner.align(transcript, sequence)
@@ -1582,14 +1582,14 @@ class PairwiseAlignment:
         >>> alignment2 = alignments2[0]
         >>> print(alignment2)
         CCCCCCCGGGGGG
-           ||||||||
-           CCCCGGGG
+           ||||||||  
+           CCCCGGGG  
         <BLANKLINE>
         >>> alignment = alignment1.map(alignment2)
         >>> print(alignment)
         AAAAAAAACCCCCCCAAAAAAAAAAAGGGGGGAAAAAAAA
-                   ||||-----------||||
-                   CCCC-----------GGGG
+                   ||||-----------||||          
+                   CCCC-----------GGGG          
         <BLANKLINE>
         >>> format(alignment, "psl")
         '8\t0\t0\t0\t0\t0\t1\t11\t+\tquery\t8\t0\t8\ttarget\t40\t11\t30\t2\t4,4,\t0,4,\t11,26,\n'

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -241,11 +241,13 @@ class MultipleSeqAlignment:
         are shown, with the record identifiers.  This should fit nicely on a
         single screen. e.g.
 
+        >>> from Bio.Seq import Seq
+        >>> from Bio.SeqRecord import SeqRecord
         >>> from Bio.Align import MultipleSeqAlignment
-        >>> align = MultipleSeqAlignment([])
-        >>> align.add_sequence("Alpha", "ACTGCTAGCTAG")
-        >>> align.add_sequence("Beta",  "ACT-CTAGCTAG")
-        >>> align.add_sequence("Gamma", "ACTGCTAGATAG")
+        >>> a = SeqRecord(Seq("ACTGCTAGCTAG"), id="Alpha")
+        >>> b = SeqRecord(Seq("ACT-CTAGCTAG"), id="Beta")
+        >>> c = SeqRecord(Seq("ACTGCTAGATAG"), id="Gamma")
+        >>> align = MultipleSeqAlignment([a, b, c])
         >>> print(align)
         Alignment with 3 rows and 12 columns
         ACTGCTAGCTAG Alpha
@@ -304,10 +306,10 @@ class MultipleSeqAlignment:
         e.g.
 
         >>> from Bio.Align import MultipleSeqAlignment
-        >>> align = MultipleSeqAlignment([])
-        >>> align.add_sequence("Alpha", "ACTGCTAGCTAG")
-        >>> align.add_sequence("Beta",  "ACT-CTAGCTAG")
-        >>> align.add_sequence("Gamma", "ACTGCTAGATAG")
+        >>> a = SeqRecord(Seq("ACTGCTAGCTAG"), id="Alpha", description="")
+        >>> b = SeqRecord(Seq("ACT-CTAGCTAG"), id="Beta", description="")
+        >>> c = SeqRecord(Seq("ACTGCTAGATAG"), id="Gamma", description="")
+        >>> align = MultipleSeqAlignment([a, b, c])
         >>> print(format(align, "fasta"))
         >Alpha
         ACTGCTAGCTAG
@@ -340,10 +342,10 @@ class MultipleSeqAlignment:
         e.g.
 
         >>> from Bio.Align import MultipleSeqAlignment
-        >>> align = MultipleSeqAlignment([])
-        >>> align.add_sequence("Alpha", "ACTGCTAGCTAG")
-        >>> align.add_sequence("Beta",  "ACT-CTAGCTAG")
-        >>> align.add_sequence("Gamma", "ACTGCTAGATAG")
+        >>> a = SeqRecord(Seq("ACTGCTAGCTAG"), id="Alpha")
+        >>> b = SeqRecord(Seq("ACT-CTAGCTAG"), id="Beta")
+        >>> c = SeqRecord(Seq("ACTGCTAGATAG"), id="Gamma")
+        >>> align = MultipleSeqAlignment([a, b, c])
         >>> for record in align:
         ...    print(record.id)
         ...    print(record.seq)
@@ -377,10 +379,10 @@ class MultipleSeqAlignment:
         by finding the maximum length of sequences in the alignment.
 
         >>> from Bio.Align import MultipleSeqAlignment
-        >>> align = MultipleSeqAlignment([])
-        >>> align.add_sequence("Alpha", "ACTGCTAGCTAG")
-        >>> align.add_sequence("Beta",  "ACT-CTAGCTAG")
-        >>> align.add_sequence("Gamma", "ACTGCTAGATAG")
+        >>> a = SeqRecord(Seq("ACTGCTAGCTAG"), id="Alpha")
+        >>> b = SeqRecord(Seq("ACT-CTAGCTAG"), id="Beta")
+        >>> c = SeqRecord(Seq("ACTGCTAGATAG"), id="Gamma")
+        >>> align = MultipleSeqAlignment([a, b, c])
         >>> align.get_alignment_length()
         12
 

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -399,56 +399,6 @@ class MultipleSeqAlignment:
 
         return max_length
 
-    def add_sequence(self, descriptor, sequence, start=None, end=None, weight=1.0):
-        """Add a sequence to the alignment.
-
-        This doesn't do any kind of alignment, it just adds in the sequence
-        object, which is assumed to be prealigned with the existing
-        sequences.
-
-        Arguments:
-            - descriptor - The descriptive id of the sequence being added.
-              This will be used as the resulting SeqRecord's
-              .id property (and, for historical compatibility,
-              also the .description property)
-            - sequence - A string with sequence info.
-            - start - You can explicitly set the start point of the sequence.
-              This is useful (at least) for BLAST alignments, which can
-              just be partial alignments of sequences.
-            - end - Specify the end of the sequence, which is important
-              for the same reason as the start.
-            - weight - The weight to place on the sequence in the alignment.
-              By default, all sequences have the same weight. (0.0 =>
-              no weight, 1.0 => highest weight)
-
-        In general providing a SeqRecord and calling .append is preferred.
-        """
-        new_seq = Seq(sequence)
-
-        # We are now effectively using the SeqRecord's .id as
-        # the primary identifier (e.g. in Bio.SeqIO) so we should
-        # populate it with the descriptor.
-        # For backwards compatibility, also store this in the
-        # SeqRecord's description property.
-        new_record = SeqRecord(new_seq, id=descriptor, description=descriptor)
-
-        # hack! We really need to work out how to deal with annotations
-        # and features in biopython. Right now, I'll just use the
-        # generic annotations dictionary we've got to store the start
-        # and end, but we should think up something better. I don't know
-        # if I'm really a big fan of the LocatableSeq thing they've got
-        # in BioPerl, but I'm not positive what the best thing to do on
-        # this is...
-        if start:
-            new_record.annotations["start"] = start
-        if end:
-            new_record.annotations["end"] = end
-
-        # another hack to add weight information to the sequence
-        new_record.annotations["weight"] = weight
-
-        self._records.append(new_record)
-
     def extend(self, records):
         """Add more SeqRecord objects to the alignment as rows.
 
@@ -1620,8 +1570,8 @@ class PairwiseAlignment:
         >>> alignment1 = alignments1[0]
         >>> print(alignment1)
         AAAAAAAACCCCCCCAAAAAAAAAAAGGGGGGAAAAAAAA
-                |||||||-----------||||||        
-                CCCCCCC-----------GGGGGG        
+                |||||||-----------||||||
+                CCCCCCC-----------GGGGGG
         <BLANKLINE>
         >>> sequence = "CCCCGGGG"
         >>> alignments2 = aligner.align(transcript, sequence)
@@ -1630,14 +1580,14 @@ class PairwiseAlignment:
         >>> alignment2 = alignments2[0]
         >>> print(alignment2)
         CCCCCCCGGGGGG
-           ||||||||  
-           CCCCGGGG  
+           ||||||||
+           CCCCGGGG
         <BLANKLINE>
         >>> alignment = alignment1.map(alignment2)
         >>> print(alignment)
         AAAAAAAACCCCCCCAAAAAAAAAAAGGGGGGAAAAAAAA
-                   ||||-----------||||          
-                   CCCC-----------GGGG          
+                   ||||-----------||||
+                   CCCC-----------GGGG
         <BLANKLINE>
         >>> format(alignment, "psl")
         '8\t0\t0\t0\t0\t0\t1\t11\t+\tquery\t8\t0\t8\ttarget\t40\t11\t30\t2\t4,4,\t0,4,\t11,26,\n'

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -860,11 +860,17 @@ please consider using Bio.Align.substitution_matrices.
 
 Bio.Align
 ---------
-The methods ``get_column`` and ``add_sequence`` of the MultipleSeqAlignment
-class were deprecated in Release 1.57 and removed in Release 1.69.
+The ``get_column`` method of the MultipleSeqAlignment was deprecated in
+Release 1.57 and removed in Release 1.69.
+
+The ``add_sequence`` method of the MultipleSeqAlignment was deprecated in
+Release 1.57 and should have been removed in Release 1.69. It was actually
+removed in Release 1.79.
+
 The ``format`` method of the MultipleSeqAlignment class and the
 PairwiseAlignment class were deprecated in Release 1.76. This decision was
 reversed in Release 1.79.
+
 The ``__format__`` method of the Array class in Bio.Align.substitution_matrices
 was deprecated in Release 1.79.
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
See discussion https://github.com/biopython/biopython/commit/422b5051624bcf3c0c145e9e951f551d86b52931#r50771274

Pull request #922 intended to remove the method, but accidentally restored it as part of removing
the legacy base class. The add_sequence zombie method has since stayed in place since Biopython 1.69
