### PR TITLE
Allow a single line to be extracted from a pairwise alignment

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -971,14 +971,23 @@ class PairwiseAlignment:
 
         self[:, :]
 
-        which returns a copy of the PairwiseAlignment object, and
+        which returns a copy of the PairwiseAlignment object;
 
         self[:, i:]
         self[:, :j]
         self[:, i:j]
 
         which returns a new PairwiseAlignment object spanning the indicated
-        columns.
+        columns; and
+
+        self[k, i]
+        self[k, i:]
+        self[k, :j]
+        self[k, i:j]
+
+        which returns a string with the aligned sequence (including gaps)
+        for the indicated columns, where k = 0 represents the target and
+        k = 1 represents the query sequence.
 
         >>> from Bio.Align import PairwiseAligner
         >>> aligner = PairwiseAligner()
@@ -989,6 +998,14 @@ class PairwiseAlignment:
         ||-||-||-
         AC-GGGTT-
         <BLANKLINE>
+        >>> alignment[0, :]
+        'ACCGG-TTT'
+        >>> alignment[1, :]
+        'AC-GGGTT-'
+        >>> alignment[0, 1:-2]
+        'CCGG-T'
+        >>> alignment[1, 1:-2]
+        'C-GGGT'
         >>> alignment[:, 1:]  # doctest:+ELLIPSIS
         <Bio.Align.PairwiseAlignment object at ...>
         >>> print(alignment[:, 1:])
@@ -1028,7 +1045,66 @@ class PairwiseAlignment:
             except ValueError:
                 raise ValueError("only tuples of length 2 can be alignment indices")
             if isinstance(row, int):
-                raise NotImplementedError
+                sequences = self.target, self.query
+                n, m = self.shape
+                if row < 0:
+                    row += n
+                if row < 0 or row >= n:
+                    raise IndexError("row index %d is out of bounds (%d rows)" % (row, n))
+                sequence = sequences[row]
+
+                if isinstance(col, slice):
+                    start_index, stop_index, step = col.indices(m)
+                    if step != 1:
+                        raise NotImplementedError
+                elif isinstance(col, int):
+                    start_index = col
+                    if start_index < 0:
+                        start_index += m
+                    if start_index < 0 or start_index >= m:
+                        raise IndexError("column index %d is out of bounds (%d columns)" % (col, m))
+                    stop_index = start_index + 1
+                else:
+                    raise TypeError("second index must be an integer or slice")
+                line = ""
+                index = 0
+                path_iterator = iter(self.path)
+                starts = next(path_iterator)
+                for ends in path_iterator:
+                    step = max(e - s for s, e in zip(starts, ends))
+                    index += step
+                    if start_index < index:
+                        offset = index - start_index
+                        if starts[row] < ends[row]:
+                            i = ends[row] - offset
+                        else:
+                            i = starts[row]
+                        step = offset
+                        break
+                    starts = ends
+                while True:
+                    if stop_index <= index:
+                        offset = index - stop_index
+                        if starts[row] < ends[row]:
+                            j = ends[row] - offset
+                        else:
+                            j = starts[row]
+                        if i < j:
+                            line += sequence[i:j]
+                        else:
+                            line += "-" * (step - offset)
+                        break
+                    j = ends[row]
+                    if i < j:
+                        line += sequence[i:j]
+                    else:
+                        line += "-" * step
+                    i = j
+                    starts = ends
+                    ends = next(path_iterator)
+                    step = max(e - s for s, e in zip(starts, ends))
+                    index += step
+                return line
             if isinstance(row, slice):
                 if row.indices(len(self)) != (0, 2, 1):
                     raise NotImplementedError

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1050,7 +1050,9 @@ class PairwiseAlignment:
                 if row < 0:
                     row += n
                 if row < 0 or row >= n:
-                    raise IndexError("row index %d is out of bounds (%d rows)" % (row, n))
+                    raise IndexError(
+                        "row index %d is out of bounds (%d rows)" % (row, n)
+                    )
                 sequence = sequences[row]
 
                 if isinstance(col, slice):
@@ -1062,7 +1064,9 @@ class PairwiseAlignment:
                     if start_index < 0:
                         start_index += m
                     if start_index < 0 or start_index >= m:
-                        raise IndexError("column index %d is out of bounds (%d columns)" % (col, m))
+                        raise IndexError(
+                            "column index %d is out of bounds (%d columns)" % (col, m)
+                        )
                     stop_index = start_index + 1
                 else:
                     raise TypeError("second index must be an integer or slice")

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -127,6 +127,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Hye-Shik Chang <perky at domain fallin.lv>
 - Iddo Friedberg <https://github.com/idoerg>
 - Ilya Flyamer <https://github.com/Phlya>
