### PR TITLE
use numpy for the aligned property of PairwiseAlignment

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -2086,7 +2086,7 @@ class PairwiseAlignment:
         steps = numpy.diff(coordinates, axis=0).min(1)
         indices = numpy.flatnonzero(steps)
         starts = coordinates[indices, :]
-        ends = coordinates[indices+1, :]
+        ends = coordinates[indices + 1, :]
         segments = numpy.stack([starts, ends], axis=0).transpose()
         for i, sequence in enumerate(self.sequences):
             if self.coordinates[i, 0] > self.coordinates[i, -1]:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -2021,7 +2021,11 @@ class PairwiseAlignment:
         GA--T
         <BLANKLINE>
         >>> alignment.aligned
-        (((0, 2), (4, 5)), ((0, 2), (2, 3)))
+        array([[[0, 2],
+                [4, 5]],
+        <BLANKLINE>
+               [[0, 2],
+                [2, 3]]])
         >>> alignment = alignments[1]
         >>> print(alignment)
         GAACT
@@ -2029,7 +2033,13 @@ class PairwiseAlignment:
         G-A-T
         <BLANKLINE>
         >>> alignment.aligned
-        (((0, 1), (2, 3), (4, 5)), ((0, 1), (1, 2), (2, 3)))
+        array([[[0, 1],
+                [2, 3],
+                [4, 5]],
+        <BLANKLINE>
+               [[0, 1],
+                [1, 2],
+                [2, 3]]])
 
         Note that different alignments may have the same subsequences
         aligned to each other. In particular, this may occur if alignments
@@ -2045,45 +2055,45 @@ class PairwiseAlignment:
         AAA-GAAA
         <BLANKLINE>
         >>> alignments[0].aligned
-        (((0, 3), (4, 7)), ((0, 3), (4, 7)))
+        array([[[0, 3],
+                [4, 7]],
+        <BLANKLINE>
+               [[0, 3],
+                [4, 7]]])
         >>> print(alignments[1])
         AAA-CAAA
         |||--|||
         AAAG-AAA
         <BLANKLINE>
         >>> alignments[1].aligned
-        (((0, 3), (4, 7)), ((0, 3), (4, 7)))
+        array([[[0, 3],
+                [4, 7]],
+        <BLANKLINE>
+               [[0, 3],
+                [4, 7]]])
 
         The property can be used to identify alignments that are identical
         to each other in terms of their aligned sequences.
         """
-        segments1 = []
-        segments2 = []
-        coordinates = self.coordinates.transpose()
-        if coordinates[0, 1] < coordinates[-1, 1]:  # mapped to forward strand
-            i1, i2 = coordinates[0]
-            for node in coordinates[1:]:
-                j1, j2 = node
-                if j1 > i1 and j2 > i2:
-                    segment1 = (i1, j1)
-                    segment2 = (i2, j2)
-                    segments1.append(segment1)
-                    segments2.append(segment2)
-                i1, i2 = j1, j2
-        else:  # mapped to reverse strand
-            n2 = len(self.sequences[1])
-            i1, i2 = coordinates[0]
-            i2 = n2 - i2
-            for node in coordinates[1:]:
-                j1, j2 = node
-                j2 = n2 - j2
-                if j1 > i1 and j2 > i2:
-                    segment1 = (i1, j1)
-                    segment2 = (n2 - i2, n2 - j2)
-                    segments1.append(segment1)
-                    segments2.append(segment2)
-                i1, i2 = j1, j2
-        return tuple(segments1), tuple(segments2)
+        import numpy
+
+        coordinates = self.coordinates.copy()
+        for i, sequence in enumerate(self.sequences):
+            if coordinates[i, 0] > coordinates[i, -1]:  # mapped to reverse strand
+                n = len(sequence)
+                coordinates[i, :] = n - coordinates[i, :]
+        coordinates = coordinates.transpose()
+        steps = numpy.diff(coordinates, axis=0).min(1)
+        indices = numpy.flatnonzero(steps)
+        starts = coordinates[indices, :]
+        ends = coordinates[indices+1, :]
+        segments = numpy.stack([starts, ends], axis=0).transpose()
+        for i, sequence in enumerate(self.sequences):
+            if self.coordinates[i, 0] > self.coordinates[i, -1]:
+                # mapped to reverse strand
+                n = len(sequence)
+                segments[i, :] = n - segments[i, :]
+        return segments
 
     def sort(self, key=None, reverse=False):
         """Sort the sequences of the alignment in place.

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2240,7 +2240,7 @@ TGAACT
 
 Use the \verb+aligned+ property to find the start and end indices of subsequences in the target and query sequence that were aligned to each other.
 Generally, if the alignment between target (t) and query (q) consists of $N$
-chunks, you get two tuples of length $N$:
+chunks, you get a numpy array with dimensions $2 \times N \times 2$:
 
 \begin{minted}{python}
 (
@@ -2254,7 +2254,11 @@ In the current example, \verb+alignment.aligned+ returns two tuples of length 2:
 %cont-doctest
 \begin{minted}{pycon}
 >>> alignment.aligned
-(((0, 2), (4, 5)), ((0, 2), (2, 3)))
+array([[[0, 2],
+        [4, 5]],
+<BLANKLINE>
+       [[0, 2],
+        [2, 3]]])
 \end{minted}
 while for the alternative alignment, two tuples of length 3 are returned:
 
@@ -2267,7 +2271,13 @@ GAACT
 G-A-T
 <BLANKLINE>
 >>> alignment.aligned
-(((0, 1), (2, 3), (4, 5)), ((0, 1), (1, 2), (2, 3)))
+array([[[0, 1],
+        [2, 3],
+        [4, 5]],
+<BLANKLINE>
+       [[0, 1],
+        [1, 2],
+        [2, 3]]])
 \end{minted}
 Note that different alignments may have the same subsequences aligned to each other. In particular, this may occur if alignments differ from each other in terms of their gap placement only:
 
@@ -2284,14 +2294,22 @@ AAAC-AAA
 AAA-GAAA
 <BLANKLINE>
 >>> alignments[0].aligned
-(((0, 3), (4, 7)), ((0, 3), (4, 7)))
+array([[[0, 3],
+        [4, 7]],
+<BLANKLINE>
+       [[0, 3],
+        [4, 7]]])
 >>> print(alignments[1])
 AAA-CAAA
 |||--|||
 AAAG-AAA
 <BLANKLINE>
 >>> alignments[1].aligned
-(((0, 3), (4, 7)), ((0, 3), (4, 7)))
+array([[[0, 3],
+        [4, 7]],
+<BLANKLINE>
+       [[0, 3],
+        [4, 7]]])
 \end{minted}
 The \verb+aligned+ property can be used to identify alignments that are identical to each other in terms of their aligned sequences.
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -265,7 +265,8 @@ G-A-T
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 1], [2, 3], [4, 5]], [[0, 1], [1, 2], [2, 3]]])
+                alignment.aligned,
+                numpy.array([[[0, 1], [2, 3], [4, 5]], [[0, 1], [1, 2], [2, 3]]]),
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -559,9 +560,7 @@ GAXT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]]))
-        )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]])))
 
     def test_needlemanwunsch_simple2(self):
         seq1 = "GA?AT"
@@ -633,7 +632,8 @@ GA-AXT
         self.assertEqual(alignment.shape, (2, 6))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]])
+                alignment.aligned,
+                numpy.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]]),
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -838,7 +838,8 @@ G-A
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[2, 1], [1, 0]]]))
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[2, 1], [1, 0]]])
+            )
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -2356,8 +2357,7 @@ abcce
         )
         self.assertEqual(alignment.shape, (2, 1))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[3, 4]], [[0, 1]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[3, 4]], [[0, 1]]]))
         )
 
     def test_align_one_char3(self):
@@ -2756,7 +2756,8 @@ TTGG-AA
         self.assertEqual(alignment.shape, (2, 7))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 2], [2, 3], [4, 6]], [[0, 2], [3, 4], [4, 6]]])
+                alignment.aligned,
+                numpy.array([[[0, 2], [2, 3], [4, 6]], [[0, 2], [3, 4], [4, 6]]]),
             )
         )
         alignment = alignments[1]
@@ -2856,7 +2857,8 @@ TT-GGAA
         self.assertEqual(alignment.shape, (2, 7))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 6]], [[6, 4], [4, 3], [2, 0]]]))
+                alignment.aligned,
+                numpy.array([[[0, 2], [3, 4], [4, 6]], [[6, 4], [4, 3], [2, 0]]])),
         )
         alignment = alignments[3]
         self.assertAlmostEqual(alignment.score, -8.0)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -9,6 +9,15 @@ import array
 import os
 import unittest
 
+try:
+    import numpy
+except ImportError:
+    from Bio import MissingPythonDependencyError
+
+    raise MissingPythonDependencyError(
+        "Install numpy if you want to use Bio.Align.PairwiseAlignment.map."
+    ) from None
+
 from Bio import Align, SeqIO
 from Bio.Seq import Seq, reverse_complement
 from Bio.SeqUtils import GC
