### PR TITLE
reverse_complement on SeqRecord

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -3123,6 +3123,7 @@ def reverse_complement(sequence):
 
     If given a string, returns a new string object.
     Given a Seq or a MutableSeq, returns a new Seq object.
+    Given a SeqRecord, returns a new SeqRecord object.
 
     Supports unambiguous and ambiguous nucleotide sequences.
 
@@ -3136,15 +3137,18 @@ def reverse_complement(sequence):
     >>> reverse_complement("A")
     'T'
     """
-    return complement(sequence)[::-1]
+    try:
+        return sequence.reverse_complement()  # Seq, MutableSeq, or SeqRecord
+    except AttributeError:
+        return complement(sequence)[::-1]
 
 
 def complement(sequence):
     """Return the complement sequence of a DNA string.
 
     If given a string, returns a new string object.
-
     Given a Seq or a MutableSeq, returns a new Seq object.
+    Given a SeqRecord, returns a new SeqRecord object.
 
     Supports unambiguous and ambiguous nucleotide sequences.
 
@@ -3166,8 +3170,7 @@ def complement(sequence):
         return sequence.complement()
     elif isinstance(sequence, MutableSeq):
         # Return a Seq
-        # Don't use the MutableSeq reverse_complement method as it is
-        # 'in place'.
+        # Don't use the MutableSeq complement method as it is 'in place'.
         return Seq(sequence).complement()
 
     # Assume it's a string.

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -12,6 +12,7 @@ import unittest
 from Bio import SeqIO
 from Bio.Seq import MutableSeq
 from Bio.Seq import Seq
+from Bio.Seq import reverse_complement
 from Bio.SeqFeature import AfterPosition
 from Bio.SeqFeature import BeforePosition
 from Bio.SeqFeature import ExactPosition
@@ -432,6 +433,20 @@ class SeqRecordMethodsMore(unittest.TestCase):
                 letter_annotations={"test": "abcd"}
             ).letter_annotations,
         )
+
+        rc = reverse_complement(s)
+
+        self.assertEqual("CAGT", rc.seq)
+        self.assertEqual("<unknown id>", rc.id)
+        self.assertEqual("<unknown name>", rc.name)
+        self.assertEqual("<unknown description>", rc.description)
+        self.assertEqual([], rc.dbxrefs)
+        self.assertEqual(
+            "[SeqFeature(FeatureLocation(ExactPosition(1), ExactPosition(4)), type='Site')]",
+            repr(rc.features),
+        )
+        self.assertEqual({}, rc.annotations)
+        self.assertEqual({"test": "dcba"}, rc.letter_annotations)
 
     def test_reverse_complement_mutable_seq(self):
         s = SeqRecord(MutableSeq("ACTG"))


### PR DESCRIPTION
The `reverse_complement` function in `Bio/Seq.py` acts on plain strings, `Seq`, and `MutableSeq` objects, but not on `SeqRecord`, although `SeqRecord` has a `reverse_complement` method:

```python
>>> from Bio.Seq import Seq
>>> from Bio.SeqRecord import SeqRecord
>>> s = Seq("ACCGGGTTTT")
>>> r = SeqRecord(s)
>>> from Bio.Seq import reverse_complement
>>> s.reverse_complement()
Seq('AAAACCCGGT')
>>> reverse_complement(s)
Seq('AAAACCCGGT')
>>> r.reverse_complement()
SeqRecord(seq=Seq('AAAACCCGGT'), id='<unknown id>', name='<unknown name>', description='<unknown description>', dbxrefs=[])
>>> reverse_complement(r)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/biopython-1.80.dev0-py3.9-macosx-10.9-universal2.egg/Bio/Seq.py", line 3139, in reverse_complement
    return complement(sequence)[::-1]
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/biopython-1.80.dev0-py3.9-macosx-10.9-universal2.egg/Bio/Seq.py", line 3178, in complement
    sequence = sequence.encode("ASCII")
AttributeError: 'SeqRecord' object has no attribute 'encode'
>>>
```

This PR lets the `reverse_complement` function cover `SeqRecord`s also.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