+- Isaac Ellmen <https://github.com/Ellmen>
 - Ivan Antonov <https://github.com/vanya-antonov>
 - Jacek Śmietański <https://github.com/dadoskawina>
 - Jack Twilley <https://github.com/mathuin>

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2427,7 +2427,11 @@ obviously lose the ability to print the sequence alignment):
 
 \paragraph*{Slicing and indexing a pairwise alignment}
 
-Currently, only slices of the form \verb+alignment[:, i:j]+ are implemented, where \verb+i+ and \verb+j+ are integers or are absent. This returns a new \verb+PairwiseAlignment+ object that includes only the columns \verb+i+ through \verb+j+ in the printed alignment. To illustrate this, in the following example the printed alignment has 5 columns:
+Currently, slicing and indexing is only partially implemented.
+
+Slices of the form \verb+alignment[k, i:j]+, where \verb+k+ is an integer and \verb+i+ and \verb+j+ are integers or are absent, return a string showing the aligned sequence (including gaps) for the target (if \verb+k=0+) or the query (if \verb+k=1+) that includes only the columns \verb+i+ through \verb+j+ in the printed alignment.
+
+To illustrate this, in the following example the printed alignment has 5 columns:
 
 %cont-doctest
 \begin{minted}{pycon}
@@ -2438,7 +2442,22 @@ G-A-T
 <BLANKLINE>
 \end{minted}
 
-Extracting the first 4 columns gives:
+To get the aligned sequence strings individually, use
+%cont-doctest
+\begin{minted}{pycon}
+>>> alignment[0, :]
+'GAACT'
+>>> alignment[1, :]
+'G-A-T'
+>>> alignment[0, 1:-1]
+'AAC'
+>>> alignment[1, 1:-1:]
+'-A-'
+\end{minted}
+
+Slices of the form \verb+alignment[:, i:j]+, where \verb+i+ and \verb+j+ are integers or are absent, return a new \verb+PairwiseAlignment+ object that includes only the columns \verb+i+ through \verb+j+ in the printed alignment.
+
+Extracting the first 4 columns for the example alignment above gives:
 %cont-doctest
 \begin{minted}{pycon}
 >>> alignment[:, :4]  # doctest:+ELLIPSIS

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4020,8 +4020,8 @@ A-C-GG-AAC--
 """,
         )
         self.assertAlmostEqual(alignment.score, 6.0)
-        self.assertEqual(alignment[0, :], 'AACCGGGA-CCG')
-        self.assertEqual(alignment[1, :], 'A-C-GG-AAC--')
+        self.assertEqual(alignment[0, :], "AACCGGGA-CCG")
+        self.assertEqual(alignment[1, :], "A-C-GG-AAC--")
         self.assertAlmostEqual(alignment[:, :].score, 6.0)
         self.assertEqual(
             str(alignment[:, :]),
@@ -4031,8 +4031,8 @@ AACCGGGA-CCG
 A-C-GG-AAC--
 """,
         )
-        self.assertEqual(alignment[0, 0:], 'AACCGGGA-CCG')
-        self.assertEqual(alignment[1, 0:], 'A-C-GG-AAC--')
+        self.assertEqual(alignment[0, 0:], "AACCGGGA-CCG")
+        self.assertEqual(alignment[1, 0:], "A-C-GG-AAC--")
         self.assertAlmostEqual(alignment[:, 0:].score, 6.0)
         self.assertEqual(
             str(alignment[:, 0:]),
@@ -4042,8 +4042,8 @@ AACCGGGA-CCG
 A-C-GG-AAC--
 """,
         )
-        self.assertEqual(alignment[0, :12], 'AACCGGGA-CCG')
-        self.assertEqual(alignment[1, :12], 'A-C-GG-AAC--')
+        self.assertEqual(alignment[0, :12], "AACCGGGA-CCG")
+        self.assertEqual(alignment[1, :12], "A-C-GG-AAC--")
         self.assertAlmostEqual(alignment[:, :12].score, 6.0)
         self.assertEqual(
             str(alignment[:, :12]),
@@ -4053,8 +4053,8 @@ AACCGGGA-CCG
 A-C-GG-AAC--
 """,
         )
