### PR TITLE
allow iterables as column indices in a PairwiseAlignment

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -973,32 +973,33 @@ class PairwiseAlignment:
     def __getitem__(self, key):
         """Return self[key].
 
-        Currently, this is implemented only for indices of the form
+        Indices of the form
 
         self[:, :]
 
-        which returns a copy of the PairwiseAlignment object;
+        return a copy of the PairwiseAlignment object;
 
         self[:, i:]
         self[:, :j]
         self[:, i:j]
 
-        which returns a new PairwiseAlignment object spanning the selected
+        return a new PairwiseAlignment object spanning the selected
         columns;
 
         self[k, i]
         self[k, i:]
         self[k, :j]
         self[k, i:j]
+        self[k, iterable] (where iterable returns integers)
         self[k] (equivalent to self[k, :])
 
-        which returns a string with the aligned sequence (including gaps)
-        for the selected columns, where k = 0 represents the target and
-        k = 1 represents the query sequence; and
+        return a string with the aligned sequence (including gaps) for the
+        selected columns, where k = 0 represents the target and k = 1
+        represents the query sequence; and
 
         self[:, i]
 
-        which returns a string with the selected column in the alignment.
+        returns a string with the selected column in the alignment.
 
         >>> from Bio.Align import PairwiseAligner
         >>> aligner = PairwiseAligner()
@@ -1021,6 +1022,10 @@ class PairwiseAlignment:
         'CCGG-T'
         >>> alignment[1, 1:-2]
         'C-GGGT'
+        >>> alignment[0, (1, 2, 5)]
+        'CC-'
+        >>> alignment[1, range(0, 9, 2)]
+        'A-GT-'
         >>> alignment[:, 0]
         'AA'
         >>> alignment[:, 5]
@@ -1099,13 +1104,7 @@ class PairwiseAlignment:
                     raise IndexError(
                         "row index %d is out of bounds (%d rows)" % (row, n)
                     )
-                sequence = sequences[row]
-
-                if isinstance(col, slice):
-                    start_index, stop_index, step = col.indices(m)
-                    if step != 1:
-                        raise NotImplementedError
-                elif isinstance(col, int):
+                if isinstance(col, int):
                     start_index = col
                     if start_index < 0:
                         start_index += m
@@ -1113,48 +1112,76 @@ class PairwiseAlignment:
                         raise IndexError(
                             "column index %d is out of bounds (%d columns)" % (col, m)
                         )
-                    stop_index = start_index + 1
-                else:
-                    raise TypeError("second index must be an integer or slice")
-                line = ""
-                index = 0
-                path_iterator = iter(path)
-                starts = next(path_iterator)
-                for ends in path_iterator:
-                    step = max(e - s for s, e in zip(starts, ends))
-                    index += step
-                    if start_index < index:
+                    index = 0
+                    path_iterator = iter(path)
+                    starts = next(path_iterator)
+                    for ends in path_iterator:
+                        index += max(e - s for s, e in zip(starts, ends))
+                        if start_index < index:
+                            break
+                        starts = ends
+                    if starts[row] < ends[row]:
                         offset = index - start_index
-                        if starts[row] < ends[row]:
-                            i = ends[row] - offset
-                        else:
-                            i = starts[row]
-                        step = offset
-                        break
-                    starts = ends
-                while True:
-                    if stop_index <= index:
-                        offset = index - stop_index
-                        if starts[row] < ends[row]:
-                            j = ends[row] - offset
-                        else:
-                            j = starts[row]
-                        if i < j:
-                            line += sequence[i:j]
-                        else:
-                            line += "-" * (step - offset)
-                        break
-                    j = ends[row]
-                    if i < j:
-                        line += sequence[i:j]
+                        i = ends[row] - offset
+                        line = sequences[row][i:i+1]
                     else:
-                        line += "-" * step
-                    i = j
-                    starts = ends
-                    ends = next(path_iterator)
-                    step = max(e - s for s, e in zip(starts, ends))
-                    index += step
-                return line
+                        line = "-"
+                    return line
+                if isinstance(col, slice):
+                    sequence = sequences[row]
+                    start_index, stop_index, step = col.indices(m)
+                    if step == 1:
+                        line = ""
+                        index = 0
+                        path_iterator = iter(path)
+                        starts = next(path_iterator)
+                        for ends in path_iterator:
+                            step = max(e - s for s, e in zip(starts, ends))
+                            index += step
+                            if start_index < index:
+                                offset = index - start_index
+                                if starts[row] < ends[row]:
+                                    i = ends[row] - offset
+                                else:
+                                    i = starts[row]
+                                step = offset
+                                break
+                            starts = ends
+                        while True:
+                            if stop_index <= index:
+                                offset = index - stop_index
+                                if starts[row] < ends[row]:
+                                    j = ends[row] - offset
+                                else:
+                                    j = starts[row]
+                                if i < j:
+                                    line += sequence[i:j]
+                                else:
+                                    line += "-" * (step - offset)
+                                break
+                            j = ends[row]
+                            if i < j:
+                                line += sequence[i:j]
+                            else:
+                                line += "-" * step
+                            i = j
+                            starts = ends
+                            ends = next(path_iterator)
+                            step = max(e - s for s, e in zip(starts, ends))
+                            index += step
+                        return line
+                    # make an iterable if step != 1
+                    col = range(start_index, stop_index, step)
+                # try if we can use col as an iterable
+                line = self[row]
+                try:
+                    line = "".join(line[index] for index in col)
+                except IndexError:
+                    raise
+                except Exception:
+                    raise TypeError("second index must be an integer, slice, or iterable of integers") from None
+                else:
+                    return line
             if isinstance(row, slice):
                 if row.indices(len(self)) != (0, 2, 1):
                     raise NotImplementedError

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1123,7 +1123,7 @@ class PairwiseAlignment:
                     if starts[row] < ends[row]:
                         offset = index - start_index
                         i = ends[row] - offset
-                        line = sequences[row][i:i + 1]
+                        line = sequences[row][i : i + 1]
                     else:
                         line = "-"
                     return line

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1123,7 +1123,7 @@ class PairwiseAlignment:
                     if starts[row] < ends[row]:
                         offset = index - start_index
                         i = ends[row] - offset
-                        line = sequences[row][i:i+1]
+                        line = sequences[row][i:i + 1]
                     else:
                         line = "-"
                     return line
@@ -1179,7 +1179,9 @@ class PairwiseAlignment:
                 except IndexError:
                     raise
                 except Exception:
-                    raise TypeError("second index must be an integer, slice, or iterable of integers") from None
+                    raise TypeError(
+                        "second index must be an integer, slice, or iterable of integers"
+                    ) from None
                 else:
                     return line
             if isinstance(row, slice):

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2427,8 +2427,6 @@ obviously lose the ability to print the sequence alignment):
 
 \paragraph*{Slicing and indexing a pairwise alignment}
 
-Currently, slicing and indexing is only partially implemented.
-
 Slices of the form \verb+alignment[k, i:j]+, where \verb+k+ is an integer and \verb+i+ and \verb+j+ are integers or are absent, return a string showing the aligned sequence (including gaps) for the target (if \verb+k=0+) or the query (if \verb+k=1+) that includes only the columns \verb+i+ through \verb+j+ in the printed alignment.
 
 To illustrate this, in the following example the printed alignment has 5 columns:
@@ -2455,17 +2453,22 @@ To get the aligned sequence strings individually, use
 'G-A-T'
 >>> alignment[0, 1:-1]
 'AAC'
->>> alignment[1, 1:-1:]
+>>> alignment[1, 1:-1]
 '-A-'
+\end{minted}
+
+Columns to be included can also be selected using an iterable over integers:
+%cont-doctest
+\begin{minted}{pycon}
+>>> alignment[0, (1, 3, 4)]
+'ACT'
+>>> alignment[1, range(0, 5, 2)]
+'GAT'
 \end{minted}
 
 To get specific columns in the alignment, use
 %cont-doctest
 \begin{minted}{pycon}
->>> alignment[0, :]
-'GAACT'
->>> alignment[1, :]
-'G-A-T'
 >>> alignment[:, 0]
 'GG'
 >>> alignment[:, 1]

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4048,6 +4048,13 @@ A-C-GG-AAC--
         self.assertEqual(alignment[:, -3], "CC", msg=msg)
         self.assertEqual(alignment[:, -2], "C-", msg=msg)
         self.assertEqual(alignment[:, -1], "G-", msg=msg)
+        self.assertEqual(alignment[0, 0:12], "AACCGGGA-CCG", msg=msg)
+        self.assertEqual(alignment[1, 0:12], "A-C-GG-AAC--", msg=msg)
+        self.assertEqual(alignment[0, range(0, 12, 2)], "ACGG-C", msg=msg)
+        self.assertEqual(alignment[1, range(1, 12, 2)], "--GAC-", msg=msg)
+        self.assertEqual(alignment[0, (1, 4, 9)], "AGC", msg=msg)
+        self.assertEqual(alignment[1, (1, 4, 9)], "-GC", msg=msg)
+        self.assertEqual(alignment[1, 0:12], "A-C-GG-AAC--", msg=msg)
         self.assertAlmostEqual(alignment[:, :].score, 6.0, msg=msg)
         self.assertEqual(
             str(alignment[:, :]),


### PR DESCRIPTION
In a `PairwiseAlignment` object, allow iterables of integers to be used as column indices

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

