### PR TITLE
Remove all occurrences of OrderedDict in biopython

### DIFF
--- a/Bio/AlignIO/StockholmIO.py
+++ b/Bio/AlignIO/StockholmIO.py
@@ -152,8 +152,6 @@ You can also see this in the Stockholm output of this partial-alignment:
     <BLANKLINE>
 
 """
-from collections import OrderedDict
-
 from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
@@ -381,7 +379,7 @@ class StockholmIterator(AlignmentIterator):
         # if present it agrees with our parsing.
 
         seqs = {}
-        ids = OrderedDict()  # Really only need an OrderedSet, but python lacks this
+        ids = {}
         gs = {}
         gr = {}
         gf = {}

--- a/Bio/AlignIO/StockholmIO.py
+++ b/Bio/AlignIO/StockholmIO.py
@@ -379,7 +379,7 @@ class StockholmIterator(AlignmentIterator):
         # if present it agrees with our parsing.
 
         seqs = {}
-        ids = {}
+        ids = {}  # Really only need an OrderedSet, but python lacks this
         gs = {}
         gr = {}
         gf = {}

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -31,7 +31,7 @@ Feature Table Documentation:
 import warnings
 import re
 import sys
-from collections import OrderedDict
+from collections import defaultdict
 
 from Bio.File import as_handle
 from Bio.Seq import Seq
@@ -1737,7 +1737,7 @@ class GenBankScanner(InsdcScanner):
                     if self.debug > 1:
                         print("Found comment")
                     comment_list = []
-                    structured_comment_dict = OrderedDict()
+                    structured_comment_dict = defaultdict(dict)
                     regex = fr"([^#]+){self.STRUCTURED_COMMENT_START}$"
                     structured_comment_key = re.search(regex, data)
                     if structured_comment_key is not None:
@@ -1771,9 +1771,6 @@ class GenBankScanner(InsdcScanner):
                                         self.STRUCTURED_COMMENT_DELIM
                                     ),
                                     data,
-                                )
-                                structured_comment_dict.setdefault(
-                                    structured_comment_key, OrderedDict()
                                 )
                                 structured_comment_dict[structured_comment_key][
                                     match.group(1)

--- a/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
+++ b/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
@@ -6,7 +6,6 @@
 """Bio.SearchIO parser for HHSUITE version 2 and 3 plain text output format."""
 
 import re
-from collections import OrderedDict
 import warnings
 
 from Bio.SearchIO._utils import read_forward
@@ -193,7 +192,7 @@ class Hhsuite2TextParser:
     def _create_qresult(self, hit_blocks):
         """Create the Biopython data structures from the parsed data (PRIVATE)."""
         query_id = self.query_id
-        hit_dict = OrderedDict()
+        hit_dict = {}
 
         for output_index, block in enumerate(hit_blocks):
             hit_id = block["hit_id"]

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -8,7 +8,6 @@
 
 from copy import deepcopy
 from itertools import chain
-from collections import OrderedDict
 
 from Bio.SearchIO._utils import optionalcascade
 
@@ -193,7 +192,7 @@ class QueryResult(_BaseSearchObject):
         # default values
         self._id = id
         self._hit_key_function = hit_key_function or _hit_key_func
-        self._items = OrderedDict()
+        self._items = {}
         self._description = None
         self.__alt_hit_ids = {}
         self.program = "<unknown program>"
@@ -717,10 +716,7 @@ class QueryResult(_BaseSearchObject):
 
         # if sorting is in-place, don't create a new QueryResult object
         if in_place:
-            new_hits = OrderedDict()
-            for hit in sorted_hits:
-                new_hits[self._hit_key_function(hit)] = hit
-            self._items = new_hits
+            self._items = {self._hit_key_function(hit): hit for hit in sorted_hits}
         # otherwise, return a new sorted QueryResult object
         else:
             obj = self.__class__(sorted_hits, self.id, self._hit_key_function)

--- a/Bio/SearchIO/_utils.py
+++ b/Bio/SearchIO/_utils.py
@@ -132,7 +132,7 @@ def optionalcascade(cont_attr, item_attr, doc=""):
     def getter(self):
         if self._items:
             # don't use self._items here, so QueryResult can use this property
-            # as well (the underlying OrderedDict is not integer-indexable)
+            # as well (the underlying dict is not integer-indexable)
             return getattr(self[0], item_attr)
         else:
             return getattr(self, cont_attr)

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -53,8 +53,6 @@ Classes:
 """
 import functools
 
