### PR TITLE
Use Github Actions for CI in place of Travis

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -68,35 +68,35 @@ jobs:
         python setup.py sdist --formats=gztar,zip
 
   # RST linting
-  check_rst:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9]
+  # check_rst:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       python-version: [3.9]
 
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up Python ${{ matrix.python-version }}
+  #     uses: actions/setup-python@v2
+  #     with:
+  #       python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
-      run: |
-        python --version
-        python -m pip install black==19.10b0
+  #   - name: Install dependencies
+  #     run: |
+  #       python --version
+  #       python -m pip install black==19.10b0
 
-    - name: Run tests on RST formatting
-      run: |
-        # Check sort order (bash call work around for pipe character)
-        bash -c \' grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f \'
-        # Check copyright date
-        bash -c \' grep "1999-`date +'%Y'`" LICENSE.rst \'
-        # Check no __docformat__ lines
-        bash -c "if grep --include '*.py' -rn '^__docformat__ ' Bio BioSQL Tests Scripts Doc ; then echo 'Remove __docformat__ line(s), we assume restructuredtext.'; false; fi"
-        # Black style check:
-        black --check --diff .
-      shell: bash
+  #   - name: Run tests on RST formatting
+  #     run: |
+  #       # Check sort order (bash call work around for pipe character)
+  #       bash -c \' grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f \'
+  #       # Check copyright date
+  #       bash -c \' grep "1999-`date +'%Y'`" LICENSE.rst \'
+  #       # Check no __docformat__ lines
+  #       bash -c "if grep --include '*.py' -rn '^__docformat__ ' Bio BioSQL Tests Scripts Doc ; then echo 'Remove __docformat__ line(s), we assume restructuredtext.'; false; fi"
+  #       # Black style check:
+  #       black --check --diff .
+  #     shell: bash
 
   build_wheels:
     needs: [style, build, check_rst]

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -99,7 +99,6 @@ jobs:
   #     shell: bash
 
   build_wheels:
