### PR TITLE
replace isinstance(int) by isinstance(numbers.Integral)

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -20,6 +20,7 @@ See also the Seq_ wiki and the chapter in our tutorial:
 
 """
 import array
+import numbers
 import warnings
 
 from abc import ABC
@@ -425,7 +426,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> mutable_seq[5:8]
         MutableSeq('ACG')
         """
-        if isinstance(index, int):
+        if isinstance(index, numbers.Integral):
             # Return a single letter as a string
             return chr(self._data[index])
         else:
@@ -479,7 +480,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> MutableSeq('ATG') * 2
         MutableSeq('ATGATG')
         """
-        if not isinstance(other, int):
+        if not isinstance(other, numbers.Integral):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(self._data * other)
 
@@ -490,7 +491,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> 2 * Seq('ATG')
         Seq('ATGATG')
         """
-        if not isinstance(other, int):
+        if not isinstance(other, numbers.Integral):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(self._data * other)
 
@@ -519,7 +520,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> id(seq) == id(seq2)
         False
         """
-        if not isinstance(other, int):
+        if not isinstance(other, numbers.Integral):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
         return self.__class__(self._data * other)
 
@@ -2591,7 +2592,7 @@ class MutableSeq(_SeqAbstractBaseClass):
         >>> my_seq
         MutableSeq('TCTCGACGTCG')
         """
-        if isinstance(index, int):
+        if isinstance(index, numbers.Integral):
             # Replacing a single letter with a new string
             self._data[index] = ord(value)
         else:

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -298,6 +298,7 @@ class _SeqAbstractBaseClass(ABC):
     """
 
     __slots__ = ("_data",)
+    __array_ufunc__ = None  # turn off numpy Ufuncs
 
     @abstractmethod
     def __init__(self):
@@ -2126,7 +2127,7 @@ class UnknownSeq(Seq):
         >>> print(unk[1:-1:2])
         NNN
         """
-        if isinstance(index, int):
+        if isinstance(index, numbers.Integral):
             if index >= -self._length and index < self._length:
                 return self._character
             raise IndexError("sequence index out of range")

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -11,6 +11,7 @@
 # In particular, the SeqRecord and BioSQL.BioSeq.DBSeqRecord classes
 # need to be in sync (this is the BioSQL "Database SeqRecord").
 from io import StringIO
+import numbers
 
 from Bio import StreamModeError
 from Bio.Seq import UndefinedSequenceError
@@ -444,7 +445,7 @@ class SeqRecord:
         >>> rec.seq[5]
         'K'
         """
-        if isinstance(index, int):
+        if isinstance(index, numbers.Integral):
             # NOTE - The sequence level annotation like the id, name, etc
             # do not really apply to a single character.  However, should
             # we try and expose any per-letter-annotation here?  If so how?

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -12,6 +12,7 @@ and position-specific scoring matrices.
 """
 
 import math
+import numbers
 
 try:
     import numpy as np
@@ -63,7 +64,7 @@ class GenericPositionMatrix(dict):
                     indices1 = range(start1, stop1, stride1)
                     letters1 = [self.alphabet[i] for i in indices1]
                     dim1 = 2
-                elif isinstance(key1, int):
+                elif isinstance(key1, numbers.Integral):
                     letter1 = self.alphabet[key1]
                     dim1 = 1
                 elif isinstance(key1, tuple):
@@ -81,7 +82,7 @@ class GenericPositionMatrix(dict):
                     start2, stop2, stride2 = key2.indices(self.length)
                     indices2 = range(start2, stop2, stride2)
                     dim2 = 2
-                elif isinstance(key2, int):
+                elif isinstance(key2, numbers.Integral):
                     index2 = key2
                     dim2 = 1
                 else:
@@ -114,7 +115,7 @@ class GenericPositionMatrix(dict):
             indices = range(start, stop, stride)
             letters = [self.alphabet[i] for i in indices]
             dim = 2
-        elif isinstance(key, int):
+        elif isinstance(key, numbers.Integral):
             letter = self.alphabet[key]
             dim = 1
         elif isinstance(key, tuple):

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -9,6 +9,11 @@ and confirms they are consistent using our different parsers.
 """
 import unittest
 
+try:
+    import numpy
+except ImportError:
+    numpy = None
+
 from Bio import SeqIO
 from Bio.Seq import MutableSeq
 from Bio.Seq import Seq
@@ -217,6 +222,10 @@ Seq('ABCDEFGHIJKLMNOPQRSTUVWZYX')"""
         self.assertEqual("BC", self.record[1:3].seq)
         with self.assertRaises(ValueError):
             c = self.record["a"].seq
