### PR TITLE
In PairwiseAlignment, allow iterables as column indices when extracting a subalignment

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -982,13 +982,19 @@ class PairwiseAlignment:
         for i in range(m):
             next_state = [line[i] != "-" for line in lines]
             if next_state == current_state:
-                step += 1
+                step += 1  # noqa: F821
             else:
-                indices = [index + step if state else index for index, state in zip(indices, current_state)]
+                indices = [
+                    index + step if state else index
+                    for index, state in zip(indices, current_state)
+                ]
                 path.append(indices)
                 step = 1
                 current_state = next_state
-        indices = [index + step if state else index for index, state in zip(indices, current_state)]
+        indices = [
+            index + step if state else index
+            for index, state in zip(indices, current_state)
+        ]
         path.append(indices)
         return path
 
@@ -1265,7 +1271,8 @@ class PairwiseAlignment:
                             if start_index < index:
                                 offset = index - start_index
                                 point = tuple(
-                                    e - offset if s < e else s for s, e in zip(starts, ends)
+                                    e - offset if s < e else s
+                                    for s, e in zip(starts, ends)
                                 )
                                 path.append(point)
                                 break
@@ -1274,7 +1281,8 @@ class PairwiseAlignment:
                             if stop_index <= index:
                                 offset = index - stop_index
                                 point = tuple(
-                                    e - offset if s < e else s for s, e in zip(starts, ends)
+                                    e - offset if s < e else s
+                                    for s, e in zip(starts, ends)
                                 )
                                 path.append(point)
                                 break
@@ -1287,7 +1295,8 @@ class PairwiseAlignment:
                                 # mapped to reverse strand
                                 n = len(sequences[i])
                                 path = tuple(
-                                    row[:i] + (n - row[i],) + row[i + 1 :] for row in path
+                                    row[:i] + (n - row[i],) + row[i + 1 :]
+                                    for row in path
                                 )
                         path = tuple(path)
                         target = self.target

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2505,6 +2505,17 @@ GAACT
 \end{minted}
 This is also now a local alignment, with the initial \verb+GA+ nucleotides in the target and \verb+G+ nucleotide in the query not aligned to each other.
 
+The column index can also be an iterable of integers:
+%cont-doctest
+\begin{minted}{pycon}
+>>> alignment[:, -3:]  # doctest:+ELLIPSIS
+<Bio.Align.PairwiseAlignment object at ...>
+>>> print(alignment[:, (1, 3, 0)])
+ACG
+--|
+--G
+<BLANKLINE>
+\end{minted}
 
 \paragraph*{Exporting alignments}
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4233,12 +4233,40 @@ AACCGGGA-CCG
 """,
             msg=msg,
         )
+        self.assertIsNone(alignment[:, ::2].score, msg=msg)
+        self.assertEqual(
+            str(alignment[:, ::2]),
+            """\
+ACGG-C
+|||---
+ACG-A-
+""",
+            msg=msg,
+        )
+        self.assertIsNone(alignment[:, range(0, 12, 2)].score, msg=msg)
+        self.assertEqual(
+            str(alignment[:, range(0, 12, 2)]),
+            """\
+ACGG-C
+|||---
+ACG-A-
+""",
+            msg=msg,
+        )
+        self.assertIsNone(alignment[:, (1, 8, 5)].score, msg=msg)
+        self.assertEqual(
+            str(alignment[:, (1, 8, 5)]),
+            """\
+A-G
+--|
+-AG
+""",
+            msg=msg,
+        )
         with self.assertRaises(NotImplementedError, msg=msg):
             alignment[:1]
         with self.assertRaises(NotImplementedError, msg=msg):
             alignment[:1, :]
-        with self.assertRaises(NotImplementedError, msg=msg):
-            alignment[:, ::3]
 
     def test_indexing_slicing(self):
         target = "AACCGGGACCG"


### PR DESCRIPTION
Allow indices of the form `alignment[:, iterable]`, where `iterable` returns integers, when extracting a subalignment from an alignment.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