@@ -238,7 +247,11 @@ GA--T
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 2), (4, 5)), ((0, 2), (2, 3))))
+        self.assertTrue(
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 2], [4, 5]], [[0, 2], [2, 3]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
@@ -250,8 +263,9 @@ G-A-T
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(
-            alignment.aligned, (((0, 1), (2, 3), (4, 5)), ((0, 1), (1, 2), (2, 3)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3], [4, 5]], [[0, 1], [1, 2], [2, 3]]])
+            )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
@@ -266,7 +280,10 @@ GA--T
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 2), (4, 5)), ((3, 1), (1, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 5]], [[3, 1], [1, 0]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
@@ -278,8 +295,9 @@ G-A-T
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(
-            alignment.aligned, (((0, 1), (2, 3), (4, 5)), ((3, 2), (2, 1), (1, 0)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3], [4, 5]], [[3, 2], [2, 1], [1, 0]]])
+            )
         )
 
     def test_align_affine1_score(self):
@@ -363,7 +381,10 @@ zA-Bz
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((1, 2), (2, 3))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[1, 2], [2, 3]]])
+            )
+        )
 
     def test_gotoh_local(self):
         aligner = Align.PairwiseAligner()
@@ -408,7 +429,10 @@ zA-Bz
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((1, 2), (2, 3))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[1, 2], [2, 3]]])
+            )
+        )
 
 
 class TestUnknownCharacter(unittest.TestCase):
@@ -437,7 +461,10 @@ GA?T
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 4),), ((0, 4),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 4]], [[0, 4]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -451,7 +478,10 @@ GA?T
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 4),), ((4, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 4]], [[4, 0]]])
+            )
+        )
         seq2 = "GAXT"
         aligner.wildcard = "X"
         score = aligner.score(seq1, seq2)
@@ -471,7 +501,10 @@ GAXT
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 4),), ((0, 4),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 4],], [[0, 4]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -485,7 +518,10 @@ GAXT
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 4),), ((4, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]])
+            )
+        )
         aligner.wildcard = None
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 2.0)
@@ -504,7 +540,10 @@ GAXT
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 4),), ((0, 4),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 4]], [[0, 4]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -518,7 +557,10 @@ GAXT
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 4),), ((4, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 4]], [[4, 0]]])
+            )
+        )
 
     def test_needlemanwunsch_simple2(self):
         seq1 = "GA?AT"
@@ -543,8 +585,9 @@ GA-A?T
 """,
         )
         self.assertEqual(alignment.shape, (2, 6))
-        self.assertEqual(
-            alignment.aligned, (((0, 2), (3, 4), (4, 5)), ((0, 2), (2, 3), (4, 5)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]])
+            )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
@@ -559,8 +602,9 @@ GA-A?T
 """,
         )
         self.assertEqual(alignment.shape, (2, 6))
-        self.assertEqual(
-            alignment.aligned, (((0, 2), (3, 4), (4, 5)), ((5, 3), (3, 2), (1, 0)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]])
+            )
         )
         seq1 = "GAXAT"
         seq2 = "GAAXT"
@@ -582,8 +626,9 @@ GA-AXT
 """,
         )
         self.assertEqual(alignment.shape, (2, 6))
-        self.assertEqual(
-            alignment.aligned, (((0, 2), (3, 4), (4, 5)), ((0, 2), (2, 3), (4, 5)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]])
+            )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
@@ -598,8 +643,9 @@ GA-AXT
 """,
         )
         self.assertEqual(alignment.shape, (2, 6))
-        self.assertEqual(
-            alignment.aligned, (((0, 2), (3, 4), (4, 5)), ((5, 3), (3, 2), (1, 0)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]])
+            )
         )
 
 
@@ -653,7 +699,10 @@ AA
 """,
         )
         self.assertEqual(alignment.shape, (2, 2))
-        self.assertEqual(alignment.aligned, (((1, 2),), ((0, 1),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[1, 2]], [[0, 1]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.9)
         self.assertEqual(
@@ -665,7 +714,10 @@ A-
 """,
         )
         self.assertEqual(alignment.shape, (2, 2))
-        self.assertEqual(alignment.aligned, (((0, 1),), ((0, 1),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1]], [[0, 1]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -679,7 +731,10 @@ AA
 """,
         )
         self.assertEqual(alignment.shape, (2, 2))
-        self.assertEqual(alignment.aligned, (((1, 2),), ((1, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[1, 2]], [[1, 0]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.9)
         self.assertEqual(
@@ -691,7 +746,10 @@ A-
 """,
         )
         self.assertEqual(alignment.shape, (2, 2))
-        self.assertEqual(alignment.aligned, (((0, 1),), ((1, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1]], [[1, 0]]])
+            )
+        )
 
     def test_match_score_open_penalty2(self):
         aligner = Align.PairwiseAligner()
@@ -742,7 +800,10 @@ G-A
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((0, 1), (1, 2))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[0, 1], [1, 2]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.9)
         self.assertEqual(
@@ -754,7 +815,10 @@ GA-
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 2),), ((0, 2),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[0, 2]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -768,7 +832,10 @@ G-A
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((2, 1), (1, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[2, 1], [1, 0]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.9)
         self.assertEqual(
@@ -780,7 +847,10 @@ GA-
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 2),), ((2, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[2, 0]]])
+            )
+        )
 
     def test_match_score_open_penalty3(self):
         aligner = Align.PairwiseAligner()
@@ -829,7 +899,10 @@ GA--T
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 2), (4, 5)), ((0, 2), (2, 3))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [4, 5]], [[0, 2], [2, 3]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -843,7 +916,10 @@ GA--T
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 2), (4, 5)), ((3, 1), (1, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [4, 5]], [[3, 1], [1, 0]]])
+            )
+        )
 
     def test_match_score_open_penalty4(self):
         aligner = Align.PairwiseAligner()
@@ -893,7 +969,10 @@ GA-TA
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((0, 1), (2, 3))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[0, 1], [2, 3]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.7)
         self.assertEqual(
@@ -905,7 +984,10 @@ G-ATA
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((0, 1), (2, 3))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[0, 1], [2, 3]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -919,7 +1001,10 @@ GA-TA
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((4, 3), (2, 1))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[4, 3], [2, 1]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.7)
         self.assertEqual(
@@ -931,7 +1016,10 @@ G-ATA
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((4, 3), (2, 1))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[4, 3], [2, 1]]])
+            )
+        )
 
 
 class TestPairwiseExtendPenalty(unittest.TestCase):
@@ -982,7 +1070,10 @@ G--T
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 1), (3, 4)), ((0, 1), (1, 2))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [3, 4]], [[0, 1], [1, 2]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -996,7 +1087,10 @@ G--T
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 1), (3, 4)), ((2, 1), (1, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [3, 4]], [[2, 1], [1, 0]]])
+            )
+        )
 
     def test_extend_penalty2(self):
         aligner = Align.PairwiseAligner()
@@ -1045,7 +1139,10 @@ GACT
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((1, 2), (3, 4)), ((0, 1), (1, 2))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[1, 2], [3, 4]], [[0, 1], [1, 2]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 0.6)
         self.assertEqual(
@@ -1057,7 +1154,10 @@ G-T-
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((0, 1), (1, 2))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[0, 1], [1, 2]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -1071,7 +1171,10 @@ GACT
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((1, 2), (3, 4)), ((2, 1), (1, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[1, 2], [3, 4]], [[2, 1], [1, 0]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 0.6)
         self.assertEqual(
@@ -1083,7 +1186,10 @@ G-T-
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((2, 1), (1, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[2, 1], [1, 0]]])
+            )
+        )
 
 
 class TestPairwisePenalizeExtendWhenOpening(unittest.TestCase):
@@ -1134,7 +1240,10 @@ G--T
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 1), (3, 4)), ((0, 1), (1, 2))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[0, 1], [1, 2]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -1148,7 +1257,10 @@ G--T
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 1), (3, 4)), ((2, 1), (1, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[2, 1], [1, 0]]])
+            )
+        )
 
 
 class TestPairwisePenalizeEndgaps(unittest.TestCase):
@@ -1202,7 +1314,10 @@ GACT
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((2, 4),), ((0, 2),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 4]], [[0, 2]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(
@@ -1214,7 +1329,10 @@ G--T
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 1), (3, 4)), ((0, 1), (1, 2))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[0, 1], [1, 2]]])
+            )
+        )
         alignment = alignments[2]
         self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(
@@ -1226,7 +1344,10 @@ GT--
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 2),), ((0, 2),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2]], [[0, 2]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
@@ -1240,7 +1361,10 @@ GACT
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((2, 4),), ((2, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 4]], [[2, 0]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(
@@ -1252,7 +1376,10 @@ G--T
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 1), (3, 4)), ((2, 1), (1, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[2, 1], [1, 0]]])
+            )
+        )
         alignment = alignments[2]
         self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(
@@ -1264,7 +1391,10 @@ GT--
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 2),), ((2, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2]], [[2, 0]]])
+            )
+        )
 
 
 class TestPairwiseSeparateGapPenalties(unittest.TestCase):