+        if numpy is not None:
+            start, stop = numpy.array([1, 3])  # numpy integers
+            self.assertEqual("B", self.record[start])
+            self.assertEqual("BC", self.record[start:stop].seq)
 
     def test_slice_variants(self):
         """Simple slices using different start/end values."""

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -19,6 +19,10 @@ from Bio.Seq import translate
 from Bio.Seq import UndefinedSequenceError
 from Bio.Seq import UnknownSeq
 
+try:
+    import numpy
+except ImportError:
+    numpy = None
 
 # This is just the standard table with less stop codons
 # (replaced with coding for O as an artificial example)
@@ -96,6 +100,9 @@ class StringMethodTests(unittest.TestCase):
         if not isinstance(seq, UnknownSeq):
             _examples.append(MutableSeq(seq))
     _start_end_values = [0, 1, 2, 1000, -1, -2, -999, None]
+    if numpy is not None:
+        # test with numpy integers (numpy.int32, numpy.int64 etc.)
+        _start_end_values.extend(numpy.array([3, 5]))
 
     def _test_method(self, method_name, start_end=False):
         """Check this method matches the plain string's method."""

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -12,6 +12,15 @@ import os
 import unittest
 import math
 
+try:
+    import numpy
+except ImportError:
+    from Bio import MissingExternalDependencyError
+
+    raise MissingExternalDependencyError(
+        "Install numpy if you want to use Bio.motifs."
+    ) from None
+
 from Bio import motifs
 from Bio.Seq import Seq
 
@@ -2247,6 +2256,76 @@ class MotifTestPWM(unittest.TestCase):
         with open("motifs/SRF.pfm") as handle:
             self.m = motifs.read(handle, "pfm")
         self.s = Seq("ACGTGTGCGTAGTGCGT")
+
+    def test_getitem(self):
+        counts = self.m.counts
+        python_integers = range(13)
+        numpy_integers = numpy.array(python_integers)
+        integers = {'python': python_integers, 'numpy': numpy_integers}
+        for int_type in ("python", "numpy"):
+            i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12 = integers[int_type]
+            msg = "using %s integers as indices" % int_type
+            # slice, slice
+            d = counts[i1::i2,i2:i12:i3]
+            self.assertIsInstance(d, dict, msg=msg)
+            self.assertEqual(len(d), 2, msg=msg)
+            self.assertEqual(len(d['C']), 4, msg=msg)
+            self.assertEqual(len(d['T']), 4, msg=msg)
+            self.assertAlmostEqual(d['C'][i0], 45.0, msg=msg)
+            self.assertAlmostEqual(d['C'][i1],  1.0, msg=msg)
+            self.assertAlmostEqual(d['C'][i2],  0.0, msg=msg)
+            self.assertAlmostEqual(d['C'][i3],  1.0, msg=msg)
+            self.assertAlmostEqual(d['T'][i0],  0.0, msg=msg)
+            self.assertAlmostEqual(d['T'][i1], 42.0, msg=msg)
+            self.assertAlmostEqual(d['T'][i2],  3.0, msg=msg)
+            self.assertAlmostEqual(d['T'][i3],  0.0, msg=msg)
+            # slice, int
+            d = counts[i1::i2, i4]
+            self.assertIsInstance(d, dict, msg=msg)
+            self.assertEqual(len(d), 2, msg=msg)
+            self.assertAlmostEqual(d['C'],  1.0, msg=msg)
+            self.assertAlmostEqual(d['T'], 13.0, msg=msg)
+            # int, slice
+            t = counts[i2, i3:i12:i2]
+            self.assertIsInstance(t, tuple, msg=msg)
+            self.assertAlmostEqual(t[i0],  0.0, msg=msg)
+            self.assertAlmostEqual(t[i1],  0.0, msg=msg)
+            self.assertAlmostEqual(t[i2],  0.0, msg=msg)
+            self.assertAlmostEqual(t[i3],  0.0, msg=msg)
+            self.assertAlmostEqual(t[i4], 43.0, msg=msg)
+            # int, int
+            v = counts[i1, i5]
+            self.assertAlmostEqual(v, 1.0, msg=msg)
+            # tuple, slice
+            d = counts[(i0, i3), i3:i12:i2]
+            self.assertIsInstance(d, dict, msg=msg)
+            self.assertEqual(len(d), 2, msg=msg)
+            self.assertEqual(len(d['A']), 5, msg=msg)
+            self.assertEqual(len(d['T']), 5, msg=msg)
+            self.assertAlmostEqual(d['A'][i0],  1.0, msg=msg)
+            self.assertAlmostEqual(d['A'][i1],  3.0, msg=msg)
+            self.assertAlmostEqual(d['A'][i2],  1.0, msg=msg)
+            self.assertAlmostEqual(d['A'][i3], 15.0, msg=msg)
+            self.assertAlmostEqual(d['A'][i4],  2.0, msg=msg)
+            self.assertAlmostEqual(d['T'][i0],  0.0, msg=msg)
+            self.assertAlmostEqual(d['T'][i1], 42.0, msg=msg)
+            self.assertAlmostEqual(d['T'][i2], 45.0, msg=msg)
+            self.assertAlmostEqual(d['T'][i3], 30.0, msg=msg)
+            self.assertAlmostEqual(d['T'][i4],  0.0, msg=msg)
+            # tuple, int
+            d = counts[(i0, i3), i5]
+            self.assertIsInstance(d, dict, msg=msg)
+            self.assertEqual(len(d), 2, msg=msg)
+            self.assertAlmostEqual(d['A'],  3.0, msg=msg)
+            self.assertAlmostEqual(d['T'], 42.0, msg=msg)
+            # str, slice
+            t = counts['C', i2:i12:i4]
+            self.assertIsInstance(t, tuple, msg=msg)
+            self.assertAlmostEqual(t[i0], 45.0, msg=msg)
+            self.assertAlmostEqual(t[i1],  0.0, msg=msg)
+            self.assertAlmostEqual(t[i2],  0.0, msg=msg)
+            # str, int
+            self.assertAlmostEqual(counts['T', i4], 13.0, msg=msg)
 
     def test_simple(self):
         """Test if Bio.motifs PWM scoring works."""

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -2261,37 +2261,37 @@ class MotifTestPWM(unittest.TestCase):
         counts = self.m.counts
         python_integers = range(13)
         numpy_integers = numpy.array(python_integers)
