### PR TITLE
Refactor inner loops in consensus functions

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -14,11 +14,14 @@ The latest news is at the top of this file.
 Add tests for ``UniprotIO.Parser`` qualifiers "description", "evidence" and
 "status" information for sequence features as ``SeqFeature`` qualifiers.
 
+Speed up and refactoring of code in ``AlignInfo`` consensus methods.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
 Fixed typos of triple underscore.
 
+- Caio Fontes
 - Chenghao Zhu
 - Fabian Egli
 


### PR DESCRIPTION
Use Counter objects internally and factor out _get_column_counts function from consensus functions.
Updates NEWS.rst

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #1872 (maybe?).

Applies the suggested refactoring to `AlignInfo` consensus methods, but I'm not sure how to benchmark if this is actually an improvement, would appreciate some guidance, since the tests seen to be to small for this to matter much.

I'm also not sure if the `multiprocess` changes are desired, but I can also implement them if they are.
