### PR TITLE
Add timeouts to CI steps.

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -6,6 +6,7 @@ jobs:
   # Style Checking: one OS and Python version only.
   style:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: [3.9]
@@ -48,6 +49,7 @@ jobs:
   # Build package: sdist, bdist_wheel
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
@@ -70,6 +72,7 @@ jobs:
   # RST linting
   check_rst:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         python-version: [3.9]
@@ -100,6 +103,7 @@ jobs:
 
   build_wheels:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -129,6 +133,7 @@ jobs:
   test_linux:
     needs: [build, style, check_rst, build_wheels]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, pypy3]
@@ -171,6 +176,7 @@ jobs:
   test_macos:
     needs: [build, style, check_rst, build_wheels]
     runs-on: macos-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, pypy3]
@@ -198,6 +204,7 @@ jobs:
   test_windows:
     needs: [build, style, check_rst, build_wheels]
     runs-on: windows-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, pypy3]
@@ -233,6 +240,7 @@ jobs:
   docs:
     needs: [check_tests]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: [3.9]
@@ -259,7 +267,7 @@ jobs:
       run: |
         make -C Doc/api html
       shell: bash
-    
+
   cleanup:
     if: always()
     needs: [build_wheels]


### PR DESCRIPTION
To avoid GHA to run for a long time in case something hangs.
