### PR TITLE
enable kegg_get to download json files

### DIFF
--- a/Bio/KEGG/REST.py
+++ b/Bio/KEGG/REST.py
@@ -199,7 +199,7 @@ def kegg_get(dbentries, option=None):
     # <org> = KEGG organism code or T number
     #
     # <option> = aaseq | ntseq | mol | kcf | image
-    if option in ["aaseq", "ntseq", "mol", "kcf", "image", "kgml"]:
+    if option in ["aaseq", "ntseq", "mol", "kcf", "image", "kgml", "json"]:
         resp = _q("get", dbentries, option)
     elif option:
         raise ValueError("Invalid option arg for kegg get request.")

--- a/Tests/test_KEGG_online.py
+++ b/Tests/test_KEGG_online.py
@@ -126,6 +126,11 @@ class KEGGTests(unittest.TestCase):
             handle.url, "http://rest.kegg.jp/find/compound/300-310/mol_weight"
         )
 
+    def test_get_br_ko00002(self):
+        with kegg_get('br:ko00002', 'json') as handle:
+            handle.read()
+        self.assertEqual(handle.url, "http://rest.kegg.jp/get/br:ko00002/json")
+
     def test_get_cpd_C01290_plus_gl_G00092(self):
         with kegg_get("cpd:C01290+gl:G00092") as handle:
             handle.read()


### PR DESCRIPTION
Enable to read json file of Brite database.
Example:
```python
from Bio.KEGG import REST
import json
ko00002=json.load(REST.kegg_get('br:ko00002', 'json'))
```

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
