### PR TITLE
Pairwise alignment getitem

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1013,6 +1013,55 @@ class PairwiseAlignment:
         return self.path >= other.path
 
     def __getitem__(self, key):
+        """Return self[key].
+
+        Currently, this is implemented only for indices of the form
+
+        self[:, :]
+
+        which returns a copy of the PairwiseAlignment object, and
+
+        self[:, i:]
+        self[:, :j]
+        self[:, i:j]
+
+        which returns a new PairwiseAlignment object spanning the indicated
+        columns.
+
+        >>> from Bio.Align import PairwiseAligner
+        >>> aligner = PairwiseAligner()
+        >>> a = "ACCGGTTT"
+        >>> b = "ACGGGTT"
+        >>> alignments = aligner.align(a, b)
+        >>> alignment = alignments[0]
+        >>> print(alignment)
+        ACCGG-TTT
+        ||-||-|--
+        AC-GGGT--
+        <BLANKLINE>
+        >>> alignment[:, 1:]  # doctest:+ELLIPSIS
+        <Bio.Align.PairwiseAlignment object at ...>
+        >>> print(alignment[:, 1:])
+        ACCGG-TTT
+         |-||-|--
+        AC-GGGT--
+        <BLANKLINE>
+        >>> print(alignment[:, 2:])
+        ACCGG-TTT
+          -||-|--
+        AC-GGGT--
+        <BLANKLINE>
+        >>> print(alignment[:, 3:])
+        ACCGG-TTT
+           ||-|--
+         ACGGGT--
+        <BLANKLINE>
+        >>> print(alignment[:, 3:-1])
+        ACCGG-TTT
+           ||-|-
+         ACGGGT-
+        <BLANKLINE>
+        """
         if isinstance(key, slice):
             if key.indices(len(self)) == (0, 2, 1):
                 target = self.target

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1037,35 +1037,31 @@ class PairwiseAlignment:
                     raise NotImplementedError
                 if isinstance(col, slice):
                     n, m = self.shape
-                    start, stop, step = col.indices(m)
+                    start_index, stop_index, step = col.indices(m)
                     if step != 1:
                         raise NotImplementedError
-                    index = start
                     path = []
-                    end = 0
+                    index = 0
                     path_iterator = iter(self.path)
                     starts = next(path_iterator)
                     for ends in path_iterator:
-                        start = end
-                        end = start + max(e - s for s, e in zip(starts, ends))
-                        if index < end:
-                            offset = index - start
-                            point = tuple(s + offset for s in starts)
+                        index += max(e - s for s, e in zip(starts, ends))
+                        if start_index < index:
+                            offset = index - start_index
+                            point = tuple(e - offset if s < e else s for s, e in zip(starts, ends))
                             path.append(point)
                             break
                         starts = ends
-                    index = stop
                     while True:
-                        if index < end:
-                            offset = index - start
-                            point = tuple(s + offset for s in starts)
+                        if stop_index <= index:
+                            offset = index - stop_index
+                            point = tuple(e - offset if s < e else s for s, e in zip(starts, ends))
                             path.append(point)
                             break
                         path.append(ends)
                         starts = ends
                         ends = next(path_iterator)
-                        start = end
-                        end = start + max(e - s for s, e in zip(starts, ends))
+                        index += max(e - s for s, e in zip(starts, ends))
                     path = tuple(path)
                     target = self.target
                     query = self.query

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1030,36 +1030,34 @@ class PairwiseAlignment:
 
         >>> from Bio.Align import PairwiseAligner
         >>> aligner = PairwiseAligner()
-        >>> a = "ACCGGTTT"
-        >>> b = "ACGGGTT"
-        >>> alignments = aligner.align(a, b)
+        >>> alignments = aligner.align("ACCGGTTT", "ACGGGTT")
         >>> alignment = alignments[0]
         >>> print(alignment)
         ACCGG-TTT
-        ||-||-|--
-        AC-GGGT--
+        ||-||-||-
+        AC-GGGTT-
         <BLANKLINE>
         >>> alignment[:, 1:]  # doctest:+ELLIPSIS
         <Bio.Align.PairwiseAlignment object at ...>
         >>> print(alignment[:, 1:])
         ACCGG-TTT
-         |-||-|--
-        AC-GGGT--
+         |-||-||-
+        AC-GGGTT-
         <BLANKLINE>
         >>> print(alignment[:, 2:])
         ACCGG-TTT
