### PR TITLE
aligner documentation update

### DIFF
--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1480,13 +1480,11 @@ version 1.72). Both can perform global and local alignments and offer numerous
 options to change the alignment parameters. Although \verb|pairwise2| has gained
 some speed and memory enhancements recently, the new \verb|PairwiseAligner| is
 much faster; so if you need to make many alignments with larger sequences, the
-latter would be the tool to choose. \verb|pairwise2|, on the contrary, is also
-able to align lists, which can be useful if your sequences do not consist of
-single characters only. 
+latter would be the tool to choose.
 
 Given that the parameters and sequences are the same, both aligners will return
-the same alignments and alignment score (if the number of alignments is too high
-they may return different subsets of all valid alignments).
+the same alignments and alignment score (if the number of alignments is too
+high, \verb|pairwise2| may return a subset of all valid alignments).
 
 \subsection{pairwise2}
 \label{sec:pairwise2}


### PR DESCRIPTION
Nowadays the pairwise aligner is also able to align lists:
```
>>> from Bio.Align import PairwiseAligner
>>> aligner = PairwiseAligner()
>>> aligner.alphabet = ["Gly", "Ala", "Cys", "Thr"] 
>>> alignments = aligner.align(["Gly", "Ala", "Thr"], ["Gly", "Ala", "Ala", "Cys", "Thr"])
>>> print(alignments[0])
Gly Ala --- --- Thr
||| ||| --- --- |||
Gly Ala Ala Cys Thr

```

Also, the pairwise aligner does not return a subset of valid alignments; it will always iterate over all valid alignments.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)