### PR TITLE
simplify substitutions

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1620,7 +1620,7 @@ class PairwiseAlignment:
 
         Helper for self.format() .
         """
-        query, target = self.sequences
+        target, query = self.sequences
         # variable names follow those in the BED file format specification
         try:
             chrom = target.id
@@ -2357,16 +2357,7 @@ class PairwiseAlignment:
         The total number of substitutions between T's and C's in the alignment
         is 3.5 + 3.5 = 7.
         """
-        target, query = self.sequences
-        try:
-            target = target.seq
-        except AttributeError:
-            pass
-        try:
-            query = query.seq
-        except AttributeError:
-            pass
-        sequences = (str(target), str(query))
+        sequences = self.sequences
         letters = set.union(*[set(sequence) for sequence in sequences])
         letters = "".join(sorted(letters))
         m = substitution_matrices.Array(letters, dims=2)


### PR DESCRIPTION
In `PairwiseAlignment`, simplify the `substitutions` method.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
