### PR TITLE
add 'i' lines in MafIO

### DIFF
--- a/Bio/AlignIO/MafIO.py
+++ b/Bio/AlignIO/MafIO.py
@@ -166,6 +166,10 @@ def MafIterator(handle, seq_count=None):
                     "size": int(line_split[3]),
                     "strand": strand,
                     "srcSize": int(line_split[5]),
+                    "leftStatus": None,
+                    "leftCount": None,
+                    "rightStatus": None,
+                    "rightCount": None,
                 }
 
                 sequence = line_split[6]
@@ -195,9 +199,26 @@ def MafIterator(handle, seq_count=None):
                     )
                 )
             elif line.startswith("i"):
-                # TODO: information about what is in the aligned species DNA before
+                # information about what is in the aligned species DNA before
                 # and after the immediately preceding "s" line
-                pass
+                # i (literal), src (ID), leftStatus, leftCount, rightStatus, rightCount
+                line_split = line.strip().split()
+                # First check that the format is correct
+                if len(line_split) != 6:
+                    raise ValueError(
+                        "Error parsing information - 'i' line must have 7 fields"
+                    )
+                if not records:
+                    raise ValueError("Found 'i' line before sequence of alignment")
+                if records[-1].id != line_split[1]:
+                    raise ValueError(
+                        "Found 'i' line with src different from previous alignment"
+                    )
+                # Add the annotations:
+                records[-1].annotations["leftStatus"] = line_split[2]
+                records[-1].annotations["leftCount"] = int(line_split[3])
+                records[-1].annotations["rightStatus"] = line_split[4]
+                records[-1].annotations["rightCount"] = int(line_split[5])
             elif line.startswith("e"):
                 # TODO: information about the size of the gap between the alignments
                 # that span the current block

--- a/Tests/test_MafIO_index.py
+++ b/Tests/test_MafIO_index.py
@@ -204,6 +204,10 @@ if sqlite3:
                     "srcSize": 129993255,
                     "strand": 1,
                     "size": 162,
+                    "leftStatus": None,
+                    "leftCount": None,
+                    "rightStatus": None,
+                    "rightCount": None,
                 },
             )
 
@@ -222,6 +226,10 @@ if sqlite3:
                     "srcSize": 13221,
                     "strand": 1,
                     "size": 164,
+                    "leftStatus": "N",
+                    "leftCount": 0,
+                    "rightStatus": "N",
+                    "rightCount": 0,
                 },
             )
 
@@ -242,6 +250,10 @@ if sqlite3:
                     "srcSize": 129993255,
                     "strand": 1,
                     "size": 42,
+                    "leftStatus": None,
+                    "leftCount": None,
+                    "rightStatus": None,
+                    "rightCount": None,
                 },
             )
 
@@ -255,6 +267,10 @@ if sqlite3:
                     "srcSize": 174210431,
                     "strand": -1,
                     "size": 46,
+                    "leftStatus": "I",
+                    "leftCount": 9,
+                    "rightStatus": "I",
+                    "rightCount": 943,
                 },
             )
 
@@ -268,6 +284,10 @@ if sqlite3:
                     "srcSize": 173908612,
                     "strand": -1,
                     "size": 46,
+                    "leftStatus": "I",
+                    "leftCount": 9,
+                    "rightStatus": "I",
+                    "rightCount": 10,
                 },
             )
 
@@ -281,6 +301,10 @@ if sqlite3:
                     "srcSize": 170899992,
                     "strand": -1,
                     "size": 46,
+                    "leftStatus": "I",
+                    "leftCount": 9,
+                    "rightStatus": "I",
+                    "rightCount": 931,
                 },
             )
 
@@ -294,6 +318,10 @@ if sqlite3:
                     "srcSize": 125616256,
                     "strand": -1,
                     "size": 46,
+                    "leftStatus": "I",
+                    "leftCount": 13,
+                    "rightStatus": "I",
+                    "rightCount": 1,
                 },
             )
 
@@ -307,6 +335,10 @@ if sqlite3:
                     "srcSize": 54797317,
                     "strand": -1,
                     "size": 36,
+                    "leftStatus": "C",
+                    "leftCount": 0,
+                    "rightStatus": "C",
+                    "rightCount": 0,
                 },
             )
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
Hi,
I would be interested in having informations from 'i' lines in the MafIO.
I propose here something but this is just an idea and maybe it is not the best way to store the info.
I would be happy to have comments.