### PR TITLE
Add a substitutions method to PairwiseAlignment

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1758,15 +1758,33 @@ class PairwiseAlignment:
         ATACTTACCTGGCAGGGGAGATACCATGATCACGAAGGTGGTTTTCCCAGGGCGAGGCTTATCCATTGCACTCCGGATGTGCTGACCCCTGCGATTTCCCCAAATGTGGGAAACTCGACTGCATAATTTGTGGTAGTGGGGGACTGCGTTCGCGCTTTCCCCTG
         |||||||||||.||||||||..|||||||||||..|||||||..|||||||||||||||..|||||||||||.|||..|.|.|||||||||||||||||||||||||||||||||||||||.||||||||||||||||||||||||||||||||||.|||||.|
         ATACTTACCTGACAGGGGAGGCACCATGATCACACAGGTGGTCCTCCCAGGGCGAGGCTCTTCCATTGCACTGCGGGAGGGTTGACCCCTGCGATTTCCCCAAATGTGGGAAACTCGACTGTATAATTTGTGGTAGTGGGGGACTGCGTTCGCGCTATCCCCCG
-
+        <BLANKLINE>
         >>> m = alignment.substitutions
         >>> print(m)
              A    C    G    T
-        A 28.0  0.0  2.0  2.0
-        C  1.0 39.0  0.0  5.0
-        G  2.0  1.0 45.0  1.0
-        T  1.0  2.0  0.0 35.0
+        A 28.0  1.0  2.0  1.0
+        C  0.0 39.0  1.0  2.0
+        G  2.0  0.0 45.0  0.0
+        T  2.0  5.0  1.0 35.0
         <BLANKLINE>
+
+        Note that the matrix is not symmetric: rows correspond to the target
+        sequence, and columns to the query sequence.  For example, the number
+        of T's in the target sequence that are aligned to a C in the query
+        sequence is
+
+        >>> m['T', 'C']
+        5.0
+
+        and the number of C's in the query sequence tat are aligned to a T in
+        the query sequence is
+
+        >>> m['C', 'T']
+        2.0
+
+        For some applications (for example, to define a scoring matrix from
+        the substitution matrix), a symmetric matrix may be preferred, which
+        can be calculated as follows:
 
         >>> m += m.transpose()
         >>> m /= 2.0
@@ -1778,9 +1796,16 @@ class PairwiseAlignment:
         T  1.5  3.5  0.5 35.0
         <BLANKLINE>
 
-        Note that the matrix is symmetric, with counts divided equally on both
-        sides of the diagonal. For example, the total number of substitutions
-        between C and T in the alignment is 3.5 + 3.5 = 7.
+        The matrix is now symmetric, with counts divided equally on both sides
+        of the diagonal:
+
+        >>> m['C', 'T']
+        3.5
+        >>> m['T', 'C']
+        3.5
+
+        The total number of substitutions between T's and C's in the alignment
+        is 3.5 + 3.5 = 7.
         """
         target = self.target
         try:
@@ -1800,7 +1825,7 @@ class PairwiseAlignment:
         for i1 in range(n):
             path1 = [p[i1] for p in self.path]
             sequence1 = sequences[i1]
-            for i2 in range(i1+1, n):
+            for i2 in range(i1 + 1, n):
                 path2 = [p[i2] for p in self.path]
                 sequence2 = sequences[i2]
                 start1, start2 = sys.maxsize, sys.maxsize
@@ -1810,6 +1835,7 @@ class PairwiseAlignment:
                             m[c1, c2] += 1.0
                     start1, start2 = end1, end2
         return m
+
 
 class PairwiseAlignments:
     """Implements an iterator over pairwise alignments returned by the aligner.

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1831,7 +1831,9 @@ class PairwiseAlignment:
                 start1, start2 = sys.maxsize, sys.maxsize
                 for end1, end2 in zip(path1, path2):
                     if start1 < end1 and start2 < end2:  # aligned
-                        for c1, c2 in zip(sequence1[start1:end1], sequence2[start2:end2]):
+                        segment1 = sequence1[start1:end1]
+                        segment2 = sequence2[start2:end2]
+                        for c1, c2 in zip(segment1, segment2):
                             m[c1, c2] += 1.0
                     start1, start2 = end1, end2
         return m

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1762,6 +1762,16 @@ class PairwiseAlignment:
         >>> m = alignment.substitutions
         >>> print(m)
              A    C    G    T