-        integers = {'python': python_integers, 'numpy': numpy_integers}
+        integers = {"python": python_integers, "numpy": numpy_integers}
         for int_type in ("python", "numpy"):
             i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12 = integers[int_type]
             msg = "using %s integers as indices" % int_type
             # slice, slice
-            d = counts[i1::i2,i2:i12:i3]
+            d = counts[i1::i2, i2:i12:i3]
             self.assertIsInstance(d, dict, msg=msg)
             self.assertEqual(len(d), 2, msg=msg)
-            self.assertEqual(len(d['C']), 4, msg=msg)
-            self.assertEqual(len(d['T']), 4, msg=msg)
-            self.assertAlmostEqual(d['C'][i0], 45.0, msg=msg)
-            self.assertAlmostEqual(d['C'][i1],  1.0, msg=msg)
-            self.assertAlmostEqual(d['C'][i2],  0.0, msg=msg)
-            self.assertAlmostEqual(d['C'][i3],  1.0, msg=msg)
-            self.assertAlmostEqual(d['T'][i0],  0.0, msg=msg)
-            self.assertAlmostEqual(d['T'][i1], 42.0, msg=msg)
-            self.assertAlmostEqual(d['T'][i2],  3.0, msg=msg)
-            self.assertAlmostEqual(d['T'][i3],  0.0, msg=msg)
+            self.assertEqual(len(d["C"]), 4, msg=msg)
+            self.assertEqual(len(d["T"]), 4, msg=msg)
+            self.assertAlmostEqual(d["C"][i0], 45.0, msg=msg)
+            self.assertAlmostEqual(d["C"][i1], 1.0, msg=msg)
+            self.assertAlmostEqual(d["C"][i2], 0.0, msg=msg)
+            self.assertAlmostEqual(d["C"][i3], 1.0, msg=msg)
+            self.assertAlmostEqual(d["T"][i0], 0.0, msg=msg)
+            self.assertAlmostEqual(d["T"][i1], 42.0, msg=msg)
+            self.assertAlmostEqual(d["T"][i2], 3.0, msg=msg)
+            self.assertAlmostEqual(d["T"][i3], 0.0, msg=msg)
             # slice, int
             d = counts[i1::i2, i4]
             self.assertIsInstance(d, dict, msg=msg)
             self.assertEqual(len(d), 2, msg=msg)
-            self.assertAlmostEqual(d['C'],  1.0, msg=msg)
-            self.assertAlmostEqual(d['T'], 13.0, msg=msg)
+            self.assertAlmostEqual(d["C"], 1.0, msg=msg)
+            self.assertAlmostEqual(d["T"], 13.0, msg=msg)
             # int, slice
             t = counts[i2, i3:i12:i2]
             self.assertIsInstance(t, tuple, msg=msg)
