### PR TITLE
simplify PhyloXML

### DIFF
--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -254,14 +254,8 @@ class Phylogeny(PhyloElement, BaseTree.Tree):
             return False
 
         seqs = self._filter_search(is_aligned_seq, "preorder", True)
-        try:
-            first_seq = next(seqs)
-        except StopIteration:
-            # No aligned sequences were found --> empty MSA
-            return MultipleSeqAlignment([])
-        msa = MultipleSeqAlignment([first_seq.to_seqrecord()])
-        msa.extend(seq.to_seqrecord() for seq in seqs)
-        return msa
+        records = (seq.to_seqrecord() for seq in seqs)
+        return MultipleSeqAlignment(records)
 
     # Singular property for plural attribute
     def _get_confidence(self):


### PR DESCRIPTION
Simplifies the `to_alignment` method of the `Phylogeny` class in `Bio.PhyloXML`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