@@ -1323,7 +1453,10 @@ GTCT
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 1), (1, 3)), ((0, 1), (2, 4))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [1, 3]], [[0, 1], [2, 4]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.7)
         self.assertEqual(
@@ -1335,7 +1468,10 @@ GTCT
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 2), (2, 3)), ((0, 2), (3, 4))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [2, 3]], [[0, 2], [3, 4]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -1349,7 +1485,10 @@ GTCT
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 1), (1, 3)), ((4, 3), (2, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [1, 3]], [[4, 3], [2, 0]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.7)
         self.assertEqual(
@@ -1361,7 +1500,10 @@ GTCT
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 2), (2, 3)), ((4, 2), (1, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [2, 3]], [[4, 2], [1, 0]]])
+            )
+        )
 
     def test_separate_gap_penalties2(self):
         aligner = Align.PairwiseAligner()
@@ -1412,7 +1554,10 @@ G-TCT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((0, 1), (1, 2))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[0, 1], [1, 2]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -1426,7 +1571,10 @@ G-TCT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((4, 3), (3, 2))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[4, 3], [3, 2]]])
+            )
+        )
 
 
 class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
@@ -1483,7 +1631,10 @@ GTCCT
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 1), (1, 4)), ((0, 1), (2, 5))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [1, 4]], [[0, 1], [2, 5]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.9)
         self.assertEqual(
@@ -1495,7 +1646,10 @@ GTCCT
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 2), (2, 4)), ((0, 2), (3, 5))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [2, 4]], [[0, 2], [3, 5]]])
+            )
+        )
         alignment = alignments[2]
         self.assertAlmostEqual(alignment.score, 1.9)
         self.assertEqual(
@@ -1507,7 +1661,10 @@ GTCCT
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 3), (3, 4)), ((0, 3), (4, 5))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3], [3, 4]], [[0, 3], [4, 5]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
@@ -1521,7 +1678,10 @@ GTCCT
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 1), (1, 4)), ((5, 4), (3, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [1, 4]], [[5, 4], [3, 0]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.9)
         self.assertEqual(
@@ -1533,7 +1693,10 @@ GTCCT
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 2), (2, 4)), ((5, 3), (2, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [2, 4]], [[5, 3], [2, 0]]])
+            )
+        )
         alignment = alignments[2]
         self.assertAlmostEqual(alignment.score, 1.9)
         self.assertEqual(
@@ -1545,7 +1708,10 @@ GTCCT
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 3), (3, 4)), ((5, 2), (1, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3], [3, 4]], [[5, 2], [1, 0]]])
+            )
+        )
 
 
 class TestPairwiseMatchDictionary(unittest.TestCase):
@@ -1605,7 +1771,10 @@ ATT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 3),), ((0, 3),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[0, 3]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
@@ -1617,7 +1786,10 @@ AT-T
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 2), (3, 4)), ((0, 2), (2, 3))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[0, 2], [2, 3]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -1631,7 +1803,10 @@ ATT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 3),), ((3, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[3, 0]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
@@ -1643,7 +1818,10 @@ AT-T
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 2), (3, 4)), ((3, 1), (1, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[3, 1], [1, 0]]])
+            )
+        )
 
     def test_match_dictionary2(self):
         try:
@@ -1697,7 +1875,10 @@ ATT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 3),), ((0, 3),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[0, 3]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -1711,7 +1892,10 @@ ATT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 3),), ((3, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[3, 0]]])
+            )
+        )
 
     def test_match_dictionary3(self):
         try:
@@ -1765,7 +1949,10 @@ ATAT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 3),), ((0, 3),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[0, 3]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -1779,7 +1966,10 @@ ATAT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 3),), ((4, 1),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[4, 1]]])
+            )
+        )
 
     def test_match_dictionary4(self):
         try:
@@ -1836,7 +2026,10 @@ ATT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 3),), ((0, 3),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[0, 3]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
@@ -1848,7 +2041,10 @@ AT-T
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 2), (3, 4)), ((0, 2), (2, 3))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[0, 2], [2, 3]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -1862,7 +2058,10 @@ ATT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 3),), ((3, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[3, 0]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
@@ -1874,7 +2073,10 @@ AT-T
 """,
         )
         self.assertEqual(alignment.shape, (2, 4))
-        self.assertEqual(alignment.aligned, (((0, 2), (3, 4)), ((3, 1), (1, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[3, 1], [1, 0]]])
+            )
+        )
 
     def test_match_dictionary5(self):
         try:
@@ -1930,7 +2132,10 @@ ATT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 3),), ((0, 3),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[0, 3]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -1944,7 +2149,10 @@ ATT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 3),), ((3, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[3, 0]]])
+            )
+        )
 
     def test_match_dictionary6(self):
         try:
@@ -2000,7 +2208,10 @@ ATAT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 3),), ((0, 3),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[0, 3]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -2014,7 +2225,10 @@ ATAT
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 3),), ((4, 1),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[4, 1]]])
+            )
+        )
 
 
 class TestPairwiseOneCharacter(unittest.TestCase):
@@ -2061,7 +2275,10 @@ abcde
 """,
         )
         self.assertEqual(alignment.shape, (2, 1))
-        self.assertEqual(alignment.aligned, (((2, 3),), ((0, 1),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 3]], [[0, 1]]])
+            )
+        )
 
     def test_align_one_char2(self):
         aligner = Align.PairwiseAligner()
@@ -2106,7 +2323,10 @@ abcce
 """,
         )
         self.assertEqual(alignment.shape, (2, 1))
-        self.assertEqual(alignment.aligned, (((2, 3),), ((0, 1),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 3]], [[0, 1]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1)
         self.assertEqual(
@@ -2118,7 +2338,10 @@ abcce
 """,
         )
         self.assertEqual(alignment.shape, (2, 1))
-        self.assertEqual(alignment.aligned, (((3, 4),), ((0, 1),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 3, 4]], [[0, 1]]])
+            )
+        )
 
     def test_align_one_char3(self):
         aligner = Align.PairwiseAligner()
@@ -2165,7 +2388,10 @@ abcde
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((2, 3),), ((0, 1),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 3]], [[0, 1]]])
+            )
+        )
 
     def test_align_one_char_score3(self):
         aligner = Align.PairwiseAligner()
@@ -2261,7 +2487,10 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 36))
-        self.assertEqual(alignment.aligned, (((2, 13), (23, 34)), ((0, 11), (11, 22))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 13], [23, 34]], [[0, 11], [11, 22]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -2275,7 +2504,10 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 36))
-        self.assertEqual(alignment.aligned, (((2, 13), (23, 34)), ((22, 11), (11, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 13], [23, 34]], [[22, 11], [11, 0]]])
+            )
+        )
 
     def test_gap_here_only_2(self):
         # Force a bad alignment.
@@ -2337,7 +2569,10 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 36))
-        self.assertEqual(alignment.aligned, (((2, 5), (15, 34)), ((0, 3), (3, 22))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 5], [15, 34]], [[0, 3], [3, 22]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, -10)
         self.assertEqual(
@@ -2349,7 +2584,10 @@ AAB------------BBAAAACCCCAAAABBBAA--
 """,
         )
         self.assertEqual(alignment.shape, (2, 36))
-        self.assertEqual(alignment.aligned, (((0, 3), (15, 34)), ((0, 3), (3, 22))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3], [15, 34]], [[0, 3], [3, 22]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -2363,7 +2601,10 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 36))
-        self.assertEqual(alignment.aligned, (((2, 21), (33, 36)), ((22, 3), (3, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 21], [33, 36]], [[22, 3], [3, 0]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, -10)
         self.assertEqual(
@@ -2375,7 +2616,10 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 36))
-        self.assertEqual(alignment.aligned, (((2, 21), (31, 34)), ((22, 3), (3, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 21], [31, 34]], [[22, 3], [3, 0]]])
+            )
+        )
 
     def test_gap_here_only_3(self):
         # Check if gap open and gap extend penalties are handled correctly.
@@ -2432,7 +2676,10 @@ TTG--GAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 8))
-        self.assertEqual(alignment.aligned, (((0, 2), (4, 6)), ((0, 2), (4, 6))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[0, 2], [4, 6]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -2446,7 +2693,10 @@ TTG--GAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 8))
-        self.assertEqual(alignment.aligned, (((0, 2), (4, 6)), ((6, 4), (2, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[6, 4], [2, 0]]])
+            )
+        )
         aligner.query_gap_score = gap_score
         self.assertEqual(
             str(aligner),
@@ -2478,8 +2728,9 @@ TTGG-AA
 """,
         )
         self.assertEqual(alignment.shape, (2, 7))