-    needs: [style, build, check_rst]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -126,9 +125,9 @@ jobs:
           dist/*whl
 
   # Run test suite
-  # Triggers only if build_wheels pass.
+  # Triggers only if all previous stages pass.
   tests:
-    needs: [build_wheels]
+    needs: [build, style, check_rst, build_wheels]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -142,7 +141,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install Python dependencies
+    - name: Install basic dependencies
+      run: |
+        python -m pip install numpy
+
+    - name: Install extra dependencies (Linux only)
+      if: runner.os == 'Linux'
       run: |
         python --version
         python -m pip install coverage codecov numpy scipy mmtf-python

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -225,6 +225,9 @@ jobs:
   # Flag step
   check_tests:
     needs: [test_linux, test_macos, test_windows]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo All tests passed.
 
   # Build API documentation if everything passes.
   docs:

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -109,7 +109,9 @@ jobs:
 
     - name: Install from wheel
       run: |
-        python -m pip install dist/biopython-*.whl
+        pwd
+        ls
+        python -m pip install biopython_wheels/biopython-*.whl
 
     - name: Run test suite and get coverage
       run: |

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -187,7 +187,8 @@ jobs:
       shell: bash
     
   cleanup:
-    needs: [build]
+    if: always()
+    needs: [style, build, tests, docs, check_rst]
     runs-on: ubuntu-latest
     steps:
       - uses: geekyeggo/delete-artifact@v1

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -68,23 +68,23 @@ jobs:
         python setup.py sdist --formats=gztar,zip
 
   # RST linting
-  # check_rst:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       python-version: [3.9]
+  check_rst:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - name: Set up Python ${{ matrix.python-version }}
-  #     uses: actions/setup-python@v2
-  #     with:
-  #       python-version: ${{ matrix.python-version }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
 
-  #   - name: Install dependencies
-  #     run: |
-  #       python --version
-  #       python -m pip install black==19.10b0
+    - name: Install dependencies
+      run: |
+        python --version
+        python -m pip install black==19.10b0
 
   #   - name: Run tests on RST formatting
   #     run: |

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -76,7 +76,7 @@ jobs:
       with:
         name: biopython_wheels
         path: |
-          dist/*whl
+          dist/
 
   # Run test suite
   # Triggers only if style & build pass.
@@ -109,9 +109,7 @@ jobs:
 
     - name: Install from wheel
       run: |
-        pwd
-        ls
-        python -m pip install biopython_wheels/biopython-*.whl
+        python -m pip install dist/biopython-*.whl
 
     - name: Run test suite and get coverage
       run: |

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -67,8 +67,39 @@ jobs:
       run: |
         python setup.py sdist --formats=gztar,zip
 
+  # RST linting
+  check_rst:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python --version
+        python -m pip install black==19.10b0
+
+    - name: Run tests on RST formatting
+      run: |
+        # Check sort order (bash call work around for pipe character)
+        bash -c \'grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f\'
+        # Check copyright date
+        bash -c \'grep "1999-`date +'%Y'`" LICENSE.rst\'
+        # Check no __docformat__ lines
+        bash -c "if grep --include '*.py' -rn '^__docformat__ ' Bio BioSQL Tests Scripts Doc ; then echo 'Remove __docformat__ line(s), we assume restructuredtext.'; false; fi"
+        # Black style check:
+        black --check --diff .
+      shell: bash
+
   build_wheels:
-    needs: [style, build]
+    needs: [style, build, check_rst]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -135,41 +166,9 @@ jobs:
         fi
       shell: bash
 
-  # RST linting
-  check_rst:
-    needs: [style, build, tests]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.9]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install dependencies
-      run: |
-        python --version
-        python -m pip install black==19.10b0
-
-    - name: Run tests on RST formatting
-      run: |
-        # Check sort order (bash call work around for pipe character)
-        bash -c \'grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f\'
-        # Check copyright date
-        bash -c \'grep "1999-`date +'%Y'`" LICENSE.rst\'
-        # Check no __docformat__ lines
-        bash -c "if grep --include '*.py' -rn '^__docformat__ ' Bio BioSQL Tests Scripts Doc ; then echo 'Remove __docformat__ line(s), we assume restructuredtext.'; false; fi"
-        # Black style check:
-        black --check --diff .
-      shell: bash
-
   # Build API documentation if everything passes.
   docs:
-    needs: [style, build, tests]
+    needs: [tests]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -107,6 +107,12 @@ jobs:
         python-version: [3.7, 3.8, 3.9, pypy3]
 
     steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - name: Build wheel
       run: |
         python setup.py bdist_wheel

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,0 +1,195 @@
+name: Basic Checks
+
+on: [push, pull_request]
+
+jobs:
+  # Style Checking: one OS and Python version only.
+  style:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: trilom/file-changes-action@v1.2.4
+      with:
+        # Creates files.txt
+        output: ' '
+        fileOutput: ' '
+
+    - name: Cache pre-commit hooks
+      id: cache-precommit
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-precommit-hooks
+      with:
+        path: ~/.cache/pre-commit
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/.pre-commit-config.yaml') }}
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Installing pre-commit
+      run: |
+        python -m pip install pre-commit
+
+    - name: Installing pre-commit hooks
+      if: steps.cache-precommit.outputs.cache-hit != 'true'
+      run: |
+        pre-commit install --install-hooks
+
+    - name: Run style checking via pre-commit
+      run: |
+        pre-commit run --files $( cat ${HOME}/files.txt )
+
+  # Build package: sdist, bdist_wheel
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+
+    - name: Package tarball
+      run: |
+        python setup.py sdist --formats=gztar,zip
+
+    - name: Build wheel
+      run: |
+        python setup.py bdist_wheel
+
+    - name: Archive wheels
+      uses: actions/upload-artifact@v2
+      with:
+        name: biopython_wheels
+        path: |
+          dist/*whl
+
+  # Run test suite
+  # Triggers only if style & build pass.
+  tests:
+    needs: [style, build]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9, pypy3]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Python dependencies
+      run: |
+        python --version
+        python -m pip install coverage codecov numpy scipy mmtf-python
+        python -m pip install mysqlclient mysql-connector-python rdflib
+        python -m pip install networkx matplotlib reportlab
+
+    - name: Fetch archived wheels from previous job
+      uses: actions/download-artifact@v2
+      with:
+        name: biopython_wheels
+
+    - name: Install from wheel
+      run: |
+        python -m pip install dist/biopython-*.whl
+
+    - name: Run test suite and get coverage
+      run: |
+        cd Tests
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          rm -rf coverage.xml
+          coverage run run_tests.py --offline
+          coverage xml
+        else
+          python run_tests.py --offline
+        fi
+      shell: bash
+
+  # RST linting
+  check_rst:
+    needs: [style, build, tests]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python --version
+        python -m pip install black==19.10b0
+
+    - name: Run tests on RST formatting
+      run: |
+        # Check sort order (bash call work around for pipe character)
+        bash -c \'grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f\'
+        # Check copyright date
+        bash -c \'grep "1999-`date +'%Y'`" LICENSE.rst\'
+        # Check no __docformat__ lines
+        bash -c "if grep --include '*.py' -rn '^__docformat__ ' Bio BioSQL Tests Scripts Doc ; then echo 'Remove __docformat__ line(s), we assume restructuredtext.'; false; fi"
+        # Black style check:
+        black --check --diff .
+      shell: bash
+
+  # Build API documentation if everything passes.
+  docs:
+    needs: [style, build, tests]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install documentation dependencies
+      run: |
+        python --version
+        python -m pip install sphinx>=3.5.0 numpydoc==1.0.0 pygments sphinx_rtd_theme
+        python -m pip install mysql-connector-python-rf numpy rdflib scipy
+        python -m pip install reportlab mmtf-python
+
+    - name: Install from source
+      run: |
+        python setup.py install
+
+    - name: Make documentation
+      run: |
+        make -C Doc/api html
+      shell: bash
+    
+    cleanup:
+      needs: [build]
+      runs-on: ubuntu-latest
+      steps:
+        - uses: geekyeggo/delete-artifact@v1
+          with:
+            name: biopython_wheels

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -109,7 +109,9 @@ jobs:
 
     - name: Install from wheel
       run: |
-        python -m pip install dist/biopython-*.whl
+        pwd
+        ls
+        python -m pip install dist/biopython*.whl
 
     - name: Run test suite and get coverage
       run: |

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -67,6 +67,15 @@ jobs:
       run: |
         python setup.py sdist --formats=gztar,zip
 
+  build_wheels:
+    needs: [style, build]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9, pypy3]
+
+    steps:
     - name: Build wheel
       run: |
         python setup.py bdist_wheel
@@ -76,12 +85,12 @@ jobs:
       with:
         name: biopython_wheels
         path: |
-          dist/
+          dist/*whl
 
   # Run test suite
-  # Triggers only if style & build pass.
+  # Triggers only if build_wheels pass.
   tests:
-    needs: [style, build]
+    needs: [build_wheels]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -106,8 +115,9 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: biopython_wheels
+        path: dist
 
-    - name: Install from wheel
+    - name: Install from wheels
       run: |
         pwd
         ls

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -115,6 +115,7 @@ jobs:
 
     - name: Build wheel
       run: |
+        python -m pip install --upgrade pip setuptools wheel
         python setup.py bdist_wheel
 
     - name: Archive wheels

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -149,17 +149,15 @@ jobs:
         python -m pip install mysqlclient mysql-connector-python rdflib
         python -m pip install networkx matplotlib reportlab
 
-    - name: Fetch archived wheels from previous job
-      uses: actions/download-artifact@v2
-      with:
-        name: biopython_wheels
-        path: dist
+    # - name: Fetch archived wheels from previous job
+    #   uses: actions/download-artifact@v2
+    #   with:
+    #     name: biopython_wheels
+    #     path: dist
 
-    - name: Install from wheels
+    - name: Install from source
       run: |
-        pwd
-        ls
-        python -m pip install dist/biopython*.whl
+        python setup.py install
 
     - name: Run test suite and get coverage
       run: |

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -124,14 +124,13 @@ jobs:
         path: |
           dist/*whl
 
-  # Run test suite
+  # Run test suite in parallel across the 3 OSes
   # Triggers only if all previous stages pass.
-  tests:
+  test_linux:
     needs: [build, style, check_rst, build_wheels]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9, pypy3]
 
     steps:
@@ -146,9 +145,7 @@ jobs:
         python -m pip install numpy
 
     - name: Install extra dependencies (Linux only)
-      if: runner.os == 'Linux'
       run: |
-        python --version
         python -m pip install coverage codecov numpy scipy mmtf-python
         python -m pip install mysqlclient mysql-connector-python rdflib
         python -m pip install networkx matplotlib reportlab
@@ -166,18 +163,72 @@ jobs:
     - name: Run test suite and get coverage
       run: |
         cd Tests
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          rm -rf coverage.xml
-          coverage run run_tests.py --offline
-          coverage xml
-        else
-          python run_tests.py --offline
-        fi
+        rm -rf coverage.xml
+        coverage run run_tests.py --offline
+        coverage xml
       shell: bash
+
+  test_macos:
+    needs: [build, style, check_rst, build_wheels]
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, pypy3]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install basic dependencies
+      run: |
+        python -m pip install numpy
+
+    - name: Install from source
+      run: |
+        python setup.py install
+
+    - name: Run test suite and get coverage
+      run: |
+        cd Tests
+        python run_tests.py --offline
+
+  test_windows:
+    needs: [build, style, check_rst, build_wheels]
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, pypy3]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install basic dependencies
+      run: |
+        python -m pip install numpy
+
+    - name: Install from source
+      run: |
+        python setup.py install
+
+    - name: Run test suite and get coverage
+      run: |
+        cd Tests
+        python run_tests.py --offline
+
+  # Flag step
+  check_tests:
+    needs: [test_linux, test_macos, test_windows]
 
   # Build API documentation if everything passes.
   docs:
-    needs: [tests]
+    needs: [check_tests]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -208,7 +259,7 @@ jobs:
     
   cleanup:
     if: always()
-    needs: [style, build, tests, docs, check_rst]
+    needs: [build_wheels]
     runs-on: ubuntu-latest
     steps:
       - uses: geekyeggo/delete-artifact@v1

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -186,10 +186,10 @@ jobs:
         make -C Doc/api html
       shell: bash
     
-    cleanup:
-      needs: [build]
-      runs-on: ubuntu-latest
-      steps:
-        - uses: geekyeggo/delete-artifact@v1
-          with:
-            name: biopython_wheels
+  cleanup:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: geekyeggo/delete-artifact@v1
+        with:
+          name: biopython_wheels

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -89,9 +89,9 @@ jobs:
     - name: Run tests on RST formatting
       run: |
         # Check sort order (bash call work around for pipe character)
-        bash -c \'grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f\'
+        bash -c \' grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f \'
         # Check copyright date
-        bash -c \'grep "1999-`date +'%Y'`" LICENSE.rst\'
+        bash -c \' grep "1999-`date +'%Y'`" LICENSE.rst \'
         # Check no __docformat__ lines
         bash -c "if grep --include '*.py' -rn '^__docformat__ ' Bio BioSQL Tests Scripts Doc ; then echo 'Remove __docformat__ line(s), we assume restructuredtext.'; false; fi"
         # Black style check:


### PR DESCRIPTION
This PR drops TravisCI and Appveyor as CI providers and moves to Github Actions. GHA offer several advantages over the current setup, namely:
- All major OSes are available for testing (Win, Linux, and MacOS).
- Simpler configuration (less config files).
- Free & Faster.

Roadmap:
- [x] Style checking using pre-commit.
- [x] Bonus: style checking only on files modified by PR to save time.
- [x] Check RST files.
- [x] Building steps (dist and wheel).
- [x] Offline tests (base dependencies).
- [ ] Offline tests (all dependencies).
- [x] Testing on PyPy.
- [x] Coverage.
- [x] Building Documentation with Sphinx

Possible Wishlist:
- [ ] Automatic deployment to conda/PyPI of development / tagged versions / releases (see https://github.com/pypa/cibuildwheel)

Work in progress.

References #3340 