+        A 28.0  0.0  2.0  2.0
+        C  1.0 39.0  0.0  5.0
+        G  2.0  1.0 45.0  1.0
+        T  1.0  2.0  0.0 35.0
+        <BLANKLINE>
+
+        >>> m += m.transpose()
+        >>> m /= 2.0
+        >>> print(m)
+             A    C    G    T
         A 28.0  0.5  2.0  1.5
         C  0.5 39.0  0.5  3.5
         G  2.0  0.5 45.0  0.5
@@ -1790,7 +1800,7 @@ class PairwiseAlignment:
         for i1 in range(n):
             path1 = [p[i1] for p in self.path]
             sequence1 = sequences[i1]
-            for i2 in range(i1):
+            for i2 in range(i1+1, n):
                 path2 = [p[i2] for p in self.path]
                 sequence2 = sequences[i2]
                 start1, start2 = sys.maxsize, sys.maxsize
@@ -1799,8 +1809,6 @@ class PairwiseAlignment:
                         for c1, c2 in zip(sequence1[start1:end1], sequence2[start2:end2]):
                             m[c1, c2] += 1.0
                     start1, start2 = end1, end2
-        m += m.transpose()
-        m /= 2.0
         return m
 
 class PairwiseAlignments:

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2244,6 +2244,63 @@ AAAG-AAA
 \end{minted}
 The \verb+aligned+ property can be used to identify alignments that are identical to each other in terms of their aligned sequences.
 
+Use the \verb+substitutions+ method to find the number of substitutions between each pair of nucleotides:
+%cont-doctest
+\begin{minted}{pycon}
+>>> target = "AAAAAAAACCCCCCCCGGGGGGGGTTTTTTTT"
+>>> query = "AAAAAAACCCTCCCCGGCCGGGGTTTAGTTT"
+>>> alignments = aligner.align(target, query)
+>>> aligner.mismatch_score = -1
+>>> aligner.gap_score = -1
+>>> alignments = aligner.align(target, query)
+>>> len(alignments)
+8
+>>> print(alignments[0])
+AAAAAAAACCCCCCCCGGGGGGGGTTTTTTTT
+|||||||-|||.||||||..|||||||..|||
+AAAAAAA-CCCTCCCCGGCCGGGGTTTAGTTT
+<BLANKLINE>
+>>> m = alignments[0].substitutions
+>>> print(m)
+    A   C   G   T
+A 7.0 0.0 0.0 0.0
+C 0.0 7.0 0.0 1.0
+G 0.0 2.0 6.0 0.0
+T 1.0 0.0 1.0 6.0
+<BLANKLINE>
+\end{minted}{pycon}
+
+Note that the matrix is not symmetric: rows correspond to the target sequence, and columns to the query sequence.  For example, the number of G's in the target sequence that are aligned to a C in the query sequence is
+%cont-doctest
+\begin{minted}{pycon}
+>>> m['G', 'C']
+2.0
+\end{minted}{pycon}
+and the number of C's in the query sequence tat are aligned to a T in the query sequence is
+%cont-doctest
+\begin{minted}{pycon}
+>>> m['C', 'G']
+0.0
+\end{minted}{pycon}
+To get a symmetric matrix, use
+%cont-doctest
+\begin{minted}{pycon}
+>>> m += m.transpose()
+>>> m /= 2.0
+>>> print(m)
+    A   C   G   T
+A 7.0 0.0 0.0 0.5
+C 0.0 7.0 1.0 0.5
+G 0.0 1.0 6.0 0.5
+T 0.5 0.5 0.5 6.0
+<BLANKLINE>
+>>> m['G', 'C']
+1.0
+>>> m['C', 'G']
+1.0
+\end{minted}{pycon}
+The total number of substitutions between C's and G's in the alignment is 1.0 + 1.0 = 2.
+
 The \verb+map+ method can be applied on a pairwise alignment \verb+alignment1+ to find the pairwise alignment of the query of \verb+alignment2+ to the target of \verb+alignment1+, where the target of \verb+alignment2+ and the query of \verb+alignment1+ are identical. A typical example is where \verb+alignment1+ is the pairwise alignment between a chromosome and a transcript, \verb+alignment2+ is the pairwise alignment between the transcript and a sequence (e.g., an RNA-seq read), and we want to find the alignment of the sequence to the chromosome:
         
 %cont-doctest

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -3866,7 +3866,7 @@ class TestAlignmentMethods(unittest.TestCase):
         aligner.extend_gap_score = -2
         aligner.match = +1
         aligner.mismatch = -3
