### PR TITLE
simplify `mult_align` in `Bio.FSSP.FSSPTools`

### DIFF
--- a/Bio/FSSP/FSSPTools.py
+++ b/Bio/FSSP/FSSPTools.py
@@ -48,12 +48,11 @@ def mult_align(sum_dict, align_dict):
         for j in align_dict.abs(i).pos_align_dict:
             # loop within a position
             mult_align_dict[j] += align_dict.abs(i).pos_align_dict[j].aa
-    fssp_align = MultipleSeqAlignment([])
-    for i in sorted(mult_align_dict):
-        fssp_align.append(
-            SeqRecord(Seq(mult_align_dict[i]), sum_dict[i].pdb2 + sum_dict[i].chain2)
-        )
-    return fssp_align
+    records = [
+        SeqRecord(Seq(mult_align_dict[i]), sum_dict[i].pdb2 + sum_dict[i].chain2)
+        for i in sorted(mult_align_dict)
+    ]
+    return MultipleSeqAlignment(records)
 
 
 #


### PR DESCRIPTION
Simplify `mult_align` by using the `MultipleSeqAlignment` initializer instead of the `append` method.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)