-        self.assertEqual(
-            alignment.aligned, (((0, 2), (2, 3), (4, 6)), ((0, 2), (3, 4), (4, 6)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [2, 3], [4, 6]], [[0, 2], [3, 4], [4, 6]]])
+            )
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, -8.0)
@@ -2492,7 +2743,10 @@ TT-GG-AA
 """,
         )
         self.assertEqual(alignment.shape, (2, 8))
-        self.assertEqual(alignment.aligned, (((0, 2), (4, 6)), ((0, 2), (4, 6))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[0, 2], [4, 6]]])
+            )
+        )
         alignment = alignments[2]
         self.assertAlmostEqual(alignment.score, -8.0)
         self.assertEqual(
@@ -2504,8 +2758,9 @@ TT-GGAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 7))
-        self.assertEqual(
-            alignment.aligned, (((0, 2), (3, 4), (4, 6)), ((0, 2), (2, 3), (4, 6)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 6]], [[0, 2], [2, 3], [4, 6]]])
+            )
         )
         alignment = alignments[3]
         self.assertAlmostEqual(alignment.score, -8.0)
@@ -2518,7 +2773,10 @@ TTG--GAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 8))
-        self.assertEqual(alignment.aligned, (((0, 2), (4, 6)), ((0, 2), (4, 6))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[0, 2], [4, 6]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 4)
         alignment = alignments[0]
@@ -2532,8 +2790,9 @@ TTGG-AA
 """,
         )
         self.assertEqual(alignment.shape, (2, 7))
-        self.assertEqual(
-            alignment.aligned, (((0, 2), (2, 3), (4, 6)), ((6, 4), (3, 2), (2, 0)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [2, 3], [4, 6]], [[6, 4], [3, 2], [2, 0]]])
+            )
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, -8.0)
@@ -2546,7 +2805,10 @@ TT-GG-AA
 """,
         )
         self.assertEqual(alignment.shape, (2, 8))
-        self.assertEqual(alignment.aligned, (((0, 2), (4, 6)), ((6, 4), (2, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[6, 4], [2, 0]]])
+            )
+        )
         alignment = alignments[2]
         self.assertAlmostEqual(alignment.score, -8.0)
         self.assertEqual(
@@ -2558,8 +2820,9 @@ TT-GGAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 7))
-        self.assertEqual(
-            alignment.aligned, (((0, 2), (3, 4), (4, 6)), ((6, 4), (4, 3), (2, 0)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 6]], [[6, 4], [4, 3], [2, 0]]])
+            )
         )
         alignment = alignments[3]
         self.assertAlmostEqual(alignment.score, -8.0)
@@ -2572,7 +2835,10 @@ TTG--GAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 8))
-        self.assertEqual(alignment.aligned, (((0, 2), (4, 6)), ((6, 4), (2, 0))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[6, 4], [2, 0]]])
+            )
+        )
 
     def test_gap_here_only_local_1(self):
         seq1 = "AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA"
@@ -2629,7 +2895,10 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 13))
-        self.assertEqual(alignment.aligned, (((2, 15),), ((0, 13),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 15]], [[0, 13]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 13)
         self.assertEqual(
@@ -2641,7 +2910,10 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 13))
-        self.assertEqual(alignment.aligned, (((21, 34),), ((9, 22),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 21, 34]], [[9, 22]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -2655,7 +2927,10 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 13))
-        self.assertEqual(alignment.aligned, (((2, 15),), ((22, 9),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 15]], [[22, 9]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 13)
         self.assertEqual(
@@ -2667,7 +2942,10 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 13))
-        self.assertEqual(alignment.aligned, (((21, 34),), ((13, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 21, 34]], [[13, 0]]])
+            )
+        )
 
     def test_gap_here_only_local_2(self):
         # Force a bad alignment.
@@ -2729,7 +3007,10 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 13))
-        self.assertEqual(alignment.aligned, (((2, 15),), ((0, 13),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 15]], [[0, 13]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 13)
         self.assertEqual(
@@ -2741,7 +3022,10 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 13))
-        self.assertEqual(alignment.aligned, (((21, 34),), ((9, 22),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 21, 34]], [[9, 22]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -2755,7 +3039,10 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 13))
-        self.assertEqual(alignment.aligned, (((2, 15),), ((22, 9),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 15]], [[22, 9]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 13)
         self.assertEqual(
@@ -2767,7 +3054,10 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 13))
-        self.assertEqual(alignment.aligned, (((21, 34),), ((13, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 21, 34]], [[13, 0]]])
+            )
+        )
 
     def test_gap_here_only_local_3(self):
         # Check if gap open and gap extend penalties are handled correctly.
@@ -2824,7 +3114,10 @@ TTGGAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 2))
-        self.assertEqual(alignment.aligned, (((0, 2),), ((0, 2),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2]], [[0, 2]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.0)
         self.assertEqual(
@@ -2836,7 +3129,10 @@ TTGGAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 2))
-        self.assertEqual(alignment.aligned, (((4, 6),), ((4, 6),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 4, 6]], [[4, 6]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -2850,7 +3146,10 @@ TTGGAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 2))
-        self.assertEqual(alignment.aligned, (((0, 2),), ((6, 4),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2]], [[6, 4]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.0)
         self.assertEqual(
@@ -2862,7 +3161,10 @@ TTGGAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 2))
-        self.assertEqual(alignment.aligned, (((4, 6),), ((2, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 4, 6]], [[2, 0]]])
+            )
+        )
         aligner.query_gap_score = gap_score
         self.assertEqual(
             str(aligner),
@@ -2894,7 +3196,10 @@ TTGGAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 2))
-        self.assertEqual(alignment.aligned, (((0, 2),), ((0, 2),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2]], [[0, 2]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.0)
         self.assertEqual(
@@ -2906,7 +3211,10 @@ TTGGAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 2))
-        self.assertEqual(alignment.aligned, (((4, 6),), ((4, 6),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 4, 6]], [[4, 6]]])
+            )
+        )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
@@ -2920,7 +3228,10 @@ TTGGAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 2))
-        self.assertEqual(alignment.aligned, (((0, 2),), ((6, 4),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2]], [[6, 4]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.0)
         self.assertEqual(
@@ -2932,7 +3243,10 @@ TTGGAA
 """,
         )
         self.assertEqual(alignment.shape, (2, 2))
-        self.assertEqual(alignment.aligned, (((4, 6),), ((2, 0),)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 4, 6]], [[2, 0]]])
+            )
+        )
 
     def test_broken_gap_function(self):
         # Check if an Exception is propagated if the gap function raises one
@@ -3297,7 +3611,10 @@ class TestUnicodeStrings(unittest.TestCase):
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(alignment.aligned, (((0, 2), (4, 5)), ((0, 2), (2, 3))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 5]], [[0, 2], [2, 3]]])
+            )
+        )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
@@ -3309,8 +3626,9 @@ class TestUnicodeStrings(unittest.TestCase):
 """,
         )
         self.assertEqual(alignment.shape, (2, 5))
-        self.assertEqual(
-            alignment.aligned, (((0, 1), (2, 3), (4, 5)), ((0, 1), (1, 2), (2, 3)))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3], [4, 5]], [[0, 1], [1, 2], [2, 3]]])
+            )
         )
 
     def test_align_affine1_score(self):
@@ -3346,7 +3664,10 @@ class TestUnicodeStrings(unittest.TestCase):
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((1, 2), (2, 3))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[1, 2], [2, 3]]])
+            )
+        )
 
     def test_gotoh_local(self):
         aligner = Align.PairwiseAligner()
@@ -3370,7 +3691,10 @@ class TestUnicodeStrings(unittest.TestCase):
 """,
         )
         self.assertEqual(alignment.shape, (2, 3))
-        self.assertEqual(alignment.aligned, (((0, 1), (2, 3)), ((1, 2), (2, 3))))
+        self.assertTrue(
+            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[1, 2], [2, 3]]])
+            )
+        )
 
 
 class TestAlignerPickling(unittest.TestCase):

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -507,7 +507,7 @@ GAXT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 4],], [[0, 4]]]))
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 4]], [[0, 4]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -560,7 +560,8 @@ GAXT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]])))
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]]))
+        )
 
     def test_needlemanwunsch_simple2(self):
         seq1 = "GA?AT"
@@ -2858,7 +2859,8 @@ TT-GGAA
         self.assertTrue(
             numpy.array_equal(
                 alignment.aligned,
-                numpy.array([[[0, 2], [3, 4], [4, 6]], [[6, 4], [4, 3], [2, 0]]])),
+                numpy.array([[[0, 2], [3, 4], [4, 6]], [[6, 4], [4, 3], [2, 0]]])
+            ),
         )
         alignment = alignments[3]
         self.assertAlmostEqual(alignment.score, -8.0)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -299,7 +299,8 @@ G-A-T
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 1], [2, 3], [4, 5]], [[3, 2], [2, 1], [1, 0]]])
+                alignment.aligned,
+                numpy.array([[[0, 1], [2, 3], [4, 5]], [[3, 2], [2, 1], [1, 0]]]),
             )
         )
 
@@ -467,9 +468,7 @@ GA?T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 4]], [[0, 4]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 4]], [[0, 4]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
@@ -485,9 +484,7 @@ GA?T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]]))
         )
         seq2 = "GAXT"
         aligner.wildcard = "X"
@@ -509,9 +506,7 @@ GAXT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 4],], [[0, 4]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 4],], [[0, 4]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
@@ -527,9 +522,7 @@ GAXT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]]))
         )
         aligner.wildcard = None
         score = aligner.score(seq1, seq2)