-          -||-|--
-        AC-GGGT--
+          -||-||-
+        AC-GGGTT-
         <BLANKLINE>
         >>> print(alignment[:, 3:])
         ACCGG-TTT
-           ||-|--
-         ACGGGT--
+           ||-||-
+         ACGGGTT-
         <BLANKLINE>
         >>> print(alignment[:, 3:-1])
         ACCGG-TTT
-           ||-|-
-         ACGGGT-
+           ||-||
+         ACGGGTT
         <BLANKLINE>
         """
         if isinstance(key, slice):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1081,7 +1081,7 @@ class PairwiseAlignment:
                 raise NotImplementedError
             if isinstance(row, slice):
                 if row.indices(len(self)) != (0, 2, 1):
-                   raise NotImplementedError
+                    raise NotImplementedError
                 if isinstance(col, int):
                     raise NotImplementedError
                 if isinstance(col, slice):
@@ -1097,14 +1097,18 @@ class PairwiseAlignment:
                         index += max(e - s for s, e in zip(starts, ends))
                         if start_index < index:
                             offset = index - start_index
-                            point = tuple(e - offset if s < e else s for s, e in zip(starts, ends))
+                            point = tuple(
+                                e - offset if s < e else s for s, e in zip(starts, ends)
+                            )
                             path.append(point)
                             break
                         starts = ends
                     while True:
                         if stop_index <= index:
                             offset = index - stop_index
-                            point = tuple(e - offset if s < e else s for s, e in zip(starts, ends))
+                            point = tuple(
+                                e - offset if s < e else s for s, e in zip(starts, ends)
+                            )
                             path.append(point)
                             break
                         path.append(ends)

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2389,6 +2389,46 @@ obviously lose the ability to print the sequence alignment):
 '8\t0\t0\t0\t0\t0\t1\t11\t+\tquery\t8\t0\t8\ttarget\t40\t11\t30\t2\t4,4,\t0,4,\t11,26,\n'
 \end{minted}
 
+\paragraph*{Slicing and indexing a pairwise alignment}
+
+Currently, only slices of the form \verb+alignment[:, i:j]+ are implemented, where \verb+i+ and \verb+j+ are integers or are absent. This returns a new \verb+PairwiseAlignment+ object that includes only the columns \verb+i+ through \verb+j+ in the printed alignment. To illustrate this, in the following example the printed alignment has 5 columns:
+
+%cont-doctest
+\begin{minted}{pycon}
+>>> print(alignment)
+GAACT
+|-|-|
+G-A-T
+<BLANKLINE>
+\end{minted}
+
+Extracting the first 4 columns gives:
+%cont-doctest
+\begin{minted}{pycon}
+>>> alignment[:, :4]  # doctest:+ELLIPSIS
+<Bio.Align.PairwiseAlignment object at ...>
+>>> print(alignment[:, :4])
+GAACT
+|-|-
+G-A-T
+<BLANKLINE>
+\end{minted}
+Here, the final \verb+T+ nucleotides are still shown, but they are not aligned to each other. Note that \verb+alignment+ is a global alignment, but \verb+alignment[:, :4]+ is a local alignment.
+
+Similarly, extracting the last 3 columns gives:
+%cont-doctest
+\begin{minted}{pycon}
+>>> alignment[:, -3:]  # doctest:+ELLIPSIS
+<Bio.Align.PairwiseAlignment object at ...>
+>>> print(alignment[:, -3:])
+GAACT
+  |-|
+ GA-T
+<BLANKLINE>
+\end{minted}
+This is also now a local alignment, with the initial \verb+GA+ nucleotides in the target and \verb+G+ nucleotide in the query not aligned to each other.
+
+
 \paragraph*{Exporting alignments}
 
 Use the \verb+format+ method to create a string representation of the alignment in various file formats. This method takes an argument \verb+fmt+ specifying the file format, and may take additional keyword arguments depending on file type. The following values for \verb+fmt+ are supported:

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4016,7 +4016,8 @@ class TestAlignmentMethods(unittest.TestCase):
 AACCGGGA-CCG
 |-|-||-|-|--
 A-C-GG-AAC--
-""")
+""",
+        )
         self.assertAlmostEqual(alignment.score, 6.0)
         self.assertAlmostEqual(alignment[:, :].score, 6.0)
         self.assertEqual(
@@ -4025,7 +4026,8 @@ A-C-GG-AAC--
 AACCGGGA-CCG
 |-|-||-|-|--
 A-C-GG-AAC--
-""")
+""",
+        )
         self.assertAlmostEqual(alignment[:, 0:].score, 6.0)
         self.assertEqual(
             str(alignment[:, 0:]),
@@ -4033,7 +4035,8 @@ A-C-GG-AAC--
 AACCGGGA-CCG
 |-|-||-|-|--
 A-C-GG-AAC--
-""")
+""",
+        )
         self.assertAlmostEqual(alignment[:, :12].score, 6.0)
         self.assertEqual(
             str(alignment[:, :12]),
@@ -4041,7 +4044,8 @@ A-C-GG-AAC--
 AACCGGGA-CCG
 |-|-||-|-|--
 A-C-GG-AAC--
-""")
+""",
+        )
         self.assertAlmostEqual(alignment[:, 0:12].score, 6.0)
         self.assertEqual(
             str(alignment[:, 0:12]),
@@ -4049,7 +4053,8 @@ A-C-GG-AAC--
 AACCGGGA-CCG
 |-|-||-|-|--
 A-C-GG-AAC--
-""")
+""",
+        )
         self.assertIsNone(alignment[:, 1:].score)
         self.assertEqual(
             str(alignment[:, 1:]),
@@ -4057,7 +4062,8 @@ A-C-GG-AAC--
 AACCGGGA-CCG
  -|-||-|-|--
 A-C-GG-AAC--
-""")
+""",
+        )
         self.assertIsNone(alignment[:, 2:].score)
         self.assertEqual(
             str(alignment[:, 2:]),
@@ -4065,7 +4071,8 @@ A-C-GG-AAC--
 AACCGGGA-CCG
   |-||-|-|--
  AC-GG-AAC--
-""")
+""",
+        )
         self.assertIsNone(alignment[:, 3:].score)
         self.assertEqual(
             str(alignment[:, 3:]),
@@ -4073,7 +4080,8 @@ AACCGGGA-CCG
 AACCGGGA-CCG
    -||-|-|--
  AC-GG-AAC--
-""")
+""",
+        )
         self.assertIsNone(alignment[:, 4:].score)
         self.assertEqual(
             str(alignment[:, 4:]),
@@ -4081,7 +4089,8 @@ AACCGGGA-CCG
 AACCGGGA-CCG
     ||-|-|--
   ACGG-AAC--
-""")
+""",
+        )
         self.assertIsNone(alignment[:, :-1].score)
         self.assertEqual(
             str(alignment[:, :-1]),
@@ -4089,7 +4098,8 @@ AACCGGGA-CCG
 AACCGGGA-CCG
 |-|-||-|-|-
 A-C-GG-AAC-
-""")
+""",
+        )
         self.assertIsNone(alignment[:, :-2].score)
         self.assertEqual(
             str(alignment[:, :-2]),
@@ -4097,7 +4107,8 @@ A-C-GG-AAC-
 AACCGGGA-CCG
 |-|-||-|-|
 A-C-GG-AAC
-""")
+""",
+        )
         self.assertIsNone(alignment[:, :-3].score)
         self.assertEqual(
             str(alignment[:, :-3]),
@@ -4105,7 +4116,8 @@ A-C-GG-AAC
 AACCGGGA-CCG
 |-|-||-|-
 A-C-GG-AAC
-""")
+""",
+        )
         self.assertIsNone(alignment[:, 1:-1].score)
         self.assertEqual(
             str(alignment[:, 1:-1]),
@@ -4113,7 +4125,8 @@ A-C-GG-AAC
 AACCGGGA-CCG
  -|-||-|-|-
 A-C-GG-AAC-
-""")
+""",
+        )
         self.assertIsNone(alignment[:, 1:-2].score)
         self.assertEqual(
             str(alignment[:, 1:-2]),
@@ -4121,7 +4134,8 @@ A-C-GG-AAC-
 AACCGGGA-CCG
  -|-||-|-|
 A-C-GG-AAC
-""")
+""",
+        )
         self.assertIsNone(alignment[:, 2:-1].score)
         self.assertEqual(
             str(alignment[:, 2:-1]),
@@ -4129,7 +4143,8 @@ A-C-GG-AAC
 AACCGGGA-CCG
   |-||-|-|-
  AC-GG-AAC-
-""")
+""",
+        )
         self.assertIsNone(alignment[:, 2:-2].score)
         self.assertEqual(
             str(alignment[:, 2:-2]),
@@ -4137,7 +4152,8 @@ AACCGGGA-CCG
 AACCGGGA-CCG
   |-||-|-|
  AC-GG-AAC
-""")
+""",
+        )
 
     def test_substitutions(self):
         aligner = Align.PairwiseAligner()

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4154,6 +4154,18 @@ AACCGGGA-CCG
  AC-GG-AAC
 """,
         )
