### PR TITLE
In PairwiseAlignment, store sequences under a single attribute

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -952,12 +952,12 @@ class PairwiseAlignment:
 
     @property
     def target(self):
-        """Returns self.sequences[0] for a pairwise alignment."""
+        """Return self.sequences[0] for a pairwise alignment."""
         n = len(self.sequences)
         if n != 2:
             raise ValueError(
                 "self.target is defined for pairwise alignments only (found alignment of % sequences)"
-                 % n
+                % n
             )
         return self.sequences[0]
 
@@ -968,18 +968,18 @@ class PairwiseAlignment:
         if n != 2:
             raise ValueError(
                 "self.target is defined for pairwise alignments only (found alignment of % sequences)"
-                 % n
+                % n
             )
         self.sequences[0] = value
 
     @property
     def query(self):
-        """Returns self.sequences[1] for a pairwise alignment."""
+        """Return self.sequences[1] for a pairwise alignment."""
         n = len(self.sequences)
         if n != 2:
             raise ValueError(
                 "self.query is defined for pairwise alignments only (found alignment of % sequences)"
-                 % n
+                % n
             )
         return self.sequences[1]
 
@@ -990,7 +990,7 @@ class PairwiseAlignment:
         if n != 2:
             raise ValueError(
                 "self.query is defined for pairwise alignments only (found alignment of % sequences)"
-                 % n
+                % n
             )
         self.sequences[1] = value
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4415,6 +4415,31 @@ T  12.0  16.5   7.0 145.0
         self.assertAlmostEqual(m["C", "T"], 16.5)
         self.assertAlmostEqual(m["T", "C"], 16.5)
 
+    def test_target_query_properties(self):
+        target = "ABCD"
+        query = "XYZ"
+        alignment = Align.PairwiseAlignment(target, query, None, None)
+        self.assertEqual(alignment.sequences[0], target)
+        self.assertEqual(alignment.sequences[1], query)
+        self.assertEqual(alignment.target, target)
+        self.assertEqual(alignment.query, query)
+        target = "EFGH"
+        query = "UVW"
+        alignment.target = target
+        alignment.query = query
+        self.assertEqual(alignment.sequences[0], target)
+        self.assertEqual(alignment.sequences[1], query)
+        self.assertEqual(alignment.target, target)
+        self.assertEqual(alignment.query, query)
+        target = "IJKL"
+        query = "RST"
+        sequences = [target, query]
+        alignment.sequences = sequences
+        self.assertEqual(alignment.sequences[0], target)
+        self.assertEqual(alignment.sequences[1], query)
+        self.assertEqual(alignment.target, target)
+        self.assertEqual(alignment.query, query)
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
In `PairwiseAlignment`, store sequences as the list `[target, query]` under the attribute `.sequences`, instead of separate attributes `.target`, `.query`. Add properties `.target`, `.query`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
