### PR TITLE
allow extraction of a single row using a row index only

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1063,9 +1063,7 @@ class PairwiseAlignment:
             if row < 0:
                 row += n
             if row < 0 or row >= n:
-                raise IndexError(
-                    "row index %d is out of bounds (%d rows)" % (row, n)
-                )
+                raise IndexError("row index %d is out of bounds (%d rows)" % (row, n))
             sequence = sequences[row]
             line = ""
             starts = [sys.maxsize] * m

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -990,6 +990,7 @@ class PairwiseAlignment:
         self[k, i:]
         self[k, :j]
         self[k, i:j]
+        self[k] (equivalent to self[k, :])
 
         which returns a string with the aligned sequence (including gaps)
         for the selected columns, where k = 0 represents the target and
@@ -1011,6 +1012,10 @@ class PairwiseAlignment:
         >>> alignment[0, :]
         'ACCGG-TTT'
         >>> alignment[1, :]
+        'AC-GGGTT-'
+        >>> alignment[0]
+        'ACCGG-TTT'
+        >>> alignment[1]
         'AC-GGGTT-'
         >>> alignment[0, 1:-2]
         'CCGG-T'
@@ -1051,15 +1056,38 @@ class PairwiseAlignment:
                 score = self.score
                 return PairwiseAlignment(target, query, path, score)
             raise NotImplementedError
+        sequences = self.target, self.query
         if isinstance(key, int):
-            raise NotImplementedError
+            n, m = self.shape
+            row = key
+            if row < 0:
+                row += n
+            if row < 0 or row >= n:
+                raise IndexError(
+                    "row index %d is out of bounds (%d rows)" % (row, n)
+                )
+            sequence = sequences[row]
+            line = ""
+            starts = [sys.maxsize] * m
+            for ends in self.path:
+                step = max(e - s for s, e in zip(starts, ends))
+                if step < 0:
+                    index = 0
+                else:
+                    index += step
+                    s, e = starts[row], ends[row]
+                    if s < e:
+                        line += sequence[s:e]
+                    elif s == e:
+                        line += "-" * step
+                starts = ends
+            return line
         if isinstance(key, tuple):
             try:
                 row, col = key
             except ValueError:
                 raise ValueError("only tuples of length 2 can be alignment indices")
             if isinstance(row, int):
-                sequences = self.target, self.query
                 n, m = self.shape
                 if row < 0:
                     row += n

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2445,6 +2445,10 @@ G-A-T
 To get the aligned sequence strings individually, use
 %cont-doctest
 \begin{minted}{pycon}
+>>> alignment[0]
+'GAACT'
+>>> alignment[1]
+'G-A-T'
 >>> alignment[0, :]
 'GAACT'
 >>> alignment[1, :]

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4020,6 +4020,10 @@ A-C-GG-AAC--
 """,
         )
         self.assertAlmostEqual(alignment.score, 6.0)
+        self.assertEqual(alignment[0], "AACCGGGA-CCG")
+        self.assertEqual(alignment[1], "A-C-GG-AAC--")
+        self.assertEqual(alignment[-2], "AACCGGGA-CCG")
+        self.assertEqual(alignment[-1], "A-C-GG-AAC--")
         self.assertEqual(alignment[0, :], "AACCGGGA-CCG")
         self.assertEqual(alignment[1, :], "A-C-GG-AAC--")
         self.assertEqual(alignment[-2, :], "AACCGGGA-CCG")
@@ -4213,8 +4217,6 @@ AACCGGGA-CCG
         )
         with self.assertRaises(NotImplementedError):
             alignment[:1]
-        with self.assertRaises(NotImplementedError):
-            alignment[0]
         with self.assertRaises(NotImplementedError):
             alignment[:1, :]
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
Allow extraction of a single row from a `PairwiseAlignment` using a row index only.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