@@ -550,9 +543,7 @@ GAXT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 4]], [[0, 4]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 4]], [[0, 4]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
@@ -569,8 +560,7 @@ GAXT
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]])
-            )
+                alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]]))
         )
 
     def test_needlemanwunsch_simple2(self):
@@ -598,7 +588,8 @@ GA-A?T
         self.assertEqual(alignment.shape, (2, 6))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]])
+                alignment.aligned,
+                numpy.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]]),
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -616,7 +607,8 @@ GA-A?T
         self.assertEqual(alignment.shape, (2, 6))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]])
+                alignment.aligned,
+                numpy.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]]),
             )
         )
         seq1 = "GAXAT"
@@ -659,7 +651,8 @@ GA-AXT
         self.assertEqual(alignment.shape, (2, 6))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]])
+                alignment.aligned,
+                numpy.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]]),
             )
         )
 
@@ -715,8 +708,7 @@ AA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[1, 2]], [[0, 1]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[1, 2]], [[0, 1]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -730,8 +722,7 @@ A-
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1]], [[0, 1]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1]], [[0, 1]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
@@ -747,8 +738,7 @@ AA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[1, 2]], [[1, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[1, 2]], [[1, 0]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -762,8 +752,7 @@ A-
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1]], [[1, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1]], [[1, 0]]]))
         )
 
     def test_match_score_open_penalty2(self):
@@ -832,8 +821,7 @@ GA-
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[0, 2]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[0, 2]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
@@ -850,8 +838,7 @@ G-A
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[2, 1], [1, 0]]])
-            )
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[2, 1], [1, 0]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -865,8 +852,7 @@ GA-
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[2, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[2, 0]]]))
         )
 
     def test_match_score_open_penalty3(self):
@@ -1346,8 +1332,7 @@ GACT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[2, 4]], [[0, 2]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 4]], [[0, 2]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -1361,7 +1346,8 @@ G--T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [3, 4]], [[0, 1], [1, 2]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [3, 4]], [[0, 1], [1, 2]]])
             )
         )
         alignment = alignments[2]
@@ -1376,8 +1362,7 @@ GT--
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[0, 2]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[0, 2]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 3)
@@ -1393,8 +1378,7 @@ GACT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[2, 4]], [[2, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 4]], [[2, 0]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -1424,8 +1408,7 @@ GT--
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[2, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[2, 0]]]))
         )
 
 
@@ -1816,8 +1799,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1849,8 +1831,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[3, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[3, 0]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1922,8 +1903,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
@@ -1939,8 +1919,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[3, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[3, 0]]]))
         )
 
     def test_match_dictionary3(self):
@@ -1996,8 +1975,7 @@ ATAT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
@@ -2013,8 +1991,7 @@ ATAT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[4, 1]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[4, 1]]]))
         )
 
     def test_match_dictionary4(self):
@@ -2073,8 +2050,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -2106,8 +2082,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[3, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[3, 0]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -2181,8 +2156,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
@@ -2198,8 +2172,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[3, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[3, 0]]]))
         )
 
     def test_match_dictionary6(self):
@@ -2257,8 +2230,7 @@ ATAT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
@@ -2274,8 +2246,7 @@ ATAT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[4, 1]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[4, 1]]]))
         )
 
 
@@ -2324,8 +2295,7 @@ abcde
         )
         self.assertEqual(alignment.shape, (2, 1))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[2, 3]], [[0, 1]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 3]], [[0, 1]]]))
         )
 
     def test_align_one_char2(self):
@@ -2372,8 +2342,7 @@ abcce
         )
         self.assertEqual(alignment.shape, (2, 1))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[2, 3]], [[0, 1]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 3]], [[0, 1]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 1)
@@ -2437,8 +2406,7 @@ abcde
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[2, 3]], [[0, 1]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 3]], [[0, 1]]]))
         )
 
     def test_align_one_char_score3(self):
@@ -2537,7 +2505,8 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[2, 13], [23, 34]], [[0, 11], [11, 22]]])
+                alignment.aligned,
+                numpy.array([[[2, 13], [23, 34]], [[0, 11], [11, 22]]]),
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2555,7 +2524,8 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[2, 13], [23, 34]], [[22, 11], [11, 0]]])
+                alignment.aligned,
+                numpy.array([[[2, 13], [23, 34]], [[22, 11], [11, 0]]]),
             )
         )
 
@@ -2818,7 +2788,8 @@ TT-GGAA
         self.assertEqual(alignment.shape, (2, 7))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 6]], [[0, 2], [2, 3], [4, 6]]])
+                alignment.aligned,
+                numpy.array([[[0, 2], [3, 4], [4, 6]], [[0, 2], [2, 3], [4, 6]]]),
             )
         )
         alignment = alignments[3]
@@ -2852,7 +2823,8 @@ TTGG-AA
         self.assertEqual(alignment.shape, (2, 7))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 2], [2, 3], [4, 6]], [[6, 4], [3, 2], [2, 0]]])
+                alignment.aligned,
+                numpy.array([[[0, 2], [2, 3], [4, 6]], [[6, 4], [3, 2], [2, 0]]]),
             )
         )
         alignment = alignments[1]
@@ -2884,8 +2856,7 @@ TT-GGAA
         self.assertEqual(alignment.shape, (2, 7))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 6]], [[6, 4], [4, 3], [2, 0]]])
-            )
+                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 6]], [[6, 4], [4, 3], [2, 0]]]))
         )
         alignment = alignments[3]
         self.assertAlmostEqual(alignment.score, -8.0)
@@ -2960,8 +2931,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[2, 15]], [[0, 13]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 15]], [[0, 13]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 13)
@@ -2975,8 +2945,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[21, 34]], [[9, 22]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[21, 34]], [[9, 22]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
@@ -2992,8 +2961,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[2, 15]], [[22, 9]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 15]], [[22, 9]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 13)
@@ -3007,8 +2975,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[21, 34]], [[13, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[21, 34]], [[13, 0]]]))
         )
 
     def test_gap_here_only_local_2(self):
@@ -3072,8 +3039,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[2, 15]], [[0, 13]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 15]], [[0, 13]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 13)
@@ -3087,8 +3053,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[21, 34]], [[9, 22]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[21, 34]], [[9, 22]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
@@ -3104,8 +3069,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[2, 15]], [[22, 9]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 15]], [[22, 9]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 13)
@@ -3119,8 +3083,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[21, 34]], [[13, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[21, 34]], [[13, 0]]]))
         )
 
     def test_gap_here_only_local_3(self):
@@ -3179,8 +3142,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[0, 2]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[0, 2]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -3194,8 +3156,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[4, 6]], [[4, 6]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[4, 6]], [[4, 6]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
@@ -3211,8 +3172,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[6, 4]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[6, 4]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -3226,8 +3186,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[4, 6]], [[2, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[4, 6]], [[2, 0]]]))
         )
         aligner.query_gap_score = gap_score
         self.assertEqual(
@@ -3261,8 +3220,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[0, 2]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[0, 2]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -3276,8 +3234,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[4, 6]], [[4, 6]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[4, 6]], [[4, 6]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 2)
@@ -3293,8 +3250,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[6, 4]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[6, 4]]]))
         )
         alignment = alignments[1]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -3308,8 +3264,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[4, 6]], [[2, 0]]])
-            )
+            numpy.array_equal(alignment.aligned, numpy.array([[[4, 6]], [[2, 0]]]))
         )
 
     def test_broken_gap_function(self):
@@ -3693,7 +3648,8 @@ class TestUnicodeStrings(unittest.TestCase):
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[0, 1], [2, 3], [4, 5]], [[0, 1], [1, 2], [2, 3]]])
+                alignment.aligned,
+                numpy.array([[[0, 1], [2, 3], [4, 5]], [[0, 1], [1, 2], [2, 3]]]),
             )
         )
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -264,7 +264,8 @@ G-A-T
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3], [4, 5]], [[0, 1], [1, 2], [2, 3]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [2, 3], [4, 5]], [[0, 1], [1, 2], [2, 3]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -281,7 +282,8 @@ GA--T
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 5]], [[3, 1], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [4, 5]], [[3, 1], [1, 0]]])
             )
         )
         alignment = alignments[1]
@@ -296,7 +298,8 @@ G-A-T
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3], [4, 5]], [[3, 2], [2, 1], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [2, 3], [4, 5]], [[3, 2], [2, 1], [1, 0]]])
             )
         )
 
@@ -382,7 +385,8 @@ zA-Bz
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[1, 2], [2, 3]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[1, 2], [2, 3]]])
             )
         )
 
@@ -430,7 +434,8 @@ zA-Bz
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[1, 2], [2, 3]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[1, 2], [2, 3]]])
             )
         )
 
@@ -462,7 +467,8 @@ GA?T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 4]], [[0, 4]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 4]], [[0, 4]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -479,7 +485,8 @@ GA?T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 4]], [[4, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 4]], [[4, 0]]])
             )
         )
         seq2 = "GAXT"