-from collections import OrderedDict
-
 from Bio.Seq import MutableSeq
 from Bio.Seq import reverse_complement
 from Bio.Seq import Seq
@@ -85,7 +83,7 @@ class SeqFeature:
      - qualifiers - A dictionary of qualifiers on the feature. These are
        analogous to the qualifiers from a GenBank feature table. The keys of
        the dictionary are qualifier names, the values are the qualifier
-       values. As of Biopython 1.69 this is an ordered dictionary.
+       values.
 
     """
 
@@ -162,9 +160,9 @@ class SeqFeature:
             # TODO - Deprecation warning
             self.strand = strand
         self.id = id
-        if qualifiers is None:
-            qualifiers = OrderedDict()
-        self.qualifiers = qualifiers
+        self.qualifiers = {}
+        if qualifiers is not None:
+            self.qualifiers.update(qualifiers)
         if sub_features is not None:
             raise TypeError("Rather than sub_features, use a CompoundFeatureLocation")
         if ref is not None:
@@ -295,8 +293,8 @@ class SeqFeature:
         if self.id and self.id != "<unknown id>":
             out += "id: %s\n" % self.id
         out += "qualifiers:\n"
-        for qual_key in sorted(self.qualifiers):
-            out += "    Key: %s, Value: %s\n" % (qual_key, self.qualifiers[qual_key])
+        for key, value in self.qualifiers.items():
+            out += f"    Key: {key}, Value: {value}\n"
         return out
 
     def _shift(self, offset):
@@ -309,7 +307,7 @@ class SeqFeature:
             type=self.type,
             location_operator=self.location_operator,
             id=self.id,
-            qualifiers=OrderedDict(self.qualifiers.items()),
+            qualifiers=self.qualifiers.copy(),
         )
 
     def _flip(self, length):
@@ -327,7 +325,7 @@ class SeqFeature:
             type=self.type,
             location_operator=self.location_operator,
             id=self.id,
-            qualifiers=OrderedDict(self.qualifiers.items()),
+            qualifiers=self.qualifiers.copy(),
         )
 
     def extract(self, parent_sequence, references=None):

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -293,8 +293,8 @@ class SeqFeature:
         if self.id and self.id != "<unknown id>":
             out += "id: %s\n" % self.id
         out += "qualifiers:\n"
-        for key, value in self.qualifiers.items():
-            out += f"    Key: {key}, Value: {value}\n"
+        for qual_key in sorted(self.qualifiers):
+            out += "    Key: %s, Value: %s\n" % (qual_key, self.qualifiers[qual_key])
         return out
 
     def _shift(self, offset):

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -717,10 +717,7 @@ def to_dict(sequences, key_function=None):
     the SeqRecord objects are held in memory. Instead, consider using the
     Bio.SeqIO.index() function (if it supports your particular file format).
 
-    Since Python 3.6, the default dict class maintains key order, meaning
-    this dictionary will reflect the order of records given to it. As of
-    Biopython 1.72, on older versions of Python we explicitly use an
-    OrderedDict so that you can always assume the record order is preserved.
+    This dictionary will reflect the order of records given to it.
     """
     # This is to avoid a lambda function:
 

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -213,7 +213,7 @@ class SeqRecord:
         if annotations is None:
             annotations = {}
         elif not isinstance(annotations, dict):
-            raise TypeError("annotations argument should be a dict")
+            raise TypeError("annotations argument must be a dict or None")
         self.annotations = annotations
 
         if letter_annotations is None:

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -14,6 +14,10 @@ The latest news is at the top of this file.
 Add tests for ``UniprotIO.Parser`` qualifiers "description", "evidence" and
 "status" information for sequence features as ``SeqFeature`` qualifiers.
 
+Because dict retains the item order by default since Python3.6, all instaces of
+``collections.OrderedDict`` have been replaced by either standard ``dict`` or
+where appropriate by ``collections.defaultsdict``.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3594

* This PR removes all uses of OrderedDict from the project completely.
* Improves the SeqFeature qualifiers assignmet (only works with dicts now) 
* use dict comprehension to avoid temporary variable in Bio/SearchIO/_model/query.py