### PR TITLE
Add a sort method to `PairwiseAlignment`

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1754,7 +1754,7 @@ class PairwiseAlignment:
         AAGAA
         <BLANKLINE>
 
-        You can reverse the sort order by passing \verb+reverse=True+:
+        You can reverse the sort order by passing `reverse=True`:
 
         >>> alignment.sort(key=GC, reverse=True)
         >>> print(alignment)

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1716,6 +1716,70 @@ class PairwiseAlignment:
                 i1, i2 = j1, j2
         return tuple(segments1), tuple(segments2)
 
+    def sort(self, key=None, reverse=False):
+        """Sort the sequences of the alignment in place.
+
+        By default, this sorts the sequences alphabetically using their id
+        attribute if available, or by their sequence contents otherwise.
+        For example,
+
+        >>> from Bio.Align import PairwiseAligner
+        >>> aligner = PairwiseAligner()
+        >>> aligner.gap_score = -1
+        >>> alignments = aligner.align("AATAA", "AAGAA")
+        >>> len(alignments)
+        1
+        >>> alignment = alignments[0]
+        >>> print(alignment)
+        AATAA
+        ||.||
+        AAGAA
+        <BLANKLINE>
+        >>> alignment.sort()
+        >>> print(alignment)
+        AAGAA
+        ||.||
+        AATAA
+        <BLANKLINE>
+
+        Alternatively, a key function can be supplied that maps each sequence
+        to a sort value.  For example, you could sort on the GC content of each
+        sequence.
+
+        >>> from Bio.SeqUtils import GC
+        >>> alignment.sort(key=GC)
+        >>> print(alignment)
+        AATAA
+        ||.||
+        AAGAA
+        <BLANKLINE>
+
+        You can reverse the sort order by passing \verb+reverse=True+:
+
+        >>> alignment.sort(key=GC, reverse=True)
+        >>> print(alignment)
+        AAGAA
+        ||.||
+        AATAA
+        <BLANKLINE>
+
+        The sequences are now sorted by decreasing GC content value.
+        """
+        path = self.path
+        sequences = self.target, self.query
+        if key is None:
+            try:
+                values = [sequence.id for sequence in sequences]
+            except AttributeError:
+                values = sequences
+        else:
+            values = [key(sequence) for sequence in sequences]
+        indices = sorted(range(len(sequences)), key=values.__getitem__, reverse=reverse)
+        sequences = [sequences[index] for index in indices]
+        self.target, self.query = sequences
+        path = tuple(tuple(row[index] for index in indices) for row in path)
+        self.path = path
+
     def map(self, alignment):
         r"""Map the alignment to self.target and return the resulting alignment.
 

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2278,6 +2278,42 @@ AAAG-AAA
 \end{minted}
 The \verb+aligned+ property can be used to identify alignments that are identical to each other in terms of their aligned sequences.
 
+The \verb+sort+ method sorts the alignment sequences. By default, sorting is done based on the \verb+id+ attribute of each sequence if available, or the sequence contents otherwise.
+%cont-doctest
+\begin{minted}{pycon}
+>>> print(local_alignment)
+TGAACT
+ ||-|
+ GA-C
+<BLANKLINE>
+>>> local_alignment.sort()
+>>> print(local_alignment)
+ GA-C
+ ||-|
+TGAACT
+<BLANKLINE>
+\end{minted}{pycon}
+Alternatively, you can supply a \verb+key+ function to determine the sort order. For example, you can sort the sequences by increasing GC content:
+%cont-doctest
+\begin{minted}{pycon}
+>>> from Bio.SeqUtils import GC
+>>> local_alignment.sort(key=GC)
+>>> print(local_alignment)
+TGAACT
+ ||-|
+ GA-C
+<BLANKLINE>
+\end{minted}{pycon}
+The \verb+reverse+ argument lets you reverse the sort order to obtain the sequences in decreasing GC content:
+\begin{minted}{pycon}
+>>> local_alignment.sort(key=GC, reverse=True)
+>>> print(local_alignment)
+ GA-C
+ ||-|
+TGAACT
+<BLANKLINE>
+\end{minted}{pycon}
+
 Use the \verb+substitutions+ method to find the number of substitutions between each pair of nucleotides:
 %cont-doctest
 \begin{minted}{pycon}

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -11,6 +11,7 @@ import unittest
 
 from Bio import Align, SeqIO
 from Bio.Seq import Seq, reverse_complement
+from Bio.SeqUtils import GC
 
 
 class TestAlignerProperties(unittest.TestCase):
@@ -4166,6 +4167,79 @@ AACCGGGA-CCG
             alignment[:, 0]
         with self.assertRaises(NotImplementedError):
             alignment[:, ::3]
+
+    def test_sort(self):
+        aligner = Align.PairwiseAligner()
+        aligner.gap_score = -1
+        target = Seq("ACTT")
+        query = Seq("ACCT")
+        alignments = aligner.align(target, query)
+        self.assertEqual(len(alignments), 1)
+        alignment = alignments[0]
+        self.assertEqual(
+            str(alignment),
+            """\
+ACTT
+||.|
+ACCT
+""",
+        )
+        alignment.sort()
+        self.assertEqual(
+            str(alignment),
+            """\
+ACCT
+||.|
+ACTT
+""",
+        )
+        alignment.sort(reverse=True)
+        self.assertEqual(
+            str(alignment),
+            """\
+ACTT
+||.|
+ACCT
+""",
+        )
+        target.id = "seq1"
+        query.id = "seq2"
+        alignment.sort()
+        self.assertEqual(
+            str(alignment),
+            """\
+ACTT
+||.|
+ACCT
+""",
+        )
+        alignment.sort(reverse=True)
+        self.assertEqual(
+            str(alignment),
+            """\
+ACCT
+||.|
+ACTT
+""",
+        )
+        alignment.sort(key=GC)
+        self.assertEqual(
+            str(alignment),
+            """\
+ACTT
+||.|
+ACCT
+""",
+        )
+        alignment.sort(key=GC, reverse=True)
+        self.assertEqual(
+            str(alignment),
+            """\
+ACCT
+||.|
+ACTT
+""",
+        )
 
     def test_substitutions(self):
         aligner = Align.PairwiseAligner()


### PR DESCRIPTION
For consistency with `MultipleSeqAlignment`, add a `sort` method to `PairwiseAlignment`

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