-        self.assertEqual(alignment[0, 0:12], 'AACCGGGA-CCG')
-        self.assertEqual(alignment[1, 0:12], 'A-C-GG-AAC--')
+        self.assertEqual(alignment[0, 0:12], "AACCGGGA-CCG")
+        self.assertEqual(alignment[1, 0:12], "A-C-GG-AAC--")
         self.assertAlmostEqual(alignment[:, 0:12].score, 6.0)
         self.assertEqual(
             str(alignment[:, 0:12]),
@@ -4064,8 +4064,8 @@ AACCGGGA-CCG
 A-C-GG-AAC--
 """,
         )
-        self.assertEqual(alignment[0, 1:], 'ACCGGGA-CCG')
-        self.assertEqual(alignment[1, 1:], '-C-GG-AAC--')
+        self.assertEqual(alignment[0, 1:], "ACCGGGA-CCG")
+        self.assertEqual(alignment[1, 1:], "-C-GG-AAC--")
         self.assertIsNone(alignment[:, 1:].score)
         self.assertEqual(
             str(alignment[:, 1:]),
@@ -4075,8 +4075,8 @@ AACCGGGA-CCG
 A-C-GG-AAC--
 """,
         )
-        self.assertEqual(alignment[0, 2:], 'CCGGGA-CCG')
-        self.assertEqual(alignment[1, 2:], 'C-GG-AAC--')
+        self.assertEqual(alignment[0, 2:], "CCGGGA-CCG")
+        self.assertEqual(alignment[1, 2:], "C-GG-AAC--")
         self.assertIsNone(alignment[:, 2:].score)
         self.assertEqual(
             str(alignment[:, 2:]),
@@ -4086,8 +4086,8 @@ AACCGGGA-CCG
  AC-GG-AAC--
 """,
         )
-        self.assertEqual(alignment[0, 3:], 'CGGGA-CCG')
-        self.assertEqual(alignment[1, 3:], '-GG-AAC--')
+        self.assertEqual(alignment[0, 3:], "CGGGA-CCG")
+        self.assertEqual(alignment[1, 3:], "-GG-AAC--")
         self.assertIsNone(alignment[:, 3:].score)
         self.assertEqual(
             str(alignment[:, 3:]),
@@ -4097,8 +4097,8 @@ AACCGGGA-CCG
  AC-GG-AAC--
 """,
         )
-        self.assertEqual(alignment[0, 4:], 'GGGA-CCG')
-        self.assertEqual(alignment[1, 4:], 'GG-AAC--')
+        self.assertEqual(alignment[0, 4:], "GGGA-CCG")
+        self.assertEqual(alignment[1, 4:], "GG-AAC--")
         self.assertIsNone(alignment[:, 4:].score)
         self.assertEqual(
             str(alignment[:, 4:]),
@@ -4108,8 +4108,8 @@ AACCGGGA-CCG
   ACGG-AAC--
 """,
         )
-        self.assertEqual(alignment[0, :-1], 'AACCGGGA-CC')
-        self.assertEqual(alignment[1, :-1], 'A-C-GG-AAC-')
+        self.assertEqual(alignment[0, :-1], "AACCGGGA-CC")
+        self.assertEqual(alignment[1, :-1], "A-C-GG-AAC-")
         self.assertIsNone(alignment[:, :-1].score)
         self.assertEqual(
             str(alignment[:, :-1]),
@@ -4119,8 +4119,8 @@ AACCGGGA-CCG
 A-C-GG-AAC-
 """,
         )
-        self.assertEqual(alignment[0, :-2], 'AACCGGGA-C')
-        self.assertEqual(alignment[1, :-2], 'A-C-GG-AAC')
+        self.assertEqual(alignment[0, :-2], "AACCGGGA-C")
+        self.assertEqual(alignment[1, :-2], "A-C-GG-AAC")
         self.assertIsNone(alignment[:, :-2].score)
         self.assertEqual(
             str(alignment[:, :-2]),
@@ -4130,8 +4130,8 @@ AACCGGGA-CCG
 A-C-GG-AAC
 """,
         )
-        self.assertEqual(alignment[0, :-3], 'AACCGGGA-')
-        self.assertEqual(alignment[1, :-3], 'A-C-GG-AA')
+        self.assertEqual(alignment[0, :-3], "AACCGGGA-")
+        self.assertEqual(alignment[1, :-3], "A-C-GG-AA")
         self.assertIsNone(alignment[:, :-3].score)
         self.assertEqual(
             str(alignment[:, :-3]),
@@ -4141,8 +4141,8 @@ AACCGGGA-CCG
 A-C-GG-AAC
 """,
         )