+        with self.assertRaises(NotImplementedError):
+            alignment[:1]
+        with self.assertRaises(NotImplementedError):
+            alignment[0]
+        with self.assertRaises(NotImplementedError):
+            alignment[0, :]
+        with self.assertRaises(NotImplementedError):
+            alignment[:1, :]
+        with self.assertRaises(NotImplementedError):
+            alignment[:, 0]
+        with self.assertRaises(NotImplementedError):
+            alignment[:, ::3]
 
     def test_substitutions(self):
         aligner = Align.PairwiseAligner()

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4005,6 +4005,72 @@ query	16	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
 
 
 class TestAlignmentMethods(unittest.TestCase):
+    def test_indexing_slicing(self):
+        aligner = Align.PairwiseAligner()
+        alignments = aligner.align("AACCGGGACCG", "ACGGAAC")
+        self.assertEqual(len(alignments), 88)
+        alignment = alignments[0]
+        self.assertEqual(str(alignment), """\
+AACCGGGA-CCG
+|-|-||-|-|--
+A-C-GG-AAC--
+""")
+        self.assertEqual(str(alignment[:, 1:]), """\
+AACCGGGA-CCG
+ -|-||-|-|--
+A-C-GG-AAC--
+""")
+        self.assertEqual(str(alignment[:, 2:]), """\
+AACCGGGA-CCG
+  |-||-|-|--
+ AC-GG-AAC--
+""")
+        self.assertEqual(str(alignment[:, 3:]), """\
+AACCGGGA-CCG
+   -||-|-|--
+ AC-GG-AAC--
+""")
+        self.assertEqual(str(alignment[:, 4:]), """\
+AACCGGGA-CCG
+    ||-|-|--
+  ACGG-AAC--
+""")
+        self.assertEqual(str(alignment[:, :-1]), """\
+AACCGGGA-CCG
+|-|-||-|-|-
+A-C-GG-AAC-
+""")
+        self.assertEqual(str(alignment[:, :-2]), """\
+AACCGGGA-CCG
+|-|-||-|-|
+A-C-GG-AAC
+""")
+        self.assertEqual(str(alignment[:, :-3]), """\
+AACCGGGA-CCG
+|-|-||-|-
+A-C-GG-AAC
+""")
+        self.assertEqual(str(alignment[:, 1:-1]), """\
+AACCGGGA-CCG
+ -|-||-|-|-
+A-C-GG-AAC-
+""")
+        self.assertEqual(str(alignment[:, 1:-2]), """\
+AACCGGGA-CCG
+ -|-||-|-|
+A-C-GG-AAC
+""")
+        self.assertEqual(str(alignment[:, 2:-1]), """\
+AACCGGGA-CCG
+  |-||-|-|-
+ AC-GG-AAC-
+""")
+        self.assertEqual(str(alignment[:, 2:-2]), """\
+AACCGGGA-CCG
+  |-||-|-|
+ AC-GG-AAC
+""")
+
     def test_substitutions(self):
         aligner = Align.PairwiseAligner()
         path = os.path.join("Align", "ecoli.fa")

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4010,62 +4010,130 @@ class TestAlignmentMethods(unittest.TestCase):
         alignments = aligner.align("AACCGGGACCG", "ACGGAAC")
         self.assertEqual(len(alignments), 88)
         alignment = alignments[0]