-            self.assertAlmostEqual(t[i0],  0.0, msg=msg)
-            self.assertAlmostEqual(t[i1],  0.0, msg=msg)
-            self.assertAlmostEqual(t[i2],  0.0, msg=msg)
-            self.assertAlmostEqual(t[i3],  0.0, msg=msg)
+            self.assertAlmostEqual(t[i0], 0.0, msg=msg)
+            self.assertAlmostEqual(t[i1], 0.0, msg=msg)
+            self.assertAlmostEqual(t[i2], 0.0, msg=msg)
+            self.assertAlmostEqual(t[i3], 0.0, msg=msg)
             self.assertAlmostEqual(t[i4], 43.0, msg=msg)
             # int, int
             v = counts[i1, i5]
@@ -2300,32 +2300,32 @@ class MotifTestPWM(unittest.TestCase):
             d = counts[(i0, i3), i3:i12:i2]
             self.assertIsInstance(d, dict, msg=msg)
             self.assertEqual(len(d), 2, msg=msg)
-            self.assertEqual(len(d['A']), 5, msg=msg)
-            self.assertEqual(len(d['T']), 5, msg=msg)
-            self.assertAlmostEqual(d['A'][i0],  1.0, msg=msg)
-            self.assertAlmostEqual(d['A'][i1],  3.0, msg=msg)
-            self.assertAlmostEqual(d['A'][i2],  1.0, msg=msg)
-            self.assertAlmostEqual(d['A'][i3], 15.0, msg=msg)
-            self.assertAlmostEqual(d['A'][i4],  2.0, msg=msg)
-            self.assertAlmostEqual(d['T'][i0],  0.0, msg=msg)
-            self.assertAlmostEqual(d['T'][i1], 42.0, msg=msg)
-            self.assertAlmostEqual(d['T'][i2], 45.0, msg=msg)
-            self.assertAlmostEqual(d['T'][i3], 30.0, msg=msg)
-            self.assertAlmostEqual(d['T'][i4],  0.0, msg=msg)
+            self.assertEqual(len(d["A"]), 5, msg=msg)
+            self.assertEqual(len(d["T"]), 5, msg=msg)
+            self.assertAlmostEqual(d["A"][i0], 1.0, msg=msg)
+            self.assertAlmostEqual(d["A"][i1], 3.0, msg=msg)
+            self.assertAlmostEqual(d["A"][i2], 1.0, msg=msg)
+            self.assertAlmostEqual(d["A"][i3], 15.0, msg=msg)
+            self.assertAlmostEqual(d["A"][i4], 2.0, msg=msg)
+            self.assertAlmostEqual(d["T"][i0], 0.0, msg=msg)
+            self.assertAlmostEqual(d["T"][i1], 42.0, msg=msg)
+            self.assertAlmostEqual(d["T"][i2], 45.0, msg=msg)
+            self.assertAlmostEqual(d["T"][i3], 30.0, msg=msg)
+            self.assertAlmostEqual(d["T"][i4], 0.0, msg=msg)
             # tuple, int
             d = counts[(i0, i3), i5]
             self.assertIsInstance(d, dict, msg=msg)
             self.assertEqual(len(d), 2, msg=msg)
-            self.assertAlmostEqual(d['A'],  3.0, msg=msg)
-            self.assertAlmostEqual(d['T'], 42.0, msg=msg)
+            self.assertAlmostEqual(d["A"], 3.0, msg=msg)
+            self.assertAlmostEqual(d["T"], 42.0, msg=msg)
             # str, slice
-            t = counts['C', i2:i12:i4]
+            t = counts["C", i2:i12:i4]
             self.assertIsInstance(t, tuple, msg=msg)
             self.assertAlmostEqual(t[i0], 45.0, msg=msg)
-            self.assertAlmostEqual(t[i1],  0.0, msg=msg)
-            self.assertAlmostEqual(t[i2],  0.0, msg=msg)
+            self.assertAlmostEqual(t[i1], 0.0, msg=msg)
+            self.assertAlmostEqual(t[i2], 0.0, msg=msg)
             # str, int
-            self.assertAlmostEqual(counts['T', i4], 13.0, msg=msg)
+            self.assertAlmostEqual(counts["T", i4], 13.0, msg=msg)
 
     def test_simple(self):
         """Test if Bio.motifs PWM scoring works."""

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -9,6 +9,11 @@ import copy
 import unittest
 import warnings
 
