### PR TITLE
allow extracting one column from a `PairwiseAlignment`

### DIFF
--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2455,6 +2455,21 @@ To get the aligned sequence strings individually, use
 '-A-'
 \end{minted}
 
+To get specific columns in the alignment, use
+%cont-doctest
+\begin{minted}{pycon}
+>>> alignment[0, :]
+'GAACT'
+>>> alignment[1, :]
+'G-A-T'
+>>> alignment[:, 0]
+'GG'
+>>> alignment[:, 1]
+'A-'
+>>> alignment[:, 2]
+'AA'
+\end{minted}
+
 Slices of the form \verb+alignment[:, i:j]+, where \verb+i+ and \verb+j+ are integers or are absent, return a new \verb+PairwiseAlignment+ object that includes only the columns \verb+i+ through \verb+j+ in the printed alignment.
 
 Extracting the first 4 columns for the example alignment above gives:

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4022,6 +4022,32 @@ A-C-GG-AAC--
         self.assertAlmostEqual(alignment.score, 6.0)
         self.assertEqual(alignment[0, :], "AACCGGGA-CCG")
         self.assertEqual(alignment[1, :], "A-C-GG-AAC--")
+        self.assertEqual(alignment[-2, :], "AACCGGGA-CCG")
+        self.assertEqual(alignment[-1, :], "A-C-GG-AAC--")
+        self.assertEqual(alignment[:, 0], "AA")
+        self.assertEqual(alignment[:, 1], "A-")
+        self.assertEqual(alignment[:, 2], "CC")
+        self.assertEqual(alignment[:, 3], "C-")
+        self.assertEqual(alignment[:, 4], "GG")
+        self.assertEqual(alignment[:, 5], "GG")
+        self.assertEqual(alignment[:, 6], "G-")
+        self.assertEqual(alignment[:, 7], "AA")
+        self.assertEqual(alignment[:, 8], "-A")
+        self.assertEqual(alignment[:, 9], "CC")
+        self.assertEqual(alignment[:, 10], "C-")
+        self.assertEqual(alignment[:, 11], "G-")
+        self.assertEqual(alignment[:, -12], "AA")
+        self.assertEqual(alignment[:, -11], "A-")
+        self.assertEqual(alignment[:, -10], "CC")
+        self.assertEqual(alignment[:, -9], "C-")
+        self.assertEqual(alignment[:, -8], "GG")
+        self.assertEqual(alignment[:, -7], "GG")
+        self.assertEqual(alignment[:, -6], "G-")
+        self.assertEqual(alignment[:, -5], "AA")
+        self.assertEqual(alignment[:, -4], "-A")
+        self.assertEqual(alignment[:, -3], "CC")
+        self.assertEqual(alignment[:, -2], "C-")
+        self.assertEqual(alignment[:, -1], "G-")
         self.assertAlmostEqual(alignment[:, :].score, 6.0)
         self.assertEqual(
             str(alignment[:, :]),
@@ -4191,8 +4217,6 @@ AACCGGGA-CCG
             alignment[0]
         with self.assertRaises(NotImplementedError):
             alignment[:1, :]
-        with self.assertRaises(NotImplementedError):
-            alignment[:, 0]
         with self.assertRaises(NotImplementedError):
             alignment[:, ::3]
 


### PR DESCRIPTION
Allowing extracting one column from a `PairwiseAlignment` using `alignment[:, i]`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