-        self.assertEqual(alignment[0, 1:-1], 'ACCGGGA-CC')
-        self.assertEqual(alignment[1, 1:-1], '-C-GG-AAC-')
+        self.assertEqual(alignment[0, 1:-1], "ACCGGGA-CC")
+        self.assertEqual(alignment[1, 1:-1], "-C-GG-AAC-")
         self.assertIsNone(alignment[:, 1:-1].score)
         self.assertEqual(
             str(alignment[:, 1:-1]),
@@ -4152,8 +4152,8 @@ AACCGGGA-CCG
 A-C-GG-AAC-
 """,
         )
-        self.assertEqual(alignment[0, 1:-2], 'ACCGGGA-C')
-        self.assertEqual(alignment[1, 1:-2], '-C-GG-AAC')
+        self.assertEqual(alignment[0, 1:-2], "ACCGGGA-C")
+        self.assertEqual(alignment[1, 1:-2], "-C-GG-AAC")
         self.assertIsNone(alignment[:, 1:-2].score)
         self.assertEqual(
             str(alignment[:, 1:-2]),
@@ -4163,8 +4163,8 @@ AACCGGGA-CCG
 A-C-GG-AAC
 """,
         )
-        self.assertEqual(alignment[0, 2:-1], 'CCGGGA-CC')
-        self.assertEqual(alignment[1, 2:-1], 'C-GG-AAC-')
+        self.assertEqual(alignment[0, 2:-1], "CCGGGA-CC")
+        self.assertEqual(alignment[1, 2:-1], "C-GG-AAC-")
         self.assertIsNone(alignment[:, 2:-1].score)
         self.assertEqual(
             str(alignment[:, 2:-1]),
@@ -4174,8 +4174,8 @@ AACCGGGA-CCG
  AC-GG-AAC-
 """,
         )
-        self.assertEqual(alignment[0, 2:-2], 'CCGGGA-C')
-        self.assertEqual(alignment[1, 2:-2], 'C-GG-AAC')
+        self.assertEqual(alignment[0, 2:-2], "CCGGGA-C")
+        self.assertEqual(alignment[1, 2:-2], "C-GG-AAC")
         self.assertIsNone(alignment[:, 2:-2].score)
         self.assertEqual(
             str(alignment[:, 2:-2]),

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4020,6 +4020,8 @@ A-C-GG-AAC--
 """,
         )
         self.assertAlmostEqual(alignment.score, 6.0)
+        self.assertEqual(alignment[0, :], 'AACCGGGA-CCG')
+        self.assertEqual(alignment[1, :], 'A-C-GG-AAC--')
         self.assertAlmostEqual(alignment[:, :].score, 6.0)
         self.assertEqual(
             str(alignment[:, :]),
@@ -4029,6 +4031,8 @@ AACCGGGA-CCG
 A-C-GG-AAC--
 """,
         )
+        self.assertEqual(alignment[0, 0:], 'AACCGGGA-CCG')
+        self.assertEqual(alignment[1, 0:], 'A-C-GG-AAC--')
         self.assertAlmostEqual(alignment[:, 0:].score, 6.0)
         self.assertEqual(
             str(alignment[:, 0:]),
@@ -4038,6 +4042,8 @@ AACCGGGA-CCG
 A-C-GG-AAC--
 """,
         )
+        self.assertEqual(alignment[0, :12], 'AACCGGGA-CCG')
+        self.assertEqual(alignment[1, :12], 'A-C-GG-AAC--')
         self.assertAlmostEqual(alignment[:, :12].score, 6.0)
         self.assertEqual(
             str(alignment[:, :12]),
@@ -4047,6 +4053,8 @@ AACCGGGA-CCG
 A-C-GG-AAC--
 """,
         )
+        self.assertEqual(alignment[0, 0:12], 'AACCGGGA-CCG')
+        self.assertEqual(alignment[1, 0:12], 'A-C-GG-AAC--')
         self.assertAlmostEqual(alignment[:, 0:12].score, 6.0)
         self.assertEqual(
             str(alignment[:, 0:12]),
@@ -4056,6 +4064,8 @@ AACCGGGA-CCG
 A-C-GG-AAC--
 """,
         )
+        self.assertEqual(alignment[0, 1:], 'ACCGGGA-CCG')
+        self.assertEqual(alignment[1, 1:], '-C-GG-AAC--')
         self.assertIsNone(alignment[:, 1:].score)
         self.assertEqual(
             str(alignment[:, 1:]),
@@ -4065,6 +4075,8 @@ AACCGGGA-CCG
 A-C-GG-AAC--
 """,
         )
+        self.assertEqual(alignment[0, 2:], 'CCGGGA-CCG')
+        self.assertEqual(alignment[1, 2:], 'C-GG-AAC--')
         self.assertIsNone(alignment[:, 2:].score)
         self.assertEqual(
             str(alignment[:, 2:]),
@@ -4074,6 +4086,8 @@ AACCGGGA-CCG
  AC-GG-AAC--
 """,
         )