-        aligner.mode = 'local'
+        aligner.mode = "local"
         alignments = aligner.align(target, query)
         self.assertEqual(len(alignments), 9031680)
         alignment = alignments[0]
@@ -3878,8 +3878,8 @@ C   5.0 186.0   9.0  14.0
 G  12.0  11.0 248.0   8.0
 T  11.0  19.0   6.0 145.0
 """)
-        self.assertAlmostEqual(m['T', 'C'], 19.0)
-        self.assertAlmostEqual(m['C', 'T'], 14.0)
+        self.assertAlmostEqual(m["T", "C"], 19.0)
+        self.assertAlmostEqual(m["C", "T"], 14.0)
         m += m.transpose()
         m /= 2.0
         self.assertEqual(str(m), """\
@@ -3889,8 +3889,8 @@ C   4.0 186.0  10.0  16.5
 G  13.5  10.0 248.0   7.0
 T  12.0  16.5   7.0 145.0
 """)
-        self.assertAlmostEqual(m['C', 'T'], 16.5)
-        self.assertAlmostEqual(m['T', 'C'], 16.5)
+        self.assertAlmostEqual(m["C", "T"], 16.5)
+        self.assertAlmostEqual(m["T", "C"], 16.5)
 
 
 if __name__ == "__main__":

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -3871,24 +3871,30 @@ class TestAlignmentMethods(unittest.TestCase):
         self.assertEqual(len(alignments), 9031680)
         alignment = alignments[0]
         m = alignment.substitutions
-        self.assertEqual(str(m), """\
+        self.assertEqual(
+            str(m),
+            """\
       A     C     G     T
 A 191.0   3.0  15.0  13.0
 C   5.0 186.0   9.0  14.0
 G  12.0  11.0 248.0   8.0
 T  11.0  19.0   6.0 145.0
-""")
+""",
+        )
         self.assertAlmostEqual(m["T", "C"], 19.0)
         self.assertAlmostEqual(m["C", "T"], 14.0)
         m += m.transpose()
         m /= 2.0
-        self.assertEqual(str(m), """\
+        self.assertEqual(
+            str(m),
+            """\
       A     C     G     T
 A 191.0   4.0  13.5  12.0
 C   4.0 186.0  10.0  16.5
 G  13.5  10.0 248.0   7.0
 T  12.0  16.5   7.0 145.0
-""")
+""",
+        )
         self.assertAlmostEqual(m["C", "T"], 16.5)
         self.assertAlmostEqual(m["T", "C"], 16.5)
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -3852,6 +3852,47 @@ query	16	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         )
 
 
+class TestAlignmentMethods(unittest.TestCase):
+    def test_substitutions(self):
+        aligner = Align.PairwiseAligner()
+        path = os.path.join("Align", "ecoli.fa")
+        record = SeqIO.read(path, "fasta")
+        target = record.seq
+        path = os.path.join("Align", "bsubtilis.fa")
+        record = SeqIO.read(path, "fasta")
+        query = record.seq
+        # blastn default parameters:
+        aligner.open_gap_score = -5
+        aligner.extend_gap_score = -2
+        aligner.match = +1
+        aligner.mismatch = -3
+        aligner.mode = 'local'
+        alignments = aligner.align(target, query)
+        self.assertEqual(len(alignments), 9031680)
+        alignment = alignments[0]
+        m = alignment.substitutions
+        self.assertEqual(str(m), """\
+      A     C     G     T
+A 191.0   3.0  15.0  13.0
+C   5.0 186.0   9.0  14.0
+G  12.0  11.0 248.0   8.0
+T  11.0  19.0   6.0 145.0
+""")
+        self.assertAlmostEqual(m['T', 'C'], 19.0)
+        self.assertAlmostEqual(m['C', 'T'], 14.0)
+        m += m.transpose()
+        m /= 2.0
+        self.assertEqual(str(m), """\
+      A     C     G     T
+A 191.0   4.0  13.5  12.0
+C   4.0 186.0  10.0  16.5
+G  13.5  10.0 248.0   7.0
+T  12.0  16.5   7.0 145.0
+""")
+        self.assertAlmostEqual(m['C', 'T'], 16.5)
+        self.assertAlmostEqual(m['T', 'C'], 16.5)
+
+
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)
     unittest.main(testRunner=runner)


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Adding a `substitutions` method to `PairwiseAlignment` to calculate a substitutions matrix from an alignment. Essentially the same as the `substitutions` method to `MultipleSeqAlignment`.