@@ -502,7 +509,8 @@ GAXT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 4],], [[0, 4]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 4],], [[0, 4]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -519,7 +527,8 @@ GAXT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]])
             )
         )
         aligner.wildcard = None
@@ -541,7 +550,8 @@ GAXT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 4]], [[0, 4]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 4]], [[0, 4]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -558,7 +568,8 @@ GAXT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 4]], [[4, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 4]], [[4, 0]]])
             )
         )
 
@@ -586,7 +597,8 @@ GA-A?T
         )
         self.assertEqual(alignment.shape, (2, 6))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -603,7 +615,8 @@ GA-A?T
         )
         self.assertEqual(alignment.shape, (2, 6))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]])
             )
         )
         seq1 = "GAXAT"
@@ -627,7 +640,8 @@ GA-AXT
         )
         self.assertEqual(alignment.shape, (2, 6))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -644,7 +658,8 @@ GA-AXT
         )
         self.assertEqual(alignment.shape, (2, 6))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]])
             )
         )
 
@@ -801,7 +816,8 @@ G-A
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[0, 1], [1, 2]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[0, 1], [1, 2]]])
             )
         )
         alignment = alignments[1]
@@ -833,7 +849,8 @@ G-A
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[2, 1], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[2, 1], [1, 0]]])
             )
         )
         alignment = alignments[1]
@@ -900,7 +917,8 @@ GA--T
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [4, 5]], [[0, 2], [2, 3]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 2], [4, 5]], [[0, 2], [2, 3]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -917,7 +935,8 @@ GA--T
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [4, 5]], [[3, 1], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 2], [4, 5]], [[3, 1], [1, 0]]])
             )
         )
 
@@ -970,7 +989,8 @@ GA-TA
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[0, 1], [2, 3]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[0, 1], [2, 3]]])
             )
         )
         alignment = alignments[1]
@@ -985,7 +1005,8 @@ G-ATA
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[0, 1], [2, 3]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[0, 1], [2, 3]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1002,7 +1023,8 @@ GA-TA
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[4, 3], [2, 1]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[4, 3], [2, 1]]])
             )
         )
         alignment = alignments[1]
@@ -1017,7 +1039,8 @@ G-ATA
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[4, 3], [2, 1]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[4, 3], [2, 1]]])
             )
         )
 
@@ -1071,7 +1094,8 @@ G--T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [3, 4]], [[0, 1], [1, 2]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [3, 4]], [[0, 1], [1, 2]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1088,7 +1112,8 @@ G--T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [3, 4]], [[2, 1], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [3, 4]], [[2, 1], [1, 0]]])
             )
         )
 
@@ -1140,7 +1165,8 @@ GACT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[1, 2], [3, 4]], [[0, 1], [1, 2]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[1, 2], [3, 4]], [[0, 1], [1, 2]]])
             )
         )
         alignment = alignments[1]
@@ -1155,7 +1181,8 @@ G-T-
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[0, 1], [1, 2]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[0, 1], [1, 2]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1172,7 +1199,8 @@ GACT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[1, 2], [3, 4]], [[2, 1], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[1, 2], [3, 4]], [[2, 1], [1, 0]]])
             )
         )
         alignment = alignments[1]
@@ -1187,7 +1215,8 @@ G-T-
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[2, 1], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[2, 1], [1, 0]]])
             )
         )
 
@@ -1241,7 +1270,8 @@ G--T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[0, 1], [1, 2]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[0, 1], [1, 2]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1258,7 +1288,8 @@ G--T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[2, 1], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[2, 1], [1, 0]]])
             )
         )
 
@@ -1377,7 +1408,8 @@ G--T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[2, 1], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[2, 1], [1, 0]]])
             )
         )
         alignment = alignments[2]
@@ -1454,7 +1486,8 @@ GTCT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [1, 3]], [[0, 1], [2, 4]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 1], [1, 3]], [[0, 1], [2, 4]]])
             )
         )
         alignment = alignments[1]
@@ -1469,7 +1502,8 @@ GTCT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [2, 3]], [[0, 2], [3, 4]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [2, 3]], [[0, 2], [3, 4]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1486,7 +1520,8 @@ GTCT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [1, 3]], [[4, 3], [2, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 1], [1, 3]], [[4, 3], [2, 0]]])
             )
         )
         alignment = alignments[1]
@@ -1501,7 +1536,8 @@ GTCT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [2, 3]], [[4, 2], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [2, 3]], [[4, 2], [1, 0]]])
             )
         )
 
@@ -1555,7 +1591,8 @@ G-TCT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[0, 1], [1, 2]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[0, 1], [1, 2]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1572,7 +1609,8 @@ G-TCT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[4, 3], [3, 2]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[4, 3], [3, 2]]])
             )
         )
 
@@ -1632,7 +1670,8 @@ GTCCT
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [1, 4]], [[0, 1], [2, 5]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 1], [1, 4]], [[0, 1], [2, 5]]])
             )
         )
         alignment = alignments[1]
@@ -1647,7 +1686,8 @@ GTCCT
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [2, 4]], [[0, 2], [3, 5]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [2, 4]], [[0, 2], [3, 5]]])
             )
         )
         alignment = alignments[2]
@@ -1662,7 +1702,8 @@ GTCCT
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3], [3, 4]], [[0, 3], [4, 5]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 3], [3, 4]], [[0, 3], [4, 5]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1679,7 +1720,8 @@ GTCCT
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [1, 4]], [[5, 4], [3, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 1], [1, 4]], [[5, 4], [3, 0]]])
             )
         )
         alignment = alignments[1]
@@ -1694,7 +1736,8 @@ GTCCT
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [2, 4]], [[5, 3], [2, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [2, 4]], [[5, 3], [2, 0]]])
             )
         )
         alignment = alignments[2]
@@ -1709,7 +1752,8 @@ GTCCT
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3], [3, 4]], [[5, 2], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 3], [3, 4]], [[5, 2], [1, 0]]])
             )
         )
 
@@ -1787,7 +1831,8 @@ AT-T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[0, 2], [2, 3]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[0, 2], [2, 3]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1819,7 +1864,8 @@ AT-T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[3, 1], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[3, 1], [1, 0]]])
             )
         )
 
@@ -2042,7 +2088,8 @@ AT-T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[0, 2], [2, 3]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[0, 2], [2, 3]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2074,7 +2121,8 @@ AT-T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[3, 1], [1, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[3, 1], [1, 0]]])
             )
         )
 
@@ -2488,7 +2536,8 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 13], [23, 34]], [[0, 11], [11, 22]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 2, 13], [23, 34]], [[0, 11], [11, 22]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2505,7 +2554,8 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 13], [23, 34]], [[22, 11], [11, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 2, 13], [23, 34]], [[22, 11], [11, 0]]])
             )
         )
 
@@ -2570,7 +2620,8 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 5], [15, 34]], [[0, 3], [3, 22]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 2, 5], [15, 34]], [[0, 3], [3, 22]]])
             )
         )
         alignment = alignments[1]
@@ -2585,7 +2636,8 @@ AAB------------BBAAAACCCCAAAABBBAA--
         )
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3], [15, 34]], [[0, 3], [3, 22]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 3], [15, 34]], [[0, 3], [3, 22]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2602,7 +2654,8 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 21], [33, 36]], [[22, 3], [3, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 2, 21], [33, 36]], [[22, 3], [3, 0]]])
             )
         )
         alignment = alignments[1]
@@ -2617,7 +2670,8 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 21], [31, 34]], [[22, 3], [3, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 2, 21], [31, 34]], [[22, 3], [3, 0]]])
             )
         )
 
@@ -2677,7 +2731,8 @@ TTG--GAA
         )
         self.assertEqual(alignment.shape, (2, 8))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[0, 2], [4, 6]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[0, 2], [4, 6]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2694,7 +2749,8 @@ TTG--GAA
         )
         self.assertEqual(alignment.shape, (2, 8))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[6, 4], [2, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[6, 4], [2, 0]]])
             )
         )
         aligner.query_gap_score = gap_score
@@ -2729,7 +2785,8 @@ TTGG-AA
         )
         self.assertEqual(alignment.shape, (2, 7))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [2, 3], [4, 6]], [[0, 2], [3, 4], [4, 6]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 2], [2, 3], [4, 6]], [[0, 2], [3, 4], [4, 6]]])
             )
         )
         alignment = alignments[1]
@@ -2744,7 +2801,8 @@ TT-GG-AA
         )
         self.assertEqual(alignment.shape, (2, 8))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[0, 2], [4, 6]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[0, 2], [4, 6]]])
             )
         )
         alignment = alignments[2]
@@ -2759,7 +2817,8 @@ TT-GGAA
         )
         self.assertEqual(alignment.shape, (2, 7))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 6]], [[0, 2], [2, 3], [4, 6]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 6]], [[0, 2], [2, 3], [4, 6]]])
             )
         )
         alignment = alignments[3]