+        self.assertEqual(alignment[0, 3:], 'CGGGA-CCG')
+        self.assertEqual(alignment[1, 3:], '-GG-AAC--')
         self.assertIsNone(alignment[:, 3:].score)
         self.assertEqual(
             str(alignment[:, 3:]),
@@ -4083,6 +4097,8 @@ AACCGGGA-CCG
  AC-GG-AAC--
 """,
         )
+        self.assertEqual(alignment[0, 4:], 'GGGA-CCG')
+        self.assertEqual(alignment[1, 4:], 'GG-AAC--')
         self.assertIsNone(alignment[:, 4:].score)
         self.assertEqual(
             str(alignment[:, 4:]),
@@ -4092,6 +4108,8 @@ AACCGGGA-CCG
   ACGG-AAC--
 """,
         )
+        self.assertEqual(alignment[0, :-1], 'AACCGGGA-CC')
+        self.assertEqual(alignment[1, :-1], 'A-C-GG-AAC-')
         self.assertIsNone(alignment[:, :-1].score)
         self.assertEqual(
             str(alignment[:, :-1]),
@@ -4101,6 +4119,8 @@ AACCGGGA-CCG
 A-C-GG-AAC-
 """,
         )
+        self.assertEqual(alignment[0, :-2], 'AACCGGGA-C')
+        self.assertEqual(alignment[1, :-2], 'A-C-GG-AAC')
         self.assertIsNone(alignment[:, :-2].score)
         self.assertEqual(
             str(alignment[:, :-2]),
@@ -4110,6 +4130,8 @@ AACCGGGA-CCG
 A-C-GG-AAC
 """,
         )
+        self.assertEqual(alignment[0, :-3], 'AACCGGGA-')
+        self.assertEqual(alignment[1, :-3], 'A-C-GG-AA')
         self.assertIsNone(alignment[:, :-3].score)
         self.assertEqual(
             str(alignment[:, :-3]),
@@ -4119,6 +4141,8 @@ AACCGGGA-CCG
 A-C-GG-AAC
 """,
         )
+        self.assertEqual(alignment[0, 1:-1], 'ACCGGGA-CC')
+        self.assertEqual(alignment[1, 1:-1], '-C-GG-AAC-')
         self.assertIsNone(alignment[:, 1:-1].score)
         self.assertEqual(
             str(alignment[:, 1:-1]),
@@ -4128,6 +4152,8 @@ AACCGGGA-CCG
 A-C-GG-AAC-
 """,
         )
+        self.assertEqual(alignment[0, 1:-2], 'ACCGGGA-C')
+        self.assertEqual(alignment[1, 1:-2], '-C-GG-AAC')
         self.assertIsNone(alignment[:, 1:-2].score)
         self.assertEqual(
             str(alignment[:, 1:-2]),
@@ -4137,6 +4163,8 @@ AACCGGGA-CCG
 A-C-GG-AAC
 """,
         )
+        self.assertEqual(alignment[0, 2:-1], 'CCGGGA-CC')
+        self.assertEqual(alignment[1, 2:-1], 'C-GG-AAC-')
         self.assertIsNone(alignment[:, 2:-1].score)
         self.assertEqual(
             str(alignment[:, 2:-1]),
@@ -4146,6 +4174,8 @@ AACCGGGA-CCG
  AC-GG-AAC-
 """,
         )
+        self.assertEqual(alignment[0, 2:-2], 'CCGGGA-C')
+        self.assertEqual(alignment[1, 2:-2], 'C-GG-AAC')
         self.assertIsNone(alignment[:, 2:-2].score)
         self.assertEqual(
             str(alignment[:, 2:-2]),
@@ -4159,8 +4189,6 @@ AACCGGGA-CCG
             alignment[:1]
         with self.assertRaises(NotImplementedError):
             alignment[0]
-        with self.assertRaises(NotImplementedError):
-            alignment[0, :]
         with self.assertRaises(NotImplementedError):
             alignment[:1, :]
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
This adds support for slices of the form `[k, i:j]` to a `PairwiseAlignment`, where `k` is an integer. This will return a single line from the printed alignment as a plain string,

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

See also #2642, #2632 .
