### PR TITLE
Replace accession by locus id in EMBL header line

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -1268,10 +1268,17 @@ class EmblWriter(_InsdcWriter):
         # Get the taxonomy division
         division = self._get_data_division(record)
 
+        # Get the locus name/id in line with the GenBank output (line 714)
+        locus = record.name
+        if not locus or locus == "<unknown name>":
+            locus = record.id
+        if not locus or locus == "<unknown id>":
+            locus = self._get_annotation_str(record, "accession", just_first=True)
+        
         # TODO - Full ID line
         handle = self.handle
         # ID   <1>; SV <2>; <3>; <4>; <5>; <6>; <7> BP.
-        # 1. Primary accession number
+        # 1. Locus name/id
         # 2. Sequence version number
         # 3. Topology: 'circular' or 'linear'
         # 4. Molecule type
@@ -1281,7 +1288,7 @@ class EmblWriter(_InsdcWriter):
         self._write_single_line(
             "ID",
             "%s; %s; %s; %s; ; %s; %i %s."
-            % (accession, version, topology, mol_type, division, len(record), units),
+            % (locus, version, topology, mol_type, division, len(record), units),
         )
         handle.write("XX\n")
         self._write_single_line("AC", accession + ";")

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -224,6 +224,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Nicolas Fontrodona <https://github.com/NFontrodona>
 - Nigel Delaney <https://github.com/evolvedmicrobe>
 - Noam Kremen <https://github.com/noamkremen>
+- Oliver Schwengers <https://github.com/oschwengers>
 - Olivier Morelle <https://github.com/Oli4>
 - Oscar G. Garcia <https://github.com/oscarmaestre>
 - Osvaldo Zagordi <https://github.com/ozagordi>


### PR DESCRIPTION
Hello,
If the `SeqRecord`/`SeqFeature` API is used to create an in-memory data structure of an, _e.g._ bacterial genome annotation for subsequent serialization via `SeqIO`, the `GenBankWriter` writes both the *locus id* and the *accession*, the latter only if provided via the sequence annotations.

However, the `EmblWriter` writes the *accession* in both fields ignoring the *locus id*. 

I do not exactly know if this is a bug or a feature, i.e. something that is strictly required by the EMBL format - I could not find any specs on the web.

This became an issue when we annotated local genome assemblies for which no public *accession* is available - but an unique *locus id* is of course required to identify the records within multi EMBL/Genbank files.

I therefore replaced the *accession* by the *locus id* in the EMBL header line to my best understandings and in line with the behaviors of the `GenBankWriter`.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