@@ -2774,7 +2833,8 @@ TTG--GAA
         )
         self.assertEqual(alignment.shape, (2, 8))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[0, 2], [4, 6]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[0, 2], [4, 6]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2791,7 +2851,8 @@ TTGG-AA
         )
         self.assertEqual(alignment.shape, (2, 7))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [2, 3], [4, 6]], [[6, 4], [3, 2], [2, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 2], [2, 3], [4, 6]], [[6, 4], [3, 2], [2, 0]]])
             )
         )
         alignment = alignments[1]
@@ -2806,7 +2867,8 @@ TT-GG-AA
         )
         self.assertEqual(alignment.shape, (2, 8))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[6, 4], [2, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[6, 4], [2, 0]]])
             )
         )
         alignment = alignments[2]
@@ -2821,7 +2883,8 @@ TT-GGAA
         )
         self.assertEqual(alignment.shape, (2, 7))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 6]], [[6, 4], [4, 3], [2, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 2], [3, 4], [4, 6]], [[6, 4], [4, 3], [2, 0]]])
             )
         )
         alignment = alignments[3]
@@ -2836,7 +2899,8 @@ TTG--GAA
         )
         self.assertEqual(alignment.shape, (2, 8))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[6, 4], [2, 0]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[6, 4], [2, 0]]])
             )
         )
 
@@ -3612,7 +3676,8 @@ class TestUnicodeStrings(unittest.TestCase):
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2], [4, 5]], [[0, 2], [2, 3]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 2], [4, 5]], [[0, 2], [2, 3]]])
             )
         )
         alignment = alignments[1]
@@ -3627,7 +3692,8 @@ class TestUnicodeStrings(unittest.TestCase):
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [2, 3], [4, 5]], [[0, 1], [1, 2], [2, 3]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[0, 1], [2, 3], [4, 5]], [[0, 1], [1, 2], [2, 3]]])
             )
         )
 
@@ -3665,7 +3731,8 @@ class TestUnicodeStrings(unittest.TestCase):
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[1, 2], [2, 3]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[1, 2], [2, 3]]])
             )
         )
 
@@ -3692,7 +3759,8 @@ class TestUnicodeStrings(unittest.TestCase):
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[1, 2], [2, 3]]])
+            numpy.array_equal(
+                alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[1, 2], [2, 3]]])
             )
         )
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2859,7 +2859,7 @@ TT-GGAA
         self.assertTrue(
             numpy.array_equal(
                 alignment.aligned,
-                numpy.array([[[0, 2], [3, 4], [4, 6]], [[6, 4], [4, 3], [2, 0]]])
+                numpy.array([[[0, 2], [3, 4], [4, 6]], [[6, 4], [4, 3], [2, 0]]]),
             ),
         )
         alignment = alignments[3]

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -283,7 +283,7 @@ GA--T
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [4, 5]], [[3, 1], [1, 0]]])
+                alignment.aligned, numpy.array([[[0, 2], [4, 5]], [[3, 1], [1, 0]]])
             )
         )
         alignment = alignments[1]
@@ -468,7 +468,7 @@ GA?T
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 4]], [[0, 4]]])
+                alignment.aligned, numpy.array([[[0, 4]], [[0, 4]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -486,7 +486,7 @@ GA?T
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 4]], [[4, 0]]])
+                alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]])
             )
         )
         seq2 = "GAXT"
@@ -510,7 +510,7 @@ GAXT
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 4],], [[0, 4]]])
+                alignment.aligned, numpy.array([[[0, 4],], [[0, 4]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -551,7 +551,7 @@ GAXT
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 4]], [[0, 4]]])
+                alignment.aligned, numpy.array([[[0, 4]], [[0, 4]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -569,7 +569,7 @@ GAXT
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 4]], [[4, 0]]])
+                alignment.aligned, numpy.array([[[0, 4]], [[4, 0]]])
             )
         )
 
@@ -1216,7 +1216,7 @@ G-T-
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[2, 1], [1, 0]]])
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[2, 1], [1, 0]]])
             )
         )
 
@@ -1271,7 +1271,7 @@ G--T
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[0, 1], [1, 2]]])
+                alignment.aligned, numpy.array([[[0, 1], [3, 4]], [[0, 1], [1, 2]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1289,7 +1289,7 @@ G--T
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[2, 1], [1, 0]]])
+                alignment.aligned, numpy.array([[[0, 1], [3, 4]], [[2, 1], [1, 0]]])
             )
         )
 
@@ -1346,7 +1346,7 @@ GACT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 4]], [[0, 2]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 4]], [[0, 2]]])
             )
         )
         alignment = alignments[1]
@@ -1361,7 +1361,7 @@ G--T
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[0, 1], [1, 2]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 1], [3, 4]], [[0, 1], [1, 2]]])
             )
         )
         alignment = alignments[2]
@@ -1376,7 +1376,7 @@ GT--
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2]], [[0, 2]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[0, 2]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1393,7 +1393,7 @@ GACT
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 4]], [[2, 0]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 4]], [[2, 0]]])
             )
         )
         alignment = alignments[1]
@@ -1409,7 +1409,7 @@ G--T
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 1], [3, 4]], [[2, 1], [1, 0]]])
+                alignment.aligned, numpy.array([[[0, 1], [3, 4]], [[2, 1], [1, 0]]])
             )
         )
         alignment = alignments[2]
@@ -1424,7 +1424,7 @@ GT--
         )
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2]], [[2, 0]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[2, 0]]])
             )
         )
 
@@ -1487,7 +1487,7 @@ GTCT
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 1], [1, 3]], [[0, 1], [2, 4]]])
+                alignment.aligned, numpy.array([[[0, 1], [1, 3]], [[0, 1], [2, 4]]])
             )
         )
         alignment = alignments[1]
@@ -1503,7 +1503,7 @@ GTCT
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [2, 3]], [[0, 2], [3, 4]]])
+                alignment.aligned, numpy.array([[[0, 2], [2, 3]], [[0, 2], [3, 4]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1521,7 +1521,7 @@ GTCT
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 1], [1, 3]], [[4, 3], [2, 0]]])
+                alignment.aligned, numpy.array([[[0, 1], [1, 3]], [[4, 3], [2, 0]]])
             )
         )
         alignment = alignments[1]
@@ -1537,7 +1537,7 @@ GTCT
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [2, 3]], [[4, 2], [1, 0]]])
+                alignment.aligned, numpy.array([[[0, 2], [2, 3]], [[4, 2], [1, 0]]])
             )
         )
 
@@ -1592,7 +1592,7 @@ G-TCT
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[0, 1], [1, 2]]])
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[0, 1], [1, 2]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1610,7 +1610,7 @@ G-TCT
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[4, 3], [3, 2]]])
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[4, 3], [3, 2]]])
             )
         )
 
@@ -1671,7 +1671,7 @@ GTCCT
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 1], [1, 4]], [[0, 1], [2, 5]]])
+                alignment.aligned, numpy.array([[[0, 1], [1, 4]], [[0, 1], [2, 5]]])
             )
         )
         alignment = alignments[1]
@@ -1687,7 +1687,7 @@ GTCCT
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [2, 4]], [[0, 2], [3, 5]]])
+                alignment.aligned, numpy.array([[[0, 2], [2, 4]], [[0, 2], [3, 5]]])
             )
         )
         alignment = alignments[2]
@@ -1703,7 +1703,7 @@ GTCCT
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 3], [3, 4]], [[0, 3], [4, 5]]])
+                alignment.aligned, numpy.array([[[0, 3], [3, 4]], [[0, 3], [4, 5]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1721,7 +1721,7 @@ GTCCT
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 1], [1, 4]], [[5, 4], [3, 0]]])
+                alignment.aligned, numpy.array([[[0, 1], [1, 4]], [[5, 4], [3, 0]]])
             )
         )
         alignment = alignments[1]
@@ -1737,7 +1737,7 @@ GTCCT
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [2, 4]], [[5, 3], [2, 0]]])
+                alignment.aligned, numpy.array([[[0, 2], [2, 4]], [[5, 3], [2, 0]]])
             )
         )
         alignment = alignments[2]
@@ -1753,7 +1753,7 @@ GTCCT
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 3], [3, 4]], [[5, 2], [1, 0]]])
+                alignment.aligned, numpy.array([[[0, 3], [3, 4]], [[5, 2], [1, 0]]])
             )
         )
 
@@ -1816,7 +1816,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[0, 3]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]])
             )
         )
         alignment = alignments[1]
@@ -1832,7 +1832,7 @@ AT-T
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[0, 2], [2, 3]]])
+                alignment.aligned, numpy.array([[[0, 2], [3, 4]], [[0, 2], [2, 3]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1849,7 +1849,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[3, 0]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[3, 0]]])
             )
         )
         alignment = alignments[1]
@@ -1865,7 +1865,7 @@ AT-T
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[3, 1], [1, 0]]])
+                alignment.aligned, numpy.array([[[0, 2], [3, 4]], [[3, 1], [1, 0]]])
             )
         )
 
@@ -1922,7 +1922,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[0, 3]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -1939,7 +1939,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[3, 0]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[3, 0]]])
             )
         )
 