-        self.assertEqual(str(alignment), """\
+        self.assertEqual(
+            str(alignment),
+            """\
 AACCGGGA-CCG
 |-|-||-|-|--
 A-C-GG-AAC--
 """)
-        self.assertEqual(str(alignment[:, 1:]), """\
+        self.assertAlmostEqual(alignment.score, 6.0)
+        self.assertAlmostEqual(alignment[:, :].score, 6.0)
+        self.assertEqual(
+            str(alignment[:, :]),
+            """\
+AACCGGGA-CCG
+|-|-||-|-|--
+A-C-GG-AAC--
+""")
+        self.assertAlmostEqual(alignment[:, 0:].score, 6.0)
+        self.assertEqual(
+            str(alignment[:, 0:]),
+            """\
+AACCGGGA-CCG
+|-|-||-|-|--
+A-C-GG-AAC--
+""")
+        self.assertAlmostEqual(alignment[:, :12].score, 6.0)
+        self.assertEqual(
+            str(alignment[:, :12]),
+            """\
+AACCGGGA-CCG
+|-|-||-|-|--
+A-C-GG-AAC--
+""")
+        self.assertAlmostEqual(alignment[:, 0:12].score, 6.0)
+        self.assertEqual(
+            str(alignment[:, 0:12]),
+            """\
+AACCGGGA-CCG
+|-|-||-|-|--
+A-C-GG-AAC--
+""")
+        self.assertIsNone(alignment[:, 1:].score)
+        self.assertEqual(
+            str(alignment[:, 1:]),
+            """\
 AACCGGGA-CCG
  -|-||-|-|--
 A-C-GG-AAC--
 """)
-        self.assertEqual(str(alignment[:, 2:]), """\
+        self.assertIsNone(alignment[:, 2:].score)
+        self.assertEqual(
+            str(alignment[:, 2:]),
+            """\
 AACCGGGA-CCG
   |-||-|-|--
  AC-GG-AAC--
 """)
-        self.assertEqual(str(alignment[:, 3:]), """\
+        self.assertIsNone(alignment[:, 3:].score)
+        self.assertEqual(
+            str(alignment[:, 3:]),
+            """\
 AACCGGGA-CCG
    -||-|-|--
  AC-GG-AAC--
 """)
-        self.assertEqual(str(alignment[:, 4:]), """\
+        self.assertIsNone(alignment[:, 4:].score)
+        self.assertEqual(
+            str(alignment[:, 4:]),
+            """\
 AACCGGGA-CCG
     ||-|-|--
   ACGG-AAC--
 """)
-        self.assertEqual(str(alignment[:, :-1]), """\
+        self.assertIsNone(alignment[:, :-1].score)
+        self.assertEqual(
+            str(alignment[:, :-1]),
+            """\
 AACCGGGA-CCG
 |-|-||-|-|-
 A-C-GG-AAC-
 """)
-        self.assertEqual(str(alignment[:, :-2]), """\
+        self.assertIsNone(alignment[:, :-2].score)
+        self.assertEqual(
+            str(alignment[:, :-2]),
+            """\
 AACCGGGA-CCG
 |-|-||-|-|
 A-C-GG-AAC
 """)
-        self.assertEqual(str(alignment[:, :-3]), """\
+        self.assertIsNone(alignment[:, :-3].score)
+        self.assertEqual(
+            str(alignment[:, :-3]),
+            """\
 AACCGGGA-CCG
 |-|-||-|-
 A-C-GG-AAC
 """)
-        self.assertEqual(str(alignment[:, 1:-1]), """\
+        self.assertIsNone(alignment[:, 1:-1].score)
+        self.assertEqual(
+            str(alignment[:, 1:-1]),
+            """\
 AACCGGGA-CCG
  -|-||-|-|-
 A-C-GG-AAC-
 """)
-        self.assertEqual(str(alignment[:, 1:-2]), """\
+        self.assertIsNone(alignment[:, 1:-2].score)
+        self.assertEqual(
+            str(alignment[:, 1:-2]),
+            """\
 AACCGGGA-CCG
  -|-||-|-|
 A-C-GG-AAC
 """)
-        self.assertEqual(str(alignment[:, 2:-1]), """\
+        self.assertIsNone(alignment[:, 2:-1].score)
+        self.assertEqual(
+            str(alignment[:, 2:-1]),
+            """\
 AACCGGGA-CCG
   |-||-|-|-
  AC-GG-AAC-
 """)
-        self.assertEqual(str(alignment[:, 2:-2]), """\
+        self.assertIsNone(alignment[:, 2:-2].score)
+        self.assertEqual(
+            str(alignment[:, 2:-2]),
+            """\
 AACCGGGA-CCG
   |-||-|-|
  AC-GG-AAC


### PR DESCRIPTION
Add a `__getitem__` method to `PairwiseAlignment`. Currently, it only implements indices of the form `alignment[:, i:j]`, which returns a new `PairwiseAlignment` object for the specified columns only.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