+try:
+    import numpy
+except ImportError:
+    numpy = None
+
 from Bio import BiopythonWarning, BiopythonDeprecationWarning
 from Bio import Seq
 from Bio.Data.IUPACData import (
@@ -424,6 +429,10 @@ class TestSeqMultiplication(unittest.TestCase):
         """Test mul method; relies on addition method."""
         for seq in test_seqs + protein_seqs:
             self.assertEqual(seq * 3, seq + seq + seq)
+        if numpy is not None:
+            factor = numpy.intc(3)  # numpy integer
+            for seq in test_seqs + protein_seqs:
+                self.assertEqual(seq * factor, seq + seq + seq)
 
     def test_mul_method_exceptions(self):
         """Test mul method exceptions."""
@@ -437,6 +446,10 @@ class TestSeqMultiplication(unittest.TestCase):
         """Test rmul method; relies on addition method."""
         for seq in test_seqs + protein_seqs:
             self.assertEqual(3 * seq, seq + seq + seq)
+        if numpy is not None:
+            factor = numpy.intc(3)  # numpy integer
+            for seq in test_seqs + protein_seqs:
+                self.assertEqual(factor * seq, seq + seq + seq)
 
     def test_rmul_method_exceptions(self):
         """Test rmul method exceptions."""
@@ -452,6 +465,12 @@ class TestSeqMultiplication(unittest.TestCase):
             original_seq = seq * 1  # make a copy
             seq *= 3
             self.assertEqual(seq, original_seq + original_seq + original_seq)
+        if numpy is not None:
+            factor = numpy.intc(3)  # numpy integer
+            for seq in test_seqs + protein_seqs:
+                original_seq = seq * 1  # make a copy
+                seq *= factor
+                self.assertEqual(seq, original_seq + original_seq + original_seq)
 
     def test_imul_method_exceptions(self):
         """Test imul method exceptions."""
@@ -620,10 +639,33 @@ class TestMutableSeq(unittest.TestCase):
             self.mutable_s,
             "Set slice with MutableSeq",
         )
+        if numpy is not None:
+            one, three, five, seven = numpy.array([1, 3, 5, 7])  # numpy integers
+            self.assertEqual(
+                Seq.MutableSeq("AATA"), self.mutable_s[one:five], "Slice mutable seq",
+            )
+
+            self.mutable_s[one:three] = "GAT"
+            self.assertEqual(
+                Seq.MutableSeq("TGATTAAAGGATGCATCATG"),
+                self.mutable_s,
+                "Set slice with string and adding extra nucleotide",
+            )
+
+            self.mutable_s[one:three] = self.mutable_s[five:seven]
+            self.assertEqual(
+                Seq.MutableSeq("TAATTAAAGGATGCATCATG"),
+                self.mutable_s,
+                "Set slice with MutableSeq",
+            )
 
     def test_setting_item(self):
         self.mutable_s[3] = "G"
         self.assertEqual(Seq.MutableSeq("TCAGAAGGATGCATCATG"), self.mutable_s)
+        if numpy is not None:
+            i = numpy.intc(3)
+            self.mutable_s[i] = "X"
+            self.assertEqual(Seq.MutableSeq("TCAXAAGGATGCATCATG"), self.mutable_s)
 
     def test_deleting_slice(self):
         del self.mutable_s[4:5]
@@ -752,6 +794,10 @@ class TestMutableSeq(unittest.TestCase):
         """Test setting wobble codon to N (set slice with stride 3)."""
         self.mutable_s[2::3] = "N" * len(self.mutable_s[2::3])
         self.assertEqual(Seq.MutableSeq("TCNAANGGNTGNATNATN"), self.mutable_s)
+        if numpy is not None:
+            start, step = numpy.array([2, 3])  # numpy integers
+            self.mutable_s[start::step] = "X" * len(self.mutable_s[2::3])
+            self.assertEqual(Seq.MutableSeq("TCXAAXGGXTGXATXATX"), self.mutable_s)
 
 
 class TestUnknownSeq(unittest.TestCase):


### PR DESCRIPTION
See issue #3641 .`isinstance(x, int)` will return `False` if x is an integer other than a Python plain integer, e.g. a numpy integer. This PR replaces `isinstance(x, int)` by `isinstance(x, numbers.Integral)` for a few obvious cases, including `Seq` and `SeqRecord`. This is useful for the slicing & indexing code in `Bio.Align`, where the alignment coordinates are stored in a numpy array of integers.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