@@ -1996,7 +1996,7 @@ ATAT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[0, 3]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2013,7 +2013,7 @@ ATAT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[4, 1]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[4, 1]]])
             )
         )
 
@@ -2073,7 +2073,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[0, 3]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]])
             )
         )
         alignment = alignments[1]
@@ -2089,7 +2089,7 @@ AT-T
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[0, 2], [2, 3]]])
+                alignment.aligned, numpy.array([[[0, 2], [3, 4]], [[0, 2], [2, 3]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2106,7 +2106,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[3, 0]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[3, 0]]])
             )
         )
         alignment = alignments[1]
@@ -2122,7 +2122,7 @@ AT-T
         self.assertEqual(alignment.shape, (2, 4))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [3, 4]], [[3, 1], [1, 0]]])
+                alignment.aligned, numpy.array([[[0, 2], [3, 4]], [[3, 1], [1, 0]]])
             )
         )
 
@@ -2181,7 +2181,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[0, 3]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2198,7 +2198,7 @@ ATT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[3, 0]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[3, 0]]])
             )
         )
 
@@ -2257,7 +2257,7 @@ ATAT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[0, 3]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[0, 3]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2274,7 +2274,7 @@ ATAT
         )
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 3]], [[4, 1]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 3]], [[4, 1]]])
             )
         )
 
@@ -2324,7 +2324,7 @@ abcde
         )
         self.assertEqual(alignment.shape, (2, 1))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 3]], [[0, 1]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 3]], [[0, 1]]])
             )
         )
 
@@ -2372,7 +2372,7 @@ abcce
         )
         self.assertEqual(alignment.shape, (2, 1))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 3]], [[0, 1]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 3]], [[0, 1]]])
             )
         )
         alignment = alignments[1]
@@ -2387,7 +2387,7 @@ abcce
         )
         self.assertEqual(alignment.shape, (2, 1))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 3, 4]], [[0, 1]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[3, 4]], [[0, 1]]])
             )
         )
 
@@ -2437,7 +2437,7 @@ abcde
         )
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 3]], [[0, 1]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 3]], [[0, 1]]])
             )
         )
 
@@ -2537,7 +2537,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 2, 13], [23, 34]], [[0, 11], [11, 22]]])
+                alignment.aligned, numpy.array([[[2, 13], [23, 34]], [[0, 11], [11, 22]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2555,7 +2555,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 2, 13], [23, 34]], [[22, 11], [11, 0]]])
+                alignment.aligned, numpy.array([[[2, 13], [23, 34]], [[22, 11], [11, 0]]])
             )
         )
 
@@ -2621,7 +2621,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 2, 5], [15, 34]], [[0, 3], [3, 22]]])
+                alignment.aligned, numpy.array([[[2, 5], [15, 34]], [[0, 3], [3, 22]]])
             )
         )
         alignment = alignments[1]
@@ -2637,7 +2637,7 @@ AAB------------BBAAAACCCCAAAABBBAA--
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 3], [15, 34]], [[0, 3], [3, 22]]])
+                alignment.aligned, numpy.array([[[0, 3], [15, 34]], [[0, 3], [3, 22]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2655,7 +2655,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 2, 21], [33, 36]], [[22, 3], [3, 0]]])
+                alignment.aligned, numpy.array([[[2, 21], [33, 36]], [[22, 3], [3, 0]]])
             )
         )
         alignment = alignments[1]
@@ -2671,7 +2671,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         self.assertEqual(alignment.shape, (2, 36))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 2, 21], [31, 34]], [[22, 3], [3, 0]]])
+                alignment.aligned, numpy.array([[[2, 21], [31, 34]], [[22, 3], [3, 0]]])
             )
         )
 
@@ -2732,7 +2732,7 @@ TTG--GAA
         self.assertEqual(alignment.shape, (2, 8))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[0, 2], [4, 6]]])
+                alignment.aligned, numpy.array([[[0, 2], [4, 6]], [[0, 2], [4, 6]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2750,7 +2750,7 @@ TTG--GAA
         self.assertEqual(alignment.shape, (2, 8))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[6, 4], [2, 0]]])
+                alignment.aligned, numpy.array([[[0, 2], [4, 6]], [[6, 4], [2, 0]]])
             )
         )
         aligner.query_gap_score = gap_score
@@ -2802,7 +2802,7 @@ TT-GG-AA
         self.assertEqual(alignment.shape, (2, 8))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[0, 2], [4, 6]]])
+                alignment.aligned, numpy.array([[[0, 2], [4, 6]], [[0, 2], [4, 6]]])
             )
         )
         alignment = alignments[2]
@@ -2834,7 +2834,7 @@ TTG--GAA
         self.assertEqual(alignment.shape, (2, 8))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[0, 2], [4, 6]]])
+                alignment.aligned, numpy.array([[[0, 2], [4, 6]], [[0, 2], [4, 6]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2868,7 +2868,7 @@ TT-GG-AA
         self.assertEqual(alignment.shape, (2, 8))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[6, 4], [2, 0]]])
+                alignment.aligned, numpy.array([[[0, 2], [4, 6]], [[6, 4], [2, 0]]])
             )
         )
         alignment = alignments[2]
@@ -2900,7 +2900,7 @@ TTG--GAA
         self.assertEqual(alignment.shape, (2, 8))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [4, 6]], [[6, 4], [2, 0]]])
+                alignment.aligned, numpy.array([[[0, 2], [4, 6]], [[6, 4], [2, 0]]])
             )
         )
 
@@ -2960,7 +2960,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 15]], [[0, 13]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 15]], [[0, 13]]])
             )
         )
         alignment = alignments[1]
@@ -2975,7 +2975,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 21, 34]], [[9, 22]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[21, 34]], [[9, 22]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -2992,7 +2992,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 15]], [[22, 9]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 15]], [[22, 9]]])
             )
         )
         alignment = alignments[1]
@@ -3007,7 +3007,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 21, 34]], [[13, 0]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[21, 34]], [[13, 0]]])
             )
         )
 
@@ -3072,7 +3072,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 15]], [[0, 13]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 15]], [[0, 13]]])
             )
         )
         alignment = alignments[1]
@@ -3087,7 +3087,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 21, 34]], [[9, 22]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[21, 34]], [[9, 22]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -3104,7 +3104,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 2, 15]], [[22, 9]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[2, 15]], [[22, 9]]])
             )
         )
         alignment = alignments[1]
@@ -3119,7 +3119,7 @@ AAAABBBAAAACCCCCCCCCCCCCCAAAABBBAAAA
         )
         self.assertEqual(alignment.shape, (2, 13))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 21, 34]], [[13, 0]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[21, 34]], [[13, 0]]])
             )
         )
 
@@ -3179,7 +3179,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2]], [[0, 2]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[0, 2]]])
             )
         )
         alignment = alignments[1]
@@ -3194,7 +3194,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 4, 6]], [[4, 6]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[4, 6]], [[4, 6]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -3211,7 +3211,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2]], [[6, 4]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[6, 4]]])
             )
         )
         alignment = alignments[1]
@@ -3226,7 +3226,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 4, 6]], [[2, 0]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[4, 6]], [[2, 0]]])
             )
         )
         aligner.query_gap_score = gap_score
@@ -3261,7 +3261,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2]], [[0, 2]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[0, 2]]])
             )
         )
         alignment = alignments[1]
@@ -3276,7 +3276,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 4, 6]], [[4, 6]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[4, 6]], [[4, 6]]])
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
@@ -3293,7 +3293,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 0, 2]], [[6, 4]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[0, 2]], [[6, 4]]])
             )
         )
         alignment = alignments[1]
@@ -3308,7 +3308,7 @@ TTGGAA
         )
         self.assertEqual(alignment.shape, (2, 2))
         self.assertTrue(
-            numpy.array_equal(alignment.aligned, numpy.array([[[ 4, 6]], [[2, 0]]])
+            numpy.array_equal(alignment.aligned, numpy.array([[[4, 6]], [[2, 0]]])
             )
         )
 
@@ -3677,7 +3677,7 @@ class TestUnicodeStrings(unittest.TestCase):
         self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 2], [4, 5]], [[0, 2], [2, 3]]])
+                alignment.aligned, numpy.array([[[0, 2], [4, 5]], [[0, 2], [2, 3]]])
             )
         )
         alignment = alignments[1]
@@ -3732,7 +3732,7 @@ class TestUnicodeStrings(unittest.TestCase):
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[1, 2], [2, 3]]])
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[1, 2], [2, 3]]])
             )
         )
 
@@ -3760,7 +3760,7 @@ class TestUnicodeStrings(unittest.TestCase):
         self.assertEqual(alignment.shape, (2, 3))
         self.assertTrue(
             numpy.array_equal(
-                alignment.aligned, numpy.array([[[ 0, 1], [2, 3]], [[1, 2], [2, 3]]])
+                alignment.aligned, numpy.array([[[0, 1], [2, 3]], [[1, 2], [2, 3]]])
             )
         )
 


### PR DESCRIPTION
For `PairwiseAlignment`, use a numpy array for the property `aligned`

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
